### PR TITLE
doc: Ornith-1.0 local coding model — research, design, and eval plan

### DIFF
--- a/docs/superpowers/plans/2026-07-25-ornith-1-local-coding-model-plan.md
+++ b/docs/superpowers/plans/2026-07-25-ornith-1-local-coding-model-plan.md
@@ -1,0 +1,139 @@
+---
+status: blocked-on-backlog-filing
+backlogItem: PENDING-MCP-FILING
+epic: EP-BUILD-STUDIO
+spec: docs/superpowers/specs/2026-07-25-ornith-1-local-coding-model-design.md
+date: 2026-07-25
+---
+
+# Ornith-1.0 Local Coding Model Evaluation — Implementation Plan
+
+Phased so each phase lands as one PR with its own gates, mirroring the precedent set by
+`docs/superpowers/plans/2026-06-10-local-llm-build-agent.md` (OpenCode admission). Spec holds the
+rationale; this file holds the order of operations.
+
+## Backlog coverage
+
+**Not filed.** This plan was written in a remote session with no reachable `dpf` MCP connector and
+no reachable live Postgres (see the spec's MCP/DB availability note). Per the `dpf-writing-plans`
+skill guardrail — "No plan without a BI" / "No silent MCP bypass: unreachable MCP, a missing tool,
+or insufficient token scope stops planning before source implementation" — this plan does not
+fabricate a `record_plan_backlog_coverage` receipt. The exact `create_backlog_item` payload is
+drafted at the end of the spec, ready to file from a session with live MCP or DB access; this
+document itself is a source-control-only artifact until that BI exists.
+
+**Next action for a session with `dpf` MCP access:** file the draft BI, link it to `EP-BUILD-STUDIO`
+(existing epic — no new epic needed, confirmed no overlap conflict since `EP-BUILD-STUDIO` already
+covers the sibling OpenCode-admission BI `BI-01D6A51B`), then run `record_plan_backlog_coverage`
+against this plan path with a `decomposed` mapping: Phase 0 → the filed BI itself (tool admission is
+not independently shippable product work); Phase 1 → one BI (eval harness run); Phase 2 → no code,
+decision only; Phase 3 → filed only if Phase 2's evidence supports moving forward, as a new BI
+scoped to whatever the evidence supports (add-as-option / promote-default / do-not-adopt writeup).
+
+## Phase 0 — Tool admission & verification (no code)
+
+1. Read the actual `LICENSE` file at the pinned Ornith-1.0 release (not just the README paraphrase)
+   and confirm MIT, matching the rigor of the opencode registry entry's license finding.
+2. Determine the pull path: check whether Ornith-1.0 ships in Docker's `ai/...` model-runner
+   catalog (the mechanism `LOCAL_MODEL_TIERS` already pulls from) or requires a manual GGUF
+   import / `docker model package` step. This materially changes install-story complexity — a
+   catalog hit is near-zero-effort; a manual import path needs its own documented recipe before it
+   can be a `LOCAL_MODEL_TIERS` entry (install scripts mirror that constant and cannot run
+   arbitrary import commands blindly).
+3. Confirm the tag(s) actually served (needed to know whether `pickDefaultCodingModel()`'s
+   `/coder|code/i` regex already matches it, per the spec's Design section).
+4. Run `/project:tool-evaluation` (EP-GOVERN-002, `toolType: "ai_provider"`) covering security,
+   license, architecture fit, integration, supply-chain (publisher provenance for
+   `deepreinforce-ai`), compliance. Record the result in
+   `packages/db/data/approved_tools_registry.json`, following the `opencode` entry's shape:
+   `status: "conditional"` pending Phase 1 eval evidence, explicit `conditions[]`
+   (version/digest-pinned, local-endpoint-only, sandbox-only where applicable), `findings[]` with
+   real `evidence` URLs, `reEvaluateAfter`.
+
+Exit: registry row merged with real (not paraphrased) license/provenance/pull-path findings; exact
+model tag(s) and pull mechanism documented.
+
+## Phase 1 — Comparative evaluation (the evidence-gathering phase)
+
+1. Pull the size tier(s) that map onto documented DPF hardware bands (9B-Dense ≈ current 8B/14B
+   tiers; 31B-Dense / 35B-MoE ≈ current 30B/35B tiers) on the shared local-CI convergence sandbox or
+   canonical local install per AGENTS.md §5 ("Where each gate runs") — not a from-scratch runtime in
+   a topic worktree.
+2. Verify tool-call emission format empirically: does it produce OpenAI-native `tool_calls`, or
+   does `extractTextualToolCalls()`'s existing Gemma/Llama-style textual-marker patterns already
+   parse it, or does it need a new pattern? Record the answer regardless of outcome — a model that
+   needs a new textual-marker pattern is not disqualified, it's a scoped addition to
+   `ai-inference.ts`.
+3. Run the same benchmark harness DPF already anchors local-model claims to — the mini-SWE-agent
+   precedent named in the 2026-06-10 opencode spec — head-to-head against the install's current
+   default `qwen3-coder`-class tier, on identical hardware. Capture: task completion rate at the
+   quantization DPF would actually ship (Q4/Q4_K-class per `LocalModelTier.weightsGb`
+   conventions, not vendor-reported bf16 numbers), tool-call reliability, context utilization
+   against `RECOMMENDED_BUILD_CONTEXT_TOKENS` / `MAX_LOCAL_CONTEXT_TOKENS`, and latency/throughput.
+4. Optionally: one real end-to-end Build Studio dispatch via the `opencode` runner pointed at the
+   pulled Ornith model on a contained BI, using `classifyOutcome()`'s existing
+   `DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT` signal as the honest quality readout —
+   same pattern as Phase 3 of the 2026-06-10 opencode plan.
+5. Record evidence via the Build Studio evidence tools / `record_execution_evidence`, naming the
+   substrate (per AGENTS.md §6, "Execution evidence is canonical-runtime evidence").
+
+Exit: a written comparison (completion rate, tool-call reliability, context fit, latency) between
+Ornith and the current Qwen3 default at matched hardware tiers, backed by real dispatch/eval runs,
+not vendor claims.
+
+## Phase 2 — Decision gate (no code)
+
+Using Phase 1's evidence, decide one of:
+
+- **Augment:** add Ornith tier(s) to `LOCAL_MODEL_TIERS` as an operator-selectable option alongside
+  Qwen3, no change to the default recommendation ordering. Lowest-risk outcome; appropriate if
+  Ornith is competitive but not clearly superior, or superior only on some task classes.
+- **Promote to default at a specific tier:** change `recommendGenerationModelForHost()`'s ordering
+  at that tier only, if evidence shows a clear, reproducible uplift over the current Qwen3 tier at
+  matched hardware and quantization. Ship as an install-time recommendation change, not a forced
+  migration of already-installed models (existing installs keep what they have; `OverCommitVerdict`
+  / `recommendKeepGenerationModel()` logic already treats "coder in the name" as a keep-signal, so
+  this needs care if Ornith's tag doesn't self-identify as a coder model).
+- **Reject / defer:** if Phase 1 shows no meaningful uplift, or blocking issues (tool-call format
+  incompatible without disproportionate new-pattern work, no viable pull path, license/provenance
+  concern), record the finding in the registry (`status` moves to whatever EP-GOVERN-002 defines
+  for a non-adopted evaluation) and stop. A documented "evaluated, not adopted, here's why" is a
+  complete and valuable outcome — matches "governance approves evidence, not provenance."
+
+This phase produces a decision record, not code. It should update the design spec's status field
+and file whatever new BI(s) Phase 3 needs, if any.
+
+## Phase 3 — Implementation (only if Phase 2 selects augment or promote)
+
+Scoped once Phase 2 lands; sketch only, not committed work:
+
+1. `local-model-policy.ts`: add `LOCAL_MODEL_TIER` entries with real measured `weightsGb` (Q4
+   resident, on-box measured — per the module's existing precedent of citing actual RTX 4090
+   measurements, not spec-sheet numbers).
+2. `opencode-dispatch.ts`: extend `pickDefaultCodingModel()`'s regex only if the shipped tag
+   doesn't already self-identify as a coder model (per Phase 0 finding #3).
+3. `ai-inference.ts`: add a textual tool-call marker pattern only if Phase 1 finding #2 shows it's
+   needed.
+4. `agent-model-defaults.ts`-adjacent classification: assign `minimumTier` for coworker-floor
+   eligibility once eval evidence supports a tier assignment.
+5. Docs: update `docs/architecture/local-llm-build-engine.md` to describe the model as an
+   alternative/addition, not just `qwen3-coder`.
+6. Mirror install-script constants (`scripts/detect-hardware-host.ts`, `install-dpf.{ps1,sh}`) per
+   the existing "keep these in sync" comment convention in `local-model-policy.ts`.
+
+Exit: `pnpm --filter web exec vitest run` and `pnpm --filter web typecheck` green; UX verification
+of the new model appearing/selectable in the Providers UX (`OllamaManagement.tsx`); production build
+gate per AGENTS.md §5.
+
+## Risks
+
+- **Vendor benchmark inflation.** Mitigated entirely by Phase 1's requirement to re-measure on
+  DPF's own harness at DPF's actual quantization, never trusting the README numbers directly.
+- **New/unproven publisher.** Standard tool-evaluation supply-chain scrutiny (Phase 0) is the
+  mitigation, same bar as any other adopted tool.
+- **Catalog availability unknown.** If no `ai/...` catalog entry exists, Phase 0's pull-path
+  determination could turn this into a much larger effort (documenting and shipping a manual GGUF
+  import recipe) than a simple tier addition — flag this early rather than discovering it mid-Phase-1.
+- **Fragmenting the local-model story.** Mitigated by keeping `LOCAL_MODEL_TIERS` as the single
+  source of truth regardless of outcome — Ornith entries follow the exact same tier/selector
+  mechanism as Qwen3, not a parallel code path.

--- a/docs/superpowers/specs/2026-07-25-ornith-1-local-coding-model-design.md
+++ b/docs/superpowers/specs/2026-07-25-ornith-1-local-coding-model-design.md
@@ -1,0 +1,182 @@
+---
+status: proposed
+backlogItem: PENDING-MCP-FILING
+epic: EP-BUILD-STUDIO
+date: 2026-07-25
+---
+
+# Ornith-1.0 as a Local Coding Model Option — Research & Design
+
+## Origin
+
+Operator request: investigate `deepreinforce-ai/Ornith-1` (github.com/deepreinforce-ai/Ornith-1)
+for applicability to DPF, then capture the research, file it to the backlog, and take one more
+pass at a design + plan for evaluating it as a coding method — augmenting or possibly replacing
+part of the existing local-model story, pending more fit data.
+
+**MCP/DB availability note (read first):** this research and design was produced in a Claude Code
+on the web / remote session with no reachable `dpf` MCP connector (no `.mcp.json` bearer token
+resolved, `http://127.0.0.1:3000` not serving) and no reachable live Postgres (`DATABASE_URL` only
+present in `.env.*.example` templates; no Docker daemon in this sandbox). Per AGENTS.md §6 and the
+`dpf-writing-plans` skill guardrail ("No silent MCP bypass — unreachable MCP, a missing tool, or
+insufficient token scope stops planning before source implementation"), this session does **not**
+fabricate a `BacklogItem` row or a `record_plan_backlog_coverage` receipt. The exact BI content is
+drafted below, ready to file from a session with live `dpf` MCP or DB access. Everything else in
+this doc (research findings, design, phased plan) is real analysis grounded in the current repo.
+
+## Research: what Ornith-1.0 is
+
+Source: `https://github.com/deepreinforce-ai/Ornith-1` README (fetched 2026-07-25; **vendor's own
+claims, not independently corroborated** — see Open Questions).
+
+- **What:** a family of open-source LLMs post-trained specifically for *agentic coding* —
+  autonomous software-engineering tasks, not general chat.
+- **Sizes:** 9B-Dense, 31B-Dense, 35B-MoE, 397B-MoE.
+- **Base models:** post-trained on Gemma 4 and Qwen 3.5.
+- **Training approach:** described as a "self-improving framework" using reinforcement learning
+  that optimizes both solution generation and the agent scaffolding around it.
+- **Capabilities claimed:** chain-of-thought reasoning with thinking/output separation, native
+  function calling / tool integration, 256K context window.
+- **Serving:** vLLM, SGLang, Hugging Face Transformers; bf16, FP8, and GGUF precisions; exposes an
+  OpenAI-compatible API.
+- **Benchmarks claimed:** the 397B variant is positioned as competitive with larger proprietary
+  models on Terminal-Bench 2.1, SWE-Bench, and NL2Repo.
+- **License:** MIT, "globally accessible, and free from regional limitations" (per README —
+  Open Questions below flags that the actual `LICENSE` file has not yet been read directly).
+- **Intended deployment:** OpenHands, Hermes Agent, OpenCode integrations named explicitly.
+
+## Why this is relevant to DPF
+
+DPF already has a governed, shipped local-coding-model story that this would extend, not
+originate:
+
+- **`apps/web/lib/inference/local-model-policy.ts`** — `LOCAL_MODEL_TIERS`, the single source of
+  truth for which local generation model a host runs, is **Qwen3-family only** today:
+  `qwen3-coder-next` (80B MoE) → `qwen3.6:35B-A3B` → `qwen3-coder` (30B MoE, "the 24 GB-card sweet
+  spot") → `qwen3:14B` → `qwen3:8B` → `qwen3:4B`. Every tier is sized in Q4-resident GB and
+  selected by `recommendGenerationModelForHost()` against detected VRAM/RAM.
+- **`apps/web/lib/integrate/opencode-dispatch.ts`** — `pickDefaultCodingModel()` already prefers
+  *any* served model whose id matches `/coder|[-_]code\b|code[-_]/i` **before** it falls back to a
+  Qwen3-specific regex, then to the first remaining chat model. A model served under a tag like
+  `ornith-coder` would already win the existing preference order with **no code change**; a tag
+  without "coder"/"code" in it would fall through to "any remaining chat model" (still usable, just
+  unpreferenced).
+- **`apps/web/lib/inference/ai-inference.ts`** — `extractTextualToolCalls()` already parses
+  Gemma/Llama-style textual `<tool_call>...</tool_call>` markup for local models that don't emit
+  OpenAI-native structured `tool_calls`. Ornith is post-trained on Gemma 4 + Qwen 3.5, so its
+  native tool-call emission format needs to be checked against this parser, not assumed compatible.
+- **`packages/db/src/agent-model-defaults.ts`** — every AI coworker declares a `minimumTier`
+  (`basic`/`adequate`/`strong`), `budgetClass`, `minimumCapabilities` (e.g. `toolUse`), and
+  `minimumContextTokens`. Slotting Ornith in as a routable model requires classifying it into this
+  scheme so coworker-floor eligibility resolves correctly — this is a governance gate
+  (`establish_coworker` conformance), not a config toggle.
+- **`docs/architecture/local-llm-build-engine.md`** — the canonical local-AI-build strategy doc,
+  currently framed entirely around `qwen3-coder` via Docker Model Runner (DMR) as the model behind
+  the `opencode` Build Studio dispatch engine (`EP-BUILD-STUDIO`, `BI-01D6A51B`,
+  `docs/superpowers/specs/2026-06-10-local-llm-build-agent-design.md`). That spec already
+  benchmarked several *harness* alternatives (OpenCode, Aider, OpenHands, etc.) against Claude/Codex
+  and set the pattern this doc follows for a *model* alternative: evaluate on evidence, admit at
+  `preview` tier, promote only when eval history earns it. It also recorded the operating
+  benchmark reality as of June 2026: consumer-hardware local tiers (30B-class) land around
+  35–55% on SWE-bench Verified vs. ~80% for the best open-weight giants and ~88.6–95% for frontier
+  Claude/current-frontier — the bar Ornith's claimed numbers should be read against.
+- **Tool Evaluation Pipeline (EP-GOVERN-002)** — `ToolEvaluation.toolType` already has an
+  `"ai_provider"` case (`docs/superpowers/specs/2026-03-25-tool-evaluation-pipeline-design.md`),
+  and `packages/db/data/approved_tools_registry.json` has a direct precedent entry shape to follow
+  (the `opencode` npm-package entry: `status: "conditional"`, license finding, supply-chain finding,
+  live-verified integration finding, `conditions[]`, `reEvaluateAfter`). A new Ornith entry would
+  use the same shape with `toolType: "ai_provider"`.
+
+## Design
+
+### Framing: augment first, decide replace/keep-both/reject only from eval evidence
+
+The operator explicitly does not want a premature replace-vs-augment call. That matches DPF's own
+precedent: the 2026-06-10 opencode spec did not declare OpenCode superior to Claude/Codex — it
+admitted it at `tier: "preview"` and required real eval evidence (`classifyOutcome()` results on
+actual dispatched builds, optionally mini-SWE-agent benchmarking) before any tier promotion.
+"Governance approves evidence, not provenance" (2026-06-10 spec, Capability tier section) is the
+operative principle here too.
+
+Concretely, Ornith should land as an **additional selectable local generation model**, not a
+default-tier swap:
+
+1. **`LOCAL_MODEL_TIERS` gains Ornith entries** at whichever sizes are realistically hostable
+   (9B-Dense and 31B-Dense/35B-MoE map onto the existing 8B/14B and 30B/35B hardware bands; the
+   397B-MoE is out of reach of any local install tier documented here, same as it would be for any
+   model at that size — this is a *server-class* model, not a local one).
+2. **No forced default change.** `recommendGenerationModelForHost()` keeps recommending the
+   Qwen3 tiers unless/until eval evidence justifies changing the recommendation function's
+   ordering. An operator can still explicitly select an Ornith tier via the Providers UX
+   (`OllamaManagement.tsx`) once it is a known tier + pullable.
+3. **Coder-preference tag check.** Confirm what tag Ornith is actually published under in whatever
+   catalog DPF pulls from (Docker Model Runner `ai/...` catalog vs. manual GGUF import — see Open
+   Questions). If the published tag doesn't already match opencode's `/coder|code/i` preference
+   regex, that's a one-line, low-risk addition to `pickDefaultCodingModel()` — not a redesign.
+4. **Model floor classification.** Once eval evidence exists, classify Ornith's tiers into the
+   `minimumTier`/`minimumCapabilities`/`minimumContextTokens` scheme so it becomes eligible for
+   coworker routing on the same terms as any other local model — this is what actually determines
+   "augment" (coexists as a routable option) vs. staying inert in the catalog.
+5. **Tool-call format.** Verify empirically whether Ornith emits OpenAI-native `tool_calls` or a
+   textual marker format, and whether the existing `extractTextualToolCalls()` patterns
+   (Gemma/Llama style) already cover it or need a new pattern. This gates whether it can drive the
+   `opencode` agent loop at all, independent of raw benchmark quality.
+
+### What "replace" would require, if the evidence supports it
+
+Only after Phase 2 (below) produces head-to-head evidence on DPF's actual hardware tiers would a
+"replace the Qwen3 default at tier N" change be justified — and even then, per the migration-safety
+and fleet-wide doctrine in AGENTS.md §2, changing an install's *default* recommended model is a
+behavior change that should ship as an operator-visible option first (already true here, since
+`LOCAL_MODEL_TIERS` selection is host-driven, not silently mutated) before any change to
+`recommendGenerationModelForHost()`'s ordering.
+
+## Open questions / risks (unverified — do not treat as settled)
+
+- **Benchmark provenance.** All performance claims are the vendor's own README; no independent
+  SWE-bench/Terminal-Bench reproduction has been done by DPF. Treat as a hypothesis to test with
+  DPF's own eval harness (mini-SWE-agent precedent from the 2026-06-10 spec), not a fact to route
+  on.
+- **Publisher provenance.** `deepreinforce-ai` is a new/unfamiliar org to this codebase; no history
+  of prior DPF interaction. Standard tool-evaluation supply-chain scrutiny applies (who maintains
+  it, release signing, weight provenance/checksums on Hugging Face).
+- **License file, not just README.** The MIT claim should be verified against the actual `LICENSE`
+  file in the repo/weights release, not the README's paraphrase, before any registry entry claims
+  "MIT" as verified (mirrors the opencode registry entry's explicit license finding with an
+  `evidence` URL).
+- **Catalog availability.** Unconfirmed whether Ornith ships in Docker's `ai/...` model-runner
+  catalog (the mechanism `LOCAL_MODEL_TIERS` pulls from today) or would require a manual GGUF
+  import/`docker model package` step — this materially changes Phase 0 effort.
+- **Tool-call format compatibility**, as above.
+- **Quantization quality at the sizes DPF can actually host** (Q4/Q4_K-class, per
+  `LocalModelTier.weightsGb` conventions) — vendor benchmarks are typically run at full/bf16
+  precision, not the quantized weights an install would actually run.
+
+## Out of scope for this design
+
+- The 397B-MoE variant (server-class; no DPF local-install tier reaches it).
+- Any change to the cloud-credentialed `claude`/`codex`/`grok` Build Studio dispatch engines.
+- Automatic frontier-escalation routing (tracked separately under `EP-COST-001` per the 2026-06-10
+  spec's Out of scope section).
+- Declaring a replace/augment/reject verdict — that is exactly what Phase 2 below produces evidence
+  for.
+
+## Draft BacklogItem (file from a session with live `dpf` MCP/DB access)
+
+```
+type: product
+workType: tool
+source: user-request
+epicLink: EP-BUILD-STUDIO
+title: Evaluate Ornith-1.0 as an additional local Build Studio coding model
+description: >
+  Ornith-1.0 (deepreinforce-ai, MIT, OpenAI-compatible, agentic-coding-tuned,
+  9B/31B/35B-MoE/397B-MoE) is a candidate additional entry in LOCAL_MODEL_TIERS
+  alongside the current Qwen3-only tiers, feeding the opencode Build Studio
+  dispatch engine (EP-BUILD-STUDIO / BI-01D6A51B). Run it through the Tool
+  Evaluation Pipeline (EP-GOVERN-002, ai_provider) and DPF's existing local-model
+  eval harness (mini-SWE-agent precedent) before deciding augment vs. replace vs.
+  reject for any hardware tier. See design:
+  docs/superpowers/specs/2026-07-25-ornith-1-local-coding-model-design.md and
+  plan: docs/superpowers/plans/2026-07-25-ornith-1-local-coding-model-plan.md.
+```


### PR DESCRIPTION
## Summary

Investigates `deepreinforce-ai/Ornith-1` (an open-source, MIT-licensed family of agentic-coding-tuned LLMs) for applicability to DPF's local-model substrate, and captures that research as a design spec + phased evaluation plan under `docs/superpowers/`.

## Changes

- `docs/superpowers/specs/2026-07-25-ornith-1-local-coding-model-design.md` — research findings (what Ornith-1.0 is, sizes, license, benchmarks claimed) plus a design proposing an **augment-first** evaluation (mirroring the existing `EP-BUILD-STUDIO` / `BI-01D6A51B` OpenCode-admission precedent: admit at preview tier, promote only on real eval evidence — no premature replace/augment call, per the operator's request).
- `docs/superpowers/plans/2026-07-25-ornith-1-local-coding-model-plan.md` — phased plan: Phase 0 tool admission (license/provenance/pull-path verification, `EP-GOVERN-002` Tool Evaluation Pipeline entry), Phase 1 comparative eval against the current Qwen3 default on DPF's own harness, Phase 2 decision gate (augment/promote/reject), Phase 3 implementation sketch.

**Backlog note:** this session had no reachable `dpf` MCP connector and no reachable live Postgres (remote GitHub session; `.mcp.json` bearer token unresolved, no Docker daemon). Per the `dpf-writing-plans` skill guardrail ("no silent MCP bypass"), no `BacklogItem` was fabricated — the exact `create_backlog_item` payload is drafted at the end of the spec, ready to file from a session with live MCP/DB access, linked to the existing `EP-BUILD-STUDIO` epic (no new epic needed).

## Test plan

- [x] **Source-only change** (doc-only; no application code touched)
  - [x] Regenerated `apps/web/lib/docs/doc-index.generated.json` via `node scripts/gen-doc-index.mjs` — no diff, since `docs/superpowers/specs/` and `docs/superpowers/plans/` are not part of the public/portal-published surface the indexer tracks.
  - N/A: no `.ts`/`.tsx` changed, so no typecheck/unit-test surface affected.

## Related issues / Epic

Relates to `EP-BUILD-STUDIO` (existing epic covering `BI-01D6A51B`, the OpenCode local-LLM dispatch precedent this plan follows). No BacklogItem filed yet — see Backlog note above.

## Notes for the reviewer

Docs-only PR: no behavior change, no migration, no runtime surface touched. The two files are read-only research/planning artifacts; the actual `LOCAL_MODEL_TIERS` / `opencode-dispatch.ts` / registry changes described in Phase 3 are explicitly **not** part of this PR — they're gated behind Phase 0–2 evidence per the plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd8nmGx4HcxgxQifJndT7v)_