### PR TITLE
feat(federation): add no-shell organization join workflow

### DIFF
--- a/apps/web/app/(shell)/platform/federation-links/page.tsx
+++ b/apps/web/app/(shell)/platform/federation-links/page.tsx
@@ -19,6 +19,8 @@ import {
   PartnerBusinessPanel,
   type PartnerBusinessRow,
 } from "@/components/platform/federation-links/PartnerBusinessPanel";
+import { OrganizationJoinPanel } from "@/components/platform/federation-links/OrganizationJoinPanel";
+import { getOrganizationJoinNodeSummariesAction } from "@/lib/actions/organization-join";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +39,7 @@ export default async function FederationLinksPage() {
     redirect("/403");
   }
 
-  const [links, discoveryCapabilities, partnerAccounts, nearbyPairingSessions] = await Promise.all([
+  const [links, discoveryCapabilities, partnerAccounts, nearbyPairingSessions, organizationJoinNodes] = await Promise.all([
     prisma.federationLink.findMany({
       include: { principal: { select: { displayName: true } } },
       orderBy: { createdAt: "desc" },
@@ -70,6 +72,7 @@ export default async function FederationLinksPage() {
       orderBy: { requestedAt: "desc" },
       take: 20,
     }),
+    getOrganizationJoinNodeSummariesAction(),
   ]);
 
   const enabledDiscovery = discoveryCapabilities.filter(
@@ -176,6 +179,7 @@ export default async function FederationLinksPage() {
           both sides approve; either side can pause or revoke the connection.
         </p>
       </div>
+      <OrganizationJoinPanel nodes={organizationJoinNodes.ok ? organizationJoinNodes.nodes : []} />
       <FederationLinksAdminClient
         rows={rows}
         nearbyCandidates={listNearbyFederationCandidates()}

--- a/apps/web/components/platform/federation-links/OrganizationJoinPanel.test.tsx
+++ b/apps/web/components/platform/federation-links/OrganizationJoinPanel.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockAuthorize,
+  mockCancel,
+  mockConfirm,
+  mockDownload,
+  mockQueue,
+  mockStatus,
+} = vi.hoisted(() => ({
+  mockAuthorize: vi.fn(),
+  mockCancel: vi.fn(),
+  mockConfirm: vi.fn(),
+  mockDownload: vi.fn(),
+  mockQueue: vi.fn(),
+  mockStatus: vi.fn(),
+}));
+
+vi.mock("@/components/ui/Dialog", () => ({ confirmDialog: mockConfirm }));
+vi.mock("@/lib/actions/organization-join", () => ({
+  authorizeOrganizationJoinNodeAction: mockAuthorize,
+  cancelOrganizationJoinActionAction: mockCancel,
+  downloadIssuedJoinPackageAction: mockDownload,
+  getOrganizationJoinActionStatusAction: mockStatus,
+  queueOrganizationJoinActionAction: mockQueue,
+}));
+
+import { OrganizationJoinPanel } from "./OrganizationJoinPanel";
+import type { OrganizationJoinNodeSummary } from "@/lib/actions/organization-join";
+
+const authority: OrganizationJoinNodeSummary = {
+  edgeNodeId: "edge-authority",
+  nodeId: "edge-1",
+  displayName: "Founder Hub Mac",
+  platform: "darwin",
+  status: "active",
+  trustState: "trusted",
+  role: "authority",
+  actionType: "organization.join.issue",
+  hostIdentity: "founder-hub.local",
+  ready: true,
+  readinessMessage: "Secure host action channel ready",
+  latestAction: null,
+};
+
+const member: OrganizationJoinNodeSummary = {
+  edgeNodeId: "edge-member",
+  nodeId: "edge-2",
+  displayName: "Windows test installation",
+  platform: "win32",
+  status: "active",
+  trustState: "trusted",
+  role: "member",
+  actionType: "organization.join.import",
+  hostIdentity: "windows-dev.local",
+  ready: true,
+  readinessMessage: "Secure host action channel ready",
+  latestAction: null,
+};
+
+function joinPackage(expiresAt = new Date(Date.now() + 10 * 60_000), peer = member.hostIdentity!) {
+  return [
+    "DPF_ORGANIZATION_JOIN_V2",
+    "package_id=0123456789abcdef0123456789abcdef",
+    "ca_url=https://founder-hub.local:9000",
+    `root_fingerprint=${"A".repeat(64)}`,
+    `intended_hostname=${peer}`,
+    `intended_sans=${peer}`,
+    `expires_at=${Math.floor(expiresAt.getTime() / 1000)}`,
+    "enrollment_token=must-never-render",
+    "edge_client_enrollment_token=must-never-render-either",
+    "",
+  ].join("\n");
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockConfirm.mockResolvedValue(true);
+  mockAuthorize.mockResolvedValue({ ok: true });
+  mockQueue.mockResolvedValue({ ok: true, actionKey: "ra-join-1" });
+  mockStatus.mockResolvedValue({
+    ok: true,
+    actionKey: "ra-join-1",
+    actionType: "organization.join.issue",
+    status: "queued",
+    approvalState: "approved",
+    packageReady: false,
+    evidence: {},
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("OrganizationJoinPanel", () => {
+  it("presents the no-command workflow before technical detail", () => {
+    render(<OrganizationJoinPanel nodes={[authority, member]} />);
+
+    expect(screen.getByRole("heading", { name: "Connect your own installations" })).toBeTruthy();
+    expect(screen.getByText(/No commands, certificate copying, or CA password handling/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create join file" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Join this installation" })).toBeTruthy();
+    expect(screen.getByText(/does not share backlog data/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
+    expect(screen.getByRole("button", { name: "Back to choices" }).className).toContain("min-h-11");
+  });
+
+  it("explicitly enables only the named host action after confirmation", async () => {
+    render(<OrganizationJoinPanel nodes={[{ ...member, ready: false, readinessMessage: "Allow the organization setup action for this installation" }]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Enable secure setup" }));
+
+    await waitFor(() => expect(mockAuthorize).toHaveBeenCalledWith({
+      edgeNodeId: "edge-member",
+      actionType: "organization.join.import",
+      operatorConfirmed: true,
+    }));
+  });
+
+  it("queues a short-lived authority issue only after local confirmation", async () => {
+    render(<OrganizationJoinPanel nodes={[authority]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
+    fireEvent.change(screen.getByLabelText(/^Installation name/), { target: { value: "windows-dev.local" } });
+    fireEvent.change(screen.getByLabelText(/^Join file expiry/), { target: { value: "600" } });
+    fireEvent.click(screen.getByLabelText(/I confirm this file is for windows-dev.local/));
+    fireEvent.click(screen.getByRole("button", { name: "Create one-time file" }));
+
+    await waitFor(() => expect(mockQueue).toHaveBeenCalledWith({
+      actionType: "organization.join.issue",
+      edgeNodeId: "edge-authority",
+      parameters: { intendedPeer: "windows-dev.local", ttlSeconds: 600 },
+      operatorConfirmed: true,
+    }));
+  });
+
+  it("previews a valid file without rendering either enrollment token", async () => {
+    render(<OrganizationJoinPanel nodes={[member]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
+    const file = new File([joinPackage()], "founder-hub-to-windows.dpfjoin", { type: "application/octet-stream" });
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [file] } });
+
+    expect(await screen.findByText("founder-hub.local:9000")).toBeTruthy();
+    expect(screen.getByText("windows-dev.local")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("must-never-render");
+    expect(screen.getByRole("button", { name: "Join organization" }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("rejects an expired or wrong-installation file before approval", async () => {
+    render(<OrganizationJoinPanel nodes={[member]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Join this installation" }));
+    const file = new File([joinPackage(new Date(Date.now() + 10 * 60_000), "another-host.local")], "wrong.dpfjoin");
+    fireEvent.change(screen.getByLabelText(/^Choose a \.dpfjoin file/), { target: { files: [file] } });
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(/created for another installation/i);
+    expect(mockQueue).not.toHaveBeenCalled();
+  });
+
+  it("resumes a queued action from server state after refresh", () => {
+    render(<OrganizationJoinPanel nodes={[{
+      ...authority,
+      latestAction: {
+        actionKey: "ra-resume",
+        actionType: "organization.join.issue",
+        status: "queued",
+        approvalState: "approved",
+        packageReady: false,
+        evidence: { intendedPeer: "windows-dev.local" },
+        createdAt: new Date().toISOString(),
+      },
+    }]} />);
+
+    expect(screen.getByText("Approved and waiting for Founder Hub Mac")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel request" })).toBeTruthy();
+  });
+
+  it("offers a fresh request after a failed host action", () => {
+    render(<OrganizationJoinPanel nodes={[{
+      ...authority,
+      latestAction: {
+        actionKey: "ra-failed",
+        actionType: "organization.join.issue",
+        status: "failed",
+        approvalState: "approved",
+        packageReady: false,
+        evidence: { errorCode: "portal-health-failed" },
+        createdAt: new Date().toISOString(),
+      },
+    }]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create join file" }));
+    expect(screen.getByLabelText(/^Installation name/)).toBeTruthy();
+    expect(screen.getByText(/restored its previous settings/i)).toBeTruthy();
+  });
+});

--- a/apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
+++ b/apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import { parseOrganizationJoinPackage, type OrganizationJoinActionType, type OrganizationJoinPackagePreview } from "@dpf/db/organization-join-action";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import { confirmDialog } from "@/components/ui/Dialog";
+import { InlineBusy } from "@/components/ui/InlineBusy";
+import {
+  CheckboxField,
+  FormField,
+  FormStatus,
+  SelectField,
+  SubmitButton,
+  TextField,
+} from "@/components/ui/form";
+import {
+  authorizeOrganizationJoinNodeAction,
+  cancelOrganizationJoinActionAction,
+  downloadIssuedJoinPackageAction,
+  getOrganizationJoinActionStatusAction,
+  queueOrganizationJoinActionAction,
+  type OrganizationJoinNodeSummary,
+} from "@/lib/actions/organization-join";
+
+type PanelMode = "overview" | "issue" | "import";
+type Notice = { kind: "success" | "error"; text: string } | null;
+type ActionState = NonNullable<OrganizationJoinNodeSummary["latestAction"]>;
+
+const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed-out"]);
+
+function blocksNewRequest(action: ActionState | undefined): boolean {
+  if (!action) return false;
+  if (!TERMINAL_STATUSES.has(action.status)) return true;
+  if (action.status !== "succeeded") return false;
+  return action.actionType === "organization.join.import" || action.packageReady;
+}
+
+function safeEvidenceText(evidence: Record<string, unknown>, key: string): string | null {
+  return typeof evidence[key] === "string" ? evidence[key] : null;
+}
+
+function recoveryMessage(evidence: Record<string, unknown>): string {
+  switch (safeEvidenceText(evidence, "errorCode")) {
+    case "join-package-expired":
+      return "The join file expired. Create a new file on the organization installation.";
+    case "join-package-intended-for-another-host":
+      return "The join file was created for another installation.";
+    case "portal-health-failed":
+      return "The installation restored its previous settings because the portal health check failed.";
+    case "edge-heartbeat-failed":
+      return "The installation restored its previous settings because its secure host connection did not recover.";
+    default:
+      return "Secure setup did not finish. Review the technical details, then try again with a new join file.";
+  }
+}
+
+function ActionProgress({
+  action,
+  node,
+  busy,
+  onCancel,
+  onDownload,
+}: {
+  action: ActionState;
+  node: OrganizationJoinNodeSummary;
+  busy: boolean;
+  onCancel: () => void;
+  onDownload: () => void;
+}) {
+  const verification = [
+    ["certificateTrust", "Certificate trust"],
+    ["overlayPersistence", "Saved organization settings"],
+    ["portalHealth", "Portal health"],
+    ["edgeHeartbeat", "Secure host connection"],
+  ] as const;
+
+  let message = `Secure setup status: ${action.status}.`;
+  if (action.status === "queued") message = `Approved and waiting for ${node.displayName}`;
+  if (action.status === "claimed" || action.status === "running") message = `${node.displayName} is applying and checking the secure setup.`;
+  if (action.status === "succeeded" && action.actionType === "organization.join.issue") {
+    message = action.packageReady ? "The one-time join file is ready to download." : "The join file has already been downloaded or expired.";
+  }
+  if (action.status === "succeeded" && action.actionType === "organization.join.import") {
+    message = "This installation joined the organization and passed its local checks.";
+  }
+  if (action.status === "failed" || action.status === "timed-out") message = recoveryMessage(action.evidence);
+  if (action.status === "cancelled") message = "The secure setup request was cancelled before it started.";
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4" aria-live="polite">
+      <p className="text-sm font-medium text-[var(--dpf-text)]">{message}</p>
+      {action.status === "succeeded" && action.actionType === "organization.join.import" ? (
+        <ul className="mt-3 grid gap-1 text-sm text-[var(--dpf-muted)] sm:grid-cols-2">
+          {verification.map(([key, label]) => (
+            <li key={key}>{action.evidence[key] === true ? "Passed" : "Not confirmed"}: {label}</li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {action.status === "queued" ? (
+          <button type="button" className="rounded-md border border-[var(--dpf-border)] px-3 py-2 text-sm text-[var(--dpf-text)]" disabled={busy} onClick={onCancel}>
+            {busy ? <InlineBusy label="Cancelling…" /> : "Cancel request"}
+          </button>
+        ) : null}
+        {action.status === "succeeded" && action.actionType === "organization.join.issue" && action.packageReady ? (
+          <button type="button" className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-[var(--dpf-bg)]" disabled={busy} onClick={onDownload}>
+            {busy ? <InlineBusy label="Preparing file…" tone="current" /> : "Download join file"}
+          </button>
+        ) : null}
+      </div>
+      <details className="mt-3 text-sm text-[var(--dpf-muted)]">
+        <summary className="cursor-pointer text-[var(--dpf-accent)]">Technical details</summary>
+        <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 break-all">
+          <dt>Installation</dt><dd>{node.nodeId}</dd>
+          <dt>Request</dt><dd>{action.actionKey}</dd>
+          <dt>Status</dt><dd>{action.status}</dd>
+          {safeEvidenceText(action.evidence, "errorCode") ? <><dt>Error code</dt><dd>{safeEvidenceText(action.evidence, "errorCode")}</dd></> : null}
+        </dl>
+      </details>
+    </div>
+  );
+}
+
+export function OrganizationJoinPanel({ nodes }: { nodes: OrganizationJoinNodeSummary[] }) {
+  const [mode, setMode] = useState<PanelMode>("overview");
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [intendedPeer, setIntendedPeer] = useState("");
+  const [ttlSeconds, setTtlSeconds] = useState(600);
+  const [issueConfirmed, setIssueConfirmed] = useState(false);
+  const [joinPackage, setJoinPackage] = useState<string | null>(null);
+  const [packagePreview, setPackagePreview] = useState<OrganizationJoinPackagePreview | null>(null);
+  const [importConfirmed, setImportConfirmed] = useState(false);
+  const [notice, setNotice] = useState<Notice>(null);
+  const [actions, setActions] = useState<Record<string, ActionState>>(() => Object.fromEntries(
+    nodes.flatMap((node) => node.latestAction ? [[node.edgeNodeId, node.latestAction]] : []),
+  ));
+  const [isPending, startTransition] = useTransition();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const authorityNodes = useMemo(() => nodes.filter((node) => node.role === "authority"), [nodes]);
+  const memberNodes = useMemo(() => nodes.filter((node) => node.role === "member"), [nodes]);
+  const selectedNode = nodes.find((node) => node.edgeNodeId === selectedNodeId) ?? null;
+
+  useEffect(() => {
+    const active = Object.entries(actions).find(([, action]) => !TERMINAL_STATUSES.has(action.status));
+    if (!active) return;
+    const [edgeNodeId, action] = active;
+    const timer = window.setTimeout(() => {
+      void getOrganizationJoinActionStatusAction(action.actionKey).then((result) => {
+        if (!result.ok) {
+          setNotice({ kind: "error", text: result.message });
+          return;
+        }
+        setActions((current) => ({
+          ...current,
+          [edgeNodeId]: {
+            ...action,
+            actionType: result.actionType as OrganizationJoinActionType,
+            status: result.status,
+            approvalState: result.approvalState,
+            packageReady: result.packageReady,
+            evidence: result.evidence,
+          },
+        }));
+      });
+    }, 2_500);
+    return () => window.clearTimeout(timer);
+  }, [actions]);
+
+  function openMode(nextMode: "issue" | "import") {
+    const candidates = nextMode === "issue" ? authorityNodes : memberNodes;
+    setMode(nextMode);
+    setSelectedNodeId(candidates[0]?.edgeNodeId ?? null);
+    setNotice(null);
+  }
+
+  async function authorize(node: OrganizationJoinNodeSummary) {
+    if (!node.actionType) {
+      setNotice({ kind: "error", text: node.readinessMessage });
+      return;
+    }
+    const confirmed = await confirmDialog({
+      title: "Enable secure setup",
+      message: `Allow only the ${node.actionType === "organization.join.issue" ? "join-file creation" : "organization join"} action on ${node.displayName}?`,
+      confirmLabel: "Enable secure setup",
+    });
+    if (!confirmed) return;
+    startTransition(async () => {
+      const result = await authorizeOrganizationJoinNodeAction({
+        edgeNodeId: node.edgeNodeId,
+        actionType: node.actionType!,
+        operatorConfirmed: true,
+      });
+      setNotice(result.ok
+        ? { kind: "success", text: `Secure setup enabled for ${node.displayName}. Refresh this page to continue.` }
+        : { kind: "error", text: result.message });
+    });
+  }
+
+  function queueIssue() {
+    if (!selectedNode || !issueConfirmed || !intendedPeer.trim()) return;
+    startTransition(async () => {
+      const result = await queueOrganizationJoinActionAction({
+        actionType: "organization.join.issue",
+        edgeNodeId: selectedNode.edgeNodeId,
+        parameters: { intendedPeer: intendedPeer.trim(), ttlSeconds },
+        operatorConfirmed: true,
+      });
+      if (!result.ok) {
+        setNotice({ kind: "error", text: result.message });
+        return;
+      }
+      setActions((current) => ({
+        ...current,
+        [selectedNode.edgeNodeId]: {
+          actionKey: result.actionKey,
+          actionType: "organization.join.issue",
+          status: "queued",
+          approvalState: "approved",
+          packageReady: false,
+          evidence: { intendedPeer: intendedPeer.trim() },
+          createdAt: new Date().toISOString(),
+        },
+      }));
+      setNotice({ kind: "success", text: "Join file request approved. The installation will create it shortly." });
+    });
+  }
+
+  async function readJoinFile(file: File | undefined) {
+    setNotice(null);
+    setJoinPackage(null);
+    setPackagePreview(null);
+    setImportConfirmed(false);
+    if (!file) return;
+    if (file.size > 64 * 1024) {
+      setNotice({ kind: "error", text: "This join file is larger than DPF allows." });
+      return;
+    }
+    const raw = await file.text();
+    const parsed = parseOrganizationJoinPackage(raw);
+    if (!parsed.ok) {
+      setNotice({ kind: "error", text: parsed.reason === "join-package-expired" ? "This join file has expired. Create a new one." : "This is not a valid DPF organization join file." });
+      return;
+    }
+    if (!selectedNode?.hostIdentity || parsed.value.intendedPeer !== selectedNode.hostIdentity) {
+      setNotice({ kind: "error", text: "This join file was created for another installation." });
+      return;
+    }
+    setJoinPackage(raw);
+    setPackagePreview(parsed.value);
+  }
+
+  function queueImport() {
+    if (!selectedNode || !joinPackage || !importConfirmed) return;
+    startTransition(async () => {
+      const result = await queueOrganizationJoinActionAction({
+        actionType: "organization.join.import",
+        edgeNodeId: selectedNode.edgeNodeId,
+        parameters: { joinPackage },
+        operatorConfirmed: true,
+      });
+      setJoinPackage(null);
+      setPackagePreview(null);
+      setImportConfirmed(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      if (!result.ok) {
+        setNotice({ kind: "error", text: result.message });
+        return;
+      }
+      setActions((current) => ({
+        ...current,
+        [selectedNode.edgeNodeId]: {
+          actionKey: result.actionKey,
+          actionType: "organization.join.import",
+          status: "queued",
+          approvalState: "approved",
+          packageReady: false,
+          evidence: {},
+          createdAt: new Date().toISOString(),
+        },
+      }));
+      setNotice({ kind: "success", text: "Organization join approved. The installation will apply and verify it shortly." });
+    });
+  }
+
+  function cancel(node: OrganizationJoinNodeSummary, action: ActionState) {
+    startTransition(async () => {
+      const result = await cancelOrganizationJoinActionAction(action.actionKey);
+      if (!result.ok) setNotice({ kind: "error", text: result.message });
+      else setActions((current) => ({ ...current, [node.edgeNodeId]: { ...action, status: "cancelled" } }));
+    });
+  }
+
+  function download(node: OrganizationJoinNodeSummary, action: ActionState) {
+    startTransition(async () => {
+      const result = await downloadIssuedJoinPackageAction(action.actionKey);
+      if (!result.ok) {
+        setNotice({ kind: "error", text: result.message });
+        return;
+      }
+      const url = URL.createObjectURL(new Blob([result.content], { type: "application/octet-stream" }));
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = result.fileName;
+      link.click();
+      URL.revokeObjectURL(url);
+      setActions((current) => ({ ...current, [node.edgeNodeId]: { ...action, packageReady: false } }));
+      setNotice({ kind: "success", text: "Join file downloaded once. Move it to the installation that will join." });
+    });
+  }
+
+  const visibleNodes = mode === "issue" ? authorityNodes : mode === "import" ? memberNodes : nodes;
+
+  return (
+    <section className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5" aria-labelledby="organization-join-heading">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 id="organization-join-heading" className="text-lg font-semibold text-[var(--dpf-text)]">Connect your own installations</h2>
+          <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
+            Create a short-lived file on your organization installation, then choose it on the installation joining your organization. No commands, certificate copying, or CA password handling.
+          </p>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            This establishes machine trust. It does not share backlog data; sharing is chosen and approved separately in Delivery Flow.
+          </p>
+        </div>
+        {mode !== "overview" ? (
+          <button type="button" className="min-h-11 rounded-md px-3 text-sm text-[var(--dpf-accent)]" onClick={() => setMode("overview")}>Back to choices</button>
+        ) : null}
+      </div>
+
+      {notice && mode === "overview" ? (
+        <FormStatus
+          error={notice.kind === "error" ? notice.text : null}
+          success={notice.kind === "success" ? notice.text : null}
+          className="mt-4 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+        />
+      ) : null}
+
+      {mode === "overview" ? (
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          <button type="button" aria-label="Create join file" className="rounded-lg border border-[var(--dpf-border)] p-4 text-left hover:border-[var(--dpf-accent)]" onClick={() => openMode("issue")}>
+            <span className="block font-medium text-[var(--dpf-text)]">Create join file</span>
+            <span className="mt-1 block text-sm text-[var(--dpf-muted)]">Use your organization installation to create a one-time file for another installation.</span>
+          </button>
+          <button type="button" aria-label="Join this installation" className="rounded-lg border border-[var(--dpf-border)] p-4 text-left hover:border-[var(--dpf-accent)]" onClick={() => openMode("import")}>
+            <span className="block font-medium text-[var(--dpf-text)]">Join this installation</span>
+            <span className="mt-1 block text-sm text-[var(--dpf-muted)]">Choose the one-time file on the installation that will join your organization.</span>
+          </button>
+        </div>
+      ) : null}
+
+      {mode === "overview" ? nodes.filter((node) => !node.ready).map((node) => (
+        <div key={node.edgeNodeId} className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+          <p className="text-sm font-medium text-[var(--dpf-text)]">{node.displayName}</p>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">{node.readinessMessage}</p>
+          {node.trustState === "trusted" && node.actionType ? (
+            <button type="button" className="mt-3 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-[var(--dpf-bg)]" disabled={isPending} onClick={() => void authorize(node)}>
+              {isPending ? <InlineBusy label="Enabling…" tone="current" /> : "Enable secure setup"}
+            </button>
+          ) : null}
+        </div>
+      )) : null}
+
+      {mode !== "overview" ? (
+        <div className="mt-5 space-y-4">
+          {visibleNodes.length > 1 ? (
+            <SelectField
+              name="organization-join-installation"
+              label="Installation"
+              value={selectedNodeId ?? ""}
+              onValueChange={setSelectedNodeId}
+              options={visibleNodes.map((node) => ({ value: node.edgeNodeId, label: node.displayName }))}
+              required
+            />
+          ) : null}
+          {!selectedNode ? <p className="text-sm text-[var(--dpf-muted)]">No installation has reported the required organization role yet.</p> : null}
+          {selectedNode && !selectedNode.ready ? (
+            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+              <p className="text-sm text-[var(--dpf-text)]">{selectedNode.readinessMessage}</p>
+              {selectedNode.trustState === "trusted" && selectedNode.actionType ? (
+                <button type="button" className="mt-3 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-sm font-medium text-[var(--dpf-bg)]" disabled={isPending} onClick={() => void authorize(selectedNode)}>
+                  {isPending ? <InlineBusy label="Enabling…" tone="current" /> : "Enable secure setup"}
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {selectedNode && actions[selectedNode.edgeNodeId] ? (
+            <ActionProgress action={actions[selectedNode.edgeNodeId]} node={selectedNode} busy={isPending} onCancel={() => cancel(selectedNode, actions[selectedNode.edgeNodeId])} onDownload={() => download(selectedNode, actions[selectedNode.edgeNodeId])} />
+          ) : null}
+
+          {mode === "issue" && selectedNode?.ready && !blocksNewRequest(actions[selectedNode.edgeNodeId]) ? (
+            <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); queueIssue(); }}>
+              <TextField
+                name="intended-installation"
+                label="Installation name"
+                required
+                autoComplete="off"
+                value={intendedPeer}
+                onValueChange={(value) => {
+                  setIntendedPeer(value);
+                  setIssueConfirmed(false);
+                }}
+                placeholder="windows-office.local"
+              />
+              <SelectField
+                name="join-file-expiry"
+                label="Join file expiry"
+                required
+                value={String(ttlSeconds)}
+                onValueChange={(value) => setTtlSeconds(Number(value))}
+                options={[
+                  { value: "300", label: "5 minutes" },
+                  { value: "600", label: "10 minutes" },
+                  { value: "900", label: "15 minutes" },
+                ]}
+              />
+              {intendedPeer.trim() ? (
+                <CheckboxField
+                  name="confirm-intended-installation"
+                  label={<>I confirm this file is for {intendedPeer.trim()}</>}
+                  checked={issueConfirmed}
+                  onCheckedChange={setIssueConfirmed}
+                />
+              ) : null}
+              <div className="flex flex-wrap items-center gap-3">
+                <SubmitButton
+                  pending={isPending}
+                  pendingLabel="Creating…"
+                  disabled={!issueConfirmed || !intendedPeer.trim()}
+                  data-dpf-primary-action
+                >
+                  Create one-time file
+                </SubmitButton>
+                <FormStatus
+                  error={notice?.kind === "error" ? notice.text : null}
+                  success={notice?.kind === "success" ? notice.text : null}
+                />
+              </div>
+            </form>
+          ) : null}
+
+          {mode === "import" && selectedNode?.ready && !blocksNewRequest(actions[selectedNode.edgeNodeId]) ? (
+            <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); queueImport(); }}>
+              <FormField name="organization-join-file" label="Choose a .dpfjoin file" required>
+                {(control) => (
+                  <input
+                    {...control}
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".dpfjoin,application/octet-stream"
+                    className="block w-full text-sm text-[var(--dpf-muted)]"
+                    onChange={(event) => void readJoinFile(event.target.files?.[0])}
+                  />
+                )}
+              </FormField>
+              {packagePreview ? (
+                <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4 text-sm text-[var(--dpf-text)]">
+                  <p className="font-medium">Join file preview</p>
+                  <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 break-all text-[var(--dpf-muted)]">
+                    <dt>Organization host</dt><dd>{new URL(packagePreview.caUrl).host}</dd>
+                    <dt>For installation</dt><dd>{packagePreview.intendedPeer}</dd>
+                    <dt>Expires</dt><dd>{packagePreview.expiresAt.toLocaleString()}</dd>
+                    <dt>Trust fingerprint</dt><dd>{packagePreview.rootFingerprint.slice(0, 12)}…</dd>
+                  </dl>
+                </div>
+              ) : null}
+              {packagePreview ? (
+                <CheckboxField
+                  name="confirm-organization-join"
+                  label={<>I confirm this file is for {selectedNode.hostIdentity} and I want this installation to join that organization.</>}
+                  checked={importConfirmed}
+                  onCheckedChange={setImportConfirmed}
+                />
+              ) : null}
+              <div className="flex flex-wrap items-center gap-3">
+                <SubmitButton
+                  pending={isPending}
+                  pendingLabel="Joining…"
+                  disabled={!packagePreview || !importConfirmed}
+                  data-dpf-primary-action
+                >
+                  Join organization
+                </SubmitButton>
+                <FormStatus
+                  error={notice?.kind === "error" ? notice.text : null}
+                  success={notice?.kind === "success" ? notice.text : null}
+                />
+              </div>
+            </form>
+          ) : null}
+        </div>
+      ) : null}
+
+      {mode === "overview" ? nodes.flatMap((node) => actions[node.edgeNodeId] ? [
+        <div key={node.edgeNodeId} className="mt-4"><ActionProgress action={actions[node.edgeNodeId]} node={node} busy={isPending} onCancel={() => cancel(node, actions[node.edgeNodeId])} onDownload={() => download(node, actions[node.edgeNodeId])} /></div>,
+      ] : []) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/actions/organization-join.test.ts
+++ b/apps/web/lib/actions/organization-join.test.ts
@@ -28,8 +28,9 @@ const {
     mockPrisma: {
       principalAlias: { findFirst: vi.fn() },
       employeeProfile: { findUnique: vi.fn() },
-      edgeNode: { findMany: vi.fn() },
-      remoteAction: { findUnique: vi.fn() },
+      edgeNode: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+      edgeNodeCapability: { update: vi.fn() },
+      remoteAction: { findMany: vi.fn(), findUnique: vi.fn() },
       $transaction: vi.fn(async (callback: (client: typeof transactionClient) => unknown) => callback(transactionClient)),
     },
   };
@@ -51,6 +52,7 @@ vi.mock("@/lib/remote-action/organization-join-actions", () => ({
 }));
 
 import {
+  authorizeOrganizationJoinNodeAction,
   getOrganizationJoinActionStatusAction,
   getOrganizationJoinNodeSummariesAction,
   queueOrganizationJoinActionAction,
@@ -64,6 +66,7 @@ beforeEach(() => {
   mockCan.mockReturnValue(true);
   mockPrisma.principalAlias.findFirst.mockResolvedValue({ principalId: "principal-1" });
   mockPrisma.employeeProfile.findUnique.mockResolvedValue({ id: "employee-1" });
+  mockPrisma.remoteAction.findMany.mockResolvedValue([]);
   tx.changeRequest.create.mockResolvedValue({ id: "change-1" });
   mockCreateAction.mockResolvedValue({ ok: true, actionKey: "ra-join-1" });
   mockPrisma.$transaction.mockImplementation(async (callback) => callback(tx));
@@ -110,6 +113,89 @@ describe("organization join action boundary", () => {
       expect(result.nodes[0]).toMatchObject({ displayName: "Founder Hub", actionType: "organization.join.issue", ready: true });
       expect(result.nodes[1]).toMatchObject({ displayName: "Windows test", actionType: "organization.join.import", ready: false });
     }
+  });
+
+  it("returns the safe latest action so progress survives a page refresh", async () => {
+    mockPrisma.edgeNode.findMany.mockResolvedValue([{
+      id: "edge-row-1",
+      nodeId: "edge-1",
+      platform: "darwin",
+      status: "online",
+      trustState: "trusted",
+      metadata: { hostname: "founder-hub.local" },
+      scopePolicy: { actionTypes: ["organization.join.issue"] },
+      principal: { displayName: "Founder Hub" },
+      capabilityRows: [{ mode: "enabled", status: "healthy", evidence: { organizationTrustRole: "authority" } }],
+    }]);
+    mockPrisma.remoteAction.findMany.mockResolvedValue([{
+      actionKey: "ra-join-1",
+      actionType: "organization.join.issue",
+      edgeNodeId: "edge-row-1",
+      status: "succeeded",
+      approvalState: "approved",
+      result: { joinPackageEnc: "enc:must-not-escape" },
+      evidence: { intendedPeer: "windows-dev.local", enrollmentToken: "must-not-escape" },
+      createdAt: new Date("2026-07-22T10:00:00Z"),
+    }]);
+
+    const result = await getOrganizationJoinNodeSummariesAction();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.nodes[0]).toMatchObject({
+        hostIdentity: "founder-hub.local",
+        latestAction: {
+          actionKey: "ra-join-1",
+          status: "succeeded",
+          packageReady: true,
+          evidence: { intendedPeer: "windows-dev.local" },
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain("must-not-escape");
+    }
+  });
+
+  it("explicitly authorizes only the role-correct action on the named installation", async () => {
+    mockPrisma.edgeNode.findUnique.mockResolvedValue({
+      id: "edge-row-2",
+      trustState: "trusted",
+      scopePolicy: { actionTypes: ["inventory.collect"] },
+      capabilityRows: [{ id: "cap-1", evidence: { organizationTrustRole: "member" } }],
+    });
+    mockPrisma.edgeNode.update.mockResolvedValue({});
+    mockPrisma.edgeNodeCapability.update.mockResolvedValue({});
+    mockPrisma.$transaction.mockResolvedValue([]);
+
+    const result = await authorizeOrganizationJoinNodeAction({
+      edgeNodeId: "edge-row-2",
+      actionType: "organization.join.import",
+      operatorConfirmed: true,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockPrisma.edgeNode.update).toHaveBeenCalledWith({
+      where: { id: "edge-row-2" },
+      data: { scopePolicy: { actionTypes: ["inventory.collect", "organization.join.import"] } },
+    });
+    expect(mockPrisma.edgeNodeCapability.update).toHaveBeenCalledWith({
+      where: { id: "cap-1" },
+      data: { mode: "enabled" },
+    });
+  });
+
+  it("does not authorize a host action without explicit confirmation", async () => {
+    const result = await authorizeOrganizationJoinNodeAction({
+      edgeNodeId: "edge-row-2",
+      actionType: "organization.join.import",
+      operatorConfirmed: false,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "invalid_input",
+      message: "Confirm this installation before enabling secure organization setup",
+    });
+    expect(mockPrisma.edgeNode.findUnique).not.toHaveBeenCalled();
   });
 
   it("creates the approved high-risk change anchor and action atomically", async () => {

--- a/apps/web/lib/actions/organization-join.ts
+++ b/apps/web/lib/actions/organization-join.ts
@@ -7,7 +7,10 @@
 import { revalidatePath } from "next/cache";
 
 import { prisma } from "@dpf/db";
-import type { OrganizationJoinActionType } from "@dpf/db/organization-join-action";
+import {
+  isOrganizationJoinActionType,
+  type OrganizationJoinActionType,
+} from "@dpf/db/organization-join-action";
 
 import { auth } from "@/lib/auth";
 import { makeRfcId } from "@/lib/change-management/lifecycle";
@@ -69,8 +72,18 @@ export interface OrganizationJoinNodeSummary {
   trustState: string;
   role: "authority" | "member" | null;
   actionType: OrganizationJoinActionType | null;
+  hostIdentity: string | null;
   ready: boolean;
   readinessMessage: string;
+  latestAction: {
+    actionKey: string;
+    actionType: OrganizationJoinActionType;
+    status: string;
+    approvalState: string;
+    packageReady: boolean;
+    evidence: Record<string, unknown>;
+    createdAt: string;
+  } | null;
 }
 
 export async function getOrganizationJoinNodeSummariesAction(): Promise<
@@ -82,7 +95,7 @@ export async function getOrganizationJoinNodeSummariesAction(): Promise<
     orderBy: { updatedAt: "desc" },
     select: {
       id: true, nodeId: true, platform: true, status: true, trustState: true,
-      scopePolicy: true,
+      metadata: true, scopePolicy: true,
       principal: { select: { displayName: true } },
       capabilityRows: {
         where: { capability: "action.execute" },
@@ -90,6 +103,29 @@ export async function getOrganizationJoinNodeSummariesAction(): Promise<
       },
     },
   });
+  const actions = rows.length === 0
+    ? []
+    : await prisma.remoteAction.findMany({
+        where: {
+          edgeNodeId: { in: rows.map((row) => row.id) },
+          actionType: { in: ["organization.join.issue", "organization.join.import"] },
+        },
+        orderBy: { createdAt: "desc" },
+        select: {
+          actionKey: true,
+          actionType: true,
+          edgeNodeId: true,
+          status: true,
+          approvalState: true,
+          result: true,
+          evidence: true,
+          createdAt: true,
+        },
+      });
+  const latestByNode = new Map<string, (typeof actions)[number]>();
+  for (const action of actions) {
+    if (action.edgeNodeId && !latestByNode.has(action.edgeNodeId)) latestByNode.set(action.edgeNodeId, action);
+  }
   return {
     ok: true,
     nodes: rows.map((row) => {
@@ -105,6 +141,7 @@ export async function getOrganizationJoinNodeSummariesAction(): Promise<
         ? row.scopePolicy.actionTypes.includes(actionType)
         : false;
       const ready = row.trustState === "trusted" && capability?.mode === "enabled" && actionType !== null && configured;
+      const latest = latestByNode.get(row.id);
       return {
         edgeNodeId: row.id,
         nodeId: row.nodeId,
@@ -114,6 +151,7 @@ export async function getOrganizationJoinNodeSummariesAction(): Promise<
         trustState: row.trustState,
         role,
         actionType,
+        hostIdentity: edgeHostIdentity(row.metadata),
         ready,
         readinessMessage: ready
           ? "Secure host action channel ready"
@@ -124,9 +162,83 @@ export async function getOrganizationJoinNodeSummariesAction(): Promise<
               : !role
                 ? "The installation has not reported its organization role"
                 : "Allow the organization setup action for this installation",
+        latestAction: latest && isOrganizationJoinActionType(latest.actionType)
+          ? {
+              actionKey: latest.actionKey,
+              actionType: latest.actionType,
+              status: latest.status,
+              approvalState: latest.approvalState,
+              packageReady: isRecord(latest.result) && typeof latest.result.joinPackageEnc === "string",
+              evidence: sanitizeActionEvidence(isRecord(latest.evidence) ? latest.evidence : undefined),
+              createdAt: latest.createdAt.toISOString(),
+            }
+          : null,
       };
     }),
   };
+}
+
+export async function authorizeOrganizationJoinNodeAction(input: {
+  edgeNodeId: string;
+  actionType: OrganizationJoinActionType;
+  operatorConfirmed: boolean;
+}): Promise<{ ok: true } | OrganizationJoinActionFailure> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  if (!input.operatorConfirmed) {
+    return {
+      ok: false,
+      error: "invalid_input",
+      message: "Confirm this installation before enabling secure organization setup",
+    };
+  }
+  const node = await prisma.edgeNode.findUnique({
+    where: { id: input.edgeNodeId },
+    select: {
+      id: true,
+      trustState: true,
+      scopePolicy: true,
+      capabilityRows: {
+        where: { capability: "action.execute" },
+        select: { id: true, mode: true, evidence: true },
+      },
+    },
+  });
+  if (!node || node.trustState !== "trusted") {
+    return { ok: false, error: "not_ready", message: "Trust this installation before enabling organization setup" };
+  }
+  const capability = node.capabilityRows[0];
+  const evidence = isRecord(capability?.evidence) ? capability.evidence : {};
+  const role = evidence.organizationTrustRole === "authority" || evidence.organizationTrustRole === "member"
+    ? evidence.organizationTrustRole
+    : null;
+  const expectedAction = role === "authority"
+    ? "organization.join.issue"
+    : role === "member" ? "organization.join.import" : null;
+  if (!capability || expectedAction !== input.actionType) {
+    return {
+      ok: false,
+      error: "not_ready",
+      message: "This installation has not reported the required secure organization role",
+    };
+  }
+  const scopePolicy = isRecord(node.scopePolicy) ? node.scopePolicy : {};
+  const existing = Array.isArray(scopePolicy.actionTypes)
+    ? scopePolicy.actionTypes.filter((value): value is string => typeof value === "string")
+    : [];
+  const actionTypes = [...new Set([...existing, input.actionType])];
+  await prisma.$transaction([
+    prisma.edgeNode.update({
+      where: { id: node.id },
+      data: { scopePolicy: { ...scopePolicy, actionTypes } },
+    }),
+    prisma.edgeNodeCapability.update({
+      where: { id: capability.id },
+      data: { mode: "enabled" },
+    }),
+  ]);
+  revalidatePath(CONNECTIONS_PATH);
+  return { ok: true };
 }
 
 export async function queueOrganizationJoinActionAction(input: {
@@ -285,4 +397,9 @@ function actionFailure(reason: string): OrganizationJoinActionFailure {
     default:
       return { ok: false, error: "invalid_input", message: "The organization setup request is not valid" };
   }
+}
+function edgeHostIdentity(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.hostname === "string") return value.hostname;
+  return isRecord(value.host) && typeof value.host.hostname === "string" ? value.host.hostname : null;
 }

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -49,23 +49,22 @@ installations. The matching code is only a visual check; it is never a password
 or bearer credential.
 
 When the second installation does not yet trust the organization's private
-HTTPS authority, DPF support can create a private `.dpfjoin` file for that one
-installation. Move the file to the joining computer within 15 minutes and let
-the DPF installer apply it. The file carries the public-root fingerprint and a
-one-time enrollment authority; it never carries the organization's CA private
-key. It works only for the named installation and is removed after successful
-use. This establishes certificate trust only—the two Connections screens still
-show the matching code and still require independent approval before any demand
-is shared.
+HTTPS authority, use **Connect your own installations** on the Connections
+page. On the organization installation, choose **Create join file**, enter the
+joining installation's reported host name, confirm it, and download the file
+when ready. Move the `.dpfjoin` file to the joining computer within its 5- to
+15-minute lifetime. On that installation, choose **Join this installation**,
+select the file, check the safe preview, and approve the join. No command line,
+certificate copying, CA password, or installer rerun is required.
 
-The installer owns the technical work. On macOS/Linux it accepts the file as
-the **organization join package** input; the Windows installer accepts the same
-`.dpfjoin` file. After validation, DPF obtains the local HTTPS certificate,
-stores the public organization root, configures the HTTPS endpoint, and remembers
-that trust on later starts. A joining installation does not run or receive the
-organization CA. Until the Connections file picker is enabled, support may need
-to supply this installer input during setup; operators should never extract the
-file or copy certificates and environment settings by hand.
+The file carries the public-root fingerprint and one-time enrollment authority;
+it never carries the organization's CA private key. It works only for the named
+installation and can be downloaded once. The native Edge host applies the trust
+settings, checks certificate trust, saved settings, portal health, and its secure
+heartbeat, and restores the prior settings if a check fails. The Connections
+page keeps showing progress after a refresh. This establishes machine trust
+only—it does not share backlog data. Demand sharing is a separate, explicit
+choice in Delivery Flow.
 
 If the candidate uses HTTP, its certificate cannot be verified, or discovery is
 unavailable, use the invitation controls on the same page. Never bypass the TLS


### PR DESCRIPTION
## Summary

- Add guided **Create join file** and **Join this installation** actions to the existing Platform → Connections page.
- Keep certificate lifecycle, host execution, one-time package handling, and recovery state behind governed `RemoteAction` capabilities.
- Present safe previews and capability-aware empty/error states; machine trust remains separate from backlog sharing approvals.
- Update the operator guide for the no-command same-organization setup flow.

## UX-fit decision

Fits with guardrails: this is a progressive-disclosure action within the existing Platform-owned Connections route for founder/platform operators. It introduces no new route or navigation surface, uses the durable remote-action state as source of truth, exposes honest unsupported/empty/recovery states, and keeps technical certificate handling out of the operator workflow.

## Verification

- Focused server-action and panel tests: 16/16 passed.
- Exact-SHA merged-code gate passed at `4bdd194b67d4525644c561673bdf03cceda44d10`: full web/package tests, guards, TypeScript production build, and migration deploy.
- Signed-in contributor-preview verification at `/platform/federation-links`: both guided choices render; capability-aware empty state is honest; no CSS/build overlay.
- Responsive verification at 390×844: no page or panel horizontal overflow; panel width 358px within the viewport; back action has a 44px touch target. Desktop reset at 1728px also had no horizontal overflow.
- No overlap with open PRs across the six changed files.

## Documentation impact

`docs/user-guide/platform/index.md` documents the operator workflow and explicitly separates machine trust from later backlog sharing.

Backlog: BI-87B0DBD7
Umbrella: BI-52D34506
Local-CI-Evidence: cmrzsya070el001pg0o9m2wsj

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-07-21-federated-demand-sharing-direction.md
  - docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
- Current code substrate reviewed:
  - apps/web/app/(shell)/platform/federation-links/page.tsx
  - apps/web/lib/actions/organization-join.ts
  - apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx
- Source of truth: RemoteAction capability and status records govern host execution; the existing Connections route owns operator setup.
- Decision: extend the existing route and host-action substrate with progressive disclosure; do not introduce a parallel setup route or expose certificate mechanics.