### PR TITLE
docs: redesign public documentation overview

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,2035 +3,1576 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Open Digital Product Factory — Documentation Overview</title>
-<meta name="description" content="A pre-install tour of the Open Digital Product Factory: the open AI-operated company platform, what it does, how it is governed, and where to read the user guide, architecture, and specifications." />
+<title>Open Digital Product Factory &mdash; Run the business with governed AI coworkers</title>
+<meta
+  name="description"
+  content="A clear tour of Open Digital Product Factory: who it is for, how the local-first platform works, what is available now, how AI actions are governed, and where to install or read the detailed guides."
+/>
 <style>
   :root {
-    --bg: #0b0d10;
-    --surface: #14181d;
-    --surface-2: #1b2027;
-    --border: #262d36;
-    --fg: #e6e8eb;
-    --fg-muted: #a4adb8;
-    --accent: #6aa9ff;
-    --accent-2: #8be0c7;
-    --warn: #ffcf66;
+    color-scheme: dark light;
+    --bg: #071019;
+    --surface: #0d1a27;
+    --surface-raised: #132335;
+    --surface-soft: #172a3d;
+    --border: #284158;
+    --border-strong: #3e607d;
+    --text: #f4f8fb;
+    --muted: #afc0cf;
+    --blue: #78b7ff;
+    --blue-strong: #2d82e8;
+    --mint: #70e1bd;
+    --gold: #ffd27a;
+    --rose: #ff9faa;
+    --shadow: 0 20px 60px rgba(0, 0, 0, 0.24);
+    --radius-sm: 10px;
+    --radius: 18px;
+    --radius-lg: 28px;
+    --page: 1180px;
   }
+
   @media (prefers-color-scheme: light) {
     :root {
-      --bg: #f7f8fa;
+      --bg: #f3f7fb;
       --surface: #ffffff;
-      --surface-2: #f0f3f7;
-      --border: #d9dde3;
-      --fg: #1a1f25;
-      --fg-muted: #515b66;
-      --accent: #1f5fbf;
-      --accent-2: #1f7a5a;
-      --warn: #8a5a00;
+      --surface-raised: #f8fbfe;
+      --surface-soft: #eaf2f8;
+      --border: #cbd9e5;
+      --border-strong: #9eb5c8;
+      --text: #122235;
+      --muted: #516579;
+      --blue: #135fae;
+      --blue-strong: #1d70c8;
+      --mint: #14775d;
+      --gold: #8a5a00;
+      --rose: #a52f45;
+      --shadow: 0 18px 50px rgba(37, 69, 97, 0.12);
     }
   }
-  * { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
-    background: var(--bg);
-    color: var(--fg);
-    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    margin: 0;
+    background:
+      radial-gradient(circle at 8% 4%, rgba(45, 130, 232, 0.16), transparent 28rem),
+      radial-gradient(circle at 92% 14%, rgba(112, 225, 189, 0.10), transparent 24rem),
+      var(--bg);
+    color: var(--text);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
   }
-  a { color: var(--accent); text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  header.hero {
-    padding: 56px 24px 40px;
-    border-bottom: 1px solid var(--border);
-    background:
-      radial-gradient(1200px 400px at 20% -10%, rgba(106,169,255,0.10), transparent 60%),
-      radial-gradient(900px 300px at 90% 0%, rgba(139,224,199,0.08), transparent 60%),
-      var(--surface);
-  }
-  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
-  .hero-logo {
+
+  img,
+  svg {
     display: block;
-    height: 140px;
-    width: auto;
-    margin-bottom: 24px;
-  }
-  @media (prefers-color-scheme: dark) {
-    .hero-logo { filter: invert(1) hue-rotate(180deg); }
-  }
-  h1 {
-    font-size: clamp(28px, 4vw, 44px);
-    line-height: 1.15;
-    margin: 0 0 12px;
-    letter-spacing: -0.01em;
-  }
-  .lede {
-    font-size: clamp(16px, 1.6vw, 19px);
-    color: var(--fg-muted);
-    max-width: 820px;
-    margin: 0 0 24px;
-  }
-  .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; }
-  .btn {
-    display: inline-block;
-    padding: 10px 16px;
-    border-radius: 8px;
-    border: 1px solid var(--border);
-    background: var(--surface-2);
-    color: var(--fg);
-    font-weight: 600;
-    font-size: 14px;
-  }
-  .btn.primary {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: #0b0d10;
-  }
-  .btn:hover { text-decoration: none; filter: brightness(1.05); }
-
-  main { padding: 48px 24px 80px; }
-  section { margin-bottom: 56px; }
-  section h2 {
-    font-size: 22px;
-    margin: 0 0 8px;
-    letter-spacing: -0.005em;
-  }
-  section .sub {
-    color: var(--fg-muted);
-    margin: 0 0 20px;
-    max-width: 820px;
+    max-width: 100%;
   }
 
-  .grid {
-    display: grid;
-    gap: 14px;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  }
-  .card {
-    border: 1px solid var(--border);
-    background: var(--surface);
-    border-radius: 8px;
-    padding: 16px 18px;
-  }
-  .card h3 {
-    font-size: 15px;
-    margin: 0 0 6px;
-    color: var(--fg);
-  }
-  .card p { margin: 0; color: var(--fg-muted); font-size: 14px; }
-
-  table.guide {
-    width: 100%;
-    border-collapse: collapse;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    overflow: hidden;
-    font-size: 14px;
-  }
-  table.guide th, table.guide td {
-    padding: 10px 14px;
-    border-bottom: 1px solid var(--border);
-    text-align: left;
-    vertical-align: top;
-  }
-  table.guide th {
-    background: var(--surface-2);
-    font-weight: 600;
-    color: var(--fg);
-  }
-  table.guide tr:last-child td { border-bottom: none; }
-
-  .pillars {
-    display: grid;
-    gap: 14px;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-  .pillar {
-    border: 1px solid var(--border);
-    background: var(--surface);
-    border-radius: 8px;
-    padding: 16px;
-  }
-  .pillar .tag {
-    display: inline-block;
-    font-size: 11px;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--accent-2);
-    margin-bottom: 6px;
+  a {
+    color: var(--blue);
+    text-underline-offset: 0.18em;
+    text-decoration-thickness: 0.08em;
   }
 
-  .install {
-    border: 1px solid var(--border);
-    background: var(--surface);
-    border-radius: 8px;
-    padding: 16px 18px;
+  a:hover {
+    text-decoration-thickness: 0.14em;
   }
-  .install h3 { margin: 0 0 10px; font-size: 16px; }
-  pre {
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 12px 14px;
-    margin: 0;
-    overflow-x: auto;
-    font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    color: var(--fg);
-  }
-  .note {
-    border-left: 3px solid var(--warn);
-    padding: 8px 12px;
-    background: var(--surface-2);
-    color: var(--fg-muted);
+
+  a:focus-visible,
+  summary:focus-visible {
+    outline: 3px solid var(--gold);
+    outline-offset: 4px;
     border-radius: 4px;
-    font-size: 14px;
-    margin-top: 12px;
   }
 
-  .process-strip {
-    display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    margin: 22px 0;
+  .skip-link {
+    position: fixed;
+    top: 12px;
+    left: 12px;
+    z-index: 100;
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    background: var(--text);
+    color: var(--bg);
+    font-weight: 800;
+    transform: translateY(-160%);
   }
-  .process-step {
-    border: 1px solid var(--border);
-    background: var(--surface);
-    border-radius: 8px;
-    padding: 14px;
-    min-height: 118px;
+
+  .skip-link:focus {
+    transform: translateY(0);
   }
-  .process-step .num {
+
+  .page {
+    width: min(100% - 40px, var(--page));
+    margin-inline: auto;
+  }
+
+  .eyebrow {
+    margin: 0 0 12px;
+    color: var(--mint);
+    font-size: 0.75rem;
+    font-weight: 850;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  h1,
+  h2,
+  h3 {
+    line-height: 1.12;
+    letter-spacing: -0.025em;
+  }
+
+  h1 {
+    max-width: 920px;
+    margin: 0;
+    font-size: clamp(2.55rem, 7vw, 5.6rem);
+  }
+
+  h2 {
+    max-width: 780px;
+    margin: 0 0 18px;
+    font-size: clamp(2rem, 4.5vw, 3.6rem);
+  }
+
+  h3 {
+    margin: 0 0 8px;
+    font-size: 1.08rem;
+  }
+
+  p {
+    margin-block: 0 1rem;
+  }
+
+  .muted {
+    color: var(--muted);
+  }
+
+  .hero {
+    padding: 28px 0 70px;
+    overflow: hidden;
+  }
+
+  .brand-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: clamp(64px, 10vw, 126px);
+  }
+
+  .brand {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    border-radius: 999px;
-    background: var(--surface-2);
-    color: var(--accent-2);
-    font-size: 12px;
-    font-weight: 700;
-    margin-bottom: 10px;
-  }
-  .process-step strong {
-    display: block;
-    font-size: 14px;
-    margin-bottom: 4px;
-  }
-  .process-step span {
-    color: var(--fg-muted);
-    font-size: 13px;
-    line-height: 1.45;
-  }
-
-  .analysis-matrix {
-    display: grid;
     gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-    margin-top: 14px;
+    color: var(--text);
+    font-size: 0.88rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    text-decoration: none;
   }
-  .analysis-axis {
+
+  .brand img {
+    width: 46px;
+    height: 46px;
+    object-fit: contain;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .brand img {
+      filter: invert(1) hue-rotate(180deg);
+    }
+  }
+
+  .brand-links {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    font-size: 0.88rem;
+    font-weight: 750;
+  }
+
+  .brand-links a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    color: var(--muted);
+  }
+
+  .hero-copy {
+    position: relative;
+  }
+
+  .hero-copy::after {
+    position: absolute;
+    top: -90px;
+    right: -110px;
+    width: 390px;
+    height: 390px;
     border: 1px solid var(--border);
-    background: var(--surface-2);
-    border-radius: 8px;
-    padding: 14px;
-  }
-  .analysis-axis strong {
-    display: block;
-    font-size: 14px;
-    margin-bottom: 4px;
-  }
-  .analysis-axis span {
-    color: var(--fg-muted);
-    font-size: 13px;
-    line-height: 1.45;
+    border-radius: 50%;
+    background:
+      radial-gradient(circle, rgba(112, 225, 189, 0.18) 0 2px, transparent 3px) 0 0 / 28px 28px;
+    content: "";
+    opacity: 0.5;
+    pointer-events: none;
   }
 
-  footer {
-    border-top: 1px solid var(--border);
-    padding: 24px;
-    color: var(--fg-muted);
-    font-size: 13px;
-    text-align: center;
+  .hero-lede {
+    position: relative;
+    z-index: 1;
+    max-width: 780px;
+    margin: 26px 0 0;
+    color: var(--muted);
+    font-size: clamp(1.1rem, 2vw, 1.35rem);
   }
 
-  /* Smooth scroll + offset for anchored jumps so headings clear the sticky bar */
-  html { scroll-behavior: smooth; }
-  section { scroll-margin-top: 96px; }
+  .actions {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 30px;
+  }
 
-  /* Hero highlights — short value props directly under the lede */
-  .hero-highlights {
+  .button {
+    display: inline-flex;
+    min-height: 48px;
+    align-items: center;
+    justify-content: center;
+    padding: 11px 18px;
+    border: 1px solid var(--border-strong);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    font-size: 0.92rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .button:hover {
+    border-color: var(--blue);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+
+  .button.primary {
+    border-color: var(--blue-strong);
+    background: var(--blue-strong);
+    color: #fff;
+  }
+
+  .proof-strip {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 14px;
-    margin: 28px 0 8px;
-  }
-  .hero-highlight {
+    grid-template-columns: repeat(4, 1fr);
+    margin-top: clamp(50px, 8vw, 92px);
     border: 1px solid var(--border);
-    background: rgba(255,255,255,0.02);
-    border-radius: 8px;
-    padding: 14px 16px;
+    border-radius: var(--radius);
+    background: rgba(13, 26, 39, 0.72);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(14px);
   }
+
   @media (prefers-color-scheme: light) {
-    .hero-highlight { background: rgba(0,0,0,0.02); }
-  }
-  .hero-highlight strong { display: block; margin-bottom: 4px; font-size: 14px; }
-  .hero-highlight span { color: var(--fg-muted); font-size: 13px; line-height: 1.5; }
-
-  @media (max-width: 640px) {
-    header.hero { padding: 32px 16px 28px; }
-    .wrap { padding: 0 16px; }
-    main { padding: 32px 16px 64px; }
-    section { scroll-margin-top: 74px; }
-    .hero-logo {
-      height: 96px;
-      margin: 0 auto 16px;
-    }
-    h1 { font-size: 28px; }
-    .lede { font-size: 15px; }
-    .cta-row { margin-top: 16px; }
-    .btn {
-      width: 100%;
-      text-align: center;
-    }
-    .hero-highlights { margin-top: 18px; }
-    .process-strip,
-    .analysis-matrix {
-      grid-template-columns: 1fr;
-    }
-    table.guide {
-      display: block;
-      max-width: 100%;
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
-    }
-    pre code {
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
+    .proof-strip {
+      background: rgba(255, 255, 255, 0.82);
     }
   }
 
-  /* Sticky in-page navigation rail */
-  nav.toc {
+  .proof {
+    min-width: 0;
+    padding: 20px;
+  }
+
+  .proof + .proof {
+    border-left: 1px solid var(--border);
+  }
+
+  .proof strong {
+    display: block;
+    margin-bottom: 3px;
+    font-size: 1.05rem;
+  }
+
+  .proof span {
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .site-nav {
     position: sticky;
     top: 0;
     z-index: 50;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border);
-    padding: 10px 0;
-    margin: 0;
+    border-block: 1px solid var(--border);
+    background: var(--bg);
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(18px);
   }
-  nav.toc .toc-inner {
-    max-width: 1080px;
-    margin: 0 auto;
-    padding: 0 24px;
+
+  .site-nav-inner {
     display: flex;
-    flex-wrap: wrap;
-    gap: 6px 12px;
+    min-height: 58px;
     align-items: center;
-    font-size: 13px;
+    justify-content: space-between;
+    gap: 20px;
+    scrollbar-width: none;
   }
-  nav.toc .toc-label {
-    color: var(--fg-muted);
-    font-weight: 600;
-    letter-spacing: 0.04em;
+
+  .site-nav-inner::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-label {
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 850;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    font-size: 11px;
-    margin-right: 4px;
-  }
-  nav.toc a {
-    color: var(--fg-muted);
-    padding: 4px 8px;
-    border-radius: 6px;
-    border: 1px solid transparent;
     white-space: nowrap;
   }
-  nav.toc a:hover {
-    color: var(--fg);
-    background: var(--surface-2);
-    border-color: var(--border);
+
+  .nav-links {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .nav-links a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    padding: 7px 10px;
+    border-radius: 999px;
+    color: var(--muted);
+    font-size: 0.84rem;
+    font-weight: 750;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .nav-links a:hover {
+    background: var(--surface-raised);
+    color: var(--text);
+  }
+
+  main {
+    overflow: hidden;
+  }
+
+  section {
+    position: relative;
+    padding-block: clamp(76px, 10vw, 128px);
+    scroll-margin-top: 74px;
+  }
+
+  section + section {
+    border-top: 1px solid var(--border);
+  }
+
+  .section-intro {
+    max-width: 780px;
+    margin-bottom: 38px;
+    color: var(--muted);
+    font-size: 1.08rem;
+  }
+
+  .anchor-alias {
+    position: absolute;
+    top: -74px;
+  }
+
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+
+  .card {
+    min-width: 0;
+    padding: 24px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+
+  .card .label {
+    display: inline-block;
+    margin-bottom: 22px;
+    color: var(--mint);
+    font-size: 0.7rem;
+    font-weight: 850;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .card p {
+    color: var(--muted);
+    font-size: 0.92rem;
+  }
+
+  .card p:last-child {
+    margin-bottom: 0;
+  }
+
+  .business-paths {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 10px;
+    margin-top: 20px;
+  }
+
+  .business-path {
+    display: flex;
+    min-height: 142px;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 18px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-raised);
+    color: var(--text);
     text-decoration: none;
   }
-  @media (max-width: 640px) {
-    nav.toc .toc-inner {
-      flex-wrap: nowrap;
-      overflow-x: auto;
-      padding: 0 16px 2px;
-      gap: 8px;
-      -webkit-overflow-scrolling: touch;
+
+  .business-path:hover {
+    border-color: var(--blue);
+    text-decoration: none;
+    transform: translateY(-2px);
+  }
+
+  .business-path span:first-child {
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .business-path strong {
+    font-size: 0.98rem;
+    line-height: 1.25;
+  }
+
+  figure {
+    margin: 0;
+  }
+
+  .system-figure {
+    padding: clamp(20px, 4vw, 38px);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background:
+      linear-gradient(135deg, rgba(45, 130, 232, 0.10), transparent 42%),
+      var(--surface);
+    box-shadow: var(--shadow);
+  }
+
+  .system-map {
+    display: grid;
+    grid-template-columns: 1fr 46px 1fr 46px 1fr;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  .system-node {
+    display: flex;
+    min-height: 238px;
+    flex-direction: column;
+    padding: 24px;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    background: var(--surface-raised);
+  }
+
+  .system-node .node-number {
+    display: grid;
+    width: 34px;
+    height: 34px;
+    place-items: center;
+    margin-bottom: auto;
+    border: 1px solid var(--border-strong);
+    border-radius: 50%;
+    color: var(--mint);
+    font-size: 0.76rem;
+    font-weight: 900;
+  }
+
+  .system-node h3 {
+    margin-top: 30px;
+    font-size: 1.2rem;
+  }
+
+  .system-node p {
+    margin-bottom: 0;
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+
+  .system-arrow {
+    display: grid;
+    place-items: center;
+    color: var(--blue);
+    font-size: 1.7rem;
+    font-weight: 300;
+  }
+
+  .governance-rail {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    margin-top: 18px;
+    padding: 14px;
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-sm);
+  }
+
+  .governance-rail span {
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 750;
+    text-align: center;
+  }
+
+  figcaption {
+    max-width: 820px;
+    margin-top: 16px;
+    color: var(--muted);
+    font-size: 0.84rem;
+  }
+
+  .capability-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-top: 26px;
+  }
+
+  .capability {
+    padding: 18px;
+    border-left: 3px solid var(--blue);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    background: var(--surface-raised);
+  }
+
+  .capability:nth-child(2n) {
+    border-left-color: var(--mint);
+  }
+
+  .capability p {
+    margin: 5px 0 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+
+  .trust-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+    gap: 22px;
+    align-items: stretch;
+  }
+
+  .trust-flow {
+    min-width: 0;
+    padding: 24px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--surface);
+  }
+
+  .trust-flow svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .trust-flow-mobile {
+    display: none;
+    gap: 30px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .trust-flow-mobile li {
+    position: relative;
+    padding: 18px;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--surface-raised);
+  }
+
+  .trust-flow-mobile li:not(:last-child)::after {
+    position: absolute;
+    bottom: -27px;
+    left: calc(50% - 8px);
+    color: var(--blue);
+    content: "\2193";
+    font-size: 1.4rem;
+  }
+
+  .trust-flow-mobile strong,
+  .trust-flow-mobile span {
+    display: block;
+    text-align: center;
+  }
+
+  .trust-flow-mobile span {
+    margin-top: 3px;
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+
+  .trust-principles {
+    display: grid;
+    gap: 12px;
+  }
+
+  .principle {
+    padding: 18px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-raised);
+  }
+
+  .principle strong {
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  .principle span {
+    color: var(--muted);
+    font-size: 0.84rem;
+  }
+
+  .deep-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 24px;
+  }
+
+  .deep-links a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    padding: 7px 11px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface-raised);
+    font-size: 0.8rem;
+    font-weight: 750;
+    text-decoration: none;
+  }
+
+  .status-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+  }
+
+  .status-panel {
+    padding: clamp(22px, 4vw, 34px);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--surface);
+  }
+
+  .status-panel.now {
+    border-top: 4px solid var(--mint);
+  }
+
+  .status-panel.moving {
+    border-top: 4px solid var(--gold);
+  }
+
+  .status-panel ul {
+    display: grid;
+    gap: 14px;
+    margin: 22px 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .status-panel li {
+    position: relative;
+    padding-left: 24px;
+    color: var(--muted);
+  }
+
+  .status-panel li::before {
+    position: absolute;
+    top: 0.56em;
+    left: 2px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--mint);
+    content: "";
+  }
+
+  .status-panel.moving li::before {
+    background: var(--gold);
+  }
+
+  .status-more {
+    margin-top: 22px;
+  }
+
+  .status-more a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+  }
+
+  .install-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+  }
+
+  .install-card {
+    display: flex;
+    min-height: 210px;
+    flex-direction: column;
+    padding: 22px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+
+  .status-badge {
+    align-self: flex-start;
+    margin-bottom: auto;
+    padding: 4px 8px;
+    border: 1px solid var(--border-strong);
+    border-radius: 999px;
+    color: var(--mint);
+    font-size: 0.68rem;
+    font-weight: 900;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .status-badge.early {
+    color: var(--gold);
+  }
+
+  .install-card h3 {
+    margin-top: 28px;
+  }
+
+  .install-card p {
+    color: var(--muted);
+    font-size: 0.84rem;
+  }
+
+  .install-card a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    margin-top: auto;
+    font-size: 0.84rem;
+    font-weight: 800;
+  }
+
+  .note {
+    margin-top: 18px;
+    padding: 18px 20px;
+    border-left: 3px solid var(--gold);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    background: var(--surface-raised);
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .docs-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+  }
+
+  .doc-path {
+    display: flex;
+    min-height: 180px;
+    flex-direction: column;
+    padding: 22px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--text);
+    text-decoration: none;
+  }
+
+  .doc-path:hover {
+    border-color: var(--blue);
+    text-decoration: none;
+    transform: translateY(-2px);
+  }
+
+  .doc-path .doc-kind {
+    margin-bottom: auto;
+    color: var(--mint);
+    font-size: 0.68rem;
+    font-weight: 900;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+  }
+
+  .doc-path strong {
+    margin-top: 28px;
+    font-size: 1.08rem;
+  }
+
+  .doc-path span:last-child {
+    margin-top: 5px;
+    color: var(--muted);
+    font-size: 0.83rem;
+  }
+
+  .faq-list {
+    display: grid;
+    max-width: 900px;
+    gap: 10px;
+  }
+
+  details {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+  }
+
+  summary {
+    padding: 18px 20px;
+    cursor: pointer;
+    font-weight: 800;
+  }
+
+  details p {
+    max-width: 780px;
+    margin: 0;
+    padding: 0 20px 20px;
+    color: var(--muted);
+  }
+
+  details p a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+  }
+
+  .closing {
+    padding-block: clamp(80px, 12vw, 150px);
+    text-align: center;
+  }
+
+  .closing h2 {
+    margin-inline: auto;
+  }
+
+  .closing p {
+    max-width: 660px;
+    margin-inline: auto;
+    color: var(--muted);
+  }
+
+  .closing .actions {
+    justify-content: center;
+  }
+
+  footer {
+    padding: 30px 0 46px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+
+  .footer-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+  }
+
+  .footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .footer-links a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+  }
+
+  @media (max-width: 920px) {
+    .proof-strip {
+      grid-template-columns: 1fr 1fr;
     }
-    nav.toc .toc-label,
-    nav.toc a {
-      flex: 0 0 auto;
+
+    .proof:nth-child(3) {
+      border-top: 1px solid var(--border);
+      border-left: 0;
+    }
+
+    .proof:nth-child(4) {
+      border-top: 1px solid var(--border);
+    }
+
+    .business-paths {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    .system-map {
+      grid-template-columns: 1fr;
+    }
+
+    .system-node {
+      min-height: 190px;
+    }
+
+    .system-arrow {
+      min-height: 34px;
+      transform: rotate(90deg);
+    }
+
+    .trust-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .install-grid {
+      grid-template-columns: 1fr 1fr;
     }
   }
 
-  /* Back-to-top button */
-  a.back-top {
-    position: fixed;
-    right: 24px;
-    bottom: 24px;
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    color: var(--fg);
-    padding: 8px 12px;
-    border-radius: 999px;
-    font-size: 12px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.18);
-    opacity: 0.92;
+  @media (max-width: 680px) {
+    .page {
+      width: min(100% - 28px, var(--page));
+    }
+
+    .hero {
+      padding-top: 18px;
+    }
+
+    .brand-row {
+      margin-bottom: 72px;
+    }
+
+    .brand span,
+    .brand-links a:not(:last-child),
+    .nav-label {
+      display: none;
+    }
+
+    .brand-links {
+      gap: 10px;
+    }
+
+    .hero-copy::after {
+      top: -40px;
+      right: -220px;
+      opacity: 0.32;
+    }
+
+    .actions {
+      display: grid;
+      grid-template-columns: 1fr;
+    }
+
+    .proof-strip,
+    .card-grid,
+    .business-paths,
+    .capability-grid,
+    .status-grid,
+    .install-grid,
+    .docs-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .proof + .proof,
+    .proof:nth-child(3) {
+      border-top: 1px solid var(--border);
+      border-left: 0;
+    }
+
+    .site-nav-inner {
+      overflow-x: auto;
+    }
+
+    .nav-links {
+      padding-block: 8px;
+    }
+
+    .system-figure {
+      padding: 16px;
+    }
+
+    .trust-flow svg {
+      display: none;
+    }
+
+    .trust-flow-mobile {
+      display: grid;
+    }
+
+    .governance-rail {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .install-card,
+    .doc-path {
+      min-height: 170px;
+    }
+
+    .footer-inner {
+      align-items: flex-start;
+      flex-direction: column;
+    }
   }
-  a.back-top:hover { text-decoration: none; opacity: 1; }
+
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+      transition-duration: 0.01ms !important;
+    }
+  }
 </style>
 </head>
 <body id="top">
+<a class="skip-link" href="#main">Skip to main content</a>
+
 <header class="hero">
-  <div class="wrap">
-    <img class="hero-logo" src="assets/logos/OpenDigitalProductFactory.png" alt="Open Digital Product Factory" width="934" height="688" />
-    <h1>Open Digital Product Factory</h1>
-    <p class="lede">
-      An open AI-operated company platform that helps small teams run the business, not the software stack. You get a public website, a back office, and AI coworkers that already speak your trade &mdash; HVAC jobs, clinic visits, retail orders, member gifts, HOA requests. Edge integrations meet the tools you already use; the common workflows become simpler native capability over time. Every important action stays under your control, on your own computers.
-    </p>
-    <div class="cta-row">
-      <a class="btn primary" href="#audience">Is it for me?</a>
-      <a class="btn primary" href="/business-types/">Find your business</a>
-      <a class="btn" href="#install">Install</a>
-      <a class="btn" href="#what-it-does">What it does</a>
-      <a class="btn" href="#mobile">Mobile vision</a>
-      <a class="btn" href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory">GitHub</a>
+  <div class="page">
+    <div class="brand-row">
+      <a class="brand" href="#top" aria-label="Open Digital Product Factory documentation home">
+        <img src="assets/logos/OpenDigitalProductFactory.png" alt="" width="934" height="688" />
+        <span>Open Digital Product Factory</span>
+      </a>
+      <div class="brand-links" aria-label="Project links">
+        <a href="/user-guide/">User guide</a>
+        <a href="#install">Install</a>
+        <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory">GitHub &nearr;</a>
+      </div>
     </div>
-    <div class="hero-highlights">
-      <div class="hero-highlight">
-        <strong>Runs on your hardware</strong>
-        <span>Bundled local AI, single-org install, no data leaves your environment unless you opt in.</span>
+
+    <div class="hero-copy">
+      <p class="eyebrow">Open source &middot; local first &middot; human governed</p>
+      <h1>Run the business with AI coworkers you can inspect.</h1>
+      <p class="hero-lede">
+        DPF gives one organization a customer experience, an operating workspace, and purposed
+        AI coworkers on the same governed platform. Start from the business you run, keep
+        important actions under human authority, and retain an evidence trail of what changed.
+      </p>
+      <div class="actions">
+        <a class="button primary" href="/business-types/">Find your business</a>
+        <a class="button" href="#install">Choose an install path</a>
+        <a class="button" href="/user-guide/">Read the operator guide</a>
       </div>
-      <div class="hero-highlight">
-        <strong>Purposed AI coworkers, governed</strong>
-        <span>Role-bound helpers for setup, marketing, operations, finance, compliance, customers, and platform work.</span>
+    </div>
+
+    <div class="proof-strip" aria-label="Platform at a glance">
+      <div class="proof">
+        <strong>100+ business types</strong>
+        <span>Packaged operating patterns, not a blank canvas</span>
       </div>
-      <div class="hero-highlight">
-        <strong>Shaped to your business</strong>
-        <span>Pick what you do &mdash; the storefront, coworker vocabulary, daily boards, scheduling, and finance defaults all reshape to match. No blank-canvas setup.</span>
+      <div class="proof">
+        <strong>One organization</strong>
+        <span>A dedicated install and data boundary</span>
       </div>
-      <div class="hero-highlight">
-        <strong>Integrates at the edge, simplifies in the core</strong>
-        <span>QuickBooks, Stripe, HubSpot, ADP, Microsoft 365 and similar tools can be bridges, while DPF keeps the company primitives coherent.</span>
+      <div class="proof">
+        <strong>Local by default</strong>
+        <span>External providers and integrations are explicit choices</span>
       </div>
-      <div class="hero-highlight">
-        <strong>Autonomy with inspectable judgment</strong>
-        <span>WWMD asks the founder-kernel wiki how to resolve ambiguity, then returns a confidence-scored rationale and audit trail.</span>
+      <div class="proof">
+        <strong>Governed change</strong>
+        <span>Authority, approvals, receipts, and PR-gated platform updates</span>
       </div>
     </div>
   </div>
 </header>
 
-<nav class="toc" aria-label="In-page navigation">
-  <div class="toc-inner">
-    <span class="toc-label">Jump to</span>
-    <a href="#audience">Who it&rsquo;s for</a>
-    <a href="#market-vision">Market vision</a>
-    <a href="#find-your-business">Find your business</a>
-    <a href="#mobile">Mobile vision</a>
-    <a href="#install">Install</a>
-    <a href="#what-it-does">What it does</a>
-    <a href="#archetypes">Business catalogue</a>
-    <span class="toc-label">Going deeper</span>
-    <a href="#build-studio">Build Studio</a>
-    <a href="#autonomy-wwmd">Autonomy &amp; WWMD</a>
-    <a href="#coworkers">Coworkers</a>
-    <a href="#ai-workforce">AI workforce</a>
-    <a href="#compliance">Compliance</a>
-    <a href="#security">Security</a>
-    <a href="#governance">Governance</a>
-    <a href="#standards">Standards</a>
-    <a href="#docs">Docs</a>
-    <a href="#roadmap">Roadmap</a>
-    <a href="#faq">FAQ</a>
+<nav class="site-nav" aria-label="Documentation overview">
+  <div class="page site-nav-inner">
+    <span class="nav-label">Explore DPF</span>
+    <div class="nav-links">
+      <a href="#business">For your business</a>
+      <a href="#system">How it works</a>
+      <a href="#trust">Trust</a>
+      <a href="#install">Install</a>
+      <a href="#docs">Documentation</a>
+    </div>
   </div>
 </nav>
 
-<main class="wrap">
-
-  <div style="border:1px solid var(--border); border-left:4px solid var(--accent); border-radius:12px; padding:18px 22px; margin-bottom:44px; background:var(--surface);">
-    <div style="font-size:11px; letter-spacing:0.09em; text-transform:uppercase; font-weight:800; color:var(--accent); margin-bottom:8px;">In plain terms</div>
-    <p style="margin:0; font-size:clamp(16px,1.7vw,19px); line-height:1.45; color:var(--fg);">One install gives you a <strong style="color:var(--accent-2);">website your customers can use</strong>, a <strong style="color:var(--accent-2);">place to run the work</strong>, and <strong style="color:var(--accent-2);">AI coworkers that already speak your line of work</strong> — with every important action approved by you and kept on record. <a href="/business-types/">See it for your business &rarr;</a></p>
-  </div>
-
-  <section id="audience">
-    <h2>Who this is for</h2>
-    <p class="sub">
-      DPF is built first for the people who <strong>run a business day to day</strong> &mdash; not for a tech team. If you also build on it or resell it, that matters too. We cover that here; it just comes second. <em>All everyday copy on this site is written to a high-school reading level.</em>
+<main id="main" class="page">
+  <section id="business">
+    <span id="audience" class="anchor-alias" aria-hidden="true"></span>
+    <span id="find-your-business" class="anchor-alias" aria-hidden="true"></span>
+    <span id="archetypes" class="anchor-alias" aria-hidden="true"></span>
+    <p class="eyebrow">Begin with your operating model</p>
+    <h2>Start with the business, not the software.</h2>
+    <p class="section-intro">
+      Choose what your organization does and DPF shapes the public experience, everyday
+      vocabulary, workflows, finance assumptions, and coworker context around that choice.
+      The detailed catalogue groups more than 100 packaged business types into approachable
+      paths without exposing internal taxonomy first.
     </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Primary &middot; runs the business</div>
-        <strong>Owners &amp; operators</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Trades, clinics, salons, shops, nonprofits, property managers, town offices &mdash; people who serve customers, not set up software. The platform shows up already speaking your trade. <a href="/business-types/">Find your business &rarr;</a></p>
+
+    <div class="card-grid">
+      <article class="card">
+        <span class="label">Primary audience</span>
+        <h3>Owners and operators</h3>
+        <p>
+          Run customers, work, money, people, assets, and follow-up in one coherent workspace
+          instead of stitching together a dozen disconnected tools.
+        </p>
+      </article>
+      <article class="card">
+        <span class="label">Built-in evidence</span>
+        <h3>Regulated and licensed teams</h3>
+        <p>
+          Keep approvals, controls, obligations, evidence, and decision receipts close to the
+          work that produced them.
+        </p>
+      </article>
+      <article class="card">
+        <span class="label">Extension path</span>
+        <h3>Builders, partners, and resellers</h3>
+        <p>
+          Extend a shared platform through governed source changes. Build Studio is available,
+          but external development clients and normal pull requests remain supported paths.
+        </p>
+      </article>
+    </div>
+
+    <div class="business-paths" aria-label="Browse business types by operating pattern">
+      <a class="business-path" href="/business-types/trades-and-home-services.html">
+        <span>You go to the customer</span>
+        <strong>Trades, field service, automotive, moving</strong>
+      </a>
+      <a class="business-path" href="/business-types/clinics-and-wellness.html">
+        <span>Customers come to you</span>
+        <strong>Clinics, wellness, beauty, fitness</strong>
+      </a>
+      <a class="business-path" href="/business-types/retail-and-goods.html">
+        <span>You sell goods</span>
+        <strong>Retail, food, inventory, fulfilment</strong>
+      </a>
+      <a class="business-path" href="/business-types/nonprofits-and-community.html">
+        <span>You serve a community</span>
+        <strong>Nonprofits, HOAs, civic organizations</strong>
+      </a>
+      <a class="business-path" href="/business-types/">
+        <span>Explore the catalogue</span>
+        <strong>See every packaged business path &rarr;</strong>
+      </a>
+    </div>
+  </section>
+
+  <section id="system">
+    <span id="market-vision" class="anchor-alias" aria-hidden="true"></span>
+    <span id="what-it-does" class="anchor-alias" aria-hidden="true"></span>
+    <span id="going-deeper" class="anchor-alias" aria-hidden="true"></span>
+    <span id="data-layer" class="anchor-alias" aria-hidden="true"></span>
+    <p class="eyebrow">One install, three working surfaces</p>
+    <h2>The customer journey and the work behind it stay connected.</h2>
+    <p class="section-intro">
+      DPF is not a chat box beside a collection of apps. It is a shared operating model where
+      customer activity, internal work, and governed coworker assistance meet the same company
+      primitives and authority rules.
+    </p>
+
+    <figure class="system-figure" aria-labelledby="system-map-title">
+      <div id="system-map-title" class="eyebrow">How value moves through the platform</div>
+      <div class="system-map">
+        <div class="system-node">
+          <span class="node-number" aria-hidden="true">01</span>
+          <h3>Customer experience</h3>
+          <p>Discover, request, book, buy, pay, track, and communicate through a business-shaped public surface.</p>
+        </div>
+        <div class="system-arrow" aria-hidden="true">&rarr;</div>
+        <div class="system-node">
+          <span class="node-number" aria-hidden="true">02</span>
+          <h3>Operating workspace</h3>
+          <p>Turn demand into owned work across customers, money, people, assets, knowledge, and compliance.</p>
+        </div>
+        <div class="system-arrow" aria-hidden="true">&rarr;</div>
+        <div class="system-node">
+          <span class="node-number" aria-hidden="true">03</span>
+          <h3>Purposed AI coworkers</h3>
+          <p>Gather context, draft, reconcile, route, and prepare decisions within role, route, and tool authority.</p>
+        </div>
       </div>
-      <div class="pillar">
-        <div class="tag">Primary &middot; audit built in</div>
-        <strong>Regulated &amp; licensed businesses</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Health care, banks and credit unions, town and police offices, security firms. The sign-offs, notices, proof, and &lsquo;no&rsquo; answers a regulated business needs are built in &mdash; not bolted on.</p>
+      <div class="governance-rail" aria-label="Rules shared by every surface">
+        <span>One company vocabulary</span>
+        <span>One authority model</span>
+        <span>One evidence trail</span>
+        <span>One governed change path</span>
       </div>
-      <div class="pillar">
-        <div class="tag" style="color:var(--fg-muted);">Secondary</div>
-        <strong>IT &amp; operations leaders</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">One trusted platform to map your systems, manage your products, and track work in step &mdash; on your own computers, with AI as a first-class, logged team member.</p>
+      <figcaption>
+        The arrows show operating flow, not unrestricted automation. Consequential actions still
+        pass through capability checks, risk policy, human approval where required, and audit.
+      </figcaption>
+    </figure>
+
+    <div class="capability-grid" aria-label="Core operating capabilities">
+      <div class="capability">
+        <strong>Customers and demand</strong>
+        <p>Accounts, engagement, pipeline, quotes, orders, campaigns, and the next action.</p>
       </div>
-      <div class="pillar">
-        <div class="tag" style="color:var(--fg-muted);">Tertiary</div>
-        <strong>Builders, contractors &amp; resellers</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Developers, partners and resellers who extend the platform in Build Studio, contribute upstream, or package it for clients. See how partners <a href="/business-types/#archetype-engine">package and resell a vertical</a>, DPF&rsquo;s <a href="/architecture/agent-standards-dpf-conformance">TAK / GAID standards posture</a>, and the deep technical detail in <a href="#what-it-does">What it does</a> below.</p>
+      <div class="capability">
+        <strong>Work and delivery</strong>
+        <p>Portfolios, products, epics, backlog, schedules, operating cases, and ownership.</p>
+      </div>
+      <div class="capability">
+        <strong>Money and assets</strong>
+        <p>Budgets, costs, invoices, inventory, fulfilment, and lifecycle context.</p>
+      </div>
+      <div class="capability">
+        <strong>People and authority</strong>
+        <p>Human roles, coworker identities, grants, delegation, approvals, and escalation.</p>
+      </div>
+      <div class="capability">
+        <strong>Knowledge and decisions</strong>
+        <p>Source-traced company context, professional guidance, principles, and decision history.</p>
+      </div>
+      <div class="capability">
+        <strong>Compliance and evidence</strong>
+        <p>Obligations, controls, proof, posture, licensing readiness, and chain of custody.</p>
       </div>
     </div>
   </section>
 
-  <section id="find-your-business">
-    <h2>Find your business</h2>
-    <p class="sub">
-      DPF isn&rsquo;t a blank tool you configure for weeks. Pick what you do and the whole platform &mdash; your public storefront, the words your AI coworkers use, your scheduling, your finances, your compliance defaults &mdash; reshapes itself to match. Here are the businesses we ship for, grouped by <em>how you actually operate</em> rather than by industry jargon.
+  <section id="trust">
+    <span id="coworkers" class="anchor-alias" aria-hidden="true"></span>
+    <span id="ai-workforce" class="anchor-alias" aria-hidden="true"></span>
+    <span id="autonomy-wwmd" class="anchor-alias" aria-hidden="true"></span>
+    <span id="identity" class="anchor-alias" aria-hidden="true"></span>
+    <span id="observability" class="anchor-alias" aria-hidden="true"></span>
+    <span id="compliance" class="anchor-alias" aria-hidden="true"></span>
+    <span id="security" class="anchor-alias" aria-hidden="true"></span>
+    <span id="hive-mind" class="anchor-alias" aria-hidden="true"></span>
+    <span id="mcp" class="anchor-alias" aria-hidden="true"></span>
+    <span id="roles" class="anchor-alias" aria-hidden="true"></span>
+    <span id="privacy" class="anchor-alias" aria-hidden="true"></span>
+    <span id="standards" class="anchor-alias" aria-hidden="true"></span>
+    <span id="governance" class="anchor-alias" aria-hidden="true"></span>
+    <p class="eyebrow">Autonomy is earned, not assumed</p>
+    <h2>A coworker can recommend. Authority still decides what happens.</h2>
+    <p class="section-intro">
+      DPF treats human identity, coworker identity, tool authority, and evidence as one system.
+      The model can help reason about work; it does not gain permission merely because a user
+      asked in natural language.
     </p>
-    <div class="grid">
-      <a class="card" style="display:block;" href="/business-types/#g-field">
-        <h3>You go to the customer &rarr;</h3>
-        <p><strong style="color:var(--accent-2);">Field &amp; dispatch.</strong> Trades &amp; home services, automotive, moving &amp; logistics, security. A technician or crew travels to the job.</p>
-      </a>
-      <a class="card" style="display:block;" href="/business-types/#g-book">
-        <h3>Customers come to you &rarr;</h3>
-        <p><strong style="color:var(--accent-2);">Appointments.</strong> Clinics &amp; wellness, beauty, pet services, fitness, education &amp; training. The calendar is the product.</p>
-      </a>
-      <a class="card" style="display:block;" href="/business-types/#g-sell">
-        <h3>You sell goods &rarr;</h3>
-        <p><strong style="color:var(--accent-2);">Catalogue &amp; orders.</strong> Retail &amp; goods, food &amp; hospitality. Browse, cart, checkout, fulfil &mdash; without dropping the sale.</p>
-      </a>
-      <a class="card" style="display:block;" href="/business-types/#g-members">
-        <h3>You serve members &amp; community &rarr;</h3>
-        <p><strong style="color:var(--accent-2);">Members &amp; regulated.</strong> Nonprofits &amp; co-ops, HOAs, public sector &amp; civic, banking &amp; credit unions. A trust gate comes first; money is a receipt or a statutory fee.</p>
-      </a>
-      <a class="card" style="display:block;" href="/business-types/#g-build">
-        <h3>You rent, build &amp; advise &rarr;</h3>
-        <p><strong style="color:var(--accent-2);">Projects &amp; rentals.</strong> Equipment &amp; storage rental, home building, professional services, software. Value delivered over time under a scope or agreement.</p>
-      </a>
-      <a class="card" style="display:block; border-style:dashed;" href="/business-types/">
-        <h3>See all 21 &rarr;</h3>
-        <p>Every business type gets its own page &mdash; the value we deliver, the problems we solve, a business-model diagram, and the capabilities. <strong>Explore the full catalogue.</strong></p>
-      </a>
+
+    <div class="trust-layout">
+      <figure class="trust-flow" aria-labelledby="trust-flow-title trust-flow-desc">
+        <svg viewBox="0 0 760 500" role="img">
+          <title id="trust-flow-title">Governed coworker action flow</title>
+          <desc id="trust-flow-desc">
+            A user request enters an authority gate. Allowed work reaches a purposed coworker.
+            Low-risk actions can execute under policy; consequential actions pause for human
+            approval. Every outcome writes an audit receipt.
+          </desc>
+          <defs>
+            <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+              <path d="M0,0 L0,6 L9,3 z" fill="currentColor"></path>
+            </marker>
+          </defs>
+          <g fill="none" stroke="var(--border-strong)" stroke-width="2">
+            <rect x="30" y="34" width="210" height="94" rx="18" fill="var(--surface-raised)"></rect>
+            <rect x="275" y="34" width="210" height="94" rx="18" fill="var(--surface-raised)"></rect>
+            <rect x="520" y="34" width="210" height="94" rx="18" fill="var(--surface-raised)"></rect>
+            <rect x="150" y="218" width="210" height="94" rx="18" fill="var(--surface-raised)"></rect>
+            <rect x="400" y="218" width="210" height="94" rx="18" fill="var(--surface-raised)"></rect>
+            <rect x="275" y="398" width="210" height="70" rx="18" fill="var(--surface-raised)"></rect>
+          </g>
+          <g fill="none" stroke="var(--blue)" stroke-width="3" marker-end="url(#arrow)">
+            <path d="M240 81 H268"></path>
+            <path d="M485 81 H513"></path>
+            <path d="M625 128 V170 Q625 190 605 190 H275 Q255 190 255 211"></path>
+            <path d="M360 265 H393"></path>
+            <path d="M505 312 V360 Q505 380 485 380 H400 Q380 380 380 391"></path>
+          </g>
+          <g fill="var(--text)" font-family="Segoe UI, Arial, sans-serif" text-anchor="middle">
+            <text x="135" y="72" font-size="17" font-weight="700">User intent</text>
+            <text x="135" y="98" fill="var(--muted)" font-size="13">request and context</text>
+            <text x="380" y="72" font-size="17" font-weight="700">Authority gate</text>
+            <text x="380" y="98" fill="var(--muted)" font-size="13">role &cap; grant &cap; policy</text>
+            <text x="625" y="72" font-size="17" font-weight="700">Purposed coworker</text>
+            <text x="625" y="98" fill="var(--muted)" font-size="13">bounded tools and scope</text>
+            <text x="255" y="256" font-size="17" font-weight="700">Risk decision</text>
+            <text x="255" y="282" fill="var(--muted)" font-size="13">act, propose, escalate, defer</text>
+            <text x="505" y="256" font-size="17" font-weight="700">Human approval</text>
+            <text x="505" y="282" fill="var(--muted)" font-size="13">when impact requires it</text>
+            <text x="380" y="427" font-size="17" font-weight="700">Outcome + receipt</text>
+            <text x="380" y="451" fill="var(--muted)" font-size="13">who, what, why, authority, result</text>
+          </g>
+        </svg>
+        <ol class="trust-flow-mobile" aria-label="Governed coworker action flow">
+          <li><strong>User intent</strong><span>request and context</span></li>
+          <li><strong>Authority gate</strong><span>role &cap; grant &cap; policy</span></li>
+          <li><strong>Purposed coworker</strong><span>bounded tools and scope</span></li>
+          <li><strong>Risk decision</strong><span>act, propose, escalate, or defer</span></li>
+          <li><strong>Human approval</strong><span>when impact requires it</span></li>
+          <li><strong>Outcome and receipt</strong><span>who, what, why, authority, and result</span></li>
+        </ol>
+        <figcaption>
+          The same authority and evidence model applies to in-product coworkers, screen actions,
+          Build Studio work, and external clients using the platform&rsquo;s MCP tools.
+        </figcaption>
+      </figure>
+
+      <div class="trust-principles">
+        <div class="principle">
+          <strong>Default deny</strong>
+          <span>A tool is unavailable until both the coworker grant and the acting user&rsquo;s capability allow it.</span>
+        </div>
+        <div class="principle">
+          <strong>Risk raises the human surface</strong>
+          <span>High-impact work pauses for an explicit proposal, approval, escalation, or refusal.</span>
+        </div>
+        <div class="principle">
+          <strong>Identity survives delegation</strong>
+          <span>The user, coworker, delegated authority, tool call, and result remain linked.</span>
+        </div>
+        <div class="principle">
+          <strong>Judgment is inspectable</strong>
+          <span>Principles, company knowledge, and professional sources support explainable decisions.</span>
+        </div>
+      </div>
     </div>
-    <div class="note" style="margin-top:14px;">
-      Twenty-one market categories and 95 ready archetypes ship in the box. Don&rsquo;t see an exact match? They&rsquo;re starting points &mdash; setup adapts further to your specifics, and your coworkers keep tailoring as you go.
+
+    <div class="deep-links" aria-label="Trust and architecture deep dives">
+      <a href="/architecture/trusted-ai-kernel">Trusted AI Kernel</a>
+      <a href="/architecture/GAID">Agent identity and governance</a>
+      <a href="/architecture/agent-standards-dpf-conformance">Standards conformance</a>
+      <a href="/user-guide/platform/identity-and-access">Identity and access guide</a>
+      <a href="/user-guide/compliance/">Compliance guide</a>
+      <a href="/user-guide/ai-workforce/">AI workforce guide</a>
     </div>
   </section>
 
-  <section id="mobile">
-    <h2>The mobile app &mdash; the vision</h2>
-    <p class="sub">
-      Today DPF runs in the browser on your own hardware. The next frontier is mobile &mdash; and we want to be honest about where it stands.
+  <section id="maturity">
+    <span id="build-studio" class="anchor-alias" aria-hidden="true"></span>
+    <span id="mobile" class="anchor-alias" aria-hidden="true"></span>
+    <span id="moving" class="anchor-alias" aria-hidden="true"></span>
+    <span id="roadmap" class="anchor-alias" aria-hidden="true"></span>
+    <p class="eyebrow">Honest product posture</p>
+    <h2>Useful now, still becoming more complete.</h2>
+    <p class="section-intro">
+      DPF is an active open-source platform. The overview separates working platform contracts
+      from areas still being hardened or verified, so a vision statement is not mistaken for
+      current product behavior.
     </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">The vision</div>
-        <strong>One app that becomes your business.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A single native iOS/Android app (published by Arcamanus&nbsp;LLC) that connects to your own install and lets the platform drive its look and features. A field technician sees the next job, navigates to the address, captures photos and a signature, and raises the invoice on-site &mdash; even offline. An owner gets a ping when a coworker pauses for a high-risk approval, and can approve from a phone. Customers get a branded app to book, track, and pay.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">What exists today</div>
-        <strong>The foundation is real and in the codebase.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A React&nbsp;Native / Expo app shell, a REST API, secure sign-in, and an offline-capable form-and-screen renderer are already built, with an end-to-end test harness. The platform-drives-the-app contract is designed and roughly 60% of its substrate already exists in DPF.</p>
-      </div>
-    </div>
-    <div class="note" style="margin-top:14px;">
-      <strong>Not yet available.</strong> The end-user experience &mdash; persona-aware screens, connecting one app to <em>any</em> install, push notifications, and App&nbsp;Store / Play delivery &mdash; is the next phase and is not shipped today. We&rsquo;re building toward field dispatch and owner approvals first; customer-facing surfaces follow. Every business page flags how mobile will help that specific trade.
+
+    <div class="status-grid">
+      <article class="status-panel now">
+        <p class="eyebrow">Implemented now</p>
+        <h3>Working platform contracts</h3>
+        <ul>
+          <li>Single-organization, local-first deployment with a public site and internal operating workspace.</li>
+          <li>More than 100 packaged business types with business-shaped vocabulary and defaults.</li>
+          <li>Purposed coworker registry, governed tool execution, approvals, and audit evidence.</li>
+          <li>Portfolio, backlog, customer, workforce, finance, compliance, knowledge, and platform operations.</li>
+          <li>Build Studio as a governed development and evidence surface, alongside supported external contributor paths.</li>
+          <li>Self-upgrade, recovery, CI, migration, and pull-request contracts for platform change.</li>
+        </ul>
+      </article>
+      <article class="status-panel moving">
+        <p class="eyebrow">Still moving</p>
+        <h3>Active maturity work</h3>
+        <ul>
+          <li>The native mobile companion is a documented direction, not a generally available application.</li>
+          <li>Native Linux and cloud single-VM installers remain early access pending broader real-host evidence.</li>
+          <li>Build Studio continues to improve reliability, right-sized workflow, and autonomous phase handoff.</li>
+          <li>Public and federated agent identity profiles remain a standards and interoperability journey.</li>
+          <li>Individual integrations advertise capability support; unsupported operations must remain explicit.</li>
+        </ul>
+        <p class="status-more">
+          <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues">Inspect open work on GitHub &rarr;</a>
+        </p>
+      </article>
     </div>
   </section>
 
   <section id="install">
-    <h2>Install</h2>
-    <p class="sub">
-      Windows and macOS are generally available (GA); native Linux and Cloud Single-VM are in early access. Whichever you pick, the installer asks a single question &mdash; <strong>Ready to go</strong> (pre-built images; extend the platform with Build Studio inside the portal) or <strong>Customizable</strong> (full source; Build Studio and your editor work from the same workspace) &mdash; and handles everything else: container runtime, hardware detection, AI model selection, credential generation, and auto-start. Use Customizable for serious source edits while Build Studio hardening continues. Expect 5&ndash;10 minutes for the platform itself, plus additional time for the initial AI model download; login credentials are shown at the end and saved to <code>.admin-credentials</code> in your install directory.
+    <p class="eyebrow">Deployment choices</p>
+    <h2>Pick the host that matches your evidence tolerance.</h2>
+    <p class="section-intro">
+      Windows and Apple Silicon macOS are generally available. Native Linux and cloud
+      single-VM paths are available for early adopters and need broader host verification
+      before graduation. Each path preserves the same canonical platform contracts.
     </p>
-    <div class="install">
-      <h3>Windows 10 / 11 &mdash; GA</h3>
-      <p style="color:var(--fg-muted); margin:6px 0 10px; font-size:14px;">The PowerShell installer clones the repo for you. Open PowerShell and paste one snippet.</p>
-      <pre><code># With the GitHub CLI
-gh api repos/OpenDigitalProductFactory/opendigitalproductfactory/contents/install-dpf.ps1 -H "Accept: application/vnd.github.raw" &gt; install-dpf.ps1
-powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
-      <pre><code># Without the GitHub CLI
-iwr https://raw.githubusercontent.com/OpenDigitalProductFactory/opendigitalproductfactory/main/install-dpf.ps1 -OutFile install-dpf.ps1
-powershell -ExecutionPolicy Bypass -File install-dpf.ps1</code></pre>
-    </div>
-    <div class="install" style="margin-top:18px;">
-      <h3>macOS Apple Silicon &mdash; GA</h3>
-      <p style="color:var(--fg-muted); margin:6px 0 10px; font-size:14px;">Validated end-to-end on real Apple Silicon (M-series, macOS 14+), including the voice STT + native-host TTS path. The Unix installer sources helper libraries from inside the repo, so clone first.</p>
-      <pre><code>git clone https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git
-cd opendigitalproductfactory
-bash install-dpf.sh</code></pre>
-      <div class="note">
-        See the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/install/macos.md">macOS install guide</a> (including voice setup). After installation: <code>dpf-start</code> to start, <code>dpf-stop</code> to stop.
-      </div>
-    </div>
-    <div class="note" style="margin-top:14px;">
-      <strong>Native Linux &amp; Cloud Single-VM (AWS / GCP / Azure) &mdash; early access, pilots wanted:</strong> both installers (Terraform modules included for the cloud path) are code-complete on <code>main</code> with green CI; real-hardware verification reports are what graduate them from Early Access to GA. See the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/README.md#quick-install">Quick Install table</a> and the per-platform runbooks under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/install">docs/install/</a>.
-    </div>
-    <div class="note" style="margin-top:14px;">
-      <strong>Releases &amp; versions:</strong> each stable version is published on the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/releases">Releases page</a> with a changelog and downloadable source archives. The installers above remain the recommended path &mdash; Releases are where you see what changed between versions and grab a specific one.
-    </div>
-  </section>
 
-  <section>
-    <h2>Recommended hardware</h2>
-    <p class="sub">
-      The platform supports a broad range of hardware, but the experience changes depending on whether you want simple evaluation, day-to-day local AI, or sandbox-heavy self-building. The installer detects your CPU, RAM, and GPU and picks an appropriate local model automatically &mdash; you do not need to size anything by hand.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:26%;">Tier</th><th>CPU</th><th>RAM</th><th>Storage</th><th>GPU</th><th>Best for</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>Minimum viable</strong></td>
-          <td>Modern 4 cores</td>
-          <td>16 GB</td>
-          <td>50&ndash;100 GB SSD</td>
-          <td>None required</td>
-          <td>Evaluation, administration, and external-provider-first usage</td>
-        </tr>
-        <tr>
-          <td><strong>Recommended</strong></td>
-          <td>8+ cores</td>
-          <td>32 GB</td>
-          <td>100&ndash;200 GB NVMe SSD</td>
-          <td>Optional, 8&ndash;12 GB VRAM</td>
-          <td>Small-team use, local-first AI, moderate sandbox iteration</td>
-        </tr>
-        <tr>
-          <td><strong>Self-building</strong></td>
-          <td>12+ cores</td>
-          <td>64 GB+</td>
-          <td>200+ GB NVMe SSD</td>
-          <td>16 GB+ VRAM</td>
-          <td>Frequent sandbox launches, heavier local models, tighter iteration</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      For the full deployment picture &mdash; container topology, the local-AI model selection table, and the monitoring stack &mdash; see <a href="/architecture/platform-overview">architecture/platform-overview</a>.
-    </p>
-  </section>
-
-  <section>
-    <h2>What this page is</h2>
-    <p class="sub">
-      You can explore the platform's documentation here without installing anything. The full user guide, architecture references, and standards documents are kept inside the repository so they stay in lock-step with the running code; this page is a curated entry point that links into them.
-    </p>
-    <div class="grid">
-      <div class="card">
-        <h3>User Guide</h3>
-        <p>Day-to-day operating guidance for everyone who uses the platform &mdash; market archetypes, getting started, AI coworkers, Build Studio, Edge Nodes, wiki, managed documents, compliance, finance, HR, customers, and more.</p>
-      </div>
-      <div class="card">
-        <h3>Architecture &amp; Standards</h3>
-        <p>The Trusted AI Kernel (TAK), Global AI Agent Identification and Governance (GAID), the white paper, and the platform's own conformance assessment.</p>
-      </div>
-      <div class="card">
-        <h3>Specifications &amp; Plans</h3>
-        <p>Long-form design specs that record how each capability was built. Useful as historical context, not as onboarding material.</p>
-      </div>
-    </div>
-  </section>
-
-  <section>
-    <h2>Why the platform exists</h2>
-    <p class="sub">
-      Enterprise software for portfolio management, enterprise architecture, backlog tracking, and lifecycle governance has traditionally been locked behind expensive platforms that require dedicated teams to operate. Capable AI agents change that economics: the know-how of those professionals can be commoditized into a limitless workforce, as long as governance keeps humans in the loop.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Premise</div>
-        <strong>AI agents are first-class participants.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Every screen has a context-aware AI coworker. Every action they propose flows through human-in-the-loop governance. Every decision is audit-logged.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Sovereignty</div>
-        <strong>Runs on your hardware.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A built-in local AI engine ships with the platform, so no data leaves your environment unless you opt into an external provider.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Direction</div>
-        <strong>A platform that grows from within.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Build Studio is the governed self-development surface: it drafts, records evidence, and prepares changes through review gates. Complex source work can still use VS Code in customizable installs while Build Studio continues hardening.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Hive Mind</div>
-        <strong>Opt-in community sharing.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Each install is a node. You can share what you build with the community and pull in what others have built. Sharing is always opt-in.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="market-vision">
-    <h2>Run the company, not the software stack</h2>
-    <p class="sub">
-      Most small and mid-sized companies are forced to stitch together accounting, payroll, CRM, support, identity, payments, work management, documents, and vertical tools. The owner or employee becomes the integration layer. DPF&rsquo;s market thesis is different: connect at the edge where a company already depends on outside systems, then absorb the repeatable company-running workflows into one governed native core.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Market</div>
-        <strong>AI changes the operating model.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The opportunity is not another app with an AI chat box. It is a company platform where AI coworkers handle the work around the work: context gathering, routing, drafting, reconciliation, evidence, follow-up, and decision preparation.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Competitors</div>
-        <strong>The ecosystem becomes the benchmark.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Workday, QuickBooks, WorkOS, Stripe, Plaid, HubSpot, Zendesk, Slack, Asana, Gusto, ADP, Shopify, Xero and others show the capability map. DPF should bridge them first, then native-build the common workflows when doing so removes complexity for many installs.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Architecture</div>
-        <strong>Shared company primitives beat brittle integrations.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">DPF organizes around Party, Work, Money, Asset, Knowledge, and Authority primitives. Adapters feed those primitives; AI operates over them; humans approve high-impact actions; receipts remain inspectable.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Ecosystem</div>
-        <strong>Missing functionality should compound.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">When one install needs a missing workflow, the goal is to build it, generalize it, merge it, and let the next company benefit &mdash; not leave it as a private one-off integration.</p>
-      </div>
-    </div>
-    <p class="note" style="margin-top:14px;">
-      Strategy detail: <a href="/marketing/dpf-market-vision">DPF Market Vision</a> explains the market, competitor map, adapter-to-native strategy, roadmap priorities, and current-state guardrails.
-    </p>
-  </section>
-
-  <section id="what-it-does">
-    <h2>What you can do with it</h2>
-    <p class="sub">A condensed view of the capability surface. Each capability has its own section in the user guide. Capabilities are aligned to the IT4IT v3.0.1 value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate) so governance and lifecycle stay in lock-step with how the rest of your IT estate is modelled.</p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:32%;">Capability</th><th>What it is for</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>Portfolio Management</td><td>Organize digital products into portfolios with health metrics, investment tracking, and lifecycle management.</td></tr>
-        <tr><td>HR &amp; Workforce</td><td>Manage employees, roles, reviews, timesheets, and organizational structure. The same role hierarchy (HR-000 through HR-500) drives platform access.</td></tr>
-        <tr><td>Customer Relationships &amp; CRM</td><td>Track customer accounts and engagement history through a low-friction, Pipedrive-inspired visual pipeline with visible next actions &mdash; a customer-acquisition loop from lead to qualify to opportunity to quote/order/campaign.</td></tr>
-        <tr><td>Compliance &amp; Regulatory</td><td>Onboard regulations and standards, map controls to obligations, collect evidence, track posture, and manage licensing readiness.</td></tr>
-        <tr><td>Financial Management</td><td>Invoices, suppliers and bills, purchase orders, banking and reconciliation, AI-spend visibility.</td></tr>
-        <tr><td>Enterprise Architecture</td><td>Model the application, technology, and business layers with ArchiMate notation; graph-backed via Neo4j.</td></tr>
-        <tr><td>Archetype-led portal</td><td>Public-facing storefront or service portal plus internal vocabulary for the selected business type. Driven by an archetype that seeds sections, flows, item templates, finance assumptions, marketing posture, and worker-home direction.</td></tr>
-        <tr><td>Internal workspace homes</td><td>Archetype-driven daily boards for the people doing the work &mdash; dispatch boards for trades, appointment-readiness for clinics, merchandising for retail &mdash; rendered from a reusable primitive library and a projection service that speaks worker vocabulary (jobs, technicians, sites, handoffs) rather than platform jargon.</td></tr>
-        <tr><td>Partner &amp; reseller channel</td><td>Activate a reseller, distributor, MSP, or technology-partner program when the business model calls for it. Support is derived from the archetype&rsquo;s operating-model axes (rather than per-archetype flags) and can be turned on at setup or later from admin.</td></tr>
-        <tr><td>Marketing execution loop</td><td>Draft &rarr; approve &rarr; publish &rarr; respond &rarr; measure for outbound marketing across LinkedIn posts, LinkedIn Ads, and email &mdash; with hard spend ceilings, per-send human approval, and a bounded autopilot scheduler. Every external publish is gated and audited.</td></tr>
-        <tr><td>Coworker screen actions</td><td>Coworkers can read what a screen offers (via a screen manifest) and propose on-screen actions on your behalf. Destructive actions flow through a propose &rarr; approve &rarr; dispatch envelope so the coworker drives the real UI under the same human-in-the-loop gates as a button click.</td></tr>
-        <tr><td>Organization knowledge corpus (WWWD)</td><td>A governed, org-scoped knowledge base built from onboarding context, uploaded business documents, Q&amp;A, and approved AI research. Everything enters draft-by-default with provenance and trust grading; reviewed material feeds the WWMD decision gate and coworker recall.</td></tr>
-        <tr><td>Profession corpus (WSID)</td><td>The third decision scope: a per-role professional body of knowledge (DAMA-DMBOK, GAAP, the marketing canon&hellip;) so each coworker&rsquo;s craft judgment is source-traced and audited rather than improvised by the underlying model.</td></tr>
-        <tr><td>Build Studio</td><td>A guided five-phase pipeline (ideate, plan, build, review, ship) with AI coworkers, sandbox execution, code intelligence, impact reports, and promotion or PR handoff where configured. Active hardening is underway for oversized-build decomposition and safer portal upgrades.</td></tr>
-        <tr><td>Operations &amp; Backlog</td><td>Manage delivery work with epics, items, priorities, and status tracking. Coworkers create, triage, size, and link items through governed MCP tools.</td></tr>
-        <tr><td>AI Workforce</td><td>Provider configuration, dynamic model discovery, capability-tier routing, operations map, capacity continuity, capability-needs review, agent registry, and per-agent grants.</td></tr>
-        <tr><td>Autonomy &amp; WWMD</td><td>Decision Perspective Gate for ambiguity: wiki retrieval, principle-vector scoring, risk and confidence guardrails, outcome ledger, and escalation or deferral when the platform should learn before acting.</td></tr>
-        <tr><td>Wiki &amp; Managed Documents</td><td>Governed platform knowledge, founder-kernel principles, source citations, linting, maintained documents, versions, references, and publication state.</td></tr>
-        <tr><td>Edge Node</td><td>Host-resident trust and discovery component with enrollment, operator approval, heartbeat freshness, local collectors, and multi-host/air-gapped runbooks.</td></tr>
-        <tr><td>Identity &amp; Federation</td><td>LDAP, Active Directory, and Microsoft Entra federation for sign-in and directory bootstrap; the platform remains the source of truth for roles, route bundles, and coworker associations.</td></tr>
-        <tr><td>Common Skills Library</td><td>A registry of reusable, role-bound AI skills (<code>.skill.md</code> files) declaring tools, triggers, risk band, and which coworkers can invoke them.</td></tr>
-        <tr><td>Agent Interoperability</td><td>Internal coworker runtime structured around an A2A-aligned task envelope; MCP (Model Context Protocol) for tool and context interoperability.</td></tr>
-        <tr><td>Observability &amp; Evidence</td><td>Full-stack monitoring &mdash; Prometheus metrics plus Loki/Alloy container-log aggregation with real-time error-storm and novel-signature detection. Every signal (metric, log, crash, user report) converges into one deduped issue inbox, auto-triaged to the backlog and reflected on a shell-nav health dot. Plus an append-only authorization decision log and chain-of-custody traces linking principal, agent, tool call, approval, and outcome.</td></tr>
-        <tr><td>Hive Mind</td><td>Opt-in cross-install contribution: features built locally can be reviewed, parameterized, and shared so the next install gets them out of the box.</td></tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section>
-    <h2>Themes that shape the experience</h2>
-    <p class="sub">
-      Beyond a list of features, four themes shape what working on the platform feels like day-to-day. Each is a deliberate design stance, not just a checkbox.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Onboarding</div>
-        <strong>An AI COO greets you on first run.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled local AI (Docker Model Runner) starts before the platform does, so an <em>onboarding-coo</em> coworker can introduce itself, explain provider options in plain language, and walk you through identity, branding, and finance setup using the real settings pages &mdash; not a throwaway wizard. Honest about its own limitations (it&rsquo;s running on a local 8B model), interruptible, and resumable.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Archetypes</div>
-        <strong>Pick a market archetype &mdash; the platform reshapes itself.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Twenty-one market categories and 95 leaf archetype templates ship with the platform &mdash; spanning small-business services through banking and credit unions, civic bodies (municipalities, utilities, law enforcement), rental/shared-asset operators, media, live events, field dispatch, and more. Choosing one bootstraps the customer portal, vocabulary, booking and form rules, finance assumptions, marketing posture, and internal worker-home direction. The archetype is the single source of truth for industry; downstream surfaces read from it rather than from a separately editable string.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Common Skills</div>
-        <strong>Coworkers share a registry of role-bound skills.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Skills are declared as <code>.skill.md</code> files with frontmatter for required tools, triggers, risk band, and which coworkers can invoke them. They are seeded idempotently and gated by the same grant model as every other tool call &mdash; default-deny, audit-logged.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Self-improvement</div>
-        <strong>Every coworker has an improvement loop.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Responses are scored. Conventions are accumulated. Stable conventions graduate into codified tools. Build features go through a Reusability Check at design time so domain-specific instances get parameterized for the hive mind, not hard-coded.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="archetypes">
-    <h2>The full business catalogue</h2>
-    <p class="sub">
-      Twenty-one market categories and 95 ready archetypes ship in the box. Each card opens a dedicated page with that business&rsquo;s model, a value-stream diagram, the problems we solve, and the capabilities we provide. Pick what you do and the platform reshapes itself &mdash; storefront, vocabulary, scheduling, finance, and compliance defaults all follow. <a href="/business-types/">Browse the grouped catalogue &rarr;</a>
-    </p>
-    <p class="sub" style="font-size:13px; margin-top:-8px;">
-      <em>For builders &amp; resellers:</em> internally each is a market <strong>archetype</strong> &mdash; the bootstrap mechanism and single source of truth for industry that every downstream surface reads from. It also drives internal <strong>workspace homes</strong> (dispatch boards for trades, appointment-readiness for clinics, merchandising for retail). <strong>Detailed guide:</strong> <a href="/user-guide/market-archetypes">market-archetypes</a>.
-    </p>
-    <div class="grid">
-      <a class="card" style="display:block;" href="/business-types/clinics-and-wellness.html"><h3>Healthcare &amp; Wellness &rarr;</h3><p>Clinics, practitioners, wellness providers; appointment-centric flows.</p></a>
-      <a class="card" style="display:block;" href="/business-types/beauty-and-personal-care.html"><h3>Beauty &amp; Personal Care &rarr;</h3><p>Salons, spas, stylists; service menus, booking, deposits.</p></a>
-      <a class="card" style="display:block;" href="/business-types/trades-and-home-services.html"><h3>Trades &amp; Maintenance &rarr;</h3><p>Plumbing, electrical, HVAC, handywork; quote-and-job workflows.</p></a>
-      <a class="card" style="display:block;" href="/business-types/professional-services.html"><h3>Professional Services &rarr;</h3><p>Consultancies, advisors, agencies; engagements, retainers, deliverables.</p></a>
-      <a class="card" style="display:block;" href="/business-types/software-and-platforms.html"><h3>Software Platform &rarr;</h3><p>Software products and SaaS; subscription, releases, support.</p></a>
-      <a class="card" style="display:block;" href="/business-types/education-and-training.html"><h3>Education &amp; Training &rarr;</h3><p>Schools, training providers, coaches; cohorts, enrollment, certification.</p></a>
-      <a class="card" style="display:block;" href="/business-types/pet-services.html"><h3>Pet Services &rarr;</h3><p>Vets, groomers, trainers, boarding; pet records and visit history.</p></a>
-      <a class="card" style="display:block;" href="/business-types/food-and-hospitality.html"><h3>Food &amp; Hospitality &rarr;</h3><p>Restaurants, caterers, hosts; menus, reservations, events.</p></a>
-      <a class="card" style="display:block;" href="/business-types/retail-and-goods.html"><h3>Retail &amp; Goods &rarr;</h3><p>Retailers and product sellers; inventory, orders, fulfillment. Includes a B2B wholesale-distribution leaf that derives a partner/reseller program.</p></a>
-      <a class="card" style="display:block;" href="/business-types/fitness-and-recreation.html"><h3>Fitness &amp; Recreation &rarr;</h3><p>Gyms, studios, leagues; memberships, classes, attendance.</p></a>
-      <a class="card" style="display:block;" href="/business-types/nonprofits-and-community.html"><h3>Nonprofit &amp; Community &rarr;</h3><p>Charities, associations, community groups; donations, programs, volunteers.</p></a>
-      <a class="card" style="display:block;" href="/business-types/hoa-and-property-management.html"><h3>HOA &amp; Property Management &rarr;</h3><p>Homeowners associations and property managers; residents, dues, violations.</p></a>
-      <a class="card" style="display:block;" href="/business-types/banking-and-credit-unions.html"><h3>Banking &amp; Financial Services &rarr;</h3><p>Community banks, credit unions, mortgage lending; BIAN-grounded, with jurisdiction-specific regulatory governance and member-equity for credit unions.</p></a>
-      <a class="card" style="display:block;" href="/business-types/public-sector-and-civic.html"><h3>Public Sector &amp; Civic &rarr;</h3><p>Small-town municipalities, municipal utilities (water/electric), law enforcement; resident and ratepayer skins, open-meetings governance, records requests, and 311 service routing.</p></a>
-      <a class="card" style="display:block;" href="/business-types/equipment-and-storage-rental.html"><h3>Rental &amp; Shared Assets &rarr;</h3><p>Equipment and tool rental, self-storage, and agricultural shared-machinery co-ops; the reserve &rarr; use &rarr; return &amp; inspect &rarr; re-pool value stream over a pooled asset.</p></a>
-      <a class="card" style="display:block;" href="/business-types/"><h3>Field &amp; mobile trades &rarr;</h3><p>Automotive services, moving &amp; logistics, security services, and home building &mdash; dispatch-native business types with their own pages in the grouped catalogue.</p></a>
-    </div>
-  </section>
-
-  <section id="going-deeper">
-    <div style="border-top:1px solid var(--border); padding-top:30px;">
-      <div style="font-size:11px; letter-spacing:0.1em; text-transform:uppercase; color:var(--accent-2); font-weight:700; margin-bottom:6px;">For builders, contractors &amp; resellers &mdash; secondary</div>
-      <h2 style="font-size:24px;">Going deeper &mdash; how the platform works under the hood</h2>
-      <p class="sub">
-        Everything above is what most owners need to decide if DPF fits. The rest of this page is the robust technical detail for the people who <strong>extend, operate, integrate, or resell</strong> the platform: the AI workforce, Build Studio, the autonomy engine, the data layer, identity and interoperability, observability, compliance, security, governance, and standards. Skim what&rsquo;s relevant or skip it &mdash; your business runs without you ever touching any of it.
-      </p>
-    </div>
-  </section>
-
-  <section id="coworkers">
-    <h2>Meet the coworker workforce</h2>
-    <p class="sub">
-      Coworkers are role-bound AI personas, each scoped to a value stream, each with its own grant set and skill library. They are the platform&rsquo;s primary surface for getting work done &mdash; you talk to the coworker who owns the area you&rsquo;re working in, and the platform routes you correctly based on the page, active archetype, and permissions in play. The full registry holds <strong>63 agents</strong> (48 value-stream specialists, 9 orchestrators, 6 cross-cutting); the personas below are the ones an operator talks to directly. <strong>Detailed guide:</strong> <a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a> and <a href="/user-guide/market-archetypes">market-archetypes</a>.
-    </p>
-    <div class="grid">
-      <div class="card"><h3>onboarding-coo</h3><p>Hosts first-run setup. Introduces the platform, explains AI providers, walks through identity, branding, and finance configuration.</p></div>
-      <div class="card"><h3>coo</h3><p>Ongoing operational partner once onboarding completes. Cross-functional: pulls from any value stream when the question doesn&rsquo;t fit a single specialist.</p></div>
-      <div class="card"><h3>portfolio-advisor</h3><p>Digital products and portfolios &mdash; health, investment, lifecycle.</p></div>
-      <div class="card"><h3>ea-architect</h3><p>Enterprise architecture &mdash; ArchiMate views, capability maps, dependencies.</p></div>
-      <div class="card"><h3>build-specialist</h3><p>Drives Build Studio: design docs, sandbox builds, code intelligence, test-first decomposition, docs impact, and code review.</p></div>
-      <div class="card"><h3>licensing-specialist</h3><p>Archetype-aware licensing and permit readiness, control mapping, evidence collection, posture tracking. (aka compliance-licensing-specialist.)</p></div>
-      <div class="card"><h3>hr-specialist</h3><p>Workforce, roles, reviews, timesheets, organizational structure.</p></div>
-      <div class="card"><h3>customer-advisor</h3><p>Customer accounts, sales pipeline, engagement history.</p></div>
-      <div class="card"><h3>finance-agent</h3><p>Budget, chargeback, P&amp;L attribution, AI-spend visibility, and financial reporting.</p></div>
-      <div class="card"><h3>inventory-specialist</h3><p>Items, stock, fulfillment, orders, product lifecycle and market fit. (aka estate-specialist.)</p></div>
-      <div class="card"><h3>marketing-specialist</h3><p>Brand voice, content, campaigns, storefront sections &mdash; reads from the same archetype that seeded the storefront.</p></div>
-      <div class="card"><h3>ops-coordinator</h3><p>Operations and backlog: epics, items, priorities, status, scheduling (Scrum Master for delivery flow and WIP limits).</p></div>
-      <div class="card"><h3>platform-engineer</h3><p>Platform health: providers, model routing, agent registry, infrastructure observability.</p></div>
-      <div class="card"><h3>documentation-specialist</h3><p>Keeps user guides, public docs, architecture docs, prompt/registry text, and cross-references current as platform behavior changes.</p></div>
-      <div class="card"><h3>external-catalog-scout</h3><p>Scouts external coworker and archetype patterns from the hive mind. (aka hive-scout.)</p></div>
-      <div class="card"><h3>admin-assistant</h3><p>Cross-cutting administrative work: scheduling, reminders, filing, follow-ups.</p></div>
+    <div class="install-grid">
+      <article class="install-card">
+        <span class="status-badge">Generally available</span>
+        <h3>Windows 10 / 11</h3>
+        <p>Guided PowerShell installer for a local Docker Desktop deployment.</p>
+        <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory#quick-install">Windows install steps &rarr;</a>
+      </article>
+      <article class="install-card">
+        <span class="status-badge">Generally available</span>
+        <h3>macOS Apple Silicon</h3>
+        <p>Native shell installer for supported Apple Silicon hosts.</p>
+        <a href="/install/macos">macOS install guide &rarr;</a>
+      </article>
+      <article class="install-card">
+        <span class="status-badge early">Early access</span>
+        <h3>Native Linux</h3>
+        <p>Docker-based native host path for contributors and pilot operators.</p>
+        <a href="/install/linux">Linux install guide &rarr;</a>
+      </article>
+      <article class="install-card">
+        <span class="status-badge early">Early access</span>
+        <h3>Cloud single VM</h3>
+        <p>Single-tenant VM deployment patterns for AWS, Google Cloud, and Azure.</p>
+        <a href="/install/cloud-single-vm">Cloud install guide &rarr;</a>
+      </article>
     </div>
 
-    <h3 style="margin-top:24px; font-size:16px;">Behind the personas: value-stream orchestrators and build sub-agents</h3>
-    <p class="sub" style="margin-top:0;">
-      The personas above front a deeper bench. Nine <strong>value-stream orchestrators</strong> (one per IT4IT value stream plus a coordinating COO orchestrator) sequence specialist work, and Build Studio fans a feature out to implementation, verification, and documentation specialists who each own a slice of the release evidence.
-    </p>
-    <div class="grid">
-      <div class="card"><h3>Value-stream orchestrators</h3><p>coo-orchestrator (COO), then evaluate-, explore-, integrate-, deploy-, release-, consume-, operate-, and governance-orchestrator &mdash; each owns flow, prioritization, and gate enforcement within its value stream.</p></div>
-      <div class="card"><h3>Build specialists</h3><p>build-data-architect (schema, migrations), build-software-engineer (APIs, server actions), build-frontend-engineer (pages, components, WCAG), build-qa-engineer (tests, typecheck), and documentation-specialist (user guide, public docs, architecture docs) &mdash; the team a single build is decomposed across.</p></div>
-      <div class="card"><h3>WSID professional grounding</h3><p>Each coworker role now resolves against a profession corpus (WSID, in the Autonomy section below) so its craft judgment &mdash; data-architecture, finance, marketing &mdash; is sourced and audited, not LLM folklore.</p></div>
+    <div class="note">
+      <strong>Ready-to-go or customizable?</strong> Choose ready-to-go when you want packaged
+      platform images. Choose customizable when you expect serious source work from an editor
+      or external agent client. Build Studio is available in both modes; it is not the only
+      supported development path. Hardware and model-download time vary, so use the platform
+      guide for current requirements rather than relying on a copied number here.
     </div>
-  </section>
-
-  <section id="build-studio">
-    <h2>Build Studio: the five-phase pipeline</h2>
-    <p class="sub">
-      Build Studio is how the platform extends itself. A user (or a coworker on a user&rsquo;s behalf) proposes a feature, and the request flows through five governed phases. Each phase has its own gate &mdash; nothing advances until the previous gate&rsquo;s artifacts are present and acceptable. Phase-to-phase dispatch is now automatic: once a build is approved to start, Ideate &rarr; Plan &rarr; Build &rarr; Review run without an operator clicking between them, and the deliberate human gate is the final diff review before anything ships. The lifecycle is also right-sized by work type and size, so a bug fix or doc change carries lighter ceremony than a net-new feature. Documentation impact is part of done: a build updates user-facing, coworker-facing, public, architecture, or contributor docs when it changes those surfaces, or records why no docs changed. End-to-end reliability hardening continues, so treat Build Studio as the governed evidence and development surface rather than a guarantee that every complex source change lands untouched. <strong>Detailed guide:</strong> <a href="/user-guide/build-studio/">user-guide/build-studio</a> (with <a href="/user-guide/build-studio/sandbox">sandbox</a> and <a href="/user-guide/build-studio/deployment">deployment</a> notes).
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:18%;">Phase</th><th style="width:30%;">What happens</th><th>Gate / artifacts</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>1. Ideate</strong></td>
-          <td>Intake and creative discovery. The onboarding-coo or build-specialist drafts a feature brief, runs the Reusability Check, and creates a backlog item with a constrained goal.</td>
-          <td>Feature brief, backlog item, reusability analysis stored on the design doc.</td>
-        </tr>
-        <tr>
-          <td><strong>2. Plan</strong></td>
-          <td>Architecture review and test-first task decomposition. Build-specialist drafts a design document covering problem statement, data model, reuse plan, and acceptance criteria.</td>
-          <td>Design document approved; severity-driven review (critical fails, important and minor pass).</td>
-        </tr>
-        <tr>
-          <td><strong>3. Build</strong></td>
-          <td>Test-first implementation in a sandbox container. Each task: write failing test &rarr; implement &rarr; code review &rarr; pass &rarr; next task. Commit SHAs and task results captured.</td>
-          <td>All tasks complete; sandbox tests green; commits recorded.</td>
-        </tr>
-        <tr>
-          <td><strong>4. Review</strong></td>
-          <td>Acceptance verification. Full test suite, typecheck, manual acceptance checks, UX verification, code-impact review.</td>
-          <td>Verification output, impact report, acceptance criteria checked, manual test steps documented.</td>
-        </tr>
-        <tr>
-          <td><strong>5. Ship</strong></td>
-          <td>Delivery. Promotion evidence is prepared; where configured, a pull request opens against <code>main</code> with required CI checks and DCO sign-off. Hive contribution mode (<code>fork_only</code>, <code>selective</code>, or <code>contribute_all</code>) decides whether the change is also offered upstream.</td>
-          <td>PR/promotion record, deployment or handoff confirmation, optional hive contribution PR.</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      Build Studio captures phase-by-phase evidence so the path from idea to ship is fully reconstructable &mdash; the same evidence trail the compliance module uses when it asks &ldquo;what changed and who authorized it?&rdquo;
-    </p>
-    <div class="pillars" style="margin-top:18px;">
-      <div class="pillar">
-        <div class="tag">Develops itself on local AI</div>
-        <strong>Build Studio writes code on your own local LLM.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A dedicated dispatch engine, <strong>opencode</strong>, runs the bundled Docker Model Runner model (e.g. <code>qwen3-coder</code>) as a coding agent inside the sandbox &mdash; no vendor credential, zero token cost, air-gappable. It parses the local model&rsquo;s native tool-call format itself, so the platform can ideate, plan, and build a change end-to-end without a cloud API. Architecture: <a href="/architecture/local-llm-build-engine">local-llm-build-engine</a>.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Design-time decomposition</div>
-        <strong>Oversized builds split before Plan churn.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The Dale HVAC dogfood run exposed a real cliff: a feature can be directionally correct but too large for one Build Studio plan. The new design-time decomposition work keeps one parent design contract and creates smaller child builds before plan review oscillates.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Phase auto-dispatch</div>
-        <strong>Approve once; the pipeline runs itself.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Approving a build to start dispatches Ideate, Plan, Build, and Review verification in sequence without an operator clicking between phases. The intentional human gate is the final diff review before ship &mdash; closing the long-standing &ldquo;autonomy gap&rdquo; where promoted builds stalled at a phase boundary.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Right-sized lifecycle</div>
-        <strong>Ceremony scales to the work.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A (work-type &times; work-size) policy matrix replaces binary feature/fix branching. Bugs, chores, and docs carry fewer gates and thinner prompts; a net-new feature gets the full design-doc and review treatment. Reported issues route into a lighter fix-kind build with repro / expected / actual / root-cause context.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Advisory architecture review</div>
-        <strong>An EA persona rides along.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A chief-architect persona reviews at the Ideate and Plan gates as advisory-only &mdash; surfacing alignment concerns without gating pass/fail &mdash; so architectural drift is caught early without adding a hard stop.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Concurrency</div>
-        <strong>Sandbox slot pool with queued builds.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Multiple builds run in parallel up to a configured sandbox-slot limit; further work queues rather than oversubscribing the host. The queue and concurrency surface is part of the Build Studio layout, not a hidden setting.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Stall detection</div>
-        <strong>Stuck pipelines surface a recovery affordance.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Heartbeat tickers wrap slow LLM awaits; the orchestrator detects stalled-at-pending and contradictory pipeline states and surfaces a <em>Reset Build</em> action so an operator can recover without writing SQL or restarting a container.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Cost visibility</div>
-        <strong>Per-phase cost breakdown.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Each build records token, tool, and cache spend per phase in <code>BuildPhaseRun</code> + <code>ToolExecution</code>. The Build Studio card breaks down where a build&rsquo;s budget went; the same numbers flow into the finance module&rsquo;s actual AI spend.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Workflow-primary layout</div>
-        <strong>Workflow, history, inspector in one view.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The Build Studio surface is workflow-primary with an anchored inspector, a history strip that folds duplicate stall events, and per-task drawers &mdash; designed for an operator running multiple concurrent builds, not a single demo path.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="ai-workforce">
-    <h2>AI workforce: local-first, with optional cloud</h2>
-    <p class="sub">
-      The AI workforce ships ready-to-run on your own hardware and grows as you connect external providers. Routing decisions are dynamic and capability-tier driven &mdash; never hard-pinned to a specific model in seed data &mdash; so the platform can pick the right LLM for each task type and sensitivity level without manual configuration. <strong>Detailed guides:</strong> <a href="/user-guide/ai-workforce/">ai-workforce</a>, <a href="/user-guide/ai-workforce/connecting-providers">connecting-providers</a>, <a href="/user-guide/ai-workforce/model-routing-lifecycle">model-routing-lifecycle</a>, <a href="/user-guide/ai-workforce/ai-cost-governance">ai-cost-governance</a>, and <a href="/user-guide/ai-workforce/decision-perspective">decision-perspective</a> (WWMD / WSID + voice).
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Local first</div>
-        <strong>Bundled inference, no signup.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Docker Model Runner is built into Docker Desktop 4.40+ &mdash; the platform pulls an appropriately-sized local model on first run, with real-time progress, and activates it before you see a setup screen.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Optional cloud</div>
-        <strong>Connect Anthropic, OpenAI, Grok, and others.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">External providers are an upgrade, not a prerequisite. Connect with an API key, a subscription OAuth sign-in (Claude Max, ChatGPT Codex), or a device-code sign-in (xAI / Grok). Sensitivity clearance per provider decides which traffic each one is allowed to see; local stays the default for restricted data.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">xAI / Grok</div>
-        <strong>First-class Grok support, signed in without an API key.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Grok is a direct provider alongside Anthropic and OpenAI, seeded with Grok&nbsp;4.3 (reasoning) and Grok&nbsp;Build&nbsp;0.1 (agentic coding). Because hunting for an xAI key is poor UX for a non-technical founder, the platform drives the Grok CLI&rsquo;s own <code>device-auth</code> OAuth: a coworker or the provider page starts the flow (<code>grok_signin_start</code>), you confirm a code in your browser (Google / X / Apple), and the captured credential is injected into each build sandbox and self-refreshed. See <a href="/user-guide/ai-workforce/provider-xai">provider-xai</a> and <a href="/user-guide/ai-workforce/connecting-providers">connecting-providers</a>.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Dynamic discovery</div>
-        <strong>No stale model catalog.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">When supported, the platform queries each provider&rsquo;s <code>/v1/models</code> endpoint at activation time rather than relying on a hard-coded list, so newly released models become available without a platform update.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Capability-tier routing</div>
-        <strong>The right LLM, picked dynamically.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Routing chooses by capability tier (reasoning, coding, summarization, etc.) and task type, intersected with sensitivity clearance and provider rate budgets. Champion/challenger A/B with promotion gates lets routing improve over time.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Per-agent grants</div>
-        <strong>Default-deny, audit-logged.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Every coworker has an explicit grant set. The TOOL_TO_GRANTS map intersects user capability with agent grants on every call &mdash; missing grants are logged with a rationale code, not silently bypassed.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Cost governance</div>
-        <strong>AI cost is a financial fact.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Provider usage flows into the finance module as actual AP spend &mdash; per provider, per agent, per workflow, per Build Studio phase. Anthropic prompt-cache hit/miss telemetry and accurate per-model pricing make the numbers real, not estimates. Budget events fire at phase boundaries; rolling thread compaction and phase-boundary summarization keep token consumption bounded on long-running work.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Decision Perspective Gate</div>
-        <strong>WWMD: open questions get a canonical handler.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Whenever a coworker hits an ambiguity or an open product question, the Decision Perspective Gate aggregates platform principles as weighted vectors and returns one of <em>recommend</em>, <em>arbitrate</em>, <em>escalate</em>, or <em>defer</em> with a confidence score and an audit record. Same gate is exposed as an MCP tool so external clients use it under the same rules.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Persona Voice Layer</div>
-        <strong>Coworkers can speak, without gaining authority.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled speaches (faster-whisper) STT service handles voice input, and a founder seed voice now ships in the install seed (with a consent record) so spoken output works out of the box. TTS defaults to <strong>self-hosted</strong> so audio stays on your hardware, and the backend is operating-system-dependent: a Chatterbox <code>dpf-tts</code> container on Linux/Windows with an NVIDIA GPU, or a native-host MLX sidecar on Apple Silicon (Docker Desktop on macOS has no GPU passthrough). Cloud TTS (Cartesia, Fish Audio, ElevenLabs) is an optional opt-in. Voice never changes approval, confidence, or audit rules, and real-person voice requires consent. See <a href="/user-guide/ai-workforce/decision-perspective">decision-perspective</a>.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Routing resilience</div>
-        <strong>Dead providers fail over in seconds, not minutes.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A runtime circuit breaker excludes a failing endpoint from selection the moment it errors &mdash; turning a multi-iteration stall on a dead provider into sub-second failover when a live alternative exists. A live-health projection separates admin lifecycle from runtime circuit state from operator-visible health, and failover never surfaces &ldquo;your work wasn&rsquo;t recorded&rdquo; fabrication copy after an infrastructure blip.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Operations map</div>
-        <strong>See the workforce as an operating system.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Saved operator views, reset controls, capacity continuity, and capability-needs review help operators see where AI work is active, blocked, underused, or asking for new platform support. Route topology overlays live provider activity, failover curves, quota pressure, and scheduled-window forecasts onto a single time-scrubbable map, and coworker-to-coworker (A2A) interactions are surfaced so delegation between agents is visible, not hidden.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="autonomy-wwmd">
-    <h2>Autonomy grows through WWMD, not blind automation</h2>
-    <p class="sub">
-      DPF is deliberately walking toward more autonomous AI coworkers, but autonomy is earned through inspectable decisions. WWMD &mdash; the working shorthand for &ldquo;What Would Mark Do?&rdquo; &mdash; is the Decision Perspective Gate that turns the founder-kernel wiki into a repeatable answer path for ambiguous questions. The point is not to make a founder persona magic; the point is to make product judgment explicit enough that a coworker can explain why it recommends, arbitrates, escalates, or defers.
-    </p>
-
-    <div class="process-strip" aria-label="WWMD decision flow">
-      <div class="process-step">
-        <div class="num">1</div>
-        <strong>Retrieve the wiki</strong>
-        <span><code>wiki_query</code> searches founder-kernel and organization overlay pages. Vector search finds semantic matches; optional PPR re-ranks pages through the wiki link graph.</span>
-      </div>
-      <div class="process-step">
-        <div class="num">2</div>
-        <strong>Frame options</strong>
-        <span>The coworker converts the ambiguity into 2-4 concrete options with plain-language descriptions and scored feature signals.</span>
-      </div>
-      <div class="process-step">
-        <div class="num">3</div>
-        <strong>Score principles</strong>
-        <span><code>principle_decide</code> compares options against tiered commandments, core principles, and contextual rules using signed dimension vectors.</span>
-      </div>
-      <div class="process-step">
-        <div class="num">4</div>
-        <strong>Apply guardrails</strong>
-        <span>Close margins, weak structured coverage, commandment conflicts, high risk, stale material, and recent human overrides all reduce autonomy.</span>
-      </div>
-      <div class="process-step">
-        <div class="num">5</div>
-        <strong>Write the ledger</strong>
-        <span>Every decision records the profile, sources, confidence, rationale, outcome, and whether a human escalation or deferral was captured.</span>
-      </div>
-    </div>
-
-    <h3 style="margin-top:24px; font-size:16px;">Multiple vector analysis, one explainable answer</h3>
-    <p class="sub" style="margin-top:0;">
-      WWMD does not answer by vibe. It combines several kinds of signal so the response is balanced rather than overfit to one principle or one nearest-neighbor search result.
-    </p>
-    <div class="analysis-matrix">
-      <div class="analysis-axis">
-        <strong>Semantic retrieval vector</strong>
-        <span>Finds relevant wiki pages and principles by meaning, not exact wording, then keeps source slugs and previews attached.</span>
-      </div>
-      <div class="analysis-axis">
-        <strong>Link-graph vector</strong>
-        <span>Personalized PageRank can promote pages connected to the seed set, which helps multi-hop questions that plain cosine search misses.</span>
-      </div>
-      <div class="analysis-axis">
-        <strong>Principle dimension vector</strong>
-        <span>Scores options against axes such as maintainability, blast radius, evidence density, human cognitive load, governance, privacy, cost, and vendor lock-in.</span>
-      </div>
-      <div class="analysis-axis">
-        <strong>Authority and scope vector</strong>
-        <span>Filters judgment by calling population and Reduction Gear ring scope so a Build Studio decision does not accidentally borrow a rule meant for a different surface.</span>
-      </div>
-      <div class="analysis-axis">
-        <strong>Evidence-quality vector</strong>
-        <span>Decision Perspective material is weighted by freshness, review status, promotion state, evidence grade, and recent operator overrides.</span>
-      </div>
-      <div class="analysis-axis">
-        <strong>Risk and confidence vector</strong>
-        <span>High risk, low confidence, missing coverage, or conflicting principles force escalation instead of letting a coworker overclaim authority.</span>
-      </div>
-    </div>
-
-    <table class="guide" style="margin-top:20px;">
-      <thead>
-        <tr><th style="width:26%;">Outcome</th><th>What it means for trust at scale</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>Recommend</strong></td>
-          <td>The gate has enough signal to advise a path, but the caller still owns execution and approval.</td>
-        </tr>
-        <tr>
-          <td><strong>Arbitrate</strong></td>
-          <td>For low-risk decisions with very high confidence, the coworker may continue under its declared autonomy policy.</td>
-        </tr>
-        <tr>
-          <td><strong>Escalate</strong></td>
-          <td>The gate found risk, conflict, weak confidence, or policy boundaries that need a human resolver.</td>
-        </tr>
-        <tr>
-          <td><strong>Defer</strong></td>
-          <td>The wiki or decision profile lacks enough coverage. The unresolved question becomes learning material instead of a hidden guess.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3 style="margin-top:24px; font-size:16px;">A worked example: one question, scored end-to-end</h3>
-    <p class="sub" style="margin-top:0;">
-      Abstractly, &ldquo;weighted vectors&rdquo; is hard to picture. Concretely, it is a column you can add up. During the Dale HVAC dogfood install, the <code>build-specialist</code> coworker built an &ldquo;overdue jobs&rdquo; widget and hit an open product question before shipping it &mdash; <em>should this be generalized for the Hive Mind, or kept local to one install?</em> The gate framed two options and scored each against the principles in scope. Every cell below is a <em>contribution</em> (<code>tier&nbsp;weight &times; alignment</code>); the composite is the column sum.
-    </p>
-    <table class="guide" style="margin-top:8px;">
-      <thead>
-        <tr>
-          <th style="width:46%;">Principle (tier &middot; weight)</th>
-          <th>Option A &mdash; keep local</th>
-          <th>Option B &mdash; parameterize for the hive</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td>Learnings belong in the shared commons (<strong>commandment &middot; 1.0</strong>)</td><td>+0.10</td><td><strong>+0.85</strong></td></tr>
-        <tr><td>Architecture over shortcuts (<strong>core &middot; 0.4</strong>)</td><td>+0.12</td><td><strong>+0.32</strong></td></tr>
-        <tr><td>Speed to value (<strong>contextual &middot; 0.1</strong>)</td><td><strong>+0.09</strong></td><td>+0.05</td></tr>
-        <tr><td><strong>Composite</strong></td><td><strong>0.31</strong></td><td><strong>1.22</strong></td></tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:10px;">
-      Winner <strong>B</strong> by a margin of <strong>0.91</strong> &mdash; far above the tie threshold, so confidence is <em>high</em>. Note what the tiers do: the contextual &ldquo;ship faster&rdquo; pull toward keeping it local is real, but at weight <code>0.1</code> it can never overrule a commandment-tier reusability pull at weight <code>1.0</code>. The gate returns <strong>recommend Option B</strong> with that contribution ledger attached &mdash; the coworker still owns execution and approval. <strong>See the same loop run for an organization business decision (WWWD, which escalates) and a profession craft question (WSID, which blocks the tempting-wrong answer) in the deep dive:</strong> <a href="/user-guide/ai-workforce/decision-perspective-in-practice">Decision Perspective in Practice</a>.
-    </p>
-
-    <p class="note">
-      Why this matters: every unanswered or low-confidence WWMD question is a chance to improve the kernel. Over time, repeated human resolutions become reviewed wiki and perspective material, which lets coworkers handle more decisions safely without losing the audit trail. See the deeper architecture note: <a href="/architecture/autonomy-and-wwmd">Autonomy, WWMD, and trusted coworker decisions</a>, and the worked walkthrough for all three scopes: <a href="/user-guide/ai-workforce/decision-perspective-in-practice">Decision Perspective in Practice</a>.
-    </p>
-
-    <h3 style="margin-top:24px; font-size:16px;">The organization corpus (WWWD): your business, not just the founder kernel</h3>
-    <p class="sub" style="margin-top:0;">
-      WWMD draws on the shared founder-kernel principles. WWWD &mdash; the organization knowledge corpus &mdash; is the org-specific complement: a governed, single-org knowledge base built from onboarding context, uploaded business documents, market Q&amp;A, and approved AI research. Every source &mdash; data entry, document upload, scheduled research, integrations, coverage-gap detection &mdash; flows through one enrichment contract that handles idempotency, provenance, and trust grading (first-party, derived, researched). Material lands <em>draft-by-default</em> regardless of source; human review promotes it to authoritative before it influences anything. Reviewed material projects into the decision profile that feeds the WWMD gate and coworker recall, and a freshness-governance layer supersedes stale material and re-enqueues research when coverage gaps appear.
-    </p>
-    <p class="sub" style="margin-top:8px;">
-      <strong>In practice:</strong> a customer asks the <code>customer-advisor</code> coworker to approve net-60 terms instead of the standard net-15 on a $12k job. If the organization hasn&rsquo;t yet encoded a credit-terms policy, the gate finds <em>zero</em> applicable org material &mdash; and the non-inherit boundary means it must <strong>not</strong> borrow DPF&rsquo;s platform doctrine as authority for a customer&rsquo;s business decision. So it <strong>escalates</strong> to the business owner rather than guessing. The owner&rsquo;s resolution is captured as draft WWWD material; once reviewed and promoted, the <em>next</em> such question can resolve with the org&rsquo;s own policy as the cited source. A customer&rsquo;s business judgment is the customer&rsquo;s to author.
-    </p>
-
-    <h3 style="margin-top:24px; font-size:16px;">The profession corpus (WSID): what a competent professional in this role should do</h3>
-    <p class="sub" style="margin-top:0;">
-      WWMD answers <em>&ldquo;what would the founder/platform do?&rdquo;</em> and WWWD answers <em>&ldquo;what would this organization do?&rdquo;</em> &mdash; but a coworker doing a specialist&rsquo;s job also needs a governed source for <em>what a competent professional in that role should do</em>. WSID (&ldquo;What Should I Do?&rdquo;) is the third scope in the same family, reusing the same architecture &mdash; a versioned profile, a source-traced corpus, weighted retrieval, and an audited gate &mdash; but scoped to the <strong>profession</strong> rather than the founder or the org. Each coworker role family gets its own profile (<code>WSID-DATA-ARCHITECT</code>, <code>WSID-FINANCE</code>, <code>WSID-MARKETING</code>, &hellip;) backed by a corpus distilled from <em>fetched, verifiable sources</em> &mdash; DAMA-DMBOK and ANSI SQL and OWASP for a data architect, GAAP and SOX control concepts for finance, the AMA body of knowledge and CAN-SPAM / GDPR consent rules for marketing &mdash; never authored from model memory. When a coworker hits a craft question, the gate resolves against its profession profile first, then falls back through role &rarr; org WWWD &rarr; DPF doctrine &rarr; defer-with-gap-capture. The contract is full-roster: WSID is designed to scope <em>every</em> coworker on the platform, with data-architect, finance, and marketing as the pilot three that prove the pipeline.
-    </p>
-    <p class="sub" style="margin-top:8px;">
-      <strong>In practice:</strong> mid-build, the <code>build-data-architect</code> coworker must choose how to store a money column &mdash; <code>FLOAT</code>, <code>DECIMAL(12,2)</code>, or integer cents. It resolves against the <code>WSID-DATA-ARCHITECT</code> corpus (DAMA-DMBOK, ANSI&nbsp;SQL exact-numeric types) and <strong>recommends <code>DECIMAL</code></strong> with the source pages cited. The interesting part is the guardrail: <code>FLOAT</code> trips a <em>commandment conflict</em> &mdash; a commandment-tier principle contributes strongly negatively to it &mdash; so even if the underlying model were nudged toward <code>FLOAT</code> &ldquo;for performance,&rdquo; the gate flags it as violating professional doctrine. The judgment is source-traced, not LLM folklore.
-    </p>
-
-    <h3 style="margin-top:24px; font-size:16px;">Human-in-the-loop and the immutable decision ledger</h3>
-    <p class="sub" style="margin-top:0;">
-      The four outcomes are not a fixed automation level &mdash; they are inputs to the calling coworker&rsquo;s autonomy policy and HITL tier. Two rules keep this honest rather than theatrical: <strong>high risk overrides confidence</strong> (a <em>high</em> or <em>critical</em> risk tier raises a human surface even when the math looks strong &mdash; that is partly why the WWWD example above escalates), and <strong>HITL tiers bound autonomy independently of the gate</strong> (Tier&nbsp;0 executive oversight through Tier&nbsp;3 informational gate whether a coworker may <em>act</em>; the gate only decides what it <em>recommends</em>). Confidence itself is earned in drops and lost in buckets &mdash; a recommendation made, observed, and human-confirmed raises it slowly; one contradicted or stale rationale pulls it back fast.
-    </p>
-    <p class="sub" style="margin-top:8px;">
-      None of this is trustworthy unless it is reconstructable. <strong>Every</strong> gate call &mdash; <em>recommend</em>, <em>arbitrate</em>, <em>escalate</em>, and even <em>defer</em> &mdash; writes an append-only <code>DecisionInteraction</code> row: the profile and its version, the domain class, the outcome, confidence before/after, the cited sources, the rationale, the resolved profile chain, and whether a human follow-up was captured. Nothing is edited in place &mdash; a profile change snapshots a new version, so an old decision always resolves against the doctrine that was live when it ran. That ledger is one strand of the platform&rsquo;s broader append-only authorization decision log and chain-of-custody traces (principal &rarr; agent &rarr; tool call &rarr; approval &rarr; outcome). Full walkthrough, including ledger fields per scope: <a href="/user-guide/ai-workforce/decision-perspective-in-practice">Decision Perspective in Practice</a>.
-    </p>
-  </section>
-
-  <section id="data-layer">
-    <h2>The data layer and sandbox containers</h2>
-    <p class="sub">
-      The platform is a containerized stack with a small, deliberate set of stateful services. Knowing what lives where helps you reason about backups, sovereignty, and the boundary between safe iteration and production state. <strong>Detailed reference:</strong> <a href="/architecture/platform-overview">architecture/platform-overview</a>.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:24%;">Service</th><th>Role</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>portal</strong></td>
-          <td>The Next.js application surface for everything users touch &mdash; operations, portfolio, architecture, coworkers, storefront, governance. Only service published externally.</td>
-        </tr>
-        <tr>
-          <td><strong>portal-init</strong></td>
-          <td>One-shot startup container that waits for infrastructure, applies Prisma migrations, runs idempotent seeds (archetypes, skills, agents, role bundles), and exits.</td>
-        </tr>
-        <tr>
-          <td><strong>postgres</strong></td>
-          <td>System of record. Transactional platform data: organizations, products, portfolios, backlog, agents, grants, decisions, evidence.</td>
-        </tr>
-        <tr>
-          <td><strong>neo4j</strong></td>
-          <td>Graph storage for relationship-rich models &mdash; enterprise architecture, capability views, dependency chains, delegation chains.</td>
-        </tr>
-        <tr>
-          <td><strong>qdrant</strong></td>
-          <td>Vector database for semantic indexing, retrieval, and memory-style AI support.</td>
-        </tr>
-        <tr>
-          <td><strong>inngest + redis</strong></td>
-          <td>Durable execution engine for scheduled jobs, event-driven workflows, and retryable background tasks. Long-running coworker work surfaces through the coworker panel rather than blocking the UI.</td>
-        </tr>
-        <tr>
-          <td><strong>Docker Model Runner</strong></td>
-          <td>Local AI inference, built into Docker Desktop 4.40+. Models managed via <code>docker model pull</code>; GPU passthrough is automatic when supported hardware is present.</td>
-        </tr>
-        <tr>
-          <td><strong>Sandbox containers</strong></td>
-          <td>Disposable, on-demand containers used by Build Studio. New features get drafted, tested, and reviewed inside a sandbox before any change touches the running portal. Sandboxes are not part of the steady-state runtime &mdash; they spin up when work needs them and tear down when it ships.</td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section id="identity">
-    <h2>Identity, federation, and agent interoperability</h2>
-    <p class="sub">
-      The platform treats human and agent identity as one design surface. Humans sign in through your existing directory; agents carry their own durable identifiers and traceable claims; coworker-to-coworker work travels as a governed task, not as an implicit chat side-effect. <strong>Detailed guides:</strong> <a href="/user-guide/platform/identity-and-access">platform/identity-and-access</a>; architecture: <a href="/architecture/GAID">GAID</a> and <a href="/architecture/trusted-ai-kernel">trusted-ai-kernel</a>.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:30%;">Surface</th><th>What it provides</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>LDAP / Active Directory / Entra</strong></td>
-          <td>Federation for sign-in and directory bootstrap. Upstream identities are linked to internal principal records via a principal-linking layer. Directory facts and legacy app compatibility flow through the upstream authority; platform roles, route bundles, and coworker associations stay authoritative inside the platform.</td>
-        </tr>
-        <tr>
-          <td><strong>GAID identifiers</strong></td>
-          <td>Every agent carries a stable identifier formatted as <code>gaid:priv:&lt;issuer&gt;:&lt;agent-id&gt;</code>. The Agent Identity Document (AIDoc) carries badging, assurance claims, and authorization classes. Contributions are obfuscated rather than anonymous &mdash; a stable pseudonym makes contributors distinguishable across the hive mind.</td>
-        </tr>
-        <tr>
-          <td><strong>A2A-aligned task envelope</strong></td>
-          <td>The internal coworker runtime is being refactored into an A2A-shaped, task-native architecture. Coworker-to-coworker handoffs are represented as governed tasks, outputs as task artifacts, clarifications and progress as task messages and status events. TAK runtime controls and GAID receipt semantics layer onto the same envelope, so future private or public A2A endpoint exposure is a projection rather than a rewrite.</td>
-        </tr>
-        <tr>
-          <td><strong>Model Context Protocol (MCP)</strong></td>
-          <td>Tool and context interoperability for the AI workforce. Platform capabilities, backlog operations, build operations, and hive contribution all expose MCP tools that any conformant client can call &mdash; under the same grant and approval gates that the in-product coworkers face.</td>
-        </tr>
-        <tr>
-          <td><strong>Pseudo-user contract (screen actions)</strong></td>
-          <td>A coworker discovers what a screen offers through a registered <em>screen manifest</em> rather than guessing, then drives view commands (navigate, select, focus, fill) directly. Anything destructive &mdash; a form submit, a domain mutation &mdash; is written as a <code>CoworkerActionEnvelope</code> the user approves or declines inline before the underlying tool runs. Per-turn elevation allows a small number of approved actions without re-confirming; hard floors (irreversible operations) always require an explicit typed phrase. Every action is recorded under both the delegating user and the coworker principal.</td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section id="observability">
-    <h2>Observability and evidence</h2>
-    <p class="sub">
-      Governance is only worth the policy if you can see what happened &mdash; and the platform has to notice problems before you do. It ships with full-stack monitoring (metrics <em>and</em> container logs), proactive anomaly detection, a single deduped issue inbox that every signal converges into, and an append-only audit ledger, so anything that happens to a human or an agent is both <em>caught</em> and reviewable end-to-end. <strong>Detailed guides:</strong> <a href="/architecture/platform-overview#how-the-platform-handles-anything-that-happens">how the platform handles anything that happens</a>, <a href="/user-guide/platform/authority-and-audit">platform/authority-and-audit</a>, and <a href="/user-guide/operations/infrastructure-discovery">operations/infrastructure-discovery</a>.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Log monitoring</div>
-        <strong>Full-stack logs, not just metrics.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Loki + Alloy tail every container&rsquo;s stdout/stderr &mdash; one config, cross-platform via the Docker socket, so the macOS/Windows installs that exporters can&rsquo;t cover are still watched. A Loki ruler catches error-rate spikes and storms in real time; a novel-signature scanner files an issue the first time an unseen error appears, even once. A per-stream rate cap keeps a flooding container from filling the disk.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">One issue inbox</div>
-        <strong>Every signal converges and is tracked.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Metric breaches, log storms, novel errors, in-process crashes, and user reports all land in one deduped inbox (<code>PlatformIssueReport</code> / <code>PortfolioQualityIssue</code>), auto-triage into the backlog, flip a shell-nav health dot visible on every page, and are tracked to resolution &mdash; no source gets its own parallel inbox, so the platform surfaces hidden problems without anyone watching Docker.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Discovery</div>
-        <strong>Prometheus-based estate inventory.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A discovery collector queries Prometheus targets, classifies scrape jobs (postgres, neo4j, qdrant, portal, sandbox, model runner, node exporter), and feeds the estate inventory used by enterprise architecture views.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Decisions</div>
-        <strong>Append-only authorization log.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Every allow/deny decision records actor type, action key, GAID context, rationale code, and timestamp. Tools are gated by a default-deny <em>tool-to-grant</em> map; unapproved calls do not silently succeed.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Receipts</div>
-        <strong>Chain-of-custody traces.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Tool executions are traced with W3C Trace Context, signed message envelopes, and links between principal, delegated authority, approval gate, and resulting state change &mdash; the substrate for compliance answers like &ldquo;what did agent X do, and who authorized it?&rdquo;</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Evidence</div>
-        <strong>Compliance-ready evidence trails.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The compliance module attaches collected evidence to mapped controls. Build Studio captures phase-by-phase artifacts (design doc, verification output, acceptance check) so the path from idea to ship is reconstructable.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Cost telemetry</div>
-        <strong>Token, cache, and dollar accounting.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Every coworker call records token counts, prompt-cache hit/miss, model, and elapsed time. <code>BuildPhaseRun</code> and <code>ToolExecution</code> roll those up by phase and by tool; <code>AgentBudgetEvent</code> records budget pressure events and pre-dispatch rate-limit checks against the CLI pool.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="compliance">
-    <h2>Compliance, evidence, and audit</h2>
-    <p class="sub">
-      Compliance is treated as a first-class concern in the data model rather than a reporting layer bolted on top. Standards and regulations are first-class objects, controls map to obligations, evidence is collected against controls, and the audit ledger ties every governed action back to a principal, an authority, and an outcome. <strong>Detailed guides:</strong> <a href="/user-guide/compliance/">compliance</a> &mdash; <a href="/user-guide/compliance/controls-and-evidence">controls &amp; evidence</a>, <a href="/user-guide/compliance/posture-and-gaps">posture &amp; gaps</a>, <a href="/user-guide/compliance/licensing-readiness">licensing readiness</a>.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:28%;">Surface</th><th>What it provides</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>Standards onboarding</strong></td>
-          <td>Bring in regulations and standards as structured records (e.g., ISO/IEC 27001, SOC 2, HIPAA, PCI-DSS). Each standard&rsquo;s clauses become obligations the platform can map to.</td>
-        </tr>
-        <tr>
-          <td><strong>Control mapping</strong></td>
-          <td>Map your operating controls to obligations across one or more standards. The same control can satisfy clauses in multiple standards without duplication.</td>
-        </tr>
-        <tr>
-          <td><strong>Evidence collection</strong></td>
-          <td>Attach evidence to controls &mdash; screenshots, exported reports, signed records. Build Studio phase artifacts (design doc, verification output, acceptance check) are addressable evidence by default.</td>
-        </tr>
-        <tr>
-          <td><strong>Authorization decision log</strong></td>
-          <td>Append-only record of every allow/deny decision with actor type, action key, GAID context, rationale code, and timestamp. The substrate for the auditor question &ldquo;who authorized this, on what basis?&rdquo;</td>
-        </tr>
-        <tr>
-          <td><strong>Chain-of-custody traces</strong></td>
-          <td>Tool executions are traced with W3C Trace Context and signed message envelopes (RFC 9421-aligned), linking principal, delegated authority, approval gate, and resulting state change.</td>
-        </tr>
-        <tr>
-          <td><strong>Posture tracking</strong></td>
-          <td>Standing posture view across the standards you have onboarded &mdash; which obligations are covered, which controls are stale, where evidence gaps exist.</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      Because human and agent actions flow through the same authority resolution, evidence and audit cover the AI workforce on the same footing as the human workforce. An agent is just another principal whose decisions are logged.
-    </p>
-  </section>
-
-  <section id="security">
-    <h2>Security and operational posture</h2>
-    <p class="sub">
-      Security choices follow from the sovereignty stance: the smallest viable network exposure, the smallest viable trust radius, and the smallest viable amount of data leaving your environment.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Network exposure</div>
-        <strong>One service published, the rest internal.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Only the portal is published externally (typically port 3000). Postgres, Neo4j, Qdrant, Redis, Inngest, and the model runner stay on the internal Docker network. Sandbox containers are launched on demand and torn down when they ship.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Secrets handling</div>
-        <strong>Generated, stored locally, never in the seed.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Install-time credentials are generated locally and saved to <code>.admin-credentials</code> in your install directory. External provider credentials live in the platform&rsquo;s credentials store, not in environment files; no provider key is hard-coded or shipped in seed data.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Default-deny tools</div>
-        <strong>Every tool call passes through the gate.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The TOOL_TO_GRANTS map enforces default-deny for both in-product coworkers and external MCP clients. Missing grants are logged with rationale; nothing is silently bypassed. Proposal-mode tools break out for human approval unless an explicit <code>autoApproveWhen</code> predicate matches a pre-authorized flow.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Sandbox isolation</div>
-        <strong>New code runs in a disposable container first.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Build Studio drafts, tests, and reviews changes inside an isolated sandbox container before any change touches the running portal. Production state is read-protected from the sandbox; the sandbox is reset on each build.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">PR-gated change flow</div>
-        <strong>No code reaches main without review and CI.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Every code change &mdash; whether opened by a human, a coworker, or the hive contribution flow &mdash; lands via a pull request with required CI checks and DCO sign-off. Force-push protection on <code>main</code>; the platform never bypasses signing or hooks.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Defenses against prompt-driven misuse</div>
-        <strong>Immutable directives, never user-controlled.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A platform preamble is injected into every coworker&rsquo;s system prompt and never appears in user input. Combined with default-deny tool gating, this defends against prompt-injection attempts that try to widen agent authority through conversation.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="hive-mind">
-    <h2>Hive Mind: how cross-install value travels</h2>
-    <p class="sub">
-      The platform is open-source and runs as a single-organization install &mdash; one company, one database, no multi-tenancy. Cross-company value moves through the Hive Mind: features built locally are reviewed, parameterized, and offered back so the next install gets them out of the box. Sharing is opt-in, contributors are obfuscated but distinguishable (stable pseudonym via GAID), and every contribution flows through a pull request with required CI checks and DCO sign-off.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:22%;">Contribution mode</th><th>What it does</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>fork_only</strong></td>
-          <td>Build Studio ships the change to your install only. Nothing leaves your environment. The right setting for company-specific customizations.</td>
-        </tr>
-        <tr>
-          <td><strong>selective</strong></td>
-          <td>Each finished build is assessed for community value (the contribution-assessment uses the design-time Reusability Analysis as input). You decide per-build whether to contribute upstream.</td>
-        </tr>
-        <tr>
-          <td><strong>contribute_all</strong></td>
-          <td>Every successful build that passes the contribution gate is offered upstream automatically. The right setting for installs running ahead of the community on shared problems.</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      Generic features become better business-model templates for everyone. The HOA example: a customer&rsquo;s violation-logging feature gets reviewed in Build Studio; if broadly applicable, it is re-factored into the HOA archetype so future HOA installs adopt it on day one. This is what &ldquo;the platform grows from within&rdquo; means in practice &mdash; recursive self-improvement, where every platform improvement is also a sellable capability for the next operator.
-    </p>
-  </section>
-
-  <section id="mcp">
-    <h2>The platform as a programmable surface (MCP)</h2>
-    <p class="sub">
-      The Model Context Protocol (MCP) lets external clients drive the platform with the same tools, the same grants, and the same approval gates that the in-product coworkers face. That means you can connect the platform to your existing AI tooling without giving anything a back-door &mdash; every external call is authorized, audited, and traceable, just like a button click. <strong>Detailed guide:</strong> <a href="/user-guide/platform/tools-and-integrations">platform/tools-and-integrations</a>.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Tool catalogue</div>
-        <strong>The platform is a tool host.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Backlog operations, digital-product registration, build orchestration, evidence recording, taxonomy placement, hive contribution, and feedback all surface as MCP tools with declared <code>requiredCapability</code>, <code>executionMode</code>, and <code>sideEffect</code> fields.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Same gates</div>
-        <strong>External clients face the same checks.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bearer token maps to a principal; the principal&rsquo;s capabilities intersect with the calling agent&rsquo;s grants on every tool call. Proposal-mode tools still break out for human approval; <code>autoApproveWhen</code> predicates allow pre-authorized flows for autonomous use.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Trace context</div>
-        <strong>Every external call is an auditable event.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Tool execution is logged under <code>[tool-trace]</code> with the request, response, principal, agent, decision, and rationale &mdash; the same trail in-product coworker calls produce.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Compatible clients</div>
-        <strong>Work with the tools you already use.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Any MCP-conformant client (Claude Code, Claude Desktop, Codex CLI, custom orchestrators) can call into the platform once registered, without bespoke integration work. CLI vs Messages-API rate limits are tracked separately so a busy CLI session does not throttle the in-product coworkers.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="roles">
-    <h2>Roles and access</h2>
-    <p class="sub">
-      The platform uses a two-tier role model so platform-wide governance is separated from product-specific operating structures. Tier 1 is six immutable roles aligned to IT4IT v3.0.1 value-stream authority. Tier 2 is per-product roles defined by the business model the product runs on (SaaS, Marketplace, IoT, etc.) &mdash; a user can hold different business-model roles on different products. <strong>Detailed guides:</strong> <a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a> and <a href="/user-guide/products/business-model-roles">products/business-model-roles</a>.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:14%;">Role</th><th style="width:30%;">Name</th><th>Authority domain</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><strong>HR-000</strong></td><td>CDIO / Executive Sponsor</td><td>Strategic direction, executive escalation, full platform access including user management and governance settings.</td></tr>
-        <tr><td><strong>HR-100</strong></td><td>Portfolio Manager</td><td>Portfolio governance, investment allocation, approval of Portfolio Backlog Items (PBIs).</td></tr>
-        <tr><td><strong>HR-200</strong></td><td>Digital Product Manager</td><td>Product lifecycle, backlog, delivery; the escalation target for blocked Product Backlog Items (PRODs).</td></tr>
-        <tr><td><strong>HR-300</strong></td><td>Enterprise Architect</td><td>Architecture guardrails, technology standards, capability map ownership.</td></tr>
-        <tr><td><strong>HR-400</strong></td><td>ITFM Director</td><td>Financial governance, cost allocation, AI-spend approval.</td></tr>
-        <tr><td><strong>HR-500</strong></td><td>Operations Manager</td><td>SLA, incident response, operational continuity.</td></tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      Authorization is the intersection of two systems: the user&rsquo;s platform-role capabilities (e.g., <code>view_portfolio</code>, <code>manage_compliance</code>, <code>manage_users</code>) and the calling agent&rsquo;s declared grants. A coworker can only do what the user is allowed to do <em>and</em> the agent itself is granted to do. Superuser status (intended for initial setup, limited to one or two administrators) bypasses checks; everything else is default-deny and audited.
-    </p>
-  </section>
-
-  <section id="privacy">
-    <h2>Privacy and sovereignty posture</h2>
-    <p class="sub">
-      &ldquo;Runs on your hardware&rdquo; is more than a deployment choice &mdash; it is a posture the rest of the platform is designed around. Local stays the default; cloud is an opt-in upgrade with explicit clearance; sharing is opt-in with a stable but obfuscated identity.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Local default</div>
-        <strong>The platform never phones home.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">A bundled local model is activated on first run. Postgres, Neo4j, Qdrant, Inngest, and the model runner stay on your internal Docker network. Only the portal is published externally, and only on the port you choose.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Sensitivity clearance</div>
-        <strong>Each provider has explicit clearance.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">External providers carry a sensitivity-clearance set (<code>public</code>, <code>internal</code>, <code>confidential</code>, <code>restricted</code>). Routing&rsquo;s hard filter refuses to send a request to a provider whose clearance does not cover the data&rsquo;s sensitivity. Local providers are cleared for everything.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Single-org install</div>
-        <strong>Your data is not multi-tenant.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Each install is one Organization &mdash; no multi-tenancy, ever. Cross-company value travels through the Hive Mind contribution flow, not through shared database rows. Company-specific customizations stay local; only what you explicitly contribute leaves.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Customer-brought integrations</div>
-        <strong>The platform is a conduit first, then an absorber.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Enterprise integrations (ADP, HRIS, ERP, banking) use your accounts, your credentials, and your vendor agreements. The platform connects on your behalf, learns from the workflow, and only promotes broadly useful capability into native DPF once mapping, reconciliation, authority, rollback, and evidence are proven.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Obfuscated, not anonymous</div>
-        <strong>Contributions carry a stable pseudonym.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">When you contribute back, GAID provides a durable identifier so distinct contributors are distinguishable across the hive mind &mdash; without exposing your organization&rsquo;s real identity unless you choose to.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Open source</div>
-        <strong>You can see and change anything.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The platform is open source. The seeds, prompts, agent registry, route bundles, archetypes, and migration history are all in the repository. The customizable install is a full source clone &mdash; Build Studio and your local IDE share the same workspace.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="standards">
-    <h2>Standards conformance profiles</h2>
-    <p class="sub">
-      TAK and GAID are not single-tier standards &mdash; they define a ladder so an implementation can declare what it actually supports and earn higher levels over time. The platform is the first proving ground; the conformance assessment in <a href="/architecture/agent-standards-dpf-conformance">architecture/agent-standards-dpf-conformance</a> shows the current mapping.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:24%;">Standard</th><th>Profiles</th><th>What rises with each level</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>TAK</strong></td>
-          <td><code>TAK-Basic</code>, <code>TAK-Managed</code>, <code>TAK-Assured</code></td>
-          <td>From baseline runtime mediation (auth, capability, tool gating, audit) up through delegation chains, immutable directives, evaluation discipline, and non-repudiation evidence sufficient for assurance review.</td>
-        </tr>
-        <tr>
-          <td><strong>GAID</strong></td>
-          <td><code>GAID-Private</code>, <code>GAID-Federated</code>, <code>GAID-Public</code></td>
-          <td>From private namespace identifiers up through federated issuer trust, public AIDoc resolution, badging, and independently certified assurance claims.</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      Both standards reference the broader policy context &mdash; ISO/IEC 42001:2023, NIST AI RMF 1.0, the NIST AI Agent Standards Initiative, the NCCoE concept paper on software-and-AI-agent identity and authorization, MCP, W3C Trace Context, RFC 9421 HTTP Message Signatures, and the OWASP GenAI Security Project &mdash; rather than reinventing them.
-    </p>
   </section>
 
   <section id="docs">
-    <h2>User guide &mdash; in-product help, also published here</h2>
-    <p class="sub">These pages are bundled into the platform's in-app help and also live in the source tree. Start at the User Guide index and follow the section that matches your role.</p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:30%;">Section</th><th>Read</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>User Guide index</td><td><a href="/user-guide/">user-guide/</a></td></tr>
-        <tr><td>Getting started</td><td><a href="/user-guide/getting-started/">user-guide/getting-started</a></td></tr>
-        <tr><td>Market archetypes and coworkers</td><td><a href="/user-guide/market-archetypes">user-guide/market-archetypes</a></td></tr>
-        <tr><td>AI coworker</td><td><a href="/user-guide/getting-started/ai-coworker">getting-started/ai-coworker</a></td></tr>
-        <tr><td>Roles &amp; access</td><td><a href="/user-guide/getting-started/roles-and-access">getting-started/roles-and-access</a></td></tr>
-        <tr><td>Development workspace</td><td><a href="/user-guide/development-workspace">user-guide/development-workspace</a></td></tr>
-        <tr><td>Agent dev environments (Claude, Codex, Grok)</td><td><a href="/user-guide/getting-started/agent-dev-environments">getting-started/agent-dev-environments</a></td></tr>
-        <tr><td>AI workforce &amp; providers</td><td><a href="/user-guide/ai-workforce/">user-guide/ai-workforce</a></td></tr>
-        <tr><td>Build Studio</td><td><a href="/user-guide/build-studio/">user-guide/build-studio</a></td></tr>
-        <tr><td>Compliance</td><td><a href="/user-guide/compliance/">user-guide/compliance</a></td></tr>
-        <tr><td>Licensing readiness</td><td><a href="/user-guide/compliance/licensing-readiness">user-guide/compliance/licensing-readiness</a></td></tr>
-        <tr><td>Customers</td><td><a href="/user-guide/customers/">user-guide/customers</a></td></tr>
-        <tr><td>Finance</td><td><a href="/user-guide/finance/">user-guide/finance</a></td></tr>
-        <tr><td>HR</td><td><a href="/user-guide/hr/">user-guide/hr</a></td></tr>
-        <tr><td>Operations</td><td><a href="/user-guide/operations/">user-guide/operations</a></td></tr>
-        <tr><td>Platform &amp; AI ops</td><td><a href="/user-guide/platform/">user-guide/platform</a></td></tr>
-        <tr><td>Edge Nodes</td><td><a href="/user-guide/platform/edge-nodes">user-guide/platform/edge-nodes</a></td></tr>
-        <tr><td>Portfolios</td><td><a href="/user-guide/portfolios/">user-guide/portfolios</a></td></tr>
-        <tr><td>Products</td><td><a href="/user-guide/products/">user-guide/products</a></td></tr>
-        <tr><td>Storefront</td><td><a href="/user-guide/storefront/">user-guide/storefront</a></td></tr>
-        <tr><td>Wiki</td><td><a href="/user-guide/wiki/">user-guide/wiki</a></td></tr>
-        <tr><td>Managed documents</td><td><a href="/user-guide/workspace/documents">user-guide/workspace/documents</a></td></tr>
-        <tr><td>Workspace</td><td><a href="/user-guide/workspace/">user-guide/workspace</a></td></tr>
-        <tr><td>Admin</td><td><a href="/user-guide/admin/">user-guide/admin</a></td></tr>
-      </tbody>
-    </table>
-  </section>
+    <p class="eyebrow">Choose the depth you need</p>
+    <h2>One documentation system, several reader paths.</h2>
+    <p class="section-intro">
+      The public overview explains the system. Canonical guides own the operational and
+      technical detail. This keeps one fact in one place while still giving operators,
+      installers, builders, and reviewers an obvious next step.
+    </p>
 
-  <section>
-    <h2>Architecture &amp; standards</h2>
-    <p class="sub">
-      The repository carries a draft standards family for trustworthy AI-agent operation and identity. The platform itself is the first implementation and conformance case. These documents are intended to be read together: TAK defines the runtime kernel and control model, GAID defines identity and governance claims, the white paper explains the policy context, and the conformance assessment shows how the platform maps to the proposed standards today.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:42%;">Document</th><th>Read on GitHub</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>Platform overview</td><td><a href="/architecture/platform-overview">architecture/platform-overview</a></td></tr>
-        <tr><td>Trusted AI Kernel (TAK)</td><td><a href="/architecture/trusted-ai-kernel">architecture/trusted-ai-kernel</a></td></tr>
-        <tr><td>Global AI Agent Identification &amp; Governance (GAID)</td><td><a href="/architecture/GAID">architecture/GAID</a></td></tr>
-        <tr><td>Trusted AI Agent Governance white paper</td><td><a href="/architecture/2026-04-18-trusted-ai-agent-governance-white-paper">white paper (markdown)</a></td></tr>
-        <tr><td>Standards conformance assessment</td><td><a href="/architecture/agent-standards-dpf-conformance">agent-standards-dpf-conformance</a></td></tr>
-        <tr><td>A2A-aligned coworker runtime design</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-04-23-a2a-aligned-coworker-runtime-design.md">2026-04-23-a2a-aligned-coworker-runtime-design</a></td></tr>
-        <tr><td>COO-led onboarding design</td><td><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-03-21-coo-led-onboarding-design.md">2026-03-21-coo-led-onboarding-design</a></td></tr>
-        <tr><td>AI coworker development principles</td><td><a href="/architecture/ai-coworker-development-principles">ai-coworker-development-principles</a></td></tr>
-        <tr><td>Platform usability standards</td><td><a href="/platform-usability-standards">platform-usability-standards</a></td></tr>
-      </tbody>
-    </table>
-    <p class="sub" style="margin-top:14px;">
-      Reference material that influenced the platform's modelling &mdash; including IT4IT mapping and the broader product-management taxonomy &mdash; lives under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/Reference">docs/Reference</a>.
-    </p>
-  </section>
-
-  <section>
-    <h2>Specifications &amp; plans</h2>
-    <p class="sub">
-      Long-form design specs that document how each capability was built. They are historical records rather than onboarding material, but they are useful if you want to understand the design rationale behind a particular feature, or if you are evaluating the platform's engineering discipline.
-    </p>
-    <div class="grid">
-      <div class="card">
-        <h3>Specs index</h3>
-        <p><a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers/specs">docs/superpowers/specs</a> &mdash; one design document per dated initiative.</p>
-      </div>
-      <div class="card">
-        <h3>Trusted AI Kernel context</h3>
-        <p>For runtime governance and control flow, start with the <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/architecture/trusted-ai-kernel.md">TAK markdown</a> alongside the specs.</p>
-      </div>
-      <div class="card">
-        <h3>Build Studio specs</h3>
-        <p>Search the specs directory for "build-studio" to follow the evolution of the guided build pipeline.</p>
-      </div>
+    <div class="docs-grid">
+      <a class="doc-path" href="/business-types/">
+        <span class="doc-kind">Evaluate</span>
+        <strong>Business catalogue</strong>
+        <span>See how the platform changes for the organization you run.</span>
+      </a>
+      <a class="doc-path" href="/user-guide/">
+        <span class="doc-kind">Operate</span>
+        <strong>User guide</strong>
+        <span>Setup, daily work, coworkers, compliance, and platform administration.</span>
+      </a>
+      <a class="doc-path" href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/install">
+        <span class="doc-kind">Install</span>
+        <strong>Deployment guides</strong>
+        <span>Host-specific prerequisites, setup, verification, and recovery.</span>
+      </a>
+      <a class="doc-path" href="/architecture/platform-overview">
+        <span class="doc-kind">Understand</span>
+        <strong>Architecture and standards</strong>
+        <span>System boundaries, data, identity, governance, deployment, and conformance.</span>
+      </a>
+      <a class="doc-path" href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers/specs">
+        <span class="doc-kind">Inspect intent</span>
+        <strong>Specifications</strong>
+        <span>Approved design direction and the contracts implementation should satisfy.</span>
+      </a>
+      <a class="doc-path" href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/AGENTS.md">
+        <span class="doc-kind">Contribute</span>
+        <strong>Contributor rulebook</strong>
+        <span>Architecture, worktrees, verification, documentation impact, and delivery rules.</span>
+      </a>
     </div>
-  </section>
-
-  <section id="governance">
-    <h2>Governance posture (at a glance)</h2>
-    <p class="sub">
-      &ldquo;Humans hold authority. Agents hold capability. The kernel mediates.&rdquo; That single sentence is the operating principle behind TAK and shapes everything below.
-    </p>
-    <div class="pillars">
-      <div class="pillar">
-        <div class="tag">Human-in-the-loop</div>
-        <p style="margin:0; color:var(--fg-muted); font-size:14px;">HITL tiers (0&ndash;3) decide when an agent can act on its own, when it must propose, and when escalation is mandatory. Proposal mode gates destructive actions; approval surfaces are explicit, not implicit.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Five-layer authority</div>
-        <p style="margin:0; color:var(--fg-muted); font-size:14px;">Every tool call is resolved through auth &rarr; role &rarr; capability &rarr; per-agent grant &rarr; execution mode. Default-deny at every layer; misses are logged with a rationale code.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Immutable directives</div>
-        <p style="margin:0; color:var(--fg-muted); font-size:14px;">A platform preamble is injected into every coworker&rsquo;s system prompt and is never part of user input &mdash; defending against prompt injection and keeping persona discipline consistent across the workforce.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Audit by default</div>
-        <p style="margin:0; color:var(--fg-muted); font-size:14px;">Decisions, tool calls, and approvals are recorded so the runtime is reviewable end-to-end.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">Identity for agents</div>
-        <p style="margin:0; color:var(--fg-muted); font-size:14px;">GAID provides badging, issuer, and traceability so contributions from agents are distinguishable, not anonymous.</p>
-      </div>
-      <div class="pillar">
-        <div class="tag">PR-based change flow</div>
-        <p style="margin:0; color:var(--fg-muted); font-size:14px;">All code changes flow through pull requests with required CI checks and DCO sign-off before they reach the main branch.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="moving">
-    <h2>What&rsquo;s still moving</h2>
-    <p class="sub">
-      The platform is a working system, and it is also actively evolving. This section is the honest list &mdash; what is in production, what is partially in production, and what is currently specced. Read it as a maturity map, not a sales sheet.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:30%;">Area</th><th style="width:20%;">Maturity</th><th>Notes</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Build Studio (5 phases)</td>
-          <td><strong>Production</strong></td>
-          <td>Governed lifecycle through ship with sandbox execution, review evidence, code intelligence, and promotion or PR handoff where configured. Phase auto-dispatch (Ideate&nbsp;&rarr;&nbsp;Plan&nbsp;&rarr;&nbsp;Build&nbsp;&rarr;&nbsp;Review) now runs without operator clicks between phases, with the final diff review as the kept human gate; lifecycle is right-sized by work type and size; an advisory chief-architect reviews at Ideate and Plan. End-to-end reliability hardening for oversized builds and safer portal upgrades continues.</td>
-        </tr>
-        <tr>
-          <td>Marketing execution loop</td>
-          <td><strong>Early access</strong></td>
-          <td>Full draft&nbsp;&rarr;&nbsp;approve&nbsp;&rarr;&nbsp;publish&nbsp;&rarr;&nbsp;respond&nbsp;&rarr;&nbsp;measure lifecycle across LinkedIn posts, LinkedIn Ads, and email shipped in five phases, with hard spend ceilings, per-send human approval, an inbound responder, and a bounded autopilot scheduler. Real-account pilots are what graduate it to GA.</td>
-        </tr>
-        <tr>
-          <td>Internal workspace homes</td>
-          <td><strong>Partial</strong></td>
-          <td>Substrate is live &mdash; registry, resolver, platform fallback, activation summary, and the GearInterface&nbsp;&rarr;&nbsp;worker-signal projection service with banned-copy lint. The 11-primitive renderer library and the first vertical (HVAC dispatcher board) are in implementation.</td>
-        </tr>
-        <tr>
-          <td>Partner &amp; reseller channel</td>
-          <td><strong>Early access</strong></td>
-          <td>Axes-derived partner-program profiles, the wholesale-distribution and IT-managed-services archetypes, and setup-time / admin add-later capability activation have landed. Partner identity convergence, the <code>/partners</code> portal, deal registration, and tiering are designed and staged.</td>
-        </tr>
-        <tr>
-          <td>Coworker screen actions (pseudo-user contract)</td>
-          <td><strong>Partial</strong></td>
-          <td>Substrate complete: screen-manifest registry, the <code>screen_*</code> view-command tools, the <code>CoworkerActionEnvelope</code> propose&nbsp;&rarr;&nbsp;approve&nbsp;&rarr;&nbsp;dispatch state machine with approve/deny routes, finer screen-grant taxonomy, and a Screen Actions authority tab. Build Studio is the first vertical; storefront, admin, and platform verticals follow.</td>
-        </tr>
-        <tr>
-          <td>Organization knowledge corpus (WWWD)</td>
-          <td><strong>Early access</strong></td>
-          <td>One governed enrichment contract with idempotency, provenance, and trust grading; draft-by-default review; onboarding seeds (mission, business documents, market &amp; scope); a market-research producer with proposal&nbsp;&rarr;&nbsp;approval&nbsp;&rarr;&nbsp;scheduled-refresh; and freshness governance (supersession + decay). Deeper Build Studio profile-resolver integration is the closing piece.</td>
-        </tr>
-        <tr>
-          <td>Routing resilience &amp; failover</td>
-          <td><strong>Production</strong></td>
-          <td>Runtime circuit breaker excludes failing endpoints for sub-second failover; live-health projection separates admin lifecycle, runtime circuit, and operator-visible health; failover no longer surfaces fabrication copy. Layered on top of the existing capability-tier routing.</td>
-        </tr>
-        <tr>
-          <td>Coworker workforce, grants, tool gating</td>
-          <td><strong>Production</strong></td>
-          <td>Default-deny grants, route-scoped agent identity, immutable directive injection, audit log all live.</td>
-        </tr>
-        <tr>
-          <td>Archetypes (21 categories, 95 leaf templates)</td>
-          <td><strong>Production</strong></td>
-          <td>Bootstrap on storefront setup; sections, vocabulary, finance profile, design system, marketing posture, and workspace-home direction seeded.</td>
-        </tr>
-        <tr>
-          <td>LDAP / Active Directory / Entra federation</td>
-          <td><strong>Production</strong></td>
-          <td>Federation page live; principal linking from upstream identities to internal records.</td>
-        </tr>
-        <tr>
-          <td>GAID identity issuance &amp; audit</td>
-          <td><strong>Production</strong></td>
-          <td>Identifier issuance, authorization decision logging, chain-of-custody traces all in place.</td>
-        </tr>
-        <tr>
-          <td>Local-first inference (Docker Model Runner)</td>
-          <td><strong>Production</strong></td>
-          <td>Bundled with Docker Desktop 4.40+; auto-pull on first run with progress reporting.</td>
-        </tr>
-        <tr>
-          <td>Operations Map, capacity continuity, capability needs</td>
-          <td><strong>Production</strong></td>
-          <td>Operator views and saved preferences live for workforce posture; capacity continuity and capability-needs review route AI follow-up into durable evidence and backlog work.</td>
-        </tr>
-        <tr>
-          <td>Wiki and managed documents</td>
-          <td><strong>Production</strong></td>
-          <td>Global wiki browse/detail, wiki linting, founder-kernel pages, managed document list/detail, lifecycle state, versions, and references are live.</td>
-        </tr>
-        <tr>
-          <td>Licensing readiness</td>
-          <td><strong>Production</strong></td>
-          <td>Compliance licensing workspace and route-specific coworker tools capture factual licensing posture, readiness issues, and investigation evidence.</td>
-        </tr>
-        <tr>
-          <td>Edge Node &mdash; envelope, adapters, Go agent</td>
-          <td><strong>Early access</strong></td>
-          <td>Canonical event envelope with change events (Slice 0/1) live on portal ingest. UniFi adapter (controller discovery + clients), ARP collector with MAC-OUI vendor enrichment, and SNMP/LLDP telemetry adapters are shipped. A Go host agent (enroll, heartbeat, host-info, ARP collector) is in place with wire-contract parity tests. Deployment matrix covers single-host, multi-host, and macvlan; air-gapped runbooks exist. Native binaries beyond the Go scaffold and mTLS hardening are follow-on.</td>
-        </tr>
-        <tr>
-          <td>Capability-tier model routing</td>
-          <td><strong>Production</strong></td>
-          <td>Dynamic, capability-tier driven; sensitivity clearance enforced; champion/challenger A/B with promotion gates.</td>
-        </tr>
-        <tr>
-          <td>MCP tool surface</td>
-          <td><strong>Production</strong></td>
-          <td>Backlog, build, evidence, contribution, and feedback all callable as MCP tools under the same gates as in-product coworkers.</td>
-        </tr>
-        <tr>
-          <td>Hive Mind contribution flow</td>
-          <td><strong>Production</strong></td>
-          <td>Three contribution modes; Reusability Check at design time; assessment uses analysis as input.</td>
-        </tr>
-        <tr>
-          <td>Observability &mdash; Prometheus discovery</td>
-          <td><strong>Production</strong></td>
-          <td>Estate inventory, scrape-job classification, evidence trails.</td>
-        </tr>
-        <tr>
-          <td>AI cost governance (EP-COST)</td>
-          <td><strong>Early access</strong></td>
-          <td>Anthropic cache telemetry, accurate per-model pricing, <code>BuildPhaseRun</code> + <code>ToolExecution</code> metering, <code>AgentBudgetEvent</code>, rolling thread compaction, phase-boundary summarization, and CLI-pool pre-dispatch rate-limit checks are live. Per-phase cost breakdown surfaces in Build Studio. Budget enforcement (hard stops vs. soft alerts) is the closing piece.</td>
-        </tr>
-        <tr>
-          <td>Decision Perspective Gate (WWMD / WWWD / WSID) + Persona Voice Layer</td>
-          <td><strong>Early access</strong></td>
-          <td>WWMD is the canonical handler for open-question and ambiguity surfaces, returning <em>recommend</em> / <em>arbitrate</em> / <em>escalate</em> / <em>defer</em> with confidence and audit trail; also exposed as an MCP tool, and now backed by the org WWWD corpus for org-specific judgment. The Persona Voice Layer ships speaches-based STT, a seeded founder voice, Apple-Silicon-native TTS sidecars (Chatterbox, MLX) with sentence-level streaming, and per-profile voice tuning.</td>
-        </tr>
-        <tr>
-          <td>WSID profession corpus (third decision scope)</td>
-          <td><strong>Early access</strong></td>
-          <td>The third decision-perspective scope after WWMD (founder/platform) and WWWD (org): a per-role professional corpus so coworker craft judgment is source-traced and audited. Phase&nbsp;0 (profession profile kind + professional-practice domain class), Phase&nbsp;1 (Profession Source Registry + 23 family profiles + role resolver), and the data-architect corpus with provenance lint and seed wiring are merged; finance and marketing corpora and deeper gate-resolution wiring are the pilot-three completion work. Reuses the existing profile + corpus + retrieval + gate substrate &mdash; no new tables.</td>
-        </tr>
-        <tr>
-          <td>xAI / Grok provider support (EP-GROK-001)</td>
-          <td><strong>Early access</strong></td>
-          <td>Grok is a direct provider with seeded Grok&nbsp;4.3 and Grok&nbsp;Build&nbsp;0.1 models. API-key auth plus a device-code OAuth path (drives the Grok CLI&rsquo;s own <code>device-auth</code>, stores and self-refreshes the credential, injects it into build sandboxes) are merged across slices 1&ndash;4, with operator-page and coworker-driven (<code>grok_signin_start</code> / <code>grok_signin_status</code>) setup. End-to-end functional verification on a real sandbox with operator authorization is the closing step.</td>
-        </tr>
-        <tr>
-          <td>Cloud Single-VM (AWS / GCP / Azure)</td>
-          <td><strong>Early access</strong></td>
-          <td>Terraform modules for single-VM deployment on AWS, GCP, and Azure are merged on <code>main</code>; the Linux installer runs headlessly inside the VM. Pilots wanted to graduate the path to GA.</td>
-        </tr>
-        <tr>
-          <td>Portal self-upgrade runtime</td>
-          <td><strong>Early access</strong></td>
-          <td>Self-upgrade keeps a long-lived install current with <code>main</code> using merge-based source prep; the upgrade window is when the storefront is closed (operating hours), with an operator emergency override and next-check visibility. Governed pre-upgrade recovery points (Postgres, Neo4j, Qdrant) can be restored from the upgrade center, and an on-demand &ldquo;What&rsquo;s in this update?&rdquo; impact summary is available before draining. Seed/customization reconciliation on merge and in-session UX continuity during recycles remain the active hardening surfaces.</td>
-        </tr>
-        <tr>
-          <td>A2A-aligned coworker runtime</td>
-          <td><strong>Partial</strong></td>
-          <td>Internal building blocks present (TaskRun, TaskNode, delegation chains, proposal mode). Refactor to a unified A2A-shaped task envelope is specced and underway. External A2A endpoints are deferred until the internal substrate is task-native.</td>
-        </tr>
-        <tr>
-          <td>COO-led onboarding</td>
-          <td><strong>Partial</strong></td>
-          <td>Onboarding-coo coworker, archetype bootstrap, local-provider setup, and install-mode guidance are live. The MCP onboarding step has known friction; zero-click provider setup is the goal.</td>
-        </tr>
-        <tr>
-          <td>Improvement loops for every coworker</td>
-          <td><strong>Partial</strong></td>
-          <td>Per-agent scoring and instruction phases (learning &rarr; practicing &rarr; innate) live. Build conventions that feed prompt-level learning back to build specialists are specced; extension to other coworker types is the gap being closed.</td>
-        </tr>
-        <tr>
-          <td>OpenTelemetry tracing</td>
-          <td><strong>Specced</strong></td>
-          <td>Discovery and metrics are live; native OTEL traces are not yet emitted by the runtime, though the architecture supports pluggable collectors.</td>
-        </tr>
-        <tr>
-          <td>Public A2A endpoint exposure</td>
-          <td><strong>Specced</strong></td>
-          <td>Internal substrate must be task-native first; once that is in place, private and public A2A endpoint exposure is a projection rather than a rewrite.</td>
-        </tr>
-        <tr>
-          <td>Build orchestrator resume after restart</td>
-          <td><strong>Specced</strong></td>
-          <td>Phase data persists; resume logic at task granularity after a process restart is tracked work.</td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section id="roadmap">
-    <h2>Roadmap and backlog</h2>
-    <p class="sub">
-      Beyond the &ldquo;What&rsquo;s still moving&rdquo; table above, the platform has a deliberate roadmap of larger initiatives that are in early access, designed, or under active research. They are listed here so evaluators can see where the platform is heading &mdash; not as commitments to a date, but as the shape of the open backlog.
-    </p>
-
-    <h3 style="margin-top:24px; font-size:16px;">Deployment maturity beyond Windows + Docker Desktop</h3>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:24%;">Target</th><th style="width:18%;">Status</th><th>Notes</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>Windows + Docker Desktop</strong></td>
-          <td>Production</td>
-          <td>The current shipped install. PowerShell installer, MSI host-network bridge, auto-pull local model, one-question setup.</td>
-        </tr>
-        <tr>
-          <td><strong>Linux single-host</strong></td>
-          <td>Early access</td>
-          <td>The native Linux installer is code-complete on <code>main</code>; Ubuntu CI exercises the full stack. More distro, reboot, provider, and real-hardware verification reports are needed before GA.</td>
-        </tr>
-        <tr>
-          <td><strong>macOS workstation</strong></td>
-          <td><strong>GA</strong></td>
-          <td>The macOS Apple Silicon installer is validated end-to-end on real Apple Silicon hardware (M-series, macOS 14+) with Docker Desktop and Docker Model Runner, including the voice STT + native-host TTS sidecar path. Verification reports on additional Mac models / macOS versions remain welcome to widen the tested matrix.</td>
-        </tr>
-        <tr>
-          <td><strong>Cloud single-VM (AWS / GCP / Azure)</strong></td>
-          <td>Early access</td>
-          <td>Terraform modules for AWS, GCP, and Azure are merged on <code>main</code>. The Linux installer runs headlessly inside the provisioned VM; the dedicated runbook adds cloud-specific provisioning, public-URL / TLS, and persistent-storage guidance. Pilots wanted before GA.</td>
-        </tr>
-        <tr>
-          <td><strong>Cloud-managed services (RDS, ElastiCache, Neo4j Aura, Qdrant Cloud)</strong></td>
-          <td>Designed &mdash; low coupling</td>
-          <td>Postgres, Redis, Neo4j, Qdrant, browser-use, and AI inference all reach the portal through environment variables. Swapping any of them for a managed cloud equivalent is a configuration change, not a code change.</td>
-        </tr>
-        <tr>
-          <td><strong>ECS / Container Apps / Cloud Run</strong></td>
-          <td>Designed &mdash; medium coupling</td>
-          <td>Portal and sandbox containers are deployable as container tasks today. The MSI host-network bridge gets replaced by cloud-native ingress (ALB/NLB, App Gateway, Cloud Load Balancing, or a Traefik/Caddy/nginx front). Inngest can run self-hosted or move to Inngest Cloud.</td>
-        </tr>
-        <tr>
-          <td><strong>Kubernetes / Helm chart</strong></td>
-          <td>Designed</td>
-          <td>Reference architecture covers the Kubernetes path. A first-class Helm chart and operator are tracked work, not yet shipped.</td>
-        </tr>
-        <tr>
-          <td><strong>DPF-on-DPF production instance</strong></td>
-          <td>Specced</td>
-          <td>The production instance the project itself runs on, hosted on the platform. Closes the recursive-self-improvement loop end-to-end.</td>
-        </tr>
-        <tr>
-          <td><strong>Mobile companion app (iOS + Android)</strong></td>
-          <td>In progress</td>
-          <td>React Native 0.83 + Expo SDK 55 + React 19.2 companion app under <code>apps/mobile</code>. Approval surfaces, coworker chat, and offline-cached views are the early targets.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3 style="margin-top:24px; font-size:16px;">Open backlog &mdash; designed, not yet delivered</h3>
-    <p class="sub" style="margin-top:0;">
-      Each line is anchored in a dated design doc under <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers/specs">docs/superpowers/specs</a>. The order is rough thematic grouping, not priority.
-    </p>
-    <table class="guide">
-      <thead>
-        <tr><th style="width:36%;">Initiative</th><th>What it brings</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>External customer AI coworker</strong></td>
-          <td>A storefront-facing assistant separate from internal coworkers, with strong trust disclosure, constrained tool use, customer-safe data access, and adaptive human escalation. GAID-backed trust badging is the future state.</td>
-        </tr>
-        <tr>
-          <td><strong>Public contribution mode (fork-based PR flow)</strong></td>
-          <td>Fork-based contribution so installs without upstream write access can still contribute. Replaces the current upstream-write-token model now that the repo is public.</td>
-        </tr>
-        <tr>
-          <td><strong>Company operations parity map</strong></td>
-          <td>WorkOS, Workday, QuickBooks, and adjacent ecosystem analysis translated into product lanes for IAM, people/HCM, workforce, payroll, finance/accounting, QuickBooks coexistence, planning, spend/procurement, and talent. This is the market-backed roadmap for the company operating platform DPF wants to become.</td>
-        </tr>
-        <tr>
-          <td><strong>Ecosystem absorption architecture</strong></td>
-          <td>Adapter-to-native doctrine, external-entity crosswalks, graduation gates, event/action/receipt bus, and shared primitives for Party, Work, Money, Asset, Knowledge, and Authority. The goal is to turn useful outside-system workflows into a better engineered DPF whole instead of brittle one-off integrations.</td>
-        </tr>
-        <tr>
-          <td><strong>Connector factory framework</strong></td>
-          <td>A repeatable factory for adding integrations (HRIS, ERP, banking, CRM) under the conduit-not-broker stance &mdash; customer brings their own account and credentials. Connectors are bridges and evidence sources; native promotion waits for mapping, reconciliation, authority, rollback/export, and compliance gates.</td>
-        </tr>
-        <tr>
-          <td><strong>ADP / payroll MCP integration</strong></td>
-          <td>First connector through the factory: payroll feeds, position management, employment lifecycle.</td>
-        </tr>
-        <tr>
-          <td><strong>Tax remittance</strong></td>
-          <td>Sales-tax / VAT calculation and remittance flow tied to storefront orders and the finance module.</td>
-        </tr>
-        <tr>
-          <td><strong>Coworker execution adapter substrate</strong></td>
-          <td>Unifies the way coworkers dispatch to local LLMs, hosted APIs, and CLI providers (Claude Code, Codex CLI) so adapter-specific quirks stop leaking into the runtime.</td>
-        </tr>
-        <tr>
-          <td><strong>Routing control / data plane split</strong></td>
-          <td>Separates routing decisions (control plane) from inference (data plane) so routing changes can be deployed independently and audited as configuration.</td>
-        </tr>
-        <tr>
-          <td><strong>Orchestration primitives</strong></td>
-          <td>First-class building blocks for multi-step coworker work &mdash; durable handoffs, parallel branches, conditional escalation.</td>
-        </tr>
-        <tr>
-          <td><strong>Artifact provenance receipts</strong></td>
-          <td>Signed receipts attached to every produced artifact (design doc, code change, evidence record) so downstream consumers can verify origin and authority.</td>
-        </tr>
-        <tr>
-          <td><strong>Discovery / fingerprint contribution pipeline</strong></td>
-          <td>Estate discovery feeds fingerprints back into the hive mind so the next install gets better defaults from the community&rsquo;s collected experience.</td>
-        </tr>
-        <tr>
-          <td><strong>Multi-layer topology graph + views</strong></td>
-          <td>Graph views that span business, application, and technology layers (ArchiMate-aligned) with traversal for impact analysis.</td>
-        </tr>
-        <tr>
-          <td><strong>Async coworker messaging</strong></td>
-          <td>Coworker conversations that survive across sessions, devices, and durable background work &mdash; not just one chat thread at a time.</td>
-        </tr>
-        <tr>
-          <td><strong>Browser-use integration</strong></td>
-          <td>A bundled headless browser MCP service so coworkers can carry out web tasks (form fills, lookups, evidence capture) under the same governance as every other tool.</td>
-        </tr>
-        <tr>
-          <td><strong>Lifecycle evidence specialist</strong></td>
-          <td>A dedicated coworker that curates the evidence trail across the lifecycle &mdash; making sure compliance, audit, and contribution all draw from the same canonical record.</td>
-        </tr>
-        <tr>
-          <td><strong>Custom archetype creation and refinement</strong></td>
-          <td>A path to add and refine market archetypes beyond the bundled catalog, including parameterizable vocabulary, finance profile, design tokens, and worker-home composition.</td>
-        </tr>
-        <tr>
-          <td><strong>IT service provider (MSP) archetype</strong></td>
-          <td>Adds an archetype for managed-service providers &mdash; a frequent customer profile that doesn&rsquo;t fit the core service categories cleanly.</td>
-        </tr>
-        <tr>
-          <td><strong>Local-LLM grading (incremental)</strong></td>
-          <td>Lets local models grade local work, reducing dependence on cloud providers for evaluation traffic.</td>
-        </tr>
-        <tr>
-          <td><strong>Build orchestrator resume after restart</strong></td>
-          <td>Task-level resume of an in-flight build after a process restart. Phase data already persists; the resume logic is the gap.</td>
-        </tr>
-        <tr>
-          <td><strong>Zero-click provider setup &amp; MCP onboarding polish</strong></td>
-          <td>Removes the manual paste-and-restart step from MCP setup; OAuth becomes the only required interaction.</td>
-        </tr>
-        <tr>
-          <td><strong>OpenTelemetry tracing</strong></td>
-          <td>Native OTEL trace emission across portal, sandbox, coworker runtime, and MCP tool calls &mdash; complementing the Prometheus discovery already in place.</td>
-        </tr>
-        <tr>
-          <td><strong>Public A2A endpoint exposure</strong></td>
-          <td>Once the internal coworker runtime is fully task-native, expose private and public A2A endpoints so external agents can call into the platform under the same governance gates as in-product coworkers.</td>
-        </tr>
-        <tr>
-          <td><strong>Improvement-loop coverage for every coworker</strong></td>
-          <td>Build conventions feed prompt-level learning back to build specialists today; extending the same observe&nbsp;&rarr;&nbsp;classify&nbsp;&rarr;&nbsp;accumulate&nbsp;&rarr;&nbsp;inject&nbsp;&rarr;&nbsp;graduate pattern to every coworker is the explicit goal.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3 style="margin-top:24px; font-size:16px;">Research and exploration</h3>
-    <p class="sub" style="margin-top:0;">
-      Areas under active research. They are influencing design today even though no shipped feature depends on them yet.
-    </p>
-    <div class="grid">
-      <div class="card"><h3>Standards engagement</h3><p>Tracking ISO/IEC 42001, NIST AI RMF, the NIST AI Agent Standards Initiative, and the NCCoE concept paper on agent identity and authorization. The platform is intended as a proving ground for TAK and GAID under those frameworks.</p></div>
-      <div class="card"><h3>Open-source agent identity registries</h3><p>How GAID-Federated and GAID-Public profiles interact with public issuer accreditation, revocation, and verifier infrastructure outside any single install.</p></div>
-      <div class="card"><h3>External A2A interoperability</h3><p>What it takes for the platform to be both a caller of external A2A agents and a callee &mdash; specifically how delegation chains and TAK runtime controls cross trust boundaries.</p></div>
-      <div class="card"><h3>Continuous improvement flywheel</h3><p>Portfolio-aware observe &rarr; normalize &rarr; evaluate &rarr; propose &rarr; govern &rarr; execute &rarr; contribute cycle that turns every install&rsquo;s operating data into shared platform improvement.</p></div>
-    </div>
-
-    <p class="note" style="margin-top:18px;">
-      Honest qualifier: dates are not a contract. Priorities follow what installs actually need and what the hive mind is producing. Specs land in <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers/specs">docs/superpowers/specs</a>; plans land in <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/docs/superpowers/plans">docs/superpowers/plans</a>. If you want the most current view, that is where to look.
-    </p>
   </section>
 
   <section id="faq">
-    <h2>Frequently asked questions</h2>
-    <p class="sub">Common questions from people evaluating the platform pre-install. The user guide and architecture docs go deeper on each.</p>
-    <div class="grid">
-      <div class="card">
-        <h3>Is the platform really open source?</h3>
-        <p>Yes. The repository is public and contributions land via pull request with DCO sign-off. The customizable install is a full source clone &mdash; Build Studio and your local IDE share the same workspace.</p>
-      </div>
-      <div class="card">
-        <h3>Does my data leave my environment?</h3>
-        <p>Not unless you opt in. The platform ships with a bundled local model and runs everything on your hardware. External providers are an upgrade with explicit sensitivity clearance per provider; Hive Mind contribution is opt-in and goes through a pull request you review.</p>
-      </div>
-      <div class="card">
-        <h3>Can multiple companies share one install?</h3>
-        <p>No. Each install is one Organization &mdash; no multi-tenancy. The cross-company value path is the Hive Mind, not shared database rows.</p>
-      </div>
-      <div class="card">
-        <h3>Do I need a developer to use it?</h3>
-        <p>No for day-to-day business operation. Archetypes, the portal, and AI coworkers are meant for operators. For changing the platform itself, Build Studio is the governed development surface, and customizable installs can pair it with a local IDE while that surface continues to mature.</p>
-      </div>
-      <div class="card">
-        <h3>What if I do not want to run AI locally?</h3>
-        <p>Plug in a cloud provider (Anthropic, OpenAI, others). Set its sensitivity clearance, and routing will pick it for traffic that the clearance covers. Local stays the default for restricted data.</p>
-      </div>
-      <div class="card">
-        <h3>How do I get help?</h3>
-        <p>The in-product COO coworker is the first stop. Beyond that: the user guide is published in the repo, issues and discussions live on GitHub, and the AI coworker development principles document explains how to extend the workforce.</p>
-      </div>
-      <div class="card">
-        <h3>Can I trust an agent&rsquo;s actions?</h3>
-        <p>Every meaningful action carries an approval surface, a tool grant, and an audit log entry. The platform&rsquo;s posture is &ldquo;humans hold authority, agents hold capability, the kernel mediates.&rdquo; What an agent did, when, and on whose authority is always reconstructable.</p>
-      </div>
-      <div class="card">
-        <h3>What does the install include?</h3>
-        <p>Portal, init container, Postgres, Neo4j, Qdrant, Inngest, Redis, the local model runner, and on-demand sandbox containers. Twenty-one market categories, 95 leaf archetype templates, purposed coworkers, the skill registry, and a seeded role hierarchy come pre-loaded.</p>
-      </div>
-      <div class="card">
-        <h3>How do I uninstall?</h3>
-        <p>Stop the stack with <code>dpf-stop</code>, remove the Docker volumes (your data lives there &mdash; back up first if you want to keep it), and delete the install directory. Nothing is registered outside your machine.</p>
-      </div>
-      <div class="card">
-        <h3>What does it cost?</h3>
-        <p>The platform is free and open source. Cloud provider usage (if you connect external models) is billed by the provider; the platform shows AI spend alongside the rest of your operating costs in the finance module.</p>
-      </div>
-      <div class="card">
-        <h3>What does the &ldquo;ready-to-go&rdquo; vs &ldquo;customizable&rdquo; install mean?</h3>
-        <p>Ready-to-go uses pre-built images and the guided portal surfaces. Customizable clones the source and shares the workspace with Build Studio plus a local IDE. Same platform either way; customizable is the safer choice for serious source edits while Build Studio hardening continues.</p>
-      </div>
-      <div class="card">
-        <h3>Where do I file an issue or suggest a feature?</h3>
-        <p>The in-product coworker can submit feedback and improvement proposals through governed MCP tools. You can also open issues directly on the GitHub repository.</p>
-      </div>
+    <p class="eyebrow">Common questions</p>
+    <h2>Short answers before you go deeper.</h2>
+    <div class="faq-list">
+      <details>
+        <summary>Does company data leave the install?</summary>
+        <p>
+          DPF is local-first. Your organization data stays inside its dedicated install unless
+          you deliberately configure an external AI provider, integration, or contribution path.
+          Those paths remain subject to platform authority and audit controls.
+        </p>
+      </details>
+      <details>
+        <summary>Can several companies share one DPF database?</summary>
+        <p>
+          No. One install represents one organization. Cross-install learning moves through
+          governed, opt-in contribution rather than shared tenant rows.
+        </p>
+      </details>
+      <details>
+        <summary>Do I need Build Studio to change the platform?</summary>
+        <p>
+          No. Build Studio is the in-platform governed development surface. Customizable installs
+          also support normal editor and external agent-client workflows, with the same pull-request,
+          DCO, CI, and verification expectations for upstream changes.
+        </p>
+      </details>
+      <details>
+        <summary>Are coworkers allowed to take actions without asking?</summary>
+        <p>
+          It depends on the user&rsquo;s authority, the coworker&rsquo;s grants, the tool, risk policy,
+          and configured human-in-the-loop tier. High-impact work has approval floors; unsupported
+          and denied actions must remain explicit.
+        </p>
+      </details>
+      <details>
+        <summary>Is everything described here generally available?</summary>
+        <p>
+          No. The maturity section explicitly separates implemented contracts from active direction.
+          Host status is also labeled in the install section. Detailed specifications describe intent;
+          the user guide describes current operator behavior.
+        </p>
+      </details>
+      <details>
+        <summary>Where should I report a problem or suggest an improvement?</summary>
+        <p>
+          Use the project&rsquo;s
+          <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues">GitHub issues</a>.
+          Include what you expected, what happened, and which host or platform route was involved.
+        </p>
+      </details>
     </div>
   </section>
 
-  <section>
-    <h2>Ready when you are</h2>
-    <p class="sub">Install on your own hardware in minutes, pick what you do, and let your AI coworkers take it from there.</p>
-    <div class="cta-row">
-      <a class="btn primary" href="#install">Install</a>
-      <a class="btn" href="/business-types/">Find your business</a>
-      <a class="btn" href="#mobile">The mobile vision</a>
-      <a class="btn" href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory">GitHub</a>
+  <section class="closing" aria-labelledby="closing-title">
+    <h2 id="closing-title">See the platform through your business.</h2>
+    <p>
+      The clearest next step is not a feature matrix. Pick the kind of organization you run,
+      see the operating pattern DPF starts with, and then choose an install path when the fit is clear.
+    </p>
+    <div class="actions">
+      <a class="button primary" href="/business-types/">Find your business</a>
+      <a class="button" href="/user-guide/">Explore the user guide</a>
     </div>
   </section>
-
 </main>
 
 <footer>
-  <div class="wrap">
-    Open Digital Product Factory &middot; Documentation overview page &middot;
-    <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory">GitHub repository</a>
+  <div class="page footer-inner">
+    <span>Open Digital Product Factory &middot; open source &middot; local first</span>
+    <div class="footer-links">
+      <a href="#top">Back to top</a>
+      <a href="/user-guide/">User guide</a>
+      <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory">Source</a>
+      <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/LICENSE">License</a>
+    </div>
   </div>
 </footer>
-
-<a class="back-top" href="#top" aria-label="Back to top">&uarr; Top</a>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary

- replace the 34-section, table-heavy public overview with an eight-section semantic information architecture and five durable navigation choices
- add two accessible relationship graphics for the operating model and governed coworker action flow, including a mobile-native vertical version of the governance diagram
- remove stale hand-maintained catalogue/workforce totals, preserve legacy fragment anchors, and route deep detail to canonical operator, architecture, install, and contributor sources
- clarify current maturity, single-organization/local-first boundaries, and Build Studio as one governed development path rather than the only path

## Grounding

- plan: `docs/superpowers/plans/2026-07-26-documentation-content-visual-quality.html`
- backlog: `BI-5CC999F1`
- source audit: 23 archetype modules / 103 packaged archetypes and 68 registry coworkers proved the old 21/95/63 public counts had drifted; durable public copy now uses `100+` and role descriptions instead of brittle exact totals

## Verification

- `node scripts/gen-doc-index.mjs --check` — fresh, 554 pages
- `node scripts/check-doc-links.mjs` — PASS, 74 user-guide pages
- Python standard-library HTML parse — PASS
- structural assertions — PASS: one H1, no tables, no inline styles, no stale counts, every legacy fragment anchor retained
- all local public destinations and the logo returned HTTP 200
- `git diff --check` — clean
- staged Gitleaks scan + pre-commit scan — PASS
- governed preview lease `NPEL-669A88E37C`
  - desktop 1440x1000: 8 sections, 5-item nav, 2 figures, equal-height system nodes, no missing images
  - mobile 390x844: no page overflow, no missing images, no duplicate IDs, no empty links, no heading skips, no visible interaction target below 40px, readable stacked governance flow
  - mobile page height reduced from the audited legacy 74,386px to 14,568px

## UX-Fit-Decision

Hybrid-by-surface: semantic HTML and responsive CSS for the public story, enriched Markdown for canonical guides, and selective GitHub-safe visuals for repository entry points. This slice follows progressive disclosure, preserves deep-link compatibility, and uses graphics only for relationships that are materially easier to understand visually.

## Docs-Impact-Decision

This PR changes documentation presentation and public explanatory copy only. It does not change platform behavior, routes, setup contracts, prompts, or contributor doctrine, so no additional user-guide, architecture, setup, or AGENTS.md update is required in this slice. The README and in-platform guide are separately tracked child items under the merged documentation program plan.

## Data / migration impact

Not applicable: static HTML documentation only; no schema, migration, seed, or runtime data changes.