### PR TITLE
feat(decision-perspective): score open-ended org-business/profession gates from caller-supplied option features (BI-6DCF772F part 1)

### DIFF
--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -11,7 +11,7 @@ import {
 } from "./persistence";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
-import { recommendOptionAgainstCommandments } from "./option-recommendation";
+import { resolveRecommendedOptionId } from "./option-recommendation";
 import type {
   DecisionPerspectiveEvaluationInput,
   DecisionPerspectiveEvaluationResult,
@@ -676,21 +676,16 @@ export async function evaluatePerspectiveGate(input: {
     evaluation.resolvedProfileChain = resolved.resolvedProfileChain;
   }
 
-  // BI-D88DFEEA Phase 1. Only when the gate supplied scored options AND the
-  // verdict is a path forward (recommend/arbitrate) — an escalate/defer
-  // verdict means the kernel explicitly declined to pick among the options,
-  // so recording a recommendation there would misrepresent what happened.
-  if (
-    input.scoredOptions
-    && input.scoredOptions.length > 0
-    && (evaluation.outcomeType === "recommend" || evaluation.outcomeType === "arbitrate")
-  ) {
-    evaluation.recommendedOptionId = await recommendOptionAgainstCommandments({
-      db: input.db,
-      scoredOptions: input.scoredOptions,
-      organizationId: input.organizationId ?? null,
-    });
-  }
+  // BI-D88DFEEA Phase 1 / BI-6DCF772F. Recommend only when the gate supplied
+  // scored options AND the verdict is a path forward — the guard now lives in
+  // the shared resolveRecommendedOptionId helper so profession-gate applies it
+  // identically.
+  evaluation.recommendedOptionId = await resolveRecommendedOptionId({
+    db: input.db,
+    scoredOptions: input.scoredOptions,
+    organizationId: input.organizationId ?? null,
+    outcomeType: evaluation.outcomeType,
+  });
 
   console.info(
     `[tool-trace] ${prefix}.evaluator.complete ${JSON.stringify({

--- a/apps/web/lib/decision-perspective/option-recommendation.test.ts
+++ b/apps/web/lib/decision-perspective/option-recommendation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { recommendOptionAgainstCommandments } from "./option-recommendation";
+import { recommendOptionAgainstCommandments, resolveRecommendedOptionId } from "./option-recommendation";
 
 // BI-D88DFEEA Phase 1. This module is deliberately commandments-only (see its
 // header) — these tests pin that it reuses listPrinciplesByTier + decide()
@@ -88,5 +88,35 @@ describe("recommendOptionAgainstCommandments", () => {
       ],
     });
     expect(result).toBe("a");
+  });
+});
+
+describe("resolveRecommendedOptionId (BI-6DCF772F guard)", () => {
+  const scoredOptions = [
+    { id: "revise", description: "Revise the plan", features: { long_term_maintainability: 0.9, speed_to_value: 0.2 } },
+    { id: "proceed", description: "Proceed now", features: { long_term_maintainability: 0.2, speed_to_value: 0.9 } },
+  ];
+  const commandmentDb = () => ({ wikiPage: { findMany: vi.fn().mockResolvedValue([fakeCommandment()]) } });
+
+  it("returns null for an escalate/defer verdict even when scored options are present — never invents a recommendation the kernel declined", async () => {
+    const db = commandmentDb();
+    for (const outcomeType of ["escalate", "defer"]) {
+      expect(await resolveRecommendedOptionId({ db, scoredOptions, outcomeType })).toBeNull();
+    }
+    expect(db.wikiPage.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no scored options are supplied, regardless of verdict", async () => {
+    const db = commandmentDb();
+    expect(await resolveRecommendedOptionId({ db, scoredOptions: undefined, outcomeType: "recommend" })).toBeNull();
+    expect(await resolveRecommendedOptionId({ db, scoredOptions: [], outcomeType: "recommend" })).toBeNull();
+    expect(db.wikiPage.findMany).not.toHaveBeenCalled();
+  });
+
+  it("delegates to the commandment argmax for recommend/arbitrate verdicts", async () => {
+    for (const outcomeType of ["recommend", "arbitrate"]) {
+      const result = await resolveRecommendedOptionId({ db: commandmentDb(), scoredOptions, outcomeType });
+      expect(result).toBe("revise");
+    }
   });
 });

--- a/apps/web/lib/decision-perspective/option-recommendation.ts
+++ b/apps/web/lib/decision-perspective/option-recommendation.ts
@@ -67,3 +67,37 @@ export async function recommendOptionAgainstCommandments(input: {
   const result = decide(options, principles);
   return result.recommendation?.optionId ?? null;
 }
+
+/**
+ * Gate-level wrapper around {@link recommendOptionAgainstCommandments} that
+ * applies the shared "only recommend when it means something" guard: a
+ * recommendation is only recorded when the gate actually supplied scored
+ * options AND the verdict is a path forward (`recommend`/`arbitrate`). An
+ * `escalate`/`defer` verdict means the kernel explicitly declined to pick among
+ * the options, so recording a recommendation there would misrepresent what
+ * happened. Returns `null` in every other case.
+ *
+ * Extracted from `evaluatePerspectiveGate` (BI-D88DFEEA) so the two gates that
+ * write their own DecisionInteraction row — the async wrapper and
+ * `profession-gate` — share one argmax implementation instead of hand-rolling
+ * the guard twice (BI-6DCF772F).
+ */
+export async function resolveRecommendedOptionId(input: {
+  db: CommandmentClient;
+  scoredOptions?: DecisionScoredOption[] | null;
+  organizationId?: string | null;
+  outcomeType: string;
+}): Promise<string | null> {
+  if (
+    input.scoredOptions
+    && input.scoredOptions.length > 0
+    && (input.outcomeType === "recommend" || input.outcomeType === "arbitrate")
+  ) {
+    return recommendOptionAgainstCommandments({
+      db: input.db,
+      scoredOptions: input.scoredOptions,
+      organizationId: input.organizationId ?? null,
+    });
+  }
+  return null;
+}

--- a/apps/web/lib/decision-perspective/org-business-gate.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.ts
@@ -26,6 +26,7 @@ import type {
   DecisionPerspectiveEvaluationResult,
   DecisionRiskTier,
   DecisionEvidenceItem,
+  DecisionScoredOption,
 } from "./types";
 
 type OrgBusinessGateClient = any;
@@ -51,6 +52,13 @@ export async function evaluateOrgBusinessDecisionGate(input: {
   organizationId: string | null | undefined;
   question: string;
   options: string[];
+  /**
+   * Optional per-option feature vectors (index-aligned to `options`). When
+   * present, the gate scores them against kernel commandments and records a
+   * real `recommendedOptionId`; when absent, only the coverage-based verdict is
+   * recorded (BI-6DCF772F).
+   */
+  scoredOptions?: DecisionScoredOption[];
   domainClass: DecisionDomainClass;
   riskTier: DecisionRiskTier;
   /** Where the decision originated, e.g. "/coworker-business". Recorded on the ledger. */
@@ -73,6 +81,7 @@ export async function evaluateOrgBusinessDecisionGate(input: {
     fallbackProfileId: input.fallbackProfileId,
     question: input.question,
     options: input.options,
+    scoredOptions: input.scoredOptions,
     domainClass: input.domainClass,
     riskTier: input.riskTier,
     routeContext: input.routeContext,

--- a/apps/web/lib/decision-perspective/profession-gate.test.ts
+++ b/apps/web/lib/decision-perspective/profession-gate.test.ts
@@ -101,6 +101,56 @@ describe("evaluateProfessionDecisionGate", () => {
     expect(data.gateFallbackUsed).toBe(false);
   });
 
+  const commandmentRow = {
+    id: "c1",
+    title: "Architecture Over Shortcuts",
+    principleTier: "commandment",
+    principleWeight: null,
+    principleDimensionVector: { long_term_maintainability: 0.8, speed_to_value: -0.3 },
+  };
+
+  it("records a real recommendedOptionId + scoredOptions when the caller supplies option features and the verdict is a path forward (BI-6DCF772F)", async () => {
+    const db = {
+      ...makeDb(),
+      wikiPage: { findMany: vi.fn().mockResolvedValue([commandmentRow]) },
+    };
+    const scoredOptions = [
+      { id: "Compatibility view", description: "Compatibility view", features: { long_term_maintainability: 0.9, speed_to_value: 0.2 } },
+      { id: "Hard cutover", description: "Hard cutover", features: { long_term_maintainability: 0.2, speed_to_value: 0.9 } },
+    ];
+    await evaluateProfessionDecisionGate({
+      ...base,
+      db: db as never,
+      scoredOptions,
+      resolver: fakeResolver() as never,
+      evaluator: (input) => makeEval({ outcomeType: "recommend", scoredOptions: input.scoredOptions }),
+    });
+
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    // Compatibility view wins: high long_term_maintainability (weighted +), low speed_to_value (weighted -).
+    expect(data.recommendedOptionId).toBe("Compatibility view");
+    expect(data.scoredOptions).toEqual(scoredOptions);
+  });
+
+  it("records NO recommendedOptionId for an escalate verdict even when option features are supplied", async () => {
+    const db = {
+      ...makeDb(),
+      wikiPage: { findMany: vi.fn() },
+    };
+    await evaluateProfessionDecisionGate({
+      ...base,
+      db: db as never,
+      scoredOptions: [{ id: "a", description: "a", features: { long_term_maintainability: 1 } }],
+      resolver: fakeResolver() as never,
+      evaluator: (input) => makeEval({ outcomeType: "escalate", scoredOptions: input.scoredOptions }),
+    });
+
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    expect(data.recommendedOptionId ?? null).toBeNull();
+    // The commandment lookup is never even attempted when the verdict isn't a path forward.
+    expect(db.wikiPage.findMany).not.toHaveBeenCalled();
+  });
+
   it("falls back to platform as ADVISORY when the craft corpus is silent", async () => {
     const db = makeDb();
     const result = await evaluateProfessionDecisionGate({

--- a/apps/web/lib/decision-perspective/profession-gate.ts
+++ b/apps/web/lib/decision-perspective/profession-gate.ts
@@ -17,6 +17,7 @@
 import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
 import { evaluateDecisionPerspective } from "./evaluator";
 import { resolveProfileMaterialForProfession } from "./material";
+import { resolveRecommendedOptionId } from "./option-recommendation";
 import { createDecisionInteractionId, persistDecisionInteraction } from "./persistence";
 import type {
   DecisionDomainClass,
@@ -25,6 +26,7 @@ import type {
   DecisionPerspectiveEvaluationResult,
   DecisionPerspectiveProfile,
   DecisionRiskTier,
+  DecisionScoredOption,
 } from "./types";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
@@ -129,6 +131,13 @@ export async function evaluateProfessionDecisionGate(input: {
   agentIdentity: ProfessionAgentIdentityInput;
   question: string;
   options: string[];
+  /**
+   * Optional per-option feature vectors (index-aligned to `options`). When
+   * present and the verdict is a path forward, the gate scores them against
+   * kernel commandments and records a real `recommendedOptionId`; when absent,
+   * only the coverage-based verdict is recorded (BI-6DCF772F).
+   */
+  scoredOptions?: DecisionScoredOption[];
   domainClass: DecisionDomainClass;
   riskTier: DecisionRiskTier;
   /** Where the decision originated, e.g. "/coworker". Recorded on the ledger. */
@@ -254,6 +263,7 @@ export async function evaluateProfessionDecisionGate(input: {
       question,
       questionDomain: domainClass,
       options,
+      scoredOptions: input.scoredOptions,
       riskTier,
       recentOverrideCount: input.recentOverrideCount ?? 0,
       evidence: input.evidence ?? [],
@@ -283,6 +293,18 @@ export async function evaluateProfessionDecisionGate(input: {
       : "No applicable craft guidance: this coworker maps to no profession family and no fallback covered the decision class.";
     evaluation.resolvedProfileChain = resolved.resolvedProfileChain;
   }
+
+  // BI-6DCF772F. The synchronous evaluator echoes scoredOptions but cannot do
+  // the async commandment lookup; apply the same guarded argmax the WWMD/WWWD
+  // wrapper uses so a profession decision with caller-supplied option features
+  // records a real recommendedOptionId (and the weight-inference adapter can
+  // extract an observation once chosenOptionId is captured).
+  evaluation.recommendedOptionId = await resolveRecommendedOptionId({
+    db: input.db,
+    scoredOptions: input.scoredOptions,
+    organizationId: null,
+    outcomeType: evaluation.outcomeType,
+  });
 
   traceWsid("wsid.evaluator.complete", {
     interactionId,

--- a/apps/web/lib/decision-perspective/profession-gate.ts
+++ b/apps/web/lib/decision-perspective/profession-gate.ts
@@ -31,7 +31,9 @@ import type {
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 type ProfessionGateClient = Parameters<typeof resolveProfileMaterialForProfession>[0]["db"] &
-  Parameters<typeof persistDecisionInteraction>[0]["db"];
+  Parameters<typeof persistDecisionInteraction>[0]["db"] &
+  // BI-6DCF772F: the shared argmax reads kernel commandments via wikiPage.
+  Parameters<typeof resolveRecommendedOptionId>[0]["db"];
 
 type GateEvaluator = (input: DecisionPerspectiveEvaluationInput) => DecisionPerspectiveEvaluationResult;
 

--- a/apps/web/lib/decision-perspective/scored-option-input.test.ts
+++ b/apps/web/lib/decision-perspective/scored-option-input.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { parseOptionFeatures } from "./scored-option-input";
+
+describe("parseOptionFeatures (BI-6DCF772F)", () => {
+  const options = ["ship it", "hold for review"];
+
+  it("returns ok with no scoredOptions when optionFeatures is absent (coverage-only, backward compatible)", () => {
+    expect(parseOptionFeatures(options, undefined)).toEqual({ ok: true });
+    expect(parseOptionFeatures(options, null)).toEqual({ ok: true });
+  });
+
+  it("builds index-aligned DecisionScoredOption[] using the option label as id", () => {
+    const result = parseOptionFeatures(options, [
+      { speed_to_value: 0.8, blast_radius: 0.2 },
+      { speed_to_value: 0.3, blast_radius: 0.1 },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      scoredOptions: [
+        { id: "ship it", description: "ship it", features: { speed_to_value: 0.8, blast_radius: 0.2 } },
+        { id: "hold for review", description: "hold for review", features: { speed_to_value: 0.3, blast_radius: 0.1 } },
+      ],
+    });
+  });
+
+  it("fails loudly when optionFeatures length does not match options (caller opted into scoring)", () => {
+    const result = parseOptionFeatures(options, [{ speed_to_value: 0.8 }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/aligned 1:1 with options \(expected 2\)/);
+  });
+
+  it("rejects a non-object option-feature entry", () => {
+    const result = parseOptionFeatures(options, [{ speed_to_value: 0.8 }, "nope"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/optionFeatures\[1\] must be an object/);
+  });
+
+  it("rejects a non-finite axis value", () => {
+    const result = parseOptionFeatures(options, [{ speed_to_value: Number.NaN }, { speed_to_value: 0.3 }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/optionFeatures\[0\]\.speed_to_value must be a finite number/);
+  });
+
+  it("rejects an array (not an object) as an entry", () => {
+    const result = parseOptionFeatures(options, [[0.8], { speed_to_value: 0.3 }]);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/web/lib/decision-perspective/scored-option-input.ts
+++ b/apps/web/lib/decision-perspective/scored-option-input.ts
@@ -1,0 +1,58 @@
+// BI-6DCF772F. Parse the optional `optionFeatures` MCP param for the open-ended
+// decision gates (evaluate_org_business_decision / evaluate_profession_decision)
+// into DecisionScoredOption[]. Unlike build-studio-gate / work-pattern-review —
+// which score a fixed, hand-authored menu — these gates take arbitrary
+// caller-supplied option text, so the per-option feature vectors have to come
+// from the caller too. Shared by both packs so the validation contract is one
+// implementation.
+
+import type { DecisionScoredOption } from "./types";
+
+export type ScoredOptionParseResult =
+  | { ok: true; scoredOptions?: DecisionScoredOption[] }
+  | { ok: false; message: string };
+
+/**
+ * Turn an optional `optionFeatures` param (index-aligned per-option axis→score
+ * maps) plus the already-parsed `options` labels into DecisionScoredOption[].
+ *
+ * - Absent/null → `ok` with NO scoredOptions: the gate keeps today's
+ *   coverage-only behaviour, fully backward compatible.
+ * - Present but malformed (wrong length, a non-object entry, or a non-finite
+ *   axis value) → `ok:false` with a caller-facing message. The caller
+ *   explicitly opted into scoring, so a mismatch is a loud boundary error, not
+ *   a silent skip that would quietly drop the recommendation they asked for.
+ *
+ * The option label is used as the DecisionScoredOption `id` (mirroring how
+ * work-pattern-review uses its action label as the id), so a later
+ * `chosenOptionId` captured from the escalation form resolves against the same
+ * key.
+ */
+export function parseOptionFeatures(options: string[], raw: unknown): ScoredOptionParseResult {
+  if (raw === undefined || raw === null) return { ok: true };
+
+  if (!Array.isArray(raw) || raw.length !== options.length) {
+    return {
+      ok: false,
+      message: `optionFeatures, when provided, must be an array of per-option feature maps aligned 1:1 with options (expected ${options.length}).`,
+    };
+  }
+
+  const scoredOptions: DecisionScoredOption[] = [];
+  for (let i = 0; i < options.length; i += 1) {
+    const entry = raw[i];
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      return { ok: false, message: `optionFeatures[${i}] must be an object mapping axis names to numeric scores.` };
+    }
+    const features: Record<string, number> = {};
+    for (const [axis, value] of Object.entries(entry as Record<string, unknown>)) {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        return { ok: false, message: `optionFeatures[${i}].${axis} must be a finite number.` };
+      }
+      features[axis] = value;
+    }
+    scoredOptions.push({ id: options[i], description: options[i], features });
+  }
+
+  return { ok: true, scoredOptions };
+}

--- a/apps/web/lib/mcp/packs/org-decision-pack.test.ts
+++ b/apps/web/lib/mcp/packs/org-decision-pack.test.ts
@@ -24,6 +24,11 @@ vi.mock("@/lib/wiki/inference-adapter", () => ({
   },
 }));
 
+const gateMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/decision-perspective/org-business-gate", () => ({
+  evaluateOrgBusinessDecisionGate: (...args: unknown[]) => gateMock(...args),
+}));
+
 import { orgDecisionPack } from "./org-decision-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 
@@ -111,5 +116,73 @@ describe("org-decision pack — record_org_business_answer", () => {
   it("keeps the tool description provenance-free (no BI/phase/source-path leakage)", () => {
     const def = orgDecisionPack.definitions.find((d) => d.name === "record_org_business_answer")!;
     expect(def.description).not.toMatch(/BI-|Phase \d|apps\/web|EP-/);
+  });
+});
+
+describe("org-decision pack — evaluate_org_business_decision optionFeatures (BI-6DCF772F)", () => {
+  it("rejects optionFeatures that don't align 1:1 with options, before invoking the gate", async () => {
+    const res = await orgDecisionPack.handlers.evaluate_org_business_decision!(
+      {
+        question: "Refund this customer?",
+        options: ["Full refund", "Store credit"],
+        optionFeatures: [{ speed_to_value: 0.8 }], // only one, options has two
+        domainClass: "risk-assessment",
+        riskTier: "medium",
+      },
+      "user-1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("invalid_params");
+    expect(String(res.message)).toMatch(/aligned 1:1 with options/);
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+
+  it("threads caller-supplied optionFeatures into the gate as scoredOptions and surfaces recommendedOptionId", async () => {
+    gateMock.mockResolvedValue({
+      interactionId: "DI-1",
+      allowed: true,
+      evaluation: { outcomeType: "recommend", confidenceScore: 0.8, recommendedOptionId: "Full refund", rationale: "ok" },
+      orgProfileSelected: true,
+    });
+
+    const res = await orgDecisionPack.handlers.evaluate_org_business_decision!(
+      {
+        question: "Refund this customer?",
+        options: ["Full refund", "Store credit"],
+        optionFeatures: [
+          { customer_consent_state: 0.9, cost_efficiency: 0.2 },
+          { customer_consent_state: 0.4, cost_efficiency: 0.8 },
+        ],
+        domainClass: "risk-assessment",
+        riskTier: "medium",
+      },
+      "user-1",
+    );
+
+    expect(res.success).toBe(true);
+    expect(gateMock).toHaveBeenCalledTimes(1);
+    const gateArgs = gateMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(gateArgs.scoredOptions).toEqual([
+      { id: "Full refund", description: "Full refund", features: { customer_consent_state: 0.9, cost_efficiency: 0.2 } },
+      { id: "Store credit", description: "Store credit", features: { customer_consent_state: 0.4, cost_efficiency: 0.8 } },
+    ]);
+    expect((res.data as Record<string, unknown>).recommendedOptionId).toBe("Full refund");
+  });
+
+  it("omitting optionFeatures leaves scoredOptions undefined (coverage-only, backward compatible)", async () => {
+    gateMock.mockResolvedValue({
+      interactionId: "DI-2",
+      allowed: true,
+      evaluation: { outcomeType: "recommend", confidenceScore: 0.8, recommendedOptionId: null, rationale: "ok" },
+      orgProfileSelected: true,
+    });
+
+    await orgDecisionPack.handlers.evaluate_org_business_decision!(
+      { question: "Refund?", options: ["yes", "no"], domainClass: "risk-assessment", riskTier: "medium" },
+      "user-1",
+    );
+
+    const gateArgs = gateMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(gateArgs.scoredOptions).toBeUndefined();
   });
 });

--- a/apps/web/lib/mcp/packs/org-decision-pack.ts
+++ b/apps/web/lib/mcp/packs/org-decision-pack.ts
@@ -49,6 +49,12 @@ const definitions: ToolDefinition[] = [
       properties: {
         question: { type: "string", description: "The business decision to weigh, e.g. 'Should we send this customer a free replacement?'" },
         options: { type: "array", items: { type: "string" }, description: "The distinct options under consideration (at least one)." },
+        optionFeatures: {
+          type: "array",
+          items: { type: "object", additionalProperties: { type: "number" } },
+          description:
+            "Optional. Per-option feature vectors, index-aligned to `options` (optionFeatures[i] scores options[i]). Each is an axis→score map in [0,1] over the platform decision axes (e.g. speed_to_value, reversibility, blast_radius, human_cognitive_load, governance_compliance, long_term_maintainability). Provide one map per option to receive a real recommendedOptionId scored against kernel commandments; omit entirely for a coverage-based verdict only.",
+        },
         domainClass: {
           type: "string",
           enum: ["plan-readiness", "architecture-tradeoff", "risk-assessment", "professional-practice"],
@@ -95,6 +101,7 @@ async function evaluateOrgBusinessDecision(
 ): Promise<ToolResult> {
   const { evaluateOrgBusinessDecisionGate } = await import("@/lib/decision-perspective/org-business-gate");
   const { DECISION_DOMAIN_CLASSES, DECISION_RISK_TIERS } = await import("@/lib/decision-perspective/types");
+  const { parseOptionFeatures } = await import("@/lib/decision-perspective/scored-option-input");
   const { prisma } = await import("@dpf/db");
 
   const org = await prisma.organization.findFirst({ select: { id: true } });
@@ -117,11 +124,17 @@ async function evaluateOrgBusinessDecision(
     };
   }
 
+  const parsedFeatures = parseOptionFeatures(options, params["optionFeatures"]);
+  if (!parsedFeatures.ok) {
+    return { success: false, error: "invalid_params", message: parsedFeatures.message };
+  }
+
   const decision = await evaluateOrgBusinessDecisionGate({
     db: prisma,
     organizationId: org.id,
     question,
     options,
+    scoredOptions: parsedFeatures.scoredOptions,
     domainClass: domainClass as Parameters<typeof evaluateOrgBusinessDecisionGate>[0]["domainClass"],
     riskTier: riskTier as Parameters<typeof evaluateOrgBusinessDecisionGate>[0]["riskTier"],
     routeContext: context?.routeContext ?? "/coworker-business",
@@ -140,6 +153,7 @@ async function evaluateOrgBusinessDecision(
       outcomeType: decision.evaluation.outcomeType,
       confidenceScore: decision.evaluation.confidenceScore,
       orgProfileSelected: decision.orgProfileSelected,
+      recommendedOptionId: decision.evaluation.recommendedOptionId ?? null,
       rationale: rationale.length > 500 ? `${rationale.slice(0, 500)}...` : rationale,
     },
   };

--- a/apps/web/lib/mcp/packs/profession-decision-pack.test.ts
+++ b/apps/web/lib/mcp/packs/profession-decision-pack.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentMock = vi.hoisted(() => vi.fn());
+vi.mock("@dpf/db", () => ({
+  prisma: { agent: { findFirst: (...args: unknown[]) => agentMock(...args) } },
+}));
+
+const gateMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/decision-perspective/profession-gate", () => ({
+  evaluateProfessionDecisionGate: (...args: unknown[]) => gateMock(...args),
+}));
+
+import { professionDecisionPack } from "./profession-decision-pack";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentMock.mockResolvedValue({ agentId: "AGT-1", name: "Data Architect", slugId: "build-data-architect" });
+  gateMock.mockResolvedValue({
+    interactionId: "DI-1",
+    allowed: true,
+    evaluation: { outcomeType: "recommend", confidenceScore: 0.8, recommendedOptionId: "view", rationale: "ok" },
+    professionKey: "data-architect",
+    professionProfileSelected: true,
+  });
+});
+
+describe("profession-decision pack — evaluate_profession_decision optionFeatures (BI-6DCF772F)", () => {
+  it("rejects optionFeatures that don't align 1:1 with options, before invoking the gate", async () => {
+    const res = await professionDecisionPack.handlers.evaluate_profession_decision!(
+      {
+        question: "Compatibility view or hard cutover?",
+        options: ["view", "cutover"],
+        optionFeatures: [{ long_term_maintainability: 0.9 }], // one, options has two
+        domainClass: "professional-practice",
+        riskTier: "medium",
+      },
+      "user-1",
+      { agentId: "AGT-1" },
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("invalid_params");
+    expect(String(res.message)).toMatch(/aligned 1:1 with options/);
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+
+  it("threads caller-supplied optionFeatures into the gate as scoredOptions and surfaces recommendedOptionId", async () => {
+    const res = await professionDecisionPack.handlers.evaluate_profession_decision!(
+      {
+        question: "Compatibility view or hard cutover?",
+        options: ["view", "cutover"],
+        optionFeatures: [{ long_term_maintainability: 0.9 }, { speed_to_value: 0.9 }],
+        domainClass: "professional-practice",
+        riskTier: "medium",
+      },
+      "user-1",
+      { agentId: "AGT-1" },
+    );
+
+    expect(res.success).toBe(true);
+    expect(gateMock).toHaveBeenCalledTimes(1);
+    const gateArgs = gateMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(gateArgs.scoredOptions).toEqual([
+      { id: "view", description: "view", features: { long_term_maintainability: 0.9 } },
+      { id: "cutover", description: "cutover", features: { speed_to_value: 0.9 } },
+    ]);
+    expect((res.data as Record<string, unknown>).recommendedOptionId).toBe("view");
+  });
+
+  it("omitting optionFeatures leaves scoredOptions undefined (coverage-only, backward compatible)", async () => {
+    await professionDecisionPack.handlers.evaluate_profession_decision!(
+      { question: "Q", options: ["a", "b"], domainClass: "professional-practice", riskTier: "medium" },
+      "user-1",
+      { agentId: "AGT-1" },
+    );
+    const gateArgs = gateMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(gateArgs.scoredOptions).toBeUndefined();
+  });
+
+  it("requires an agent identity (profession decisions are coworker-scoped)", async () => {
+    const res = await professionDecisionPack.handlers.evaluate_profession_decision!(
+      { question: "Q", options: ["a", "b"], domainClass: "professional-practice", riskTier: "medium" },
+      "user-1",
+      undefined,
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("no_agent_identity");
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/mcp/packs/profession-decision-pack.ts
+++ b/apps/web/lib/mcp/packs/profession-decision-pack.ts
@@ -29,6 +29,12 @@ const definitions: ToolDefinition[] = [
           items: { type: "string" },
           description: "The distinct options under consideration (at least one).",
         },
+        optionFeatures: {
+          type: "array",
+          items: { type: "object", additionalProperties: { type: "number" } },
+          description:
+            "Optional. Per-option feature vectors, index-aligned to `options` (optionFeatures[i] scores options[i]). Each is an axis→score map in [0,1] over the platform decision axes (e.g. speed_to_value, reversibility, blast_radius, human_cognitive_load, governance_compliance, long_term_maintainability). Provide one map per option to receive a real recommendedOptionId scored against kernel commandments; omit entirely for a coverage-based verdict only.",
+        },
         domainClass: {
           type: "string",
           enum: ["plan-readiness", "architecture-tradeoff", "risk-assessment", "professional-practice"],
@@ -69,6 +75,7 @@ async function evaluateProfessionDecision(
   const { DECISION_DOMAIN_CLASSES, DECISION_RISK_TIERS } = await import(
     "@/lib/decision-perspective/types"
   );
+  const { parseOptionFeatures } = await import("@/lib/decision-perspective/scored-option-input");
   const { prisma } = await import("@dpf/db");
 
   const question = String(params["question"] ?? "").trim();
@@ -86,6 +93,11 @@ async function evaluateProfessionDecision(
       error: "invalid_params",
       message: "Provide a question, a non-empty options array, a valid domainClass, and a valid riskTier.",
     };
+  }
+
+  const parsedFeatures = parseOptionFeatures(options, params["optionFeatures"]);
+  if (!parsedFeatures.ok) {
+    return { success: false, error: "invalid_params", message: parsedFeatures.message };
   }
 
   if (!context?.agentId) {
@@ -111,6 +123,7 @@ async function evaluateProfessionDecision(
     },
     question,
     options,
+    scoredOptions: parsedFeatures.scoredOptions,
     domainClass: domainClass as Parameters<typeof evaluateProfessionDecisionGate>[0]["domainClass"],
     riskTier: riskTier as Parameters<typeof evaluateProfessionDecisionGate>[0]["riskTier"],
     routeContext: context?.routeContext ?? "/coworker",
@@ -136,6 +149,7 @@ async function evaluateProfessionDecision(
       confidenceScore: decision.evaluation.confidenceScore,
       professionKey: decision.professionKey,
       professionProfileSelected: decision.professionProfileSelected,
+      recommendedOptionId: decision.evaluation.recommendedOptionId ?? null,
       rationale: rationale.length > 500 ? `${rationale.slice(0, 500)}...` : rationale,
     },
   };

--- a/docs/superpowers/plans/2026-07-24-weight-inference-from-rulings.md
+++ b/docs/superpowers/plans/2026-07-24-weight-inference-from-rulings.md
@@ -49,6 +49,16 @@ Shipped: `DecisionInteraction.scoredOptions`/`recommendedOptionId`/`chosenOption
 
 Explicitly NOT wired: what a `ruled` weight-adjustment proposal actually does to a live composite score. That is JSI spec Phase 4 ("founder review of the first real weight-adjustment proposals... before either is allowed to influence a live composite score") — correctly out of scope until real proposals have accumulated and been reviewed.
 
+### Phase 1.5 (follow-up) — open-ended gate scoring (SHIPPED as BI-6DCF772F part 1)
+
+The two open-ended gates deferred above are now instrumented. Because their options are arbitrary MCP-caller text (no fixed hand-authored menu to score), the per-option feature vectors must come from the caller:
+
+- `evaluate_org_business_decision` / `evaluate_profession_decision` (`org-decision-pack.ts` / `profession-decision-pack.ts`) accept an **optional** `optionFeatures` param — per-option axis→score maps, index-aligned to `options`. Absent → today's coverage-only verdict, fully backward compatible. Present but misaligned (wrong length / non-numeric) → a loud `invalid_params` at the tool boundary, never a silent skip (`scored-option-input.ts` `parseOptionFeatures`, shared by both packs).
+- The guarded argmax (`recommend`/`arbitrate` verdict + scored options only) was extracted from `evaluatePerspectiveGate` into a shared `resolveRecommendedOptionId` (`option-recommendation.ts`), so `org-business-gate` (via the wrapper) and `profession-gate` (which writes its own row) share ONE implementation instead of hand-rolling the guard twice. `profession-gate` now applies it after its synchronous evaluator call; `org-business-gate` forwards `scoredOptions` and inherits it.
+- No migration: the `scoredOptions`/`recommendedOptionId` columns already exist (Phase 1.5). `chosenOptionId` for these gates still awaits **part 2** (below), so `weight-inference-adapter.ts` — which requires all three columns non-null — will begin extracting observations from org-business/profession rows only once part 2 lands.
+
+**Still deferred to BI-6DCF772F part 2** (live UX, routed through `dpf-ux-fit-review`): the escalation-capture form redesign (`decision-perspective.ts` / `org-decision-capture.ts`) so a human resolving an escalate/defer picks a structured option (populating `chosenOptionId`) alongside the existing free-text rationale.
+
 ## Acceptance
 
 A run over real `humanOutcome` history produces a weight-adjustment proposal, it surfaces for a ruling, and it mutates nothing until ruled; a group below the sample floor produces nothing. Phase 1 delivers the inference + floor + proposal-authority contract; Phases 1.5–3 deliver the live extraction and the ledger, for the two gates (`build-studio-gate.ts`, `work-pattern-review.ts`) instrumented this session. `org-business-gate.ts`/`profession-gate.ts` and the two escalation-capture-form redesigns remain in a follow-up BI.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -12430,15 +12430,19 @@ model DecisionInteraction {
   principleConflict Boolean                           @default(false)
   outcomePayload    Json                              @default("{}")
   humanOutcome      Json?
-  // BI-D88DFEEA Phase 1 (gate instrumentation). When the gate scored real
-  // per-option feature vectors (build-studio, work-pattern-review; NOT the
-  // open-ended org-business/profession gates yet), `scoredOptions` carries the
-  // DecisionOption[] (id/description/features) actually scored,
+  // BI-D88DFEEA Phase 1 (gate instrumentation) / BI-6DCF772F (open-ended gates).
+  // When the gate scored real per-option feature vectors, `scoredOptions`
+  // carries the DecisionOption[] (id/description/features) actually scored,
   // `recommendedOptionId` is the kernel's argmax pick via decide(), and
   // `chosenOptionId` is populated once the human's response resolves to one of
-  // `scoredOptions`. All three are null for every other DecisionInteraction —
-  // the weight-inference adapter (weight-inference-adapter.ts) treats null as
-  // "cannot extract an observation from this row", never as zero-signal.
+  // `scoredOptions`. Populated by: build-studio-gate and work-pattern-review
+  // (fixed hand-authored menus), and the org-business/profession gates when the
+  // MCP caller supplies per-option `optionFeatures` (BI-6DCF772F). All three are
+  // null for every other DecisionInteraction — the weight-inference adapter
+  // (weight-inference-adapter.ts) treats null as "cannot extract an observation
+  // from this row", never as zero-signal. (`chosenOptionId` for the escalation-
+  // capture paths still awaits the structured-option form redesign, BI-6DCF772F
+  // part 2.)
   scoredOptions     Json?
   recommendedOptionId String?
   chosenOptionId    String?

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -12430,19 +12430,15 @@ model DecisionInteraction {
   principleConflict Boolean                           @default(false)
   outcomePayload    Json                              @default("{}")
   humanOutcome      Json?
-  // BI-D88DFEEA Phase 1 (gate instrumentation) / BI-6DCF772F (open-ended gates).
-  // When the gate scored real per-option feature vectors, `scoredOptions`
-  // carries the DecisionOption[] (id/description/features) actually scored,
+  // BI-D88DFEEA Phase 1 (gate instrumentation). When the gate scored real
+  // per-option feature vectors (build-studio, work-pattern-review; NOT the
+  // open-ended org-business/profession gates yet), `scoredOptions` carries the
+  // DecisionOption[] (id/description/features) actually scored,
   // `recommendedOptionId` is the kernel's argmax pick via decide(), and
   // `chosenOptionId` is populated once the human's response resolves to one of
-  // `scoredOptions`. Populated by: build-studio-gate and work-pattern-review
-  // (fixed hand-authored menus), and the org-business/profession gates when the
-  // MCP caller supplies per-option `optionFeatures` (BI-6DCF772F). All three are
-  // null for every other DecisionInteraction — the weight-inference adapter
-  // (weight-inference-adapter.ts) treats null as "cannot extract an observation
-  // from this row", never as zero-signal. (`chosenOptionId` for the escalation-
-  // capture paths still awaits the structured-option form redesign, BI-6DCF772F
-  // part 2.)
+  // `scoredOptions`. All three are null for every other DecisionInteraction —
+  // the weight-inference adapter (weight-inference-adapter.ts) treats null as
+  // "cannot extract an observation from this row", never as zero-signal.
   scoredOptions     Json?
   recommendedOptionId String?
   chosenOptionId    String?


### PR DESCRIPTION
**BI-6DCF772F part 1** — the deferred half of the JSI weight-inference loop (BI-D88DFEEA / #3540). Closes the two **open-ended** decision gates that BI-D88DFEEA couldn't hand-score.

## Why these two were deferred
`build-studio-gate` and `work-pattern-review` score a fixed, hand-authored option menu. `org-business-gate` and `profession-gate` take **arbitrary MCP-caller option text** — there's no menu to score. This PR lets the caller supply the per-option feature vectors.

## What changes
| File | Change |
|---|---|
| `scored-option-input.ts` (new) | `parseOptionFeatures()` — optional, index-aligned `optionFeatures` → `DecisionScoredOption[]`. Absent → coverage-only (backward compatible); misaligned → loud `invalid_params`, never a silent skip. Shared by both packs. |
| `option-recommendation.ts` | Extracted the guarded argmax into shared `resolveRecommendedOptionId()` so `evaluatePerspectiveGate` (WWMD/WWWD) and `profession-gate` (WSID) apply **one** guard, not two hand-rolled copies. |
| `evaluator.ts` | Uses the shared helper. |
| `org-business-gate.ts` / `profession-gate.ts` | Accept `scoredOptions?`; profession-gate applies the argmax before persisting (it writes its own row). |
| `org-decision-pack.ts` / `profession-decision-pack.ts` | `evaluate_org_business_decision` / `evaluate_profession_decision` gain optional `optionFeatures`, thread it, surface `recommendedOptionId`. |
| `schema.prisma` | Comment-only (columns already exist — **no migration**). |

**Result:** org-business/profession decisions with caller features now persist real `scoredOptions` + `recommendedOptionId`. `weight-inference-adapter.ts` (unchanged) extracts observations from these rows once **part 2** captures `chosenOptionId`.

## Deferred to part 2 (separate PR, live UX)
The escalation-capture form redesign (`decision-perspective.ts` / `org-decision-capture.ts`) so a human picks a **structured option** (populating `chosenOptionId`) — routed through `dpf-ux-fit-review` since it changes a human-facing surface.

## Verification
**66 tests / 8 files pass** — new: `scored-option-input`, `profession-decision-pack`; extended: `option-recommendation`, `profession-gate`, `org-decision-pack`. Existing build-studio/org-business/evaluator suites stay green after the argmax extraction. doc-link + module-size pass. Local typecheck noise is the source-only worktree's missing-`next` resolution (`app/` route files, pre-existing) — CI Typecheck is authoritative.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
