### PR TITLE
fix(backlog): allow reopening done items to open or triaging

### DIFF
--- a/apps/web/lib/backlog/transitions.test.ts
+++ b/apps/web/lib/backlog/transitions.test.ts
@@ -47,18 +47,18 @@ describe("isLegalTransition", () => {
     expect(isLegalTransition("deferred", "done")).toBe(false);
   });
 
-  it("locks done as terminal except for admin reopen", () => {
+  it("permits reopen from done to open or triaging", () => {
     expect(isLegalTransition("done", "done")).toBe(true);
-    expect(isLegalTransition("done", "open")).toBe(false);
+    expect(isLegalTransition("done", "open")).toBe(true);
+    expect(isLegalTransition("done", "triaging")).toBe(true);
     expect(isLegalTransition("done", "in-progress")).toBe(false);
   });
 
-  it("permits retriage from open / in-progress / deferred (BI-7D4AF644)", () => {
+  it("permits retriage from open / in-progress / deferred / done", () => {
     expect(isLegalTransition("open", "triaging")).toBe(true);
     expect(isLegalTransition("in-progress", "triaging")).toBe(true);
     expect(isLegalTransition("deferred", "triaging")).toBe(true);
-    // Retriage from done is still blocked (done is terminal except admin reopen).
-    expect(isLegalTransition("done", "triaging")).toBe(false);
+    expect(isLegalTransition("done", "triaging")).toBe(true);
   });
 });
 

--- a/apps/web/lib/backlog/transitions.ts
+++ b/apps/web/lib/backlog/transitions.ts
@@ -19,7 +19,7 @@ const LEGAL: Record<BacklogStatus, ReadonlySet<BacklogStatus>> = {
   // Closes BI-7D4AF644.
   open: new Set<BacklogStatus>(["triaging", "in-progress", "done", "deferred"]),
   "in-progress": new Set<BacklogStatus>(["triaging", "open", "done", "deferred"]),
-  done: new Set<BacklogStatus>(["done"]),
+  done: new Set<BacklogStatus>(["done", "open", "triaging"]),
   deferred: new Set<BacklogStatus>(["triaging", "open", "in-progress"]),
 };
 

--- a/apps/web/lib/ea/reconcile-process.ts
+++ b/apps/web/lib/ea/reconcile-process.ts
@@ -10,13 +10,14 @@
 
 import { prisma } from "@dpf/db";
 import { ENVELOPE_STATUSES, TERMINAL_STATUSES, canTransition as envelopeCanTransition } from "@/lib/coworker/envelope-state-machine";
-import { BACKLOG_STATUSES, isLegalTransition } from "@/lib/backlog/transitions";
+import { BACKLOG_STATUSES, isLegalTransition, requiresAdminGrant } from "@/lib/backlog/transitions";
 import { buildProcessModel, type ProcessStateMachine } from "./process-extract";
 import { applySysmlModel, type SysmlSeedResult } from "./sysml-model-seed";
 
 const envelopeTerminals = new Set<string>(TERMINAL_STATUSES);
 const envelopeCan = envelopeCanTransition as (from: string, to: string) => boolean;
 const backlogCan = isLegalTransition as (from: string, to: string) => boolean;
+const backlogRequiresAdmin = requiresAdminGrant as (from: string, to: string) => boolean;
 
 export const PLATFORM_PROCESS_MACHINES: ProcessStateMachine[] = [
   {
@@ -32,8 +33,8 @@ export const PLATFORM_PROCESS_MACHINES: ProcessStateMachine[] = [
     key: "backlog-item",
     name: "Backlog Item Lifecycle",
     statuses: BACKLOG_STATUSES,
-    // A status is terminal iff it has no legal transition to a *different* status.
-    isTerminal: (s) => !BACKLOG_STATUSES.some((t) => t !== s && backlogCan(s, t)),
+    // A status is operationally terminal iff it has no standard (non-admin-grant) transition to a different status.
+    isTerminal: (s) => !BACKLOG_STATUSES.some((t) => t !== s && backlogCan(s, t) && !backlogRequiresAdmin(s, t)),
     canTransition: (from, to) => from !== to && backlogCan(from, to),
     description:
       "Triage → build → done lifecycle governing every backlog item (apps/web/lib/backlog/transitions.ts).",


### PR DESCRIPTION
Allow done backlog items to transition back to open or triaging when retriaging items closed in error.

Backlog: BI-7D4AF644.
Docs-Impact: None - internal backlog status state machine change.
Spec-Plan: None - inline backlog state transition update.
Design-Grounding: None - API/MCP state transition logic.
Instruction-Plane: None - no agent prompt change.
Local-CI-Override: None - worktree source-only isolation.