### PR TITLE
chore(deps): block incomplete FullCalendar majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,14 @@ updates:
       # mode code. Upgrade deliberately, not through Dependabot.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # FullCalendar packages are version-coupled. Core/react published 7.0.0
+      # before daygrid/timegrid/interaction had final 7.0.0 releases (those
+      # plugins still stop at 7.0.0-rc.0 / beta), so separate major PRs create
+      # an impossible install: peer/type mismatches and missing runtime exports.
+      # Keep 6.x flowing; move to 7.x only when the whole family has final
+      # releases and can be bumped in one branch.
+      - dependency-name: "@fullcalendar/*"
+        update-types: ["version-update:semver-major"]
       # react-data-grid has no stable release yet; every version is a
       # 7.0.0-* prerelease. The maintainer ships the recommended build on
       # the `beta` channel, while `canary` is the nightly/dev channel and


### PR DESCRIPTION
## Summary

- Blocks Dependabot semver-major PRs for `@fullcalendar/*` until the whole package family has final v7 releases.
- Core/react published `7.0.0`, but `daygrid`, `timegrid`, and `interaction` still stop at `7.0.0-rc.0` / beta, so split major PRs cannot produce a coherent install.

## Verification

- `git diff --check`
- pre-commit gitleaks scan
- GitHub CI: typecheck, production build, unit shards, UX Route Budget Sweep, CodeQL, ADP integration tests, and policy guards all passing on PR head.

Docs impact: no user-facing docs needed; this is dependency automation policy only.

Local-CI-Override: dependency automation config-only guard verified by diff check, pre-commit gitleaks, and full GitHub CI on the PR head SHA.