### PR TITLE
fix(deps): floor valibot for GHSA-5qjj-4xww-7phc

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   ip-address: ^10.2.0
   sharp: ^0.35.3
   body-parser: ^2.3.0
+  valibot@<=1.4.1: 1.4.2
   jest: ^30.0.0
   jest-cli: ^30.0.0
   jest-config: ^30.0.0
@@ -9296,8 +9297,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -12428,7 +12429,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -19751,7 +19752,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.2.0(typescript@6.0.3):
+  valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,10 @@ overrides:
   # body-parser < 2.3.0: GHSA-v422-hmwv-36x6 DoS when an invalid `limit` value silently
   # disables body size enforcement (Dependabot #104, low). Transitive; floor to 2.3.0.
   body-parser: '^2.3.0'
+  # valibot <= 1.4.1: GHSA-5qjj-4xww-7phc / CVE-2026-59952 request-path
+  # DoS when flatten() receives record issue paths matching inherited Object keys
+  # (Dependabot #132, medium). Transitive through @prisma/dev; floor to 1.4.2.
+  'valibot@<=1.4.1': '1.4.2'
   # --- jest 30 unification (apps/mobile) ---
   # Force the ENTIRE jest family to a single major (30) so apps/mobile runs a
   # unified jest 30 install. jest-expo@~56 (Expo SDK 55/56) still *declares* jest


### PR DESCRIPTION
## Summary
- floor transitive `valibot` versions affected by GHSA-5qjj-4xww-7phc / CVE-2026-59952 at patched `1.4.2`
- regenerate `pnpm-lock.yaml` with the repository's fresh-store workflow; only `valibot` changes (`1.2.0` to `1.4.2`)
- record Dependabot alert #132 provenance beside the override

Advisory: https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/security/dependabot/132

## Test plan
- [x] `node scripts/regen-lockfile.mjs --expect valibot` — scoped and stable
- [x] lockfile inspection — vulnerable `valibot@1.2.0` absent; only `valibot@1.4.2` resolves
- [x] `node scripts/check-override-comments.mjs` — 68 overrides pass provenance guard
- [x] `node --test scripts/check-override-comments.test.mjs` — 10/10 pass
- [x] SBOM dependency-shape check — no new first-party version splits
- [x] merged-code pregate — typecheck and Docker production build passed for identical tree delta at `347ecef6` (evidence `cms24p8q609o001lhl8f1gzvv`)
- [x] UX verification — n/a; dependency policy and lockfile only
- [x] migration verification — n/a; no migration

Local-CI-Evidence: cms24p8q609o001lhl8f1gzvv (fix/dependabot-132-valibot@347ecef6e8b8be100f1fe04b1a63486d7fbe501c)
Local-CI-Override: The current `8ed772f3` tip is a clean parent-only rebase of the identical tested tree delta. Its SHA-refresh run was recorded `blocked_sandbox_drift` because an earlier branch's convergence process outlived its expired lease and retained the sandbox mutex; PR CI verifies the current base.

Documentation impact: none; this changes only a transitive security floor and lockfile resolution, with provenance documented at the override source of truth.