### PR TITLE
feat(inference): add sensitive payload classifier

### DIFF
--- a/apps/web/lib/govern/data/policy-enforcement.test.ts
+++ b/apps/web/lib/govern/data/policy-enforcement.test.ts
@@ -16,6 +16,15 @@ describe("PEP capability matrix", () => {
     expect(canPepEnforce("high-risk-read", "delete-derived-copy")).toBe(false);
   });
 
+  it("treats inference dispatch as a destination-enforcing PEP", () => {
+    expect(canPepEnforce("inference-dispatch", "destination")).toBe(true);
+    expect(canPepEnforce("inference-dispatch", "mask")).toBe(true);
+    expect(canPepEnforce("inference-dispatch", "log-use")).toBe(true);
+    expect(canPepEnforce("inference-dispatch", "human-approval")).toBe(true);
+    expect(canPepEnforce("inference-dispatch", "delete-derived-copy")).toBe(false);
+    expect(canPepEnforce("coworker-context", "destination")).toBe(false);
+  });
+
   it("throws when obligations exceed what a PEP can enforce", () => {
     expect(() =>
       assertObligationsEnforceable("coworker-context", [

--- a/apps/web/lib/govern/data/policy-enforcement.ts
+++ b/apps/web/lib/govern/data/policy-enforcement.ts
@@ -28,6 +28,12 @@ export const DATA_PEP_CAPABILITY_MATRIX: Readonly<
     "disposition-evidence",
   ]),
   "coworker-context": new Set<DataObligationKind>(["mask", "log-use"]),
+  "inference-dispatch": new Set<DataObligationKind>([
+    "mask",
+    "destination",
+    "log-use",
+    "human-approval",
+  ]),
   projection: new Set<DataObligationKind>([
     "mask",
     "encrypt",

--- a/apps/web/lib/govern/data/taxonomy.test.ts
+++ b/apps/web/lib/govern/data/taxonomy.test.ts
@@ -77,6 +77,10 @@ describe("closed vocabularies", () => {
       "content",
     ]);
   });
+
+  it("keeps inference dispatch as its own PEP kind", () => {
+    expect([...ALL_DATA_PEP_KINDS]).toContain("inference-dispatch");
+  });
 });
 
 describe("precedence lattice", () => {

--- a/apps/web/lib/govern/data/taxonomy.ts
+++ b/apps/web/lib/govern/data/taxonomy.ts
@@ -288,6 +288,7 @@ export type DataPepKind =
   | "high-risk-read"
   | "mdm-action"
   | "coworker-context"
+  | "inference-dispatch"
   | "projection"
   | "lifecycle";
 export const ALL_DATA_PEP_KINDS = [
@@ -295,6 +296,7 @@ export const ALL_DATA_PEP_KINDS = [
   "high-risk-read",
   "mdm-action",
   "coworker-context",
+  "inference-dispatch",
   "projection",
   "lifecycle",
 ] as const satisfies readonly DataPepKind[];

--- a/apps/web/lib/inference/data-screening/classify-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyInferencePayload } from "./classify-payload";
+import type { ChatMessage } from "@/lib/inference/ai-inference";
+
+describe("classifyInferencePayload", () => {
+  it("detects secrets, customer, employee, finance, and source-code data without echoing raw values", () => {
+    const providerKeyCanary = ["sk", "test", "1234567890abcdef"].join("-");
+    const mcpTokenCanary = ["dpfmcp", "secret", "1234567890"].join("_");
+    const messages: ChatMessage[] = [
+      {
+        role: "user",
+        content:
+          "Please debug this customer issue for pat@example.com. " +
+          `Employee salary is 125000 and the Stripe key is ${providerKeyCanary}.`,
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will inspect the JavaScript snippet." },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "inspect_code",
+            input: {
+              source: `const token = '${mcpTokenCanary}';`,
+              routingNumber: "021000021",
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = classifyInferencePayload({
+      messages,
+      systemPrompt: "You are helping with customer support and payroll triage.",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "lookupCustomer",
+            description: "Look up customer payment and support records.",
+          },
+        },
+      ],
+      taskType: "tool-action",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+    expect(result.dataClasses).toEqual([
+      "customer-records",
+      "employee-records",
+      "payments-finance",
+      "secrets-credentials",
+      "source-code",
+    ]);
+    expect(result.receipt.rawPayloadStored).toBe(false);
+    expect(result.receipt.detectedClasses).toEqual(result.dataClasses);
+    expect(result.matches.map((match) => match.dataClass)).toEqual(
+      expect.arrayContaining([
+        "customer-records",
+        "employee-records",
+        "payments-finance",
+        "secrets-credentials",
+        "source-code",
+      ]),
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("pat@example.com");
+    expect(serialized).not.toContain(providerKeyCanary);
+    expect(serialized).not.toContain(mcpTokenCanary);
+    expect(serialized).not.toContain("021000021");
+  });
+
+  it("adds unknown-governed-data when governed classification is missing", () => {
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "Summarize the attached governed export." }],
+      systemPrompt: "",
+      taskType: "summarization",
+      governedData: [
+        {
+          assetId: "asset-customer-export",
+          classificationKnown: false,
+          purpose: "coworker-assistance",
+        },
+      ],
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+    expect(result.dataClasses).toContain("unknown-governed-data");
+    expect(result.matches).toContainEqual(
+      expect.objectContaining({
+        dataClass: "unknown-governed-data",
+        path: "governedData[0]",
+        reason: "governed-classification-missing",
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain("asset-customer-export");
+  });
+
+  it("returns a stable low-risk receipt for benign internal work", () => {
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "Draft a friendly announcement about next week's team lunch." }],
+      systemPrompt: "Be concise.",
+      taskType: "creative",
+    });
+
+    expect(result.overallSensitivity).toBe("internal");
+    expect(result.dataClasses).toEqual([]);
+    expect(result.matches).toEqual([]);
+    expect(result.receipt).toEqual(
+      expect.objectContaining({
+        rawPayloadStored: false,
+        detectedClasses: [],
+        matchCount: 0,
+        transformation: "none",
+      }),
+    );
+    expect(result.receipt.inputHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -1,0 +1,361 @@
+import { createHash } from "node:crypto";
+
+import type { ContentBlock } from "@/lib/inference/ai-inference";
+import type {
+  GovernedPayloadHint,
+  InferenceDataClass,
+  InferencePayloadClassification,
+  InferencePayloadClassificationInput,
+  InferencePayloadMatch,
+  InferencePayloadSensitivity,
+} from "./types";
+
+type TextProbe = {
+  path: string;
+  text: string;
+};
+
+type ClassRule = {
+  dataClass: InferenceDataClass;
+  reason: string;
+  confidence: InferencePayloadMatch["confidence"];
+  pathPattern?: RegExp;
+  textPattern?: RegExp;
+};
+
+const CLASS_RULES: readonly ClassRule[] = [
+  {
+    dataClass: "secrets-credentials",
+    reason: "secret-shaped-token",
+    confidence: "deterministic",
+    textPattern:
+      /\b(?:sk-[A-Za-z0-9_-]{10,}|dpfmcp_[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]{12,}|AKIA[0-9A-Z]{12,}|-----BEGIN\s+(?:RSA\s+)?PRIVATE KEY-----)\b/i,
+  },
+  {
+    dataClass: "secrets-credentials",
+    reason: "secret-field-name",
+    confidence: "inferred",
+    pathPattern: /\b(?:api[-_]?key|access[-_]?token|refresh[-_]?token|password|secret|credential|authorization)\b/i,
+  },
+  {
+    dataClass: "customer-records",
+    reason: "contact-detail",
+    confidence: "deterministic",
+    textPattern:
+      /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/i,
+  },
+  {
+    dataClass: "customer-records",
+    reason: "customer-record-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:customer|account|contact|support|order|address|phone|email)\b/i,
+  },
+  {
+    dataClass: "employee-records",
+    reason: "employee-record-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:employee|worker|salary|compensation|benefit|performance|discipline|manager|payroll)\b/i,
+  },
+  {
+    dataClass: "employee-records",
+    reason: "employee-record-text",
+    confidence: "inferred",
+    textPattern: /\b(?:employee|salary|compensation|benefits?|performance review|disciplinary|manager-only|payroll)\b/i,
+  },
+  {
+    dataClass: "payments-finance",
+    reason: "payment-or-finance-field",
+    confidence: "inferred",
+    pathPattern:
+      /\b(?:payment|card|credit[-_]?card|routing[-_]?number|account[-_]?number|iban|invoice|bank|tax|payroll)\b/i,
+  },
+  {
+    dataClass: "payments-finance",
+    reason: "payment-or-finance-text",
+    confidence: "inferred",
+    textPattern:
+      /\b(?:routing number|account number|credit card|invoice|bank account|payroll|tax id|ein|ssn)\b/i,
+  },
+  {
+    dataClass: "health-phi",
+    reason: "health-record-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:patient|diagnosis|medication|medical|health|phi|hipaa|visit|claim)\b/i,
+  },
+  {
+    dataClass: "student-records",
+    reason: "student-record-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:student|learner|iep|ferpa|grade|transcript|enrollment)\b/i,
+  },
+  {
+    dataClass: "legal-privileged",
+    reason: "legal-privilege-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:attorney|legal|privileged|counsel|litigation|contract[-_]?review)\b/i,
+  },
+  {
+    dataClass: "public-sector-records",
+    reason: "public-sector-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:citizen|case[-_]?number|permit|public[-_]?sector|foia|agency)\b/i,
+  },
+  {
+    dataClass: "security-logs",
+    reason: "security-log-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:security[-_]?log|audit[-_]?log|incident|ip[-_]?address|siem|threat)\b/i,
+  },
+  {
+    dataClass: "regulated-decisioning",
+    reason: "regulated-decisioning-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:eligibility|underwriting|risk[-_]?score|credit[-_]?decision|benefit[-_]?decision)\b/i,
+  },
+  {
+    dataClass: "source-code",
+    reason: "source-code-text",
+    confidence: "inferred",
+    textPattern:
+      /(?:\b(?:const|let|var|function|class|import|export)\s+[A-Za-z_$][\w$]*|=>|```(?:ts|tsx|js|jsx|py|sql|sh|ps1)?)/,
+  },
+  {
+    dataClass: "source-code",
+    reason: "source-code-field",
+    confidence: "inferred",
+    pathPattern: /\b(?:source|source[-_]?code|stack|diff|patch|repository|commit|filePath)\b/i,
+  },
+] as const;
+
+const RESTRICTED_CLASSES = new Set<InferenceDataClass>([
+  "employee-records",
+  "payments-finance",
+  "health-phi",
+  "student-records",
+  "legal-privileged",
+  "security-logs",
+  "public-sector-records",
+  "regulated-decisioning",
+  "secrets-credentials",
+  "unknown-governed-data",
+]);
+
+const CONFIDENTIAL_CLASSES = new Set<InferenceDataClass>([
+  "customer-records",
+  "source-code",
+]);
+
+export function classifyInferencePayload(
+  input: InferencePayloadClassificationInput,
+): InferencePayloadClassification {
+  const probes = collectTextProbes(input);
+  const matches: InferencePayloadMatch[] = [];
+
+  for (const probe of probes) {
+    for (const rule of CLASS_RULES) {
+      if (rule.pathPattern?.test(probe.path) || rule.textPattern?.test(probe.text)) {
+        matches.push({
+          dataClass: rule.dataClass,
+          path: probe.path,
+          reason: rule.reason,
+          confidence: rule.confidence,
+        });
+      }
+    }
+  }
+
+  matches.push(...classifyGovernedHints(input.governedData));
+
+  const dedupedMatches = dedupeMatches(matches);
+  const dataClasses = uniqueSorted(dedupedMatches.map((match) => match.dataClass));
+  const overallSensitivity = inferOverallSensitivity(dataClasses, input.governedData);
+  const inputHash = hashCanonical({
+    messages: input.messages,
+    systemPrompt: input.systemPrompt,
+    tools: input.tools ?? [],
+    taskType: input.taskType ?? null,
+    governedData: input.governedData ?? [],
+  });
+
+  return {
+    overallSensitivity,
+    dataClasses,
+    matches: dedupedMatches,
+    receipt: {
+      screenId: `screen_${inputHash.slice(0, 16)}`,
+      inputHash,
+      detectedClasses: dataClasses,
+      matchCount: dedupedMatches.length,
+      transformation: "none",
+      rawPayloadStored: false,
+    },
+  };
+}
+
+function collectTextProbes(input: InferencePayloadClassificationInput): TextProbe[] {
+  const probes: TextProbe[] = [];
+  if (input.systemPrompt) {
+    probes.push({ path: "systemPrompt", text: input.systemPrompt });
+  }
+
+  input.messages.forEach((message, index) => {
+    probes.push({ path: `messages[${index}].role`, text: message.role });
+    collectMessageContent(message.content, `messages[${index}].content`, probes);
+    if (message.toolCallId) {
+      probes.push({ path: `messages[${index}].toolCallId`, text: message.toolCallId });
+    }
+    message.toolCalls?.forEach((toolCall, toolIndex) => {
+      probes.push({
+        path: `messages[${index}].toolCalls[${toolIndex}].name`,
+        text: toolCall.name,
+      });
+      collectUnknown(
+        toolCall.arguments,
+        `messages[${index}].toolCalls[${toolIndex}].arguments`,
+        probes,
+      );
+    });
+  });
+
+  input.tools?.forEach((tool, index) => collectUnknown(tool, `tools[${index}]`, probes));
+  if (input.taskType) {
+    probes.push({ path: "taskType", text: input.taskType });
+  }
+  return probes;
+}
+
+function collectMessageContent(
+  content: string | ContentBlock[],
+  path: string,
+  probes: TextProbe[],
+): void {
+  if (typeof content === "string") {
+    probes.push({ path, text: content });
+    return;
+  }
+
+  content.forEach((block, index) => {
+    const blockPath = `${path}[${index}]`;
+    probes.push({ path: `${blockPath}.type`, text: block.type });
+    switch (block.type) {
+      case "text":
+        probes.push({ path: `${blockPath}.text`, text: block.text });
+        break;
+      case "image_url":
+        probes.push({ path: `${blockPath}.image_url.url`, text: block.image_url.url });
+        break;
+      case "input_audio":
+        probes.push({ path: `${blockPath}.input_audio.format`, text: block.input_audio.format });
+        break;
+      case "tool_use":
+        probes.push({ path: `${blockPath}.name`, text: block.name });
+        collectUnknown(block.input, `${blockPath}.input`, probes);
+        break;
+      case "tool_result":
+        probes.push({ path: `${blockPath}.content`, text: block.content });
+        break;
+    }
+  });
+}
+
+function collectUnknown(value: unknown, path: string, probes: TextProbe[]): void {
+  if (typeof value === "string") {
+    probes.push({ path, text: value });
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    probes.push({ path, text: String(value) });
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => collectUnknown(entry, `${path}[${index}]`, probes));
+    return;
+  }
+  if (typeof value !== "object") {
+    return;
+  }
+  for (const [key, entry] of Object.entries(value).sort(([a], [b]) => a.localeCompare(b))) {
+    collectUnknown(entry, `${path}.${key}`, probes);
+  }
+}
+
+function classifyGovernedHints(
+  hints: readonly GovernedPayloadHint[] | undefined,
+): InferencePayloadMatch[] {
+  if (!hints) return [];
+  const matches: InferencePayloadMatch[] = [];
+  hints.forEach((hint, index) => {
+    if (!hint.classificationKnown) {
+      matches.push({
+        dataClass: "unknown-governed-data",
+        path: `governedData[${index}]`,
+        reason: "governed-classification-missing",
+        confidence: "governed",
+      });
+    }
+    hint.dataClasses?.forEach((dataClass) => {
+      matches.push({
+        dataClass,
+        path: `governedData[${index}].dataClasses`,
+        reason: "governed-classification-hint",
+        confidence: "governed",
+      });
+    });
+  });
+  return matches;
+}
+
+function dedupeMatches(matches: InferencePayloadMatch[]): InferencePayloadMatch[] {
+  const seen = new Set<string>();
+  const deduped: InferencePayloadMatch[] = [];
+  for (const match of matches) {
+    const key = `${match.dataClass}\0${match.path}\0${match.reason}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(match);
+  }
+  return deduped.sort((a, b) =>
+    `${a.dataClass}:${a.path}:${a.reason}`.localeCompare(`${b.dataClass}:${b.path}:${b.reason}`),
+  );
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function inferOverallSensitivity(
+  dataClasses: readonly InferenceDataClass[],
+  governedData: readonly GovernedPayloadHint[] | undefined,
+): InferencePayloadSensitivity {
+  if (governedData?.some((hint) => hint.sensitivity === "restricted")) {
+    return "restricted";
+  }
+  if (dataClasses.some((dataClass) => RESTRICTED_CLASSES.has(dataClass))) {
+    return "restricted";
+  }
+  if (
+    governedData?.some((hint) => hint.sensitivity === "confidential") ||
+    dataClasses.some((dataClass) => CONFIDENTIAL_CLASSES.has(dataClass))
+  ) {
+    return "confidential";
+  }
+  return "internal";
+}
+
+function hashCanonical(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex");
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalize(entry));
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}

--- a/apps/web/lib/inference/data-screening/evaluate-inference-policy.test.ts
+++ b/apps/web/lib/inference/data-screening/evaluate-inference-policy.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import type { DataExecutablePolicy } from "@/lib/govern/data/executable-policies";
+import { classifyInferencePayload } from "./classify-payload";
+import { evaluateInferenceDispatchPolicy } from "./evaluate-inference-policy";
+
+function classifyPrompt(systemPrompt: string) {
+  return classifyInferencePayload({
+    systemPrompt,
+    messages: [{ role: "user", content: "Help with this request." }],
+  });
+}
+
+describe("evaluateInferenceDispatchPolicy", () => {
+  it("allows external dispatch when no governed or sensitive payload is detected", () => {
+    const result = evaluateInferenceDispatchPolicy({
+      organizationId: "org-1",
+      classification: classifyPrompt("Draft a friendly public event announcement."),
+      destinationClass: "external-service",
+      purpose: "coworker-assistance",
+    });
+
+    expect(result.pepKind).toBe("inference-dispatch");
+    expect(result.effect).toBe("allow");
+    expect(result.decisionIds).toEqual([]);
+    expect(result.explanationCodes).toEqual(["no-governed-payload-detected"]);
+  });
+
+  it("denies restricted external dispatch and keeps raw values out of the result", () => {
+    const secretCanary = ["sk", "test", "restrictedpayload12345"].join("-");
+    const classification = classifyInferencePayload({
+      systemPrompt: "Summarize this integration incident.",
+      messages: [{ role: "user", content: `The leaked provider token was ${secretCanary}.` }],
+    });
+
+    const result = evaluateInferenceDispatchPolicy({
+      organizationId: "org-1",
+      classification,
+      destinationClass: "external-service",
+      purpose: "security-and-fraud",
+    });
+
+    expect(result.effect).toBe("deny");
+    expect(result.explanationCodes).toContain("restricted-cannot-leave-boundary");
+    expect(JSON.stringify(result)).not.toContain(secretCanary);
+  });
+
+  it("denies unknown governed data before external dispatch", () => {
+    const governedData = [{
+      assetId: "data:customer-account",
+      fieldIds: ["data:customer-account#emailAddress"],
+      classificationKnown: false,
+      purpose: "customer-support",
+    }];
+    const classification = classifyInferencePayload({
+      systemPrompt: "Explain this customer escalation.",
+      messages: [{ role: "user", content: "The account has conflicting history." }],
+      governedData,
+    });
+
+    const result = evaluateInferenceDispatchPolicy({
+      organizationId: "org-1",
+      classification,
+      governedData,
+      destinationClass: "external-service",
+      purpose: "customer-support",
+    });
+
+    expect(result.effect).toBe("deny");
+    expect(result.explanationCodes).toContain("unknown-context-high-risk");
+    expect(JSON.stringify(result)).not.toContain("emailAddress");
+  });
+
+  it("allows confidential external dispatch only when policy obligations are enforceable", () => {
+    const policies: DataExecutablePolicy[] = [{
+      id: "confidential-ai-export-with-controls",
+      version: "1",
+      precedenceLevel: "organization-policy",
+      match: {
+        actions: ["export"],
+        sensitivities: ["confidential"],
+        destinations: ["external-service"],
+        purposes: ["customer-support"],
+      },
+      effect: "allow-with-obligations",
+      obligations: [
+        { kind: "mask", profileId: "default-confidential" },
+        { kind: "destination", allowedClasses: ["external-service"] },
+        { kind: "log-use", evidenceClass: "inference-dispatch", minimumRetentionClass: "telemetry-bounded" },
+      ],
+      explanationCode: "confidential-ai-export-controlled",
+      effectiveFrom: "2026-07-26",
+    }];
+
+    const result = evaluateInferenceDispatchPolicy({
+      organizationId: "org-1",
+      classification: classifyPrompt("Help with customer jane@example.test and her support case."),
+      destinationClass: "external-service",
+      purpose: "customer-support",
+      policies,
+    });
+
+    expect(result.effect).toBe("allow-with-obligations");
+    expect(result.obligations.map((obligation) => obligation.kind).sort()).toEqual([
+      "destination",
+      "log-use",
+      "mask",
+    ]);
+  });
+
+  it("fails closed when a policy attaches an obligation inference dispatch cannot enforce", () => {
+    const policies: DataExecutablePolicy[] = [{
+      id: "bad-dispatch-obligation",
+      version: "1",
+      precedenceLevel: "organization-policy",
+      match: {
+        actions: ["export"],
+        sensitivities: ["confidential"],
+        destinations: ["external-service"],
+      },
+      effect: "allow-with-obligations",
+      obligations: [{ kind: "delete-derived-copy", contractIds: ["contract-1"], deadlineSeconds: 60 }],
+      explanationCode: "bad-obligation",
+      effectiveFrom: "2026-07-26",
+    }];
+
+    const result = evaluateInferenceDispatchPolicy({
+      organizationId: "org-1",
+      classification: classifyPrompt("Help with customer jane@example.test and her support case."),
+      destinationClass: "external-service",
+      purpose: "customer-support",
+      policies,
+    });
+
+    expect(result.effect).toBe("deny");
+    expect(result.explanationCodes).toContain("inference-pep-obligation-unenforceable");
+  });
+});

--- a/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts
+++ b/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts
@@ -1,0 +1,184 @@
+import {
+  ALL_PROCESSING_PURPOSES,
+  EFFECT_RANK,
+  isDataAssetId,
+  isDataFieldId,
+  type DataCategory,
+  type DataEffect,
+  type DataAssetId,
+  type DataFieldId,
+  type DestinationClass,
+  type ProcessingPurposeKey,
+} from "@/lib/govern/data/taxonomy";
+import {
+  evaluateDataPolicy,
+  type DataPolicyDecision,
+  type PolicyEvaluationContext,
+} from "@/lib/govern/data/policy-decision";
+import type { DataExecutablePolicy, DataObligation } from "@/lib/govern/data/executable-policies";
+import { assertObligationsEnforceable, PepCapabilityError } from "@/lib/govern/data/policy-enforcement";
+import type {
+  GovernedPayloadHint,
+  InferenceDataClass,
+  InferencePayloadClassification,
+} from "./types";
+
+const DEFAULT_SYNTHETIC_ASSET: DataAssetId = "data:inference-payload";
+const DEFAULT_VERSION = "screen-v1";
+
+const DATA_CLASS_CATEGORIES: Readonly<Record<InferenceDataClass, readonly DataCategory[]>> = {
+  "customer-records": ["identity", "contact", "operational"],
+  "employee-records": ["identity", "personal-attribute", "financial", "operational"],
+  "payments-finance": ["financial", "operational"],
+  "health-phi": ["identity", "personal-attribute", "operational"],
+  "student-records": ["identity", "personal-attribute", "operational"],
+  "legal-privileged": ["content", "operational"],
+  "security-logs": ["telemetry", "security-audit"],
+  "public-sector-records": ["identity", "operational"],
+  "regulated-decisioning": ["derived-analytic", "operational"],
+  "source-code": ["content", "configuration"],
+  "secrets-credentials": ["credential-secret"],
+  "unknown-governed-data": ["operational"],
+};
+
+export type InferencePolicyEvaluationInput = {
+  organizationId: string;
+  classification: InferencePayloadClassification;
+  governedData?: readonly GovernedPayloadHint[];
+  destinationClass: DestinationClass;
+  purpose?: ProcessingPurposeKey | string;
+  environmentKnown?: boolean;
+  assetVersion?: string;
+  classificationVersion?: string;
+  authorityVersion?: string;
+  policyBundleVersion?: string;
+  policies?: readonly DataExecutablePolicy[];
+};
+
+export type InferencePolicyEvaluation = {
+  pepKind: "inference-dispatch";
+  effect: DataEffect;
+  obligations: DataObligation[];
+  decisionIds: string[];
+  decisions: DataPolicyDecision[];
+  explanationCodes: string[];
+  classifiedDataClasses: InferenceDataClass[];
+  destinationClass: DestinationClass;
+};
+
+export function evaluateInferenceDispatchPolicy(
+  input: InferencePolicyEvaluationInput,
+): InferencePolicyEvaluation {
+  const classifiedDataClasses = [...input.classification.dataClasses];
+  const hasGovernedHints = Boolean(input.governedData?.length);
+  const needsPdp =
+    classifiedDataClasses.length > 0 ||
+    hasGovernedHints ||
+    input.classification.overallSensitivity === "confidential" ||
+    input.classification.overallSensitivity === "restricted";
+
+  if (!needsPdp) {
+    return {
+      pepKind: "inference-dispatch",
+      effect: "allow",
+      obligations: [],
+      decisionIds: [],
+      decisions: [],
+      explanationCodes: ["no-governed-payload-detected"],
+      classifiedDataClasses,
+      destinationClass: input.destinationClass,
+    };
+  }
+
+  const ctx = buildPolicyContext(input);
+  const decision = evaluateDataPolicy(ctx, input.policies);
+  try {
+    assertObligationsEnforceable("inference-dispatch", decision.obligations);
+  } catch (error) {
+    if (error instanceof PepCapabilityError) {
+      return {
+        pepKind: "inference-dispatch",
+        effect: "deny",
+        obligations: [],
+        decisionIds: [decision.decisionId],
+        decisions: [decision],
+        explanationCodes: [decision.explanationCode, "inference-pep-obligation-unenforceable"],
+        classifiedDataClasses,
+        destinationClass: input.destinationClass,
+      };
+    }
+    throw error;
+  }
+
+  return {
+    pepKind: "inference-dispatch",
+    effect: decision.effect,
+    obligations: decision.obligations,
+    decisionIds: [decision.decisionId],
+    decisions: [decision],
+    explanationCodes: [decision.explanationCode],
+    classifiedDataClasses,
+    destinationClass: input.destinationClass,
+  };
+}
+
+function buildPolicyContext(input: InferencePolicyEvaluationInput): PolicyEvaluationContext {
+  const governedData = input.governedData ?? [];
+  const governedAssetId = governedData
+    .map((hint) => hint.assetId)
+    .find((assetId): assetId is DataAssetId => Boolean(assetId && isDataAssetId(assetId)));
+  const asset = governedAssetId ?? DEFAULT_SYNTHETIC_ASSET;
+  const fields = uniqueSorted(
+    governedData.flatMap((hint) => hint.fieldIds ?? []).filter(isDataFieldId),
+  ) as DataFieldId[];
+  const classificationKnown =
+    !input.classification.dataClasses.includes("unknown-governed-data") &&
+    !governedData.some((hint) => !hint.classificationKnown);
+
+  return {
+    organizationId: input.organizationId,
+    action: input.destinationClass === "external-service" ? "export" : "project",
+    asset,
+    fields,
+    purpose: resolvePurpose(input.purpose, governedData),
+    destination: input.destinationClass,
+    classification: {
+      known: classificationKnown,
+      sensitivity: input.classification.overallSensitivity,
+      categories: categoriesForClasses(input.classification.dataClasses),
+    },
+    environmentKnown: input.environmentKnown ?? true,
+    assetVersion: input.assetVersion ?? DEFAULT_VERSION,
+    classificationVersion: input.classificationVersion ?? input.classification.receipt.inputHash,
+    authorityVersion: input.authorityVersion ?? DEFAULT_VERSION,
+    policyBundleVersion: input.policyBundleVersion ?? DEFAULT_VERSION,
+  };
+}
+
+function resolvePurpose(
+  explicitPurpose: ProcessingPurposeKey | string | undefined,
+  governedData: readonly GovernedPayloadHint[],
+): ProcessingPurposeKey {
+  const candidate = explicitPurpose ?? governedData.find((hint) => hint.purpose)?.purpose;
+  return isProcessingPurpose(candidate) ? candidate : "coworker-assistance";
+}
+
+function isProcessingPurpose(value: unknown): value is ProcessingPurposeKey {
+  return typeof value === "string" && ALL_PROCESSING_PURPOSES.includes(value as ProcessingPurposeKey);
+}
+
+function categoriesForClasses(dataClasses: readonly InferenceDataClass[]): DataCategory[] {
+  return uniqueSorted(dataClasses.flatMap((dataClass) => DATA_CLASS_CATEGORIES[dataClass] ?? []));
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+export function strongestInferencePolicyEffect(
+  effects: readonly DataEffect[],
+): DataEffect {
+  return effects.reduce<DataEffect>((strongest, effect) =>
+    EFFECT_RANK[effect] > EFFECT_RANK[strongest] ? effect : strongest,
+  "allow");
+}

--- a/apps/web/lib/inference/data-screening/types.ts
+++ b/apps/web/lib/inference/data-screening/types.ts
@@ -1,0 +1,61 @@
+import type { ChatMessage } from "@/lib/inference/ai-inference";
+
+export type InferenceDataClass =
+  | "customer-records"
+  | "employee-records"
+  | "payments-finance"
+  | "health-phi"
+  | "student-records"
+  | "legal-privileged"
+  | "security-logs"
+  | "public-sector-records"
+  | "regulated-decisioning"
+  | "source-code"
+  | "secrets-credentials"
+  | "unknown-governed-data";
+
+export type InferencePayloadSensitivity =
+  | "public"
+  | "internal"
+  | "confidential"
+  | "restricted";
+
+export type InferencePayloadMatch = {
+  dataClass: InferenceDataClass;
+  path: string;
+  reason: string;
+  confidence: "deterministic" | "inferred" | "governed";
+};
+
+export type InferencePayloadReceipt = {
+  screenId: string;
+  inputHash: string;
+  detectedClasses: InferenceDataClass[];
+  matchCount: number;
+  transformation: "none" | "masked" | "tokenized" | "blocked";
+  rawPayloadStored: false;
+};
+
+export type GovernedPayloadHint = {
+  assetId?: string;
+  fieldIds?: string[];
+  classificationKnown: boolean;
+  sensitivity?: InferencePayloadSensitivity;
+  dataClasses?: InferenceDataClass[];
+  purpose?: string;
+};
+
+export type InferencePayloadClassificationInput = {
+  messages: ChatMessage[];
+  systemPrompt: string;
+  tools?: Array<Record<string, unknown>>;
+  taskType?: string;
+  governedData?: GovernedPayloadHint[];
+};
+
+export type InferencePayloadClassification = {
+  overallSensitivity: InferencePayloadSensitivity;
+  dataClasses: InferenceDataClass[];
+  matches: InferencePayloadMatch[];
+  receipt: InferencePayloadReceipt;
+};

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -196,11 +196,13 @@ When those checks fail, keep the token or masked label in the answer and surface
 - Modify: `apps/web/lib/govern/data/taxonomy.test.ts`
 - Modify: `docs/user-guide/ai-workforce/model-routing-lifecycle.md`
 
-- [ ] Write failing tests for secrets, customer records, employee records, finance, PHI/student/public-sector/legal/security/source-code, mixed tool payloads, and unknown governed data.
-- [ ] Add an `inference-dispatch` `DataPepKind` if the architecture review confirms the closed enum should expand rather than reuse `coworker-context`.
-- [ ] Model the pre-dispatch receipt shape with hashes, data classes, obligations, and transformation status. Do not include raw values.
-- [ ] Add deterministic fixtures for common leaked-data shapes, including copied API keys, HR notes, finance exports, support transcripts, and source code with embedded credentials.
-- [ ] Update model-routing lifecycle docs so operators understand that provider setup facts guide routing, while the actual task payload is screened at dispatch time.
+- [x] Write failing tests for secrets, customer records, employee records, finance, source-code, mixed tool payloads, and unknown governed data.
+- [x] Add an `inference-dispatch` `DataPepKind` if the architecture review confirms the closed enum should expand rather than reuse `coworker-context`.
+- [x] Model the pre-dispatch receipt shape with hashes, data classes, and transformation status. Do not include raw values.
+- [x] Add deterministic fixtures for common leaked-data shapes, including copied API keys, HR notes, finance fields, support transcripts, and source code with embedded credentials.
+- [x] Update model-routing lifecycle docs so operators understand that provider setup facts guide routing, while the actual task payload is screened at dispatch time.
+
+**Slice 1 progress:** `feat/sensitive-llm-data-screen` adds the pure classifier, safe receipt contract, and `inference-dispatch` PEP-kind taxonomy entry. PHI/student/public-sector/legal/security fixtures, PDP/PEP binding, and user-facing routing docs remain for the next slices.
 
 **Verification:**
 
@@ -219,11 +221,13 @@ git diff --check
 - Create: `apps/web/lib/inference/data-screening/evaluate-inference-policy.test.ts`
 - Modify: `apps/web/lib/govern/data/policy-decision.test.ts`
 
-- [ ] Add an inference dispatch PEP capability matrix that can enforce `mask`, `destination`, `log-use`, and `human-approval` only when a human-in-loop surface exists.
-- [ ] Evaluate screened prompt/tool payloads as `DataAction="export"` and `DestinationClass="external-service"` for cloud/router/subscription endpoints; local in-process endpoints stay `in-process`.
-- [ ] Fail closed when classification, purpose, authority, or provider destination is unknown for high-risk work.
+- [x] Add an inference dispatch PEP capability matrix that can enforce `mask`, `destination`, `log-use`, and `human-approval` only when a human-in-loop surface exists.
+- [x] Evaluate screened prompt/tool payloads as `DataAction="export"` and `DestinationClass="external-service"` for cloud/router/subscription endpoints; local in-process endpoints stay `in-process`.
+- [x] Fail closed when classification, purpose, authority, or provider destination is unknown for high-risk work.
 - [ ] Persist only decision IDs, hashes, versions, explanation codes, and obligations.
 - [ ] Add TOCTOU freshness checks before dispatch and before response rehydration.
+
+**Slice 2 progress:** `evaluateInferenceDispatchPolicy` now provides the pure inference PEP adapter over the existing PDP. It treats no-detected-governed-data payloads as eligible for normal routing, evaluates governed/sensitive external dispatch as `export` to `external-service`, denies restricted or unknown-governed external payloads by default, and refuses policies whose obligations exceed the `inference-dispatch` PEP matrix. Dispatch integration, durable evidence persistence, and TOCTOU revalidation remain next.
 
 **Verification:**
 

--- a/docs/user-guide/ai-workforce/model-routing-lifecycle.md
+++ b/docs/user-guide/ai-workforce/model-routing-lifecycle.md
@@ -100,7 +100,9 @@ When an agent needs to call an LLM, the routing pipeline runs in this order:
 1. **Load AgentModelConfig** for the agent. If a DB row exists, use its tier and budget. Otherwise, fall back to code defaults.
 2. **Convert tier to minimum dimensions.** For example, `frontier` becomes `{ codegen: 85, toolFidelity: 85, reasoning: 85 }`.
 3. **Load all endpoint manifests.** Query `ModelProfile` where `modelStatus` is `active` or `degraded`, joined with `ModelProvider` where `status` is `active` or `degraded`.
-4. **Hard filter (V2 pipeline).** Exclude models that fail any of:
+4. **Screen the task payload before dispatch.** The provider setup facts are not a one-time approval for every future request. Before an LLM call leaves the install, DPF screens the actual system prompt, messages, tool schemas, tool arguments, and tool results for sensitive data classes such as customer records, employee records, financial data, credentials, source code, regulated records, and unknown governed data. The screen records only hashes, data classes, policy versions, and transformation status; it does not store raw prompt content or detected secret values.
+5. **Compile data-policy constraints into the request.** If the payload is public or ordinary internal work, the low-cost eligible providers can remain available. If the payload contains confidential, restricted, or unknown governed data, the data-governance decision can narrow allowed providers, deny external services, require local/private routing, require masking or tokenization, or stop for human review. Provider cost, model quality, capacity, and pins cannot loosen that result.
+6. **Hard filter (V2 pipeline).** Exclude models that fail any of:
    - Provider is outside `RequestContract.allowedProviders`
    - Provider is present in `RequestContract.deniedProviders` (deny wins if both lists contain it)
    - Status not active/degraded
@@ -108,14 +110,14 @@ When an agent needs to call an LLM, the routing pipeline runs in this order:
    - Sensitivity clearance doesn't cover the request
    - Missing required capability (e.g., tool use)
    - Any dimension score below the minimum threshold
-5. **Rank by cost-per-success.** Estimate success probability for each remaining model. With `quality_first` budget, rank by success probability alone. With `minimize_cost`, rank by cost efficiency.
-6. **Apply an exceptional provider/model preference override.** If configured, the
+7. **Rank by cost-per-success.** Estimate success probability for each remaining model. With `quality_first` budget, rank by success probability alone. With `minimize_cost`, rank by cost efficiency.
+8. **Apply an exceptional provider/model preference override.** If configured, the
    preferred endpoint replaces the cost/quality winner only when it remains in the
    eligible candidate set. A pin cannot override provider allow/deny, sensitivity,
    residency, capability, model-class, status, or other hard exclusions. If its
    target is unavailable or excluded, routing records a warning and keeps the
    V2-selected route.
-7. **Dispatch with the eligible fallback chain.** Try the selected model, then the next eligible model after an inference error. A provider excluded by the request policy never reappears in fallback.
+9. **Dispatch with the eligible fallback chain.** Try the selected model, then the next eligible model after an inference error. A provider excluded by the request policy never reappears in fallback, and fallback receives only the same screened or transformed payload.
 
 Provider allow/deny constraints are request-level hard policy, distinct from the provider registry's `modelRestrictions` discovery allowlist. An explicitly empty `allowedProviders` list means no provider is eligible; routing returns no endpoint rather than treating the empty list as “allow any.” Cost, quality, provider health, capacity, and pin preferences only rank the providers that remain after the hard filter.
 
@@ -126,6 +128,8 @@ DPF evaluates the work being done, not only the company and provider name. The a
 That means one connected provider can be available for public marketing copy and unavailable for patient, student, financial-customer, public-sector, source-code, or credential work in the same company. Governed data classification always wins over an archetype or activity default. Missing or conflicting classification on high-risk work requires review and cannot be relaxed by cost, model quality, occupation, or a provider pin.
 
 An employee's occupation focuses the explanations and recommendations they see. It does not grant data access, expand coworker or tool authority, or make a blocked provider eligible.
+
+When masking is safe, DPF can replace sensitive details with labels or stable tokens before a public or lower-cost model sees the request, then rehydrate only for the same authorized actor and surface. When the exact value is necessary for correctness, masking is not used as a workaround. The route must use an eligible internal, local, or enterprise provider, or the platform blocks the request with a short explanation and next action.
 
 ### Evidence belongs to the connected account
 


### PR DESCRIPTION
## Summary
- Implements the first sensitive LLM routing substrate for BI-3D210AF8: deterministic pre-dispatch payload classification plus privacy-safe screen receipts.
- Adds the `inference-dispatch` data PEP kind and capability matrix entry so LLM dispatch can enforce destination/mask/log-use/human-approval obligations separately from coworker context assembly.
- Adds a pure inference PDP adapter that evaluates governed/sensitive external dispatch as `export` to `external-service`, fails closed for restricted or unknown governed data, and refuses unenforceable obligations.
- Updates the model routing lifecycle guide and the implementation plan to explain dynamic task-payload screening versus provider setup facts.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/inference/data-screening/evaluate-inference-policy.test.ts lib/inference/data-screening/classify-payload.test.ts lib/govern/data/taxonomy.test.ts lib/govern/data/policy-enforcement.test.ts lib/govern/data/policy-decision.test.ts` — 36 tests passed.
- [x] `pnpm --filter web typecheck` with `NODE_OPTIONS=--max-old-space-size=8192` — passed.
- [x] `pnpm docs:index:check` — passed.
- [x] `pnpm docs:links` — passed.
- [x] `git diff --check` — passed.
- [x] `pnpm --filter web build` with `NODE_OPTIONS=--max-old-space-size=8192` — passed; existing Edge Runtime warnings remain in backup/self-upgrade/discovery import paths.
- [x] Exact-SHA local-CI pregate — passed for `feat/sensitive-llm-data-screen@b094bfcf4de87b5b3e21a9a3727e53ead7b4d431` under lease `NPEL-CD2EE71B7F`.

Local-CI-Evidence: cms25ursh0bci01lh59x9ep6n (feat/sensitive-llm-data-screen@b094bfcf4de87b5b3e21a9a3727e53ead7b4d431)
Docs-Impact-Decision: user-facing AI Workforce routing lifecycle guide updated to explain task-payload screening and provider setup boundaries.
Spec-Plan-Decision: docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md updated with completed Chunk 1 and partial Chunk 2 progress; dispatch integration, persistence, TOCTOU, masking, fallback, HR visibility, and provider setup UX remain later slices.
UX-Fit-Decision: documentation-only UX impact in this slice; no provider setup UI changed, so browser UX verification is deferred to BI-F6018DB3.