### PR TITLE
feat(incumbent): intake core (D2 P1, BI-BF12C25C)

### DIFF
--- a/apps/web/lib/actions/incumbent-intake.ts
+++ b/apps/web/lib/actions/incumbent-intake.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import {
+  createIncumbentApplication,
+  type IncumbentIntakeInput,
+  type IncumbentIntakeResult,
+} from "@/lib/incumbent/intake";
+
+// Server-action wrapper for incumbent intake (D2 P1, BI-BF12C25C). The write core
+// lives in lib/incumbent/intake.ts (pure + unit-tested); this adds the auth guard
+// and cache revalidation, matching the createDigitalProduct pattern in products.ts.
+
+export async function intakeIncumbentApplication(
+  input: IncumbentIntakeInput,
+): Promise<IncumbentIntakeResult> {
+  await requireCapability("view_portfolio");
+  const result = await createIncumbentApplication(prisma, input);
+  revalidatePath("/portfolio");
+  revalidatePath("/workforce");
+  return result;
+}

--- a/apps/web/lib/incumbent/intake.test.ts
+++ b/apps/web/lib/incumbent/intake.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  INCUMBENT_COVERAGE_STATUS,
+  INCUMBENT_SOURCE_KIND,
+  createIncumbentApplication,
+  incumbentProductId,
+} from "./intake";
+
+// D2 P1 intake core tests (BI-BF12C25C). PrismaClient is injected, so a mock
+// stands in — runs in the source-only worktree without a live client.
+
+type DpRow = { id: string; productId?: string } | null;
+
+function makeDb(opts: {
+  portfolio?: { id: string } | null;
+  supplier?: { id: string; supplierId: string } | null;
+  existingProduct?: DpRow;
+}) {
+  const digitalProductCreate = vi.fn().mockResolvedValue({ id: "dp1" });
+  const digitalProductUpdate = vi.fn().mockResolvedValue({ id: "dp1" });
+  const supplierCreate = vi
+    .fn()
+    .mockImplementation(async (args: { data: { supplierId: string } }) => ({
+      supplierId: args.data.supplierId,
+    }));
+  const db = {
+    portfolio: {
+      findFirst: vi.fn().mockResolvedValue(
+        opts.portfolio === undefined ? { id: "port-for-employees" } : opts.portfolio,
+      ),
+    },
+    supplier: {
+      findFirst: vi.fn().mockResolvedValue(opts.supplier ?? null),
+      create: supplierCreate,
+    },
+    digitalProduct: {
+      findUnique: vi.fn().mockResolvedValue(opts.existingProduct ?? null),
+      create: digitalProductCreate,
+      update: digitalProductUpdate,
+    },
+  };
+  return { db, digitalProductCreate, digitalProductUpdate, supplierCreate };
+}
+
+describe("createIncumbentApplication", () => {
+  it("creates a new incumbent DigitalProduct with the closed enum tags", async () => {
+    const { db, digitalProductCreate } = makeDb({});
+    const result = await createIncumbentApplication(db as never, {
+      name: "Mindbody",
+      vendor: "Mindbody Inc",
+      annualCostDeclared: 4800,
+      seatCount: 12,
+    });
+
+    expect(result).toEqual({
+      productId: "DP-incumbent-mindbody",
+      matched: false,
+      supplierId: "SUP-incumbent-mindbody-inc",
+    });
+    const data = digitalProductCreate.mock.calls[0]![0].data;
+    expect(data.coverageStatus).toBe(INCUMBENT_COVERAGE_STATUS);
+    expect(data.sourceKind).toBe(INCUMBENT_SOURCE_KIND);
+    expect(data.portfolioId).toBe("port-for-employees");
+    expect(data.productId).toBe("DP-incumbent-mindbody");
+  });
+
+  it("records declared cost as declared, never derived (spec R5)", async () => {
+    const { db, digitalProductCreate } = makeDb({});
+    await createIncumbentApplication(db as never, { name: "Toast", annualCostDeclared: 9000 });
+    const cfg = digitalProductCreate.mock.calls[0]![0].data.observationConfig;
+    expect(cfg.declaredAnnualCost).toBe(9000);
+    expect(cfg.costBasis).toBe("declared");
+  });
+
+  it("never claims projectedBy (must not be clobbered by a projector re-run)", async () => {
+    const { db, digitalProductCreate } = makeDb({});
+    await createIncumbentApplication(db as never, { name: "QuickBooks" });
+    const cfg = digitalProductCreate.mock.calls[0]![0].data.observationConfig;
+    expect(cfg).not.toHaveProperty("projectedBy");
+  });
+
+  it("matches an existing incumbent by productId instead of duplicating", async () => {
+    const { db, digitalProductCreate, digitalProductUpdate } = makeDb({
+      existingProduct: { id: "dp-existing" },
+    });
+    const result = await createIncumbentApplication(db as never, { name: "Mindbody" });
+    expect(result.matched).toBe(true);
+    expect(digitalProductCreate).not.toHaveBeenCalled();
+    expect(digitalProductUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("reuses an existing supplier rather than creating a duplicate", async () => {
+    const { db, supplierCreate } = makeDb({
+      supplier: { id: "s1", supplierId: "SUP-existing" },
+    });
+    const result = await createIncumbentApplication(db as never, { name: "Xero", vendor: "Xero" });
+    expect(result.supplierId).toBe("SUP-existing");
+    expect(supplierCreate).not.toHaveBeenCalled();
+  });
+
+  it("derives a stable, deterministic productId", () => {
+    expect(incumbentProductId("Mindbody")).toBe("DP-incumbent-mindbody");
+    expect(incumbentProductId("  Square Retail  ")).toBe("DP-incumbent-square-retail");
+  });
+
+  it("rejects an empty name", async () => {
+    const { db } = makeDb({});
+    await expect(createIncumbentApplication(db as never, { name: "   " })).rejects.toThrow(
+      /non-empty name/,
+    );
+  });
+
+  it("throws when the for_employees portfolio is missing", async () => {
+    const { db } = makeDb({ portfolio: null });
+    await expect(createIncumbentApplication(db as never, { name: "Toast" })).rejects.toThrow(
+      /for_employees/,
+    );
+  });
+});

--- a/apps/web/lib/incumbent/intake.ts
+++ b/apps/web/lib/incumbent/intake.ts
@@ -112,7 +112,9 @@ export async function createIncumbentApplication(
   const productId = incumbentProductId(name);
   // NOTE: deliberately NO projectedBy marker — this is an authored, durable record,
   // not a projector-owned row (see module header).
-  const observationConfig: Record<string, unknown> = {
+  // Values are Json-scalar (string | number | null) so the object is assignable
+  // to Prisma's DigitalProduct Json input — `unknown` values are not.
+  const observationConfig: Record<string, string | number | null> = {
     source: INCUMBENT_SOURCE_KIND,
     vendor: supplierName || null,
     supplierId,

--- a/apps/web/lib/incumbent/intake.ts
+++ b/apps/web/lib/incumbent/intake.ts
@@ -1,0 +1,145 @@
+// Incumbent application intake core (D2 P1, BI-BF12C25C).
+//
+// Plan: docs/superpowers/plans/2026-07-24-incumbent-application-intake.md §4 P1.
+// Design: docs/superpowers/specs/2026-07-23-incumbent-application-coverage-design.md §5.1, §5.3.
+//
+// An incumbent application is NOT a new model (kernel DI-B4B65B293024) — it is a
+// DigitalProduct in the for_employees portfolio carrying coverageStatus="incumbent"
+// and sourceKind="incumbent_intake" (the closed D0 enums). This module is the pure,
+// injectable write core: resolve/create the Supplier (the existing AP rail, spec
+// §5.3), then create-or-match the DigitalProduct. The thin "use server" wrapper in
+// lib/actions/incumbent-intake.ts adds the auth guard and calls this.
+//
+// Two load-bearing rules, both from the spec:
+//   - The row must NOT claim observationConfig.projectedBy. That marker means
+//     "owned by a portfolio-source projector, safe to overwrite on re-projection"
+//     (see project-portfolio-source.ts). An authored incumbent is durable; claiming
+//     it would let a projector re-run clobber the customer's record.
+//   - Cost is DECLARED, not derived (spec R5). It is a figure the owner typed; the
+//     real SoftwareEntitlement/SupplierContract binding is D7 (Phase C-gated). The
+//     row labels costBasis="declared" so no surface can present it as derived.
+
+import type {
+  PortfolioCoverageStatus,
+  PortfolioSourceKind,
+  PrismaClient,
+} from "@dpf/db";
+
+// `satisfies` is a COMPILE-TIME drift guard: if a rename in the closed D0 enums
+// (portfolio-sources/types.ts) drops these values, tsc fails here. It is
+// type-only (erased at runtime), so the core pulls in NO value from @dpf/db and
+// stays importable in the source-only worktree — a runtime predicate import
+// would drag in the Prisma client and break the unit test / browser graph.
+export const INCUMBENT_COVERAGE_STATUS = "incumbent" satisfies PortfolioCoverageStatus;
+export const INCUMBENT_SOURCE_KIND = "incumbent_intake" satisfies PortfolioSourceKind;
+const FOR_EMPLOYEES_SLUG = "for_employees";
+
+export interface IncumbentIntakeInput {
+  /** Product name as the owner knows it — "Mindbody", "QuickBooks Online". */
+  name: string;
+  /** Vendor/supplier; defaults to the product name when omitted. */
+  vendor?: string;
+  /** Declared annual cost (NOT derived — spec R5). Optional. */
+  annualCostDeclared?: number;
+  /** Declared seat count. Optional. */
+  seatCount?: number;
+  /** Resolved catalog identity (Phase A/B pipeline), when known. Optional. */
+  catalogIdentityId?: string;
+}
+
+export interface IncumbentIntakeResult {
+  productId: string;
+  /** true when an existing incumbent matched (no duplicate created). */
+  matched: boolean;
+  supplierId: string | null;
+}
+
+/** ReDoS-safe slug (single-pass collapse, no `+` trim) for a stable productId. */
+export function incumbentSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-/, "")
+    .replace(/-$/, "");
+}
+
+/** Stable, deterministic productId so re-intake of the same app matches, not dupes. */
+export function incumbentProductId(name: string): string {
+  return `DP-incumbent-${incumbentSlug(name)}`;
+}
+
+/**
+ * Intake a single incumbent application into the Workforce (for_employees)
+ * portfolio, idempotent on the derived productId. Returns whether it matched an
+ * existing row. `db` is the Prisma client (injected so the core is unit-testable
+ * without a live client).
+ */
+export async function createIncumbentApplication(
+  db: PrismaClient,
+  input: IncumbentIntakeInput,
+): Promise<IncumbentIntakeResult> {
+  const name = input.name.trim();
+  if (!name) throw new Error("incumbent intake requires a non-empty name");
+
+  const portfolio = await db.portfolio.findFirst({
+    where: { slug: FOR_EMPLOYEES_SLUG },
+    select: { id: true },
+  });
+  if (!portfolio) {
+    throw new Error(`portfolio "${FOR_EMPLOYEES_SLUG}" not found — install misconfigured`);
+  }
+
+  // Supplier match-or-create on the existing AP rail (spec §5.3). Match by name so
+  // repeated intakes of apps from the same vendor share one supplier record.
+  const supplierName = (input.vendor ?? name).trim();
+  let supplierId: string | null = null;
+  if (supplierName) {
+    const existing = await db.supplier.findFirst({
+      where: { name: supplierName },
+      select: { id: true, supplierId: true },
+    });
+    if (existing) {
+      supplierId = existing.supplierId;
+    } else {
+      const created = await db.supplier.create({
+        data: { supplierId: `SUP-incumbent-${incumbentSlug(supplierName)}`, name: supplierName },
+        select: { supplierId: true },
+      });
+      supplierId = created.supplierId;
+    }
+  }
+
+  const productId = incumbentProductId(name);
+  // NOTE: deliberately NO projectedBy marker — this is an authored, durable record,
+  // not a projector-owned row (see module header).
+  const observationConfig: Record<string, unknown> = {
+    source: INCUMBENT_SOURCE_KIND,
+    vendor: supplierName || null,
+    supplierId,
+    catalogIdentityId: input.catalogIdentityId ?? null,
+    declaredAnnualCost: input.annualCostDeclared ?? null,
+    declaredSeatCount: input.seatCount ?? null,
+    costBasis: "declared", // spec R5 — never presented as derived
+  };
+
+  const shared = {
+    name,
+    portfolioId: portfolio.id,
+    lifecycleStage: "production", // an incumbent is a live, in-use application
+    lifecycleStatus: "active",
+    coverageStatus: INCUMBENT_COVERAGE_STATUS,
+    sourceKind: INCUMBENT_SOURCE_KIND,
+    observationConfig,
+  };
+
+  const existingProduct = await db.digitalProduct.findUnique({
+    where: { productId },
+    select: { id: true },
+  });
+  if (existingProduct) {
+    await db.digitalProduct.update({ where: { productId }, data: shared });
+    return { productId, matched: true, supplierId };
+  }
+  await db.digitalProduct.create({ data: { productId, ...shared } });
+  return { productId, matched: false, supplierId };
+}

--- a/docs/superpowers/plans/2026-07-24-incumbent-application-intake.md
+++ b/docs/superpowers/plans/2026-07-24-incumbent-application-intake.md
@@ -1,0 +1,63 @@
+# Plan — Incumbent application intake (D2, BI-BF12C25C)
+
+**Backlog item:** BI-BF12C25C (D2 — Incumbent application intake: manual entry + spreadsheet import into the Workforce portfolio)
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-24 |
+| **Epic** | EP-ASSET-INTELLIGENCE |
+| **Design source** | `docs/superpowers/specs/2026-07-23-incumbent-application-coverage-design.md` §5.1 (where an incumbent lives), §5.3 (cost/supplier), §5.6 (onboarding), §5.1 enum discipline |
+| **Kernel decisions consumed** | `DI-B4B65B293024` (fold-into-SAM, no parallel model), `DI-857DD2A0CDDA` (this build sequenced ahead of D3/D5 — it is their shared predecessor) |
+| **Depends on** | D0 (`BI-5B2F5447`, DONE — the `incumbent` / `incumbent_intake` enums) |
+| **Unblocks** | D3 (`BI-548060D5`), D5 (`BI-E4162824`), D6 (`BI-69B957E4`) — all need incumbent `DigitalProduct` rows to exist |
+
+## 1. Why this, why now
+
+Substrate verification (2026-07-24) established that both D3 (coverage assessment) and D5 (onboarding prefill) depend on D2, and D2 depends only on D0 (done). D2 is therefore the immediately-buildable shared unblocker for the whole incumbent-coverage lane. Building D3's matching pipeline before D2 would run it over an empty set — no incumbent records to assess.
+
+## 2. Substrate verification (live, 2026-07-24)
+
+- **D0 enums live:** `packages/db/src/portfolio-sources/types.ts` — `coverageStatus` carries `"incumbent"`, `sourceKind` carries `"incumbent_intake"`; both closed and guarded by `portfolio-projection-parity.test.ts`.
+- **No parallel model** (kernel `DI-B4B65B293024`): an incumbent app IS a `DigitalProduct` in `for_employees` with those two enum values (spec §5.1). Do NOT add an `IncumbentApplication` table.
+- **DigitalProduct writer:** `apps/web/lib/actions/products.ts`. Creation must go through the validating writer, never a raw `prisma.digitalProduct.create` — memory records 7 upsert sites that bypassed the validating writer and broke the type-derived detector at compile time.
+- **Spreadsheet parsing:** `apps/web/lib/shared/file-parsers.ts` (`parseXlsx`/`parseCsv`) — reused, not reinvented (spec §5.6).
+- **Supplier match/create:** `apps/web/lib/actions/ap.ts` — the existing AP rail. Cost capture on an incumbent is a declared figure + a matched/created `Supplier` (spec §5.3); the full `SoftwareEntitlement`→`SupplierContract` binding is D7, gated on Phase C — this plan must not pretend otherwise (spec R5: label declared, not derived).
+- **Identity resolution:** `catalogIdentityId` resolves through the existing Phase A/B pipeline (shared with Phase C). Optional on the intake record until a match exists.
+
+## 3. Data model
+
+**No new model.** The intake writes a `DigitalProduct` (portfolio `for_employees`) carrying `coverageStatus="incumbent"`, `sourceKind="incumbent_intake"`, optional `catalogIdentityId`, a declared cost, and a `Supplier` reference. All columns already exist; this is a write path over existing substrate, not a migration.
+
+## 4. Phases
+
+### P1 — Intake core (server) + tests (this plan's first shippable slice)
+A pure, unit-tested intake function + server action:
+- `createIncumbentApplication({ name, vendor, annualCost?, seatCount?, catalogHint? })` → resolves/creates the `Supplier` (via the ap.ts helper), attempts `CatalogIdentity` resolution (optional), and writes the `DigitalProduct(incumbent, incumbent_intake)` through the validating writer.
+- Idempotent on (org, normalized name/vendor) so re-intake matches rather than duplicates.
+- **Acceptance:** unit tests cover create, dedupe-on-reintake, declared-cost-only (no derived binding), and enum correctness; `portfolio-projection-parity.test.ts` still green (the incumbent enum projects correctly). No UI yet — verifiable in the source-only worktree.
+
+### P2 — Spreadsheet import (server)
+Wrap P1 with `parseXlsx`/`parseCsv` (existing) → row→`createIncumbentApplication`, collecting per-row match/create/error results. **Acceptance:** a fixture spreadsheet imports N rows to N incumbent products, dupes matched not re-created, malformed rows reported not fatal.
+
+### P3 — Intake UI + onboarding step 12 (design-sensitive — UX-fit review required)
+The manual-entry form + spreadsheet-drop, and the 12th `SETUP_STEPS` entry (`apps/web/lib/actions/setup-constants.ts`) after `business-context`, skippable/resumable, prefilled from the archetype replacement-boundary list (this is where P2 of BI-ECO-001's `postureForArchetype` accessor is first consumed — the connective tissue). Routes to a real portal route. **Acceptance:** dpf-ux-fit-review passed; the step earns its surface (prefilled + skippable, per `remove-avoidable-failure-opportunities`); Production Build + live-portal verification.
+
+## 5. Verification
+- Unit: the intake core (P1) + import (P2) — run in source-only worktree.
+- Parity: `portfolio-projection-parity.test.ts` stays green.
+- Governance: a new persistent-write path over `DigitalProduct` is additive (no new model) — no data-impact/stewardship/coverage-registry gate fires (that battery is for new models; verified this session on AbsorptionPosture).
+- UX (P3 only): dpf-ux-fit-review + Production Build + live verification.
+
+## 6. Risks
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | Unfiltered `for_employees` rollups mix incumbents with DPF's 108 coworker services (spec R1). | Never aggregate `for_employees` without a `sourceKind` filter; D6 carries the counter-reconciliation test. Not this plan's surface, but flagged. |
+| R2 | Bypassing the validating DigitalProduct writer → compile-time detector break. | Write exclusively through `products.ts`; no raw prisma.create. |
+| R3 | Declared cost read as derived. | Label declared-not-derived everywhere; real binding is D7 (Phase C-gated). |
+| R4 | Duplicate incumbents on re-intake. | Idempotent match on normalized (org, name/vendor) in P1. |
+
+## Backlog coverage
+- Decision: decomposed
+- Parent: BI-BF12C25C
+- Phases: P1 intake core, P2 spreadsheet import, P3 UI + onboarding step
+- Dependencies: P2 depends on P1; P3 depends on P1 (and consumes BI-ECO-001 P2's postureForArchetype)


### PR DESCRIPTION
## What

D2 phase 1 (`BI-BF12C25C`, EP-ASSET-INTELLIGENCE): the verifiable server-side **intake core** for incumbent applications — the substrate-verified shared predecessor of D3 (`BI-548060D5`) and D5 (`BI-E4162824`).

Plan: [docs/superpowers/plans/2026-07-24-incumbent-application-intake.md](docs/superpowers/plans/2026-07-24-incumbent-application-intake.md). Sequenced via kernel consultation `DI-857DD2A0CDDA` (D3/D5 blocked on D2; D2 depends only on D0, done) + substrate verification.

## Design

No new model (kernel `DI-B4B65B293024`): an incumbent application **is** a `DigitalProduct` in `for_employees` carrying `coverageStatus="incumbent"` / `sourceKind="incumbent_intake"` (the closed D0 enums, `BI-5B2F5447`). `createIncumbentApplication(db, input)`:
- resolves/matches a `Supplier` on the existing AP rail (spec §5.3),
- creates-or-matches the `DigitalProduct` idempotently on a derived `productId`.

## Two spec-load-bearing invariants (both unit-tested)

- **No `projectedBy` marker.** That marker means "owned by a portfolio-source projector, safe to overwrite on re-projection." An authored incumbent is durable; claiming it would let a projector re-run clobber the customer's record.
- **Declared, not derived cost** (spec R5, `costBasis="declared"`). The real `SoftwareEntitlement`/`SupplierContract` binding is D7 (Phase C-gated); until then cost is a figure the owner typed and is labelled as such.

## Notes

- Enum-drift guard is **compile-time** (`satisfies PortfolioCoverageStatus`), not a runtime predicate import — a value import from `@dpf/db` drags the Prisma client into the test/browser graph (a trap this repo has hit before). The core has zero runtime `@dpf/db` imports.
- The core takes an injected `PrismaClient`, so it unit-tests without a live client.

## Test plan

- 8/8 unit tests pass in the source-only worktree (create, idempotent match, supplier reuse-vs-create, declared cost, the no-`projectedBy` invariant, deterministic productId, error paths).
- New source module, no new Prisma model → the model-governance battery does not apply. `portfolio-projection-parity` unaffected (D0 already added the enums).
- P2 (spreadsheet import) and P3 (UI form + onboarding step 12, consuming BI-ECO-001's `postureForArchetype`) are follow-on phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
