### PR TITLE
fix(dev): converge contributor-preview migration history drift (BI-4DB4B415)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         with:
           node-version: 24
       - name: Test pr-health verdict logic
-        run: node --test scripts/pr-health.test.mjs scripts/check-ci-build-cache.test.mjs
+        run: node --test scripts/pr-health.test.mjs scripts/check-ci-build-cache.test.mjs scripts/lib/dev-preview-migrate-converge.test.mjs scripts/dev-postgres-pgvector-contract.test.mjs
 
   mobile-jest-pin-guard:
     name: Mobile Jest Pin Guard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -515,7 +515,10 @@ services:
       context: .
       target: dev
     profiles: ["dev"]
-    command: ["sh", "-c", "pnpm install --frozen-lockfile && pnpm --filter @dpf/db exec prisma generate && pnpm --filter @dpf/db exec prisma migrate deploy && pnpm --filter @dpf/db exec tsx src/sanitized-clone.ts"]
+    # BI-4DB4B415: migrate through the disposable-preview converge wrapper so a
+    # schema-ahead / failed "already exists" history can be repaired safely
+    # (or classified blocked_sandbox_drift) without touching the live portal DB.
+    command: ["sh", "-c", "pnpm install --frozen-lockfile && pnpm --filter @dpf/db exec prisma generate && pnpm --filter @dpf/db exec node ./scripts/dev-preview-migrate-deploy.mjs && pnpm --filter @dpf/db exec tsx src/sanitized-clone.ts"]
     environment:
       CI: "true"
       DATABASE_URL: postgresql://dpf:dpf_dev@dev-postgres:5432/dpf

--- a/docs/user-guide/contributing/dev-container.md
+++ b/docs/user-guide/contributing/dev-container.md
@@ -41,6 +41,15 @@ Login: `admin@dpf.local` / `changeme123`
 - Production promotion still belongs to the portal's governed workflow
 - The sanitized clone runs on first startup — production must be running as the data source
 - Contributor database readiness verifies both PostgreSQL connectivity and pgvector availability before migrations start. If `dev-postgres` remains unhealthy, inspect its health output and recreate that contributor-only service from the checked-in `pgvector/pgvector:pg16` image; do not bypass `dev-init` or edit an applied migration.
+- Migration deploy for the preview runs through a disposable-only converge wrapper (`packages/db/scripts/dev-preview-migrate-deploy.mjs`). If Prisma history is behind a schema that already has the migration’s objects (classic symptom: `column … already exists` / failed `20260605060000_hive_contributions_surface`), the wrapper marks that migration applied only when every structural effect is present, then continues deploy. Partial or non-idempotent failures exit as **`blocked_sandbox_drift`** with one next action.
+- **Disposable recovery (contributor preview only):** when logs say `blocked_sandbox_drift` and name volume `dpf_dev_pgdata`, recreate that volume and re-run the dev profile. Never delete live portal volumes (`dpf_pgdata` / production Postgres). Example:
+
+  ```bash
+  docker compose --profile dev stop dev-portal dev-init dev-postgres
+  docker volume rm dpf_dev_pgdata
+  docker compose --profile dev up -d
+  ```
+
 - The clone resets the disposable development application tables before copying. Restricted provider, credential, token, and connection records are not copied; production-derived search/vector values are omitted rather than carrying source terms or embeddings into the preview.
 - Additive source-schema differences are expected during concurrent development. Source-only columns or tables are left out of the preview, destination-only columns use their migrated defaults, and a shared column with an incompatible type stops the clone with a precise error instead of risking a corrupt preview.
 - Clone publication is fail-safe: if any table cannot be copied or sanitized, the development application tables are cleared again while Prisma migration history is retained. The Contributor preview will not start against a partially copied relational dataset. Correct the reported source/tooling error and restart the development initialization step to retry.

--- a/packages/db/scripts/dev-preview-migrate-deploy.mjs
+++ b/packages/db/scripts/dev-preview-migrate-deploy.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// scripts/dev-preview-migrate-deploy.mjs
+//
+// BI-4DB4B415 — governed migrate deploy for the disposable contributor-preview DB.
+// Used by docker-compose dev-init instead of bare `prisma migrate deploy`.
+//
+// Safety:
+// - Only runs when DPF_ENVIRONMENT=dev (or --allow-dev-preview).
+// - Never targets the live portal; DATABASE_URL must point at dev-postgres.
+// - Marks a failed migration applied only when every structural effect is present.
+// - Unrecoverable drift → exit 3 (blocked_sandbox_drift) with one next action.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+
+import {
+  BLOCKED_SANDBOX_DRIFT_EXIT,
+  MAX_REPAIR_ROUNDS,
+  decideMigrationRepair,
+  formatBlockedMessage,
+  parseFailedMigrationFromStatus,
+  parseMigrationEffects,
+  probeEffectsPresent,
+  readMigrationSql,
+} from "../../../scripts/lib/dev-preview-migrate-converge.mjs";
+
+const { Client } = pg;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_DB_ROOT = resolve(HERE, "..");
+const REPO_ROOT = resolve(PKG_DB_ROOT, "../..");
+
+function log(msg) {
+  process.stderr.write(`[dev-preview-migrate] ${msg}\n`);
+}
+
+function prismaInvocation() {
+  // Prefer the package-local / workspace prisma binary so Prisma 7 loads
+  // packages/db/prisma.config.ts (cwd = packages/db).
+  const nodePrisma = [
+    resolve(REPO_ROOT, "node_modules/prisma/build/index.js"),
+    resolve(PKG_DB_ROOT, "node_modules/prisma/build/index.js"),
+  ].find((p) => existsSync(p));
+  if (nodePrisma) {
+    return { command: process.execPath, argsPrefix: [nodePrisma], cwd: PKG_DB_ROOT };
+  }
+  return {
+    command: "pnpm",
+    argsPrefix: ["exec", "prisma"],
+    cwd: PKG_DB_ROOT,
+  };
+}
+
+function runPrisma(args, { env = process.env, allowFail = false } = {}) {
+  const inv = prismaInvocation();
+  try {
+    const out = execFileSync(inv.command, [...inv.argsPrefix, ...args], {
+      encoding: "utf8",
+      env,
+      cwd: inv.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    return { ok: true, stdout: out, stderr: "", code: 0, combined: out };
+  } catch (error) {
+    const stdout = String(error.stdout ?? "");
+    const stderr = String(error.stderr ?? "");
+    const code = Number(error.status ?? 1);
+    return {
+      ok: false,
+      stdout,
+      stderr,
+      code,
+      combined: `${stdout}\n${stderr}`,
+    };
+  }
+}
+
+function assertDevPreviewContext() {
+  const envName = String(process.env.DPF_ENVIRONMENT ?? "").toLowerCase();
+  const allow = process.argv.includes("--allow-dev-preview");
+  if (envName !== "dev" && !allow) {
+    log("refusing to run: DPF_ENVIRONMENT must be 'dev' (or pass --allow-dev-preview for tests)");
+    process.exit(2);
+  }
+  const url = String(process.env.DATABASE_URL ?? "");
+  if (!url) {
+    log("DATABASE_URL is required");
+    process.exit(2);
+  }
+  // Soft guard: prefer hostnames that look like the contributor preview DB.
+  const looksLive =
+    /@postgres:|@dpf-postgres|PRODUCTION_DATABASE_URL/i.test(url)
+    && !/dev-postgres|localhost:5433|127\.0\.0\.1:5433/i.test(url);
+  if (looksLive && !allow) {
+    log("refusing DATABASE_URL that looks like the live portal database");
+    process.exit(2);
+  }
+}
+
+async function loadFailedMigrationState(client) {
+  const { rows } = await client.query(
+    `SELECT migration_name, logs, finished_at, rolled_back_at
+       FROM _prisma_migrations
+      WHERE finished_at IS NULL
+      ORDER BY started_at DESC
+      LIMIT 5`,
+  );
+  return rows;
+}
+
+async function main() {
+  assertDevPreviewContext();
+  const databaseUrl = process.env.DATABASE_URL;
+
+  log("running prisma migrate deploy (contributor-preview)");
+  let deploy = runPrisma(["migrate", "deploy"], { allowFail: true });
+  if (deploy.ok) {
+    log("migrate deploy succeeded with no repair");
+    process.stdout.write(deploy.stdout);
+    return;
+  }
+
+  log("migrate deploy failed; evaluating disposable repair path");
+  process.stderr.write(deploy.combined.slice(0, 4000));
+
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    for (let round = 1; round <= MAX_REPAIR_ROUNDS; round += 1) {
+      const failedRows = await loadFailedMigrationState(client);
+      let migrationName =
+        failedRows[0]?.migration_name
+        ?? parseFailedMigrationFromStatus(deploy.combined);
+
+      if (!migrationName) {
+        const status = runPrisma(["migrate", "status"], { allowFail: true });
+        migrationName = parseFailedMigrationFromStatus(
+          `${status.combined ?? ""}\n${deploy.combined}`,
+        );
+      }
+
+      if (!migrationName) {
+        const decision = {
+          action: "blocked_sandbox_drift",
+          reason: "unparseable-migrate-failure",
+          nextAction:
+            "Inspect dev-init logs. For disposable contributor preview only, recreate volume dpf_dev_pgdata and re-run the dev profile. Never delete live portal volumes.",
+        };
+        process.stderr.write(`${formatBlockedMessage(decision)}\n`);
+        process.exit(BLOCKED_SANDBOX_DRIFT_EXIT);
+      }
+
+      const failureLog = failedRows.find((r) => r.migration_name === migrationName)?.logs
+        ?? deploy.combined;
+
+      let effects;
+      try {
+        effects = parseMigrationEffects(readMigrationSql(migrationName));
+      } catch (error) {
+        const decision = {
+          action: "blocked_sandbox_drift",
+          reason: "missing-migration-sql",
+          migrationName,
+          nextAction: String(error.message),
+        };
+        process.stderr.write(`${formatBlockedMessage(decision)}\n`);
+        process.exit(BLOCKED_SANDBOX_DRIFT_EXIT);
+      }
+
+      const present = await probeEffectsPresent(
+        async (sql) => (await client.query(sql)).rows,
+        effects,
+      );
+
+      const decision = decideMigrationRepair({
+        migrationName,
+        failureLog,
+        effects,
+        present,
+      });
+
+      log(`round=${round} decision=${decision.action} migration=${migrationName} reason=${decision.reason}`);
+
+      if (decision.action === "mark-applied") {
+        log(`marking ${migrationName} applied (schema effects already present)`);
+        const resolved = runPrisma(
+          ["migrate", "resolve", "--applied", migrationName],
+          { allowFail: true },
+        );
+        if (!resolved.ok) {
+          process.stderr.write(resolved.combined);
+          process.stderr.write(
+            `${formatBlockedMessage({
+              action: "blocked_sandbox_drift",
+              reason: "resolve-applied-failed",
+              migrationName,
+              nextAction:
+                "prisma migrate resolve --applied failed. Recreate disposable dpf_dev_pgdata only, then re-run dev-init.",
+            })}\n`,
+          );
+          process.exit(BLOCKED_SANDBOX_DRIFT_EXIT);
+        }
+        deploy = runPrisma(["migrate", "deploy"], { allowFail: true });
+        if (deploy.ok) {
+          log("migrate deploy succeeded after repair");
+          process.stdout.write(deploy.stdout);
+          return;
+        }
+        process.stderr.write(deploy.combined.slice(0, 4000));
+        continue;
+      }
+
+      if (decision.action === "blocked_sandbox_drift") {
+        process.stderr.write(`${formatBlockedMessage(decision)}\n`);
+        process.exit(BLOCKED_SANDBOX_DRIFT_EXIT);
+      }
+
+      // migrate-deploy with no failed migration name — surface original failure
+      process.stderr.write(deploy.combined);
+      process.exit(deploy.code || 1);
+    }
+
+    process.stderr.write(
+      `${formatBlockedMessage({
+        action: "blocked_sandbox_drift",
+        reason: "repair-round-limit",
+        nextAction:
+          "Exceeded disposable repair rounds. Recreate dpf_dev_pgdata only and re-run dev-init.",
+      })}\n`,
+    );
+    process.exit(BLOCKED_SANDBOX_DRIFT_EXIT);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+const isDirect =
+  process.argv[1]
+  && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isDirect) {
+  main().catch((error) => {
+    process.stderr.write(`[dev-preview-migrate] ${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/dev-postgres-pgvector-contract.test.mjs
+++ b/scripts/dev-postgres-pgvector-contract.test.mjs
@@ -29,4 +29,9 @@ test("Contributor preview waits for a pgvector-capable database", async () => {
     /dev-postgres:\n        condition: service_healthy/,
     "dev-init must not run migrations until extension-aware readiness passes",
   );
+  assert.match(
+    init,
+    /dev-preview-migrate-deploy/,
+    "dev-init must use the disposable migrate converge wrapper (BI-4DB4B415)",
+  );
 });

--- a/scripts/lib/dev-preview-migrate-converge.mjs
+++ b/scripts/lib/dev-preview-migrate-converge.mjs
@@ -12,7 +12,6 @@
 // Unrecoverable drift exits with blocked_sandbox_drift (code 3) and one next
 // action: recreate the disposable dev_pgdata volume only.
 
-import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/lib/dev-preview-migrate-converge.mjs
+++ b/scripts/lib/dev-preview-migrate-converge.mjs
@@ -1,0 +1,260 @@
+// scripts/lib/dev-preview-migrate-converge.mjs
+//
+// BI-4DB4B415 — Contributor-preview (dev-postgres) migration convergence.
+// Disposable environment only: never touch the live portal database.
+//
+// Problem class: schema is ahead of Prisma history (or a migration failed with
+// "already exists") so `prisma migrate deploy` wedges and dev-init never
+// completes, blocking the leased :3001 preview.
+//
+// Safe repair: when every effect of the failed migration is already present,
+// mark it applied (`prisma migrate resolve --applied`) and continue deploy.
+// Unrecoverable drift exits with blocked_sandbox_drift (code 3) and one next
+// action: recreate the disposable dev_pgdata volume only.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const HIVE_CONTRIBUTIONS_MIGRATION = "20260605060000_hive_contributions_surface";
+export const BLOCKED_SANDBOX_DRIFT_EXIT = 3;
+export const MAX_REPAIR_ROUNDS = 25;
+
+const ALREADY_EXISTS_RE =
+  /already exists|column .* of relation .* already exists|relation .* already exists|duplicate key value|42701|42P07|42710/i;
+
+/**
+ * Parse a Prisma migration SQL file for structural effects we can probe.
+ * Intentionally narrow: ADD COLUMN / CREATE TABLE / CREATE INDEX only.
+ *
+ * @param {string} sql
+ * @returns {{ addColumns: { table: string, column: string }[], createTables: string[], createIndexes: string[] }}
+ */
+export function parseMigrationEffects(sql) {
+  const addColumns = [];
+  const createTables = [];
+  const createIndexes = [];
+  const text = String(sql ?? "");
+
+  // ALTER TABLE "Foo" ADD COLUMN "bar" ...
+  // ALTER TABLE "Foo" ADD COLUMN IF NOT EXISTS "bar" ...
+  const colRe =
+    /ALTER\s+TABLE\s+"([^"]+)"\s+ADD\s+COLUMN(?:\s+IF\s+NOT\s+EXISTS)?\s+"([^"]+)"/gi;
+  for (const match of text.matchAll(colRe)) {
+    addColumns.push({ table: match[1], column: match[2] });
+  }
+
+  const tableRe = /CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+"([^"]+)"/gi;
+  for (const match of text.matchAll(tableRe)) {
+    createTables.push(match[1]);
+  }
+
+  const indexRe = /CREATE\s+(?:UNIQUE\s+)?INDEX(?:\s+IF\s+NOT\s+EXISTS)?\s+"([^"]+)"/gi;
+  for (const match of text.matchAll(indexRe)) {
+    createIndexes.push(match[1]);
+  }
+
+  return { addColumns, createTables, createIndexes };
+}
+
+/**
+ * Decide how to handle a failed / pending migration given live schema probes.
+ *
+ * @param {{
+ *   migrationName: string,
+ *   failureLog?: string | null,
+ *   effects: ReturnType<typeof parseMigrationEffects>,
+ *   present: {
+ *     columns: Record<string, boolean>, // key: Table.column
+ *     tables: Record<string, boolean>,
+ *     indexes: Record<string, boolean>,
+ *   },
+ * }} input
+ */
+export function decideMigrationRepair(input) {
+  const migrationName = String(input.migrationName ?? "").trim();
+  if (!migrationName) {
+    return {
+      action: "blocked_sandbox_drift",
+      reason: "missing-migration-name",
+      nextAction:
+        "Recreate the disposable contributor-preview volume only: docker compose --profile dev stop dev-portal dev-init dev-postgres && docker volume rm dpf_dev_pgdata && docker compose --profile dev up -d --profile dev",
+    };
+  }
+
+  const failureLog = String(input.failureLog ?? "");
+  const alreadyExists = ALREADY_EXISTS_RE.test(failureLog);
+  const effects = input.effects ?? { addColumns: [], createTables: [], createIndexes: [] };
+  const present = input.present ?? { columns: {}, tables: {}, indexes: {} };
+
+  const missingColumns = effects.addColumns.filter(
+    (c) => !present.columns[`${c.table}.${c.column}`],
+  );
+  const missingTables = effects.createTables.filter((t) => !present.tables[t]);
+  // Indexes are optional for "complete enough to mark applied" when tables exist —
+  // Prisma will not re-run the migration; missing indexes would be a separate defect.
+  // Require tables + columns; indexes reported as soft gaps.
+  const missingIndexes = effects.createIndexes.filter((i) => !present.indexes[i]);
+
+  const structuralComplete = missingColumns.length === 0 && missingTables.length === 0;
+
+  if (structuralComplete && (alreadyExists || failureLog.includes("failed to apply") || !failureLog)) {
+    return {
+      action: "mark-applied",
+      migrationName,
+      reason: alreadyExists
+        ? "schema-ahead-already-exists"
+        : "schema-effects-already-present",
+      softGaps: missingIndexes.length > 0 ? { missingIndexes } : undefined,
+    };
+  }
+
+  if (alreadyExists && !structuralComplete) {
+    return {
+      action: "blocked_sandbox_drift",
+      reason: "partial-schema-ahead",
+      migrationName,
+      missingColumns,
+      missingTables,
+      nextAction:
+        "Contributor-preview schema is partially ahead of migration history. Recreate disposable volume dpf_dev_pgdata only (never the live portal volume), then re-run dev-init.",
+    };
+  }
+
+  if (!alreadyExists && failureLog) {
+    return {
+      action: "blocked_sandbox_drift",
+      reason: "non-idempotent-migrate-failure",
+      migrationName,
+      nextAction:
+        "Inspect dev-init logs for the failed migration. For disposable contributor preview only: recreate dpf_dev_pgdata and re-run `docker compose --profile dev up`. Do not resolve --applied without evidence the schema matches.",
+    };
+  }
+
+  return {
+    action: "migrate-deploy",
+    reason: "no-repair-needed",
+    migrationName,
+  };
+}
+
+/**
+ * Known high-signal probe for BI-4DB4B415 (hive contributions surface).
+ */
+export function hiveContributionsPresentProbe(row) {
+  return {
+    columns: {
+      "PlatformDevConfig.deviceFingerprintOptIn": Boolean(row?.deviceFingerprintOptIn),
+      "PlatformDevConfig.hiveContributionsPaused": Boolean(row?.hiveContributionsPaused),
+    },
+    tables: {
+      HiveContributionLedger: Boolean(row?.hasLedger),
+    },
+    indexes: {
+      HiveContributionLedger_contributionType_idx: Boolean(row?.hasLedger),
+      HiveContributionLedger_status_idx: Boolean(row?.hasLedger),
+      HiveContributionLedger_contributor_idx: Boolean(row?.hasLedger),
+    },
+  };
+}
+
+export function formatBlockedMessage(decision) {
+  return [
+    "[dev-preview-migrate] blocked_sandbox_drift",
+    `reason=${decision.reason}`,
+    decision.migrationName ? `migration=${decision.migrationName}` : null,
+    `next=${decision.nextAction}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+// ── runtime helpers (I/O) ───────────────────────────────────────────────────
+
+function repoRootFromHere() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+}
+
+function migrationsDir(root = repoRootFromHere()) {
+  return join(root, "packages/db/prisma/migrations");
+}
+
+export function readMigrationSql(migrationName, root = repoRootFromHere()) {
+  const path = join(migrationsDir(root), migrationName, "migration.sql");
+  if (!existsSync(path)) {
+    throw new Error(`migration SQL not found: ${migrationName}`);
+  }
+  return readFileSync(path, "utf8");
+}
+
+export function listMigrationNames(root = repoRootFromHere()) {
+  return readdirSync(migrationsDir(root), { withFileTypes: true })
+    .filter((d) => d.isDirectory() && /^\d{14}_/.test(d.name))
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * Build a present-map by probing information_schema via a provided query fn.
+ * @param {(sql: string) => Promise<any[]>} query
+ * @param {ReturnType<typeof parseMigrationEffects>} effects
+ */
+export async function probeEffectsPresent(query, effects) {
+  const columns = {};
+  const tables = {};
+  const indexes = {};
+
+  for (const { table, column } of effects.addColumns) {
+    const rows = await query(
+      `SELECT 1 AS ok FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = '${table.replace(/'/g, "''")}'
+          AND column_name = '${column.replace(/'/g, "''")}'
+        LIMIT 1`,
+    );
+    columns[`${table}.${column}`] = Array.isArray(rows) && rows.length > 0;
+  }
+
+  for (const table of effects.createTables) {
+    const rows = await query(
+      `SELECT 1 AS ok FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = '${table.replace(/'/g, "''")}'
+        LIMIT 1`,
+    );
+    tables[table] = Array.isArray(rows) && rows.length > 0;
+  }
+
+  for (const index of effects.createIndexes) {
+    const rows = await query(
+      `SELECT 1 AS ok FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = '${index.replace(/'/g, "''")}'
+        LIMIT 1`,
+    );
+    indexes[index] = Array.isArray(rows) && rows.length > 0;
+  }
+
+  return { columns, tables, indexes };
+}
+
+export function parseFailedMigrationFromStatus(statusText) {
+  const text = String(statusText ?? "");
+  // Prisma prints: "Following migration have failed:" / "The `name` migration ..."
+  const patterns = [
+    /Migration name:\s*([0-9]{14}_[A-Za-z0-9_]+)/i,
+    /The `([0-9]{14}_[A-Za-z0-9_]+)` migration/i,
+    /migrate found failed migrations in the target database.*?([0-9]{14}_[A-Za-z0-9_]+)/is,
+    /failed migration[s]?:\s*([0-9]{14}_[A-Za-z0-9_]+)/i,
+  ];
+  for (const re of patterns) {
+    const m = text.match(re);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+export function parseAlreadyExistsFromLog(text) {
+  return ALREADY_EXISTS_RE.test(String(text ?? ""));
+}

--- a/scripts/lib/dev-preview-migrate-converge.test.mjs
+++ b/scripts/lib/dev-preview-migrate-converge.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  BLOCKED_SANDBOX_DRIFT_EXIT,
+  HIVE_CONTRIBUTIONS_MIGRATION,
+  decideMigrationRepair,
+  formatBlockedMessage,
+  hiveContributionsPresentProbe,
+  parseAlreadyExistsFromLog,
+  parseFailedMigrationFromStatus,
+  parseMigrationEffects,
+  readMigrationSql,
+} from "./dev-preview-migrate-converge.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("parseMigrationEffects extracts hive contributions surface objects", () => {
+  const sql = readMigrationSql(HIVE_CONTRIBUTIONS_MIGRATION, root);
+  const effects = parseMigrationEffects(sql);
+  assert.deepEqual(effects.addColumns, [
+    { table: "PlatformDevConfig", column: "deviceFingerprintOptIn" },
+    { table: "PlatformDevConfig", column: "hiveContributionsPaused" },
+  ]);
+  assert.deepEqual(effects.createTables, ["HiveContributionLedger"]);
+  assert.ok(effects.createIndexes.includes("HiveContributionLedger_contributionType_idx"));
+});
+
+test("decideMigrationRepair marks applied when schema is fully ahead (BI-4DB4B415)", () => {
+  const sql = readMigrationSql(HIVE_CONTRIBUTIONS_MIGRATION, root);
+  const effects = parseMigrationEffects(sql);
+  const present = hiveContributionsPresentProbe({
+    deviceFingerprintOptIn: true,
+    hiveContributionsPaused: true,
+    hasLedger: true,
+  });
+  const decision = decideMigrationRepair({
+    migrationName: HIVE_CONTRIBUTIONS_MIGRATION,
+    failureLog:
+      'ERROR: column "deviceFingerprintOptIn" of relation "PlatformDevConfig" already exists\nDatabase error code: 42701',
+    effects,
+    present,
+  });
+  assert.equal(decision.action, "mark-applied");
+  assert.equal(decision.migrationName, HIVE_CONTRIBUTIONS_MIGRATION);
+  assert.match(decision.reason, /schema-ahead|already-exists/);
+});
+
+test("decideMigrationRepair blocks partial schema-ahead without inventing objects", () => {
+  const effects = parseMigrationEffects(
+    'ALTER TABLE "PlatformDevConfig" ADD COLUMN "deviceFingerprintOptIn" BOOLEAN;\n' +
+      'CREATE TABLE "HiveContributionLedger" ("id" TEXT NOT NULL);',
+  );
+  const decision = decideMigrationRepair({
+    migrationName: HIVE_CONTRIBUTIONS_MIGRATION,
+    failureLog: 'column "deviceFingerprintOptIn" of relation "PlatformDevConfig" already exists',
+    effects,
+    present: {
+      columns: { "PlatformDevConfig.deviceFingerprintOptIn": true },
+      tables: { HiveContributionLedger: false },
+      indexes: {},
+    },
+  });
+  assert.equal(decision.action, "blocked_sandbox_drift");
+  assert.equal(decision.reason, "partial-schema-ahead");
+  assert.match(decision.nextAction, /dpf_dev_pgdata/);
+  // Must name the disposable volume, not instruct deleting the live volume.
+  assert.doesNotMatch(decision.nextAction, /volume rm dpf_pgdata(?!_)/);
+  assert.doesNotMatch(decision.nextAction, /delete live|drop production/i);
+});
+
+test("decideMigrationRepair does not auto-resolve non-already-exists failures", () => {
+  const decision = decideMigrationRepair({
+    migrationName: "20260101000000_example",
+    failureLog: "ERROR: relation \"Foo\" does not exist",
+    effects: { addColumns: [], createTables: [], createIndexes: [] },
+    present: { columns: {}, tables: {}, indexes: {} },
+  });
+  assert.equal(decision.action, "blocked_sandbox_drift");
+  assert.equal(decision.reason, "non-idempotent-migrate-failure");
+});
+
+test("parseFailedMigrationFromStatus extracts migration name from Prisma output", () => {
+  const status = `
+A migration failed to apply. New migrations cannot be applied before the error is recovered from.
+Migration name: 20260605060000_hive_contributions_surface
+Database error code: 42701
+`;
+  assert.equal(
+    parseFailedMigrationFromStatus(status),
+    HIVE_CONTRIBUTIONS_MIGRATION,
+  );
+  assert.equal(parseAlreadyExistsFromLog(status), true);
+});
+
+test("formatBlockedMessage is explicit about blocked_sandbox_drift", () => {
+  const msg = formatBlockedMessage({
+    reason: "partial-schema-ahead",
+    migrationName: HIVE_CONTRIBUTIONS_MIGRATION,
+    nextAction: "recreate dpf_dev_pgdata",
+  });
+  assert.match(msg, /blocked_sandbox_drift/);
+  assert.match(msg, /dpf_dev_pgdata/);
+});
+
+test("compose dev-init uses the converge wrapper instead of bare migrate deploy", () => {
+  const compose = readFileSync(join(root, "docker-compose.yml"), "utf8");
+  assert.match(compose, /dev-preview-migrate-deploy\.mjs/);
+  assert.match(compose, /node \.\/scripts\/dev-preview-migrate-deploy\.mjs/);
+});
+
+test("blocked exit code is reserved and distinct from generic failure", () => {
+  assert.equal(BLOCKED_SANDBOX_DRIFT_EXIT, 3);
+});


### PR DESCRIPTION
## Summary

Fixes **BI-4DB4B415**: a leased contributor preview cannot start when the disposable `dev-postgres` volume is schema-ahead of Prisma history (observed: failed `20260605060000_hive_contributions_surface` with `column "deviceFingerprintOptIn" already exists`, which blocked every later migration).

### What changed
- `packages/db/scripts/dev-preview-migrate-deploy.mjs` — disposable-only migrate deploy wrapper (refuses live portal URLs / non-dev env)
- `scripts/lib/dev-preview-migrate-converge.mjs` — pure decision logic: mark-applied only when every structural effect is present; otherwise `blocked_sandbox_drift` (exit 3)
- `docker-compose.yml` `dev-init` uses the wrapper instead of bare `prisma migrate deploy`
- Operator recovery documented in `docs/user-guide/contributing/dev-container.md` (recreate `dpf_dev_pgdata` only — never live volumes)
- Unit tests wired into CI

### Live evidence (this host)
Against the existing `dpf_dev_pgdata` volume (not production):
1. Detected failed hive migration + columns/table already present
2. Wrapper marked applied and continued
3. Repaired a second already-exists failure (`upstreamFeedbackOptIn`)
4. Applied all remaining migrations successfully — **exit 0**

Live portal DB was not touched.

## Test plan
- [x] `node --test scripts/lib/dev-preview-migrate-converge.test.mjs scripts/dev-postgres-pgvector-contract.test.mjs` — 9/9
- [x] Live converge on disposable `dev-postgres` / `dpf_dev_pgdata`
- [ ] CI green on this PR

## Trailers
Backlog: BI-4DB4B415

Design-Grounding-Decision: reviewed live _prisma_migrations failure logs and docker-compose dev-init path; substrate packages/db migrate + scripts/lib converge helper
Docs-Impact-Decision: docs/user-guide/contributing/dev-container.md recovery procedure
Process-Spine-Decision: ops/dev tooling only; no process-spine replacements change
Spec-Plan-Decision: bugfix from live detection; no separate design doc required beyond runbook
Local-CI-Override: unit tests + live disposable migrate evidence; no portal runtime code path
