### PR TITLE
feat(build-studio): terminal sandbox worktree release + fleet GC

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -106,7 +106,7 @@ vi.mock("@/lib/integrate/sandbox/build-branch", () => ({
   startBuildBranch: mockStartBuildBranch,
   getClientIdentity: mockGetClientIdentity,
 }));
-
+vi.mock("@/lib/integrate/sandbox/sandbox-build-gc", () => ({ releaseSandboxForTerminalBuild: vi.fn() }));
 vi.mock("@/lib/build-review-verification-trigger", () => ({
   queueBuildReviewVerification: mockQueueBuildReviewVerification,
 }));

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -106,7 +106,7 @@ vi.mock("@/lib/integrate/sandbox/build-branch", () => ({
   startBuildBranch: mockStartBuildBranch,
   getClientIdentity: mockGetClientIdentity,
 }));
-vi.mock("@/lib/integrate/sandbox/sandbox-build-gc", () => ({ releaseSandboxForTerminalBuild: vi.fn() }));
+vi.mock("@/lib/integrate/sandbox/sandbox-build-gc", () => ({ releaseSandboxForTerminalBuild: vi.fn(async () => {}) }));
 vi.mock("@/lib/build-review-verification-trigger", () => ({
   queueBuildReviewVerification: mockQueueBuildReviewVerification,
 }));

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -1527,11 +1527,10 @@ export async function completeBuild(buildId: string): Promise<void> {
   await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
     console.error("[completeBuild] dependency readiness check failed:", err);
   });
-  // BI-8BD61C30: drop sandbox .builds/<id> when the build completes.
-  const { releaseSandboxForTerminalBuild } = await import(
-    "@/lib/integrate/sandbox/sandbox-build-gc"
-  );
-  await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
+  // BI-8BD61C30: drop sandbox .builds/<id> when the build completes (best-effort).
+  void import("@/lib/integrate/sandbox/sandbox-build-gc")
+    .then((m) => m.releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }))
+    .catch(() => {});
   revalidatePath("/build");
 }
 

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -1529,7 +1529,7 @@ export async function completeBuild(buildId: string): Promise<void> {
   });
   // BI-8BD61C30: drop sandbox .builds/<id> when the build completes.
   const { releaseSandboxForTerminalBuild } = await import(
-    "@/lib/integrate/sandbox/build-branch"
+    "@/lib/integrate/sandbox/sandbox-build-gc"
   );
   await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
   revalidatePath("/build");

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -1527,6 +1527,11 @@ export async function completeBuild(buildId: string): Promise<void> {
   await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
     console.error("[completeBuild] dependency readiness check failed:", err);
   });
+  // BI-8BD61C30: drop sandbox .builds/<id> when the build completes.
+  const { releaseSandboxForTerminalBuild } = await import(
+    "@/lib/integrate/sandbox/build-branch"
+  );
+  await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
   revalidatePath("/build");
 }
 

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -462,7 +462,7 @@ export async function reconcileBuildCompletion(buildId: string): Promise<boolean
   // BI-8BD61C30: release sandbox isolation worktree on complete (promote may
   // already have done this; teardown is idempotent).
   const { releaseSandboxForTerminalBuild } = await import(
-    "@/lib/integrate/sandbox/build-branch"
+    "@/lib/integrate/sandbox/sandbox-build-gc"
   );
   await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
 

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -459,6 +459,13 @@ export async function reconcileBuildCompletion(buildId: string): Promise<boolean
     console.error("[reconcileBuildCompletion] dependency readiness check failed:", err);
   });
 
+  // BI-8BD61C30: release sandbox isolation worktree on complete (promote may
+  // already have done this; teardown is idempotent).
+  const { releaseSandboxForTerminalBuild } = await import(
+    "@/lib/integrate/sandbox/build-branch"
+  );
+  await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
+
   // Emit phase:change so the UI updates without a full refresh. Dynamic
   // import keeps the event bus out of the cold-path module graph.
   try {

--- a/apps/web/lib/build/escalate-build-to-human.ts
+++ b/apps/web/lib/build/escalate-build-to-human.ts
@@ -219,7 +219,7 @@ export async function escalateBuildToHuman(args: EscalateBuildArgs): Promise<Esc
     wipFreed = true;
     // BI-8BD61C30: tear down isolation worktree when escalating (same as self-abandon).
     const { releaseSandboxForTerminalBuild } = await import(
-      "@/lib/integrate/sandbox/build-branch"
+      "@/lib/integrate/sandbox/sandbox-build-gc"
     );
     await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
   } catch (err) {

--- a/apps/web/lib/build/escalate-build-to-human.ts
+++ b/apps/web/lib/build/escalate-build-to-human.ts
@@ -217,6 +217,11 @@ export async function escalateBuildToHuman(args: EscalateBuildArgs): Promise<Esc
       },
     });
     wipFreed = true;
+    // BI-8BD61C30: tear down isolation worktree when escalating (same as self-abandon).
+    const { releaseSandboxForTerminalBuild } = await import(
+      "@/lib/integrate/sandbox/build-branch"
+    );
+    await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }).catch(() => {});
   } catch (err) {
     await safeLog(`Failed to abandon build to free WIP: ${String(err)}`.slice(0, 300));
   }

--- a/apps/web/lib/build/inert-build-reaper.ts
+++ b/apps/web/lib/build/inert-build-reaper.ts
@@ -228,7 +228,7 @@ export async function reapInertStuckBuilds(
       );
       // BI-8BD61C30: free sandbox .builds/<id> — inert reaper previously left worktrees behind.
       const { releaseSandboxForTerminalBuild } = await import(
-        "@/lib/integrate/sandbox/build-branch"
+        "@/lib/integrate/sandbox/sandbox-build-gc"
       );
       await releaseSandboxForTerminalBuild(c.buildId, { deleteBranch: false }).catch(() => {});
     } catch (err) {

--- a/apps/web/lib/build/inert-build-reaper.ts
+++ b/apps/web/lib/build/inert-build-reaper.ts
@@ -226,6 +226,11 @@ export async function reapInertStuckBuilds(
       console.warn(
         `[inert-build-reaper] reaped ${inert ? "inert" : "stalled"} build ${c.buildId} (${hoursOld}h old, phase=${c.phase}, last activity ${staleHours}h ago)`,
       );
+      // BI-8BD61C30: free sandbox .builds/<id> — inert reaper previously left worktrees behind.
+      const { releaseSandboxForTerminalBuild } = await import(
+        "@/lib/integrate/sandbox/build-branch"
+      );
+      await releaseSandboxForTerminalBuild(c.buildId, { deleteBranch: false }).catch(() => {});
     } catch (err) {
       console.warn(`[inert-build-reaper] failed to reap build ${c.buildId}:`, err);
     }

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -698,16 +698,40 @@ async function provisionBuildWorktree(args: {
 }
 
 /**
- * Tear down a build's worktree (isolation-ON cleanup on promote/abandon).
+ * Tear down a build's worktree (isolation-ON cleanup on promote/abandon/terminal).
  * Best-effort — the symlinked node_modules are not real files so removal never
  * touches the shared install, and a missing worktree is not an error.
+ * Exported for BI-8BD61C30 so every terminal path can share one cleanup door.
  */
-async function teardownBuildWorktree(buildId: string): Promise<void> {
+export async function teardownBuildWorktree(buildId: string): Promise<void> {
+  if (!isBuildWorktreeIsolationEnabled()) return;
   await execSandboxGit(buildSandboxWorktreeRemoveCommand(buildId)).catch((err) => {
     console.warn(
       `[build-branch] worktree teardown skipped (non-fatal): ${(err as Error).message?.slice(0, 200)}`,
     );
   });
+}
+
+/**
+ * Release sandbox disk for a terminal FeatureBuild (BI-8BD61C30).
+ * Always tears down `.builds/<buildId>` when isolation is on.
+ * Optionally deletes `build/<buildId>` (use after promote; abandon keeps branch for audit).
+ */
+export async function releaseSandboxForTerminalBuild(
+  buildId: string,
+  options?: { deleteBranch?: boolean },
+): Promise<void> {
+  await teardownBuildWorktree(buildId);
+  if (options?.deleteBranch) {
+    const branch = `build/${buildId}`;
+    await execSandboxGit(
+      `cd ${WORKSPACE} && git branch -D "${branch}" 2>/dev/null || true`,
+    ).catch((err) => {
+      console.warn(
+        `[build-branch] branch delete skipped for ${branch}: ${(err as Error).message?.slice(0, 160)}`,
+      );
+    });
+  }
 }
 
 /**
@@ -917,11 +941,9 @@ export async function promoteBuildBranch(buildId: string): Promise<void> {
     ].join(" && "),
   );
 
-  // Isolation ON: the merge reads build/<id> from git regardless of which tree
-  // holds it, so the now-merged worktree can be torn down.
-  if (isBuildWorktreeIsolationEnabled()) {
-    await teardownBuildWorktree(buildId);
-  }
+  // Isolation ON: tear down worktree; branch is already merged into client/* so
+  // delete build/<id> to stop branch-list growth (BI-8BD61C30).
+  await releaseSandboxForTerminalBuild(buildId, { deleteBranch: true });
 
   console.log(`[build-branch] Promoted ${branchName} → ${identity.clientBranch}`);
 }
@@ -933,12 +955,8 @@ export async function promoteBuildBranch(buildId: string): Promise<void> {
 export async function abandonBuildBranch(buildId: string): Promise<void> {
   const identity = await getClientIdentity();
   try {
-    // Isolation ON: the build lived in its own worktree, so /workspace is
-    // already on the client branch (checkout is a harmless no-op) — just drop
-    // the worktree. The branch itself is preserved in git for audit/recovery.
-    if (isBuildWorktreeIsolationEnabled()) {
-      await teardownBuildWorktree(buildId);
-    }
+    // Drop isolation worktree; keep build/<id> branch for audit/recovery.
+    await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false });
     await execSandboxGit(
       `cd ${WORKSPACE} && git checkout "${identity.clientBranch}"`,
     );

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -701,7 +701,7 @@ async function provisionBuildWorktree(args: {
  * Tear down a build's worktree (isolation-ON cleanup on promote/abandon/terminal).
  * Best-effort — the symlinked node_modules are not real files so removal never
  * touches the shared install, and a missing worktree is not an error.
- * Exported for BI-8BD61C30 so every terminal path can share one cleanup door.
+ * Exported for BI-8BD61C30 (releaseSandboxForTerminalBuild in sandbox-build-gc.ts).
  */
 export async function teardownBuildWorktree(buildId: string): Promise<void> {
   if (!isBuildWorktreeIsolationEnabled()) return;
@@ -710,28 +710,6 @@ export async function teardownBuildWorktree(buildId: string): Promise<void> {
       `[build-branch] worktree teardown skipped (non-fatal): ${(err as Error).message?.slice(0, 200)}`,
     );
   });
-}
-
-/**
- * Release sandbox disk for a terminal FeatureBuild (BI-8BD61C30).
- * Always tears down `.builds/<buildId>` when isolation is on.
- * Optionally deletes `build/<buildId>` (use after promote; abandon keeps branch for audit).
- */
-export async function releaseSandboxForTerminalBuild(
-  buildId: string,
-  options?: { deleteBranch?: boolean },
-): Promise<void> {
-  await teardownBuildWorktree(buildId);
-  if (options?.deleteBranch) {
-    const branch = `build/${buildId}`;
-    await execSandboxGit(
-      `cd ${WORKSPACE} && git branch -D "${branch}" 2>/dev/null || true`,
-    ).catch((err) => {
-      console.warn(
-        `[build-branch] branch delete skipped for ${branch}: ${(err as Error).message?.slice(0, 160)}`,
-      );
-    });
-  }
 }
 
 /**
@@ -941,8 +919,10 @@ export async function promoteBuildBranch(buildId: string): Promise<void> {
     ].join(" && "),
   );
 
-  // Isolation ON: tear down worktree; branch is already merged into client/* so
-  // delete build/<id> to stop branch-list growth (BI-8BD61C30).
+  // Tear down isolation worktree; branch already merged into client/* so drop it
+  // (BI-8BD61C30). releaseSandboxForTerminalBuild lives in sandbox-build-gc to
+  // keep this module under the size ratchet.
+  const { releaseSandboxForTerminalBuild } = await import("./sandbox-build-gc");
   await releaseSandboxForTerminalBuild(buildId, { deleteBranch: true });
 
   console.log(`[build-branch] Promoted ${branchName} → ${identity.clientBranch}`);
@@ -956,7 +936,7 @@ export async function abandonBuildBranch(buildId: string): Promise<void> {
   const identity = await getClientIdentity();
   try {
     // Drop isolation worktree; keep build/<id> branch for audit/recovery.
-    await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false });
+    await teardownBuildWorktree(buildId);
     await execSandboxGit(
       `cd ${WORKSPACE} && git checkout "${identity.clientBranch}"`,
     );

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -925,7 +925,8 @@ export async function promoteBuildBranch(buildId: string): Promise<void> {
   const { releaseSandboxForTerminalBuild } = await import("./sandbox-build-gc");
   await releaseSandboxForTerminalBuild(buildId, { deleteBranch: true });
 
-  console.log(`[build-branch] Promoted ${branchName} → ${identity.clientBranch}`);
+  // Avoid logging request-scoped ids (CodeQL js/log-injection).
+  console.log("[build-branch] Promoted build branch into client branch");
 }
 
 /**
@@ -940,7 +941,7 @@ export async function abandonBuildBranch(buildId: string): Promise<void> {
     await execSandboxGit(
       `cd ${WORKSPACE} && git checkout "${identity.clientBranch}"`,
     );
-    console.log(`[build-branch] Abandoned build/${buildId} — back on ${identity.clientBranch}`);
+    console.log("[build-branch] Abandoned build — sandbox worktree released");
   } catch (err) {
     console.warn(`[build-branch] abandon failed (non-fatal): ${(err as Error).message?.slice(0, 100)}`);
   }

--- a/apps/web/lib/integrate/sandbox/sandbox-build-gc.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-build-gc.test.ts
@@ -10,6 +10,12 @@ import {
 } from "./sandbox-build-gc";
 
 describe("sandbox-build-gc pure rules (BI-8BD61C30)", () => {
+  it("assertSafeBuildId accepts FB- ids and rejects shell metacharacters", async () => {
+    const { assertSafeBuildId } = await import("./sandbox-build-gc");
+    expect(assertSafeBuildId("FB-ADA4BA8F")).toBe("FB-ADA4BA8F");
+    expect(() => assertSafeBuildId("evil;rm -rf /")).toThrow(/invalid buildId/);
+  });
+
   it("gc worktree dir for missing and terminal phases only", () => {
     expect(shouldGcSandboxWorktreeDir(null)).toBe(true);
     expect(shouldGcSandboxWorktreeDir("complete")).toBe(true);

--- a/apps/web/lib/integrate/sandbox/sandbox-build-gc.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-build-gc.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseBuildBranchIds,
+  parseBuildWorktreeDirNames,
+  runSandboxBuildGc,
+  shouldGcSandboxBuildBranch,
+  shouldGcSandboxWorktreeDir,
+  SANDBOX_BUILD_GC_ENABLED_FLAG,
+  SANDBOX_BUILD_GC_DELETE_BRANCHES_FLAG,
+} from "./sandbox-build-gc";
+
+describe("sandbox-build-gc pure rules (BI-8BD61C30)", () => {
+  it("gc worktree dir for missing and terminal phases only", () => {
+    expect(shouldGcSandboxWorktreeDir(null)).toBe(true);
+    expect(shouldGcSandboxWorktreeDir("complete")).toBe(true);
+    expect(shouldGcSandboxWorktreeDir("failed")).toBe(true);
+    expect(shouldGcSandboxWorktreeDir("abandoned")).toBe(true);
+    expect(shouldGcSandboxWorktreeDir("build")).toBe(false);
+    expect(shouldGcSandboxWorktreeDir("ideate")).toBe(false);
+  });
+
+  it("gc build branch only for aged terminal builds", () => {
+    const now = new Date("2026-07-26T00:00:00Z");
+    const grace = 7 * 86400_000;
+    expect(
+      shouldGcSandboxBuildBranch({
+        phase: "complete",
+        updatedAt: new Date("2026-07-01T00:00:00Z"),
+        now,
+        graceMs: grace,
+      }),
+    ).toBe(true);
+    expect(
+      shouldGcSandboxBuildBranch({
+        phase: "complete",
+        updatedAt: new Date("2026-07-25T00:00:00Z"),
+        now,
+        graceMs: grace,
+      }),
+    ).toBe(false);
+    expect(
+      shouldGcSandboxBuildBranch({
+        phase: "build",
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        now,
+        graceMs: grace,
+      }),
+    ).toBe(false);
+  });
+
+  it("parses .builds dir names and build/* branches", () => {
+    expect(parseBuildWorktreeDirNames("FB-ADA4BA8F\nFB-6AF43DEB\n.smoke-check\n")).toEqual([
+      "FB-ADA4BA8F",
+      "FB-6AF43DEB",
+    ]);
+    expect(parseBuildBranchIds("  build/FB-1\n* build/FB-2\n  main\n")).toEqual(["FB-1", "FB-2"]);
+  });
+});
+
+describe("runSandboxBuildGc", () => {
+  it("skips when flag off", async () => {
+    const result = await runSandboxBuildGc({ env: {} });
+    expect(result.skipped).toBe(true);
+  });
+
+  it("removes terminal/orphan worktrees and keeps active", async () => {
+    const removeWorktree = vi.fn(async () => {});
+    const deleteBranch = vi.fn(async () => {});
+    const result = await runSandboxBuildGc({
+      env: { [SANDBOX_BUILD_GC_ENABLED_FLAG]: "1" },
+      sandboxUp: async () => true,
+      listWorktreeDirs: async () => ["FB-OLD", "FB-LIVE", "FB-ORPHAN"],
+      listBuildBranches: async () => ["FB-OLD", "FB-LIVE"],
+      lookupPhases: async () =>
+        new Map([
+          ["FB-OLD", { phase: "complete", updatedAt: new Date("2026-01-01") }],
+          ["FB-LIVE", { phase: "build", updatedAt: new Date() }],
+        ]),
+      removeWorktree,
+      deleteBranch,
+      now: new Date("2026-07-26"),
+    });
+    expect(result.skipped).toBe(false);
+    expect(result.worktreesRemoved.sort()).toEqual(["FB-OLD", "FB-ORPHAN"].sort());
+    expect(result.keptActive).toEqual(["FB-LIVE"]);
+    expect(deleteBranch).not.toHaveBeenCalled(); // branch delete flag off
+    expect(removeWorktree).toHaveBeenCalledTimes(2);
+  });
+
+  it("deletes aged terminal branches when branch flag on", async () => {
+    const deleteBranch = vi.fn(async () => {});
+    const result = await runSandboxBuildGc({
+      env: {
+        [SANDBOX_BUILD_GC_ENABLED_FLAG]: "1",
+        [SANDBOX_BUILD_GC_DELETE_BRANCHES_FLAG]: "1",
+      },
+      sandboxUp: async () => true,
+      listWorktreeDirs: async () => [],
+      listBuildBranches: async () => ["FB-AGED", "FB-FRESH"],
+      lookupPhases: async () =>
+        new Map([
+          ["FB-AGED", { phase: "abandoned", updatedAt: new Date("2026-01-01") }],
+          ["FB-FRESH", { phase: "complete", updatedAt: new Date("2026-07-25") }],
+        ]),
+      removeWorktree: async () => {},
+      deleteBranch,
+      now: new Date("2026-07-26"),
+    });
+    expect(result.branchesDeleted).toEqual(["FB-AGED"]);
+    expect(deleteBranch).toHaveBeenCalledWith("FB-AGED");
+  });
+});

--- a/apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
@@ -1,0 +1,258 @@
+// apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
+//
+// BI-8BD61C30 — Build Studio sandbox disk GC for leftover isolation worktrees
+// and aged build/* branches.
+//
+// PRIMARY cleanup is transactional: releaseSandboxForTerminalBuild on promote /
+// abandon / complete / fail / inert-reap / escalate. This module is the
+// FLEET BACKSTOP for leftovers when those paths were skipped (crash mid-flight).
+//
+// Lives in the portal process and docker-execs into dpf-sandbox-1 — not a host
+// CLI session hook.
+
+import { prisma } from "@dpf/db";
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+import {
+  BUILD_WORKTREE_ROOT_SEGMENT,
+  buildSandboxWorktreeRemoveCommand,
+  isBuildWorktreeIsolationEnabled,
+  releaseSandboxForTerminalBuild,
+} from "./build-branch";
+import { execInSandbox, isSandboxRunning } from "./sandbox";
+
+const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
+const WORKSPACE = "/workspace";
+
+/** Master switch for the scheduled GC (default OFF). */
+export const SANDBOX_BUILD_GC_ENABLED_FLAG = "DPF_SANDBOX_BUILD_GC_ENABLED";
+
+/**
+ * When set with ENABLED, GC also deletes aged terminal build/* branches.
+ * Worktree dirs for terminal/orphan builds are always removed when ENABLED.
+ */
+export const SANDBOX_BUILD_GC_DELETE_BRANCHES_FLAG = "DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES";
+
+/** Default 7d before terminal build/* branches are deleted by GC. */
+export const SANDBOX_BUILD_BRANCH_GRACE_MS =
+  Number(process.env.DPF_SANDBOX_BUILD_BRANCH_GRACE_MS) || 7 * 24 * 60 * 60 * 1000;
+
+export const TERMINAL_SANDBOX_PHASES = ["complete", "failed", "abandoned"] as const;
+
+export function isTerminalSandboxPhase(phase: string | null | undefined): boolean {
+  if (!phase) return false;
+  return (TERMINAL_SANDBOX_PHASES as readonly string[]).includes(phase);
+}
+
+/**
+ * Pure: should the isolation worktree dir for this build be removed?
+ * - no FeatureBuild row → orphan dir → yes
+ * - terminal phase → yes
+ * - active non-terminal → no
+ */
+export function shouldGcSandboxWorktreeDir(phase: string | null): boolean {
+  if (phase === null) return true;
+  return isTerminalSandboxPhase(phase);
+}
+
+/**
+ * Pure: should the git branch build/<id> be deleted by the fleet GC?
+ * Only terminal builds older than graceMs (audit retention window).
+ */
+export function shouldGcSandboxBuildBranch(args: {
+  phase: string | null;
+  updatedAt: Date | null;
+  now: Date;
+  graceMs: number;
+}): boolean {
+  if (!args.phase || !isTerminalSandboxPhase(args.phase)) return false;
+  if (!args.updatedAt) return false;
+  return args.now.getTime() - args.updatedAt.getTime() >= args.graceMs;
+}
+
+/** Parse `ls` of .builds — only FB-* style build ids. */
+export function parseBuildWorktreeDirNames(lsOutput: string): string[] {
+  return lsOutput
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => /^FB-[A-Za-z0-9_-]+$/i.test(s) || /^[A-Za-z0-9][A-Za-z0-9_-]{3,}$/.test(s));
+}
+
+/** Parse `git branch` lines for build/* names → buildId. */
+export function parseBuildBranchIds(branchListOutput: string): string[] {
+  const ids: string[] = [];
+  for (const line of branchListOutput.split(/\r?\n/)) {
+    const m = line.trim().replace(/^\*\s*/, "").match(/^build\/(.+)$/);
+    if (m?.[1]) ids.push(m[1]);
+  }
+  return ids;
+}
+
+export type SandboxBuildGcResult = {
+  skipped: boolean;
+  reason?: string;
+  worktreesRemoved: string[];
+  branchesDeleted: string[];
+  keptActive: string[];
+};
+
+export type RunSandboxBuildGcOptions = {
+  env?: Record<string, string | undefined>;
+  now?: Date;
+  /** Injectable for tests */
+  listWorktreeDirs?: () => Promise<string[]>;
+  listBuildBranches?: () => Promise<string[]>;
+  lookupPhases?: (
+    buildIds: string[],
+  ) => Promise<Map<string, { phase: string; updatedAt: Date }>>;
+  removeWorktree?: (buildId: string) => Promise<void>;
+  deleteBranch?: (buildId: string) => Promise<void>;
+  sandboxUp?: () => Promise<boolean>;
+};
+
+async function defaultListWorktreeDirs(): Promise<string[]> {
+  const out = await execInSandbox(
+    SANDBOX_CONTAINER,
+    `ls -1 ${WORKSPACE}/${BUILD_WORKTREE_ROOT_SEGMENT} 2>/dev/null || true`,
+  );
+  return parseBuildWorktreeDirNames(out);
+}
+
+async function defaultListBuildBranches(): Promise<string[]> {
+  const out = await execInSandbox(
+    SANDBOX_CONTAINER,
+    `git -C ${WORKSPACE} branch --list 'build/*' 2>/dev/null || true`,
+  );
+  return parseBuildBranchIds(out);
+}
+
+async function defaultLookupPhases(
+  buildIds: string[],
+): Promise<Map<string, { phase: string; updatedAt: Date }>> {
+  const map = new Map<string, { phase: string; updatedAt: Date }>();
+  if (buildIds.length === 0) return map;
+  const rows = await prisma.featureBuild.findMany({
+    where: { buildId: { in: buildIds } },
+    select: { buildId: true, phase: true, updatedAt: true },
+  });
+  for (const r of rows) {
+    map.set(r.buildId, { phase: r.phase, updatedAt: r.updatedAt });
+  }
+  return map;
+}
+
+/**
+ * Fleet backstop GC. Flag-gated. Never touches non-terminal active builds.
+ */
+export async function runSandboxBuildGc(
+  options: RunSandboxBuildGcOptions = {},
+): Promise<SandboxBuildGcResult> {
+  const env = options.env ?? process.env;
+  if (!envFlagEnabled(env, SANDBOX_BUILD_GC_ENABLED_FLAG)) {
+    return {
+      skipped: true,
+      reason: `disabled (${SANDBOX_BUILD_GC_ENABLED_FLAG} not set)`,
+      worktreesRemoved: [],
+      branchesDeleted: [],
+      keptActive: [],
+    };
+  }
+
+  const sandboxUp = options.sandboxUp ?? (() => isSandboxRunning(SANDBOX_CONTAINER));
+  if (!(await sandboxUp())) {
+    return {
+      skipped: true,
+      reason: `sandbox ${SANDBOX_CONTAINER} not running`,
+      worktreesRemoved: [],
+      branchesDeleted: [],
+      keptActive: [],
+    };
+  }
+
+  if (!isBuildWorktreeIsolationEnabled() && !envFlagEnabled(env, SANDBOX_BUILD_GC_DELETE_BRANCHES_FLAG)) {
+    // Still allow branch-only GC when isolation is off.
+  }
+
+  const now = options.now ?? new Date();
+  const listDirs = options.listWorktreeDirs ?? defaultListWorktreeDirs;
+  const listBranches = options.listBuildBranches ?? defaultListBuildBranches;
+  const lookup = options.lookupPhases ?? defaultLookupPhases;
+  const removeWorktree =
+    options.removeWorktree ??
+    (async (buildId: string) => {
+      await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false });
+    });
+  const deleteBranch =
+    options.deleteBranch ??
+    (async (buildId: string) => {
+      await execInSandbox(
+        SANDBOX_CONTAINER,
+        `git -C ${WORKSPACE} branch -D "build/${buildId}" 2>/dev/null || true`,
+      );
+    });
+
+  const dirIds = await listDirs().catch(() => [] as string[]);
+  const branchIds = await listBranches().catch(() => [] as string[]);
+  const allIds = [...new Set([...dirIds, ...branchIds])];
+  const phases = await lookup(allIds);
+
+  const worktreesRemoved: string[] = [];
+  const branchesDeleted: string[] = [];
+  const keptActive: string[] = [];
+  const deleteBranches = envFlagEnabled(env, SANDBOX_BUILD_GC_DELETE_BRANCHES_FLAG);
+  const graceMs = SANDBOX_BUILD_BRANCH_GRACE_MS;
+
+  for (const buildId of dirIds) {
+    const row = phases.get(buildId);
+    const phase = row?.phase ?? null;
+    if (!shouldGcSandboxWorktreeDir(phase)) {
+      keptActive.push(buildId);
+      continue;
+    }
+    try {
+      await removeWorktree(buildId);
+      worktreesRemoved.push(buildId);
+      console.warn(`[sandbox-build-gc] removed worktree .builds/${buildId} (phase=${phase ?? "missing"})`);
+    } catch (err) {
+      console.warn(
+        `[sandbox-build-gc] worktree remove failed for ${buildId}: ${(err as Error).message?.slice(0, 160)}`,
+      );
+    }
+  }
+
+  if (deleteBranches) {
+    for (const buildId of branchIds) {
+      const row = phases.get(buildId);
+      if (
+        !shouldGcSandboxBuildBranch({
+          phase: row?.phase ?? null,
+          updatedAt: row?.updatedAt ?? null,
+          now,
+          graceMs,
+        })
+      ) {
+        continue;
+      }
+      try {
+        await deleteBranch(buildId);
+        branchesDeleted.push(buildId);
+        console.warn(`[sandbox-build-gc] deleted branch build/${buildId}`);
+      } catch (err) {
+        console.warn(
+          `[sandbox-build-gc] branch delete failed for ${buildId}: ${(err as Error).message?.slice(0, 160)}`,
+        );
+      }
+    }
+  }
+
+  const result: SandboxBuildGcResult = {
+    skipped: false,
+    worktreesRemoved,
+    branchesDeleted,
+    keptActive,
+  };
+  console.warn(`[sandbox-build-gc] summary: ${JSON.stringify(result)}`);
+  return result;
+}
+
+// Re-export for callers that only need the command builder path.
+export { buildSandboxWorktreeRemoveCommand };

--- a/apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
@@ -14,14 +14,37 @@ import { prisma } from "@dpf/db";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 import {
   BUILD_WORKTREE_ROOT_SEGMENT,
-  buildSandboxWorktreeRemoveCommand,
   isBuildWorktreeIsolationEnabled,
-  releaseSandboxForTerminalBuild,
+  teardownBuildWorktree,
 } from "./build-branch";
 import { execInSandbox, isSandboxRunning } from "./sandbox";
 
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const WORKSPACE = "/workspace";
+
+/**
+ * Release sandbox disk for a terminal FeatureBuild (BI-8BD61C30).
+ * Always tears down `.builds/<buildId>` when isolation is on.
+ * Optionally deletes `build/<buildId>` (use after promote; abandon keeps branch for audit).
+ * Lives here (not build-branch.ts) so the module-size ratchet on build-branch stays green.
+ */
+export async function releaseSandboxForTerminalBuild(
+  buildId: string,
+  options?: { deleteBranch?: boolean },
+): Promise<void> {
+  await teardownBuildWorktree(buildId);
+  if (options?.deleteBranch) {
+    const branch = `build/${buildId}`;
+    await execInSandbox(
+      SANDBOX_CONTAINER,
+      `git -C ${WORKSPACE} branch -D "${branch}" 2>/dev/null || true`,
+    ).catch((err) => {
+      console.warn(
+        `[sandbox-build-gc] branch delete skipped for ${branch}: ${(err as Error).message?.slice(0, 160)}`,
+      );
+    });
+  }
+}
 
 /** Master switch for the scheduled GC (default OFF). */
 export const SANDBOX_BUILD_GC_ENABLED_FLAG = "DPF_SANDBOX_BUILD_GC_ENABLED";
@@ -179,7 +202,7 @@ export async function runSandboxBuildGc(
   const removeWorktree =
     options.removeWorktree ??
     (async (buildId: string) => {
-      await releaseSandboxForTerminalBuild(buildId, { deleteBranch: false });
+      await teardownBuildWorktree(buildId);
     });
   const deleteBranch =
     options.deleteBranch ??
@@ -254,5 +277,3 @@ export async function runSandboxBuildGc(
   return result;
 }
 
-// Re-export for callers that only need the command builder path.
-export { buildSandboxWorktreeRemoveCommand };

--- a/apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-build-gc.ts
@@ -12,6 +12,7 @@
 
 import { prisma } from "@dpf/db";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
+import { sanitizeForLog } from "@/lib/security/safe-log";
 import {
   BUILD_WORKTREE_ROOT_SEGMENT,
   isBuildWorktreeIsolationEnabled,
@@ -28,19 +29,30 @@ const WORKSPACE = "/workspace";
  * Optionally deletes `build/<buildId>` (use after promote; abandon keeps branch for audit).
  * Lives here (not build-branch.ts) so the module-size ratchet on build-branch stays green.
  */
+/** Reject shell-metacharacters so buildId is safe in git/docker argv fragments. */
+export function assertSafeBuildId(buildId: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{2,64}$/.test(buildId)) {
+    throw new Error("invalid buildId for sandbox cleanup");
+  }
+  return buildId;
+}
+
 export async function releaseSandboxForTerminalBuild(
   buildId: string,
   options?: { deleteBranch?: boolean },
 ): Promise<void> {
-  await teardownBuildWorktree(buildId);
+  const safeId = assertSafeBuildId(buildId);
+  await teardownBuildWorktree(safeId);
   if (options?.deleteBranch) {
-    const branch = `build/${buildId}`;
+    const branch = `build/${safeId}`;
     await execInSandbox(
       SANDBOX_CONTAINER,
       `git -C ${WORKSPACE} branch -D "${branch}" 2>/dev/null || true`,
     ).catch((err) => {
       console.warn(
-        `[sandbox-build-gc] branch delete skipped for ${branch}: ${(err as Error).message?.slice(0, 160)}`,
+        "[sandbox-build-gc] branch delete skipped for %s: %s",
+        sanitizeForLog(branch),
+        sanitizeForLog((err as Error).message?.slice(0, 160) ?? ""),
       );
     });
   }
@@ -234,10 +246,16 @@ export async function runSandboxBuildGc(
     try {
       await removeWorktree(buildId);
       worktreesRemoved.push(buildId);
-      console.warn(`[sandbox-build-gc] removed worktree .builds/${buildId} (phase=${phase ?? "missing"})`);
+      console.warn(
+        "[sandbox-build-gc] removed worktree .builds/%s (phase=%s)",
+        sanitizeForLog(buildId),
+        sanitizeForLog(phase ?? "missing"),
+      );
     } catch (err) {
       console.warn(
-        `[sandbox-build-gc] worktree remove failed for ${buildId}: ${(err as Error).message?.slice(0, 160)}`,
+        "[sandbox-build-gc] worktree remove failed for %s: %s",
+        sanitizeForLog(buildId),
+        sanitizeForLog((err as Error).message?.slice(0, 160) ?? ""),
       );
     }
   }
@@ -258,10 +276,12 @@ export async function runSandboxBuildGc(
       try {
         await deleteBranch(buildId);
         branchesDeleted.push(buildId);
-        console.warn(`[sandbox-build-gc] deleted branch build/${buildId}`);
+        console.warn("[sandbox-build-gc] deleted branch build/%s", sanitizeForLog(buildId));
       } catch (err) {
         console.warn(
-          `[sandbox-build-gc] branch delete failed for ${buildId}: ${(err as Error).message?.slice(0, 160)}`,
+          "[sandbox-build-gc] branch delete failed for %s: %s",
+          sanitizeForLog(buildId),
+          sanitizeForLog((err as Error).message?.slice(0, 160) ?? ""),
         );
       }
     }

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -217,6 +217,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "sandbox-build-gc",
+    inngestId: "ops/sandbox-build-gc",
+    name: "Build Studio sandbox build GC",
+    purpose:
+      "Backstop: removes leftover /workspace/.builds/<FB-*> for terminal or missing FeatureBuilds; optional aged build/* branch delete when DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES=1. Primary cleanup is transactional on promote/abandon/complete. Enable with DPF_SANDBOX_BUILD_GC_ENABLED=1.",
+    cron: "50 5 * * *",
+    cadence: "Daily at 05:50",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "infra-prune",
     inngestId: "ops/infra-prune",
     name: "Infrastructure prune",

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -51,6 +51,7 @@ import {
 } from "./postgres-daily-backup";
 import { runtimeTargetJanitor } from "./runtime-target-janitor";
 import { runtimeArtifactJanitor } from "./runtime-artifact-janitor";
+import { sandboxBuildGc } from "./sandbox-build-gc";
 import {
   dataRetentionSweepScheduled,
   dataRetentionSweepRequested,
@@ -122,6 +123,7 @@ export const scheduledFunctions = [
   selfUpgradeScheduled,
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   runtimeArtifactJanitor, // BI-DBF3F426: OBSERVE-ONLY dry-run scan of orphaned CI images + stray compose projects (logs would-reap, never deletes; --apply is founder-gated), daily 05:20, flag-gated DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED
+  sandboxBuildGc, // BI-8BD61C30: BS sandbox .builds worktree + aged build/* branch GC (flag DPF_SANDBOX_BUILD_GC_ENABLED), daily 05:50
   dataRetentionSweepScheduled, // EP-DATA-RETENTION: daily DB purge of aged logs/telemetry/chat, 04:00
   qualityIssueDriftSweepScheduled, // BI-0B420A1D: runtime governance — self-heal recovery/orphan backstop + detect per-type open-count drift vs registry budgets, daily 05:00
 

--- a/apps/web/lib/queue/functions/sandbox-build-gc.ts
+++ b/apps/web/lib/queue/functions/sandbox-build-gc.ts
@@ -1,0 +1,20 @@
+// BI-8BD61C30 — scheduled fleet backstop for Build Studio sandbox .builds worktrees.
+//
+// Primary cleanup is transactional (releaseSandboxForTerminalBuild on terminal
+// FeatureBuild transitions). This job sweeps leftovers after crashes.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { runSandboxBuildGc } from "@/lib/integrate/sandbox/sandbox-build-gc";
+
+export const sandboxBuildGc = inngest.createFunction(
+  {
+    id: "ops/sandbox-build-gc",
+    retries: 1,
+    // After host worktree backstop (05:40) — sandbox disk hygiene.
+    triggers: [cron("50 5 * * *")],
+  },
+  async ({ step }) => {
+    return await step.run("sandbox-build-gc", () => runSandboxBuildGc());
+  },
+);


### PR DESCRIPTION
## Summary

**BI-8BD61C30** — stop Build Studio sandbox disk growth from leftover isolation worktrees and `build/*` branches.

Host SessionEnd hygiene does **not** apply inside BS. Live evidence showed leftover `.builds/FB-*` and ~29 `build/FB-*` branches plus multi-GB Docker images.

### Transactional (primary)
| Terminal path | Worktree | Branch |
|---------------|----------|--------|
| promote | remove | delete `build/<id>` |
| abandon / self-abandon | remove | keep (audit) |
| complete (`completeBuild`, `reconcileBuildCompletion`) | remove | keep |
| inert/stalled reaper | remove | keep |
| escalate-to-human | remove | keep |

API: `releaseSandboxForTerminalBuild(buildId, { deleteBranch? })`.

### Fleet backstop
`ops/sandbox-build-gc` @ 05:50:
- Enable: `DPF_SANDBOX_BUILD_GC_ENABLED=1`
- Optional branch prune: `DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES=1` (7d grace)

### Not in this PR
Docker local-integration image reclaim (BI-DBF3F426 observe-only).

## Test plan
- [x] Pure GC rules unit tests in `sandbox-build-gc.test.ts`
- [ ] CI Unit Tests / typecheck
- [ ] After merge: enable GC flag; confirm leftover `.builds/FB-ADA4BA8F` removed on next run or manual invoke

Process-Spine-Decision: BI-8BD61C30 transactional + backstop.

Docs-Impact-Decision: catalog only.

UX-Fit-Decision: no UI.

Local-CI-Override: source-only worktree.