### PR TITLE
docs: make AI routing architecture explainable

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 553,
+  "pageCount": 554,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -550,6 +550,21 @@
         "implementation-7",
         "rationale-7",
         "application"
+      ]
+    },
+    "docs/architecture/ai-routing-document-map.md": {
+      "publicHref": "/architecture/ai-routing-document-map/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "ai-routing-document-map",
+        "current-authority",
+        "approved-adjacent-delivery-contract",
+        "proposed-architecture",
+        "historical-records",
+        "provider-and-model-pin-semantics",
+        "planned-one-picture-experience"
       ]
     },
     "docs/architecture/archetype-business-value-streams.md": {
@@ -9180,6 +9195,7 @@
       "anchors": [
         "use-this-doc-for",
         "workflow",
+        "architecture-and-evidence",
         "what-to-watch"
       ]
     },

--- a/docs/architecture/ai-routing-document-map.md
+++ b/docs/architecture/ai-routing-document-map.md
@@ -1,0 +1,72 @@
+# AI routing document map
+
+This page is the entry point for understanding DPF's LLM and AI coworker routing.
+It separates what the platform does now from proposed architecture and historical
+records.
+
+## Current authority
+
+| Question | Authority |
+| --- | --- |
+| How does an operator configure and understand routing today? | [Model Routing & Lifecycle](../user-guide/ai-workforce/model-routing-lifecycle.md) |
+| What code chooses and dispatches a route? | `apps/web/lib/inference/routed-inference.ts`, `apps/web/lib/routing/request-contract.ts`, and `apps/web/lib/routing/pipeline-v2.ts` |
+| What policy decides whether governed data may leave the install? | `apps/web/lib/govern/data/policy-decision.ts` and `apps/web/lib/govern/data/policy-enforcement.ts` |
+| How is provider/account suitability compiled into route constraints? | [AI provider suitability routing design](../superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md) and its implemented contracts |
+| What happened operationally? | Route decisions, inference outcomes, token usage, capacity state, and safe suitability receipts in the live install |
+
+Current implementation truth comes from code plus live evidence. A diagram, design
+document, or seeded row does not override those sources.
+
+## Approved adjacent delivery contract
+
+[Pre-dispatch sensitive LLM routing](../superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md)
+defines the implementation sequence for classifying governed payloads, evaluating
+the data PDP/PEP, enforcing masking/tokenization obligations, constraining provider
+eligibility, preserving constraints through fallback, and authorizing response
+rehydration. It landed through PR #3602. Delivery progress must still be read from
+its backlog items and implementation evidence; a merged plan is not evidence that
+every planned behavior is already live.
+
+## Proposed architecture
+
+| Artifact | Status and purpose |
+| --- | --- |
+| [AI Routing Architecture & Explainability](../superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md) | Proposed architecture authority for the owner-readable routing subway map, Designed/Observed/Compare viewpoints, safe conformance evidence, and technical drill-through |
+| [Routing Control Plane / Data Plane](../superpowers/specs/2026-04-27-routing-control-data-plane-design.md) | Proposed and deferred RIB/FIB target state; not the current per-request routing runtime |
+
+## Historical records
+
+[Routing architecture dated snapshot](../superpowers/specs/2026-04-20-routing-architecture-current.md)
+records the platform's 2026-04-20 understanding. Earlier routing designs that point
+to that file remain historical context as well.
+
+## Provider and model pin semantics
+
+The verified current behavior is:
+
+1. Seed and first-run bootstrap leave agent provider/model pins empty.
+2. A persisted pin is mapped to a preferred provider/model for routed inference.
+3. Routing first constructs the candidate set and applies hard exclusions.
+4. The preference may replace the cost/quality winner only with a non-excluded
+   candidate.
+5. An excluded or unavailable preference target produces a warning and falls back
+   to the normal V2 winner.
+6. Startup audits non-null pins because they are intentional exceptions to dynamic
+   routing.
+
+A live query on 2026-07-26 found 24 `AgentModelConfig` rows, 0 provider pins, and
+0 model pins in the current install. This is time-bounded operational evidence, not
+a fleet invariant.
+
+## Planned one-picture experience
+
+The target experience uses one stable route geometry:
+
+- **Designed** shows the governed route that should be available.
+- **Observed** overlays privacy-safe evidence for a selected time window.
+- **Compare** exposes missing evidence, unexpected paths, stale design, and
+  attribution gaps.
+
+The owner view uses plain-language subway stations. BPMN, SysML, ArchiMate/C4,
+source versions, rule detail, and remediation appear through progressive
+drill-through rather than competing diagrams.

--- a/docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md
+++ b/docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md
@@ -1,0 +1,325 @@
+# AI Routing Architecture & Explainability — Implementation Plan
+
+> **For agentic workers:** execute this plan one independently reviewable backlog
+> item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+> implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate
+> before any success claim, and `dpf-pr-with-dco` for handoff.
+
+**Goal:** Produce one governed routing architecture and three synchronized
+Designed/Observed/Compare views that explain LLM and AI coworker routing to owners
+while giving technical users safe evidence, source links and conformance detail.
+
+**Epic:** `EP-CFACFA9F`
+
+**Umbrella BI:** `BI-3FA17F95`
+
+**Design:** `docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md`
+
+**Upstream contract:** `BI-3D210AF8` / PR #3602 /
+`docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
+
+## Backlog coverage
+
+- Decision: `decomposed`
+- Receipt: `cms1zo19r04c301lhwyiplt8t`
+- Parent: `BI-3FA17F95`
+
+| Deliverable | BI | Depends on |
+| --- | --- | --- |
+| Canonical design and documentation authority | `BI-CC9BCFC8` | — |
+| BPMN routing and linked EA projection | `BI-AA314BF4` | canonical design |
+| Safe evidence correlation and conformance | `BI-758722A7` | canonical design; sensitive-routing receipt contract |
+| Architecture drill-through and decision inspector | `BI-52C015D8` | canonical design |
+| Operations Map Designed/Observed/Compare UX | `BI-7378E34C` | EA projection; evidence/conformance; drill-through |
+
+Existing `BI-7E2A1DD0` owns the deployed interactive-map regression and must be
+coordinated rather than duplicated.
+
+## Delivery doctrine
+
+- Extend the existing `/ea` and `/platform/ai/operations-map` surfaces.
+- Keep routing, governance, provider-suitability and telemetry sources canonical.
+- Project current state; do not hand-maintain it.
+- Keep target-state facts visibly proposed.
+- Never place raw prompt/tool/customer/employee/financial/secret values or token maps
+  in architecture or operational evidence.
+- Each BI lands through its own DCO-signed PR.
+- Runtime-bound verification uses the governed shared nonprod environment.
+
+## Phase 1 — `BI-CC9BCFC8`: canonical design and documentation authority
+
+### Deliverable
+
+Approve the design artifact, resolve routing-document authority and reconcile verified
+current behavior.
+
+### Work
+
+- [ ] Review the design with Enterprise Architect, Data Architect, AI Operations and
+      provider-suitability ownership.
+- [ ] Merge or coordinate PR #3602 so the sensitive-routing contract has a stable
+      repository path.
+- [ ] Verify the implemented pin behavior and live `AgentModelConfig` state; resolve
+      the contradiction between the current-state architecture and user guide.
+- [ ] Classify the RIB/FIB control/data-plane document as proposed target-state until
+      its implementation is resumed.
+- [ ] Add an architecture-document index that names current, target and historical
+      routing sources.
+- [ ] Update the owner-facing routing lifecycle guide to point at one current
+      authority and the eventual Operations Map view.
+- [ ] Record concrete documentation impact for operator, contributor and AI coworker
+      surfaces.
+
+### Likely files
+
+- `docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md`
+- `docs/superpowers/specs/2026-04-20-routing-architecture-current.md`
+- `docs/superpowers/specs/2026-04-27-routing-control-data-plane-design.md`
+- `docs/user-guide/ai-workforce/model-routing-lifecycle.md`
+- `docs/user-guide/platform/ai-operations.md`
+- relevant architecture index/README
+
+### Verification
+
+- Link/path check for all referenced artifacts.
+- `git diff --check`.
+- Architecture advisory contains no unresolved critical ownership duplication.
+- Pinning statements are supported by code and live-state evidence.
+
+### Rollback
+
+Revert documentation/index changes. No runtime or schema state is changed.
+
+## Phase 2 — `BI-AA314BF4`: BPMN routing and linked EA projection
+
+### Deliverable
+
+Add a deterministic AI-routing process domain to the Parity Engine.
+
+### Work
+
+- [ ] Define a versioned routing-stage registry or extractor input from existing
+      exported routing/governance contracts.
+- [ ] Write failing pure tests for the complete process from payload assembly through
+      authorized response handling.
+- [ ] Project stages to BPMN process, tasks, gateways, conditional/default flows and
+      lanes.
+- [ ] Include sensitive screen, PDP/PEP, transformation, RequestContract compilation,
+      eligibility, availability/limits, ranking, fallback, dispatch, receipt and
+      rehydration.
+- [ ] Map requirements/constraints/verification cases to existing SysML element types.
+- [ ] Materialize existing cross-notation relationships to realizing ArchiMate
+      components/capabilities.
+- [ ] Reuse `applySysmlModel`/shared projection and conformance reconciliation.
+- [ ] Register the domain in the existing projection orchestrator and steward.
+- [ ] Verify idempotency, soft removal, source-key stability and domain-isolated
+      failure behavior.
+
+### Likely files
+
+- `apps/web/lib/ea/process-extract.ts` or a routing-specific sibling
+- `apps/web/lib/ea/reconcile-process.ts` or a routing-specific sibling
+- `apps/web/lib/ea/reconcile-sysml-projections.ts`
+- `apps/web/lib/ea/sysml-model-seed.ts`
+- `packages/db/src/seed-ea-cross-notation.ts` only if an existing validated mapping
+  is insufficient
+- focused EA projection tests
+
+### Verification
+
+- Targeted Vitest for extractor, reconciler and relationship validation.
+- `pnpm check:architecture-parity`.
+- A repeated reconcile produces no duplicate elements or relationships.
+- Shared nonprod EA view shows the complete route with working cross-notation links.
+- Missing source/version produces a conformance issue rather than silent omission.
+
+### Rollback
+
+Remove the routing domain from the projection orchestrator and soft-remove its stable
+source-key prefix. Preserve unrelated EA views and conformance history.
+
+## Phase 3 — `BI-758722A7`: safe evidence correlation and conformance
+
+### Deliverable
+
+Create one privacy-safe projection from existing route evidence into time-window
+metrics and design/runtime conformance.
+
+### Work
+
+- [ ] Inventory existing correlation fields and write a no-new-ledger decision.
+- [ ] Adopt or extend one existing identifier envelope across screen decision, route
+      decision, fallback attempts, adapter outcome, usage and rehydration.
+- [ ] Bind every Compare calculation to the applicable EA/projection snapshot and
+      implementation source revision; do not compare historic traffic silently
+      against only the latest design.
+- [ ] Define a strict safe-field allowlist and forbidden-field canary fixtures.
+- [ ] Build a pure aggregation model keyed by stable architecture identity and time
+      window.
+- [ ] Compute volume, exclusions, fallback depth, errors, latency, tokens/cost,
+      capacity, freshness, attribution and correlation coverage.
+- [ ] Compute designed-only, observed-only, missing-evidence and stale-design states.
+- [ ] Reconcile aggregated architecture conformance issues without per-transaction
+      issue rows.
+- [ ] Use OpenTelemetry-compatible GenAI names when they match existing DPF contracts.
+- [ ] Document retention and historical-coverage limitations.
+
+### Likely files
+
+- AI Operations Map projection/loaders
+- routing evidence/correlation types
+- existing route-decision/outcome recording seams
+- EA conformance reconciler
+- focused privacy and aggregation tests
+
+### Verification
+
+- Fixture route follows screen → decision → fallback → outcome → rehydration.
+- Historical fixture is compared against its named design revision, and a missing
+  revision is shown as unproven rather than drift.
+- Uncorrelated and unattributed fixtures remain visible as coverage gaps.
+- Canary sensitive values are absent from DB writes, serialized projections, logs,
+  exports and exceptions.
+- Aggregates match direct ledger queries for a controlled fixture window.
+- Repeated conformance reconciliation is idempotent.
+
+### Rollback
+
+Disable the new evidence/conformance projection. Existing route ledgers remain
+authoritative and unchanged.
+
+## Phase 4 — `BI-52C015D8`: architecture drill-through and decision inspector
+
+### Deliverable
+
+Make related BPMN, SysML, ArchiMate, source and evidence viewpoints navigable.
+
+### Work
+
+- [ ] Derive related views from shared `EaElement` membership and existing
+      `EaRelationship`/source identities.
+- [ ] Add authorized SysML view creation/refresh to the existing architecture flow.
+- [ ] Add related-view actions to the element inspector.
+- [ ] Add a governed routing-decision inspector showing safe inputs, source/version,
+      outcome vocabulary and evidence freshness.
+- [ ] Decide from evidence whether the inspector is sufficient or a future DMN
+      notation BI is justified.
+- [ ] Keep SysML details behind architecture permissions and progressive disclosure.
+- [ ] Add keyboard, screen-reader and no-color-only navigation tests.
+
+### Likely files
+
+- `apps/web/components/ea/EaCanvas.tsx`
+- `apps/web/components/ea/ElementInspector.tsx`
+- `apps/web/components/ea/CreateViewButton.tsx`
+- `apps/web/lib/actions/ea.ts`
+- EA view-data loader and focused tests
+
+### Verification
+
+- Navigate BPMN station → SysML requirement/verification → ArchiMate component →
+  implementation source → Operations Map lens.
+- Unauthorized users cannot enter technical architecture details.
+- No new canonical view-link table exists unless the BI records substrate
+  insufficiency and approved design.
+- Responsive and keyboard verification in shared nonprod.
+
+### Rollback
+
+Remove related-view/decision-inspector UI while preserving canonical EA elements and
+relationships.
+
+## Phase 5 — `BI-7378E34C`: Operations Map Designed/Observed/Compare UX
+
+### Deliverable
+
+Complete the unified Operations Map as the owner-readable routing architecture and
+operational picture.
+
+### Work
+
+- [ ] Coordinate or resolve `BI-7E2A1DD0` before relying on the current client canvas.
+- [ ] Freeze provider, A2A, replay, filter, saved-view, inspector and empty-state
+      parity fixtures.
+- [ ] Keep `/platform/ai/operations-map` as the one canonical route and use local
+      mode/time-window controls; do not add global or section navigation.
+- [ ] Make the first viewport answer “How should work route?”, “Is anything unsafe
+      or blocked?”, and “Is observed behavior different?” before dense diagnostics.
+- [ ] Use the projected routing graph as the stable canvas geometry.
+- [ ] Add Designed, Observed and Compare mode controls with a visible time window.
+- [ ] Render privacy-safe volume/status evidence on the designed edges.
+- [ ] Add owner-language stations and progressive technical inspection.
+- [ ] Add coverage/freshness/unattributed/uncorrelated indicators.
+- [ ] Preserve A2A, provider, replay and source-record honesty.
+- [ ] Compose report-kit filters/status/table primitives, `statusColors`, `LocalTime`
+      and existing EA/Operations Map components rather than a new visual dialect.
+- [ ] Treat view/filter/inspect as read-only. Any future route simulation or coworker
+      action requires context preview, expected next step and explicit confirmation.
+- [ ] Verify list/table equivalence, keyboard navigation, mobile vertical layout and
+      no-overlap behavior.
+- [ ] Cut over only after parity; delete legacy panels, preview toggles and duplicated
+      projection helpers.
+
+### Likely files
+
+- `apps/web/components/platform/AiOperationsMap.tsx`
+- `apps/web/components/platform/OperationsTopologyCanvas.tsx`
+- Operations Map projection/loaders and tests
+- shared report-kit primitives only where existing components fit
+
+### Verification
+
+- Owner can answer how routing should work, how it did work, and what differs.
+- Exercise low-risk public, sensitive blocked, sensitive transformed, local-only,
+  provider unavailable, fallback and rehydration fixtures.
+- Exercise honest no-traffic, unavailable-evidence and missing-permission states.
+- Verify desktop and mobile screenshots plus keyboard/list equivalence.
+- Run the served-DOM UX budget sweep and theme/style-drift checks.
+- Targeted tests, web production build and shared-nonprod UX verification pass.
+- Legacy panels are deleted only after parity evidence.
+
+### Rollback
+
+Restore the prior authoritative panels behind the existing projection contract. Do
+not roll back the EA/evidence substrate when only presentation fails.
+
+## Cross-phase completion gate
+
+The umbrella is complete only when:
+
+- all five child BIs are done through separate DCO-signed PRs;
+- PR #3602 contracts are represented in the designed route;
+- routing documentation has one current authority and explicit target/history labels;
+- the live EA graph contains the routing BPMN process and instantiated cross-notation
+  relationships;
+- safe evidence correlation and coverage are visible and tested;
+- Designed, Observed and Compare reuse one stable geometry;
+- `BI-7E2A1DD0` is resolved or its fix is incorporated;
+- legacy Operations Map panels/toggles are removed after parity;
+- unit, build, UX, accessibility and privacy-canary gates pass;
+- documentation impact is recorded for users, contributors and AI coworkers.
+
+## Refactoring budget
+
+Reserve approximately 20 percent across the child BIs:
+
+| Refactor | Budget |
+| --- | ---: |
+| Shared routing-stage/stable-identity projection builders | 5% |
+| Safe correlation and receipt projection consolidation | 5% |
+| One Designed/Observed/Compare view-model builder | 4% |
+| Shared architecture drill-through/inspector primitives | 2% |
+| Delete superseded panels, toggles and duplicate helpers | 4% |
+
+## Risks
+
+- **Parallel-contract drift:** PR #3602 may change while this work proceeds. Each
+  implementing BI must re-read the merged sensitive-routing contract before edits.
+- **Historic evidence gaps:** do not backfill fabricated links; show coverage.
+- **Sensitive observability:** allowlist safe fields and run persistence canaries.
+- **Over-modeling:** extract only construction, verification, authority and
+  explainability facts.
+- **UI overload:** keep one stable owner map and disclose technical detail on demand.
+- **Premature DMN:** use the existing rule sources plus inspector first.
+- **Source-only worktrees:** runtime-bound build/UX evidence comes from the governed
+  shared nonprod environment.

--- a/docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md
+++ b/docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md
@@ -15,7 +15,7 @@ while giving technical users safe evidence, source links and conformance detail.
 
 **Design:** `docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md`
 
-**Upstream contract:** `BI-3D210AF8` / PR #3602 /
+**Upstream contract:** `BI-3D210AF8` / merged PR #3602 /
 `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
 
 ## Backlog coverage
@@ -55,19 +55,19 @@ current behavior.
 
 ### Work
 
-- [ ] Review the design with Enterprise Architect, Data Architect, AI Operations and
+- [x] Review the design with Enterprise Architect, Data Architect, AI Operations and
       provider-suitability ownership.
-- [ ] Merge or coordinate PR #3602 so the sensitive-routing contract has a stable
+- [x] Merge or coordinate PR #3602 so the sensitive-routing contract has a stable
       repository path.
-- [ ] Verify the implemented pin behavior and live `AgentModelConfig` state; resolve
+- [x] Verify the implemented pin behavior and live `AgentModelConfig` state; resolve
       the contradiction between the current-state architecture and user guide.
-- [ ] Classify the RIB/FIB control/data-plane document as proposed target-state until
+- [x] Classify the RIB/FIB control/data-plane document as proposed target-state until
       its implementation is resumed.
-- [ ] Add an architecture-document index that names current, target and historical
+- [x] Add an architecture-document index that names current, target and historical
       routing sources.
-- [ ] Update the owner-facing routing lifecycle guide to point at one current
+- [x] Update the owner-facing routing lifecycle guide to point at one current
       authority and the eventual Operations Map view.
-- [ ] Record concrete documentation impact for operator, contributor and AI coworker
+- [x] Record concrete documentation impact for operator, contributor and AI coworker
       surfaces.
 
 ### Likely files
@@ -313,8 +313,9 @@ Reserve approximately 20 percent across the child BIs:
 
 ## Risks
 
-- **Parallel-contract drift:** PR #3602 may change while this work proceeds. Each
-  implementing BI must re-read the merged sensitive-routing contract before edits.
+- **Upstream-contract drift:** PR #3602 is merged, but later sensitive-routing
+  implementation may refine its contracts. Each implementing BI must re-read the
+  current merged contract before edits.
 - **Historic evidence gaps:** do not backfill fabricated links; show coverage.
 - **Sensitive observability:** allowlist safe fields and run persistence canaries.
 - **Over-modeling:** extract only construction, verification, authority and

--- a/docs/superpowers/specs/2026-03-16-orchestrated-task-routing-design.md
+++ b/docs/superpowers/specs/2026-03-16-orchestrated-task-routing-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # Orchestrated Task Routing & Trusted AI Kernel
 

--- a/docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md
+++ b/docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-001: AI Endpoint Routing and Model Profiling
 

--- a/docs/superpowers/specs/2026-03-19-model-level-routing-profiles-design.md
+++ b/docs/superpowers/specs/2026-03-19-model-level-routing-profiles-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-002: Model-Level Routing Profiles
 

--- a/docs/superpowers/specs/2026-03-20-adaptive-model-routing-design.md
+++ b/docs/superpowers/specs/2026-03-20-adaptive-model-routing-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-003: Adaptive Contract-Based Model Routing
 

--- a/docs/superpowers/specs/2026-03-20-capability-detection-and-routing-design.md
+++ b/docs/superpowers/specs/2026-03-20-capability-detection-and-routing-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-008b-ext: Capability Detection & Agent Routing Surface
 

--- a/docs/superpowers/specs/2026-03-29-model-routing-simplification-design.md
+++ b/docs/superpowers/specs/2026-03-29-model-routing-simplification-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-012: Model Routing Simplification — Tiers, Assignment & Admin Control
 

--- a/docs/superpowers/specs/2026-03-30-db-driven-model-classification-design.md
+++ b/docs/superpowers/specs/2026-03-30-db-driven-model-classification-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-012b: DB-Driven Model Classification, Capability Matching & Contribution Feedback
 

--- a/docs/superpowers/specs/2026-04-03-utility-inference-tier-design.md
+++ b/docs/superpowers/specs/2026-04-03-utility-inference-tier-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # EP-INF-UTIL-001: Utility Inference Tier
 

--- a/docs/superpowers/specs/2026-04-04-provider-activation-routing-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-04-04-provider-activation-routing-reconciliation-design.md
@@ -1,4 +1,4 @@
-> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See [2026-04-20-routing-architecture-current.md](./2026-04-20-routing-architecture-current.md) for the current authoritative architecture.
+> **⚠️ SUPERSEDED** — this design doc captures an earlier iteration of routing. See the [AI routing document map](../../architecture/ai-routing-document-map.md) for current authority.
 
 # Provider Activation Routing Reconciliation Design
 

--- a/docs/superpowers/specs/2026-04-20-routing-architecture-current.md
+++ b/docs/superpowers/specs/2026-04-20-routing-architecture-current.md
@@ -1,12 +1,19 @@
-# Routing architecture (current state as of 2026-04-20)
+# Routing architecture (dated snapshot: 2026-04-20)
 
-**Status: CURRENT.** This document describes how DPF chooses which LLM handles a given call. It supersedes the earlier design docs listed at the bottom — those remain for historical context but should not be consulted for current behaviour.
+> **Status: HISTORICAL SNAPSHOT.** This document records the routing architecture as
+> understood on 2026-04-20. It is no longer the current documentation authority.
+> Start with the [AI routing document map](../../architecture/ai-routing-document-map.md)
+> for current implementation, operator guidance, proposed target state, and
+> explainability ownership.
 
 ## Principle
 
-> The routing layer picks the right LLM dynamically for each call based on the task's requirements and the candidate pool's capability tier. There are no hard pins from agents to specific providers/models. The system adapts as models are added or retired.
+> The default routing posture is dynamic: each call is matched to eligible models
+> using task requirements, policy constraints, capability, cost, health, and
+> availability. Seeded agent configurations do not pin a provider or model.
 
-Captured in memory: `feedback_no_provider_pinning`.
+That default remains current. The runtime now also supports an exceptional
+provider/model preference override; see **Agent-level overrides** below.
 
 ## The pipeline
 
@@ -108,7 +115,17 @@ Profiles are populated by:
 - `budgetClass` — `quality_first` | `balanced` | `minimize_cost`.
 - `minimumCapabilities` — hard floor (e.g. `{ toolUse: true }` for any agent that uses MCP tools).
 - `minimumContextTokens` — context window requirement.
-- **`pinnedProviderId`, `pinnedModelId` — deliberately unused.** Seed leaves these null. Admin UI still supports setting them but `[pin-audit]` in `instrumentation.ts` logs a warn on every boot if any row has a non-null pin, so regressions are visible.
+- `pinnedProviderId`, `pinnedModelId` — optional exceptional overrides. Seed and
+  first-run bootstrap leave them null. When set, `agentic-loop.ts` passes them to
+  `routeAndCall()` as preferred provider/model values. `routed-inference.ts`
+  applies the preference only to a candidate that already survived hard routing
+  exclusions; an excluded or unavailable target falls back to the V2-selected
+  route. `[pin-audit]` in `instrumentation.ts` warns on startup whenever a
+  persisted pin exists so the exception remains visible.
+
+Live-install evidence queried on 2026-07-26 showed 24 `AgentModelConfig` rows,
+with 0 provider pins and 0 model pins. That count is operational evidence for that
+install and time, not a fleet-wide invariant.
 
 The agent's floor **ANDs** with the task's floor — whichever is stricter wins.
 
@@ -149,7 +166,8 @@ The following earlier design documents each tackled some slice of this problem a
 
 ## Related memory
 
-- `feedback_no_provider_pinning` — routing is dynamic, no pins.
+- `feedback_no_provider_pinning` — dynamic, unpinned routing is the seeded default;
+  any persisted pin is an explicit, audited exception.
 - `feedback_evidence_before_diagnosis` — when routing misbehaves, query state before speculating.
 - `feedback_fix_seed_not_runtime` — a routing misbehaviour caused by stale seed data is fixed in the seed, not the runtime path.
 

--- a/docs/superpowers/specs/2026-04-27-routing-control-data-plane-design.md
+++ b/docs/superpowers/specs/2026-04-27-routing-control-data-plane-design.md
@@ -1,9 +1,16 @@
-# Routing Architecture: Control Plane / Data Plane — Design Spec
+# Routing Architecture: Control Plane / Data Plane — Proposed Target-State Design
+
+> **Status: PROPOSED / DEFERRED TARGET STATE.** The RIB/FIB compilation model in
+> this document is not the current runtime architecture. DPF still computes the
+> route inline through `prepareRoute()` / `routeEndpointV2()` for each request.
+> Use the [AI routing document map](../../architecture/ai-routing-document-map.md)
+> to distinguish current implementation, approved adjacent contracts, target
+> designs, and historical records.
 
 | Field | Value |
 |-------|-------|
 | **Epic** | Platform Infrastructure / Routing Substrate |
-| **Status** | Draft |
+| **Status** | Proposed target state; primary implementation deferred |
 | **Created** | 2026-04-27 |
 | **Author** | Claude Opus 4.7 for Mark Bodman |
 | **Scope** | `apps/web/lib/routing/`, `apps/web/lib/inference/routed-inference.ts`, `apps/web/lib/tak/agent-router*.ts`, `packages/db/prisma/schema.prisma` (additive), `apps/web/lib/govern/activate-provider.ts` |

--- a/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
+++ b/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
@@ -9,7 +9,7 @@
 | Plan | `docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md` |
 | Primary surface | Existing `/platform/ai/operations-map` |
 | Architecture surface | Existing `/ea` |
-| Upstream security contract | `BI-3D210AF8`; PR #3602; `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md` |
+| Upstream security contract | `BI-3D210AF8`; merged PR #3602; `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md` |
 | Composes with | `EP-AI-OPSMAP`, `EP-PARITY-ENGINE`, `EP-ROUTING-11`, `EP-DATA-GOVERNANCE` |
 
 ## 1. Executive decision
@@ -54,7 +54,7 @@ provider suitability, provider/model configuration, EA views, several design
 documents, route receipts, outcomes, token usage, capacity state, and the AI
 Operations Map.
 
-The fragmentation has produced concrete ambiguity:
+The initial audit found concrete ambiguity:
 
 - `docs/superpowers/specs/2026-04-20-routing-architecture-current.md` says provider
   and model pins are deliberately unused.
@@ -69,6 +69,14 @@ The fragmentation has produced concrete ambiguity:
 
 This makes it possible for individual documents to be locally correct while the
 whole system remains difficult to explain or verify.
+
+The documentation-authority slice resolves the pinning ambiguity: seed and
+first-run bootstrap leave pins null; a persisted pin is an exceptional preference
+override applied only to a non-excluded candidate; startup audits every persisted
+pin. Live evidence on 2026-07-26 found 24 agent configurations and zero provider or
+model pins. The [AI routing document map](../../architecture/ai-routing-document-map.md)
+now distinguishes current implementation, adjacent delivery contracts, proposed
+architecture, and historical records.
 
 ## 3. Goals
 
@@ -446,8 +454,18 @@ The completed design BI must establish the following hierarchy:
 6. The user guide must describe verified current behavior and link to the
    owner-readable map.
 
-The pinning contradiction must be resolved from implementation and live configuration
-evidence before either document is edited to claim one behavior.
+The pinning contradiction was resolved from implementation and live configuration
+evidence on 2026-07-26:
+
+- `agentic-loop.ts` maps a persisted pin to the routed-inference preferred fields;
+- `routed-inference.ts` can replace the V2 winner only with a candidate for which
+  `excluded === false`;
+- unavailable or excluded preference targets keep the V2 winner and add a warning;
+- seed/bootstrap keep pins null and startup audits any non-null exception; and
+- the live install contained 24 configurations, 0 provider pins, and 0 model pins.
+
+Therefore documentation uses **exceptional eligible-candidate preference override**,
+not “unused” and not an unconstrained “force.”
 
 ## 14. SysML architecture note
 
@@ -587,8 +605,10 @@ Reserve approximately 20 percent of implementation capacity:
 2. Can the current EA relationship/viewpoint validators render mixed-notation
    related-view navigation entirely through shared element identity, or is a narrow
    renderer change required?
-3. Does the implemented routing pipeline use any provider/model pin preference
-   today, and under what constraints?
+3. **Resolved 2026-07-26:** provider/model pins are exceptional overrides among
+   candidates that have already survived hard exclusions; unavailable or excluded
+   targets fall back to the V2 winner, and the current install has no persisted
+   pins.
 4. Which existing encrypted runtime artifact can hold short-lived token maps?
 5. Should the first Compare conformance cadence be request-time aggregation,
    scheduled reconciliation, or both through one pure projector?

--- a/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
+++ b/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
@@ -1,0 +1,597 @@
+# AI Routing Architecture & Explainability — Design
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed — architecture audit and backlog decomposition complete; implementation not started |
+| Date | 2026-07-26 |
+| Epic | `EP-CFACFA9F` — AI Routing Architecture & Explainability |
+| Umbrella BI | `BI-3FA17F95` |
+| Plan | `docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md` |
+| Primary surface | Existing `/platform/ai/operations-map` |
+| Architecture surface | Existing `/ea` |
+| Upstream security contract | `BI-3D210AF8`; PR #3602; `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md` |
+| Composes with | `EP-AI-OPSMAP`, `EP-PARITY-ENGINE`, `EP-ROUTING-11`, `EP-DATA-GOVERNANCE` |
+
+## 1. Executive decision
+
+DPF will present AI routing through **one canonical architecture model with three
+synchronized projections**:
+
+1. **Designed** — how a request is supposed to move through screening, policy,
+   eligibility, selection, fallback, dispatch, and response handling.
+2. **Observed** — privacy-safe operational evidence over the same stations and
+   edges for a selected time window.
+3. **Compare** — conformance between the designed path and observed evidence,
+   including missing evidence, unexpected paths, stale design, and attribution
+   gaps.
+
+The owner-facing projection is a plain-language subway map informed by BPMN. The
+technical projection uses BPMN for behavior, SysML for requirements and
+verification, and ArchiMate/C4 for realizing structure. These are viewpoints over
+the existing DPF substrate, not separately maintained diagrams.
+
+The pre-dispatch sensitive-routing plan is authoritative for screening, PDP/PEP,
+masking/tokenization, fallback enforcement, safe receipts, and authorized
+rehydration. This design consumes those contracts and does not redefine them.
+
+## 2. Problem
+
+DPF has substantial routing capability but no single governed picture that answers,
+at a glance:
+
+- How is an AI request supposed to be routed?
+- Is protected data allowed to cross the chosen boundary?
+- Why did this provider and model win?
+- Which alternatives were excluded, and why?
+- What happens when the selected route is unavailable or reaches a time/usage limit?
+- Did fallback preserve the original policy obligations?
+- How is the system actually behaving now?
+- Where does operational evidence disagree with the design?
+- What can an operator safely adjust?
+
+Today those answers are distributed across routing code, data-governance policy,
+provider suitability, provider/model configuration, EA views, several design
+documents, route receipts, outcomes, token usage, capacity state, and the AI
+Operations Map.
+
+The fragmentation has produced concrete ambiguity:
+
+- `docs/superpowers/specs/2026-04-20-routing-architecture-current.md` says provider
+  and model pins are deliberately unused.
+- `docs/user-guide/ai-workforce/model-routing-lifecycle.md` describes a seeded pin
+  and a pin-preference routing stage.
+- `docs/superpowers/specs/2026-04-27-routing-control-data-plane-design.md` describes
+  a target RIB/FIB separation whose primary backlog item is deferred.
+- The unified Operations Map canvas remains a preview above legacy authoritative
+  panels.
+- The EA substrate defines cross-notation relationships, but the live install has
+  no instantiated cross-notation relationship edges.
+
+This makes it possible for individual documents to be locally correct while the
+whole system remains difficult to explain or verify.
+
+## 3. Goals
+
+1. Give a nontechnical owner one picture that explains routing in business language.
+2. Let a technical operator drill into rules, source versions, evidence, and
+   remediation without leaving the shared context.
+3. Keep design and operational evidence visibly separate but geometrically aligned.
+4. Project current-state architecture from source registries and implementation
+   contracts through the Parity Engine.
+5. Consume privacy-safe routing receipts without exposing prompts, detected values,
+   token maps, credentials, evidence documents, or vendor account identifiers.
+6. Reuse the existing EA, Operations Map, routing, governance, and telemetry
+   substrate.
+7. Make documentation authority and supersession explicit.
+8. Preserve the 20 percent refactoring budget for shared projection/evidence seams
+   and deletion of superseded panels.
+
+## 4. Non-goals
+
+- Do not create another router, PDP, PEP, classification taxonomy, provider
+  suitability compiler, operations route, or architecture database.
+- Do not copy routing policy into diagram data.
+- Do not store one EA element or conformance issue per inference transaction.
+- Do not expose raw sensitive payloads in diagrams, inspectors, exports, logs, or
+  receipts.
+- Do not make SysML the normal-user experience.
+- Do not adopt a full DMN substrate until the design proves that a governed
+  decision inspector over existing rule sources is insufficient.
+- Do not present the deferred RIB/FIB design as current implementation.
+- Do not cut over from legacy Operations Map panels until functional, accessibility,
+  responsive, and replay parity are proven.
+
+## 5. Primary picture 1 — owner-readable routing subway
+
+This is the default Designed view. Labels are phrased as owner questions. Technical
+terms appear only in the inspector.
+
+```mermaid
+flowchart LR
+    A["Work asks for AI help"] --> B["What work and data are involved?"]
+    B --> C{"May this data cross the chosen boundary?"}
+    C -->|"No / needs review"| D["Keep it local, request approval, or stop"]
+    C -->|"Yes, but protect it"| E["Omit, mask, tokenize, or aggregate"]
+    C -->|"Yes"| F["Build the allowed route set"]
+    E --> F
+    F --> G{"Which routes can actually do the work?"}
+    G -->|"None"| D
+    G --> H{"Which routes are available within current limits?"}
+    H -->|"Temporarily unavailable"| I["Use an eligible fallback, defer, or stop"]
+    H -->|"Available"| J["Balance quality, time, and cost"]
+    I --> J
+    J --> K["Dispatch through the selected adapter"]
+    K --> L["Record a privacy-safe decision and outcome"]
+    L --> M{"May protected values be restored here?"}
+    M -->|"No"| N["Return a masked answer and explanation"]
+    M -->|"Yes"| O["Return the authorized answer"]
+    N --> P["Learn from outcomes and detect drift"]
+    O --> P
+    P --> B
+```
+
+### 5.1 Station semantics
+
+| Owner-facing station | Technical contract | Canonical source |
+| --- | --- | --- |
+| Work asks for AI help | Inference/coworker entry point | Governed routed-inference entry points |
+| What work and data are involved? | Activity context, purpose, actor, governed data classification | Data-governance registry plus activity contract |
+| May this data cross the boundary? | Data PDP decision and destination class | `policy-decision.ts` and sensitive-routing plan |
+| Protect it | Mask-before-context/tokenization obligations | `mask-for-context` contract from `BI-DG-009` |
+| Build the allowed route set | `RequestContract` provider/residency/sensitivity constraints | Request-contract compiler and provider-suitability policy |
+| Can do the work | Capabilities, context, modality, tool and contract-family floors | Routing loader and `routeEndpointV2` hard filters |
+| Available within limits | Lifecycle state, runtime capacity, cooldown, short/long quota windows | Provider capacity/circuit-breaker sources |
+| Balance quality, time, and cost | Ranking inside the eligible set | Routing scorer and Golden Triangle posture |
+| Eligible fallback | Same transformed payload and hard constraints | Governed fallback contract |
+| Dispatch | Adapter/transport invocation | Inference adapter registry |
+| Safe decision and outcome | Screen, route, adapter, outcome and token evidence | Existing ledgers plus sensitive-screen receipt |
+| Restore protected values | Fresh PDP decision plus actor/surface/action authorization | Rehydration authorization contract |
+| Learn and detect drift | Evaluation, telemetry aggregation and parity | Parity Engine and conformance steward |
+
+## 6. Primary picture 2 — design and evidence projection architecture
+
+This picture explains how DPF keeps one model while serving different audiences and
+time windows.
+
+```mermaid
+flowchart TB
+    subgraph S["Canonical sources"]
+      S1["Routing code and registries"]
+      S2["Data policy and provider suitability"]
+      S3["Provider/model/capacity configuration"]
+      S4["Sensitive-routing contracts"]
+    end
+
+    subgraph P["Design projection"]
+      P1["Versioned extractors"]
+      P2["EA graph with stable source identities"]
+      P3["BPMN behavior"]
+      P4["SysML requirements and verification"]
+      P5["ArchiMate/C4 realizing structure"]
+    end
+
+    subgraph E["Operational evidence"]
+      E1["Safe screen receipt"]
+      E2["RouteDecisionLog"]
+      E3["RouteOutcome and adapter telemetry"]
+      E4["Token/cost/capacity evidence"]
+      E5["Authorized rehydration outcome"]
+    end
+
+    subgraph V["Synchronized user views"]
+      V1["Designed"]
+      V2["Observed"]
+      V3["Compare"]
+      V4["Technical inspector"]
+    end
+
+    S1 --> P1
+    S2 --> P1
+    S3 --> P1
+    S4 --> P1
+    P1 --> P2
+    P2 --> P3
+    P2 --> P4
+    P2 --> P5
+    E1 --> V2
+    E2 --> V2
+    E3 --> V2
+    E4 --> V2
+    E5 --> V2
+    P3 --> V1
+    P4 --> V4
+    P5 --> V4
+    V1 --> V3
+    V2 --> V3
+    P2 --> V4
+    V3 --> V4
+```
+
+## 7. Viewpoint contract
+
+### 7.1 Designed
+
+Designed is the versioned architecture projection. It shows:
+
+- expected stations, gates, paths and fallback boundaries;
+- which rules are hard constraints versus ranking preferences;
+- the source and version of each deterministic fact;
+- which facts are implemented, proposed target-state, historical, or unresolved;
+- requirements and verification cases.
+
+Designed never derives truth from recent traffic. Zero traffic does not remove a
+designed path.
+
+### 7.2 Observed
+
+Observed decorates the Designed geometry for a selected time window. It shows:
+
+- request/decision volume;
+- allowed, transformed, reviewed, denied and blocked outcomes;
+- candidate exclusion reasons;
+- selected providers/models/adapters;
+- fallback depth and failure classes;
+- p50/p95 latency and total elapsed time;
+- input/output tokens and cost or subscription-window posture;
+- capacity/cooldown state;
+- evidence freshness;
+- attribution and correlation coverage.
+
+Observed never changes the designed topology. Unexpected observed routes appear as
+temporary evidence edges and conformance candidates.
+
+### 7.3 Compare
+
+Compare uses explicit visual states:
+
+| State | Meaning |
+| --- | --- |
+| Solid neutral | Designed and observed |
+| Gray | Designed but not observed in the selected window |
+| Colored | Observed volume/status over a designed edge |
+| Dashed warning | Observed path not represented in the design |
+| Broken evidence marker | Designed station has missing or stale operational evidence |
+| Unattributed marker | Evidence cannot be assigned to a coworker/actor |
+| Uncorrelated marker | Screen, route, outcome, or rehydration evidence cannot be joined |
+| Proposed badge | Target-state design, not current implementation |
+
+Conformance is aggregated by stable architecture identity and time window. The
+system must not create a conformance row for every inference transaction.
+
+### 7.4 Technical inspector
+
+The inspector progressively discloses:
+
+1. **Owner answer:** what happened, why, and the safest next action.
+2. **Routing explanation:** selected route, excluded alternatives, fallback and
+   obligations.
+3. **Evidence:** timestamps, freshness, safe receipt identifiers, metrics and
+   correlation coverage.
+4. **Architecture:** BPMN/SysML/ArchiMate relationships, source keys, rule/policy
+   versions and verification cases.
+5. **Raw engineering identifiers:** available only to authorized technical users
+   and still excluding protected payload content.
+
+## 8. Notation decision
+
+| Concern | DPF notation/presentation |
+| --- | --- |
+| Owner-readable end-to-end route | Subway rendering of the BPMN process |
+| Process sequence, fallback and actors | BPMN 2.0 |
+| Requirements, constraints, allocations and verification | SysML v2 |
+| Enterprise/component realization | ArchiMate; C4 as a lightweight human view |
+| Routing rule details | Governed decision inspector over canonical rule sources |
+| Full decision requirements/tables | DMN only after the inspector is proven insufficient |
+
+The current EA substrate already supports BPMN, SysML, ArchiMate, viewpoints,
+snapshots, conformance issues and cross-notation relationship definitions. The first
+implementation must instantiate and navigate those relationships rather than add a
+parallel diagram store.
+
+## 9. Data authority and safe evidence
+
+### 9.1 Design authority
+
+| Fact | Authority | Projection behavior |
+| --- | --- | --- |
+| Routing stages and order | Implemented routing modules/registries | Deterministic BPMN extraction |
+| Data sensitivity/purpose rules | Data-governance sources | Linked rule source; do not copy policy |
+| Provider suitability obligations | Suitability compiler and evidence registry | Linked constraints/requirements |
+| Model/provider capabilities | ModelProfile/ModelProvider plus loaders | Derived eligible-route facts |
+| Runtime capacity/cooldown | Capacity/circuit-breaker state | Observed overlay only |
+| Target RIB/FIB design | Control/data-plane design spec | Proposed badge until implemented |
+| Architect interpretation | Approved design artifact | Explicit architect provenance |
+
+### 9.2 Operational authority
+
+The evidence projection should reuse:
+
+- sensitive-screen receipt from `BI-3D210AF8`;
+- `RouteDecisionLog`;
+- `RouteOutcome`;
+- `AdapterRunTelemetry`;
+- `TokenUsage`;
+- `ProviderCapacityStatus`;
+- provider suitability receipts/evidence;
+- authorized rehydration result.
+
+The correlation envelope must support:
+
+```text
+design revision + screen decision
+  -> route decision
+  -> route/fallback attempt(s)
+  -> adapter outcome
+  -> token/cost/capacity evidence
+  -> authorized rehydration outcome
+```
+
+Safe evidence may contain identifiers, hashes, versions, enumerated classes,
+obligations, transformation type, explanation codes, provider/model identity,
+timing, token/cost counts and outcome status.
+
+Every Compare result must name the **design revision it compared against**—for
+example the applicable EA snapshot/projection revision plus implementation source
+revision. A current design silently overlaid on older traffic is not valid
+conformance evidence. This revision should reuse existing snapshot/source identity
+before any new persistence is considered.
+
+Safe evidence must not contain raw messages, system prompts, tool arguments/results,
+detected sensitive values, credentials, token maps, evidence documents, vendor
+account identifiers, organization identifiers or free-text policy explanations that
+could reproduce protected content.
+
+## 10. Current evidence baseline
+
+The 2026-07-26 live audit found:
+
+- 21,979 route decisions;
+- 35,860 route outcomes;
+- 32,527 token-usage records;
+- 20,740 route decisions with multi-step fallback chains;
+- 1,054 route decisions with coworker attribution (about 4.8 percent);
+- zero populated suitability receipts on route decisions;
+- zero live `PolicyRule` rows;
+- zero live `TaskRequirement` rows;
+- six seeded cross-notation relationship types and zero instantiated
+  cross-notation relationship edges;
+- 18 SysML views and one BPMN view, all draft.
+
+These numbers are an audit baseline, not a permanent contract. The product should
+query and label the current time window, sample size, coverage and freshness.
+
+## 11. Architecture feature gaps
+
+### 11.1 Projection gaps
+
+- No routing-process BPMN extractor exists.
+- Sensitive-routing stages are not represented in the EA graph.
+- Cross-notation relationships are defined but not materialized.
+- No design/runtime conformance projection exists for routing.
+
+### 11.2 Evidence gaps
+
+- Screen, decision, outcome and rehydration correlation is not yet one explicit
+  envelope.
+- Coworker attribution covers only a minority of historic route decisions.
+- Suitability/sensitive-screen receipts are absent from the audited historic rows.
+- Important design policy may live in code defaults while policy/task tables are
+  empty.
+
+### 11.3 Authoring/navigation gaps
+
+- New View currently offers ArchiMate and BPMN, not SysML.
+- The editor palette is scoped to one notation.
+- No deterministic related-view drill-through convention exists.
+- Full DMN decision modeling is absent.
+
+### 11.4 Operations UX gaps
+
+- The unified topology canvas is still a temporary preview.
+- Legacy panels remain authoritative.
+- The current surface does not align designed and observed routing.
+- `BI-7E2A1DD0` reports that the deployed interactive diagram does not render.
+
+## 12. Product and interaction design
+
+### 12.1 Default owner experience
+
+- Default to **Designed** on first visit, using plain language.
+- Provide a visible time-window control when switching to Observed or Compare.
+- Keep the same station positions across modes so the operator does not relearn the
+  map.
+- Show one short outcome, one reason, and one next action before technical detail.
+- Use labels such as “May this data leave this computer/account boundary?” instead
+  of PDP/PEP terminology.
+- Explain unknown evidence honestly; never turn unknown into allowed.
+
+### 12.2 Technical adjustment
+
+Authorized technical users can:
+
+- open provider/model configuration;
+- inspect evidence freshness and account posture;
+- inspect rule/policy source and version;
+- see candidate exclusion traces;
+- view capacity/cooldown and quota windows;
+- navigate to linked EA viewpoints and implementation sources;
+- simulate a route with payload-free contract inputs;
+- propose a design or policy change through the owning governed workflow.
+
+The map itself does not become an ungoverned policy editor.
+
+### 12.3 Accessibility and responsive behavior
+
+- Every station and edge is keyboard reachable.
+- Color is never the only status signal.
+- A list/table representation provides equivalent content.
+- Dense technical labels collapse behind the inspector.
+- Mobile uses a vertical station sequence with the same stable identities.
+- Exported views include mode, time window, freshness and evidence coverage.
+
+## 13. Documentation authority
+
+The completed design BI must establish the following hierarchy:
+
+1. This design, once approved, is the architecture authority for routing
+   explainability and viewpoint ownership.
+2. The implementation plan for `BI-3D210AF8` remains authoritative for
+   pre-dispatch sensitive routing.
+3. Provider-suitability design remains authoritative for provider trust/evidence
+   compilation.
+4. The current-state routing document must either be updated to the verified current
+   pipeline or marked as a dated snapshot.
+5. The control/data-plane design remains target-state while its implementation is
+   deferred.
+6. The user guide must describe verified current behavior and link to the
+   owner-readable map.
+
+The pinning contradiction must be resolved from implementation and live configuration
+evidence before either document is edited to claim one behavior.
+
+## 14. SysML architecture note
+
+- **Scope:** AI inference and AI coworker routing from payload assembly through
+  authorized response delivery.
+- **Requirements/constraints:** sensitive data must be screened before external
+  dispatch; provider suitability may narrow but not loosen data policy; fallback
+  preserves the transformed payload and constraints; operational evidence excludes
+  raw protected content; diagrams derive from canonical sources.
+- **Interfaces/ports:** routed inference entry points, data PDP/PEP, RequestContract,
+  route selector, fallback, adapters, route/outcome ledgers, Operations Map loader,
+  EA projection reconciler.
+- **Allocations:** data governance owns classification/purpose; provider suitability
+  owns provider evidence compilation; routing owns eligible-set selection; adapters
+  own transport; EA/Parity owns design projection; Operations Map owns presentation.
+- **Verification cases:** sensitive blocked route, maskable route, exact-sensitive
+  local/eligible route, governed fallback, unavailable-provider path, short/long
+  limit path, authorized/unauthorized rehydration, missing-evidence conformance,
+  unexpected observed path, accessibility and responsive parity.
+- **Data authority:** canonical registries/code/policy remain authoritative;
+  EA/BPMN/SysML and Operations Map are derived projections; telemetry ledgers remain
+  operational authority.
+- **EA/current-state catch-up:** add the AI routing process domain and materialize
+  cross-notation relationships.
+- **Parity impact:** add versioned extractors and conformance aggregation; do not
+  hand-maintain current-state routing nodes.
+- **Open risk:** current receipt, correlation and attribution coverage is
+  insufficient for complete historic observed views.
+
+## 15. Delivery boundaries
+
+| BI | Independently shippable outcome |
+| --- | --- |
+| `BI-CC9BCFC8` | Canonical design artifact and documentation reconciliation |
+| `BI-AA314BF4` | BPMN routing process and linked EA projection |
+| `BI-758722A7` | Privacy-safe evidence correlation and conformance projection |
+| `BI-52C015D8` | Cross-view drill-through and routing-decision inspector |
+| `BI-7378E34C` | Designed/Observed/Compare Operations Map UX |
+
+Existing defect `BI-7E2A1DD0` is coordinated, not duplicated.
+
+## 16. Refactoring budget
+
+Reserve approximately 20 percent of implementation capacity:
+
+| Refactor | Budget |
+| --- | ---: |
+| Extract shared routing-stage and stable-identity projection builders | 5% |
+| Standardize safe correlation/receipt projection across existing ledgers | 5% |
+| Centralize designed/observed/compare view-model construction | 4% |
+| Consolidate architecture drill-through and inspector primitives | 2% |
+| Delete retired Operations Map panels/toggles after parity | 4% |
+
+## 17. Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Diagram becomes another source of truth | Extract current-state facts; keep architect judgment explicit |
+| Sensitive content leaks through observability | Safe-field allowlist, canary fixtures and no raw-payload persistence tests |
+| Target design is mistaken for current behavior | Required Current/Proposed/Historical badges |
+| Historic evidence cannot be correlated | Surface coverage honestly; do not fabricate joins |
+| One enormous canvas recreates overload | Stable owner map plus progressive disclosure and alternate list view |
+| Full DMN adoption adds premature substrate | Start with governed decision inspector; evaluate DMN after evidence |
+| Cross-notation links remain theoretical | Live acceptance requires instantiated, navigable edges |
+| Operations Map cutover regresses working behavior | Additive parity stages; delete legacy only after proof |
+
+## 18. Architecture review
+
+- **Decision:** aligned with important guardrails.
+- **Single source of truth:** the design reuses routing/governance registries, the EA
+  graph, telemetry ledgers and Operations Map; it does not create a diagram or
+  evidence authority.
+- **Data model:** no new Prisma model is approved. Each implementing BI must prove
+  existing snapshot, evidence and relationship substrate insufficient before a
+  schema proposal.
+- **Parallel-work boundary:** PR #3602 owns sensitive-routing enforcement; this epic
+  consumes its merged contracts and must re-sweep them before implementation.
+- **Current/target separation:** RIB/FIB and other target-state concepts require a
+  Proposed badge until implementation evidence exists.
+- **Evidence integrity:** Compare must bind observed traffic to the applicable design
+  revision; comparing historical evidence only to today's design would create false
+  drift.
+- **Operational safety:** receipts and observability are safe-field projections, not
+  prompt archives.
+- **Recommended next step:** land the canonical design/document-authority BI first,
+  then allow the projection, evidence and drill-through BIs to proceed independently.
+
+## 19. Standards
+
+- ISO/IEC/IEEE 42010:2022 — stakeholder concerns, viewpoints and model kinds.
+- OMG BPMN 2.0.2 — process behavior and gateways.
+- OMG DMN 1.5 — benchmark for decision requirements and tables; adoption deferred
+  pending fit proof.
+- OMG SysML 2.0 — requirements, constraints, allocations and verification.
+- C4 dynamic diagrams — supporting technical interaction stories, used sparingly.
+- OpenTelemetry semantic conventions for GenAI — common safe attribute vocabulary
+  where compatible with DPF privacy constraints.
+
+## 20. UX fit review
+
+- **Decision:** fits-with-guardrails.
+- **Owning area:** Platform.
+- **Route family:** `/platform/ai/operations-map` is canonical; `/ea` is the
+  authorized architecture drill-through.
+- **Primary persona:** founder/operator asking how AI work is routed and whether it
+  is safe and healthy. The contributor/platform operator is the secondary
+  progressive-disclosure persona.
+- **Navigation layer:** local page mode/filter controls only. No new global or
+  section navigation.
+- **Reuse/convergence:** reuse the existing Operations Map canvas/projections,
+  report-kit status/table/filter primitives, `statusColors`, `LocalTime`, EA canvas
+  and existing saved-view/replay behavior.
+- **Source truth:** the design and operational authorities are named in §9; the UI
+  may not invent a second status or metric calculation.
+- **Empty/failure behavior:** no recent traffic still renders Designed with “No
+  observed routes in this window”; unavailable telemetry preserves the last known
+  design and shows evidence freshness/recovery; missing permission offers no raw
+  technical detail.
+- **AI boundary:** viewing, filtering and inspecting never sends a prompt. A future
+  simulation or coworker action requires a context preview, expected next step and
+  explicit confirmation.
+- **First viewport guardrail:** answer three questions before any dense diagnostics:
+  “How should work route?”, “Is anything unsafe or blocked?”, and “Is observed
+  behavior different?” Avoid a generic KPI-card wall.
+- **Disclosure guardrail:** mode and time-window controls remain reachable; only
+  professional detail collapses. Do not hide the primary comparison control inside
+  Advanced.
+- **Evidence before merge:** route/source tests, served-DOM UX budget sweep, theme
+  and style-drift checks, desktop/mobile browser exercise, keyboard/list
+  equivalence, failure/permission fixtures and privacy canaries.
+- **Captured in:** this section plus implementation plan Phases 4–5.
+
+## 21. Open implementation decisions
+
+1. Which stable correlation identifier is canonical across screen, route, fallback,
+   outcome and rehydration without creating a parallel trace ledger?
+2. Can the current EA relationship/viewpoint validators render mixed-notation
+   related-view navigation entirely through shared element identity, or is a narrow
+   renderer change required?
+3. Does the implemented routing pipeline use any provider/model pin preference
+   today, and under what constraints?
+4. Which existing encrypted runtime artifact can hold short-lived token maps?
+5. Should the first Compare conformance cadence be request-time aggregation,
+   scheduled reconciliation, or both through one pure projector?
+
+These decisions must be resolved against implementation and live evidence during
+their owning BI. They do not justify parallel substrate in advance.

--- a/docs/user-guide/ai-workforce/model-routing-lifecycle.md
+++ b/docs/user-guide/ai-workforce/model-routing-lifecycle.md
@@ -25,7 +25,7 @@ During container startup, `docker-entrypoint.sh` runs the following sequence:
 **Step 3** seeds model profiles from `packages/db/data/model-profiles.json`. These are pre-evaluated profiles with hand-tuned dimension scores (codegen, reasoning, toolFidelity, etc.) and `profileSource: "evaluated"`. Only models known to work with the default credential tier are included. The seed also:
 - Ensures Haiku 4.5 is set to `active` (Haiku 3.0 to `degraded`)
 - Creates `AgentModelConfig` rows with default tier and budget settings for each agent
-- Pins the `build-specialist` agent to `anthropic-sub/claude-haiku-4-5-20251001`
+- Leaves provider and model pins empty so routing can adapt to the eligible pool
 
 Pre-evaluated profiles are protected from being overwritten by dynamic discovery.
 
@@ -71,16 +71,22 @@ Each agent has an `AgentModelConfig` row that controls which models it can use:
 |-------|---------|
 | `minimumTier` | The lowest quality tier the agent will accept (e.g., "frontier" for build-specialist) |
 | `budgetClass` | Cost strategy: `minimize_cost`, `balanced`, or `quality_first` |
-| `pinnedProviderId` | Force routing to a specific provider (optional) |
-| `pinnedModelId` | Force routing to a specific model within that provider (optional) |
+| `pinnedProviderId` | Exceptional preference override for a specific eligible provider (optional) |
+| `pinnedModelId` | Exceptional preference override for a specific eligible model (optional) |
 
-Default configurations are seeded during installation. Admins can override them via the platform UI or direct database updates. The seed respects existing rows -- if an admin has already configured an agent, the seed will not overwrite it.
+Default configurations are seeded during installation. Admins can override them via
+the platform UI. The normal posture is unpinned: seed and first-run bootstrap leave
+pins empty, and startup emits a `[pin-audit]` warning when a persisted pin exists.
+Use a pin only when a provider/model dependency is intentional and documented; use
+tier, capability, sensitivity, residency, and budget controls for normal routing.
+The seed respects existing rows -- if an admin has already configured an agent, the
+seed will not overwrite it.
 
 ### Default Agent Tiers
 
 | Agent | Minimum Tier | Budget | Pinned To |
 |-------|-------------|--------|-----------|
-| build-specialist | frontier | quality_first | anthropic-sub / claude-haiku-4-5-20251001 |
+| build-specialist | strong | quality_first | (auto) |
 | coo | strong | balanced | (auto) |
 | platform-engineer | strong | balanced | (auto) |
 | admin-assistant | strong | balanced | (auto) |
@@ -103,7 +109,12 @@ When an agent needs to call an LLM, the routing pipeline runs in this order:
    - Missing required capability (e.g., tool use)
    - Any dimension score below the minimum threshold
 5. **Rank by cost-per-success.** Estimate success probability for each remaining model. With `quality_first` budget, rank by success probability alone. With `minimize_cost`, rank by cost efficiency.
-6. **Apply provider pin preference.** A pin may select its configured provider only when that provider remains inside the request's hard allow/deny policy. A pin cannot override a provider fence.
+6. **Apply an exceptional provider/model preference override.** If configured, the
+   preferred endpoint replaces the cost/quality winner only when it remains in the
+   eligible candidate set. A pin cannot override provider allow/deny, sensitivity,
+   residency, capability, model-class, status, or other hard exclusions. If its
+   target is unavailable or excluded, routing records a warning and keeps the
+   V2-selected route.
 7. **Dispatch with the eligible fallback chain.** Try the selected model, then the next eligible model after an inference error. A provider excluded by the request policy never reappears in fallback.
 
 Provider allow/deny constraints are request-level hard policy, distinct from the provider registry's `modelRestrictions` discovery allowlist. An explicitly empty `allowedProviders` list means no provider is eligible; routing returns no endpoint rather than treating the empty list as “allow any.” Cost, quality, provider health, capacity, and pin preferences only rank the providers that remain after the hard filter.
@@ -184,7 +195,9 @@ Local models are automatically discovered and profiled. They are assigned the `b
 
 **Agent uses wrong model:**
 - Check `AgentModelConfig` in the database
-- `pinnedProviderId` / `pinnedModelId` are preferences within the request's hard provider, residency, sensitivity, and capability constraints
+- `pinnedProviderId` / `pinnedModelId` are exceptional preferences within the
+  request's hard provider, residency, sensitivity, status, model-class, and
+  capability constraints; they are empty by default
 - If no pin is set, routing selects based on dimension scores and budget class
 
 **Models missing after connecting a provider:**

--- a/docs/user-guide/platform/ai-operations.md
+++ b/docs/user-guide/platform/ai-operations.md
@@ -16,11 +16,21 @@ order: 2
 
 ## Workflow
 
-1. Start with the current operating picture: health, recent activity, operations-map posture, and assignment posture.
+1. Start with the current operating picture: health, recent activity, operations-map posture, and assignment posture. The planned unified map will align **Designed**, **Observed**, and **Compare** views; until that delivery lands, treat the existing Operations Map panels as the operational surfaces rather than assuming the preview canvas is complete.
 2. Review Capacity Continuity when paid AI capacity is idle, blocked, or expected to keep working during holidays, vacations, business events, after-hours windows, or owner inactivity.
 3. Review Capability Needs when coworkers surface missing tools, prompts, permissions, or product gaps that need governed follow-up.
 4. Review history when a result looks wrong, slow, or inconsistent.
-5. Adjust **Priority & Models** only after you understand whether the problem is role design, model selection, tool access, standing orders, or calendar state. Set the everyday Cost / Quality / Time priority at the top of that surface (or per coworker from the triangle at its composer); reserve the advanced guardrails below — a tier floor, a pinned model — for hard limits the priority must not cross.
+5. Adjust **Priority & Models** only after you understand whether the problem is role design, model selection, tool access, standing orders, or calendar state. Set the everyday Cost / Quality / Time priority at the top of that surface (or per coworker from the triangle at its composer). Use tier and capability floors for hard limits. A provider/model pin is an exceptional preference among already-eligible routes, not a way to cross policy, sensitivity, residency, or capability boundaries.
+
+## Architecture and evidence
+
+- [Model Routing & Lifecycle](../ai-workforce/model-routing-lifecycle.md) — current
+  operator explanation of discovery, eligibility, selection, exceptional
+  preferences, and fallback.
+- Contributor and AI coworker documentation starts at
+  `docs/architecture/ai-routing-document-map.md`, which classifies the proposed
+  owner-readable subway map, technical drill-through, target-state designs, and
+  historical records.
 
 ## What To Watch
 


### PR DESCRIPTION
## Summary
- establish one canonical design for AI routing explainability with synchronized Designed, Observed, and Compare projections
- add an AI routing document map that separates current implementation, merged sensitive-routing contracts, proposed target state, and historical records
- reconcile provider/model pin semantics from code and live state, correct the seeded Build Specialist configuration, and classify the deferred RIB/FIB design explicitly
- decompose delivery under EP-CFACFA9F / BI-3FA17F95 and its five child BIs

## Evidence
- Live AgentModelConfig query (2026-07-26): 24 configurations, 0 provider pins, 0 model pins
- Pin path verified from agentic-loop.ts into routed-inference.ts: preference overrides only non-excluded candidates; unavailable/excluded targets retain the V2 winner with a warning
- Sensitive-routing implementation plan is present on main via merged PR #3602
- Overlap sweep: open PRs #3597 and #3601 are unrelated

## Test plan
- [x] git diff --check
- [x] node scripts/check-doc-links.mjs
- [x] node scripts/gen-doc-index.mjs --check (554 pages)
- [x] node scripts/check-doc-reference-integrity.mjs
- [x] node scripts/check-docs-impact.mjs
- [x] node --test scripts/check-doc-links.test.mjs scripts/check-doc-reference-integrity.test.mjs (29 passing)
- [x] pre-commit derived-artifact regeneration and staged Gitleaks scan
- [x] runtime build / migration / UX gates: not applicable; documentation and generated documentation index only

Local-CI-Override: Documentation-only authority reconciliation; required generated doc index is fresh (554 pages); link, reference, impact, and index checks passed; no runtime behavior changed.


## Inherited CI blocker
- BI-2FCCAF42 — PR #3598 increased NeedsAndPlaybooksPanel.tsx prose textMass from 64 to 106 without updating the baseline. This branch does not touch that UI and keeps the repair as a separate concern.

