### PR TITLE
feat(agent-toolchain): Grok session plane, competitive disable, BS sandbox seed

### DIFF
--- a/apps/web/lib/integrate/grok-dispatch.ts
+++ b/apps/web/lib/integrate/grok-dispatch.ts
@@ -23,6 +23,7 @@ import {
   sandboxExec,
   writeSandboxFile,
 } from "./sandbox/agent-cli-runtime";
+import { ensureSandboxGrokGovernance } from "./sandbox/grok-governance-seed";
 import { getDecryptedCredential } from "@/lib/inference/ai-provider-internals";
 import { resolveBuildWorkdir } from "./sandbox/build-branch";
 import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
@@ -196,6 +197,23 @@ export async function dispatchGrokTask(params: {
     await ensureSandboxNodeUser(containerId);
   } catch {
     // Non-fatal; proceed (some sandboxes may already be correct)
+  }
+
+  // BI-C5F9A232: seed dpf-platform skills + global hooks for headless Grok.
+  // Best-effort — missing workspace skill pack must not wedge an unrelated auth path.
+  try {
+    const gov = await ensureSandboxGrokGovernance({ containerId });
+    if (!gov.ok) {
+      console.warn(
+        `[grok-dispatch] governance seed incomplete: plugin=${gov.plugin} hooks=${gov.hooks} detail=${gov.detail ?? ""}`,
+      );
+    } else {
+      console.log(
+        `[grok-dispatch] governance seed ok: plugin=${gov.plugin}; ${gov.hooks}`,
+      );
+    }
+  } catch (e) {
+    console.warn(`[grok-dispatch] governance seed error: ${(e as Error).message}`);
   }
 
   let grokAuth: GrokAuthInjection;

--- a/apps/web/lib/integrate/sandbox/grok-governance-seed.test.ts
+++ b/apps/web/lib/integrate/sandbox/grok-governance-seed.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildSandboxGrokHooksPayload } from "./grok-governance-seed";
+
+describe("buildSandboxGrokHooksPayload (BI-C5F9A232)", () => {
+  it("wires PreToolUse guards plus SessionStart and Stop/SessionEnd", () => {
+    const payload = buildSandboxGrokHooksPayload("/home/node/.agents/plugins/plugins/dpf-platform/hooks");
+    expect(payload.hooks.PreToolUse).toHaveLength(6);
+    const cmds = payload.hooks.PreToolUse.flatMap((g) => g.hooks.map((h) => h.command));
+    expect(cmds.some((c) => c.includes("lease-guard.mjs"))).toBe(true);
+    expect(cmds.some((c) => c.includes("plan-backlog-coverage-guard.mjs"))).toBe(true);
+
+    const session = payload.hooks.SessionStart.flatMap((g) => g.hooks.map((h) => h.command));
+    expect(session.some((c) => c.includes("grok-session-start.mjs"))).toBe(true);
+
+    const stop = payload.hooks.Stop.flatMap((g) => g.hooks.map((h) => h.command));
+    expect(stop.some((c) => c.includes("uncommitted-work-guard.mjs"))).toBe(true);
+    expect(payload.hooks.SessionEnd).toEqual(payload.hooks.Stop);
+  });
+
+  it("uses absolute node commands against the managed hooks dir", () => {
+    const dir = "/opt/dpf/hooks";
+    const payload = buildSandboxGrokHooksPayload(dir);
+    for (const group of payload.hooks.PreToolUse) {
+      for (const hook of group.hooks) {
+        expect(hook.command).toContain(`node "${dir}/`);
+        expect(hook.type).toBe("command");
+      }
+    }
+  });
+});

--- a/apps/web/lib/integrate/sandbox/grok-governance-seed.ts
+++ b/apps/web/lib/integrate/sandbox/grok-governance-seed.ts
@@ -1,0 +1,168 @@
+// apps/web/lib/integrate/sandbox/grok-governance-seed.ts
+// BI-C5F9A232 — seed dpf-platform skills + plane-1/session hooks into the Build
+// Studio sandbox so Grok under --always-approve shares host governance outcomes.
+//
+// Grok's hook-execution plane ignores plugin-bundled hooks (BI-883FC2FC). Host
+// installers write ~/.grok/hooks/dpf-guards.json; the sandbox must do the same
+// for the `node` user that runs dispatch. Skills still need `grok plugin install`.
+//
+// Prefer the workspace skill pack at /workspace/packages/dpf-skill-pack (always
+// the branch under build) so the sandbox tracks the PR, not a stale image bake.
+
+import { sandboxExec, writeSandboxFile } from "./agent-cli-runtime";
+
+const WORKSPACE_SKILL_PACK = "/workspace/packages/dpf-skill-pack";
+const NODE_HOME = "/home/node";
+const MANAGED_PLUGIN = `${NODE_HOME}/.agents/plugins/plugins/dpf-platform`;
+const HOOKS_FILE = `${NODE_HOME}/.grok/hooks/dpf-guards.json`;
+
+const PRE_TOOL_GUARDS = [
+  "lease-punt-guard.mjs",
+  "decision-routing-guard.mjs",
+  "lease-guard.mjs",
+  "root-clone-guard.mjs",
+  "compose-guard.mjs",
+  "plan-backlog-coverage-guard.mjs",
+] as const;
+
+const COMPETITIVE_PLUGIN_IDS = [
+  "superpowers",
+  "superpowers@openai-curated",
+  "superpowers@openai-bundled",
+] as const;
+
+export type GrokGovernanceSeedResult = {
+  ok: boolean;
+  plugin: string;
+  hooks: string;
+  competitive: string;
+  detail?: string;
+};
+
+function commandEntry(scriptPath: string, timeout: number) {
+  return {
+    hooks: [
+      {
+        type: "command" as const,
+        command: `node "${scriptPath}"`,
+        timeout,
+      },
+    ],
+  };
+}
+
+/** Build the same global hooks payload host install_grok_hooks writes. */
+export function buildSandboxGrokHooksPayload(hooksDir: string): {
+  hooks: Record<string, Array<{ hooks: Array<{ type: string; command: string; timeout: number }> }>>;
+} {
+  const pre = PRE_TOOL_GUARDS.map((g) => commandEntry(`${hooksDir}/${g}`, 15));
+  const sessionStart = commandEntry(`${hooksDir}/grok-session-start.mjs`, 30);
+  const sessionEnd = commandEntry(`${hooksDir}/uncommitted-work-guard.mjs`, 15);
+  return {
+    hooks: {
+      PreToolUse: pre,
+      SessionStart: [sessionStart],
+      SessionEnd: [sessionEnd],
+      Stop: [sessionEnd],
+    },
+  };
+}
+
+/**
+ * Ensure the sandbox `node` user has dpf-platform installed, global hooks wired,
+ * and known competitive process plugins disabled. Idempotent; best-effort —
+ * returns ok:false with detail rather than throwing so dispatch can decide.
+ */
+export async function ensureSandboxGrokGovernance(params: {
+  containerId: string;
+  skillPackPath?: string;
+}): Promise<GrokGovernanceSeedResult> {
+  const { containerId } = params;
+  const skillPack = params.skillPackPath ?? WORKSPACE_SKILL_PACK;
+  const exec = sandboxExec();
+
+  const probe = await exec(
+    `docker exec --user node ${containerId} sh -c "test -d '${skillPack}/.grok-plugin' && test -d '${skillPack}/skills' && echo OK || echo MISSING"`,
+    { timeout: 10_000 },
+  ).catch((e: Error) => ({ stdout: "", stderr: e.message }));
+  if (!String((probe as { stdout?: string }).stdout ?? "").includes("OK")) {
+    return {
+      ok: false,
+      plugin: "skipped",
+      hooks: "skipped",
+      competitive: "skipped",
+      detail: `skill pack not present at ${skillPack} (workspace not bootstrapped?)`,
+    };
+  }
+
+  // Sync managed copy for absolute hook paths that survive plugin reinstall.
+  const sync = await exec(
+    `docker exec --user node ${containerId} sh -c "mkdir -p '${NODE_HOME}/.agents/plugins/plugins' && rm -rf '${MANAGED_PLUGIN}' && cp -a '${skillPack}' '${MANAGED_PLUGIN}' && echo SYNCED"`,
+    { timeout: 60_000 },
+  ).catch((e: Error) => ({ stdout: "", stderr: e.message }));
+  if (!String((sync as { stdout?: string }).stdout ?? "").includes("SYNCED")) {
+    return {
+      ok: false,
+      plugin: "failed-sync",
+      hooks: "skipped",
+      competitive: "skipped",
+      detail: String((sync as { stderr?: string }).stderr ?? "sync failed").slice(0, 300),
+    };
+  }
+
+  // Install / reinstall into Grok's plugin store (skills surface).
+  const install = await exec(
+    `docker exec --user node ${containerId} sh -c '
+      set -e
+      if grok plugin list --json 2>/dev/null | grep -q "\\"name\\":\\"dpf-platform\\""; then
+        grok plugin uninstall dpf-platform --confirm --keep-data 2>/dev/null || true
+      fi
+      grok plugin install "${MANAGED_PLUGIN}" --trust
+      grok plugin list --json 2>/dev/null | head -c 2000
+    '`,
+    { timeout: 120_000 },
+  ).catch((e: Error) => ({ stdout: "", stderr: e.message }));
+  const installOut = String((install as { stdout?: string }).stdout ?? "");
+  const pluginOk = installOut.includes("dpf-platform") || installOut.includes('"name"');
+  const pluginStatus = pluginOk ? "installed" : `failed:${String((install as { stderr?: string }).stderr ?? installOut).slice(0, 200)}`;
+
+  // Global hooks plane (PreToolUse + SessionStart + Stop).
+  const hooksDir = `${MANAGED_PLUGIN}/hooks`;
+  const payload = buildSandboxGrokHooksPayload(hooksDir);
+  try {
+    await writeSandboxFile({
+      containerId,
+      path: HOOKS_FILE,
+      content: `${JSON.stringify(payload, null, 2)}\n`,
+      mode: "644",
+      asNodeUser: true,
+      mkdirParents: `${NODE_HOME}/.grok/hooks`,
+      timeoutMs: 15_000,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      plugin: pluginStatus,
+      hooks: "failed-write",
+      competitive: "skipped",
+      detail: (e as Error).message.slice(0, 300),
+    };
+  }
+
+  // Disable competitive process plugins when present (disable-not-delete).
+  const competitiveParts: string[] = [];
+  for (const id of COMPETITIVE_PLUGIN_IDS) {
+    const dis = await exec(
+      `docker exec --user node ${containerId} sh -c "grok plugin list --json 2>/dev/null | grep -q '\\"name\\":\\"${id}\\"' && grok plugin disable '${id}' 2>&1 || echo not-installed:${id}"`,
+      { timeout: 30_000 },
+    ).catch((e: Error) => ({ stdout: e.message, stderr: "" }));
+    competitiveParts.push(String((dis as { stdout?: string }).stdout ?? "").trim().slice(0, 80) || id);
+  }
+
+  return {
+    ok: pluginOk,
+    plugin: pluginStatus,
+    hooks: `wired ${PRE_TOOL_GUARDS.length} PreToolUse + SessionStart/Stop -> ${HOOKS_FILE}`,
+    competitive: competitiveParts.join("; ").slice(0, 400),
+  };
+}

--- a/packages/dpf-skill-pack/README.md
+++ b/packages/dpf-skill-pack/README.md
@@ -44,8 +44,12 @@ The same JSON file also owns the cleanup/update lifecycle policy. The policy is
 `disable-not-delete`: rerunning bootstrap or the updater after a skill-pack
 change replaces the managed DPF copy and lets tested client adapters disable
 known competitive plugins. It does not remove user-owned skill files or plugin
-caches. Today Codex has a safe config adapter; Claude, Grok, and Antigravity
-report warn-only until their active-state cleanup adapters are verified.
+caches. Today Codex and Grok have safe disable adapters (`enabled = false` / `grok
+plugin disable`); Claude and Antigravity report warn-only until their
+active-state cleanup adapters are verified. Grok also materializes a global
+`~/.grok/hooks/dpf-guards.json` (PreToolUse + SessionStart + SessionEnd/Stop)
+because its hook plane ignores plugin-bundled hooks; Build Studio Grok seeds
+the same pack at dispatch time (BI-BCA23DBB / BI-C5F9A232).
 
 ## Skills shipped in v0.1.0
 

--- a/packages/dpf-skill-pack/hooks/grok-session-start.mjs
+++ b/packages/dpf-skill-pack/hooks/grok-session-start.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Grok SessionStart entry (BI-BCA23DBB).
+//
+// Grok's hook plane ignores plugin-bundled hooks; host + sandbox installers
+// wire this file into ~/.grok/hooks/dpf-guards.json SessionStart. It:
+//   1. Probes active Grok plugins via grok-skill-exposure-adapter (when `grok`
+//      is on PATH) so process-spine can report exposed vs installed honestly;
+//   2. Runs process-spine-health-check --hook (injects additionalContext when
+//      replacements are missing or competitive plugins still win);
+//   3. Runs governance-freshness-check for branch drift of plane-1 wiring.
+//
+// Fail-open: any sub-step error exits 0 so SessionStart never wedges Grok.
+
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const hooksDir = dirname(fileURLToPath(import.meta.url));
+const skillPackRoot = join(hooksDir, "..");
+
+function runNode(script, args, env) {
+  try {
+    return spawnSync(process.execPath, [script, ...args], {
+      encoding: "utf8",
+      env,
+      timeout: 25_000,
+      windowsHide: true,
+    });
+  } catch {
+    return { status: 1, stdout: "", stderr: "spawn failed" };
+  }
+}
+
+function main() {
+  const env = { ...process.env };
+  const adapter = join(hooksDir, "grok-skill-exposure-adapter.mjs");
+  const adapterResult = runNode(adapter, ["--skill-pack-root", skillPackRoot], env);
+  if (adapterResult.status === 0 && adapterResult.stdout?.trim()) {
+    env.DPF_PROCESS_SPINE_EXPOSED_SKILLS_JSON = adapterResult.stdout.trim();
+  }
+
+  const contexts = [];
+
+  const spine = runNode(
+    join(hooksDir, "process-spine-health-check.mjs"),
+    ["--hook", "--skill-pack-root", skillPackRoot],
+    env,
+  );
+  if (spine.stdout?.trim()) {
+    try {
+      const parsed = JSON.parse(spine.stdout);
+      const ctx = parsed?.hookSpecificOutput?.additionalContext;
+      if (typeof ctx === "string" && ctx.trim()) contexts.push(ctx.trim());
+    } catch {
+      // ignore non-JSON (severity ok exits with empty stdout)
+    }
+  }
+
+  const freshness = runNode(join(hooksDir, "governance-freshness-check.mjs"), [], env);
+  if (freshness.stdout?.trim()) {
+    try {
+      const parsed = JSON.parse(freshness.stdout);
+      const ctx = parsed?.hookSpecificOutput?.additionalContext;
+      if (typeof ctx === "string" && ctx.trim()) contexts.push(ctx.trim());
+    } catch {
+      // ignore
+    }
+  }
+
+  if (contexts.length > 0) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "SessionStart",
+          additionalContext: contexts.join("\n\n"),
+        },
+      }),
+    );
+  }
+  process.exit(0);
+}
+
+main();

--- a/packages/dpf-skill-pack/hooks/process-spine-health.test.mjs
+++ b/packages/dpf-skill-pack/hooks/process-spine-health.test.mjs
@@ -51,7 +51,12 @@ test("cleanup policy is contract-backed and never destructive", () => {
   const summary = renderCleanupPolicySummary(policy).join("\n");
   assert.match(summary, /disable-not-delete/);
   assert.match(summary, /Codex/);
-  assert.match(summary, /warn-only/);
+  // Grok (and Codex) reconcile via disable-plugin; Claude/Antigravity remain warn-only.
+  assert.match(summary, /Grok/);
+  assert.match(summary, /warn-only|disables known competitive/);
+  const grok = policy.clients.find((c) => c.client === "grok");
+  assert.equal(grok?.status, "reconciles-safe-config");
+  assert.equal(grok?.action, "disable-plugin");
 });
 
 test("distinguishes installed-on-disk from exposed-in-session evidence", () => {

--- a/packages/dpf-skill-pack/process-spine-replacements.json
+++ b/packages/dpf-skill-pack/process-spine-replacements.json
@@ -27,13 +27,13 @@
       },
       {
         "client": "grok",
-        "status": "warn-only",
+        "status": "reconciles-safe-config",
         "competitivePluginIds": [
           "superpowers",
           "superpowers@openai-curated",
           "superpowers@openai-bundled"
         ],
-        "action": "warn-until-adapter-verified"
+        "action": "disable-plugin"
       },
       {
         "client": "antigravity",

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -946,13 +946,52 @@ GROK_HOOK_GUARDS = (
     "plan-backlog-coverage-guard.mjs",
 )
 
+# Session/Stop plane for Grok (BI-BCA23DBB). Plugin hooks.json already names
+# these for Claude; Grok only executes the global ~/.grok/hooks plane.
+GROK_SESSION_START_SCRIPT = "grok-session-start.mjs"
+GROK_SESSION_END_SCRIPT = "uncommitted-work-guard.mjs"
+
 
 def grok_hooks_file(home: Path) -> Path:
     return home / ".grok" / "hooks" / "dpf-guards.json"
 
 
+def _grok_command_entry(hooks_dir: Path, script: str, timeout: int = 15) -> dict[str, Any]:
+    return {
+        "hooks": [
+            {
+                "type": "command",
+                "command": f'node "{hooks_dir / script}"',
+                "timeout": timeout,
+            }
+        ]
+    }
+
+
+def build_grok_hooks_payload(managed: Path, dry_run: bool = False) -> dict[str, Any]:
+    """Build the global Grok hooks payload (PreToolUse + SessionStart + SessionEnd/Stop)."""
+    hooks_dir = managed / "hooks"
+    pre_entries = [
+        _grok_command_entry(hooks_dir, guard, timeout=15)
+        for guard in GROK_HOOK_GUARDS
+        if dry_run or (hooks_dir / guard).exists()
+    ]
+    payload: dict[str, Any] = {"hooks": {}}
+    if pre_entries:
+        payload["hooks"]["PreToolUse"] = pre_entries
+    if dry_run or (hooks_dir / GROK_SESSION_START_SCRIPT).exists():
+        payload["hooks"]["SessionStart"] = [
+            _grok_command_entry(hooks_dir, GROK_SESSION_START_SCRIPT, timeout=30)
+        ]
+    if dry_run or (hooks_dir / GROK_SESSION_END_SCRIPT).exists():
+        end_entry = _grok_command_entry(hooks_dir, GROK_SESSION_END_SCRIPT, timeout=15)
+        payload["hooks"]["SessionEnd"] = [end_entry]
+        payload["hooks"]["Stop"] = [end_entry]
+    return payload
+
+
 def install_grok_hooks(managed: Path, home: Path, dry_run: bool) -> str:
-    """Wire the plane-1 guards into a hook plane Grok actually executes.
+    """Wire plane-1 + session plane into a hook plane Grok actually executes.
 
     Live probe (BI-883FC2FC, Grok 0.2.87) proved Grok runs PreToolUse blocking
     command-hooks and honors deny, but its hook-execution plane loads ONLY from
@@ -964,22 +1003,99 @@ def install_grok_hooks(managed: Path, home: Path, dry_run: bool) -> str:
     folder-trust prompt); the guards self-scope to DPF checkouts (inDpfWorkspace)
     so they never fire DPF-branded denials in unrelated repos. Kernel ledger
     DI-C17A5861CE0E (opt_global_context_gated).
+
+    BI-BCA23DBB extends the same file with SessionStart (process-spine + competitive
+    exposure via grok-session-start.mjs) and SessionEnd/Stop (uncommitted durable
+    artifact warn) so headless and interactive Grok share one session plane.
     """
-    hooks_dir = managed / "hooks"
-    entries = [
-        {"hooks": [{"type": "command", "command": f'node "{hooks_dir / guard}"', "timeout": 15}]}
-        for guard in GROK_HOOK_GUARDS
-        if (dry_run or (hooks_dir / guard).exists())
-    ]
-    if not entries:
+    payload = build_grok_hooks_payload(managed, dry_run=dry_run)
+    pre_count = len(payload.get("hooks", {}).get("PreToolUse", []))
+    if pre_count == 0 and "SessionStart" not in payload.get("hooks", {}):
         return "skipped: no guard scripts found in managed copy"
-    payload = {"hooks": {"PreToolUse": entries}}
     path = grok_hooks_file(home)
     if dry_run:
-        return f"dry-run: would write {len(entries)} guard(s) to {path}"
+        return (
+            f"dry-run: would write {pre_count} PreToolUse guard(s) "
+            f"+ SessionStart/Stop plane to {path}"
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     changed = write_json(path, payload)
-    return f"wired {len(entries)} guard(s) -> {path}" + ("" if changed else " (unchanged)")
+    session = "SessionStart+Stop" if "SessionStart" in payload.get("hooks", {}) else "no-session"
+    return (
+        f"wired {pre_count} PreToolUse guard(s) + {session} -> {path}"
+        + ("" if changed else " (unchanged)")
+    )
+
+
+def disable_competitive_grok_plugins(skill_pack: Optional[Path] = None, dry_run: bool = False) -> str:
+    """Disable known competitive process plugins on Grok (disable-not-delete).
+
+    Codex already writes enabled=false into config.toml. Grok uses
+    `grok plugin disable <name>` against plugins reported by
+    `grok plugin list --json`. Only acts when a competitive plugin is installed
+    and not already disabled. Never uninstalls or deletes caches.
+    """
+    grok = resolve_grok_binary()
+    if not grok:
+        return "skipped: Grok CLI not found"
+    plugin_ids = grok_competitive_plugin_ids(skill_pack)
+    if not plugin_ids:
+        return "skipped: no competitive plugin ids in cleanup policy"
+    if dry_run:
+        return f"dry-run: would disable competitive plugins {plugin_ids}"
+
+    list_result = subprocess.run(
+        [grok, "plugin", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if list_result.returncode != 0:
+        return f"failed: grok plugin list exited {list_result.returncode}"
+    try:
+        installed = json.loads(list_result.stdout or "[]")
+    except json.JSONDecodeError:
+        return "failed: grok plugin list returned invalid JSON"
+    if not isinstance(installed, list):
+        return "failed: grok plugin list shape unexpected"
+
+    by_name = {
+        str(p.get("name")): p
+        for p in installed
+        if isinstance(p, dict) and p.get("name")
+    }
+    disabled: list[str] = []
+    already: list[str] = []
+    missing: list[str] = []
+    failed: list[str] = []
+    for plugin_id in dict.fromkeys(plugin_ids):
+        if plugin_id == PLUGIN_NAME:
+            continue
+        entry = by_name.get(plugin_id)
+        if entry is None:
+            missing.append(plugin_id)
+            continue
+        if entry.get("enabled") is False or entry.get("status") == "disabled":
+            already.append(plugin_id)
+            continue
+        result = subprocess.run(
+            [grok, "plugin", "disable", plugin_id],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            disabled.append(plugin_id)
+        else:
+            failed.append(plugin_id)
+    parts = []
+    if disabled:
+        parts.append(f"disabled {disabled}")
+    if already:
+        parts.append(f"already-disabled {already}")
+    if missing:
+        parts.append(f"not-installed {missing}")
+    if failed:
+        parts.append(f"failed {failed}")
+    return "; ".join(parts) if parts else "no competitive plugins present"
 
 
 # Bash-scoped blocking guards for Codex's user hook plane (~/.codex/hooks.json).
@@ -1168,6 +1284,7 @@ HOOK_PURPOSES = {
     "worktree-create.mjs": "seeds a new worktree with MCP config on WorktreeCreate",
     "process-spine-health-check.mjs": "SessionStart: warns when DPF-native replacement skills are missing or hidden by retired generic skills",
     "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",
+    "grok-session-start.mjs": "Grok SessionStart: process-spine exposure probe + governance-freshness (global hook plane)",
     "uncommitted-work-guard.mjs": "SessionEnd/Stop/post-checkout: warns before uncommitted spec/plan loss",
 }
 
@@ -1318,9 +1435,16 @@ def main(argv: list[str]) -> int:
             grok_status = install_grok_plugin(shared_managed, args.dry_run)
         print(f"  Grok       : plugin install {grok_status}")
         # Grok's hook plane ignores plugin-bundled hooks (BI-883FC2FC), so the
-        # blocking guards are delivered via the always-trusted global hook plane.
+        # blocking guards + session plane are delivered via the always-trusted
+        # global hook plane (BI-BCA23DBB).
         grok_hooks_status = install_grok_hooks(shared_managed, home, args.dry_run)
         print(f"  Grok hooks : {grok_hooks_status}")
+        grok_competitive_status = "skipped by flag"
+        if not args.skip_grok_cli_install:
+            grok_competitive_status = disable_competitive_grok_plugins(
+                process_spine_root, dry_run=args.dry_run
+            )
+        print(f"  Grok competitive: {grok_competitive_status}")
         # Antigravity (agy): MCP-config wiring + skill-pack sync.
         antigravity_status = "skipped by flag"
         if not args.skip_antigravity_cli_install:

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -67,7 +67,8 @@ class InstallGrokHooksTest(unittest.TestCase):
             managed = home / ".agents" / "plugins" / "plugins" / "dpf-platform"
             updater.copy_skill_pack(skill_pack, managed, dry_run=False)
             status = updater.install_grok_hooks(managed, home, dry_run=False)
-            self.assertIn("wired 6 guard", status)
+            self.assertIn("wired 6 PreToolUse guard", status)
+            self.assertIn("SessionStart+Stop", status)
             hook_file = updater.grok_hooks_file(home)
             self.assertTrue(hook_file.exists())
             data = json.loads(hook_file.read_text())
@@ -80,6 +81,15 @@ class InstallGrokHooksTest(unittest.TestCase):
             self.assertTrue(any("plan-backlog-coverage-guard.mjs" in c for c in cmds))
             for guard in updater.GROK_HOOK_GUARDS:
                 self.assertTrue((managed / "hooks" / guard).exists(), guard)
+            session_cmds = [
+                h["command"]
+                for e in data["hooks"]["SessionStart"]
+                for h in e["hooks"]
+            ]
+            self.assertTrue(any("grok-session-start.mjs" in c for c in session_cmds))
+            stop_cmds = [h["command"] for e in data["hooks"]["Stop"] for h in e["hooks"]]
+            self.assertTrue(any("uncommitted-work-guard.mjs" in c for c in stop_cmds))
+            self.assertIn("SessionEnd", data["hooks"])
 
     def test_dry_run_writes_nothing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -87,6 +97,39 @@ class InstallGrokHooksTest(unittest.TestCase):
             status = updater.install_grok_hooks(home / "managed", home, dry_run=True)
             self.assertIn("dry-run", status)
             self.assertFalse(updater.grok_hooks_file(home).exists())
+
+    def test_disable_competitive_grok_plugins_skips_when_no_cli(self) -> None:
+        with patch.object(updater, "resolve_grok_binary", return_value=None):
+            status = updater.disable_competitive_grok_plugins(dry_run=False)
+            self.assertIn("skipped: Grok CLI not found", status)
+
+    def test_disable_competitive_grok_plugins_dry_run(self) -> None:
+        with patch.object(updater, "resolve_grok_binary", return_value="grok"):
+            status = updater.disable_competitive_grok_plugins(dry_run=True)
+            self.assertIn("dry-run", status)
+
+    def test_disable_competitive_grok_plugins_disables_active(self) -> None:
+        from unittest.mock import Mock
+
+        list_payload = json.dumps(
+            [
+                {"name": "superpowers", "enabled": True, "status": "installed"},
+                {"name": "dpf-platform", "enabled": True, "status": "installed"},
+            ]
+        )
+
+        def fake_run(cmd, capture_output=True, text=True):  # type: ignore[no-untyped-def]
+            if cmd[1:3] == ["plugin", "list"]:
+                return Mock(returncode=0, stdout=list_payload, stderr="")
+            if cmd[1:3] == ["plugin", "disable"]:
+                return Mock(returncode=0, stdout="", stderr="")
+            return Mock(returncode=1, stdout="", stderr="unexpected")
+
+        with patch.object(updater, "resolve_grok_binary", return_value="grok"):
+            with patch.object(updater.subprocess, "run", side_effect=fake_run):
+                status = updater.disable_competitive_grok_plugins(dry_run=False)
+        self.assertIn("disabled", status)
+        self.assertIn("superpowers", status)
 
 
 class HookRosterTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Wave 1 of multi-client governance parity — **BI-BCA23DBB** + **BI-C5F9A232**.

### Host Grok
- `~/.grok/hooks/dpf-guards.json` now includes:
  - **PreToolUse**: 6 plane-1 guards (unchanged)
  - **SessionStart**: `grok-session-start.mjs` (process-spine exposure probe + governance-freshness)
  - **SessionEnd / Stop**: uncommitted-work guard
- Competitive process plugins: `grok plugin disable` for superpowers-family; cleanup policy status → `reconciles-safe-config`

### Build Studio Grok
- `ensureSandboxGrokGovernance()` seeds `/workspace/packages/dpf-skill-pack` into the sandbox `node` user:
  - managed plugin copy + `grok plugin install --trust`
  - same global hooks payload
  - competitive disable best-effort
- Called from `grok-dispatch.ts` before auth/task run (best-effort log on failure)

## Why
BS sandbox previously had **zero** Grok plugins under `--always-approve`. Host Grok lacked SessionStart/Stop plane and competitive disable.

## Test plan
- [x] `python -m unittest update_agent_toolchain_test` — 51 OK
- [x] `node --test process-spine-health.test.mjs` — 7 OK
- [x] Host updater applied live: hooks show PreToolUse + SessionStart + SessionEnd + Stop
- [ ] CI typecheck / Unit Tests (worktree was source-only; `DPF_SKIP_TYPECHECK` local)
- [ ] After merge: one BS Grok dispatch should log `governance seed ok` and `grok plugin list` non-empty in sandbox

## Related
- Spec: `docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md` (PR #3594)
- BI-BCA23DBB, BI-C5F9A232 · EP-INSTALL-HARDENING-2026-05-23

Process-Spine-Decision: implements filed install-hardening BIs from multi-client governance parity design.

Docs-Impact-Decision: skill-pack README adapter note only.

UX-Fit-Decision: no new UI; headless path only.

Local-CI-Override: source-only worktree; skill-pack unit tests green.