### PR TITLE
feat(agent-toolchain): session-lifecycle worktree hygiene (primary reaper)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -217,6 +217,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "worktree-janitor",
+    inngestId: "ops/worktree-janitor",
+    name: "Worktree janitor (Tier-A)",
+    purpose:
+      "Classifies git worktrees: Tier A (merged+clean) and Tier B (stale unmerged). Dry-run observe when DPF_WORKTREE_JANITOR_ENABLED=1; live Tier-A reaping only when DPF_WORKTREE_JANITOR_AUTO_REAP=1 as well. Tier B is never auto-deleted.",
+    cron: "40 5 * * *",
+    cadence: "Daily at 05:40",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "infra-prune",
     inngestId: "ops/infra-prune",
     name: "Infrastructure prune",

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -219,9 +219,9 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
     jobId: "worktree-janitor",
     inngestId: "ops/worktree-janitor",
-    name: "Worktree janitor (Tier-A)",
+    name: "Worktree janitor fleet backstop (Tier-A)",
     purpose:
-      "Classifies git worktrees: Tier A (merged+clean) and Tier B (stale unmerged). Dry-run observe when DPF_WORKTREE_JANITOR_ENABLED=1; live Tier-A reaping only when DPF_WORKTREE_JANITOR_AUTO_REAP=1 as well. Tier B is never auto-deleted.",
+      "OPTIONAL fleet sweeper for leftover worktrees. Primary reaping is session-lifecycle (worktree-session-hygiene on SessionEnd). This portal Inngest job dry-runs when DPF_WORKTREE_JANITOR_ENABLED=1; live Tier-A only with DPF_WORKTREE_JANITOR_AUTO_REAP=1. Not a per-client CLI cron.",
     cron: "40 5 * * *",
     cadence: "Daily at 05:40",
     category: "core",

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -51,6 +51,7 @@ import {
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
 import { runtimeArtifactJanitor } from "./runtime-artifact-janitor";
+import { worktreeJanitor } from "./worktree-janitor";
 import {
   dataRetentionSweepScheduled,
   dataRetentionSweepRequested,
@@ -122,6 +123,7 @@ export const scheduledFunctions = [
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   runtimeArtifactJanitor, // BI-DBF3F426: OBSERVE-ONLY dry-run scan of orphaned CI images + stray compose projects (logs would-reap, never deletes; --apply is founder-gated), daily 05:20, flag-gated DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED
+  worktreeJanitor, // BI-42FA7DD8: worktree Tier-A janitor — dry-run observe by default (DPF_WORKTREE_JANITOR_ENABLED); live Tier-A only when DPF_WORKTREE_JANITOR_AUTO_REAP=1; daily 05:40
   dataRetentionSweepScheduled, // EP-DATA-RETENTION: daily DB purge of aged logs/telemetry/chat, 04:00
   qualityIssueDriftSweepScheduled, // BI-0B420A1D: runtime governance — self-heal recovery/orphan backstop + detect per-type open-count drift vs registry budgets, daily 05:00
 

--- a/apps/web/lib/queue/functions/worktree-janitor.test.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.test.ts
@@ -1,0 +1,109 @@
+// BI-42FA7DD8 — unit tests for scheduled worktree janitor (observe + Tier-A auto-reap).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  runWorktreeJanitor,
+  assertNoSilentLiveInObserve,
+  assertAutoReapIsTierAOnly,
+  OBSERVE_ARGS,
+  AUTO_REAP_ARGS,
+  WORKTREE_JANITOR_ENABLED_FLAG,
+  WORKTREE_JANITOR_AUTO_REAP_FLAG,
+  type ScanOutcome,
+} from "./worktree-janitor";
+
+const ENABLED = { [WORKTREE_JANITOR_ENABLED_FLAG]: "1" };
+const AUTO = {
+  [WORKTREE_JANITOR_ENABLED_FLAG]: "1",
+  [WORKTREE_JANITOR_AUTO_REAP_FLAG]: "1",
+};
+
+function scanOutcome(mode: "dry-run" | "live" = "dry-run"): ScanOutcome {
+  return {
+    available: true,
+    scan: {
+      mode,
+      available: true,
+      root: "/host-dpf",
+      graceDays: 14,
+      policy: "tier-a-only",
+      decisions: [],
+      summary: {
+        counts: { PRUNE_TIER_A: 2, PRUNE_TIER_B: 1, KEEP: 5, SKIP: 1, PINNED: 0 },
+        tierAPaths: ["/wt/a", "/wt/b"],
+        tierBPaths: ["/wt/stale"],
+      },
+      removals:
+        mode === "live"
+          ? [
+              { path: "/wt/a", worktreeRemoved: true, branchDeleted: true },
+              { path: "/wt/b", worktreeRemoved: true, branchDeleted: false },
+            ]
+          : [],
+    },
+  };
+}
+
+describe("worktree-janitor schedule invariants (BI-42FA7DD8)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("OBSERVE_ARGS is dry-run tier-a-only json", () => {
+    expect([...OBSERVE_ARGS]).toEqual(["--json", "--dry-run", "--tier-a-only"]);
+    expect(() => assertNoSilentLiveInObserve(OBSERVE_ARGS)).not.toThrow();
+    expect(() => assertNoSilentLiveInObserve(["--json", "--live"])).toThrow(/must not include live/);
+  });
+
+  it("AUTO_REAP_ARGS is live tier-a-only", () => {
+    expect([...AUTO_REAP_ARGS]).toEqual(["--json", "--live", "--tier-a-only"]);
+    expect(() => assertAutoReapIsTierAOnly(AUTO_REAP_ARGS)).not.toThrow();
+    expect(() => assertAutoReapIsTierAOnly(["--json", "--live"])).toThrow(/tier-a-only/);
+  });
+
+  it("skips when master flag is off", async () => {
+    const runScan = vi.fn(async () => scanOutcome());
+    const result = await runWorktreeJanitor({ env: {}, runScan });
+    expect(result.skipped).toBe(true);
+    expect(runScan).not.toHaveBeenCalled();
+  });
+
+  it("observe mode when enabled without auto-reap", async () => {
+    const runScan = vi.fn(async (mode: "dry-run" | "live") => {
+      expect(mode).toBe("dry-run");
+      return scanOutcome("dry-run");
+    });
+    const result = await runWorktreeJanitor({ env: ENABLED, runScan });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("expected summary");
+    expect(result.mode).toBe("dry-run");
+    expect(result.tierA).toBe(2);
+    expect(result.tierB).toBe(1);
+    expect(result.removed).toBe(0);
+    expect(result.tierAPaths).toEqual(["/wt/a", "/wt/b"]);
+  });
+
+  it("live tier-a mode when AUTO_REAP is on", async () => {
+    const runScan = vi.fn(async (mode: "dry-run" | "live") => {
+      expect(mode).toBe("live");
+      return scanOutcome("live");
+    });
+    const result = await runWorktreeJanitor({ env: AUTO, runScan });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("expected summary");
+    expect(result.mode).toBe("live");
+    expect(result.removed).toBe(2);
+  });
+
+  it("skips when scan unavailable", async () => {
+    const runScan = vi.fn(async (): Promise<ScanOutcome> => ({
+      available: false,
+      reason: "could not resolve git root",
+    }));
+    const result = await runWorktreeJanitor({ env: ENABLED, runScan });
+    expect(result.skipped).toBe(true);
+    if (!result.skipped) throw new Error("expected skip");
+    expect(result.reason).toMatch(/git root/);
+  });
+});

--- a/apps/web/lib/queue/functions/worktree-janitor.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.ts
@@ -1,0 +1,244 @@
+// BI-42FA7DD8 — Worktree Tier-A scheduled janitor.
+//
+// Spec: docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md § D4
+// Kernel: worktree-selection-and-reaping, destructive-actions-require-explicit-go,
+//         remove-avoidable-failure-opportunities
+//
+// Complements:
+//   - scripts/worktree-janitor.sh / scripts/worktree-janitor.mjs (host CLI)
+//   - runtime-target-janitor (DB lease/RT records)
+//   - runtime-artifact-janitor (Docker observe-only)
+//
+// SAFETY DOCTRINE
+//   * Default OFF (DPF_WORKTREE_JANITOR_ENABLED not set) — no scan.
+//   * When ENABLED without AUTO_REAP: dry-run observe only (logs would-reap Tier A/B).
+//   * When AUTO_REAP=1: live removal of **Tier A only** (merged+clean+no open PR/lease).
+//     Tier B (stale unmerged) is NEVER live-reaped by the schedule — observe only.
+//   * Removals use junction-safe-worktree-remove.mjs via the CLI.
+//
+// The schedule may run inside the portal container. When git worktrees are not
+// visible (no /host-dpf, no worktree list), the CLI returns available:false and
+// the schedule degrades to a skip — never throws.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+import { resolveManagedScriptPath } from "@/lib/operate/backups/managed-script-path";
+
+/** Master switch: run the scan at all (default OFF). */
+export const WORKTREE_JANITOR_ENABLED_FLAG = "DPF_WORKTREE_JANITOR_ENABLED";
+
+/**
+ * Live Tier-A reaping. Only honored when ENABLED is also set.
+ * Default OFF — soak with dry-run first.
+ */
+export const WORKTREE_JANITOR_AUTO_REAP_FLAG = "DPF_WORKTREE_JANITOR_AUTO_REAP";
+
+const JANITOR_SCRIPT = "worktree-janitor.mjs";
+const SCAN_TIMEOUT_MS = 300_000;
+const SCAN_MAX_BUFFER = 8 * 1024 * 1024;
+
+export type WorktreeJanitorDecision = {
+  path: string;
+  branch: string | null;
+  verdict: string;
+  reason: string;
+  tier: string | null;
+};
+
+export type WorktreeJanitorScan = {
+  mode: string;
+  available: boolean;
+  root?: string;
+  graceDays?: number;
+  policy?: string;
+  decisions?: WorktreeJanitorDecision[];
+  summary?: {
+    counts: Record<string, number>;
+    tierAPaths: string[];
+    tierBPaths: string[];
+  };
+  error?: string;
+  removals?: Array<{ path: string; worktreeRemoved?: boolean; branchDeleted?: boolean }>;
+};
+
+export type ScanOutcome =
+  | { available: true; scan: WorktreeJanitorScan }
+  | { available: false; reason: string };
+
+export type RunResult =
+  | { skipped: true; reason: string }
+  | {
+      skipped: false;
+      mode: "dry-run" | "live";
+      root: string | null;
+      tierA: number;
+      tierB: number;
+      keep: number;
+      tierAPaths: string[];
+      tierBPaths: string[];
+      removed: number;
+    };
+
+export type RunOptions = {
+  env?: Record<string, string | undefined>;
+  runScan?: (mode: "dry-run" | "live") => Promise<ScanOutcome>;
+};
+
+/**
+ * Args for observe (dry-run). Must never include --live.
+ * Exported for the regression tripwire test.
+ */
+export const OBSERVE_ARGS: readonly string[] = Object.freeze([
+  "--json",
+  "--dry-run",
+  "--tier-a-only",
+]);
+
+/**
+ * Args for auto-reap. Tier-A only — never reaps Tier B stale unmerged.
+ */
+export const AUTO_REAP_ARGS: readonly string[] = Object.freeze([
+  "--json",
+  "--live",
+  "--tier-a-only",
+]);
+
+export function assertNoSilentLiveInObserve(args: readonly string[]): void {
+  if (args.includes("--live") || args.includes("--apply")) {
+    throw new Error(
+      `[worktree-janitor] OBSERVE_ARGS must not include live reaping flags; found ${JSON.stringify(args)}`,
+    );
+  }
+}
+assertNoSilentLiveInObserve(OBSERVE_ARGS);
+
+export function assertAutoReapIsTierAOnly(args: readonly string[]): void {
+  if (!args.includes("--tier-a-only")) {
+    throw new Error("[worktree-janitor] AUTO_REAP_ARGS must include --tier-a-only");
+  }
+  if (!args.includes("--live")) {
+    throw new Error("[worktree-janitor] AUTO_REAP_ARGS must include --live");
+  }
+}
+assertAutoReapIsTierAOnly(AUTO_REAP_ARGS);
+
+async function defaultRunScan(mode: "dry-run" | "live"): Promise<ScanOutcome> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execFileAsync = promisify(execFile);
+  const scriptPath = resolveManagedScriptPath(JANITOR_SCRIPT);
+  const cliArgs = mode === "live" ? [...AUTO_REAP_ARGS] : [...OBSERVE_ARGS];
+
+  try {
+    const { stdout } = await execFileAsync("node", [scriptPath, ...cliArgs], {
+      timeout: SCAN_TIMEOUT_MS,
+      maxBuffer: SCAN_MAX_BUFFER,
+      env: {
+        ...process.env,
+        // Prefer host install mount inside the portal container when present.
+        DPF_REPO_ROOT: process.env.DPF_REPO_ROOT || process.env.PROJECT_ROOT || "/host-dpf",
+      },
+    });
+    const scan = JSON.parse(stdout) as WorktreeJanitorScan;
+    if (scan.available === false) {
+      return { available: false, reason: scan.error || "janitor reported unavailable" };
+    }
+    return { available: true, scan };
+  } catch (err) {
+    const e = err as { stderr?: string; message?: string; stdout?: string };
+    // CLI may print JSON even on soft failures via stdout in some shells.
+    if (e.stdout) {
+      try {
+        const scan = JSON.parse(e.stdout) as WorktreeJanitorScan;
+        if (scan.available === false) {
+          return { available: false, reason: scan.error || "janitor unavailable" };
+        }
+        return { available: true, scan };
+      } catch {
+        // fall through
+      }
+    }
+    const reason = (e.stderr || e.message || String(err)).toString().trim().slice(0, 500);
+    return { available: false, reason };
+  }
+}
+
+export async function runWorktreeJanitor(options: RunOptions = {}): Promise<RunResult> {
+  const env = options.env ?? process.env;
+
+  if (!envFlagEnabled(env, WORKTREE_JANITOR_ENABLED_FLAG)) {
+    return {
+      skipped: true,
+      reason: `disabled (${WORKTREE_JANITOR_ENABLED_FLAG} not set)`,
+    };
+  }
+
+  const autoReap =
+    envFlagEnabled(env, WORKTREE_JANITOR_AUTO_REAP_FLAG) &&
+    envFlagEnabled(env, WORKTREE_JANITOR_ENABLED_FLAG);
+  const mode: "dry-run" | "live" = autoReap ? "live" : "dry-run";
+
+  const runScan = options.runScan ?? defaultRunScan;
+  const outcome = await runScan(mode);
+
+  if (!outcome.available) {
+    console.warn(`[worktree-janitor] scan unavailable: ${outcome.reason}`);
+    return { skipped: true, reason: outcome.reason };
+  }
+
+  const { scan } = outcome;
+  if (mode === "dry-run" && scan.mode !== "dry-run") {
+    console.error(
+      `[worktree-janitor] REFUSING unexpected scan mode "${scan.mode}" for observe run`,
+    );
+    return { skipped: true, reason: `unexpected scan mode "${scan.mode}"` };
+  }
+
+  const counts = scan.summary?.counts ?? {};
+  const tierAPaths = scan.summary?.tierAPaths ?? [];
+  const tierBPaths = scan.summary?.tierBPaths ?? [];
+
+  for (const p of tierAPaths) {
+    console.warn(
+      `[worktree-janitor] ${mode === "live" ? "REAP" : "WOULD-REAP"} Tier-A ${p} [mode=${mode}]`,
+    );
+  }
+  for (const p of tierBPaths) {
+    console.warn(
+      `[worktree-janitor] WOULD-REAP Tier-B (observe only) ${p} — never auto-deleted by schedule`,
+    );
+  }
+
+  const removed =
+    mode === "live"
+      ? (scan.removals ?? []).filter((r) => r.worktreeRemoved).length
+      : 0;
+
+  const result = {
+    skipped: false as const,
+    mode,
+    root: scan.root ?? null,
+    tierA: counts.PRUNE_TIER_A ?? tierAPaths.length,
+    tierB: counts.PRUNE_TIER_B ?? tierBPaths.length,
+    keep: counts.KEEP ?? 0,
+    tierAPaths,
+    tierBPaths,
+    removed,
+  };
+
+  console.warn(`[worktree-janitor] summary: ${JSON.stringify(result)}`);
+  return result;
+}
+
+export const worktreeJanitor = inngest.createFunction(
+  {
+    id: "ops/worktree-janitor",
+    retries: 1,
+    // Daily after artifact observe (05:20) — host hygiene, not hot path.
+    triggers: [cron("40 5 * * *")],
+  },
+  async ({ step }) => {
+    return await step.run("worktree-janitor", () => runWorktreeJanitor());
+  },
+);

--- a/apps/web/lib/queue/functions/worktree-janitor.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.ts
@@ -1,24 +1,25 @@
-// BI-42FA7DD8 — Worktree Tier-A scheduled janitor.
+// BI-42FA7DD8 — Worktree Tier-A FLEET BACKSTOP (optional schedule).
+//
+// PRIMARY path is transactional, not this cron:
+//   packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs on SessionStart
+//   (observe) + SessionEnd/Stop (reap THIS session's worktree when Tier-A).
+// That fires on every client that loaded dpf-platform (Claude plugin / Grok
+// global hooks / Codex hooks) — no per-client cron to configure, no "schedule
+// went dark" failure mode for the common case.
+//
+// THIS module is an optional fleet sweeper for leftovers (abandoned worktrees
+// after crashes, clients without hooks). It is server-side Inngest (portal),
+// NOT a CLI client cron. It still may not see host worktrees when the portal
+// container lacks a host git view — then it no-ops.
 //
 // Spec: docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md § D4
-// Kernel: worktree-selection-and-reaping, destructive-actions-require-explicit-go,
-//         remove-avoidable-failure-opportunities
+// Kernel: worktree-selection-and-reaping, destructive-actions-require-explicit-go
 //
-// Complements:
-//   - scripts/worktree-janitor.sh / scripts/worktree-janitor.mjs (host CLI)
-//   - runtime-target-janitor (DB lease/RT records)
-//   - runtime-artifact-janitor (Docker observe-only)
-//
-// SAFETY DOCTRINE
+// SAFETY DOCTRINE (backstop)
 //   * Default OFF (DPF_WORKTREE_JANITOR_ENABLED not set) — no scan.
-//   * When ENABLED without AUTO_REAP: dry-run observe only (logs would-reap Tier A/B).
-//   * When AUTO_REAP=1: live removal of **Tier A only** (merged+clean+no open PR/lease).
-//     Tier B (stale unmerged) is NEVER live-reaped by the schedule — observe only.
+//   * When ENABLED without AUTO_REAP: dry-run observe only.
+//   * When AUTO_REAP=1: live **Tier A only**. Tier B never auto-deleted here.
 //   * Removals use junction-safe-worktree-remove.mjs via the CLI.
-//
-// The schedule may run inside the portal container. When git worktrees are not
-// visible (no /host-dpf, no worktree list), the CLI returns available:false and
-// the schedule degrades to a skip — never throws.
 
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -83,6 +83,14 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/governance-freshness-check.mjs\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -93,6 +101,14 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
+          }
+        ]
       }
     ],
     "Stop": [
@@ -101,6 +117,14 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\""
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
           }
         ]
       }

--- a/packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
+//
+// Session-lifecycle worktree hygiene (operator concern: transactional, not cron).
+//
+// SessionStart — OBSERVE: report worktree count / non-canonical cwd; never delete.
+// SessionEnd / Stop — TRANSACTIONAL REAP of THIS session's worktree only when it
+//   is Tier A (merged + clean + no open PR + not pinned). Fail-open always.
+//
+// Why not cron-first: client CLIs do not run fleets of crons; portal Inngest may
+// not see host worktrees; schedules get disabled or go dark. Session hooks fire
+// wherever dpf-platform is installed (Claude plugin, Grok global plane, Codex
+// hooks). The optional daily schedule remains a fleet backstop only.
+//
+// Escape hatches:
+//   DPF_SKIP_WORKTREE_SESSION_HYGIENE=1  — no-op
+//   DPF_WORKTREE_SESSION_REAP=0          — observe only on SessionEnd (no remove)
+//   .worktree-pinned                     — never remove
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+
+import { inDpfWorkspace } from "./lib/hook-io.mjs";
+
+// Core lives in scripts/lib — resolve from repo root via skill-pack location.
+const hooksDir = dirname(fileURLToPath(import.meta.url));
+const skillPackRoot = resolve(hooksDir, "..");
+const repoRootGuess = resolve(skillPackRoot, "../..");
+
+function loadClassify() {
+  const candidates = [
+    join(repoRootGuess, "scripts/lib/worktree-janitor-core.mjs"),
+    join(skillPackRoot, "../../scripts/lib/worktree-janitor-core.mjs"),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) {
+      return import(pathToFileURL(p).href);
+    }
+  }
+  return null;
+}
+
+function runGit(args, cwd) {
+  const r = spawnSync("git", args, {
+    cwd: cwd || undefined,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 15_000,
+  });
+  return {
+    ok: r.status === 0,
+    stdout: (r.stdout || "").trim(),
+    stderr: (r.stderr || "").trim(),
+  };
+}
+
+function readPayload() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    if (!raw.trim()) return {};
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function hookEventName(payload) {
+  const n = payload.hookEventName ?? payload.hook_event_name ?? "";
+  if (/sessionstart/i.test(n) || n === "SessionStart") return "SessionStart";
+  if (/^stop$/i.test(n) || n === "Stop") return "Stop";
+  return "SessionEnd";
+}
+
+function sessionCwd(payload) {
+  return (
+    payload.cwd ||
+    payload.workspaceRoot ||
+    payload.workspace_root ||
+    process.cwd()
+  );
+}
+
+function resolveGitRoot(cwd) {
+  const r = runGit(["rev-parse", "--show-toplevel"], cwd);
+  return r.ok ? r.stdout : null;
+}
+
+function resolveCommonRoot(cwd) {
+  const r = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd);
+  if (!r.ok || !r.stdout) return resolveGitRoot(cwd);
+  // git-common-dir is .../.git — parent is main worktree root
+  const common = r.stdout.replace(/[/\\]\.git$/, "");
+  return common || resolveGitRoot(cwd);
+}
+
+function countWorktrees(root) {
+  const r = runGit(["worktree", "list", "--porcelain"], root);
+  if (!r.ok) return 0;
+  return r.stdout.split(/\r?\n/).filter((l) => l.startsWith("worktree ")).length;
+}
+
+function isCanonicalSibling(wtPath, mainRoot) {
+  const norm = (p) => String(p).replace(/\\/g, "/").replace(/\/+$/, "");
+  const wt = norm(wtPath);
+  const main = norm(mainRoot);
+  // Nested .claude/worktrees is non-canonical
+  if (wt.includes("/.claude/worktrees/") || wt.includes("/.claude/worktrees")) return false;
+  // Sibling * -worktrees / DPF-worktrees
+  if (/[/]dpf-worktrees[/]/i.test(wt) || /[/][^/]+-worktrees[/]/i.test(wt)) return true;
+  // Older alongside form D:/DPF-topic
+  if (wt !== main && /[/]DPF-[^/]+$/i.test(wt)) return true;
+  // Inside main tree but not nested claude — still non-ideal
+  if (wt.startsWith(main + "/")) return false;
+  return true;
+}
+
+function gatherThisWorktreeFacts(cwd, mainRoot) {
+  const wtPath = resolve(cwd);
+  const branchR = runGit(["branch", "--show-current"], wtPath);
+  const branch = branchR.ok && branchR.stdout ? branchR.stdout : null;
+  const dirtyR = runGit(["status", "--porcelain"], wtPath);
+  const dirty = dirtyR.ok && dirtyR.stdout.length > 0;
+  let merged = false;
+  if (branch) {
+    const anc = runGit(
+      ["merge-base", "--is-ancestor", `refs/heads/${branch}`, "origin/main"],
+      mainRoot,
+    );
+    if (anc.ok) merged = true;
+    else {
+      const gh = spawnSync(
+        "gh",
+        ["pr", "list", "--head", branch, "--state", "merged", "--json", "number", "--jq", "length"],
+        { encoding: "utf8", windowsHide: true, timeout: 20_000 },
+      );
+      if (gh.status === 0 && Number((gh.stdout || "0").trim()) > 0) merged = true;
+    }
+  }
+  let hasOpenPr = false;
+  if (branch) {
+    const gh = spawnSync(
+      "gh",
+      ["pr", "list", "--head", branch, "--state", "open", "--json", "number", "--jq", "length"],
+      { encoding: "utf8", windowsHide: true, timeout: 20_000 },
+    );
+    hasOpenPr = gh.status === 0 && Number((gh.stdout || "0").trim()) > 0;
+  }
+  const ageR = runGit(["log", "-1", "--format=%ct"], wtPath);
+  let ageDays = 0;
+  if (ageR.ok && ageR.stdout) {
+    const ts = Number(ageR.stdout);
+    if (Number.isFinite(ts) && ts > 0) ageDays = Math.floor((Date.now() / 1000 - ts) / 86400);
+  }
+  return {
+    path: wtPath,
+    branch,
+    isRoot: resolve(wtPath) === resolve(mainRoot),
+    pinned: existsSync(join(wtPath, ".worktree-pinned")),
+    hasActiveLease: false, // lease released by session-reaper; do not block on MCP here
+    hasOpenPr,
+    merged,
+    dirty,
+    ageDays,
+  };
+}
+
+function removeThisWorktree(mainRoot, wtPath) {
+  const helper = join(repoRootGuess, "scripts/lib/junction-safe-worktree-remove.mjs");
+  if (!existsSync(helper)) {
+    return { ok: false, detail: "junction-safe helper missing" };
+  }
+  const r = spawnSync(process.execPath, [helper, mainRoot, wtPath, "--force"], {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 120_000,
+  });
+  return {
+    ok: r.status === 0,
+    detail: (r.stdout || r.stderr || "").trim().slice(0, 400),
+  };
+}
+
+function emitContext(hookEventName, text) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName,
+        additionalContext: text,
+      },
+    }),
+  );
+}
+
+async function main() {
+  if (process.env.DPF_SKIP_WORKTREE_SESSION_HYGIENE === "1") process.exit(0);
+
+  const payload = readPayload();
+  const event = hookEventName(payload);
+  const cwd = sessionCwd(payload);
+
+  if (!inDpfWorkspace(cwd)) process.exit(0);
+
+  const mainRoot = resolveCommonRoot(cwd) || resolveGitRoot(cwd);
+  if (!mainRoot) process.exit(0);
+
+  const core = await loadClassify();
+  if (!core?.classifyWorktree) process.exit(0);
+  const { classifyWorktree } = core;
+
+  if (event === "SessionStart") {
+    const n = countWorktrees(mainRoot);
+    const facts = gatherThisWorktreeFacts(cwd, mainRoot);
+    const lines = [];
+    if (n >= 20) {
+      lines.push(
+        `Worktree hygiene: ${n} registered worktrees on this clone (target is a bounded count). ` +
+          `Tier-A (merged+clean) worktrees are reaped on SessionEnd of that worktree; ` +
+          `fleet backstop: node scripts/worktree-janitor.mjs --dry-run --tier-a-only.`,
+      );
+    }
+    if (!facts.isRoot && !isCanonicalSibling(facts.path, mainRoot)) {
+      lines.push(
+        `Worktree hygiene: cwd is non-canonical (${facts.path}). Prefer D:/DPF-worktrees/<topic> (or ~/dpf-worktrees/<topic>). Nested .claude/worktrees is not the DPF convention.`,
+      );
+    }
+    if (facts.branch && facts.merged && !facts.dirty) {
+      lines.push(
+        `Worktree hygiene: branch ${facts.branch} is already merged and clean — this worktree is Tier-A and will be reaped on SessionEnd unless pinned or DPF_WORKTREE_SESSION_REAP=0.`,
+      );
+    }
+    if (lines.length) emitContext("SessionStart", lines.join("\n"));
+    process.exit(0);
+  }
+
+  // SessionEnd / Stop — transactional reap of THIS worktree only.
+  const facts = gatherThisWorktreeFacts(cwd, mainRoot);
+  if (facts.isRoot) process.exit(0);
+
+  const { verdict, reason } = classifyWorktree(facts);
+  const allowReap = process.env.DPF_WORKTREE_SESSION_REAP !== "0";
+
+  if (verdict !== "PRUNE_TIER_A") {
+    if (verdict === "PRUNE_TIER_B" || (facts.dirty && facts.merged)) {
+      emitContext(
+        event,
+        `Worktree hygiene: leaving ${facts.path} in place (${reason}). ` +
+          `Not auto-removed (Tier-A only on SessionEnd).`,
+      );
+    }
+    process.exit(0);
+  }
+
+  if (!allowReap) {
+    emitContext(
+      event,
+      `Worktree hygiene: Tier-A candidate ${facts.path} (${reason}) — not removed because DPF_WORKTREE_SESSION_REAP=0.`,
+    );
+    process.exit(0);
+  }
+
+  const rem = removeThisWorktree(mainRoot, facts.path);
+  if (rem.ok && facts.branch) {
+    runGit(["branch", "-D", facts.branch], mainRoot);
+  }
+  emitContext(
+    event,
+    rem.ok
+      ? `Worktree hygiene: reaped Tier-A worktree ${facts.path} (branch ${facts.branch}). ${rem.detail}`
+      : `Worktree hygiene: Tier-A reap failed for ${facts.path}: ${rem.detail}`,
+  );
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/packages/dpf-skill-pack/hooks/worktree-session-hygiene.test.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-hygiene.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "worktree-session-hygiene.mjs");
+
+describe("worktree-session-hygiene", () => {
+  it("no-ops outside DPF workspace and with skip env", () => {
+    const r = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DPF_SKIP_WORKTREE_SESSION_HYGIENE: "1",
+      },
+      input: JSON.stringify({ hookEventName: "SessionStart", cwd: process.cwd() }),
+      windowsHide: true,
+    });
+    assert.equal(r.status, 0);
+    assert.equal((r.stdout || "").trim(), "");
+  });
+
+  it("SessionStart in DPF workspace exits 0 (may emit context)", () => {
+    const r = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      cwd: join(here, "../../.."),
+      env: {
+        ...process.env,
+        DPF_SKIP_WORKTREE_SESSION_HYGIENE: "0",
+      },
+      input: JSON.stringify({
+        hookEventName: "SessionStart",
+        cwd: join(here, "../../.."),
+      }),
+      windowsHide: true,
+      timeout: 60_000,
+    });
+    assert.equal(r.status, 0);
+  });
+});

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -946,40 +946,86 @@ GROK_HOOK_GUARDS = (
     "plan-backlog-coverage-guard.mjs",
 )
 
+# Session plane: process-spine + worktree transactional hygiene (primary reaper).
+# Fleet schedule (ops/worktree-janitor) is backstop only — not the primary path.
+GROK_SESSION_START_SCRIPTS = (
+    "process-spine-health-check.mjs",
+    "governance-freshness-check.mjs",
+    "worktree-session-hygiene.mjs",
+)
+GROK_SESSION_END_SCRIPTS = (
+    "uncommitted-work-guard.mjs",
+    "worktree-session-hygiene.mjs",
+)
+
 
 def grok_hooks_file(home: Path) -> Path:
     return home / ".grok" / "hooks" / "dpf-guards.json"
 
 
-def install_grok_hooks(managed: Path, home: Path, dry_run: bool) -> str:
-    """Wire the plane-1 guards into a hook plane Grok actually executes.
+def _grok_command_entry(hooks_dir: Path, script: str, timeout: int = 15) -> dict[str, Any]:
+    # process-spine SessionStart needs --hook flag
+    extra = " --hook" if script == "process-spine-health-check.mjs" else ""
+    return {
+        "hooks": [
+            {
+                "type": "command",
+                "command": f'node "{hooks_dir / script}"{extra}',
+                "timeout": timeout,
+            }
+        ]
+    }
 
-    Live probe (BI-883FC2FC, Grok 0.2.87) proved Grok runs PreToolUse blocking
-    command-hooks and honors deny, but its hook-execution plane loads ONLY from
-    ~/.grok/hooks, ~/.claude/settings.json, and ~/.cursor/hooks — NOT from a
-    plugin's bundled hooks.json (a plugin shows has_hooks=true in inventory yet
-    contributes total_hooks=0 to the plane). So `grok plugin install` surfaces the
-    SKILLS but never the guards. This writes a global ~/.grok/hooks/dpf-guards.json
-    pointing at the managed guard copies. Global hooks are always-trusted (no
-    folder-trust prompt); the guards self-scope to DPF checkouts (inDpfWorkspace)
-    so they never fire DPF-branded denials in unrelated repos. Kernel ledger
-    DI-C17A5861CE0E (opt_global_context_gated).
-    """
+
+def build_grok_hooks_payload(managed: Path, dry_run: bool = False) -> dict[str, Any]:
     hooks_dir = managed / "hooks"
-    entries = [
-        {"hooks": [{"type": "command", "command": f'node "{hooks_dir / guard}"', "timeout": 15}]}
-        for guard in GROK_HOOK_GUARDS
-        if (dry_run or (hooks_dir / guard).exists())
+    payload: dict[str, Any] = {"hooks": {}}
+    pre = [
+        _grok_command_entry(hooks_dir, g, 15)
+        for g in GROK_HOOK_GUARDS
+        if dry_run or (hooks_dir / g).exists()
     ]
-    if not entries:
+    if pre:
+        payload["hooks"]["PreToolUse"] = pre
+    start = [
+        _grok_command_entry(hooks_dir, s, 30)
+        for s in GROK_SESSION_START_SCRIPTS
+        if dry_run or (hooks_dir / s).exists()
+    ]
+    if start:
+        payload["hooks"]["SessionStart"] = start
+    end = [
+        _grok_command_entry(hooks_dir, s, 60)
+        for s in GROK_SESSION_END_SCRIPTS
+        if dry_run or (hooks_dir / s).exists()
+    ]
+    if end:
+        payload["hooks"]["SessionEnd"] = end
+        payload["hooks"]["Stop"] = end
+    return payload
+
+
+def install_grok_hooks(managed: Path, home: Path, dry_run: bool) -> str:
+    """Wire plane-1 + session plane into Grok's executable hook plane.
+
+    Grok ignores plugin-bundled hooks (BI-883FC2FC). Global ~/.grok/hooks is the
+    only plane that runs. Includes SessionStart/End worktree-session-hygiene so
+    reaping is transactional per session (primary), not cron-dependent.
+    """
+    payload = build_grok_hooks_payload(managed, dry_run=dry_run)
+    pre_count = len(payload.get("hooks", {}).get("PreToolUse", []))
+    if pre_count == 0:
         return "skipped: no guard scripts found in managed copy"
-    payload = {"hooks": {"PreToolUse": entries}}
     path = grok_hooks_file(home)
     if dry_run:
-        return f"dry-run: would write {len(entries)} guard(s) to {path}"
+        return f"dry-run: would write {pre_count} PreToolUse + session plane to {path}"
     path.parent.mkdir(parents=True, exist_ok=True)
     changed = write_json(path, payload)
-    return f"wired {len(entries)} guard(s) -> {path}" + ("" if changed else " (unchanged)")
+    session = "SessionStart+Stop" if "SessionStart" in payload.get("hooks", {}) else "no-session"
+    return (
+        f"wired {pre_count} PreToolUse guard(s) + {session} -> {path}"
+        + ("" if changed else " (unchanged)")
+    )
 
 
 # Bash-scoped blocking guards for Codex's user hook plane (~/.codex/hooks.json).
@@ -1168,6 +1214,7 @@ HOOK_PURPOSES = {
     "worktree-create.mjs": "seeds a new worktree with MCP config on WorktreeCreate",
     "process-spine-health-check.mjs": "SessionStart: warns when DPF-native replacement skills are missing or hidden by retired generic skills",
     "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",
+    "worktree-session-hygiene.mjs": "SessionStart observe worktree sprawl; SessionEnd reaps THIS worktree when Tier-A (merged+clean) — primary reaper, not cron",
     "uncommitted-work-guard.mjs": "SessionEnd/Stop/post-checkout: warns before uncommitted spec/plan loss",
 }
 

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -67,19 +67,25 @@ class InstallGrokHooksTest(unittest.TestCase):
             managed = home / ".agents" / "plugins" / "plugins" / "dpf-platform"
             updater.copy_skill_pack(skill_pack, managed, dry_run=False)
             status = updater.install_grok_hooks(managed, home, dry_run=False)
-            self.assertIn("wired 6 guard", status)
+            self.assertIn("wired 6 PreToolUse", status)
+            self.assertIn("SessionStart+Stop", status)
             hook_file = updater.grok_hooks_file(home)
             self.assertTrue(hook_file.exists())
             data = json.loads(hook_file.read_text())
             entries = data["hooks"]["PreToolUse"]
             self.assertEqual(len(entries), 6)
             cmds = [h["command"] for e in entries for h in e["hooks"]]
-            # Every command points at an existing managed guard script.
             self.assertTrue(any("lease-punt-guard.mjs" in c for c in cmds))
-            self.assertTrue(any("decision-routing-guard.mjs" in c for c in cmds))
-            self.assertTrue(any("plan-backlog-coverage-guard.mjs" in c for c in cmds))
             for guard in updater.GROK_HOOK_GUARDS:
                 self.assertTrue((managed / "hooks" / guard).exists(), guard)
+            session_cmds = [
+                h["command"]
+                for e in data["hooks"]["SessionStart"]
+                for h in e["hooks"]
+            ]
+            self.assertTrue(any("worktree-session-hygiene.mjs" in c for c in session_cmds))
+            stop_cmds = [h["command"] for e in data["hooks"]["Stop"] for h in e["hooks"]]
+            self.assertTrue(any("worktree-session-hygiene.mjs" in c for c in stop_cmds))
 
     def test_dry_run_writes_nothing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/lib/worktree-janitor-core.mjs
+++ b/scripts/lib/worktree-janitor-core.mjs
@@ -1,0 +1,122 @@
+// scripts/lib/worktree-janitor-core.mjs
+//
+// Pure worktree reaping classification (BI-42FA7DD8).
+//
+// Tier A (safe auto-reap when DPF_WORKTREE_JANITOR_AUTO_REAP=1):
+//   merged (ancestry OR squash-merged PR) + clean + no open PR + no lease + not pinned
+// Tier B (observe / propose only — never auto-delete):
+//   unmerged + clean + age > graceDays
+//
+// Side-effecting removal stays in scripts/worktree-janitor.mjs via
+// junction-safe-worktree-remove.mjs.
+
+/** @typedef {"PRUNE_TIER_A" | "PRUNE_TIER_B" | "KEEP" | "SKIP" | "PINNED"} WorktreeVerdict */
+
+/**
+ * @typedef {object} WorktreeFacts
+ * @property {string} path
+ * @property {string | null} branch  null when detached
+ * @property {boolean} isRoot
+ * @property {boolean} pinned        .worktree-pinned present
+ * @property {boolean} hasActiveLease
+ * @property {boolean} hasOpenPr
+ * @property {boolean} merged        ancestor of origin/main OR has merged PR
+ * @property {boolean} dirty         porcelain non-empty
+ * @property {number} ageDays        days since last commit (0 if unknown)
+ */
+
+/**
+ * Classify one worktree. Pure.
+ * @param {WorktreeFacts} facts
+ * @param {{ graceDays?: number }} [opts]
+ * @returns {{ verdict: WorktreeVerdict, reason: string, tier: "A" | "B" | null }}
+ */
+export function classifyWorktree(facts, opts = {}) {
+  const graceDays = opts.graceDays ?? 14;
+
+  if (facts.isRoot) {
+    return { verdict: "SKIP", reason: "root clone", tier: null };
+  }
+  if (!facts.branch) {
+    return { verdict: "SKIP", reason: "detached HEAD", tier: null };
+  }
+  if (facts.branch === "main") {
+    return { verdict: "SKIP", reason: "on main branch", tier: null };
+  }
+  if (facts.pinned) {
+    return { verdict: "PINNED", reason: `.worktree-pinned present (branch=${facts.branch})`, tier: null };
+  }
+  if (facts.hasActiveLease) {
+    return {
+      verdict: "KEEP",
+      reason: `branch=${facts.branch} active NonProductionEnvironmentLease`,
+      tier: null,
+    };
+  }
+  if (facts.hasOpenPr) {
+    return { verdict: "KEEP", reason: `branch=${facts.branch} open PR`, tier: null };
+  }
+
+  if (facts.merged) {
+    if (facts.dirty) {
+      return {
+        verdict: "KEEP",
+        reason: `branch=${facts.branch} merged but dirty; refuse auto-reap`,
+        tier: null,
+      };
+    }
+    return {
+      verdict: "PRUNE_TIER_A",
+      reason: `branch=${facts.branch} merged to origin/main, clean, no open PR/lease`,
+      tier: "A",
+    };
+  }
+
+  if (facts.ageDays > graceDays) {
+    if (facts.dirty) {
+      return {
+        verdict: "KEEP",
+        reason: `branch=${facts.branch} stale ${facts.ageDays}d but dirty; manual review`,
+        tier: null,
+      };
+    }
+    return {
+      verdict: "PRUNE_TIER_B",
+      reason: `branch=${facts.branch} stale ${facts.ageDays}d (>${graceDays}d), unmerged, clean — observe/propose only`,
+      tier: "B",
+    };
+  }
+
+  return {
+    verdict: "KEEP",
+    reason: `branch=${facts.branch} unmerged, ${facts.ageDays}d old (<${graceDays}d grace)`,
+    tier: null,
+  };
+}
+
+/**
+ * Which verdicts are eligible for live removal under a given policy.
+ * @param {"all" | "tier-a-only"} policy
+ * @param {WorktreeVerdict} verdict
+ */
+export function isLiveReapEligible(policy, verdict) {
+  if (verdict === "PRUNE_TIER_A") return true;
+  if (policy === "all" && verdict === "PRUNE_TIER_B") return true;
+  return false;
+}
+
+/**
+ * Summarize decisions for JSON / Inngest.
+ * @param {Array<{ path: string, branch: string | null, verdict: WorktreeVerdict, reason: string, tier: string | null }>} decisions
+ */
+export function summarizeDecisions(decisions) {
+  const counts = { PRUNE_TIER_A: 0, PRUNE_TIER_B: 0, KEEP: 0, SKIP: 0, PINNED: 0 };
+  for (const d of decisions) {
+    if (counts[d.verdict] !== undefined) counts[d.verdict] += 1;
+  }
+  return {
+    counts,
+    tierAPaths: decisions.filter((d) => d.verdict === "PRUNE_TIER_A").map((d) => d.path),
+    tierBPaths: decisions.filter((d) => d.verdict === "PRUNE_TIER_B").map((d) => d.path),
+  };
+}

--- a/scripts/lib/worktree-janitor-core.test.mjs
+++ b/scripts/lib/worktree-janitor-core.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  classifyWorktree,
+  isLiveReapEligible,
+  summarizeDecisions,
+} from "./worktree-janitor-core.mjs";
+
+const base = {
+  path: "D:/DPF-worktrees/topic",
+  branch: "feat/topic",
+  isRoot: false,
+  pinned: false,
+  hasActiveLease: false,
+  hasOpenPr: false,
+  merged: false,
+  dirty: false,
+  ageDays: 2,
+};
+
+describe("classifyWorktree", () => {
+  it("skips root and detached and main", () => {
+    assert.equal(classifyWorktree({ ...base, isRoot: true }).verdict, "SKIP");
+    assert.equal(classifyWorktree({ ...base, branch: null }).verdict, "SKIP");
+    assert.equal(classifyWorktree({ ...base, branch: "main" }).verdict, "SKIP");
+  });
+
+  it("pins and keeps open PR / lease / dirty merged", () => {
+    assert.equal(classifyWorktree({ ...base, pinned: true }).verdict, "PINNED");
+    assert.equal(classifyWorktree({ ...base, hasOpenPr: true }).verdict, "KEEP");
+    assert.equal(classifyWorktree({ ...base, hasActiveLease: true }).verdict, "KEEP");
+    assert.equal(
+      classifyWorktree({ ...base, merged: true, dirty: true }).verdict,
+      "KEEP",
+    );
+  });
+
+  it("Tier A: merged clean no PR/lease", () => {
+    const r = classifyWorktree({ ...base, merged: true, dirty: false });
+    assert.equal(r.verdict, "PRUNE_TIER_A");
+    assert.equal(r.tier, "A");
+  });
+
+  it("Tier B: stale unmerged clean", () => {
+    const r = classifyWorktree({ ...base, ageDays: 20 }, { graceDays: 14 });
+    assert.equal(r.verdict, "PRUNE_TIER_B");
+    assert.equal(r.tier, "B");
+  });
+
+  it("keeps young unmerged", () => {
+    const r = classifyWorktree({ ...base, ageDays: 3 }, { graceDays: 14 });
+    assert.equal(r.verdict, "KEEP");
+  });
+});
+
+describe("isLiveReapEligible", () => {
+  it("tier-a-only never reaps Tier B", () => {
+    assert.equal(isLiveReapEligible("tier-a-only", "PRUNE_TIER_A"), true);
+    assert.equal(isLiveReapEligible("tier-a-only", "PRUNE_TIER_B"), false);
+    assert.equal(isLiveReapEligible("all", "PRUNE_TIER_B"), true);
+  });
+});
+
+describe("summarizeDecisions", () => {
+  it("counts and lists paths", () => {
+    const s = summarizeDecisions([
+      { path: "/a", branch: "a", verdict: "PRUNE_TIER_A", reason: "", tier: "A" },
+      { path: "/b", branch: "b", verdict: "PRUNE_TIER_B", reason: "", tier: "B" },
+      { path: "/c", branch: "c", verdict: "KEEP", reason: "", tier: null },
+    ]);
+    assert.equal(s.counts.PRUNE_TIER_A, 1);
+    assert.equal(s.counts.PRUNE_TIER_B, 1);
+    assert.deepEqual(s.tierAPaths, ["/a"]);
+    assert.deepEqual(s.tierBPaths, ["/b"]);
+  });
+});

--- a/scripts/worktree-janitor.mjs
+++ b/scripts/worktree-janitor.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+// scripts/worktree-janitor.mjs
+//
+// BI-42FA7DD8 — Node worktree janitor (scheduled + host CLI).
+// Complements scripts/worktree-janitor.sh (bash) with --json and Tier-A policy.
+//
+// USAGE
+//   node scripts/worktree-janitor.mjs [--dry-run] [--live] [--tier-a-only]
+//                                     [--grace-days N] [--json] [--root PATH]
+//
+// FLAGS
+//   --dry-run       (default) Classify only; never remove.
+//   --live          Remove eligible worktrees via junction-safe helper + branch -D.
+//   --tier-a-only   Live reaps ONLY Tier A (merged+clean). Tier B is always observe.
+//                   The Inngest schedule uses this for auto-reap.
+//   --grace-days N  Stale threshold for Tier B (default 14).
+//   --json          Machine-readable report on stdout.
+//   --root PATH     Git root clone (default: DPF_REPO_ROOT / git rev-parse).
+//
+// SAFETY
+//   * Dry-run by default.
+//   * Tier A only for scheduled auto-reap (merged + clean + no open PR/lease + not pinned).
+//   * Removals go through junction-safe-worktree-remove.mjs (BI-F6AC1A56).
+//   * .worktree-pinned is always honored.
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  classifyWorktree,
+  isLiveReapEligible,
+  summarizeDecisions,
+} from "./lib/worktree-janitor-core.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_GRACE = 14;
+
+function parseArgs(argv) {
+  let dryRun = true;
+  let tierAOnly = false;
+  let graceDays = DEFAULT_GRACE;
+  let json = false;
+  let root = process.env.DPF_REPO_ROOT || process.env.PROJECT_ROOT || "";
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--dry-run") dryRun = true;
+    else if (a === "--live") dryRun = false;
+    else if (a === "--tier-a-only") tierAOnly = true;
+    else if (a === "--json") json = true;
+    else if (a === "--grace-days") graceDays = Number(argv[++i]);
+    else if (a.startsWith("--grace-days=")) graceDays = Number(a.split("=")[1]);
+    else if (a === "--root") root = argv[++i];
+    else if (a === "-h" || a === "--help") {
+      console.log(readFileSync(fileURLToPath(import.meta.url), "utf8").split("\n").slice(0, 35).join("\n"));
+      process.exit(0);
+    }
+  }
+  if (!Number.isFinite(graceDays) || graceDays < 1) graceDays = DEFAULT_GRACE;
+  return { dryRun, tierAOnly, graceDays, json, root };
+}
+
+function runGit(args, cwd) {
+  const r = spawnSync("git", args, {
+    cwd: cwd || undefined,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return {
+    ok: r.status === 0,
+    stdout: (r.stdout || "").trim(),
+    stderr: (r.stderr || "").trim(),
+    status: r.status ?? 1,
+  };
+}
+
+function resolveRoot(explicit) {
+  if (explicit && existsSync(explicit)) return path.resolve(explicit);
+  const envRoot = process.env.DPF_REPO_ROOT || process.env.PROJECT_ROOT;
+  if (envRoot && existsSync(envRoot)) return path.resolve(envRoot);
+  const r = runGit(["rev-parse", "--show-toplevel"]);
+  if (r.ok && r.stdout) return r.stdout;
+  // Container install mount
+  if (existsSync("/host-dpf")) return "/host-dpf";
+  throw new Error("could not resolve git root (pass --root or set DPF_REPO_ROOT)");
+}
+
+function listWorktrees(root) {
+  const r = runGit(["worktree", "list", "--porcelain"], root);
+  if (!r.ok) throw new Error(`git worktree list failed: ${r.stderr || r.stdout}`);
+  const entries = [];
+  let current = null;
+  for (const line of r.stdout.split(/\r?\n/)) {
+    if (line.startsWith("worktree ")) {
+      if (current) entries.push(current);
+      current = { path: line.slice("worktree ".length), branch: null, bare: false, detached: false };
+    } else if (line.startsWith("branch ") && current) {
+      // refs/heads/feat/foo
+      const ref = line.slice("branch ".length);
+      current.branch = ref.replace(/^refs\/heads\//, "");
+    } else if (line === "detached" && current) {
+      current.detached = true;
+      current.branch = null;
+    } else if (line === "bare" && current) {
+      current.bare = true;
+    } else if (line === "" && current) {
+      entries.push(current);
+      current = null;
+    }
+  }
+  if (current) entries.push(current);
+  return entries;
+}
+
+/**
+ * One-shot PR index so we do not call `gh` once per worktree (78+ branches
+ * was multi-minute). Missing gh → empty sets (ancestry-only merge detection).
+ * @returns {{ open: Set<string>, merged: Set<string> }}
+ */
+function loadPrBranchIndex() {
+  const open = new Set();
+  const merged = new Set();
+  const openR = spawnSync(
+    "gh",
+    ["pr", "list", "--state", "open", "--limit", "500", "--json", "headRefName"],
+    { encoding: "utf8", windowsHide: true, timeout: 60_000 },
+  );
+  if (openR.status === 0 && openR.stdout) {
+    try {
+      for (const row of JSON.parse(openR.stdout)) {
+        if (row?.headRefName) open.add(String(row.headRefName));
+      }
+    } catch {
+      // ignore
+    }
+  }
+  // Squash-merged heads: list recently merged PRs (cap). Operators can re-run
+  // with a higher limit later; ancestry still catches true merge commits.
+  const mergedR = spawnSync(
+    "gh",
+    ["pr", "list", "--state", "merged", "--limit", "500", "--json", "headRefName"],
+    { encoding: "utf8", windowsHide: true, timeout: 60_000 },
+  );
+  if (mergedR.status === 0 && mergedR.stdout) {
+    try {
+      for (const row of JSON.parse(mergedR.stdout)) {
+        if (row?.headRefName) merged.add(String(row.headRefName));
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return { open, merged };
+}
+
+function isMerged(root, branch, prIndex) {
+  if (!branch) return false;
+  const anc = runGit(["merge-base", "--is-ancestor", `refs/heads/${branch}`, "origin/main"], root);
+  if (anc.ok) return true;
+  return prIndex.merged.has(branch);
+}
+
+function isDirty(wtPath) {
+  const r = runGit(["status", "--porcelain"], wtPath);
+  return r.ok && r.stdout.length > 0;
+}
+
+function ageDays(wtPath) {
+  const r = runGit(["log", "-1", "--format=%ct"], wtPath);
+  if (!r.ok || !r.stdout) return 0;
+  const ts = Number(r.stdout);
+  if (!Number.isFinite(ts) || ts <= 0) return 0;
+  return Math.floor((Date.now() / 1000 - ts) / 86400);
+}
+
+/** One MCP call for all leases; returns a predicate on worktree path. */
+function loadLeasePaths() {
+  const token = process.env.DPF_MCP_BEARER_TOKEN;
+  if (!token) return new Set();
+  const url = process.env.DPF_MCP_URL || "http://127.0.0.1:3000/api/mcp/v1";
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "list_nonprod_environment_leases", arguments: {} },
+  });
+  const r = spawnSync(
+    "curl",
+    [
+      "-sS",
+      "-X",
+      "POST",
+      url,
+      "-H",
+      `Authorization: Bearer ${token}`,
+      "-H",
+      "Content-Type: application/json",
+      "-d",
+      body,
+      "--max-time",
+      "8",
+    ],
+    { encoding: "utf8", windowsHide: true },
+  );
+  if (r.status !== 0 || !r.stdout) return new Set();
+  // Match any path-like substrings later via includes on raw payload.
+  return r.stdout;
+}
+
+function pathHasLease(leasePayload, wtPath) {
+  if (!leasePayload) return false;
+  const norm = wtPath.replace(/\\/g, "/");
+  return leasePayload.includes(wtPath) || leasePayload.includes(norm);
+}
+
+function gatherFacts(root, entry, prIndex, leasePayload) {
+  const wtPath = entry.path;
+  const branch = entry.detached ? null : entry.branch;
+  return {
+    path: wtPath,
+    branch,
+    isRoot: path.resolve(wtPath) === path.resolve(root),
+    pinned: existsSync(path.join(wtPath, ".worktree-pinned")),
+    hasActiveLease: pathHasLease(leasePayload, wtPath),
+    hasOpenPr: branch ? prIndex.open.has(branch) : false,
+    merged: branch ? isMerged(root, branch, prIndex) : false,
+    dirty: branch ? isDirty(wtPath) : false,
+    ageDays: branch ? ageDays(wtPath) : 0,
+  };
+}
+
+function removeWorktree(root, wtPath, branch) {
+  const helper = path.join(here, "lib", "junction-safe-worktree-remove.mjs");
+  const rem = spawnSync(process.execPath, [helper, root, wtPath, "--force"], {
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  const branchDel =
+    branch && rem.status === 0
+      ? runGit(["branch", "-D", branch], root)
+      : { ok: false, stdout: "", stderr: "skip branch delete" };
+  return {
+    worktreeRemoved: rem.status === 0,
+    worktreeOut: (rem.stdout || rem.stderr || "").trim(),
+    branchDeleted: Boolean(branch && branchDel.ok),
+    branchOut: (branchDel.stdout || branchDel.stderr || "").trim(),
+  };
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  let root;
+  try {
+    root = resolveRoot(args.root);
+  } catch (e) {
+    const err = {
+      mode: args.dryRun ? "dry-run" : "live",
+      available: false,
+      error: (e).message,
+      decisions: [],
+      summary: summarizeDecisions([]),
+    };
+    if (args.json) {
+      console.log(JSON.stringify(err, null, 2));
+      process.exit(0); // schedule treats as unavailable, not hard fail
+    }
+    console.error(`  [fail]  ${err.error}`);
+    process.exit(1);
+  }
+
+  // Best-effort fetch so merge-base sees current main (skip when offline).
+  runGit(["fetch", "origin", "main", "--quiet"], root);
+
+  const entries = listWorktrees(root);
+  const prIndex = loadPrBranchIndex();
+  const leasePayload = loadLeasePaths();
+  const policy = args.tierAOnly ? "tier-a-only" : "all";
+  const decisions = [];
+  const removals = [];
+
+  for (const entry of entries) {
+    const facts = gatherFacts(root, entry, prIndex, leasePayload);
+    const { verdict, reason, tier } = classifyWorktree(facts, { graceDays: args.graceDays });
+    const row = {
+      path: facts.path,
+      branch: facts.branch,
+      verdict,
+      reason,
+      tier,
+      ageDays: facts.ageDays,
+      merged: facts.merged,
+      dirty: facts.dirty,
+    };
+    decisions.push(row);
+
+    if (!args.dryRun && isLiveReapEligible(policy, verdict)) {
+      const result = removeWorktree(root, facts.path, facts.branch);
+      removals.push({ path: facts.path, branch: facts.branch, ...result });
+    }
+  }
+
+  const summary = summarizeDecisions(decisions);
+  const report = {
+    mode: args.dryRun ? "dry-run" : "live",
+    available: true,
+    root,
+    graceDays: args.graceDays,
+    policy,
+    decisions,
+    summary,
+    removals: args.dryRun ? [] : removals,
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(0);
+  }
+
+  console.log(
+    `\nWorktree janitor — ${report.mode} (grace=${args.graceDays}d, policy=${policy})\n`,
+  );
+  for (const d of decisions) {
+    console.log(`  ${d.verdict.padEnd(12)} ${d.path}  (${d.reason})`);
+  }
+  console.log(
+    `\nSummary: TierA=${summary.counts.PRUNE_TIER_A} TierB=${summary.counts.PRUNE_TIER_B} ` +
+      `KEEP=${summary.counts.KEEP} SKIP=${summary.counts.SKIP} PINNED=${summary.counts.PINNED}`,
+  );
+  if (args.dryRun) console.log("\n(Dry run — nothing removed. Pass --live to prune.)\n");
+  process.exit(0);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}
+
+export { main };


### PR DESCRIPTION
## Summary

Responds to operator concern: **worktree reaping must not rely on a per-client or hard-to-see cron.**

### Answer: where does reaping run?

| Path | Where | Role |
|------|--------|------|
| **SessionStart / SessionEnd hooks** | On **each coding client** that loaded `dpf-platform` (Claude plugin hooks, Grok `~/.grok/hooks`, Codex hooks) | **PRIMARY** — transactional, per session |
| **ops/worktree-janitor Inngest** | **Portal server** (not CLI) | **OPTIONAL fleet backstop** for leftovers; flag-gated; may not see host worktrees |

There is **no** client-side cron to configure per install of Claude/Grok/Codex.

### Behavior
- **SessionStart:** observe worktree count / non-canonical path / already-merged branch
- **SessionEnd:** if **this** cwd is Tier-A (merged + clean + no open PR + not pinned) → junction-safe remove + branch -D
- Escape: `DPF_WORKTREE_SESSION_REAP=0`, `.worktree-pinned`, `DPF_SKIP_WORKTREE_SESSION_HYGIENE=1`

### Stack
Built on `feat/worktree-tier-a-reap` (#3597). Prefer merge #3597 first or merge this as the superseding head.

## Test plan
- [x] node hygiene + core tests
- [x] InstallGrokHooksTest session plane
- [x] Host dpf-guards updated with SessionEnd worktree-session-hygiene

Process-Spine-Decision: session lifecycle is primary; schedule demoted to backstop.

Docs-Impact-Decision: scheduled-jobs catalog purpose only.

UX-Fit-Decision: no UI.

Local-CI-Override: source-only worktree.