### PR TITLE
fix(ci): retighten governed playbook prose baseline

### DIFF
--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -6367,7 +6367,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 64
+    "textMass": 106
   },
   "apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx": {
     "vocabulary": 0,
@@ -7107,9 +7107,9 @@
   "apps/web/components/storefront/SlotBookingFlow.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
-    "readability": 12,
+    "readability": 11,
     "longSentences": 0,
-    "textMass": 178
+    "textMass": 166
   },
   "apps/web/components/storefront/StorefrontTrustFooter.tsx": {
     "vocabulary": 0,
@@ -7417,7 +7417,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 219
+    "textMass": 203
   },
   "apps/web/components/workbooks/GridSelect.tsx": {
     "vocabulary": 0,
@@ -7489,14 +7489,14 @@
     "longSentences": 0,
     "textMass": 18
   },
-  "apps/web/components/workbooks/grid-reorder-group.ts": {
+  "apps/web/components/workbooks/grid-range.ts": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
     "textMass": 20
   },
-  "apps/web/components/workbooks/grid-range.ts": {
+  "apps/web/components/workbooks/grid-reorder-group.ts": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,


### PR DESCRIPTION
## Summary
- repair the prose-quality baseline omitted when governed playbook experimentation PR #3598 expanded `NeedsAndPlaybooksPanel.tsx`
- preserve the guard's ratchet behavior by also accepting current reductions in `SlotBookingFlow.tsx` and `GridPanels.tsx`
- restore merge-queue compatibility for the now-merged evidence-earned autonomy controls (#3603)

## Design grounding
This is a generated quality-ratchet repair, not a product or architecture change. The baseline was regenerated from current `main` plus this branch using the repository's canonical `check:prose-lint -- --update` path. It accepts only measured current source state and tightens improved values rather than weakening the guard globally.

## Root cause
PR #3598 added governed playbook experiment copy after its branch-level baseline snapshot. When #3603 entered the merge queue, current-main testing correctly caught `NeedsAndPlaybooksPanel.tsx` text mass growing from 64 to 106. The failure was in merge-group run 30210565644, Prose Lint Guard job 89815993811.

## Verification
- `pnpm run check:prose-lint:test` — 15/15 passed
- `pnpm run check:prose-lint` — passed across 1,093 files
- exact-head shared Local-CI convergence gate — passed against `main` at `2dac3e0999`
- production Docker build — passed
- full web unit suite — passed
- Prisma migrate deploy — passed

## Documentation and UX impact
No documentation or UX update is required: this branch changes only the generated prose-lint ratchet and does not alter rendered copy, routes, behavior, or architecture.

Backlog: BI-2FCCAF42
Work Capsule: WC-DB174D3C
Local-CI-Evidence: cms21m61x063v01lh5nopl7q1 (fix/playbook-prose-baseline@01c3fbf2df)