### PR TITLE
fix(process): self-heal shallow-graft merge failures in local-ci-runner.sh (BI-AA2201B0)

### DIFF
--- a/scripts/lib/git-fetch-shared-safe.mjs
+++ b/scripts/lib/git-fetch-shared-safe.mjs
@@ -71,6 +71,27 @@ export function assertRepoNotShallow(git, opts = {}) {
   }
 }
 
+/**
+ * Deepen a shallow repo in place (BI-AA2201B0). A `git merge` against a
+ * candidate ref that landed via a disjoint shallow graft (e.g. a separate
+ * depth-limited fetch of just that ref) fails with "refusing to merge
+ * unrelated histories" even when the two refs share real ancestry on the
+ * remote — the local object store just can't see it. `--unshallow` is the
+ * same repair `assertRepoNotShallow` already documents; this wraps it so
+ * mutating callers (a merge that MUST succeed, not just a read-only diff)
+ * can self-repair instead of failing loud. No-op when already full, so it is
+ * safe to call unconditionally before every merge — only fetches once, the
+ * first time the shallow boundary is still present.
+ *
+ * @param {(args: string[]) => string} git
+ * @param {{ remote?: string }} [opts]
+ */
+export function unshallowRootSharedSafe(git, opts = {}) {
+  if (!isShallowRepository(git)) return { mode: "already-full" };
+  git(["fetch", "--unshallow", opts.remote ?? "origin"]);
+  return { mode: "unshallowed" };
+}
+
 /** Default git runner for CLI use. */
 export function defaultGit(args) {
   return execFileSync("git", args, {

--- a/scripts/lib/git-fetch-shared-safe.test.mjs
+++ b/scripts/lib/git-fetch-shared-safe.test.mjs
@@ -7,6 +7,7 @@ import {
   assertRepoNotShallow,
   fetchOriginMainSharedSafe,
   isShallowRepository,
+  unshallowRootSharedSafe,
 } from "./git-fetch-shared-safe.mjs";
 
 describe("isShallowRepository", () => {
@@ -74,5 +75,49 @@ describe("assertRepoNotShallow", () => {
   it("passes on a full repository", () => {
     const git = () => "false\n";
     assert.doesNotThrow(() => assertRepoNotShallow(git));
+  });
+});
+
+describe("unshallowRootSharedSafe (BI-AA2201B0)", () => {
+  it("fetches --unshallow origin when the repo is shallow", () => {
+    /** @type {string[][]} */
+    const calls = [];
+    const git = (args) => {
+      calls.push(args);
+      if (args[0] === "rev-parse") return "true\n";
+      return "";
+    };
+    const r = unshallowRootSharedSafe(git);
+    assert.equal(r.mode, "unshallowed");
+    assert.deepEqual(
+      calls.find((c) => c[0] === "fetch"),
+      ["fetch", "--unshallow", "origin"],
+    );
+  });
+
+  it("is a no-op on an already-full repository", () => {
+    /** @type {string[][]} */
+    const calls = [];
+    const git = (args) => {
+      calls.push(args);
+      return "false\n";
+    };
+    const r = unshallowRootSharedSafe(git);
+    assert.equal(r.mode, "already-full");
+    assert.equal(calls.some((c) => c[0] === "fetch"), false);
+  });
+
+  it("honors a custom remote", () => {
+    const git = (args) => (args[0] === "rev-parse" ? "true\n" : "");
+    const calls = [];
+    const spyGit = (args) => {
+      calls.push(args);
+      return git(args);
+    };
+    unshallowRootSharedSafe(spyGit, { remote: "upstream" });
+    assert.deepEqual(
+      calls.find((c) => c[0] === "fetch"),
+      ["fetch", "--unshallow", "upstream"],
+    );
   });
 });

--- a/scripts/local-ci-runner.sh
+++ b/scripts/local-ci-runner.sh
@@ -79,6 +79,20 @@ if [ -z "$WORKSPACE" ]; then
   WORKSPACE="$(dirname "$root")/$(basename "$root")-worktrees/.local-ci-runner"
 fi
 
+# Shared-object-store self-repair (BI-AA2201B0): the scratch workspace below
+# is a linked worktree of $root, so it shares $root's .git/shallow. If that
+# shallow boundary is a disjoint graft for the candidate branch or base ref
+# (e.g. a prior per-ref depth-limited fetch), the merge step a few lines down
+# fails hard with "fatal: refusing to merge unrelated histories" even though
+# the branches share real ancestry on the remote — the local object store
+# just can't see it (verified mechanism, BI-AA2201B0). Deepen $root once
+# up front so the merge can find the true common ancestor; a no-op on every
+# call after the first, since the check gates on still-being-shallow.
+if [ "$DRY_RUN" != "1" ] && [ "$(git -C "$root" rev-parse --is-shallow-repository 2>/dev/null || printf 'false')" = "true" ]; then
+  printf 'local-ci-runner: root clone is shallow — fetching full history so the scratch merge has a common ancestor (BI-AA2201B0)\n'
+  git -C "$root" fetch --unshallow origin || die "failed to unshallow root clone at $root"
+fi
+
 candidate_sha="$(git -C "$repo_top" rev-parse --verify "$CANDIDATE" 2>/dev/null || true)"
 base_sha="$(git -C "$repo_top" rev-parse --verify "$BASE_REF" 2>/dev/null || true)"
 base_commit_date=""

--- a/tests/release/local-ci-gate-contract.test.mjs
+++ b/tests/release/local-ci-gate-contract.test.mjs
@@ -888,3 +888,96 @@ test("local-ci-runner.sh refuses to gate main or a detached HEAD", () => {
   assert.notEqual(onMain.status, 0);
   assert.match(onMain.stderr, /gate topic branches, not main/);
 });
+
+// ── shared-object-store self-repair (BI-AA2201B0) ────────────────────────────
+// The scratch merge workspace is a linked worktree of the root clone and
+// shares its .git/shallow. A disjoint shallow graft there makes the merge
+// step fail with "refusing to merge unrelated histories" even when the
+// branches share real ancestry on the remote. local-ci-runner.sh must
+// unshallow the root once, up front, before that merge ever runs.
+
+function stubGitFor(shallow) {
+  const stubDir = mkdtempSync(join(tmpdir(), "dpf-local-ci-shallow-stub-"));
+  const callsFile = join(stubDir, "calls.log");
+  const fakeRoot = join(stubDir, "fake-root").replace(/\\/g, "/");
+  writeFileSync(join(stubDir, "git"), `#!/bin/sh
+echo "$*" >> "${callsFile}"
+case "$*" in
+  "rev-parse --show-toplevel")
+    echo "${fakeRoot}" ;;
+  "-C ${fakeRoot} worktree list --porcelain")
+    echo "worktree ${fakeRoot}" ;;
+  "-C ${fakeRoot} rev-parse --is-shallow-repository")
+    echo "${shallow ? "true" : "false"}" ;;
+  "-C ${fakeRoot} fetch --unshallow origin")
+    exit 0 ;;
+  *)
+    exit 7 ;;
+esac
+`);
+  chmodSync(join(stubDir, "git"), 0o755);
+  return { stubDir, callsFile };
+}
+
+test("local-ci-runner.sh unshallows the root clone before merging when the root is shallow", () => {
+  const { stubDir, callsFile } = stubGitFor(true);
+  const metadataFile = join(stubDir, "metadata.json");
+
+  const result = spawnSync("sh", [runnerScript, "--candidate", "feat/topic"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH}`,
+      DPF_LOCAL_CI_METADATA_FILE: metadataFile,
+    },
+  });
+
+  const calls = readFileSync(callsFile, "utf8");
+  assert.match(calls, /-C .*fake-root rev-parse --is-shallow-repository/);
+  assert.match(calls, /-C .*fake-root fetch --unshallow origin/);
+  assert.match(result.stdout, /root clone is shallow.*BI-AA2201B0/);
+  // Stub git doesn't understand `rev-parse --verify`, so the script dies
+  // resolving the candidate sha next — proving the unshallow step ran
+  // BEFORE any merge attempt, without needing to fake the whole pipeline.
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /candidate ref not found locally/);
+});
+
+test("local-ci-runner.sh skips the unshallow fetch when the root clone is already full", () => {
+  const { stubDir, callsFile } = stubGitFor(false);
+  const metadataFile = join(stubDir, "metadata.json");
+
+  spawnSync("sh", [runnerScript, "--candidate", "feat/topic"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH}`,
+      DPF_LOCAL_CI_METADATA_FILE: metadataFile,
+    },
+  });
+
+  const calls = readFileSync(callsFile, "utf8");
+  assert.match(calls, /-C .*fake-root rev-parse --is-shallow-repository/);
+  assert.doesNotMatch(calls, /fetch --unshallow/);
+});
+
+test("local-ci-runner.sh --dry-run never fetches --unshallow even on a shallow root", () => {
+  const { stubDir, callsFile } = stubGitFor(true);
+  const metadataFile = join(stubDir, "metadata.json");
+
+  const result = spawnSync("sh", [runnerScript, "--dry-run", "--candidate", "feat/topic"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH}`,
+      DPF_LOCAL_CI_METADATA_FILE: metadataFile,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const calls = readFileSync(callsFile, "utf8");
+  assert.doesNotMatch(calls, /fetch --unshallow/);
+});


### PR DESCRIPTION
## Summary
- `scripts/local-ci-runner.sh`'s scratch merge workspace shares the root clone's object store, including `.git/shallow`. A disjoint shallow graft there (e.g. a per-ref depth-limited fetch) makes `git merge --no-ff --no-edit <candidate>` fail with `fatal: refusing to merge unrelated histories` even when the branches share real ancestry on the remote.
- `local-ci-runner.sh` now detects a shallow root before the merge and runs `git fetch --unshallow origin` once, up front, so the merge always has full history to find the true common ancestor. No-op once already full.
- Added `unshallowRootSharedSafe` to `scripts/lib/git-fetch-shared-safe.mjs` (the existing BI-1ADD56FC shallow-state helper module) with unit tests, as the single source of truth for the still-unmerged Node port (`scripts/local-ci-runner.mjs`, BI-2272D840, open PR #3555) to adopt once it lands.
- Also directly unshallowed the live shared root clone (it was carrying a stale July-15 shallow boundary), resolving today's actual blocked `pnpm run pregate` state on top of the defensive script fix.

## Root cause verification
Reproduced the exact mechanism in an isolated sandbox (not the shared root): a clone with a depth=1 fetch of `main` plus a separate depth=1 fetch of a `topic` ref (two disjoint `.git/shallow` grafts) reproduces `fatal: refusing to merge unrelated histories` (exit 128) on `git merge --no-ff --no-edit topic`. `git fetch --unshallow origin` in that same clone removes `.git/shallow` and the merge then succeeds cleanly.

## Test plan
- [x] `node --test scripts/lib/git-fetch-shared-safe.test.mjs` — 9/9 passing, including 3 new `unshallowRootSharedSafe` tests.
- [x] 3 new tests in `tests/release/local-ci-gate-contract.test.mjs` covering shallow→fetches, full→skips, dry-run→skips. Note: this whole test file currently fails to spawn `sh` on this native-Windows dev host (`new URL(...).pathname` yields a `/D:/...` path Git-Bash's `sh` can't resolve) — pre-existing and unrelated to this change (confirmed via `git stash`); unaffected on the `ubuntu-latest` CI runner. Verified the new logic correctness via direct black-box execution of the real script against a controlled `git` stub instead.
- [x] Real, non-stub `pnpm run pregate` (`sh scripts/local-ci-runner.sh --candidate claude/fervent-burnell-a4521a`) run end-to-end after the fix: cleared the merge step (`git merge --no-ff --no-edit claude/fervent-burnell-a4521a`, no unrelated-histories failure) and continued through sandbox-freshness, prisma generate, tests, typecheck, and the production build.
- [x] `git fetch --unshallow origin` verified against the live shared root clone: `git -C D:\DPF rev-parse --is-shallow-repository` now `false`, full history (5784 commits) present.
- [x] `node scripts/check-guards.mjs` — unaffected by this change (one pre-existing, unrelated failure confirmed present before this change too).

Filed as [BI-AA2201B0](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory) via the DPF backlog MCP; body updated with full implementation notes and the `local-ci-runner.mjs` follow-up (deferred — that file doesn't exist on `main` yet, only on open PR #3555).

🤖 Generated with [Claude Code](https://claude.com/claude-code)