### PR TITLE
fix(test): normalize Windows PostCSS gate boundaries

### DIFF
--- a/apps/web/design/tokens-utilities.test.ts
+++ b/apps/web/design/tokens-utilities.test.ts
@@ -51,7 +51,13 @@ async function compile(utilities: string[]): Promise<string> {
     `@source inline("${utilities.join(" ")}");`,
     "",
   ].join("\n");
-  const result = await postcss([tailwind()]).process(css, {
+  // pnpm's hoisted layout can expose the same locked PostCSS release through
+  // both the workspace root and apps/web. TypeScript treats those physical
+  // declaration paths as distinct even though the runtime plugin contract is
+  // identical, so normalize the third-party boundary once instead of leaking
+  // the duplicate-package identity through this test.
+  const tailwindPlugin = tailwind() as unknown as postcss.AcceptedPlugin;
+  const result = await postcss([tailwindPlugin]).process(css, {
     // The dirname must stay apps/web/app so `./tokens.generated.css` resolves. The
     // FILENAME is unique per call on purpose: @tailwindcss/postcss keys its compiler
     // cache on `from`, so reusing one path lets an earlier compile's candidate set

--- a/apps/web/lib/actions/gate-clear-invariant.test.ts
+++ b/apps/web/lib/actions/gate-clear-invariant.test.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -39,6 +39,10 @@ function tsFiles(dir: string): string[] {
 
 const WRITES_A_CAPTURE = /(escalationCapture|deferralCapture)\.create\b/;
 
+function relativeSourcePath(file: string): string {
+  return relative(LIB_ROOT, file).replaceAll("\\", "/");
+}
+
 /**
  * True when a source file contains a `clearsGate:` write whose value is not the
  * literal `false` — i.e. `clearsGate: true` or a dynamic expression that can
@@ -60,7 +64,7 @@ describe("gate-clear write invariant (BI-6EC1EE25)", () => {
       const src = readFileSync(file, "utf8");
       if (!setsClearsGateTruthy(src)) continue;
       if (!WRITES_A_CAPTURE.test(src)) {
-        offenders.push(file.slice(LIB_ROOT.length + 1));
+        offenders.push(relativeSourcePath(file));
       }
     }
     expect(
@@ -75,7 +79,7 @@ describe("gate-clear write invariant (BI-6EC1EE25)", () => {
     // Guards against the regex silently matching nothing (e.g. a rename) and the
     // invariant passing vacuously.
     const writers = tsFiles(LIB_ROOT).filter((f) => setsClearsGateTruthy(readFileSync(f, "utf8")));
-    const rel = writers.map((f) => f.slice(LIB_ROOT.length + 1)).sort();
+    const rel = writers.map(relativeSourcePath).sort();
     expect(rel).toEqual([
       "actions/decision-perspective.ts",
       "actions/org-decision-capture.ts",


### PR DESCRIPTION
## Summary
- normalize Windows path separators in the gate-clear invariant
- normalize the third-party PostCSS plugin type boundary when pnpm hoisting exposes the same locked release through two physical declaration paths
- unblock the canonical local-CI standalone TypeScript gate without changing runtime behavior

## Backlog
- BI-4D852EC2
- WC-69B5EC38

## Verification
- `pnpm run pregate` passed on merged code
- candidate: `20e0b0b73f676f4ec78355b6f22e716017fbaabe`
- base: `eea92b880cb6d068d11b68d5f15628871bee08a5`
- integration commit: `fb038228f5d5de5d355c2ce3b77983acff4f018d`
- full Vitest suite, standalone `web` typecheck, Prisma migrate deploy, docs/guards, and production Docker build passed

## Documentation impact
No user, operator, architecture, setup, route, prompt, or coworker workflow changes. This only repairs test/toolchain portability, so no human-readable docs change is required.