### PR TITLE
fix(prose-lint): retighten baseline for two shipped copy changes

### DIFF
--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1488,14 +1488,14 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 156
+    "textMass": 157
   },
   "apps/web/app/(shell)/platform/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 84
+    "textMass": 86
   },
   "apps/web/app/(shell)/platform/schedule/page.tsx": {
     "vocabulary": 0,
@@ -3294,7 +3294,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 4,
-    "textMass": 369
+    "textMass": 384
   },
   "apps/web/components/agent/AgentCoworkerShell.tsx": {
     "vocabulary": 0,
@@ -6465,7 +6465,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 50
+    "textMass": 60
   },
   "apps/web/components/platform/identity/ApplicationAssignmentsPanel.tsx": {
     "vocabulary": 0,
@@ -6521,7 +6521,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 11
+    "textMass": 13
   },
   "apps/web/components/platform/identity/PrincipalDirectoryPanel.tsx": {
     "vocabulary": 0,
@@ -6549,7 +6549,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 97
+    "textMass": 99
   },
   "apps/web/components/platform/service-desk/ServiceTicketsTable.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

CI's **Prose Lint Guard** (`scripts/check-prose-lint.ts`, BI-88D8C725, non-required check) has been red on `main` since at least e99359bb. The `textMass` axis grew on 6 files without the baseline (`scripts/prose-lint-baseline.json`) being retightened after the copy changes that caused it landed.

Investigated each flagged file — all growth traces to two already-shipped, intentional copy changes, not verbosity that needs trimming:

- `apps/web/app/(shell)/platform/identity/page.tsx`, `apps/web/app/(shell)/platform/page.tsx`, `apps/web/components/platform/identity/AgentIdentityPanel.tsx`, `apps/web/components/platform/identity/IdentityTabNav.tsx`, `apps/web/components/platform/platform-nav.ts` — [PR #3527](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3527)'s "Agent" → "AI coworker" terminology rename plus one new bridge sentence ("These are your AI coworkers, viewed as identity principals.") — a decision-scoped, Design-Grounding-reviewed rename.
- `apps/web/components/agent/AgentCoworkerPanel.tsx` — [PR #3533](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3533)'s new orphaned-session banner ("Your sign-in session is no longer valid. Sign in again to continue." + a "Sign in again" button) — genuinely new, already-terse functional copy.

No `vocabulary`/`genericLabels`/`readability`/`longSentences` regressions on any file — only `textMass` moved, and only by the exact word deltas those two PRs introduced. Regenerated the baseline via `--update` rather than rewriting copy that doesn't need shortening.

## Test plan

- [x] `node node_modules/tsx/dist/cli.mjs scripts/check-prose-lint.ts` — now passes (was failing before this change)
- [x] `node node_modules/vitest/vitest.mjs run scripts/check-prose-lint.test.ts` — 15/15 assertions pass, unchanged (script logic untouched, only the baseline data file)
- [x] Diffed `scripts/prose-lint-baseline.json` — confirmed only the 6 expected entries changed, each by the exact word count the two source PRs added

Signed-off-by: DPF Build Studio <build@opendigitalproductfactory.com>