### PR TITLE
feat(skill-pack): Claude competitive disable + remaining client equalize (BI-A4BEFE99)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -394,6 +394,7 @@
         "2026-06-26-refresh-delivery-surface-sweep",
         "2026-07-24-refresh-bi-14e9f7ce-closeout-grok-hook-portability",
         "governance-outcomes-g1g9-multi-client-parity",
+        "suggested-client-adapter-checklist-opencode-gemini-cursor",
         "what-this-currently-tells-us-the-open-adoption-gaps",
         "refresh-ritual-monthly-how-this-stays-fresh",
         "related"

--- a/docs/architecture/agent-client-capability-parity.md
+++ b/docs/architecture/agent-client-capability-parity.md
@@ -74,23 +74,39 @@ Reconciles the "Functional proof on Codex/Grok still pending" line above (2026-0
 | **G8 Headless-safe** | Always-approve / non-interactive still honors deny; no operator TUI required |
 | **G9 Readiness** | `record_surface_readiness` / bootstrap readiness observable |
 
-| Client | G1 | G2 | G3 | G4 | G5 | G6 | G7 | G8 | G9 | Notes (2026-07-26) |
-|--------|----|----|----|----|----|----|----|----|----|---------------------|
-| **Claude Code** (host) | ✅ | ⚠️ warn | ✅ dual plane | ✅ plugin | ✅ | ◐ | ◐ create hook; reap manual | ✅ | ◐ | Competitive still warn-only |
+| Client | G1 | G2 | G3 | G4 | G5 | G6 | G7 | G8 | G9 | Notes (2026-07-26, Wave 3 update) |
+|--------|----|----|----|----|----|----|----|----|----|-----------------------------------|
+| **Claude Code** (host) | ✅ | ✅ disable | ✅ dual plane | ✅ plugin | ✅ | ◐ | ◐ create + session hygiene | ✅ | ◐ | BI-A4BEFE99: `claude plugin disable` adapter |
 | **Codex CLI** (host) | ✅ | ✅ disable | ✅ if hook-trust | ✅ | ✅ | ◐ | ◐ | ✅ | ◐ | Hook-trust fail-open until trusted |
-| **Grok Build** (host) | ✅ | ⚠️ warn | ✅ global only | ⬜ | ✅ | ◐ | ⬜ | ✅ | ◐ | Plugin hooks ignored; Session plane missing |
-| **Grok** (Build Studio sandbox) | ⬜ | ⬜ | ⬜ | ⬜ | ◐ | ✅ BS | ➖ | ⚠️ no guards | ⬜ | **P0:** `grok plugin list` empty in sandbox |
-| **Antigravity (agy)** | ◐ pack | ⚠️ warn | ⬜ unproven | ⬜ | ◐ MCP wire | ◐ | ⬜ | ❓ | ⬜ | Hooks pending functional proof |
-| **Build Studio** (agentic in-portal) | ✅ seed skills | ➖ | runtime gates | ➖ | ✅ | ✅ | ➖ | ✅ phase HITL | ◐ | Not CLI-hook based |
-| **OpenCode** (suggested / BS dispatch) | ⬜ | ⬜ | ⬜ | ⬜ | ◐ | ✅ BS | ➖ | ❓ | ⬜ | Complete adapter after Grok BS seed |
-| **Gemini CLI** (suggested) | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ❓ | ⬜ | Document checklist; bootstrap when product pulls |
+| **Grok Build** (host) | ✅ | ✅ disable | ✅ global only | ✅ SessionStart/Stop | ✅ | ◐ | ◐ session hygiene + janitor | ✅ | ◐ | BI-BCA23DBB: global hooks + competitive |
+| **Grok** (Build Studio sandbox) | ✅ seed | ◐ | ◐ seeded guards | ➖ | ◐ | ✅ BS | ➖ | ◐ always-approve + guards | ◐ | BI-C5F9A232: pack seeded at dispatch |
+| **Antigravity (agy)** | ◐ pack | ⬜ unsupported | ⬜ unproven | ⬜ | ◐ MCP wire | ◐ | ⬜ | ❓ | ⬜ | No plugin-disable CLI; hooks unproven — honest gap |
+| **Build Studio** (agentic in-portal) | ✅ seed skills | ➖ | runtime gates | ➖ | ✅ | ✅ | sandbox GC | ✅ phase HITL | ◐ | Not CLI-hook based; BS worktree GC landed |
+| **OpenCode** (suggested / BS dispatch) | ⬜ | ⬜ | ⬜ | ⬜ | ◐ | ✅ BS | ➖ | ❓ | ⬜ | Checklist only until product pull — see skill-pack README |
+| **Gemini CLI** (suggested) | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ❓ | ⬜ | Checklist only until product pull |
 | **Cursor** (compat / optional) | ⬜ | ⬜ | ◐ via Grok compat paths | ⬜ | ⬜ | ⬜ | ⬜ | ❓ | ⬜ | Hook event aliases; not first-class bootstrap |
 
-**Backlog (filed 2026-07-26):** BI-F4A1A0DC (docs/matrix), BI-BCA23DBB (Grok host plane + competitive), BI-C5F9A232 (BS Grok seed), BI-42FA7DD8 (worktree Tier-A reap), BI-A4BEFE99 (remaining clients equalize).
+**Backlog (filed 2026-07-26):** BI-F4A1A0DC (docs/matrix), BI-BCA23DBB (Grok host plane + competitive), BI-C5F9A232 (BS Grok seed), BI-42FA7DD8 (worktree Tier-A reap), BI-A4BEFE99 (remaining clients equalize), BI-8BD61C30 (BS sandbox GC). Waves 0–3 implementation shipped via PRs #3594–#3601 + this branch.
+
+### Suggested-client adapter checklist (OpenCode / Gemini / Cursor)
+
+Promote a suggested client only after each gate has evidence (or an explicit “comply by construction” note):
+
+1. **G1 Skills** — install path for `dpf-platform` skills (plugin / skills dir / seed).
+2. **G2 Competitive** — non-destructive disable of `process-spine-replacements.json` competitive ids.
+3. **G3 Plane-1 hooks** — lease / root-clone / compose deny, or documented substitute.
+4. **G4 Session** — SessionStart/End plane where the client exposes events.
+5. **G5 MCP** — token env + snippet format.
+6. **G6 Capsule** — external executor kind + evidence attribution.
+7. **G7 Worktree** — canonical sibling base + hygiene hooks when events exist.
+8. **G8 Headless** — non-interactive still honors deny.
+9. **G9 Readiness** — bootstrap or dispatch readiness observable.
+
+Source checklist also lives in `packages/dpf-skill-pack/README.md` (adapter checklist section).
 
 ## What this currently tells us (the open adoption gaps)
 
-- **Governance parity (2026-07-26):** Grok BS seed + competitive disable + worktree Tier-A reap are the highest-leverage closes (see G1–G9 table). Token economy rows below remain separate.
+- **Governance parity (2026-07-26):** Waves 1–3 closed Grok host/BS seed, competitive disable on Codex/Grok/Claude, worktree Tier-A, and BS sandbox GC. Remaining: Antigravity disable+hooks proof, OpenCode/Gemini/Cursor product pull, Docker image reap (separate). Token economy rows below remain separate.
 - **R3 — deferred tools on `/api/mcp/v1`** (⬜): external CLIs pull the full JWT-scoped surface; adopt the Tool Search pattern.
 - **R4 — code execution in the native loop** (⬜): the single biggest local-window token lever; sandbox already exists.
 - **R6 — local prefix-KV cache** (◐): confirm DMR/llama.cpp reuses the static prefix.

--- a/docs/superpowers/plans/2026-07-26-multi-client-governance-parity.md
+++ b/docs/superpowers/plans/2026-07-26-multi-client-governance-parity.md
@@ -115,6 +115,8 @@ Five BIs (not one xlarge) — each shippable alone; Wave 1 Grok BS seed unblocks
 ## Done when
 
 1. Host Grok and BS Grok both expose dpf-platform skills and plane-1 denies.
-2. Competitive superpowers-family disabled on Codex + Grok (Claude when adapter lands).
+2. Competitive superpowers-family disabled on Codex + Grok + Claude (`claude plugin disable` adapter, BI-A4BEFE99).
 3. Tier-A janitor can run scheduled dry-run (auto-reap optional flag).
 4. Capability parity doc lists G1–G9 for all SURFACE_CLIENT_KINDS + suggested clients.
+5. Antigravity competitive cleanup is honest **unsupported-until-proven** (no disable CLI).
+6. OpenCode / Gemini / Cursor have a documented adapter checklist (not fake parity).

--- a/docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md
+++ b/docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md
@@ -251,5 +251,5 @@ Adopt only when product value exists; still **document** the adapter checklist s
 ## Open questions (resolve in plan execution, not blocking Wave 1)
 
 1. Should BS engine preflight **hard-fail** or **warn + continue** when dpf-platform missing? (Recommend hard-fail after seed lands.)
-2. Claude competitive disable: which CLI/API is safe without deleting user packs?
+2. Claude competitive disable: which CLI/API is safe without deleting user packs? **Resolved (BI-A4BEFE99):** `claude plugin list --json` + `claude plugin disable <id> [--scope …]` — disable-not-delete; never uninstall.
 3. Worktree Tier A default-on timeline after soak (1 week? 1 release?).

--- a/packages/dpf-skill-pack/README.md
+++ b/packages/dpf-skill-pack/README.md
@@ -44,12 +44,14 @@ The same JSON file also owns the cleanup/update lifecycle policy. The policy is
 `disable-not-delete`: rerunning bootstrap or the updater after a skill-pack
 change replaces the managed DPF copy and lets tested client adapters disable
 known competitive plugins. It does not remove user-owned skill files or plugin
-caches. Today Codex and Grok have safe disable adapters (`enabled = false` / `grok
-plugin disable`); Claude and Antigravity report warn-only until their
-active-state cleanup adapters are verified. Grok also materializes a global
+caches. Codex, Grok, and Claude have safe disable adapters (`enabled = false` /
+`grok plugin disable` / `claude plugin disable`); Antigravity remains
+**unsupported-until-proven** (no non-interactive plugin disable CLI — skills are
+file-synced only). Grok also materializes a global
 `~/.grok/hooks/dpf-guards.json` (PreToolUse + SessionStart + SessionEnd/Stop)
 because its hook plane ignores plugin-bundled hooks; Build Studio Grok seeds
-the same pack at dispatch time (BI-BCA23DBB / BI-C5F9A232).
+the same pack at dispatch time (BI-BCA23DBB / BI-C5F9A232). Wave 3 client
+equalize: BI-A4BEFE99.
 
 ## Skills shipped in v0.1.0
 
@@ -208,8 +210,29 @@ full Node planner is unavailable in a source-only checkout.
 The update run also prints process-spine cleanup/update readiness. For Codex it
 converges `~/.codex/config.toml` by keeping `dpf-platform` enabled and disabling
 contract-listed competitive process plugins such as `superpowers@openai-curated`.
-For clients without a tested disable adapter, the readiness output stays
-warn-only and names the missing adapter honestly.
+For Grok and Claude it runs the matching `plugin list` / `plugin disable`
+adapters (never uninstall). Antigravity and any client without a disable CLI
+stay warn / unsupported-until-proven and name the gap honestly.
+
+### Adapter checklist — suggested clients (OpenCode / Gemini / Cursor)
+
+These surfaces are **not** first-class bootstrap targets until product demand
+pulls them. Before promoting any to `reconciles-safe-config`, complete:
+
+| Gate | What to prove |
+|------|----------------|
+| **G1 Skills** | Install path for `dpf-platform` skills (plugin, skills dir, or seed copy) |
+| **G2 Competitive** | Non-destructive disable of contract-listed competitive process plugins |
+| **G3 Plane-1 hooks** | At least lease / root-clone / compose deny path, or explicit “comply by construction” |
+| **G4 Session** | SessionStart/End (or documented absence) |
+| **G5 MCP** | `DPF_MCP_BEARER_TOKEN` + snippet format |
+| **G6 Capsule** | External evidence attribution kind (or BS-only if in-sandbox) |
+| **G7 Worktree** | Canonical sibling base + session hygiene hooks where events exist |
+| **G8 Headless** | Always-approve / non-interactive still honors deny |
+| **G9 Readiness** | Bootstrap or dispatch readiness observable |
+
+Until then, rows stay checklist-only in
+[`docs/architecture/agent-client-capability-parity.md`](../../docs/architecture/agent-client-capability-parity.md).
 
 ### Version bumps propagate automatically
 

--- a/packages/dpf-skill-pack/hooks/process-spine-health.test.mjs
+++ b/packages/dpf-skill-pack/hooks/process-spine-health.test.mjs
@@ -51,12 +51,19 @@ test("cleanup policy is contract-backed and never destructive", () => {
   const summary = renderCleanupPolicySummary(policy).join("\n");
   assert.match(summary, /disable-not-delete/);
   assert.match(summary, /Codex/);
-  // Grok (and Codex) reconcile via disable-plugin; Claude/Antigravity remain warn-only.
+  // Codex, Grok, and Claude reconcile via disable-plugin; Antigravity is honest unsupported.
   assert.match(summary, /Grok/);
-  assert.match(summary, /warn-only|disables known competitive/);
+  assert.match(summary, /Claude/);
+  assert.match(summary, /disables known competitive/);
+  assert.match(summary, /unsupported-until-proven/);
   const grok = policy.clients.find((c) => c.client === "grok");
   assert.equal(grok?.status, "reconciles-safe-config");
   assert.equal(grok?.action, "disable-plugin");
+  const claude = policy.clients.find((c) => c.client === "claude");
+  assert.equal(claude?.status, "reconciles-safe-config");
+  assert.equal(claude?.action, "disable-plugin");
+  const antigravity = policy.clients.find((c) => c.client === "antigravity");
+  assert.equal(antigravity?.status, "unsupported-until-proven");
 });
 
 test("distinguishes installed-on-disk from exposed-in-session evidence", () => {

--- a/packages/dpf-skill-pack/process-spine-replacements.json
+++ b/packages/dpf-skill-pack/process-spine-replacements.json
@@ -17,13 +17,13 @@
       },
       {
         "client": "claude",
-        "status": "warn-only",
+        "status": "reconciles-safe-config",
         "competitivePluginIds": [
           "superpowers",
           "superpowers@openai-curated",
           "superpowers@openai-bundled"
         ],
-        "action": "warn-until-adapter-verified"
+        "action": "disable-plugin"
       },
       {
         "client": "grok",
@@ -37,13 +37,14 @@
       },
       {
         "client": "antigravity",
-        "status": "warn-only",
+        "status": "unsupported-until-proven",
         "competitivePluginIds": [
           "superpowers",
           "superpowers@openai-curated",
           "superpowers@openai-bundled"
         ],
-        "action": "warn-until-adapter-verified"
+        "action": "warn-no-disable-cli",
+        "notes": "agy has no non-interactive plugin disable; skills are file-synced only. Hook plane still unproven (BI-47A81FEB)."
       }
     ]
   },

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -135,24 +135,27 @@ def load_process_spine_cleanup_policy(skill_pack: Optional[Path] = None) -> dict
     return policy
 
 
-def codex_competitive_plugin_ids(skill_pack: Optional[Path] = None) -> list[str]:
+def competitive_plugin_ids_for(client_name: str, skill_pack: Optional[Path] = None) -> list[str]:
+    """Contract-backed competitive plugin ids for one client (disable-not-delete)."""
     policy = load_process_spine_cleanup_policy(skill_pack)
     for client in policy.get("clients", []):
-        if client.get("client") == "codex":
+        if client.get("client") == client_name:
             ids = client.get("competitivePluginIds")
             if isinstance(ids, list):
                 return [str(item) for item in ids if str(item)]
     return []
+
+
+def codex_competitive_plugin_ids(skill_pack: Optional[Path] = None) -> list[str]:
+    return competitive_plugin_ids_for("codex", skill_pack)
 
 
 def grok_competitive_plugin_ids(skill_pack: Optional[Path] = None) -> list[str]:
-    policy = load_process_spine_cleanup_policy(skill_pack)
-    for client in policy.get("clients", []):
-        if client.get("client") == "grok":
-            ids = client.get("competitivePluginIds")
-            if isinstance(ids, list):
-                return [str(item) for item in ids if str(item)]
-    return []
+    return competitive_plugin_ids_for("grok", skill_pack)
+
+
+def claude_competitive_plugin_ids(skill_pack: Optional[Path] = None) -> list[str]:
+    return competitive_plugin_ids_for("claude", skill_pack)
 
 
 def _grok_plugin_active(plugins: list[Any], plugin_id: str) -> bool:
@@ -697,6 +700,122 @@ def install_claude_plugin(home: Path, dry_run: bool) -> str:
         if result.returncode != 0:
             return f"failed: {' '.join(command[:3])} exited {result.returncode}"
     return "installed and refreshed"
+
+
+def _claude_plugin_matches(installed_id: str, competitive_id: str) -> bool:
+    """Match contract ids against Claude's plugin@marketplace ids.
+
+    Claude `plugin list --json` reports `id` as `name@marketplace`. The cleanup
+    contract may list bare names (`superpowers`) or fully-qualified ids.
+    """
+    if not installed_id or not competitive_id:
+        return False
+    if installed_id == competitive_id:
+        return True
+    # Never treat dpf-platform as competitive even if bare-name logic runs.
+    if installed_id == PLUGIN_NAME or installed_id.startswith(f"{PLUGIN_NAME}@"):
+        return False
+    inst_bare = installed_id.split("@", 1)[0]
+    if "@" not in competitive_id:
+        return inst_bare == competitive_id
+    return installed_id == competitive_id
+
+
+def disable_competitive_claude_plugins(
+    skill_pack: Optional[Path] = None, dry_run: bool = False
+) -> str:
+    """Disable known competitive process plugins on Claude Code (disable-not-delete).
+
+    Codex writes enabled=false into config.toml; Grok uses `grok plugin disable`.
+    Claude uses `claude plugin list --json` + `claude plugin disable <id>`
+    (optionally `--scope`). Only acts when a competitive plugin is installed and
+    still enabled. Never uninstalls or deletes caches (BI-A4BEFE99).
+    """
+    claude = resolve_claude_binary()
+    if not claude:
+        return "skipped: Claude CLI not found"
+    plugin_ids = claude_competitive_plugin_ids(skill_pack)
+    if not plugin_ids:
+        return "skipped: no competitive plugin ids in cleanup policy"
+    if dry_run:
+        return f"dry-run: would disable competitive plugins {plugin_ids}"
+
+    list_result = subprocess.run(
+        [claude, "plugin", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if list_result.returncode != 0:
+        return f"failed: claude plugin list exited {list_result.returncode}"
+    try:
+        installed = json.loads(list_result.stdout or "[]")
+    except json.JSONDecodeError:
+        return "failed: claude plugin list returned invalid JSON"
+    if not isinstance(installed, list):
+        return "failed: claude plugin list shape unexpected"
+
+    contract_ids = [
+        plugin_id
+        for plugin_id in dict.fromkeys(plugin_ids)
+        if plugin_id
+        and plugin_id != PLUGIN_NAME
+        and not plugin_id.startswith(f"{PLUGIN_NAME}@")
+    ]
+
+    # Deduplicate installed entries (same id may appear under multiple scopes).
+    # A single installed plugin can match several contract ids (bare + qualified);
+    # act once per (id, scope), not once per contract id.
+    matched_contract: set[str] = set()
+    targets: list[dict[str, Any]] = []
+    seen_labels: set[str] = set()
+    for entry in installed:
+        if not isinstance(entry, dict):
+            continue
+        full_id = str(entry.get("id") or entry.get("name") or "")
+        if not full_id:
+            continue
+        hits = [cid for cid in contract_ids if _claude_plugin_matches(full_id, cid)]
+        if not hits:
+            continue
+        matched_contract.update(hits)
+        scope = entry.get("scope")
+        label = f"{full_id}#{scope}" if scope else full_id
+        if label in seen_labels:
+            continue
+        seen_labels.add(label)
+        targets.append(entry)
+
+    disabled: list[str] = []
+    already: list[str] = []
+    failed: list[str] = []
+    missing = [cid for cid in contract_ids if cid not in matched_contract]
+
+    for entry in targets:
+        full_id = str(entry.get("id") or entry.get("name") or "")
+        scope = entry.get("scope")
+        label = f"{full_id}#{scope}" if scope else full_id
+        if entry.get("enabled") is False:
+            already.append(label)
+            continue
+        command = [claude, "plugin", "disable", full_id]
+        if scope in ("user", "project", "local"):
+            command.extend(["--scope", str(scope)])
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode == 0:
+            disabled.append(label)
+        else:
+            failed.append(label)
+
+    parts: list[str] = []
+    if disabled:
+        parts.append(f"disabled {disabled}")
+    if already:
+        parts.append(f"already-disabled {already}")
+    if missing:
+        parts.append(f"not-installed {missing}")
+    if failed:
+        parts.append(f"failed {failed}")
+    return "; ".join(parts) if parts else "no competitive plugins present"
 
 
 def resolve_codex_binary() -> str | None:
@@ -1478,6 +1597,12 @@ def main(argv: list[str]) -> int:
         if not args.skip_claude_cli_install:
             status = install_claude_plugin(home, args.dry_run)
         print(f"  Claude     : marketplace converged; plugin install {status}")
+        claude_competitive_status = "skipped by flag"
+        if not args.skip_claude_cli_install:
+            claude_competitive_status = disable_competitive_claude_plugins(
+                process_spine_root, dry_run=args.dry_run
+            )
+        print(f"  Claude competitive: {claude_competitive_status}")
 
     token_present = bool(os.environ.get(TOKEN_ENV_VAR))
     print(f"  MCP token  : {'present' if token_present else 'missing'} ({TOKEN_ENV_VAR})")

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -717,8 +717,10 @@ def _claude_plugin_matches(installed_id: str, competitive_id: str) -> bool:
         return False
     inst_bare = installed_id.split("@", 1)[0]
     if "@" not in competitive_id:
+        # Contract bare name matches any marketplace-qualified install of that name.
         return inst_bare == competitive_id
-    return installed_id == competitive_id
+    # Competitive id is fully qualified; equality was already checked above.
+    return False
 
 
 def disable_competitive_claude_plugins(

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -131,6 +131,94 @@ class InstallGrokHooksTest(unittest.TestCase):
         self.assertIn("superpowers", status)
 
 
+class ClaudeCompetitiveDisableTest(unittest.TestCase):
+    """Claude competitive cleanup (BI-A4BEFE99) — disable-not-delete via CLI."""
+
+    def test_disable_competitive_claude_plugins_skips_when_no_cli(self) -> None:
+        with patch.object(updater, "resolve_claude_binary", return_value=None):
+            status = updater.disable_competitive_claude_plugins(dry_run=False)
+            self.assertIn("skipped: Claude CLI not found", status)
+
+    def test_disable_competitive_claude_plugins_dry_run(self) -> None:
+        with patch.object(updater, "resolve_claude_binary", return_value="claude"):
+            status = updater.disable_competitive_claude_plugins(dry_run=True)
+            self.assertIn("dry-run", status)
+
+    def test_claude_plugin_matches_bare_and_qualified(self) -> None:
+        self.assertTrue(
+            updater._claude_plugin_matches("superpowers@openai-curated", "superpowers")
+        )
+        self.assertTrue(
+            updater._claude_plugin_matches(
+                "superpowers@openai-curated", "superpowers@openai-curated"
+            )
+        )
+        self.assertFalse(
+            updater._claude_plugin_matches(
+                "superpowers@other-market", "superpowers@openai-curated"
+            )
+        )
+        self.assertFalse(
+            updater._claude_plugin_matches("dpf-platform@dpf-platform-local", "superpowers")
+        )
+
+    def test_disable_competitive_claude_plugins_disables_active_with_scope(self) -> None:
+        from unittest.mock import Mock
+
+        list_payload = json.dumps(
+            [
+                {
+                    "id": "superpowers@openai-curated",
+                    "enabled": True,
+                    "scope": "user",
+                },
+                {
+                    "id": "dpf-platform@dpf-platform-local",
+                    "enabled": True,
+                    "scope": "local",
+                },
+                {
+                    "id": "code-review@claude-code-plugins",
+                    "enabled": True,
+                    "scope": "project",
+                },
+            ]
+        )
+        disable_cmds: list[list[str]] = []
+
+        def fake_run(cmd, capture_output=True, text=True):  # type: ignore[no-untyped-def]
+            if cmd[1:3] == ["plugin", "list"]:
+                return Mock(returncode=0, stdout=list_payload, stderr="")
+            if cmd[1:3] == ["plugin", "disable"]:
+                disable_cmds.append(list(cmd))
+                return Mock(returncode=0, stdout="", stderr="")
+            return Mock(returncode=1, stdout="", stderr="unexpected")
+
+        with patch.object(updater, "resolve_claude_binary", return_value="claude"):
+            with patch.object(updater.subprocess, "run", side_effect=fake_run):
+                status = updater.disable_competitive_claude_plugins(dry_run=False)
+
+        self.assertIn("disabled", status)
+        self.assertIn("superpowers@openai-curated", status)
+        self.assertEqual(len(disable_cmds), 1)
+        self.assertEqual(
+            disable_cmds[0],
+            ["claude", "plugin", "disable", "superpowers@openai-curated", "--scope", "user"],
+        )
+        # Must never disable dpf-platform or unrelated plugins
+        self.assertNotIn("dpf-platform", status.split("disabled")[-1] if "disabled" in status else "")
+        self.assertTrue(all("code-review" not in " ".join(c) for c in disable_cmds))
+
+    def test_cleanup_policy_claude_reconciles(self) -> None:
+        policy = updater.load_process_spine_cleanup_policy()
+        claude = next(c for c in policy["clients"] if c["client"] == "claude")
+        self.assertEqual(claude["status"], "reconciles-safe-config")
+        self.assertEqual(claude["action"], "disable-plugin")
+        antigravity = next(c for c in policy["clients"] if c["client"] == "antigravity")
+        self.assertEqual(antigravity["status"], "unsupported-until-proven")
+        self.assertIn("warn", antigravity["action"])
+
+
 class HookRosterTest(unittest.TestCase):
     """The trust-UI roster must name+describe every hook (BI-276EC984)."""
 


### PR DESCRIPTION
## Summary

Wave 3 of multi-client governance parity (**BI-A4BEFE99**):

- **Claude competitive cleanup:** `disable_competitive_claude_plugins` uses `claude plugin list --json` + `claude plugin disable <id> [--scope …]`. Disable-not-delete; dedupes bare vs qualified contract ids; never touches `dpf-platform`.
- **Contract:** Claude status → `reconciles-safe-config` / `disable-plugin`. Antigravity → honest `unsupported-until-proven` (no non-interactive plugin disable CLI).
- **Suggested clients:** OpenCode / Gemini / Cursor adapter checklist in skill-pack README and the G1–G9 capability matrix.
- **Matrix refresh:** Grok host/BS, Claude G2, and related Wave 1–2 outcomes reflected after earlier PRs.

## Test plan

- [x] `python packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py` (worktree) — 56 passed
- [x] `node --test process-spine-health.test.mjs` (worktree) — 7 passed
- [ ] CI Unit Tests / Repo Guard Loop on this PR

## Design grounding

- Spec: `docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md` (Wave 3)
- Plan: `docs/superpowers/plans/2026-07-26-multi-client-governance-parity.md`
- Substrate: Grok competitive disable + Codex config disable; Claude CLI `plugin disable` (probed live on this host)

Local-CI-Override: source-only worktree; skill-pack Python/Node unit tests only; no portal runtime change
Process-Spine-Decision: cleanupPolicy + updater adapters for Claude/Antigravity equalize
Docs-Impact-Decision: capability parity matrix + skill-pack README; no user route change