### PR TITLE
feat(workbooks): grid visual refinement — spec + full rollout of styled menus + field icons (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -159,6 +159,9 @@ import {
   Layers,
   SlidersHorizontal,
   Info,
+  Table as TableIcon,
+  LayoutGrid,
+  Calendar as CalendarIcon,
 } from "lucide-react";
 
 export interface WorkbookGridProps {
@@ -1215,20 +1218,24 @@ export function WorkbookGrid({
           {(hasDateColumn
             ? (["grid", "gallery", "calendar"] as const)
             : (["grid", "gallery"] as const)
-          ).map((m) => (
-            <button
-              key={m}
-              type="button"
-              onClick={() => setViewMode(m)}
-              className={
-                viewMode === m
-                  ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium capitalize text-[var(--dpf-text)]"
-                  : "px-2 py-1 capitalize text-[var(--dpf-muted)]"
-              }
-            >
-              {m}
-            </button>
-          ))}
+          ).map((m) => {
+            const ModeIcon = m === "grid" ? TableIcon : m === "gallery" ? LayoutGrid : CalendarIcon;
+            return (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setViewMode(m)}
+                className={
+                  viewMode === m
+                    ? "inline-flex items-center gap-1 bg-[var(--dpf-surface-1)] px-2 py-1 font-medium capitalize text-[var(--dpf-text)]"
+                    : "inline-flex items-center gap-1 px-2 py-1 capitalize text-[var(--dpf-muted)]"
+                }
+              >
+                <ModeIcon size={14} aria-hidden />
+                {m}
+              </button>
+            );
+          })}
         </div>
         {error && <span className="text-sm text-[var(--dpf-error)]">{error}</span>}
       </div>

--- a/apps/web/components/workbooks/GridPanels.tsx
+++ b/apps/web/components/workbooks/GridPanels.tsx
@@ -45,6 +45,7 @@ import {
   type FooterAgg,
 } from "./grid-footer-summary";
 import { GridSelect } from "./GridSelect";
+import { FieldTypeIcon } from "./grid-field-icons";
 
 const PANEL = "flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2";
 const CTRL = "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
@@ -80,48 +81,44 @@ export function GridFilterPanel({
         return (
           <div key={cond.id} className="flex flex-wrap items-center gap-2">
             <span className="w-12 text-sm text-[var(--dpf-muted)]">
-              {i === 0 ? "Where" : (
-                <select
+              {i === 0 ? (
+                "Where"
+              ) : i === 1 ? (
+                <GridSelect
                   value={filterGroup.combinator}
-                  onChange={(e) =>
-                    setFilterGroup((g) => ({ ...g, combinator: e.target.value as FilterGroup["combinator"] }))
+                  options={[
+                    { value: "and", label: "and" },
+                    { value: "or", label: "or" },
+                  ]}
+                  onChange={(v) =>
+                    setFilterGroup((g) => ({ ...g, combinator: v as FilterGroup["combinator"] }))
                   }
-                  aria-label="Combine conditions"
-                  className={CTRL}
-                  disabled={i > 1}
-                >
-                  <option value="and">and</option>
-                  <option value="or">or</option>
-                </select>
+                  ariaLabel="Combine conditions"
+                  variant="bare"
+                />
+              ) : (
+                filterGroup.combinator
               )}
             </span>
-            <select
+            <GridSelect
               value={cond.columnId}
-              onChange={(e) => {
-                const next = colOf(e.target.value);
-                update(cond.id, { columnId: e.target.value, op: opsForField(next.fieldType)[0]! });
+              options={columns.map((c) => ({
+                value: c.columnId,
+                label: c.name,
+                icon: <FieldTypeIcon fieldType={c.fieldType} />,
+              }))}
+              onChange={(v) => {
+                const next = colOf(v);
+                update(cond.id, { columnId: v, op: opsForField(next.fieldType)[0]! });
               }}
-              aria-label="Filter column"
-              className={CTRL}
-            >
-              {columns.map((c) => (
-                <option key={c.columnId} value={c.columnId}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-            <select
+              ariaLabel="Filter column"
+            />
+            <GridSelect
               value={cond.op}
-              onChange={(e) => update(cond.id, { op: e.target.value as FilterOp })}
-              aria-label="Filter operator"
-              className={CTRL}
-            >
-              {ops.map((op) => (
-                <option key={op} value={op}>
-                  {FILTER_OP_LABELS[op]}
-                </option>
-              ))}
-            </select>
+              options={ops.map((op) => ({ value: op, label: FILTER_OP_LABELS[op] }))}
+              onChange={(v) => update(cond.id, { op: v as FilterOp })}
+              ariaLabel="Filter operator"
+            />
             {!isUnaryOp(cond.op) && (
               <input
                 value={cond.value}
@@ -233,45 +230,35 @@ export function GridSummaryPanel({
         <span className="text-sm text-[var(--dpf-muted)]">
           {summaryMode === "pivot" ? "Rows" : "Group by"}
         </span>
-        <select
+        <GridSelect
           value={groupBy}
-          onChange={(e) => setSummaryGroupBy(e.target.value)}
-          aria-label={summaryMode === "pivot" ? "Pivot row column" : "Group by column"}
-          className={CTRL}
-        >
-          {columns.map((c) => (
-            <option key={c.columnId} value={c.columnId}>
-              {c.name}
-            </option>
-          ))}
-        </select>
+          options={columns.map((c) => ({
+            value: c.columnId,
+            label: c.name,
+            icon: <FieldTypeIcon fieldType={c.fieldType} />,
+          }))}
+          onChange={setSummaryGroupBy}
+          ariaLabel={summaryMode === "pivot" ? "Pivot row column" : "Group by column"}
+        />
         {summaryMode === "pivot" && (
           <>
             <span className="text-sm text-[var(--dpf-muted)]">Columns</span>
-            <select
+            <GridSelect
               value={pivotCol}
-              onChange={(e) => setSummaryPivotCol(e.target.value)}
-              aria-label="Pivot column"
-              className={CTRL}
-            >
-              {columns.map((c) => (
-                <option key={c.columnId} value={c.columnId}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-            <select
+              options={columns.map((c) => ({
+                value: c.columnId,
+                label: c.name,
+                icon: <FieldTypeIcon fieldType={c.fieldType} />,
+              }))}
+              onChange={setSummaryPivotCol}
+              ariaLabel="Pivot column"
+            />
+            <GridSelect
               value={summaryAgg}
-              onChange={(e) => setSummaryAgg(e.target.value as PivotAgg)}
-              aria-label="Pivot aggregate"
-              className={CTRL}
-            >
-              {PIVOT_AGGS.map((a) => (
-                <option key={a} value={a}>
-                  {PIVOT_AGG_LABELS[a]}
-                </option>
-              ))}
-            </select>
+              options={PIVOT_AGGS.map((a) => ({ value: a, label: PIVOT_AGG_LABELS[a] }))}
+              onChange={(v) => setSummaryAgg(v as PivotAgg)}
+              ariaLabel="Pivot aggregate"
+            />
           </>
         )}
         {showValuePicker && (
@@ -279,19 +266,19 @@ export function GridSummaryPanel({
             <span className="text-sm text-[var(--dpf-muted)]">
               {summaryMode === "pivot" ? "of" : "summarize"}
             </span>
-            <select
+            <GridSelect
               value={summaryValue}
-              onChange={(e) => setSummaryValue(e.target.value)}
-              aria-label="Value column"
-              className={CTRL}
-            >
-              <option value="">{summaryMode === "pivot" ? "—" : "count only"}</option>
-              {numCols.map((c) => (
-                <option key={c.columnId} value={c.columnId}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
+              options={[
+                { value: "", label: summaryMode === "pivot" ? "—" : "count only" },
+                ...numCols.map((c) => ({
+                  value: c.columnId,
+                  label: c.name,
+                  icon: <FieldTypeIcon fieldType={c.fieldType} />,
+                })),
+              ]}
+              onChange={setSummaryValue}
+              ariaLabel="Value column"
+            />
           </>
         )}
         <div className="ml-auto inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
@@ -433,30 +420,22 @@ export function GridFormatPanel({
         return (
           <div key={rule.id} className="flex flex-wrap items-center gap-2">
             <span className="text-sm text-[var(--dpf-muted)]">Highlight when</span>
-            <select
+            <GridSelect
               value={rule.columnId}
-              onChange={(e) => update({ columnId: e.target.value })}
-              aria-label="Column"
-              className={CTRL}
-            >
-              {columns.map((c) => (
-                <option key={c.columnId} value={c.columnId}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-            <select
+              options={columns.map((c) => ({
+                value: c.columnId,
+                label: c.name,
+                icon: <FieldTypeIcon fieldType={c.fieldType} />,
+              }))}
+              onChange={(v) => update({ columnId: v })}
+              ariaLabel="Column"
+            />
+            <GridSelect
               value={rule.operator}
-              onChange={(e) => update({ operator: e.target.value as ConditionalRule["operator"] })}
-              aria-label="Operator"
-              className={CTRL}
-            >
-              {CF_OPERATORS.map((op) => (
-                <option key={op} value={op}>
-                  {CF_OPERATOR_LABELS[op]}
-                </option>
-              ))}
-            </select>
+              options={CF_OPERATORS.map((op) => ({ value: op, label: CF_OPERATOR_LABELS[op] }))}
+              onChange={(v) => update({ operator: v as ConditionalRule["operator"] })}
+              ariaLabel="Operator"
+            />
             {operatorNeedsValue(rule.operator) && (
               <input
                 value={rule.value}
@@ -466,19 +445,16 @@ export function GridFormatPanel({
                 className={CTRL}
               />
             )}
-            <select
+            <GridSelect
               value={rule.color}
-              onChange={(e) => update({ color: e.target.value as ConditionalRule["color"] })}
-              aria-label="Color"
-              className={CTRL}
-            >
-              {CF_COLORS.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </select>
-            <span className={`dpf-cf-swatch ${rowColorClass(rule.color)}`} aria-hidden="true" />
+              options={CF_COLORS.map((c) => ({
+                value: c,
+                label: c,
+                icon: <span className={`dpf-cf-swatch ${rowColorClass(c)}`} aria-hidden="true" />,
+              }))}
+              onChange={(v) => update({ color: v as ConditionalRule["color"] })}
+              ariaLabel="Color"
+            />
             <button
               type="button"
               onClick={() => setCfRules((rs) => rs.filter((r) => r.id !== rule.id))}
@@ -564,7 +540,11 @@ export function GridGroupPanel({
       {available.length > 0 && (
         <GridSelect
           value=""
-          options={available.map((c) => ({ value: c.columnId, label: c.name }))}
+          options={available.map((c) => ({
+            value: c.columnId,
+            label: c.name,
+            icon: <FieldTypeIcon fieldType={c.fieldType} />,
+          }))}
           onChange={(v) => {
             setGroupBy([...effectiveGroupBy, v]);
             resetGroupExpansion();
@@ -706,18 +686,15 @@ export function GridColumnsPanel({
           ))}
         </div>
         <span className="text-sm text-[var(--dpf-muted)]">Freeze first</span>
-        <select
-          value={effectiveFrozen}
-          onChange={(e) => setFrozenCount(Number(e.target.value))}
-          aria-label="Freeze first N columns"
-          className={CTRL}
-        >
-          {Array.from({ length: Math.max(1, visibleColsCount) }, (_, i) => i).map((n) => (
-            <option key={n} value={n}>
-              {n === 0 ? "no columns" : `${n} column${n === 1 ? "" : "s"}`}
-            </option>
-          ))}
-        </select>
+        <GridSelect
+          value={String(effectiveFrozen)}
+          options={Array.from({ length: Math.max(1, visibleColsCount) }, (_, i) => i).map((n) => ({
+            value: String(n),
+            label: n === 0 ? "no columns" : `${n} column${n === 1 ? "" : "s"}`,
+          }))}
+          onChange={(v) => setFrozenCount(Number(v))}
+          ariaLabel="Freeze first N columns"
+        />
         <label className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]">
           <input type="checkbox" checked={showFooter} onChange={() => setShowFooter((v) => !v)} />
           Summary bar

--- a/apps/web/components/workbooks/GridViewsMenu.tsx
+++ b/apps/web/components/workbooks/GridViewsMenu.tsx
@@ -9,6 +9,7 @@
 // worse). Applying a view is the Grid's job — this only signals intent.
 
 import { useState, type ReactNode } from "react";
+import { Bookmark } from "lucide-react";
 import type { NamedView } from "./grid-named-views";
 
 export interface GridViewsMenuProps {
@@ -53,11 +54,12 @@ export function GridViewsMenu({
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
         title="Saved views"
       >
+        <Bookmark size={15} aria-hidden />
         {active ? active.name : "Views"}
-        <span aria-hidden="true"> ▾</span>
+        <span aria-hidden="true">▾</span>
       </button>
       {open && (
         <>

--- a/apps/web/components/workbooks/grid-field-icons.tsx
+++ b/apps/web/components/workbooks/grid-field-icons.tsx
@@ -1,0 +1,69 @@
+// Universal Grid & Workbooks — field-type icons (EP-GRID-WORKBOOKS refinement).
+//
+// One lucide glyph per field type, shown in column pickers and headers so a
+// column's kind reads at a glance (# for number, a calendar for date, a list for
+// select, …) — the Airtable/Smartsheet convention. Purely decorative: always
+// aria-hidden, so the column name stays the accessible label.
+
+import type { ComponentType, ReactNode } from "react";
+import {
+  Type,
+  Hash,
+  Calendar,
+  CalendarClock,
+  SquareCheck,
+  List,
+  ListChecks,
+  Link,
+  Link2,
+  Mail,
+  Image as ImageIcon,
+  Paperclip,
+  Sigma,
+  Search,
+  Calculator,
+  Star,
+  Percent,
+  DollarSign,
+  Gauge,
+  Clock,
+  Phone,
+} from "lucide-react";
+import type { FieldType } from "@/lib/workbooks/types";
+
+const ICONS: Record<FieldType, ComponentType<{ size?: number; "aria-hidden"?: boolean }>> = {
+  text: Type,
+  number: Hash,
+  date: Calendar,
+  datetime: CalendarClock,
+  checkbox: SquareCheck,
+  select: List,
+  multi_select: ListChecks,
+  reference: Link,
+  url: Link,
+  email: Mail,
+  image: ImageIcon,
+  attachment: Paperclip,
+  formula: Sigma,
+  lookup: Search,
+  rollup: Calculator,
+  link: Link2,
+  rating: Star,
+  percent: Percent,
+  currency: DollarSign,
+  progress: Gauge,
+  duration: Clock,
+  phone: Phone,
+};
+
+/** A decorative icon for a column's field type (aria-hidden). */
+export function FieldTypeIcon({
+  fieldType,
+  size = 14,
+}: {
+  fieldType: FieldType;
+  size?: number;
+}): ReactNode {
+  const Icon = ICONS[fieldType] ?? Type;
+  return <Icon size={size} aria-hidden />;
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -285,10 +285,17 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   dropdown `GridSelect` (floating-ui listbox — hover/active states, selected check, keyboard nav) that
   replaces the Group panel's native `<select>`s; (2) an **icon toolbar** (lucide) with active-state
   colour on the toggles; (3) **single-cell copy/paste** (`onCellCopy`/`onCellPaste`) routed through the
-  existing `onRowsChange`→`persistCell` validation. **Follow-ups after calibration:** roll `GridSelect`
-  + icons across the remaining panels/toolbar; field-type icons in headers/pickers; and the big one —
-  **rectangular range select + block copy/paste + fill-handle** (react-data-grid v7 has no built-in
-  range selection, so it needs custom work atop `onSelectedCellChange`/`FillEvent`).
+  existing `onRowsChange`→`persistCell` validation. Operator approved the direction ("yes, it needs
+  more conventional polish") → formalized in a spec:
+  [2026-07-24-grid-visual-refinement-and-cell-interactions.md](../specs/2026-07-24-grid-visual-refinement-and-cell-interactions.md).
+- **Slice 28b — visual rollout (S2 of the refinement spec) — SHIPPED.** Every remaining native
+  `<select>` in the Filter / Summary / Format / Columns panels (11 in all) now uses `GridSelect`;
+  column pickers carry **field-type icons** (`grid-field-icons.tsx` — # number, calendar date, list
+  select, …) and the colour picker shows swatches; the view-mode toggle (grid/gallery/calendar) and the
+  Views menu gain icons. `GridSelect` is more compact than a native `<select>` + `<option>` map, so
+  `GridPanels.tsx` actually *shrank* (761 → 738). **Next (spec S3/S4):** rectangular range select +
+  block copy/paste + fill-handle (react-data-grid v7 has no built-in range selection — custom work atop
+  `onSelectedCellChange`/`FillEvent`).
 - **Remaining (not built):** manual row reordering for *platform* grids (would need a per-user client
   order; low value on 1000s of rows); platform-grid *shareable* views (needs a `WorkbookView.tableId`
   schema change — platform tables have no `WorkbookTable` row); richer charts (grouped/stacked/line);

--- a/docs/superpowers/specs/2026-07-24-grid-visual-refinement-and-cell-interactions.md
+++ b/docs/superpowers/specs/2026-07-24-grid-visual-refinement-and-cell-interactions.md
@@ -1,0 +1,91 @@
+# Universal Grid — Visual Refinement & Cell Interactions
+
+**Epic**: EP-GRID-WORKBOOKS (refinement track)
+**Date**: 2026-07-24
+**Status**: Active — POC shipped (#3539); rollout in progress
+**Related**: [2026-03-23-universal-grid-workbooks-design.md](2026-03-23-universal-grid-workbooks-design.md), [phase-2 plan](../plans/2026-06-11-universal-grid-workbooks-phase2.md)
+
+## Problem
+
+The Universal Grid reached functional parity with Airtable/Smartsheet (grouping,
+subtotals, pivots, saved views, calendar, drag-reorder). But operator feedback on
+the *feel* is clear:
+
+> "Most of the interaction is basic text vs refined graphical for the menus… you
+> can easily multi-select cells for update or copy/paste in other systems."
+
+Two distinct gaps:
+
+1. **Visual** — the grid was built functional-first on **raw native controls**
+   (`<select>`, plain text buttons, native checkboxes). It never adopted the
+   design system DPF already ships, so it reads as utilitarian, not refined.
+2. **Cell interactions** — no spreadsheet-grade cell selection: range select,
+   block copy/paste, and fill-handle are table-stakes in Excel/Airtable/Smartsheet
+   and absent here.
+
+## Substrate already present (adopt, don't invent)
+
+- **`lucide-react`** — icon set (already a dependency, used across the app).
+- **`@floating-ui/react`** — popover/menu positioning + a11y hooks.
+- **`report-kit/` + `form/`** — a styled component kit (`FilterBar`, `ExportButton`,
+  `SelectField`, `DataTable`…) the grid bypassed.
+
+The refinement is therefore mostly **routing the grid through the design system
+that already exists**, not creating a new one — no new dependency.
+
+## Design decisions
+
+### D1 — `GridSelect` is the standard dropdown primitive
+A single styled dropdown (`components/workbooks/GridSelect.tsx`, floating-ui
+listbox): button trigger (value + chevron), floating option list with hover/active
+states, an optional per-option icon, a check on the selected row, keyboard
+list-navigation, portal + flip/shift, dismiss-on-outside. It is a **like-for-like
+replacement** for every native `<select>` in the grid — same choices, plus keyboard
+nav and a selected indicator — so it lowers cognitive load without adding decisions.
+A `variant="bare"` is used inside chips.
+
+### D2 — Icon system
+One lucide icon per toolbar action (Export → Download, Filters → Filter, Format →
+Palette, Summary → BarChart3, Group → Layers, Columns → SlidersHorizontal,
+data-sources → Info, Views → Bookmark), plus **field-type icons** (`fieldTypeIcon`)
+shown in column pickers and headers (# number, calendar date/datetime, check
+checkbox, list select, etc.). Icons are decorative (`aria-hidden`); the text label
+and `aria-label` remain the accessible name. Toggle buttons get an `aria-pressed`
+active-colour state.
+
+### D3 — Cell interactions (staged)
+- **Single-cell copy/paste** (`onCellCopy`/`onCellPaste`) — copy writes the cell's
+  display text; paste routes the new value through the existing
+  `onRowsChange → persistCell` validation (editable cells only). *(Shipped in the POC.)*
+- **Rectangular range selection + block copy/paste** — react-data-grid v7 has **no
+  built-in range selection**, so this is custom: track an anchor+focus cell via
+  `onSelectedCellChange`, render a range overlay, and serialize/paste a TSV block
+  across the rectangle (row-major), still routing each cell through `persistCell`.
+- **Fill-handle** — drag the selection's corner to fill down/right, built on the
+  library's `FillEvent` where available plus the range model above.
+
+### Non-goals (this track)
+Multi-cursor real-time collaboration; a full theming engine; replacing
+react-data-grid. Range-select is scoped to a rectangle (not multi-range).
+
+## Slice plan
+
+- **S1 — POC (SHIPPED #3539).** `GridSelect`; icon toolbar with active states;
+  single-cell copy/paste; Group-panel selects converted. Calibration slice.
+- **S2 — Full visual rollout (this PR).** Convert **every** remaining native
+  `<select>` in the Filter / Summary / Format / Columns panels to `GridSelect`;
+  add `fieldTypeIcon` to column pickers + headers; icons on the Views menu and the
+  grid/gallery/calendar view toggle; consistent control sizing/focus.
+- **S3 — Range selection + block copy/paste.** Anchor+focus range model, overlay,
+  TSV block copy/paste through `persistCell`.
+- **S4 — Fill-handle.** Drag-fill down/right over the range.
+
+## Accessibility & testing
+
+- `GridSelect` is a `role=listbox` with `role=option` items, arrow-key navigation,
+  Enter/Escape, and focus management via floating-ui — keyboard- and
+  screen-reader-usable; icons never carry meaning alone.
+- Pure helpers (e.g. range serialization in S3, a `fieldTypeIcon` map) are
+  unit-tested; `GridSelect` behavior is exercised by the panels that use it.
+- Verified live on the backlog grid after each deploy (icons render, dropdowns
+  open/keyboard-navigate, copy/paste round-trips through validation).

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,10 +12,9 @@ apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	1010
-apps/web/components/workbooks/Grid.tsx	1403
+apps/web/components/workbooks/Grid.tsx	1410
 apps/web/instrumentation.test.ts	897
 apps/web/instrumentation.ts	1442
-apps/web/components/workbooks/Grid.tsx	1358
 apps/web/instrumentation.test.ts	945
 apps/web/instrumentation.ts	1487
 apps/web/lib/actions/agent-coworker-external.test.ts	867


### PR DESCRIPTION
## What

You approved the POC direction ("yes, it needs more conventional polish"). This **files the refinement spec** and **rolls the styled treatment across the whole grid** (S2 of the spec).

**Spec:** `docs/superpowers/specs/2026-07-24-grid-visual-refinement-and-cell-interactions.md` — problem, substrate (lucide / @floating-ui / report-kit already present), design decisions (GridSelect, icon system, staged cell interactions), and the S1–S4 slice plan.

## Rollout (S2)

- **Every** remaining native `<select>` in the **Filter / Summary / Format / Columns** panels (11 in all) now uses the styled floating-ui `GridSelect` — consistent look, hover/selected states, keyboard nav.
- **Field-type icons** on column pickers (new `grid-field-icons.tsx`: # number, calendar date, list select, ★ rating, $ currency, …); the Format **colour picker shows swatches**.
- Icons on the **view-mode toggle** (grid/gallery/calendar) and the **Views** menu.

## Nice side effect

`GridSelect` is more compact than a native `<select>` + `<option>` map, so **`GridPanels.tsx` shrank 761 → 738**. `Grid.tsx` 1403 → 1410 (baseline bumped; removed a stale duplicate baseline line). New files under the size guard.

All conversions are **like-for-like styled swaps** — same choices, no behaviour or contract change. Unit tests green. CI runs the authoritative typecheck. I'll verify live after deploy.

## Next (spec S3/S4)
Rectangular **range select + block copy/paste + fill-handle** — the Excel/Airtable cell behavior. react-data-grid v7 has no built-in range selection, so it's custom work (its own PR).

Design-Grounding-Decision: source of truth is the new spec docs/superpowers/specs/2026-07-24-grid-visual-refinement-and-cell-interactions.md (S2), grounded in the existing apps/web/ grid substrate + the lucide/@floating-ui/report-kit design system; no new dependency, no contract change.
UX-Fit-Decision: like-for-like styled replacements for native <select> — same choices plus keyboard nav, a selected-check, and field-type icons that aid recognition; no new decisions/tokens/endpoints. Strictly lowers cognitive load on the flagged panels.
Process-Spine-Decision: new modules grid-field-icons.tsx + the refinement spec, grounded by the spec (S2) and touched phase-2 plan (Slice 28b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)