### PR TITLE
fix(build): prevent wildcard token CSS generation

### DIFF
--- a/apps/web/lib/build/ui-quality-checks.test.ts
+++ b/apps/web/lib/build/ui-quality-checks.test.ts
@@ -1,7 +1,15 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import { scanUiSource, formatUiQualityReport } from "./ui-quality-checks";
 
 describe("scanUiSource — design tokens", () => {
+  it("does not expose a wildcard arbitrary-value utility to Tailwind's content scanner", () => {
+    const source = readFileSync(new URL("./ui-quality-checks.ts", import.meta.url), "utf8");
+    const wildcardUtility = ["bg-[", "var(--dpf-*", ")]"].join("");
+
+    expect(source).not.toContain(wildcardUtility);
+  });
+
   it("flags a hardcoded hex on platform UI as critical", () => {
     const r = scanUiSource(`<div style={{ color: "#4ade80" }}>hi</div>`);
     expect(r.findings.some((f) => f.rule === "hardcoded-hex" && f.severity === "critical")).toBe(true);

--- a/apps/web/lib/build/ui-quality-checks.ts
+++ b/apps/web/lib/build/ui-quality-checks.ts
@@ -82,7 +82,7 @@ export function scanUiSource(source: string, opts?: { isPlatformUi?: boolean }):
         findings.push({ severity: colorSeverity, rule: "hardcoded-hex", description: "Hardcoded hex color — use a var(--dpf-*) token.", line: lineNo, snippet: line.trim().slice(0, 120) });
       }
       if (TW_COLOR_RE.test(line)) {
-        findings.push({ severity: colorSeverity, rule: "tailwind-color-class", description: "Tailwind color-shade class — use a var(--dpf-*) token via bg-[var(--dpf-*)].", line: lineNo, snippet: line.trim().slice(0, 120) });
+        findings.push({ severity: colorSeverity, rule: "tailwind-color-class", description: "Tailwind color-shade class — use an arbitrary-value utility backed by a concrete DPF design token.", line: lineNo, snippet: line.trim().slice(0, 120) });
       }
       if (!usesToken && RGB_RE.test(line)) {
         findings.push({ severity: colorSeverity, rule: "inline-rgb", description: "Inline rgb/hsl color literal — use a var(--dpf-*) token.", line: lineNo, snippet: line.trim().slice(0, 120) });


### PR DESCRIPTION
## Summary
- remove the Tailwind-extractable wildcard utility example from UI-quality guidance
- add a regression guard that keeps the dangerous candidate out of the scanned source
- restore Contributor preview compilation for unrelated UI verification work

## Evidence
- focused unit test: `ui-quality-checks.test.ts` — 16/16 passed
- exact-SHA merged-code pregate passed at `18100767b725388f0932e722223f6aded2e0d4a7`
- full web tests, typecheck, production build, guard loop, and migration deploy passed in the governed sandbox
- local pre-commit typecheck was skipped only because the host is running unsupported Node 26 and crashed before diagnostics; the supported sandbox typecheck passed

## Documentation impact
No user, operator, architecture, setup, or external-agent documentation changes are needed. This corrects an implementation string and adds a source regression test; the existing design-token guidance remains semantically unchanged.

Backlog: BI-B9F78F47
Local-CI-Evidence: cmrzqflet0bf501pgwob95fsb