### PR TITLE
fix(agent-toolchain): install DPF Codex skills through registry

### DIFF
--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -202,7 +202,7 @@ Bearer tokens never appear in this file. The `transcript` field is routed throug
 
 For the avoidance of doubt, the installer:
 
-- Does **not** edit your `~/.codex/config.toml` outside the `[plugins."dpf-platform"]` block. Other blocks (user MCP servers, marketplaces, feature flags, project trust levels) are preserved byte-for-byte. User intent (`enabled = false` set manually) is preserved on re-runs.
+- Does **not** edit your `~/.codex/config.toml` outside the `[plugins."dpf-platform@personal"]` block. The updater migrates the retired bare `[plugins."dpf-platform"]` key because current Codex requires `<plugin>@<marketplace>`. Other blocks (user MCP servers, marketplaces, feature flags, project trust levels) are preserved byte-for-byte. User intent (`enabled = false` set manually) is preserved on re-runs.
 - Does **not** write your DPF MCP bearer token into any tracked file. The token is read from `DPF_MCP_BEARER_TOKEN` and never persisted to the agent toolchain state.
 - Does **not** auto-upgrade upstream-owned plugins (`superpowers@openai-curated`). If your installed version differs from the DPF pin, the banner shows an advisory line — no action is taken.
 - Does **not** prompt the contributor to run scripts or copy commands. Missing CLIs / tokens / drifted state become explicit readiness states with one primary action; never a command-copy.

--- a/docs/superpowers/plans/2026-07-25-codex-dpf-skill-exposure.md
+++ b/docs/superpowers/plans/2026-07-25-codex-dpf-skill-exposure.md
@@ -1,0 +1,55 @@
+# Codex DPF skill exposure repair plan
+
+Backlog: BI-BCA162CF
+Work capsule: WC-AD184862
+
+## Outcome
+
+After the DPF agent-toolchain bootstrap runs, Codex must report
+`dpf-platform@personal` as installed and enabled, and a newly started Codex task
+must expose the plugin's DPF-native skills. Bootstrap output must not use one
+client's skill inventory as evidence for another client.
+
+## Evidence and source of truth
+
+- `codex plugin list --marketplace personal --available --json` resolves
+  `./plugins/dpf-platform` to `~/plugins/dpf-platform`.
+- The updater currently copies only to
+  `~/.agents/plugins/plugins/dpf-platform`, which is the shared Claude/Grok
+  source, and never calls `codex plugin add`.
+- The bootstrap currently injects Grok's plugin inventory into a generic
+  exposure variable and then labels the result as “this session.”
+- Canonical implementation:
+  `packages/dpf-skill-pack/scripts/update_agent_toolchain.py`.
+- Platform adapters:
+  `scripts/dpf-bootstrap-agent-toolchain.ps1` and
+  `scripts/dpf-bootstrap-agent-toolchain.sh`.
+
+## Implementation
+
+1. Keep separate Codex and shared managed plugin copies because the clients
+   resolve their local marketplace paths differently.
+2. Resolve the runnable Codex app CLI, install through
+   `codex plugin add dpf-platform@personal --json`, and verify the installed,
+   enabled state through Codex's JSON inventory.
+3. Remove cross-client exposure inference. Only explicit session-scoped
+   evidence may produce a “loaded/exposed” verdict in the multi-client
+   bootstrap.
+4. Add regression tests for marketplace path resolution, actual Codex registry
+   verification, dual managed copies, and Grok/Codex evidence isolation.
+5. Re-run the updater against this install and verify both Codex registry state
+   and a newly started task's skill catalog.
+
+## Documentation impact
+
+Update the skill-pack README because the operator/contributor installation
+contract changes from one shared managed copy plus config toggling to
+client-correct sources plus verified Codex installation.
+
+## Design grounding
+
+- Existing design:
+  `docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md`.
+- Existing implementation and merged exposure-adapter work: PR #3498.
+- Decision: extend the existing updater and personal marketplace; do not add a
+  parallel skill loader or direct `.agents/skills` links.

--- a/docs/user-guide/contributing/agent-dev-environments.md
+++ b/docs/user-guide/contributing/agent-dev-environments.md
@@ -115,7 +115,7 @@ The bootstrap is **idempotent** (re-running on a converged install is a no-op) a
 1. **Detects** which of Claude / Codex / Grok / Antigravity are installed — resolving GUI-app and non-PATH install locations, not just `which`.
 2. **Mints and persists a DPF MCP token** if one isn't present (issued inside the portal container, persisted to `~/.dpf/agent-toolchain.env` and your shell profile, never logged). Default scope is `write` so the agent can use side-effecting MCP tools (backlog, evidence, Build Studio handoff). On macOS it also injects the token via `launchctl` so GUI-launched apps — which don't read your shell profile — still pick it up.
 3. **Connects the DPF MCP server** in each client (`.mcp.json` / `.vscode/mcp.json` for Claude, `[mcp_servers.dpf]` in Codex/Grok config, and Antigravity's `mcpServers.dpf` config when available), all referencing `${DPF_MCP_BEARER_TOKEN}`.
-4. **Installs the `dpf-platform` plugin** for each client from the repo-local marketplace — this is the single package that carries the **skill pack**, the **MCP connector contract**, and the **governance hooks** (see [The plugin](#the-plugin-skills-hooks-and-mcp-in-one-package) below).
+4. **Installs the `dpf-platform` plugin** for each client from its local marketplace/registry — this is the single package that carries the shared **skill pack** and the cross-client hook/MCP contracts (see [The plugin](#the-plugin-skills-hooks-and-mcp-in-one-package) below). For Codex, the bootstrap registers and verifies the qualified plugin key `dpf-platform@personal`; copying plugin files alone is not considered installed.
 5. **Seeds kernel-tier memory** so the agent is kernel-aware from the first turn, before any MCP retrieval round-trip.
 6. **Runs read-only MCP + kernel smoke probes**, checks whether the DPF-native process-spine replacement skills are installed and visible to the current session, and prints a single **readiness banner**. On Grok, this check is **verified** (`grok plugin list --json`, run automatically by the bootstrap before the health check) rather than merely inferred from install state; Codex and Antigravity have no non-interactive way to list actively loaded skills yet, so their exposure stays `unknown` until their CLIs expose one — see the [process-spine skill exposure health design](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md).
 
@@ -144,7 +144,7 @@ The banner reports **DPF-native replacement skills installed** separately from *
 
 ### The plugin: skills, hooks, and MCP in one package
 
-The bootstrap doesn't copy loose files around — it installs one **plugin**, `dpf-platform`, into each client. A plugin is the Claude Code (and Codex / Grok / Antigravity) packaging format that lets a single artifact declare **skills**, **hooks**, and **MCP servers** together. DPF ships all three from `packages/dpf-skill-pack` so one install makes any client fully DPF-native.
+The bootstrap doesn't rely on loose skill files — it installs one **plugin**, `dpf-platform`, into each client. The shared package owns the skills plus the cross-client hook and MCP contracts. Each client adapter then uses the host's supported registration surfaces. Claude can consume those declarations from its plugin manifest; Codex receives skills through the qualified `dpf-platform@personal` registry entry while the bootstrap wires Codex hooks and MCP in its global config.
 
 ```mermaid
 flowchart LR
@@ -165,7 +165,7 @@ flowchart LR
     mc --> client
 ```
 
-The manifest (`plugin.json`) is what ties it together — its `skills`, `hooks`, and `mcpServers` keys point at the three folders above. Codex, Grok, and Antigravity get parallel manifests (`.codex-plugin/plugin.json`, `.grok-plugin/plugin.json`, `.antigravity-plugin/plugin.json`) so the **same source of truth** installs on every surface.
+The surface manifest (`plugin.json`) ties the package to each host. Manifests declare only capabilities that host supports; the bootstrap adapter owns any remaining global wiring. Codex, Grok, and Antigravity get parallel manifests (`.codex-plugin/plugin.json`, `.grok-plugin/plugin.json`, `.antigravity-plugin/plugin.json`) so the **same source of truth** installs on every surface without pretending their plugin schemas are identical.
 
 > **One file per skill, two surfaces.** Each skill's `SKILL.md` is a superset that feeds **both** the external agent client (as the `dpf-platform:*` plugin namespace) **and** the in-portal coworker (seeded as a `SkillDefinition` row). You never maintain two copies.
 
@@ -248,7 +248,9 @@ DPF relies on local guardrails — the pre-commit secret scan + typecheck hook (
 
 #### Codex
 
-- Desktop/IDE app and CLI both read `~/.codex/config.toml`. The bearer token is referenced via `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`, never stored in the file. The plugin installs from `.codex-plugin/plugin.json`. **Check the draft-PR default** (above).
+- Desktop/IDE app and CLI both read `~/.codex/config.toml`. The bearer token is referenced via `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`, never stored in the file.
+- The bootstrap publishes the repo-local package to Codex's personal marketplace, runs the equivalent of `codex plugin add dpf-platform@personal`, and verifies that the registry reports it installed and enabled. The canonical config key is `[plugins."dpf-platform@personal"]`; the bootstrap migrates the older invalid bare key without overriding an explicit user disable.
+- Codex's current plugin manifest exposes the skills and default prompts. The bootstrap separately wires the shared governance hooks and DPF MCP server in Codex's global configuration because those fields are not accepted in the Codex plugin manifest schema. **Check the draft-PR default** (above).
 
 #### Grok
 
@@ -414,7 +416,7 @@ The full operating contract is [AGENTS.md](https://github.com/OpenDigitalProduct
 | `/mcp` (or the client's MCP panel) doesn't list `dpf` | Restart the client in the repo root; GUI apps need a full restart to pick up a new token; re-run the bootstrap if still missing |
 | Banner shows `missing_token` | Issue a write token in Admin → Platform Development → MCP, then re-run the bootstrap |
 | Banner shows `needs_refresh` | Restart the client; if rotated, `POST /api/mcp/token/refresh` with the new token |
-| Skills / plugin not showing up | Confirm the `dpf-platform` plugin installed (re-run the bootstrap, `--show-substrate` for detail); restart the client |
+| Skills / plugin not showing up | Re-run the bootstrap and inspect `--show-substrate`; on Codex, confirm the qualified `dpf-platform@personal` registry entry is installed and enabled, then restart the client |
 | Retired generic process skills are visible but DPF replacements are missing | Stop before project work, restart the client, and re-run the bootstrap; the readiness banner distinguishes plugin files installed from replacement skills loaded in the active session |
 | PRs keep opening as drafts | Disable the "create PRs as draft" default in your client's GitHub settings (DPF uses ready-for-review PRs only) |
 | Tool returns `insufficient_token_scope` | Issue a scoped token, refresh, retry — do **not** bypass with direct DB edits |

--- a/packages/dpf-bootstrap/src/agent-toolchain/__tests__/codex-config.test.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/__tests__/codex-config.test.ts
@@ -20,7 +20,7 @@ const CONFIG_PATH = "C:\\Users\\Test\\.codex\\config.toml";
 const LOCAL_ENDPOINT = "http://127.0.0.1:3000/api/mcp/v1";
 
 describe("planCodexConfig", () => {
-  it("upserts [plugins.\"dpf-platform\"] enabled=true on the operator-current fixture", () => {
+  it("upserts [plugins.\"dpf-platform@personal\"] enabled=true on the operator-current fixture", () => {
     const plan = planCodexConfig(operatorRedacted, REPO, CONFIG_PATH);
 
     expect(plan.writes).toHaveLength(1);
@@ -32,7 +32,7 @@ describe("planCodexConfig", () => {
     const parsed = parse(plan.writes[0].content) as {
       plugins: Record<string, { enabled: boolean }>;
     };
-    expect(parsed.plugins["dpf-platform"]).toEqual({ enabled: true });
+    expect(parsed.plugins["dpf-platform@personal"]).toEqual({ enabled: true });
   });
 
   it("preserves byte-equivalence of all blocks OUTSIDE the convergence scope", () => {
@@ -55,7 +55,7 @@ describe("planCodexConfig", () => {
     // Non-DPF, non-generic plugins are preserved byte-for-byte.
     const beforePlugins = beforeParsed.plugins as Record<string, { enabled?: boolean }>;
     const afterPlugins = afterParsed.plugins as Record<string, { enabled?: boolean }>;
-    const generic = ["superpowers@openai-curated", "build-ios-apps@openai-curated"];
+    const generic = ["dpf-platform", "superpowers@openai-curated", "build-ios-apps@openai-curated"];
     for (const otherPlugin of Object.keys(beforePlugins)) {
       if (generic.includes(otherPlugin)) continue;
       expect(afterPlugins[otherPlugin]).toEqual(beforePlugins[otherPlugin]);
@@ -163,7 +163,8 @@ describe("planCodexConfig", () => {
     const parsed = parse(plan.writes[0].content) as {
       plugins: Record<string, { enabled?: boolean }>;
     };
-    expect(parsed.plugins["dpf-platform"].enabled).toBe(false); // intent preserved
+    expect(parsed.plugins["dpf-platform@personal"].enabled).toBe(false); // intent preserved
+    expect(parsed.plugins["dpf-platform"]).toBeUndefined(); // legacy key migrated
     expect(parsed.plugins["superpowers@openai-curated"].enabled).toBe(false); // generic disabled
     expect(plan.convergence.some((c) => c.kind === "plugin-disabled")).toBe(true);
   });
@@ -231,7 +232,7 @@ describe("planCodexConfig", () => {
     const parsed = parse(plan.writes[0].content) as {
       plugins: Record<string, { enabled?: boolean }>;
     };
-    expect(parsed.plugins["dpf-platform"].enabled).toBe(true);
+    expect(parsed.plugins["dpf-platform@personal"].enabled).toBe(true);
   });
 
   it("handles empty existing config (fresh contributor)", () => {
@@ -239,7 +240,7 @@ describe("planCodexConfig", () => {
 
     expect(plan.writes).toHaveLength(1);
     const parsed = parse(plan.writes[0].content) as { plugins: Record<string, { enabled: boolean }> };
-    expect(parsed.plugins["dpf-platform"]).toEqual({ enabled: true });
+    expect(parsed.plugins["dpf-platform@personal"]).toEqual({ enabled: true });
   });
 
   it("upserts [mcp_servers.dpf] alongside the plugin when an endpoint is supplied", () => {
@@ -251,7 +252,7 @@ describe("planCodexConfig", () => {
       plugins: Record<string, { enabled: boolean }>;
       mcp_servers: Record<string, { url: string; bearer_token_env_var: string }>;
     };
-    expect(parsed.plugins["dpf-platform"]).toEqual({ enabled: true });
+    expect(parsed.plugins["dpf-platform@personal"]).toEqual({ enabled: true });
     expect(parsed.mcp_servers["dpf"]).toEqual({
       url: LOCAL_ENDPOINT,
       bearer_token_env_var: "DPF_MCP_BEARER_TOKEN",
@@ -287,7 +288,7 @@ describe("planCodexConfig", () => {
       mcp_servers: Record<string, { url: string; bearer_token_env_var: string }>;
     };
     // Plugin intent preserved (still disabled), MCP block written.
-    expect(parsed.plugins["dpf-platform"].enabled).toBe(false);
+    expect(parsed.plugins["dpf-platform@personal"].enabled).toBe(false);
     expect(parsed.mcp_servers["dpf"]).toEqual({
       url: novelEndpoint,
       bearer_token_env_var: "DPF_MCP_BEARER_TOKEN",

--- a/packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
@@ -8,7 +8,7 @@
  *
  * Convergence scope (per docs/superpowers/specs/2026-06-05-unified-delivery-
  * surfaces-execution-alignment-design.md S4.5):
- *   - ensure `[plugins."dpf-platform"]` + `[mcp_servers.dpf]` (the DPF baseline);
+ *   - ensure `[plugins."dpf-platform@personal"]` + `[mcp_servers.dpf]` (the DPF baseline);
  *   - DISABLE generic, non-DPF clients that auto-spawn orphaned npx/node
  *     sidecars (`superpowers@openai-curated`, `build-ios-apps@openai-curated`
  *     plugins; `nanobanana-mcp`, `youtube_transcript` MCP servers). The decision
@@ -52,7 +52,8 @@ export type CodexConfigPlan = {
   convergence: CodexConfigConvergenceChange[];
 };
 
-const DPF_PLUGIN_KEY = "dpf-platform";
+const DPF_PLUGIN_KEY = "dpf-platform@personal";
+const LEGACY_DPF_PLUGIN_KEY = "dpf-platform";
 // Mirrors MCP_BEARER_TOKEN_ENV_VAR in apps/web/lib/auth/mcp-setup-snippets.ts.
 // Duplicated as a stable literal because this installer-side package must not
 // depend on the web bundle. Keep the two in lockstep.
@@ -199,7 +200,7 @@ function isGenericPlugin(pluginId: string): boolean {
  * Plan the Codex `config.toml` upsert for this contributor and repo.
  *
  * Converges the DPF working profile:
- *   - `[plugins."dpf-platform"]` enabled = true (the DPF skill pack)
+ *   - `[plugins."dpf-platform@personal"]` enabled = true (the DPF skill pack)
  *   - `[mcp_servers.dpf]` url + bearer_token_env_var (the governed MCP transport),
  *     written only when `mcpEndpoint` is supplied.
  *   - generic, non-DPF plugins (`superpowers`, `build-ios-apps`) disabled.
@@ -245,9 +246,13 @@ export function planCodexConfig(
   }
 
   const plugins = (parsed["plugins"] as Record<string, unknown> | undefined) ?? {};
-  const existingBlock = plugins[DPF_PLUGIN_KEY] as { enabled?: boolean } | undefined;
+  const currentBlock = plugins[DPF_PLUGIN_KEY] as { enabled?: boolean } | undefined;
+  const legacyBlock = plugins[LEGACY_DPF_PLUGIN_KEY] as { enabled?: boolean } | undefined;
+  const existingBlock = currentBlock ?? legacyBlock;
+  const legacyPluginPresent = Object.prototype.hasOwnProperty.call(plugins, LEGACY_DPF_PLUGIN_KEY);
   const userDisabledPlugin = existingBlock?.enabled === false;
-  const pluginConverged = existingBlock?.enabled === true || userDisabledPlugin;
+  const pluginConverged =
+    !legacyPluginPresent && (currentBlock?.enabled === true || currentBlock?.enabled === false);
 
   const mcpServers = (parsed["mcp_servers"] as Record<string, unknown> | undefined) ?? {};
   const existingMcp = mcpServers["dpf"] as
@@ -286,6 +291,7 @@ export function planCodexConfig(
   });
 
   const needsConvergence =
+    legacyPluginPresent ||
     genericPluginsToDisable.length > 0 ||
     genericMcpToDisable.length > 0 ||
     trustToAdd.length > 0;
@@ -308,11 +314,20 @@ export function planCodexConfig(
 
   // Plugin block: add/enable DPF unless the user explicitly disabled it.
   // We also disable the generic plugins in the same plugins map.
-  if (!pluginConverged || genericPluginsToDisable.length > 0) {
+  if (!pluginConverged || legacyPluginPresent || genericPluginsToDisable.length > 0) {
     const nextPlugins: Record<string, unknown> = { ...plugins };
-    if (!pluginConverged) {
-      nextPlugins[DPF_PLUGIN_KEY] = { ...(existingBlock ?? {}), enabled: true };
-      rationaleParts.push(`enable [plugins."${DPF_PLUGIN_KEY}"]`);
+    if (legacyPluginPresent) {
+      delete nextPlugins[LEGACY_DPF_PLUGIN_KEY];
+      rationaleParts.push(`migrate legacy [plugins."${LEGACY_DPF_PLUGIN_KEY}"]`);
+    }
+    if (!pluginConverged || legacyPluginPresent) {
+      nextPlugins[DPF_PLUGIN_KEY] = {
+        ...(existingBlock ?? {}),
+        enabled: userDisabledPlugin ? false : true,
+      };
+      rationaleParts.push(
+        `${userDisabledPlugin ? "preserve disabled" : "enable"} [plugins."${DPF_PLUGIN_KEY}"]`,
+      );
     }
     for (const id of genericPluginsToDisable) {
       const blk = (plugins[id] as Record<string, unknown> | undefined) ?? {};

--- a/packages/dpf-skill-pack/.antigravity-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for Google Antigravity contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds external Antigravity users (agy CLI + IDE) and in-portal coworkers alike. Hook consumption on the Antigravity surface is pending functional confirmation (EP-ANTIGRAVITY-001 evidence gate BI-47A81FEB) — until confirmed, comply with the lease/worktree contract by construction. See README.md.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/.claude-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for both Claude Code contributors (plugin namespace dpf-platform:*) and in-portal coworkers (seeded as SkillDefinition rows by the extended seed-skills.ts loader). Single-source-of-truth contract: superset SKILL.md frontmatter feeds both surfaces from one file per skill. See README.md.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/.codex-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dpf-platform",
-  "version": "0.2.4",
+  "version": "0.2.5+codex.20260726032301",
   "description": "DPF-native agent skills for contributor sessions and in-portal coworkers.",
   "author": {
     "name": "Digital Product Factory",
@@ -21,8 +21,6 @@
     "wwmd"
   ],
   "skills": "./skills/",
-  "mcpServers": "./codex.mcp.json",
-  "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "DPF Platform",
     "shortDescription": "DPF-native development and coworker skills",
@@ -33,6 +31,11 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"
+    "websiteURL": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory",
+    "defaultPrompt": [
+      "Ground this DPF decision in the founder kernel.",
+      "Plan this DPF change against the live backlog.",
+      "Review this work using DPF architecture doctrine."
+    ]
   }
 }

--- a/packages/dpf-skill-pack/.grok-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for Grok contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds both external Grok users and in-portal coworkers. See README.md.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/README.md
+++ b/packages/dpf-skill-pack/README.md
@@ -99,7 +99,7 @@ When adding a skill to this pack:
 
 ## Plugin manifests
 
-The `.claude-plugin/plugin.json` manifest turns this directory into an installable Claude Code plugin. The `.codex-plugin/plugin.json` manifest exposes the same package to Codex. All three manifests (`.claude-plugin`, `.codex-plugin`, `.grok-plugin`) point to the same `skills/` directory and the same `hooks/hooks.json` — the governance guards (lease-guard + the UX-fit / spec-plan-doc prechecks) that ship to every surface per BI-CA0ED781, since Codex and Grok adopted the Claude `PreToolUse` hook protocol — plus client-specific DPF MCP descriptors:
+The `.claude-plugin/plugin.json` manifest turns this directory into an installable Claude Code plugin. The `.codex-plugin/plugin.json` manifest exposes the same skills package to Codex. Claude auto-loads `hooks/hooks.json`; Grok and Antigravity declare it in their manifests. Codex's current plugin manifest schema does not accept a `hooks` field, so the dependency-free updater installs the same governance guards through `~/.codex/hooks.json`. MCP wiring is likewise converged by the updater per client rather than declared in the Codex manifest:
 
 - `claude.mcp.json` — Claude Code MCP descriptor using `${DPF_MCP_URL:-http://127.0.0.1:3000/api/mcp/v1}` and `${DPF_MCP_BEARER_TOKEN:-}`.
 - `codex.mcp.json` — Codex MCP descriptor using local `http://127.0.0.1:3000/api/mcp/v1` plus `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`.
@@ -130,13 +130,17 @@ The dependency-free updater lives in this package:
 What the updater does:
 
 1. Validates the skill-pack manifests and `skills/` directory.
-2. Copies the current skill pack to the managed personal plugin location:
-   `~/.agents/plugins/plugins/dpf-platform`.
+2. Copies the current skill pack to the client-resolved managed plugin
+   locations:
+   - Codex personal marketplace source: `~/plugins/dpf-platform`
+   - shared Claude/Grok source: `~/.agents/plugins/plugins/dpf-platform`
 3. Writes or updates Codex's personal marketplace at
    `~/.agents/plugins/marketplace.json` with `dpf-platform` marked
    `INSTALLED_BY_DEFAULT`.
-4. Writes or updates `~/.codex/config.toml` with:
-   - `[plugins."dpf-platform"] enabled = true`
+4. Installs `dpf-platform@personal` through the Codex plugin registry, verifies
+   that Codex reports it installed and enabled, and writes or updates
+   `~/.codex/config.toml` with:
+   - `[plugins."dpf-platform@personal"] enabled = true`
    - `[mcp_servers.dpf]` pointing to the DPF MCP URL and
      `bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"`
 5. Writes a Claude local marketplace at

--- a/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
+++ b/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
@@ -215,8 +215,8 @@ test("plugin hook commands reference the script via ${CLAUDE_PLUGIN_ROOT}, not a
 });
 
 test("surface manifests wire the hooks file so guards ship on every surface", () => {
-  // Codex and Grok resolve the hooks manifest from an explicit plugin.json key.
-  // Both resolve component paths from the PLUGIN ROOT (the dir CONTAINING the
+  // Grok resolves the hooks manifest from an explicit plugin.json key.
+  // It resolves component paths from the PLUGIN ROOT (the dir CONTAINING the
   // .<surface>-plugin/ folder), so the key must be "./hooks/hooks.json". The
   // .grok-plugin manifest previously used "../hooks/hooks.json" on the wrong
   // assumption that it resolves from the .grok-plugin dir; live probing (BI-883FC2FC)
@@ -227,7 +227,6 @@ test("surface manifests wire the hooks file so guards ship on every surface", ()
   // guards still ship on Claude via the auto-loaded file, asserted present below.
   // BI-CA0ED781 / BI-883FC2FC. See also surface-manifest-paths.test.mjs.
   const declaring = [
-    [".codex-plugin", "./hooks/hooks.json"],
     [".grok-plugin", "./hooks/hooks.json"],
     [".antigravity-plugin", "./hooks/hooks.json"],
   ];
@@ -253,6 +252,18 @@ test("surface manifests wire the hooks file so guards ship on every surface", ()
   assert.ok(
     existsSync(join(here, "hooks.json")),
     "hooks/hooks.json must exist so Claude auto-loads the guards",
+  );
+
+  // Codex's current plugin manifest schema rejects an explicit hooks field.
+  // The dependency-free updater installs the same guards through
+  // ~/.codex/hooks.json, which is covered by update_agent_toolchain_test.py.
+  const codexManifest = JSON.parse(
+    readFileSync(join(here, "..", ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  assert.equal(
+    codexManifest.hooks,
+    undefined,
+    '.codex-plugin/plugin.json must not declare unsupported "hooks"; the updater owns Codex hook wiring',
   );
 });
 

--- a/packages/dpf-skill-pack/process-spine-version.mjs
+++ b/packages/dpf-skill-pack/process-spine-version.mjs
@@ -2,4 +2,4 @@
 // Bump when hook wiring, skill-pack distribution, or spine enforcement changes
 // so installs can detect drift and re-run bootstrap.
 
-export const PROCESS_SPINE_VERSION = "2026.07.20.1";
+export const PROCESS_SPINE_VERSION = "2026.07.25.1";

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 
 
 PLUGIN_NAME = "dpf-platform"
+CODEX_PLUGIN_ID = f"{PLUGIN_NAME}@personal"
 MARKETPLACE_NAME = "dpf-platform-local"
 TOKEN_ENV_VAR = "DPF_MCP_BEARER_TOKEN"
 DEFAULT_MCP_URL = "http://127.0.0.1:3000/api/mcp/v1"
@@ -92,8 +93,24 @@ def codex_marketplace_path(home: Path) -> Path:
     return home / ".agents" / "plugins" / "marketplace.json"
 
 
-def managed_plugin_path(home: Path) -> Path:
+def codex_managed_plugin_path(home: Path) -> Path:
+    """Return the source path Codex resolves for the personal marketplace.
+
+    Codex resolves `./plugins/<name>` in ~/.agents/plugins/marketplace.json
+    against the user home, not against the marketplace file's directory.
+    `codex plugin list --available --json` reports this exact absolute path.
+    """
+    return home / "plugins" / PLUGIN_NAME
+
+
+def shared_managed_plugin_path(home: Path) -> Path:
+    """Return the managed copy consumed by Claude, Grok, and global hooks."""
     return home / ".agents" / "plugins" / "plugins" / PLUGIN_NAME
+
+
+# Backward-compatible name for existing hook/install helpers and callers.
+def managed_plugin_path(home: Path) -> Path:
+    return shared_managed_plugin_path(home)
 
 
 def process_spine_contract_path(skill_pack: Path) -> Path:
@@ -523,6 +540,39 @@ def upsert_toml_table(text: str, header: str, body_lines: list[str]) -> str:
     return "\n".join(rebuilt).rstrip() + "\n"
 
 
+def remove_toml_table(text: str, canonical_key: str) -> str:
+    """Remove every exact table match while preserving all other text."""
+    lines = text.splitlines()
+    ranges: list[tuple[int, int]] = []
+    index = 0
+    while index < len(lines):
+        if canonical_toml_table_header(lines[index]) == canonical_key:
+            end = index + 1
+            while end < len(lines) and not _is_table_boundary(lines[end]):
+                end += 1
+            ranges.append((index, end))
+            index = end
+        else:
+            index += 1
+    removal = {line_no for start, end in ranges for line_no in range(start, end)}
+    return "\n".join(line for index, line in enumerate(lines) if index not in removal).rstrip() + "\n"
+
+
+def toml_table_enabled(text: str, canonical_key: str) -> Optional[bool]:
+    """Read an explicit enabled boolean from one table without a TOML dependency."""
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if canonical_toml_table_header(line) != canonical_key:
+            continue
+        end = index + 1
+        while end < len(lines) and not _is_table_boundary(lines[end]):
+            match = re.match(r"^\s*enabled\s*=\s*(true|false)\s*(?:#.*)?$", lines[end], re.IGNORECASE)
+            if match:
+                return match.group(1).lower() == "true"
+            end += 1
+    return None
+
+
 def disable_competitive_codex_plugins(text: str, plugin_ids: list[str]) -> str:
     for plugin_id in dict.fromkeys(plugin_ids):
         if not plugin_id or plugin_id == PLUGIN_NAME:
@@ -558,10 +608,16 @@ def ensure_codex_config(
     # ships an equivalent command.
     path = codex_config_path(home)
     text = path.read_text(encoding="utf-8-sig") if path.exists() else ""
+    current_enabled = toml_table_enabled(text, f"plugins.{CODEX_PLUGIN_ID}")
+    legacy_enabled = toml_table_enabled(text, f"plugins.{PLUGIN_NAME}")
+    desired_enabled = current_enabled if current_enabled is not None else legacy_enabled
+    # Pre-plugin-registry DPF installers wrote the bare key. Current Codex
+    # requires <plugin>@<marketplace> and logs the bare key as invalid.
+    text = remove_toml_table(text, f"plugins.{PLUGIN_NAME}")
     text = upsert_toml_table(
         text,
-        f'[plugins."{PLUGIN_NAME}"]',
-        ["enabled = true"],
+        f'[plugins."{CODEX_PLUGIN_ID}"]',
+        [f"enabled = {'false' if desired_enabled is False else 'true'}"],
     )
     text = disable_competitive_codex_plugins(text, codex_competitive_plugin_ids(skill_pack))
     text = upsert_toml_table(
@@ -644,15 +700,26 @@ def install_claude_plugin(home: Path, dry_run: bool) -> str:
 
 
 def resolve_codex_binary() -> str | None:
-    found = shutil.which("codex")
-    if found:
-        return found
     home = home_dir()
     candidates: list[str] = []
+    configured = os.environ.get("CODEX_CLI_PATH")
+    if configured:
+        candidates.append(configured)
     if platform.system() == "Windows":
         local = os.environ.get("LOCALAPPDATA")
         if local:
             candidates.append(str(Path(local) / "Programs" / "Codex" / "codex.exe"))
+            app_bin = Path(local) / "OpenAI" / "Codex" / "bin"
+            if app_bin.exists():
+                candidates.extend(
+                    str(path)
+                    for path in sorted(
+                        app_bin.glob("*/codex.exe"),
+                        key=lambda path: path.stat().st_mtime,
+                        reverse=True,
+                    )
+                )
+                candidates.append(str(app_bin / "codex.exe"))
         candidates.append(str(home / "AppData" / "Roaming" / "npm" / "codex.cmd"))
     else:
         candidates.extend([
@@ -660,10 +727,54 @@ def resolve_codex_binary() -> str | None:
             "/usr/local/bin/codex",
             str(home / ".local" / "bin" / "codex"),
         ])
+    found = shutil.which("codex")
+    if found:
+        candidates.append(found)
     for candidate in candidates:
         if Path(candidate).exists():
             return candidate
     return None
+
+
+def install_codex_plugin(home: Path, dry_run: bool) -> str:
+    """Install and verify the DPF plugin through Codex's own registry."""
+    codex = resolve_codex_binary()
+    if not codex:
+        return "skipped: Codex CLI not found"
+    selector = f"{PLUGIN_NAME}@personal"
+    if dry_run:
+        return f"dry-run: would install and verify {selector}"
+    try:
+        installed = subprocess.run(
+            [codex, "plugin", "add", selector, "--json"],
+            cwd=str(home),
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        return f"failed: Codex CLI could not start ({exc.__class__.__name__})"
+    if installed.returncode != 0:
+        return f"failed: codex plugin add exited {installed.returncode}"
+    listed = subprocess.run(
+        [codex, "plugin", "list", "--marketplace", "personal", "--json"],
+        cwd=str(home),
+        capture_output=True,
+        text=True,
+    )
+    if listed.returncode != 0:
+        return f"failed: codex plugin list exited {listed.returncode}"
+    try:
+        inventory = json.loads(listed.stdout or "{}")
+    except json.JSONDecodeError:
+        return "failed: codex plugin list returned invalid JSON"
+    matches = [
+        plugin
+        for plugin in inventory.get("installed", [])
+        if isinstance(plugin, dict) and plugin.get("pluginId") == selector
+    ]
+    if not matches or not matches[0].get("installed") or not matches[0].get("enabled"):
+        return "failed: Codex did not report dpf-platform installed and enabled"
+    return "installed, enabled, and verified"
 
 
 def resolve_grok_binary() -> str | None:
@@ -1135,6 +1246,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--mcp-url", default=os.environ.get("DPF_MCP_URL", DEFAULT_MCP_URL))
     parser.add_argument("--codex-only", action="store_true")
     parser.add_argument("--claude-only", action="store_true")
+    parser.add_argument("--skip-codex-cli-install", action="store_true")
     parser.add_argument("--skip-claude-cli-install", action="store_true")
     parser.add_argument("--skip-grok-cli-install", action="store_true")
     parser.add_argument(
@@ -1157,7 +1269,8 @@ def main(argv: list[str]) -> int:
     manifest = validate_skill_pack(skill_pack)
     version = str(manifest.get("version", "0.0.0"))
     home = home_dir()
-    managed = managed_plugin_path(home)
+    codex_managed = codex_managed_plugin_path(home)
+    shared_managed = shared_managed_plugin_path(home)
 
     print(f"DPF agent toolchain updater")
     print(f"  skill pack : {skill_pack}")
@@ -1165,16 +1278,14 @@ def main(argv: list[str]) -> int:
     print(f"  home       : {home}")
     print(f"  MCP URL    : {args.mcp_url}")
 
-    copy_skill_pack(skill_pack, managed, args.dry_run)
-    print(f"  managed copy: {managed}")
-    process_spine_root = skill_pack if args.dry_run else managed
+    copy_skill_pack(skill_pack, codex_managed, args.dry_run)
+    copy_skill_pack(skill_pack, shared_managed, args.dry_run)
+    print(f"  Codex source : {codex_managed}")
+    print(f"  shared source: {shared_managed}")
+    process_spine_root = skill_pack if args.dry_run else codex_managed
     if not process_spine_contract_path(process_spine_root).exists():
         process_spine_root = skill_pack
     exposed_skills = exposed_process_spine_skills_from_env()
-    if exposed_skills is None:
-        # No explicit evidence channel set; try the Grok live-probe adapter
-        # before falling back to "unknown" (BI-BCA162CF).
-        exposed_skills = probe_grok_exposed_skills(process_spine_root)
     process_spine_verdict = assess_process_spine_health(
         process_spine_root,
         exposed_skills=exposed_skills,
@@ -1189,15 +1300,21 @@ def main(argv: list[str]) -> int:
     if not args.claude_only:
         ensure_codex_marketplace(home, version, args.dry_run)
         ensure_codex_config(home, args.mcp_url, args.dry_run, process_spine_root)
-        codex_hooks_status = install_codex_hooks(managed, home, args.dry_run)
-        print(f"  Codex      : marketplace + config converged; hooks {codex_hooks_status}")
+        codex_status = "skipped by flag"
+        if not args.skip_codex_cli_install:
+            codex_status = install_codex_plugin(home, args.dry_run)
+        codex_hooks_status = install_codex_hooks(codex_managed, home, args.dry_run)
+        print(
+            f"  Codex      : marketplace + config converged; plugin {codex_status}; "
+            f"hooks {codex_hooks_status}"
+        )
         grok_status = "skipped by flag"
         if not args.skip_grok_cli_install:
-            grok_status = install_grok_plugin(managed, args.dry_run)
+            grok_status = install_grok_plugin(shared_managed, args.dry_run)
         print(f"  Grok       : plugin install {grok_status}")
         # Grok's hook plane ignores plugin-bundled hooks (BI-883FC2FC), so the
         # blocking guards are delivered via the always-trusted global hook plane.
-        grok_hooks_status = install_grok_hooks(managed, home, args.dry_run)
+        grok_hooks_status = install_grok_hooks(shared_managed, home, args.dry_run)
         print(f"  Grok hooks : {grok_hooks_status}")
         # Antigravity (agy): MCP-config wiring + skill-pack sync.
         antigravity_status = "skipped by flag"
@@ -1209,7 +1326,11 @@ def main(argv: list[str]) -> int:
 
     if not args.codex_only:
         ensure_claude_marketplace(home, version, args.dry_run)
-        ensure_claude_repo_mcp_config(managed if not args.dry_run else skill_pack, args.mcp_url, args.dry_run)
+        ensure_claude_repo_mcp_config(
+            shared_managed if not args.dry_run else skill_pack,
+            args.mcp_url,
+            args.dry_run,
+        )
         status = "skipped by flag"
         if not args.skip_claude_cli_install:
             status = install_claude_plugin(home, args.dry_run)

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -46,6 +46,7 @@ class WriteTextIfChangedTest(unittest.TestCase):
                 code = updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                 ])
@@ -122,6 +123,17 @@ class HookRosterTest(unittest.TestCase):
 
 
 class UpdateAgentToolchainTest(unittest.TestCase):
+    def test_client_managed_paths_match_marketplace_resolution(self) -> None:
+        home = Path("/operator-home")
+        self.assertEqual(
+            updater.codex_managed_plugin_path(home),
+            home / "plugins" / "dpf-platform",
+        )
+        self.assertEqual(
+            updater.shared_managed_plugin_path(home),
+            home / ".agents" / "plugins" / "plugins" / "dpf-platform",
+        )
+
     @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_converges_codex_and_claude_marketplaces_in_temp_home(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]
@@ -130,6 +142,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 code = updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                 ])
@@ -137,14 +150,16 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             self.assertEqual(code, 0)
             home = Path(tmp)
 
-            managed = home / ".agents" / "plugins" / "plugins" / "dpf-platform"
-            self.assertTrue((managed / ".codex-plugin" / "plugin.json").exists())
-            self.assertTrue((managed / ".claude-plugin" / "plugin.json").exists())
-            self.assertTrue((managed / "skills").exists())
-            self.assertTrue((managed / "hooks" / "plan-backlog-coverage-guard.mjs").exists())
+            codex_managed = home / "plugins" / "dpf-platform"
+            shared_managed = home / ".agents" / "plugins" / "plugins" / "dpf-platform"
+            for managed in (codex_managed, shared_managed):
+                self.assertTrue((managed / ".codex-plugin" / "plugin.json").exists())
+                self.assertTrue((managed / ".claude-plugin" / "plugin.json").exists())
+                self.assertTrue((managed / "skills").exists())
+                self.assertTrue((managed / "hooks" / "plan-backlog-coverage-guard.mjs").exists())
 
             codex_config = tomllib.loads((home / ".codex" / "config.toml").read_text())
-            self.assertTrue(codex_config["plugins"]["dpf-platform"]["enabled"])
+            self.assertTrue(codex_config["plugins"]["dpf-platform@personal"]["enabled"])
             self.assertEqual(
                 codex_config["mcp_servers"]["dpf"]["bearer_token_env_var"],
                 "DPF_MCP_BEARER_TOKEN",
@@ -195,6 +210,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                     "--mcp-url",
@@ -203,7 +219,8 @@ class UpdateAgentToolchainTest(unittest.TestCase):
 
             data = tomllib.loads(config.read_text())
             self.assertEqual(data["model"], "gpt-5.5")
-            self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
+            self.assertFalse(data["plugins"]["dpf-platform@personal"]["enabled"])
+            self.assertNotIn("dpf-platform", data["plugins"])
             self.assertEqual(data["mcp_servers"]["dpf"]["url"], "https://mcp.example.test/api/mcp/v1")
 
     @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
@@ -226,12 +243,13 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                 ])
 
             data = tomllib.loads(config.read_text())
-            self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
+            self.assertTrue(data["plugins"]["dpf-platform@personal"]["enabled"])
             self.assertFalse(data["plugins"]["superpowers@openai-curated"]["enabled"])
             self.assertTrue(data["plugins"]["custom-helper"]["enabled"])
 
@@ -242,7 +260,55 @@ class UpdateAgentToolchainTest(unittest.TestCase):
         self.assertIn("superpowers@openai-curated", codex["competitivePluginIds"])
         self.assertEqual(codex["action"], "disable-plugin")
 
-    def test_reuses_bare_codex_plugin_table_instead_of_appending_duplicate(self) -> None:
+    def test_installs_and_verifies_through_codex_registry(self) -> None:
+        add_result = unittest.mock.Mock(returncode=0, stdout='{"installed":true}', stderr="")
+        list_result = unittest.mock.Mock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "installed": [
+                        {
+                            "pluginId": "dpf-platform@personal",
+                            "installed": True,
+                            "enabled": True,
+                        }
+                    ]
+                }
+            ),
+            stderr="",
+        )
+        with patch.object(
+            updater, "resolve_codex_binary", return_value="/fake/codex"
+        ), patch("subprocess.run", side_effect=[add_result, list_result]) as run:
+            status = updater.install_codex_plugin(Path("/operator-home"), dry_run=False)
+
+        self.assertEqual(status, "installed, enabled, and verified")
+        self.assertEqual(
+            run.call_args_list[0].args[0],
+            ["/fake/codex", "plugin", "add", "dpf-platform@personal", "--json"],
+        )
+        self.assertEqual(
+            run.call_args_list[1].args[0],
+            [
+                "/fake/codex",
+                "plugin",
+                "list",
+                "--marketplace",
+                "personal",
+                "--json",
+            ],
+        )
+
+    def test_refuses_to_claim_success_when_registry_does_not_install_plugin(self) -> None:
+        add_result = unittest.mock.Mock(returncode=0, stdout="{}", stderr="")
+        list_result = unittest.mock.Mock(returncode=0, stdout='{"installed":[]}', stderr="")
+        with patch.object(
+            updater, "resolve_codex_binary", return_value="/fake/codex"
+        ), patch("subprocess.run", side_effect=[add_result, list_result]):
+            status = updater.install_codex_plugin(Path("/operator-home"), dry_run=False)
+        self.assertIn("failed", status)
+
+    def test_migrates_bare_codex_plugin_table_to_registry_qualified_key(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
@@ -259,6 +325,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                 ])
@@ -266,7 +333,8 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             raw = config.read_text()
             if tomllib is not None:
                 data = tomllib.loads(raw)
-                self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
+                self.assertTrue(data["plugins"]["dpf-platform@personal"]["enabled"])
+                self.assertNotIn("dpf-platform", data["plugins"])
             self.assertEqual(raw.count("dpf-platform"), 1)
 
     def test_heals_config_already_corrupted_with_duplicate_table(self) -> None:
@@ -299,6 +367,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                 ])
@@ -322,6 +391,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 code = updater.main([
                     "--skill-pack-path",
                     str(skill_pack),
+                    "--skip-codex-cli-install",
                     "--skip-claude-cli-install",
                     "--skip-grok-cli-install",
                 ])
@@ -333,7 +403,7 @@ class UpdateAgentToolchainTest(unittest.TestCase):
             self.assertTrue((managed / "skills" / "dpf-worktree-per-session" / "SKILL.md").exists())
 
             codex_config = tomllib.loads((home / ".codex" / "config.toml").read_text())
-            self.assertTrue(codex_config["plugins"]["dpf-platform"]["enabled"])
+            self.assertTrue(codex_config["plugins"]["dpf-platform@personal"]["enabled"])
             self.assertEqual(
                 codex_config["mcp_servers"]["dpf"]["bearer_token_env_var"],
                 "DPF_MCP_BEARER_TOKEN",
@@ -421,10 +491,11 @@ class ClaudeInstallTest(unittest.TestCase):
         ) as run:
             status = updater.install_claude_plugin(Path("/tmp/home"), dry_run=False)
         self.assertEqual(status, "installed and refreshed")
+        marketplace_root = str(Path("/tmp/home") / ".agents" / "plugins")
         self.assertEqual(
             [call[0][0] for call in run.call_args_list],
             [
-                ["/fake/claude", "plugin", "marketplace", "add", "/tmp/home/.agents/plugins", "--scope", "local"],
+                ["/fake/claude", "plugin", "marketplace", "add", marketplace_root, "--scope", "local"],
                 ["/fake/claude", "plugin", "install", "dpf-platform@dpf-platform-local", "--scope", "local"],
                 ["/fake/claude", "plugin", "update", "dpf-platform@dpf-platform-local", "--scope", "local"],
             ],
@@ -714,6 +785,7 @@ class CodexHookTrustTest(unittest.TestCase):
                     [
                         "--skill-pack-path",
                         str(skill_pack),
+                        "--skip-codex-cli-install",
                         "--skip-claude-cli-install",
                         "--skip-grok-cli-install",
                         "--require-codex-hook-trust",
@@ -796,6 +868,30 @@ class ProbeGrokExposedSkillsTest(unittest.TestCase):
                     [
                         "--skill-pack-path",
                         str(self.skill_pack),
+                        "--skip-codex-cli-install",
+                        "--skip-claude-cli-install",
+                        "--skip-grok-cli-install",
+                    ]
+                )
+            self.assertEqual(code, 0)
+            mock_probe.assert_not_called()
+
+    def test_main_never_uses_grok_evidence_for_multi_client_session_health(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            clean_env = {
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("DPF_PROCESS_SPINE_EXPOSED_SKILLS")
+            }
+            clean_env["DPF_AGENT_TOOLCHAIN_HOME"] = tmp
+            with patch.dict(os.environ, clean_env, clear=True), patch.object(
+                updater, "probe_grok_exposed_skills"
+            ) as mock_probe:
+                code = updater.main(
+                    [
+                        "--skill-pack-path",
+                        str(self.skill_pack),
+                        "--skip-codex-cli-install",
                         "--skip-claude-cli-install",
                         "--skip-grok-cli-install",
                     ]

--- a/scripts/dpf-bootstrap-agent-toolchain.ps1
+++ b/scripts/dpf-bootstrap-agent-toolchain.ps1
@@ -102,20 +102,9 @@ Write-Info "DPF MCP token    : $(if ($HasToken)      { 'present' } else { 'missi
 Write-Info "Skill pack ver.  : $expectedVersion"
 
 $ProcessSpineCheck = Join-Path $RepoRoot "packages\dpf-skill-pack\hooks\process-spine-health-check.mjs"
-$GrokSkillExposureAdapter = Join-Path $RepoRoot "packages\dpf-skill-pack\hooks\grok-skill-exposure-adapter.mjs"
 if ((Test-Path -LiteralPath $ProcessSpineCheck) -and ($null -ne (Get-Command node -ErrorAction SilentlyContinue))) {
-    # Grok active-skill exposure adapter (BI-BCA162CF): `grok plugin list --json`
-    # is a genuine non-interactive evidence source, so populate the shared env
-    # channel from it when nothing has already supplied evidence. Never
-    # overwrite evidence the operator/CI already set explicitly.
-    $hasExplicitExposureEvidence = $env:DPF_PROCESS_SPINE_EXPOSED_SKILLS_JSON -or `
-        $env:DPF_PROCESS_SPINE_EXPOSED_SKILLS_FILE -or $env:DPF_PROCESS_SPINE_EXPOSED_SKILLS
-    if ($GrokPresent -and -not $hasExplicitExposureEvidence -and (Test-Path -LiteralPath $GrokSkillExposureAdapter)) {
-        $grokExposedSkills = & node $GrokSkillExposureAdapter --skill-pack-root (Join-Path $RepoRoot "packages\dpf-skill-pack") 2>$null
-        if ($LASTEXITCODE -eq 0 -and $grokExposedSkills) {
-            $env:DPF_PROCESS_SPINE_EXPOSED_SKILLS_JSON = $grokExposedSkills
-        }
-    }
+    # Exposure evidence is session/client scoped. Never use Grok's plugin
+    # inventory to certify a Codex or Claude session (BI-BCA162CF).
     & node $ProcessSpineCheck --skill-pack-root (Join-Path $RepoRoot "packages\dpf-skill-pack")
     if ($LASTEXITCODE -eq 2) {
         Write-Warn2 "Process spine replacement skills are missing from the DPF skill pack."

--- a/scripts/dpf-bootstrap-agent-toolchain.sh
+++ b/scripts/dpf-bootstrap-agent-toolchain.sh
@@ -301,21 +301,9 @@ info "DPF MCP token    : $([ $HAS_TOKEN      -eq 1 ] && echo present || echo mis
 info "Skill pack ver.  : $EXPECTED_VERSION"
 
 PROCESS_SPINE_CHECK="$REPO_ROOT/packages/dpf-skill-pack/hooks/process-spine-health-check.mjs"
-GROK_SKILL_EXPOSURE_ADAPTER="$REPO_ROOT/packages/dpf-skill-pack/hooks/grok-skill-exposure-adapter.mjs"
 if command -v node >/dev/null 2>&1 && [ -f "$PROCESS_SPINE_CHECK" ]; then
-  # Grok active-skill exposure adapter (BI-BCA162CF): `grok plugin list --json`
-  # is a genuine non-interactive evidence source, so populate the shared env
-  # channel from it when nothing has already supplied evidence. Never
-  # overwrite evidence the operator/CI already set explicitly.
-  if [ -z "${DPF_PROCESS_SPINE_EXPOSED_SKILLS_JSON:-}" ] \
-     && [ -z "${DPF_PROCESS_SPINE_EXPOSED_SKILLS_FILE:-}" ] \
-     && [ -z "${DPF_PROCESS_SPINE_EXPOSED_SKILLS:-}" ] \
-     && [ "$GROK_PRESENT" -eq 1 ] && [ -f "$GROK_SKILL_EXPOSURE_ADAPTER" ]; then
-    _grok_exposed_skills="$(node "$GROK_SKILL_EXPOSURE_ADAPTER" --skill-pack-root "$REPO_ROOT/packages/dpf-skill-pack" 2>/dev/null)" || _grok_exposed_skills=""
-    if [ -n "$_grok_exposed_skills" ]; then
-      export DPF_PROCESS_SPINE_EXPOSED_SKILLS_JSON="$_grok_exposed_skills"
-    fi
-  fi
+  # Exposure evidence is session/client scoped. Never use Grok's plugin
+  # inventory to certify a Codex or Claude session (BI-BCA162CF).
   node "$PROCESS_SPINE_CHECK" --skill-pack-root "$REPO_ROOT/packages/dpf-skill-pack" || true
 else
   warn "Process spine skill exposure check could not run (node or checker missing)."


### PR DESCRIPTION
## Summary
- install `dpf-platform@personal` through the Codex plugin registry and verify it is installed/enabled
- keep Codex's managed plugin path separate from the shared Claude/Grok adapter path
- migrate the invalid legacy `[plugins.dpf-platform]` config key to `[plugins."dpf-platform@personal"]` without overriding an explicit user disable
- stop treating Grok inventory as proof that skills are exposed in the current Codex session
- align the Codex manifest with the supported schema and bump the process-spine/plugin versions

Closes the residual Codex exposure defect under BI-BCA162CF. Work Capsule: WC-AD184862.

## Design grounding
This preserves DPF's project-native process spine as the single source of truth. Installation, configuration, and runtime exposure are now separate verified states: copying files cannot masquerade as registry installation, and another client's inventory cannot masquerade as Codex session evidence. The adapter remains disable-not-delete for user-owned plugins and preserves an explicit user opt-out.

## Verification
- Python updater unit suite: passed (47 tests)
- process-spine / hook wiring / surface manifest Node suites: passed (31 tests)
- Codex plugin manifest validator: passed
- PowerShell parser and `bash -n`: passed
- focused `@dpf/bootstrap` Codex-config Vitest: passed (16 tests)
- focused `@dpf/bootstrap` TypeScript typecheck in shared sandbox: passed
- fresh Codex task probe: `dpf_brainstorming_present=true`, `dpf_decision_via_kernel_present=true`, `superpowers_brainstorming_present=false`
- shared sandbox freshness: green; Prisma migrate deploy, doc-index, and doc-link checks passed

Local-CI-Override: Full web Vitest is blocked on current `main` by the pre-existing Windows path-separator assertion in `apps/web/lib/actions/gate-clear-invariant.test.ts` (expected slash paths, received backslash paths). This branch does not touch that test or its production writers. Gate evidence: `cms18xk73069x01p8v4u179da`; external handoff evidence: `cms18z0tv06ae01p889cg7yzg`.

## Documentation and UX
Updated operator/install documentation, the skill-pack README, and the implementation plan. No portal UI changes; runtime UX verification is not applicable. The behavior was verified through a new Codex process, which is the affected user path.