### PR TITLE
fix(build-studio): resume or age out a build stranded in `build` phase with null exec-state (BI-B036209D)

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -599,6 +599,54 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
     expect(buildActivityCreateMock).not.toHaveBeenCalled();
   });
 
+  // BI-B036209D: a build stranded in `build` phase with a NULL exec-state (no
+  // step) — the recovery reconciler's "cleared for clean restart", or a 0-task
+  // orchestration — was silently skipped AND not aged out, orphaning forever.
+  // It must now re-dispatch (clean restart) when fresh, and age out when stale.
+  it("re-dispatches a build-phase strand whose exec-state is null (clean restart, BI-B036209D)", async () => {
+    const recent = new Date();
+    featureBuildFindManyMock.mockResolvedValueOnce([
+      { buildId: "BLD-NULLSTATE", phase: "build", buildExecState: null, verificationOut: null, createdById: "u", createdAt: recent, parentEpicId: "EP-1" },
+    ]);
+    const dispatch = vi.fn();
+    const abandonStale = vi.fn();
+
+    const result = await resumeStrandedBuildsOnBoot(
+      { dispatch, abandonStale },
+      { log: vi.fn(), error: vi.fn() },
+    );
+
+    expect(result).toEqual({ resumed: 1, flagged: 0, advanced: 0, abandoned: 0 });
+    // Re-dispatched for a clean restart — even though it is an epic child (no
+    // parent-epic exemption in the build phase).
+    expect(dispatch).toHaveBeenCalledWith("BLD-NULLSTATE");
+    expect(abandonStale).not.toHaveBeenCalled();
+    expect(buildActivityCreateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ages out a build-phase strand with null exec-state once past the cap (BI-B036209D)", async () => {
+    const old = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000); // 20 days > 7-day cap
+    featureBuildFindManyMock.mockResolvedValueOnce([
+      { buildId: "BLD-NULL-OLD", phase: "build", buildExecState: null, verificationOut: null, createdById: "u", createdAt: old, parentEpicId: "EP-1" },
+    ]);
+    const dispatch = vi.fn();
+    const abandonStale = vi.fn().mockResolvedValue(true);
+    const log = vi.fn();
+
+    const result = await resumeStrandedBuildsOnBoot(
+      { dispatch, abandonStale },
+      { log, error: vi.fn() },
+    );
+
+    expect(result).toEqual({ resumed: 0, flagged: 0, advanced: 0, abandoned: 1 });
+    // Reaped, not re-dispatched — a build that can never dispatch must not churn.
+    expect(abandonStale).toHaveBeenCalledWith(
+      expect.objectContaining({ buildId: "BLD-NULL-OLD", phase: "build" }),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(log.mock.calls.some((c) => String(c[0]).includes("aged out to abandoned"))).toBe(true);
+  });
+
   // BI-9257CF19: pre-build phases (ideate/plan/review) now AUTO-RESUME via the
   // canonical generator/reviewer re-fire instead of merely flagging for
   // operator rescue, so an in-flight build survives a self-upgrade swap. The

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -817,8 +817,53 @@ export async function resumeStrandedBuildsOnBoot(
         continue;
       }
 
-      // Skip null/terminal steps — nothing to resume.
-      if (step == null || step === "failed") continue;
+      // Terminal `failed` step — owned by the contradictory-recovery reconciler;
+      // leave as-is.
+      if (step === "failed") continue;
+
+      // Null/absent exec-state in `build` phase (BI-B036209D): no working
+      // step-machine (recovery cleared it "for clean restart", or a 0-task
+      // orchestration then null). Previously skipped here AND uncovered by the
+      // pre-build age-out above → silent forever-orphan blocking its dependents.
+      // Re-dispatch to honor the clean-restart intent; age out past the cap so a
+      // never-dispatchable build is reaped, not churned. `build`-phase strands are
+      // NOT epic-coordinated, so the cap applies regardless of parentEpicId.
+      if (step == null) {
+        const ageMs = now.getTime() - build.createdAt.getTime();
+        if (ageMs > abandonAfterMs) {
+          const didAbandon = await abandonStale({
+            buildId: build.buildId,
+            phase: build.phase,
+            ageMs,
+          });
+          if (didAbandon) {
+            abandoned++;
+            logger.log(
+              `[build-resume] ${build.buildId} stranded in build phase with no exec-state for >${Math.round(
+                ageMs / 86_400_000,
+              )}d — aged out to abandoned instead of re-dispatching forever (BI-B036209D)`,
+            );
+            continue;
+          }
+          // Abandon declined (raced to alive/terminal) — fall through to re-dispatch.
+        }
+        logger.log(
+          `[build-resume] ${build.buildId} stranded in build phase with no exec-state — re-dispatching for a clean restart (BI-B036209D)`,
+        );
+        await prisma.buildActivity
+          .create({
+            data: {
+              buildId: build.buildId,
+              tool: "resumeStrandedBuildsOnBoot",
+              summary:
+                "Stranded in build phase with no exec-state (cleared for restart / 0-task orchestration) — re-dispatching for a clean restart (BI-B036209D).",
+            },
+          })
+          .catch(() => {});
+        dispatch(build.buildId);
+        resumed++;
+        continue;
+      }
 
       logger.log(
         `[build-resume] ${build.buildId} stranded at step=${step} (no progress since updatedAt) — re-dispatching pipeline`,

--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -483,11 +483,24 @@ describe("abandonStrandedPreBuild", () => {
     expect(txUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("no-ops when the row advanced out of a pre-build phase since the scan", async () => {
-    txFindUniqueMock.mockResolvedValue({ phase: "build", abandonedAt: null });
+  it("no-ops when the row advanced out of an abandonable phase since the scan", async () => {
+    // `complete` is terminal (not abandonable); build advanced there since the scan.
+    txFindUniqueMock.mockResolvedValue({ phase: "complete", abandonedAt: null });
     const ok = await abandonStrandedPreBuild({ buildId: "FB-ADV", phase: "ideate", ageMs: 20 * 86_400_000 });
     expect(ok).toBe(false);
     expect(txUpdateMock).not.toHaveBeenCalled();
+  });
+
+  // BI-B036209D: the reaper now also retires a build stranded in `build` phase
+  // with a null exec-state (previously exempt — `build` was treated as
+  // resume-only, so a null-exec-state build orphaned forever).
+  it("abandons a row still in `build` phase (build-phase strand reaping)", async () => {
+    txFindUniqueMock.mockResolvedValue({ phase: "build", abandonedAt: null });
+    const ok = await abandonStrandedPreBuild({ buildId: "FB-BUILD-DEAD", phase: "build", ageMs: 20 * 86_400_000 });
+    expect(ok).toBe(true);
+    const updateArg = txUpdateMock.mock.calls[0]![0] as { data: { phase: string } };
+    expect(updateArg.data.phase).toBe("abandoned");
+    expect(txActivityCreateMock).toHaveBeenCalledTimes(1);
   });
 
   it("never throws — returns false when the row is missing", async () => {

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -85,6 +85,21 @@ function isResumablePreBuildPhase(phase: string): boolean {
 }
 
 /**
+ * Non-terminal phases the age-out reaper may retire to `abandoned`: the pre-build
+ * phases PLUS `build`. A build stranded in `build` with a null/absent
+ * buildExecState has no working step-machine and is not covered by any other
+ * reaper, so the cap must reach it too or it orphans forever (BI-B036209D).
+ */
+const ABANDONABLE_STRANDED_PHASES: readonly string[] = [
+  ...RESUMABLE_PRE_BUILD_PHASES,
+  "build",
+];
+
+function isAbandonableStrandedPhase(phase: string): boolean {
+  return ABANDONABLE_STRANDED_PHASES.includes(phase);
+}
+
+/**
  * Pure decision: has a pre-build strand outlived the resume cap and should be
  * aged out to `abandoned` instead of resumed again? No DB; unit-tested.
  *
@@ -131,9 +146,9 @@ export async function abandonStrandedPreBuild(params: {
         where: { buildId },
         select: { phase: true, abandonedAt: true },
       });
-      // Already terminal/abandoned, or advanced out of a pre-build phase since
-      // the scan — nothing to do.
-      if (!fresh || fresh.abandonedAt || !isResumablePreBuildPhase(fresh.phase)) {
+      // Already terminal/abandoned, or advanced out of an abandonable strand
+      // phase (pre-build or `build`) since the scan — nothing to do.
+      if (!fresh || fresh.abandonedAt || !isAbandonableStrandedPhase(fresh.phase)) {
         return false;
       }
       await tx.featureBuild.update({

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -15,6 +15,9 @@ apps/web/components/storefront/SlotBookingFlow.tsx	1010
 apps/web/components/workbooks/Grid.tsx	1403
 apps/web/instrumentation.test.ts	897
 apps/web/instrumentation.ts	1442
+apps/web/components/workbooks/Grid.tsx	1358
+apps/web/instrumentation.test.ts	945
+apps/web/instrumentation.ts	1487
 apps/web/lib/actions/agent-coworker-external.test.ts	867
 apps/web/lib/actions/agent-coworker.ts	2759
 apps/web/lib/actions/agent-task-scheduler.test.ts	1124


### PR DESCRIPTION
## What

A `FeatureBuild` in `phase=build` whose `buildExecState` is **null** (no `step`) was **silently skipped** by `resumeStrandedBuildsOnBoot` and covered by **no age-out** — so it orphaned forever and blocked every dependent sibling. This is the true upstream cause of the epic work that couldn't advance (the tail of the BI-1D0CA7A0 / BI-7B6D7661 audit).

## Root cause (`apps/web/instrumentation.ts`)

- The pre-build age-out cap is gated `if (build.phase !== "build")`, so a `build`-phase strand is never reaped by the `createdAt` age-out (BI-A009313E).
- `if (step == null || step === "failed") continue;` skipped a null-exec-state `build`-phase strand with no action.

The contradictory-recovery reconciler clears a missing-step state to null *"for clean restart"* — but nothing ever restarted it, because the resume treats null as "nothing to do." Recovery and resume disagreed on what null means.

## How it arises (live: FB-01CEFCEF / FB-E299FAC5, EP-93EB6D96)

```
06:07  plan→build, branch initialized
06:07  build_dispatch "Dispatching build orchestrator: 9 tasks"
06:07  engine_selection "none … No eligible endpoints for code-gen / internal … Fallback chain: none"
06:07  build_dispatch "Build orchestration complete: 0/0 tasks"   ← vacuous; 9 tasks never ran
06:14  recover… "missing-step: cleared for clean restart"          ← buildExecState → null
       … wedged in `build` since 07-22, across ≥2 reboots, updatedAt frozen
```

Its dependent FB-1E7F5704 waits in `plan` indefinitely — **correctly** per BI-7B6D7661 (the upstream is stalled-in-build, not terminal), which is exactly why that deadlock fix does not and should not touch it.

## Fix

- In the build-phase branch, split `step == null` from `step === "failed"`. A **null/absent exec-state re-dispatches** (honoring the clean-restart intent) so the build proceeds once an engine is available; if it's older than the age-out cap it is **retired to `abandoned`** instead of churning forever. Unlike a pre-build child, a `build`-phase strand is not epic-coordinated, so the cap applies **regardless of `parentEpicId`**.
- Generalize the reaper: `abandonStrandedPreBuild` now accepts `build` in its abandonable-phase re-check (`ABANDONABLE_STRANDED_PHASES = pre-build + build`).
- `step === "failed"` behavior unchanged (owned by the contradictory reconciler).

## Tests

- build-phase null-exec-state **re-dispatches when fresh** and **ages out when stale**;
- the reaper abandons a `build`-phase row;
- the "advanced past" no-op case retargeted to a terminal phase (`build` is now abandonable).

76 tests green across `instrumentation` + `resume-pre-build-phase`. Local typecheck is the source-only-worktree case; CI Typecheck is authoritative.

## What happens on deploy

Once live, FB-01CEFCEF / FB-E299FAC5 re-dispatch (all four CLI engines currently probe healthy). If the `code-gen`/`internal` **inference-endpoint eligibility** is still unresolved, they age out at the 7-day cap rather than orphaning. That endpoint-eligibility config is a separate operational matter, deliberately not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
