### PR TITLE
feat: enforce evidence-earned backlog completion

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -975,15 +975,10 @@ export async function register() {
     // kernel (principle_decide) is gated. Registration is in-memory + idempotent
     // (deduped by hook id); mode is DPF_DECISION_GATE_MODE (enforce default).
     {
-      const { registerToolLifecycleHook } = await import("@/lib/mcp-governed-execute");
-      const { createDecisionRoutingGovernanceHook } = await import(
-        "@/lib/tak/decision-routing-governance-hook"
+      const { registerServerToolGovernanceHooks } = await import(
+        "@/lib/governance/register-tool-governance-hooks"
       );
-      const { createCompletionEvidenceGovernanceHook } = await import(
-        "@/lib/backlog/completion-evidence-governance-hook"
-      );
-      registerToolLifecycleHook(createDecisionRoutingGovernanceHook());
-      registerToolLifecycleHook(createCompletionEvidenceGovernanceHook());
+      registerServerToolGovernanceHooks();
     }
 
     // Mirror version.json into PlatformConfig["platform.version"] so the

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -979,7 +979,11 @@ export async function register() {
       const { createDecisionRoutingGovernanceHook } = await import(
         "@/lib/tak/decision-routing-governance-hook"
       );
+      const { createCompletionEvidenceGovernanceHook } = await import(
+        "@/lib/backlog/completion-evidence-governance-hook"
+      );
       registerToolLifecycleHook(createDecisionRoutingGovernanceHook());
+      registerToolLifecycleHook(createCompletionEvidenceGovernanceHook());
     }
 
     // Mirror version.json into PlatformConfig["platform.version"] so the

--- a/apps/web/lib/backlog/completion-evidence-governance-hook.test.ts
+++ b/apps/web/lib/backlog/completion-evidence-governance-hook.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/attention/notify-live", () => ({ notifyAttentionLive: vi.fn() }));
+
+import {
+  createCompletionEvidenceGovernanceHook,
+  isAgentCompletionRequest,
+  resolveCompletionEvidenceGateMode,
+} from "./completion-evidence-governance-hook";
+import type { ToolLifecycleEvent } from "@/lib/mcp-governed-execute";
+
+function event(
+  source: ToolLifecycleEvent["source"] = "external-jsonrpc",
+  rawParams: Record<string, unknown> = { itemId: "BI-1", status: "done" },
+): ToolLifecycleEvent {
+  return {
+    toolName: "update_backlog_item_status",
+    rawParams,
+    userId: "user-1",
+    userContext: { userId: "user-1", isSuperuser: true, platformRole: null },
+    context: {
+      agentId: "agent-1",
+      apiTokenId: "token-1",
+      callerClient: "antigravity/2.3.1",
+    },
+    source,
+  };
+}
+
+function deniedVerdict() {
+  return {
+    kind: "evaluated" as const,
+    item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "feature" },
+    verdict: {
+      allowed: false,
+      noOp: false,
+      normalizedManifest: null,
+      blockers: [
+        {
+          code: "missing-manifest" as const,
+          message: "completion manifest missing",
+          dimension: "manifest" as const,
+        },
+      ],
+      nextAction: "record evidence",
+    },
+  };
+}
+
+function allowedVerdict() {
+  return {
+    kind: "evaluated" as const,
+    item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "feature" },
+    verdict: {
+      allowed: true,
+      noOp: false,
+      normalizedManifest: {
+        workClass: "implementation" as const,
+        evidenceActivityIds: ["e1"],
+        useActiveBuildEvidence: false,
+        ux: { disposition: "not-applicable" as const, reason: "No user interface files changed." },
+        migration: { disposition: "not-applicable" as const, reason: "No database schema changed." },
+      },
+      blockers: [],
+      nextAction: null,
+    },
+  };
+}
+
+describe("completion evidence governance hook", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("governs every agent execution surface but not direct operator REST", () => {
+    for (const source of ["external-jsonrpc", "internal-mcp-session", "agentic-loop", "jsonrpc"] as const) {
+      expect(isAgentCompletionRequest(event(source))).toBe(true);
+    }
+    expect(isAgentCompletionRequest(event("rest"))).toBe(true);
+    const operatorRest = event("rest");
+    operatorRest.context = {};
+    expect(isAgentCompletionRequest(operatorRest)).toBe(false);
+    expect(isAgentCompletionRequest(event("external-jsonrpc", { itemId: "BI-1", status: "open" }))).toBe(false);
+  });
+
+  it("defaults to enforce and supports shadow/off kill switches", () => {
+    expect(resolveCompletionEvidenceGateMode({})).toBe("enforce");
+    expect(resolveCompletionEvidenceGateMode({ DPF_COMPLETION_EVIDENCE_GATE_MODE: "shadow" })).toBe("shadow");
+    expect(resolveCompletionEvidenceGateMode({ DPF_COMPLETION_EVIDENCE_GATE_MODE: "off" })).toBe("off");
+    expect(resolveCompletionEvidenceGateMode({ DPF_COMPLETION_EVIDENCE_GATE_MODE: "unexpected" })).toBe("enforce");
+  });
+
+  it("denies incomplete agent completion with an actionable reason", async () => {
+    const resolve = vi.fn().mockResolvedValue(deniedVerdict());
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve,
+      countRecentInvalidAttempts: vi.fn().mockResolvedValue(0),
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn(),
+      mode: "enforce",
+    });
+    const decision = await hook.onPreToolUse?.(event());
+    expect(decision).toMatchObject({ decision: "deny" });
+    expect(decision?.reason).toContain("completion manifest missing");
+    expect(decision?.reason).toContain("record evidence");
+  });
+
+  it("allows complete evidence even after prior invalid attempts", async () => {
+    const count = vi.fn().mockResolvedValue(99);
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockResolvedValue(allowedVerdict()),
+      countRecentInvalidAttempts: count,
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn(),
+      mode: "enforce",
+    });
+    expect(await hook.onPreToolUse?.(event())).toEqual({ decision: "allow" });
+    expect(count).not.toHaveBeenCalled();
+  });
+
+  it("records but allows an incomplete request in shadow mode", async () => {
+    const recordShadow = vi.fn();
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockResolvedValue(deniedVerdict()),
+      countRecentInvalidAttempts: vi.fn().mockResolvedValue(0),
+      recordShadow,
+      notifyCircuit: vi.fn(),
+      mode: "shadow",
+    });
+    expect(await hook.onPreToolUse?.(event())).toMatchObject({
+      decision: "allow",
+      reason: expect.stringContaining("shadow"),
+    });
+    expect(recordShadow).toHaveBeenCalledWith(
+      expect.objectContaining({ itemRowId: "row-1", callerClient: "antigravity/2.3.1" }),
+    );
+  });
+
+  it("never turns a shadow audit-write failure into a denial", async () => {
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockResolvedValue(deniedVerdict()),
+      countRecentInvalidAttempts: vi.fn(),
+      recordShadow: vi.fn().mockRejectedValue(new Error("audit unavailable")),
+      notifyCircuit: vi.fn(),
+      mode: "shadow",
+    });
+    expect(await hook.onPreToolUse?.(event())).toMatchObject({ decision: "allow" });
+  });
+
+  it("does not resolve evidence when the gate is off or the request is outside scope", async () => {
+    const resolve = vi.fn();
+    const off = createCompletionEvidenceGovernanceHook({
+      resolve,
+      countRecentInvalidAttempts: vi.fn(),
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn(),
+      mode: "off",
+    });
+    expect(await off.onPreToolUse?.(event())).toEqual({ decision: "allow" });
+    expect(resolve).not.toHaveBeenCalled();
+
+    const enforce = createCompletionEvidenceGovernanceHook({
+      resolve,
+      countRecentInvalidAttempts: vi.fn(),
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn(),
+      mode: "enforce",
+    });
+    const operatorRest = event("rest");
+    operatorRest.context = {};
+    expect(await enforce.onPreToolUse?.(operatorRest)).toEqual({ decision: "allow" });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("emits one circuit notification at the repeated-invalid threshold", async () => {
+    const notifyCircuit = vi.fn();
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockResolvedValue(deniedVerdict()),
+      countRecentInvalidAttempts: vi.fn().mockResolvedValue(4),
+      recordShadow: vi.fn(),
+      notifyCircuit,
+      mode: "enforce",
+    });
+    const decision = await hook.onPreToolUse?.(event());
+    expect(decision?.reason).toContain("Repeated unsupported completion attempts");
+    expect(notifyCircuit).toHaveBeenCalledTimes(1);
+    expect(notifyCircuit).toHaveBeenCalledWith(expect.objectContaining({
+      principalKey: "token:token-1",
+      callerClient: "antigravity/2.3.1",
+    }));
+  });
+
+  it("keeps the evidence denial when attention delivery fails", async () => {
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockResolvedValue(deniedVerdict()),
+      countRecentInvalidAttempts: vi.fn().mockResolvedValue(4),
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn().mockRejectedValue(new Error("notification unavailable")),
+      mode: "enforce",
+    });
+    expect(await hook.onPreToolUse?.(event())).toMatchObject({
+      decision: "deny",
+      reason: expect.stringContaining("Repeated unsupported completion attempts"),
+    });
+  });
+
+  it("uses token, then agent, then user as the circuit identity", async () => {
+    const observed: string[] = [];
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockResolvedValue(deniedVerdict()),
+      countRecentInvalidAttempts: vi.fn(async ({ principalKey }) => {
+        observed.push(principalKey);
+        return 0;
+      }),
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn(),
+      mode: "enforce",
+    });
+    await hook.onPreToolUse?.(event());
+    const agentEvent = event();
+    agentEvent.context = { agentId: "agent-1" };
+    await hook.onPreToolUse?.(agentEvent);
+    const userEvent = event();
+    userEvent.context = {};
+    await hook.onPreToolUse?.(userEvent);
+    expect(observed).toEqual(["token:token-1", "agent:agent-1", "user:user-1"]);
+  });
+
+  it("fails closed when evidence resolution fails on a consequential request", async () => {
+    const hook = createCompletionEvidenceGovernanceHook({
+      resolve: vi.fn().mockRejectedValue(new Error("database unavailable")),
+      countRecentInvalidAttempts: vi.fn(),
+      recordShadow: vi.fn(),
+      notifyCircuit: vi.fn(),
+      mode: "enforce",
+    });
+    const decision = await hook.onPreToolUse?.(event());
+    expect(decision).toMatchObject({ decision: "deny" });
+    expect(decision?.reason).toContain("could not be verified");
+  });
+});

--- a/apps/web/lib/backlog/completion-evidence-governance-hook.ts
+++ b/apps/web/lib/backlog/completion-evidence-governance-hook.ts
@@ -1,0 +1,275 @@
+import { prisma } from "@dpf/db";
+
+import { notifyAttentionLive } from "@/lib/attention/notify-live";
+import type {
+  ToolLifecycleDecision,
+  ToolLifecycleEvent,
+  ToolLifecycleHook,
+} from "@/lib/mcp-governed-execute";
+
+import {
+  resolveCompletionEvidence,
+  type CompletionEvidenceRuntimeDb,
+  type ResolveCompletionEvidenceResult,
+} from "./completion-evidence-runtime";
+import type { CompletionEvidenceBlocker } from "./completion-evidence-policy";
+
+export type CompletionEvidenceGateMode = "enforce" | "shadow" | "off";
+
+const CIRCUIT_WINDOW_MS = 10 * 60 * 1000;
+const CIRCUIT_THRESHOLD = 5;
+
+type CircuitIdentity = {
+  principalKey: string;
+  apiTokenId?: string;
+  agentId?: string;
+  userId: string;
+};
+
+type InvalidAttemptCountInput = CircuitIdentity & {
+  since: Date;
+};
+
+type ShadowInput = {
+  itemRowId: string;
+  userId: string;
+  agentId: string | null;
+  source: ToolLifecycleEvent["source"];
+  callerClient: string | null;
+  blockers: CompletionEvidenceBlocker[];
+};
+
+type CircuitNotificationInput = CircuitIdentity & {
+  itemId: string;
+  callerClient: string | null;
+  blockers: CompletionEvidenceBlocker[];
+};
+
+type CompletionEvidenceHookDeps = {
+  resolve: (input: {
+    itemId: string;
+    rawManifest: unknown;
+    now: Date;
+  }) => Promise<ResolveCompletionEvidenceResult>;
+  countRecentInvalidAttempts: (input: InvalidAttemptCountInput) => Promise<number>;
+  recordShadow: (input: ShadowInput) => Promise<void>;
+  notifyCircuit: (input: CircuitNotificationInput) => Promise<void>;
+  now?: () => Date;
+  mode?: CompletionEvidenceGateMode;
+};
+
+export function resolveCompletionEvidenceGateMode(
+  env: Record<string, string | undefined> = process.env,
+): CompletionEvidenceGateMode {
+  const raw = (env.DPF_COMPLETION_EVIDENCE_GATE_MODE ?? "enforce").trim().toLowerCase();
+  return raw === "shadow" || raw === "off" ? raw : "enforce";
+}
+
+export function isAgentCompletionRequest(
+  event: Pick<ToolLifecycleEvent, "toolName" | "rawParams" | "source" | "context">,
+): boolean {
+  const agentSurface = event.source !== "rest" || Boolean(event.context?.agentId);
+  return (
+    event.toolName === "update_backlog_item_status"
+    && event.rawParams.status === "done"
+    && agentSurface
+  );
+}
+
+function circuitIdentity(event: ToolLifecycleEvent): CircuitIdentity {
+  if (event.context?.apiTokenId) {
+    return {
+      principalKey: `token:${event.context.apiTokenId}`,
+      apiTokenId: event.context.apiTokenId,
+      userId: event.userId,
+    };
+  }
+  if (event.context?.agentId) {
+    return {
+      principalKey: `agent:${event.context.agentId}`,
+      agentId: event.context.agentId,
+      userId: event.userId,
+    };
+  }
+  return { principalKey: `user:${event.userId}`, userId: event.userId };
+}
+
+function blockerSummary(blockers: CompletionEvidenceBlocker[]): string {
+  return blockers
+    .slice(0, 4)
+    .map((entry) => entry.message)
+    .join("; ");
+}
+
+function denialReason(
+  blockers: CompletionEvidenceBlocker[],
+  nextAction: string | null,
+  circuitOpen: boolean,
+): string {
+  const prefix = circuitOpen
+    ? "Repeated unsupported completion attempts were detected; no additional items will be closed without valid evidence. "
+    : "This backlog item is not complete yet. ";
+  return (
+    prefix
+    + blockerSummary(blockers)
+    + (nextAction ? ` Next action: ${nextAction}` : "")
+  );
+}
+
+async function countRecentInvalidAttemptsLive(
+  input: InvalidAttemptCountInput,
+): Promise<number> {
+  const identityWhere = input.apiTokenId
+    ? { apiTokenId: input.apiTokenId }
+    : input.agentId
+      ? { agentId: input.agentId }
+      : { userId: input.userId };
+  return prisma.toolExecution.count({
+    where: {
+      ...identityWhere,
+      toolName: "update_backlog_item_status",
+      success: false,
+      createdAt: { gte: input.since },
+      parameters: {
+        path: ["status"],
+        equals: "done",
+      },
+    },
+  });
+}
+
+async function recordShadowLive(input: ShadowInput): Promise<void> {
+  const recent = await prisma.backlogItemActivity.findFirst({
+    where: {
+      backlogItemId: input.itemRowId,
+      kind: "completion_gate_shadow",
+      recordedByAgentId: input.agentId,
+      recordedAt: { gte: new Date(Date.now() - CIRCUIT_WINDOW_MS) },
+    },
+    select: { id: true },
+  });
+  if (recent) return;
+  await prisma.backlogItemActivity.create({
+    data: {
+      backlogItemId: input.itemRowId,
+      kind: "completion_gate_shadow",
+      summary: `Completion evidence shadow: ${blockerSummary(input.blockers)}`.slice(0, 240),
+      payload: {
+        source: input.source,
+        callerClient: input.callerClient,
+        blockers: input.blockers,
+      },
+      recordedById: input.userId,
+      recordedByAgentId: input.agentId,
+    },
+  });
+}
+
+async function notifyCircuitLive(input: CircuitNotificationInput): Promise<void> {
+  const client = input.callerClient ?? "an AI client";
+  await notifyAttentionLive({
+    source: "platform-health",
+    itemKey: `completion-evidence:${client}`,
+    userId: input.userId,
+    title: "AI completion claims need evidence",
+    body:
+      `${client} repeatedly tried to close backlog work without sufficient evidence. `
+      + `${blockerSummary(input.blockers)} Review the item before granting more autonomy.`,
+    deepLink: `/ops?itemId=${encodeURIComponent(input.itemId)}`,
+    riskClass: "high-risk",
+  });
+}
+
+function liveDeps(): CompletionEvidenceHookDeps {
+  return {
+    resolve: (input) =>
+      resolveCompletionEvidence(prisma as unknown as CompletionEvidenceRuntimeDb, input),
+    countRecentInvalidAttempts: countRecentInvalidAttemptsLive,
+    recordShadow: recordShadowLive,
+    notifyCircuit: notifyCircuitLive,
+  };
+}
+
+export function createCompletionEvidenceGovernanceHook(
+  overrides: Partial<CompletionEvidenceHookDeps> = {},
+): ToolLifecycleHook {
+  const deps = { ...liveDeps(), ...overrides };
+  const now = deps.now ?? (() => new Date());
+  return {
+    id: "completion-evidence-governance",
+    onPreToolUse: async (event: ToolLifecycleEvent): Promise<ToolLifecycleDecision> => {
+      const mode = deps.mode ?? resolveCompletionEvidenceGateMode();
+      if (mode === "off" || !isAgentCompletionRequest(event)) {
+        return { decision: "allow" };
+      }
+      const itemId = typeof event.rawParams.itemId === "string"
+        ? event.rawParams.itemId.trim()
+        : "";
+      if (!itemId) return { decision: "allow" };
+
+      try {
+        const evaluated = await deps.resolve({
+          itemId,
+          rawManifest: event.rawParams.completionEvidence,
+          now: now(),
+        });
+        if (evaluated.kind === "not-found" || evaluated.verdict.allowed) {
+          return { decision: "allow" };
+        }
+
+        if (mode === "shadow") {
+          try {
+            await deps.recordShadow({
+              itemRowId: evaluated.item.id,
+              userId: event.userId,
+              agentId: event.context?.agentId ?? null,
+              source: event.source,
+              callerClient: event.context?.callerClient ?? null,
+              blockers: evaluated.verdict.blockers,
+            });
+          } catch {
+            // Shadow is audit-only by contract. An audit write cannot become a denial.
+          }
+          return {
+            decision: "allow",
+            reason: `completion-evidence: shadow — ${blockerSummary(evaluated.verdict.blockers)}`,
+          };
+        }
+
+        const identity = circuitIdentity(event);
+        const invalidAttempts = await deps.countRecentInvalidAttempts({
+          ...identity,
+          since: new Date(now().getTime() - CIRCUIT_WINDOW_MS),
+        });
+        const circuitOpen = invalidAttempts >= CIRCUIT_THRESHOLD - 1;
+        if (circuitOpen) {
+          try {
+            await deps.notifyCircuit({
+              ...identity,
+              itemId,
+              callerClient: event.context?.callerClient ?? null,
+              blockers: evaluated.verdict.blockers,
+            });
+          } catch {
+            // Attention is best-effort; the evidence denial remains authoritative.
+          }
+        }
+        return {
+          decision: "deny",
+          reason: denialReason(
+            evaluated.verdict.blockers,
+            evaluated.verdict.nextAction,
+            circuitOpen,
+          ),
+        };
+      } catch {
+        return {
+          decision: "deny",
+          reason:
+            "This completion claim could not be verified by the server, so the item was not closed. "
+            + "Retry after the evidence service is available; do not substitute a prose resolution.",
+        };
+      }
+    },
+  };
+}

--- a/apps/web/lib/backlog/completion-evidence-policy.test.ts
+++ b/apps/web/lib/backlog/completion-evidence-policy.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateCompletionEvidence,
+  type CompletionEvidenceFact,
+  type CompletionEvidencePolicyInput,
+} from "./completion-evidence-policy";
+
+const NOW = new Date("2026-07-26T12:00:00.000Z");
+const CUTOFF = new Date("2026-07-25T12:00:00.000Z");
+
+function fact(
+  id: string,
+  evidenceKind: CompletionEvidenceFact["evidenceKind"],
+  recordedAt = new Date("2026-07-26T10:00:00.000Z"),
+  itemId = "row-1",
+): CompletionEvidenceFact {
+  return { id, itemId, evidenceKind, recordedAt, structurallyValid: true };
+}
+
+function input(overrides: Partial<CompletionEvidencePolicyInput> = {}): CompletionEvidencePolicyInput {
+  return {
+    item: { id: "row-1", itemId: "BI-1", status: "in-progress", workType: "feature" },
+    rawManifest: {
+      workClass: "implementation",
+      evidenceActivityIds: ["source", "tests", "build"],
+      ux: { disposition: "not-applicable", reason: "No user interface files or routes changed." },
+      migration: { disposition: "not-applicable", reason: "No database schema or persisted data changed." },
+    },
+    evidence: [
+      fact("source", "source_verified"),
+      fact("tests", "test_pass"),
+      fact("build", "build_pass"),
+    ],
+    activeBuildEvidence: null,
+    evidenceCutoff: CUTOFF,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("evaluateCompletionEvidence", () => {
+  it("allows a proportionate implementation manifest", () => {
+    expect(evaluateCompletionEvidence(input())).toMatchObject({
+      allowed: true,
+      normalizedManifest: { workClass: "implementation" },
+      blockers: [],
+    });
+  });
+
+  it("allows documentation with a fresh spec review", () => {
+    const result = evaluateCompletionEvidence(input({
+      item: { id: "row-1", itemId: "BI-DOC", status: "open", workType: "doc" },
+      rawManifest: {
+        workClass: "documentation",
+        evidenceActivityIds: ["spec"],
+      },
+      evidence: [fact("spec", "spec_review")],
+    }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows verified-existing work with source and manual verification", () => {
+    const result = evaluateCompletionEvidence(input({
+      rawManifest: {
+        workClass: "verified-existing",
+        evidenceActivityIds: ["source", "manual"],
+      },
+      evidence: [fact("source", "source_verified"), fact("manual", "manual_check")],
+    }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows operational chores without forcing code gates", () => {
+    const result = evaluateCompletionEvidence(input({
+      item: { id: "row-1", itemId: "BI-OPS", status: "open", workType: "chore" },
+      rawManifest: {
+        workClass: "operational",
+        evidenceActivityIds: ["manual"],
+      },
+      evidence: [fact("manual", "manual_check")],
+    }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("prevents implementation work from masquerading as documentation", () => {
+    const result = evaluateCompletionEvidence(input({
+      rawManifest: { workClass: "documentation", evidenceActivityIds: ["spec"] },
+      evidence: [fact("spec", "spec_review")],
+    }));
+    expect(result.allowed).toBe(false);
+    expect(result.blockers.map((blocker) => blocker.code)).toContain("incompatible-work-class");
+  });
+
+  it("requires concrete UX and migration not-applicable reasons", () => {
+    const result = evaluateCompletionEvidence(input({
+      rawManifest: {
+        workClass: "implementation",
+        evidenceActivityIds: ["source", "tests", "build"],
+        ux: { disposition: "not-applicable", reason: "none" },
+        migration: { disposition: "not-applicable", reason: "" },
+      },
+    }));
+    expect(result.allowed).toBe(false);
+    expect(result.blockers.map((blocker) => blocker.dimension)).toEqual(
+      expect.arrayContaining(["ux", "migration"]),
+    );
+  });
+
+  it("requires UX and migration evidence when declared verified", () => {
+    const result = evaluateCompletionEvidence(input({
+      rawManifest: {
+        workClass: "implementation",
+        evidenceActivityIds: ["source", "tests", "build"],
+        ux: { disposition: "verified" },
+        migration: { disposition: "verified" },
+      },
+    }));
+    expect(result.allowed).toBe(false);
+    expect(result.blockers.map((blocker) => blocker.dimension)).toEqual(
+      expect.arrayContaining(["ux", "migration"]),
+    );
+  });
+
+  it("rejects foreign and stale evidence references", () => {
+    const result = evaluateCompletionEvidence(input({
+      evidence: [
+        fact("source", "source_verified", new Date("2026-07-26T10:00:00Z"), "another-row"),
+        fact("tests", "test_pass", new Date("2026-07-20T10:00:00Z")),
+        fact("build", "build_pass"),
+      ],
+    }));
+    expect(result.allowed).toBe(false);
+    expect(result.blockers.map((blocker) => blocker.code)).toEqual(
+      expect.arrayContaining(["foreign-evidence", "stale-evidence"]),
+    );
+  });
+
+  it("rejects a dangling evidence reference", () => {
+    const result = evaluateCompletionEvidence(input({
+      evidence: [fact("source", "source_verified"), fact("tests", "test_pass")],
+    }));
+    expect(result.allowed).toBe(false);
+    expect(result.blockers.map((blocker) => blocker.code)).toContain("missing-evidence-reference");
+  });
+
+  it("lets a newer failure invalidate an older referenced pass", () => {
+    const result = evaluateCompletionEvidence(input({
+      evidence: [
+        fact("source", "source_verified"),
+        fact("tests", "test_pass", new Date("2026-07-26T09:00:00Z")),
+        fact("build", "build_pass"),
+        fact("latest-test", "test_fail", new Date("2026-07-26T11:00:00Z")),
+      ],
+    }));
+    expect(result.allowed).toBe(false);
+    expect(result.blockers).toContainEqual(expect.objectContaining({
+      code: "newer-failure",
+      dimension: "unit-tests",
+    }));
+  });
+
+  it("uses active Build Studio evidence only for dimensions it proves", () => {
+    const allowed = evaluateCompletionEvidence(input({
+      rawManifest: {
+        workClass: "implementation",
+        evidenceActivityIds: ["source"],
+        useActiveBuildEvidence: true,
+        ux: { disposition: "verified" },
+        migration: { disposition: "not-applicable", reason: "No database schema or persisted data changed." },
+      },
+      evidence: [fact("source", "source_verified")],
+      activeBuildEvidence: {
+        testsPassed: true,
+        productionBuildPassed: true,
+        ux: "verified",
+      },
+    }));
+    expect(allowed.allowed).toBe(true);
+
+    const skipped = evaluateCompletionEvidence(input({
+      rawManifest: {
+        workClass: "implementation",
+        evidenceActivityIds: ["source"],
+        useActiveBuildEvidence: true,
+        ux: { disposition: "verified" },
+        migration: { disposition: "not-applicable", reason: "No database schema or persisted data changed." },
+      },
+      evidence: [fact("source", "source_verified")],
+      activeBuildEvidence: {
+        testsPassed: true,
+        productionBuildPassed: true,
+        ux: "skipped",
+      },
+    }));
+    expect(skipped.allowed).toBe(false);
+    expect(skipped.blockers).toContainEqual(expect.objectContaining({ dimension: "ux" }));
+  });
+
+  it("keeps an already-done transition idempotent without new evidence", () => {
+    const result = evaluateCompletionEvidence(input({
+      item: { id: "row-1", itemId: "BI-1", status: "done", workType: "feature" },
+      rawManifest: null,
+      evidence: [],
+    }));
+    expect(result).toMatchObject({ allowed: true, noOp: true, blockers: [] });
+  });
+});

--- a/apps/web/lib/backlog/completion-evidence-policy.ts
+++ b/apps/web/lib/backlog/completion-evidence-policy.ts
@@ -1,0 +1,357 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+import {
+  evidenceKindMetadata,
+  isExecutionEvidenceKind,
+  type ExecutionEvidenceDimension,
+  type ExecutionEvidenceKind,
+} from "./execution-evidence";
+
+export const COMPLETION_WORK_CLASSES = [
+  "documentation",
+  "verified-existing",
+  "implementation",
+  "operational",
+] as const;
+
+export type CompletionWorkClass = (typeof COMPLETION_WORK_CLASSES)[number];
+export type CompletionDisposition =
+  | { disposition: "verified" }
+  | { disposition: "not-applicable"; reason: string };
+
+export type CompletionEvidenceManifest = {
+  workClass: CompletionWorkClass;
+  evidenceActivityIds: string[];
+  useActiveBuildEvidence: boolean;
+  ux?: CompletionDisposition;
+  migration?: CompletionDisposition;
+};
+
+export type CompletionEvidenceFact = {
+  id: string;
+  itemId: string;
+  evidenceKind: ExecutionEvidenceKind;
+  recordedAt: Date;
+  structurallyValid: boolean;
+};
+
+export type ActiveBuildCompletionEvidence = {
+  testsPassed: boolean;
+  productionBuildPassed: boolean;
+  ux: "verified" | "skipped" | "failed" | "not-run";
+};
+
+export type CompletionEvidencePolicyInput = {
+  item: {
+    id: string;
+    itemId: string;
+    status: string;
+    workType: string | null;
+  };
+  rawManifest: unknown;
+  evidence: CompletionEvidenceFact[];
+  activeBuildEvidence: ActiveBuildCompletionEvidence | null;
+  evidenceCutoff: Date;
+  now: Date;
+};
+
+export type CompletionEvidenceBlockerCode =
+  | "missing-manifest"
+  | "invalid-manifest"
+  | "incompatible-work-class"
+  | "missing-evidence-reference"
+  | "foreign-evidence"
+  | "stale-evidence"
+  | "invalid-evidence"
+  | "missing-dimension"
+  | "newer-failure"
+  | "invalid-not-applicable-reason"
+  | "active-build-evidence-missing";
+
+export type CompletionEvidenceBlocker = {
+  code: CompletionEvidenceBlockerCode;
+  message: string;
+  dimension?: ExecutionEvidenceDimension | "manifest";
+  evidenceActivityId?: string;
+};
+
+export type CompletionEvidenceVerdict = {
+  allowed: boolean;
+  noOp: boolean;
+  normalizedManifest: CompletionEvidenceManifest | null;
+  blockers: CompletionEvidenceBlocker[];
+  nextAction: string | null;
+};
+
+const WORK_CLASS_SET: ReadonlySet<string> = new Set(COMPLETION_WORK_CLASSES);
+const MIN_NOT_APPLICABLE_REASON_LENGTH = 12;
+
+const ALLOWED_WORK_CLASSES_BY_TYPE: Record<string, ReadonlySet<CompletionWorkClass>> = {
+  doc: new Set(["documentation"]),
+  feature: new Set(["implementation", "verified-existing"]),
+  bug: new Set(["implementation", "verified-existing"]),
+  refactor: new Set(["implementation", "verified-existing"]),
+  tool: new Set(["implementation", "verified-existing", "operational"]),
+  skill: new Set(["implementation", "verified-existing", "operational"]),
+  chore: new Set(["implementation", "verified-existing", "operational"]),
+};
+
+const REQUIRED_DIMENSIONS: Record<CompletionWorkClass, readonly ExecutionEvidenceDimension[]> = {
+  documentation: ["documentation"],
+  "verified-existing": ["source", "manual"],
+  implementation: ["source", "unit-tests", "production-build"],
+  operational: ["manual"],
+};
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeDisposition(raw: unknown): CompletionDisposition | null {
+  if (!isRecord(raw)) return null;
+  if (raw.disposition === "verified") return { disposition: "verified" };
+  if (raw.disposition === "not-applicable") {
+    return {
+      disposition: "not-applicable",
+      reason: stringValue(raw.reason) ?? "",
+    };
+  }
+  return null;
+}
+
+export function normalizeCompletionEvidenceManifest(
+  raw: unknown,
+): CompletionEvidenceManifest | null {
+  if (!isRecord(raw) || !WORK_CLASS_SET.has(String(raw.workClass))) return null;
+  if (!Array.isArray(raw.evidenceActivityIds)) return null;
+  if (
+    raw.evidenceActivityIds.length > 50
+    || raw.evidenceActivityIds.some((value) => stringValue(value) == null)
+  ) {
+    return null;
+  }
+  const evidenceActivityIds = Array.from(
+    new Set(raw.evidenceActivityIds.map(stringValue).filter((value): value is string => Boolean(value))),
+  );
+  return {
+    workClass: raw.workClass as CompletionWorkClass,
+    evidenceActivityIds,
+    useActiveBuildEvidence: raw.useActiveBuildEvidence === true,
+    ...(raw.ux === undefined ? {} : { ux: normalizeDisposition(raw.ux) ?? undefined }),
+    ...(raw.migration === undefined
+      ? {}
+      : { migration: normalizeDisposition(raw.migration) ?? undefined }),
+  };
+}
+
+function blocker(
+  code: CompletionEvidenceBlockerCode,
+  message: string,
+  dimension?: CompletionEvidenceBlocker["dimension"],
+  evidenceActivityId?: string,
+): CompletionEvidenceBlocker {
+  return {
+    code,
+    message,
+    ...(dimension ? { dimension } : {}),
+    ...(evidenceActivityId ? { evidenceActivityId } : {}),
+  };
+}
+
+function validateWorkClass(
+  workType: string | null,
+  workClass: CompletionWorkClass,
+): CompletionEvidenceBlocker | null {
+  const allowed = workType ? ALLOWED_WORK_CLASSES_BY_TYPE[workType] : null;
+  if (allowed?.has(workClass)) return null;
+  return blocker(
+    "incompatible-work-class",
+    `workType=${workType ?? "missing"} cannot complete as ${workClass}`,
+    "manifest",
+  );
+}
+
+function validateApplicability(
+  manifest: CompletionEvidenceManifest,
+  blockers: CompletionEvidenceBlocker[],
+): ExecutionEvidenceDimension[] {
+  if (manifest.workClass !== "implementation") return [];
+  const required: ExecutionEvidenceDimension[] = [];
+  for (const dimension of ["ux", "migration"] as const) {
+    const disposition = manifest[dimension];
+    if (!disposition) {
+      blockers.push(blocker(
+        "invalid-manifest",
+        `implementation completion must declare ${dimension} as verified or not-applicable`,
+        dimension,
+      ));
+      continue;
+    }
+    if (disposition.disposition === "verified") {
+      required.push(dimension);
+      continue;
+    }
+    if (disposition.reason.trim().length < MIN_NOT_APPLICABLE_REASON_LENGTH) {
+      blockers.push(blocker(
+        "invalid-not-applicable-reason",
+        `${dimension} not-applicable requires a concrete rationale`,
+        dimension,
+      ));
+    }
+  }
+  return required;
+}
+
+function nextActionFor(blockers: CompletionEvidenceBlocker[]): string | null {
+  if (blockers.length === 0) return null;
+  const dimensions = Array.from(
+    new Set(blockers.map((entry) => entry.dimension).filter((entry) => entry && entry !== "manifest")),
+  );
+  if (dimensions.length > 0) {
+    return `Record fresh evidence for ${dimensions.join(", ")} with record_execution_evidence, then retry with those activity IDs.`;
+  }
+  return "Correct completionEvidence so it matches this backlog item's work type, then retry.";
+}
+
+export function evaluateCompletionEvidence(
+  input: CompletionEvidencePolicyInput,
+): CompletionEvidenceVerdict {
+  if (input.item.status === "done") {
+    return {
+      allowed: true,
+      noOp: true,
+      normalizedManifest: null,
+      blockers: [],
+      nextAction: null,
+    };
+  }
+
+  const manifest = normalizeCompletionEvidenceManifest(input.rawManifest);
+  if (!manifest) {
+    const blockers = [
+      blocker(
+        input.rawManifest == null ? "missing-manifest" : "invalid-manifest",
+        "status=done from an agent surface requires a typed completionEvidence manifest",
+        "manifest",
+      ),
+    ];
+    return {
+      allowed: false,
+      noOp: false,
+      normalizedManifest: null,
+      blockers,
+      nextAction: nextActionFor(blockers),
+    };
+  }
+
+  const blockers: CompletionEvidenceBlocker[] = [];
+  const workClassBlocker = validateWorkClass(input.item.workType, manifest.workClass);
+  if (workClassBlocker) blockers.push(workClassBlocker);
+  const applicabilityDimensions = validateApplicability(manifest, blockers);
+
+  const byId = new Map(input.evidence.map((entry) => [entry.id, entry]));
+  const satisfied = new Set<ExecutionEvidenceDimension>();
+  for (const evidenceActivityId of manifest.evidenceActivityIds) {
+    const evidence = byId.get(evidenceActivityId);
+    if (!evidence) {
+      blockers.push(blocker(
+        "missing-evidence-reference",
+        `Evidence activity ${evidenceActivityId} does not resolve`,
+        undefined,
+        evidenceActivityId,
+      ));
+      continue;
+    }
+    const metadata = evidenceKindMetadata(evidence.evidenceKind);
+    if (evidence.itemId !== input.item.id) {
+      blockers.push(blocker(
+        "foreign-evidence",
+        `Evidence activity ${evidenceActivityId} belongs to another backlog item`,
+        metadata.dimension,
+        evidenceActivityId,
+      ));
+      continue;
+    }
+    if (evidence.recordedAt < input.evidenceCutoff || evidence.recordedAt > input.now) {
+      blockers.push(blocker(
+        "stale-evidence",
+        `Evidence activity ${evidenceActivityId} is outside the current completion window`,
+        metadata.dimension,
+        evidenceActivityId,
+      ));
+      continue;
+    }
+    if (!evidence.structurallyValid || !metadata.gateEligible || metadata.polarity !== "pass") {
+      blockers.push(blocker(
+        "invalid-evidence",
+        `Evidence activity ${evidenceActivityId} cannot satisfy a completion gate`,
+        metadata.dimension,
+        evidenceActivityId,
+      ));
+      continue;
+    }
+    satisfied.add(metadata.dimension);
+  }
+
+  if (manifest.useActiveBuildEvidence) {
+    const build = input.activeBuildEvidence;
+    if (!build) {
+      blockers.push(blocker(
+        "active-build-evidence-missing",
+        "useActiveBuildEvidence was requested but no active Build Studio evidence resolved",
+        "manifest",
+      ));
+    } else {
+      if (build.testsPassed) satisfied.add("unit-tests");
+      if (build.productionBuildPassed) satisfied.add("production-build");
+      if (build.ux === "verified") satisfied.add("ux");
+    }
+  }
+
+  const required = [...REQUIRED_DIMENSIONS[manifest.workClass], ...applicabilityDimensions];
+  for (const dimension of required) {
+    if (!satisfied.has(dimension)) {
+      blockers.push(blocker(
+        "missing-dimension",
+        `Completion evidence is missing ${dimension}`,
+        dimension,
+      ));
+    }
+  }
+
+  const latestByDimension = new Map<ExecutionEvidenceDimension, CompletionEvidenceFact>();
+  for (const evidence of input.evidence) {
+    if (
+      evidence.itemId !== input.item.id
+      || evidence.recordedAt < input.evidenceCutoff
+      || evidence.recordedAt > input.now
+      || !isExecutionEvidenceKind(evidence.evidenceKind)
+    ) {
+      continue;
+    }
+    const dimension = evidenceKindMetadata(evidence.evidenceKind).dimension;
+    const current = latestByDimension.get(dimension);
+    if (!current || current.recordedAt < evidence.recordedAt) {
+      latestByDimension.set(dimension, evidence);
+    }
+  }
+  for (const dimension of new Set(required)) {
+    const latest = latestByDimension.get(dimension);
+    if (latest && evidenceKindMetadata(latest.evidenceKind).polarity === "fail") {
+      blockers.push(blocker(
+        "newer-failure",
+        `A newer ${dimension} failure invalidates the prior pass`,
+        dimension,
+        latest.id,
+      ));
+    }
+  }
+
+  return {
+    allowed: blockers.length === 0,
+    noOp: false,
+    normalizedManifest: manifest,
+    blockers,
+    nextAction: nextActionFor(blockers),
+  };
+}

--- a/apps/web/lib/backlog/completion-evidence-runtime.test.ts
+++ b/apps/web/lib/backlog/completion-evidence-runtime.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveCompletionEvidence,
+  type ResolveCompletionEvidenceResult,
+} from "./completion-evidence-runtime";
+
+function evaluated(result: ResolveCompletionEvidenceResult) {
+  expect(result.kind).toBe("evaluated");
+  if (result.kind !== "evaluated") throw new Error("expected evaluated completion evidence");
+  return result;
+}
+
+function db() {
+  return {
+    backlogItem: { findUnique: vi.fn() },
+    backlogItemActivity: { findMany: vi.fn() },
+  };
+}
+
+const manifest = {
+  workClass: "implementation",
+  evidenceActivityIds: ["source"],
+  useActiveBuildEvidence: true,
+  ux: { disposition: "verified" },
+  migration: { disposition: "not-applicable", reason: "No database schema or persisted data changed." },
+};
+
+describe("resolveCompletionEvidence", () => {
+  it("resolves item evidence and reuses canonical Build Studio verification", async () => {
+    const fake = db();
+    fake.backlogItem.findUnique.mockResolvedValue({
+      id: "row-1",
+      itemId: "BI-1",
+      status: "in-progress",
+      workType: "feature",
+      claimedAt: new Date("2026-07-25T00:00:00Z"),
+      createdAt: new Date("2026-07-20T00:00:00Z"),
+      activeBuild: {
+        verificationOut: { typecheckPassed: true, testsFailed: 0, buildPassed: true },
+        uxVerificationStatus: "complete",
+      },
+    });
+    fake.backlogItemActivity.findMany.mockResolvedValue([
+      {
+        id: "source",
+        backlogItemId: "row-1",
+        kind: "evidence",
+        recordedAt: new Date("2026-07-26T10:00:00Z"),
+        payload: {
+          evidenceKind: "source_verified",
+          url: "https://github.com/acme/repo/pull/1",
+        },
+      },
+    ]);
+
+    const result = await resolveCompletionEvidence(fake, {
+      itemId: "BI-1",
+      rawManifest: manifest,
+      now: new Date("2026-07-26T12:00:00Z"),
+    });
+
+    expect(evaluated(result).verdict.allowed).toBe(true);
+    expect(fake.backlogItemActivity.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 250,
+        orderBy: { recordedAt: "desc" },
+      }),
+    );
+  });
+
+  it("does not treat skipped UX as verified", async () => {
+    const fake = db();
+    fake.backlogItem.findUnique.mockResolvedValue({
+      id: "row-1",
+      itemId: "BI-1",
+      status: "in-progress",
+      workType: "feature",
+      claimedAt: new Date("2026-07-25T00:00:00Z"),
+      createdAt: new Date("2026-07-20T00:00:00Z"),
+      activeBuild: {
+        verificationOut: { typecheckPassed: true, testsFailed: 0, buildPassed: true },
+        uxVerificationStatus: "skipped",
+      },
+    });
+    fake.backlogItemActivity.findMany.mockResolvedValue([
+      {
+        id: "source",
+        backlogItemId: "row-1",
+        kind: "evidence",
+        recordedAt: new Date("2026-07-26T10:00:00Z"),
+        payload: {
+          evidenceKind: "source_verified",
+          url: "https://github.com/acme/repo/pull/1",
+        },
+      },
+    ]);
+
+    const result = await resolveCompletionEvidence(fake, {
+      itemId: "BI-1",
+      rawManifest: manifest,
+      now: new Date("2026-07-26T12:00:00Z"),
+    });
+
+    const verdict = evaluated(result).verdict;
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.blockers).toContainEqual(expect.objectContaining({ dimension: "ux" }));
+  });
+
+  it("loads referenced foreign evidence so the policy distinguishes it from dangling evidence", async () => {
+    const fake = db();
+    fake.backlogItem.findUnique.mockResolvedValue({
+      id: "row-1",
+      itemId: "BI-1",
+      status: "in-progress",
+      workType: "feature",
+      claimedAt: null,
+      createdAt: new Date("2026-07-20T00:00:00Z"),
+      activeBuild: null,
+    });
+    fake.backlogItemActivity.findMany.mockResolvedValue([
+      {
+        id: "foreign",
+        backlogItemId: "row-2",
+        kind: "evidence",
+        recordedAt: new Date("2026-07-26T10:00:00Z"),
+        payload: { evidenceKind: "source_verified", url: "https://example.com/pr/2" },
+      },
+    ]);
+
+    const result = await resolveCompletionEvidence(fake, {
+      itemId: "BI-1",
+      rawManifest: {
+        ...manifest,
+        useActiveBuildEvidence: false,
+        evidenceActivityIds: ["foreign"],
+        ux: { disposition: "not-applicable", reason: "No user interface files or routes changed." },
+      },
+      now: new Date("2026-07-26T12:00:00Z"),
+    });
+
+    expect(evaluated(result).verdict.blockers.map((entry) => entry.code)).toContain("foreign-evidence");
+  });
+
+  it("fails structurally-invalid source evidence", async () => {
+    const fake = db();
+    fake.backlogItem.findUnique.mockResolvedValue({
+      id: "row-1",
+      itemId: "BI-1",
+      status: "in-progress",
+      workType: "feature",
+      claimedAt: null,
+      createdAt: new Date("2026-07-20T00:00:00Z"),
+      activeBuild: null,
+    });
+    fake.backlogItemActivity.findMany.mockResolvedValue([
+      {
+        id: "source",
+        backlogItemId: "row-1",
+        kind: "evidence",
+        recordedAt: new Date("2026-07-26T10:00:00Z"),
+        payload: { evidenceKind: "source_verified", url: null },
+      },
+    ]);
+
+    const result = await resolveCompletionEvidence(fake, {
+      itemId: "BI-1",
+      rawManifest: {
+        ...manifest,
+        useActiveBuildEvidence: false,
+        evidenceActivityIds: ["source"],
+        ux: { disposition: "not-applicable", reason: "No user interface files or routes changed." },
+      },
+      now: new Date("2026-07-26T12:00:00Z"),
+    });
+    expect(evaluated(result).verdict.blockers.map((entry) => entry.code)).toContain("invalid-evidence");
+  });
+
+  it("returns not-found without querying activities", async () => {
+    const fake = db();
+    fake.backlogItem.findUnique.mockResolvedValue(null);
+    const result = await resolveCompletionEvidence(fake, {
+      itemId: "BI-MISSING",
+      rawManifest: manifest,
+      now: new Date("2026-07-26T12:00:00Z"),
+    });
+    expect(result).toEqual({ kind: "not-found", itemId: "BI-MISSING" });
+    expect(fake.backlogItemActivity.findMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps an already-done retry idempotent without loading evidence", async () => {
+    const fake = db();
+    fake.backlogItem.findUnique.mockResolvedValue({
+      id: "row-1",
+      itemId: "BI-1",
+      status: "done",
+      workType: "feature",
+      claimedAt: new Date("2026-07-25T00:00:00Z"),
+      createdAt: new Date("2026-07-20T00:00:00Z"),
+      activeBuild: null,
+    });
+    const result = await resolveCompletionEvidence(fake, {
+      itemId: "BI-1",
+      rawManifest: null,
+      now: new Date("2026-07-26T12:00:00Z"),
+    });
+    expect(evaluated(result).verdict).toMatchObject({ allowed: true, noOp: true });
+    expect(fake.backlogItemActivity.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/backlog/completion-evidence-runtime.ts
+++ b/apps/web/lib/backlog/completion-evidence-runtime.ts
@@ -1,0 +1,207 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+import {
+  evaluateCompletionEvidence,
+  normalizeCompletionEvidenceManifest,
+  type ActiveBuildCompletionEvidence,
+  type CompletionEvidenceFact,
+  type CompletionEvidenceVerdict,
+} from "./completion-evidence-policy";
+import {
+  evidenceKindMetadata,
+  normalizeExecutionEvidencePayload,
+  validateExecutionEvidenceStructure,
+} from "./execution-evidence";
+
+const EVIDENCE_FRESHNESS_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_ACTIVITY_ROWS = 250;
+
+type BacklogItemRow = {
+  id: string;
+  itemId: string;
+  status: string;
+  workType: string | null;
+  claimedAt: Date | null;
+  createdAt: Date;
+  activeBuild: {
+    verificationOut: unknown;
+    uxVerificationStatus: string | null;
+  } | null;
+};
+
+type BacklogItemActivityRow = {
+  id: string;
+  backlogItemId: string;
+  kind: string;
+  recordedAt: Date;
+  payload: unknown;
+};
+
+export type CompletionEvidenceRuntimeDb = {
+  backlogItem: {
+    findUnique(args: unknown): Promise<BacklogItemRow | null>;
+  };
+  backlogItemActivity: {
+    findMany(args: unknown): Promise<BacklogItemActivityRow[]>;
+  };
+};
+
+export type ResolveCompletionEvidenceResult =
+  | { kind: "not-found"; itemId: string }
+  | {
+      kind: "evaluated";
+      item: Pick<BacklogItemRow, "id" | "itemId" | "status" | "workType">;
+      verdict: CompletionEvidenceVerdict;
+    };
+
+function laterDate(a: Date, b: Date): Date {
+  return a >= b ? a : b;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function projectActiveBuildCompletionEvidence(
+  row: BacklogItemRow["activeBuild"],
+): ActiveBuildCompletionEvidence | null {
+  if (!row) return null;
+  const verification = isRecord(row.verificationOut) ? row.verificationOut : {};
+  const ux: ActiveBuildCompletionEvidence["ux"] =
+    row.uxVerificationStatus === "complete"
+      ? "verified"
+      : row.uxVerificationStatus === "skipped"
+        ? "skipped"
+        : row.uxVerificationStatus === "failed"
+          ? "failed"
+          : "not-run";
+  return {
+    testsPassed:
+      verification.typecheckPassed === true
+      && numberValue(verification.testsFailed) === 0,
+    productionBuildPassed: verification.buildPassed === true,
+    ux,
+  };
+}
+
+function projectEvidenceFact(row: BacklogItemActivityRow): CompletionEvidenceFact | null {
+  if (row.kind !== "evidence") return null;
+  const payload = normalizeExecutionEvidencePayload(row.payload);
+  if (!payload) return null;
+  return {
+    id: row.id,
+    itemId: row.backlogItemId,
+    evidenceKind: payload.evidenceKind,
+    recordedAt: row.recordedAt,
+    structurallyValid:
+      evidenceKindMetadata(payload.evidenceKind).polarity !== "pass"
+      || validateExecutionEvidenceStructure(payload.evidenceKind, payload.url) == null,
+  };
+}
+
+export async function resolveCompletionEvidence(
+  db: CompletionEvidenceRuntimeDb,
+  input: {
+    itemId: string;
+    rawManifest: unknown;
+    now?: Date;
+  },
+): Promise<ResolveCompletionEvidenceResult> {
+  const item = await db.backlogItem.findUnique({
+    where: { itemId: input.itemId },
+    select: {
+      id: true,
+      itemId: true,
+      status: true,
+      workType: true,
+      claimedAt: true,
+      createdAt: true,
+      activeBuild: {
+        select: {
+          verificationOut: true,
+          uxVerificationStatus: true,
+        },
+      },
+    },
+  });
+  if (!item) return { kind: "not-found", itemId: input.itemId };
+
+  const now = input.now ?? new Date();
+  const freshnessCutoff = new Date(now.getTime() - EVIDENCE_FRESHNESS_MS);
+  const evidenceCutoff = laterDate(item.claimedAt ?? item.createdAt, freshnessCutoff);
+  if (item.status === "done") {
+    return {
+      kind: "evaluated",
+      item: {
+        id: item.id,
+        itemId: item.itemId,
+        status: item.status,
+        workType: item.workType,
+      },
+      verdict: evaluateCompletionEvidence({
+        item: {
+          id: item.id,
+          itemId: item.itemId,
+          status: item.status,
+          workType: item.workType,
+        },
+        rawManifest: input.rawManifest,
+        evidence: [],
+        activeBuildEvidence: null,
+        evidenceCutoff,
+        now,
+      }),
+    };
+  }
+  const manifest = normalizeCompletionEvidenceManifest(input.rawManifest);
+  const referencedIds = manifest?.evidenceActivityIds ?? [];
+  const activities = await db.backlogItemActivity.findMany({
+    where: {
+      OR: [
+        ...(referencedIds.length > 0 ? [{ id: { in: referencedIds } }] : []),
+        {
+          backlogItemId: item.id,
+          kind: "evidence",
+          recordedAt: { gte: evidenceCutoff },
+        },
+      ],
+    },
+    select: {
+      id: true,
+      backlogItemId: true,
+      kind: true,
+      recordedAt: true,
+      payload: true,
+    },
+    orderBy: { recordedAt: "desc" },
+    take: MAX_ACTIVITY_ROWS,
+  });
+  const evidence = activities
+    .map(projectEvidenceFact)
+    .filter((entry): entry is CompletionEvidenceFact => entry != null);
+  const verdict = evaluateCompletionEvidence({
+    item: {
+      id: item.id,
+      itemId: item.itemId,
+      status: item.status,
+      workType: item.workType,
+    },
+    rawManifest: input.rawManifest,
+    evidence,
+    activeBuildEvidence: manifest?.useActiveBuildEvidence
+      ? projectActiveBuildCompletionEvidence(item.activeBuild)
+      : null,
+    evidenceCutoff,
+    now,
+  });
+  return {
+    kind: "evaluated",
+    item: {
+      id: item.id,
+      itemId: item.itemId,
+      status: item.status,
+      workType: item.workType,
+    },
+    verdict,
+  };
+}

--- a/apps/web/lib/backlog/execution-evidence.test.ts
+++ b/apps/web/lib/backlog/execution-evidence.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXECUTION_EVIDENCE_KINDS,
+  evidenceKindMetadata,
+  normalizeExecutionEvidencePayload,
+  validateExecutionEvidenceStructure,
+} from "./execution-evidence";
+
+describe("execution evidence registry", () => {
+  it("maps every closed evidence kind to one dimension and polarity", () => {
+    expect(EXECUTION_EVIDENCE_KINDS).toHaveLength(12);
+    for (const kind of EXECUTION_EVIDENCE_KINDS) {
+      const metadata = evidenceKindMetadata(kind);
+      expect(metadata.dimension).toBeTruthy();
+      expect(["pass", "fail", "neutral"]).toContain(metadata.polarity);
+    }
+  });
+
+  it("keeps external links as supporting context rather than gate evidence", () => {
+    expect(evidenceKindMetadata("external_link")).toMatchObject({
+      dimension: "supporting-context",
+      polarity: "neutral",
+      gateEligible: false,
+    });
+  });
+
+  it("requires HTTP(S) provenance for source evidence", () => {
+    expect(validateExecutionEvidenceStructure("source_verified", null)).toContain("HTTP");
+    expect(validateExecutionEvidenceStructure("source_verified", "file:///tmp/change")).toContain("HTTP");
+    expect(validateExecutionEvidenceStructure("source_verified", "https://github.com/acme/repo/pull/42")).toBeNull();
+  });
+
+  it("normalizes the persisted activity payload without trusting unknown fields", () => {
+    expect(normalizeExecutionEvidencePayload({
+      evidenceKind: "migration_pass",
+      url: "https://ci.example/run/1",
+      body: "Applied against upgrade fixture",
+      toolExecutionId: "te-1",
+      callerVerdict: "trust-me",
+    })).toEqual({
+      evidenceKind: "migration_pass",
+      url: "https://ci.example/run/1",
+      body: "Applied against upgrade fixture",
+      toolExecutionId: "te-1",
+    });
+  });
+
+  it("rejects malformed and unknown persisted evidence", () => {
+    expect(normalizeExecutionEvidencePayload(null)).toBeNull();
+    expect(normalizeExecutionEvidencePayload({ evidenceKind: "made_up" })).toBeNull();
+    expect(normalizeExecutionEvidencePayload({ evidenceKind: "test_pass", url: 42 })).toEqual({
+      evidenceKind: "test_pass",
+      url: null,
+      body: null,
+      toolExecutionId: null,
+    });
+  });
+});

--- a/apps/web/lib/backlog/execution-evidence.ts
+++ b/apps/web/lib/backlog/execution-evidence.ts
@@ -1,0 +1,101 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+export const EXECUTION_EVIDENCE_KINDS = [
+  "test_pass",
+  "test_fail",
+  "build_pass",
+  "build_fail",
+  "ux_verified",
+  "ux_fail",
+  "migration_pass",
+  "migration_fail",
+  "source_verified",
+  "spec_review",
+  "manual_check",
+  "external_link",
+] as const;
+
+export type ExecutionEvidenceKind = (typeof EXECUTION_EVIDENCE_KINDS)[number];
+
+export type ExecutionEvidenceDimension =
+  | "unit-tests"
+  | "production-build"
+  | "ux"
+  | "migration"
+  | "source"
+  | "documentation"
+  | "manual"
+  | "supporting-context";
+
+export type EvidencePolarity = "pass" | "fail" | "neutral";
+
+type EvidenceKindMetadata = {
+  dimension: ExecutionEvidenceDimension;
+  polarity: EvidencePolarity;
+  gateEligible: boolean;
+};
+
+const EVIDENCE_KIND_METADATA: Record<ExecutionEvidenceKind, EvidenceKindMetadata> = {
+  test_pass: { dimension: "unit-tests", polarity: "pass", gateEligible: true },
+  test_fail: { dimension: "unit-tests", polarity: "fail", gateEligible: false },
+  build_pass: { dimension: "production-build", polarity: "pass", gateEligible: true },
+  build_fail: { dimension: "production-build", polarity: "fail", gateEligible: false },
+  ux_verified: { dimension: "ux", polarity: "pass", gateEligible: true },
+  ux_fail: { dimension: "ux", polarity: "fail", gateEligible: false },
+  migration_pass: { dimension: "migration", polarity: "pass", gateEligible: true },
+  migration_fail: { dimension: "migration", polarity: "fail", gateEligible: false },
+  source_verified: { dimension: "source", polarity: "pass", gateEligible: true },
+  spec_review: { dimension: "documentation", polarity: "pass", gateEligible: true },
+  manual_check: { dimension: "manual", polarity: "pass", gateEligible: true },
+  external_link: { dimension: "supporting-context", polarity: "neutral", gateEligible: false },
+};
+
+const EVIDENCE_KIND_SET: ReadonlySet<string> = new Set(EXECUTION_EVIDENCE_KINDS);
+
+export function isExecutionEvidenceKind(value: unknown): value is ExecutionEvidenceKind {
+  return typeof value === "string" && EVIDENCE_KIND_SET.has(value);
+}
+
+export function evidenceKindMetadata(kind: ExecutionEvidenceKind): EvidenceKindMetadata {
+  return EVIDENCE_KIND_METADATA[kind];
+}
+
+export type NormalizedExecutionEvidencePayload = {
+  evidenceKind: ExecutionEvidenceKind;
+  url: string | null;
+  body: string | null;
+  toolExecutionId: string | null;
+};
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function normalizeExecutionEvidencePayload(
+  raw: unknown,
+): NormalizedExecutionEvidencePayload | null {
+  if (!isRecord(raw) || !isExecutionEvidenceKind(raw.evidenceKind)) return null;
+  return {
+    evidenceKind: raw.evidenceKind,
+    url: optionalString(raw.url),
+    body: optionalString(raw.body),
+    toolExecutionId: optionalString(raw.toolExecutionId),
+  };
+}
+
+export function validateExecutionEvidenceStructure(
+  kind: ExecutionEvidenceKind,
+  url: string | null,
+): string | null {
+  if (kind !== "source_verified") return null;
+  if (!url) return "source_verified evidence requires an HTTP(S) source or pull-request URL";
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "source_verified evidence requires an HTTP(S) source or pull-request URL";
+    }
+    return null;
+  } catch {
+    return "source_verified evidence requires an HTTP(S) source or pull-request URL";
+  }
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 552,
+  "pageCount": 553,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -397,6 +397,21 @@
         "what-this-currently-tells-us-the-open-adoption-gaps",
         "refresh-ritual-monthly-how-this-stays-fresh",
         "related"
+      ]
+    },
+    "docs/architecture/agent-client-governance.md": {
+      "publicHref": "/architecture/agent-client-governance/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "agent-client-governance",
+        "the-four-governance-altitudes",
+        "which-plane-owns-what",
+        "evidence-earned-completion",
+        "client-identity-and-trust",
+        "operator-attention",
+        "adding-another-consequential-gate"
       ]
     },
     "docs/architecture/agent-skill-index.md": {

--- a/apps/web/lib/governance/register-tool-governance-hooks.ts
+++ b/apps/web/lib/governance/register-tool-governance-hooks.ts
@@ -1,0 +1,8 @@
+import { createCompletionEvidenceGovernanceHook } from "@/lib/backlog/completion-evidence-governance-hook";
+import { registerToolLifecycleHook } from "@/lib/mcp-governed-execute";
+import { createDecisionRoutingGovernanceHook } from "@/lib/tak/decision-routing-governance-hook";
+
+export function registerServerToolGovernanceHooks(): void {
+  registerToolLifecycleHook(createDecisionRoutingGovernanceHook());
+  registerToolLifecycleHook(createCompletionEvidenceGovernanceHook());
+}

--- a/apps/web/lib/mcp/packs/backlog-pack.test.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.test.ts
@@ -54,6 +54,14 @@ vi.mock("@/lib/mcp-handlers/update-backlog-item", () => ({
 const backlogBridge = vi.hoisted(() => ({ bridgeBacklogItemToWorkItem: vi.fn() }));
 vi.mock("@/lib/queue/bridges/backlog-bridge", () => backlogBridge);
 
+const specPlanSearch = vi.hoisted(() => ({
+  buildSpecPlanReferenceIndex: vi.fn(async () => ({
+    specs: new Map<string, string>(),
+    plans: new Map<string, string>(),
+  })),
+}));
+vi.mock("@/lib/backlog/spec-plan-search", () => specPlanSearch);
+
 import { backlogPack } from "./backlog-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 

--- a/apps/web/lib/mcp/packs/backlog-pack.test.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.test.ts
@@ -11,6 +11,10 @@ const db = vi.hoisted(() => ({
   epicCount: vi.fn(),
   platformDevConfigFindUnique: vi.fn(),
   transaction: vi.fn(),
+  txBacklogItemUpdate: vi.fn(),
+  txActivityCreate: vi.fn(),
+  txBacklogItemCount: vi.fn(),
+  txEpicUpdate: vi.fn(),
 }));
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -47,6 +51,9 @@ vi.mock("@/lib/mcp-handlers/update-backlog-item", () => ({
   handleUpdateBacklogItem: (...a: unknown[]) => updateHandler.handleUpdateBacklogItem(...a),
 }));
 
+const backlogBridge = vi.hoisted(() => ({ bridgeBacklogItemToWorkItem: vi.fn() }));
+vi.mock("@/lib/queue/bridges/backlog-bridge", () => backlogBridge);
+
 import { backlogPack } from "./backlog-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 
@@ -70,6 +77,20 @@ const EXPECTED_TOOLS = [
 
 beforeEach(() => {
   vi.clearAllMocks();
+  db.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
+    callback({
+      backlogItem: {
+        update: (...a: unknown[]) => db.txBacklogItemUpdate(...a),
+        count: (...a: unknown[]) => db.txBacklogItemCount(...a),
+      },
+      backlogItemActivity: {
+        create: (...a: unknown[]) => db.txActivityCreate(...a),
+      },
+      epic: {
+        update: (...a: unknown[]) => db.txEpicUpdate(...a),
+      },
+    }),
+  );
 });
 
 describe("backlog pack — registration", () => {
@@ -155,6 +176,94 @@ describe("backlog pack — handler behavior (delegation preserved)", () => {
     );
     expect(res.success).toBe(false);
     expect(res.error).toBe("invalid_status");
+  });
+
+  it("update_backlog_item_status exposes the typed completion evidence schema", () => {
+    const definition = backlogPack.definitions.find((entry) => entry.name === "update_backlog_item_status");
+    const rootProperties = definition?.inputSchema.properties as
+      | Record<string, unknown>
+      | undefined;
+    const completionEvidence = rootProperties?.completionEvidence as
+      | { properties?: Record<string, { enum?: unknown[]; maxItems?: number }> }
+      | undefined;
+    expect(completionEvidence?.properties?.workClass.enum).toEqual([
+      "documentation",
+      "verified-existing",
+      "implementation",
+      "operational",
+    ]);
+    expect(completionEvidence?.properties?.evidenceActivityIds.maxItems).toBe(50);
+  });
+
+  it("update_backlog_item_status records the normalized completion evidence receipt", async () => {
+    db.backlogItemFindUnique.mockResolvedValue({
+      id: "row-1",
+      status: "in-progress",
+      epicId: null,
+      triageOutcome: "build",
+      effortSize: "medium",
+      activeBuildId: null,
+      claimStatus: "active",
+      claimedById: "u1",
+      claimedByAgentId: "agent-1",
+      claimedAt: new Date("2026-07-26T09:00:00Z"),
+    });
+    db.txBacklogItemUpdate.mockResolvedValue({
+      itemId: "BI-1",
+      status: "done",
+      epicId: null,
+      completedAt: new Date("2026-07-26T12:00:00Z"),
+    });
+    db.txActivityCreate.mockResolvedValue({ id: "activity-1" });
+    const res = await backlogPack.handlers.update_backlog_item_status(
+      {
+        itemId: "BI-1",
+        status: "done",
+        resolution: "Delivered through PR #1.",
+        completionEvidence: {
+          workClass: "implementation",
+          evidenceActivityIds: ["source", "tests", "tests"],
+          useActiveBuildEvidence: false,
+          ux: { disposition: "not-applicable", reason: "No user interface files or routes changed." },
+          migration: { disposition: "not-applicable", reason: "No database schema or persisted data changed." },
+          callerVerdict: "allow",
+        },
+      },
+      "u1",
+      { agentId: "agent-1" },
+    );
+    expect(res.success).toBe(true);
+    const payload = db.txActivityCreate.mock.calls[0][0].data.payload;
+    expect(payload.completionEvidence).toEqual({
+      workClass: "implementation",
+      evidenceActivityIds: ["source", "tests"],
+      useActiveBuildEvidence: false,
+      ux: { disposition: "not-applicable", reason: "No user interface files or routes changed." },
+      migration: { disposition: "not-applicable", reason: "No database schema or persisted data changed." },
+    });
+    expect(payload.completionEvidence.callerVerdict).toBeUndefined();
+  });
+
+  it("update_backlog_item_status keeps an already-done retry a no-op without a new receipt", async () => {
+    db.backlogItemFindUnique.mockResolvedValue({
+      id: "row-1",
+      status: "done",
+      epicId: null,
+      triageOutcome: "build",
+      effortSize: "medium",
+      activeBuildId: null,
+      claimStatus: "released",
+      claimedById: "u1",
+      claimedByAgentId: "agent-1",
+      claimedAt: new Date("2026-07-26T09:00:00Z"),
+    });
+    const res = await backlogPack.handlers.update_backlog_item_status(
+      { itemId: "BI-1", status: "done", resolution: "already done" },
+      "u1",
+    );
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("no-op");
+    expect(db.transaction).not.toHaveBeenCalled();
   });
 
   it("link_backlog_item_to_epic requires an itemId", async () => {

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -38,6 +38,7 @@ import type { BacklogIngestInput } from "@/lib/operate/backlog-ingest";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import { tryAcquireBacklogClaimAtomic } from "@/lib/backlog/claim-on-start";
+import { normalizeCompletionEvidenceManifest } from "@/lib/backlog/completion-evidence-policy";
 
 const definitions: ToolDefinition[] = [
   {
@@ -268,7 +269,7 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "update_backlog_item_status",
-    description: "Move a backlog item between lifecycle statuses. Enforces the legal-transition table; same-status calls are no-op successes. Setting status='triaging' on an already-triaged item is the *retriage* path — clears triageOutcome and effortSize so triage_backlog_item can re-decide. Setting status='done' requires a resolution. Writes a status_change activity row and may auto-close the parent epic. Moving an item to in-progress ACQUIRES its work claim and is rejected with error=claim_conflict if another session already holds a fresh active claim (pass force=true to take it over); the claim is released when the item leaves in-progress. NOTE: this only changes the status field — it does NOT start work. For a triageOutcome=build item, starting the work means promote_to_build_studio (creates the FeatureBuild + Build Studio Ideate); flipping such an item to in-progress returns an advisory and does not build anything.",
+    description: "Move a backlog item between lifecycle statuses. Enforces the legal-transition table; same-status calls are no-op successes. Agent callers setting status='done' must supply completionEvidence that cites fresh, server-resolved evidence proportional to documentation, verified-existing, implementation, or operational work. Setting status='triaging' on an already-triaged item is the retriage path. Moving an item to in-progress acquires its work claim; it does not start Build Studio.",
     inputSchema: {
       type: "object",
       properties: {
@@ -277,6 +278,39 @@ const definitions: ToolDefinition[] = [
         reason: { type: "string", description: "Free-text rationale captured in the activity row. Required when status=triaging from a triaged status." },
         resolution: { type: "string", description: "Outcome summary, required when status=done" },
         force: { type: "boolean", description: "When moving to in-progress, take over a claim already held by another active session (default false). The takeover is recorded on the status_change activity row." },
+        completionEvidence: {
+          type: "object",
+          description: "Required for agent callers when status=done. Cite evidence activity IDs; implementation work must explicitly classify UX and migration as verified or not-applicable with a concrete reason.",
+          properties: {
+            workClass: {
+              type: "string",
+              enum: ["documentation", "verified-existing", "implementation", "operational"],
+            },
+            evidenceActivityIds: {
+              type: "array",
+              items: { type: "string" },
+              maxItems: 50,
+            },
+            useActiveBuildEvidence: { type: "boolean" },
+            ux: {
+              type: "object",
+              properties: {
+                disposition: { type: "string", enum: ["verified", "not-applicable"] },
+                reason: { type: "string" },
+              },
+              required: ["disposition"],
+            },
+            migration: {
+              type: "object",
+              properties: {
+                disposition: { type: "string", enum: ["verified", "not-applicable"] },
+                reason: { type: "string" },
+              },
+              required: ["disposition"],
+            },
+          },
+          required: ["workClass", "evidenceActivityIds"],
+        },
       },
       required: ["itemId", "status"],
     },
@@ -643,6 +677,10 @@ async function updateBacklogItemStatus(
     };
   const reason = typeof params["reason"] === "string" ? params["reason"] : null;
   const resolution = typeof params["resolution"] === "string" ? params["resolution"] : null;
+  const completionEvidence =
+    target === "done"
+      ? normalizeCompletionEvidenceManifest(params["completionEvidence"])
+      : null;
   if (target === "done" && !resolution)
     return {
       success: false,
@@ -755,6 +793,17 @@ async function updateBacklogItemStatus(
           to: target,
           reason: reason ?? null,
           resolution: resolution ?? null,
+          ...(completionEvidence
+            ? {
+                completionEvidence: {
+                  workClass: completionEvidence.workClass,
+                  evidenceActivityIds: completionEvidence.evidenceActivityIds,
+                  useActiveBuildEvidence: completionEvidence.useActiveBuildEvidence,
+                  ux: completionEvidence.ux ?? null,
+                  migration: completionEvidence.migration ?? null,
+                },
+              }
+            : {}),
           ...(isRetriage
             ? {
                 retriage: true,

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -39,7 +39,7 @@ import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import { tryAcquireBacklogClaimAtomic } from "@/lib/backlog/claim-on-start";
 import { normalizeCompletionEvidenceManifest } from "@/lib/backlog/completion-evidence-policy";
-
+import { backlogStatusToolDefinition } from "./backlog-status-tool-definition";
 const definitions: ToolDefinition[] = [
   {
     name: "create_backlog_item",
@@ -267,56 +267,7 @@ const definitions: ToolDefinition[] = [
     executionMode: "immediate",
     sideEffect: false,
   },
-  {
-    name: "update_backlog_item_status",
-    description: "Move a backlog item between lifecycle statuses. Enforces the legal-transition table; same-status calls are no-op successes. Agent callers setting status='done' must supply completionEvidence that cites fresh, server-resolved evidence proportional to documentation, verified-existing, implementation, or operational work. Setting status='triaging' on an already-triaged item is the retriage path. Moving an item to in-progress acquires its work claim; it does not start Build Studio.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        itemId: { type: "string", description: "Semantic backlog item id" },
-        status: { type: "string", enum: ["triaging", "open", "in-progress", "done", "deferred"], description: "Target status. 'triaging' from a triaged status is allowed and clears the prior triage decision." },
-        reason: { type: "string", description: "Free-text rationale captured in the activity row. Required when status=triaging from a triaged status." },
-        resolution: { type: "string", description: "Outcome summary, required when status=done" },
-        force: { type: "boolean", description: "When moving to in-progress, take over a claim already held by another active session (default false). The takeover is recorded on the status_change activity row." },
-        completionEvidence: {
-          type: "object",
-          description: "Required for agent callers when status=done. Cite evidence activity IDs; implementation work must explicitly classify UX and migration as verified or not-applicable with a concrete reason.",
-          properties: {
-            workClass: {
-              type: "string",
-              enum: ["documentation", "verified-existing", "implementation", "operational"],
-            },
-            evidenceActivityIds: {
-              type: "array",
-              items: { type: "string" },
-              maxItems: 50,
-            },
-            useActiveBuildEvidence: { type: "boolean" },
-            ux: {
-              type: "object",
-              properties: {
-                disposition: { type: "string", enum: ["verified", "not-applicable"] },
-                reason: { type: "string" },
-              },
-              required: ["disposition"],
-            },
-            migration: {
-              type: "object",
-              properties: {
-                disposition: { type: "string", enum: ["verified", "not-applicable"] },
-                reason: { type: "string" },
-              },
-              required: ["disposition"],
-            },
-          },
-          required: ["workClass", "evidenceActivityIds"],
-        },
-      },
-      required: ["itemId", "status"],
-    },
-    requiredCapability: "manage_backlog",
-    sideEffect: true,
-  },
+  backlogStatusToolDefinition,
   {
     name: "link_backlog_item_to_epic",
     description: "Link a backlog item to an epic (or unlink with epicId=null). Recomputes target epic status — if a done epic gains a new open item, it flips back to open. Writes an epic_link activity row. NOTE: linking is organizational only — it does NOT triage the item (use triage_backlog_item) and does NOT promote it or create a build (use promote_to_build_studio). Linking an untriaged/unpromoted item returns an advisory; never report an epic link as 'triaged' or 'promoted'.",

--- a/apps/web/lib/mcp/packs/backlog-status-tool-definition.ts
+++ b/apps/web/lib/mcp/packs/backlog-status-tool-definition.ts
@@ -1,0 +1,52 @@
+import type { ToolDefinition } from "@/lib/mcp-tools";
+
+export const backlogStatusToolDefinition: ToolDefinition = {
+  name: "update_backlog_item_status",
+  description: "Move a backlog item between lifecycle statuses. Enforces the legal-transition table; same-status calls are no-op successes. Agent callers setting status='done' must supply completionEvidence that cites fresh, server-resolved evidence proportional to documentation, verified-existing, implementation, or operational work. Setting status='triaging' on an already-triaged item is the retriage path. Moving an item to in-progress acquires its work claim; it does not start Build Studio.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      itemId: { type: "string", description: "Semantic backlog item id" },
+      status: { type: "string", enum: ["triaging", "open", "in-progress", "done", "deferred"], description: "Target status. 'triaging' from a triaged status is allowed and clears the prior triage decision." },
+      reason: { type: "string", description: "Free-text rationale captured in the activity row. Required when status=triaging from a triaged status." },
+      resolution: { type: "string", description: "Outcome summary, required when status=done" },
+      force: { type: "boolean", description: "When moving to in-progress, take over a claim already held by another active session (default false). The takeover is recorded on the status_change activity row." },
+      completionEvidence: {
+        type: "object",
+        description: "Required for agent callers when status=done. Cite evidence activity IDs; implementation work must explicitly classify UX and migration as verified or not-applicable with a concrete reason.",
+        properties: {
+          workClass: {
+            type: "string",
+            enum: ["documentation", "verified-existing", "implementation", "operational"],
+          },
+          evidenceActivityIds: {
+            type: "array",
+            items: { type: "string" },
+            maxItems: 50,
+          },
+          useActiveBuildEvidence: { type: "boolean" },
+          ux: {
+            type: "object",
+            properties: {
+              disposition: { type: "string", enum: ["verified", "not-applicable"] },
+              reason: { type: "string" },
+            },
+            required: ["disposition"],
+          },
+          migration: {
+            type: "object",
+            properties: {
+              disposition: { type: "string", enum: ["verified", "not-applicable"] },
+              reason: { type: "string" },
+            },
+            required: ["disposition"],
+          },
+        },
+        required: ["workClass", "evidenceActivityIds"],
+      },
+    },
+    required: ["itemId", "status"],
+  },
+  requiredCapability: "manage_backlog",
+  sideEffect: true,
+};

--- a/apps/web/lib/mcp/packs/build-evidence-pack.test.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.test.ts
@@ -6,6 +6,7 @@ const db = vi.hoisted(() => ({
   backlogItemCreate: vi.fn(),
   backlogItemUpdate: vi.fn(),
   activityCreate: vi.fn(),
+  toolExecutionFindUnique: vi.fn(),
 }));
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -17,6 +18,9 @@ vi.mock("@dpf/db", () => ({
     },
     backlogItemActivity: {
       create: (...a: unknown[]) => db.activityCreate(...a),
+    },
+    toolExecution: {
+      findUnique: (...a: unknown[]) => db.toolExecutionFindUnique(...a),
     },
   },
 }));
@@ -81,6 +85,33 @@ describe("build-evidence pack — handler behavior (delegation preserved)", () =
     expect(res.error).toBe("invalid_kind");
   });
 
+  it("record_execution_evidence rejects source evidence without HTTP(S) provenance", async () => {
+    const res = await buildEvidencePack.handlers.record_execution_evidence(
+      { itemId: "BI-1", kind: "source_verified", summary: "source", url: "file:///tmp/repo" },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("invalid_evidence");
+    expect(db.backlogItemFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("record_execution_evidence validates a supplied ToolExecution reference", async () => {
+    db.backlogItemFindUnique.mockResolvedValue({ id: "row-1" });
+    db.toolExecutionFindUnique.mockResolvedValue({ id: "te-1", success: false });
+    const res = await buildEvidencePack.handlers.record_execution_evidence(
+      {
+        itemId: "BI-1",
+        kind: "test_pass",
+        summary: "green",
+        toolExecutionId: "te-1",
+      },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("invalid_tool_execution");
+    expect(db.activityCreate).not.toHaveBeenCalled();
+  });
+
   it("record_execution_evidence writes an evidence activity for a known item", async () => {
     db.backlogItemFindUnique.mockResolvedValue({ id: "row-1" });
     db.activityCreate.mockResolvedValue({ id: "act-1", recordedAt: new Date("2026-01-01T00:00:00Z") });
@@ -95,6 +126,16 @@ describe("build-evidence pack — handler behavior (delegation preserved)", () =
     const arg = db.activityCreate.mock.calls[0][0];
     expect(arg.data.recordedById).toBe("u1");
     expect(arg.data.recordedByAgentId).toBe("agent-x");
+  });
+
+  it("uses the canonical registry in the MCP enum", () => {
+    const definition = buildEvidencePack.definitions.find((entry) => entry.name === "record_execution_evidence");
+    const properties = definition?.inputSchema.properties as
+      | Record<string, { enum?: unknown[] }>
+      | undefined;
+    expect(properties?.kind.enum).toContain("migration_pass");
+    expect(properties?.kind.enum).toContain("ux_fail");
+    expect(properties?.kind.enum).toContain("source_verified");
   });
 
   it("record_execution_evidence surfaces not_found for an unknown item", async () => {

--- a/apps/web/lib/mcp/packs/build-evidence-pack.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.ts
@@ -16,6 +16,11 @@ import * as crypto from "crypto";
 import { prisma } from "@dpf/db";
 
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import {
+  EXECUTION_EVIDENCE_KINDS,
+  isExecutionEvidenceKind,
+  validateExecutionEvidenceStructure,
+} from "@/lib/backlog/execution-evidence";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 
 /** Strip bearer tokens / MCP tokens / Anthropic keys out of operator-supplied failure text. */
@@ -35,23 +40,14 @@ function redactFunctionalFailureText(text: string): string {
 const definitions: ToolDefinition[] = [
   {
     name: "record_execution_evidence",
-    description: "Attach an evidence record to a backlog item (test pass/fail, build pass/fail, ux verification, spec review, manual check, external link). Writes an evidence activity row; the cross-cutting audit lives in ToolExecution. Side-effecting.",
+    description: "Attach typed evidence to a backlog item (tests, production build, UX, migration, source provenance, spec review, manual check, or supporting link). Positive completion evidence is later resolved server-side; a supplied ToolExecution reference must identify a successful execution owned by the same user.",
     inputSchema: {
       type: "object",
       properties: {
         itemId: { type: "string", description: "Semantic backlog item id" },
         kind: {
           type: "string",
-          enum: [
-            "test_pass",
-            "test_fail",
-            "build_pass",
-            "build_fail",
-            "ux_verified",
-            "spec_review",
-            "manual_check",
-            "external_link",
-          ],
+          enum: [...EXECUTION_EVIDENCE_KINDS],
           description: "Evidence kind",
         },
         summary: { type: "string", description: "Headline for the timeline (<= 240 chars)" },
@@ -140,30 +136,37 @@ async function recordExecutionEvidenceHandler(
   const body = typeof params["body"] === "string" ? params["body"].slice(0, 8000) : null;
   const toolExecutionId =
     typeof params["toolExecutionId"] === "string" ? params["toolExecutionId"] : null;
-  const ALLOWED_KINDS = new Set([
-    "test_pass",
-    "test_fail",
-    "build_pass",
-    "build_fail",
-    "ux_verified",
-    "spec_review",
-    "manual_check",
-    "external_link",
-  ]);
   if (!itemIdRaw || !kindRaw || !summaryRaw)
     return {
       success: false,
       error: "missing_required",
       message: "itemId, kind, summary are all required",
     };
-  if (!ALLOWED_KINDS.has(kindRaw))
+  if (!isExecutionEvidenceKind(kindRaw))
     return { success: false, error: "invalid_kind", message: `kind=${kindRaw} not allowed` };
+  const structuralError = validateExecutionEvidenceStructure(kindRaw, url);
+  if (structuralError) {
+    return { success: false, error: "invalid_evidence", message: structuralError };
+  }
   const item = await prisma.backlogItem.findUnique({
     where: { itemId: itemIdRaw },
     select: { id: true },
   });
   if (!item)
     return { success: false, error: "not_found", message: `Item ${itemIdRaw} not found` };
+  if (toolExecutionId) {
+    const toolExecution = await prisma.toolExecution.findUnique({
+      where: { id: toolExecutionId },
+      select: { id: true, success: true, userId: true },
+    });
+    if (!toolExecution?.success || toolExecution.userId !== userId) {
+      return {
+        success: false,
+        error: "invalid_tool_execution",
+        message: `ToolExecution ${toolExecutionId} does not resolve to a successful execution owned by this user`,
+      };
+    }
+  }
   const activity = await prisma.backlogItemActivity.create({
     data: {
       backlogItemId: item.id,

--- a/docs/architecture/agent-client-governance.md
+++ b/docs/architecture/agent-client-governance.md
@@ -1,0 +1,118 @@
+# Agent Client Governance
+
+DPF supports embedded AI coworkers and external coding clients such as Claude,
+Codex, Grok, Antigravity, and customer-owned MCP agents. Trust does not come
+from a client brand or from the client saying that it followed instructions.
+Trust comes from layered controls and observed outcomes.
+
+## The four governance altitudes
+
+| Altitude | Purpose | Authoritative mechanism |
+| --- | --- | --- |
+| Instructions | Teach the agent how DPF works and how to make decisions | `AGENTS.md`, DPF skills, WWMD/WWWD/WSID |
+| Client harness | Catch known procedural mistakes near the client | bootstrap conformance, hooks, worktree and lease guards |
+| Server authority | Decide which actions DPF accepts | MCP token scope, agent grants, lifecycle hooks, evidence gates |
+| Learning and trust | Decide when autonomy may widen | `DecisionShadowLedger`, `TrustState`, regulatory ceilings, governed playbooks |
+
+Each layer solves a different failure class.
+
+- Instructions are portable and expressive, but a client may misunderstand,
+  omit, or override them.
+- Client hooks provide fast feedback, but delivery and trust behavior differs by
+  client and customer-owned agents may not install them.
+- Server gates apply to every caller, but should be reserved for consequential
+  transitions so normal work does not become bureaucratic.
+- Trust learning improves autonomy over time, but only from reconciled outcomes;
+  self-attestation is not an outcome.
+
+## Which plane owns what
+
+```mermaid
+flowchart TD
+  A["AGENTS.md + DPF skills"] --> B["Client bootstrap and hooks"]
+  B --> C["MCP discovery, token scope, and grants"]
+  C --> D["Consequential mutation policy"]
+  D --> E["Evidence and outcome ledgers"]
+  E --> F["Per-activity trust state"]
+  F -->|proved lane| D
+  F -->|missing evidence or ceiling| G["Attention / Work Case"]
+```
+
+Tool discovery and mutation acceptance are intentionally separate:
+
+- Per-client conformance and progressive disclosure decide which tools a caller
+  sees and whether grants permit the call.
+- Consequential mutation policies decide whether the requested state change is
+  supportable now.
+
+A client can therefore possess `backlog_write` and still be denied when it tries
+to mark unsupported work complete. The grant means “may attempt this class of
+action,” not “every claim is true.”
+
+## Evidence-earned completion
+
+`BacklogItem.status="done"` is organizational truth. Agent callers must provide a
+typed completion manifest citing evidence already recorded on the BI. The server
+resolves ownership, freshness, polarity, and supersession before allowing the
+transition.
+
+Evidence requirements are proportional:
+
+- documentation needs a review;
+- verified-existing implementation needs source provenance plus a manual
+  verification record;
+- operational work needs a manual completion check; and
+- new implementation needs source, tests, production build, and any applicable
+  UX or migration evidence.
+
+Inapplicable UX and migration dimensions require a concrete rationale. This is
+less costly than forcing irrelevant tests and more trustworthy than silently
+assuming that a missing record means “not applicable.”
+
+Build Studio is not exempt. Its canonical `FeatureBuild` verification can
+satisfy dimensions through an adapter, so evidence is reused rather than copied.
+
+## Client identity and trust
+
+Client identity is useful attribution:
+
+- which client family and version connected;
+- which token and human principal authorized the request;
+- which coworker or task run acted; and
+- which session or Work Capsule contained the work.
+
+It is not authority. A new Antigravity, Grok, Codex, or customer agent receives
+the same server policy. Measured trust is keyed to coworker, activity, and risk,
+then bounded by regulation and intrinsic authority.
+
+## Operator attention
+
+The platform asks for attention only when attention changes the outcome:
+
+- evidence is genuinely missing;
+- a newer failure invalidates an older pass;
+- repeated unsupported mutations suggest a runaway client;
+- a regulatory or authority ceiling requires a human; or
+- bounded autonomous recovery is exhausted.
+
+The preferred interaction gives one plain-language reason and one recommended
+next action. Raw activity, token, policy, and ledger identifiers remain behind
+engineer-level disclosure.
+
+## Adding another consequential gate
+
+Before adding a gate:
+
+1. verify the canonical record and policy do not already exist;
+2. classify the transition’s reversibility and blast radius;
+3. route real architectural alternatives through WWMD;
+4. reuse `governedExecuteTool` rather than adding a client-specific server path;
+5. reuse existing evidence, attention, and trust records;
+6. provide shadow, enforce, and emergency-off rollout modes when compatibility
+   risk warrants them; and
+7. verify every supported client through the server, even if its local hooks are
+   absent.
+
+The default is not to gate everything. Server enforcement belongs at
+organizational truth, irreversible state, external effect, regulatory floor, or
+material authority-boundary transitions.

--- a/docs/superpowers/plans/2026-07-26-evidence-earned-autonomy.md
+++ b/docs/superpowers/plans/2026-07-26-evidence-earned-autonomy.md
@@ -1,0 +1,275 @@
+# Evidence-Earned Autonomy Implementation Plan
+
+- **Status:** approved for implementation
+- **Date:** 2026-07-26
+- **BI:** `BI-D872BD16`
+- **Epic:** `EP-CLIENT-HOOK-PLANE`
+- **Work Capsule:** `WC-31705B72`
+- **Coverage receipt:** `cms1y0e4v01rc01lhco9fbrke` (`atomic`)
+- **Design:** `docs/superpowers/specs/2026-07-26-evidence-earned-autonomy-design.md`
+- **Branch:** `feat/evidence-earned-autonomy`
+- **Worktree:** `D:/DPF-worktrees/evidence-earned-autonomy`
+
+## Outcome
+
+Ship one atomic, server-authoritative completion-evidence gate that every AI
+client inherits. The delivery is complete when an agent cannot move a BI to
+`done` without server-resolved evidence proportional to the work, while direct
+operator remediation, no-op transitions, and non-consequential work remain
+available.
+
+## Delivery shape and coverage
+
+This plan is **atomic**. The policy, resolver, hook registration, MCP schema,
+status receipt, and evidence writer must ship together:
+
+- a policy without the hook does not enforce;
+- a hook without the schema gives clients no valid retry;
+- a schema without server resolution trusts self-attestation; and
+- a gate without evidence-kind convergence creates two vocabularies.
+
+No phase below is independently shippable. The live backlog-coverage receipt is
+recorded on `BI-D872BD16` before production source edits begin.
+
+## Coordination boundary
+
+- Do not modify the governed-playbook experiment runtime under
+  `apps/web/lib/tak/work-pattern-*`.
+- Read `FeatureBuild` verification through a small adapter only.
+- Do not modify per-client bootstrap/conformance files owned by
+  `BI-71310615`, `BI-88681BE0`, PR #3594, or PR #3596.
+- Do not mutate the 25 audited backlog items.
+- Do not introduce public lifecycle enums or schema migrations.
+
+## Budget
+
+**10 effort units = 8 feature + 2 refactor (20%).**
+
+The two refactor units are limited to:
+
+1. one canonical execution-evidence kind/dimension registry; and
+2. one shared evidence parsing/projection seam used by the writer and verifier.
+
+## Task 1 — TDD the canonical evidence registry (refactor, 1 unit)
+
+**Create:**
+
+- `apps/web/lib/backlog/execution-evidence.ts`
+- `apps/web/lib/backlog/execution-evidence.test.ts`
+
+**Modify:**
+
+- `apps/web/lib/mcp/packs/build-evidence-pack.ts`
+- `apps/web/lib/mcp/packs/build-evidence-pack.test.ts`
+
+**Tests first:**
+
+- every evidence kind maps to one dimension and polarity;
+- neutral `external_link` cannot satisfy a completion gate;
+- source evidence requires an HTTP(S) URL;
+- tool-execution references resolve only to successful audit rows when supplied;
+- the MCP enum and runtime validator consume the same registry.
+
+## Task 2 — TDD the pure completion policy (feature, 3 units)
+
+**Create:**
+
+- `apps/web/lib/backlog/completion-evidence-policy.ts`
+- `apps/web/lib/backlog/completion-evidence-policy.test.ts`
+
+**Contract:**
+
+- parse and normalize `CompletionEvidenceManifest`;
+- enforce item-work-type/work-class compatibility;
+- derive required evidence dimensions;
+- require concrete UX/migration not-applicable rationales;
+- reject dangling, foreign, stale, negative, superseded, or neutral evidence;
+- allow an already-done no-op;
+- return structured blockers and one recommended next action.
+
+**Tests first:**
+
+- documentation, verified-existing, operational, implementation;
+- UI and migration applicability combinations;
+- implementation cannot masquerade as documentation;
+- newer test/build/UX/migration failure invalidates an older pass;
+- evidence from another BI never counts;
+- invalid not-applicable rationale fails;
+- no-op completion remains idempotent.
+
+## Task 3 — TDD the runtime resolver and Build Studio adapter (feature, 2 units;
+refactor, 1 unit)
+
+**Create:**
+
+- `apps/web/lib/backlog/completion-evidence-runtime.ts`
+- `apps/web/lib/backlog/completion-evidence-runtime.test.ts`
+
+**Requirements:**
+
+- load the target item, claim/start cutoff, referenced and newer evidence;
+- project `BacklogItemActivity.payload` through the shared parsing seam;
+- optionally project test/build/UX facts from the active `FeatureBuild`;
+- do not copy Build Studio evidence into a second store;
+- return an evidence verdict with no writes.
+
+**Tests first:**
+
+- active build fulfills only dimensions it proves;
+- skipped UX supports not-applicable, not verified;
+- stale and foreign activity IDs fail;
+- a newer unreferenced failure blocks;
+- missing Build Studio state fails closed;
+- query shape is bounded and indexed.
+
+## Task 4 — TDD the server governance hook and circuit breaker (feature, 2 units)
+
+**Create:**
+
+- `apps/web/lib/backlog/completion-evidence-governance-hook.ts`
+- `apps/web/lib/backlog/completion-evidence-governance-hook.test.ts`
+
+**Modify:**
+
+- `apps/web/instrumentation.ts`
+- `apps/web/lib/mcp-governed-execute.test.ts`
+
+**Requirements:**
+
+- govern only `update_backlog_item_status(status="done")`;
+- govern `external-jsonrpc`, `internal-mcp-session`, and `agentic-loop`;
+- leave direct portal REST and non-completion transitions unchanged;
+- modes: `enforce | shadow | off`;
+- enforce returns actionable blockers;
+- shadow records one item-scoped finding;
+- count recent invalid attempts from `ToolExecution`;
+- after five invalid attempts in ten minutes, send one deduped attention
+  notification; valid evidence-backed retries remain allowed;
+- fail closed on evidence-resolution errors for a consequential request.
+
+**Tests first:**
+
+- every agent source is governed;
+- REST operator path, no-op, and non-done transitions pass;
+- shadow/off behavior;
+- audit/circuit identity precedence: API token, then agent, then user;
+- valid retry bypasses the breaker;
+- attention is deduped and contains no secret.
+
+## Task 5 — wire the MCP contract and durable status receipt (feature, 1 unit)
+
+**Modify:**
+
+- `apps/web/lib/mcp/packs/backlog-pack.ts`
+- `apps/web/lib/mcp/packs/backlog-pack.test.ts`
+
+**Requirements:**
+
+- add the nested `completionEvidence` input schema;
+- update tool guidance with proportional examples;
+- persist the normalized work class, evidence references, Build Studio adapter
+  use, and UX/migration dispositions in the `status_change` activity payload;
+- never persist a caller-supplied gate verdict;
+- keep legal-transition and claim semantics unchanged.
+
+**Tests first:**
+
+- normalized receipt fields are written on completion;
+- evidence parameters are absent from non-completion receipts;
+- no-op does not create a new receipt;
+- existing invalid-status/resolution/claim tests remain green.
+
+## Task 6 — architecture and operator documentation (feature, 1 unit)
+
+**Create:**
+
+- `docs/architecture/agent-client-governance.md`
+
+**Update:**
+
+- this design and plan with implementation/PR pointers;
+- `docs/superpowers/specs/2026-07-24-per-client-configuration-conformance-design.md`
+  with the tool-disclosure versus mutation-acceptance boundary;
+- `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`
+  with the Build Studio evidence-producer relationship if the parallel delivery
+  has not already added the pointer.
+
+The architecture page owns the durable four-altitude explanation. Historical
+specs link to it instead of copying the rules.
+
+## Architecture review findings folded into the plan
+
+- **Aligned:** reuse `BacklogItemActivity`, `FeatureBuild`, `ToolExecution`,
+  Attention, `DecisionShadowLedger`, and `TrustState`; add no table.
+- **Important:** client identity is attribution, never authority. The hook keys
+  policy to source/risk and evidence, not client brand.
+- **Important:** Build Studio is an evidence producer. Read its canonical state
+  through an adapter; never emit duplicate evidence rows just to satisfy this
+  gate.
+- **Important:** self-attested pass strings are insufficient. The server
+  resolves item ownership, polarity, freshness, and supersession.
+- **Minor:** use SLSA’s provenance/verification separation as an architectural
+  analogy only; do not claim SLSA compliance.
+
+## Source-local verification
+
+The worktree is `source-only`. Run focused tests through the available shared
+dependency graph if safe; otherwise classify them unrun locally and execute the
+same commands in the leased integration sandbox:
+
+```powershell
+pnpm --filter web exec vitest run `
+  lib/backlog/execution-evidence.test.ts `
+  lib/backlog/completion-evidence-policy.test.ts `
+  lib/backlog/completion-evidence-runtime.test.ts `
+  lib/backlog/completion-evidence-governance-hook.test.ts `
+  lib/mcp/packs/build-evidence-pack.test.ts `
+  lib/mcp/packs/backlog-pack.test.ts `
+  lib/mcp-governed-execute.test.ts
+pnpm --filter web typecheck
+node scripts/check-module-size.mjs
+node scripts/check-style-drift.mjs
+```
+
+## Governed runtime verification
+
+Lease `local-integration-ci`, run
+`node scripts/sandbox-freshness-preflight.mjs --converge`, and capture branch,
+SHA, lease ID, freshness verdict, and resolved dependency versions.
+
+Exercise:
+
+1. external client implementation completion with resolution only — denied;
+2. documentation with fresh `spec_review` — allowed;
+3. verified-existing with source + manual evidence — allowed;
+4. implementation with source + test + build and UX/migration N/A reasons —
+   allowed;
+5. UI implementation without UX evidence — denied;
+6. migration implementation with a newer migration failure — denied;
+7. active Build Studio evidence reuse — allowed only for proved dimensions;
+8. evidence ID from another BI — denied;
+9. direct operator remediation path — allowed and audited;
+10. five repeated unsupported attempts — one attention notification;
+11. a valid retry after repeated failures — allowed;
+12. shadow and off kill switches — observed without mutation-policy drift.
+
+Then run:
+
+```powershell
+pnpm --filter web build
+```
+
+No migration gate is required because this delivery adds no migration.
+
+## PR completion
+
+- record tests, build, runtime matrix, and no-migration rationale on
+  `WC-31705B72` and `BI-D872BD16`;
+- commit with DCO sign-off;
+- push the branch;
+- run the local merged-code gate;
+- open one ready, non-draft PR;
+- run `pnpm pr:health <n>`;
+- enroll through `gh pr merge <n> --squash --auto`;
+- do not mark the BI done until the PR is merged and the governed release has
+  made the enforcing behavior live.

--- a/docs/superpowers/specs/2026-07-24-per-client-configuration-conformance-design.md
+++ b/docs/superpowers/specs/2026-07-24-per-client-configuration-conformance-design.md
@@ -1,5 +1,14 @@
 # Per-client configuration conformance — server-authoritative minimal substrate + client-advisory optimization
 
+> **Related authority boundary (2026-07-26):** this design governs client
+> identity, conformance, and the tool surface available below the grant ceiling.
+> It does not treat a conforming client as trusted to make every mutation.
+> Consequential mutation acceptance is owned by
+> [`docs/architecture/agent-client-governance.md`](../../architecture/agent-client-governance.md)
+> and the evidence-earned completion design. Tool access means a caller may
+> attempt an action; server-resolved evidence determines whether an
+> organizational-truth transition is accepted.
+
 - **Backlog item:** BI-71310615 — "Per-client configuration conformance across heterogeneous agent clients"
 - **Status:** Design (decision-bearing). No code in this document.
 - **Author:** Claude (external_coding_agent), 2026-07-24

--- a/docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md
+++ b/docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md
@@ -318,6 +318,13 @@ until fleet convergence permits a later contract phase.
 
 ## 8. Outcome evidence and decision rule
 
+Build Studio is also an evidence producer for the cross-surface
+[agent-client governance contract](../../architecture/agent-client-governance.md).
+Its canonical `FeatureBuild` verification may satisfy a consequential backlog
+completion policy through a read adapter; the completion gate must not copy
+Build Studio results into a parallel evidence ledger or grant Build Studio a
+privileged bypass.
+
 Do not collapse quality into a single reward number. Store the dimensions, then apply a versioned
 decision rule appropriate to the activity and risk.
 

--- a/docs/superpowers/specs/2026-07-26-evidence-earned-autonomy-design.md
+++ b/docs/superpowers/specs/2026-07-26-evidence-earned-autonomy-design.md
@@ -9,6 +9,21 @@
 - **Coordinates with:** `BI-71310615`, `BI-88681BE0`, `BI-DE4BF92F`,
   `BI-0A636528`, `BI-522E754E`, and `BI-356E69B1`
 
+## Design grounding
+
+- **Existing specs/plans reviewed:** the per-client configuration conformance
+  design, governed playbook experimentation design, and the parallel autonomous
+  Build Studio experimentation plan.
+- **Current code substrate reviewed:** `mcp-governed-execute.ts`, the backlog
+  and build-evidence tool packs, `ToolExecution`, `BacklogItemActivity`, active
+  Build Studio verification, attention delivery, and startup hook registration.
+- **Source of truth:** server-resolved evidence evaluated by the shared governed
+  lifecycle hook; client instructions and caller-supplied verdicts are not
+  authority.
+- **Decision:** enforce risk-tiered evidence profiles at the common server
+  execution seam. Build Studio and governed playbook experiments may produce
+  qualifying evidence, but cannot bypass the completion gate.
+
 ## 1. Executive decision
 
 DPF will enforce a risk-tiered evidence contract at the server seam where an AI

--- a/docs/superpowers/specs/2026-07-26-evidence-earned-autonomy-design.md
+++ b/docs/superpowers/specs/2026-07-26-evidence-earned-autonomy-design.md
@@ -1,0 +1,341 @@
+# Evidence-Earned Autonomy Across Agent Surfaces
+
+- **Status:** approved for implementation
+- **Date:** 2026-07-26
+- **Primary BI:** `BI-D872BD16`
+- **Epic:** `EP-CLIENT-HOOK-PLANE`
+- **Work Capsule:** `WC-31705B72`
+- **Kernel decision:** `DI-1EAC16AD8524`
+- **Coordinates with:** `BI-71310615`, `BI-88681BE0`, `BI-DE4BF92F`,
+  `BI-0A636528`, `BI-522E754E`, and `BI-356E69B1`
+
+## 1. Executive decision
+
+DPF will enforce a risk-tiered evidence contract at the server seam where an AI
+agent turns a claim into durable organizational truth.
+
+The first enforcing transition is:
+
+```text
+BacklogItem.status: open | in-progress | deferred -> done
+```
+
+Instructions and client hooks remain valuable, but neither is authoritative for
+an arbitrary external client. The shared MCP server is authoritative because
+every external and embedded AI executor must cross it to mutate DPF state.
+
+The operating doctrine is:
+
+> Instructions shape judgment. The harness constrains authority. Evidence earns
+> autonomy.
+
+This is deliberately not a broker around every action. Read-only work, local
+analysis, drafting, and reversible implementation remain fluid. The hard gate
+appears when an agent attempts to record that organizational work is complete.
+
+## 2. Incident and verified gap
+
+An Antigravity audit found that 25 backlog items had been moved to `done` through
+`update_backlog_item_status` without source, schema, test, build, UX, migration,
+or deployment evidence supporting the implementation claims. The audit itself
+made no mutations.
+
+The current handler validates:
+
+- semantic item identity;
+- the closed status vocabulary;
+- legal lifecycle transitions;
+- a non-empty free-text resolution; and
+- work-claim behavior.
+
+It does not validate the evidence behind a `done` claim. That means the prose
+Build Gate in `AGENTS.md` is advisory at the exact point where a claim becomes
+authoritative.
+
+## 3. Relationship to neighboring programs
+
+The platform now has four complementary governance altitudes:
+
+| Altitude | Existing owner | Responsibility |
+| --- | --- | --- |
+| Instruction | `AGENTS.md` + DPF skills | Shape reasoning, workflow, and doctrine |
+| Client harness | bootstrap + per-client hooks | Prevent known local procedural mistakes and surface conformance |
+| Server authority | MCP grants, client conformance, this design | Bound which mutations are accepted regardless of client behavior |
+| Learning and trust | `DecisionShadowLedger`, `TrustState`, governed playbooks | Measure outcomes and widen autonomy only from evidence |
+
+`BI-71310615` and `BI-88681BE0` control which tools a client sees and may call.
+This design controls whether a consequential completion call succeeds.
+
+The governed-playbook program controls how Build Studio compares, promotes, and
+uses methods inside its lifecycle. This design does not duplicate that lifecycle.
+Build Studio remains an evidence producer; its canonical verification state is
+read through an adapter by the completion gate.
+
+## 4. Architecture
+
+```mermaid
+flowchart LR
+  C["Any agent client"] --> G["governedExecuteTool"]
+  G --> P["Completion evidence pre-tool policy"]
+  P -->|read/reversible/non-completion| A["Allow"]
+  P -->|done + complete evidence| M["Backlog status transaction"]
+  P -->|done + missing/invalid evidence| D["Deny with next action"]
+  D --> T["ToolExecution failure audit"]
+  D -->|repeated attempts| N["Deduped operator attention"]
+  M --> B["BacklogItemActivity status receipt"]
+  B --> L["Outcome/trust learning consumers"]
+  E["Backlog evidence activities"] --> P
+  F["FeatureBuild verification"] --> P
+  R["ToolExecution receipts"] --> P
+```
+
+No new table is introduced. The authoritative records remain:
+
+- `BacklogItem` and `BacklogItemActivity` for item lifecycle and item-scoped
+  evidence;
+- `FeatureBuild` for Build Studio verification and acceptance;
+- `ToolExecution` and `ToolExecutionReceipt` for cross-surface execution audit;
+- `DecisionShadowLedger` and `TrustState` for measured decision quality and
+  graduated autonomy; and
+- the existing Attention notification spine for an operator signal.
+
+## 5. Completion manifest
+
+Agent callers supply one typed `completionEvidence` object when `status="done"`:
+
+```ts
+type CompletionEvidenceManifest = {
+  workClass:
+    | "documentation"
+    | "verified-existing"
+    | "implementation"
+    | "operational";
+  evidenceActivityIds: string[];
+  useActiveBuildEvidence?: boolean;
+  ux:
+    | { disposition: "verified" }
+    | { disposition: "not-applicable"; reason: string };
+  migration:
+    | { disposition: "verified" }
+    | { disposition: "not-applicable"; reason: string };
+};
+```
+
+Documentation and operational profiles may omit `ux` and `migration`. An
+implementation profile must declare both dimensions. A not-applicable reason is
+recorded in the status receipt and must be concrete; it is not inferred from the
+absence of evidence.
+
+Work-class compatibility is derived from the item:
+
+| `BacklogItem.workType` | Allowed completion work class |
+| --- | --- |
+| `doc` | `documentation` |
+| `feature`, `bug`, `refactor` | `implementation`, `verified-existing` |
+| `tool`, `skill`, `chore` | `implementation`, `verified-existing`, `operational` |
+
+This prevents an implementation BI from self-classifying as documentation to
+escape build evidence.
+
+## 6. Canonical evidence dimensions
+
+The existing execution-evidence kinds become one typed registry shared by the
+evidence writer and completion verifier:
+
+| Evidence kind | Dimension | Polarity | Gate-eligible |
+| --- | --- | --- | --- |
+| `test_pass` / `test_fail` | unit tests | pass / fail | yes |
+| `build_pass` / `build_fail` | production build | pass / fail | yes |
+| `ux_verified` / `ux_fail` | UX verification | pass / fail | yes |
+| `migration_pass` / `migration_fail` | migration apply | pass / fail | yes |
+| `source_verified` | source/PR provenance | pass | yes |
+| `spec_review` | documentation review | pass | yes |
+| `manual_check` | operational or verified-existing check | pass | yes |
+| `external_link` | supporting context | neutral | no |
+
+Required dimensions:
+
+| Work class | Required evidence |
+| --- | --- |
+| `documentation` | `spec_review` |
+| `verified-existing` | `source_verified`, `manual_check` |
+| `operational` | `manual_check` |
+| `implementation` | `source_verified`, `test_pass`, `build_pass`, plus verified UX/migration when applicable |
+
+An explicit evidence reference is accepted only when it:
+
+1. resolves to an `evidence` activity on the target BI;
+2. uses a gate-eligible, positive kind;
+3. is newer than the item evidence cutoff;
+4. is not superseded by a newer failure in the same dimension; and
+5. satisfies any kind-specific structural requirement, such as a source URL for
+   `source_verified`.
+
+The evidence cutoff is the later of the item claim/start timestamp and the
+bounded freshness window. Evidence created before the current work attempt or
+older than the window cannot close the item.
+
+## 7. Build Studio adapter
+
+When `useActiveBuildEvidence=true`, the verifier may satisfy test, production
+build, and UX dimensions directly from the item’s active `FeatureBuild`:
+
+- `verificationOut.typecheckPassed === true`;
+- `verificationOut.testsFailed === 0`;
+- `verificationOut.buildPassed === true`; and
+- `uxVerificationStatus === "complete"` for applicable UX.
+
+Skipped UX can support a manifest’s not-applicable disposition but cannot be
+reported as verified. Migration and source provenance remain explicit evidence
+unless a later canonical Build Studio receipt owns those dimensions.
+
+This is an adapter over the existing record, not copied evidence and not a
+second Build Studio gate.
+
+## 8. Surface and override policy
+
+The completion gate applies to:
+
+- `external-jsonrpc` — Claude, Codex, Grok, Antigravity, and customer agents;
+- `internal-mcp-session` — authenticated internal adapters; and
+- `agentic-loop` — embedded coworkers and Build Studio agents.
+
+The direct authenticated portal REST path remains the operator remediation
+path only when it carries no agent identity. A REST call carrying `agentId` is
+governed like every other agent surface. The path is still audited, and an
+external AI caller cannot select its governed source or self-authorize an
+override through tool parameters.
+
+No-op calls on an already-done item remain idempotent and do not require new
+evidence.
+
+## 9. Rollout and failure behavior
+
+`DPF_COMPLETION_EVIDENCE_GATE_MODE` supports:
+
+- `shadow` — evaluate and record the missing evidence, but allow;
+- `enforce` — deny incomplete completion claims;
+- `off` — emergency kill switch.
+
+The intended rollout is shadow in the shared sandbox, then enforce for all
+agent sources after the compatibility fixture passes. The code default is
+`enforce`; an operator may temporarily select shadow while an older client is
+being upgraded.
+
+Denials are normal governed outcomes. The response names:
+
+- which evidence dimensions are missing or invalid;
+- whether a newer failure invalidated a pass;
+- which tool to call to record evidence; and
+- the exact retry shape.
+
+The hook fails closed for a well-formed consequential completion request whose
+evidence cannot be resolved. Database unavailability follows the server’s
+ordinary tool failure behavior; it is not converted into approval.
+
+## 10. Repeated-attempt circuit breaker
+
+Unsupported completion attempts are counted from recent failed
+`ToolExecution` rows for the same API token, agent, or user.
+
+- A valid evidence-backed retry is always allowed.
+- Five invalid completion attempts inside ten minutes emit one deduped
+  operator notification and return a circuit-breaker explanation.
+- The notification links to the target BI and identifies the caller client and
+  missing evidence classes without exposing secrets.
+- The breaker cools down automatically; it does not create a new queue or
+  persistent lock.
+
+This turns the observed 25-item sweep into a bounded, visible event while
+keeping legitimate batch completion possible when every item carries evidence.
+
+## 11. Trust and learning contract
+
+Gate outcomes are already represented by `ToolExecution`:
+
+- enforced denials are failed, audited calls;
+- successful evidence-backed completions are successful calls plus a
+  `BacklogItemActivity` receipt containing the normalized manifest; and
+- shadow findings are item-scoped activities.
+
+Those records can be projected into the existing
+`DecisionShadowLedger(activityType="backlog-completion",
+riskClass="internal-irreversible")`. This delivery does not directly graduate
+trust from self-attestation. Trust changes require reconciled outcome evidence
+under the existing `TrustState` policy.
+
+Client kind is attribution, not trust. A new client does not become trusted
+because its name appears in `initialize.clientInfo` or User-Agent.
+
+## 12. Operator experience
+
+This slice adds no dashboard. The operator sees:
+
+- a concise denial explaining what is missing;
+- a deduped attention notification only after repeated invalid attempts; and
+- the evidence manifest and not-applicable rationales in the BI timeline.
+
+Raw activity IDs remain an engineer-level retry detail. The default message is
+outcome-first: “This item is not complete yet because production-build evidence
+is missing.”
+
+## 13. Standards alignment
+
+The design adopts the useful shape of current standards without claiming
+compliance:
+
+- [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework)’s
+  Govern, Map, Measure, and Manage structure supports
+  risk-proportional controls and ongoing monitoring of AI-enabled activity.
+- [SLSA 1.2](https://slsa.dev/spec/v1.2/) separates provenance claims from verification against
+  producer-defined expectations. DPF similarly resolves evidence server-side
+  against a completion policy instead of trusting an agent’s prose claim.
+- [SLSA Verification Summary Attestations](https://slsa.dev/spec/v1.2/verification_summary)
+  reinforce the architectural value of
+  reusing a trusted verifier’s result; the Build Studio adapter follows that
+  pattern without inventing a new attestation store.
+
+DPF does not claim SLSA provenance or NIST conformance from this feature.
+
+## 14. Refactoring budget
+
+Implementation budget: **10 effort units**, exactly **2 refactor units (20%)**.
+
+| Work | Feature units | Refactor units |
+| --- | ---: | ---: |
+| Completion policy and manifest | 3 | 0 |
+| Runtime evidence resolver and Build Studio adapter | 2 | 0 |
+| Governed-execution hook, circuit breaker, attention | 2 | 0 |
+| MCP wiring, receipts, rollout, docs, verification | 1 | 0 |
+| Canonical execution-evidence kind registry | 0 | 1 |
+| Shared evidence parsing/projection seam | 0 | 1 |
+| **Total** | **8** | **2** |
+
+The refactor is a cap as well as a reservation. It does not include a general
+MCP pack rewrite, audit-ledger redesign, or Build Studio lifecycle cleanup.
+
+## 15. Non-goals
+
+- Brokering every tool call.
+- Replacing MCP grants or per-client conformance.
+- Creating a new evidence, trust, attention, or approval table.
+- Automatically reopening the 25 audited items.
+- Treating client identity as authority.
+- Letting an agent override the gate.
+- Duplicating governed-playbook experimentation or Build Studio acceptance.
+- Requiring UX or migration evidence when the dimension is genuinely
+  inapplicable and a concrete rationale is recorded.
+
+## 16. Success criteria
+
+- A newly installed agent client cannot close an implementation BI from prose
+  alone.
+- Documentation and operational work remain proportionate and low friction.
+- Existing, verified implementation can be closed without pretending it was
+  newly built.
+- A newer failure invalidates an older pass.
+- Build Studio evidence is consumed from its canonical record.
+- Repeated unsupported attempts become visible before they become a sweep.
+- Every outcome is attributable to human, client, token/session, and agent where
+  those identities are available.
+- No second authority or evidence rail exists.


### PR DESCRIPTION
## Summary
- enforce server-authoritative completion evidence for agent-driven `update_backlog_item_status(..., done)` calls across embedded, JSON-RPC, and external MCP clients
- introduce typed evidence profiles for implementation, documentation, verified-existing, and operational work, including freshness, failure supersession, and work-type compatibility
- add repeated-invalid-attempt attention without blocking valid retries, plus `enforce` / `shadow` / `off` rollout modes
- document the cross-surface governance architecture and coordinate it with PR #3598: Build Studio/playbook experiments produce evidence but cannot bypass organizational truth gates
- implements BI-D872BD16; records WWMD decision DI-1EAC16AD8524

## Verification
- [x] sandbox freshness: green (Next 16.2.11, React 19.2.8, TypeScript 6.0.3, Prisma 7.8.0, Vitest 4.1.10)
- [x] full Vitest: 2,212 files / 19,222 tests passed
- [x] focused completion-evidence suites: 71 tests passed
- [x] `pnpm --filter web typecheck`: passed
- [x] production Docker build (`--target build`): passed
- [x] Prisma migrate deploy: 444 migrations found, none pending
- [x] documentation index, links, repository guards, and pre-commit Gitleaks: passed
- [x] UX verification: not applicable — no routes, components, forms, or visual behavior changed; tool lifecycle behavior is covered by policy/runtime/integration tests

## Coordination and boundaries
- overlap sweep found no duplicate open PR
- PR #3598 owns governed playbook experiment ledger and Build Studio method learning
- this PR owns cross-client authority over claims that organizational work is complete
- no schema migration and no new trust-state model; existing evidence, activity, ToolExecution, Build Studio verification, and attention substrates are reused

Local-CI-Evidence: cms20adxa04ym01lhdulhy2dk (feat/evidence-earned-autonomy@ede29ff173d564ebac9a83af976dfd27e05c8384)

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-24-per-client-configuration-conformance-design.md`
  - `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`
  - `D:/DPF-worktrees/governed-playbook-experimentation/docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`
- Current code substrate reviewed:
  - `apps/web/lib/mcp-governed-execute.ts` lifecycle authority and ToolExecution audit
  - backlog/build-evidence tool packs, BacklogItemActivity evidence, active Build Studio verification, attention delivery, and startup hook registration
- Source of truth:
  - server-resolved evidence and the shared governed lifecycle hook; client instructions and caller-supplied verdicts are not authority
- Decision:
  - enforce risk-tiered evidence profiles at the common server execution seam; allow Build Studio and governed playbook experiments to produce qualifying evidence, never to bypass the completion gate

