### PR TITLE
feat(ux-audit): portal survey orchestrator core (EP-UX-AUDITOR P1)

### DIFF
--- a/apps/web/lib/ux-audit/portal-survey.test.ts
+++ b/apps/web/lib/ux-audit/portal-survey.test.ts
@@ -5,7 +5,6 @@ import {
   isSurveyable,
   verdictForFindings,
   dedupeFindings,
-  aggregateReport,
   BUTTON_DECISION_LENS,
   type RouteManifest,
   type RouteManifestEntry,

--- a/apps/web/lib/ux-audit/portal-survey.test.ts
+++ b/apps/web/lib/ux-audit/portal-survey.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import {
+  planSurvey,
+  runSurvey,
+  isSurveyable,
+  verdictForFindings,
+  dedupeFindings,
+  aggregateReport,
+  BUTTON_DECISION_LENS,
+  type RouteManifest,
+  type RouteManifestEntry,
+  type LensSpec,
+  type AuditFinding,
+  type UxFinding,
+} from "./portal-survey";
+
+function entry(partial: Partial<RouteManifestEntry> & { routePath: string }): RouteManifestEntry {
+  return {
+    kind: "page",
+    segments: [],
+    dynamicParams: [],
+    file: `apps/web/app${partial.routePath}/page.tsx`,
+    ...partial,
+  };
+}
+
+const PAGE_LENS: LensSpec = { id: "accessibility", mode: "page", description: "axe page eval" };
+const LENSES = [PAGE_LENS, BUTTON_DECISION_LENS];
+const lensById = new Map(LENSES.map((l) => [l.id, l]));
+
+function finding(sev: UxFinding["severity"], route: string, element = "el"): AuditFinding {
+  return {
+    severity: sev,
+    category: "accessibility",
+    element,
+    issue: "x",
+    recommendation: "y",
+    route,
+  };
+}
+
+describe("isSurveyable", () => {
+  it("accepts a plain page route", () => {
+    expect(isSurveyable(entry({ routePath: "/workspace" }))).toBe(true);
+  });
+  it("rejects API/handler routes", () => {
+    expect(isSurveyable(entry({ routePath: "/api/x", kind: "route" }))).toBe(false);
+  });
+  it("rejects dynamic-param routes (can't visit without values)", () => {
+    expect(isSurveyable(entry({ routePath: "/x/[id]", dynamicParams: ["id"] }))).toBe(false);
+  });
+  it("folds redirects by default, but includes them when asked", () => {
+    const e = entry({ routePath: "/", redirectTo: "/welcome" });
+    expect(isSurveyable(e)).toBe(false);
+    expect(isSurveyable(e, { includeRedirects: true })).toBe(true);
+  });
+});
+
+describe("verdictForFindings", () => {
+  it("empty → pass", () => expect(verdictForFindings([])).toBe("pass"));
+  it("minor → pass-with-minor", () =>
+    expect(verdictForFindings([{ severity: "minor" }])).toBe("pass-with-minor"));
+  it("important → concerns", () =>
+    expect(verdictForFindings([{ severity: "minor" }, { severity: "important" }])).toBe("concerns"));
+  it("critical → fail (worst wins)", () =>
+    expect(
+      verdictForFindings([{ severity: "minor" }, { severity: "critical" }, { severity: "important" }]),
+    ).toBe("fail"));
+});
+
+describe("planSurvey", () => {
+  const manifest: RouteManifest = {
+    routes: [
+      entry({ routePath: "/workspace" }),
+      entry({ routePath: "/api/agent/send", kind: "route" }),
+      entry({ routePath: "/", redirectTo: "/welcome" }),
+      entry({ routePath: "/build/[id]", dynamicParams: ["id"] }),
+      entry({ routePath: "/platform" }),
+      entry({ routePath: "/knowledge" }),
+    ],
+  };
+
+  it("keeps only surveyable routes and records why the rest were skipped", () => {
+    const plan = planSurvey(manifest, { lenses: LENSES });
+    expect(plan.entries.map((e) => e.route)).toEqual(["/knowledge", "/platform", "/workspace"]); // sorted, surveyable only
+    const skippedReasons = Object.fromEntries(plan.skipped.map((s) => [s.route, s.reason]));
+    expect(skippedReasons["/api/agent/send"]).toMatch(/not a page/);
+    expect(skippedReasons["/build/[id]"]).toMatch(/dynamic params/);
+    expect(skippedReasons["/"]).toMatch(/redirect/);
+  });
+
+  it("assigns page lenses to all, behavioral lenses only to coworker routes", () => {
+    const plan = planSurvey(manifest, {
+      lenses: LENSES,
+      coworkerRoute: (r) => r === "/workspace",
+    });
+    const byRoute = Object.fromEntries(plan.entries.map((e) => [e.route, e.lenses]));
+    expect(byRoute["/platform"]).toEqual(["accessibility"]);
+    expect(byRoute["/workspace"]).toEqual(["accessibility", "coworker-button-decision"]);
+  });
+
+  it("honors the sample cap deterministically and records the overflow", () => {
+    const plan = planSurvey(manifest, { lenses: LENSES, sample: 2 });
+    expect(plan.entries.map((e) => e.route)).toEqual(["/knowledge", "/platform"]);
+    expect(plan.skipped.some((s) => s.route === "/workspace" && /sample cap/.test(s.reason))).toBe(true);
+  });
+});
+
+describe("dedupeFindings", () => {
+  it("removes duplicates by route+element+category+lens", () => {
+    const a = finding("minor", "/x", "btn");
+    const b = { ...finding("minor", "/x", "btn"), lens: "page" };
+    const c = { ...finding("minor", "/x", "btn"), lens: "coworker-button-decision" };
+    const out = dedupeFindings([a, { ...a }, b, c]);
+    // a and its clone collapse; b and c differ by lens.
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe("runSurvey + aggregateReport", () => {
+  const plan = {
+    entries: [
+      { route: "/workspace", lenses: ["accessibility", "coworker-button-decision"] },
+      { route: "/platform", lenses: ["accessibility"] },
+      { route: "/knowledge", lenses: ["accessibility"] },
+    ],
+    skipped: [],
+  };
+
+  it("runs injected evaluators, rolls up verdicts, and aggregates the portal report", async () => {
+    const report = await runSurvey(
+      plan,
+      {
+        page: async (route) =>
+          route === "/platform" ? [finding("critical", route, "a")] : [],
+        behavioral: async (route) =>
+          route === "/workspace" ? [finding("important", route, "decision")] : [],
+      },
+      lensById,
+    );
+    expect(report.routeCount).toBe(3);
+    expect(report.evaluatedRouteCount).toBe(3);
+    const byRoute = Object.fromEntries(report.routes.map((r) => [r.route, r.verdict]));
+    expect(byRoute["/platform"]).toBe("fail"); // critical
+    expect(byRoute["/workspace"]).toBe("concerns"); // important (behavioral)
+    expect(byRoute["/knowledge"]).toBe("pass");
+    expect(report.portalVerdict).toBe("fail"); // worst route
+    expect(report.verdictCounts).toMatchObject({ fail: 1, concerns: 1, pass: 1 });
+    expect(report.findingCounts).toEqual({ critical: 1, important: 1, minor: 0 });
+  });
+
+  it("tags each finding with the route and lens that produced it", async () => {
+    const report = await runSurvey(
+      { entries: [{ route: "/workspace", lenses: ["coworker-button-decision"] }], skipped: [] },
+      { behavioral: async (route) => [finding("minor", route, "d")] },
+      lensById,
+    );
+    const f = report.routes[0]!.findings[0]!;
+    expect(f.route).toBe("/workspace");
+    expect(f.lens).toBe("coworker-button-decision");
+  });
+
+  it("a thrown evaluator degrades that route to a concerns+error entry, never aborts the run", async () => {
+    const report = await runSurvey(
+      plan,
+      {
+        page: async (route) => {
+          if (route === "/platform") throw new Error("browser-use timeout");
+          return [];
+        },
+      },
+      lensById,
+    );
+    const platform = report.routes.find((r) => r.route === "/platform")!;
+    expect(platform.verdict).toBe("concerns");
+    expect(platform.error).toMatch(/browser-use timeout/);
+    // The other routes still completed.
+    expect(report.routes.find((r) => r.route === "/knowledge")!.verdict).toBe("pass");
+  });
+
+  it("skips a lens whose evaluator is absent without failing the route", async () => {
+    const report = await runSurvey(
+      { entries: [{ route: "/workspace", lenses: ["accessibility", "coworker-button-decision"] }], skipped: [] },
+      { page: async () => [] }, // no behavioral evaluator provided
+      lensById,
+    );
+    expect(report.routes[0]!.evaluated).toEqual({ page: true, behavioral: false });
+    expect(report.routes[0]!.verdict).toBe("pass");
+  });
+});

--- a/apps/web/lib/ux-audit/portal-survey.ts
+++ b/apps/web/lib/ux-audit/portal-survey.ts
@@ -1,0 +1,305 @@
+// Portal Survey Orchestrator — core (EP-UX-AUDITOR Phase 1, BI-A01DC56C).
+// Spec: docs/superpowers/specs/2026-05-16-ux-auditor-coworker-design.md
+// Plan: docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
+//
+// The missing piece the substrate map identified: an orchestrator that walks the
+// route set, runs per-route evaluators, and aggregates their findings into ONE
+// portal report with per-route + portal verdicts. This module is the pure,
+// unit-testable core — evaluators are INJECTED (an interface), so the real
+// evaluate_page (browser-use + axe) and askCoworker behavioral wiring land in
+// Phase 2 (BI-C3768478) without changing this logic.
+//
+// Reuse, not reinvention: UxFinding is the shipped finding shape
+// (apps/web/lib/tak/page-evaluator.ts); the route manifest
+// (apps/web/lib/ea/route-manifest.json) is the enumeration source. Per spec §0.2
+// the per-finding severity vocabulary is critical|important|minor and the
+// per-route VERDICT vocabulary is pass|pass-with-minor|concerns|fail — distinct
+// axes, rolled up here.
+
+import type { UxFinding } from "@/lib/tak/page-evaluator";
+
+/** One entry from apps/web/lib/ea/route-manifest.json. */
+export type RouteManifestEntry = {
+  routePath: string;
+  kind: "page" | "route";
+  segments: string[];
+  dynamicParams: string[];
+  file: string;
+  redirectTo?: string;
+};
+
+export type RouteManifest = {
+  generator?: string;
+  routeCount?: number;
+  routes: RouteManifestEntry[];
+};
+
+/** Per-route / portal verdict — distinct from per-finding severity (spec §0.2). */
+export type SurveyVerdict = "pass" | "pass-with-minor" | "concerns" | "fail";
+
+/**
+ * A finding as it appears in the aggregated report: the shipped UxFinding plus
+ * the route it was found on and, additively (spec §5.3), which lens/agent
+ * produced it. `category` stays; `lens`/`agentId` are optional overlays.
+ */
+export type AuditFinding = UxFinding & {
+  route: string;
+  lens?: string;
+  agentId?: string;
+};
+
+/** Whether a lens evaluates the static page or drives an interactive behavior. */
+export type LensMode = "page" | "behavioral";
+
+export type LensSpec = {
+  id: string;
+  mode: LensMode;
+  description: string;
+};
+
+/**
+ * The coworker button-decision lens (validates BI-3237B5D6 + the P1.5 prose
+ * fallback INSIDE the survey). Defined here; executed by the behavioral
+ * evaluator wired in Phase 2 — drive a coworker to a proceed/choice closeout
+ * and assert the recommended-first decision buttons render.
+ */
+export const BUTTON_DECISION_LENS: LensSpec = {
+  id: "coworker-button-decision",
+  mode: "behavioral",
+  description:
+    "Drive the route's coworker to a next-step decision (a proceed or A/B closeout) and assert clickable, recommended-first decision buttons render instead of a free-text 'type your reply' prompt.",
+};
+
+export type SurveyPlanEntry = {
+  route: string;
+  /** Lens ids assigned to this route. */
+  lenses: string[];
+};
+
+export type SurveyPlan = {
+  entries: SurveyPlanEntry[];
+  /** Routes considered but dropped, with why — surfaced so coverage is honest. */
+  skipped: Array<{ route: string; reason: string }>;
+};
+
+export type PlanOptions = {
+  lenses: LensSpec[];
+  /** Extra predicate to include a route (after the built-in surveyable filter). */
+  include?: (entry: RouteManifestEntry) => boolean;
+  /** Cap the plan to the first N surveyable routes (stable routePath order). 0/undefined = all. */
+  sample?: number;
+  /** Which routes host a coworker → get behavioral lenses. Defaults to none. */
+  coworkerRoute?: (routePath: string) => boolean;
+  /** Include redirect routes (default false — the redirect target is surveyed on its own entry). */
+  includeRedirects?: boolean;
+};
+
+export type RouteSurveyResult = {
+  route: string;
+  verdict: SurveyVerdict;
+  findings: AuditFinding[];
+  /** Which lens modes actually ran (an evaluator may be absent). */
+  evaluated: { page: boolean; behavioral: boolean };
+  /** Present when an evaluator threw — the route is reported, not silently dropped. */
+  error?: string;
+};
+
+export type FindingCounts = { critical: number; important: number; minor: number };
+
+export type UxAuditReport = {
+  routeCount: number;
+  evaluatedRouteCount: number;
+  portalVerdict: SurveyVerdict;
+  verdictCounts: Record<SurveyVerdict, number>;
+  findingCounts: FindingCounts;
+  routes: RouteSurveyResult[];
+};
+
+/** Injected evaluators — the seam that keeps this core pure + testable. */
+export type PageLensEvaluator = (route: string) => Promise<UxFinding[]>;
+export type BehavioralLensEvaluator = (
+  route: string,
+  lens: LensSpec,
+) => Promise<UxFinding[]>;
+
+export type SurveyEvaluators = {
+  page?: PageLensEvaluator;
+  behavioral?: BehavioralLensEvaluator;
+};
+
+const VERDICT_ORDER: SurveyVerdict[] = ["pass", "pass-with-minor", "concerns", "fail"];
+
+/**
+ * A route is surveyable if it renders a page a user can visit: page kind, no
+ * dynamic params (can't be visited without concrete values in P1), and — unless
+ * asked — not a bare redirect (its target is surveyed on that target's entry).
+ */
+export function isSurveyable(
+  entry: RouteManifestEntry,
+  opts: { includeRedirects?: boolean } = {},
+): boolean {
+  if (entry.kind !== "page") return false;
+  if (entry.dynamicParams.length > 0) return false;
+  if (!opts.includeRedirects && entry.redirectTo) return false;
+  return true;
+}
+
+/** Map a set of findings to a route verdict (worst severity wins). */
+export function verdictForFindings(findings: Pick<UxFinding, "severity">[]): SurveyVerdict {
+  let worst: SurveyVerdict = "pass";
+  for (const f of findings) {
+    if (f.severity === "critical") return "fail";
+    if (f.severity === "important") worst = maxVerdict(worst, "concerns");
+    else if (f.severity === "minor") worst = maxVerdict(worst, "pass-with-minor");
+  }
+  return worst;
+}
+
+function maxVerdict(a: SurveyVerdict, b: SurveyVerdict): SurveyVerdict {
+  return VERDICT_ORDER.indexOf(a) >= VERDICT_ORDER.indexOf(b) ? a : b;
+}
+
+/**
+ * Plan a survey: filter the manifest to surveyable routes, sort by routePath for
+ * determinism, optionally sample the first N, and assign lenses — page lenses to
+ * every route, behavioral lenses only to coworker-bearing routes.
+ */
+export function planSurvey(manifest: RouteManifest, options: PlanOptions): SurveyPlan {
+  const entries: SurveyPlanEntry[] = [];
+  const skipped: SurveyPlan["skipped"] = [];
+
+  const pageLenses = options.lenses.filter((l) => l.mode === "page").map((l) => l.id);
+  const behavioralLenses = options.lenses.filter((l) => l.mode === "behavioral").map((l) => l.id);
+
+  const surveyable = [...manifest.routes]
+    .sort((a, b) => a.routePath.localeCompare(b.routePath))
+    .filter((entry) => {
+      if (!isSurveyable(entry, { includeRedirects: options.includeRedirects })) {
+        skipped.push({ route: entry.routePath, reason: unsurveyableReason(entry, options) });
+        return false;
+      }
+      if (options.include && !options.include(entry)) {
+        skipped.push({ route: entry.routePath, reason: "excluded by include predicate" });
+        return false;
+      }
+      return true;
+    });
+
+  const capped =
+    options.sample && options.sample > 0 ? surveyable.slice(0, options.sample) : surveyable;
+
+  for (const entry of surveyable.slice(capped.length)) {
+    skipped.push({ route: entry.routePath, reason: `beyond sample cap (${options.sample})` });
+  }
+
+  for (const entry of capped) {
+    const lenses = [...pageLenses];
+    if (options.coworkerRoute?.(entry.routePath)) lenses.push(...behavioralLenses);
+    entries.push({ route: entry.routePath, lenses });
+  }
+
+  return { entries, skipped };
+}
+
+function unsurveyableReason(entry: RouteManifestEntry, options: PlanOptions): string {
+  if (entry.kind !== "page") return "not a page route (API/handler)";
+  if (entry.dynamicParams.length > 0) return `dynamic params (${entry.dynamicParams.join(",")})`;
+  if (!options.includeRedirects && entry.redirectTo) return `redirect → ${entry.redirectTo}`;
+  return "not surveyable";
+}
+
+/** De-duplicate findings within a route by (element, category, lens) — spec Q9 join key. */
+export function dedupeFindings(findings: AuditFinding[]): AuditFinding[] {
+  const seen = new Set<string>();
+  const out: AuditFinding[] = [];
+  for (const f of findings) {
+    const key = `${f.route}::${f.element}::${f.category}::${f.lens ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(f);
+  }
+  return out;
+}
+
+/** Fold per-route results into one portal report. */
+export function aggregateReport(routes: RouteSurveyResult[]): UxAuditReport {
+  const verdictCounts: Record<SurveyVerdict, number> = {
+    pass: 0,
+    "pass-with-minor": 0,
+    concerns: 0,
+    fail: 0,
+  };
+  const findingCounts: FindingCounts = { critical: 0, important: 0, minor: 0 };
+  let portalVerdict: SurveyVerdict = "pass";
+  let evaluatedRouteCount = 0;
+
+  for (const r of routes) {
+    verdictCounts[r.verdict] += 1;
+    portalVerdict = maxVerdict(portalVerdict, r.verdict);
+    if (r.evaluated.page || r.evaluated.behavioral) evaluatedRouteCount += 1;
+    for (const f of r.findings) findingCounts[f.severity] += 1;
+  }
+
+  return {
+    routeCount: routes.length,
+    evaluatedRouteCount,
+    portalVerdict,
+    verdictCounts,
+    findingCounts,
+    routes,
+  };
+}
+
+/**
+ * Run a planned survey with the injected evaluators and aggregate the report.
+ * Sequential + deterministic for P1 (bounded concurrency is a Phase-2 concern).
+ * A thrown evaluator degrades that route to an error entry — it never aborts the
+ * whole survey. A route whose evaluator is absent simply doesn't run that lens.
+ */
+export async function runSurvey(
+  plan: SurveyPlan,
+  evaluators: SurveyEvaluators,
+  lensById: Map<string, LensSpec>,
+): Promise<UxAuditReport> {
+  const results: RouteSurveyResult[] = [];
+
+  for (const entry of plan.entries) {
+    const findings: AuditFinding[] = [];
+    const evaluated = { page: false, behavioral: false };
+    let error: string | undefined;
+
+    const hasPageLens = entry.lenses.some((id) => lensById.get(id)?.mode === "page");
+    const behavioralLenses = entry.lenses
+      .map((id) => lensById.get(id))
+      .filter((l): l is LensSpec => l?.mode === "behavioral");
+
+    try {
+      if (hasPageLens && evaluators.page) {
+        const pageFindings = await evaluators.page(entry.route);
+        for (const f of pageFindings) findings.push({ ...f, route: entry.route, lens: "page" });
+        evaluated.page = true;
+      }
+      for (const lens of behavioralLenses) {
+        if (!evaluators.behavioral) break;
+        const behFindings = await evaluators.behavioral(entry.route, lens);
+        for (const f of behFindings) {
+          findings.push({ ...f, route: entry.route, lens: lens.id });
+        }
+        evaluated.behavioral = true;
+      }
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    }
+
+    const deduped = dedupeFindings(findings);
+    results.push({
+      route: entry.route,
+      verdict: error ? "concerns" : verdictForFindings(deduped),
+      findings: deduped,
+      evaluated,
+      ...(error ? { error } : {}),
+    });
+  }
+
+  return aggregateReport(results);
+}

--- a/apps/web/lib/ux-audit/portal-survey.ts
+++ b/apps/web/lib/ux-audit/portal-survey.ts
@@ -17,6 +17,11 @@
 // axes, rolled up here.
 
 import type { UxFinding } from "@/lib/tak/page-evaluator";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+// Re-exported so consumers (and tests) can take the finding shape from the
+// survey module without reaching into page-evaluator directly.
+export type { UxFinding };
 
 /** One entry from apps/web/lib/ea/route-manifest.json. */
 export type RouteManifestEntry = {
@@ -288,7 +293,7 @@ export async function runSurvey(
         evaluated.behavioral = true;
       }
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      error = getErrorMessage(e);
     }
 
     const deduped = dedupeFindings(findings);

--- a/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
+++ b/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
@@ -1,0 +1,37 @@
+# Plan: UX Auditor — comprehensive portal survey (EP-UX-AUDITOR)
+
+**Epic:** EP-UX-AUDITOR · **Spec:** docs/superpowers/specs/2026-05-16-ux-auditor-coworker-design.md
+**Origin:** founder directive (2026-07-16) — the coworker button-decision (BI-3237B5D6) must be validated inside a comprehensive portal survey, not spot-checked. Kernel (`principle_decide`, surface `portal-survey-approach`) recommended the FULL reusable auditor over a one-time script or thin hybrid: composite 11.51 vs 10.20 vs 4.19, high confidence, no commandment conflict. Founder ratified.
+
+## Substrate (verified — build ON, do not reinvent)
+
+| Concern | Existing | Path |
+| --- | --- | --- |
+| Route enumeration | 582-route manifest (337 pages) | `apps/web/lib/ea/route-manifest.json` |
+| Per-page evaluation | `evaluate_page` MCP tool → browser-use + axe + visual-cognitive-load | `apps/web/lib/mcp-tools.ts` |
+| Finding shape | `UxFinding` (severity critical\|important\|minor) | `apps/web/lib/tak/page-evaluator.ts` |
+| Coworker driving | `askCoworker` / `expectRouteCoworker` | `e2e/helpers/coworker.ts` |
+| Findings → backlog | `record_functional_failure_evidence` | `apps/web/lib/testing/functional-evidence.ts` |
+| WCAG lens (shipped) | `AGT-903 ux-accessibility-agent` | `packages/db/data/agent_registry.json` |
+
+The **gap** = the orchestrator that walks routes, runs evaluators per route, aggregates verdicts into one report, files findings. Verdict grammar `pass \| pass-with-minor \| concerns \| fail` (distinct from finding severity, spec §0.2).
+
+## Phases
+
+- **P1 — Orchestrator core (BI-A01DC56C, THIS PR).** `apps/web/lib/ux-audit/portal-survey.ts`: `planSurvey` (surveyable filter = page kind, no dynamic params, redirects folded; stable order; sample cap; page lenses to all routes, behavioral lenses to coworker routes), `runSurvey` (injected evaluators; per-route try/catch → error entry, never aborts), `verdictForFindings` (worst-severity rollup), `dedupeFindings` ({route,element,category,lens}), `aggregateReport` (portal verdict + counts). The `BUTTON_DECISION_LENS` is defined here (executed in P2). Pure + unit-tested; no coworker, no Prisma model yet.
+- **P2 — First-mission run (BI-C3768478).** Wire the real evaluators: `page` = evaluate_page; `behavioral` = askCoworker, including the button-decision lens (drive coworker to a proceed/choice closeout, assert recommended-first buttons render — validates BI-3237B5D6 + the P1.5 prose fallback live). Run against the portal shell (/workspace, /business, /products, /platform, /knowledge — spec Goal 7). File findings via `record_functional_failure_evidence`. Live-verify (needs browser-use service).
+- **P3 — AGT-906 ux-design-critic.** Establish the coworker (heuristic-law + agentic-AI + enterprise-density lenses) via the establish_coworker paved road; run as a deliberation pair with AGT-903. Its lenses become behavioral/page lens specs the orchestrator plans.
+- **P4 — Persistence + surfacing.** `UxAuditReport` / `UxAuditFinding` Prisma models (the new-model CI gauntlet applies) + Operations Map surfacing; each run lands as a `TaskRun`.
+- **P5 — AGT-907 ux-test-automator + gate + schedule.** Convert findings to browser-use regression tests (`tests/ux/`), integrate the `build/review.verify` ship gate, and schedule the weekly portal audit.
+
+## Verification
+
+- P1: unit tests for planner (filter/sample/lens-assignment) + aggregator (severity→verdict rollup, dedup, portal rollup) against the real transpiled source; esbuild transform-clean.
+- P2+: functional — a real survey run against the live portal produces a report and files findings (structural≠functional).
+
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/superpowers/specs/2026-05-16-ux-auditor-coworker-design.md` (architect-reviewed; AGT-906/907, 22-lens rubric, deliberation-pair, first-mission) and `docs/superpowers/specs/2026-05-11-ai-routing-ux-verification-test-architecture-design.md` (5-layer verification model). No existing orchestrator walks all routes — confirmed via substrate map.
+- Current code substrate reviewed: `apps/web/lib/ea/route-manifest.json`, `apps/web/lib/tak/page-evaluator.ts` (`UxFinding`/`PageEvaluation`), `e2e/helpers/coworker.ts`, `apps/web/lib/testing/functional-evidence.ts`.
+- Source of truth: EP-UX-AUDITOR under the EP-UX-SYSTEM enforced-quality program.
+- Decision: build the full auditor incrementally (kernel pick); P1 is the pure orchestrator core with injected evaluators so the logic is tested before the browser-use/coworker runtime is wired.


### PR DESCRIPTION
## What

Phase 1 of **EP-UX-AUDITOR** — activates the designed-but-never-built UX Auditor as a **comprehensive portal survey** capability. Founder directive: the AI-coworker button-decision (BI-3237B5D6) must be validated *inside* a portal survey, not spot-checked. The kernel (`principle_decide`, surface `portal-survey-approach`) recommended the **full reusable auditor** over a one-time script or thin hybrid — composite **11.51 vs 10.20 vs 4.19**, high confidence, no commandment conflict (top contributors: Research-and-Use-Standards, Ground-New-Work-in-Existing-Platform, Architecture-Over-Shortcuts, Ship-Real-Functionality). Founder ratified.

This PR is the **orchestrator core** — the missing piece the substrate map found. All the other blocks already exist (route manifest, `evaluate_page`, `askCoworker`, `functional-evidence`); nothing here reinvents them.

## `apps/web/lib/ux-audit/portal-survey.ts` (pure, unit-tested)

- **planSurvey** — filter the 582-route manifest to *surveyable* routes (page kind, no dynamic params, redirects folded to their target), stable order, optional sample cap; assign **page lenses to all routes** and **behavioral lenses only to coworker-bearing routes**; every dropped route is recorded with a reason (honest coverage, not silent truncation).
- **runSurvey** — **injected evaluators** (`page` = evaluate_page, `behavioral` = askCoworker in P2) so the orchestration logic is tested *before* the browser-use/coworker runtime is wired. A thrown evaluator degrades that one route to a `concerns`+error entry and the run continues.
- **verdictForFindings** (worst-severity rollup), **dedupeFindings** (`{route,element,category,lens}`), **aggregateReport** (portal verdict + verdict/finding counts).
- **BUTTON_DECISION_LENS** defined here (executed in P2): drive a coworker to a proceed/choice closeout and assert recommended-first decision buttons render — the button-decision is one lens *inside* the survey.

Verdict grammar `pass | pass-with-minor | concerns | fail` is distinct from finding severity `critical | important | minor` (spec §0.2). No new coworker or Prisma model yet (P3/P4).

## Verification

- **25 assertions** against the real esbuild-transpiled source — planner (filter/sample/lens-assignment/skip-reasons), verdict rollup, dedup, aggregate, error degradation, absent-evaluator — all pass. Matching vitest suite committed.
- esbuild transform-clean; module-size + style-drift guards green locally.

## Sequence (EP-UX-AUDITOR)

- **P1 (this) — BI-A01DC56C:** orchestrator core.
- **P2 — BI-C3768478:** wire real evaluate_page + askCoworker (incl. button-decision lens), run against the portal shell, file findings, live-verify.
- P3 AGT-906 critic · P4 persistence models + Operations Map · P5 AGT-907 automator + ship-gate + weekly schedule.

## Design grounding

- Existing specs reviewed: `docs/superpowers/specs/2026-05-16-ux-auditor-coworker-design.md` (architect-reviewed), `.../2026-05-11-ai-routing-ux-verification-test-architecture-design.md` (5-layer model). No existing orchestrator walks all routes — confirmed via substrate map.
- Code substrate reviewed: `apps/web/lib/ea/route-manifest.json`, `apps/web/lib/tak/page-evaluator.ts`, `e2e/helpers/coworker.ts`, `apps/web/lib/testing/functional-evidence.ts`.
- Decision: build the full auditor incrementally (kernel pick); P1 = pure core with injected evaluators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)