### PR TITLE
fix(ui): baseline organization join prose

### DIFF
--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -6446,6 +6446,13 @@
     "longSentences": 0,
     "textMass": 326
   },
+  "apps/web/components/platform/federation-links/OrganizationJoinPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 222
+  },
   "apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary

- Add the merged OrganizationJoinPanel to the prose-lint ratchet at its measured textMass of 222.
- Restore a clean mainline prose guard after PR #3571 introduced the new guided Connections panel.

## Design grounding

Design-Grounding-Decision: extend-code, no-spec-update — this is a generated ratchet baseline repair for the already-reviewed and merged organization-join UI. It introduces no product behavior or architecture.

## Verification

- Exact-SHA merged-code gate passed at 5d874d2633254565fc95d6a47df0ab1ecb122601 against main df8bc33895da89a23bc536b5dd826455d6b4a6a1.
- Full guards, tests, production build, and migration deploy passed.
- The diff is one baseline entry and has no runtime UX change.

## Documentation impact

No documentation change is needed: this PR changes only CI ratchet metadata for behavior documented and merged in PR #3571.

Backlog: BI-4C3FCE20
Local-CI-Evidence: cmrzu04dh0g1201pga36smf5j