### PR TITLE
fix(ux-sweep): await blank-page isolation

### DIFF
--- a/apps/web/scripts/ux-route-sweep.test.ts
+++ b/apps/web/scripts/ux-route-sweep.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { resetSweepPage } from "./ux-route-sweep";
+
+describe("resetSweepPage", () => {
+  it("waits for the blank isolation navigation to finish before the next route starts", async () => {
+    let navigationFinished = false;
+    let releaseNavigation!: () => void;
+    const navigationFinishedPromise = new Promise<void>((resolve) => {
+      releaseNavigation = () => {
+        navigationFinished = true;
+        resolve();
+      };
+    });
+    const page = {
+      goto: async (
+        url: string,
+        options: { waitUntil: "commit" | "load"; timeout: number },
+      ) => {
+        expect(url).toBe("about:blank");
+        expect(options.timeout).toBe(10_000);
+        if (options.waitUntil === "commit") return null;
+        await navigationFinishedPromise;
+        return null;
+      },
+    };
+
+    let resetFinished = false;
+    const reset = resetSweepPage(page).then(() => {
+      resetFinished = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(navigationFinished).toBe(false);
+    expect(resetFinished).toBe(false);
+    releaseNavigation();
+    await reset;
+    expect(navigationFinished).toBe(true);
+    expect(resetFinished).toBe(true);
+  });
+});

--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -91,6 +91,19 @@ function pruneInvisible(): string {
 /** Why a route produced no measurement — reported, never silently dropped. */
 export type SkipReason = { routePath: string; reason: string };
 
+export async function resetSweepPage(
+  page: {
+    goto(
+      url: string,
+      options: { waitUntil: "load"; timeout: number },
+    ): Promise<unknown>;
+  },
+): Promise<void> {
+  await page
+    .goto("about:blank", { waitUntil: "load", timeout: 10_000 })
+    .catch(() => {});
+}
+
 async function measureRoute(
   page: Page,
   row: ShellRow,
@@ -205,11 +218,11 @@ async function main(): Promise<void> {
         // "Navigation to X is interrupted by another navigation to Y" — a route that is
         // then measured on one run and skipped on another, which reads as a false
         // regression. Resetting to about:blank between routes cancels any pending
-        // navigation and gives every route the same clean starting state. It is
-        // side-effect-free: each real route re-navigates with its own page.goto.
-        await page
-          .goto("about:blank", { waitUntil: "commit", timeout: 10_000 })
-          .catch(() => {});
+        // navigation and gives every route the same clean starting state. Wait for
+        // the full blank-page load: waiting only for "commit" lets that isolation
+        // navigation race and interrupt the next real route. It is side-effect-free:
+        // each real route re-navigates with its own page.goto.
+        await resetSweepPage(page);
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

- Wait for the inter-route `about:blank` isolation navigation to fully load before starting the next real route.
- Prevent the blank-page reset from racing and interrupting the next `page.goto()`.
- Add a regression test that stays pending until isolation navigation completion; it fails under the old `waitUntil: commit` behavior and passes under `waitUntil: load`.

## Design grounding

- Existing specs/plans reviewed:
  - EP-UX-SYSTEM route-budget sweep contract as implemented in apps/web/scripts/ux-route-sweep.ts
  - BI-EA221325 / PR #3550 inter-route isolation change
- Current code substrate reviewed:
  - apps/web/scripts/ux-route-sweep.ts
  - Playwright `page.goto()` lifecycle used by the sequential sweep
- Source of truth:
  - The sweep loop owns route isolation and must not return from reset while its navigation is still active.
- Decision:
  - Preserve the existing `about:blank` isolation design, but wait for the full load lifecycle instead of introducing a new browser/page architecture.

## Verification

- TDD red: the regression test fails with `waitUntil: commit` because reset finishes while blank navigation is still pending.
- TDD green: 1/1 regression test passes with `waitUntil: load`.
- Scoped pre-commit TypeScript check passed with the repository heap budget.
- Exact-SHA merged-code gate passed at 48e005ba9c993d9966ed5c4fe95378b4cd052bc5 against main bb412ab3da8d769f55b5d0b6faa77fc5f562093d: full guards/tests, production build, and migration deploy.
- No file overlap with open PRs.

## Documentation impact

No operator documentation change is needed: this repairs CI browser lifecycle containment without changing product behavior.

Closes BI-57985DF1
Local-CI-Evidence: cmrzvwgba0ipr01pgbedt7f4v