### PR TITLE
fix(data): complete edge certificate stewardship

### DIFF
--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 582,
+  "routeCount": 583,
   "routes": [
     {
       "routePath": "/",
@@ -2200,6 +2200,20 @@
         "id"
       ],
       "file": "apps/web/app/api/v1/dynamic/views/[id]/data/route.ts"
+    },
+    {
+      "routePath": "/api/v1/edge/actions/certificates/register",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "edge",
+        "actions",
+        "certificates",
+        "register"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/edge/actions/certificates/register/route.ts"
     },
     {
       "routePath": "/api/v1/edge/actions/claim",

--- a/docs/data-impact/2026-07-24-edge-node-certificate.data-impact.json
+++ b/docs/data-impact/2026-07-24-edge-node-certificate.data-impact.json
@@ -1,0 +1,70 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "Edge fleet authorization registry",
+    "Sanitized contributor-preview clone policy"
+  ],
+  "migration": {
+    "name": "20260722023000_edge_node_certificates",
+    "backfill": "none — existing Edge Nodes remain unbound until a machine certificate is explicitly registered"
+  },
+  "tests": [
+    "apps/web/lib/auth/edge-node-mtls.test.ts",
+    "apps/web/lib/auth/register-edge-certificate.test.ts",
+    "apps/web/lib/govern/data/assets.test.ts",
+    "packages/db/src/edge-node-types.test.ts",
+    "scripts/installer/pki-contract.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:edge-node-certificate",
+      "prismaModel": "EdgeNodeCertificate",
+      "lifecycleDisposition": "domain-managed through Edge Node enrollment, certificate rotation and revocation, and cascade deletion with the owning Edge Node",
+      "fields": [
+        {
+          "fieldId": "data:edge-node-certificate#certificateId",
+          "resolution": "governed",
+          "reason": "provides the stable public certificate identity used for request authorization and lifecycle updates",
+          "provenance": "organization-rooted Edge Node certificate registration",
+          "flags": ["sensitive"],
+          "fieldPolicy": "authorization metadata only; no private key or bearer credential is stored"
+        },
+        {
+          "fieldId": "data:edge-node-certificate#fingerprintSha256",
+          "resolution": "governed",
+          "reason": "binds the certificate verified at the mTLS proxy to the registered Edge Node",
+          "provenance": "SHA-256 fingerprint of the presented X.509 certificate",
+          "flags": ["sensitive"],
+          "fieldPolicy": "restricted local authorization metadata; exact-match lookup only"
+        },
+        {
+          "fieldId": "data:edge-node-certificate#subject",
+          "resolution": "governed",
+          "reason": "records the machine identity asserted by the organization certificate authority",
+          "provenance": "verified X.509 certificate subject",
+          "flags": ["sensitive"],
+          "fieldPolicy": "restricted to platform and security operators"
+        },
+        {
+          "fieldId": "data:edge-node-certificate#issuer",
+          "resolution": "governed",
+          "reason": "records which organization-rooted authority issued the accepted machine identity",
+          "provenance": "verified X.509 certificate issuer",
+          "flags": ["sensitive"],
+          "fieldPolicy": "restricted to platform and security operators"
+        },
+        {
+          "fieldId": "data:edge-node-certificate#status",
+          "resolution": "governed",
+          "reason": "makes active and revoked authorization state explicit for every request",
+          "provenance": "Edge Node certificate lifecycle service",
+          "flags": ["sensitive"],
+          "fieldPolicy": "fail closed unless the registered certificate is active and within its validity window"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -225,6 +225,9 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   TaskEvaluation: "restricted",
   EndpointTestRun: "restricted",
   AuthorizationDecisionLog: "restricted",
+  // Machine certificate binding and lifecycle metadata is authorization
+  // material. The private key remains on the Edge Node and is never stored.
+  EdgeNodeCertificate: "restricted",
   PatientProfile: "restricted",
   PatientAuthority: "restricted",
   PatientConsentDirective: "restricted",

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1488,14 +1488,14 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 156
+    "textMass": 157
   },
   "apps/web/app/(shell)/platform/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 84
+    "textMass": 86
   },
   "apps/web/app/(shell)/platform/schedule/page.tsx": {
     "vocabulary": 0,
@@ -3294,7 +3294,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 4,
-    "textMass": 369
+    "textMass": 384
   },
   "apps/web/components/agent/AgentCoworkerShell.tsx": {
     "vocabulary": 0,
@@ -6465,7 +6465,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 50
+    "textMass": 60
   },
   "apps/web/components/platform/identity/ApplicationAssignmentsPanel.tsx": {
     "vocabulary": 0,
@@ -6521,7 +6521,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 11
+    "textMass": 13
   },
   "apps/web/components/platform/identity/PrincipalDirectoryPanel.tsx": {
     "vocabulary": 0,
@@ -6549,7 +6549,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 97
+    "textMass": 99
   },
   "apps/web/components/platform/service-desk/ServiceTicketsTable.tsx": {
     "vocabulary": 0,

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -59,3 +59,4 @@ WeightAdjustmentProposal  domain-lifecycle-managed  # BI-D88DFEEA. status transi
   # evidence a real regulated-retention floor doesn't apply to but the
   # decision ledger it's attached to (DecisionInteraction) does need intact.
 AbsorptionPosture  reference-data  # Authored absorption classification (BI-ECO-001); superseded by replacement, never aged out. Reseeded idempotently from the vertical-incumbents manifest.
+EdgeNodeCertificate  domain-lifecycle-managed  # Certificate records follow the Edge Node enrollment, rotation, revocation, and cascade-delete lifecycle; an age-based purge could remove an active authorization binding.


### PR DESCRIPTION
## Summary
- add the missing data-impact manifest, restricted table classification, and domain-lifecycle retention disposition for the merged `EdgeNodeCertificate` model
- refresh the route manifest for the merged certificate-registration API route
- refresh the deterministic prose-lint baseline exposed by the original PR checks

## Test plan
- [x] Exact-head local merged-code CI against `main` at `7c560f2da6a114e4054ac797e423fab73638b8db`
- [x] Full web/package unit suite passed
- [x] Web typecheck and Next.js production build passed
- [x] Prisma migration deploy passed
- [x] Route-manifest, stewardship-scope, data-impact, prose-lint, documentation-index, link-integrity, and repository guards passed
- [x] UX verification: n/a — governance and generated artifacts only

Local-CI-Evidence: cmrznr2oq083h01pgelcc54ki (fix/edge-certificate-stewardship@44cc2dd6138a0bca599c04cd3570e2787f46ea89)

## Delivery notes
- Follow-up to merged PR #3556; this PR contains only the five governance/generated artifacts that did not enter its merged head.
- Documentation impact is captured in the data-impact manifest; no operator workflow changes are introduced.