### PR TITLE
fix(agent-toolchain): reconverge Codex config after install

### DIFF
--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -1303,6 +1303,11 @@ def main(argv: list[str]) -> int:
         codex_status = "skipped by flag"
         if not args.skip_codex_cli_install:
             codex_status = install_codex_plugin(home, args.dry_run)
+            # Codex currently writes a legacy `[plugins."<name>"]` alias while
+            # installing a qualified registry id. Converge again after the CLI
+            # mutation so the next process does not warn that `dpf-platform`
+            # lacks its `@marketplace` qualifier.
+            ensure_codex_config(home, args.mcp_url, args.dry_run, process_spine_root)
         codex_hooks_status = install_codex_hooks(codex_managed, home, args.dry_run)
         print(
             f"  Codex      : marketplace + config converged; plugin {codex_status}; "

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -337,6 +337,41 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 self.assertNotIn("dpf-platform", data["plugins"])
             self.assertEqual(raw.count("dpf-platform"), 1)
 
+    def test_reconverges_config_after_codex_plugin_install_recreates_legacy_alias(self) -> None:
+        skill_pack = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            config = home / ".codex" / "config.toml"
+
+            def install_with_legacy_alias(_home: Path, _dry_run: bool) -> str:
+                with config.open("a", encoding="utf-8") as handle:
+                    handle.write('[plugins."dpf-platform"]\nenabled = true\n')
+                return "installed, enabled, and verified"
+
+            with patch.dict(
+                os.environ,
+                {"DPF_AGENT_TOOLCHAIN_HOME": tmp},
+                clear=False,
+            ), patch.object(
+                updater,
+                "install_codex_plugin",
+                side_effect=install_with_legacy_alias,
+            ):
+                updater.main([
+                    "--skill-pack-path",
+                    str(skill_pack),
+                    "--skip-claude-cli-install",
+                    "--skip-grok-cli-install",
+                    "--skip-antigravity-cli-install",
+                ])
+
+            raw = config.read_text(encoding="utf-8")
+            if tomllib is not None:
+                data = tomllib.loads(raw)
+                self.assertTrue(data["plugins"]["dpf-platform@personal"]["enabled"])
+                self.assertNotIn("dpf-platform", data["plugins"])
+            self.assertEqual(raw.count("dpf-platform"), 1)
+
     def test_heals_config_already_corrupted_with_duplicate_table(self) -> None:
         """A config a pre-#2657 updater left with a stray appended
         `[mcp_servers.dpf]` (a TOML redefinition error) is healed back to a single


### PR DESCRIPTION
## Summary
- reconverge Codex config after `codex plugin add dpf-platform@personal`
- remove the legacy unqualified alias that the Codex CLI recreates during installation
- cover the CLI mutation with a regression test

Closes BI-5D3A9E1C. Work Capsule: WC-59B95020.

## Design grounding
The qualified registry id remains the single source of truth. The host CLI is allowed to mutate its config during install, so the DPF adapter performs its canonical normalization after that mutation as well as before it. This preserves explicit disable state while preventing the next Codex process from loading an invalid bare alias.

## Verification
- Python updater suite: 48 passed
- live updater left only `[plugins."dpf-platform@personal"]`
- fresh Codex process: DPF brainstorming and kernel-decision skills present; Superpowers brainstorming absent
- fresh Codex process: zero invalid/failed `dpf-platform` plugin-key warnings
- `git diff --check`: passed

Local-CI-Override: Two-file Python updater sequencing fix with 48 focused tests and a live fresh-process exposure/warning probe. Full Windows sandbox web suite remains blocked by the unrelated path-separator invariant documented in #3589. Evidence: `cms1ba6qe08xa01p8jhmy816c`.

Docs-Impact-Decision: No operator workflow changed; this makes the already-documented registry installation converge cleanly after the host CLI mutation.

No portal UI or migration impact.