### PR TITLE
fix(coworker): reject unproven backlog create claims in chat (BI-1BB7408D)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -45,6 +45,7 @@ import {
 import { persistExecutionPlan, loadExecutionPlan } from "./execution-plan-store";
 import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
+import { sanitizeBacklogCreateClaims } from "./backlog-create-claim-guard";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import {
@@ -2069,19 +2070,23 @@ export async function runAgenticLoop(params: {
           console.warn(
             `[agentic-loop] conversational fabrication retry exhausted — keeping the advice${makesHardCompletionClaim ? " with an unsaved-work note" : ""} rather than discarding it.`,
           );
-          return {
-            content: makesHardCompletionClaim
+          {
+            const base = makesHardCompletionClaim
               ? `${trimmed}\n\n${buildUnsavedAdviceNote(routeContext)}`
-              : trimmed,
-            providerId: result.providerId,
-            modelId: result.modelId,
-            downgraded: result.downgraded,
-            downgradeMessage: result.downgradeMessage,
-            totalInputTokens,
-            totalOutputTokens,
-            executedTools,
-            proposal: null,
-          };
+              : trimmed;
+            const guarded = sanitizeBacklogCreateClaims(base, executedTools);
+            return {
+              content: guarded.content,
+              providerId: result.providerId,
+              modelId: result.modelId,
+              downgraded: result.downgraded,
+              downgradeMessage: result.downgradeMessage,
+              totalInputTokens,
+              totalOutputTokens,
+              executedTools,
+              proposal: null,
+            };
+          }
         }
 
         // BI-PIR-cc091267 — a build-route fabrication signal (completion claim
@@ -2308,9 +2313,21 @@ export async function runAgenticLoop(params: {
       // If the final response is empty but we had a good pre-nudge response,
       // use that instead of returning nothing. This prevents quality-gate
       // failures when the nudge causes the model to return empty.
-      const finalContent = trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content);
+      let finalContent = trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content);
       if (trimmed.length === 0 && bestPreNudgeContent.length > 0) {
         console.log(`[agentic-loop] recovering pre-nudge content (${bestPreNudgeContent.length} chars)`);
+      }
+
+      // BI-1BB7408D: never render "Created: BI-XXXX" unless create_backlog_item
+      // succeeded this turn for that id (structural-verification-is-not-functional).
+      {
+        const guarded = sanitizeBacklogCreateClaims(finalContent, executedTools);
+        if (guarded.strippedClaimIds.length > 0) {
+          console.warn(
+            `[agentic-loop] BI-1BB7408D stripped unproven backlog create claims: ${guarded.strippedClaimIds.join(",")}`,
+          );
+          finalContent = guarded.content;
+        }
       }
 
       logTurnSummary(result.providerId, result.modelId);

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -45,7 +45,7 @@ import {
 import { persistExecutionPlan, loadExecutionPlan } from "./execution-plan-store";
 import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
-import { sanitizeBacklogCreateClaims } from "./backlog-create-claim-guard";
+import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import {
@@ -2070,23 +2070,20 @@ export async function runAgenticLoop(params: {
           console.warn(
             `[agentic-loop] conversational fabrication retry exhausted — keeping the advice${makesHardCompletionClaim ? " with an unsaved-work note" : ""} rather than discarding it.`,
           );
-          {
-            const base = makesHardCompletionClaim
-              ? `${trimmed}\n\n${buildUnsavedAdviceNote(routeContext)}`
-              : trimmed;
-            const guarded = sanitizeBacklogCreateClaims(base, executedTools);
-            return {
-              content: guarded.content,
-              providerId: result.providerId,
-              modelId: result.modelId,
-              downgraded: result.downgraded,
-              downgradeMessage: result.downgradeMessage,
-              totalInputTokens,
-              totalOutputTokens,
-              executedTools,
-              proposal: null,
-            };
-          }
+          const base = makesHardCompletionClaim
+            ? `${trimmed}\n\n${buildUnsavedAdviceNote(routeContext)}`
+            : trimmed;
+          return {
+            content: applyBacklogCreateClaimGuard(base, executedTools),
+            providerId: result.providerId,
+            modelId: result.modelId,
+            downgraded: result.downgraded,
+            downgradeMessage: result.downgradeMessage,
+            totalInputTokens,
+            totalOutputTokens,
+            executedTools,
+            proposal: null,
+          };
         }
 
         // BI-PIR-cc091267 — a build-route fabrication signal (completion claim
@@ -2310,26 +2307,12 @@ export async function runAgenticLoop(params: {
         }
       }
 
-      // If the final response is empty but we had a good pre-nudge response,
-      // use that instead of returning nothing. This prevents quality-gate
-      // failures when the nudge causes the model to return empty.
-      let finalContent = trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content);
+      // Prefer pre-nudge content over empty; BI-1BB7408D strips unproven create claims.
       if (trimmed.length === 0 && bestPreNudgeContent.length > 0) {
         console.log(`[agentic-loop] recovering pre-nudge content (${bestPreNudgeContent.length} chars)`);
       }
-
-      // BI-1BB7408D: never render "Created: BI-XXXX" unless create_backlog_item
-      // succeeded this turn for that id (structural-verification-is-not-functional).
-      {
-        const guarded = sanitizeBacklogCreateClaims(finalContent, executedTools);
-        if (guarded.strippedClaimIds.length > 0) {
-          console.warn(
-            `[agentic-loop] BI-1BB7408D stripped unproven backlog create claims: ${guarded.strippedClaimIds.join(",")}`,
-          );
-          finalContent = guarded.content;
-        }
-      }
-
+      const finalContent = applyBacklogCreateClaimGuard(
+        trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content), executedTools);
       logTurnSummary(result.providerId, result.modelId);
       return {
         content: finalContent,

--- a/apps/web/lib/tak/backlog-create-claim-guard.test.ts
+++ b/apps/web/lib/tak/backlog-create-claim-guard.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractClaimedCreatedBacklogIds,
+  extractToolCreatedBacklogIds,
+  sanitizeBacklogCreateClaims,
+} from "./backlog-create-claim-guard";
+
+describe("extractClaimedCreatedBacklogIds", () => {
+  it("finds Created: BI- style claims", () => {
+    expect(
+      extractClaimedCreatedBacklogIds(
+        "Created: BI-0D1C52AE in EP-BUILD-STUDIO with your title.",
+      ),
+    ).toEqual(["BI-0D1C52AE"]);
+  });
+
+  it("finds multiple create claims in one reply", () => {
+    const text = [
+      "Created: BI-AAAA1111 for the first item.",
+      "Created: BI-BBBB2222 for the second item.",
+      "Created: BI-CCCC3333 for the third.",
+    ].join("\n");
+    expect(extractClaimedCreatedBacklogIds(text).sort()).toEqual([
+      "BI-AAAA1111",
+      "BI-BBBB2222",
+      "BI-CCCC3333",
+    ]);
+  });
+
+  it("does not treat a mere BI mention as a create claim", () => {
+    expect(
+      extractClaimedCreatedBacklogIds(
+        "See BI-0D1C52AE for the external-PR ship path; no new item needed.",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("extractToolCreatedBacklogIds", () => {
+  it("reads entityId from successful create_backlog_item", () => {
+    expect(
+      extractToolCreatedBacklogIds([
+        {
+          name: "create_backlog_item",
+          result: { success: true, entityId: "BI-NEW12345", message: "Created backlog item BI-NEW12345" },
+        },
+      ]),
+    ).toEqual(["BI-NEW12345"]);
+  });
+
+  it("ignores failed creates and other tools", () => {
+    expect(
+      extractToolCreatedBacklogIds([
+        { name: "create_backlog_item", result: { success: false, error: "validation" } },
+        { name: "query_backlog", result: { success: true, entityId: "BI-OLD" } },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("sanitizeBacklogCreateClaims (BI-1BB7408D)", () => {
+  it("leaves content alone when tool evidence matches the claim", () => {
+    const content = "Created: BI-NEW12345 in EP-FOO with your acceptance criteria.";
+    const { content: next, strippedClaimIds, verifiedIds } = sanitizeBacklogCreateClaims(content, [
+      {
+        name: "create_backlog_item",
+        result: { success: true, entityId: "BI-NEW12345", message: "Created backlog item BI-NEW12345" },
+      },
+    ]);
+    expect(next).toBe(content);
+    expect(strippedClaimIds).toEqual([]);
+    expect(verifiedIds).toEqual(["BI-NEW12345"]);
+  });
+
+  it("rewrites recycled pre-existing BI create claims with no tool evidence", () => {
+    // The live incident: three identical bubbles claiming BI-0D1C52AE was
+    // "created" when the row was 18h old and create_backlog_item never ran.
+    const content =
+      'Created: BI-0D1C52AE in EP-BUILD-STUDIO with your title, source, and full acceptance criteria…';
+    const { content: next, strippedClaimIds, verifiedIds } = sanitizeBacklogCreateClaims(content, []);
+    expect(strippedClaimIds).toEqual(["BI-0D1C52AE"]);
+    expect(verifiedIds).toEqual([]);
+    expect(next).not.toMatch(/Created:\s*BI-0D1C52AE/i);
+    expect(next).toContain("not created this turn");
+    expect(next).toContain("no backlog item was created in this turn");
+  });
+
+  it("keeps verified creates and flags only the unproven ones", () => {
+    const content = [
+      "Created: BI-REAL0001 for the promoter fix.",
+      "Created: BI-FAKE0002 for the second item.",
+    ].join("\n");
+    const { content: next, strippedClaimIds, verifiedIds } = sanitizeBacklogCreateClaims(content, [
+      {
+        name: "create_backlog_item",
+        result: { success: true, entityId: "BI-REAL0001" },
+      },
+    ]);
+    expect(verifiedIds).toEqual(["BI-REAL0001"]);
+    expect(strippedClaimIds).toEqual(["BI-FAKE0002"]);
+    expect(next).toMatch(/Created:\s*BI-REAL0001/i);
+    expect(next).toContain("BI-FAKE0002");
+    expect(next).toContain("not created this turn");
+  });
+
+  it("is a no-op when there is no create claim", () => {
+    const content = "Here is the backlog status. Open items remain under EP-BUILD-STUDIO.";
+    const result = sanitizeBacklogCreateClaims(content, []);
+    expect(result.content).toBe(content);
+    expect(result.strippedClaimIds).toEqual([]);
+  });
+});

--- a/apps/web/lib/tak/backlog-create-claim-guard.ts
+++ b/apps/web/lib/tak/backlog-create-claim-guard.ts
@@ -85,7 +85,7 @@ export function extractToolCreatedBacklogIds(executedTools: readonly ExecutedToo
     }
     // structured data.itemId
     const data = tool.result.data;
-    if (data && typeof data === "object" && data !== null && "itemId" in data) {
+    if (data && typeof data === "object" && "itemId" in data) {
       const itemId = (data as { itemId?: unknown }).itemId;
       if (typeof itemId === "string" && /^BI-/i.test(itemId)) {
         found.add(itemId.toUpperCase());

--- a/apps/web/lib/tak/backlog-create-claim-guard.ts
+++ b/apps/web/lib/tak/backlog-create-claim-guard.ts
@@ -147,3 +147,20 @@ export function sanitizeBacklogCreateClaims(
 
   return { content: next, strippedClaimIds, verifiedIds };
 }
+
+/**
+ * Apply create-claim sanitization for the agentic loop. Logs when claims are
+ * stripped so operators can find the incident in portal logs.
+ */
+export function applyBacklogCreateClaimGuard(
+  content: string,
+  executedTools: readonly ExecutedToolLike[],
+): string {
+  const guarded = sanitizeBacklogCreateClaims(content, executedTools);
+  if (guarded.strippedClaimIds.length > 0) {
+    console.warn(
+      `[agentic-loop] BI-1BB7408D stripped unproven backlog create claims: ${guarded.strippedClaimIds.join(",")}`,
+    );
+  }
+  return guarded.content;
+}

--- a/apps/web/lib/tak/backlog-create-claim-guard.ts
+++ b/apps/web/lib/tak/backlog-create-claim-guard.ts
@@ -1,0 +1,149 @@
+// apps/web/lib/tak/backlog-create-claim-guard.ts
+//
+// BI-1BB7408D: structural-verification-is-not-functional for backlog creates.
+// Models on /ops have claimed "Created: BI-XXXX" while returning a pre-existing
+// id (or inventing one) without a successful create_backlog_item tool result.
+// The chat layer must only allow create claims that match tool evidence from
+// this turn.
+
+export type ToolResultLike = {
+  success?: boolean;
+  entityId?: string | null;
+  message?: string | null;
+  data?: unknown;
+  error?: string | null;
+};
+
+export type ExecutedToolLike = {
+  name: string;
+  result: ToolResultLike;
+};
+
+/** Semantic BI ids as returned by create_backlog_item (BI-*, BI-IMP-*, etc.). */
+const BI_ID_PATTERN = /BI-[A-Z0-9][A-Z0-9-]{3,}/gi;
+
+/**
+ * Phrases that assert a backlog item was created this turn.
+ * Intentionally requires "created" proximity so mere mentions of BI ids
+ * (e.g. "see BI-FOO for context") are left alone.
+ */
+const CREATE_CLAIM_NEAR_BI =
+  /(?:created|filed|opened|added)\s+(?:backlog\s+item\s+)?(?:as\s+)?(BI-[A-Z0-9][A-Z0-9-]{3,})/gi;
+
+const CREATED_COLON_BI = /created:\s*(BI-[A-Z0-9][A-Z0-9-]{3,})/gi;
+
+/**
+ * Collect BI ids the model claims were created in free text.
+ */
+export function extractClaimedCreatedBacklogIds(content: string): string[] {
+  if (!content) return [];
+  const found = new Set<string>();
+  for (const re of [CREATE_CLAIM_NEAR_BI, CREATED_COLON_BI]) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(content)) !== null) {
+      const id = match[1]?.toUpperCase();
+      if (id) found.add(id);
+    }
+  }
+  // Also catch "Created backlog item BI-XXX" via the tool message phrasing
+  // when "created" appears earlier in the same sentence.
+  const sentences = content.split(/(?<=[.!\n])/);
+  for (const sentence of sentences) {
+    if (!/\bcreat(?:ed|ing)\b/i.test(sentence)) continue;
+    BI_ID_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = BI_ID_PATTERN.exec(sentence)) !== null) {
+      found.add(match[0].toUpperCase());
+    }
+  }
+  return [...found];
+}
+
+/**
+ * BI ids successfully returned by create_backlog_item in this turn's tools.
+ */
+export function extractToolCreatedBacklogIds(executedTools: readonly ExecutedToolLike[]): string[] {
+  const found = new Set<string>();
+  for (const tool of executedTools) {
+    if (tool.name !== "create_backlog_item") continue;
+    if (!tool.result?.success) continue;
+    const entityId =
+      typeof tool.result.entityId === "string" && tool.result.entityId.trim()
+        ? tool.result.entityId.trim()
+        : null;
+    if (entityId && /^BI-/i.test(entityId)) {
+      found.add(entityId.toUpperCase());
+      continue;
+    }
+    // Fallback: parse message "Created backlog item BI-XXXX"
+    const message = typeof tool.result.message === "string" ? tool.result.message : "";
+    BI_ID_PATTERN.lastIndex = 0;
+    const fromMessage = message.match(BI_ID_PATTERN);
+    if (fromMessage) {
+      for (const id of fromMessage) found.add(id.toUpperCase());
+    }
+    // structured data.itemId
+    const data = tool.result.data;
+    if (data && typeof data === "object" && data !== null && "itemId" in data) {
+      const itemId = (data as { itemId?: unknown }).itemId;
+      if (typeof itemId === "string" && /^BI-/i.test(itemId)) {
+        found.add(itemId.toUpperCase());
+      }
+    }
+  }
+  return [...found];
+}
+
+const UNSUPPORTED_CREATE_NOTE =
+  "Correction: no backlog item was created in this turn. " +
+  "I did not get a confirmed create_backlog_item tool result for the id(s) above, " +
+  "so I cannot treat them as newly filed. Ask me to file the item again and I will call the tool.";
+
+/**
+ * Rewrite or annotate a reply that claims backlog creates without tool proof.
+ *
+ * - If the model claims BI ids that are not in this turn's successful
+ *   create_backlog_item results, append a clear correction.
+ * - When every claimed id is backed by a tool result, leave content unchanged.
+ * - When there are no create claims, leave content unchanged.
+ */
+export function sanitizeBacklogCreateClaims(
+  content: string,
+  executedTools: readonly ExecutedToolLike[],
+): { content: string; strippedClaimIds: string[]; verifiedIds: string[] } {
+  const claimed = extractClaimedCreatedBacklogIds(content);
+  if (claimed.length === 0) {
+    return { content, strippedClaimIds: [], verifiedIds: [] };
+  }
+
+  const toolCreated = new Set(extractToolCreatedBacklogIds(executedTools));
+  const verifiedIds = claimed.filter((id) => toolCreated.has(id));
+  const strippedClaimIds = claimed.filter((id) => !toolCreated.has(id));
+
+  if (strippedClaimIds.length === 0) {
+    return { content, strippedClaimIds: [], verifiedIds };
+  }
+
+  // Soft rewrite: keep advice, but invalidate unproven create claims so the
+  // operator never trusts a recycled BI id as "just created".
+  let next = content;
+  for (const id of strippedClaimIds) {
+    // Soften "Created: BI-X" style claims without deleting surrounding advice.
+    const idEsc = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    next = next.replace(
+      new RegExp(`(?:created|filed|opened|added)\\s+(?:backlog\\s+item\\s+)?(?:as\\s+)?${idEsc}`, "gi"),
+      `referenced existing id ${id} (not created this turn)`,
+    );
+    next = next.replace(
+      new RegExp(`created:\\s*${idEsc}`, "gi"),
+      `referenced (not created this turn): ${id}`,
+    );
+  }
+
+  if (!next.includes("no backlog item was created in this turn")) {
+    next = `${next.trimEnd()}\n\n${UNSUPPORTED_CREATE_NOTE}`;
+  }
+
+  return { content: next, strippedClaimIds, verifiedIds };
+}


### PR DESCRIPTION
## Summary

Closes the live class of bug where the /ops coworker said **Created: BI-XXXX** for a pre-existing backlog id without calling `create_backlog_item` (incident used BI-0D1C52AE as a fake success).

- New pure guard `sanitizeBacklogCreateClaims` / `applyBacklogCreateClaimGuard` compares free-text create claims against this turn's successful `create_backlog_item` tool results.
- Unproven claims are rewritten and a clear correction is appended.
- Wired at the agentic-loop final-response boundary (and the conversational fabrication keep-advice path) without growing the baselined `agentic-loop.ts` LOC.

## Why this shape

Prompt rules already say not to claim persistence without tools; models still do it. The chat layer must enforce **structural-verification-is-not-functional** for create claims specifically.

## Test plan

- [x] Pure unit assertions via node on `backlog-create-claim-guard`
- [x] `node scripts/check-module-size.mjs` OK (agentic-loop stays at baseline 2683)
- [ ] CI Unit Tests / typecheck on this PR
- [ ] Optional live: ask /ops to file a BI without tools and confirm no bare Created: BI- success

## Design grounding

- Existing specs/plans reviewed:
  - docs/founder-kernel/wiki/principles/structural-verification-is-not-functional (kernel principle)
  - BI-1BB7408D acceptance criteria (tool evidence required before Created: BI- claims)
- Current code substrate reviewed:
  - apps/web/lib/tak/agentic-loop.ts (detectFabrication, HARD_COMPLETION_CLAIM_PATTERN, evidence gate)
  - apps/web/lib/mcp/packs/backlog-pack.ts (create_backlog_item returns entityId/message)
- Source of truth:
  - Kernel principle + agentic-loop completion-claim gates own honesty of tool-backed claims
- Decision:
  - Add a pure create-claim sanitizer and apply at final response; do not invent a parallel chat pipeline

Design-Grounding-Decision: reviewed docs/founder-kernel/wiki/principles/ structural-verification-is-not-functional and code substrate apps/web/lib/tak/agentic-loop.ts + apps/web/lib/mcp/packs/backlog-pack.ts; localized create-claim sanitizer, no routing/UX contract change.

Process-Spine-Decision: small bug fix extending existing completion-claim gates.

Docs-Impact-Decision: none (chat honesty only).

UX-Fit-Decision: no new form controls; plain-language correction.

Local-CI-Override: source-only worktree; node assertions; CI is verification of record.