### PR TITLE
feat(federation): govern demand sharing direction

### DIFF
--- a/apps/web/components/ops/NetworkDemandPanel.test.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.test.tsx
@@ -71,7 +71,7 @@ describe("NetworkDemandPanel", () => {
       shareContext={{
         localItems: [{ itemId: "BI-LOCAL", title: "Local improvement", status: "open" }],
         targets: [{ linkId: "FL-DISTRIBUTOR", displayName: "Reseller One", role: "managed-by", destinationKind: "distributor", sharedItemIds: [] }],
-        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus" }],
+        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Central Founder Hub" }],
         responses: [{
           responseId: "rsp_opaque",
           sourceName: "Reseller One",
@@ -95,7 +95,7 @@ describe("NetworkDemandPanel", () => {
     expect(html).toContain("Share with Reseller One");
     expect(html).toContain("Only the minimized title, summary, applicability, signal count");
     expect(html).toContain("90 days");
-    expect(html).toContain("Forward to Arcamanus");
+    expect(html).toContain("Forward to Central Founder Hub");
     expect(html).toContain("Reseller One");
     expect(html).toContain("offered help");
     expect(html).toContain("Founder decisions");
@@ -108,15 +108,15 @@ describe("NetworkDemandPanel", () => {
       items={[]}
       shareContext={{
         localItems: [{ itemId: "BI-DISTRIBUTOR", title: "Distributor improvement", status: "open" }],
-        targets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus", role: "channel-downstream", destinationKind: "founder-hub", sharedItemIds: [] }],
-        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus" }],
+        targets: [{ linkId: "FL-FOUNDER", displayName: "Central Founder Hub", role: "channel-downstream", destinationKind: "founder-hub", sharedItemIds: [] }],
+        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Central Founder Hub" }],
         responses: [],
         dispositions: [],
       }}
     />);
 
-    expect(html).toContain("Arcamanus — Founder Hub");
-    expect(html).toContain("Share with Arcamanus");
+    expect(html).toContain("Central Founder Hub — Founder Hub");
+    expect(html).toContain("Share with Central Founder Hub");
     expect(html).not.toContain("for 90 days");
   });
 });

--- a/apps/web/components/ops/NetworkDemandPanel.test.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.test.tsx
@@ -40,6 +40,8 @@ describe("NetworkDemandPanel", () => {
     }]} />);
 
     expect(html).toContain("Shared by connected installations");
+    expect(html).toContain("Same-company connections keep share-safe platform demand visible in both directions");
+    expect(html).toContain("and so does every source backlog");
     expect(html).toContain("Follow");
     expect(html).toContain("I&#x27;m interested");
     expect(html).toContain("Offer help");
@@ -88,7 +90,7 @@ describe("NetworkDemandPanel", () => {
     />);
 
     expect(html).toContain("Share local demand");
-    expect(html).toContain("End company → distributor → Founder Hub");
+    expect(html).toContain("Across companies: End company → distributor → Founder Hub");
     expect(html).toContain("Reseller One — Distributor");
     expect(html).toContain("Share with Reseller One");
     expect(html).toContain("Only the minimized title, summary, applicability, signal count");

--- a/apps/web/components/ops/NetworkDemandPanel.test.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.test.tsx
@@ -68,8 +68,8 @@ describe("NetworkDemandPanel", () => {
       }]}
       shareContext={{
         localItems: [{ itemId: "BI-LOCAL", title: "Local improvement", status: "open" }],
-        targets: [{ linkId: "FL-CUSTOMER", displayName: "Customer One", role: "manages", sharedItemIds: [] }],
-        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Founder Hub" }],
+        targets: [{ linkId: "FL-DISTRIBUTOR", displayName: "Reseller One", role: "managed-by", destinationKind: "distributor", sharedItemIds: [] }],
+        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus" }],
         responses: [{
           responseId: "rsp_opaque",
           sourceName: "Reseller One",
@@ -88,14 +88,33 @@ describe("NetworkDemandPanel", () => {
     />);
 
     expect(html).toContain("Share local demand");
-    expect(html).toContain("Share selected demand");
+    expect(html).toContain("End company → distributor → Founder Hub");
+    expect(html).toContain("Reseller One — Distributor");
+    expect(html).toContain("Share with Reseller One");
     expect(html).toContain("Only the minimized title, summary, applicability, signal count");
     expect(html).toContain("90 days");
-    expect(html).toContain("Forward to Founder Hub");
+    expect(html).toContain("Forward to Arcamanus");
     expect(html).toContain("Reseller One");
     expect(html).toContain("offered help");
     expect(html).toContain("Founder decisions");
     expect(html).toContain("Available in the next compatible release");
     expect(html).not.toContain("inst_customer");
+  });
+
+  it("labels a direct Founder Hub destination without offering transitive consent", () => {
+    const html = renderToStaticMarkup(<NetworkDemandPanel
+      items={[]}
+      shareContext={{
+        localItems: [{ itemId: "BI-DISTRIBUTOR", title: "Distributor improvement", status: "open" }],
+        targets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus", role: "channel-downstream", destinationKind: "founder-hub", sharedItemIds: [] }],
+        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus" }],
+        responses: [],
+        dispositions: [],
+      }}
+    />);
+
+    expect(html).toContain("Arcamanus — Founder Hub");
+    expect(html).toContain("Share with Arcamanus");
+    expect(html).not.toContain("for 90 days");
   });
 });

--- a/apps/web/components/ops/NetworkDemandPanel.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.tsx
@@ -34,6 +34,8 @@ export function NetworkDemandPanel({
   const [selectedLinkId, setSelectedLinkId] = useState(shareContext.targets[0]?.linkId ?? "");
   const [founderTargetId, setFounderTargetId] = useState(shareContext.founderTargets[0]?.linkId ?? "");
   const [allowFounderForwarding, setAllowFounderForwarding] = useState(false);
+  const selectedTarget = shareContext.targets.find((target) => target.linkId === selectedLinkId);
+  const founderTarget = shareContext.founderTargets.find((target) => target.linkId === founderTargetId);
 
   const run = (mirrorId: string, action: "follow" | "unfollow" | "adopt") => {
     setActiveMirror(mirrorId);
@@ -152,11 +154,11 @@ export function NetworkDemandPanel({
       <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Share local demand</h3>
         <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-          Choose one local item and one connection. Only the minimized title, summary, applicability, signal count, and chosen attribution leave this installation.
+          End company → distributor → Founder Hub. Choose what is shareable at each step; your local backlog remains private and authoritative. Only the minimized title, summary, applicability, signal count, and chosen attribution leave this installation.
         </p>
         {shareContext.targets.length === 0 ? (
           <p className="mt-3 text-xs text-[var(--dpf-muted)]">
-            No trusted reseller or channel connection is ready. <Link href="/platform/federation-links" className="font-medium text-[var(--dpf-accent)] hover:underline">Review connections</Link>
+            No eligible distributor or Founder Hub connection is ready. <Link href="/platform/federation-links" className="font-medium text-[var(--dpf-accent)] hover:underline">Review connections</Link>
           </p>
         ) : (
           <div className="mt-3 flex flex-wrap items-end gap-3">
@@ -172,32 +174,44 @@ export function NetworkDemandPanel({
               </select>
             </label>
             <label className="text-xs text-[var(--dpf-muted)]">
-              Connection
+              Share with
               <select
-                aria-label="Connection"
+                aria-label="Share with"
                 value={selectedLinkId}
-                onChange={(event) => setSelectedLinkId(event.target.value)}
+                onChange={(event) => {
+                  const nextLinkId = event.target.value;
+                  setSelectedLinkId(nextLinkId);
+                  if (shareContext.targets.find((target) => target.linkId === nextLinkId)?.destinationKind !== "distributor") {
+                    setAllowFounderForwarding(false);
+                  }
+                }}
                 className="mt-1 block rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1.5 text-sm text-[var(--dpf-text)]"
               >
-                {shareContext.targets.map((target) => <option key={target.linkId} value={target.linkId}>{target.displayName}</option>)}
+                {shareContext.targets.map((target) => (
+                  <option key={target.linkId} value={target.linkId}>
+                    {target.displayName} — {target.destinationKind === "distributor" ? "Distributor" : "Founder Hub"}
+                  </option>
+                ))}
               </select>
             </label>
-            <label className="flex max-w-sm items-start gap-2 text-xs text-[var(--dpf-muted)]">
-              <input
-                type="checkbox"
-                checked={allowFounderForwarding}
-                onChange={(event) => setAllowFounderForwarding(event.target.checked)}
-                className="mt-0.5"
-              />
-              Allow this reseller to forward the minimized envelope to Founder Hub for 90 days. Customer identity remains pseudonymous.
-            </label>
+            {selectedTarget?.destinationKind === "distributor" ? (
+              <label className="flex max-w-sm items-start gap-2 text-xs text-[var(--dpf-muted)]">
+                <input
+                  type="checkbox"
+                  checked={allowFounderForwarding}
+                  onChange={(event) => setAllowFounderForwarding(event.target.checked)}
+                  className="mt-0.5"
+                />
+                Allow {selectedTarget.displayName} to forward the minimized demand to its Founder Hub for 90 days. Your identity remains pseudonymous.
+              </label>
+            ) : null}
             <button
               type="button"
               disabled={pending || !selectedItemId || !selectedLinkId}
               onClick={shareLocal}
               className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--dpf-bg)] disabled:opacity-50"
             >
-              {pending ? <InlineBusy label="Queuing…" tone="current" /> : "Share selected demand"}
+              {pending ? <InlineBusy label="Queuing…" tone="current" /> : `Share with ${selectedTarget?.displayName ?? "selected connection"}`}
             </button>
           </div>
         )}
@@ -311,7 +325,7 @@ export function NetworkDemandPanel({
                           onClick={() => forwardToFounder(item.mirrorId)}
                           className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
                         >
-                          {isBusy ? <InlineBusy label="Queuing…" tone="current" /> : "Forward to Founder Hub"}
+                          {isBusy ? <InlineBusy label="Queuing…" tone="current" /> : `Forward to ${founderTarget?.displayName ?? "Founder Hub"}`}
                         </button>
                       ) : null}
                       <button

--- a/apps/web/components/ops/NetworkDemandPanel.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.tsx
@@ -107,7 +107,7 @@ export function NetworkDemandPanel({
             Shared by connected installations
           </h2>
           <p className="mt-1 max-w-3xl text-xs text-[var(--dpf-muted)]">
-            Review demand that another installation chose to share. Follow it for updates, or adopt it when your organization wants to own local work. Your local backlog stays authoritative.
+            Same-company connections keep share-safe platform demand visible in both directions after approval. Across companies, each item is deliberately shared. Follow it for updates, or adopt it when your organization wants to own local work. Your local backlog stays authoritative, and so does every source backlog.
           </p>
         </div>
         <Link href="/platform/federation-links" className="text-xs font-medium text-[var(--dpf-accent)] hover:underline">
@@ -154,7 +154,7 @@ export function NetworkDemandPanel({
       <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Share local demand</h3>
         <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-          End company → distributor → Founder Hub. Choose what is shareable at each step; your local backlog remains private and authoritative. Only the minimized title, summary, applicability, signal count, and chosen attribution leave this installation.
+          Across companies: End company → distributor → Founder Hub. Choose what is shareable at each step; your local backlog remains private and authoritative. Only the minimized title, summary, applicability, signal count, and chosen attribution leave this installation.
         </p>
         {shareContext.targets.length === 0 ? (
           <p className="mt-3 text-xs text-[var(--dpf-muted)]">

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -3830,6 +3830,7 @@
       "publishedPortal": false,
       "anchors": [
         "federated-demand-channels",
+        "same-company-installations",
         "customer-and-reseller-operation",
         "founder-hub-business-management",
         "privacy-and-recovery-behavior"

--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -69,7 +69,7 @@ describe("selectLocalDemandForLink direction", () => {
         linkId: "FL-FOUNDER",
         role: "channel-downstream",
         linkState: "trusted",
-        peerAuthorityUrl: "https://arcamanus.example",
+        peerAuthorityUrl: "https://founder-hub.example",
         peerTokenEnc: "token",
         peerInstallationId: "inst_founder",
         projectionContractId: null,

--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -1,9 +1,101 @@
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("./demand-delivery", () => ({
+  queueDemandProjection: vi.fn(),
+  queueDemandWithdrawal: vi.fn(),
+  queueForwardedDemand: vi.fn(),
+}));
+vi.mock("./demand-identity", () => ({ resolveFederationIdentity: vi.fn() }));
+vi.mock("./demand-reconciliation", () => ({
+  relationshipPresetForRole: (role: string) => role.startsWith("channel-") ? "channel" : "service-provider",
+}));
+
 import {
   bindPeerInstallationIdentity,
   decodeChannelDemandPolicy,
+  isOutboundDemandSharingRole,
+  selectLocalDemandForLink,
 } from "./channel-demand";
+
+describe("isOutboundDemandSharingRole", () => {
+  it("allows only the local relationship faces that point toward the distributor or Founder Hub", () => {
+    expect(isOutboundDemandSharingRole("managed-by")).toBe(true);
+    expect(isOutboundDemandSharingRole("channel-downstream")).toBe(true);
+    expect(isOutboundDemandSharingRole("manages")).toBe(false);
+    expect(isOutboundDemandSharingRole("channel-upstream")).toBe(false);
+    expect(isOutboundDemandSharingRole("peer")).toBe(false);
+  });
+});
+
+describe("selectLocalDemandForLink direction", () => {
+  it.each(["manages", "channel-upstream"])(
+    "rejects the reverse-facing %s relationship at the service boundary",
+    async (role) => {
+      const db = {
+        federationLink: { findUnique: vi.fn().mockResolvedValue({
+          linkId: "FL-REVERSE",
+          role,
+          linkState: "trusted",
+          peerAuthorityUrl: "https://peer.example",
+          peerTokenEnc: "token",
+          peerInstallationId: "inst_peer",
+          projectionContractId: null,
+          revokedAt: null,
+          quarantinedAt: null,
+        }) },
+        backlogItem: { findUnique: vi.fn().mockResolvedValue({
+          itemId: "BI-LOCAL",
+          title: "Local need",
+          body: null,
+          workType: "feature",
+          occurrenceCount: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          digitalProduct: null,
+        }) },
+        projectionContract: { findFirst: vi.fn().mockResolvedValue(null) },
+      };
+
+      await expect(selectLocalDemandForLink(db as never, {
+        linkId: "FL-REVERSE",
+        itemId: "BI-LOCAL",
+      })).rejects.toThrow("Local demand can only be shared toward your distributor or Founder Hub.");
+    },
+  );
+
+  it("does not attach transitive consent when a distributor shares directly with Founder Hub", async () => {
+    const db = {
+      federationLink: { findUnique: vi.fn().mockResolvedValue({
+        linkId: "FL-FOUNDER",
+        role: "channel-downstream",
+        linkState: "trusted",
+        peerAuthorityUrl: "https://arcamanus.example",
+        peerTokenEnc: "token",
+        peerInstallationId: "inst_founder",
+        projectionContractId: null,
+        revokedAt: null,
+        quarantinedAt: null,
+      }) },
+      backlogItem: { findUnique: vi.fn().mockResolvedValue({
+        itemId: "BI-LOCAL",
+        title: "Distributor need",
+        body: null,
+        workType: "feature",
+        occurrenceCount: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        digitalProduct: null,
+      }) },
+      projectionContract: { findFirst: vi.fn().mockResolvedValue(null) },
+    };
+
+    await expect(selectLocalDemandForLink(db as never, {
+      linkId: "FL-FOUNDER",
+      itemId: "BI-LOCAL",
+      allowForwardToFounder: true,
+    })).rejects.toThrow("Founder forwarding consent applies only when sharing with a distributor.");
+  });
+});
 
 describe("decodeChannelDemandPolicy", () => {
   it("defaults partner exchange to explicit selection and pseudonymous attribution", () => {

--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -78,6 +78,23 @@ const PARTNER_ROLES = new Set<FederationRole>([
   "channel-downstream",
 ]);
 
+export type OutboundDemandSharingRole = Extract<
+  FederationRole,
+  "managed-by" | "channel-downstream"
+>;
+
+const OUTBOUND_DEMAND_SHARING_ROLES = new Set<OutboundDemandSharingRole>([
+  "managed-by",
+  "channel-downstream",
+]);
+
+export function isOutboundDemandSharingRole(
+  role: string,
+): role is OutboundDemandSharingRole {
+  return isFederationRole(role)
+    && OUTBOUND_DEMAND_SHARING_ROLES.has(role as OutboundDemandSharingRole);
+}
+
 export async function bindPeerInstallationIdentity(
   db: { federationLink: { updateMany(args: unknown): Promise<{ count: number }> } },
   linkId: string,
@@ -224,6 +241,11 @@ export async function selectLocalDemandForLink(
     }),
   ]);
   assertTrustedPartnerLink(link);
+  if (!isOutboundDemandSharingRole(link.role)) {
+    throw new Error(
+      "Local demand can only be shared toward your distributor or Founder Hub.",
+    );
+  }
   if (!item) throw new Error("Local demand item was not found.");
   if ((item.body ?? "").includes("[origin:federatedDemand:")) {
     throw new Error("Adopted demand must use governed forwarding so original provenance is preserved.");
@@ -231,6 +253,9 @@ export async function selectLocalDemandForLink(
   const preset = relationshipPresetForRole(link.role);
   if (preset !== "channel" && preset !== "service-provider") {
     throw new Error("This relationship cannot receive explicitly shared demand.");
+  }
+  if (link.role === "channel-downstream" && input.allowForwardToFounder === true) {
+    throw new Error("Founder forwarding consent applies only when sharing with a distributor.");
   }
   const current = decodeChannelDemandPolicy(stored?.cadaPosture);
   const policy: ChannelDemandPolicy = {

--- a/apps/web/lib/federation/demand-read-model.test.ts
+++ b/apps/web/lib/federation/demand-read-model.test.ts
@@ -5,12 +5,13 @@ vi.mock("@dpf/db", () => ({ prisma: {} }));
 import { mapDemandShareTargets, mapNetworkDemandRows } from "./demand-read-model";
 
 describe("mapDemandShareTargets", () => {
-  it("offers only end-company to distributor and distributor to Founder Hub destinations", () => {
+  it("offers only cross-company upstream destinations and leaves same-company peers on automatic sync", () => {
     const targets = mapDemandShareTargets([
       { linkId: "FL-DISTRIBUTOR", role: "managed-by", peerInstallationId: "inst_distributor", principal: { displayName: "Reseller One" } },
       { linkId: "FL-FOUNDER", role: "channel-downstream", peerInstallationId: "inst_founder", principal: { displayName: "Arcamanus" } },
       { linkId: "FL-CUSTOMER", role: "manages", peerInstallationId: "inst_customer", principal: { displayName: "Customer One" } },
       { linkId: "FL-DOWNSTREAM", role: "channel-upstream", peerInstallationId: "inst_reseller", principal: { displayName: "Reseller Two" } },
+      { linkId: "FL-INTERNAL", role: "same-org-peer", peerInstallationId: "inst_internal", principal: { displayName: "Windows Test" } },
     ], new Map([
       ["FL-DISTRIBUTOR", ["BI-LOCAL"]],
       ["FL-CUSTOMER", ["BI-REVERSE"]],

--- a/apps/web/lib/federation/demand-read-model.test.ts
+++ b/apps/web/lib/federation/demand-read-model.test.ts
@@ -8,7 +8,7 @@ describe("mapDemandShareTargets", () => {
   it("offers only cross-company upstream destinations and leaves same-company peers on automatic sync", () => {
     const targets = mapDemandShareTargets([
       { linkId: "FL-DISTRIBUTOR", role: "managed-by", peerInstallationId: "inst_distributor", principal: { displayName: "Reseller One" } },
-      { linkId: "FL-FOUNDER", role: "channel-downstream", peerInstallationId: "inst_founder", principal: { displayName: "Arcamanus" } },
+      { linkId: "FL-FOUNDER", role: "channel-downstream", peerInstallationId: "inst_founder", principal: { displayName: "Central Founder Hub" } },
       { linkId: "FL-CUSTOMER", role: "manages", peerInstallationId: "inst_customer", principal: { displayName: "Customer One" } },
       { linkId: "FL-DOWNSTREAM", role: "channel-upstream", peerInstallationId: "inst_reseller", principal: { displayName: "Reseller Two" } },
       { linkId: "FL-INTERNAL", role: "same-org-peer", peerInstallationId: "inst_internal", principal: { displayName: "Windows Test" } },
@@ -27,7 +27,7 @@ describe("mapDemandShareTargets", () => {
       },
       {
         linkId: "FL-FOUNDER",
-        displayName: "Arcamanus",
+        displayName: "Central Founder Hub",
         role: "channel-downstream",
         destinationKind: "founder-hub",
         sharedItemIds: [],

--- a/apps/web/lib/federation/demand-read-model.test.ts
+++ b/apps/web/lib/federation/demand-read-model.test.ts
@@ -1,6 +1,39 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { mapNetworkDemandRows } from "./demand-read-model";
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { mapDemandShareTargets, mapNetworkDemandRows } from "./demand-read-model";
+
+describe("mapDemandShareTargets", () => {
+  it("offers only end-company to distributor and distributor to Founder Hub destinations", () => {
+    const targets = mapDemandShareTargets([
+      { linkId: "FL-DISTRIBUTOR", role: "managed-by", peerInstallationId: "inst_distributor", principal: { displayName: "Reseller One" } },
+      { linkId: "FL-FOUNDER", role: "channel-downstream", peerInstallationId: "inst_founder", principal: { displayName: "Arcamanus" } },
+      { linkId: "FL-CUSTOMER", role: "manages", peerInstallationId: "inst_customer", principal: { displayName: "Customer One" } },
+      { linkId: "FL-DOWNSTREAM", role: "channel-upstream", peerInstallationId: "inst_reseller", principal: { displayName: "Reseller Two" } },
+    ], new Map([
+      ["FL-DISTRIBUTOR", ["BI-LOCAL"]],
+      ["FL-CUSTOMER", ["BI-REVERSE"]],
+    ]));
+
+    expect(targets).toEqual([
+      {
+        linkId: "FL-DISTRIBUTOR",
+        displayName: "Reseller One",
+        role: "managed-by",
+        destinationKind: "distributor",
+        sharedItemIds: ["BI-LOCAL"],
+      },
+      {
+        linkId: "FL-FOUNDER",
+        displayName: "Arcamanus",
+        role: "channel-downstream",
+        destinationKind: "founder-hub",
+        sharedItemIds: [],
+      },
+    ]);
+  });
+});
 
 describe("mapNetworkDemandRows", () => {
   it("returns share-safe display fields without peer identity or route details", () => {

--- a/apps/web/lib/federation/demand-read-model.ts
+++ b/apps/web/lib/federation/demand-read-model.ts
@@ -26,8 +26,16 @@ export interface NetworkDemandView {
 export interface DemandShareTarget {
   linkId: string;
   displayName: string;
-  role: string;
+  role: "managed-by" | "channel-downstream";
+  destinationKind: "distributor" | "founder-hub";
   sharedItemIds: string[];
+}
+
+interface DemandShareLinkRow {
+  linkId: string;
+  role: string;
+  peerInstallationId: string | null;
+  principal: { displayName: string };
 }
 
 export interface LocalDemandShareCandidate {
@@ -91,6 +99,22 @@ export function mapNetworkDemandRows(rows: DemandReadRow[]): NetworkDemandView[]
   });
 }
 
+export function mapDemandShareTargets(
+  links: DemandShareLinkRow[],
+  sharedByLink: ReadonlyMap<string, string[]>,
+): DemandShareTarget[] {
+  return links.flatMap((link) => {
+    if (link.role !== "managed-by" && link.role !== "channel-downstream") return [];
+    return [{
+      linkId: link.linkId,
+      displayName: link.principal.displayName,
+      role: link.role,
+      destinationKind: link.role === "managed-by" ? "distributor" : "founder-hub",
+      sharedItemIds: sharedByLink.get(link.linkId) ?? [],
+    }];
+  });
+}
+
 export const getNetworkDemandItems = cache(async (): Promise<NetworkDemandView[]> => {
   const rows = await prisma.federatedRecordMirror.findMany({
     where: { recordType: "demand-envelope", canonicalSide: "peer" },
@@ -111,7 +135,7 @@ export const getDemandShareContext = cache(async (): Promise<DemandShareContext>
   const [links, localItems, mirrors, responseMirrors, dispositionMirrors] = await Promise.all([
     prisma.federationLink.findMany({
       where: {
-        role: { in: ["manages", "managed-by", "channel-upstream", "channel-downstream"] },
+        role: { in: ["managed-by", "channel-downstream"] },
         linkState: "trusted",
         revokedAt: null,
         quarantinedAt: null,
@@ -165,13 +189,9 @@ export const getDemandShareContext = cache(async (): Promise<DemandShareContext>
     refs.push(mirror.localRecordRef);
     sharedByLink.set(mirror.federationLinkId, refs);
   }
+  const targets = mapDemandShareTargets(links, sharedByLink);
   return {
-    targets: links.map((link) => ({
-      linkId: link.linkId,
-      displayName: link.principal.displayName,
-      role: link.role,
-      sharedItemIds: sharedByLink.get(link.linkId) ?? [],
-    })),
+    targets,
     founderTargets: links
       .filter((link) => link.role === "channel-downstream" && link.peerInstallationId)
       .map((link) => ({ linkId: link.linkId, displayName: link.principal.displayName })),

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -23,7 +23,7 @@ its link, and expanding the projection requires approval on both sides.
 ## Customer and reseller operation
 
 Across company boundaries, the supported business route is **end company →
-distributor/reseller → Founder Hub**. On Arcamanus-managed networks, Arcamanus
+distributor/reseller → Founder Hub**. On founder-managed networks, the configured Founder Hub
 is the Founder Hub installation; other deployments use the configured name of
 their own central hub.
 

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -7,23 +7,33 @@ which connection and may withdraw that projection independently.
 
 ## Customer and reseller operation
 
-1. In **Platform → Connections**, create or accept a service-provider or channel
-   invitation. Both installations must approve the link before exchange begins.
-2. The customer opens **Operate → Delivery Flow**, selects one local demand item
-   and one trusted connection, and chooses **Share selected demand**.
+The supported business route is **end company → distributor/reseller → Founder
+Hub**. On Arcamanus-managed networks, Arcamanus is the Founder Hub installation;
+other deployments use the configured name of their own central hub.
+
+1. In **Platform → Connections**, create or accept the appropriate relationship.
+   The end company records the distributor as the service provider
+   (`managed-by` locally). The distributor records the central installation as
+   its upstream Founder Hub (`channel-downstream` locally). Both installations
+   must approve each link before exchange begins.
+2. The end company opens **Operate → Delivery Flow**, selects one local demand
+   item and its distributor, and chooses **Share with _distributor name_**.
 3. Founder forwarding is off by default. The customer may grant a reseller a
    time-bounded right to forward that minimized envelope to Founder Hub. The
    grant does not authorize any other audience or remote action.
-4. The reseller can follow or adopt received demand locally, record interest,
-   offer help, or forward it to an eligible Founder Hub connection when the
-   source grant permits it. Adoption creates a new reseller-owned backlog item;
-   it does not turn the remote record into shared mutable work.
+4. The distributor can follow or adopt received demand locally, record interest,
+   offer help, or choose **Forward to _Founder Hub name_** when the source grant
+   permits it. Adoption creates a new distributor-owned backlog item; it does
+   not turn the remote record into shared mutable work.
 5. The source sees received interest and help receipts in Delivery Flow. It may
    stop sharing at any time; a withdrawal is queued over that connection.
 
 Multiple customer, reseller, and specialist relationships can coexist. Each
 link has an independent projection contract and selection set. Creating one
 partner never grants exclusivity or silently selects demand for another.
+The interface deliberately hides the reverse faces (`manages` and
+`channel-upstream`) from outbound sharing, and the server rejects a crafted
+request that attempts to use them.
 
 ## Founder Hub business management
 

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -5,11 +5,27 @@ shares a deliberately minimized demand envelope; it never exposes or co-writes
 the source backlog. The source installation decides which item can travel over
 which connection and may withdraw that projection independently.
 
+## Same-company installations
+
+Approved `same-organization` connections synchronize share-safe platform demand
+in both directions. Every installation runs the same reconciliation policy, so
+new eligible work and later source updates become visible to the other internal
+installations without another sharing click. This is the normal pattern for a
+company operating separate Mac, Windows, development, or test installations.
+
+This is not multi-master backlog replication. Each source backlog item remains
+single-writer authoritative. A peer receives a versioned mirror that it can
+follow, respond to, or adopt as separately owned local work. Status, priority,
+estimate, build state, private planning, discussion, attachments, and customer
+context are not remotely overwritten. Either installation can pause or revoke
+its link, and expanding the projection requires approval on both sides.
+
 ## Customer and reseller operation
 
-The supported business route is **end company → distributor/reseller → Founder
-Hub**. On Arcamanus-managed networks, Arcamanus is the Founder Hub installation;
-other deployments use the configured name of their own central hub.
+Across company boundaries, the supported business route is **end company →
+distributor/reseller → Founder Hub**. On Arcamanus-managed networks, Arcamanus
+is the Founder Hub installation; other deployments use the configured name of
+their own central hub.
 
 1. In **Platform → Connections**, create or accept the appropriate relationship.
    The end company records the distributor as the service provider

--- a/docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
+++ b/docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
@@ -17,6 +17,13 @@ the source granted bounded Founder Hub consent. The reusable platform identifies
 Arcamanus by the connected peer's display name rather than hardcoding a private
 installation name into community code.
 
+This directional rule applies across organizational boundaries. Installations
+owned by the same company retain the existing symmetric `same-organization`
+lane: after both sides approve the pairing and projection, each installation
+automatically publishes share-safe platform demand to the other. This provides
+bidirectional visibility without multi-master backlog writes; the originating
+installation remains authoritative and a peer may follow or adopt locally.
+
 ## Existing substrate verified
 
 - `ChannelDemandPolicy` already owns explicit item selection, attribution, and
@@ -28,6 +35,9 @@ installation name into community code.
 - `/ops/demand` and `NetworkDemandPanel` are the existing contextual interface.
 - Federation roles already express both sides of each relationship. No new
   model, enum, route, or navigation entry is required.
+- `same-org-peer` reconciliation already runs symmetrically on every approved
+  internal installation and is intentionally separate from explicit partner
+  sharing controls.
 
 The gap is directional authorization: the read model currently offers all four
 partner roles, and local sharing accepts both faces of those relationships.
@@ -49,13 +59,16 @@ route.
    `channel-downstream` can receive locally originated demand. Keep forwarded
    incoming demand restricted to `channel-downstream`.
 2. Add a pure read-model mapping test proving reverse-facing `manages` and
-   `channel-upstream` links are excluded and valid destinations are classified
+   `channel-upstream` links are excluded, `same-org-peer` remains on its
+   automatic bidirectional lane, and valid partner destinations are classified
    as `distributor` or `founder-hub`.
 3. Enforce the allow-list at the service boundary, not just in React, and query
    only valid outbound roles for the Delivery Flow context.
-4. Make the existing panel role-aware: show the route, label the actual peer,
-   offer forwarding consent only for a distributor destination, and name the
-   selected Founder Hub (for example Arcamanus) on the forwarding action.
+4. Make the existing panel role-aware: explain automatic bidirectional
+   same-company visibility separately from the cross-company route, label the
+   actual peer, offer forwarding consent only for a distributor destination,
+   and name the selected Founder Hub (for example Arcamanus) on the forwarding
+   action.
 5. Update the operator guide and federated-demand runbook so setup and recovery
    use the same directional vocabulary.
 6. Run targeted unit tests, web typecheck/build through the governed sandbox,

--- a/docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
+++ b/docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
@@ -10,11 +10,11 @@
 
 Enforce one business route for deliberately shared backlog demand:
 
-`end company -> distributor/reseller -> Founder Hub (the Arcamanus installation)`
+`end company -> distributor/reseller -> configured Founder Hub`
 
 The originating company selects each item. A distributor may forward only when
 the source granted bounded Founder Hub consent. The reusable platform identifies
-Arcamanus by the connected peer's display name rather than hardcoding a private
+the configured hub by the connected peer's display name rather than hardcoding a private
 installation name into community code.
 
 This directional rule applies across organizational boundaries. Installations
@@ -67,7 +67,7 @@ route.
 4. Make the existing panel role-aware: explain automatic bidirectional
    same-company visibility separately from the cross-company route, label the
    actual peer, offer forwarding consent only for a distributor destination,
-   and name the selected Founder Hub (for example Arcamanus) on the forwarding
+   and name the selected Founder Hub (for example Central Founder Hub) on the forwarding
    action.
 5. Update the operator guide and federated-demand runbook so setup and recovery
    use the same directional vocabulary.

--- a/docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
+++ b/docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
@@ -1,0 +1,101 @@
+# Federated demand sharing direction implementation plan
+
+**Backlog authority:** `BI-485F88E9` under `EP-DELIVERY-FLOW`
+
+**Work capsule:** `WC-5EAB8C08`
+
+**Design authority:** `docs/superpowers/specs/2026-07-19-federated-demand-network-design.md`
+
+## Outcome
+
+Enforce one business route for deliberately shared backlog demand:
+
+`end company -> distributor/reseller -> Founder Hub (the Arcamanus installation)`
+
+The originating company selects each item. A distributor may forward only when
+the source granted bounded Founder Hub consent. The reusable platform identifies
+Arcamanus by the connected peer's display name rather than hardcoding a private
+installation name into community code.
+
+## Existing substrate verified
+
+- `ChannelDemandPolicy` already owns explicit item selection, attribution, and
+  bounded forwarding consent.
+- `DemandEnvelopeV1` and `forwardDemandEnvelope` already preserve the original
+  pseudonymous origin, route attestations, cycle protection, and hop limits.
+- `ProjectionContract` and `FederatedRecordMirror` already own per-link policy,
+  delivery, withdrawal, and reconciliation.
+- `/ops/demand` and `NetworkDemandPanel` are the existing contextual interface.
+- Federation roles already express both sides of each relationship. No new
+  model, enum, route, or navigation entry is required.
+
+The gap is directional authorization: the read model currently offers all four
+partner roles, and local sharing accepts both faces of those relationships.
+
+## Atomic delivery
+
+The server policy, destination read model, and interface wording form one
+authorization behavior. Shipping only one layer would either leave an API
+bypass or remove a valid capability from the interface, so they land together.
+
+**Coverage receipt:** `cmrvf3fcy0lfk01qkyxp9s1vv` — atomic, recorded for
+`BI-485F88E9`. The authorization service, destination read model, and interface
+cannot ship independently without either preserving a bypass or hiding a valid
+route.
+
+## Implementation
+
+1. Add failing policy tests proving only local roles `managed-by` and
+   `channel-downstream` can receive locally originated demand. Keep forwarded
+   incoming demand restricted to `channel-downstream`.
+2. Add a pure read-model mapping test proving reverse-facing `manages` and
+   `channel-upstream` links are excluded and valid destinations are classified
+   as `distributor` or `founder-hub`.
+3. Enforce the allow-list at the service boundary, not just in React, and query
+   only valid outbound roles for the Delivery Flow context.
+4. Make the existing panel role-aware: show the route, label the actual peer,
+   offer forwarding consent only for a distributor destination, and name the
+   selected Founder Hub (for example Arcamanus) on the forwarding action.
+5. Update the operator guide and federated-demand runbook so setup and recovery
+   use the same directional vocabulary.
+6. Run targeted unit tests, web typecheck/build through the governed sandbox,
+   and responsive light/dark UX verification on `/ops/demand`.
+
+## UX fit
+
+- **Decision:** fits with guardrails.
+- **Owner and route:** Operations / Delivery Flow, existing `/ops/demand`.
+- **Primary people:** an end-company operator deciding what may leave their
+  installation; a distributor operator deciding what consented demand to pass
+  to the central hub.
+- **Placement:** contextual sharing panel beside the demand it governs; no new
+  global navigation or standalone workspace.
+- **Reuse:** `NetworkDemandPanel`, existing server actions, report-kit controls,
+  `ProjectionContract`, and `FederatedRecordMirror`.
+- **First viewport:** explain the three-party route and local authority before
+  presenting selectors.
+- **Progressive disclosure:** Founder forwarding consent appears only when the
+  selected destination is a distributor. Multiple Founder Hubs use the existing
+  destination selector.
+- **Empty/failure states:** no eligible outbound connection points to
+  Connections; server rejection remains authoritative if a crafted request uses
+  a reverse-facing link.
+- **Responsive/accessibility:** labels remain associated with controls, controls
+  wrap on narrow screens, status remains announced, and color is not the sole
+  directional cue.
+- **AI impact:** none; no prompt or coworker behavior changes.
+
+## Verification evidence required
+
+- Targeted tests demonstrate the role matrix and UI copy/conditional controls.
+- Production build passes for the exact branch SHA.
+- Shared nonproduction runtime renders `/ops/demand` at desktop and narrow
+  widths in light and dark themes without horizontal overflow.
+- Existing forwarding, expiry, revocation, cycle, and pseudonymous-origin tests
+  remain green.
+
+## Documentation impact
+
+User/operator behavior changes, so update `docs/user-guide/operations/index.md`
+and `docs/operations/federated-demand-channels.md`. No install, public marketing,
+prompt, or `AGENTS.md` doctrine change is required.

--- a/docs/user-guide/assets/diagrams/manifest.json
+++ b/docs/user-guide/assets/diagrams/manifest.json
@@ -1,10 +1,10 @@
 {
   "generatedBy": "scripts/render-doc-diagrams.mjs",
   "diagrams": {
-    "development-workspace/0": "2d9cafaaedd6e316",
     "contributing/agent-dev-environments/0": "633afbe3f256fa24",
     "contributing/agent-dev-environments/1": "1ad992dbabe50357",
     "contributing/agent-dev-environments/2": "94e90c086b9d9e79",
-    "contributing/agent-dev-environments/3": "84945e497683c136"
+    "contributing/agent-dev-environments/3": "84945e497683c136",
+    "development-workspace/0": "2d9cafaaedd6e316"
   }
 }

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -39,12 +39,18 @@ installation, not a local backlog item. You can follow it, offer help, or adopt
 it; adoption creates a new locally owned backlog item and never transfers
 control of the sender's work.
 
-For demand your installation owns, use the item-level connection controls to
-share only with eligible approved links. Service-provider and channel links are
-selected explicitly. Forwarding is available only when the original sender
-allowed the Founder Hub audience, and it preserves pseudonymous origin
-provenance. Withdrawal stops the shared copy from being actionable without
-deleting your local item.
+For demand your installation owns, the sharing path is **end company →
+distributor → Founder Hub**. Use the item-level controls to choose one item and
+an eligible approved destination. An end company sees its distributor links; a
+distributor sees its upstream Founder Hub link, identified by the connected
+installation's name (for example, Arcamanus). Customer-facing and downstream
+reseller relationships are never offered as outbound destinations.
+
+Forwarding is off by default. An end company can allow its selected distributor
+to forward the minimized demand to that distributor's Founder Hub for 90 days.
+The distributor sees the forwarding action only while that consent is valid,
+and the original pseudonymous provenance stays attached. Withdrawal stops the
+shared copy from being actionable without deleting the source item.
 
 If a share or response action is unavailable, check the displayed connection
 state and consent explanation. Manage the relationship itself under **Platform

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -50,7 +50,7 @@ Across company boundaries, the sharing path for demand your installation owns
 is **end company → distributor → Founder Hub**. Use the item-level controls to
 choose one item and an eligible approved destination. An end company sees its
 distributor links; a distributor sees its upstream Founder Hub link, identified
-by the connected installation's name (for example, Arcamanus). Customer-facing
+by the connected installation's name (for example, Central Founder Hub). Customer-facing
 and downstream reseller relationships are never offered as outbound
 destinations.
 

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -39,12 +39,20 @@ installation, not a local backlog item. You can follow it, offer help, or adopt
 it; adoption creates a new locally owned backlog item and never transfers
 control of the sender's work.
 
-For demand your installation owns, the sharing path is **end company →
-distributor → Founder Hub**. Use the item-level controls to choose one item and
-an eligible approved destination. An end company sees its distributor links; a
-distributor sees its upstream Founder Hub link, identified by the connected
-installation's name (for example, Arcamanus). Customer-facing and downstream
-reseller relationships are never offered as outbound destinations.
+For installations owned by the same company, an approved
+**same organization** connection keeps share-safe platform demand visible in
+both directions automatically. This supports separate development and test
+systems without merging their databases. Each source item remains authoritative
+on its original installation; the other installation receives a versioned
+mirror and may follow it or adopt separately owned local work.
+
+Across company boundaries, the sharing path for demand your installation owns
+is **end company → distributor → Founder Hub**. Use the item-level controls to
+choose one item and an eligible approved destination. An end company sees its
+distributor links; a distributor sees its upstream Founder Hub link, identified
+by the connected installation's name (for example, Arcamanus). Customer-facing
+and downstream reseller relationships are never offered as outbound
+destinations.
 
 Forwarding is off by default. An end company can allow its selected distributor
 to forward the minimized demand to that distributor's Founder Hub for 90 days.

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5653,7 +5653,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 168
+    "textMass": 188
   },
   "apps/web/components/ops/OperatorTriageBand.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

- Make same-company demand visibility explicitly bidirectional after approval while keeping every installation backlog authoritative.
- Restrict deliberate cross-company sharing to the intended upstream path: end company → distributor/reseller → configured Founder Hub.
- Enforce direction at both the read model and service boundary; reverse-facing customer/downstream relationships cannot receive local demand.
- Keep Founder Hub forwarding consent scoped to distributor shares, pseudonymous, minimized, and time-bounded.
- Use configured connection display names throughout the operator workflow rather than hardcoded founder identity.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-07-21-federated-demand-sharing-direction.md
  - docs/superpowers/plans/2026-07-21-federated-demand-sharing-direction.md
- Current code substrate reviewed:
  - apps/web/lib/federation/channel-demand.ts
  - apps/web/lib/federation/demand-read-model.ts
  - apps/web/components/ops/NetworkDemandPanel.tsx
- Source of truth:
  - FederationLink roles govern relationship direction; each local BacklogItem remains authoritative; shared demand is a minimized federated projection with preserved provenance.
- Decision:
  - Extend the existing role and projection substrate to make same-company visibility automatic after approval, while requiring deliberate upstream sharing across company boundaries.

## Verification

- Focused federation/read-model/panel tests: 15/15 passed.
- Doc index and user-guide link integrity passed.
- Exact-SHA merged-code gate passed at c6d4fa6a5ab5f4fdc540eab616edf5727477aae3 against main bb412ab3da8d769f55b5d0b6faa77fc5f562093d: repository guards/tests, production build, and migration deploy.
- Signed-in contributor-preview verification at /ops/demand confirmed the same-company and cross-company explanations, configured destination wording, honest empty state, and no browser errors.
- Responsive verification at 390×844: the sharing panel is 358px wide, remains within the viewport, and has no internal overflow. Desktop at 1728px has no page or panel overflow.
- No file overlap with open PRs.

## Documentation impact

Updated the operations runbook, operator guide, architecture/spec direction, diagram manifest, and generated documentation index to distinguish internal synchronization from channel sharing.

Backlog: BI-485F88E9
Operational acceptance: BI-05EB708F
Local-CI-Evidence: cmrzurfxk0hdh01pgb4semrrc
