### PR TITLE
feat(incumbent): spreadsheet import (D2 P2, BI-BF12C25C)

### DIFF
--- a/apps/web/lib/actions/incumbent-intake.ts
+++ b/apps/web/lib/actions/incumbent-intake.ts
@@ -3,11 +3,17 @@
 import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 import { requireCapability } from "@/lib/actions/shared/guards";
+import { parseDelimitedGrid } from "@/lib/onboarding/roster-import";
+import { inferTableFromSheet, type SheetCell } from "@/lib/workbooks/sheet-import";
 import {
   createIncumbentApplication,
   type IncumbentIntakeInput,
   type IncumbentIntakeResult,
 } from "@/lib/incumbent/intake";
+import {
+  importIncumbentRows,
+  type IncumbentImportResult,
+} from "@/lib/incumbent/spreadsheet";
 
 // Server-action wrapper for incumbent intake (D2 P1, BI-BF12C25C). The write core
 // lives in lib/incumbent/intake.ts (pure + unit-tested); this adds the auth guard
@@ -18,6 +24,37 @@ export async function intakeIncumbentApplication(
 ): Promise<IncumbentIntakeResult> {
   await requireCapability("view_portfolio");
   const result = await createIncumbentApplication(prisma, input);
+  revalidatePath("/portfolio");
+  revalidatePath("/workforce");
+  return result;
+}
+
+// D2 P2: spreadsheet import. Parses an uploaded CSV/TSV/XLSX into a row matrix
+// (the same path workbooks.ts uses), then intakes every row through the P1 core.
+// The file→matrix→rows parsing is the only I/O here; the mapping + orchestration
+// live in the unit-tested lib/incumbent/spreadsheet.ts core.
+export async function importIncumbentSpreadsheet(
+  formData: FormData,
+): Promise<IncumbentImportResult> {
+  await requireCapability("view_portfolio");
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) throw new Error("No spreadsheet file uploaded");
+
+  const lower = file.name.toLowerCase();
+  let matrix: SheetCell[][];
+  if (lower.endsWith(".csv") || lower.endsWith(".tsv") || file.type === "text/csv") {
+    const text = Buffer.from(await file.arrayBuffer()).toString("utf-8");
+    const { columns, rows } = parseDelimitedGrid(text);
+    matrix = [columns, ...rows];
+  } else {
+    const buffer = await file.arrayBuffer();
+    const { readSheet } = await import(/* turbopackIgnore: true */ "read-excel-file/browser");
+    matrix = (await readSheet(buffer)) as SheetCell[][];
+  }
+
+  const { rows } = inferTableFromSheet(matrix);
+  const result = await importIncumbentRows(prisma, rows);
   revalidatePath("/portfolio");
   revalidatePath("/workforce");
   return result;

--- a/apps/web/lib/incumbent/spreadsheet.test.ts
+++ b/apps/web/lib/incumbent/spreadsheet.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { importIncumbentRows, mapRowToIncumbentInput } from "./spreadsheet";
+import { createIncumbentApplication } from "./intake";
+
+// D2 P2 spreadsheet-import tests (BI-BF12C25C). The P1 core is mocked so these
+// exercise the mapping + orchestration (created/matched/skipped/errors) without
+// a live Prisma client — source-only-worktree verifiable.
+
+vi.mock("./intake", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./intake")>();
+  return { ...actual, createIncumbentApplication: vi.fn() };
+});
+
+const mockedCreate = vi.mocked(createIncumbentApplication);
+
+describe("mapRowToIncumbentInput", () => {
+  it("resolves name/vendor/cost/seats from headered columns", () => {
+    const input = mapRowToIncumbentInput({
+      Application: "Mindbody",
+      Vendor: "Mindbody Inc",
+      "Annual Cost": "$4,800",
+      Seats: 12,
+    });
+    expect(input).toEqual({
+      name: "Mindbody",
+      vendor: "Mindbody Inc",
+      annualCostDeclared: 4800,
+      seatCount: 12,
+    });
+  });
+
+  it("returns null when no name column resolves", () => {
+    expect(mapRowToIncumbentInput({ Notes: "n/a", Cost: 10 })).toBeNull();
+    expect(mapRowToIncumbentInput({ Software: "   " })).toBeNull();
+  });
+
+  it("tolerates missing optional columns", () => {
+    expect(mapRowToIncumbentInput({ "Tool Name": "QuickBooks" })).toEqual({
+      name: "QuickBooks",
+      vendor: undefined,
+      annualCostDeclared: undefined,
+      seatCount: undefined,
+    });
+  });
+});
+
+describe("importIncumbentRows", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("counts created vs matched and collects productIds", async () => {
+    mockedCreate
+      .mockResolvedValueOnce({ productId: "DP-incumbent-toast", matched: false, supplierId: "s1" })
+      .mockResolvedValueOnce({ productId: "DP-incumbent-toast", matched: true, supplierId: "s1" });
+    const db = {} as never;
+    const result = await importIncumbentRows(db, [
+      { Application: "Toast" },
+      { Application: "Toast" }, // re-import → matched
+    ]);
+    expect(result.created).toBe(1);
+    expect(result.matched).toBe(1);
+    expect(result.productIds).toEqual(["DP-incumbent-toast", "DP-incumbent-toast"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("skips rows with no name without calling the core", async () => {
+    const db = {} as never;
+    const result = await importIncumbentRows(db, [{ Notes: "x" }, { Application: "Xero" }]);
+    mockedCreate.mockResolvedValue({ productId: "DP-incumbent-xero", matched: false, supplierId: null });
+    expect(result.skipped).toBe(1);
+    // only the named row reached the core
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failing row as an error and continues (never fatal)", async () => {
+    mockedCreate
+      .mockRejectedValueOnce(new Error("supplier write failed"))
+      .mockResolvedValueOnce({ productId: "DP-incumbent-clio", matched: false, supplierId: "s2" });
+    const db = {} as never;
+    const result = await importIncumbentRows(db, [
+      { Application: "Broken" },
+      { Application: "Clio" },
+    ]);
+    expect(result.errors).toEqual([{ row: 1, message: "supplier write failed" }]);
+    expect(result.created).toBe(1);
+    expect(result.productIds).toEqual(["DP-incumbent-clio"]);
+  });
+});

--- a/apps/web/lib/incumbent/spreadsheet.ts
+++ b/apps/web/lib/incumbent/spreadsheet.ts
@@ -1,0 +1,114 @@
+// Incumbent spreadsheet import core (D2 P2, BI-BF12C25C).
+//
+// Plan: docs/superpowers/plans/2026-07-24-incumbent-application-intake.md §4 P2.
+//
+// Wraps the P1 intake core (createIncumbentApplication) over the rows of an
+// imported sheet. This module is the PURE, injectable part — column-name
+// heuristics + per-row orchestration — so it unit-tests without a live Prisma
+// client. The file → matrix → rows parsing (parseDelimitedGrid / readSheet /
+// inferTableFromSheet, all existing) is thin I/O in the server action.
+//
+// Malformed rows are reported, never fatal (spec §6 acceptance): a bad row adds
+// an error entry and the import continues. Re-importing the same sheet is
+// idempotent because the P1 core matches on a derived productId.
+
+import type { PrismaClient } from "@dpf/db";
+import type { CellValue } from "@/lib/workbooks/types";
+import { createIncumbentApplication, type IncumbentIntakeInput } from "./intake";
+
+// Header heuristics — first matching column wins. The P3 UI will let an operator
+// correct the mapping; this is the zero-config default.
+const NAME_RE = /name|application|software|tool|product|system|service/i;
+const VENDOR_RE = /vendor|supplier|publisher|provider|company/i;
+const COST_RE = /cost|price|spend|annual|\$|amount/i;
+const SEAT_RE = /seat|user|licen/i;
+
+function cellToString(v: CellValue): string {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return "";
+}
+
+function cellToNumber(v: CellValue): number | undefined {
+  if (typeof v === "number") return Number.isFinite(v) ? v : undefined;
+  if (typeof v === "string") {
+    const n = Number.parseFloat(v.replace(/[$,\s]/g, ""));
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+function findKey(keys: string[], re: RegExp): string | undefined {
+  return keys.find((k) => re.test(k));
+}
+
+/**
+ * Map one imported sheet row to an incumbent intake input using column-name
+ * heuristics. Returns null when no name column resolves to a value (the row is
+ * skipped, not an error).
+ */
+export function mapRowToIncumbentInput(
+  row: Record<string, CellValue>,
+): IncumbentIntakeInput | null {
+  const keys = Object.keys(row);
+  const nameKey = findKey(keys, NAME_RE);
+  const name = nameKey ? cellToString(row[nameKey]).trim() : "";
+  if (!name) return null;
+
+  const vendorKey = findKey(keys, VENDOR_RE);
+  const costKey = findKey(keys, COST_RE);
+  const seatKey = findKey(keys, SEAT_RE);
+
+  const vendor = vendorKey ? cellToString(row[vendorKey]).trim() || undefined : undefined;
+  const annualCostDeclared = costKey ? cellToNumber(row[costKey]) : undefined;
+  const seatCount = seatKey ? cellToNumber(row[seatKey]) : undefined;
+
+  return { name, vendor, annualCostDeclared, seatCount };
+}
+
+export interface IncumbentImportResult {
+  /** New incumbent products created. */
+  created: number;
+  /** Existing incumbents matched (idempotent re-import). */
+  matched: number;
+  /** Rows with no resolvable name — skipped, not errors. */
+  skipped: number;
+  /** Per-row failures (1-indexed row number) — reported, never fatal. */
+  errors: { row: number; message: string }[];
+  productIds: string[];
+}
+
+/**
+ * Intake every mapped row through the P1 core, collecting a per-row result.
+ * `db` is the injected Prisma client (unit-testable with a mock).
+ */
+export async function importIncumbentRows(
+  db: PrismaClient,
+  rows: Record<string, CellValue>[],
+): Promise<IncumbentImportResult> {
+  const result: IncumbentImportResult = {
+    created: 0,
+    matched: 0,
+    skipped: 0,
+    errors: [],
+    productIds: [],
+  };
+
+  for (let i = 0; i < rows.length; i++) {
+    const input = mapRowToIncumbentInput(rows[i]);
+    if (!input) {
+      result.skipped += 1;
+      continue;
+    }
+    try {
+      const r = await createIncumbentApplication(db, input);
+      result.productIds.push(r.productId);
+      if (r.matched) result.matched += 1;
+      else result.created += 1;
+    } catch (e) {
+      result.errors.push({ row: i + 1, message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  return result;
+}

--- a/apps/web/lib/incumbent/spreadsheet.ts
+++ b/apps/web/lib/incumbent/spreadsheet.ts
@@ -14,6 +14,7 @@
 
 import type { PrismaClient } from "@dpf/db";
 import type { CellValue } from "@/lib/workbooks/types";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { createIncumbentApplication, type IncumbentIntakeInput } from "./intake";
 
 // Header heuristics — first matching column wins. The P3 UI will let an operator
@@ -106,7 +107,7 @@ export async function importIncumbentRows(
       if (r.matched) result.matched += 1;
       else result.created += 1;
     } catch (e) {
-      result.errors.push({ row: i + 1, message: e instanceof Error ? e.message : String(e) });
+      result.errors.push({ row: i + 1, message: getErrorMessage(e) });
     }
   }
 

--- a/docs/superpowers/plans/2026-07-24-incumbent-application-intake.md
+++ b/docs/superpowers/plans/2026-07-24-incumbent-application-intake.md
@@ -66,5 +66,10 @@ The manual-entry form + spreadsheet-drop, and the 12th `SETUP_STEPS` entry (`app
 - Decision: decomposed
 - Parent: BI-BF12C25C
 - Receipt: cmrzm7e8q0btj01o3zb3jpoq6
-- Phases (all deliver BI-BF12C25C; not xlarge, so no child-BI split required): P1 intake core, P2 spreadsheet import, P3 UI + onboarding step
 - Dependencies: P2 depends on P1; P3 depends on P1 (and consumes BI-ECO-001 P2's postureForArchetype)
+
+Deliverable -> BacklogItem (all deliver the one umbrella BI-BF12C25C; it is not xlarge, so no child-BI split is required):
+
+- P1 intake core -> BI-BF12C25C
+- P2 spreadsheet import -> BI-BF12C25C
+- P3 UI + onboarding step 12 -> BI-BF12C25C

--- a/docs/superpowers/plans/2026-07-24-incumbent-application-intake.md
+++ b/docs/superpowers/plans/2026-07-24-incumbent-application-intake.md
@@ -56,8 +56,15 @@ The manual-entry form + spreadsheet-drop, and the 12th `SETUP_STEPS` entry (`app
 | R3 | Declared cost read as derived. | Label declared-not-derived everywhere; real binding is D7 (Phase C-gated). |
 | R4 | Duplicate incumbents on re-intake. | Idempotent match on normalized (org, name/vendor) in P1. |
 
+## Implementation status
+
+- **P1 — intake core: SHIPPED** (PR #3549, merged main sha 324f1ff77c). `apps/web/lib/incumbent/intake.ts` (`createIncumbentApplication`) + `lib/actions/incumbent-intake.ts` action. 8/8 unit tests.
+- **P2 — spreadsheet import: THIS PR.** `apps/web/lib/incumbent/spreadsheet.ts` — `mapRowToIncumbentInput` (header heuristics) + `importIncumbentRows` (per-row intake through the P1 core, malformed rows reported not fatal). Server action `importIncumbentSpreadsheet` parses CSV/TSV/XLSX to a matrix (the workbooks path: `parseDelimitedGrid` / `readSheet` / `inferTableFromSheet`) then imports. 6/6 unit tests (P1 core mocked).
+- **P3 — UI + onboarding step: pending** (design-sensitive; UX-fit review).
+
 ## Backlog coverage
 - Decision: decomposed
 - Parent: BI-BF12C25C
-- Phases: P1 intake core, P2 spreadsheet import, P3 UI + onboarding step
+- Receipt: cmrzm7e8q0btj01o3zb3jpoq6
+- Phases (all deliver BI-BF12C25C; not xlarge, so no child-BI split required): P1 intake core, P2 spreadsheet import, P3 UI + onboarding step
 - Dependencies: P2 depends on P1; P3 depends on P1 (and consumes BI-ECO-001 P2's postureForArchetype)


### PR DESCRIPTION
## What

D2 phase 2 (`BI-BF12C25C`): **spreadsheet import** for incumbent applications — wraps the P1 intake core (merged in #3549) over the rows of an uploaded CSV/TSV/XLSX.

Plan: [docs/superpowers/plans/2026-07-24-incumbent-application-intake.md](docs/superpowers/plans/2026-07-24-incumbent-application-intake.md) §4 P2.

## How

- **Pure core** (`apps/web/lib/incumbent/spreadsheet.ts`, unit-tested):
  - `mapRowToIncumbentInput` — column-name heuristics (name / vendor / cost / seats); the zero-config default the P3 UI will let operators correct.
  - `importIncumbentRows` — intakes each mapped row through `createIncumbentApplication`, collecting `created / matched / skipped / errors`. **Malformed rows are reported, never fatal** (spec §6); re-import is idempotent via the P1 derived-productId match.
- **Server action** `importIncumbentSpreadsheet` does the only I/O — file → matrix via the existing workbooks path (`parseDelimitedGrid` / `readSheet` / `inferTableFromSheet`) — then delegates to the core.

## Test plan

- **14/14** unit tests across the incumbent module (6 new for P2 — mapping, created-vs-matched, skip-unnamed, error-continues; P1 core mocked). Source-only-worktree verifiable.
- New source module, no new Prisma model → the model-governance battery does not apply. Reuses the proven workbooks file→matrix path (no new parsing).
- P3 (intake UI + onboarding step 12, first consumer of BI-ECO-001's `postureForArchetype`) is the remaining, design-sensitive phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
