### PR TITLE
test(tak): isolate prompt fallback assertions

### DIFF
--- a/apps/web/lib/explore/fix-flow.test.ts
+++ b/apps/web/lib/explore/fix-flow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   FEATURE_BUILD_KIND_VALUES,
   isFixContextComplete,
@@ -7,6 +7,10 @@ import {
   type FixContext,
 } from "./feature-build-types";
 import { getBuildPhasePrompt } from "@/lib/integrate/build-agent-prompts";
+
+vi.mock("@/lib/tak/prompt-loader", () => ({
+  loadPrompt: vi.fn(async (_category: string, _slug: string, fallback?: string) => fallback ?? ""),
+}));
 
 // The fix flow is the kind="fix" branch of the Build Studio pipeline. These
 // tests pin the behavior the spec requires: a complete diagnosis substitutes

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -1,9 +1,15 @@
 // apps/web/lib/prompt-assembler.test.ts
 // TDD RED → GREEN tests for the composable system prompt assembler.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assembleSystemPrompt } from "./prompt-assembler";
 import type { PromptInput } from "./prompt-assembler";
+
+vi.mock("./prompt-loader", () => ({
+  loadPrompts: vi.fn(async (refs: Array<{ category: string; slug: string; fallback?: string }>) => {
+    return new Map(refs.map((ref) => [`${ref.category}/${ref.slug}`, ref.fallback ?? ""]));
+  }),
+}));
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Isolates prompt-assembler and fix-flow unit tests from mutable seeded/admin prompt templates in the persistent local-CI database.
- Preserves the existing fallback-prompt behavioral assertions while mocking only the prompt-loader boundary.
- Leaves production prompt loading unchanged.
- Linked blocker: BI-3D96B563.

## Test plan
- [x] Reproduced the original 6 failures against the persistent local-CI database.
- [x] Full web Vitest suite passed.
- [x] Web typecheck passed.
- [x] Prisma generation and migration convergence passed.
- [x] Documentation and repository guards passed.
- [x] Production Docker build passed.

Documentation impact: none; this is test-fixture isolation only and does not change user, operator, architecture, or contributor behavior.

Local-CI-Evidence: cms2euxzo0bon01qownexluy0 (fix/prompt-template-test-isolation@d013b50ef2cd9177b256a24ed9f6457e692ffc3f; lease NPEL-1C9B171E22)