### PR TITLE
fix(governance): founder-review queue is founder-actionable by derivation, not deny-list

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/page.tsx
@@ -20,7 +20,7 @@ import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
 import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
 import {
   dedupeFounderReviewCandidates,
-  isAgentInternalFounderReviewNoise,
+  isFounderActionable,
   isBlankFounderReviewQuestion,
   projectFounderReviewCandidate,
   type DecisionInteractionQueueRow,
@@ -70,6 +70,7 @@ const openDecisionReviewSelect = {
   taskRunId: true,
   routeContext: true,
   domainClass: true,
+  gateKey: true,
   createdAt: true,
   profile: { select: { profileId: true, name: true, kind: true } },
 } satisfies Prisma.DecisionInteractionSelect;
@@ -77,7 +78,7 @@ const openDecisionReviewSelect = {
 function countUniqueOpenReviews(rows: DecisionInteractionQueueRow[]): number {
   const candidates = rows
     .filter((row) => !isBlankFounderReviewQuestion(row))
-    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .filter((row) => isFounderActionable(row))
     .map((row) => projectFounderReviewCandidate(row));
   return dedupeFounderReviewCandidates(candidates).length;
 }

--- a/apps/web/app/(shell)/platform/ai/founder-review/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/founder-review/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import {
   dedupeFounderReviewCandidates,
   groupFounderReviewCandidates,
-  isAgentInternalFounderReviewNoise,
+  isFounderActionable,
   isBlankFounderReviewQuestion,
   projectFounderReviewCandidate,
   type DecisionInteractionQueueRow,
@@ -74,6 +74,7 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
       taskRunId: true,
       routeContext: true,
       domainClass: true,
+      gateKey: true,
       createdAt: true,
       profile: {
         select: {
@@ -87,7 +88,7 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
 
   const candidates = rows
     .filter((row) => !isBlankFounderReviewQuestion(row))
-    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .filter((row) => isFounderActionable(row))
     .map((row) => projectFounderReviewCandidate(row as DecisionInteractionQueueRow))
     .filter((candidate) => !mode || candidate.perspective === mode);
   const visibleCandidates = dedupeFounderReviewCandidates(candidates);

--- a/apps/web/lib/actions/gate-clear-invariant.test.ts
+++ b/apps/web/lib/actions/gate-clear-invariant.test.ts
@@ -1,0 +1,84 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// BI-6EC1EE25. Clearing a decision gate requires TWO things
+// (interactionWasCleared in decision-perspective/persistence.ts): a matching
+// EscalationCapture/DeferralCapture row AND humanOutcome.clearsGate === true.
+// If a code path sets clearsGate truthy WITHOUT writing a capture row, that
+// decision reads "resolved" to the review queue while remaining un-cleared for
+// gate purposes — a real build gate could then be dequeued-from-review while
+// still blocking the build, invisibly. No path in main does this today (the 25
+// live cases came from an out-of-band DB write), and both sanctioned writers
+// create the capture and set clearsGate atomically in one transaction. This
+// ratchet keeps it that way: a future writer that sets clearsGate truthy must
+// also create a capture row.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const LIB_ROOT = join(here, "..");
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".next") continue;
+      out.push(...tsFiles(full));
+    } else if (
+      entry.name.endsWith(".ts") &&
+      !entry.name.endsWith(".test.ts") &&
+      !entry.name.endsWith(".d.ts")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const WRITES_A_CAPTURE = /(escalationCapture|deferralCapture)\.create\b/;
+
+/**
+ * True when a source file contains a `clearsGate:` write whose value is not the
+ * literal `false` — i.e. `clearsGate: true` or a dynamic expression that can
+ * evaluate true. Captures the first token after the colon so `clearsGate: false`
+ * is exempt but `clearsGate: row.outcomeType === "escalate"` is caught.
+ */
+function setsClearsGateTruthy(src: string): boolean {
+  const re = /clearsGate:\s*([A-Za-z0-9_$]+)/g;
+  for (const match of src.matchAll(re)) {
+    if (match[1] !== "false") return true;
+  }
+  return false;
+}
+
+describe("gate-clear write invariant (BI-6EC1EE25)", () => {
+  it("only sets clearsGate truthy in a file that also creates a capture row", () => {
+    const offenders: string[] = [];
+    for (const file of tsFiles(LIB_ROOT)) {
+      const src = readFileSync(file, "utf8");
+      if (!setsClearsGateTruthy(src)) continue;
+      if (!WRITES_A_CAPTURE.test(src)) {
+        offenders.push(file.slice(LIB_ROOT.length + 1));
+      }
+    }
+    expect(
+      offenders,
+      `these files set humanOutcome.clearsGate truthy without creating an ` +
+        `EscalationCapture/DeferralCapture row — a gate would read resolved-to-review ` +
+        `while still blocking (BI-6EC1EE25): ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("recognises the two sanctioned writers so the ratchet is proven live", () => {
+    // Guards against the regex silently matching nothing (e.g. a rename) and the
+    // invariant passing vacuously.
+    const writers = tsFiles(LIB_ROOT).filter((f) => setsClearsGateTruthy(readFileSync(f, "utf8")));
+    const rel = writers.map((f) => f.slice(LIB_ROOT.length + 1)).sort();
+    expect(rel).toEqual([
+      "actions/decision-perspective.ts",
+      "actions/org-decision-capture.ts",
+    ]);
+  });
+});

--- a/apps/web/lib/attention/sources/ai-decision.ts
+++ b/apps/web/lib/attention/sources/ai-decision.ts
@@ -6,6 +6,7 @@
 
 import { Prisma } from "@dpf/db";
 import type { prisma } from "@dpf/db";
+import { isFounderActionable } from "@/lib/founder-review/queue";
 import type { AttentionItem, AttentionRiskClass, ResidueReason } from "../types";
 
 type Db = typeof prisma;
@@ -23,26 +24,22 @@ export type DecisionInteractionRow = {
   routeContext: string | null;
   /** Domain facet — kernel-consult rows are agent-internal WWMD consults. */
   domainClass: string | null;
+  /** Governance gate that produced the row — 'profession' rows are advisory. */
+  gateKey: string | null;
   createdAt: Date;
 };
 
 /**
- * Agent-internal kernel consults (mcp:principle_decide during dev work, or
- * domainClass=kernel-consult with no linked build/task) are already-executed
- * development decisions — audit-visible, not founder "needs-you" residue
- * (BI-9026B96C).
+ * @deprecated Use `!isFounderActionable(row)` (lib/founder-review/queue). The
+ * two copies of this deny-list drifted (BI-6EC1EE25); founder-actionability now
+ * has a single derived source of truth. Kept as its exact inverse so this
+ * source's behaviour for the agent-internal case is preserved.
  */
 export function isAgentInternalKernelConsult(row: Pick<
   DecisionInteractionRow,
-  "buildId" | "taskRunId" | "routeContext" | "domainClass"
+  "buildId" | "taskRunId" | "routeContext" | "domainClass" | "gateKey"
 >): boolean {
-  const linked = Boolean(row.buildId || row.taskRunId);
-  if (linked) return false;
-  const route = (row.routeContext ?? "").trim().toLowerCase();
-  if (route === "mcp:principle_decide" || route.startsWith("mcp:principle_decide")) return true;
-  const domain = (row.domainClass ?? "").trim().toLowerCase();
-  if (domain === "kernel-consult") return true;
-  return false;
+  return !isFounderActionable(row);
 }
 
 function clip(s: string, max = 120): string {
@@ -113,9 +110,11 @@ export async function loadAiDecisionItems(db: Db): Promise<AttentionItem[]> {
       taskRunId: true,
       routeContext: true,
       domainClass: true,
+      gateKey: true,
       createdAt: true,
     },
   });
-  // Drop agent-internal kernel-consult noise; genuine founder residue stays.
-  return rows.filter((row) => !isAgentInternalKernelConsult(row)).map(aiDecisionToAttentionItem);
+  // Keep only rows a human should actually decide; drop agent-internal consults
+  // and fail-open advisories (BI-6EC1EE25).
+  return rows.filter((row) => isFounderActionable(row)).map(aiDecisionToAttentionItem);
 }

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -54,6 +54,7 @@ describe("aiDecisionToAttentionItem", () => {
     taskRunId: null,
     routeContext: "/build",
     domainClass: "plan-readiness",
+    gateKey: "build-studio",
     createdAt: new Date("2026-06-23T08:00:00.000Z"),
   };
 
@@ -64,6 +65,7 @@ describe("aiDecisionToAttentionItem", () => {
         taskRunId: null,
         routeContext: "mcp:principle_decide",
         domainClass: "kernel-consult",
+        gateKey: null,
       }),
     ).toBe(true);
     expect(
@@ -72,6 +74,7 @@ describe("aiDecisionToAttentionItem", () => {
         taskRunId: null,
         routeContext: "mcp:principle_decide",
         domainClass: "kernel-consult",
+        gateKey: null,
       }),
     ).toBe(false);
     expect(
@@ -80,6 +83,7 @@ describe("aiDecisionToAttentionItem", () => {
         taskRunId: null,
         routeContext: "/coworker-decisions/decisions",
         domainClass: "plan-readiness",
+        gateKey: null,
       }),
     ).toBe(false);
   });

--- a/apps/web/lib/founder-review/queue.test.ts
+++ b/apps/web/lib/founder-review/queue.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type { WikiPerspective } from "@/lib/wiki/perspective-intent";
 import {
   groupFounderReviewCandidates,
+  isFounderActionable,
   projectFounderReviewCandidate,
+  type DecisionInteractionQueueRow,
   type FounderReviewCandidate,
 } from "./queue";
 
@@ -87,5 +89,85 @@ describe("founder review queue", () => {
 
     expect(groups.map((group) => group.label)).toEqual(["Principle gap", "Evidence gap"]);
     expect(groups[0]?.items).toHaveLength(1);
+  });
+});
+
+// BI-6EC1EE25. The founder-review / attention queues were inclusion-by-default:
+// every escalate/defer row was founder residue unless it matched a hardcoded
+// deny-list of "agent-internal noise", DUPLICATED across three files. A new
+// class of fail-open advisory reviews (the profession/WSID gate fired from
+// reviewDesignDoc/reviewBuildPlan, BI-D6CFE63A) was not on the list, so 109
+// advisory defers polluted the queue and grew on every review. This one derived
+// predicate replaces the duplicated deny-lists so the next advisory writer
+// cannot silently re-pollute.
+type PredicateRow = Pick<
+  DecisionInteractionQueueRow,
+  "buildId" | "taskRunId" | "routeContext" | "domainClass" | "gateKey"
+>;
+
+function predicateRow(overrides: Partial<PredicateRow> = {}): PredicateRow {
+  return {
+    buildId: null,
+    taskRunId: null,
+    routeContext: "/build",
+    domainClass: "plan-readiness",
+    gateKey: "build-studio",
+    ...overrides,
+  };
+}
+
+describe("isFounderActionable (BI-6EC1EE25)", () => {
+  it("excludes fail-open profession/WSID advisories — the #3344 regression", () => {
+    // A craft "defer" means the corpus is empty; that is a ProfessionCorpusGap
+    // signal, not a founder decision. The advisory already returned and blocks
+    // nothing (advisory by contract, BI-D6CFE63A).
+    expect(
+      isFounderActionable(predicateRow({ gateKey: "profession", routeContext: "reviewPlanDoc" })),
+    ).toBe(false);
+    expect(
+      isFounderActionable(predicateRow({ gateKey: "profession", routeContext: "reviewDesignDoc" })),
+    ).toBe(false);
+  });
+
+  it("excludes a profession advisory even if it carried a build/task link", () => {
+    // Advisory is advisory regardless of linkage — linkage must not re-admit it.
+    expect(isFounderActionable(predicateRow({ gateKey: "profession", buildId: "FB-9" }))).toBe(false);
+  });
+
+  it("excludes unlinked agent-internal kernel consults (BI-9026B96C, preserved)", () => {
+    expect(
+      isFounderActionable(
+        predicateRow({ gateKey: null, routeContext: "mcp:principle_decide", domainClass: "kernel-consult" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a kernel consult that is linked to a real build (preserved)", () => {
+    expect(
+      isFounderActionable(
+        predicateRow({ buildId: "FB-1", routeContext: "mcp:principle_decide", domainClass: "kernel-consult" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a genuine build-studio plan gate escalation", () => {
+    expect(isFounderActionable(predicateRow({ gateKey: "build-studio", buildId: "FB-3" }))).toBe(true);
+  });
+
+  it("keeps a genuine WWWD org-business stance gap", () => {
+    // The case the operator actually answered on 2026-07-10 — must still surface.
+    expect(
+      isFounderActionable(
+        predicateRow({ gateKey: "org-business", routeContext: "/coworker-business", buildId: null }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps an unlinked non-advisory decision from a real surface", () => {
+    expect(
+      isFounderActionable(
+        predicateRow({ gateKey: null, routeContext: "/coworker-decisions/decisions", domainClass: "plan-readiness" }),
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/web/lib/founder-review/queue.ts
+++ b/apps/web/lib/founder-review/queue.ts
@@ -25,6 +25,9 @@ export type DecisionInteractionQueueRow = {
   taskRunId: string | null;
   routeContext: string | null;
   domainClass?: string | null;
+  /** Which governance gate produced the row (BI-1BE30A9A). Advisory gates never
+   *  produce founder-actionable residue — see isFounderActionable. */
+  gateKey?: string | null;
   createdAt: Date;
   profile?: {
     profileId: string;
@@ -63,16 +66,58 @@ export function isBlankFounderReviewQuestion(row: Pick<DecisionInteractionQueueR
   return row.question.trim().length === 0;
 }
 
+/**
+ * Does this decision belong in front of the founder? (BI-6EC1EE25)
+ *
+ * The founder-review and attention queues were inclusion-by-default: every
+ * escalate/defer row was residue unless it matched a hardcoded deny-list of
+ * "agent-internal noise", duplicated verbatim across three files. That list was
+ * built for principle_decide consults (BI-9026B96C) and silently failed to
+ * exclude the next class that fit the same description — the fail-open
+ * profession/WSID advisory reviews (BI-D6CFE63A) — which then flooded the queue.
+ *
+ * This derives founder-actionability from what produced the row, so a new
+ * advisory or agent-internal writer cannot re-pollute by default. A decision is
+ * NOT founder-actionable when:
+ *
+ *  - it is a profession/WSID gate row. That gate is advisory by contract — it
+ *    returns a recommendation and blocks nothing. A craft "defer" means the
+ *    craft corpus is empty, which is a ProfessionCorpusGap signal, not a
+ *    question the founder answers. True regardless of build/task linkage:
+ *    advisory is advisory.
+ *  - it is an already-executed agent-internal kernel consult: an unlinked
+ *    principle_decide / kernel-consult row (BI-9026B96C). Audit-visible, not
+ *    residue. A build/task link means it gated real work, so it stays.
+ *
+ * Everything else — build-studio plan gates, WWWD org-business stance gaps,
+ * anything genuinely awaiting a human — is founder-actionable.
+ */
+export function isFounderActionable(row: Pick<
+  DecisionInteractionQueueRow,
+  "buildId" | "taskRunId" | "routeContext" | "domainClass" | "gateKey"
+>): boolean {
+  if ((row.gateKey ?? "").trim().toLowerCase() === "profession") return false;
+
+  const linked = Boolean(row.buildId || row.taskRunId);
+  if (!linked) {
+    const route = (row.routeContext ?? "").trim().toLowerCase();
+    if (route === "mcp:principle_decide" || route.startsWith("mcp:principle_decide")) return false;
+    const domain = (row.domainClass ?? "").trim().toLowerCase();
+    if (domain === "kernel-consult") return false;
+  }
+  return true;
+}
+
+/**
+ * @deprecated Use `!isFounderActionable(row)`. Retained as the exact inverse so
+ * the migration is behaviour-preserving for the agent-internal case; new
+ * callers must not add to a deny-list. BI-6EC1EE25.
+ */
 export function isAgentInternalFounderReviewNoise(row: Pick<
   DecisionInteractionQueueRow,
-  "buildId" | "taskRunId" | "routeContext" | "domainClass"
+  "buildId" | "taskRunId" | "routeContext" | "domainClass" | "gateKey"
 >): boolean {
-  const linked = Boolean(row.buildId || row.taskRunId);
-  if (linked) return false;
-  const route = (row.routeContext ?? "").trim().toLowerCase();
-  if (route === "mcp:principle_decide" || route.startsWith("mcp:principle_decide")) return true;
-  const domain = (row.domainClass ?? "").trim().toLowerCase();
-  return domain === "kernel-consult";
+  return !isFounderActionable(row);
 }
 
 function normalizeFounderReviewQuestion(question: string): string {

--- a/apps/web/lib/mcp/packs/founder-review-pack.test.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.test.ts
@@ -101,7 +101,10 @@ describe("founder-review pack — list_open_decision_reviews", () => {
     expect(args.where.outcomeType).toEqual({ in: ["defer", "escalate"] });
     expect(args.where.humanOutcome).toEqual({ equals: "DbNull" });
     expect(args.where.question).toEqual({ not: "" });
+    // Advisory profession/WSID rows and agent-internal consults are excluded at
+    // the DB so `take` counts only founder-actionable rows (BI-6EC1EE25).
     expect(args.where.NOT).toEqual([
+      { gateKey: "profession" },
       {
         buildId: null,
         taskRunId: null,

--- a/apps/web/lib/mcp/packs/founder-review-pack.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.ts
@@ -63,7 +63,7 @@ async function listOpenDecisionReviews(
   const { Prisma, prisma } = await import("@dpf/db");
   const {
     dedupeFounderReviewCandidates,
-    isAgentInternalFounderReviewNoise,
+    isFounderActionable,
     isBlankFounderReviewQuestion,
     projectFounderReviewCandidate,
   } = await import("@/lib/founder-review/queue");
@@ -102,7 +102,14 @@ async function listOpenDecisionReviews(
       outcomeType: { in: UNRESOLVED_OUTCOMES },
       humanOutcome: { equals: Prisma.DbNull },
       question: { not: "" },
+      // Mirror of isFounderActionable at the DB, so `take: limit` counts only
+      // rows a human should decide, not advisory/agent-internal noise the JS
+      // filter would drop afterward (BI-6EC1EE25). The JS filter below stays the
+      // authoritative predicate; this keeps the limit meaningful.
       NOT: [
+        // Advisory by contract — the profession/WSID gate blocks nothing.
+        { gateKey: "profession" },
+        // Already-executed agent-internal kernel consults (BI-9026B96C).
         {
           buildId: null,
           taskRunId: null,
@@ -126,6 +133,7 @@ async function listOpenDecisionReviews(
       taskRunId: true,
       routeContext: true,
       domainClass: true,
+      gateKey: true,
       createdAt: true,
       profile: { select: { profileId: true, name: true, kind: true } },
       deferralCapture: { select: { gapReason: true, domain: true, suggestedSourceTypes: true } },
@@ -135,7 +143,7 @@ async function listOpenDecisionReviews(
 
   const candidates = rows
     .filter((row) => !isBlankFounderReviewQuestion(row))
-    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .filter((row) => isFounderActionable(row))
     .map((row) => ({ row, candidate: projectFounderReviewCandidate(row) }));
   const uniqueIds = new Set(
     dedupeFounderReviewCandidates(candidates.map((item) => item.candidate)).map((candidate) => candidate.id),

--- a/apps/web/lib/tak/decision-governance-route-context.ts
+++ b/apps/web/lib/tak/decision-governance-route-context.ts
@@ -6,7 +6,7 @@ import {
 import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
 import {
   dedupeFounderReviewCandidates,
-  isAgentInternalFounderReviewNoise,
+  isFounderActionable,
   isBlankFounderReviewQuestion,
   projectFounderReviewCandidate,
   type DecisionInteractionQueueRow,
@@ -23,7 +23,12 @@ function openDecisionReviewWhere(
     outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES },
     humanOutcome: { equals: Prisma.DbNull },
     question: { not: "" },
+    // Mirror of isFounderActionable at the DB (BI-6EC1EE25): advisory
+    // profession/WSID rows and already-executed agent-internal consults are not
+    // reviews awaiting a human. A craft "defer" is a corpus-growth signal
+    // (ProfessionCorpusGap), not a founder decision.
     NOT: [
+      { gateKey: "profession" },
       {
         buildId: null,
         taskRunId: null,
@@ -47,6 +52,7 @@ const openDecisionReviewSelect = {
   taskRunId: true,
   routeContext: true,
   domainClass: true,
+  gateKey: true,
   createdAt: true,
   profile: { select: { profileId: true, name: true, kind: true } },
 } satisfies Prisma.DecisionInteractionSelect;
@@ -54,7 +60,7 @@ const openDecisionReviewSelect = {
 function countUniqueOpenReviews(rows: DecisionInteractionQueueRow[]): number {
   const candidates = rows
     .filter((row) => !isBlankFounderReviewQuestion(row))
-    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .filter((row) => isFounderActionable(row))
     .map((row) => projectFounderReviewCandidate(row));
   return dedupeFounderReviewCandidates(candidates).length;
 }
@@ -128,7 +134,7 @@ export async function getWikiGovernanceContext(): Promise<string> {
 
   const reviewCandidates = (topOpenReviews as DecisionInteractionQueueRow[])
     .filter((row) => !isBlankFounderReviewQuestion(row))
-    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .filter((row) => isFounderActionable(row))
     .map((row) => projectFounderReviewCandidate(row));
   const reviewLines = dedupeFounderReviewCandidates(reviewCandidates)
     .map((c) => `- [${c.profileLabel}] "${c.question}" — ${c.unresolvedReasonLabel}; suggested action: ${c.primaryActionLabel}; open evidence at ${c.links.decisionCanvasHref}`);


### PR DESCRIPTION
Fixes BI-6EC1EE25. The founder-review and attention queues were **inclusion-by-default**: every `DecisionInteraction` with `outcomeType` escalate/defer and `humanOutcome` NULL was founder residue *unless* it matched a hardcoded deny-list of "agent-internal noise" — **duplicated verbatim across three files** and encoded a fourth time as a Prisma `NOT` clause. Built for `principle_decide` consults (BI-9026B96C), it silently failed to exclude the next class that fit the same description: the fail-open profession/WSID advisory reviews I shipped in #3344 (BI-D6CFE63A), which defer when the craft corpus is empty.

**Result, live: 109 advisory defers polluting the queue and growing on every plan/design review** — while blocking nothing (advisory by contract). The same anti-pattern the memory-trust spec (#3348) is about: a recorded audit signal treated as an action request. This is my #3344 regression.

## Correction to the original filing

The BI claimed the 25 acknowledged rows were "still gate-blocking." **Verified false for 23 of 25** — they have `buildId=NULL`, and `interactionWasCleared` is consulted only for builds. Those were agent-internal consults correctly dequeued by the 2026-07-10 batch (via an out-of-band write). The real live defect is the advisory-defer pollution.

## Fix — founder-actionability by derivation

One shared predicate `isFounderActionable` replaces the two duplicated classifiers (which now delegate to its inverse, deprecated, behaviour-preserving). A row is **not** actionable when it is a `gateKey='profession'` row (advisory by contract, regardless of linkage — a craft defer is a `ProfessionCorpusGap` signal, not a founder decision) or an unlinked kernel consult. Keyed on `gateKey` (the durable discriminator from BI-1BE30A9A), **not** brittle route-context strings, so the next advisory writer can't silently re-pollute. Applied across all five surfaces; each Prisma `NOT` + select also drops `gateKey='profession'` so `take: limit` stays meaningful.

## Functional verification (live corpus)

The exact query the shipped code now issues, run against the live DB:

| founder-review queue | rows |
|---|---|
| **before** (old deny-list) | 115 |
| **after** (derived predicate) | **6** |
| dropped | exactly the 109 `profession` advisory defers |

The 6 survivors are all genuine **WWWD org-business escalations** — real founder judgment calls (sign a 3-year exclusive supplier contract; a customer subscription lapsed due to our own billing error; prioritize quality for existing customers). Both done-criteria met: advisory noise gone, genuine escalations survive. (Query-against-live-data rather than a full `:3001` render — the preview lease was held by a peer, and the fix is entirely query+predicate with no render change.)

## Write-contract invariant

The kernel (`principle_decide` DI-EC78AC6F72AE) recommended "both". Analysis showed the humanOutcome/gate-clear "divergence" is **two correct predicates for two different questions** (review-touched vs gate-cleared), with no code path that diverges them — both sanctioned writers create the capture row and set `clearsGate` atomically in one transaction. Rather than refactor two working transactions (a second concern; the kernel itself scored One-Concern-Per-PR), I added a **ratchet test** pinning the invariant for future code: `clearsGate` may be set truthy only in a file that also creates a capture row. The 2026-07-10 incident was a DB-plane write, outside code enforcement — stated so it isn't oversold.

## Design grounding

Extends an existing contract — source of truth is `docs/superpowers/specs/2026-07-21-memory-trust-and-evidence-currency-design.md` §2.3/§6.2/P4 (on main, #3348) and the human-attention-surface residue source (BI-AS-6). No new artifact.

TDD: failing predicate test first (7 cases red on "isFounderActionable is not a function"), then green. Gate: `pnpm run pregate` — 18,970 tests, compiled clean.

Refs BI-6EC1EE25, EP-0AF96937, BI-D6CFE63A, BI-9026B96C

🤖 Generated with [Claude Code](https://claude.com/claude-code)
