### PR TITLE
fix(ux-sweep): isolate routes with about:blank to cut navigation-interruption flake (BI-EA221325)

### DIFF
--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -198,6 +198,18 @@ async function main(): Promise<void> {
         // One unreachable route must not abort the sweep; it is reported as skipped.
         const first = (err as Error).message.split(/\r?\n/)[0];
         skipped.push({ routePath: row.routePath, reason: `error: ${first}` });
+      } finally {
+        // Isolate routes so the measured route cannot flake the NEXT one (BI-EA221325):
+        // a route can trigger a client-side navigation after domcontentloaded, and if it
+        // is still in flight when the next page.goto fires, Playwright throws
+        // "Navigation to X is interrupted by another navigation to Y" — a route that is
+        // then measured on one run and skipped on another, which reads as a false
+        // regression. Resetting to about:blank between routes cancels any pending
+        // navigation and gives every route the same clean starting state. It is
+        // side-effect-free: each real route re-navigates with its own page.goto.
+        await page
+          .goto("about:blank", { waitUntil: "commit", timeout: 10_000 })
+          .catch(() => {});
       }
     }
   } finally {


### PR DESCRIPTION
## What
Determinism-hardening for the route-budget sweep — a step toward arming the gate (BI-EA221325). Resets the shared Playwright page to `about:blank` between routes so a just-measured route's in-flight client-side navigation cannot interrupt the next route's `page.goto` ("Navigation to X interrupted by another navigation to Y"), which currently makes a route measured on one run and skipped on the next — a false regression that blocks arming.

## Why this is safe
- Correct-by-construction: each real route re-navigates with its own `page.goto`; the `about:blank` reset only clears any pending navigation between routes.
- `waitUntil:"commit"` (instant) + errors swallowed, so it cannot add flake or fail a route.

## Scope / what this does NOT do
- Does **not** flip `bootstrapped:true`. Arming stays a follow-up gated on the acceptance bar: **two consecutive same-commit CI sweeps with zero regressions.**
- Residual word-jitter on a couple of routes (e.g. `/ops/self-upgrade` relative-time/count) is tracked separately in BI-EA221325 and not addressed here.

## Verification
Local verification is impossible for a Playwright/CI sweep in a source-only worktree (no per-package `.bin`); **CI runs the sweep and is the verifier.** The signal to watch is whether the "interrupted by another navigation" skips disappear from the sweep log and the measured-route count stabilizes across runs.

Refs BI-EA221325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)