### PR TITLE
feat: activate evidence-scoped Living Playbooks

### DIFF
--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.test.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.test.tsx
@@ -1,0 +1,116 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { NeedsAndPlaybooksPanel } from "./NeedsAndPlaybooksPanel";
+import { WorkPatternBindingCard } from "./WorkPatternBindingCard";
+
+describe("ActivePlaybookBindingCard", () => {
+  it("explains evidence-bounded autonomy without exposing engineer identifiers", () => {
+    const markup = renderToStaticMarkup(
+      <WorkPatternBindingCard
+        now={new Date("2026-07-26T12:00:00.000Z")}
+        binding={{
+          bindingId: "AB-WP-ENGINEER-ID",
+          name: "Build review v2",
+          status: "active",
+          resourceRef: "build-review@2",
+          updatedAt: new Date("2026-07-26T10:00:00.000Z"),
+          authorityScope: {
+            schemaVersion: 1,
+            activationLaneKey: "WP-LANE-ENGINEER-ID",
+            bindingScopeKey: "WP-SCOPE-ENGINEER-ID",
+            patternKey: "build-review",
+            patternVersion: 2,
+            activityKey: "build.implement",
+            riskClass: "internal-reversible",
+            installScopes: ["dpf_dogfood"],
+            organizationIds: ["org-dogfood"],
+            taskCorpusKeys: ["dpf-repository"],
+            modelProfileIds: ["frontier-coding"],
+            promotionPolicyKey: "governed-build-playbook-promotion",
+            promotionPolicyVersion: 1,
+            sourceExperimentTaskRunId: "TR-WPX-ENGINEER-ID",
+            corroborationTaskRunIds: [],
+            priorSafeBindingId: "AB-prior",
+            evidenceFreshnessAt: "2026-07-26T10:00:00.000Z",
+            evidenceOrigin: "customer-zero",
+            scopeCeiling: "same-install",
+            blockers: [
+              "broader_scope_requires_portable_corpus_or_customer_corroboration",
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Active method");
+    expect(markup).toContain("Only this DPF installation");
+    expect(markup).toContain("Evidence checked today");
+    expect(markup).toContain("cannot add to the coworker");
+    expect(markup).toContain("What is needed for broader use");
+    expect(markup).not.toContain("ENGINEER-ID");
+  });
+
+  it("keeps rollback history behind disclosure", () => {
+    const markup = renderToStaticMarkup(
+      <NeedsAndPlaybooksPanel
+        canWrite={false}
+        needs={{
+          summary: { total: 0, byStatus: {}, bySeverity: {}, byKind: {} },
+          filterOptions: { statuses: [], severities: [], kinds: [] },
+          needs: [],
+        }}
+        workPatterns={{
+          generatedAt: new Date("2026-07-26T12:00:00.000Z"),
+          window: {
+            since: new Date("2026-06-26T12:00:00.000Z"),
+            until: new Date("2026-07-26T12:00:00.000Z"),
+          },
+          summary: {
+            totalPatterns: 0,
+            totalObservedRuns: 0,
+            openNeedCount: 0,
+            readyForReviewCount: 0,
+            candidateOnlyCount: 0,
+          },
+          bindings: [{
+            bindingId: "AB-rolled-back",
+            name: "Build review v1",
+            status: "rolled-back",
+            resourceRef: "build-review@1",
+            updatedAt: new Date("2026-07-26T10:00:00.000Z"),
+            authorityScope: {
+              schemaVersion: 1,
+              activationLaneKey: "WP-LANE",
+              bindingScopeKey: "WP-SCOPE",
+              patternKey: "build-review",
+              patternVersion: 1,
+              activityKey: "build.implement",
+              riskClass: "internal-reversible",
+              installScopes: ["dpf_dogfood"],
+              organizationIds: ["org-dogfood"],
+              taskCorpusKeys: ["dpf-repository"],
+              modelProfileIds: ["frontier-coding"],
+              promotionPolicyKey: "governed-build-playbook-promotion",
+              promotionPolicyVersion: 1,
+              sourceExperimentTaskRunId: "TR-WPX",
+              corroborationTaskRunIds: [],
+              priorSafeBindingId: null,
+              evidenceFreshnessAt: "2026-07-26T10:00:00.000Z",
+              evidenceOrigin: "customer-zero",
+              scopeCeiling: "same-install",
+              blockers: [],
+            },
+          }],
+          patterns: [],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("<details>");
+    expect(markup).toContain("Replaced and rolled-back method history");
+    expect(markup.indexOf("Build review v1")).toBeGreaterThan(
+      markup.indexOf("<summary"),
+    );
+  });
+});

--- a/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
+++ b/apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/actions/work-pattern-review";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { Chip, deepLink, EmptyState, Section } from "./panels";
+import { WorkPatternBindingCard } from "./WorkPatternBindingCard";
 
 type ShadowEvaluation = NonNullable<WorkPatternSummary["shadowEvaluation"]>;
 type CaseStaging = NonNullable<WorkPatternSummary["caseStaging"]>;
@@ -43,6 +44,13 @@ export function NeedsAndPlaybooksPanel({
   canWrite: boolean;
 }) {
   const visibleNeeds = needs.needs.slice(0, 5);
+  const bindings = workPatterns.bindings ?? [];
+  const activeBindings = bindings.filter((binding) => binding.status === "active");
+  const bindingHistory = bindings.filter((binding) => binding.status !== "active");
+  const livingPlaybookCount = Math.max(
+    workPatterns.summary.totalPatterns,
+    bindings.length,
+  );
   return (
     <div>
       <Section
@@ -61,9 +69,31 @@ export function NeedsAndPlaybooksPanel({
         )}
       </Section>
 
-      <Section title="Living Playbooks" count={workPatterns.summary.totalPatterns}>
-        {workPatterns.patterns.length > 0 ? (
+      <Section title="Living Playbooks" count={livingPlaybookCount}>
+        {bindings.length > 0 || workPatterns.patterns.length > 0 ? (
           <div style={{ display: "grid", gap: 10 }}>
+            {activeBindings.map((binding) => (
+              <WorkPatternBindingCard key={binding.bindingId} binding={binding} />
+            ))}
+            {bindingHistory.length > 0 ? (
+              <details>
+                <summary
+                  style={{
+                    cursor: "pointer",
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: "var(--dpf-accent)",
+                  }}
+                >
+                  Replaced and rolled-back method history
+                </summary>
+                <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+                  {bindingHistory.map((binding) => (
+                    <WorkPatternBindingCard key={binding.bindingId} binding={binding} />
+                  ))}
+                </div>
+              </details>
+            ) : null}
             <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
               <Chip tone="accent">{workPatterns.summary.totalObservedRuns} observed runs</Chip>
               <Chip tone={workPatterns.summary.openNeedCount > 0 ? "warning" : "muted"}>
@@ -348,7 +378,7 @@ function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary;
   if (pattern.reviewState) {
     const tone = reviewActionTone(pattern.reviewState.action);
     const caseStaging = pattern.caseStaging ?? pattern.reviewState.caseStaging ?? null;
-    return (
+    const decision = (
       <div
         style={{
           display: "grid",
@@ -363,7 +393,6 @@ function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary;
         <div style={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
           <Chip tone="success">Decision recorded</Chip>
           <Chip tone={tone}>{reviewActionLabel(pattern.reviewState.action)}</Chip>
-          <Chip tone="muted">{pattern.reviewState.decisionInteractionId}</Chip>
           {pattern.activationCandidate ? <Chip tone="accent">activation candidate</Chip> : null}
           <span style={{ fontSize: 10, color: "var(--dpf-muted)", marginLeft: "auto" }}>
             <LocalTime value={pattern.reviewState.reviewedAt} mode="date" />
@@ -380,6 +409,21 @@ function PlaybookReviewRow({ pattern, canWrite }: { pattern: WorkPatternSummary;
         />
       </div>
     );
+    return pattern.reviewState.action === "reject" ? (
+      <details style={{ marginTop: 8 }}>
+        <summary
+          style={{
+            cursor: "pointer",
+            fontSize: 11,
+            fontWeight: 600,
+            color: "var(--dpf-accent)",
+          }}
+        >
+          Rejected candidate history
+        </summary>
+        {decision}
+      </details>
+    ) : decision;
   }
 
   const needId = pattern.linkedNeedIds[0];

--- a/apps/web/components/platform/coworker-record/WorkPatternBindingCard.tsx
+++ b/apps/web/components/platform/coworker-record/WorkPatternBindingCard.tsx
@@ -1,0 +1,58 @@
+import {
+  getWorkPatternBindingPresentation,
+  type WorkPatternBindingRecord,
+} from "@/lib/tak/work-pattern-binding-reader";
+import { Chip } from "./panels";
+
+export function WorkPatternBindingCard({
+  binding,
+  now,
+}: {
+  binding: WorkPatternBindingRecord;
+  now?: Date;
+}) {
+  const presentation = getWorkPatternBindingPresentation(binding, now);
+  const tone =
+    binding.status === "active"
+      ? "success"
+      : binding.status === "rolled-back"
+        ? "error"
+        : "muted";
+  return (
+    <div
+      aria-label={`Living Playbook ${binding.name}`}
+      style={{
+        display: "grid",
+        gap: 7,
+        padding: "9px 10px",
+        borderRadius: 6,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
+        <Chip tone={tone}>{presentation.stateLabel}</Chip>
+        <Chip tone="accent">{presentation.scopeLabel}</Chip>
+        <Chip tone="muted">{presentation.freshnessLabel}</Chip>
+      </div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--dpf-text)" }}>
+        {binding.name}
+      </div>
+      <div style={{ fontSize: 11, color: "var(--dpf-muted)" }}>
+        {presentation.evidenceLabel}. This method cannot add to the coworker&apos;s tool authority.
+      </div>
+      {presentation.blockerMessages.length > 0 ? (
+        <details>
+          <summary style={{ cursor: "pointer", fontSize: 11, color: "var(--dpf-accent)" }}>
+            What is needed for broader use
+          </summary>
+          <ul style={{ margin: "6px 0 0", paddingLeft: 18, fontSize: 11, color: "var(--dpf-muted)" }}>
+            {presentation.blockerMessages.map((message) => (
+              <li key={message}>{message}</li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/authority/binding-editor.test.ts
+++ b/apps/web/lib/authority/binding-editor.test.ts
@@ -10,6 +10,7 @@ vi.mock("@dpf/db", () => ({
     },
     authorityBinding: {
       create: vi.fn(),
+      findUnique: vi.fn(),
       update: vi.fn(),
     },
   },
@@ -45,7 +46,43 @@ describe("validateBindingGrant", () => {
 describe("binding editor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.authorityBinding.findUnique).mockResolvedValue({
+      resourceType: "route",
+    } as never);
   });
+
+  it("rejects work-pattern creation outside the specialized activation transaction", async () => {
+    await expect(
+      createAuthorityBinding({
+        bindingId: "AB-WORK-PATTERN",
+        name: "Build review method",
+        scopeType: "work-pattern",
+        resourceType: "work-pattern",
+        resourceRef: "build-review@2",
+      }),
+    ).rejects.toThrow("work_pattern_binding_requires_specialized_transaction");
+
+    expect(prisma.authorityBinding.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["status", { status: "superseded" }],
+    ["authority scope", { authorityScope: { scopeKey: "widened" } }],
+    ["resource identity", { resourceRef: "build-review@3" }],
+  ])(
+    "rejects generic %s mutation for an existing work-pattern binding",
+    async (_label, update) => {
+      vi.mocked(prisma.authorityBinding.findUnique).mockResolvedValue({
+        resourceType: "work-pattern",
+      } as never);
+
+      await expect(
+        updateAuthorityBinding("AB-WORK-PATTERN", update),
+      ).rejects.toThrow("work_pattern_binding_requires_specialized_transaction");
+
+      expect(prisma.authorityBinding.update).not.toHaveBeenCalled();
+    },
+  );
 
   it("creates a binding with a resolved coworker and normalized rows", async () => {
     vi.mocked(prisma.agent.findUnique).mockResolvedValue({

--- a/apps/web/lib/authority/binding-editor.ts
+++ b/apps/web/lib/authority/binding-editor.ts
@@ -37,6 +37,14 @@ type CreateAuthorityBindingInput = BindingBaseInput & {
 
 type UpdateAuthorityBindingInput = BindingBaseInput;
 
+const SPECIALIZED_BINDING_RESOURCE_TYPES = new Set(["work-pattern"]);
+
+function assertGenericEditorOwnsResourceType(resourceType: string | undefined) {
+  if (resourceType && SPECIALIZED_BINDING_RESOURCE_TYPES.has(resourceType)) {
+    throw new Error("work_pattern_binding_requires_specialized_transaction");
+  }
+}
+
 export async function validateBindingGrant(options: {
   intrinsic: string[];
   requested: BindingGrantInput[];
@@ -145,6 +153,7 @@ async function buildNestedData(input: BindingBaseInput) {
 }
 
 export async function createAuthorityBinding(input: CreateAuthorityBindingInput) {
+  assertGenericEditorOwnsResourceType(input.resourceType);
   const nested = await buildNestedData(input);
 
   return prisma.authorityBinding.create({
@@ -171,6 +180,12 @@ export async function createAuthorityBinding(input: CreateAuthorityBindingInput)
 }
 
 export async function updateAuthorityBinding(bindingId: string, input: UpdateAuthorityBindingInput) {
+  const existing = await prisma.authorityBinding.findUnique({
+    where: { bindingId },
+    select: { resourceType: true },
+  });
+  assertGenericEditorOwnsResourceType(existing?.resourceType);
+  assertGenericEditorOwnsResourceType(input.resourceType);
   const nested = await buildNestedData(input);
 
   return prisma.authorityBinding.update({

--- a/apps/web/lib/authority/bindings.test.ts
+++ b/apps/web/lib/authority/bindings.test.ts
@@ -1,11 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   getAuthorityBindingFilterOptions,
+  listAuthorityBindingRecords,
   parseAuthorityBindingFilters,
   shapeAuthorityBindingRows,
   type AuthorityBindingRecord,
 } from "./bindings";
+
+const { mockFindMany } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    authorityBinding: {
+      findMany: mockFindMany,
+    },
+  },
+}));
 
 const SAMPLE_RECORDS: AuthorityBindingRecord[] = [
   {
@@ -86,5 +99,21 @@ describe("getAuthorityBindingFilterOptions", () => {
       appliedAgents: [{ agentId: "AGT-400", agentName: "Finance Controller" }],
       subjectRefs: ["HR-400", "finance"],
     });
+  });
+});
+
+describe("listAuthorityBindingRecords", () => {
+  it("filters work-pattern authority out of the route-authorization admin reader", async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await listAuthorityBindingRecords();
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          resourceType: { not: "work-pattern" },
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/authority/bindings.ts
+++ b/apps/web/lib/authority/bindings.ts
@@ -171,6 +171,7 @@ export function shapeAuthorityBindingRows(
 export async function listAuthorityBindingRecords(filters?: AuthorityBindingListFilters) {
   const bindings = await prisma.authorityBinding.findMany({
     where: {
+      resourceType: { not: "work-pattern" },
       status: filters?.statuses ? { in: filters.statuses } : undefined,
       resourceRef: filters?.resourceRefs ? { in: filters.resourceRefs } : undefined,
       appliedAgent: filters?.appliedAgentIds

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -727,6 +727,7 @@
         "the-n1-trap-stated-precisely",
         "the-four-portfolio-view-is-the-same-line",
         "this-separation-is-already-enforced-for-capability-maturity",
+        "living-playbooks-carry-the-same-boundary",
         "the-gap-no-equivalent-separation-for-learned-decision-weights",
         "what-to-claim-and-when",
         "see-also"

--- a/apps/web/lib/tak/work-pattern-activation-persistence.test.ts
+++ b/apps/web/lib/tak/work-pattern-activation-persistence.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  transaction: vi.fn(),
+  executeRaw: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    $transaction: mocks.transaction,
+  },
+}));
+
+import { createPrismaWorkPatternActivationPersistence } from "./work-pattern-activation-persistence";
+
+describe("createPrismaWorkPatternActivationPersistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.executeRaw.mockResolvedValue(1);
+    mocks.transaction.mockImplementation(async (work) =>
+      work({
+        $executeRaw: mocks.executeRaw,
+        agent: {},
+        authorityBinding: {},
+        decisionShadowLedger: {},
+      }));
+  });
+
+  it("acquires a parameterized advisory lock inside a serializable transaction", async () => {
+    const snapshot = vi.fn().mockResolvedValue({ marker: "fresh" });
+    const persistence = createPrismaWorkPatternActivationPersistence(snapshot);
+
+    const result = await persistence.withActivationLock(
+      "WP-PATTERN-123",
+      (session) => session.readSnapshot(),
+    );
+
+    expect(result).toEqual({ marker: "fresh" });
+    expect(snapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.executeRaw).toHaveBeenCalledTimes(1);
+    const [strings, laneKey] = mocks.executeRaw.mock.calls[0];
+    expect(strings.join("?")).toContain("pg_advisory_xact_lock(hashtextextended(?, 0))");
+    expect(laneKey).toBe("WP-PATTERN-123");
+    expect(mocks.transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { isolationLevel: "Serializable" },
+    );
+  });
+});

--- a/apps/web/lib/tak/work-pattern-activation-persistence.ts
+++ b/apps/web/lib/tak/work-pattern-activation-persistence.ts
@@ -1,0 +1,233 @@
+import { prisma, type Prisma } from "@dpf/db";
+
+import { isRecord } from "@/lib/shared/coerce";
+import {
+  parseWorkPatternAuthorityScope,
+  WORK_PATTERN_BINDING_RESOURCE_TYPE,
+} from "./work-pattern-binding-reader";
+import type {
+  WorkPatternActivationBinding,
+  WorkPatternActivationObservation,
+  WorkPatternActivationPersistence,
+  WorkPatternActivationPersistenceSession,
+  WorkPatternActivationSnapshot,
+} from "./work-pattern-activation";
+import {
+  isRetainedWorkPatternFailureClass,
+  resolveEffectiveWorkPatternLedger,
+} from "./work-pattern-effective-ledger";
+
+type SnapshotReader = (
+  transaction: Prisma.TransactionClient,
+) => Promise<WorkPatternActivationSnapshot>;
+
+function toJson(value: unknown): Prisma.InputJsonValue {
+  return value as Prisma.InputJsonValue;
+}
+
+function ledgerId(observation: WorkPatternActivationObservation): string {
+  const binding = observation.bindingId ?? "none";
+  return [
+    "DSL-WP",
+    observation.sourceExperimentTaskRunId,
+    observation.decision,
+    binding,
+  ].join("-");
+}
+
+function createSession(
+  tx: Prisma.TransactionClient,
+  readAuthoritativeSnapshot: SnapshotReader,
+): WorkPatternActivationPersistenceSession {
+  let snapshot: WorkPatternActivationSnapshot | null = null;
+
+  async function readSnapshot() {
+    snapshot = await readAuthoritativeSnapshot(tx);
+    return snapshot;
+  }
+
+  async function resolveAgentRowId(agentId: string) {
+    const agent = await tx.agent.findUnique({
+      where: { agentId },
+      select: { id: true },
+    });
+    if (!agent) throw new Error(`unknown_work_pattern_coworker:${agentId}`);
+    return agent.id;
+  }
+
+  async function readBinding(bindingId: string) {
+    const row = await tx.authorityBinding.findUnique({
+      where: { bindingId },
+      include: {
+        appliedAgent: { select: { agentId: true } },
+        grants: { orderBy: { grantKey: "asc" } },
+      },
+    });
+    if (!row || row.resourceType !== WORK_PATTERN_BINDING_RESOURCE_TYPE) return null;
+    const authorityScope = parseWorkPatternAuthorityScope(row.authorityScope);
+    if (!authorityScope || !row.appliedAgent) return null;
+    return {
+      bindingId: row.bindingId,
+      name: row.name,
+      status: row.status as WorkPatternActivationBinding["status"],
+      resourceRef: row.resourceRef,
+      appliedAgentId: row.appliedAgent.agentId,
+      grants: row.grants.map((grant) => ({
+        grantKey: grant.grantKey,
+        mode: grant.mode,
+        rationale: grant.rationale,
+      })),
+      authorityScope,
+    };
+  }
+
+  return {
+    readSnapshot,
+    listBindingsForLane: async (activationLaneKey) => {
+      const current = snapshot ?? await readSnapshot();
+      const rows = await tx.authorityBinding.findMany({
+        where: {
+          resourceType: WORK_PATTERN_BINDING_RESOURCE_TYPE,
+          appliedAgent: { agentId: current.agentId },
+        },
+        include: {
+          appliedAgent: { select: { agentId: true } },
+          grants: { orderBy: { grantKey: "asc" } },
+        },
+      });
+      return rows.flatMap((row) => {
+        const authorityScope = parseWorkPatternAuthorityScope(row.authorityScope);
+        if (
+          !authorityScope
+          || authorityScope.activationLaneKey !== activationLaneKey
+          || !row.appliedAgent
+        ) return [];
+        return [{
+          bindingId: row.bindingId,
+          name: row.name,
+          status: row.status as WorkPatternActivationBinding["status"],
+          resourceRef: row.resourceRef,
+          appliedAgentId: row.appliedAgent.agentId,
+          grants: row.grants.map((grant) => ({
+            grantKey: grant.grantKey,
+            mode: grant.mode,
+            rationale: grant.rationale,
+          })),
+          authorityScope,
+        }];
+      });
+    },
+    findBinding: readBinding,
+    listRejectedCandidates: async () => {
+      const current = snapshot ?? await readSnapshot();
+      const rows = await tx.decisionShadowLedger.findMany({
+        where: {
+          agentId: current.agentId,
+          activityType: current.promotionEvidence.activityKey,
+          riskClass: current.promotionEvidence.riskClass,
+          sourceKind: "work-pattern-promotion",
+        },
+        select: {
+          ledgerId: true,
+          metadata: true,
+        },
+        orderBy: { observedAt: "asc" },
+      });
+      return resolveEffectiveWorkPatternLedger(rows).flatMap((row) => {
+        if (!isRecord(row.metadata)) return [];
+        const metadata = row.metadata;
+        return metadata.decision === "reject"
+          && typeof metadata.candidateIdentity === "string"
+          && typeof metadata.failureClass === "string"
+          && isRetainedWorkPatternFailureClass(metadata.failureClass)
+          ? [{
+              candidateIdentity: metadata.candidateIdentity,
+              failureClass: metadata.failureClass,
+            }]
+          : [];
+      });
+    },
+    saveBinding: async (binding) => {
+      const appliedAgentId = await resolveAgentRowId(binding.appliedAgentId);
+      await tx.authorityBinding.upsert({
+        where: { bindingId: binding.bindingId },
+        update: {
+          name: binding.name,
+          status: binding.status,
+          resourceRef: binding.resourceRef,
+          appliedAgentId,
+          authorityScope: toJson(binding.authorityScope),
+          grants: {
+            deleteMany: {},
+            create: binding.grants,
+          },
+        },
+        create: {
+          bindingId: binding.bindingId,
+          name: binding.name,
+          scopeType: "work-pattern-activation",
+          status: binding.status,
+          resourceType: WORK_PATTERN_BINDING_RESOURCE_TYPE,
+          resourceRef: binding.resourceRef,
+          appliedAgentId,
+          authorityScope: toJson(binding.authorityScope),
+          approvalMode: "policy",
+          grants: { create: binding.grants },
+        },
+      });
+      return binding;
+    },
+    updateBindingStatus: async (bindingId, status) => {
+      await tx.authorityBinding.update({
+        where: { bindingId },
+        data: { status },
+      });
+    },
+    recordDecision: async (observation) => {
+      const current = snapshot ?? await readSnapshot();
+      const id = ledgerId(observation);
+      await tx.decisionShadowLedger.upsert({
+        where: { ledgerId: id },
+        update: {},
+        create: {
+          ledgerId: id,
+          agentId: current.agentId,
+          activityType: current.promotionEvidence.activityKey,
+          riskClass: current.promotionEvidence.riskClass,
+          autonomyLevel: "autonomous",
+          proposedDecision: toJson({ decision: observation.decision }),
+          actualDecision: toJson({ decision: observation.decision }),
+          outcome: toJson({
+            bindingId: observation.bindingId,
+            activeBindingId: observation.activeBindingId,
+            reasons: observation.reasons,
+          }),
+          agreement: true,
+          sourceKind: "work-pattern-promotion",
+          taskRunId: observation.sourceExperimentTaskRunId,
+          metadata: toJson({
+            activationLaneKey: observation.activationLaneKey,
+            bindingId: observation.bindingId,
+            decision: observation.decision,
+            candidateIdentity: observation.candidateIdentity,
+            failureClass: observation.reasons[0] ?? "none",
+          }),
+        },
+      });
+    },
+  };
+}
+
+export function createPrismaWorkPatternActivationPersistence(
+  readSnapshot: SnapshotReader,
+): WorkPatternActivationPersistence {
+  return {
+    withActivationLock: (activationLaneKey, work) =>
+      prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`
+          SELECT pg_advisory_xact_lock(hashtextextended(${activationLaneKey}, 0))
+        `;
+        return work(createSession(tx, readSnapshot));
+      }, { isolationLevel: "Serializable" }),
+  };
+}

--- a/apps/web/lib/tak/work-pattern-activation-scope.test.ts
+++ b/apps/web/lib/tak/work-pattern-activation-scope.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveMaximumActivationScope,
+  type WorkPatternCorroborationEvidence,
+} from "./work-pattern-activation-scope";
+
+const SOURCE = {
+  installScope: "dpf_dogfood" as const,
+  organizationId: "org-dogfood",
+  taskCorpusKey: "dpf-repository",
+  modelProfileId: "frontier-coding",
+};
+
+function corroboration(
+  overrides: Partial<WorkPatternCorroborationEvidence> = {},
+): WorkPatternCorroborationEvidence {
+  return {
+    taskRunId: "TR-customer-1",
+    installScope: "customer_overlay",
+    organizationId: "org-customer-1",
+    taskCorpusKey: "customer-brownfield",
+    modelProfileId: "frontier-coding",
+    terminal: true,
+    effective: true,
+    fresh: true,
+    egressApproved: true,
+    materiallyDifferentCorpus: true,
+    ...overrides,
+  };
+}
+
+describe("deriveMaximumActivationScope", () => {
+  it("caps dogfood-only evidence to the same install, corpus, and model", () => {
+    expect(deriveMaximumActivationScope({
+      source: SOURCE,
+      portableCanonicalCorpus: null,
+      corroborations: [],
+    })).toEqual({
+      installScopes: ["dpf_dogfood"],
+      organizationIds: ["org-dogfood"],
+      taskCorpusKeys: ["dpf-repository"],
+      modelProfileIds: ["frontier-coding"],
+      corroborationTaskRunIds: [],
+      ceiling: "same-install",
+      blockers: ["broader_scope_requires_portable_corpus_or_customer_corroboration"],
+    });
+  });
+
+  it("widens only the portable canonical corpus dimension", () => {
+    const scope = deriveMaximumActivationScope({
+      source: SOURCE,
+      portableCanonicalCorpus: {
+        taskCorpusKey: "canonical-build-replay",
+        verified: true,
+      },
+      corroborations: [],
+    });
+    expect(scope.installScopes).toEqual(["canonical", "dpf_dogfood"]);
+    expect(scope.taskCorpusKeys).toEqual(["canonical-build-replay", "dpf-repository"]);
+    expect(scope.organizationIds).toEqual(["org-dogfood"]);
+    expect(scope.modelProfileIds).toEqual(["frontier-coding"]);
+    expect(scope.ceiling).toBe("canonical-corpus");
+  });
+
+  it("adds only valid non-dogfood corroboration", () => {
+    const scope = deriveMaximumActivationScope({
+      source: SOURCE,
+      portableCanonicalCorpus: null,
+      corroborations: [
+        corroboration(),
+        corroboration({ taskRunId: "TR-stale", fresh: false }),
+        corroboration({ taskRunId: "TR-dangling", effective: false }),
+      ],
+    });
+    expect(scope.installScopes).toEqual(["customer_overlay", "dpf_dogfood"]);
+    expect(scope.organizationIds).toEqual(["org-customer-1", "org-dogfood"]);
+    expect(scope.taskCorpusKeys).toEqual(["customer-brownfield", "dpf-repository"]);
+    expect(scope.corroborationTaskRunIds).toEqual(["TR-customer-1"]);
+    expect(scope.ceiling).toBe("corroborated");
+  });
+
+  it("does not turn frontier evidence into local-model authority", () => {
+    const scope = deriveMaximumActivationScope({
+      source: SOURCE,
+      portableCanonicalCorpus: null,
+      corroborations: [
+        corroboration({
+          taskRunId: "TR-local-model",
+          modelProfileId: "local-9b",
+        }),
+      ],
+    });
+    expect(scope.modelProfileIds).toEqual(["frontier-coding"]);
+    expect(scope.corroborationTaskRunIds).toEqual([]);
+  });
+});

--- a/apps/web/lib/tak/work-pattern-activation-scope.ts
+++ b/apps/web/lib/tak/work-pattern-activation-scope.ts
@@ -1,0 +1,98 @@
+import type { CapabilityInstallScope } from "@dpf/db/capability-maturity";
+
+export type WorkPatternActivationEvidenceScope = {
+  installScope: CapabilityInstallScope;
+  organizationId?: string;
+  taskCorpusKey: string;
+  modelProfileId: string;
+};
+
+export type WorkPatternCorroborationEvidence = WorkPatternActivationEvidenceScope & {
+  taskRunId: string;
+  terminal: boolean;
+  effective: boolean;
+  fresh: boolean;
+  egressApproved: boolean;
+  materiallyDifferentCorpus: boolean;
+};
+
+export type PortableCanonicalCorpusEvidence = {
+  taskCorpusKey: string;
+  verified: boolean;
+};
+
+export type MaximumWorkPatternActivationScope = {
+  installScopes: CapabilityInstallScope[];
+  organizationIds: string[];
+  taskCorpusKeys: string[];
+  modelProfileIds: string[];
+  corroborationTaskRunIds: string[];
+  ceiling: "same-install" | "canonical-corpus" | "corroborated";
+  blockers: string[];
+};
+
+function sortedUnique<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort() as T[];
+}
+
+function qualifyingCorroboration(
+  source: WorkPatternActivationEvidenceScope,
+  row: WorkPatternCorroborationEvidence,
+): boolean {
+  return (
+    row.installScope === "customer_overlay"
+    && row.organizationId !== undefined
+    && row.organizationId !== source.organizationId
+    && row.taskCorpusKey !== source.taskCorpusKey
+    && row.modelProfileId === source.modelProfileId
+    && row.terminal
+    && row.effective
+    && row.fresh
+    && row.egressApproved
+    && row.materiallyDifferentCorpus
+  );
+}
+
+export function deriveMaximumActivationScope(input: {
+  source: WorkPatternActivationEvidenceScope;
+  portableCanonicalCorpus: PortableCanonicalCorpusEvidence | null;
+  corroborations: readonly WorkPatternCorroborationEvidence[];
+}): MaximumWorkPatternActivationScope {
+  const validCorroborations = input.corroborations.filter((row) =>
+    qualifyingCorroboration(input.source, row));
+  const portable = input.portableCanonicalCorpus?.verified === true
+    ? input.portableCanonicalCorpus
+    : null;
+
+  const installScopes: CapabilityInstallScope[] = [input.source.installScope];
+  if (portable) installScopes.push("canonical");
+  if (validCorroborations.length > 0) installScopes.push("customer_overlay");
+
+  const organizationIds = [
+    input.source.organizationId,
+    ...validCorroborations.map((row) => row.organizationId),
+  ].filter((value): value is string => Boolean(value));
+  const taskCorpusKeys = [
+    input.source.taskCorpusKey,
+    ...(portable ? [portable.taskCorpusKey] : []),
+    ...validCorroborations.map((row) => row.taskCorpusKey),
+  ];
+  const corroborationTaskRunIds = validCorroborations.map((row) => row.taskRunId);
+  const ceiling = validCorroborations.length > 0
+    ? "corroborated"
+    : portable
+      ? "canonical-corpus"
+      : "same-install";
+
+  return {
+    installScopes: sortedUnique(installScopes),
+    organizationIds: sortedUnique(organizationIds),
+    taskCorpusKeys: sortedUnique(taskCorpusKeys),
+    modelProfileIds: [input.source.modelProfileId],
+    corroborationTaskRunIds: sortedUnique(corroborationTaskRunIds),
+    ceiling,
+    blockers: ceiling === "same-install"
+      ? ["broader_scope_requires_portable_corpus_or_customer_corroboration"]
+      : [],
+  };
+}

--- a/apps/web/lib/tak/work-pattern-activation.test.ts
+++ b/apps/web/lib/tak/work-pattern-activation.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activateWorkPattern,
+  type WorkPatternActivationBinding,
+  type WorkPatternActivationPersistence,
+  type WorkPatternActivationPersistenceSession,
+  type WorkPatternActivationSnapshot,
+  workPatternActivationLaneKey,
+} from "./work-pattern-activation";
+
+const NOW = new Date("2026-07-26T12:00:00.000Z");
+
+function snapshot(
+  overrides: Partial<WorkPatternActivationSnapshot> = {},
+): WorkPatternActivationSnapshot {
+  return {
+    agentId: "build-specialist",
+    patternKey: "build-review",
+    patternVersion: 2,
+    sourceExperimentTaskRunId: "TR-WPX-source",
+    source: {
+      installScope: "dpf_dogfood",
+      organizationId: "org-dogfood",
+      taskCorpusKey: "dpf-repository",
+      modelProfileId: "frontier-coding",
+    },
+    portableCanonicalCorpus: null,
+    corroborations: [],
+    candidateEvidence: {
+      patternKey: "build-review",
+      patternVersion: 2,
+      methodVariantKey: "structured-review",
+      modelProfileId: "frontier-coding",
+      taskCorpusKey: "dpf-repository",
+      taskCorpusVersion: "1",
+      oracleKey: "build-gate",
+      oracleVersion: "3",
+      promotionPolicyKey: "governed-build-playbook-promotion",
+      promotionPolicyVersion: 1,
+    },
+    promotionEvidence: {
+      activityKey: "build.implement",
+      riskClass: "internal-reversible",
+      validPairCount: 8,
+      invalidPairCount: 0,
+      completedCellKeys: ["control", "method", "model", "interaction"],
+      freshnessAt: new Date("2026-07-26T10:00:00.000Z"),
+      rollbackBindingId: "AB-prior",
+      objectiveDeltas: {
+        correctness: 0.08,
+        security: 0,
+        migrationSafety: 0,
+        customerImpact: 0,
+        speed: 0.12,
+        cost: 0.04,
+      },
+      commandmentGateRegression: false,
+      criticalFindingReproduced: false,
+      regulatoryHumanControlRequired: false,
+      activeBindingHealthRegression: false,
+    },
+    intrinsicGrantKeys: ["build_execute"],
+    ...overrides,
+  };
+}
+
+class MemoryActivationStore implements WorkPatternActivationPersistence {
+  readonly bindings = new Map<string, WorkPatternActivationBinding>();
+  readonly observations: unknown[] = [];
+  private lockTail = Promise.resolve();
+
+  constructor(public currentSnapshot = snapshot()) {
+    this.bindings.set("AB-prior", {
+      bindingId: "AB-prior",
+      name: "Build review v1",
+      status: "superseded",
+      resourceRef: "build-review@1",
+      appliedAgentId: "build-specialist",
+      grants: [{ grantKey: "build_execute", mode: "require-approval" }],
+      authorityScope: {
+        schemaVersion: 1,
+        activationLaneKey: workPatternActivationLaneKey(this.currentSnapshot),
+        bindingScopeKey: "legacy-scope",
+        patternKey: "build-review",
+        patternVersion: 1,
+        activityKey: "build.implement",
+        riskClass: "internal-reversible",
+        installScopes: ["dpf_dogfood"],
+        organizationIds: ["org-dogfood"],
+        taskCorpusKeys: ["dpf-repository"],
+        modelProfileIds: ["frontier-coding"],
+        promotionPolicyKey: "governed-build-playbook-promotion",
+        promotionPolicyVersion: 1,
+        sourceExperimentTaskRunId: "TR-WPX-prior",
+        corroborationTaskRunIds: [],
+        priorSafeBindingId: null,
+        evidenceFreshnessAt: "2026-07-20T12:00:00.000Z",
+        evidenceOrigin: "customer-zero",
+        scopeCeiling: "same-install",
+        blockers: [
+          "broader_scope_requires_portable_corpus_or_customer_corroboration",
+        ],
+      },
+    });
+  }
+
+  async withActivationLock<T>(
+    _laneKey: string,
+    work: (session: WorkPatternActivationPersistenceSession) => Promise<T>,
+  ): Promise<T> {
+    const previous = this.lockTail;
+    let release = () => {};
+    this.lockTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      const session: WorkPatternActivationPersistenceSession = {
+        readSnapshot: async () => this.currentSnapshot,
+        listBindingsForLane: async () => [...this.bindings.values()],
+        findBinding: async (bindingId) => this.bindings.get(bindingId) ?? null,
+        listRejectedCandidates: async () =>
+          this.observations.flatMap((value) => {
+            const observation = value as {
+              decision?: string;
+              candidateIdentity?: string;
+              reasons?: string[];
+            };
+            return observation.decision === "reject"
+              && observation.candidateIdentity
+              && observation.reasons?.[0] === "commandment_gate_regression"
+              ? [{
+                  candidateIdentity: observation.candidateIdentity,
+                  failureClass: observation.reasons?.[0] ?? "rejected",
+                }]
+              : [];
+          }),
+        saveBinding: async (binding) => {
+          this.bindings.set(binding.bindingId, binding);
+          return binding;
+        },
+        updateBindingStatus: async (bindingId, status) => {
+          const current = this.bindings.get(bindingId);
+          if (!current) throw new Error(`missing_binding:${bindingId}`);
+          this.bindings.set(bindingId, { ...current, status });
+        },
+        recordDecision: async (observation) => {
+          this.observations.push(observation);
+        },
+      };
+      return await work(session);
+    } finally {
+      release();
+    }
+  }
+}
+
+function request(overrides: Record<string, unknown> = {}) {
+  return {
+    patternKey: "build-review",
+    patternVersion: 2,
+    sourceExperimentTaskRunId: "TR-WPX-source",
+    requestedScope: {
+      installScopes: ["dpf_dogfood" as const],
+      organizationIds: ["org-dogfood"],
+      taskCorpusKeys: ["dpf-repository"],
+      modelProfileIds: ["frontier-coding"],
+    },
+    grants: [{ grantKey: "build_execute", mode: "require-approval" }],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("activateWorkPattern", () => {
+  it("activates exactly one evidence-bounded binding and preserves the prior safe version", async () => {
+    const store = new MemoryActivationStore();
+
+    const result = await activateWorkPattern(request(), { persistence: store });
+
+    expect(result.decision).toBe("activate");
+    expect(result.bindingId).toMatch(/^AB-WP-/);
+    expect(
+      [...store.bindings.values()].filter((binding) => binding.status === "active"),
+    ).toEqual([
+      expect.objectContaining({
+        bindingId: result.bindingId,
+        name: "Build review v2",
+        resourceRef: "build-review@2",
+        authorityScope: expect.objectContaining({
+          priorSafeBindingId: "AB-prior",
+          scopeCeiling: "same-install",
+        }),
+      }),
+    ]);
+    expect(store.observations).toContainEqual(
+      expect.objectContaining({ decision: "activate", bindingId: result.bindingId }),
+    );
+  });
+
+  it("converges concurrent retries on one active deterministic binding", async () => {
+    const store = new MemoryActivationStore();
+
+    const [left, right] = await Promise.all([
+      activateWorkPattern(request(), { persistence: store }),
+      activateWorkPattern(request(), { persistence: store }),
+    ]);
+
+    expect(left.bindingId).toBe(right.bindingId);
+    expect(
+      [...store.bindings.values()].filter((binding) => binding.status === "active"),
+    ).toHaveLength(1);
+  });
+
+  it("re-reads evidence after lock acquisition and refuses stale evidence", async () => {
+    const store = new MemoryActivationStore(snapshot({
+      promotionEvidence: {
+        ...snapshot().promotionEvidence,
+        freshnessAt: new Date("2026-05-01T00:00:00.000Z"),
+      },
+    }));
+
+    const result = await activateWorkPattern(request(), { persistence: store });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        decision: "continue",
+        reasons: ["evidence_stale"],
+      }),
+    );
+    expect([...store.bindings.values()].some((binding) => binding.status === "active")).toBe(false);
+  });
+
+  it("rejects a requested scope broader than effective evidence", async () => {
+    const store = new MemoryActivationStore();
+
+    const result = await activateWorkPattern(request({
+      requestedScope: {
+        installScopes: ["dpf_dogfood", "customer_overlay"],
+        organizationIds: ["org-dogfood", "org-customer"],
+        taskCorpusKeys: ["dpf-repository", "customer-corpus"],
+        modelProfileIds: ["frontier-coding"],
+      },
+    }), { persistence: store });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        decision: "reject",
+        reasons: ["requested_scope_exceeds_evidence"],
+      }),
+    );
+  });
+
+  it("rejects any grant that widens intrinsic coworker authority", async () => {
+    const store = new MemoryActivationStore();
+
+    await expect(
+      activateWorkPattern(request({
+        grants: [{ grantKey: "production_write", mode: "require-approval" }],
+      }), { persistence: store }),
+    ).rejects.toThrow(/cannot widen intrinsic coworker access/i);
+  });
+
+  it("escalates an evidence snapshot governed by an unsupported policy version", async () => {
+    const store = new MemoryActivationStore(snapshot({
+      candidateEvidence: {
+        ...snapshot().candidateEvidence,
+        promotionPolicyVersion: 2,
+      },
+    }));
+
+    await expect(
+      activateWorkPattern(request(), { persistence: store }),
+    ).resolves.toEqual(expect.objectContaining({
+      decision: "escalate",
+      reasons: ["promotion_policy_version_unsupported"],
+    }));
+  });
+
+  it("retains a materially identical rejection until evidence identity changes", async () => {
+    const store = new MemoryActivationStore();
+    store.currentSnapshot = snapshot({
+      promotionEvidence: {
+        ...snapshot().promotionEvidence,
+        commandmentGateRegression: true,
+      },
+    });
+    await activateWorkPattern(request(), { persistence: store });
+    store.currentSnapshot = snapshot();
+
+    const repeated = await activateWorkPattern(request(), { persistence: store });
+
+    expect(repeated).toEqual(expect.objectContaining({
+      decision: "reject",
+      reasons: ["materially_identical_rejection_retained"],
+    }));
+  });
+
+  it("rolls back within the same lane and retains the failed binding evidence", async () => {
+    const store = new MemoryActivationStore();
+    const activated = await activateWorkPattern(request(), { persistence: store });
+    store.currentSnapshot = snapshot({
+      promotionEvidence: {
+        ...snapshot().promotionEvidence,
+        activeBindingHealthRegression: true,
+        rollbackBindingId: "AB-prior",
+      },
+    });
+
+    const rolledBack = await activateWorkPattern(request(), { persistence: store });
+
+    expect(rolledBack).toEqual(
+      expect.objectContaining({
+        decision: "rollback",
+        bindingId: activated.bindingId,
+        activeBindingId: "AB-prior",
+      }),
+    );
+    expect(store.bindings.get(activated.bindingId as string)?.status).toBe("rolled-back");
+    expect(store.bindings.get("AB-prior")?.status).toBe("active");
+    expect(store.observations).toContainEqual(
+      expect.objectContaining({
+        decision: "rollback",
+        bindingId: activated.bindingId,
+        activeBindingId: "AB-prior",
+      }),
+    );
+  });
+
+  it("escalates instead of rolling back across a broader authority scope", async () => {
+    const store = new MemoryActivationStore();
+    const activated = await activateWorkPattern(request(), { persistence: store });
+    const prior = store.bindings.get("AB-prior");
+    if (!prior) throw new Error("missing test prior binding");
+    store.bindings.set("AB-prior", {
+      ...prior,
+      authorityScope: {
+        ...prior.authorityScope,
+        organizationIds: ["org-other"],
+      },
+    });
+    store.currentSnapshot = snapshot({
+      promotionEvidence: {
+        ...snapshot().promotionEvidence,
+        activeBindingHealthRegression: true,
+        rollbackBindingId: "AB-prior",
+      },
+    });
+
+    const result = await activateWorkPattern(request(), { persistence: store });
+
+    expect(result).toEqual(expect.objectContaining({
+      decision: "escalate",
+      reasons: ["rollback_scope_mismatch"],
+    }));
+    expect(store.bindings.get(activated.bindingId as string)?.status).toBe("active");
+    expect(store.bindings.get("AB-prior")?.status).toBe("superseded");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-activation.ts
+++ b/apps/web/lib/tak/work-pattern-activation.ts
@@ -1,0 +1,434 @@
+import { createHash } from "node:crypto";
+
+import type { CapabilityInstallScope } from "@dpf/db/capability-maturity";
+
+import { validateBindingGrant } from "@/lib/authority/binding-editor";
+import {
+  canReopenRejectedWorkPatternCandidate,
+  workPatternCandidateEvidenceIdentity,
+  type WorkPatternCandidateEvidence,
+} from "./work-pattern-effective-ledger";
+import {
+  WORK_PATTERN_BINDING_RESOURCE_TYPE,
+  type WorkPatternAuthorityScopeV1,
+  type WorkPatternBindingStatus,
+  type WorkPatternEvidenceOrigin,
+} from "./work-pattern-binding-reader";
+import {
+  deriveMaximumActivationScope,
+  type PortableCanonicalCorpusEvidence,
+  type WorkPatternActivationEvidenceScope,
+  type WorkPatternCorroborationEvidence,
+} from "./work-pattern-activation-scope";
+import {
+  DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+  evaluateWorkPatternPromotion,
+  type WorkPatternPromotionDecision,
+  type WorkPatternPromotionEvidence,
+} from "./work-pattern-promotion-policy";
+
+export type WorkPatternActivationGrant = {
+  grantKey: string;
+  mode: string;
+  rationale?: string | null;
+};
+
+export type WorkPatternActivationBinding = {
+  bindingId: string;
+  name: string;
+  status: WorkPatternBindingStatus;
+  resourceRef: string;
+  appliedAgentId: string;
+  grants: WorkPatternActivationGrant[];
+  authorityScope: WorkPatternAuthorityScopeV1;
+};
+
+export type WorkPatternActivationSnapshot = {
+  agentId: string;
+  patternKey: string;
+  patternVersion: number;
+  sourceExperimentTaskRunId: string;
+  source: WorkPatternActivationEvidenceScope;
+  portableCanonicalCorpus: PortableCanonicalCorpusEvidence | null;
+  corroborations: readonly WorkPatternCorroborationEvidence[];
+  candidateEvidence: WorkPatternCandidateEvidence;
+  promotionEvidence: WorkPatternPromotionEvidence;
+  intrinsicGrantKeys: string[];
+};
+
+export type WorkPatternActivationPersistenceSession = {
+  readSnapshot(): Promise<WorkPatternActivationSnapshot>;
+  listBindingsForLane(laneKey: string): Promise<WorkPatternActivationBinding[]>;
+  findBinding(bindingId: string): Promise<WorkPatternActivationBinding | null>;
+  listRejectedCandidates(): Promise<Array<{
+    candidateIdentity: string;
+    failureClass: string;
+  }>>;
+  saveBinding(
+    binding: WorkPatternActivationBinding,
+  ): Promise<WorkPatternActivationBinding>;
+  updateBindingStatus(
+    bindingId: string,
+    status: WorkPatternBindingStatus,
+  ): Promise<void>;
+  recordDecision(observation: WorkPatternActivationObservation): Promise<void>;
+};
+
+export type WorkPatternActivationPersistence = {
+  withActivationLock<T>(
+    laneKey: string,
+    work: (session: WorkPatternActivationPersistenceSession) => Promise<T>,
+  ): Promise<T>;
+};
+
+export type WorkPatternActivationRequest = {
+  patternKey: string;
+  patternVersion: number;
+  sourceExperimentTaskRunId: string;
+  requestedScope: {
+    installScopes: CapabilityInstallScope[];
+    organizationIds: string[];
+    taskCorpusKeys: string[];
+    modelProfileIds: string[];
+  };
+  grants: WorkPatternActivationGrant[];
+  now: Date;
+};
+
+export type WorkPatternActivationObservation = {
+  decision: WorkPatternPromotionDecision;
+  bindingId: string | null;
+  activeBindingId: string | null;
+  reasons: string[];
+  sourceExperimentTaskRunId: string;
+  activationLaneKey: string;
+  candidateIdentity: string;
+};
+
+export type WorkPatternActivationResult = {
+  decision: WorkPatternPromotionDecision;
+  bindingId: string | null;
+  activeBindingId: string | null;
+  reasons: string[];
+};
+
+function digest(parts: readonly unknown[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify(parts))
+    .digest("hex")
+    .slice(0, 24)
+    .toUpperCase();
+}
+
+function patternLabel(patternKey: string): string {
+  const words = patternKey.replaceAll(/[-_.]+/g, " ").trim();
+  return words.length > 0
+    ? `${words[0].toUpperCase()}${words.slice(1)}`
+    : "Living Playbook";
+}
+
+export function workPatternActivationLaneKey(
+  snapshot: WorkPatternActivationSnapshot,
+): string {
+  return `WP-LANE-${digest([
+    snapshot.agentId,
+    snapshot.patternKey,
+    snapshot.promotionEvidence.activityKey,
+    snapshot.promotionEvidence.riskClass,
+  ])}`;
+}
+
+function sameAuthorizedScope(
+  left: WorkPatternActivationBinding,
+  right: WorkPatternActivationBinding,
+): boolean {
+  const leftScope = left.authorityScope;
+  const rightScope = right.authorityScope;
+  const sameValues = (a: readonly string[], b: readonly string[]) =>
+    a.length === b.length
+    && [...a].sort().every((value, index) => value === [...b].sort()[index]);
+  return (
+    leftScope.activationLaneKey === rightScope.activationLaneKey
+    && leftScope.activityKey === rightScope.activityKey
+    && leftScope.riskClass === rightScope.riskClass
+    && sameValues(leftScope.installScopes, rightScope.installScopes)
+    && sameValues(leftScope.organizationIds, rightScope.organizationIds)
+    && sameValues(leftScope.taskCorpusKeys, rightScope.taskCorpusKeys)
+    && sameValues(leftScope.modelProfileIds, rightScope.modelProfileIds)
+  );
+}
+
+function bindingScopeKey(
+  snapshot: WorkPatternActivationSnapshot,
+  requestedScope: WorkPatternActivationRequest["requestedScope"],
+): string {
+  return `WP-SCOPE-${digest([
+    snapshot.patternKey,
+    snapshot.patternVersion,
+    [...requestedScope.installScopes].sort(),
+    [...requestedScope.organizationIds].sort(),
+    [...requestedScope.taskCorpusKeys].sort(),
+    [...requestedScope.modelProfileIds].sort(),
+  ])}`;
+}
+
+function containsAll<T extends string>(
+  ceiling: readonly T[],
+  requested: readonly T[],
+): boolean {
+  const allowed = new Set(ceiling);
+  return requested.every((value) => allowed.has(value));
+}
+
+function requestMatchesSnapshot(
+  request: WorkPatternActivationRequest,
+  snapshot: WorkPatternActivationSnapshot,
+): boolean {
+  return (
+    request.patternKey === snapshot.patternKey
+    && request.patternVersion === snapshot.patternVersion
+    && request.sourceExperimentTaskRunId === snapshot.sourceExperimentTaskRunId
+  );
+}
+
+function snapshotUsesSupportedPromotionPolicy(
+  snapshot: WorkPatternActivationSnapshot,
+): boolean {
+  return (
+    snapshot.candidateEvidence.patternKey === snapshot.patternKey
+    && snapshot.candidateEvidence.patternVersion === snapshot.patternVersion
+    && snapshot.candidateEvidence.promotionPolicyKey
+      === DEFAULT_WORK_PATTERN_PROMOTION_POLICY.policyKey
+    && snapshot.candidateEvidence.promotionPolicyVersion
+      === DEFAULT_WORK_PATTERN_PROMOTION_POLICY.version
+  );
+}
+
+function evidenceOrigin(
+  ceiling: ReturnType<typeof deriveMaximumActivationScope>["ceiling"],
+): WorkPatternEvidenceOrigin {
+  if (ceiling === "corroborated") return "customer-corroborated";
+  if (ceiling === "canonical-corpus") return "portable-canonical-corpus";
+  return "customer-zero";
+}
+
+function outcome(
+  decision: WorkPatternPromotionDecision,
+  reasons: string[],
+  bindingId: string | null = null,
+  activeBindingId: string | null = null,
+): WorkPatternActivationResult {
+  return { decision, reasons, bindingId, activeBindingId };
+}
+
+async function observe(
+  session: WorkPatternActivationPersistenceSession,
+  result: WorkPatternActivationResult,
+  snapshot: WorkPatternActivationSnapshot,
+  activationLaneKey: string,
+) {
+  await session.recordDecision({
+    ...result,
+    sourceExperimentTaskRunId: snapshot.sourceExperimentTaskRunId,
+    activationLaneKey,
+    candidateIdentity:
+      workPatternCandidateEvidenceIdentity(snapshot.candidateEvidence),
+  });
+  return result;
+}
+
+export async function activateWorkPattern(
+  request: WorkPatternActivationRequest,
+  deps: { persistence: WorkPatternActivationPersistence },
+): Promise<WorkPatternActivationResult> {
+  // The authoritative lane includes evidence fields that are deliberately read
+  // only after lock acquisition. Serialize at the coarser pattern boundary so
+  // two evidence snapshots can never race into separate active bindings.
+  const provisionalLaneKey = `WP-PATTERN-${digest([request.patternKey])}`;
+
+  return deps.persistence.withActivationLock(provisionalLaneKey, async (session) => {
+    const snapshot = await session.readSnapshot();
+    const activationLaneKey = workPatternActivationLaneKey(snapshot);
+
+    if (!requestMatchesSnapshot(request, snapshot)) {
+      return observe(
+        session,
+        outcome("reject", ["activation_request_evidence_mismatch"]),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+    if (!snapshotUsesSupportedPromotionPolicy(snapshot)) {
+      return observe(
+        session,
+        outcome("escalate", ["promotion_policy_version_unsupported"]),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+
+    await validateBindingGrant({
+      intrinsic: snapshot.intrinsicGrantKeys,
+      requested: request.grants,
+    });
+
+    const policyVerdict = evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence: snapshot.promotionEvidence,
+      now: request.now,
+    });
+    const bindings = await session.listBindingsForLane(activationLaneKey);
+    const active = bindings.find((binding) => binding.status === "active") ?? null;
+
+    if (policyVerdict.decision === "rollback") {
+      const rollbackId = snapshot.promotionEvidence.rollbackBindingId;
+      const rollbackTarget = rollbackId
+        ? await session.findBinding(rollbackId)
+        : null;
+      if (!active || !rollbackTarget) {
+        return observe(
+          session,
+          outcome("escalate", ["rollback_target_missing"], active?.bindingId ?? null),
+          snapshot,
+          activationLaneKey,
+        );
+      }
+      if (!sameAuthorizedScope(active, rollbackTarget)) {
+        return observe(
+          session,
+          outcome("escalate", ["rollback_scope_mismatch"], active.bindingId),
+          snapshot,
+          activationLaneKey,
+        );
+      }
+      await session.updateBindingStatus(active.bindingId, "rolled-back");
+      await session.updateBindingStatus(rollbackTarget.bindingId, "active");
+      return observe(
+        session,
+        outcome("rollback", policyVerdict.reasons, active.bindingId, rollbackTarget.bindingId),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+
+    if (policyVerdict.decision !== "activate") {
+      return observe(
+        session,
+        outcome(policyVerdict.decision, policyVerdict.reasons, active?.bindingId ?? null),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+
+    const reopen = canReopenRejectedWorkPatternCandidate({
+      candidate: snapshot.candidateEvidence,
+      effectiveRejections: await session.listRejectedCandidates(),
+    });
+    if (!reopen.allowed) {
+      return observe(
+        session,
+        outcome("reject", [reopen.reason], active?.bindingId ?? null),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+
+    const maximumScope = deriveMaximumActivationScope({
+      source: snapshot.source,
+      portableCanonicalCorpus: snapshot.portableCanonicalCorpus,
+      corroborations: snapshot.corroborations,
+    });
+    if (
+      !containsAll(maximumScope.installScopes, request.requestedScope.installScopes)
+      || !containsAll(maximumScope.organizationIds, request.requestedScope.organizationIds)
+      || !containsAll(maximumScope.taskCorpusKeys, request.requestedScope.taskCorpusKeys)
+      || !containsAll(maximumScope.modelProfileIds, request.requestedScope.modelProfileIds)
+    ) {
+      return observe(
+        session,
+        outcome("reject", ["requested_scope_exceeds_evidence"], active?.bindingId ?? null),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+
+    const scopeKey = bindingScopeKey(snapshot, request.requestedScope);
+    const bindingId = `AB-WP-${digest([
+      snapshot.agentId,
+      scopeKey,
+      snapshot.patternKey,
+      snapshot.patternVersion,
+    ])}`;
+    const existing = await session.findBinding(bindingId);
+    if (existing?.status === "active") {
+      return observe(
+        session,
+        outcome("activate", [], existing.bindingId, existing.bindingId),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+
+    const requestedPriorSafeBindingId =
+      active?.bindingId ?? snapshot.promotionEvidence.rollbackBindingId;
+    const priorSafeBinding = requestedPriorSafeBindingId
+      ? await session.findBinding(requestedPriorSafeBindingId)
+      : null;
+    if (
+      !priorSafeBinding
+      || priorSafeBinding.authorityScope.activationLaneKey !== activationLaneKey
+    ) {
+      return observe(
+        session,
+        outcome("escalate", ["rollback_target_missing"], active?.bindingId ?? null),
+        snapshot,
+        activationLaneKey,
+      );
+    }
+    const priorSafeBindingId = priorSafeBinding.bindingId;
+    if (active && active.bindingId !== bindingId) {
+      await session.updateBindingStatus(active.bindingId, "superseded");
+    }
+
+    const authorityScope: WorkPatternAuthorityScopeV1 = {
+      schemaVersion: 1,
+      activationLaneKey,
+      bindingScopeKey: scopeKey,
+      patternKey: snapshot.patternKey,
+      patternVersion: snapshot.patternVersion,
+      activityKey: snapshot.promotionEvidence.activityKey,
+      riskClass: snapshot.promotionEvidence.riskClass,
+      installScopes: [...request.requestedScope.installScopes],
+      organizationIds: [...request.requestedScope.organizationIds],
+      taskCorpusKeys: [...request.requestedScope.taskCorpusKeys],
+      modelProfileIds: [...request.requestedScope.modelProfileIds],
+      promotionPolicyKey: DEFAULT_WORK_PATTERN_PROMOTION_POLICY.policyKey,
+      promotionPolicyVersion: DEFAULT_WORK_PATTERN_PROMOTION_POLICY.version,
+      sourceExperimentTaskRunId: snapshot.sourceExperimentTaskRunId,
+      corroborationTaskRunIds: [...maximumScope.corroborationTaskRunIds],
+      priorSafeBindingId,
+      evidenceFreshnessAt: snapshot.promotionEvidence.freshnessAt.toISOString(),
+      evidenceOrigin: evidenceOrigin(maximumScope.ceiling),
+      scopeCeiling: maximumScope.ceiling,
+      blockers: [...maximumScope.blockers],
+    };
+    await session.saveBinding({
+      bindingId,
+      name: `${patternLabel(snapshot.patternKey)} v${snapshot.patternVersion}`,
+      status: "active",
+      resourceRef: `${snapshot.patternKey}@${snapshot.patternVersion}`,
+      appliedAgentId: snapshot.agentId,
+      grants: request.grants,
+      authorityScope,
+    });
+
+    return observe(
+      session,
+      outcome("activate", [], bindingId, bindingId),
+      snapshot,
+      activationLaneKey,
+    );
+  });
+}
+
+export { WORK_PATTERN_BINDING_RESOURCE_TYPE };

--- a/apps/web/lib/tak/work-pattern-binding-reader.test.ts
+++ b/apps/web/lib/tak/work-pattern-binding-reader.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getWorkPatternBindingPresentation,
+  listWorkPatternBindingsForAgent,
+  parseWorkPatternAuthorityScope,
+  type WorkPatternAuthorityScopeV1,
+  type WorkPatternBindingReaderDb,
+} from "./work-pattern-binding-reader";
+
+const AUTHORITY_SCOPE: WorkPatternAuthorityScopeV1 = {
+  schemaVersion: 1,
+  activationLaneKey: "WPL-lane",
+  bindingScopeKey: "WPS-binding",
+  patternKey: "build-review",
+  patternVersion: 2,
+  activityKey: "build.implement",
+  riskClass: "internal-reversible",
+  installScopes: ["dpf_dogfood"],
+  organizationIds: ["org-dogfood"],
+  taskCorpusKeys: ["dpf-repository"],
+  modelProfileIds: ["frontier-coding"],
+  promotionPolicyKey: "governed-build-playbook-promotion",
+  promotionPolicyVersion: 1,
+  sourceExperimentTaskRunId: "TR-WPX-source",
+  corroborationTaskRunIds: [],
+  priorSafeBindingId: "AB-prior",
+  evidenceFreshnessAt: "2026-07-26T12:00:00.000Z",
+  evidenceOrigin: "customer-zero",
+  scopeCeiling: "same-install",
+  blockers: ["broader_scope_requires_portable_corpus_or_customer_corroboration"],
+};
+
+describe("parseWorkPatternAuthorityScope", () => {
+  it("parses a complete scope-locked work-pattern binding", () => {
+    expect(parseWorkPatternAuthorityScope(AUTHORITY_SCOPE)).toEqual(AUTHORITY_SCOPE);
+  });
+
+  it.each([
+    { ...AUTHORITY_SCOPE, schemaVersion: 2 },
+    { ...AUTHORITY_SCOPE, patternVersion: 0 },
+    { ...AUTHORITY_SCOPE, installScopes: ["fleet"] },
+    { ...AUTHORITY_SCOPE, sourceExperimentTaskRunId: "" },
+    { ...AUTHORITY_SCOPE, modelProfileIds: [] },
+  ])("fails closed for malformed or widened authority scope", (scope) => {
+    expect(parseWorkPatternAuthorityScope(scope)).toBeNull();
+  });
+});
+
+describe("listWorkPatternBindingsForAgent", () => {
+  it("returns only rows with a valid typed work-pattern scope", async () => {
+    const db: WorkPatternBindingReaderDb = {
+      listBindings: async () => [
+        {
+          bindingId: "AB-valid",
+          name: "Build review v2",
+          status: "active",
+          resourceRef: "build-review@2",
+          authorityScope: AUTHORITY_SCOPE,
+          updatedAt: new Date("2026-07-26T12:00:00.000Z"),
+        },
+        {
+          bindingId: "AB-invalid",
+          name: "Broken",
+          status: "active",
+          resourceRef: "broken@1",
+          authorityScope: { schemaVersion: 1 },
+          updatedAt: new Date("2026-07-26T12:00:00.000Z"),
+        },
+      ],
+    };
+
+    await expect(
+      listWorkPatternBindingsForAgent("build-specialist", { db }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        bindingId: "AB-valid",
+        authorityScope: AUTHORITY_SCOPE,
+      }),
+    ]);
+  });
+});
+
+describe("getWorkPatternBindingPresentation", () => {
+  it("keeps raw identifiers out of default-altitude scope and blocker copy", () => {
+    const presentation = getWorkPatternBindingPresentation({
+      bindingId: "AB-valid",
+      name: "Build review v2",
+      status: "active",
+      resourceRef: "build-review@2",
+      authorityScope: AUTHORITY_SCOPE,
+      updatedAt: new Date("2026-07-26T12:00:00.000Z"),
+    }, new Date("2026-07-27T12:00:00.000Z"));
+
+    expect(presentation).toEqual({
+      stateLabel: "Active method",
+      scopeLabel: "Only this DPF installation",
+      evidenceLabel: "Proven on DPF's own work",
+      freshnessLabel: "Evidence checked 1 day ago",
+      blockerMessages: [
+        "Broader use needs a verified replay corpus or corroborating customer evidence.",
+      ],
+    });
+    expect(JSON.stringify(presentation)).not.toContain("AB-valid");
+    expect(JSON.stringify(presentation)).not.toContain("TR-WPX-source");
+    expect(JSON.stringify(presentation)).not.toContain("WPS-binding");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-binding-reader.ts
+++ b/apps/web/lib/tak/work-pattern-binding-reader.ts
@@ -1,0 +1,294 @@
+import { prisma } from "@dpf/db";
+import {
+  CAPABILITY_INSTALL_SCOPES,
+  type CapabilityInstallScope,
+} from "@dpf/db/capability-maturity";
+
+import type { RiskClass } from "@/lib/autonomy/trust-graduation";
+import { isRecord } from "@/lib/shared/coerce";
+
+export const WORK_PATTERN_BINDING_RESOURCE_TYPE = "work-pattern";
+
+export const WORK_PATTERN_BINDING_STATUSES = [
+  "active",
+  "superseded",
+  "rolled-back",
+  "retired",
+] as const;
+
+export type WorkPatternBindingStatus =
+  (typeof WORK_PATTERN_BINDING_STATUSES)[number];
+
+export type WorkPatternScopeCeiling =
+  | "same-install"
+  | "canonical-corpus"
+  | "corroborated";
+
+export type WorkPatternEvidenceOrigin =
+  | "customer-zero"
+  | "portable-canonical-corpus"
+  | "customer-corroborated";
+
+export type WorkPatternAuthorityScopeV1 = {
+  schemaVersion: 1;
+  activationLaneKey: string;
+  bindingScopeKey: string;
+  patternKey: string;
+  patternVersion: number;
+  activityKey: string;
+  riskClass: RiskClass;
+  installScopes: CapabilityInstallScope[];
+  organizationIds: string[];
+  taskCorpusKeys: string[];
+  modelProfileIds: string[];
+  promotionPolicyKey: string;
+  promotionPolicyVersion: number;
+  sourceExperimentTaskRunId: string;
+  corroborationTaskRunIds: string[];
+  priorSafeBindingId: string | null;
+  evidenceFreshnessAt: string;
+  evidenceOrigin: WorkPatternEvidenceOrigin;
+  scopeCeiling: WorkPatternScopeCeiling;
+  blockers: string[];
+};
+
+export type WorkPatternBindingRecord = {
+  bindingId: string;
+  name: string;
+  status: string;
+  resourceRef: string;
+  authorityScope: WorkPatternAuthorityScopeV1;
+  updatedAt: Date;
+};
+
+export type WorkPatternBindingReaderDb = {
+  listBindings(agentId: string): Promise<Array<{
+    bindingId: string;
+    name: string;
+    status: string;
+    resourceRef: string;
+    authorityScope: unknown;
+    updatedAt: Date;
+  }>>;
+};
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function stringArray(value: unknown, options?: { allowEmpty?: boolean }): string[] | null {
+  if (
+    !Array.isArray(value)
+    || (!options?.allowEmpty && value.length === 0)
+    || value.some((entry) => !nonEmptyString(entry))
+  ) {
+    return null;
+  }
+  const strings = value as string[];
+  return new Set(strings).size === strings.length ? strings : null;
+}
+
+function installScopes(value: unknown): CapabilityInstallScope[] | null {
+  const values = stringArray(value);
+  if (
+    !values
+    || values.some(
+      (scope) => !(CAPABILITY_INSTALL_SCOPES as readonly string[]).includes(scope),
+    )
+  ) {
+    return null;
+  }
+  return values as CapabilityInstallScope[];
+}
+
+function riskClass(value: unknown): RiskClass | null {
+  return (
+    value === "read-only"
+    || value === "internal-reversible"
+    || value === "internal-irreversible"
+    || value === "outbound-or-floor"
+  )
+    ? value
+    : null;
+}
+
+function scopeCeiling(value: unknown): WorkPatternScopeCeiling | null {
+  return (
+    value === "same-install"
+    || value === "canonical-corpus"
+    || value === "corroborated"
+  )
+    ? value
+    : null;
+}
+
+function evidenceOrigin(value: unknown): WorkPatternEvidenceOrigin | null {
+  return (
+    value === "customer-zero"
+    || value === "portable-canonical-corpus"
+    || value === "customer-corroborated"
+  )
+    ? value
+    : null;
+}
+
+function validDateString(value: unknown): value is string {
+  return nonEmptyString(value) && Number.isFinite(Date.parse(value));
+}
+
+export function parseWorkPatternAuthorityScope(
+  value: unknown,
+): WorkPatternAuthorityScopeV1 | null {
+  if (!isRecord(value) || value.schemaVersion !== 1) return null;
+  const parsedRiskClass = riskClass(value.riskClass);
+  const parsedInstallScopes = installScopes(value.installScopes);
+  const organizationIds = stringArray(value.organizationIds, { allowEmpty: true });
+  const taskCorpusKeys = stringArray(value.taskCorpusKeys);
+  const modelProfileIds = stringArray(value.modelProfileIds);
+  const corroborationTaskRunIds = stringArray(
+    value.corroborationTaskRunIds,
+    { allowEmpty: true },
+  );
+  const blockers = stringArray(value.blockers, { allowEmpty: true });
+  const parsedCeiling = scopeCeiling(value.scopeCeiling);
+  const parsedOrigin = evidenceOrigin(value.evidenceOrigin);
+  const requiredStrings = [
+    value.activationLaneKey,
+    value.bindingScopeKey,
+    value.patternKey,
+    value.activityKey,
+    value.promotionPolicyKey,
+    value.sourceExperimentTaskRunId,
+  ];
+  if (
+    requiredStrings.some((entry) => !nonEmptyString(entry))
+    || !positiveInteger(value.patternVersion)
+    || !positiveInteger(value.promotionPolicyVersion)
+    || !parsedRiskClass
+    || !parsedInstallScopes
+    || !organizationIds
+    || !taskCorpusKeys
+    || !modelProfileIds
+    || !corroborationTaskRunIds
+    || !blockers
+    || !parsedCeiling
+    || !parsedOrigin
+    || !validDateString(value.evidenceFreshnessAt)
+    || (
+      value.priorSafeBindingId !== null
+      && !nonEmptyString(value.priorSafeBindingId)
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    schemaVersion: 1,
+    activationLaneKey: value.activationLaneKey as string,
+    bindingScopeKey: value.bindingScopeKey as string,
+    patternKey: value.patternKey as string,
+    patternVersion: value.patternVersion,
+    activityKey: value.activityKey as string,
+    riskClass: parsedRiskClass,
+    installScopes: parsedInstallScopes,
+    organizationIds,
+    taskCorpusKeys,
+    modelProfileIds,
+    promotionPolicyKey: value.promotionPolicyKey as string,
+    promotionPolicyVersion: value.promotionPolicyVersion,
+    sourceExperimentTaskRunId: value.sourceExperimentTaskRunId as string,
+    corroborationTaskRunIds,
+    priorSafeBindingId: value.priorSafeBindingId as string | null,
+    evidenceFreshnessAt: value.evidenceFreshnessAt,
+    evidenceOrigin: parsedOrigin,
+    scopeCeiling: parsedCeiling,
+    blockers,
+  };
+}
+
+function defaultDb(): WorkPatternBindingReaderDb {
+  return {
+    listBindings: (agentId) =>
+      prisma.authorityBinding.findMany({
+        where: {
+          resourceType: WORK_PATTERN_BINDING_RESOURCE_TYPE,
+          appliedAgent: { agentId },
+        },
+        select: {
+          bindingId: true,
+          name: true,
+          status: true,
+          resourceRef: true,
+          authorityScope: true,
+          updatedAt: true,
+        },
+        orderBy: [{ updatedAt: "desc" }, { bindingId: "asc" }],
+      }),
+  };
+}
+
+export async function listWorkPatternBindingsForAgent(
+  agentId: string,
+  deps?: { db?: WorkPatternBindingReaderDb },
+): Promise<WorkPatternBindingRecord[]> {
+  const rows = await (deps?.db ?? defaultDb()).listBindings(agentId);
+  return rows.flatMap((row) => {
+    const authorityScope = parseWorkPatternAuthorityScope(row.authorityScope);
+    return authorityScope ? [{ ...row, authorityScope }] : [];
+  });
+}
+
+const BLOCKER_COPY: Record<string, string> = {
+  broader_scope_requires_portable_corpus_or_customer_corroboration:
+    "Broader use needs a verified replay corpus or corroborating customer evidence.",
+};
+
+function daysAgoLabel(iso: string, now: Date): string {
+  const ageDays = Math.max(
+    0,
+    Math.floor((now.getTime() - Date.parse(iso)) / (24 * 60 * 60 * 1000)),
+  );
+  if (ageDays === 0) return "Evidence checked today";
+  if (ageDays === 1) return "Evidence checked 1 day ago";
+  return `Evidence checked ${ageDays} days ago`;
+}
+
+export function getWorkPatternBindingPresentation(
+  binding: WorkPatternBindingRecord,
+  now = new Date(),
+) {
+  const stateLabel =
+    binding.status === "active"
+      ? "Active method"
+      : binding.status === "rolled-back"
+        ? "Rolled back"
+        : binding.status === "superseded"
+          ? "Replaced by a safer method"
+          : "Retired method";
+  const scopeLabel =
+    binding.authorityScope.scopeCeiling === "same-install"
+      ? "Only this DPF installation"
+      : binding.authorityScope.scopeCeiling === "canonical-corpus"
+        ? "This installation and the verified replay corpus"
+        : "Verified installations and task corpora";
+  const evidenceLabel =
+    binding.authorityScope.evidenceOrigin === "customer-zero"
+      ? "Proven on DPF's own work"
+      : binding.authorityScope.evidenceOrigin === "portable-canonical-corpus"
+        ? "Proven on a portable replay corpus"
+        : "Corroborated with customer evidence";
+
+  return {
+    stateLabel,
+    scopeLabel,
+    evidenceLabel,
+    freshnessLabel: daysAgoLabel(binding.authorityScope.evidenceFreshnessAt, now),
+    blockerMessages: binding.authorityScope.blockers.map(
+      (blocker) => BLOCKER_COPY[blocker] ?? "More governed evidence is required.",
+    ),
+  };
+}

--- a/apps/web/lib/tak/work-pattern-effective-ledger.test.ts
+++ b/apps/web/lib/tak/work-pattern-effective-ledger.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  canReopenRejectedWorkPatternCandidate,
   resolveEffectiveWorkPatternLedger,
+  validateWorkPatternSafeBindingChain,
   validateWorkPatternPromotionPair,
+  workPatternCandidateEvidenceIdentity,
 } from "./work-pattern-effective-ledger";
 
 describe("resolveEffectiveWorkPatternLedger", () => {
@@ -146,5 +149,74 @@ describe("validateWorkPatternPromotionPair", () => {
       "oracle_mismatch",
       "resource_policy_mismatch",
     ]);
+  });
+});
+
+describe("negative work-pattern knowledge", () => {
+  const candidate = {
+    patternKey: "build-review",
+    patternVersion: 2,
+    methodVariantKey: "structured-review",
+    modelProfileId: "frontier-coding",
+    taskCorpusKey: "dpf-repository",
+    taskCorpusVersion: "1",
+    oracleKey: "build-gate",
+    oracleVersion: "3",
+    promotionPolicyKey: "bounded-promotion",
+    promotionPolicyVersion: 1,
+  };
+
+  it("dedupes a materially identical rejected candidate", () => {
+    const identity = workPatternCandidateEvidenceIdentity(candidate);
+
+    expect(canReopenRejectedWorkPatternCandidate({
+      candidate,
+      effectiveRejections: [{
+        candidateIdentity: identity,
+        failureClass: "correctness-regression",
+      }],
+    })).toEqual({
+      allowed: false,
+      reason: "materially_identical_rejection_retained",
+    });
+  });
+
+  it.each([
+    ["corpus", { taskCorpusVersion: "2" }],
+    ["model", { modelProfileId: "local-9b" }],
+    ["oracle", { oracleVersion: "4" }],
+    ["policy", { promotionPolicyVersion: 2 }],
+  ])("permits a new replicate after materially new %s evidence", (_label, change) => {
+    expect(canReopenRejectedWorkPatternCandidate({
+      candidate: { ...candidate, ...change },
+      effectiveRejections: [{
+        candidateIdentity: workPatternCandidateEvidenceIdentity(candidate),
+        failureClass: "correctness-regression",
+      }],
+    })).toEqual({ allowed: true, reason: "materially_new_evidence" });
+  });
+});
+
+describe("validateWorkPatternSafeBindingChain", () => {
+  it("accepts an append-only acyclic rollback chain", () => {
+    expect(validateWorkPatternSafeBindingChain([
+      { bindingId: "AB-v1", priorSafeBindingId: null },
+      { bindingId: "AB-v2", priorSafeBindingId: "AB-v1" },
+      { bindingId: "AB-v3", priorSafeBindingId: "AB-v2" },
+    ])).toEqual({ valid: true, reasons: [] });
+  });
+
+  it("fails closed for a dangling or cyclic prior-safe binding", () => {
+    expect(validateWorkPatternSafeBindingChain([
+      { bindingId: "AB-v1", priorSafeBindingId: "AB-v2" },
+      { bindingId: "AB-v2", priorSafeBindingId: "AB-v1" },
+      { bindingId: "AB-v3", priorSafeBindingId: "AB-missing" },
+    ])).toEqual({
+      valid: false,
+      reasons: [
+        "prior_safe_binding_dangling:AB-v3:AB-missing",
+        "prior_safe_binding_cycle",
+      ],
+    });
   });
 });

--- a/apps/web/lib/tak/work-pattern-effective-ledger.ts
+++ b/apps/web/lib/tak/work-pattern-effective-ledger.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { isRecord } from "@/lib/shared/coerce";
 
 export type WorkPatternLedgerRow = {
@@ -23,6 +25,105 @@ export type WorkPatternPromotionPairVerdict = {
   valid: boolean;
   reasons: string[];
 };
+
+export type WorkPatternCandidateEvidence = {
+  patternKey: string;
+  patternVersion: number;
+  methodVariantKey: string;
+  modelProfileId: string;
+  taskCorpusKey: string;
+  taskCorpusVersion: string;
+  oracleKey: string;
+  oracleVersion: string;
+  promotionPolicyKey: string;
+  promotionPolicyVersion: number;
+};
+
+export function workPatternCandidateEvidenceIdentity(
+  candidate: WorkPatternCandidateEvidence,
+): string {
+  const canonical = [
+    candidate.patternKey,
+    candidate.patternVersion,
+    candidate.methodVariantKey,
+    candidate.modelProfileId,
+    candidate.taskCorpusKey,
+    candidate.taskCorpusVersion,
+    candidate.oracleKey,
+    candidate.oracleVersion,
+    candidate.promotionPolicyKey,
+    candidate.promotionPolicyVersion,
+  ];
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+export function canReopenRejectedWorkPatternCandidate(input: {
+  candidate: WorkPatternCandidateEvidence;
+  effectiveRejections: readonly {
+    candidateIdentity: string;
+    failureClass: string;
+  }[];
+}) {
+  const candidateIdentity = workPatternCandidateEvidenceIdentity(input.candidate);
+  return input.effectiveRejections.some(
+    (rejection) => rejection.candidateIdentity === candidateIdentity,
+  )
+    ? { allowed: false as const, reason: "materially_identical_rejection_retained" as const }
+    : { allowed: true as const, reason: "materially_new_evidence" as const };
+}
+
+const RETAINED_FAILURE_CLASSES = new Set([
+  "commandment_gate_regression",
+  "critical_finding_reproduced",
+  "correctness_regression",
+  "security_regression",
+  "migrationSafety_regression",
+  "customerImpact_regression",
+]);
+
+export function isRetainedWorkPatternFailureClass(value: string): boolean {
+  return RETAINED_FAILURE_CLASSES.has(value);
+}
+
+export function validateWorkPatternSafeBindingChain(
+  bindings: readonly {
+    bindingId: string;
+    priorSafeBindingId: string | null;
+  }[],
+): WorkPatternPromotionPairVerdict {
+  const reasons: string[] = [];
+  const ids = new Set(bindings.map((binding) => binding.bindingId));
+  const byId = new Map(bindings.map((binding) => [binding.bindingId, binding]));
+
+  for (const binding of bindings) {
+    if (
+      binding.priorSafeBindingId
+      && !ids.has(binding.priorSafeBindingId)
+    ) {
+      reasons.push(
+        `prior_safe_binding_dangling:${binding.bindingId}:${binding.priorSafeBindingId}`,
+      );
+    }
+  }
+
+  let cycleFound = false;
+  for (const binding of bindings) {
+    const visited = new Set<string>();
+    let cursor: string | null = binding.bindingId;
+    while (cursor && byId.has(cursor)) {
+      if (visited.has(cursor)) {
+        cycleFound = true;
+        break;
+      }
+      visited.add(cursor);
+      cursor = byId.get(cursor)?.priorSafeBindingId ?? null;
+    }
+    if (cycleFound) break;
+  }
+  if (cycleFound) reasons.push("prior_safe_binding_cycle");
+
+  return { valid: reasons.length === 0, reasons };
+}
 
 function supersededLedgerId(row: WorkPatternLedgerRow): string | null {
   if (!isRecord(row.metadata)) return null;

--- a/apps/web/lib/tak/work-pattern-promotion-policy.test.ts
+++ b/apps/web/lib/tak/work-pattern-promotion-policy.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+  evaluateWorkPatternPromotion,
+  type WorkPatternPromotionEvidence,
+} from "./work-pattern-promotion-policy";
+
+const NOW = new Date("2026-07-26T12:00:00.000Z");
+
+function qualifyingEvidence(
+  overrides: Partial<WorkPatternPromotionEvidence> = {},
+): WorkPatternPromotionEvidence {
+  return {
+    activityKey: "build.implement",
+    riskClass: "internal-reversible",
+    validPairCount: 8,
+    invalidPairCount: 0,
+    completedCellKeys: ["control", "method", "model", "interaction"],
+    freshnessAt: new Date("2026-07-25T12:00:00.000Z"),
+    rollbackBindingId: "AB-work-pattern-prior",
+    objectiveDeltas: {
+      correctness: 0.08,
+      security: 0,
+      migrationSafety: 0,
+      customerImpact: 0,
+      speed: 0.12,
+      cost: 0.04,
+    },
+    commandmentGateRegression: false,
+    criticalFindingReproduced: false,
+    regulatoryHumanControlRequired: false,
+    activeBindingHealthRegression: false,
+    ...overrides,
+  };
+}
+
+describe("evaluateWorkPatternPromotion", () => {
+  it("activates only complete, fresh, objectively improved evidence with rollback", () => {
+    expect(evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence: qualifyingEvidence(),
+      now: NOW,
+    })).toEqual({ decision: "activate", reasons: [] });
+  });
+
+  it.each([
+    ["commandment regression", { commandmentGateRegression: true }],
+    ["critical finding", { criticalFindingReproduced: true }],
+    ["correctness regression", { objectiveDeltas: { ...qualifyingEvidence().objectiveDeltas, correctness: -0.01 } }],
+    ["security regression", { objectiveDeltas: { ...qualifyingEvidence().objectiveDeltas, security: -0.01 } }],
+    ["migration regression", { objectiveDeltas: { ...qualifyingEvidence().objectiveDeltas, migrationSafety: -0.01 } }],
+    ["customer-impact regression", { objectiveDeltas: { ...qualifyingEvidence().objectiveDeltas, customerImpact: -0.01 } }],
+  ])("rejects %s even when speed and cost improve", (_label, override) => {
+    const evidence = qualifyingEvidence({
+      ...override,
+      objectiveDeltas: {
+        ...qualifyingEvidence().objectiveDeltas,
+        speed: 0.9,
+        cost: 0.9,
+        ...("objectiveDeltas" in override ? override.objectiveDeltas : {}),
+      },
+    });
+    expect(evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence,
+      now: NOW,
+    }).decision).toBe("reject");
+  });
+
+  it.each([
+    ["too few pairs", { validPairCount: 7 }],
+    ["invalid pair", { invalidPairCount: 1 }],
+    ["missing required cell", { completedCellKeys: ["control", "method"] }],
+    ["stale evidence", { freshnessAt: new Date("2026-06-01T00:00:00.000Z") }],
+    ["missing rollback", { rollbackBindingId: null }],
+  ])("continues without activation for %s", (_label, override) => {
+    expect(evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence: qualifyingEvidence(override as Partial<WorkPatternPromotionEvidence>),
+      now: NOW,
+    }).decision).toBe("continue");
+  });
+
+  it("returns rollback for a same-scope health regression with a safe target", () => {
+    expect(evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence: qualifyingEvidence({ activeBindingHealthRegression: true }),
+      now: NOW,
+    }).decision).toBe("rollback");
+  });
+
+  it("escalates when regulatory policy requires human control", () => {
+    expect(evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence: qualifyingEvidence({ regulatoryHumanControlRequired: true }),
+      now: NOW,
+    }).decision).toBe("escalate");
+  });
+});

--- a/apps/web/lib/tak/work-pattern-promotion-policy.ts
+++ b/apps/web/lib/tak/work-pattern-promotion-policy.ts
@@ -1,0 +1,157 @@
+import type { RiskClass } from "@/lib/autonomy/trust-graduation";
+
+export const WORK_PATTERN_PROMOTION_DECISIONS = [
+  "continue",
+  "activate",
+  "reject",
+  "rollback",
+  "escalate",
+] as const;
+
+export type WorkPatternPromotionDecision =
+  (typeof WORK_PATTERN_PROMOTION_DECISIONS)[number];
+
+export type WorkPatternObjectiveDeltas = {
+  correctness: number;
+  security: number;
+  migrationSafety: number;
+  customerImpact: number;
+  speed: number;
+  cost: number;
+};
+
+export type WorkPatternPromotionPolicy = {
+  policyKey: string;
+  version: number;
+  accountableOwner: string;
+  supportedActivityKeys: readonly string[];
+  supportedRiskClasses: readonly RiskClass[];
+  minimumValidPairCount: number;
+  requiredCellKeys: readonly string[];
+  minimumObjectiveImprovement: number;
+  nonRegressionTolerance: Pick<
+    WorkPatternObjectiveDeltas,
+    "correctness" | "security" | "migrationSafety" | "customerImpact"
+  >;
+  freshnessWindowDays: number;
+  rollbackRequired: boolean;
+};
+
+export type WorkPatternPromotionEvidence = {
+  activityKey: string;
+  riskClass: RiskClass;
+  validPairCount: number;
+  invalidPairCount: number;
+  completedCellKeys: readonly string[];
+  freshnessAt: Date;
+  rollbackBindingId: string | null;
+  objectiveDeltas: WorkPatternObjectiveDeltas;
+  commandmentGateRegression: boolean;
+  criticalFindingReproduced: boolean;
+  regulatoryHumanControlRequired: boolean;
+  activeBindingHealthRegression: boolean;
+};
+
+export type WorkPatternPromotionVerdict = {
+  decision: WorkPatternPromotionDecision;
+  reasons: string[];
+};
+
+export const DEFAULT_WORK_PATTERN_PROMOTION_POLICY: WorkPatternPromotionPolicy = {
+  policyKey: "governed-build-playbook-promotion",
+  version: 1,
+  accountableOwner: "build-studio-governance",
+  supportedActivityKeys: ["build.implement"],
+  supportedRiskClasses: ["read-only", "internal-reversible"],
+  minimumValidPairCount: 8,
+  requiredCellKeys: ["control", "method", "model", "interaction"],
+  minimumObjectiveImprovement: 0.01,
+  nonRegressionTolerance: {
+    correctness: 0,
+    security: 0,
+    migrationSafety: 0,
+    customerImpact: 0,
+  },
+  freshnessWindowDays: 30,
+  rollbackRequired: true,
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function hardRegressionReasons(
+  policy: WorkPatternPromotionPolicy,
+  evidence: WorkPatternPromotionEvidence,
+): string[] {
+  const reasons: string[] = [];
+  if (evidence.commandmentGateRegression) reasons.push("commandment_gate_regression");
+  if (evidence.criticalFindingReproduced) reasons.push("critical_finding_reproduced");
+  for (const key of [
+    "correctness",
+    "security",
+    "migrationSafety",
+    "customerImpact",
+  ] as const) {
+    if (evidence.objectiveDeltas[key] < -policy.nonRegressionTolerance[key]) {
+      reasons.push(`${key}_regression`);
+    }
+  }
+  return reasons;
+}
+
+export function evaluateWorkPatternPromotion(input: {
+  policy: WorkPatternPromotionPolicy;
+  evidence: WorkPatternPromotionEvidence;
+  now: Date;
+}): WorkPatternPromotionVerdict {
+  const { policy, evidence, now } = input;
+  if (
+    !policy.supportedActivityKeys.includes(evidence.activityKey)
+    || !policy.supportedRiskClasses.includes(evidence.riskClass)
+  ) {
+    return { decision: "escalate", reasons: ["unsupported_activity_or_risk"] };
+  }
+  if (evidence.regulatoryHumanControlRequired) {
+    return { decision: "escalate", reasons: ["regulatory_human_control_required"] };
+  }
+  if (evidence.activeBindingHealthRegression) {
+    return evidence.rollbackBindingId
+      ? { decision: "rollback", reasons: ["active_binding_health_regression"] }
+      : { decision: "escalate", reasons: ["rollback_target_missing"] };
+  }
+
+  const regressionReasons = hardRegressionReasons(policy, evidence);
+  if (regressionReasons.length > 0) {
+    return { decision: "reject", reasons: regressionReasons };
+  }
+
+  const continueReasons: string[] = [];
+  if (evidence.validPairCount < policy.minimumValidPairCount) {
+    continueReasons.push("minimum_valid_pairs_not_met");
+  }
+  if (evidence.invalidPairCount > 0) continueReasons.push("invalid_pair_present");
+  const completed = new Set(evidence.completedCellKeys);
+  if (policy.requiredCellKeys.some((cellKey) => !completed.has(cellKey))) {
+    continueReasons.push("required_cell_missing");
+  }
+  const freshnessAge = now.getTime() - evidence.freshnessAt.getTime();
+  if (
+    !Number.isFinite(freshnessAge)
+    || freshnessAge < 0
+    || freshnessAge > policy.freshnessWindowDays * DAY_MS
+  ) {
+    continueReasons.push("evidence_stale");
+  }
+  if (policy.rollbackRequired && !evidence.rollbackBindingId) {
+    continueReasons.push("rollback_target_missing");
+  }
+  if (continueReasons.length > 0) {
+    return { decision: "continue", reasons: continueReasons };
+  }
+
+  const improved = Object.values(evidence.objectiveDeltas).some(
+    (delta) => delta >= policy.minimumObjectiveImprovement,
+  );
+  return improved
+    ? { decision: "activate", reasons: [] }
+    : { decision: "continue", reasons: ["objective_improvement_not_met"] };
+}

--- a/apps/web/lib/tak/work-pattern-read-model.ts
+++ b/apps/web/lib/tak/work-pattern-read-model.ts
@@ -37,6 +37,10 @@ import {
   parseWorkPatternExperimentProjection,
   type WorkPatternExperimentProjection,
 } from "./work-pattern-experiment-projection";
+import {
+  listWorkPatternBindingsForAgent,
+  type WorkPatternBindingRecord,
+} from "./work-pattern-binding-reader";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DEFAULT_TAKE = 200;
@@ -89,6 +93,7 @@ export type WorkPatternReadModelQuery = {
 export type WorkPatternReadModelDb = {
   listTaskRuns(query: WorkPatternReadModelQuery): Promise<WorkPatternReadModelTaskRunRow[]>;
   listCapabilityNeeds(query: WorkPatternReadModelQuery): Promise<WorkPatternReadModelNeedRow[]>;
+  listWorkPatternBindings?(agentId: string): Promise<WorkPatternBindingRecord[]>;
 };
 
 export type GetWorkPatternReadModelInput = {
@@ -144,6 +149,7 @@ export type WorkPatternReadModel = {
     readyForReviewCount: number;
     candidateOnlyCount: number;
   };
+  bindings?: WorkPatternBindingRecord[];
   patterns: WorkPatternSummary[];
 };
 
@@ -178,6 +184,7 @@ type PatternSeed = {
 
 function defaultDb(): WorkPatternReadModelDb {
   return {
+    listWorkPatternBindings: listWorkPatternBindingsForAgent,
     listTaskRuns: (query) =>
       prisma.taskRun.findMany({
         where: {
@@ -730,9 +737,10 @@ export async function getWorkPatternReadModel(
 ): Promise<WorkPatternReadModel> {
   const query = resolveQuery(input);
   const db = deps?.db ?? defaultDb();
-  const [taskRuns, needs] = await Promise.all([
+  const [taskRuns, needs, bindings] = await Promise.all([
     db.listTaskRuns(query),
     db.listCapabilityNeeds(query),
+    db.listWorkPatternBindings?.(query.agentId) ?? Promise.resolve([]),
   ]);
 
   const summaries = new Map<string, SummaryAccumulator>();
@@ -761,6 +769,7 @@ export async function getWorkPatternReadModel(
       readyForReviewCount: patterns.filter((item) => item.readiness.readyForReview).length,
       candidateOnlyCount: patterns.filter((item) => item.observedRuns === 0).length,
     },
+    bindings,
     patterns,
   };
 }

--- a/docs/architecture/customer-zero-and-use-case-zero.md
+++ b/docs/architecture/customer-zero-and-use-case-zero.md
@@ -111,6 +111,22 @@ The maturity spec also names this exact risk and its mitigation
 
 That is customer zero's boundary, already made mechanical, for *capability scores*.
 
+## Living Playbooks carry the same boundary
+
+Governed work-pattern promotion applies the same rule to learned methods. Every active
+`work-pattern` authority binding records its evidence scope: installation, organization, task
+corpus, model profile, activity, and risk class. Customer-zero evidence can therefore activate a
+method autonomously for DPF's own installation while remaining explicitly blocked from broader
+use. A verified portable corpus or materially different, egress-approved customer corroboration
+can raise that ceiling; provenance alone cannot.
+
+Activation re-reads the evidence inside a serializable, advisory-locked transaction, retains one
+active binding per lane, and records supersession or rollback in the existing
+`DecisionShadowLedger`. The generic authority editor excludes these bindings so it cannot widen
+their scope or mutate their lifecycle outside that governed transaction. Rejected candidate
+identities also remain effective negative knowledge until the corpus, model, oracle, or promotion
+policy materially changes.
+
 ## The gap: no equivalent separation for learned decision weights
 
 The same discipline does **not** exist on the JSI weight-inference path.

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -94,6 +94,19 @@ provider or model is evidence, while the orchestrating coworker remains the acco
 the audit ledger. Missing fixtures, live-environment requests, mutable code-workspace work, and
 authority-ceiling cases stop without activation or customer-state mutation.
 
+When the required comparison cells are complete, fresh, non-regressing, and within the promotion
+policy's activity and risk ceiling, DPF can activate the winning method without another approval.
+Activation is limited to the installations, organizations, task corpora, and model profile proven
+by that evidence. It never adds tool authority. The coworker's **Living Playbooks** panel shows the
+active method, where it may run, when its evidence was last checked, and what evidence is still
+needed before broader use.
+
+A rejected candidate remains useful negative knowledge: DPF will not repeat the materially same
+experiment unless the corpus, model, oracle, or promotion policy changes. If an active method later
+regresses, DPF rolls back to the recorded prior-safe method and retains both versions in the audit
+history. Unsupported risks, regulatory human-control requirements, and missing rollback targets
+still escalate.
+
 ## Tool Evaluation Pipeline
 
 External tools must be evaluated before adoption (EP-GOVERN-002). The pipeline runs 6 agents with different perspectives:

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -6367,7 +6367,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 106
+    "textMass": 133
   },
   "apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx": {
     "vocabulary": 0,
@@ -6389,6 +6389,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 63
+  },
+  "apps/web/components/platform/coworker-record/WorkPatternBindingCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
   },
   "apps/web/components/platform/coworker-record/WorkforceSummaryPanel.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary  Activates evidence-cleared Living Playbook methods deterministically within their earned activity, risk, corpus, model, organization, and install scope. Customer 0 evidence can govern the DPF install but cannot silently widen into fleet authority; unsupported or authority-ceiling cases fail closed and escalate.  ## Changes  - Adds typed promotion policy and activation-scope contracts using the existing capability install-scope vocabulary. - Persists activation under a PostgreSQL advisory lock and serializable transaction with deterministic IDs, idempotent retry, exact-lane rollback, and DecisionShadowLedger evidence retention. - Preserves FeatureBuild, TaskRun, BuildPhaseRun, AuthorityBinding, Work Case, merge-queue, and governed self-upgrade substrates; the generic AuthorityBinding editor cannot mutate work-pattern bindings. - Shows active scope, provenance, freshness, broader-use blockers, and rolled-back history in the existing coworker Needs & Playbooks panel, without raw IDs or a manual activation control. - Updates operator and architecture documentation. No database migration is required because the implementation reuses AuthorityBinding and DecisionShadowLedger. - Implements the approved slice budget exactly: 10 effort units = 8 feature + 2 bounded structural refactor units (20%).  ## Test plan  - [x] **Source-only change**   - [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck`   - [x] 11 focused Vitest files: 75 tests passed  - [x] **Runtime-bound change**   - [x] Source checks passed   - [x] Governed shared nonprod env: merged-code evidence `cms2gab8g0duc01qo996ozb4p`; UX lease `NPEL-D452CE3B7B`   - [x] Evidence captured below  - [ ] **Verification-harness limitation acknowledged** ΓÇö not applicable; all required gates ran on the governed convergence sandbox  ### Verification evidence  - Exact head: `90ecff0a0fe9a68520256b385fae4fab9bc56aea` - Merged-code integration: 2,236 test files passed (4 skipped); 19,435 tests passed; typecheck, Prisma migrate deploy, docs guards, production Docker build, module-size/style/token/security ratchets all passed. Evidence: `cms2gab8g0duc01qo996ozb4p`. - Authenticated UX: desktop and 390x844 mobile on the exact production image. Active scope, evidence freshness, broader-use blocker, rollback history, and authority-safety copy were visible; raw binding/task-run IDs and manual activation controls were absent; no mobile horizontal overflow. Runtime verification: `RV-BI522-UX-20260726` / activity `cms2i88el060701qq6gn9bqjl`. - Recovery hygiene: the temporary local-CI fixture was removed, the prior nonproduction credential hash restored exactly, the preview container removed, browser viewport reset, and the lease released. - Migration: not applicable; no schema change.  ## Related issues / Epic  Parent: `EP-COMPETENCE-FLYWHEEL`  This PR delivers: `BI-522E754E`  ## Overlap sweep  No open PR with overlapping playbook-promotion, autonomy, or AuthorityBinding scope was found immediately before PR creation.  ## Notes for the reviewer  - `UX-Fit-Decision: existing-panel-disclosure (DI-3C29E8AFB385)` - High-risk, irreversible, outbound/floor, stale-evidence, malformed-policy, and scope-widening cases remain escalation lanes. - This is the Delivery 2 substrate. End-to-end autonomous Build Studio consumption remains the separately planned `BI-356E69B1` slice. ## Design grounding  - Existing specs/plans reviewed:   - `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`   - `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md` - Current code substrate reviewed:   - Existing `FeatureBuild`, `TaskRun`, `BuildPhaseRun`, Work Case, merge-queue, and governed self-upgrade lifecycles.   - Existing `AuthorityBinding`, `AuthorityBindingGrant`, `DecisionShadowLedger`, work-pattern review/read-model, and coworker-record panel contracts.   - `CAPABILITY_INSTALL_SCOPES` and current autonomy risk classes. - Source of truth:   - The approved design and plan above own promotion/activation behavior; `AGENTS.md` owns delivery and verification doctrine; typed code contracts own runtime enforcement. - Decision:   - Extend the existing AuthorityBinding and DecisionShadowLedger substrates with deterministic, scope-locked activation; disclose it in the existing Needs & Playbooks panel; do not create a parallel authority store, route, or manual activation path.

---

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md, docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md, and code substrate apps/web/lib/tak/work-pattern-*.ts plus apps/web/components/platform/coworker-record/*; extend AuthorityBinding/DecisionShadowLedger with scope-locked activation disclosed in Needs & Playbooks (no parallel store/route).
