### PR TITLE
feat: add governed playbook experiment ledger

### DIFF
--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.test.tsx
@@ -131,6 +131,24 @@ vi.mock("@/lib/tak/work-pattern-read-model", () => ({
           },
           blockers: [],
         },
+        experiment: {
+          label: "Testing a better method",
+          lifecycle: "running",
+          validPairCount: 0,
+          resultSummary: "Candidate and baseline are still running.",
+          evidenceOrigin: "hermetic-replay",
+          moreEvidenceNeeded: true,
+          invalidPairReasons: [],
+          methodVariants: ["baseline", "candidate"],
+          modelVariants: ["model-a", "model-b"],
+          installScope: "canonical",
+          taskCorpusVersion: "1",
+          oracleVersion: "1",
+          promotionPolicyVersion: 1,
+          freshnessAt: "2026-06-28T11:30:00.000Z",
+          experimentRunId: "WPR-1",
+          experimentDefinitionKey: "WPD-1",
+        },
       },
       {
         patternKey: "prompt-refinement|hr-specialist|/build",
@@ -574,6 +592,10 @@ describe("AgentDetailPage", () => {
     expect(html).toContain("Living Playbooks");
     expect(html).toContain("Missing sandbox lease grant");
     expect(html).toContain("Shadow evidence");
+    expect(html).toContain("Testing a better method");
+    expect(html).toContain("0 valid pairs");
+    expect(html).toContain("More comparable evidence is needed");
+    expect(html).toContain("Experiment evidence details");
     expect(html).toContain("95% agreement");
     expect(html).toContain("approve narrower scope");
     expect(html).toContain("Approve candidate");

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -233,10 +233,10 @@ function ExperimentEvidenceRow({
               : "evidence origin pending"}
         </Chip>
       </div>
-      <div style={{ fontSize: 11, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
+      <div style={{ fontSize: 12, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
         {experiment.resultSummary}
       </div>
-      <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>
+      <div style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
         {experiment.moreEvidenceNeeded
           ? "More comparable evidence is needed before this method can be promoted."
           : "The evidence set is ready for governed review."}
@@ -245,7 +245,7 @@ function ExperimentEvidenceRow({
         <summary
           style={{
             cursor: "pointer",
-            fontSize: 10,
+            fontSize: 12,
             fontWeight: 600,
             color: "var(--dpf-accent)",
           }}
@@ -257,7 +257,7 @@ function ExperimentEvidenceRow({
             display: "grid",
             gap: 4,
             marginTop: 6,
-            fontSize: 10,
+            fontSize: 12,
             color: "var(--dpf-muted)",
             overflowWrap: "anywhere",
           }}

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -184,7 +184,103 @@ function PlaybookRow({ pattern, canWrite }: { pattern: WorkPatternSummary; canWr
       {pattern.shadowEvaluation ? (
         <ShadowEvidenceRow evaluation={pattern.shadowEvaluation} />
       ) : null}
+      {pattern.experiment ? <ExperimentEvidenceRow experiment={pattern.experiment} /> : null}
       <PlaybookReviewRow pattern={pattern} canWrite={canWrite} />
+    </div>
+  );
+}
+
+function ExperimentEvidenceRow({
+  experiment,
+}: {
+  experiment: NonNullable<WorkPatternSummary["experiment"]>;
+}) {
+  const hasValidEvidence = experiment.validPairCount > 0;
+  const tone =
+    experiment.lifecycle === "cancelled"
+      ? "error"
+      : hasValidEvidence && !experiment.moreEvidenceNeeded
+        ? "success"
+        : "warning";
+  const stateLabel =
+    experiment.lifecycle === "running" || experiment.lifecycle === "analyzing"
+      ? "in progress"
+      : experiment.lifecycle;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 6,
+        marginTop: 8,
+        padding: "8px 9px",
+        borderRadius: 5,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+      aria-label="Work-pattern experiment evidence"
+    >
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
+        <Chip tone="accent">{experiment.label}</Chip>
+        <Chip tone={tone}>{stateLabel}</Chip>
+        <Chip tone={hasValidEvidence ? "success" : "warning"}>
+          {experiment.validPairCount} valid {experiment.validPairCount === 1 ? "pair" : "pairs"}
+        </Chip>
+        <Chip tone="muted">
+          {experiment.evidenceOrigin === "hermetic-replay"
+            ? "replay evidence"
+            : experiment.evidenceOrigin === "matched-cohort"
+              ? "matched evidence"
+              : "evidence origin pending"}
+        </Chip>
+      </div>
+      <div style={{ fontSize: 11, color: "var(--dpf-text)", overflowWrap: "anywhere" }}>
+        {experiment.resultSummary}
+      </div>
+      <div style={{ fontSize: 10, color: "var(--dpf-muted)" }}>
+        {experiment.moreEvidenceNeeded
+          ? "More comparable evidence is needed before this method can be promoted."
+          : "The evidence set is ready for governed review."}
+      </div>
+      <details>
+        <summary
+          style={{
+            cursor: "pointer",
+            fontSize: 10,
+            fontWeight: 600,
+            color: "var(--dpf-accent)",
+          }}
+        >
+          Experiment evidence details
+        </summary>
+        <div
+          style={{
+            display: "grid",
+            gap: 4,
+            marginTop: 6,
+            fontSize: 10,
+            color: "var(--dpf-muted)",
+            overflowWrap: "anywhere",
+          }}
+        >
+          <span>Methods: {experiment.methodVariants.join(", ")}</span>
+          <span>Models: {experiment.modelVariants.join(", ")}</span>
+          <span>
+            Scope: {experiment.installScope}; corpus v{experiment.taskCorpusVersion}; oracle v
+            {experiment.oracleVersion}; promotion policy v{experiment.promotionPolicyVersion}
+          </span>
+          {experiment.invalidPairReasons.length > 0 ? (
+            <span>Pairs not used: {experiment.invalidPairReasons.join(", ")}</span>
+          ) : null}
+          {experiment.freshnessAt ? (
+            <span>
+              Evidence refreshed <LocalTime value={experiment.freshnessAt} mode="date" />
+            </span>
+          ) : null}
+          <span>
+            Engineer IDs: {experiment.experimentRunId}; {experiment.experimentDefinitionKey}
+          </span>
+        </div>
+      </details>
     </div>
   );
 }

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -24,8 +24,8 @@ import {
 import {
   evaluateWorkPatternShadowEvidence,
   parseAutonomyLevel,
+  parseLegacyWorkPatternShadowTrials,
   parseRiskClass,
-  parseWorkPatternShadowTrials,
 } from "@/lib/tak/work-pattern-shadow-evaluation";
 import {
   buildWorkPatternReview,
@@ -360,10 +360,7 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
     stringField(evidenceJson, "patternKey") ?? stringField(readinessJson, "patternKey");
   if (!patternKey) throw new Error("work_pattern_missing_pattern_key");
 
-  const shadowTrials = [
-    ...parseWorkPatternShadowTrials(evidenceJson.shadowTrials),
-    ...parseWorkPatternShadowTrials(readinessJson.shadowTrials),
-  ];
+  const shadowTrials = parseLegacyWorkPatternShadowTrials(evidenceJson, readinessJson);
   const currentLevel =
     parseAutonomyLevel(stringField(evidenceJson, "currentAutonomyLevel")) ??
     parseAutonomyLevel(stringField(readinessJson, "currentAutonomyLevel"));

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -530,6 +530,16 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
     });
   });
 
+  const { scheduleReviewedWorkPatternExperiment } = await import(
+    "@/lib/tak/work-pattern-experiment-scheduler"
+  );
+  await scheduleReviewedWorkPatternExperiment({
+    action,
+    candidate: evidenceJson.workPatternExperimentCandidate,
+    reviewerUserId: userId,
+    orchestratingAgentId: need.agentId,
+  });
+
   revalidatePath(routeContext);
   return {
     status: "recorded",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8480,6 +8480,7 @@
         "agent-authority-overview",
         "tool-execution-log",
         "effective-permissions",
+        "living-playbook-experiments",
         "tool-evaluation-pipeline",
         "development-surfaces"
       ]

--- a/apps/web/lib/integrate/work-pattern-experiment-adapter.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-adapter.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeWorkPatternFactorial,
+  type WorkPatternExperimentCellRequest,
+} from "./work-pattern-experiment-adapter";
+
+function cell(
+  methodVariantKey: string,
+  modelVariantKey: string,
+): WorkPatternExperimentCellRequest {
+  return {
+    experimentRunId: "WPR-1",
+    childTaskRunId: `TR-${methodVariantKey}-${modelVariantKey}`,
+    cellKey: `${methodVariantKey}:${modelVariantKey}`,
+    pairKey: "factorial",
+    methodVariantKey,
+    modelVariantKey,
+    executionProfile: {
+      patternKey: "review-loop",
+      patternVersion: methodVariantKey === "candidate" ? 2 : 1,
+      variantKey: methodVariantKey,
+      activityKey: "build.review",
+      riskClass: "internal-reversible",
+      providerId: "preferred-provider",
+      modelId: modelVariantKey,
+      modelProfileId: `profile-${modelVariantKey}`,
+      toolPackDigest: "tools-digest",
+      promptOrSkillDigest: "prompt-digest",
+      contextPolicyKey: "hermetic-fixture",
+      recoveryPolicyKey: "bounded-retry",
+      installScope: "canonical",
+      taskCorpusKey: "corpus",
+      taskCorpusVersion: "1",
+      environmentKey: "shadow",
+      sourceCommitSha: "abc123",
+    },
+    fixtureKey: "fixture-1",
+    oracleKey: "oracle",
+    oracleVersion: "1",
+    resourcePolicyKey: "bounded-default",
+  };
+}
+
+describe("executeWorkPatternFactorial", () => {
+  it("executes a full 2x2 matrix in separate workspaces and retains interaction data", async () => {
+    const requests = [
+      cell("baseline", "model-a"),
+      cell("baseline", "model-b"),
+      cell("candidate", "model-a"),
+      cell("candidate", "model-b"),
+    ];
+    const prepareWorkspace = vi.fn(async (request: WorkPatternExperimentCellRequest) => ({
+      workspaceId: `workspace-${request.cellKey}`,
+      workdir: `/shadow/${request.cellKey}`,
+    }));
+    const dispatch = vi.fn(async ({ request }: { request: WorkPatternExperimentCellRequest }) => ({
+      success: true,
+      providerId: "actual-provider",
+      modelId: request.modelVariantKey,
+      filesChanged: [`${request.cellKey}.ts`],
+      toolCalls: 2,
+      toolFailures: 0,
+    }));
+
+    const result = await executeWorkPatternFactorial(requests, {
+      prepareWorkspace,
+      dispatch,
+      verify: vi.fn().mockResolvedValue({
+        unitTests: "pass",
+        productionBuild: "pass",
+        uxVerification: "not-applicable",
+        migration: "not-applicable",
+      }),
+    });
+
+    expect(result.cells).toHaveLength(4);
+    expect(new Set(result.cells.map((row) => row.workspaceId)).size).toBe(4);
+    expect(result.factorial.methodVariants).toEqual(["baseline", "candidate"]);
+    expect(result.factorial.modelVariants).toEqual(["model-a", "model-b"]);
+    expect(result.factorial.interactionCells).toHaveLength(4);
+  });
+
+  it("stamps the provider/model actually used after fallback", async () => {
+    const result = await executeWorkPatternFactorial([cell("baseline", "model-a")], {
+      prepareWorkspace: vi.fn().mockResolvedValue({
+        workspaceId: "workspace-1",
+        workdir: "/shadow/1",
+      }),
+      dispatch: vi.fn().mockResolvedValue({
+        success: true,
+        providerId: "fallback-provider",
+        modelId: "fallback-model",
+        filesChanged: [],
+        toolCalls: 1,
+        toolFailures: 0,
+      }),
+      verify: vi.fn().mockResolvedValue({
+        unitTests: "pass",
+        productionBuild: "pass",
+        uxVerification: "not-applicable",
+        migration: "not-applicable",
+      }),
+    });
+
+    expect(result.cells[0]).toMatchObject({
+      actualProviderId: "fallback-provider",
+      actualModelId: "fallback-model",
+    });
+  });
+
+  it("never exposes delivery or live-mutation adapters to replay cells", async () => {
+    const prohibited = {
+      advanceFeatureBuild: vi.fn(),
+      createPullRequest: vi.fn(),
+      enqueueMerge: vi.fn(),
+      release: vi.fn(),
+      mutateLiveState: vi.fn(),
+    };
+    await executeWorkPatternFactorial([cell("baseline", "model-a")], {
+      prepareWorkspace: vi.fn().mockResolvedValue({
+        workspaceId: "workspace-1",
+        workdir: "/shadow/1",
+      }),
+      dispatch: vi.fn().mockResolvedValue({
+        success: true,
+        providerId: "provider",
+        modelId: "model-a",
+        filesChanged: [],
+        toolCalls: 0,
+        toolFailures: 0,
+      }),
+      verify: vi.fn().mockResolvedValue({
+        unitTests: "pass",
+        productionBuild: "pass",
+        uxVerification: "not-applicable",
+        migration: "not-applicable",
+      }),
+      prohibited,
+    });
+
+    for (const adapter of Object.values(prohibited)) expect(adapter).not.toHaveBeenCalled();
+  });
+
+  it("persists only compact profiles and excludes prompts, tokens, and environment values", async () => {
+    const request = {
+      ...cell("baseline", "model-a"),
+      prompt: "secret prompt",
+      apiToken: "token-value",
+      environment: { SECRET: "value" },
+    } as WorkPatternExperimentCellRequest & Record<string, unknown>;
+    const result = await executeWorkPatternFactorial([request], {
+      prepareWorkspace: vi.fn().mockResolvedValue({
+        workspaceId: "workspace-1",
+        workdir: "/shadow/1",
+      }),
+      dispatch: vi.fn().mockResolvedValue({
+        success: true,
+        providerId: "provider",
+        modelId: "model-a",
+        filesChanged: [],
+        toolCalls: 0,
+        toolFailures: 0,
+      }),
+      verify: vi.fn().mockResolvedValue({
+        unitTests: "pass",
+        productionBuild: "pass",
+        uxVerification: "not-applicable",
+        migration: "not-applicable",
+      }),
+    });
+
+    const persisted = JSON.stringify(result);
+    expect(persisted).not.toContain("secret prompt");
+    expect(persisted).not.toContain("token-value");
+    expect(persisted).not.toContain('"SECRET"');
+  });
+});

--- a/apps/web/lib/integrate/work-pattern-experiment-adapter.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-adapter.ts
@@ -1,0 +1,209 @@
+import type { WorkPatternExecutionProfile } from "@/lib/tak/work-pattern-experiment-types";
+
+export type WorkPatternExperimentCellRequest = {
+  experimentRunId: string;
+  childTaskRunId: string;
+  cellKey: string;
+  pairKey: string;
+  methodVariantKey: string;
+  modelVariantKey: string;
+  executionProfile: WorkPatternExecutionProfile;
+  fixtureKey: string;
+  oracleKey: string;
+  oracleVersion: string;
+  resourcePolicyKey: string;
+};
+
+export type WorkPatternExperimentWorkspace = {
+  workspaceId: string;
+  workdir: string;
+};
+
+export type WorkPatternExperimentDispatchResult = {
+  success: boolean;
+  providerId: string;
+  modelId: string;
+  filesChanged: string[];
+  toolCalls: number;
+  toolFailures: number;
+  error?: string;
+};
+
+export type WorkPatternExperimentVerification = {
+  unitTests: "pass" | "fail" | "not-applicable";
+  productionBuild: "pass" | "fail" | "not-run";
+  uxVerification: "pass" | "fail" | "not-applicable" | "blocked";
+  migration: "pass" | "fail" | "not-applicable" | "blocked";
+};
+
+export type WorkPatternExperimentExecutionDeps = {
+  prepareWorkspace: (
+    request: WorkPatternExperimentCellRequest,
+  ) => Promise<WorkPatternExperimentWorkspace>;
+  dispatch: (input: {
+    request: WorkPatternExperimentCellRequest;
+    workspace: WorkPatternExperimentWorkspace;
+  }) => Promise<WorkPatternExperimentDispatchResult>;
+  verify: (input: {
+    request: WorkPatternExperimentCellRequest;
+    workspace: WorkPatternExperimentWorkspace;
+    dispatch: WorkPatternExperimentDispatchResult;
+  }) => Promise<WorkPatternExperimentVerification>;
+  /**
+   * Deliberately accepted only as a negative-capability test seam. The
+   * experiment executor never calls these delivery/live-state operations.
+   */
+  prohibited?: {
+    advanceFeatureBuild?: () => unknown;
+    createPullRequest?: () => unknown;
+    enqueueMerge?: () => unknown;
+    release?: () => unknown;
+    mutateLiveState?: () => unknown;
+  };
+};
+
+export type WorkPatternExperimentCellResult = {
+  experimentRunId: string;
+  childTaskRunId: string;
+  cellKey: string;
+  pairKey: string;
+  methodVariantKey: string;
+  modelVariantKey: string;
+  fixtureKey: string;
+  oracleKey: string;
+  oracleVersion: string;
+  resourcePolicyKey: string;
+  executionProfile: WorkPatternExecutionProfile;
+  workspaceId: string;
+  actualProviderId: string;
+  actualModelId: string;
+  success: boolean;
+  filesChanged: string[];
+  toolCalls: number;
+  toolFailures: number;
+  buildGate: WorkPatternExperimentVerification;
+  failureClass?: string;
+};
+
+export type WorkPatternFactorialResult = {
+  cells: WorkPatternExperimentCellResult[];
+  factorial: {
+    methodVariants: string[];
+    modelVariants: string[];
+    interactionCells: Array<{
+      methodVariantKey: string;
+      modelVariantKey: string;
+      childTaskRunId: string;
+      success: boolean;
+    }>;
+  };
+};
+
+function uniqueInOrder(values: readonly string[]): string[] {
+  return values.filter((value, index) => values.indexOf(value) === index);
+}
+
+function assertComparableRequests(requests: readonly WorkPatternExperimentCellRequest[]): void {
+  const first = requests[0];
+  if (!first) throw new Error("missing_work_pattern_experiment_cells");
+  for (const request of requests.slice(1)) {
+    if (request.experimentRunId !== first.experimentRunId) {
+      throw new Error("experiment_run_mismatch");
+    }
+    if (request.fixtureKey !== first.fixtureKey) throw new Error("fixture_mismatch");
+    if (request.executionProfile.sourceCommitSha !== first.executionProfile.sourceCommitSha) {
+      throw new Error("source_commit_mismatch");
+    }
+    if (
+      request.executionProfile.taskCorpusKey !== first.executionProfile.taskCorpusKey
+      || request.executionProfile.taskCorpusVersion
+        !== first.executionProfile.taskCorpusVersion
+    ) {
+      throw new Error("corpus_mismatch");
+    }
+    if (request.oracleKey !== first.oracleKey || request.oracleVersion !== first.oracleVersion) {
+      throw new Error("oracle_mismatch");
+    }
+    if (request.resourcePolicyKey !== first.resourcePolicyKey) {
+      throw new Error("resource_policy_mismatch");
+    }
+  }
+}
+
+export async function executeWorkPatternExperimentCell(
+  request: WorkPatternExperimentCellRequest,
+  deps: WorkPatternExperimentExecutionDeps,
+): Promise<WorkPatternExperimentCellResult> {
+  const workspace = await deps.prepareWorkspace(request);
+  const dispatch = await deps.dispatch({ request, workspace });
+  const buildGate = await deps.verify({ request, workspace, dispatch });
+  const gatePassed =
+    buildGate.unitTests !== "fail"
+    && buildGate.productionBuild !== "fail"
+    && buildGate.uxVerification !== "fail"
+    && buildGate.migration !== "fail";
+  const success = dispatch.success && gatePassed;
+
+  // Explicit projection: do not spread request/dispatch. That would persist
+  // prompts, credentials, provider auth, or bulky tool transcripts added by a
+  // future adapter.
+  return {
+    experimentRunId: request.experimentRunId,
+    childTaskRunId: request.childTaskRunId,
+    cellKey: request.cellKey,
+    pairKey: request.pairKey,
+    methodVariantKey: request.methodVariantKey,
+    modelVariantKey: request.modelVariantKey,
+    fixtureKey: request.fixtureKey,
+    oracleKey: request.oracleKey,
+    oracleVersion: request.oracleVersion,
+    resourcePolicyKey: request.resourcePolicyKey,
+    executionProfile: request.executionProfile,
+    workspaceId: workspace.workspaceId,
+    actualProviderId: dispatch.providerId,
+    actualModelId: dispatch.modelId,
+    success,
+    filesChanged: [...dispatch.filesChanged],
+    toolCalls: dispatch.toolCalls,
+    toolFailures: dispatch.toolFailures,
+    buildGate,
+    ...(!success ? { failureClass: dispatch.error ? "dispatch_failed" : "verification_failed" } : {}),
+  };
+}
+
+export async function executeWorkPatternFactorial(
+  requests: readonly WorkPatternExperimentCellRequest[],
+  deps: WorkPatternExperimentExecutionDeps,
+): Promise<WorkPatternFactorialResult> {
+  assertComparableRequests(requests);
+  const identities = new Set<string>();
+  for (const request of requests) {
+    if (identities.has(request.cellKey)) throw new Error(`duplicate_experiment_cell:${request.cellKey}`);
+    identities.add(request.cellKey);
+  }
+
+  const cells: WorkPatternExperimentCellResult[] = [];
+  const workspaceIds = new Set<string>();
+  for (const request of requests) {
+    const result = await executeWorkPatternExperimentCell(request, deps);
+    if (workspaceIds.has(result.workspaceId)) {
+      throw new Error(`shared_mutable_experiment_workspace:${result.workspaceId}`);
+    }
+    workspaceIds.add(result.workspaceId);
+    cells.push(result);
+  }
+
+  return {
+    cells,
+    factorial: {
+      methodVariants: uniqueInOrder(requests.map((request) => request.methodVariantKey)),
+      modelVariants: uniqueInOrder(requests.map((request) => request.modelVariantKey)),
+      interactionCells: cells.map((result) => ({
+        methodVariantKey: result.methodVariantKey,
+        modelVariantKey: result.modelVariantKey,
+        childTaskRunId: result.childTaskRunId,
+        success: result.success,
+      })),
+    },
+  };
+}

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executePersistedWorkPatternExperimentCell,
+  type PersistedWorkPatternRuntimeDeps,
+} from "./work-pattern-experiment-runtime";
+
+function request(environmentKey = "shadow") {
+  return {
+    experimentRunId: "WPR-1",
+    childTaskRunId: "TR-CELL-1",
+    cellKey: "baseline:model-a",
+    pairKey: "pair",
+    methodVariantKey: "baseline",
+    modelVariantKey: "model-a",
+    executionProfile: {
+      patternKey: "review-loop",
+      patternVersion: 1,
+      variantKey: "baseline",
+      activityKey: "build.review",
+      riskClass: "internal-reversible",
+      providerId: "preferred-provider",
+      modelId: "preferred-model",
+      modelProfileId: "profile",
+      toolPackDigest: "tools",
+      promptOrSkillDigest: "method-digest",
+      contextPolicyKey: "hermetic",
+      recoveryPolicyKey: "bounded",
+      installScope: "canonical",
+      taskCorpusKey: "corpus",
+      taskCorpusVersion: "1",
+      environmentKey,
+      sourceCommitSha: "abc123",
+    },
+    fixtureKey: "fixture-1",
+    oracleKey: "oracle",
+    oracleVersion: "1",
+    resourcePolicyKey: "bounded",
+  };
+}
+
+function deps(): PersistedWorkPatternRuntimeDeps {
+  return {
+    loadContext: vi.fn().mockResolvedValue({
+      taskRun: {
+        taskRunId: "TR-CELL-1",
+        currentAgentId: "agent-orchestrator",
+        initiatingAgentId: "agent-orchestrator",
+        a2aMetadata: { workPatternExperimentCell: { attempt: 1 } },
+      },
+      fixtureParts: {
+        schemaVersion: 1,
+        kind: "inference-replay-v1",
+        messages: [{ role: "user", content: "Return READY." }],
+        systemPrompt: "Follow the replay fixture exactly.",
+        methodInstructions: {
+          "method-digest": "Use the baseline method.",
+        },
+        oracle: { kind: "exact", expected: "READY" },
+      },
+    }),
+    infer: vi.fn().mockResolvedValue({
+      content: "READY",
+      providerId: "fallback-provider",
+      modelId: "fallback-model",
+      inputTokens: 12,
+      outputTokens: 1,
+    }),
+    updateTaskRun: vi.fn().mockResolvedValue(undefined),
+    recordEvidence: vi.fn().mockImplementation(async (input) => input),
+  };
+}
+
+describe("executePersistedWorkPatternExperimentCell", () => {
+  it("runs an immutable replay autonomously and records compact assignment/outcome evidence", async () => {
+    const runtime = deps();
+
+    const result = await executePersistedWorkPatternExperimentCell(
+      "TR-CELL-1",
+      request(),
+      runtime,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      actualProviderId: "fallback-provider",
+      actualModelId: "fallback-model",
+      workspaceId: "TR-CELL-1:abc123",
+    });
+    expect(runtime.infer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: expect.stringContaining("Use the baseline method."),
+        profile: expect.objectContaining({
+          providerId: "preferred-provider",
+          modelId: "preferred-model",
+        }),
+        agentId: "agent-orchestrator",
+      }),
+    );
+    expect(runtime.recordEvidence).toHaveBeenCalledTimes(2);
+    expect(runtime.recordEvidence).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        observationKind: "outcome",
+        orchestratingAgentId: "agent-orchestrator",
+        actualDecision: {
+          actualProviderId: "fallback-provider",
+          actualModelId: "fallback-model",
+        },
+        outcome: expect.objectContaining({
+          outputDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+          inputTokens: 12,
+          outputTokens: 1,
+        }),
+      }),
+    );
+    expect(runtime.updateTaskRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        taskRunId: "TR-CELL-1",
+        status: "completed",
+        a2aMetadata: expect.objectContaining({
+          workPatternExperimentResult: expect.objectContaining({ success: true }),
+        }),
+      }),
+    );
+  });
+
+  it("fails closed before inference for authority-ceiling and unsupported fixture cases", async () => {
+    const runtime = deps();
+    await expect(
+      executePersistedWorkPatternExperimentCell("TR-CELL-1", request("live"), runtime),
+    ).rejects.toThrow("work_pattern_experiment_authority_ceiling");
+    expect(runtime.infer).not.toHaveBeenCalled();
+
+    vi.mocked(runtime.loadContext).mockResolvedValueOnce({
+      taskRun: {
+        taskRunId: "TR-CELL-1",
+        currentAgentId: "agent-orchestrator",
+        initiatingAgentId: null,
+        a2aMetadata: {},
+      },
+      fixtureParts: { kind: "mutable-code-workspace" },
+    });
+    await expect(
+      executePersistedWorkPatternExperimentCell("TR-CELL-1", request(), runtime),
+    ).rejects.toThrow("work_pattern_experiment_fixture_unavailable");
+    expect(runtime.infer).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
@@ -66,6 +66,7 @@ function deps(): PersistedWorkPatternRuntimeDeps {
       inputTokens: 12,
       outputTokens: 1,
     }),
+    markWorking: vi.fn().mockResolvedValue(undefined),
     updateTaskRun: vi.fn().mockResolvedValue(undefined),
     recordEvidence: vi.fn().mockImplementation(async (input) => input),
   };
@@ -98,6 +99,10 @@ describe("executePersistedWorkPatternExperimentCell", () => {
       }),
     );
     expect(runtime.recordEvidence).toHaveBeenCalledTimes(2);
+    expect(runtime.markWorking).toHaveBeenCalledWith({
+      taskRunId: "TR-CELL-1",
+      a2aMetadata: { workPatternExperimentCell: { attempt: 1 } },
+    });
     expect(runtime.recordEvidence).toHaveBeenLastCalledWith(
       expect.objectContaining({
         observationKind: "outcome",

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -1,0 +1,62 @@
+import { isRecord } from "@/lib/shared/coerce";
+import { parseWorkPatternExecutionProfile } from "@/lib/tak/work-pattern-experiment-types";
+
+import type { WorkPatternExperimentCellRequest } from "./work-pattern-experiment-adapter";
+
+export function parsePersistedWorkPatternExperimentExecution(
+  value: unknown,
+): WorkPatternExperimentCellRequest | null {
+  if (!isRecord(value)) return null;
+  const executionProfile = parseWorkPatternExecutionProfile(value.executionProfile);
+  const requiredStrings = [
+    "experimentRunId",
+    "childTaskRunId",
+    "cellKey",
+    "pairKey",
+    "methodVariantKey",
+    "modelVariantKey",
+    "fixtureKey",
+    "oracleKey",
+    "oracleVersion",
+    "resourcePolicyKey",
+  ] as const;
+  if (
+    !executionProfile
+    || requiredStrings.some(
+      (field) => typeof value[field] !== "string" || value[field].trim().length === 0,
+    )
+  ) {
+    return null;
+  }
+  return {
+    experimentRunId: value.experimentRunId as string,
+    childTaskRunId: value.childTaskRunId as string,
+    cellKey: value.cellKey as string,
+    pairKey: value.pairKey as string,
+    methodVariantKey: value.methodVariantKey as string,
+    modelVariantKey: value.modelVariantKey as string,
+    executionProfile,
+    fixtureKey: value.fixtureKey as string,
+    oracleKey: value.oracleKey as string,
+    oracleVersion: value.oracleVersion as string,
+    resourcePolicyKey: value.resourcePolicyKey as string,
+  };
+}
+
+/**
+ * Runtime boundary for persisted queue requests. The durable queue can safely
+ * resume and validate work now; the concrete sandbox executor is installed by
+ * the Build Studio integration seam, never serialized into TaskRun metadata.
+ */
+export async function executePersistedWorkPatternExperimentCell(
+  taskRunId: string,
+  value: unknown,
+): Promise<never> {
+  const request = parsePersistedWorkPatternExperimentExecution(value);
+  if (!request || request.childTaskRunId !== taskRunId) {
+    throw new Error(`invalid_work_pattern_experiment_execution_request:${taskRunId}`);
+  }
+  throw new Error(
+    `work_pattern_experiment_executor_unavailable:${request.executionProfile.environmentKey}`,
+  );
+}

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -55,9 +55,13 @@ export type PersistedWorkPatternRuntimeDeps = {
     inputTokens: number;
     outputTokens: number;
   }>;
+  markWorking: (input: {
+    taskRunId: string;
+    a2aMetadata: Record<string, unknown>;
+  }) => Promise<void>;
   updateTaskRun: (input: {
     taskRunId: string;
-    status: "working" | "completed" | "failed";
+    status: "completed" | "failed";
     a2aMetadata: Record<string, unknown>;
   }) => Promise<void>;
   recordEvidence: (input: {
@@ -226,16 +230,22 @@ async function defaultDeps(): Promise<PersistedWorkPatternRuntimeDeps> {
         outputTokens: result.outputTokens,
       };
     },
+    markWorking: async ({ taskRunId, a2aMetadata }) => {
+      const { markTaskRunWorking } = await import("@/lib/observability/heartbeat");
+      await markTaskRunWorking(taskRunId);
+      await prisma.taskRun.update({
+        where: { taskRunId },
+        data: { a2aMetadata: a2aMetadata as never },
+      });
+    },
     updateTaskRun: async ({ taskRunId, status, a2aMetadata }) => {
       await prisma.taskRun.update({
         where: { taskRunId },
         data: {
           status,
           a2aMetadata: a2aMetadata as never,
-          lastHeartbeatAt: status === "working" ? new Date() : null,
-          ...(status === "completed" || status === "failed"
-            ? { completedAt: new Date() }
-            : {}),
+          lastHeartbeatAt: null,
+          completedAt: new Date(),
         },
       });
     },
@@ -281,9 +291,8 @@ export async function executePersistedWorkPatternExperimentCell(
   const existingMetadata = isRecord(context.taskRun.a2aMetadata)
     ? context.taskRun.a2aMetadata
     : {};
-  await deps.updateTaskRun({
+  await deps.markWorking({
     taskRunId,
-    status: "working",
     a2aMetadata: existingMetadata,
   });
   await deps.recordEvidence({

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -1,7 +1,83 @@
-import { isRecord } from "@/lib/shared/coerce";
-import { parseWorkPatternExecutionProfile } from "@/lib/tak/work-pattern-experiment-types";
+import { createHash } from "node:crypto";
 
-import type { WorkPatternExperimentCellRequest } from "./work-pattern-experiment-adapter";
+import { isRecord } from "@/lib/shared/coerce";
+import {
+  parseWorkPatternExecutionProfile,
+  type WorkPatternExecutionProfile,
+} from "@/lib/tak/work-pattern-experiment-types";
+
+import {
+  executeWorkPatternExperimentCell,
+  type WorkPatternExperimentCellRequest,
+} from "./work-pattern-experiment-adapter";
+
+type ReplayMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type HermeticInferenceFixture = {
+  schemaVersion: 1;
+  kind: "inference-replay-v1";
+  messages: ReplayMessage[];
+  systemPrompt: string;
+  methodInstructions: Record<string, string>;
+  oracle: {
+    kind: "exact" | "contains";
+    expected: string;
+  };
+};
+
+type RuntimeContext = {
+  taskRun: {
+    taskRunId: string;
+    currentAgentId: string | null;
+    initiatingAgentId: string | null;
+    a2aMetadata: unknown;
+  };
+  fixtureParts: unknown;
+};
+
+export type PersistedWorkPatternRuntimeDeps = {
+  loadContext: (
+    taskRunId: string,
+    fixtureKey: string,
+  ) => Promise<RuntimeContext | null>;
+  infer: (input: {
+    messages: ReplayMessage[];
+    systemPrompt: string;
+    profile: WorkPatternExecutionProfile;
+    agentId: string;
+  }) => Promise<{
+    content: string;
+    providerId: string;
+    modelId: string;
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+  updateTaskRun: (input: {
+    taskRunId: string;
+    status: "working" | "completed" | "failed";
+    a2aMetadata: Record<string, unknown>;
+  }) => Promise<void>;
+  recordEvidence: (input: {
+    experimentRunId: string;
+    childTaskRunId: string;
+    observationKind: "assignment" | "outcome";
+    sequence: number;
+    orchestratingAgentId: string;
+    activityType: string;
+    riskClass: string;
+    proposedDecision: unknown;
+    actualDecision?: unknown;
+    outcome?: unknown;
+    metadata?: Record<string, unknown>;
+  }) => Promise<Record<string, unknown>>;
+};
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
 
 export function parsePersistedWorkPatternExperimentExecution(
   value: unknown,
@@ -22,9 +98,7 @@ export function parsePersistedWorkPatternExperimentExecution(
   ] as const;
   if (
     !executionProfile
-    || requiredStrings.some(
-      (field) => typeof value[field] !== "string" || value[field].trim().length === 0,
-    )
+    || requiredStrings.some((field) => !nonEmptyString(value[field]))
   ) {
     return null;
   }
@@ -43,20 +117,260 @@ export function parsePersistedWorkPatternExperimentExecution(
   };
 }
 
+function parseFixture(value: unknown): HermeticInferenceFixture | null {
+  if (
+    !isRecord(value)
+    || value.schemaVersion !== 1
+    || value.kind !== "inference-replay-v1"
+    || !Array.isArray(value.messages)
+    || value.messages.length === 0
+    || !nonEmptyString(value.systemPrompt)
+    || !isRecord(value.methodInstructions)
+    || !isRecord(value.oracle)
+    || !["exact", "contains"].includes(String(value.oracle.kind))
+    || !nonEmptyString(value.oracle.expected)
+  ) {
+    return null;
+  }
+  const messages: ReplayMessage[] = [];
+  for (const message of value.messages) {
+    if (
+      !isRecord(message)
+      || !["user", "assistant"].includes(String(message.role))
+      || !nonEmptyString(message.content)
+    ) {
+      return null;
+    }
+    messages.push({
+      role: message.role as ReplayMessage["role"],
+      content: message.content,
+    });
+  }
+  const methodInstructions: Record<string, string> = {};
+  for (const [digest, instruction] of Object.entries(value.methodInstructions)) {
+    if (!nonEmptyString(digest) || !nonEmptyString(instruction)) return null;
+    methodInstructions[digest] = instruction;
+  }
+  return {
+    schemaVersion: 1,
+    kind: "inference-replay-v1",
+    messages,
+    systemPrompt: value.systemPrompt,
+    methodInstructions,
+    oracle: {
+      kind: value.oracle.kind as HermeticInferenceFixture["oracle"]["kind"],
+      expected: value.oracle.expected,
+    },
+  };
+}
+
+function oraclePasses(fixture: HermeticInferenceFixture, content: string): boolean {
+  const actual = content.trim();
+  const expected = fixture.oracle.expected.trim();
+  return fixture.oracle.kind === "exact"
+    ? actual === expected
+    : actual.includes(expected);
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function defaultDeps(): Promise<PersistedWorkPatternRuntimeDeps> {
+  const { prisma } = await import("@dpf/db");
+  const {
+    createPrismaWorkPatternExperimentPersistence,
+    recordWorkPatternExperimentEvidence,
+  } = await import("@/lib/tak/work-pattern-experiment-store");
+  const persistence = createPrismaWorkPatternExperimentPersistence(prisma as never);
+  return {
+    loadContext: async (taskRunId, fixtureKey) => {
+      const [taskRun, artifact] = await Promise.all([
+        prisma.taskRun.findUnique({
+          where: { taskRunId },
+          select: {
+            taskRunId: true,
+            currentAgentId: true,
+            initiatingAgentId: true,
+            a2aMetadata: true,
+          },
+        }),
+        prisma.taskArtifact.findUnique({
+          where: { artifactId: fixtureKey },
+          select: { parts: true },
+        }),
+      ]);
+      return taskRun && artifact
+        ? { taskRun, fixtureParts: artifact.parts }
+        : null;
+    },
+    infer: async ({ messages, systemPrompt, profile, agentId }) => {
+      const { routeAndCall } = await import("@/lib/routed-inference");
+      const result = await routeAndCall(
+        messages,
+        systemPrompt,
+        "internal",
+        {
+          taskType: profile.activityKey,
+          preferredProviderId: profile.providerId,
+          preferredModelId: profile.modelId,
+          agentId,
+          persistDecision: true,
+        },
+      );
+      return {
+        content: result.content,
+        providerId: result.providerId,
+        modelId: result.modelId,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+      };
+    },
+    updateTaskRun: async ({ taskRunId, status, a2aMetadata }) => {
+      await prisma.taskRun.update({
+        where: { taskRunId },
+        data: {
+          status,
+          a2aMetadata: a2aMetadata as never,
+          lastHeartbeatAt: status === "working" ? new Date() : null,
+          ...(status === "completed" || status === "failed"
+            ? { completedAt: new Date() }
+            : {}),
+        },
+      });
+    },
+    recordEvidence: (input) =>
+      recordWorkPatternExperimentEvidence(input, { persistence }),
+  };
+}
+
 /**
- * Runtime boundary for persisted queue requests. The durable queue can safely
- * resume and validate work now; the concrete sandbox executor is installed by
- * the Build Studio integration seam, never serialized into TaskRun metadata.
+ * Executes the first evidence-cleared autonomous lane: immutable inference
+ * replay fixtures. Mutable code workspaces and live/customer side effects are
+ * outside this executor and therefore fail closed at fixture parsing.
  */
 export async function executePersistedWorkPatternExperimentCell(
   taskRunId: string,
   value: unknown,
-): Promise<never> {
+  injected?: PersistedWorkPatternRuntimeDeps,
+) {
   const request = parsePersistedWorkPatternExperimentExecution(value);
   if (!request || request.childTaskRunId !== taskRunId) {
     throw new Error(`invalid_work_pattern_experiment_execution_request:${taskRunId}`);
   }
-  throw new Error(
-    `work_pattern_experiment_executor_unavailable:${request.executionProfile.environmentKey}`,
-  );
+  if (request.executionProfile.environmentKey !== "shadow") {
+    throw new Error(`work_pattern_experiment_authority_ceiling:${taskRunId}`);
+  }
+
+  const deps = injected ?? await defaultDeps();
+  const context = await deps.loadContext(taskRunId, request.fixtureKey);
+  const fixture = context ? parseFixture(context.fixtureParts) : null;
+  if (!context || !fixture) {
+    throw new Error(`work_pattern_experiment_fixture_unavailable:${request.fixtureKey}`);
+  }
+  const agentId = context.taskRun.currentAgentId ?? context.taskRun.initiatingAgentId;
+  if (!agentId) throw new Error(`work_pattern_experiment_orchestrator_unavailable:${taskRunId}`);
+  const instruction =
+    fixture.methodInstructions[request.executionProfile.promptOrSkillDigest];
+  if (!instruction) {
+    throw new Error(
+      `work_pattern_experiment_method_unavailable:${request.executionProfile.promptOrSkillDigest}`,
+    );
+  }
+
+  const existingMetadata = isRecord(context.taskRun.a2aMetadata)
+    ? context.taskRun.a2aMetadata
+    : {};
+  await deps.updateTaskRun({
+    taskRunId,
+    status: "working",
+    a2aMetadata: existingMetadata,
+  });
+  await deps.recordEvidence({
+    experimentRunId: request.experimentRunId,
+    childTaskRunId: taskRunId,
+    observationKind: "assignment",
+    sequence: 0,
+    orchestratingAgentId: agentId,
+    activityType: request.executionProfile.activityKey,
+    riskClass: request.executionProfile.riskClass,
+    proposedDecision: {
+      cellKey: request.cellKey,
+      executionProfile: request.executionProfile,
+      fixtureKey: request.fixtureKey,
+      oracleKey: request.oracleKey,
+      oracleVersion: request.oracleVersion,
+      resourcePolicyKey: request.resourcePolicyKey,
+    },
+  });
+
+  let inferenceContent = "";
+  let inputTokens = 0;
+  let outputTokens = 0;
+  const result = await executeWorkPatternExperimentCell(request, {
+    prepareWorkspace: async () => ({
+      workspaceId: `${request.childTaskRunId}:${request.executionProfile.sourceCommitSha}`,
+      workdir: `artifact://${request.fixtureKey}`,
+    }),
+    dispatch: async () => {
+      const inference = await deps.infer({
+        messages: fixture.messages,
+        systemPrompt: `${fixture.systemPrompt}\n\n${instruction}`,
+        profile: request.executionProfile,
+        agentId,
+      });
+      inferenceContent = inference.content;
+      inputTokens = inference.inputTokens;
+      outputTokens = inference.outputTokens;
+      return {
+        success: true,
+        providerId: inference.providerId,
+        modelId: inference.modelId,
+        filesChanged: [],
+        toolCalls: 1,
+        toolFailures: 0,
+      };
+    },
+    verify: async () => ({
+      unitTests: oraclePasses(fixture, inferenceContent) ? "pass" : "fail",
+      productionBuild: "not-run",
+      uxVerification: "not-applicable",
+      migration: "not-applicable",
+    }),
+  });
+
+  const compactResult = {
+    success: result.success,
+    actualProviderId: result.actualProviderId,
+    actualModelId: result.actualModelId,
+    workspaceId: result.workspaceId,
+    outputDigest: digest(inferenceContent),
+    inputTokens,
+    outputTokens,
+    buildGate: result.buildGate,
+  };
+  await deps.recordEvidence({
+    experimentRunId: request.experimentRunId,
+    childTaskRunId: taskRunId,
+    observationKind: "outcome",
+    sequence: 1,
+    orchestratingAgentId: agentId,
+    activityType: request.executionProfile.activityKey,
+    riskClass: request.executionProfile.riskClass,
+    proposedDecision: { cellKey: request.cellKey },
+    actualDecision: {
+      actualProviderId: result.actualProviderId,
+      actualModelId: result.actualModelId,
+    },
+    outcome: compactResult,
+  });
+  await deps.updateTaskRun({
+    taskRunId,
+    status: result.success ? "completed" : "failed",
+    a2aMetadata: {
+      ...existingMetadata,
+      workPatternExperimentResult: compactResult,
+    },
+  });
+  return result;
 }

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -92,6 +92,7 @@ import {
 } from "./semantic-memory-reconcile";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 import { demandReconciliationScheduled } from "./demand-reconciliation";
+import { workPatternExperimentRun } from "./work-pattern-experiment";
 
 export const scheduledFunctions = [
   prometheusPoll,
@@ -179,6 +180,7 @@ export const eventFunctions = [
   coworkerCertificationRunNow, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): operator "run now" certification sweep
   semanticMemoryReconcileRequested, // BI-DG-001: operator "run now" semantic-memory orphan reconciliation
   postmarkCallbackDispatchRequested,
+  workPatternExperimentRun,
 ];
 
 export const allFunctions = [...scheduledFunctions, ...eventFunctions];

--- a/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runWorkPatternExperiment } from "./work-pattern-experiment";
+
+describe("runWorkPatternExperiment", () => {
+  it("resumes idempotently and skips terminal cells after interruption", async () => {
+    const cells = [
+      { taskRunId: "TR-1", status: "completed" },
+      { taskRunId: "TR-2", status: "submitted" },
+      { taskRunId: "TR-3", status: "working" },
+    ];
+    const executeCell = vi
+      .fn()
+      .mockResolvedValueOnce({ taskRunId: "TR-2", completed: true })
+      .mockRejectedValueOnce(new Error("interrupted"));
+    const transition = vi.fn();
+
+    await expect(
+      runWorkPatternExperiment(
+        { parentTaskRunId: "TR-PARENT" },
+        {
+          loadCells: vi.fn().mockResolvedValue(cells),
+          executeCell,
+          transition,
+        },
+      ),
+    ).rejects.toThrow("interrupted");
+    expect(executeCell.mock.calls.map(([cell]) => cell.taskRunId)).toEqual(["TR-2", "TR-3"]);
+
+    cells[1]!.status = "completed";
+    executeCell.mockReset().mockResolvedValue({ taskRunId: "TR-3", completed: true });
+    await runWorkPatternExperiment(
+      { parentTaskRunId: "TR-PARENT" },
+      {
+        loadCells: vi.fn().mockResolvedValue(cells),
+        executeCell,
+        transition,
+      },
+    );
+
+    expect(executeCell).toHaveBeenCalledTimes(1);
+    expect(executeCell).toHaveBeenCalledWith(cells[2]);
+    expect(transition.mock.calls.map((call) => call[1])).toEqual([
+      "running",
+      "running",
+      "analyzing",
+      "completed",
+    ]);
+  });
+});

--- a/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
@@ -14,6 +14,7 @@ describe("runWorkPatternExperiment", () => {
       .mockResolvedValueOnce({ taskRunId: "TR-2", completed: true })
       .mockRejectedValueOnce(new Error("interrupted"));
     const transition = vi.fn();
+    const analyze = vi.fn();
 
     await expect(
       runWorkPatternExperiment(
@@ -21,6 +22,7 @@ describe("runWorkPatternExperiment", () => {
         {
           loadCells: vi.fn().mockResolvedValue(cells),
           executeCell,
+          analyze,
           transition,
         },
       ),
@@ -34,12 +36,15 @@ describe("runWorkPatternExperiment", () => {
       {
         loadCells: vi.fn().mockResolvedValue(cells),
         executeCell,
+        analyze,
         transition,
       },
     );
 
     expect(executeCell).toHaveBeenCalledTimes(1);
     expect(executeCell).toHaveBeenCalledWith(cells[2]);
+    expect(analyze).toHaveBeenCalledTimes(1);
+    expect(analyze).toHaveBeenCalledWith("TR-PARENT", cells);
     expect(transition.mock.calls.map((call) => call[1])).toEqual([
       "running",
       "running",

--- a/apps/web/lib/queue/functions/work-pattern-experiment.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.ts
@@ -3,11 +3,16 @@ import { inngest } from "../inngest-client";
 type ExperimentQueueCell = {
   taskRunId: string;
   status: string;
+  a2aMetadata?: unknown;
 };
 
 export type RunWorkPatternExperimentDeps = {
   loadCells: (parentTaskRunId: string) => Promise<ExperimentQueueCell[]>;
   executeCell: (cell: ExperimentQueueCell) => Promise<unknown>;
+  analyze: (
+    parentTaskRunId: string,
+    cells: ExperimentQueueCell[],
+  ) => Promise<unknown> | unknown;
   transition: (
     parentTaskRunId: string,
     lifecycle: "running" | "analyzing" | "completed",
@@ -29,6 +34,7 @@ export async function runWorkPatternExperiment(
     executed += 1;
   }
   await deps.transition(input.parentTaskRunId, "analyzing");
+  await deps.analyze(input.parentTaskRunId, await deps.loadCells(input.parentTaskRunId));
   await deps.transition(input.parentTaskRunId, "completed");
   return { executed };
 }
@@ -63,7 +69,7 @@ export const workPatternExperimentRun = inngest.createFunction(
           loadCells: () =>
             prisma.taskRun.findMany({
               where: { parentTaskRunId: parent.id },
-              select: { taskRunId: true, status: true },
+              select: { taskRunId: true, status: true, a2aMetadata: true },
               orderBy: { createdAt: "asc" },
             }),
           // Dispatch wiring is intentionally fail-closed until each stored
@@ -93,6 +99,85 @@ export const workPatternExperimentRun = inngest.createFunction(
               cell.taskRunId,
               executionRequest,
             );
+          },
+          analyze: async (taskRunId, cells) => {
+            const parentRow = await prisma.taskRun.findUnique({
+              where: { taskRunId },
+              select: { a2aMetadata: true },
+            });
+            const { isRecord } = await import("@/lib/shared/coerce");
+            const {
+              analyzeWorkPatternExperimentCells,
+            } = await import("@/lib/tak/work-pattern-experiment-projection");
+            const {
+              parseWorkPatternExperimentMetadata,
+            } = await import("@/lib/tak/work-pattern-experiment-types");
+            const {
+              parsePersistedWorkPatternExperimentExecution,
+            } = await import("@/lib/integrate/work-pattern-experiment-runtime");
+            const parentMetadata = isRecord(parentRow?.a2aMetadata)
+              ? parentRow.a2aMetadata
+              : {};
+            const manifest = parseWorkPatternExperimentMetadata(
+              parentMetadata.workPatternExperiment,
+            );
+            if (!manifest) {
+              throw new Error(`invalid_work_pattern_experiment_parent:${taskRunId}`);
+            }
+            const observations = cells.flatMap((cell) => {
+              if (!isRecord(cell.a2aMetadata)) return [];
+              const cellMetadata = isRecord(
+                cell.a2aMetadata.workPatternExperimentCell,
+              )
+                ? cell.a2aMetadata.workPatternExperimentCell
+                : null;
+              const result = isRecord(
+                cell.a2aMetadata.workPatternExperimentResult,
+              )
+                ? cell.a2aMetadata.workPatternExperimentResult
+                : null;
+              const request = parsePersistedWorkPatternExperimentExecution(
+                cellMetadata?.executionRequest,
+              );
+              if (
+                !cellMetadata
+                || !result
+                || !request
+                || typeof result.success !== "boolean"
+                || typeof result.actualProviderId !== "string"
+                || typeof result.actualModelId !== "string"
+              ) {
+                return [];
+              }
+              return [{
+                status: cell.status,
+                pairKey: request.pairKey,
+                methodVariantKey: request.methodVariantKey,
+                modelVariantKey: request.modelVariantKey,
+                success: result.success,
+                requestedProviderId: request.executionProfile.providerId,
+                requestedModelId: request.executionProfile.modelId,
+                actualProviderId: result.actualProviderId,
+                actualModelId: result.actualModelId,
+                fixtureKey: request.fixtureKey,
+                sourceCommitSha: request.executionProfile.sourceCommitSha,
+                taskCorpusKey: request.executionProfile.taskCorpusKey,
+                taskCorpusVersion: request.executionProfile.taskCorpusVersion,
+                oracleKey: request.oracleKey,
+                oracleVersion: request.oracleVersion,
+                resourcePolicyKey: request.resourcePolicyKey,
+              }];
+            });
+            await prisma.taskRun.update({
+              where: { taskRunId },
+              data: {
+                a2aMetadata: {
+                  ...parentMetadata,
+                  workPatternExperimentProjection:
+                    analyzeWorkPatternExperimentCells(manifest, observations),
+                } as never,
+              },
+            });
           },
           transition: (taskRunId, lifecycle) =>
             transitionWorkPatternExperiment(taskRunId, lifecycle, { persistence }),

--- a/apps/web/lib/queue/functions/work-pattern-experiment.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.ts
@@ -75,9 +75,13 @@ export const workPatternExperimentRun = inngest.createFunction(
               select: { a2aMetadata: true },
             });
             const metadata = row?.a2aMetadata as {
-              workPatternExperimentExecution?: unknown;
+              workPatternExperimentCell?: {
+                executionRequest?: unknown;
+              };
             } | null;
-            if (!metadata?.workPatternExperimentExecution) {
+            const executionRequest =
+              metadata?.workPatternExperimentCell?.executionRequest;
+            if (!executionRequest) {
               throw new Error(
                 `missing_work_pattern_experiment_execution_request:${cell.taskRunId}`,
               );
@@ -87,7 +91,7 @@ export const workPatternExperimentRun = inngest.createFunction(
             );
             return executePersistedWorkPatternExperimentCell(
               cell.taskRunId,
-              metadata.workPatternExperimentExecution,
+              executionRequest,
             );
           },
           transition: (taskRunId, lifecycle) =>

--- a/apps/web/lib/queue/functions/work-pattern-experiment.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.ts
@@ -39,6 +39,17 @@ export async function runWorkPatternExperiment(
   return { executed };
 }
 
+export async function enqueueWorkPatternExperiment(
+  experimentRunId: string,
+  parentTaskRunId: string,
+) {
+  return inngest.send({
+    id: `work-pattern-experiment:${experimentRunId}`,
+    name: "build/work-pattern-experiment.run",
+    data: { parentTaskRunId },
+  });
+}
+
 export const workPatternExperimentRun = inngest.createFunction(
   {
     id: "build/work-pattern-experiment",

--- a/apps/web/lib/queue/functions/work-pattern-experiment.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.ts
@@ -1,0 +1,99 @@
+import { inngest } from "../inngest-client";
+
+type ExperimentQueueCell = {
+  taskRunId: string;
+  status: string;
+};
+
+export type RunWorkPatternExperimentDeps = {
+  loadCells: (parentTaskRunId: string) => Promise<ExperimentQueueCell[]>;
+  executeCell: (cell: ExperimentQueueCell) => Promise<unknown>;
+  transition: (
+    parentTaskRunId: string,
+    lifecycle: "running" | "analyzing" | "completed",
+  ) => Promise<unknown> | unknown;
+};
+
+const TERMINAL = new Set(["completed", "failed", "canceled", "rejected", "archived"]);
+
+export async function runWorkPatternExperiment(
+  input: { parentTaskRunId: string },
+  deps: RunWorkPatternExperimentDeps,
+): Promise<{ executed: number }> {
+  await deps.transition(input.parentTaskRunId, "running");
+  const cells = await deps.loadCells(input.parentTaskRunId);
+  let executed = 0;
+  for (const cell of cells) {
+    if (TERMINAL.has(cell.status)) continue;
+    await deps.executeCell(cell);
+    executed += 1;
+  }
+  await deps.transition(input.parentTaskRunId, "analyzing");
+  await deps.transition(input.parentTaskRunId, "completed");
+  return { executed };
+}
+
+export const workPatternExperimentRun = inngest.createFunction(
+  {
+    id: "build/work-pattern-experiment",
+    retries: 2,
+    concurrency: [{ key: "event.data.parentTaskRunId", limit: 1 }],
+    triggers: [{ event: "build/work-pattern-experiment.run" }],
+  },
+  async ({ event, step }) => {
+    const parentTaskRunId = String(event.data.parentTaskRunId ?? "");
+    if (!parentTaskRunId) throw new Error("missing_work_pattern_experiment_parent");
+
+    return step.run("execute-work-pattern-experiment", async () => {
+      const { prisma } = await import("@dpf/db");
+      const {
+        createPrismaWorkPatternExperimentPersistence,
+        transitionWorkPatternExperiment,
+      } = await import("@/lib/tak/work-pattern-experiment-store");
+      const persistence = createPrismaWorkPatternExperimentPersistence(prisma as never);
+      const parent = await prisma.taskRun.findUnique({
+        where: { taskRunId: parentTaskRunId },
+        select: { id: true },
+      });
+      if (!parent) throw new Error("work_pattern_experiment_parent_not_found");
+
+      return runWorkPatternExperiment(
+        { parentTaskRunId },
+        {
+          loadCells: () =>
+            prisma.taskRun.findMany({
+              where: { parentTaskRunId: parent.id },
+              select: { taskRunId: true, status: true },
+              orderBy: { createdAt: "asc" },
+            }),
+          // Dispatch wiring is intentionally fail-closed until each stored
+          // child carries a validated execution request. The action seam that
+          // creates those requests is delivered with the review scheduler.
+          executeCell: async (cell) => {
+            const row = await prisma.taskRun.findUnique({
+              where: { taskRunId: cell.taskRunId },
+              select: { a2aMetadata: true },
+            });
+            const metadata = row?.a2aMetadata as {
+              workPatternExperimentExecution?: unknown;
+            } | null;
+            if (!metadata?.workPatternExperimentExecution) {
+              throw new Error(
+                `missing_work_pattern_experiment_execution_request:${cell.taskRunId}`,
+              );
+            }
+            const { executePersistedWorkPatternExperimentCell } = await import(
+              "@/lib/integrate/work-pattern-experiment-runtime"
+            );
+            return executePersistedWorkPatternExperimentCell(
+              cell.taskRunId,
+              metadata.workPatternExperimentExecution,
+            );
+          },
+          transition: (taskRunId, lifecycle) =>
+            transitionWorkPatternExperiment(taskRunId, lifecycle, { persistence }),
+        },
+      );
+    });
+  },
+);

--- a/apps/web/lib/tak/work-pattern-effective-ledger.test.ts
+++ b/apps/web/lib/tak/work-pattern-effective-ledger.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveEffectiveWorkPatternLedger,
+  validateWorkPatternPromotionPair,
+} from "./work-pattern-effective-ledger";
+
+describe("resolveEffectiveWorkPatternLedger", () => {
+  it("keeps append-only corrections and resolves the effective tail", () => {
+    const rows = [
+      { ledgerId: "L1", metadata: {} },
+      {
+        ledgerId: "L2",
+        metadata: { supersedesLedgerId: "L1", invalidationReason: "oracle correction" },
+      },
+      {
+        ledgerId: "L3",
+        metadata: { supersedesLedgerId: "L2", invalidationReason: "review correction" },
+      },
+      { ledgerId: "L4", metadata: {} },
+    ];
+
+    expect(resolveEffectiveWorkPatternLedger(rows).map((row) => row.ledgerId)).toEqual([
+      "L3",
+      "L4",
+    ]);
+    expect(rows).toHaveLength(4);
+  });
+
+  it("fails closed for dangling supersession references", () => {
+    expect(() =>
+      resolveEffectiveWorkPatternLedger([
+        {
+          ledgerId: "L2",
+          metadata: { supersedesLedgerId: "missing", invalidationReason: "correction" },
+        },
+      ]),
+    ).toThrow("work_pattern_ledger_dangling_reference:missing");
+  });
+
+  it("detects supersession cycles", () => {
+    expect(() =>
+      resolveEffectiveWorkPatternLedger([
+        {
+          ledgerId: "L1",
+          metadata: { supersedesLedgerId: "L2", invalidationReason: "one" },
+        },
+        {
+          ledgerId: "L2",
+          metadata: { supersedesLedgerId: "L1", invalidationReason: "two" },
+        },
+      ]),
+    ).toThrow("work_pattern_ledger_supersession_cycle");
+  });
+});
+
+describe("validateWorkPatternPromotionPair", () => {
+  const completedCell = {
+    cellKey: "method-a:model-a",
+    fixtureKey: "fixture-1",
+    sourceCommitSha: "abc123",
+    taskCorpusKey: "corpus",
+    taskCorpusVersion: "1",
+    oracleKey: "oracle",
+    oracleVersion: "1",
+    resourcePolicyKey: "bounded-default",
+    status: "completed" as const,
+    budgetUsed: 10,
+    budgetLimit: 20,
+  };
+
+  it("accepts evidence-cleared, comparable terminal cells", () => {
+    expect(
+      validateWorkPatternPromotionPair({
+        requiredCellKeys: [completedCell.cellKey],
+        left: [completedCell],
+        right: [{ ...completedCell, cellKey: "method-b:model-a" }],
+      }),
+    ).toEqual({ valid: true, reasons: [] });
+  });
+
+  it.each([
+    ["missing", [], ["missing_required_cell"]],
+    [
+      "blocked",
+      [{ ...completedCell, status: "blocked" as const }],
+      ["non_terminal_required_cell"],
+    ],
+    [
+      "cancelled",
+      [{ ...completedCell, status: "canceled" as const }],
+      ["non_terminal_required_cell"],
+    ],
+    [
+      "budget-skewed",
+      [{ ...completedCell, budgetUsed: 40 }],
+      ["resource_budget_exceeded"],
+    ],
+  ])("invalidates %s cells without erasing their evidence", (_name, right, reasons) => {
+    expect(
+      validateWorkPatternPromotionPair({
+        requiredCellKeys: [completedCell.cellKey],
+        left: [completedCell],
+        right,
+      }),
+    ).toEqual({ valid: false, reasons });
+  });
+
+  it("rejects pairs that differ in fixture, source, corpus, oracle, or resource policy", () => {
+    const result = validateWorkPatternPromotionPair({
+      requiredCellKeys: [completedCell.cellKey],
+      left: [completedCell],
+      right: [
+        {
+          ...completedCell,
+          fixtureKey: "fixture-2",
+          sourceCommitSha: "different",
+          taskCorpusVersion: "2",
+          oracleVersion: "2",
+          resourcePolicyKey: "unbounded",
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reasons).toEqual([
+      "fixture_mismatch",
+      "source_commit_mismatch",
+      "corpus_mismatch",
+      "oracle_mismatch",
+      "resource_policy_mismatch",
+    ]);
+  });
+});

--- a/apps/web/lib/tak/work-pattern-effective-ledger.test.ts
+++ b/apps/web/lib/tak/work-pattern-effective-ledger.test.ts
@@ -52,6 +52,22 @@ describe("resolveEffectiveWorkPatternLedger", () => {
       ]),
     ).toThrow("work_pattern_ledger_supersession_cycle");
   });
+
+  it("fails closed when two corrections fork from the same evidence row", () => {
+    expect(() =>
+      resolveEffectiveWorkPatternLedger([
+        { ledgerId: "L1", metadata: {} },
+        {
+          ledgerId: "L2",
+          metadata: { supersedesLedgerId: "L1", invalidationReason: "first correction" },
+        },
+        {
+          ledgerId: "L3",
+          metadata: { supersedesLedgerId: "L1", invalidationReason: "second correction" },
+        },
+      ]),
+    ).toThrow("work_pattern_ledger_ambiguous_supersession");
+  });
 });
 
 describe("validateWorkPatternPromotionPair", () => {

--- a/apps/web/lib/tak/work-pattern-effective-ledger.ts
+++ b/apps/web/lib/tak/work-pattern-effective-ledger.ts
@@ -1,0 +1,142 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+export type WorkPatternLedgerRow = {
+  ledgerId: string;
+  metadata: unknown;
+};
+
+export type WorkPatternPromotionCell = {
+  cellKey: string;
+  fixtureKey: string;
+  sourceCommitSha: string;
+  taskCorpusKey: string;
+  taskCorpusVersion: string;
+  oracleKey: string;
+  oracleVersion: string;
+  resourcePolicyKey: string;
+  status: "submitted" | "working" | "completed" | "blocked" | "canceled" | "failed";
+  budgetUsed: number;
+  budgetLimit: number;
+};
+
+export type WorkPatternPromotionPairVerdict = {
+  valid: boolean;
+  reasons: string[];
+};
+
+function supersededLedgerId(row: WorkPatternLedgerRow): string | null {
+  if (!isRecord(row.metadata)) return null;
+  const supersedes = row.metadata.supersedesLedgerId;
+  const reason = row.metadata.invalidationReason;
+  if (supersedes === undefined && reason === undefined) return null;
+  if (
+    typeof supersedes !== "string"
+    || supersedes.trim().length === 0
+    || typeof reason !== "string"
+    || reason.trim().length === 0
+  ) {
+    throw new Error(`invalid_work_pattern_ledger_correction:${row.ledgerId}`);
+  }
+  return supersedes;
+}
+
+export function resolveEffectiveWorkPatternLedger<T extends WorkPatternLedgerRow>(
+  rows: readonly T[],
+): T[] {
+  const byId = new Map<string, T>();
+  for (const row of rows) {
+    if (byId.has(row.ledgerId)) {
+      throw new Error(`duplicate_work_pattern_ledger_id:${row.ledgerId}`);
+    }
+    byId.set(row.ledgerId, row);
+  }
+
+  const superseded = new Set<string>();
+  const edges = new Map<string, string>();
+  const supersederByTarget = new Map<string, string>();
+  for (const row of rows) {
+    const target = supersededLedgerId(row);
+    if (!target) continue;
+    if (!byId.has(target)) {
+      throw new Error(`work_pattern_ledger_dangling_reference:${target}`);
+    }
+    const priorSuperseder = supersederByTarget.get(target);
+    if (priorSuperseder) {
+      throw new Error(
+        `work_pattern_ledger_ambiguous_supersession:${target}:${priorSuperseder}:${row.ledgerId}`,
+      );
+    }
+    supersederByTarget.set(target, row.ledgerId);
+    superseded.add(target);
+    edges.set(row.ledgerId, target);
+  }
+
+  for (const start of edges.keys()) {
+    const visited = new Set<string>();
+    let cursor: string | undefined = start;
+    while (cursor && edges.has(cursor)) {
+      if (visited.has(cursor)) {
+        throw new Error("work_pattern_ledger_supersession_cycle");
+      }
+      visited.add(cursor);
+      cursor = edges.get(cursor);
+    }
+  }
+
+  return rows.filter((row) => !superseded.has(row.ledgerId));
+}
+
+function mismatch(
+  left: WorkPatternPromotionCell,
+  right: WorkPatternPromotionCell,
+  fields: readonly (keyof WorkPatternPromotionCell)[],
+): boolean {
+  return fields.some((field) => left[field] !== right[field]);
+}
+
+export function validateWorkPatternPromotionPair(input: {
+  requiredCellKeys: readonly string[];
+  left: readonly WorkPatternPromotionCell[];
+  right: readonly WorkPatternPromotionCell[];
+}): WorkPatternPromotionPairVerdict {
+  const reasons: string[] = [];
+  const all = [...input.left, ...input.right];
+  const presentKeys = new Set(all.map((cell) => cell.cellKey));
+  if (
+    input.left.length === 0
+    || input.right.length === 0
+    || input.requiredCellKeys.some((cellKey) => !presentKeys.has(cellKey))
+  ) {
+    reasons.push("missing_required_cell");
+  }
+  if (all.some((cell) => cell.status !== "completed")) {
+    reasons.push("non_terminal_required_cell");
+  }
+  if (all.some((cell) => cell.budgetUsed > cell.budgetLimit)) {
+    reasons.push("resource_budget_exceeded");
+  }
+
+  const pairs = input.left.flatMap((left) => input.right.map((right) => [left, right] as const));
+  if (pairs.some(([left, right]) => mismatch(left, right, ["fixtureKey"]))) {
+    reasons.push("fixture_mismatch");
+  }
+  if (pairs.some(([left, right]) => mismatch(left, right, ["sourceCommitSha"]))) {
+    reasons.push("source_commit_mismatch");
+  }
+  if (
+    pairs.some(([left, right]) =>
+      mismatch(left, right, ["taskCorpusKey", "taskCorpusVersion"]))
+  ) {
+    reasons.push("corpus_mismatch");
+  }
+  if (
+    pairs.some(([left, right]) => mismatch(left, right, ["oracleKey", "oracleVersion"]))
+  ) {
+    reasons.push("oracle_mismatch");
+  }
+  if (pairs.some(([left, right]) => mismatch(left, right, ["resourcePolicyKey"]))) {
+    reasons.push("resource_policy_mismatch");
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}

--- a/apps/web/lib/tak/work-pattern-experiment-identity.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-identity.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  workPatternCellKey,
+  workPatternExperimentChildTaskRunId,
+  workPatternExperimentDefinitionKey,
+  workPatternExperimentLedgerId,
+  workPatternExperimentParentTaskRunId,
+  workPatternExperimentRunId,
+} from "./work-pattern-experiment-identity";
+
+const definition = {
+  patternKey: "build.review",
+  taskCorpusKey: "build-review-corpus",
+  taskCorpusVersion: "2026-07-25",
+  oracleKey: "build-gates",
+  oracleVersion: "2",
+  methodVariants: [
+    { methodVariantKey: "baseline", patternVersion: 2 },
+    { methodVariantKey: "candidate", patternVersion: 3 },
+  ],
+  modelVariants: [
+    { modelVariantKey: "local", modelProfileId: "MP-LOCAL" },
+    { modelVariantKey: "frontier", modelProfileId: "MP-FRONTIER" },
+  ],
+  installScope: "dpf_dogfood" as const,
+  promotionPolicyKey: "work-pattern-promotion",
+  promotionPolicyVersion: 4,
+};
+
+describe("work-pattern experiment identity", () => {
+  it("is deterministic across factor ordering", () => {
+    const reordered = {
+      ...definition,
+      methodVariants: [...definition.methodVariants].reverse(),
+      modelVariants: [...definition.modelVariants].reverse(),
+    };
+
+    expect(workPatternExperimentDefinitionKey(definition))
+      .toBe(workPatternExperimentDefinitionKey(reordered));
+  });
+
+  it("separates definitions when a reproducibility dimension changes", () => {
+    const base = workPatternExperimentDefinitionKey(definition);
+
+    expect(workPatternExperimentDefinitionKey({
+      ...definition,
+      oracleVersion: "3",
+    })).not.toBe(base);
+    expect(workPatternExperimentDefinitionKey({
+      ...definition,
+      promotionPolicyVersion: 5,
+    })).not.toBe(base);
+  });
+
+  it("derives stable run, parent, child, and ledger identities", () => {
+    const definitionKey = workPatternExperimentDefinitionKey(definition);
+    const runId = workPatternExperimentRunId(definitionKey, 2);
+    const cellKey = workPatternCellKey({
+      methodVariantKey: "candidate",
+      modelVariantKey: "local",
+    });
+    const childId = workPatternExperimentChildTaskRunId({
+      experimentRunId: runId,
+      cellKey,
+      pairKey: "fixture-17",
+      attempt: 1,
+    });
+
+    expect(runId).toBe(workPatternExperimentRunId(definitionKey, 2));
+    expect(runId).not.toBe(workPatternExperimentRunId(definitionKey, 3));
+    expect(workPatternExperimentParentTaskRunId(runId))
+      .toBe(workPatternExperimentParentTaskRunId(runId));
+    expect(childId).toBe(workPatternExperimentChildTaskRunId({
+      experimentRunId: runId,
+      cellKey,
+      pairKey: "fixture-17",
+      attempt: 1,
+    }));
+    expect(childId).not.toBe(workPatternExperimentChildTaskRunId({
+      experimentRunId: runId,
+      cellKey,
+      pairKey: "fixture-17",
+      attempt: 2,
+    }));
+    expect(workPatternExperimentLedgerId({
+      experimentRunId: runId,
+      childTaskRunId: childId,
+      observationKind: "outcome",
+      sequence: 1,
+    })).not.toBe(workPatternExperimentLedgerId({
+      experimentRunId: runId,
+      childTaskRunId: childId,
+      observationKind: "assignment",
+      sequence: 1,
+    }));
+  });
+
+  it("rejects invalid replicate, attempt, and sequence values", () => {
+    const definitionKey = workPatternExperimentDefinitionKey(definition);
+    expect(() => workPatternExperimentRunId(definitionKey, 0)).toThrow("invalid_replicate");
+    expect(() => workPatternExperimentChildTaskRunId({
+      experimentRunId: "WPR-1",
+      cellKey: "candidate:local",
+      pairKey: "fixture-17",
+      attempt: -1,
+    })).toThrow("invalid_attempt");
+    expect(() => workPatternExperimentLedgerId({
+      experimentRunId: "WPR-1",
+      childTaskRunId: "TR-1",
+      observationKind: "outcome",
+      sequence: -1,
+    })).toThrow("invalid_sequence");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-identity.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-identity.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+
+import type { CapabilityInstallScope } from "@dpf/db/capability-maturity";
+
+import type {
+  WorkPatternMethodVariant,
+  WorkPatternModelVariant,
+} from "./work-pattern-experiment-types";
+
+export type WorkPatternExperimentDefinitionIdentity = {
+  patternKey: string;
+  taskCorpusKey: string;
+  taskCorpusVersion: string;
+  oracleKey: string;
+  oracleVersion: string;
+  methodVariants: WorkPatternMethodVariant[];
+  modelVariants: WorkPatternModelVariant[];
+  installScope: CapabilityInstallScope;
+  promotionPolicyKey: string;
+  promotionPolicyVersion: number;
+};
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 24);
+}
+
+function assertNonEmpty(value: string, error: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(error);
+}
+
+function assertPositiveInteger(value: number, error: string): void {
+  if (!Number.isInteger(value) || value <= 0) throw new Error(error);
+}
+
+function assertNonNegativeInteger(value: number, error: string): void {
+  if (!Number.isInteger(value) || value < 0) throw new Error(error);
+}
+
+export function workPatternExperimentDefinitionKey(
+  input: WorkPatternExperimentDefinitionIdentity,
+): string {
+  const canonical = {
+    patternKey: input.patternKey,
+    taskCorpusKey: input.taskCorpusKey,
+    taskCorpusVersion: input.taskCorpusVersion,
+    oracleKey: input.oracleKey,
+    oracleVersion: input.oracleVersion,
+    methodVariants: [...input.methodVariants].sort((left, right) =>
+      left.methodVariantKey.localeCompare(right.methodVariantKey)),
+    modelVariants: [...input.modelVariants].sort((left, right) =>
+      left.modelVariantKey.localeCompare(right.modelVariantKey)),
+    installScope: input.installScope,
+    promotionPolicyKey: input.promotionPolicyKey,
+    promotionPolicyVersion: input.promotionPolicyVersion,
+  };
+  return `WPD-${digest(canonical).toUpperCase()}`;
+}
+
+export function workPatternExperimentRunId(
+  experimentDefinitionKey: string,
+  replicate: number,
+): string {
+  assertNonEmpty(experimentDefinitionKey, "invalid_experiment_definition_key");
+  assertPositiveInteger(replicate, "invalid_replicate");
+  return `WPR-${digest({ experimentDefinitionKey, replicate }).toUpperCase()}`;
+}
+
+export function workPatternExperimentParentTaskRunId(experimentRunId: string): string {
+  assertNonEmpty(experimentRunId, "invalid_experiment_run_id");
+  return `TR-WPX-${digest({ experimentRunId }).toUpperCase()}`;
+}
+
+export function workPatternCellKey(input: {
+  methodVariantKey: string;
+  modelVariantKey: string;
+}): string {
+  assertNonEmpty(input.methodVariantKey, "invalid_method_variant_key");
+  assertNonEmpty(input.modelVariantKey, "invalid_model_variant_key");
+  return `${input.methodVariantKey}:${input.modelVariantKey}`;
+}
+
+export function workPatternExperimentChildTaskRunId(input: {
+  experimentRunId: string;
+  cellKey: string;
+  pairKey: string;
+  attempt: number;
+}): string {
+  assertNonEmpty(input.experimentRunId, "invalid_experiment_run_id");
+  assertNonEmpty(input.cellKey, "invalid_cell_key");
+  assertNonEmpty(input.pairKey, "invalid_pair_key");
+  assertPositiveInteger(input.attempt, "invalid_attempt");
+  return `TR-WPC-${digest(input).toUpperCase()}`;
+}
+
+export function workPatternExperimentLedgerId(input: {
+  experimentRunId: string;
+  childTaskRunId: string;
+  observationKind: string;
+  sequence: number;
+}): string {
+  assertNonEmpty(input.experimentRunId, "invalid_experiment_run_id");
+  assertNonEmpty(input.childTaskRunId, "invalid_child_task_run_id");
+  assertNonEmpty(input.observationKind, "invalid_observation_kind");
+  assertNonNegativeInteger(input.sequence, "invalid_sequence");
+  return `DSL-WPX-${digest(input).toUpperCase()}`;
+}

--- a/apps/web/lib/tak/work-pattern-experiment-projection.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-projection.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeWorkPatternExperimentCells } from "./work-pattern-experiment-projection";
+
+describe("analyzeWorkPatternExperimentCells", () => {
+  const manifest = {
+    schemaVersion: 1 as const,
+    experimentDefinitionKey: "def-1",
+    experimentRunId: "run-1",
+    replicate: 1,
+    patternKey: "review",
+    activityKey: "review",
+    riskClass: "read-only" as const,
+    methodVariants: [
+      { methodVariantKey: "baseline", patternVersion: 1 },
+      { methodVariantKey: "candidate", patternVersion: 2 },
+    ],
+    modelVariants: [{ modelVariantKey: "primary", modelProfileId: "profile-1" }],
+    requiredCellKeys: ["base", "candidate"],
+    taskCorpusKey: "corpus",
+    taskCorpusVersion: "1",
+    oracleKey: "oracle",
+    oracleVersion: "1",
+    promotionPolicyKey: "policy",
+    promotionPolicyVersion: 1,
+    installScope: "global" as const,
+    lifecycle: "analyzing" as const,
+  };
+  const cell = (methodVariantKey: string) => ({
+    status: "completed",
+    pairKey: "pair-1",
+    methodVariantKey,
+    modelVariantKey: "primary",
+    success: true,
+    requestedProviderId: "provider",
+    requestedModelId: "model",
+    actualProviderId: "provider",
+    actualModelId: "model",
+    fixtureKey: "fixture",
+    sourceCommitSha: "abc",
+    taskCorpusKey: "corpus",
+    taskCorpusVersion: "1",
+    oracleKey: "oracle",
+    oracleVersion: "1",
+    resourcePolicyKey: "bounded",
+  });
+
+  it("counts only complete, controlled baseline/candidate pairs", () => {
+    const result = analyzeWorkPatternExperimentCells(
+      manifest,
+      [cell("baseline"), cell("candidate")],
+      new Date("2026-07-26T12:00:00.000Z"),
+    );
+
+    expect(result).toEqual({
+      validPairCount: 1,
+      resultSummary: "1 of 1 comparable method pairs passed the evidence controls.",
+      evidenceOrigin: "hermetic-replay",
+      moreEvidenceNeeded: false,
+      invalidPairReasons: [],
+      freshnessAt: "2026-07-26T12:00:00.000Z",
+    });
+  });
+
+  it("fails closed when provider fallback changes a requested cell", () => {
+    const candidate = {
+      ...cell("candidate"),
+      actualModelId: "fallback-model",
+    };
+
+    const result = analyzeWorkPatternExperimentCells(
+      manifest,
+      [cell("baseline"), candidate],
+    );
+
+    expect(result.validPairCount).toBe(0);
+    expect(result.moreEvidenceNeeded).toBe(true);
+    expect(result.invalidPairReasons).toEqual([
+      "Provider or model fallback changed candidate/primary.",
+    ]);
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-projection.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-projection.test.ts
@@ -23,7 +23,7 @@ describe("analyzeWorkPatternExperimentCells", () => {
     oracleVersion: "1",
     promotionPolicyKey: "policy",
     promotionPolicyVersion: 1,
-    installScope: "global" as const,
+    installScope: "canonical" as const,
     lifecycle: "analyzing" as const,
   };
   const cell = (methodVariantKey: string) => ({

--- a/apps/web/lib/tak/work-pattern-experiment-projection.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-projection.ts
@@ -1,0 +1,99 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+import {
+  parseWorkPatternExperimentMetadata,
+  type WorkPatternExperimentLifecycle,
+} from "./work-pattern-experiment-types";
+
+export type WorkPatternExperimentProjection = {
+  label: "Testing a better method";
+  lifecycle: WorkPatternExperimentLifecycle;
+  patternKey: string;
+  riskClass: string;
+  maxPatternVersion: number;
+  validPairCount: number;
+  resultSummary: string;
+  evidenceOrigin: "hermetic-replay" | "matched-cohort" | "unknown";
+  moreEvidenceNeeded: boolean;
+  invalidPairReasons: string[];
+  methodVariants: string[];
+  modelVariants: string[];
+  installScope: string;
+  taskCorpusVersion: string;
+  oracleVersion: string;
+  promotionPolicyVersion: number;
+  freshnessAt: string | null;
+  experimentRunId: string;
+  experimentDefinitionKey: string;
+};
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && entry.trim().length > 0,
+      )
+    : [];
+}
+
+function validDateString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? value : null;
+}
+
+export function parseWorkPatternExperimentProjection(
+  value: unknown,
+): WorkPatternExperimentProjection | null {
+  if (!isRecord(value)) return null;
+  const manifest = parseWorkPatternExperimentMetadata(value.workPatternExperiment);
+  if (!manifest) return null;
+  const raw = isRecord(value.workPatternExperimentProjection)
+    ? value.workPatternExperimentProjection
+    : {};
+  const origin = raw.evidenceOrigin;
+  const evidenceOrigin =
+    origin === "hermetic-replay" || origin === "matched-cohort"
+      ? origin
+      : "unknown";
+  const validPairCount =
+    typeof raw.validPairCount === "number"
+    && Number.isInteger(raw.validPairCount)
+    && raw.validPairCount >= 0
+      ? raw.validPairCount
+      : 0;
+
+  return {
+    label: "Testing a better method",
+    lifecycle: manifest.lifecycle,
+    patternKey: manifest.patternKey,
+    riskClass: manifest.riskClass,
+    maxPatternVersion: Math.max(
+      ...manifest.methodVariants.map((variant) => variant.patternVersion),
+    ),
+    validPairCount,
+    resultSummary:
+      typeof raw.resultSummary === "string" && raw.resultSummary.trim().length > 0
+        ? raw.resultSummary.trim()
+        : "Experiment evidence is still being collected.",
+    evidenceOrigin,
+    moreEvidenceNeeded:
+      typeof raw.moreEvidenceNeeded === "boolean"
+        ? raw.moreEvidenceNeeded
+        : true,
+    invalidPairReasons: stringArray(raw.invalidPairReasons),
+    methodVariants: manifest.methodVariants.map((variant) => variant.methodVariantKey),
+    modelVariants: manifest.modelVariants.map((variant) => variant.modelVariantKey),
+    installScope: manifest.installScope,
+    taskCorpusVersion: manifest.taskCorpusVersion,
+    oracleVersion: manifest.oracleVersion,
+    promotionPolicyVersion: manifest.promotionPolicyVersion,
+    freshnessAt: validDateString(raw.freshnessAt),
+    experimentRunId: manifest.experimentRunId,
+    experimentDefinitionKey: manifest.experimentDefinitionKey,
+  };
+}
+
+export function hasWorkPatternExperimentCellMetadata(value: unknown): boolean {
+  return isRecord(value) && isRecord(value.workPatternExperimentCell);
+}

--- a/apps/web/lib/tak/work-pattern-experiment-projection.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-projection.ts
@@ -3,6 +3,7 @@ import { isRecord } from "@/lib/shared/coerce";
 import {
   parseWorkPatternExperimentMetadata,
   type WorkPatternExperimentLifecycle,
+  type WorkPatternExperimentMetadataV1,
 } from "./work-pattern-experiment-types";
 
 export type WorkPatternExperimentProjection = {
@@ -25,6 +26,34 @@ export type WorkPatternExperimentProjection = {
   freshnessAt: string | null;
   experimentRunId: string;
   experimentDefinitionKey: string;
+};
+
+export type WorkPatternExperimentAnalyzedCell = {
+  status: string;
+  pairKey: string;
+  methodVariantKey: string;
+  modelVariantKey: string;
+  success: boolean;
+  requestedProviderId: string;
+  requestedModelId: string;
+  actualProviderId: string;
+  actualModelId: string;
+  fixtureKey: string;
+  sourceCommitSha: string;
+  taskCorpusKey: string;
+  taskCorpusVersion: string;
+  oracleKey: string;
+  oracleVersion: string;
+  resourcePolicyKey: string;
+};
+
+export type WorkPatternExperimentAnalysis = {
+  validPairCount: number;
+  resultSummary: string;
+  evidenceOrigin: "hermetic-replay";
+  moreEvidenceNeeded: boolean;
+  invalidPairReasons: string[];
+  freshnessAt: string;
 };
 
 function stringArray(value: unknown): string[] {
@@ -96,4 +125,102 @@ export function parseWorkPatternExperimentProjection(
 
 export function hasWorkPatternExperimentCellMetadata(value: unknown): boolean {
   return isRecord(value) && isRecord(value.workPatternExperimentCell);
+}
+
+function comparisonFingerprint(cell: WorkPatternExperimentAnalyzedCell): string {
+  return [
+    cell.fixtureKey,
+    cell.sourceCommitSha,
+    cell.taskCorpusKey,
+    cell.taskCorpusVersion,
+    cell.oracleKey,
+    cell.oracleVersion,
+    cell.resourcePolicyKey,
+  ].join("\u001f");
+}
+
+/**
+ * Projects terminal child evidence into the parent without changing any
+ * authority, delivery, or activation substrate. The first declared method is
+ * the baseline; every later method is compared with it within the same
+ * pair/model cell.
+ */
+export function analyzeWorkPatternExperimentCells(
+  manifest: WorkPatternExperimentMetadataV1,
+  cells: readonly WorkPatternExperimentAnalyzedCell[],
+  now = new Date(),
+): WorkPatternExperimentAnalysis {
+  const baseline = manifest.methodVariants[0]?.methodVariantKey;
+  const candidates = manifest.methodVariants
+    .slice(1)
+    .map((variant) => variant.methodVariantKey);
+  const invalidReasons = new Set<string>();
+  let validPairCount = 0;
+
+  if (!baseline || candidates.length === 0) {
+    invalidReasons.add("A baseline and candidate method are required.");
+  }
+
+  for (const model of manifest.modelVariants) {
+    for (const candidate of candidates) {
+      const baselineCells = cells.filter(
+        (cell) =>
+          cell.modelVariantKey === model.modelVariantKey
+          && cell.methodVariantKey === baseline,
+      );
+      const candidateCells = cells.filter(
+        (cell) =>
+          cell.modelVariantKey === model.modelVariantKey
+          && cell.methodVariantKey === candidate,
+      );
+      if (baselineCells.length !== 1 || candidateCells.length !== 1) {
+        invalidReasons.add(`Missing or duplicate pair for ${candidate}/${model.modelVariantKey}.`);
+        continue;
+      }
+      const [baselineCell] = baselineCells;
+      const [candidateCell] = candidateCells;
+      if (
+        baselineCell.status !== "completed"
+        || candidateCell.status !== "completed"
+        || !baselineCell.success
+        || !candidateCell.success
+      ) {
+        invalidReasons.add(`Non-passing pair for ${candidate}/${model.modelVariantKey}.`);
+        continue;
+      }
+      if (baselineCell.pairKey !== candidateCell.pairKey) {
+        invalidReasons.add(`Pair identity mismatch for ${candidate}/${model.modelVariantKey}.`);
+        continue;
+      }
+      if (comparisonFingerprint(baselineCell) !== comparisonFingerprint(candidateCell)) {
+        invalidReasons.add(`Evidence controls differ for ${candidate}/${model.modelVariantKey}.`);
+        continue;
+      }
+      const actualModelsMatch =
+        baselineCell.actualProviderId === baselineCell.requestedProviderId
+        && baselineCell.actualModelId === baselineCell.requestedModelId
+        && candidateCell.actualProviderId === candidateCell.requestedProviderId
+        && candidateCell.actualModelId === candidateCell.requestedModelId;
+      if (!actualModelsMatch) {
+        invalidReasons.add(`Provider or model fallback changed ${candidate}/${model.modelVariantKey}.`);
+        continue;
+      }
+      validPairCount += 1;
+    }
+  }
+
+  const expectedPairCount = manifest.modelVariants.length * candidates.length;
+  const moreEvidenceNeeded =
+    expectedPairCount === 0 || validPairCount < expectedPairCount;
+  return {
+    validPairCount,
+    resultSummary:
+      validPairCount === 0
+        ? "No comparable experiment pairs passed the evidence controls."
+        : `${validPairCount} of ${expectedPairCount} comparable method pairs passed the evidence controls.`,
+    evidenceOrigin: "hermetic-replay",
+    moreEvidenceNeeded,
+    invalidPairReasons: [...invalidReasons],
+    freshnessAt: now.toISOString(),
+  };
 }

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRun, send } = vi.hoisted(() => ({
+  createRun: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/queue/inngest-client", () => ({ inngest: { send } }));
+vi.mock("./work-pattern-experiment-store", () => ({
+  createPrismaWorkPatternExperimentPersistence: vi.fn().mockReturnValue({}),
+  createOrResumeWorkPatternExperiment: createRun,
+}));
+
+import { scheduleReviewedWorkPatternExperiment } from "./work-pattern-experiment-scheduler";
+
+function candidate(environmentKey = "shadow") {
+  const executionProfile = {
+    patternKey: "review-loop",
+    patternVersion: 1,
+    variantKey: "baseline",
+    activityKey: "build.review",
+    riskClass: "internal-reversible",
+    providerId: "provider",
+    modelId: "model",
+    modelProfileId: "profile",
+    toolPackDigest: "tools",
+    promptOrSkillDigest: "prompt",
+    contextPolicyKey: "hermetic",
+    recoveryPolicyKey: "bounded",
+    installScope: "canonical",
+    taskCorpusKey: "corpus",
+    taskCorpusVersion: "1",
+    environmentKey,
+    sourceCommitSha: "abc123",
+  };
+  return {
+    definition: {
+      patternKey: "review-loop",
+      taskCorpusKey: "corpus",
+      taskCorpusVersion: "1",
+      oracleKey: "oracle",
+      oracleVersion: "1",
+      methodVariants: [{ methodVariantKey: "baseline", patternVersion: 1 }],
+      modelVariants: [{ modelVariantKey: "model-a", modelProfileId: "profile" }],
+      installScope: "canonical",
+      promotionPolicyKey: "bounded",
+      promotionPolicyVersion: 1,
+    },
+    activityKey: "build.review",
+    riskClass: "internal-reversible",
+    pairKey: "pair",
+    cells: [
+      {
+        methodVariantKey: "baseline",
+        modelVariantKey: "model-a",
+        executionRequest: {
+          experimentRunId: "WPR-1",
+          childTaskRunId: "TR-CELL-1",
+          cellKey: "baseline:model-a",
+          pairKey: "pair",
+          methodVariantKey: "baseline",
+          modelVariantKey: "model-a",
+          executionProfile,
+          fixtureKey: "fixture",
+          oracleKey: "oracle",
+          oracleVersion: "1",
+          resourcePolicyKey: "bounded",
+        },
+      },
+    ],
+  };
+}
+
+describe("scheduleReviewedWorkPatternExperiment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createRun.mockResolvedValue({
+      parent: { taskRunId: "TR-PARENT" },
+      manifest: { experimentRunId: "WPR-1" },
+    });
+  });
+
+  it("autonomously schedules an approved evidence-cleared shadow candidate", async () => {
+    await expect(
+      scheduleReviewedWorkPatternExperiment({
+        action: "approve",
+        candidate: candidate(),
+        reviewerUserId: "user-1",
+        orchestratingAgentId: "agent-1",
+      }),
+    ).resolves.toEqual({ scheduled: true, parentTaskRunId: "TR-PARENT" });
+
+    expect(createRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orchestratingAgentId: "agent-1",
+        cells: [
+          expect.objectContaining({
+            executionRequest: expect.objectContaining({ fixtureKey: "fixture" }),
+          }),
+        ],
+      }),
+      expect.objectContaining({ resolveOwnerUserId: expect.any(Function) }),
+    );
+    expect(send).toHaveBeenCalledWith({
+      id: "work-pattern-experiment:WPR-1",
+      name: "build/work-pattern-experiment.run",
+      data: { parentTaskRunId: "TR-PARENT" },
+    });
+  });
+
+  it("does not schedule deferred or non-shadow candidates", async () => {
+    await expect(
+      scheduleReviewedWorkPatternExperiment({
+        action: "defer",
+        candidate: candidate(),
+        reviewerUserId: "user-1",
+        orchestratingAgentId: "agent-1",
+      }),
+    ).resolves.toEqual({ scheduled: false, reason: "review_not_approved" });
+    await expect(
+      scheduleReviewedWorkPatternExperiment({
+        action: "approve",
+        candidate: candidate("live"),
+        reviewerUserId: "user-1",
+        orchestratingAgentId: "agent-1",
+      }),
+    ).resolves.toEqual({
+      scheduled: false,
+      reason: "no_evidence_cleared_experiment",
+    });
+    expect(createRun).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
@@ -6,7 +6,9 @@ const { createRun, send } = vi.hoisted(() => ({
 }));
 
 vi.mock("@dpf/db", () => ({ prisma: {} }));
-vi.mock("@/lib/queue/inngest-client", () => ({ inngest: { send } }));
+vi.mock("@/lib/queue/functions/work-pattern-experiment", () => ({
+  enqueueWorkPatternExperiment: send,
+}));
 vi.mock("./work-pattern-experiment-store", () => ({
   createPrismaWorkPatternExperimentPersistence: vi.fn().mockReturnValue({}),
   createOrResumeWorkPatternExperiment: createRun,
@@ -102,11 +104,7 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
       }),
       expect.objectContaining({ resolveOwnerUserId: expect.any(Function) }),
     );
-    expect(send).toHaveBeenCalledWith({
-      id: "work-pattern-experiment:WPR-1",
-      name: "build/work-pattern-experiment.run",
-      data: { parentTaskRunId: "TR-PARENT" },
-    });
+    expect(send).toHaveBeenCalledWith("WPR-1", "TR-PARENT");
   });
 
   it("does not schedule deferred or non-shadow candidates", async () => {

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
@@ -1,0 +1,146 @@
+import { prisma } from "@dpf/db";
+import { CAPABILITY_INSTALL_SCOPES } from "@dpf/db/capability-maturity";
+
+import { isRecord } from "@/lib/shared/coerce";
+import {
+  parsePersistedWorkPatternExperimentExecution,
+} from "@/lib/integrate/work-pattern-experiment-runtime";
+import { inngest } from "@/lib/queue/inngest-client";
+
+import {
+  createOrResumeWorkPatternExperiment,
+  createPrismaWorkPatternExperimentPersistence,
+} from "./work-pattern-experiment-store";
+import type { WorkPatternExperimentDefinitionIdentity } from "./work-pattern-experiment-identity";
+import { WORK_PATTERN_EXPERIMENT_RISK_CLASSES } from "./work-pattern-experiment-types";
+
+type ReviewedExperimentCandidate = {
+  definition: WorkPatternExperimentDefinitionIdentity;
+  activityKey: string;
+  riskClass: (typeof WORK_PATTERN_EXPERIMENT_RISK_CLASSES)[number];
+  pairKey: string;
+  cells: Array<{
+    methodVariantKey: string;
+    modelVariantKey: string;
+    executionRequest: NonNullable<
+      ReturnType<typeof parsePersistedWorkPatternExperimentExecution>
+    >;
+  }>;
+};
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseReviewedExperimentCandidate(value: unknown): ReviewedExperimentCandidate | null {
+  if (!isRecord(value) || !isRecord(value.definition) || !Array.isArray(value.cells)) {
+    return null;
+  }
+  const definition = value.definition;
+  if (
+    !nonEmptyString(value.activityKey)
+    || !nonEmptyString(value.pairKey)
+    || !WORK_PATTERN_EXPERIMENT_RISK_CLASSES.includes(
+      value.riskClass as ReviewedExperimentCandidate["riskClass"],
+    )
+    || !nonEmptyString(definition.patternKey)
+    || !nonEmptyString(definition.taskCorpusKey)
+    || !nonEmptyString(definition.taskCorpusVersion)
+    || !nonEmptyString(definition.oracleKey)
+    || !nonEmptyString(definition.oracleVersion)
+    || !Array.isArray(definition.methodVariants)
+    || !Array.isArray(definition.modelVariants)
+    || definition.methodVariants.length === 0
+    || definition.modelVariants.length === 0
+    || definition.methodVariants.some(
+      (variant) =>
+        !isRecord(variant)
+        || !nonEmptyString(variant.methodVariantKey)
+        || !Number.isInteger(variant.patternVersion)
+        || (variant.patternVersion as number) <= 0,
+    )
+    || definition.modelVariants.some(
+      (variant) =>
+        !isRecord(variant)
+        || !nonEmptyString(variant.modelVariantKey)
+        || !nonEmptyString(variant.modelProfileId),
+    )
+    || !CAPABILITY_INSTALL_SCOPES.includes(
+      definition.installScope as (typeof CAPABILITY_INSTALL_SCOPES)[number],
+    )
+    || !nonEmptyString(definition.promotionPolicyKey)
+    || !Number.isInteger(definition.promotionPolicyVersion)
+  ) {
+    return null;
+  }
+
+  const cells: ReviewedExperimentCandidate["cells"] = [];
+  for (const rawCell of value.cells) {
+    if (!isRecord(rawCell)) return null;
+    const executionRequest = parsePersistedWorkPatternExperimentExecution(
+      rawCell.executionRequest,
+    );
+    if (
+      !executionRequest
+      || !nonEmptyString(rawCell.methodVariantKey)
+      || !nonEmptyString(rawCell.modelVariantKey)
+      || executionRequest.methodVariantKey !== rawCell.methodVariantKey
+      || executionRequest.modelVariantKey !== rawCell.modelVariantKey
+      || executionRequest.executionProfile.environmentKey !== "shadow"
+    ) {
+      return null;
+    }
+    cells.push({
+      methodVariantKey: rawCell.methodVariantKey,
+      modelVariantKey: rawCell.modelVariantKey,
+      executionRequest,
+    });
+  }
+  if (cells.length === 0) return null;
+
+  return {
+    definition: definition as unknown as WorkPatternExperimentDefinitionIdentity,
+    activityKey: value.activityKey,
+    riskClass: value.riskClass as ReviewedExperimentCandidate["riskClass"],
+    pairKey: value.pairKey,
+    cells,
+  };
+}
+
+export async function scheduleReviewedWorkPatternExperiment(input: {
+  action: "approve" | "defer" | "reject";
+  candidate: unknown;
+  reviewerUserId: string;
+  orchestratingAgentId: string;
+}): Promise<{ scheduled: boolean; parentTaskRunId?: string; reason?: string }> {
+  if (input.action !== "approve") return { scheduled: false, reason: "review_not_approved" };
+  const candidate = parseReviewedExperimentCandidate(input.candidate);
+  if (!candidate) return { scheduled: false, reason: "no_evidence_cleared_experiment" };
+
+  const persistence = createPrismaWorkPatternExperimentPersistence(prisma as never);
+  const run = await createOrResumeWorkPatternExperiment(
+    {
+      definition: candidate.definition,
+      activityKey: candidate.activityKey,
+      riskClass: candidate.riskClass,
+      pairKey: candidate.pairKey,
+      orchestratingAgentId: input.orchestratingAgentId,
+      cells: candidate.cells.map((cell) => ({
+        methodVariantKey: cell.methodVariantKey,
+        modelVariantKey: cell.modelVariantKey,
+        executionRequest: cell.executionRequest,
+      })),
+    },
+    {
+      persistence,
+      resolveOwnerUserId: async () => input.reviewerUserId,
+    },
+  );
+
+  await inngest.send({
+    id: `work-pattern-experiment:${run.manifest.experimentRunId}`,
+    name: "build/work-pattern-experiment.run",
+    data: { parentTaskRunId: run.parent.taskRunId },
+  });
+  return { scheduled: true, parentTaskRunId: run.parent.taskRunId };
+}

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
@@ -5,7 +5,7 @@ import { isRecord } from "@/lib/shared/coerce";
 import {
   parsePersistedWorkPatternExperimentExecution,
 } from "@/lib/integrate/work-pattern-experiment-runtime";
-import { inngest } from "@/lib/queue/inngest-client";
+import { enqueueWorkPatternExperiment } from "@/lib/queue/functions/work-pattern-experiment";
 
 import {
   createOrResumeWorkPatternExperiment,
@@ -137,10 +137,9 @@ export async function scheduleReviewedWorkPatternExperiment(input: {
     },
   );
 
-  await inngest.send({
-    id: `work-pattern-experiment:${run.manifest.experimentRunId}`,
-    name: "build/work-pattern-experiment.run",
-    data: { parentTaskRunId: run.parent.taskRunId },
-  });
+  await enqueueWorkPatternExperiment(
+    run.manifest.experimentRunId,
+    run.parent.taskRunId,
+  );
   return { scheduled: true, parentTaskRunId: run.parent.taskRunId };
 }

--- a/apps/web/lib/tak/work-pattern-experiment-store.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.test.ts
@@ -29,7 +29,7 @@ function makePersistence(): WorkPatternExperimentPersistence & {
       });
       await prior;
       try {
-        return await work();
+        return await work(this);
       } finally {
         release();
       }
@@ -72,7 +72,7 @@ const input = {
       { methodVariantKey: "candidate", patternVersion: 2 },
     ],
     modelVariants: [{ modelVariantKey: "model-a", modelProfileId: "profile-a" }],
-    installScope: "platform" as const,
+    installScope: "canonical" as const,
     promotionPolicyKey: "bounded-promotion",
     promotionPolicyVersion: 1,
   },
@@ -173,7 +173,7 @@ describe("work-pattern experiment store", () => {
 
     expect(retry.taskRunId).not.toBe(run.children[0]!.taskRunId);
     expect(retry.parentTaskRunId).toBe(run.parent.id);
-    expect(retry.a2aMetadata.workPatternExperimentCell.attempt).toBe(2);
+    expect(retry.a2aMetadata.workPatternExperimentCell!.attempt).toBe(2);
     expect(persistence.rows).toHaveLength(4);
   });
 
@@ -196,11 +196,25 @@ describe("work-pattern experiment store", () => {
         { persistence },
       );
       expect(parent.status).toBe(status);
-      expect(parent.a2aMetadata.workPatternExperiment.lifecycle).toBe(lifecycle);
+      expect(parent.a2aMetadata.workPatternExperiment!.lifecycle).toBe(lifecycle);
     }
     await expect(
       transitionWorkPatternExperiment(run.parent.taskRunId, "running", { persistence }),
     ).rejects.toThrow("illegal_work_pattern_experiment_transition");
+  });
+
+  it("fails closed when stored lifecycle metadata and A2A status have diverged", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+    const run = await createOrResumeWorkPatternExperiment(input, deps);
+    await persistence.updateTaskRun(run.parent.taskRunId, { status: "working" });
+
+    await expect(createOrResumeWorkPatternExperiment(input, deps)).rejects.toThrow(
+      "work_pattern_experiment_status_divergence",
+    );
   });
 
   it("converges duplicate ledger writes and attributes them to the orchestrating coworker", async () => {
@@ -223,7 +237,7 @@ describe("work-pattern experiment store", () => {
     ]);
 
     expect(first).toEqual(second);
-    expect(persistence.ledgers).toHaveLength(1);
+    expect(persistence.ledgers.size).toBe(1);
     expect(first.agentId).toBe("agent-orchestrator");
     expect(first.metadata).toMatchObject({ modelProfileId: "candidate-model" });
   });

--- a/apps/web/lib/tak/work-pattern-experiment-store.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createOrResumeWorkPatternExperiment,
+  createWorkPatternExperimentRetry,
+  recordWorkPatternExperimentEvidence,
+  transitionWorkPatternExperiment,
+  type WorkPatternExperimentPersistence,
+  type WorkPatternStoredTaskRun,
+} from "./work-pattern-experiment-store";
+
+function makePersistence(): WorkPatternExperimentPersistence & {
+  rows: WorkPatternStoredTaskRun[];
+  ledgers: Map<string, Record<string, unknown>>;
+} {
+  const rows: WorkPatternStoredTaskRun[] = [];
+  const ledgers = new Map<string, Record<string, unknown>>();
+  let rowSequence = 0;
+  let lock = Promise.resolve();
+
+  return {
+    rows,
+    ledgers,
+    async withDefinitionLock(_definitionKey, work) {
+      const prior = lock;
+      let release = () => {};
+      lock = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await prior;
+      try {
+        return await work();
+      } finally {
+        release();
+      }
+    },
+    async listTaskRuns(repeatedPatternKey) {
+      return rows.filter((row) => row.repeatedPatternKey === repeatedPatternKey);
+    },
+    async findTaskRun(taskRunId) {
+      return rows.find((row) => row.taskRunId === taskRunId) ?? null;
+    },
+    async createTaskRun(data) {
+      const existing = rows.find((row) => row.taskRunId === data.taskRunId);
+      if (existing) return existing;
+      const row = { ...data, id: `row-${++rowSequence}` };
+      rows.push(row);
+      return row;
+    },
+    async updateTaskRun(taskRunId, data) {
+      const row = rows.find((candidate) => candidate.taskRunId === taskRunId);
+      if (!row) throw new Error("missing_test_task_run");
+      Object.assign(row, data);
+      return row;
+    },
+    async upsertLedger(ledgerId, create) {
+      if (!ledgers.has(ledgerId)) ledgers.set(ledgerId, create);
+      return ledgers.get(ledgerId)!;
+    },
+  };
+}
+
+const input = {
+  definition: {
+    patternKey: "review-loop",
+    taskCorpusKey: "review-fixtures",
+    taskCorpusVersion: "1",
+    oracleKey: "review-oracle",
+    oracleVersion: "1",
+    methodVariants: [
+      { methodVariantKey: "baseline", patternVersion: 1 },
+      { methodVariantKey: "candidate", patternVersion: 2 },
+    ],
+    modelVariants: [{ modelVariantKey: "model-a", modelProfileId: "profile-a" }],
+    installScope: "platform" as const,
+    promotionPolicyKey: "bounded-promotion",
+    promotionPolicyVersion: 1,
+  },
+  activityKey: "build.review",
+  riskClass: "internal-reversible" as const,
+  pairKey: "baseline-v-candidate",
+  cells: [
+    { methodVariantKey: "baseline", modelVariantKey: "model-a" },
+    { methodVariantKey: "candidate", modelVariantKey: "model-a" },
+  ],
+  orchestratingAgentId: "agent-orchestrator",
+};
+
+describe("work-pattern experiment store", () => {
+  it("concurrent creation converges on one parent and one row per deterministic cell", async () => {
+    const persistence = makePersistence();
+    const resolveOwnerUserId = vi.fn().mockResolvedValue("user-owner");
+
+    const [first, second] = await Promise.all([
+      createOrResumeWorkPatternExperiment(input, { persistence, resolveOwnerUserId }),
+      createOrResumeWorkPatternExperiment(input, { persistence, resolveOwnerUserId }),
+    ]);
+
+    expect(first.parent.taskRunId).toBe(second.parent.taskRunId);
+    expect(persistence.rows.filter((row) => row.parentTaskRunId === null)).toHaveLength(1);
+    expect(persistence.rows.filter((row) => row.parentTaskRunId !== null)).toHaveLength(2);
+    expect(
+      persistence.rows
+        .filter((row) => row.parentTaskRunId !== null)
+        .every((row) => row.parentTaskRunId === first.parent.id),
+    ).toBe(true);
+  });
+
+  it("fails before opening storage when accountable owner resolution is unavailable", async () => {
+    const persistence = makePersistence();
+    const withDefinitionLock = vi.spyOn(persistence, "withDefinitionLock");
+
+    await expect(
+      createOrResumeWorkPatternExperiment(input, {
+        persistence,
+        resolveOwnerUserId: vi.fn().mockRejectedValue(new Error("no owner")),
+      }),
+    ).rejects.toThrow("no owner");
+    expect(withDefinitionLock).not.toHaveBeenCalled();
+    expect(persistence.rows).toHaveLength(0);
+  });
+
+  it("creates an explicit new replicate without rewriting prior history", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+
+    const first = await createOrResumeWorkPatternExperiment(input, deps);
+    const second = await createOrResumeWorkPatternExperiment(
+      { ...input, replicate: 2 },
+      deps,
+    );
+
+    expect(first.manifest.replicate).toBe(1);
+    expect(second.manifest.replicate).toBe(2);
+    expect(second.parent.taskRunId).not.toBe(first.parent.taskRunId);
+    expect(persistence.rows.filter((row) => row.parentTaskRunId === null)).toHaveLength(2);
+  });
+
+  it("resume schedules only missing or non-terminal cells", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+    const first = await createOrResumeWorkPatternExperiment(input, deps);
+    await persistence.updateTaskRun(first.children[0]!.taskRunId, { status: "completed" });
+
+    const resumed = await createOrResumeWorkPatternExperiment(input, deps);
+
+    expect(resumed.scheduledChildTaskRunIds).toEqual([first.children[1]!.taskRunId]);
+    expect(persistence.rows).toHaveLength(3);
+  });
+
+  it("retries by creating a new deterministic attempt and preserving the original", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+    const run = await createOrResumeWorkPatternExperiment(input, deps);
+
+    const retry = await createWorkPatternExperimentRetry(
+      {
+        parentTaskRunId: run.parent.taskRunId,
+        cellKey: "baseline:model-a",
+        pairKey: input.pairKey,
+      },
+      deps,
+    );
+
+    expect(retry.taskRunId).not.toBe(run.children[0]!.taskRunId);
+    expect(retry.parentTaskRunId).toBe(run.parent.id);
+    expect(retry.a2aMetadata.workPatternExperimentCell.attempt).toBe(2);
+    expect(persistence.rows).toHaveLength(4);
+  });
+
+  it("keeps parent A2A status synchronized with every legal lifecycle transition", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+    const run = await createOrResumeWorkPatternExperiment(input, deps);
+
+    for (const [lifecycle, status] of [
+      ["running", "working"],
+      ["analyzing", "working"],
+      ["completed", "completed"],
+    ] as const) {
+      const parent = await transitionWorkPatternExperiment(
+        run.parent.taskRunId,
+        lifecycle,
+        { persistence },
+      );
+      expect(parent.status).toBe(status);
+      expect(parent.a2aMetadata.workPatternExperiment.lifecycle).toBe(lifecycle);
+    }
+    await expect(
+      transitionWorkPatternExperiment(run.parent.taskRunId, "running", { persistence }),
+    ).rejects.toThrow("illegal_work_pattern_experiment_transition");
+  });
+
+  it("converges duplicate ledger writes and attributes them to the orchestrating coworker", async () => {
+    const persistence = makePersistence();
+    const evidence = {
+      experimentRunId: "WPR-1",
+      childTaskRunId: "TR-WPC-1",
+      observationKind: "assignment",
+      sequence: 0,
+      orchestratingAgentId: "agent-orchestrator",
+      activityType: "build.review",
+      riskClass: "internal-reversible",
+      proposedDecision: { cellKey: "baseline:model-a" },
+      metadata: { modelProfileId: "candidate-model" },
+    };
+
+    const [first, second] = await Promise.all([
+      recordWorkPatternExperimentEvidence(evidence, { persistence }),
+      recordWorkPatternExperimentEvidence(evidence, { persistence }),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(persistence.ledgers).toHaveLength(1);
+    expect(first.agentId).toBe("agent-orchestrator");
+    expect(first.metadata).toMatchObject({ modelProfileId: "candidate-model" });
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-store.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.ts
@@ -247,6 +247,18 @@ export async function createOrResumeWorkPatternExperiment(
       });
       let child = await session.findTaskRun(taskRunId);
       if (!child) {
+        const normalizedExecutionRequest =
+          cell.executionRequest !== undefined && isRecord(cell.executionRequest)
+            ? {
+                ...cell.executionRequest,
+                experimentRunId,
+                childTaskRunId: taskRunId,
+                cellKey: cell.cellKey,
+                pairKey: input.pairKey,
+                methodVariantKey: cell.methodVariantKey,
+                modelVariantKey: cell.modelVariantKey,
+              }
+            : cell.executionRequest;
         const cellMetadata: WorkPatternCellMetadata = {
           schemaVersion: 1,
           experimentRunId,
@@ -256,8 +268,8 @@ export async function createOrResumeWorkPatternExperiment(
           methodVariantKey: cell.methodVariantKey,
           modelVariantKey: cell.modelVariantKey,
           attempt: 1,
-          ...(cell.executionRequest !== undefined
-            ? { executionRequest: cell.executionRequest }
+          ...(normalizedExecutionRequest !== undefined
+            ? { executionRequest: normalizedExecutionRequest }
             : {}),
         };
         child = await session.createTaskRun({

--- a/apps/web/lib/tak/work-pattern-experiment-store.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.ts
@@ -27,6 +27,7 @@ export type WorkPatternCellMetadata = {
   methodVariantKey: string;
   modelVariantKey: string;
   attempt: number;
+  executionRequest?: unknown;
 };
 
 export type WorkPatternStoredTaskRun = {
@@ -84,7 +85,11 @@ export type WorkPatternExperimentInput = {
   activityKey: string;
   riskClass: WorkPatternExperimentMetadataV1["riskClass"];
   pairKey: string;
-  cells: Array<{ methodVariantKey: string; modelVariantKey: string }>;
+  cells: Array<{
+    methodVariantKey: string;
+    modelVariantKey: string;
+    executionRequest?: unknown;
+  }>;
   orchestratingAgentId: string;
   buildId?: string;
   replicate?: number;
@@ -251,6 +256,9 @@ export async function createOrResumeWorkPatternExperiment(
           methodVariantKey: cell.methodVariantKey,
           modelVariantKey: cell.modelVariantKey,
           attempt: 1,
+          ...(cell.executionRequest !== undefined
+            ? { executionRequest: cell.executionRequest }
+            : {}),
         };
         child = await session.createTaskRun({
           taskRunId,

--- a/apps/web/lib/tak/work-pattern-experiment-store.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.ts
@@ -1,0 +1,476 @@
+import { resolveScheduledOwnerUserId } from "@/lib/queue/scheduled-owner";
+import { isRecord } from "@/lib/shared/coerce";
+
+import {
+  workPatternCellKey,
+  workPatternExperimentChildTaskRunId,
+  workPatternExperimentDefinitionKey,
+  workPatternExperimentLedgerId,
+  workPatternExperimentParentTaskRunId,
+  workPatternExperimentRunId,
+  type WorkPatternExperimentDefinitionIdentity,
+} from "./work-pattern-experiment-identity";
+import {
+  canTransitionWorkPatternExperiment,
+  experimentLifecycleToTaskStatus,
+  parseWorkPatternExperimentMetadata,
+  type WorkPatternExperimentLifecycle,
+  type WorkPatternExperimentMetadataV1,
+} from "./work-pattern-experiment-types";
+
+export type WorkPatternCellMetadata = {
+  schemaVersion: 1;
+  experimentRunId: string;
+  experimentDefinitionKey: string;
+  cellKey: string;
+  pairKey: string;
+  methodVariantKey: string;
+  modelVariantKey: string;
+  attempt: number;
+};
+
+export type WorkPatternStoredTaskRun = {
+  id: string;
+  taskRunId: string;
+  userId: string;
+  buildId?: string | null;
+  initiatingAgentId: string | null;
+  currentAgentId: string | null;
+  parentTaskRunId: string | null;
+  routeContext: string | null;
+  title: string;
+  objective: string;
+  source: string;
+  status: string;
+  authorityScope: unknown;
+  a2aMetadata: {
+    workPatternExperiment?: WorkPatternExperimentMetadataV1;
+    workPatternExperimentCell?: WorkPatternCellMetadata;
+    [key: string]: unknown;
+  };
+  repeatedPatternKey: string | null;
+};
+
+export type WorkPatternTaskRunCreate = Omit<WorkPatternStoredTaskRun, "id">;
+
+export type WorkPatternExperimentPersistenceSession = {
+  listTaskRuns: (repeatedPatternKey: string) => Promise<WorkPatternStoredTaskRun[]>;
+  findTaskRun: (taskRunId: string) => Promise<WorkPatternStoredTaskRun | null>;
+  createTaskRun: (data: WorkPatternTaskRunCreate) => Promise<WorkPatternStoredTaskRun>;
+  updateTaskRun: (
+    taskRunId: string,
+    data: Partial<Pick<WorkPatternStoredTaskRun, "status" | "a2aMetadata">>,
+  ) => Promise<WorkPatternStoredTaskRun>;
+  upsertLedger: (
+    ledgerId: string,
+    create: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
+};
+
+export type WorkPatternExperimentPersistence = WorkPatternExperimentPersistenceSession & {
+  withDefinitionLock: <T>(
+    definitionKey: string,
+    work: (session: WorkPatternExperimentPersistenceSession) => Promise<T>,
+  ) => Promise<T>;
+};
+
+export type WorkPatternExperimentStoreDeps = {
+  persistence: WorkPatternExperimentPersistence;
+  resolveOwnerUserId?: () => Promise<string>;
+};
+
+export type WorkPatternExperimentInput = {
+  definition: WorkPatternExperimentDefinitionIdentity;
+  activityKey: string;
+  riskClass: WorkPatternExperimentMetadataV1["riskClass"];
+  pairKey: string;
+  cells: Array<{ methodVariantKey: string; modelVariantKey: string }>;
+  orchestratingAgentId: string;
+  buildId?: string;
+  replicate?: number;
+};
+
+const TERMINAL_TASK_STATUSES = new Set([
+  "completed",
+  "failed",
+  "canceled",
+  "rejected",
+  "archived",
+]);
+
+function patternStorageKey(definitionKey: string): string {
+  return `work-pattern-experiment:${definitionKey}`;
+}
+
+function manifestFrom(row: WorkPatternStoredTaskRun): WorkPatternExperimentMetadataV1 | null {
+  return parseWorkPatternExperimentMetadata(row.a2aMetadata.workPatternExperiment);
+}
+
+function childMetadataFrom(row: WorkPatternStoredTaskRun): WorkPatternCellMetadata | null {
+  const value = row.a2aMetadata.workPatternExperimentCell;
+  if (
+    !isRecord(value)
+    || value.schemaVersion !== 1
+    || typeof value.experimentRunId !== "string"
+    || typeof value.experimentDefinitionKey !== "string"
+    || typeof value.cellKey !== "string"
+    || typeof value.pairKey !== "string"
+    || typeof value.methodVariantKey !== "string"
+    || typeof value.modelVariantKey !== "string"
+    || typeof value.attempt !== "number"
+    || !Number.isInteger(value.attempt)
+    || value.attempt <= 0
+  ) {
+    return null;
+  }
+  return value as WorkPatternCellMetadata;
+}
+
+function nextReplicate(
+  parents: readonly WorkPatternStoredTaskRun[],
+  requested: number | undefined,
+): number {
+  const manifests = parents
+    .map((row) => ({ row, manifest: manifestFrom(row) }))
+    .filter(
+      (entry): entry is { row: WorkPatternStoredTaskRun; manifest: WorkPatternExperimentMetadataV1 } =>
+        entry.manifest !== null,
+    );
+  if (requested !== undefined) {
+    if (!Number.isInteger(requested) || requested <= 0) throw new Error("invalid_replicate");
+    return requested;
+  }
+  const resumable = manifests
+    .filter(({ manifest }) => !["completed", "cancelled"].includes(manifest.lifecycle))
+    .sort((left, right) => right.manifest.replicate - left.manifest.replicate)[0];
+  if (resumable) return resumable.manifest.replicate;
+  return Math.max(0, ...manifests.map(({ manifest }) => manifest.replicate)) + 1;
+}
+
+function assertNonEmpty(value: string, error: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(error);
+}
+
+export async function createOrResumeWorkPatternExperiment(
+  input: WorkPatternExperimentInput,
+  deps: WorkPatternExperimentStoreDeps,
+): Promise<{
+  parent: WorkPatternStoredTaskRun;
+  manifest: WorkPatternExperimentMetadataV1;
+  children: WorkPatternStoredTaskRun[];
+  scheduledChildTaskRunIds: string[];
+}> {
+  assertNonEmpty(input.orchestratingAgentId, "missing_orchestrating_agent");
+  assertNonEmpty(input.activityKey, "missing_activity_key");
+  assertNonEmpty(input.pairKey, "missing_pair_key");
+  if (input.cells.length === 0) throw new Error("missing_experiment_cells");
+
+  // Resolve the accountable human before entering the write transaction so a
+  // missing install owner cannot leave a partial manifest.
+  const userId = await (deps.resolveOwnerUserId ?? resolveScheduledOwnerUserId)();
+  const definitionKey = workPatternExperimentDefinitionKey(input.definition);
+  const repeatedPatternKey = patternStorageKey(definitionKey);
+
+  return deps.persistence.withDefinitionLock(definitionKey, async (session) => {
+    const existing = await session.listTaskRuns(repeatedPatternKey);
+    const parents = existing.filter((row) => row.parentTaskRunId === null);
+    const replicate = nextReplicate(parents, input.replicate);
+    const experimentRunId = workPatternExperimentRunId(definitionKey, replicate);
+    const parentTaskRunId = workPatternExperimentParentTaskRunId(experimentRunId);
+    const requiredCells = input.cells.map((cell) => ({
+      ...cell,
+      cellKey: workPatternCellKey(cell),
+    }));
+    if (new Set(requiredCells.map((cell) => cell.cellKey)).size !== requiredCells.length) {
+      throw new Error("duplicate_experiment_cell");
+    }
+
+    const manifest: WorkPatternExperimentMetadataV1 = {
+      schemaVersion: 1,
+      experimentDefinitionKey: definitionKey,
+      experimentRunId,
+      replicate,
+      patternKey: input.definition.patternKey,
+      activityKey: input.activityKey,
+      riskClass: input.riskClass,
+      methodVariants: input.definition.methodVariants,
+      modelVariants: input.definition.modelVariants,
+      requiredCellKeys: requiredCells.map((cell) => cell.cellKey),
+      taskCorpusKey: input.definition.taskCorpusKey,
+      taskCorpusVersion: input.definition.taskCorpusVersion,
+      oracleKey: input.definition.oracleKey,
+      oracleVersion: input.definition.oracleVersion,
+      promotionPolicyKey: input.definition.promotionPolicyKey,
+      promotionPolicyVersion: input.definition.promotionPolicyVersion,
+      installScope: input.definition.installScope,
+      lifecycle: "planned",
+    };
+
+    let parent = await session.findTaskRun(parentTaskRunId);
+    if (!parent) {
+      parent = await session.createTaskRun({
+        taskRunId: parentTaskRunId,
+        userId,
+        buildId: input.buildId ?? null,
+        initiatingAgentId: input.orchestratingAgentId,
+        currentAgentId: input.orchestratingAgentId,
+        parentTaskRunId: null,
+        routeContext: "build-studio/work-pattern-experiment",
+        title: `Work-pattern experiment ${experimentRunId}`,
+        objective: `Evaluate ${input.definition.patternKey} across governed factorial cells.`,
+        source: input.buildId ? "build" : "proactive",
+        status: experimentLifecycleToTaskStatus("planned"),
+        authorityScope: [],
+        a2aMetadata: { workPatternExperiment: manifest },
+        repeatedPatternKey,
+      });
+    }
+    const storedManifest = manifestFrom(parent);
+    if (!storedManifest) throw new Error("invalid_stored_work_pattern_experiment_manifest");
+    if (parent.status !== experimentLifecycleToTaskStatus(storedManifest.lifecycle)) {
+      throw new Error("work_pattern_experiment_status_divergence");
+    }
+
+    const children: WorkPatternStoredTaskRun[] = [];
+    const scheduledChildTaskRunIds: string[] = [];
+    for (const cell of requiredCells) {
+      const taskRunId = workPatternExperimentChildTaskRunId({
+        experimentRunId,
+        cellKey: cell.cellKey,
+        pairKey: input.pairKey,
+        attempt: 1,
+      });
+      let child = await session.findTaskRun(taskRunId);
+      if (!child) {
+        const cellMetadata: WorkPatternCellMetadata = {
+          schemaVersion: 1,
+          experimentRunId,
+          experimentDefinitionKey: definitionKey,
+          cellKey: cell.cellKey,
+          pairKey: input.pairKey,
+          methodVariantKey: cell.methodVariantKey,
+          modelVariantKey: cell.modelVariantKey,
+          attempt: 1,
+        };
+        child = await session.createTaskRun({
+          taskRunId,
+          userId,
+          buildId: input.buildId ?? null,
+          initiatingAgentId: input.orchestratingAgentId,
+          currentAgentId: input.orchestratingAgentId,
+          parentTaskRunId: parent.id,
+          routeContext: "build-studio/work-pattern-experiment-cell",
+          title: `Experiment cell ${cell.cellKey}`,
+          objective: `Execute ${cell.cellKey} for ${experimentRunId}.`,
+          source: input.buildId ? "build" : "proactive",
+          status: "submitted",
+          authorityScope: [],
+          a2aMetadata: { workPatternExperimentCell: cellMetadata },
+          repeatedPatternKey,
+        });
+      }
+      children.push(child);
+      if (!TERMINAL_TASK_STATUSES.has(child.status)) {
+        scheduledChildTaskRunIds.push(child.taskRunId);
+      }
+    }
+
+    return { parent, manifest: storedManifest, children, scheduledChildTaskRunIds };
+  });
+}
+
+export async function createWorkPatternExperimentRetry(
+  input: { parentTaskRunId: string; cellKey: string; pairKey: string },
+  deps: WorkPatternExperimentStoreDeps,
+): Promise<WorkPatternStoredTaskRun> {
+  const userId = await (deps.resolveOwnerUserId ?? resolveScheduledOwnerUserId)();
+  const parent = await deps.persistence.findTaskRun(input.parentTaskRunId);
+  if (!parent) throw new Error("work_pattern_experiment_parent_not_found");
+  const manifest = manifestFrom(parent);
+  if (!manifest) throw new Error("invalid_stored_work_pattern_experiment_manifest");
+
+  return deps.persistence.withDefinitionLock(
+    manifest.experimentDefinitionKey,
+    async (session) => {
+      const rows = await session.listTaskRuns(
+        patternStorageKey(manifest.experimentDefinitionKey),
+      );
+      const prior = rows
+        .filter((row) => row.parentTaskRunId === parent.id)
+        .map((row) => ({ row, metadata: childMetadataFrom(row) }))
+        .filter(
+          (entry): entry is { row: WorkPatternStoredTaskRun; metadata: WorkPatternCellMetadata } =>
+            entry.metadata?.cellKey === input.cellKey
+            && entry.metadata.pairKey === input.pairKey,
+        )
+        .sort((left, right) => right.metadata.attempt - left.metadata.attempt);
+      const source = prior[0];
+      if (!source) throw new Error("work_pattern_experiment_cell_not_found");
+      const attempt = source.metadata.attempt + 1;
+      const taskRunId = workPatternExperimentChildTaskRunId({
+        experimentRunId: manifest.experimentRunId,
+        cellKey: input.cellKey,
+        pairKey: input.pairKey,
+        attempt,
+      });
+      const existing = await session.findTaskRun(taskRunId);
+      if (existing) return existing;
+      const { id: _priorRowId, ...retrySource } = source.row;
+      return session.createTaskRun({
+        ...retrySource,
+        taskRunId,
+        userId,
+        parentTaskRunId: parent.id,
+        status: "submitted",
+        a2aMetadata: {
+          workPatternExperimentCell: { ...source.metadata, attempt },
+        },
+      });
+    },
+  );
+}
+
+export async function transitionWorkPatternExperiment(
+  parentTaskRunId: string,
+  lifecycle: WorkPatternExperimentLifecycle,
+  deps: Pick<WorkPatternExperimentStoreDeps, "persistence">,
+): Promise<WorkPatternStoredTaskRun> {
+  const parent = await deps.persistence.findTaskRun(parentTaskRunId);
+  if (!parent) throw new Error("work_pattern_experiment_parent_not_found");
+  const initialManifest = manifestFrom(parent);
+  if (!initialManifest) throw new Error("invalid_stored_work_pattern_experiment_manifest");
+  return deps.persistence.withDefinitionLock(
+    initialManifest.experimentDefinitionKey,
+    async (session) => {
+      const current = await session.findTaskRun(parentTaskRunId);
+      if (!current) throw new Error("work_pattern_experiment_parent_not_found");
+      const manifest = manifestFrom(current);
+      if (!manifest) throw new Error("invalid_stored_work_pattern_experiment_manifest");
+      if (current.status !== experimentLifecycleToTaskStatus(manifest.lifecycle)) {
+        throw new Error("work_pattern_experiment_status_divergence");
+      }
+      if (!canTransitionWorkPatternExperiment(manifest.lifecycle, lifecycle)) {
+        throw new Error(
+          `illegal_work_pattern_experiment_transition:${manifest.lifecycle}:${lifecycle}`,
+        );
+      }
+      return session.updateTaskRun(parentTaskRunId, {
+        status: experimentLifecycleToTaskStatus(lifecycle),
+        a2aMetadata: {
+          ...current.a2aMetadata,
+          workPatternExperiment: { ...manifest, lifecycle },
+        },
+      });
+    },
+  );
+}
+
+export async function recordWorkPatternExperimentEvidence(
+  input: {
+    experimentRunId: string;
+    childTaskRunId: string;
+    observationKind: string;
+    sequence: number;
+    orchestratingAgentId: string;
+    activityType: string;
+    riskClass: string;
+    proposedDecision: unknown;
+    actualDecision?: unknown;
+    outcome?: unknown;
+    metadata?: Record<string, unknown>;
+    correction?: {
+      supersedesLedgerId: string;
+      invalidationReason: string;
+    };
+  },
+  deps: Pick<WorkPatternExperimentStoreDeps, "persistence">,
+): Promise<Record<string, unknown>> {
+  assertNonEmpty(input.orchestratingAgentId, "missing_orchestrating_agent");
+  if (input.correction) {
+    assertNonEmpty(input.correction.supersedesLedgerId, "missing_superseded_ledger_id");
+    assertNonEmpty(input.correction.invalidationReason, "missing_invalidation_reason");
+  }
+  const ledgerId = workPatternExperimentLedgerId(input);
+  return deps.persistence.upsertLedger(ledgerId, {
+    ledgerId,
+    agentId: input.orchestratingAgentId,
+    activityType: input.activityType,
+    riskClass: input.riskClass,
+    autonomyLevel: "shadow",
+    proposedDecision: input.proposedDecision,
+    ...(input.actualDecision !== undefined ? { actualDecision: input.actualDecision } : {}),
+    ...(input.outcome !== undefined ? { outcome: input.outcome } : {}),
+    sourceKind: "work-pattern-experiment",
+    taskRunId: input.childTaskRunId,
+    metadata: {
+      experimentRunId: input.experimentRunId,
+      observationKind: input.observationKind,
+      sequence: input.sequence,
+      ...(input.metadata ?? {}),
+      ...(input.correction ?? {}),
+    },
+  });
+}
+
+type PrismaLike = {
+  $transaction: <T>(
+    work: (tx: PrismaLikeTransaction) => Promise<T>,
+    options?: { isolationLevel: "Serializable" },
+  ) => Promise<T>;
+  taskRun: PrismaLikeTaskRun;
+  decisionShadowLedger: {
+    upsert: (args: unknown) => Promise<Record<string, unknown>>;
+  };
+};
+
+type PrismaLikeTaskRun = {
+  findMany: (args: unknown) => Promise<WorkPatternStoredTaskRun[]>;
+  findUnique: (args: unknown) => Promise<WorkPatternStoredTaskRun | null>;
+  create: (args: unknown) => Promise<WorkPatternStoredTaskRun>;
+  update: (args: unknown) => Promise<WorkPatternStoredTaskRun>;
+};
+
+type PrismaLikeTransaction = Omit<PrismaLike, "$transaction"> & {
+  $executeRaw: (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => Promise<unknown>;
+};
+
+function prismaSession(client: Omit<PrismaLike, "$transaction">): WorkPatternExperimentPersistenceSession {
+  return {
+    listTaskRuns: (repeatedPatternKey) =>
+      client.taskRun.findMany({ where: { repeatedPatternKey } }),
+    findTaskRun: (taskRunId) =>
+      client.taskRun.findUnique({ where: { taskRunId } }),
+    createTaskRun: (data) =>
+      client.taskRun.create({ data }),
+    updateTaskRun: (taskRunId, data) =>
+      client.taskRun.update({
+        where: { taskRunId },
+        data,
+      }),
+    upsertLedger: (ledgerId, create) =>
+      client.decisionShadowLedger.upsert({
+        where: { ledgerId },
+        create,
+        update: {},
+      }),
+  };
+}
+
+export function createPrismaWorkPatternExperimentPersistence(
+  client: PrismaLike,
+): WorkPatternExperimentPersistence {
+  const root = prismaSession(client);
+  return {
+    ...root,
+    withDefinitionLock: (definitionKey, work) =>
+      client.$transaction(async (tx) => {
+        await tx.$executeRaw`
+          SELECT pg_advisory_xact_lock(hashtextextended(${definitionKey}, 0))
+        `;
+        return work(prismaSession(tx));
+      }, { isolationLevel: "Serializable" }),
+  };
+}

--- a/apps/web/lib/tak/work-pattern-experiment-types.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-types.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canTransitionWorkPatternExperiment,
+  experimentLifecycleToTaskStatus,
+  parseWorkPatternExecutionProfile,
+  parseWorkPatternExperimentMetadata,
+} from "./work-pattern-experiment-types";
+
+function executionProfile(overrides: Record<string, unknown> = {}) {
+  return {
+    patternKey: "build.review",
+    patternVersion: 3,
+    variantKey: "review-with-focused-tests",
+    activityKey: "build.review",
+    riskClass: "internal-reversible",
+    providerId: "provider-routed",
+    modelId: "model-after-fallback",
+    modelProfileId: "MP-REVIEW",
+    toolPackDigest: "sha256:tools",
+    promptOrSkillDigest: "sha256:prompt",
+    contextPolicyKey: "context.minimized.v1",
+    recoveryPolicyKey: "recovery.build-review.v2",
+    installScope: "dpf_dogfood",
+    organizationId: "ORG-DPF",
+    taskCorpusKey: "build-review-corpus",
+    taskCorpusVersion: "2026-07-25",
+    environmentKey: "local-integration-ci",
+    sourceCommitSha: "0123456789abcdef0123456789abcdef01234567",
+    ...overrides,
+  };
+}
+
+function experimentMetadata(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    experimentDefinitionKey: "WPD-123",
+    experimentRunId: "WPR-123-R1",
+    replicate: 1,
+    patternKey: "build.review",
+    activityKey: "build.review",
+    riskClass: "internal-reversible",
+    methodVariants: [
+      { methodVariantKey: "baseline", patternVersion: 2 },
+      { methodVariantKey: "candidate", patternVersion: 3 },
+    ],
+    modelVariants: [
+      { modelVariantKey: "local", modelProfileId: "MP-LOCAL" },
+      { modelVariantKey: "frontier", modelProfileId: "MP-FRONTIER" },
+    ],
+    requiredCellKeys: [
+      "baseline:local",
+      "candidate:local",
+      "baseline:frontier",
+      "candidate:frontier",
+    ],
+    taskCorpusKey: "build-review-corpus",
+    taskCorpusVersion: "2026-07-25",
+    oracleKey: "build-gates",
+    oracleVersion: "2",
+    promotionPolicyKey: "work-pattern-promotion",
+    promotionPolicyVersion: 4,
+    installScope: "dpf_dogfood",
+    lifecycle: "planned",
+    ...overrides,
+  };
+}
+
+describe("parseWorkPatternExecutionProfile", () => {
+  it("accepts the minimized resolved execution snapshot", () => {
+    expect(parseWorkPatternExecutionProfile(executionProfile())).toEqual(executionProfile());
+  });
+
+  it.each([
+    ["riskClass", "unknown-risk"],
+    ["installScope", "dogfood"],
+  ])("rejects an unknown %s", (field, value) => {
+    expect(parseWorkPatternExecutionProfile(executionProfile({ [field]: value }))).toBeNull();
+  });
+
+  it.each([
+    ["apiKey", "secret"],
+    ["providerConfig", { token: "secret" }],
+    ["prompt", "full prompt text"],
+    ["systemPrompt", "full system prompt text"],
+  ])("rejects secret-bearing or full-prompt field %s", (field, value) => {
+    expect(parseWorkPatternExecutionProfile(executionProfile({ [field]: value }))).toBeNull();
+  });
+
+  it("keeps the routed provider/model rather than a requested fallback input", () => {
+    const parsed = parseWorkPatternExecutionProfile(executionProfile({
+      providerId: "provider-after-routing",
+      modelId: "model-after-routing",
+    }));
+
+    expect(parsed).toMatchObject({
+      providerId: "provider-after-routing",
+      modelId: "model-after-routing",
+    });
+    expect(parsed).not.toHaveProperty("requestedProviderId");
+    expect(parsed).not.toHaveProperty("requestedModelId");
+  });
+});
+
+describe("parseWorkPatternExperimentMetadata", () => {
+  it("parses a versioned factorial manifest without a two-arm restriction", () => {
+    expect(parseWorkPatternExperimentMetadata(experimentMetadata())).toEqual(experimentMetadata());
+  });
+
+  it.each([
+    ["lifecycle", "active"],
+    ["installScope", "local"],
+    ["riskClass", "critical"],
+    ["schemaVersion", 2],
+  ])("fails closed for malformed %s", (field, value) => {
+    expect(parseWorkPatternExperimentMetadata(experimentMetadata({ [field]: value }))).toBeNull();
+  });
+});
+
+describe("work-pattern experiment lifecycle", () => {
+  it.each([
+    ["planned", "submitted"],
+    ["running", "working"],
+    ["analyzing", "working"],
+    ["completed", "completed"],
+    ["cancelled", "canceled"],
+  ] as const)("maps %s to TaskRun status %s", (lifecycle, status) => {
+    expect(experimentLifecycleToTaskStatus(lifecycle)).toBe(status);
+  });
+
+  it("allows only legal transitions and idempotent resume", () => {
+    expect(canTransitionWorkPatternExperiment("planned", "planned")).toBe(true);
+    expect(canTransitionWorkPatternExperiment("planned", "running")).toBe(true);
+    expect(canTransitionWorkPatternExperiment("running", "analyzing")).toBe(true);
+    expect(canTransitionWorkPatternExperiment("analyzing", "completed")).toBe(true);
+    expect(canTransitionWorkPatternExperiment("running", "cancelled")).toBe(true);
+
+    expect(canTransitionWorkPatternExperiment("planned", "completed")).toBe(false);
+    expect(canTransitionWorkPatternExperiment("completed", "running")).toBe(false);
+    expect(canTransitionWorkPatternExperiment("cancelled", "planned")).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-types.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-types.ts
@@ -1,0 +1,326 @@
+import {
+  CAPABILITY_INSTALL_SCOPES,
+  type CapabilityInstallScope,
+} from "@dpf/db/capability-maturity";
+
+import type { RiskClass } from "@/lib/autonomy/trust-graduation";
+import { isRecord } from "@/lib/shared/coerce";
+
+export const WORK_PATTERN_EXPERIMENT_RISK_CLASSES = [
+  "read-only",
+  "internal-reversible",
+  "internal-irreversible",
+  "outbound-or-floor",
+] as const satisfies readonly RiskClass[];
+
+export const WORK_PATTERN_EXPERIMENT_LIFECYCLES = [
+  "planned",
+  "running",
+  "analyzing",
+  "completed",
+  "cancelled",
+] as const;
+
+export type WorkPatternExperimentLifecycle =
+  (typeof WORK_PATTERN_EXPERIMENT_LIFECYCLES)[number];
+
+export type WorkPatternExecutionProfile = {
+  patternKey: string;
+  patternVersion: number;
+  variantKey: string;
+  activityKey: string;
+  riskClass: RiskClass;
+  providerId: string;
+  modelId: string;
+  modelProfileId?: string;
+  toolPackDigest: string;
+  promptOrSkillDigest: string;
+  contextPolicyKey: string;
+  recoveryPolicyKey: string;
+  installScope: CapabilityInstallScope;
+  organizationId?: string;
+  taskCorpusKey: string;
+  taskCorpusVersion: string;
+  environmentKey: string;
+  sourceCommitSha: string;
+};
+
+export type WorkPatternMethodVariant = {
+  methodVariantKey: string;
+  patternVersion: number;
+};
+
+export type WorkPatternModelVariant = {
+  modelVariantKey: string;
+  modelProfileId: string;
+};
+
+export type WorkPatternExperimentMetadataV1 = {
+  schemaVersion: 1;
+  experimentDefinitionKey: string;
+  experimentRunId: string;
+  replicate: number;
+  patternKey: string;
+  activityKey: string;
+  riskClass: RiskClass;
+  methodVariants: WorkPatternMethodVariant[];
+  modelVariants: WorkPatternModelVariant[];
+  requiredCellKeys: string[];
+  taskCorpusKey: string;
+  taskCorpusVersion: string;
+  oracleKey: string;
+  oracleVersion: string;
+  promotionPolicyKey: string;
+  promotionPolicyVersion: number;
+  installScope: CapabilityInstallScope;
+  lifecycle: WorkPatternExperimentLifecycle;
+};
+
+const PROFILE_KEYS = new Set<keyof WorkPatternExecutionProfile>([
+  "patternKey",
+  "patternVersion",
+  "variantKey",
+  "activityKey",
+  "riskClass",
+  "providerId",
+  "modelId",
+  "modelProfileId",
+  "toolPackDigest",
+  "promptOrSkillDigest",
+  "contextPolicyKey",
+  "recoveryPolicyKey",
+  "installScope",
+  "organizationId",
+  "taskCorpusKey",
+  "taskCorpusVersion",
+  "environmentKey",
+  "sourceCommitSha",
+]);
+
+const MANIFEST_KEYS = new Set<keyof WorkPatternExperimentMetadataV1>([
+  "schemaVersion",
+  "experimentDefinitionKey",
+  "experimentRunId",
+  "replicate",
+  "patternKey",
+  "activityKey",
+  "riskClass",
+  "methodVariants",
+  "modelVariants",
+  "requiredCellKeys",
+  "taskCorpusKey",
+  "taskCorpusVersion",
+  "oracleKey",
+  "oracleVersion",
+  "promotionPolicyKey",
+  "promotionPolicyVersion",
+  "installScope",
+  "lifecycle",
+]);
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function includesValue<const T extends readonly string[]>(
+  values: T,
+  value: unknown,
+): value is T[number] {
+  return typeof value === "string" && (values as readonly string[]).includes(value);
+}
+
+function optionalString(value: unknown): string | undefined | null {
+  if (value === undefined) return undefined;
+  return isNonEmptyString(value) ? value : null;
+}
+
+function parseMethodVariants(value: unknown): WorkPatternMethodVariant[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const parsed: WorkPatternMethodVariant[] = [];
+  const identities = new Set<string>();
+  for (const row of value) {
+    if (
+      !isRecord(row)
+      || !hasOnlyKeys(row, new Set(["methodVariantKey", "patternVersion"]))
+      || !isNonEmptyString(row.methodVariantKey)
+      || !isPositiveInteger(row.patternVersion)
+      || identities.has(row.methodVariantKey)
+    ) {
+      return null;
+    }
+    identities.add(row.methodVariantKey);
+    parsed.push({
+      methodVariantKey: row.methodVariantKey,
+      patternVersion: row.patternVersion,
+    });
+  }
+  return parsed;
+}
+
+function parseModelVariants(value: unknown): WorkPatternModelVariant[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const parsed: WorkPatternModelVariant[] = [];
+  const identities = new Set<string>();
+  for (const row of value) {
+    if (
+      !isRecord(row)
+      || !hasOnlyKeys(row, new Set(["modelVariantKey", "modelProfileId"]))
+      || !isNonEmptyString(row.modelVariantKey)
+      || !isNonEmptyString(row.modelProfileId)
+      || identities.has(row.modelVariantKey)
+    ) {
+      return null;
+    }
+    identities.add(row.modelVariantKey);
+    parsed.push({
+      modelVariantKey: row.modelVariantKey,
+      modelProfileId: row.modelProfileId,
+    });
+  }
+  return parsed;
+}
+
+function parseUniqueStrings(value: unknown): string[] | null {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.some((entry) => !isNonEmptyString(entry))
+  ) {
+    return null;
+  }
+  const values = value as string[];
+  return new Set(values).size === values.length ? values : null;
+}
+
+export function parseWorkPatternExecutionProfile(
+  value: unknown,
+): WorkPatternExecutionProfile | null {
+  if (!isRecord(value) || !hasOnlyKeys(value, PROFILE_KEYS)) return null;
+
+  const requiredStrings = [
+    "patternKey",
+    "variantKey",
+    "activityKey",
+    "providerId",
+    "modelId",
+    "toolPackDigest",
+    "promptOrSkillDigest",
+    "contextPolicyKey",
+    "recoveryPolicyKey",
+    "taskCorpusKey",
+    "taskCorpusVersion",
+    "environmentKey",
+    "sourceCommitSha",
+  ] as const;
+  if (requiredStrings.some((field) => !isNonEmptyString(value[field]))) return null;
+  if (!isPositiveInteger(value.patternVersion)) return null;
+  if (!includesValue(WORK_PATTERN_EXPERIMENT_RISK_CLASSES, value.riskClass)) return null;
+  if (!includesValue(CAPABILITY_INSTALL_SCOPES, value.installScope)) return null;
+
+  const modelProfileId = optionalString(value.modelProfileId);
+  const organizationId = optionalString(value.organizationId);
+  if (modelProfileId === null || organizationId === null) return null;
+
+  return {
+    patternKey: value.patternKey as string,
+    patternVersion: value.patternVersion,
+    variantKey: value.variantKey as string,
+    activityKey: value.activityKey as string,
+    riskClass: value.riskClass,
+    providerId: value.providerId as string,
+    modelId: value.modelId as string,
+    ...(modelProfileId ? { modelProfileId } : {}),
+    toolPackDigest: value.toolPackDigest as string,
+    promptOrSkillDigest: value.promptOrSkillDigest as string,
+    contextPolicyKey: value.contextPolicyKey as string,
+    recoveryPolicyKey: value.recoveryPolicyKey as string,
+    installScope: value.installScope,
+    ...(organizationId ? { organizationId } : {}),
+    taskCorpusKey: value.taskCorpusKey as string,
+    taskCorpusVersion: value.taskCorpusVersion as string,
+    environmentKey: value.environmentKey as string,
+    sourceCommitSha: value.sourceCommitSha as string,
+  };
+}
+
+export function parseWorkPatternExperimentMetadata(
+  value: unknown,
+): WorkPatternExperimentMetadataV1 | null {
+  if (!isRecord(value) || !hasOnlyKeys(value, MANIFEST_KEYS)) return null;
+  if (value.schemaVersion !== 1) return null;
+  if (!isPositiveInteger(value.replicate) || !isPositiveInteger(value.promotionPolicyVersion)) {
+    return null;
+  }
+  if (!includesValue(WORK_PATTERN_EXPERIMENT_RISK_CLASSES, value.riskClass)) return null;
+  if (!includesValue(CAPABILITY_INSTALL_SCOPES, value.installScope)) return null;
+  if (!includesValue(WORK_PATTERN_EXPERIMENT_LIFECYCLES, value.lifecycle)) return null;
+
+  const requiredStrings = [
+    "experimentDefinitionKey",
+    "experimentRunId",
+    "patternKey",
+    "activityKey",
+    "taskCorpusKey",
+    "taskCorpusVersion",
+    "oracleKey",
+    "oracleVersion",
+    "promotionPolicyKey",
+  ] as const;
+  if (requiredStrings.some((field) => !isNonEmptyString(value[field]))) return null;
+
+  const methodVariants = parseMethodVariants(value.methodVariants);
+  const modelVariants = parseModelVariants(value.modelVariants);
+  const requiredCellKeys = parseUniqueStrings(value.requiredCellKeys);
+  if (!methodVariants || !modelVariants || !requiredCellKeys) return null;
+
+  return {
+    schemaVersion: 1,
+    experimentDefinitionKey: value.experimentDefinitionKey as string,
+    experimentRunId: value.experimentRunId as string,
+    replicate: value.replicate,
+    patternKey: value.patternKey as string,
+    activityKey: value.activityKey as string,
+    riskClass: value.riskClass,
+    methodVariants,
+    modelVariants,
+    requiredCellKeys,
+    taskCorpusKey: value.taskCorpusKey as string,
+    taskCorpusVersion: value.taskCorpusVersion as string,
+    oracleKey: value.oracleKey as string,
+    oracleVersion: value.oracleVersion as string,
+    promotionPolicyKey: value.promotionPolicyKey as string,
+    promotionPolicyVersion: value.promotionPolicyVersion,
+    installScope: value.installScope,
+    lifecycle: value.lifecycle,
+  };
+}
+
+export function experimentLifecycleToTaskStatus(
+  lifecycle: WorkPatternExperimentLifecycle,
+): "submitted" | "working" | "completed" | "canceled" {
+  if (lifecycle === "planned") return "submitted";
+  if (lifecycle === "running" || lifecycle === "analyzing") return "working";
+  return lifecycle === "completed" ? "completed" : "canceled";
+}
+
+export function canTransitionWorkPatternExperiment(
+  from: WorkPatternExperimentLifecycle,
+  to: WorkPatternExperimentLifecycle,
+): boolean {
+  if (from === to) return true;
+  if (from === "completed" || from === "cancelled") return false;
+  if (to === "cancelled") return true;
+  return (
+    (from === "planned" && to === "running")
+    || (from === "running" && to === "analyzing")
+    || (from === "analyzing" && to === "completed")
+  );
+}

--- a/apps/web/lib/tak/work-pattern-outcome-evidence.test.ts
+++ b/apps/web/lib/tak/work-pattern-outcome-evidence.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWorkPatternOutcomeEvidence } from "./work-pattern-outcome-evidence";
+
+function outcome(overrides: Record<string, unknown> = {}) {
+  return {
+    completed: true,
+    buildGate: {
+      unitTests: "pass",
+      productionBuild: "pass",
+      uxVerification: "not-applicable",
+      migration: "not-applicable",
+    },
+    review: {
+      decision: "pass",
+      reproducedBlockingFindings: 0,
+      nonBlockingFindings: 2,
+      reviewRounds: 1,
+    },
+    execution: {
+      toolCalls: 12,
+      toolFailures: 1,
+      retryCount: 1,
+      recoveryActions: ["provider-fallback"],
+      manualTouches: 0,
+      inputTokens: 4000,
+      outputTokens: 1200,
+      durationMs: 32000,
+      costUsd: 0.18,
+    },
+    delivery: {
+      prCreated: true,
+      mergeQueued: true,
+      merged: true,
+      deployed: true,
+      rolledBack: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("parseWorkPatternOutcomeEvidence", () => {
+  it("preserves build, review, execution, and delivery dimensions", () => {
+    expect(parseWorkPatternOutcomeEvidence(outcome())).toEqual(outcome());
+  });
+
+  it.each([
+    { buildGate: { unitTests: "green", productionBuild: "pass", uxVerification: "not-applicable", migration: "not-applicable" } },
+    { review: { decision: "pass", reproducedBlockingFindings: -1, nonBlockingFindings: 0, reviewRounds: 1 } },
+    { execution: { toolCalls: 1, toolFailures: 0, retryCount: 0, recoveryActions: [], manualTouches: 0, durationMs: -1 } },
+    { delivery: { prCreated: true, mergeQueued: true, merged: true, deployed: "yes", rolledBack: false } },
+  ])("fails closed for malformed evidence", (override) => {
+    expect(parseWorkPatternOutcomeEvidence(outcome(override))).toBeNull();
+  });
+
+  it("retains an explicit failure class without inventing a reward score", () => {
+    const parsed = parseWorkPatternOutcomeEvidence(outcome({
+      completed: false,
+      failureClass: "production-build",
+    }));
+
+    expect(parsed?.failureClass).toBe("production-build");
+    expect(parsed).not.toHaveProperty("reward");
+    expect(parsed).not.toHaveProperty("score");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-outcome-evidence.ts
+++ b/apps/web/lib/tak/work-pattern-outcome-evidence.ts
@@ -1,0 +1,150 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+export type WorkPatternOutcomeEvidence = {
+  completed: boolean;
+  buildGate: {
+    unitTests: "pass" | "fail" | "not-applicable";
+    productionBuild: "pass" | "fail" | "not-run";
+    uxVerification: "pass" | "fail" | "not-applicable" | "blocked";
+    migration: "pass" | "fail" | "not-applicable" | "blocked";
+  };
+  review: {
+    decision: "pass" | "fail";
+    reproducedBlockingFindings: number;
+    nonBlockingFindings: number;
+    reviewRounds: number;
+  };
+  execution: {
+    toolCalls: number;
+    toolFailures: number;
+    retryCount: number;
+    recoveryActions: string[];
+    manualTouches: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    durationMs: number;
+    costUsd?: number;
+  };
+  delivery: {
+    prCreated: boolean;
+    mergeQueued: boolean;
+    merged: boolean;
+    deployed: boolean;
+    rolledBack: boolean;
+  };
+  failureClass?: string;
+};
+
+function oneOf<const T extends readonly string[]>(
+  value: unknown,
+  values: T,
+): value is T[number] {
+  return typeof value === "string" && (values as readonly string[]).includes(value);
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function nonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function booleanFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+): boolean {
+  return fields.every((field) => typeof value[field] === "boolean");
+}
+
+export function parseWorkPatternOutcomeEvidence(
+  value: unknown,
+): WorkPatternOutcomeEvidence | null {
+  if (!isRecord(value) || typeof value.completed !== "boolean") return null;
+  if (
+    !isRecord(value.buildGate)
+    || !oneOf(value.buildGate.unitTests, ["pass", "fail", "not-applicable"] as const)
+    || !oneOf(value.buildGate.productionBuild, ["pass", "fail", "not-run"] as const)
+    || !oneOf(value.buildGate.uxVerification, ["pass", "fail", "not-applicable", "blocked"] as const)
+    || !oneOf(value.buildGate.migration, ["pass", "fail", "not-applicable", "blocked"] as const)
+  ) {
+    return null;
+  }
+  if (
+    !isRecord(value.review)
+    || !oneOf(value.review.decision, ["pass", "fail"] as const)
+    || !nonNegativeInteger(value.review.reproducedBlockingFindings)
+    || !nonNegativeInteger(value.review.nonBlockingFindings)
+    || !nonNegativeInteger(value.review.reviewRounds)
+  ) {
+    return null;
+  }
+  if (
+    !isRecord(value.execution)
+    || !nonNegativeInteger(value.execution.toolCalls)
+    || !nonNegativeInteger(value.execution.toolFailures)
+    || !nonNegativeInteger(value.execution.retryCount)
+    || !Array.isArray(value.execution.recoveryActions)
+    || value.execution.recoveryActions.some((item) => typeof item !== "string" || item.trim().length === 0)
+    || !nonNegativeInteger(value.execution.manualTouches)
+    || !nonNegativeNumber(value.execution.durationMs)
+    || (value.execution.inputTokens !== undefined && !nonNegativeInteger(value.execution.inputTokens))
+    || (value.execution.outputTokens !== undefined && !nonNegativeInteger(value.execution.outputTokens))
+    || (value.execution.costUsd !== undefined && !nonNegativeNumber(value.execution.costUsd))
+  ) {
+    return null;
+  }
+  if (
+    !isRecord(value.delivery)
+    || !booleanFields(value.delivery, ["prCreated", "mergeQueued", "merged", "deployed", "rolledBack"])
+  ) {
+    return null;
+  }
+  if (
+    value.failureClass !== undefined
+    && (typeof value.failureClass !== "string" || value.failureClass.trim().length === 0)
+  ) {
+    return null;
+  }
+
+  return {
+    completed: value.completed,
+    buildGate: {
+      unitTests: value.buildGate.unitTests,
+      productionBuild: value.buildGate.productionBuild,
+      uxVerification: value.buildGate.uxVerification,
+      migration: value.buildGate.migration,
+    },
+    review: {
+      decision: value.review.decision,
+      reproducedBlockingFindings: value.review.reproducedBlockingFindings,
+      nonBlockingFindings: value.review.nonBlockingFindings,
+      reviewRounds: value.review.reviewRounds,
+    },
+    execution: {
+      toolCalls: value.execution.toolCalls,
+      toolFailures: value.execution.toolFailures,
+      retryCount: value.execution.retryCount,
+      recoveryActions: value.execution.recoveryActions as string[],
+      manualTouches: value.execution.manualTouches,
+      ...(value.execution.inputTokens !== undefined
+        ? { inputTokens: value.execution.inputTokens as number }
+        : {}),
+      ...(value.execution.outputTokens !== undefined
+        ? { outputTokens: value.execution.outputTokens as number }
+        : {}),
+      durationMs: value.execution.durationMs,
+      ...(value.execution.costUsd !== undefined
+        ? { costUsd: value.execution.costUsd as number }
+        : {}),
+    },
+    delivery: {
+      prCreated: value.delivery.prCreated as boolean,
+      mergeQueued: value.delivery.mergeQueued as boolean,
+      merged: value.delivery.merged as boolean,
+      deployed: value.delivery.deployed as boolean,
+      rolledBack: value.delivery.rolledBack as boolean,
+    },
+    ...(typeof value.failureClass === "string" ? { failureClass: value.failureClass } : {}),
+  };
+}

--- a/apps/web/lib/tak/work-pattern-read-model.test.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.test.ts
@@ -322,4 +322,160 @@ describe("getWorkPatternReadModel", () => {
       shadowEvaluation: null,
     });
   });
+
+  it("projects a running governed experiment onto its existing Living Playbook", async () => {
+    const manifest = {
+      schemaVersion: 1 as const,
+      experimentDefinitionKey: "WPD-1",
+      experimentRunId: "WPR-1",
+      replicate: 1,
+      patternKey: "review-loop",
+      activityKey: "build.review",
+      riskClass: "internal-reversible" as const,
+      methodVariants: [
+        { methodVariantKey: "baseline", patternVersion: 1 },
+        { methodVariantKey: "candidate", patternVersion: 2 },
+      ],
+      modelVariants: [
+        { modelVariantKey: "model-a", modelProfileId: "profile-a" },
+        { modelVariantKey: "model-b", modelProfileId: "profile-b" },
+      ],
+      requiredCellKeys: [
+        "baseline:model-a",
+        "baseline:model-b",
+        "candidate:model-a",
+        "candidate:model-b",
+      ],
+      taskCorpusKey: "review-fixtures",
+      taskCorpusVersion: "1",
+      oracleKey: "review-oracle",
+      oracleVersion: "1",
+      promotionPolicyKey: "bounded-promotion",
+      promotionPolicyVersion: 1,
+      installScope: "canonical" as const,
+      lifecycle: "running" as const,
+    };
+    const db = {
+      listTaskRuns: vi.fn().mockResolvedValue([
+        {
+          taskRunId: "TR-WPX-1",
+          currentAgentId: "build-specialist",
+          initiatingAgentId: "build-specialist",
+          routeContext: "/build",
+          status: "working",
+          repeatedPatternKey: "work-pattern-experiment:WPD-1",
+          a2aMetadata: {
+            workPatternExperiment: manifest,
+            workPatternExperimentProjection: {
+              evidenceOrigin: "hermetic-replay",
+              validPairCount: 0,
+              resultSummary: "Candidate and baseline are still running.",
+              moreEvidenceNeeded: true,
+              invalidPairReasons: [],
+              freshnessAt: "2026-06-28T11:30:00.000Z",
+            },
+          },
+          createdAt: new Date("2026-06-28T11:00:00.000Z"),
+          completedAt: null,
+        },
+        {
+          taskRunId: "TR-WPC-1",
+          currentAgentId: "build-specialist",
+          initiatingAgentId: "build-specialist",
+          routeContext: "/build",
+          status: "submitted",
+          repeatedPatternKey: "work-pattern-experiment:WPD-1",
+          a2aMetadata: {
+            workPatternExperimentCell: {
+              schemaVersion: 1,
+              experimentRunId: "WPR-1",
+              experimentDefinitionKey: "WPD-1",
+              cellKey: "baseline:model-a",
+              pairKey: "pair",
+              methodVariantKey: "baseline",
+              modelVariantKey: "model-a",
+              attempt: 1,
+            },
+          },
+          createdAt: new Date("2026-06-28T11:01:00.000Z"),
+          completedAt: null,
+        },
+      ]),
+      listCapabilityNeeds: vi.fn().mockResolvedValue([]),
+    };
+
+    const model = await getWorkPatternReadModel({ agentId: "build-specialist", now }, { db });
+
+    expect(model.patterns).toHaveLength(1);
+    expect(model.patterns[0]).toMatchObject({
+      patternKey: "review-loop",
+      experiment: {
+        label: "Testing a better method",
+        lifecycle: "running",
+        validPairCount: 0,
+        evidenceOrigin: "hermetic-replay",
+        moreEvidenceNeeded: true,
+        methodVariants: ["baseline", "candidate"],
+        modelVariants: ["model-a", "model-b"],
+      },
+    });
+  });
+
+  it("keeps invalid completed evidence visible without styling it as active", async () => {
+    const db = {
+      listTaskRuns: vi.fn().mockResolvedValue([
+        {
+          taskRunId: "TR-WPX-2",
+          currentAgentId: "build-specialist",
+          initiatingAgentId: "build-specialist",
+          routeContext: "/build",
+          status: "completed",
+          repeatedPatternKey: "work-pattern-experiment:WPD-2",
+          a2aMetadata: {
+            workPatternExperiment: {
+              schemaVersion: 1,
+              experimentDefinitionKey: "WPD-2",
+              experimentRunId: "WPR-2",
+              replicate: 1,
+              patternKey: "review-loop",
+              activityKey: "build.review",
+              riskClass: "internal-reversible",
+              methodVariants: [{ methodVariantKey: "candidate", patternVersion: 2 }],
+              modelVariants: [{ modelVariantKey: "model-a", modelProfileId: "profile-a" }],
+              requiredCellKeys: ["candidate:model-a"],
+              taskCorpusKey: "review-fixtures",
+              taskCorpusVersion: "1",
+              oracleKey: "review-oracle",
+              oracleVersion: "1",
+              promotionPolicyKey: "bounded-promotion",
+              promotionPolicyVersion: 1,
+              installScope: "canonical",
+              lifecycle: "completed",
+            },
+            workPatternExperimentProjection: {
+              evidenceOrigin: "matched-cohort",
+              validPairCount: 0,
+              resultSummary: "The evidence could not be compared safely.",
+              moreEvidenceNeeded: true,
+              invalidPairReasons: ["source_commit_mismatch"],
+              freshnessAt: "2026-06-28T11:30:00.000Z",
+            },
+          },
+          createdAt: new Date("2026-06-28T11:00:00.000Z"),
+          completedAt: new Date("2026-06-28T11:30:00.000Z"),
+        },
+      ]),
+      listCapabilityNeeds: vi.fn().mockResolvedValue([]),
+    };
+
+    const model = await getWorkPatternReadModel({ agentId: "build-specialist", now }, { db });
+
+    expect(model.patterns[0]?.experiment).toMatchObject({
+      lifecycle: "completed",
+      validPairCount: 0,
+      invalidPairReasons: ["source_commit_mismatch"],
+      resultSummary: "The evidence could not be compared safely.",
+    });
+    expect(model.patterns[0]?.status).not.toBe("active");
+  });
 });

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -32,6 +32,10 @@ import {
   type WorkPatternReviewState,
 } from "./work-pattern-review";
 import type { WorkPatternCaseStagingState } from "./work-pattern-case-staging";
+import {
+  parseWorkPatternExperimentMetadata,
+  type WorkPatternExperimentLifecycle,
+} from "./work-pattern-experiment-types";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DEFAULT_TAKE = 200;
@@ -123,6 +127,26 @@ export type WorkPatternSummary = {
   activationCandidate: WorkPatternActivationCandidate | null;
   caseStaging: WorkPatternCaseStagingState | null;
   shadowEvaluation: WorkPatternShadowEvaluation | null;
+  experiment: WorkPatternExperimentProjection | null;
+};
+
+export type WorkPatternExperimentProjection = {
+  label: "Testing a better method";
+  lifecycle: WorkPatternExperimentLifecycle;
+  validPairCount: number;
+  resultSummary: string;
+  evidenceOrigin: "hermetic-replay" | "matched-cohort" | "unknown";
+  moreEvidenceNeeded: boolean;
+  invalidPairReasons: string[];
+  methodVariants: string[];
+  modelVariants: string[];
+  installScope: string;
+  taskCorpusVersion: string;
+  oracleVersion: string;
+  promotionPolicyVersion: number;
+  freshnessAt: string | null;
+  experimentRunId: string;
+  experimentDefinitionKey: string;
 };
 
 export type WorkPatternReadModel = {
@@ -148,10 +172,11 @@ type SummaryAccumulator = Omit<
   candidateNeedKinds: Set<CoworkerCapabilityNeedKind>;
   linkedNeedIds: Set<string>;
   evidenceRefs: Map<string, WorkPatternEvidenceRef>;
-  shadowTrials: WorkPatternShadowTrial[];
+    shadowTrials: WorkPatternShadowTrial[];
   shadowCurrentLevel: AutonomyLevel | null;
   shadowRegulatoryCeiling: AutonomyLevel | null;
   shadowRiskClass: RiskClass | null;
+  experiment: WorkPatternExperimentProjection | null;
 };
 
 type PatternSeed = {
@@ -283,6 +308,57 @@ function workPatternFromMetadata(value: unknown) {
   return parseWorkPatternMetadata(value.workPattern);
 }
 
+function experimentManifestFromMetadata(value: unknown) {
+  if (!isRecord(value)) return null;
+  return parseWorkPatternExperimentMetadata(value.workPatternExperiment);
+}
+
+function experimentProjectionFromMetadata(
+  value: unknown,
+): Omit<
+  WorkPatternExperimentProjection,
+  | "label"
+  | "lifecycle"
+  | "methodVariants"
+  | "modelVariants"
+  | "installScope"
+  | "taskCorpusVersion"
+  | "oracleVersion"
+  | "promotionPolicyVersion"
+  | "experimentRunId"
+  | "experimentDefinitionKey"
+> {
+  const projection =
+    isRecord(value) && isRecord(value.workPatternExperimentProjection)
+      ? value.workPatternExperimentProjection
+      : {};
+  const origin = projection.evidenceOrigin;
+  const evidenceOrigin =
+    origin === "hermetic-replay" || origin === "matched-cohort" ? origin : "unknown";
+  return {
+    validPairCount:
+      typeof projection.validPairCount === "number"
+      && Number.isInteger(projection.validPairCount)
+      && projection.validPairCount >= 0
+        ? projection.validPairCount
+        : 0,
+    resultSummary:
+      typeof projection.resultSummary === "string" && projection.resultSummary.trim().length > 0
+        ? projection.resultSummary.trim()
+        : "Experiment evidence is still being collected.",
+    evidenceOrigin,
+    moreEvidenceNeeded:
+      typeof projection.moreEvidenceNeeded === "boolean"
+        ? projection.moreEvidenceNeeded
+        : true,
+    invalidPairReasons: stringArrayField(projection, "invalidPairReasons"),
+    freshnessAt:
+      typeof projection.freshnessAt === "string" && dateFrom(projection.freshnessAt)
+        ? projection.freshnessAt
+        : null,
+  };
+}
+
 function riskClassFromMetadata(value: unknown): string | null {
   return stringField(value, "riskClass");
 }
@@ -319,6 +395,7 @@ function fallbackSeed(input: {
 
 function seedFromTaskRun(row: WorkPatternReadModelTaskRunRow, agentId: string): PatternSeed | null {
   const metadata = workPatternFromMetadata(row.a2aMetadata);
+  const experimentManifest = experimentManifestFromMetadata(row.a2aMetadata);
   const effectiveAgentId = row.currentAgentId ?? row.initiatingAgentId ?? agentId;
   const routeContext = row.routeContext ?? null;
   const riskClass = riskClassFromMetadata(row.a2aMetadata);
@@ -337,6 +414,36 @@ function seedFromTaskRun(row: WorkPatternReadModelTaskRunRow, agentId: string): 
       readiness: evaluatePatternReadiness(metadata),
       activationProposed: false,
     };
+  }
+
+  if (experimentManifest) {
+    return {
+      patternKey: experimentManifest.patternKey,
+      agentId: effectiveAgentId,
+      routeContext,
+      riskClass: experimentManifest.riskClass,
+      status: "candidate",
+      scope: routeContext ? "route" : "agent",
+      version: Math.max(
+        ...experimentManifest.methodVariants.map((variant) => variant.patternVersion),
+      ),
+      source: "observer",
+      decisionScope: routeContext ? patternDecisionScope("route") : patternDecisionScope("agent"),
+      candidate: null,
+      readiness: {
+        readyForReview: false,
+        readyForCaseActivation: false,
+        blockers: ["governed-experiment-incomplete"],
+      },
+      activationProposed: false,
+    };
+  }
+
+  if (
+    isRecord(row.a2aMetadata)
+    && isRecord(row.a2aMetadata.workPatternExperimentCell)
+  ) {
+    return null;
   }
 
   if (!row.repeatedPatternKey) return null;
@@ -464,6 +571,7 @@ function createAccumulator(seed: PatternSeed): SummaryAccumulator {
     shadowCurrentLevel: null,
     shadowRegulatoryCeiling: null,
     shadowRiskClass: null,
+    experiment: null,
   };
 }
 
@@ -599,6 +707,32 @@ function observeRun(summary: SummaryAccumulator, row: WorkPatternReadModelTaskRu
     summary.latestTaskRunId = row.taskRunId;
   }
   addEvidence(summary, metadataEvidence(row));
+  const manifest = experimentManifestFromMetadata(row.a2aMetadata);
+  if (manifest) {
+    summary.experiment = {
+      label: "Testing a better method",
+      lifecycle: manifest.lifecycle,
+      ...experimentProjectionFromMetadata(row.a2aMetadata),
+      methodVariants: manifest.methodVariants.map((variant) => variant.methodVariantKey),
+      modelVariants: manifest.modelVariants.map((variant) => variant.modelVariantKey),
+      installScope: manifest.installScope,
+      taskCorpusVersion: manifest.taskCorpusVersion,
+      oracleVersion: manifest.oracleVersion,
+      promotionPolicyVersion: manifest.promotionPolicyVersion,
+      experimentRunId: manifest.experimentRunId,
+      experimentDefinitionKey: manifest.experimentDefinitionKey,
+    };
+    if (manifest.lifecycle === "completed" && summary.experiment.invalidPairReasons.length === 0) {
+      summary.readiness = {
+        readyForReview: summary.experiment.validPairCount > 0,
+        readyForCaseActivation: false,
+        blockers:
+          summary.experiment.validPairCount > 0
+            ? ["experiment-evidence-awaits-governed-review"]
+            : ["insufficient-valid-experiment-pairs"],
+      };
+    }
+  }
 }
 
 function attachNeed(summary: SummaryAccumulator, row: WorkPatternReadModelNeedRow): void {

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -33,9 +33,10 @@ import {
 } from "./work-pattern-review";
 import type { WorkPatternCaseStagingState } from "./work-pattern-case-staging";
 import {
-  parseWorkPatternExperimentMetadata,
-  type WorkPatternExperimentLifecycle,
-} from "./work-pattern-experiment-types";
+  hasWorkPatternExperimentCellMetadata,
+  parseWorkPatternExperimentProjection,
+  type WorkPatternExperimentProjection,
+} from "./work-pattern-experiment-projection";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DEFAULT_TAKE = 200;
@@ -128,25 +129,6 @@ export type WorkPatternSummary = {
   caseStaging: WorkPatternCaseStagingState | null;
   shadowEvaluation: WorkPatternShadowEvaluation | null;
   experiment: WorkPatternExperimentProjection | null;
-};
-
-export type WorkPatternExperimentProjection = {
-  label: "Testing a better method";
-  lifecycle: WorkPatternExperimentLifecycle;
-  validPairCount: number;
-  resultSummary: string;
-  evidenceOrigin: "hermetic-replay" | "matched-cohort" | "unknown";
-  moreEvidenceNeeded: boolean;
-  invalidPairReasons: string[];
-  methodVariants: string[];
-  modelVariants: string[];
-  installScope: string;
-  taskCorpusVersion: string;
-  oracleVersion: string;
-  promotionPolicyVersion: number;
-  freshnessAt: string | null;
-  experimentRunId: string;
-  experimentDefinitionKey: string;
 };
 
 export type WorkPatternReadModel = {
@@ -308,57 +290,6 @@ function workPatternFromMetadata(value: unknown) {
   return parseWorkPatternMetadata(value.workPattern);
 }
 
-function experimentManifestFromMetadata(value: unknown) {
-  if (!isRecord(value)) return null;
-  return parseWorkPatternExperimentMetadata(value.workPatternExperiment);
-}
-
-function experimentProjectionFromMetadata(
-  value: unknown,
-): Omit<
-  WorkPatternExperimentProjection,
-  | "label"
-  | "lifecycle"
-  | "methodVariants"
-  | "modelVariants"
-  | "installScope"
-  | "taskCorpusVersion"
-  | "oracleVersion"
-  | "promotionPolicyVersion"
-  | "experimentRunId"
-  | "experimentDefinitionKey"
-> {
-  const projection =
-    isRecord(value) && isRecord(value.workPatternExperimentProjection)
-      ? value.workPatternExperimentProjection
-      : {};
-  const origin = projection.evidenceOrigin;
-  const evidenceOrigin =
-    origin === "hermetic-replay" || origin === "matched-cohort" ? origin : "unknown";
-  return {
-    validPairCount:
-      typeof projection.validPairCount === "number"
-      && Number.isInteger(projection.validPairCount)
-      && projection.validPairCount >= 0
-        ? projection.validPairCount
-        : 0,
-    resultSummary:
-      typeof projection.resultSummary === "string" && projection.resultSummary.trim().length > 0
-        ? projection.resultSummary.trim()
-        : "Experiment evidence is still being collected.",
-    evidenceOrigin,
-    moreEvidenceNeeded:
-      typeof projection.moreEvidenceNeeded === "boolean"
-        ? projection.moreEvidenceNeeded
-        : true,
-    invalidPairReasons: stringArrayField(projection, "invalidPairReasons"),
-    freshnessAt:
-      typeof projection.freshnessAt === "string" && dateFrom(projection.freshnessAt)
-        ? projection.freshnessAt
-        : null,
-  };
-}
-
 function riskClassFromMetadata(value: unknown): string | null {
   return stringField(value, "riskClass");
 }
@@ -395,7 +326,7 @@ function fallbackSeed(input: {
 
 function seedFromTaskRun(row: WorkPatternReadModelTaskRunRow, agentId: string): PatternSeed | null {
   const metadata = workPatternFromMetadata(row.a2aMetadata);
-  const experimentManifest = experimentManifestFromMetadata(row.a2aMetadata);
+  const experiment = parseWorkPatternExperimentProjection(row.a2aMetadata);
   const effectiveAgentId = row.currentAgentId ?? row.initiatingAgentId ?? agentId;
   const routeContext = row.routeContext ?? null;
   const riskClass = riskClassFromMetadata(row.a2aMetadata);
@@ -416,17 +347,15 @@ function seedFromTaskRun(row: WorkPatternReadModelTaskRunRow, agentId: string): 
     };
   }
 
-  if (experimentManifest) {
+  if (experiment) {
     return {
-      patternKey: experimentManifest.patternKey,
+      patternKey: experiment.patternKey,
       agentId: effectiveAgentId,
       routeContext,
-      riskClass: experimentManifest.riskClass,
+      riskClass: experiment.riskClass,
       status: "candidate",
       scope: routeContext ? "route" : "agent",
-      version: Math.max(
-        ...experimentManifest.methodVariants.map((variant) => variant.patternVersion),
-      ),
+      version: experiment.maxPatternVersion,
       source: "observer",
       decisionScope: routeContext ? patternDecisionScope("route") : patternDecisionScope("agent"),
       candidate: null,
@@ -439,10 +368,7 @@ function seedFromTaskRun(row: WorkPatternReadModelTaskRunRow, agentId: string): 
     };
   }
 
-  if (
-    isRecord(row.a2aMetadata)
-    && isRecord(row.a2aMetadata.workPatternExperimentCell)
-  ) {
+  if (hasWorkPatternExperimentCellMetadata(row.a2aMetadata)) {
     return null;
   }
 
@@ -707,22 +633,10 @@ function observeRun(summary: SummaryAccumulator, row: WorkPatternReadModelTaskRu
     summary.latestTaskRunId = row.taskRunId;
   }
   addEvidence(summary, metadataEvidence(row));
-  const manifest = experimentManifestFromMetadata(row.a2aMetadata);
-  if (manifest) {
-    summary.experiment = {
-      label: "Testing a better method",
-      lifecycle: manifest.lifecycle,
-      ...experimentProjectionFromMetadata(row.a2aMetadata),
-      methodVariants: manifest.methodVariants.map((variant) => variant.methodVariantKey),
-      modelVariants: manifest.modelVariants.map((variant) => variant.modelVariantKey),
-      installScope: manifest.installScope,
-      taskCorpusVersion: manifest.taskCorpusVersion,
-      oracleVersion: manifest.oracleVersion,
-      promotionPolicyVersion: manifest.promotionPolicyVersion,
-      experimentRunId: manifest.experimentRunId,
-      experimentDefinitionKey: manifest.experimentDefinitionKey,
-    };
-    if (manifest.lifecycle === "completed" && summary.experiment.invalidPairReasons.length === 0) {
+  const experiment = parseWorkPatternExperimentProjection(row.a2aMetadata);
+  if (experiment) {
+    summary.experiment = experiment;
+    if (experiment.lifecycle === "completed" && experiment.invalidPairReasons.length === 0) {
       summary.readiness = {
         readyForReview: summary.experiment.validPairCount > 0,
         readyForCaseActivation: false,

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -21,8 +21,8 @@ import {
 import {
   evaluateWorkPatternShadowEvidence,
   parseAutonomyLevel,
+  parseLegacyWorkPatternShadowTrials,
   parseRiskClass,
-  parseWorkPatternShadowTrials,
   type WorkPatternShadowEvaluation,
   type WorkPatternShadowTrial,
 } from "./work-pattern-shadow-evaluation";
@@ -253,10 +253,6 @@ function booleanField(source: unknown, field: string): boolean | null {
   return typeof value === "boolean" ? value : null;
 }
 
-function unknownField(source: unknown, field: string): unknown {
-  return isRecord(source) ? source[field] : undefined;
-}
-
 function dateFrom(value: unknown): Date | null {
   if (value instanceof Date && Number.isFinite(value.getTime())) return value;
   if (typeof value !== "string") return null;
@@ -395,10 +391,7 @@ function shadowRiskClassFromNeed(row: WorkPatternReadModelNeedRow): RiskClass | 
 }
 
 function shadowTrialsFromNeed(row: WorkPatternReadModelNeedRow): WorkPatternShadowTrial[] {
-  return [
-    ...parseWorkPatternShadowTrials(unknownField(row.evidenceJson, "shadowTrials")),
-    ...parseWorkPatternShadowTrials(unknownField(row.readinessJson, "shadowTrials")),
-  ];
+  return parseLegacyWorkPatternShadowTrials(row.evidenceJson, row.readinessJson);
 }
 
 function seedFromNeed(row: WorkPatternReadModelNeedRow): PatternSeed | null {

--- a/apps/web/lib/tak/work-pattern-shadow-evaluation.test.ts
+++ b/apps/web/lib/tak/work-pattern-shadow-evaluation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   evaluateWorkPatternShadowEvidence,
+  parseLegacyWorkPatternShadowTrials,
   parseWorkPatternShadowTrials,
 } from "./work-pattern-shadow-evaluation";
 
@@ -40,6 +41,28 @@ describe("parseWorkPatternShadowTrials", () => {
       toolCallDelta: -2,
     });
     expect(parsed[0].observedAt?.toISOString()).toBe("2026-06-28T10:00:00.000Z");
+  });
+});
+
+describe("parseLegacyWorkPatternShadowTrials", () => {
+  it("normalizes and deduplicates trials repeated across legacy JSON sources", () => {
+    const first = trial();
+    const second = trial({ trialId: "S-2" });
+
+    expect(parseLegacyWorkPatternShadowTrials(
+      { shadowTrials: [first, second] },
+      { shadowTrials: [first] },
+    )).toEqual(parseWorkPatternShadowTrials([first, second]));
+  });
+
+  it("preserves first-source order for compatibility", () => {
+    const first = trial({ trialId: "S-2" });
+    const second = trial({ trialId: "S-1" });
+
+    expect(parseLegacyWorkPatternShadowTrials(
+      { shadowTrials: [first] },
+      { shadowTrials: [second] },
+    ).map((row) => row.trialId)).toEqual(["S-2", "S-1"]);
   });
 });
 

--- a/apps/web/lib/tak/work-pattern-shadow-evaluation.ts
+++ b/apps/web/lib/tak/work-pattern-shadow-evaluation.ts
@@ -124,6 +124,22 @@ export function parseWorkPatternShadowTrials(value: unknown): WorkPatternShadowT
   return trials;
 }
 
+export function parseLegacyWorkPatternShadowTrials(
+  ...sources: unknown[]
+): WorkPatternShadowTrial[] {
+  const trials: WorkPatternShadowTrial[] = [];
+  const seen = new Set<string>();
+  for (const source of sources) {
+    if (!isRecord(source)) continue;
+    for (const trial of parseWorkPatternShadowTrials(source.shadowTrials)) {
+      if (seen.has(trial.trialId)) continue;
+      seen.add(trial.trialId);
+      trials.push(trial);
+    }
+  }
+  return trials;
+}
+
 function emptyDeltas(): Record<DeltaField, number> {
   return {
     toolCallDelta: 0,

--- a/docs/data-impact/2026-07-26-governed-playbook-experiment-ledger.data-impact.json
+++ b/docs/data-impact/2026-07-26-governed-playbook-experiment-ledger.data-impact.json
@@ -1,0 +1,51 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "PostgreSQL BuildPhaseRun execution evidence ledger",
+    "PostgreSQL TaskRun scheduler access path",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260726010000_add_build_phase_execution_profile_ref + 20260726020000_index_task_run_build_status",
+    "backfill": "none — executionProfileRef is additive and nullable, so existing BuildPhaseRun rows remain null and retain their prior meaning; the TaskRun composite index is a non-destructive physical access path over existing buildId/status values and does not rewrite logical records"
+  },
+  "tests": [
+    "apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts",
+    "apps/web/lib/queue/functions/work-pattern-experiment.test.ts",
+    "apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts",
+    "apps/web/lib/tak/work-pattern-experiment-store.test.ts",
+    "apps/web/lib/tak/work-pattern-effective-ledger.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:build-phase-run#execution-profile-ref",
+      "prismaModel": "BuildPhaseRun",
+      "lifecycleDisposition": "existing BuildPhaseRun rows are retained unchanged with executionProfileRef=null; new experiment phase rows may carry an immutable compact reference to the resolved execution profile, and the reference follows the existing BuildPhaseRun lifecycle and build cascade policy",
+      "fields": [
+        {
+          "fieldId": "data:build-phase-run#executionProfileRef",
+          "resolution": "governed",
+          "reason": "records the immutable execution-profile identity actually resolved for a Build Studio phase so experiment evidence can reject requested-versus-actual provider, model, method, or policy mismatches instead of inferring identity after execution",
+          "provenance": "BI-0A636528 delivery 1; approved governed playbook experimentation design; written only from the resolved work-pattern execution profile at phase execution time"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:task-run#build-status-index",
+      "prismaModel": "TaskRun",
+      "lifecycleDisposition": "no TaskRun lifecycle or retention semantics change; the composite index is retained as a physical scheduler access path and can be removed in a later forward migration without changing logical records",
+      "fields": [
+        {
+          "fieldId": "data:task-run#index-buildId-status",
+          "resolution": "not-applicable",
+          "reason": "the index duplicates no logical field and introduces no new captured value; it accelerates the existing scheduler lookup for active experiment work by canonical buildId and status",
+          "provenance": "BI-0A636528 delivery 1 scheduler query plan; migration 20260726020000_index_task_run_build_status"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md
+++ b/docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md
@@ -1,0 +1,53 @@
+# Governed playbook experimentation — Delivery 1 evidence
+
+Date: 2026-07-26  
+Branch: `feat/work-pattern-experiment-ledger`  
+Backlog item: `BI-0A636528`  
+Work Capsule: `WC-3301191A`
+
+## Delivered
+
+- Strict execution-profile, experiment-manifest, identity, outcome, and append-only effective-ledger
+  contracts.
+- Deterministic parent/child `TaskRun` storage with serialized replicate allocation, retry history,
+  accountable ownership, and synchronized experiment/A2A lifecycle.
+- Autonomous scheduling for approved, evidence-cleared shadow candidates.
+- An immutable `TaskArtifact` inference-replay lane using canonical provider/model routing,
+  deterministic oracle checks, compact result metadata, and orchestrating-coworker ledger
+  attribution.
+- Fail-closed boundaries for live-environment, missing-fixture, mutable-workspace, and unsupported
+  executor cases.
+- Living Playbooks projection and plain-language experiment evidence disclosure.
+- Nullable `BuildPhaseRun.executionProfileRef` and measured `TaskRun(buildId,status)` index.
+
+No experiment path advances `FeatureBuild.phase`, writes acceptance, creates a pull request, enters
+the merge queue, initiates release, activates an `AuthorityBinding`, or mutates live customer state.
+
+## Verification
+
+- Focused test gate: 14 files, 86 tests passed.
+- Production build: Next.js 16.2.11 compiled, typechecked, and generated all 139 static pages.
+- Prisma schema validation: passed.
+- Existing-state migration chain: 446 migrations applied successfully in the governed
+  local-integration PostgreSQL environment.
+- Module-size ratchet: passed after extracting the experiment projection from the existing
+  read-model module.
+- Full standalone web typecheck remains affected by the sandbox's duplicate PostCSS package graph
+  in `design/tokens-utilities.test.ts`; the production build's canonical TypeScript gate passed and
+  no experiment file reports a TypeScript error.
+
+## Query-plan evidence
+
+Representative sandbox volume: 100,000 `TaskRun` rows and 100,000
+`DecisionShadowLedger` rows.
+
+| Read | Plan | Measured result |
+| --- | --- | --- |
+| Parent to children | `TaskRun_parentTaskRunId_idx` | 100 rows, 0.354 ms |
+| Build and status, before | status/heartbeat index then heap filter | 20,000 candidates, 4.514 ms |
+| Build and status, after | `TaskRun_buildId_status_idx` | 200 rows, 0.691 ms |
+| Ledger by task run | `DecisionShadowLedger_taskRunId_idx` | 1 row, 0.029 ms |
+| Ledger by activity/risk/time | `DecisionShadowLedger_observedAt_idx` plus filter | 100 rows, 0.194 ms |
+
+The measured build/status read justified the optional composite index. The other existing indexes
+were retained unchanged.

--- a/docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md
+++ b/docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md
@@ -1,8 +1,10 @@
 # Governed playbook experimentation — Delivery 1 evidence
 
-Date: 2026-07-26  
-Branch: `feat/work-pattern-experiment-ledger`  
-Backlog item: `BI-0A636528`  
+Date: 2026-07-26
+
+Branch: `feat/work-pattern-experiment-ledger`
+
+Backlog item: `BI-0A636528`
 Work Capsule: `WC-3301191A`
 
 ## Delivered

--- a/docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md
+++ b/docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md
@@ -18,6 +18,8 @@ Work Capsule: `WC-3301191A`
 - Fail-closed boundaries for live-environment, missing-fixture, mutable-workspace, and unsupported
   executor cases.
 - Living Playbooks projection and plain-language experiment evidence disclosure.
+- Parent analysis that counts only terminal baseline/candidate pairs with matching fixtures,
+  source, corpus, oracle, resource policy, and requested/actual provider-model identity.
 - Nullable `BuildPhaseRun.executionProfileRef` and measured `TaskRun(buildId,status)` index.
 
 No experiment path advances `FeatureBuild.phase`, writes acceptance, creates a pull request, enters
@@ -25,16 +27,46 @@ the merge queue, initiates release, activates an `AuthorityBinding`, or mutates 
 
 ## Verification
 
-- Focused test gate: 14 files, 86 tests passed.
+- Focused test gate: 14 files, 83 tests passed.
 - Production build: Next.js 16.2.11 compiled, typechecked, and generated all 139 static pages.
 - Prisma schema validation: passed.
 - Existing-state migration chain: 446 migrations applied successfully in the governed
   local-integration PostgreSQL environment.
 - Module-size ratchet: passed after extracting the experiment projection from the existing
   read-model module.
+- Style/token drift ratchets: passed; the new experiment evidence uses theme tokens and a 12 px
+  minimum for its explanatory copy and disclosure.
+- Documentation index and user-guide link integrity: passed.
 - Full standalone web typecheck remains affected by the sandbox's duplicate PostCSS package graph
   in `design/tokens-utilities.test.ts`; the production build's canonical TypeScript gate passed and
   no experiment file reports a TypeScript error.
+
+## UX-fit verification
+
+- Decision: **fits** the existing Platform coworker-record architecture.
+- Owning area and route: Platform AI workforce,
+  `/platform/ai/agent/[agentId]`; no new route or navigation layer was added.
+- Primary persona: platform operator or contributor reviewing a coworker's Living Playbooks.
+- Existing primitives reused: `NeedsAndPlaybooksPanel`, Living Playbook row, `Chip`, `Section`,
+  and native `details` disclosure. This is contextual evidence, not a new dashboard or dense data
+  grid, so Report Kit primitives are not applicable.
+- Source of truth: parent `TaskRun` experiment manifest plus compact child outcomes and
+  `DecisionShadowLedger` evidence; missing or invalid pairs remain visibly insufficient and cannot
+  activate a method.
+- Browser verification used the actual component rendered with a completed hermetic replay:
+  desktop 1280x900 and mobile 390x844 both had zero horizontal overflow; the mobile evidence card
+  measured 344 px wide; summary/detail copy computed at 12 px; the disclosure opened and exposed
+  methods, models, scope, corpus/oracle/policy versions, freshness, and engineer IDs.
+- Dark and light token behavior was verified. The dark rendering remained legible, and light-mode
+  computed tokens resolved to background `#f5f7fb`, surface `#fff`, and text `#152033`.
+
+## Recovery verification
+
+- Queue interruption/resume skips already-terminal child cells and reruns only incomplete cells.
+- Replicate allocation and retry attempts are monotonic and preserve prior evidence.
+- Missing fixture, non-shadow environment, provider/model fallback, incomplete pair, mismatched
+  controls, and invalid manifest paths fail closed or produce “more evidence needed”; none advances
+  delivery, authority, merge, release, or live state.
 
 ## Query-plan evidence
 

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -32,6 +32,7 @@ The AI Workforce area is where platform administrators configure the AI infrastr
 - View the **Authority** tab to understand agent tool grants, HITL tiers, and escalation paths
 - Review the **Action History** to see all agent proposals and their approval status
 - Inspect the **Tool Execution Log** to audit every tool call made by any agent (who, what, when, result)
+- Open a coworker record to review **Living Playbooks** and see when the platform is testing a better method
 - Evaluate external tools via the **Tool Evaluation Pipeline** before adding them to the platform
 - Connect external coding surfaces such as Claude, Codex, and Grok while keeping the same MCP, evidence, documentation, and PR gates as Build Studio
 - Open **Runtime Health** to see which local services are required by enabled capabilities and which AI runtimes are managed by configured providers
@@ -76,6 +77,22 @@ Agent tool availability is the **intersection** of two authority systems:
 2. **Agent tool grants** — what the agent's declared grants in `agent_registry.json` permit
 
 An action is only possible if BOTH allow it. This prevents agents from exceeding their design scope, even when triggered by a user with broad permissions.
+
+## Living Playbook experiments
+
+An approved Living Playbook candidate can carry an evidence-cleared replay definition. For those
+candidates, DPF schedules a bounded shadow experiment automatically; approval still does not make
+the candidate active.
+
+The coworker record shows **Testing a better method**, the number of valid comparison pairs, the
+evidence origin, the current result, and whether more evidence is needed. Expand **Experiment
+evidence details** for method/model factors, corpus and oracle versions, invalid-pair reasons,
+freshness, and engineer IDs.
+
+Only immutable, versioned replay fixtures execute autonomously in this first lane. The compared
+provider or model is evidence, while the orchestrating coworker remains the accountable agent in
+the audit ledger. Missing fixtures, live-environment requests, mutable code-workspace work, and
+authority-ceiling cases stop without activation or customer-state mutation.
 
 ## Tool Evaluation Pipeline
 

--- a/docs/user-guide/build-studio/index.md
+++ b/docs/user-guide/build-studio/index.md
@@ -18,6 +18,12 @@ Build Studio is real, but it is still being hardened. It should be described as 
 
 Recent hardening work includes plan-review trajectory, design-time decomposition for oversized builds, activity quiescence for safer portal upgrades, and voice/follow-up guards in coworker chat. Complex source changes may still need VS Code in customizable installs while Build Studio keeps the design, review, test, and promotion record.
 
+Build Studio also has a governed experimentation substrate for reviewed Living Playbook candidates.
+Eligible immutable replay lanes can run autonomously in shadow, compare method and model factors,
+and record reproducible evidence without advancing a feature phase, creating a pull request,
+joining the merge queue, releasing software, or changing live customer state. Unsupported or
+higher-authority cases remain escalations.
+
 ## Key Concepts
 
 - **Phases** — The five stages every feature moves through: Ideate (define the problem), Plan (design the solution), Build (generate and test code), Review (quality gates), Ship (deploy to production).

--- a/packages/db/prisma/migrations/20260726010000_add_build_phase_execution_profile_ref/migration.sql
+++ b/packages/db/prisma/migrations/20260726010000_add_build_phase_execution_profile_ref/migration.sql
@@ -1,0 +1,3 @@
+-- @migration-safety: data-safe: adding a nullable JSONB column with no default or backfill cannot invalidate existing rows.
+ALTER TABLE "BuildPhaseRun"
+ADD COLUMN "executionProfileRef" JSONB;

--- a/packages/db/prisma/migrations/20260726020000_index_task_run_build_status/migration.sql
+++ b/packages/db/prisma/migrations/20260726020000_index_task_run_build_status/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "TaskRun_buildId_status_idx" ON "TaskRun"("buildId", "status");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6869,6 +6869,7 @@ model TaskRun {
   @@index([threadId])
   @@index([contextId])
   @@index([parentTaskRunId])
+  @@index([buildId, status])
   @@index([routeContext, status])
   @@index([repeatedPatternKey])
   // Watchdog query: WHERE status = 'working' AND lastHeartbeatAt < ...

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6672,6 +6672,8 @@ model BuildPhaseRun {
   costUsd        Decimal?     @db.Decimal(10, 6)
   /// Primary provider used in this phase (populated on write; may be "mixed" for multi-provider phases)
   providerId     String?
+  /// Compact immutable reference to the resolved work-pattern execution profile used by this actual phase.
+  executionProfileRef Json?
   /// Number of AI inference calls made during this phase
   inferenceCount Int          @default(0)
   build          FeatureBuild @relation(fields: [buildId], references: [buildId], onDelete: Cascade)

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -4617,7 +4617,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 64
+    "textMass": 106
   },
   "apps/web/components/ea/ReferenceModelPortfolioTable.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Outcome

Delivery 1 of the approved governed playbook experimentation design. Evidence-cleared lanes can now autonomously run immutable shadow replays, aggregate comparable baseline/candidate evidence, and show the effective result in Living Playbooks. Mutable, live, high-risk, or authority-ceiling cases remain fail-closed and escalate.

## What changed

- adds deterministic experiment contracts, identities, persistence, effective-ledger projection, scheduling, queue execution, and parent analysis
- executes only hermetic replay work through the existing queue and canonical TaskRun heartbeat seams
- accepts parent evidence only when terminal baseline/candidate pairs match fixture, source, corpus, oracle, resource, requested provider/model, and actual provider/model identity
- exposes governed evidence in the coworker Living Playbooks UI with expandable methods, models, scope, versions, freshness, and identifiers
- preserves FeatureBuild, TaskRun, BuildPhaseRun, DecisionShadowLedger, AuthorityBinding, Work Case, merge queue, and governed self-upgrade substrates

## Backlog and design

- primary delivery: BI-0A636528 / WC-3301191A
- approved program backlog: BI-522E754E, BI-356E69B1
- approved design: `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`
- approved implementation plan: `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`
- implementation evidence: `docs/superpowers/evidence/2026-07-26-governed-playbook-experimentation-delivery-1.md`

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`
  - `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`
- Current code substrate reviewed:
  - FeatureBuild, TaskRun, BuildPhaseRun, DecisionShadowLedger, AuthorityBinding, Work Case, canonical queue and heartbeat seams, merge queue, governed self-upgrade, and the Living Playbooks read model/UI
- Source of truth:
  - the approved design and implementation plan on `main`, extending the existing governed execution and evidence substrates
- Decision:
  - extend the existing substrates without a parallel build, decision, authority, queue, merge, or upgrade system; autonomously execute only immutable evidence-cleared replay lanes and fail closed to escalation for mutable, live, high-risk, incomparable, or authority-ceiling cases

## Architecture and bounded refactoring

Exactly 20% of implementation effort was reserved for bounded structural refactoring. That allocation isolated the experiment read projection, reused the canonical queue enqueue seam, reused `markTaskRunWorking`, and kept experiment policy/evidence adapters separate from existing build/runtime substrates. No parallel build, authority, decision, merge, or self-upgrade substrate was introduced.

## Database and rollout

- additive nullable `BuildPhaseRun.executionProfileRef` JSONB column, with in-file data-safe attestation; no backfill or constraint tightening
- additive `TaskRun(buildId, status)` index, justified by the experiment scheduler/query plan
- rollout sequence: additive schema -> shadow replay scheduling -> terminal comparable aggregation -> read-model/UI projection
- safe recovery: stop scheduling new experiments; queued/running work remains in existing TaskRun/queue recovery; incomplete or incomparable evidence never becomes effective; the additive column/index can remain without activating experiments

## Verification

Canonical `pnpm run pregate` passed on the previously published feature head:

- candidate: `d788308f1939f7cb7b02355279f01c62c9565da2`
- base: `65c87965d9a4f138fd671b7097e460443cdbb83d`
- integration commit: `dd65405b98c802c4e9237c10f3167c6a4d0c829a`
- 2,217 test files passed; 19,242 tests passed
- standalone `web` typecheck passed
- Prisma generate and all migrations deployed cleanly
- docs index, docs links, and all repository guards passed
- production Docker build passed

Focused feature verification also passed 83 tests across 14 files. UX verification rendered the actual component at 1280x900 and 390x844 with zero horizontal overflow, verified the evidence disclosure content, and checked dark/light design tokens.

A fresh canonical pregate will be recorded for the final correction commit before merge-readiness is claimed.

## Documentation impact

Updated operator guidance for AI Workforce/Living Playbooks and Build Studio, plus a durable implementation evidence record. No public pre-install positioning, setup/install procedure, route map, prompt contract, or external-agent doctrine changed.
### Final exact-head gate

- correction candidate: `9f12c8ec8777f077796900ceb0bd90a6e44bd667`
- current-main base: `05b208f467c17d59d675614aa6da3ff5ae1ec2d1`
- integration commit: `beeb275b9903443fb90f1d404c6a4dff0b671260`
- merge commit: `81462701df10bec0672b36387b472d41f94d73da`
- canonical receipt: `cms20opug05et01lho8lvgsua`
- result: Prisma generate and migration deploy, docs checks, repository guards, full web Vitest, standalone web typecheck, and production Docker build passed