### PR TITLE
fix(ci): baseline ops recovery prose from PR 3587

### DIFF
--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1196,6 +1196,20 @@
     "longSentences": 0,
     "textMass": 82
   },
+  "apps/web/app/(shell)/ops/error.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/app/(shell)/ops/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
   "apps/web/app/(shell)/ops/patches/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -1222,7 +1236,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 27
+    "textMass": 29
   },
   "apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary
- record the `/ops` and `/ops/self-upgrade` recovery copy already merged in PR #3587
- restore Prose Lint Guard for unrelated PRs without changing UI source

Tracks the existing prose-lint guard work under BI-88D8C725.

## Design grounding
The prose ratchet remains unchanged: new or grown UI copy must be reviewed and recorded. This PR records only the intentional fail-safe operator copy already shipped by #3587; it does not add copy or weaken any prose axis.

## Verification
- `scripts/check-prose-lint.test.ts` — 15 passed
- `scripts/check-prose-lint.ts` — passed
- `git diff --check` — passed

Docs-Impact-Decision: Baseline bookkeeping for already-documented UI copy; no user workflow or documentation content changes.

Local-CI-Override: Baseline-only repair for UI copy already merged in PR #3587; deterministic prose-lint unit suite and live guard passed, with no runtime source or migration impact.