### PR TITLE
feat: project scoped coworker authority

### DIFF
--- a/apps/web/lib/coworker-service-catalog/authority-projection-contract.ts
+++ b/apps/web/lib/coworker-service-catalog/authority-projection-contract.ts
@@ -1,0 +1,210 @@
+export const COWORKER_AUTHORITY_LEVELS = [
+  "cannot-act",
+  "advice-only",
+  "proposal-only",
+  "approval-required",
+  "review-required",
+  "autonomous",
+] as const;
+
+export type CoworkerAuthorityLevel =
+  (typeof COWORKER_AUTHORITY_LEVELS)[number];
+
+export type CoworkerAuthoritySource =
+  | "offer"
+  | "service"
+  | "agent"
+  | "governance"
+  | "grant"
+  | "authority-binding"
+  | "effective-authority"
+  | "action-proposal";
+
+export type CoworkerAuthorityEvidenceRole =
+  | "selected-base"
+  | "overridden-default"
+  | "restriction";
+
+export type CoworkerAuthorityEvidence = {
+  source: CoworkerAuthoritySource;
+  ref: string;
+  field: string;
+  role: CoworkerAuthorityEvidenceRole;
+  observedValue: string;
+  normalizedLevel: CoworkerAuthorityLevel | null;
+  detail: string;
+};
+
+type EvaluationUnavailable = {
+  state: "unavailable";
+  reason: string;
+};
+
+export type CoworkerGovernanceEvaluation =
+  | { state: "not-configured" }
+  | {
+      state: "evaluated";
+      profileId: string;
+      hitlPolicy: unknown;
+    }
+  | EvaluationUnavailable;
+
+export type CoworkerEffectiveAuthorityEvaluation =
+  | {
+      state: "evaluated";
+      actionKey: string;
+      resourceRef: string;
+      explanation: EffectiveAuthorityExplanation;
+    }
+  | EvaluationUnavailable;
+
+export type CoworkerProposalEvaluation =
+  | {
+      state: "evaluated";
+      actionKey: string;
+      resourceRef: string;
+      proposals: readonly {
+        proposalId: string;
+        actionType: string;
+        status: unknown;
+      }[];
+    }
+  | EvaluationUnavailable;
+
+export type CoworkerAuthorityScope =
+  | { kind: "default-posture" }
+  | {
+      kind: "effective-action";
+      actionKey: string;
+      resourceRef: string;
+      authorityEvaluation: CoworkerEffectiveAuthorityEvaluation;
+      proposalEvaluation: CoworkerProposalEvaluation;
+    };
+
+export type CoworkerAuthorityProjectionInput = {
+  scope: CoworkerAuthorityScope;
+  agent: {
+    agentId: string;
+    hitlTierDefault: unknown;
+  };
+  governance: CoworkerGovernanceEvaluation;
+  service?: {
+    serviceId: string;
+    authorityBoundary: unknown;
+    hitlTier?: unknown;
+  };
+  offer?: {
+    offerId: string;
+    authorityBoundary: unknown;
+    requiredApprovals: unknown;
+  };
+};
+
+export type ProjectionScopeEvidence =
+  | { kind: "default-posture" }
+  | {
+      kind: "effective-action";
+      actionKey: string;
+      resourceRef: string;
+    };
+
+export type ResolvedEvidence = CoworkerAuthorityEvidence & {
+  normalizedLevel: CoworkerAuthorityLevel;
+  ownerReason: string;
+  ownerAction: string | null;
+  specificity: number;
+};
+
+export type ResolvedCoworkerAuthorityProjection = {
+  state: "resolved";
+  scope: ProjectionScopeEvidence;
+  level: CoworkerAuthorityLevel;
+  label: string;
+  summary: string;
+  ownerReason: string;
+  ownerAction: string | null;
+  winner: CoworkerAuthorityEvidence & {
+    normalizedLevel: CoworkerAuthorityLevel;
+  };
+  evidence: CoworkerAuthorityEvidence[];
+};
+
+export type ReviewNeededCoworkerAuthorityProjection = {
+  state: "review-needed";
+  scope: ProjectionScopeEvidence;
+  level: null;
+  label: "Approval rules need review";
+  summary: string;
+  ownerReason: string;
+  ownerAction: string;
+  reasons: string[];
+  evidence: CoworkerAuthorityEvidence[];
+};
+
+export type CoworkerAuthorityProjection =
+  | ResolvedCoworkerAuthorityProjection
+  | ReviewNeededCoworkerAuthorityProjection;
+
+export const LEVEL_PRESENTATION: Record<
+  CoworkerAuthorityLevel,
+  { label: string; defaultSummary: string; actionSummary: string }
+> = {
+  "cannot-act": {
+    label: "Cannot act",
+    defaultSummary: "This coworker cannot take actions under the current rules.",
+    actionSummary: "This coworker cannot take this action under the current rules.",
+  },
+  "advice-only": {
+    label: "Advises only",
+    defaultSummary: "This coworker can advise, but cannot prepare or take actions.",
+    actionSummary: "This coworker can advise, but cannot prepare or take this action.",
+  },
+  "proposal-only": {
+    label: "Prepares work for approval",
+    defaultSummary: "This coworker prepares work for a person to decide.",
+    actionSummary: "This coworker can prepare this work for a person to decide.",
+  },
+  "approval-required": {
+    label: "Acts with approval",
+    defaultSummary: "This coworker acts after a person approves.",
+    actionSummary: "This coworker can act after a person approves this action.",
+  },
+  "review-required": {
+    label: "Acts with review",
+    defaultSummary: "This coworker acts within limits and a person reviews results.",
+    actionSummary: "This coworker can act and a person reviews the result.",
+  },
+  autonomous: {
+    label: "Can act within limits",
+    defaultSummary: "This coworker can act within its governed tools and limits.",
+    actionSummary: "This coworker can take this action within its governed limits.",
+  },
+};
+
+export const LEVEL_RANK: Record<CoworkerAuthorityLevel, number> = {
+  "cannot-act": 0,
+  "advice-only": 1,
+  "proposal-only": 2,
+  "approval-required": 3,
+  "review-required": 4,
+  autonomous: 5,
+};
+
+export const BASE_OWNER_ACTIONS: Record<
+  CoworkerAuthorityLevel,
+  string | null
+> = {
+  "cannot-act": "Choose another coworker or change the governing rule.",
+  "advice-only": "Use this coworker for guidance; another person must act.",
+  "proposal-only": "Review the prepared work before anything is sent or changed.",
+  "approval-required": "Approve the action before it runs.",
+  "review-required": "Review the result after the action runs.",
+  autonomous: null,
+};
+
+export type ProjectionWork = {
+  evidence: CoworkerAuthorityEvidence[];
+  candidates: ResolvedEvidence[];
+  errors: string[];
+};
+import type { EffectiveAuthorityExplanation } from "../authority/effective-authority";

--- a/apps/web/lib/coworker-service-catalog/authority-projection-sources.ts
+++ b/apps/web/lib/coworker-service-catalog/authority-projection-sources.ts
@@ -1,0 +1,762 @@
+import {
+  isCoworkerAuthorityBoundary,
+  type CoworkerAuthorityBoundary,
+} from "./types";
+import { isRecord } from "../shared/coerce";
+import {
+  BASE_OWNER_ACTIONS,
+  LEVEL_RANK,
+  type CoworkerAuthorityEvidence,
+  type CoworkerAuthorityEvidenceRole,
+  type CoworkerAuthorityLevel,
+  type CoworkerAuthorityProjectionInput,
+  type CoworkerAuthorityScope,
+  type CoworkerAuthoritySource,
+  type CoworkerEffectiveAuthorityEvaluation,
+  type CoworkerGovernanceEvaluation,
+  type ProjectionScopeEvidence,
+  type ProjectionWork,
+  type ResolvedEvidence,
+} from "./authority-projection-contract";
+
+const CATALOG_BOUNDARY_LEVELS: Record<
+  CoworkerAuthorityBoundary,
+  CoworkerAuthorityLevel
+> = {
+  "never-allowed": "cannot-act",
+  "advice-only": "advice-only",
+  "proposal-only": "proposal-only",
+  "approval-required": "approval-required",
+  "autonomous-allowed": "autonomous",
+};
+
+const GOVERNANCE_POLICIES = new Set([
+  "none",
+  "never",
+  "always",
+  "proposal_for_external_writes",
+]);
+const PROPOSAL_STATUSES = new Set([
+  "proposed",
+  "approve",
+  "approved",
+  "reject",
+  "rejected",
+  "executed",
+  "failed",
+]);
+const EFFECTIVE_AUTHORITY_REASON_DECISIONS = {
+  user_capability_denied: "deny",
+  agent_grant_denied: "deny",
+  binding_subject_denied: "deny",
+  binding_grant_denied: "deny",
+  binding_grant_requires_approval: "require-approval",
+  binding_approval_mode: "require-approval",
+  no_binding: "allow",
+  binding_allows: "allow",
+} as const;
+
+export function createProjectionWork(): ProjectionWork {
+  return { evidence: [], candidates: [], errors: [] };
+}
+
+export function collectProjectionEvidence(
+  input: CoworkerAuthorityProjectionInput,
+  work: ProjectionWork,
+): ProjectionScopeEvidence {
+  const scope = validateScope(input.scope, work);
+  if (input.offer) {
+    collectOffer(input.offer, "selected-base", work, true);
+    if (input.service) {
+      collectService(input.service, "overridden-default", work, false);
+    }
+    collectAgent(input.agent, "overridden-default", work, false);
+  } else if (input.service) {
+    collectService(input.service, "selected-base", work, true);
+    collectAgent(input.agent, "overridden-default", work, false);
+  } else {
+    collectAgent(input.agent, "selected-base", work, true);
+  }
+
+  collectGovernance(input.governance, work);
+  if (input.scope?.kind === "effective-action") {
+    collectEffectiveAuthority(input.scope, work);
+    collectProposals(input.scope, work);
+  }
+  return scope;
+}
+
+export function strictest(
+  candidates: readonly ResolvedEvidence[],
+): ResolvedEvidence {
+  return candidates.reduce((winner, candidate) => {
+    const rankDelta =
+      LEVEL_RANK[candidate.normalizedLevel] -
+      LEVEL_RANK[winner.normalizedLevel];
+    if (rankDelta < 0) return candidate;
+    if (rankDelta === 0 && candidate.specificity > winner.specificity) {
+      return candidate;
+    }
+    return winner;
+  });
+}
+
+export function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function validateScope(
+  scope: CoworkerAuthorityProjectionInput["scope"] | undefined,
+  work: ProjectionWork,
+): ProjectionScopeEvidence {
+  if (!scope || scope.kind === "default-posture") {
+    if (!scope) work.errors.push("Authority projection scope was not provided");
+    return { kind: "default-posture" };
+  }
+
+  const actionKey = cleanText(scope.actionKey);
+  const resourceRef = cleanText(scope.resourceRef);
+  if (!actionKey) work.errors.push("Effective action scope is missing an action key");
+  if (!resourceRef) {
+    work.errors.push("Effective action scope is missing a resource reference");
+  }
+  if (!scope.authorityEvaluation) {
+    work.errors.push("Effective authority evaluation was not provided for this action");
+  }
+  if (!scope.proposalEvaluation) {
+    work.errors.push("Action proposal evaluation was not provided for this action");
+  }
+  return { kind: "effective-action", actionKey, resourceRef };
+}
+
+function collectOffer(
+  offer: NonNullable<CoworkerAuthorityProjectionInput["offer"]>,
+  role: CoworkerAuthorityEvidenceRole,
+  work: ProjectionWork,
+  selected: boolean,
+) {
+  const ref = cleanRef(offer.offerId);
+  if (selected && !ref) work.errors.push("Offer is missing a source reference");
+
+  const boundary = normalizeCatalogBoundary(offer.authorityBoundary);
+  addCandidate(
+    work,
+    {
+      source: "offer",
+      ref,
+      field: "authorityBoundary",
+      role,
+      observedValue: safeObservedValue(offer.authorityBoundary, Boolean(boundary)),
+      normalizedLevel: boundary,
+      detail: boundary
+        ? `Offer ${ref || "<missing>"} has catalog boundary ${String(offer.authorityBoundary)}`
+        : `Offer ${ref || "<missing>"} authority boundary is unresolved`,
+    },
+    selected && boundary
+      ? {
+          level: boundary,
+          ownerReason: ownerReasonForSource("offer", boundary),
+          ownerAction: BASE_OWNER_ACTIONS[boundary],
+          specificity: 10,
+        }
+      : null,
+  );
+  if (selected && !boundary) {
+    work.errors.push(
+      `Offer ${ref || "<missing>"} has an unsupported authorityBoundary value`,
+    );
+  }
+  collectRequiredApprovals(offer, role, work, selected);
+}
+
+function collectRequiredApprovals(
+  offer: NonNullable<CoworkerAuthorityProjectionInput["offer"]>,
+  role: CoworkerAuthorityEvidenceRole,
+  work: ProjectionWork,
+  selected: boolean,
+) {
+  const ref = cleanRef(offer.offerId);
+  if (!Array.isArray(offer.requiredApprovals)) {
+    work.evidence.push({
+      source: "offer",
+      ref,
+      field: "requiredApprovals",
+      role,
+      observedValue: safeObservedValue(offer.requiredApprovals, false),
+      normalizedLevel: null,
+      detail: "Offer approval declarations could not be read",
+    });
+    if (selected) {
+      work.errors.push(
+        `Offer ${ref || "<missing>"} requiredApprovals must be an array`,
+      );
+    }
+    return;
+  }
+
+  const requiredNames: string[] = [];
+  offer.requiredApprovals.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      if (selected) {
+        work.errors.push(
+          `Offer ${ref || "<missing>"} requiredApprovals[${index}] must be an object`,
+        );
+      }
+      return;
+    }
+    if (typeof entry.required !== "boolean") {
+      if (selected) {
+        work.errors.push(
+          `Offer ${ref || "<missing>"} requiredApprovals[${index}].required must be true or false`,
+        );
+      }
+      return;
+    }
+    if (typeof entry.type !== "string" || !entry.type.trim()) {
+      if (selected) {
+        work.errors.push(
+          `Offer ${ref || "<missing>"} requiredApprovals[${index}].type must include a nonblank type`,
+        );
+      }
+      return;
+    }
+    if (entry.required) requiredNames.push(humanizeKey(entry.type));
+  });
+
+  const normalizedLevel =
+    requiredNames.length > 0 ? "approval-required" : null;
+  const ownerList = joinList(requiredNames);
+  addCandidate(
+    work,
+    {
+      source: "offer",
+      ref,
+      field: "requiredApprovals",
+      role,
+      observedValue: "[array]",
+      normalizedLevel,
+      detail:
+        requiredNames.length > 0
+          ? `Offer ${ref || "<missing>"} requires ${ownerList}`
+          : `Offer ${ref || "<missing>"} declares no additional approvals`,
+    },
+    selected && normalizedLevel
+      ? {
+          level: normalizedLevel,
+          ownerReason: `${capitalize(ownerList)} are required.`,
+          ownerAction: `Get ${ownerList} before this coworker acts.`,
+          specificity: 30,
+        }
+      : null,
+  );
+}
+
+function collectService(
+  service: NonNullable<CoworkerAuthorityProjectionInput["service"]>,
+  role: CoworkerAuthorityEvidenceRole,
+  work: ProjectionWork,
+  selected: boolean,
+) {
+  const ref = cleanRef(service.serviceId);
+  if (selected && !ref) work.errors.push("Service is missing a source reference");
+
+  if (service.hitlTier !== undefined && service.hitlTier !== null) {
+    const level = normalizeHitlTier(service.hitlTier);
+    addCandidate(
+      work,
+      {
+        source: "service",
+        ref,
+        field: "hitlTier",
+        role,
+        observedValue: safeObservedValue(service.hitlTier, Boolean(level)),
+        normalizedLevel: level,
+        detail: level
+          ? `Service ${ref || "<missing>"} uses HITL tier ${String(service.hitlTier)}`
+          : `Service ${ref || "<missing>"} HITL tier is unresolved`,
+      },
+      selected && level
+        ? {
+            level,
+            ownerReason: ownerReasonForSource("service", level),
+            ownerAction: BASE_OWNER_ACTIONS[level],
+            specificity: 20,
+          }
+        : null,
+    );
+    if (selected && !level) {
+      work.errors.push(
+        `Service ${ref || "<missing>"} has an unsupported hitlTier value`,
+      );
+    }
+  }
+
+  const boundary = normalizeCatalogBoundary(service.authorityBoundary);
+  addCandidate(
+    work,
+    {
+      source: "service",
+      ref,
+      field: "authorityBoundary",
+      role,
+      observedValue: safeObservedValue(
+        service.authorityBoundary,
+        Boolean(boundary),
+      ),
+      normalizedLevel: boundary,
+      detail: boundary
+        ? `Service ${ref || "<missing>"} has catalog boundary ${String(service.authorityBoundary)}`
+        : `Service ${ref || "<missing>"} authority boundary is unresolved`,
+    },
+    selected && boundary
+      ? {
+          level: boundary,
+          ownerReason: ownerReasonForSource("service", boundary),
+          ownerAction: BASE_OWNER_ACTIONS[boundary],
+          specificity: 10,
+        }
+      : null,
+  );
+  if (selected && !boundary) {
+    work.errors.push(
+      `Service ${ref || "<missing>"} has an unsupported authorityBoundary value`,
+    );
+  }
+}
+
+function collectAgent(
+  agent: CoworkerAuthorityProjectionInput["agent"],
+  role: CoworkerAuthorityEvidenceRole,
+  work: ProjectionWork,
+  selected: boolean,
+) {
+  const ref = cleanRef(agent.agentId);
+  if (selected && !ref) work.errors.push("Agent is missing a source reference");
+  const level = normalizeHitlTier(agent.hitlTierDefault);
+  addCandidate(
+    work,
+    {
+      source: "agent",
+      ref,
+      field: "hitlTierDefault",
+      role,
+      observedValue: safeObservedValue(agent.hitlTierDefault, Boolean(level)),
+      normalizedLevel: level,
+      detail: level
+        ? `Agent ${ref || "<missing>"} uses HITL tier ${String(agent.hitlTierDefault)}`
+        : `Agent ${ref || "<missing>"} HITL default is unresolved`,
+    },
+    selected && level
+      ? {
+          level,
+          ownerReason: ownerReasonForSource("agent", level),
+          ownerAction: BASE_OWNER_ACTIONS[level],
+          specificity: 10,
+        }
+      : null,
+  );
+  if (selected && !level) {
+    work.errors.push(
+      `Agent ${ref || "<missing>"} has an unsupported hitlTierDefault value`,
+    );
+  }
+}
+
+function collectGovernance(
+  evaluation: CoworkerGovernanceEvaluation | undefined,
+  work: ProjectionWork,
+) {
+  if (!evaluation) {
+    work.errors.push("Governance evaluation was not provided");
+    return;
+  }
+  if (evaluation.state === "not-configured") return;
+  if (evaluation.state === "unavailable") {
+    work.errors.push(
+      cleanText(evaluation.reason) || "Governance evaluation was unavailable",
+    );
+    return;
+  }
+
+  const ref = cleanRef(evaluation.profileId);
+  const policy =
+    typeof evaluation.hitlPolicy === "string"
+      ? evaluation.hitlPolicy
+      : null;
+  const recognized = Boolean(policy && GOVERNANCE_POLICIES.has(policy));
+  let level: CoworkerAuthorityLevel | null = null;
+  if (policy === "always") level = "approval-required";
+  if (policy === "proposal_for_external_writes") level = "proposal-only";
+
+  addCandidate(
+    work,
+    {
+      source: "governance",
+      ref,
+      field: "hitlPolicy",
+      role: "restriction",
+      observedValue: safeObservedValue(evaluation.hitlPolicy, recognized),
+      normalizedLevel: level,
+      detail: recognized
+        ? `Governance profile ${ref || "<missing>"} uses policy ${policy}`
+        : `Governance profile ${ref || "<missing>"} policy is unresolved`,
+    },
+    level
+      ? {
+          level,
+          ownerReason:
+            policy === "proposal_for_external_writes"
+              ? "External changes are prepared for your approval."
+              : "The coworker's governance policy requires your approval.",
+          ownerAction:
+            policy === "proposal_for_external_writes"
+              ? "Review external changes before they are sent."
+              : "Approve the action before it runs.",
+          specificity: 35,
+        }
+      : null,
+  );
+  if (!ref) work.errors.push("Governance profile is missing a source reference");
+  if (!recognized) {
+    work.errors.push(
+      `Governance profile ${ref || "<missing>"} has an unsupported hitlPolicy value`,
+    );
+  }
+}
+
+function collectEffectiveAuthority(
+  scope: Extract<CoworkerAuthorityScope, { kind: "effective-action" }>,
+  work: ProjectionWork,
+) {
+  const evaluation = scope.authorityEvaluation;
+  if (!evaluation) return;
+  if (evaluation.state === "unavailable") {
+    work.errors.push(
+      cleanText(evaluation.reason) ||
+        "Effective authority evaluation was unavailable",
+    );
+    return;
+  }
+
+  const actionKey = cleanText(evaluation.actionKey);
+  const resourceRef = cleanText(evaluation.resourceRef);
+  if (actionKey !== cleanText(scope.actionKey)) {
+    work.errors.push(
+      `Effective authority evaluation does not match action ${cleanText(scope.actionKey) || "<missing>"}`,
+    );
+  }
+  if (resourceRef !== cleanText(scope.resourceRef)) {
+    work.errors.push(
+      `Effective authority evaluation does not match resource ${cleanText(scope.resourceRef) || "<missing>"}`,
+    );
+  }
+
+  const { decision, reasonCode, binding } = evaluation.explanation;
+  const expectedDecision =
+    EFFECTIVE_AUTHORITY_REASON_DECISIONS[
+      reasonCode as keyof typeof EFFECTIVE_AUTHORITY_REASON_DECISIONS
+    ];
+  const recognizedDecision =
+    decision === "allow" ||
+    decision === "deny" ||
+    decision === "require-approval";
+  const recognizedReason = Boolean(expectedDecision);
+  const level =
+    decision === "deny"
+      ? "cannot-act"
+      : decision === "require-approval"
+        ? "approval-required"
+        : null;
+  const source = effectiveAuthoritySource(reasonCode);
+  const ref =
+    cleanRef(binding?.bindingId) ||
+    `${actionKey || "<missing>"}@${resourceRef || "<missing>"}`;
+
+  addCandidate(
+    work,
+    {
+      source,
+      ref,
+      field: "decision",
+      role: "restriction",
+      observedValue: safeObservedValue(decision, recognizedDecision),
+      normalizedLevel: level,
+      detail:
+        recognizedDecision && recognizedReason
+          ? `Effective authority returned ${decision} (${reasonCode})`
+          : "Effective authority decision could not be normalized",
+    },
+    level && recognizedDecision && recognizedReason
+      ? {
+          level,
+          ownerReason: effectiveAuthorityOwnerReason(reasonCode),
+          ownerAction: effectiveAuthorityOwnerAction(reasonCode),
+          specificity: 45,
+        }
+      : null,
+  );
+
+  if (!recognizedDecision) {
+    work.errors.push("Effective authority returned an unsupported decision");
+  }
+  if (!recognizedReason) {
+    work.errors.push(
+      "Effective authority returned an unsupported reason code",
+    );
+  } else if (decision !== expectedDecision) {
+    work.errors.push(
+      `Effective authority decision ${decision} contradicts reason ${reasonCode}`,
+    );
+  }
+}
+
+function collectProposals(
+  scope: Extract<CoworkerAuthorityScope, { kind: "effective-action" }>,
+  work: ProjectionWork,
+) {
+  const evaluation = scope.proposalEvaluation;
+  if (!evaluation) return;
+  if (evaluation.state === "unavailable") {
+    work.errors.push(
+      cleanText(evaluation.reason) ||
+        "Action proposal evaluation was unavailable",
+    );
+    return;
+  }
+
+  if (cleanText(evaluation.actionKey) !== cleanText(scope.actionKey)) {
+    work.errors.push(
+      `Action proposal evaluation does not match action ${cleanText(scope.actionKey) || "<missing>"}`,
+    );
+  }
+  if (cleanText(evaluation.resourceRef) !== cleanText(scope.resourceRef)) {
+    work.errors.push(
+      `Action proposal evaluation does not match resource ${cleanText(scope.resourceRef) || "<missing>"}`,
+    );
+  }
+
+  const statusesByProposal = new Map<string, Set<string>>();
+  for (const proposal of evaluation.proposals) {
+    const ref = cleanRef(proposal.proposalId);
+    const actionType = cleanText(proposal.actionType);
+    const status =
+      typeof proposal.status === "string" ? proposal.status : null;
+    const recognized = Boolean(status && PROPOSAL_STATUSES.has(status));
+    const level =
+      status === "proposed"
+        ? "proposal-only"
+        : status === "rejected" || status === "reject"
+          ? "cannot-act"
+          : null;
+
+    addCandidate(
+      work,
+      {
+        source: "action-proposal",
+        ref,
+        field: "status",
+        role: "restriction",
+        observedValue: safeObservedValue(proposal.status, recognized),
+        normalizedLevel: level,
+        detail: recognized
+          ? `Action proposal ${ref || "<missing>"} has status ${status}`
+          : `Action proposal ${ref || "<missing>"} status is unresolved`,
+      },
+      level
+        ? {
+            level,
+            ownerReason:
+              status === "proposed"
+                ? "This action is waiting for your decision."
+                : "This action was rejected.",
+            ownerAction:
+              status === "proposed"
+                ? "Review this proposed action before it can run."
+                : "Create a new proposal if the action should be reconsidered.",
+            specificity: 50,
+          }
+        : null,
+    );
+
+    if (!ref) work.errors.push("Action proposal is missing a source reference");
+    if (actionType !== cleanText(scope.actionKey)) {
+      work.errors.push(
+        `Action proposal ${ref || "<missing>"} does not match action ${cleanText(scope.actionKey) || "<missing>"}`,
+      );
+    }
+    if (!recognized) {
+      work.errors.push(
+        `Action proposal ${ref || "<missing>"} has an unsupported status value`,
+      );
+    }
+    if (ref && status) {
+      const statuses = statusesByProposal.get(ref) ?? new Set<string>();
+      statuses.add(status);
+      statusesByProposal.set(ref, statuses);
+    }
+  }
+
+  for (const [ref, statuses] of statusesByProposal) {
+    if (statuses.size > 1) {
+      work.errors.push(
+        `Action proposal ${ref} reports contradictory statuses`,
+      );
+    }
+  }
+}
+
+function addCandidate(
+  work: ProjectionWork,
+  evidence: CoworkerAuthorityEvidence,
+  candidate: {
+    level: CoworkerAuthorityLevel;
+    ownerReason: string;
+    ownerAction: string | null;
+    specificity: number;
+  } | null,
+) {
+  work.evidence.push(evidence);
+  if (!candidate) return;
+  work.candidates.push({
+    ...evidence,
+    normalizedLevel: candidate.level,
+    ownerReason: candidate.ownerReason,
+    ownerAction: candidate.ownerAction,
+    specificity: candidate.specificity,
+  });
+}
+
+function normalizeCatalogBoundary(
+  value: unknown,
+): CoworkerAuthorityLevel | null {
+  return isCoworkerAuthorityBoundary(value)
+    ? CATALOG_BOUNDARY_LEVELS[value]
+    : null;
+}
+
+function normalizeHitlTier(value: unknown): CoworkerAuthorityLevel | null {
+  if (value === 0) return "cannot-act";
+  if (value === 1) return "approval-required";
+  if (value === 2) return "review-required";
+  if (value === 3) return "autonomous";
+  return null;
+}
+
+function effectiveAuthoritySource(
+  reasonCode: string,
+): CoworkerAuthoritySource {
+  if (
+    reasonCode === "agent_grant_denied" ||
+    reasonCode === "binding_grant_denied" ||
+    reasonCode === "binding_grant_requires_approval"
+  ) {
+    return "grant";
+  }
+  if (
+    reasonCode === "binding_subject_denied" ||
+    reasonCode === "binding_approval_mode" ||
+    reasonCode === "binding_allows"
+  ) {
+    return "authority-binding";
+  }
+  return "effective-authority";
+}
+
+function effectiveAuthorityOwnerReason(reasonCode: string): string {
+  const reasons: Record<string, string> = {
+    user_capability_denied:
+      "Your current role does not allow this action.",
+    agent_grant_denied:
+      "This coworker does not have the required access.",
+    binding_subject_denied:
+      "The active authority binding does not allow this action.",
+    binding_grant_denied:
+      "The active authority grant does not allow this action.",
+    binding_grant_requires_approval:
+      "The active authority grant requires approval.",
+    binding_approval_mode:
+      "The active authority binding requires approval.",
+  };
+  return reasons[reasonCode] ?? "The effective authority decision applies.";
+}
+
+function effectiveAuthorityOwnerAction(reasonCode: string): string | null {
+  if (reasonCode === "user_capability_denied") {
+    return "Ask someone with permission to review this action.";
+  }
+  if (
+    reasonCode === "agent_grant_denied" ||
+    reasonCode === "binding_subject_denied" ||
+    reasonCode === "binding_grant_denied"
+  ) {
+    return "Choose a coworker with access or change the governing rule.";
+  }
+  if (
+    reasonCode === "binding_grant_requires_approval" ||
+    reasonCode === "binding_approval_mode"
+  ) {
+    return "Approve the action before it runs.";
+  }
+  return null;
+}
+
+function ownerReasonForSource(
+  source: "offer" | "service" | "agent",
+  level: CoworkerAuthorityLevel,
+): string {
+  const subject =
+    source === "offer"
+      ? "This offer"
+      : source === "service"
+        ? "This service"
+        : "This coworker's default oversight setting";
+  const ending: Record<CoworkerAuthorityLevel, string> = {
+    "cannot-act": "does not allow action.",
+    "advice-only": "allows advice only.",
+    "proposal-only": "allows proposed work for a person to decide.",
+    "approval-required": "requires approval before action.",
+    "review-required": "requires a person to review completed action.",
+    autonomous: "allows action within configured limits.",
+  };
+  return `${subject} ${ending[level]}`;
+}
+
+function safeObservedValue(value: unknown, recognized: boolean): string {
+  if (Array.isArray(value)) return "[array]";
+  if (value !== null && typeof value === "object") return "[object]";
+  if (value === undefined) return "[undefined]";
+  if (value === null) return "[null]";
+  if (typeof value === "string") {
+    return recognized
+      ? value
+      : `[unrecognized-string:length=${value.length}]`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return recognized
+      ? String(value)
+      : `[unrecognized-${typeof value}]`;
+  }
+  return `[${typeof value}]`;
+}
+
+function humanizeKey(value: string): string {
+  return value.trim().replace(/[_-]+/g, " ").toLowerCase();
+}
+
+function joinList(values: readonly string[]): string {
+  if (values.length <= 1) return values[0] ?? "";
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+
+function capitalize(value: string): string {
+  return value ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : value;
+}
+
+function cleanRef(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function cleanText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/apps/web/lib/coworker-service-catalog/authority-projection-sources.ts
+++ b/apps/web/lib/coworker-service-catalog/authority-projection-sources.ts
@@ -66,7 +66,7 @@ export function collectProjectionEvidence(
 ): ProjectionScopeEvidence {
   const scope = validateScope(input.scope, work);
   if (input.offer) {
-    collectOffer(input.offer, "selected-base", work, true);
+    collectOffer(input.offer, "selected-base", work);
     if (input.service) {
       collectService(input.service, "overridden-default", work, false);
     }
@@ -133,10 +133,9 @@ function collectOffer(
   offer: NonNullable<CoworkerAuthorityProjectionInput["offer"]>,
   role: CoworkerAuthorityEvidenceRole,
   work: ProjectionWork,
-  selected: boolean,
 ) {
   const ref = cleanRef(offer.offerId);
-  if (selected && !ref) work.errors.push("Offer is missing a source reference");
+  if (!ref) work.errors.push("Offer is missing a source reference");
 
   const boundary = normalizeCatalogBoundary(offer.authorityBoundary);
   addCandidate(
@@ -152,7 +151,7 @@ function collectOffer(
         ? `Offer ${ref || "<missing>"} has catalog boundary ${String(offer.authorityBoundary)}`
         : `Offer ${ref || "<missing>"} authority boundary is unresolved`,
     },
-    selected && boundary
+    boundary
       ? {
           level: boundary,
           ownerReason: ownerReasonForSource("offer", boundary),
@@ -161,19 +160,18 @@ function collectOffer(
         }
       : null,
   );
-  if (selected && !boundary) {
+  if (!boundary) {
     work.errors.push(
       `Offer ${ref || "<missing>"} has an unsupported authorityBoundary value`,
     );
   }
-  collectRequiredApprovals(offer, role, work, selected);
+  collectRequiredApprovals(offer, role, work);
 }
 
 function collectRequiredApprovals(
   offer: NonNullable<CoworkerAuthorityProjectionInput["offer"]>,
   role: CoworkerAuthorityEvidenceRole,
   work: ProjectionWork,
-  selected: boolean,
 ) {
   const ref = cleanRef(offer.offerId);
   if (!Array.isArray(offer.requiredApprovals)) {
@@ -186,38 +184,30 @@ function collectRequiredApprovals(
       normalizedLevel: null,
       detail: "Offer approval declarations could not be read",
     });
-    if (selected) {
-      work.errors.push(
-        `Offer ${ref || "<missing>"} requiredApprovals must be an array`,
-      );
-    }
+    work.errors.push(
+      `Offer ${ref || "<missing>"} requiredApprovals must be an array`,
+    );
     return;
   }
 
   const requiredNames: string[] = [];
   offer.requiredApprovals.forEach((entry, index) => {
     if (!isRecord(entry)) {
-      if (selected) {
-        work.errors.push(
-          `Offer ${ref || "<missing>"} requiredApprovals[${index}] must be an object`,
-        );
-      }
+      work.errors.push(
+        `Offer ${ref || "<missing>"} requiredApprovals[${index}] must be an object`,
+      );
       return;
     }
     if (typeof entry.required !== "boolean") {
-      if (selected) {
-        work.errors.push(
-          `Offer ${ref || "<missing>"} requiredApprovals[${index}].required must be true or false`,
-        );
-      }
+      work.errors.push(
+        `Offer ${ref || "<missing>"} requiredApprovals[${index}].required must be true or false`,
+      );
       return;
     }
     if (typeof entry.type !== "string" || !entry.type.trim()) {
-      if (selected) {
-        work.errors.push(
-          `Offer ${ref || "<missing>"} requiredApprovals[${index}].type must include a nonblank type`,
-        );
-      }
+      work.errors.push(
+        `Offer ${ref || "<missing>"} requiredApprovals[${index}].type must include a nonblank type`,
+      );
       return;
     }
     if (entry.required) requiredNames.push(humanizeKey(entry.type));
@@ -240,7 +230,7 @@ function collectRequiredApprovals(
           ? `Offer ${ref || "<missing>"} requires ${ownerList}`
           : `Offer ${ref || "<missing>"} declares no additional approvals`,
     },
-    selected && normalizedLevel
+    normalizedLevel
       ? {
           level: normalizedLevel,
           ownerReason: `${capitalize(ownerList)} are required.`,

--- a/apps/web/lib/coworker-service-catalog/authority-projection.test.ts
+++ b/apps/web/lib/coworker-service-catalog/authority-projection.test.ts
@@ -1,0 +1,621 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  projectCoworkerAuthority,
+  type CoworkerAuthorityProjectionInput,
+} from "./authority-projection";
+
+function input(
+  overrides: Partial<CoworkerAuthorityProjectionInput> = {},
+): CoworkerAuthorityProjectionInput {
+  return {
+    scope: { kind: "default-posture" },
+    agent: {
+      agentId: "agent-1",
+      hitlTierDefault: 3,
+    },
+    governance: { state: "not-configured" },
+    service: {
+      serviceId: "service-1",
+      authorityBoundary: "autonomous-allowed",
+      hitlTier: 3,
+    },
+    offer: {
+      offerId: "offer-1",
+      authorityBoundary: "autonomous-allowed",
+      requiredApprovals: [],
+    },
+    ...overrides,
+  };
+}
+
+function effectiveScope(): Extract<
+  CoworkerAuthorityProjectionInput["scope"],
+  { kind: "effective-action" }
+> {
+  const actionKey = "customer.update";
+  const resourceRef = "customer:123";
+  return {
+    kind: "effective-action",
+    actionKey,
+    resourceRef,
+    authorityEvaluation: {
+      state: "evaluated",
+      actionKey,
+      resourceRef,
+      explanation: {
+        decision: "allow",
+        reasonCode: "no_binding",
+        binding: null,
+      },
+    },
+    proposalEvaluation: {
+      state: "evaluated",
+      actionKey,
+      resourceRef,
+      proposals: [],
+    },
+  };
+}
+
+describe("projectCoworkerAuthority", () => {
+  it.each([
+    [0, "cannot-act", "Cannot act"],
+    [1, "approval-required", "Acts with approval"],
+    [2, "review-required", "Acts with review"],
+    [3, "autonomous", "Can act within limits"],
+  ] as const)(
+    "maps agent HITL tier %s to %s",
+    (hitlTierDefault, level, label) => {
+      const result = projectCoworkerAuthority(
+        input({
+          agent: { agentId: "agent-1", hitlTierDefault },
+          service: undefined,
+          offer: undefined,
+        }),
+      );
+
+      expect(result).toMatchObject({
+        state: "resolved",
+        scope: { kind: "default-posture" },
+        level,
+        label,
+        winner: {
+          source: "agent",
+          ref: "agent-1",
+          field: "hitlTierDefault",
+        },
+      });
+      expect(result).not.toHaveProperty("reason");
+      expect(result).toHaveProperty("ownerReason");
+    },
+  );
+
+  it.each([
+    ["never-allowed", "cannot-act", "Cannot act"],
+    ["advice-only", "advice-only", "Advises only"],
+    ["proposal-only", "proposal-only", "Prepares work for approval"],
+    ["approval-required", "approval-required", "Acts with approval"],
+    ["autonomous-allowed", "autonomous", "Can act within limits"],
+  ] as const)(
+    "maps the canonical catalog boundary %s to %s",
+    (authorityBoundary, level, label) => {
+      const result = projectCoworkerAuthority(
+        input({
+          offer: {
+            offerId: "offer-1",
+            authorityBoundary,
+            requiredApprovals: [],
+          },
+        }),
+      );
+
+      expect(result).toMatchObject({ state: "resolved", level, label });
+    },
+  );
+
+  it.each(["cannot-act", "review-required", "autonomous"])(
+    "rejects projection-only value %s as a raw catalog boundary",
+    (authorityBoundary) => {
+      const result = projectCoworkerAuthority(
+        input({
+          offer: {
+            offerId: "offer-1",
+            authorityBoundary,
+            requiredApprovals: [],
+          },
+        }),
+      );
+
+      expect(result).toMatchObject({
+        state: "review-needed",
+        label: "Approval rules need review",
+      });
+    },
+  );
+
+  it("uses an explicit offer before a stricter service or agent default", () => {
+    const result = projectCoworkerAuthority(
+      input({
+        agent: { agentId: "agent-1", hitlTierDefault: 0 },
+        service: {
+          serviceId: "service-1",
+          authorityBoundary: "never-allowed",
+          hitlTier: 0,
+        },
+        offer: {
+          offerId: "offer-1",
+          authorityBoundary: "proposal-only",
+          requiredApprovals: [],
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "resolved",
+      level: "proposal-only",
+      winner: {
+        source: "offer",
+        ref: "offer-1",
+        field: "authorityBoundary",
+      },
+    });
+    expect(result.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "service",
+          role: "overridden-default",
+        }),
+        expect.objectContaining({
+          source: "agent",
+          role: "overridden-default",
+        }),
+      ]),
+    );
+  });
+
+  it("lets a service HITL tier make its canonical boundary stricter", () => {
+    const result = projectCoworkerAuthority(
+      input({
+        service: {
+          serviceId: "service-1",
+          authorityBoundary: "autonomous-allowed",
+          hitlTier: 2,
+        },
+        offer: undefined,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "resolved",
+      level: "review-required",
+      winner: {
+        source: "service",
+        ref: "service-1",
+        field: "hitlTier",
+      },
+    });
+  });
+
+  it("aggregates required approvals and prefers their owner reason on a tie", () => {
+    const result = projectCoworkerAuthority(
+      input({
+        offer: {
+          offerId: "offer-1",
+          authorityBoundary: "approval-required",
+          requiredApprovals: [
+            { type: "finance-approval", required: true },
+            { type: "attorney-review", required: true },
+          ],
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "resolved",
+      level: "approval-required",
+      ownerReason: "Finance approval and attorney review are required.",
+      ownerAction:
+        "Get finance approval and attorney review before this coworker acts.",
+      winner: {
+        source: "offer",
+        field: "requiredApprovals",
+      },
+    });
+  });
+
+  it.each([
+    ["none", "autonomous"],
+    ["never", "autonomous"],
+    ["always", "approval-required"],
+    ["proposal_for_external_writes", "proposal-only"],
+  ] as const)(
+    "maps native governance policy %s without inventing a stored value",
+    (hitlPolicy, level) => {
+      const result = projectCoworkerAuthority(
+        input({
+          governance: {
+            state: "evaluated",
+            profileId: "governance-1",
+            hitlPolicy,
+          },
+        }),
+      );
+
+      expect(result).toMatchObject({ state: "resolved", level });
+    },
+  );
+
+  it("returns review-needed when governance evaluation was unavailable", () => {
+    const result = projectCoworkerAuthority(
+      input({
+        governance: {
+          state: "unavailable",
+          reason: "Governance profile could not be loaded",
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "review-needed",
+      reasons: ["Governance profile could not be loaded"],
+    });
+  });
+
+  it("does not treat omitted governance evaluation as no restrictions", () => {
+    const unsafe = {
+      ...input(),
+      governance: undefined,
+    } as unknown as CoworkerAuthorityProjectionInput;
+
+    expect(projectCoworkerAuthority(unsafe)).toMatchObject({
+      state: "review-needed",
+      reasons: ["Governance evaluation was not provided"],
+    });
+  });
+
+  it("consumes the canonical effective-authority denial", () => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        scope: {
+          ...scope,
+          authorityEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: scope.resourceRef,
+            explanation: {
+              decision: "deny",
+              reasonCode: "agent_grant_denied",
+              binding: null,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "resolved",
+      scope: {
+        kind: "effective-action",
+        actionKey: "customer.update",
+        resourceRef: "customer:123",
+      },
+      level: "cannot-act",
+      ownerReason: "This coworker does not have the required access.",
+      winner: {
+        source: "grant",
+        ref: "customer.update@customer:123",
+      },
+    });
+  });
+
+  it("lets an equal-rank action restriction provide the specific reason", () => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        offer: {
+          offerId: "offer-1",
+          authorityBoundary: "approval-required",
+          requiredApprovals: [],
+        },
+        scope: {
+          ...scope,
+          authorityEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: scope.resourceRef,
+            explanation: {
+              decision: "require-approval",
+              reasonCode: "binding_approval_mode",
+              binding: {
+                bindingId: "binding-1",
+                resourceRef: "customer:123",
+                appliedAgentId: "agent-1",
+                approvalMode: "human-required",
+                subjects: [],
+                grants: [],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "resolved",
+      level: "approval-required",
+      ownerReason: "The active authority binding requires approval.",
+      winner: { source: "authority-binding", ref: "binding-1" },
+    });
+  });
+
+  it("projects a native proposed action as proposal-only", () => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        scope: {
+          ...scope,
+          proposalEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: scope.resourceRef,
+            proposals: [
+              {
+                proposalId: "proposal-1",
+                actionType: "customer.update",
+                status: "proposed",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "resolved",
+      level: "proposal-only",
+      ownerAction: "Review this proposed action before it can run.",
+      winner: {
+        source: "action-proposal",
+        ref: "proposal-1",
+      },
+    });
+  });
+
+  it("requires explicit authority and proposal evaluations for effective authority", () => {
+    const unsafe = input({
+      scope: {
+        kind: "effective-action",
+        actionKey: "customer.update",
+        resourceRef: "customer:123",
+      } as CoworkerAuthorityProjectionInput["scope"],
+    });
+
+    expect(projectCoworkerAuthority(unsafe)).toMatchObject({
+      state: "review-needed",
+      reasons: [
+        "Effective authority evaluation was not provided for this action",
+        "Action proposal evaluation was not provided for this action",
+      ],
+    });
+  });
+
+  it("rejects an action proposal evaluated for a different action", () => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        scope: {
+          ...scope,
+          proposalEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: scope.resourceRef,
+            proposals: [
+              {
+                proposalId: "proposal-1",
+                actionType: "invoice.send",
+                status: "proposed",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "review-needed",
+      reasons: [
+        "Action proposal proposal-1 does not match action customer.update",
+      ],
+    });
+  });
+
+  it("rejects contextual evidence evaluated for a different resource", () => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        scope: {
+          ...scope,
+          authorityEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: "customer:other",
+            explanation: {
+              decision: "allow",
+              reasonCode: "no_binding",
+              binding: null,
+            },
+          },
+          proposalEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: "customer:other",
+            proposals: [],
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "review-needed",
+      reasons: [
+        "Effective authority evaluation does not match resource customer:123",
+        "Action proposal evaluation does not match resource customer:123",
+      ],
+    });
+  });
+
+  it.each([
+    ["approve", "autonomous"],
+    ["approved", "autonomous"],
+    ["reject", "cannot-act"],
+    ["rejected", "cannot-act"],
+  ] as const)("accepts native proposal status %s", (status, level) => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        scope: {
+          ...scope,
+          proposalEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: scope.resourceRef,
+            proposals: [
+              {
+                proposalId: "proposal-1",
+                actionType: scope.actionKey,
+                status,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({ state: "resolved", level });
+  });
+
+  it("uses scope-aware compact summaries", () => {
+    const posture = projectCoworkerAuthority(
+      input({
+        agent: { agentId: "agent-1", hitlTierDefault: 1 },
+        service: undefined,
+        offer: undefined,
+      }),
+    );
+    const action = projectCoworkerAuthority(
+      input({
+        agent: { agentId: "agent-1", hitlTierDefault: 1 },
+        service: undefined,
+        offer: undefined,
+        scope: effectiveScope(),
+      }),
+    );
+
+    expect(posture).toMatchObject({
+      summary: "This coworker acts after a person approves.",
+    });
+    expect(action).toMatchObject({
+      summary: "This coworker can act after a person approves this action.",
+    });
+  });
+
+  it("returns review-needed for the live requirements-gate declaration", () => {
+    const result = projectCoworkerAuthority(
+      input({
+        offer: {
+          offerId: "offer-build-sensitive-domain-requirements",
+          authorityBoundary: "requirements-gate",
+          requiredApprovals: [],
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "review-needed",
+      label: "Approval rules need review",
+      reasons: [
+        "Offer offer-build-sensitive-domain-requirements has an unsupported authorityBoundary value",
+      ],
+    });
+  });
+
+  it.each([
+    [{ required: true }, "must include a nonblank type"],
+    [{ type: " ", required: true }, "must include a nonblank type"],
+    [{ type: { private: "secret" }, required: true }, "must include a nonblank type"],
+  ])("fails closed for malformed approval declaration %#", (approval, message) => {
+    const result = projectCoworkerAuthority(
+      input({
+        offer: {
+          offerId: "offer-1",
+          authorityBoundary: "proposal-only",
+          requiredApprovals: [approval],
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "review-needed",
+      reasons: [`Offer offer-1 requiredApprovals[0].type ${message}`],
+    });
+  });
+
+  it("redacts an unrecognized primitive value from advanced evidence", () => {
+    const secret = `not-a-policy-${"sensitive".repeat(30)}`;
+    const result = projectCoworkerAuthority(
+      input({
+        governance: {
+          state: "evaluated",
+          profileId: "governance-1",
+          hitlPolicy: secret,
+        },
+      }),
+    );
+
+    expect(result.state).toBe("review-needed");
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(result.evidence).toContainEqual(
+      expect.objectContaining({
+        source: "governance",
+        observedValue: `[unrecognized-string:length=${secret.length}]`,
+      }),
+    );
+  });
+
+  it("returns review-needed for contradictory statuses on one proposal", () => {
+    const scope = effectiveScope();
+    const result = projectCoworkerAuthority(
+      input({
+        scope: {
+          ...scope,
+          proposalEvaluation: {
+            state: "evaluated",
+            actionKey: scope.actionKey,
+            resourceRef: scope.resourceRef,
+            proposals: [
+              {
+                proposalId: "proposal-1",
+                actionType: "customer.update",
+                status: "proposed",
+              },
+              {
+                proposalId: "proposal-1",
+                actionType: "customer.update",
+                status: "executed",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      state: "review-needed",
+      reasons: [
+        "Action proposal proposal-1 reports contradictory statuses",
+      ],
+    });
+  });
+});

--- a/apps/web/lib/coworker-service-catalog/authority-projection.ts
+++ b/apps/web/lib/coworker-service-catalog/authority-projection.ts
@@ -1,0 +1,58 @@
+import {
+  LEVEL_PRESENTATION,
+  type CoworkerAuthorityProjection,
+  type CoworkerAuthorityProjectionInput,
+} from "./authority-projection-contract";
+import {
+  collectProjectionEvidence,
+  createProjectionWork,
+  strictest,
+  unique,
+} from "./authority-projection-sources";
+
+export * from "./authority-projection-contract";
+
+export function projectCoworkerAuthority(
+  input: CoworkerAuthorityProjectionInput,
+): CoworkerAuthorityProjection {
+  const work = createProjectionWork();
+  const scope = collectProjectionEvidence(input, work);
+
+  if (work.candidates.length === 0 && work.errors.length === 0) {
+    work.errors.push("No authority default could be resolved");
+  }
+
+  if (work.errors.length > 0) {
+    return {
+      state: "review-needed",
+      scope,
+      level: null,
+      label: "Approval rules need review",
+      summary: "The current approval evidence is incomplete or contradictory.",
+      ownerReason:
+        "The platform cannot safely summarize this coworker's approval rules yet.",
+      ownerAction: "Review the supporting rules before relying on this label.",
+      reasons: unique(work.errors),
+      evidence: work.evidence,
+    };
+  }
+
+  const winner = strictest(work.candidates);
+  const presentation = LEVEL_PRESENTATION[winner.normalizedLevel];
+  const { specificity: _specificity, ownerReason, ownerAction, ...publicWinner } =
+    winner;
+  return {
+    state: "resolved",
+    scope,
+    level: winner.normalizedLevel,
+    label: presentation.label,
+    summary:
+      scope.kind === "default-posture"
+        ? presentation.defaultSummary
+        : presentation.actionSummary,
+    ownerReason,
+    ownerAction,
+    winner: publicWinner,
+    evidence: work.evidence,
+  };
+}

--- a/docs/superpowers/plans/2026-07-26-ai-workforce-availability-authority-projections.md
+++ b/docs/superpowers/plans/2026-07-26-ai-workforce-availability-authority-projections.md
@@ -12,7 +12,7 @@ The implementation sequence follows WWMD decision `DI-4A73DBCEC0E3`:
 2. Authority projection.
 3. Four-area roster and coworker-record consumption.
 
-This branch implements only deliverable 1 under `BI-4503457C`.
+This branch implements only deliverable 2 under `BI-F39A1A82`.
 
 ## Backlog Coverage
 
@@ -117,12 +117,132 @@ Every result carries:
 
 Implement in a separate branch for `BI-F39A1A82`.
 
-- Normalize existing authority sources into comparable restriction levels.
-- Apply explicit offer restrictions before service defaults, then agent defaults.
-- Let stricter downstream governance, grant, or action-proposal restrictions win.
-- Return `Approval rules need review` for malformed, contradictory, or unresolved inputs.
-- Carry the winning reason and source references.
-- Do not change enforcement or persisted authority.
+WWMD interaction `DI-072C2AC24FB8` selected the `restriction-lattice`
+approach with high confidence. The projection is a pure, evidence-bearing,
+discriminated read model over existing authority sources. It does not add a
+database model, authority store, or enforcement path.
+
+Decision ledger:
+
+| Option | Result | Rationale |
+| --- | --- | --- |
+| `restriction-lattice` | Selected, score `9.4964` | Preserves source evidence, fails closed, and reuses governed data without creating a second authority store |
+| `hitl-only` | Rejected | Too coarse; it would ignore explicit offer and service rules |
+| `live-action-probe` | Rejected | Conflates a contextual authorization check with a stable roster posture and adds runtime coupling |
+
+The recommendation margin was `1.8566`; the kernel returned high confidence
+with a usable decision signal. The lattice preserves action and resource scope
+rather than turning one denied action into a global coworker restriction.
+
+### Authority lattice
+
+Normalize authority into these levels, ordered from strictest to loosest:
+
+1. `cannot-act`
+2. `advice-only`
+3. `proposal-only`
+4. `approval-required`
+5. `review-required`
+6. `autonomous`
+
+The owner labels are:
+
+- `Cannot act`
+- `Advises only`
+- `Prepares work for approval`
+- `Acts with approval`
+- `Acts with review`
+- `Can act within limits`
+
+Catalog boundaries map as follows:
+
+| Existing value | Projection level |
+| --- | --- |
+| `never-allowed` | `cannot-act` |
+| `advice-only` | `advice-only` |
+| `proposal-only` | `proposal-only` |
+| `approval-required` | `approval-required` |
+| `autonomous-allowed` | `autonomous` |
+
+Agent and service HITL tiers map as follows:
+
+| Existing tier | Meaning | Projection level |
+| --- | --- | --- |
+| `0` | Human-only | `cannot-act` |
+| `1` | Approve | `approval-required` |
+| `2` | Review | `review-required` |
+| `3` | Autonomous | `autonomous` |
+
+### Authority precedence
+
+1. Select the most specific base: explicit offer, else service, else agent.
+2. Within that selected base, let a required offer approval or stricter
+   service HITL tier narrow the declared boundary.
+3. Preserve service and agent defaults as overridden evidence when a more
+   specific source is selected; they do not narrow an explicit offer.
+4. Apply agent-governance evidence as a general restriction.
+5. For a specific action, consume the existing
+   `EffectiveAuthorityExplanation` rather than recomputing grants or bindings.
+   This preserves user capability, agent grants, binding subjects, binding
+   grants, and binding approval modes in one canonical decision.
+6. Apply native action-proposal evidence only when the projection carries an
+   explicit action key and resource reference. These contextual restrictions
+   may only narrow, never widen, the selected base.
+7. Require explicit evaluation states. `evaluated` with no matching rows is
+   distinct from `unavailable` or an omitted evaluation.
+8. Require each contextual evaluation to attest the same action key and
+   resource reference as the projection scope.
+9. Prefer the more specific owner explanation when two candidates have equal
+   restriction strength.
+10. Return `Approval rules need review` when selected or downstream evidence is
+   malformed, unsupported, contradictory, or missing a source reference.
+
+### Authority scopes
+
+- `default-posture` is the roster and coworker-record summary. It combines the
+  selected catalog/agent base with agent-governance policy. It does not apply
+  action-specific grants or proposals globally.
+- `effective-action` adds an action key, resource reference, the canonical
+  effective-authority evaluation, and native
+  action-proposal evaluation. Each evaluation attests the same action/resource
+  pair. This scope is suitable for a specific offer or work item, not the
+  roster headline.
+
+Catalog values are validated with the existing
+`COWORKER_AUTHORITY_BOUNDARIES` registry. Projection-only levels are never
+accepted as stored offer or service boundaries. Effective action decisions use
+the existing `allow`, `deny`, and `require-approval` output. Proposal evidence
+uses the statuses written by the current proposal surfaces: `proposed`,
+`approve`, `approved`, `reject`, `rejected`, `executed`, and `failed`.
+`BI-17C845C9` owns normalizing the governance API so future rows use the
+canonical past-tense decision states; the read model remains tolerant of current
+legacy rows until that bug lands.
+
+Every resolved result carries:
+
+- `label` and `summary` for the compact badge;
+- `ownerReason` and `ownerAction` for the visible explanation;
+- the projection scope;
+- the winning source reference;
+- advanced evidence with source, field, normalized level, and technical detail.
+
+Every review-needed result carries owner guidance plus validation reasons.
+Unknown arrays and objects are represented by type markers, and unrecognized
+primitive strings are represented by type and length rather than returned
+verbatim.
+
+### Authority files and tests
+
+- Add `apps/web/lib/coworker-service-catalog/authority-projection-contract.ts`.
+- Add `apps/web/lib/coworker-service-catalog/authority-projection-sources.ts`.
+- Add `apps/web/lib/coworker-service-catalog/authority-projection.ts`.
+- Add `apps/web/lib/coworker-service-catalog/authority-projection.test.ts`.
+- Cover every HITL and catalog mapping, source precedence, within-source
+  tightening, general versus action scope, native governance/grant/proposal
+  values, explicit evaluation states, owner-copy tie behavior, malformed and
+  contradictory evidence, and the live unsupported `requirements-gate` value.
+- Do not change persisted authority, delegated-action enforcement, grants, or
+  action-proposal behavior. Those remain owned by `BI-62BFAA95`.
 
 ## Deliverable 3: Roster Consumers
 

--- a/docs/superpowers/specs/2026-07-25-ai-workforce-ia-design.md
+++ b/docs/superpowers/specs/2026-07-25-ai-workforce-ia-design.md
@@ -197,9 +197,10 @@ Each coworker card should show:
   - `Not available`
   - `Coming later`
 - Approval/autonomy badge:
-  - `Needs approval before sending`
-  - `Can respond automatically`
-  - `Internal proposal only`
+  - Use the canonical owner labels from Deliverable 2 of
+    `docs/superpowers/plans/2026-07-26-ai-workforce-availability-authority-projections.md`.
+  - The roster uses the `default-posture` projection. Action-specific grant or
+    proposal decisions appear only in scoped offer/work detail.
 - Health/attention badge when relevant:
   - `Needs setup`
   - `Blocked`


### PR DESCRIPTION
## Summary

- add one evidence-bearing, owner-readable authority projection for AI Workforce roster, coworker records, and scoped offer/action views
- keep default posture separate from action-specific effective authority so one denied action never becomes a false global coworker restriction
- reuse canonical catalog boundaries and effective-authority decisions, fail closed on malformed or unattested context, and keep raw evidence under advanced detail
- record the WWMD restriction-lattice decision and align the AI Workforce design/implementation plan with the projection contract

## Governance

- Backlog item: BI-F39A1A82
- Umbrella: BI-1AE7CE65
- Work Capsule: WC-918CB5CE
- Plan: `docs/superpowers/plans/2026-07-26-ai-workforce-availability-authority-projections.md`
- Coverage receipt: `cms1x4w5n00rf01lh562xoz3m`
- WWMD decision: `DI-072C2AC24FB8`

## Verification

- governed merged-tree `pnpm run pregate`: passed
- all web Vitest tests: passed
- web typecheck: passed
- production Docker build: passed
- Prisma generate and 444-migration deploy check: passed
- docs index, links, and project guards: passed
- two independent correctness reviews completed; final focused review reported no remaining P1/P2 findings
- rendered UX verification: not applicable in this projection-only slice; BI-C810CC5A owns roster/record consumption and live desktop/mobile verification

Local-CI-Evidence: cms26dvjl0c7r01lhkyzwwn7r (codex/ai-workforce-authority@149677d523a4ff4a56932702cf5498b3ee67f78a)

Seed-Fit-Decision: not-applicable (non-persisted read model)