### PR TITLE
feat(inference): bind sensitive screen to routing

### DIFF
--- a/apps/web/lib/inference/data-screening/screen-inference-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { screenInferencePayload } from "./screen-inference-payload";
+
+describe("screenInferencePayload", () => {
+  it("leaves ordinary payloads eligible for normal routing", () => {
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Draft a short welcome note." }],
+      systemPrompt: "You help with ordinary writing.",
+      taskType: "creative",
+      routeContext: { sensitivity: "internal" },
+    });
+
+    expect(result.routeContext).toMatchObject({ sensitivity: "internal" });
+    expect(result.routeContext.residencyPolicy).toBeUndefined();
+    expect(result.receipt).toMatchObject({
+      policyEffect: "allow",
+      routeEffect: "allow",
+      classifiedDataClasses: [],
+      rawPayloadStored: false,
+    });
+  });
+
+  it("constrains restricted external payloads to local-only routing without storing raw values", () => {
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Review employee payroll and disciplinary notes for Jane." }],
+      systemPrompt: "You help with employee records.",
+      taskType: "summarization",
+      routeContext: {
+        sensitivity: "internal",
+        residencyPolicy: "any_enabled",
+        allowedProviders: [" openai ", "openai", "local"],
+      },
+    });
+
+    expect(result.routeContext).toMatchObject({
+      sensitivity: "restricted",
+      residencyPolicy: "local_only",
+      allowedProviders: ["local", "openai"],
+    });
+    expect(result.receipt).toMatchObject({
+      schemaVersion: "inference-data-screen/v1",
+      policyEffect: "deny",
+      routeEffect: "local-only",
+      classifiedDataClasses: expect.arrayContaining(["employee-records", "payments-finance"]),
+      explanationCodes: expect.arrayContaining(["restricted-cannot-leave-boundary"]),
+      rawPayloadStored: false,
+    });
+    expect(JSON.stringify(result.receipt)).not.toContain("Jane");
+  });
+
+  it("treats activity governed-data hints without classification as unknown governed payload", () => {
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Summarize the selected records." }],
+      systemPrompt: "",
+      taskType: "summarization",
+      activityContract: {
+        activityId: "activity-1",
+        parentRef: { taskRunId: "task-1" },
+        activityClass: "summarize",
+        title: "Summarize selected records",
+        distributionShape: "center",
+        riskClass: "medium",
+        successShape: "text",
+        contextPolicy: "retrieval",
+        tokenEnvelope: {
+          maxInputTokens: 1000,
+          maxOutputTokens: 500,
+          compression: "summarize",
+        },
+        evaluationPolicy: {
+          evaluator: "human-acceptance",
+          minimumSignal: "accepted",
+        },
+        requestContractHints: {},
+        governedData: {
+          assetIds: ["data:customer-account"],
+          processingPurpose: "service-delivery",
+        },
+      },
+    });
+
+    expect(result.routeContext).toMatchObject({
+      sensitivity: "restricted",
+      residencyPolicy: "local_only",
+    });
+    expect(result.receipt.classifiedDataClasses).toContain("unknown-governed-data");
+    expect(JSON.stringify(result.receipt)).not.toContain("selected records");
+  });
+});

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -1,0 +1,148 @@
+import type { ChatMessage } from "@/lib/inference/ai-inference";
+import type {
+  DestinationClass,
+  ProcessingPurposeKey,
+} from "@/lib/govern/data/taxonomy";
+import type { RequestContract } from "@/lib/routing/request-contract";
+import type { ActivityContract } from "@/lib/routing/activity-contract";
+import { classifyInferencePayload } from "./classify-payload";
+import { evaluateInferenceDispatchPolicy } from "./evaluate-inference-policy";
+import type {
+  GovernedPayloadHint,
+  InferenceDataScreenResult,
+  InferencePayloadSensitivity,
+} from "./types";
+
+const DEFAULT_ORGANIZATION_ID = "org:local-install";
+
+const SENSITIVITY_RANK: Readonly<Record<RequestContract["sensitivity"], number>> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  restricted: 3,
+};
+
+type ScreenRouteContextInput = Partial<InferenceDataScreenResult["routeContext"]> & {
+  sensitivity?: string;
+};
+
+export type ScreenInferencePayloadInput = {
+  organizationId?: string | null;
+  messages: ChatMessage[];
+  systemPrompt: string;
+  tools?: Array<Record<string, unknown>>;
+  taskType?: string;
+  routeContext?: ScreenRouteContextInput;
+  activityContract?: ActivityContract;
+  governedData?: readonly GovernedPayloadHint[];
+  destinationClass?: DestinationClass;
+  purpose?: ProcessingPurposeKey | string;
+};
+
+export function screenInferencePayload(
+  input: ScreenInferencePayloadInput,
+): InferenceDataScreenResult {
+  const governedData = mergeGovernedHints(
+    input.governedData,
+    hintsFromActivity(input.activityContract),
+  );
+  const classification = classifyInferencePayload({
+    messages: input.messages,
+    systemPrompt: input.systemPrompt,
+    tools: input.tools,
+    taskType: input.taskType,
+    governedData,
+  });
+  const destinationClass = input.destinationClass ?? "external-service";
+  const policy = evaluateInferenceDispatchPolicy({
+    organizationId: input.organizationId ?? DEFAULT_ORGANIZATION_ID,
+    classification,
+    governedData,
+    destinationClass,
+    purpose: input.purpose,
+  });
+
+  const originalSensitivity = normalizeSensitivity(input.routeContext?.sensitivity);
+  const sensitivity = strongestSensitivity(originalSensitivity, classification.overallSensitivity);
+  const routeEffect = policy.effect === "deny" || policy.effect === "review"
+    ? "local-only"
+    : "allow";
+  const residencyPolicy = routeEffect === "local-only"
+    ? stricterResidency(input.routeContext?.residencyPolicy, "local_only")
+    : input.routeContext?.residencyPolicy;
+
+  return {
+    routeContext: {
+      sensitivity,
+      ...(input.routeContext?.allowedProviders !== undefined
+        ? { allowedProviders: normalizeProviderIds(input.routeContext.allowedProviders) }
+        : {}),
+      ...(input.routeContext?.deniedProviders !== undefined
+        ? { deniedProviders: normalizeProviderIds(input.routeContext.deniedProviders) }
+        : {}),
+      ...(residencyPolicy !== undefined ? { residencyPolicy } : {}),
+    },
+    receipt: {
+      schemaVersion: "inference-data-screen/v1",
+      screenId: classification.receipt.screenId,
+      decisionIds: policy.decisionIds,
+      inputHash: classification.receipt.inputHash,
+      classifiedDataClasses: policy.classifiedDataClasses,
+      policyEffect: policy.effect,
+      routeEffect,
+      destinationClass,
+      transformation: classification.receipt.transformation,
+      explanationCodes: policy.explanationCodes,
+      obligationKinds: policy.obligations.map((obligation) => obligation.kind).sort(),
+      rawPayloadStored: false,
+    },
+  };
+}
+
+function normalizeSensitivity(value: string | undefined): RequestContract["sensitivity"] {
+  return value === "public" ||
+    value === "internal" ||
+    value === "confidential" ||
+    value === "restricted"
+    ? value
+    : "internal";
+}
+
+function strongestSensitivity(
+  left: RequestContract["sensitivity"],
+  right: InferencePayloadSensitivity,
+): RequestContract["sensitivity"] {
+  return SENSITIVITY_RANK[left] >= SENSITIVITY_RANK[right] ? left : right;
+}
+
+function stricterResidency(
+  left: RequestContract["residencyPolicy"] | undefined,
+  right: NonNullable<RequestContract["residencyPolicy"]>,
+): NonNullable<RequestContract["residencyPolicy"]> {
+  const rank = { any_enabled: 0, approved_cloud: 1, local_only: 2 } as const;
+  const current = left ?? "any_enabled";
+  return rank[current] >= rank[right] ? current : right;
+}
+
+function normalizeProviderIds(providerIds: readonly string[]): string[] {
+  return [...new Set(providerIds.map((providerId) => providerId.trim()).filter(Boolean))].sort();
+}
+
+function hintsFromActivity(activity: ActivityContract | undefined): GovernedPayloadHint[] {
+  if (!activity?.governedData) return [];
+  const data = activity.governedData;
+  return data.assetIds.map((assetId) => ({
+    assetId,
+    fieldIds: data.fieldIds,
+    classificationKnown: false,
+    purpose: data.processingPurpose,
+  }));
+}
+
+function mergeGovernedHints(
+  first: readonly GovernedPayloadHint[] | undefined,
+  second: readonly GovernedPayloadHint[],
+): GovernedPayloadHint[] | undefined {
+  const merged = [...(first ?? []), ...second];
+  return merged.length > 0 ? merged : undefined;
+}

--- a/apps/web/lib/inference/data-screening/types.ts
+++ b/apps/web/lib/inference/data-screening/types.ts
@@ -1,4 +1,6 @@
 import type { ChatMessage } from "@/lib/inference/ai-inference";
+import type { DataEffect, DestinationClass } from "@/lib/govern/data/taxonomy";
+import type { RequestContract } from "@/lib/routing/request-contract";
 
 export type InferenceDataClass =
   | "customer-records"
@@ -34,6 +36,31 @@ export type InferencePayloadReceipt = {
   matchCount: number;
   transformation: "none" | "masked" | "tokenized" | "blocked";
   rawPayloadStored: false;
+};
+
+export type InferenceDataScreenRouteContext = Pick<
+  RequestContract,
+  "sensitivity" | "allowedProviders" | "deniedProviders" | "residencyPolicy"
+>;
+
+export type InferenceDataScreenReceipt = {
+  schemaVersion: "inference-data-screen/v1";
+  screenId: string;
+  decisionIds: string[];
+  inputHash: string;
+  classifiedDataClasses: InferenceDataClass[];
+  policyEffect: DataEffect;
+  routeEffect: "allow" | "local-only" | "block";
+  destinationClass: DestinationClass;
+  transformation: InferencePayloadReceipt["transformation"];
+  explanationCodes: string[];
+  obligationKinds: string[];
+  rawPayloadStored: false;
+};
+
+export type InferenceDataScreenResult = {
+  routeContext: InferenceDataScreenRouteContext;
+  receipt: InferenceDataScreenReceipt;
 };
 
 export type GovernedPayloadHint = {

--- a/apps/web/lib/inference/routed-inference-options.ts
+++ b/apps/web/lib/inference/routed-inference-options.ts
@@ -19,6 +19,8 @@ export interface RouteAndCallOptions {
   deniedProviders?: string[];
   /** Hard residency boundary. Never widened by fallback. */
   residencyPolicy?: RequestContract["residencyPolicy"];
+  /** Optional system prompt text for side-effect-free route previews that need data screening parity. */
+  screeningSystemPrompt?: string;
   modelTier?: "local" | "robust";
   minimumDimensions?: Record<string, number>;
   requiredModelClass?: ModelClass;

--- a/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
+++ b/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
@@ -75,21 +75,36 @@ describe("routeAndCall activity harness overrides", () => {
     mocks.persistRouteDecision.mockResolvedValue("route-log-1");
     mocks.updateProviderSuitabilityReceipt.mockResolvedValue(undefined);
     mocks.resolveDispatchPosture.mockResolvedValue(null);
-    mocks.inferContract.mockResolvedValue({
+    mocks.inferContract.mockImplementation(async (
+      taskType: string,
+      messages: Array<{ role: string; content: unknown }>,
+      tools?: Array<Record<string, unknown>>,
+      _outputSchema?: Record<string, unknown>,
+      routeContext?: Record<string, unknown>,
+    ) => ({
       contractId: "contract-1",
       contractFamily: "sync.test",
-      taskType: "summarization",
+      taskType,
       modality: { input: ["text"], output: ["text"] },
-      interactionMode: "sync",
-      sensitivity: "internal",
-      requiresTools: false,
+      interactionMode: routeContext?.interactionMode ?? "sync",
+      sensitivity: routeContext?.sensitivity ?? "internal",
+      requiresTools: (tools?.length ?? 0) > 0,
       requiresStrictSchema: false,
       requiresStreaming: false,
-      estimatedInputTokens: 1000,
+      estimatedInputTokens: messages.length * 1000,
       estimatedOutputTokens: 400,
       reasoningDepth: "low",
-      budgetClass: "minimize_cost",
-    });
+      budgetClass: routeContext?.budgetClass ?? "minimize_cost",
+      ...(routeContext?.allowedProviders !== undefined
+        ? { allowedProviders: routeContext.allowedProviders }
+        : {}),
+      ...(routeContext?.deniedProviders !== undefined
+        ? { deniedProviders: routeContext.deniedProviders }
+        : {}),
+      ...(routeContext?.residencyPolicy !== undefined
+        ? { residencyPolicy: routeContext.residencyPolicy }
+        : {}),
+    }));
     mocks.loadEndpointManifests.mockResolvedValue([
       {
         id: "openai:gpt-4o-mini",
@@ -297,6 +312,89 @@ describe("routeAndCall activity harness overrides", () => {
       selectedProviderId: "openai",
     });
     expect(JSON.stringify(result.routeDecision.providerSuitabilityReceipt)).not.toContain("customer update");
+  });
+
+  it("screens restricted prompt content before route selection and narrows external dispatch to local-only", async () => {
+    const result = await routeAndCall(
+      [{ role: "user", content: "Summarize employee salary and disciplinary notes for Jane." }],
+      "You summarize employee records.",
+      "internal",
+      {
+        taskType: "summarization",
+        persistDecision: false,
+      },
+    );
+
+    expect(mocks.inferContract).toHaveBeenCalledWith(
+      "summarization",
+      expect.any(Array),
+      undefined,
+      undefined,
+      expect.objectContaining({
+        sensitivity: "restricted",
+        residencyPolicy: "local_only",
+      }),
+    );
+    expect(mocks.routeEndpointV2).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        sensitivity: "restricted",
+        residencyPolicy: "local_only",
+      }),
+      [],
+      [],
+      expect.any(Object),
+    );
+    expect(result.routeDecision.inferenceDataScreenReceipt).toMatchObject({
+      schemaVersion: "inference-data-screen/v1",
+      policyEffect: "deny",
+      routeEffect: "local-only",
+      classifiedDataClasses: expect.arrayContaining(["employee-records"]),
+      rawPayloadStored: false,
+    });
+    expect(JSON.stringify(result.routeDecision.inferenceDataScreenReceipt)).not.toContain("Jane");
+    expect(mocks.callWithFallbackChain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inferenceDataScreenReceipt: expect.objectContaining({
+          routeEffect: "local-only",
+        }),
+      }),
+      expect.any(Array),
+      expect.any(String),
+      undefined,
+      expect.any(Object),
+      undefined,
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("applies the same pre-dispatch data screen to preview routing", async () => {
+    const preview = await previewRoute(
+      [{ role: "user", content: "Customer email is alex@example.com; summarize next action." }],
+      "internal",
+      {
+        taskType: "summarization",
+        screeningSystemPrompt: "You summarize customer records.",
+      },
+    );
+
+    expect(mocks.routeEndpointV2).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        sensitivity: "confidential",
+        residencyPolicy: "local_only",
+      }),
+      [],
+      [],
+      expect.objectContaining({ skipRecipe: true }),
+    );
+    expect(preview.decision.inferenceDataScreenReceipt).toMatchObject({
+      routeEffect: "local-only",
+      classifiedDataClasses: expect.arrayContaining(["customer-records"]),
+      rawPayloadStored: false,
+    });
+    expect(JSON.stringify(preview.decision.inferenceDataScreenReceipt)).not.toContain("alex@example.com");
   });
 });
 

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -41,6 +41,10 @@ import {
   prepareProviderSuitabilityRuntime,
   type ProviderSuitabilityRuntime,
 } from "@/lib/routing/provider-suitability/runtime";
+import {
+  screenInferencePayload,
+  type ScreenInferencePayloadInput,
+} from "@/lib/inference/data-screening/screen-inference-payload";
 export type { RouteAndCallOptions } from "./routed-inference-options";
 
 // ─── Result type ────────────────────────────────────────────────────────────
@@ -117,6 +121,7 @@ interface PreparedRoute {
  */
 async function prepareRoute(
   messages: ChatMessage[],
+  systemPrompt: string,
   sensitivity: RouteSensitivity,
   options: RouteAndCallOptions | undefined,
   prep?: { skipRecipe?: boolean },
@@ -139,6 +144,32 @@ async function prepareRoute(
   // per-coworker priority actually tunes that coworker's runs. Single-org install
   // → null org id; non-coworker runs pass null agentId (platform default).
   const posture = await resolveDispatchPosture(options?.agentId ?? null, taskType);
+  const initialRouteContext = {
+    // Posture defaults first — every explicit caller field and the local-only
+    // switch below override them (spread/assignment order = precedence).
+    ...(posture?.routeContext ?? {}),
+    sensitivity,
+    interactionMode: options?.interactionMode,
+    requiresCodeExecution: options?.requiresCodeExecution,
+    requiresWebSearch: options?.requiresWebSearch,
+    requiresComputerUse: options?.requiresComputerUse,
+    budgetClass: posture?.routeContext.budgetClass ?? options?.budgetClass,
+    allowedProviders: options?.allowedProviders,
+    deniedProviders: options?.deniedProviders,
+    residencyPolicy:
+      options?.modelTier === "local" || localOnlyInference
+        ? "local_only"
+        : options?.residencyPolicy,
+    requiredModelClass: options?.requiredModelClass,
+  };
+  const screen = screenInferencePayload({
+    messages,
+    systemPrompt,
+    tools: options?.tools,
+    taskType,
+    routeContext: initialRouteContext,
+    activityContract: options?.activityContract,
+  } satisfies ScreenInferencePayloadInput);
 
   // 1. Infer contract
   let contract = await inferContract(
@@ -147,14 +178,8 @@ async function prepareRoute(
     options?.tools,
     undefined, // outputSchema
     {
-      // Posture defaults first — every explicit caller field and the local-only
-      // switch below override them (spread/assignment order = precedence).
-      ...(posture?.routeContext ?? {}),
-      sensitivity,
-      interactionMode: options?.interactionMode,
-      requiresCodeExecution: options?.requiresCodeExecution,
-      requiresWebSearch: options?.requiresWebSearch,
-      requiresComputerUse: options?.requiresComputerUse,
+      ...initialRouteContext,
+      sensitivity: screen.routeContext.sensitivity,
       // EP-GOLDEN-TRIANGLE reconciliation: the posture (the everyday Cost/Quality
       // lever) OWNS budgetClass. AgentModelConfig.budgetClass (which defaults to
       // "balanced" and is always sent) applies only as the fallback when no
@@ -163,14 +188,9 @@ async function prepareRoute(
       // already reconciled: AgentModelConfig.minimumTier acts as a floor via the
       // per-dimension max-merge in inferContract, which the posture can raise but
       // not drop below. See docs/design/2026-06-25-coworker-work-orchestration.md.)
-      budgetClass: posture?.routeContext.budgetClass ?? options?.budgetClass,
-      allowedProviders: options?.allowedProviders,
-      deniedProviders: options?.deniedProviders,
-      residencyPolicy:
-        options?.modelTier === "local" || localOnlyInference
-          ? "local_only"
-          : options?.residencyPolicy,
-      requiredModelClass: options?.requiredModelClass,
+      allowedProviders: screen.routeContext.allowedProviders,
+      deniedProviders: screen.routeContext.deniedProviders,
+      residencyPolicy: screen.routeContext.residencyPolicy,
       // EP-MODEL-TIER-ROUTING: a "local"-tier call forces local_only (keep
       // small/simple work on-box) even when the global switch is off; "robust"
       // leaves routing free to prefer a frontier endpoint. The global local-only
@@ -247,6 +267,10 @@ async function prepareRoute(
     activityContract: options?.activityContract,
     activityHarnessConfidenceOverrides,
   });
+  decision.inferenceDataScreenReceipt = screen.receipt;
+  if (!decision.policyRulesApplied.includes("inference-dispatch")) {
+    decision.policyRulesApplied = [...decision.policyRulesApplied, "inference-dispatch"];
+  }
 
   return { contract, decision, manifests, policies, overrides, taskType, posture, suitability };
 }
@@ -283,6 +307,7 @@ export async function previewRoute(
 ): Promise<RoutePreview> {
   const { contract, decision, manifests } = await prepareRoute(
     messages,
+    options?.screeningSystemPrompt ?? "",
     sensitivity,
     options,
     { skipRecipe: true },
@@ -319,7 +344,7 @@ export async function routeAndCall(
   // prediction can never drift from what this live path actually picks. The
   // live path keeps recipe selection (skipRecipe defaults false) so the
   // executionPlan is built for dispatch below.
-  const prepared = await prepareRoute(messages, sensitivity, options);
+  const prepared = await prepareRoute(messages, systemPrompt, sensitivity, options);
   const { contract, manifests, policies, overrides, taskType } = prepared;
   let decision = prepared.decision;
   let toolsStripped = false;

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -159,6 +159,8 @@ export interface RouteDecision {
   timestamp: Date;
   /** Policy-safe provider suitability audit receipt; never contains request content or raw account ids. */
   providerSuitabilityReceipt?: import("./provider-suitability/evidence").ProviderSuitabilityRouteReceipt;
+  /** Policy-safe inference data screen receipt; never contains prompts, tool payloads, or detected values. */
+  inferenceDataScreenReceipt?: import("@/lib/inference/data-screening/types").InferenceDataScreenReceipt;
 
   // EP-INF-005b: Execution recipe fields
   selectedRecipeId?: string;

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -272,12 +272,14 @@ git diff --check
 - Modify: `apps/web/lib/routing/task-dispatcher.test.ts`
 - Modify: `apps/web/lib/routing/pipeline-v2.provider-policy.test.ts`
 
-- [ ] Run the screen before `inferContract()` so sensitivity, allowed/denied providers, and residency are compiled into the route preview and live route.
+- [x] Run the screen before `inferContract()` so sensitivity, allowed/denied providers, and residency are compiled into the route preview and live route.
 - [ ] Re-run or validate the screen immediately before provider dispatch so direct fallback execution cannot bypass the PEP.
 - [ ] Intersect allowed providers and union denied providers with any provider suitability policy already compiled from the activity contract.
-- [ ] Prove `routeEndpointV2` excludes public/non-enterprise providers when the transformed payload still carries restricted data.
+- [x] Prove `routeEndpointV2` excludes public/non-enterprise providers when the transformed payload still carries restricted data.
 - [ ] Prove fallback never sends a transformed payload to a provider that was not eligible for the original decision.
 - [ ] Surface blocked routing as a short, actionable explanation: what class of data blocked the route, what safer route is needed, and whether masking is possible.
+
+**Slice 3 progress:** `screenInferencePayload` now builds a privacy-safe `inference-data-screen/v1` receipt from the classifier/PDP result and narrows preview/live `RequestContract` inputs before `inferContract()`. When external dispatch is denied or needs review and masking/tokenization is not yet available, the screen escalates sensitivity and applies `residencyPolicy="local_only"` so `routeEndpointV2` owns provider exclusion and fallback inherits the eligible candidate set. The receipt is attached to the in-memory `RouteDecision` and contains only hashes, classes, decision IDs, effect codes, obligation kinds, destination class, and transformation status. Remaining work: durable receipt persistence, final pre-dispatch TOCTOU validation, mask/token transform, direct fallback/legacy dispatcher receipt enforcement, and blocked-route UX copy.
 
 **Verification:**
 


### PR DESCRIPTION
## Summary
- Adds `screenInferencePayload`, a shared pre-dispatch inference data screen that turns classifier/PDP results into a privacy-safe `inference-data-screen/v1` receipt.
- Wires the screen into `routeAndCall` and `previewRoute` before `inferContract()` so restricted/confidential external payloads narrow the `RequestContract` to `local_only` until masking/tokenization lands.
- Updates the sensitive LLM routing plan with Chunk 4 slice progress and remaining work.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/inference/data-screening/screen-inference-payload.test.ts lib/inference/routed-inference.activity-overrides.test.ts lib/routing/pipeline-v2.provider-policy.test.ts lib/routing/pipeline-v2.test.ts` — 4 files, 63 tests passed
- [x] `git diff --check`
- [x] `pnpm run pregate` — merged-code local-CI passed with green sandbox freshness, migrations, docs/index/link/guard checks, full web Vitest, and production Docker build

Local-CI-Evidence: cms27vavh0dty01lhdrkiroja (feat/sensitive-llm-routing-binding@8968ce75332e4814e803325696f9de196e58fbf6)