### PR TITLE
fix(deps): floor brace-expansion for GHSA-mh99-v99m-4gvg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,7 @@ overrides:
   '@types/react': ^19
   '@hono/node-server': ^2.0.5
   '@expo/cli@0.24.24>picomatch': 3.0.2
-  minimatch@3.1.5>brace-expansion: 1.1.16
-  minimatch@9.0.9>brace-expansion: 2.1.2
+  brace-expansion@<=5.0.7: 5.0.8
   lodash: 4.18.0
   lodash-es: 4.18.0
   node-forge: 1.4.0
@@ -4513,9 +4512,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -4625,15 +4621,9 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4916,9 +4906,6 @@ packages:
 
   compute-lcm@1.1.2:
     resolution: {integrity: sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
@@ -14283,8 +14270,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   barcode-detector@3.2.1(@types/emscripten@1.41.5):
@@ -14380,16 +14365,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14677,8 +14653,6 @@ snapshots:
       validate.io-array: 1.0.6
       validate.io-function: 1.0.2
       validate.io-integer-array: 1.0.0
-
-  concat-map@0.0.1: {}
 
   confbox@0.2.4: {}
 
@@ -17624,15 +17598,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,12 +13,10 @@ overrides:
   # 2.0.5 needs Node >=20 + hono ^4, both already satisfied by this workspace.
   '@hono/node-server': '^2.0.5'
   '@expo/cli@0.24.24>picomatch': '3.0.2'
-  # brace-expansion: GHSA-3jxr-9vmj-r5cp DoS via exponential-time expansion of
-  # consecutive non-expanding {} groups (Dependabot #102 for the 1.x line,
-  # #103 for the 2.x line, both high). Floor each pinned line to the patched
-  # release: 1.1.16 and 2.1.2.
-  'minimatch@3.1.5>brace-expansion': '1.1.16'
-  'minimatch@9.0.9>brace-expansion': '2.1.2'
+  # brace-expansion <= 5.0.7: GHSA-mh99-v99m-4gvg / CVE-2026-14257
+  # high-severity advisory (Dependabot #133). Floor every transitive line to
+  # the patched release accepted by OSV.
+  'brace-expansion@<=5.0.7': '5.0.8'
   lodash: '4.18.0'
   lodash-es: '4.18.0'
   node-forge: '1.4.0'


### PR DESCRIPTION
## Summary

- Floors transitive brace-expansion versions <= 5.0.7 to 5.0.8 for GHSA-mh99-v99m-4gvg / CVE-2026-14257.
- Replaces older scoped minimatch brace-expansion overrides with one advisory-specific workspace override.
- Regenerates pnpm-lock.yaml through scripts/regen-lockfile.mjs.

## Verification

- node scripts/regen-lockfile.mjs --expect brace-expansion,balanced-match,concat-map,minimatch
- rg "brace-expansion@(1\.1\.16|2\.1\.2|5\.0\.7)" pnpm-lock.yaml (no matches)
- node scripts/sbom/scan-dependencies.mjs --fail-on high --git-ref 38bfbdcef2a1ade989748ddad63d5a1bc049a9b7
- node scripts/sbom/check-lockfile-release-age.mjs --base origin/main --json sbom/lockfile-release-age.json
- node --test scripts/sbom/check-lockfile-release-age.test.mjs
- pnpm install --frozen-lockfile
- GitHub CI: OSV scan, typecheck, production build, unit shards, UX Route Budget Sweep, CodeQL, ADP integration tests all passing on PR head.

Docs impact: no user-facing docs needed; this is a dependency security floor only.

Local-CI-Override: dependency security floor verified by lockfile regeneration, OSV/high-severity SBOM scan, frozen install, release-age tests, and full GitHub CI on the PR head SHA.