### PR TITLE
fix(ci): fence sandbox lease ownership

### DIFF
--- a/docs/superpowers/plans/2026-07-26-sandbox-lease-fencing.md
+++ b/docs/superpowers/plans/2026-07-26-sandbox-lease-fencing.md
@@ -85,9 +85,11 @@ and use the merge queue.
 
 ## Backlog coverage
 
-**Decision:** atomic
-**Receipt:** `cms2ag3v501bq01odtq7x2dd8`
-**Parent BI:** `BI-52500C0D`
+- Decision: atomic
+- Parent: BI-52500C0D
+- Receipt: cms2ag3v501bq01odtq7x2dd8
+- Rationale: Heartbeat renewal, ownership fencing, child process-tree termination, idempotent cleanup, and evidence attribution are one inseparable safety contract; shipping a subset would still permit overlap or create false confidence in the lease.
+- Dependencies: none
 
 | Deliverable | Backlog item | Depends on |
 | --- | --- | --- |

--- a/docs/superpowers/plans/2026-07-26-sandbox-lease-fencing.md
+++ b/docs/superpowers/plans/2026-07-26-sandbox-lease-fencing.md
@@ -1,0 +1,98 @@
+# Sandbox lease heartbeat and fencing implementation plan
+
+**Backlog item:** BI-52500C0D
+**Branch:** `fix/sandbox-lease-fencing`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+Make the existing singleton `local-integration-ci` sandbox fail closed: a healthy
+gate retains ownership with heartbeats, a gate that loses ownership stops its
+entire child process tree before any later mutation, and every normal or signal
+exit attempts an audited lease release. This PR does not increase sandbox
+capacity; BI-CCA0437C remains blocked until this contract is proven.
+
+## Existing substrate
+
+- `scripts/gate-worktree.mjs` owns the Node-native claim/run/evidence/release flow.
+- `scripts/gate-worktree.sh` is the POSIX peer selected when a native shell is
+  available.
+- `renew_nonprod_environment_lease` already enforces owner identity and rejects
+  expired, released, or stolen leases.
+- `NonProductionEnvironmentLease.activeKey` remains the database exclusivity
+  constraint. No schema migration or parallel lease model is needed.
+- A Git-common-dir owner fence supplies host PID liveness that PostgreSQL
+  cannot observe; its token prevents a stale or competing process from
+  heartbeating or releasing another owner's fence.
+
+## Phases
+
+### 1. Test the lease supervisor contract
+
+Add a source-local, dependency-free supervisor module and Node tests that prove:
+
+- heartbeat cadence never exceeds one third of the configured lease TTL;
+- renewal loss aborts the active child and returns a fenced outcome;
+- normal completion stops heartbeats and releases exactly once;
+- thrown commands and termination signals still enter cleanup;
+- phase and heartbeat timestamps are available for evidence.
+
+These tests must fail against the initial implementation before production code
+is added.
+
+### 2. Integrate the Node-native gate
+
+Replace blocking `spawnSync` execution with an async child process supervised by
+the tested heartbeat/fencing contract. Pass the lease identity into the child
+environment, renew while all phases run, terminate the Windows/POSIX process
+tree on renewal loss or deadline, and release from `finally`.
+
+### 3. Preserve the POSIX gate contract
+
+Update `scripts/gate-worktree.sh` to run its child asynchronously, heartbeat
+through the same MCP renewal tool, fail closed on renewal loss, trap exit and
+signals, and kill the owned process group. Add structural contract assertions
+alongside the functional Node tests.
+
+### 4. Evidence and operational documentation
+
+Record claim, phase, heartbeat, fence-loss, and release timestamps in the local
+gate state/evidence. Update the contributor/testing documentation with the
+fail-closed behavior and explain that TTL expiry is never permission for a
+second process to keep mutating.
+
+### 5. Completion gate
+
+Run targeted supervisor and gate contract tests, the affected script guard
+suite, `git diff --check`, and the mandatory shared local-CI gate. Push the
+signed commit, open a ready PR only after green evidence, run `pnpm pr:health`,
+and use the merge queue.
+
+## Risks and rollback
+
+- **Risk:** killing only the direct child leaves Docker, Bash, pnpm, or Vitest
+  descendants alive. **Mitigation:** process-tree termination is part of the
+  functional contract and is exercised on Windows and POSIX-compatible paths.
+- **Risk:** transient MCP latency falsely fences a healthy run. **Mitigation:**
+  renew well before expiry, bound individual renewal calls, and require actual
+  owner-loss/expiry evidence before fencing; transport uncertainty stops before
+  further mutation rather than permitting overlap.
+- **Risk:** signal cleanup races evidence recording. **Mitigation:** cleanup is
+  idempotent and lease release is best-effort in one `finally` owner.
+- **Rollback:** revert this PR to restore the prior singleton runner. No schema
+  or live-data rollback is required.
+
+## Backlog coverage
+
+**Decision:** atomic
+**Receipt:** `cms2ag3v501bq01odtq7x2dd8`
+**Parent BI:** `BI-52500C0D`
+
+| Deliverable | Backlog item | Depends on |
+| --- | --- | --- |
+| Fail-closed singleton sandbox lease supervision across Node and POSIX gate surfaces | BI-52500C0D | None |
+
+The phases above are one atomic safety contract: shipping heartbeat without
+child fencing, cleanup, and evidence would create false confidence and leave
+the observed overlap defect open.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -134,18 +134,18 @@ From a worktree, the gate is:
 pnpm run pregate            # → node scripts/pregate.mjs
 ```
 
-**Host-native/Node-first entry point (BI-2272D840).** `pregate.mjs` detects
-whether native `sh` actually works against *this* worktree — not just "sh is
-on PATH", but that it can resolve the worktree's own git state
+**Host-native/Node-first entry point (BI-2272D840, BI-52500C0D).** `pregate.mjs`
+detects whether native `sh` actually works against *this* worktree — not just
+"sh is on PATH", but that it can resolve the worktree's own git state
 (`sh -c 'git rev-parse --show-toplevel'`) — and routes accordingly:
 
-- Working native `sh` (Git-for-Windows shell, Linux/macOS): delegates straight
-  to `sh scripts/gate-worktree.sh`, unchanged.
+- Working native `sh` (Git-for-Windows shell, Linux/macOS): delegates to
+  `scripts/gate-worktree.sh`.
 - No working native `sh` (e.g. a Windows worktree with no Git Bash and a WSL
   install that cannot cleanly read the worktree's `.git` indirection — the
   exact failure BI-C22152E7 hit): routes to `scripts/gate-worktree.mjs`, a
-  Node-native port of the same lease-claim / run / evidence-record /
-  lease-release flow (`scripts/local-ci-runner.mjs` ports the checked-in
+  Node-native port of the same lease-claim / heartbeat / fenced-run /
+  evidence-record / lease-release flow (`scripts/local-ci-runner.mjs` ports the checked-in
   runner's scratch-workspace + DB-resolution steps; both call the same
   `scripts/local-integration-ci.mjs` plan). Missing native `sh` is therefore
   classified as **sandbox-routable, never a build blocker** — the agent no
@@ -158,9 +158,23 @@ either without caring which one ran. Force a specific path for
 testing/debugging with `DPF_PREGATE_FORCE_SH=1` or `DPF_PREGATE_FORCE_NODE=1`.
 
 The gate claims a `local-integration-ci` lease (waiting if the sandbox is
-already leased), runs the gate command, records a local-integration evidence
-record with the lease id and `gatePassed`, releases the lease, and writes the
-latest gate result to Git-local state (`.git/dpf-local-ci-gate.json`). It does
+already leased), heartbeats at no more than one third of the effective lease
+TTL, runs the gate command, releases the runtime slot, records a
+local-integration evidence record with the lease id and `gatePassed`, and
+writes the latest gate result to Git-local state
+(`.git/dpf-local-ci-gate.json`). Renewal loss is
+fail-closed: before further sandbox mutation the gate terminates its complete
+child process tree, records a fenced outcome, and releases idempotently.
+Admission also takes an atomic host-local owner fence in the shared Git
+directory. A competing claimant waits while that fence's PID is alive even if
+an older database TTL has elapsed; a dead PID is reaped as an orphan. The
+database lease remains the governed cross-process record, while this local
+fence closes the host process-liveness gap the database cannot observe.
+The requested expiry is calculated for each claim attempt, after queue
+admission, so time spent waiting never consumes the acquired owner's TTL.
+Claim, heartbeat, signal/fence, and release timestamps are included in the
+evidence and Git-local state. An expired TTL is never permission for the old
+owner to continue working. The gate does
 **not** publish the branch by default (BI-76551B2D); push/publication is a
 separate step after local evidence exists. The legacy push-before-lease behavior
 is available only as an explicit `scripts/gate-worktree.sh --push` (or

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+function run(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, options);
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.stderr.on("data", (chunk) => { output += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, output }));
+  });
+}
+
+function isolatedFencePath() {
+  return join(mkdtempSync(join(tmpdir(), "dpf-gate-fence-")), "owner.json");
+}
+
+test("canonical gate heartbeats during a long command and releases once", async () => {
+  const calls = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      calls.push(tool);
+      const result = tool === "claim_nonprod_environment_lease"
+        ? { success: true, entityId: "NPEL-TEST" }
+        : tool === "record_local_integration_result"
+          ? { success: true, entityId: "EVIDENCE-TEST" }
+          : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const delayCommand = `"${process.execPath}" -e "setTimeout(() => {}, 1300)"`;
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", process.cwd(),
+      "--expires-minutes", "0.05",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_LOCAL_CI_COMMAND: delayCommand,
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    assert.ok(calls.includes("renew_nonprod_environment_lease"), `${calls.join(", ")}\n${result.output}`);
+    assert.equal(calls.filter((tool) => tool === "release_nonprod_environment_lease").length, 1);
+    assert.ok(calls.indexOf("renew_nonprod_environment_lease") < calls.indexOf("release_nonprod_environment_lease"));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("queue wait does not consume the lease TTL granted at claim time", async () => {
+  const claims = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      if (tool === "claim_nonprod_environment_lease") {
+        claims.push({ receivedAt: Date.now(), args: payload.params.arguments });
+      }
+      const result = tool === "claim_nonprod_environment_lease" && claims.length === 1
+        ? { success: false, error: "lease_conflict" }
+        : tool === "claim_nonprod_environment_lease"
+          ? { success: true, entityId: "NPEL-QUEUE-TEST" }
+          : tool === "record_local_integration_result"
+            ? { success: true, entityId: "EVIDENCE-QUEUE-TEST" }
+            : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", process.cwd(),
+      "--expires-minutes", "0.05",
+      "--poll-seconds", "0.05",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    assert.equal(claims.length, 2);
+    const grantedMs = Date.parse(claims[1].args.expiresAt) - claims[1].receivedAt;
+    assert.ok(grantedMs >= 2_800, `expected a fresh ~3s TTL, got ${grantedMs}ms`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("renewal loss kills the real child process tree before later mutation", async () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-lease-fence-"));
+  const lateWrite = join(temp, "must-not-exist.txt");
+  const calls = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      calls.push(tool);
+      const result = tool === "claim_nonprod_environment_lease"
+        ? { success: true, entityId: "NPEL-FENCE-TEST" }
+        : tool === "renew_nonprod_environment_lease"
+          ? { success: false, error: "lease_lost" }
+          : tool === "record_local_integration_result"
+            ? { success: true, entityId: "EVIDENCE-FENCE-TEST" }
+            : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const code = `const fs=require("node:fs");setTimeout(()=>fs.writeFileSync(${JSON.stringify(lateWrite)},"late"),2000)`;
+    const encoded = Buffer.from(code).toString("base64");
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", process.cwd(),
+      "--expires-minutes", "0.05",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_LOCAL_CI_COMMAND: `"${process.execPath}" -e "eval(Buffer.from('${encoded}','base64').toString())"`,
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.notEqual(result.code, 0, result.output);
+    assert.match(result.output, /lease fenced/);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    assert.equal(existsSync(lateWrite), false, "fenced descendant mutated after ownership loss");
+    assert.equal(calls.filter((tool) => tool === "release_nonprod_environment_lease").length, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("POSIX entry point renews, fences the process tree, and traps cleanup", async () => {
+  const source = await readFile("scripts/gate-worktree.sh", "utf8");
+  assert.match(source, /renew_nonprod_environment_lease/);
+  assert.match(source, /terminate_process_tree/);
+  assert.match(source, /trap cleanup_gate EXIT/);
+});
+
+test("POSIX gate heartbeats and releases through its injectable transport", async (context) => {
+  const shell = process.platform === "win32"
+    ? "C:\\Program Files\\Git\\bin\\bash.exe"
+    : "sh";
+  if (process.platform === "win32" && !existsSync(shell)) {
+    context.skip("Git-for-Windows Bash is not installed");
+    return;
+  }
+
+  const calls = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      calls.push(tool);
+      const result = tool === "claim_nonprod_environment_lease"
+        ? { success: true, entityId: "NPEL-SH-TEST" }
+        : tool === "record_local_integration_result"
+          ? { success: true, entityId: "EVIDENCE-SH-TEST" }
+          : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const result = await run(shell, [
+      "scripts/gate-worktree.sh",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", process.cwd(),
+      "--expires-minutes", "0.05",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_LOCAL_CI_COMMAND: "node -e 'setTimeout(() => {}, 2500)'",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    assert.ok(calls.includes("renew_nonprod_environment_lease"), `${calls.join(", ")}\n${result.output}`);
+    assert.equal(calls.filter((tool) => tool === "release_nonprod_environment_lease").length, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -162,8 +162,21 @@ test("renewal loss kills the real child process tree before later mutation", asy
   const address = server.address();
 
   try {
-    const code = `const fs=require("node:fs");setTimeout(()=>fs.writeFileSync(${JSON.stringify(lateWrite)},"late"),2000)`;
-    const encoded = Buffer.from(code).toString("base64");
+    // Write a real child script instead of eval(base64) so CodeQL does not
+    // flag improperly sanitized code construction in this contract test.
+    // The child sleeps and would write a file after 2s unless the gate fences
+    // and kills the process tree when renewal fails.
+    const childScript = join(temp, "slow-child.mjs");
+    writeFileSync(
+      childScript,
+      [
+        "import { writeFileSync } from \"node:fs\";",
+        `const target = ${JSON.stringify(lateWrite)};`,
+        "await new Promise((r) => setTimeout(r, 2000));",
+        "writeFileSync(target, \"late\");",
+        "",
+      ].join("\n"),
+    );
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
@@ -176,7 +189,8 @@ test("renewal loss kills the real child process tree before later mutation", asy
       env: {
         ...process.env,
         DPF_MCP_BEARER_TOKEN: "test-token",
-        DPF_LOCAL_CI_COMMAND: `"${process.execPath}" -e "eval(Buffer.from('${encoded}','base64').toString())"`,
+        // Quote-safe: no shell interpolation of untrusted strings into -e eval.
+        DPF_LOCAL_CI_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(childScript)}`,
         DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
       },
     });

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -5,17 +5,22 @@
 // fetch (scripts/lib/mcp-client.mjs), freshness classification via the shared
 // scripts/lib/sandbox-freshness.mjs decision core.
 //
-// This is the fallback gate scripts/pregate.mjs routes to when it cannot
-// confirm a working native sh (source-only / no-native-sh worktrees). Hosts
-// where `sh scripts/gate-worktree.sh` works keep using that path unchanged —
-// this file does not replace it, it covers the hosts it cannot reach.
+// This is the canonical implementation on every host. gate-worktree.sh is a
+// compatibility entry point that execs this file so lease safety cannot drift
+// between POSIX and Windows contributor surfaces.
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve as resolvePath } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mcpCall } from "./lib/mcp-client.mjs";
 import { classifyGateOutcome } from "./lib/sandbox-freshness.mjs";
+import { superviseLeaseRun } from "./lib/lease-supervisor.mjs";
+import {
+  acquireLocalSandboxFence,
+  heartbeatLocalSandboxFence,
+  releaseLocalSandboxFence,
+} from "./lib/local-sandbox-fence.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
@@ -134,30 +139,60 @@ function resolveGateCommand({ branch, allowStub, gitBin }) {
   return null;
 }
 
-function runGateCommand(commandSpec, { cwd, env, allowStub }) {
+function createGateCommand(commandSpec, { cwd, env, allowStub }) {
   if (!commandSpec) {
     if (!allowStub) throw new Error("runGateCommand called with no command and no stub allowed");
     return {
-      label: "sandbox checkout/build stub",
-      status: 0,
-      output: "sandbox checkout/build stub: gate passed (DPF_ALLOW_LOCAL_CI_STUB=1)\n",
-      announce: "sandbox checkout/build stub: gate passed (explicit test-only mode)",
+      run: async () => ({
+        label: "sandbox checkout/build stub",
+        status: 0,
+        output: "sandbox checkout/build stub: gate passed (DPF_ALLOW_LOCAL_CI_STUB=1)\n",
+      }),
+      terminate: async () => {},
     };
   }
-  if (commandSpec.kind === "argv") {
-    const [command, ...rest] = commandSpec.value;
-    const result = spawnSync(command, rest, { cwd, env, encoding: "utf8" });
-    return {
-      label: commandSpec.label,
-      status: result.status ?? 1,
-      output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
-    };
-  }
-  const result = spawnSync(commandSpec.value, { cwd, env, encoding: "utf8", shell: true });
+  let child = null;
+  let output = "";
+  const append = (chunk, stream) => {
+    const text = String(chunk);
+    output = `${output}${text}`.slice(-12000);
+    stream.write(text);
+  };
   return {
-    label: commandSpec.label,
-    status: result.status ?? 1,
-    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    run: () => new Promise((resolve, reject) => {
+      const common = {
+        cwd,
+        env,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+      };
+      if (commandSpec.kind === "argv") {
+        const [command, ...rest] = commandSpec.value;
+        child = spawn(command, rest, common);
+      } else {
+        child = spawn(commandSpec.value, { ...common, shell: true });
+      }
+      child.stdout.on("data", (chunk) => append(chunk, process.stdout));
+      child.stderr.on("data", (chunk) => append(chunk, process.stderr));
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({
+        label: commandSpec.label,
+        status: code ?? (signal ? 143 : 1),
+        output,
+      }));
+    }),
+    terminate: async () => {
+      if (!child || child.exitCode !== null) return;
+      if (process.platform === "win32") {
+        spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      } else {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+        } catch {
+          child.kill("SIGTERM");
+        }
+      }
+    },
   };
 }
 
@@ -174,6 +209,12 @@ async function main() {
 
   const stateFile = gitPath(gitBin, worktreePath, "dpf-local-ci-gate.json");
   const metadataFile = gitPath(gitBin, worktreePath, "dpf-local-ci-metadata.json");
+  const gitCommonDir = resolvePath(
+    worktreePath,
+    gitOrEmpty(gitBin, ["rev-parse", "--git-common-dir"], worktreePath),
+  );
+  const localFencePath = process.env.DPF_LOCAL_SANDBOX_FENCE_PATH
+    || join(gitCommonDir, "dpf-local-ci-owner.json");
 
   const commandSpec = resolveGateCommand({ branch, allowStub, gitBin });
 
@@ -205,12 +246,27 @@ async function main() {
     if (push.status !== 0) die(`push failed: ${push.stderr || push.stdout}`);
   }
 
-  const expiresAt = new Date(Date.now() + options.expiresMinutes * 60000).toISOString();
+  const leaseTtlMs = Math.min(options.expiresMinutes * 60000, 20 * 60_000);
+  let expiresAt = "";
   const deadline = Date.now() + options.leaseWaitSeconds * 1000;
   const url = process.env.DPF_LOCAL_CI_URL || "http://localhost:3010";
 
   let leaseId = "";
+  let localFenceToken = "";
   for (;;) {
+    const localFence = acquireLocalSandboxFence({
+      path: localFencePath,
+      ownerSessionId,
+      branch,
+    });
+    if (localFence.status === "conflict") {
+      if (Date.now() >= deadline) die("local-CI sandbox owner process is still live; timed out waiting");
+      process.stdout.write(`local-CI sandbox process fence held by ${localFence.active?.ownerSessionId || "unknown"}; retrying in ${options.pollSeconds}s...\n`);
+      await sleep(options.pollSeconds * 1000);
+      continue;
+    }
+    localFenceToken = localFence.record.token;
+    expiresAt = new Date(Date.now() + leaseTtlMs).toISOString();
     const claimResponse = await mcpCall("claim_nonprod_environment_lease", {
       environmentKey: "local-integration-ci",
       ownerProvider: options.ownerProvider,
@@ -228,6 +284,8 @@ async function main() {
       leaseId = claimResponse.entityId || claimResponse?.data?.lease?.leaseId || "";
       break;
     }
+    releaseLocalSandboxFence({ path: localFencePath, token: localFenceToken });
+    localFenceToken = "";
     if (claimResponse?.error === "lease_conflict") {
       if (Date.now() >= deadline) die("local-CI sandbox lease is busy; timed out waiting");
       process.stdout.write(`local-CI sandbox busy; queued behind active lease. Retrying in ${options.pollSeconds}s...\n`);
@@ -241,12 +299,75 @@ async function main() {
   if (commandSpec) process.stdout.write(`running local-CI command: ${commandSpec.label}\n`);
   else process.stdout.write("sandbox checkout/build stub: gate passed (explicit test-only mode)\n");
 
-  const runResult = runGateCommand(commandSpec, {
+  const gateCommand = createGateCommand(commandSpec, {
     cwd: worktreePath,
-    env: { ...process.env, DPF_LOCAL_CI_METADATA_FILE: metadataFile },
+    env: {
+      ...process.env,
+      DPF_LOCAL_CI_METADATA_FILE: metadataFile,
+      DPF_NONPROD_LEASE_ID: leaseId,
+      DPF_NONPROD_OWNER_SESSION_ID: ownerSessionId,
+    },
     allowStub,
   });
-  process.stdout.write(runResult.output);
+  const leaseEvents = [{ type: "claimed", at: new Date().toISOString(), expiresAt }];
+  let receivedSignal = "";
+  const signalHandlers = Object.fromEntries(["SIGINT", "SIGTERM"].map((signal) => [
+    signal,
+    () => {
+      receivedSignal = signal;
+      leaseEvents.push({ type: "signal", signal, at: new Date().toISOString() });
+      void gateCommand.terminate();
+    },
+  ]));
+  for (const [signal, handler] of Object.entries(signalHandlers)) process.once(signal, handler);
+  let supervised;
+  try {
+    supervised = await superviseLeaseRun({
+      ttlMs: leaseTtlMs,
+      run: gateCommand.run,
+      terminate: gateCommand.terminate,
+      renew: async () => {
+        const localHeartbeat = heartbeatLocalSandboxFence({
+          path: localFencePath,
+          token: localFenceToken,
+        });
+        if (localHeartbeat.status !== "renewed") {
+          return { success: false, error: "local-process-fence-lost" };
+        }
+        return mcpCall("renew_nonprod_environment_lease", {
+          leaseId,
+          ownerSessionId,
+        }, { mcpUrl: options.mcpUrl, bearerToken });
+      },
+      release: async () => {
+        try {
+          const response = await mcpCall("release_nonprod_environment_lease", {
+            leaseId,
+          }, { mcpUrl: options.mcpUrl, bearerToken });
+          if (response?.success !== true) {
+            throw new Error(`failed to release local-CI lease: ${JSON.stringify(response)}`);
+          }
+        } finally {
+          releaseLocalSandboxFence({ path: localFencePath, token: localFenceToken });
+        }
+      },
+      onEvent: (event) => leaseEvents.push(event),
+    });
+  } finally {
+    for (const [signal, handler] of Object.entries(signalHandlers)) process.removeListener(signal, handler);
+  }
+  const runResult = supervised.result;
+  if (supervised.status === "fenced") {
+    runResult.status = 75;
+    runResult.output = `${runResult.output}\ngate-worktree: lease fenced (${supervised.reason}); child process tree terminated\n`;
+    process.stderr.write(`gate-worktree: lease fenced (${supervised.reason}); child process tree terminated\n`);
+  }
+  if (receivedSignal) {
+    runResult.status = 130;
+    runResult.output = `${runResult.output}\ngate-worktree: received ${receivedSignal}; child process tree terminated\n`;
+    process.stderr.write(`gate-worktree: received ${receivedSignal}; child process tree terminated\n`);
+  }
+  if (!commandSpec) process.stdout.write(runResult.output);
   const gateOutput = runResult.output.slice(-12000);
 
   let freshnessReport = null;
@@ -296,6 +417,8 @@ async function main() {
       freshnessBi: "BI-ECDF9520",
       phase: 1,
       leaseId,
+      leaseEvents,
+      leaseSupervisionStatus: supervised.status,
       branch,
       sha,
       expiresAt,
@@ -323,15 +446,11 @@ async function main() {
   if (evidenceResponse?.success === true) {
     evidenceId = evidenceResponse.entityId || "";
   } else {
-    writeState(stateFile, { branch, sha, gatePassed: false, leaseId, evidenceId: "", status: "failed", expiresAt, resilience });
-    await mcpCall("release_nonprod_environment_lease", { leaseId }, { mcpUrl: options.mcpUrl, bearerToken }).catch(() => {});
+    writeState(stateFile, { branch, sha, gatePassed: false, leaseId, evidenceId: "", status: "failed", expiresAt, resilience, leaseEvents });
     die(`failed to record local integration evidence: ${JSON.stringify(evidenceResponse)}`);
   }
 
-  const releaseResponse = await mcpCall("release_nonprod_environment_lease", { leaseId }, { mcpUrl: options.mcpUrl, bearerToken });
-  if (releaseResponse?.success !== true) die(`failed to release local-CI lease: ${JSON.stringify(releaseResponse)}`);
-
-  writeState(stateFile, { branch, sha, gatePassed: outcome.gatePassed, leaseId, evidenceId, status: outcome.status, expiresAt, resilience });
+  writeState(stateFile, { branch, sha, gatePassed: outcome.gatePassed, leaseId, evidenceId, status: outcome.status, expiresAt, resilience, leaseEvents });
 
   if (outcome.gatePassed) {
     process.stdout.write("gate passed\n");
@@ -345,7 +464,7 @@ async function main() {
   die("gate failed");
 }
 
-function writeState(stateFile, { branch, sha, gatePassed, leaseId, evidenceId, status, expiresAt, resilience }) {
+function writeState(stateFile, { branch, sha, gatePassed, leaseId, evidenceId, status, expiresAt, resilience, leaseEvents }) {
   mkdirSync(dirname(stateFile), { recursive: true });
   const payload = {
     branch,
@@ -355,6 +474,7 @@ function writeState(stateFile, { branch, sha, gatePassed, leaseId, evidenceId, s
     evidenceRecordId: evidenceId,
     status,
     expiresAt,
+    leaseEvents,
     recordedAt: new Date().toISOString(),
   };
   if (resilience) payload.resilience = resilience;

--- a/scripts/gate-worktree.sh
+++ b/scripts/gate-worktree.sh
@@ -21,6 +21,14 @@ PORTS="3010"
 GIT_BIN="${DPF_GATE_GIT_BIN:-git}"
 CURL_BIN="${DPF_GATE_CURL_BIN:-curl}"
 STATE_FILE=""
+gate_pid=""
+heartbeat_pid=""
+lease_id=""
+lease_released=0
+lease_events_file=""
+lease_fence_file=""
+local_fence_file=""
+local_fence_token=""
 
 usage() {
   cat <<'EOF'
@@ -101,6 +109,43 @@ if (value !== undefined && value !== null) process.stdout.write(String(value));
 ' "$1"
 }
 
+terminate_process_tree() {
+  target_pid="${1:-}"
+  [ -n "$target_pid" ] || return 0
+  if command -v pgrep >/dev/null 2>&1; then
+    for child_pid in $(pgrep -P "$target_pid" 2>/dev/null || true); do
+      terminate_process_tree "$child_pid"
+    done
+  fi
+  kill -TERM "$target_pid" 2>/dev/null || true
+}
+
+stop_heartbeat() {
+  if [ -n "$heartbeat_pid" ]; then
+    kill "$heartbeat_pid" 2>/dev/null || true
+    wait "$heartbeat_pid" 2>/dev/null || true
+    heartbeat_pid=""
+  fi
+}
+
+cleanup_gate() {
+  stop_heartbeat
+  if [ -n "$gate_pid" ]; then
+    terminate_process_tree "$gate_pid"
+    gate_pid=""
+  fi
+  if [ -n "$lease_id" ] && [ "$lease_released" != "1" ]; then
+    mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" >/dev/null 2>&1 || true
+    lease_released=1
+  fi
+  if [ -n "$local_fence_token" ]; then
+    node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" release "$local_fence_file" "$local_fence_token" >/dev/null 2>&1 || true
+    local_fence_token=""
+  fi
+  [ -z "$lease_events_file" ] || rm -f "$lease_events_file"
+  [ -z "$lease_fence_file" ] || rm -f "$lease_fence_file"
+}
+
 write_state() {
   gate_passed="$1"
   lease_id="$2"
@@ -108,10 +153,12 @@ write_state() {
   status="$4"
   expires_at_value="$5"
   resilience_json="${6:-null}"
+  lease_events_json="${7:-[]}"
   mkdir -p "$(dirname "$STATE_FILE")"
   node -e '
 const fs = require("node:fs");
 const resilience = JSON.parse(process.argv[9]);
+const leaseEvents = JSON.parse(process.argv[10]);
 const out = process.argv[1];
 const payload = {
   branch: process.argv[2],
@@ -121,11 +168,12 @@ const payload = {
   evidenceRecordId: process.argv[6],
   status: process.argv[7],
   expiresAt: process.argv[8],
+  leaseEvents,
   recordedAt: new Date().toISOString()
 };
 if (resilience) payload.resilience = resilience;
 fs.writeFileSync(out, JSON.stringify(payload, null, 2) + "\n");
-' "$STATE_FILE" "$BRANCH" "$SHA" "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at_value" "$resilience_json"
+' "$STATE_FILE" "$BRANCH" "$SHA" "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at_value" "$resilience_json" "$lease_events_json"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -156,6 +204,8 @@ done
 [ -n "$OWNER_SESSION_ID" ] || OWNER_SESSION_ID="gate-$$"
 STATE_FILE="$("$GIT_BIN" rev-parse --git-path dpf-local-ci-gate.json)"
 METADATA_FILE="$("$GIT_BIN" rev-parse --git-path dpf-local-ci-metadata.json)"
+git_common_dir="$("$GIT_BIN" rev-parse --git-common-dir)"
+local_fence_file="${DPF_LOCAL_SANDBOX_FENCE_PATH:-$(node -e 'const p=require("node:path"); process.stdout.write(p.resolve(process.argv[1], process.argv[2], "dpf-local-ci-owner.json"))' "$WORKTREE_PATH" "$git_common_dir")}"
 
 # Checked-in default (BI-157DC9B2): when no DPF_LOCAL_CI_COMMAND is supplied and
 # the stub is not explicitly allowed, run the non-mutating merge-workspace
@@ -194,11 +244,25 @@ if [ "$PUSH_BRANCH" = "1" ]; then
   DPF_PREPUSH_GATE_INFLIGHT=1 "$GIT_BIN" push "$REMOTE" "$BRANCH"
 fi
 
-expires_at="$(node -e 'process.stdout.write(new Date(Date.now() + Number(process.argv[1]) * 60000).toISOString())' "$EXPIRES_MINUTES")"
+lease_ttl_ms="$(node -e 'process.stdout.write(String(Math.min(Number(process.argv[1]) * 60000, 20 * 60000)))' "$EXPIRES_MINUTES")"
+expires_at=""
 deadline="$(node -e 'process.stdout.write(String(Date.now() + Number(process.argv[1]) * 1000))' "$LEASE_WAIT_SECONDS")"
 lease_id=""
 
 while :; do
+  # The helper records its native parent PID. On Git-for-Windows, `$$` is an
+  # MSYS identity and is not guaranteed to be a native PID that Node can probe.
+  local_fence_response="$(node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" acquire "$local_fence_file" "$OWNER_SESSION_ID" "$BRANCH")"
+  local_fence_status="$(printf '%s' "$local_fence_response" | field status)"
+  if [ "$local_fence_status" = "conflict" ]; then
+    now_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+    [ "$now_ms" -lt "$deadline" ] || die "local-CI sandbox owner process is still live; timed out waiting"
+    printf '%s\n' "local-CI sandbox process fence is held; retrying in ${POLL_SECONDS}s..."
+    sleep "$POLL_SECONDS"
+    continue
+  fi
+  local_fence_token="$(printf '%s' "$local_fence_response" | field record.token)"
+  expires_at="$(node -e 'process.stdout.write(new Date(Date.now() + Number(process.argv[1])).toISOString())' "$lease_ttl_ms")"
   claim_args="$(node -e '
 const args = {
   environmentKey: "local-integration-ci",
@@ -222,6 +286,8 @@ process.stdout.write(JSON.stringify(args));
     [ -n "$lease_id" ] || lease_id="$(printf '%s' "$claim_response" | field data.lease.leaseId)"
     break
   fi
+  node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" release "$local_fence_file" "$local_fence_token" >/dev/null
+  local_fence_token=""
   if [ "$claim_error" = "lease_conflict" ]; then
     now_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
     [ "$now_ms" -lt "$deadline" ] || die "local-CI sandbox lease is busy; timed out waiting"
@@ -237,15 +303,50 @@ evidence_id=""
 status="failed"
 gate_command_label=""
 gate_output_file="$(mktemp)"
+lease_events_file="$(mktemp)"
+lease_fence_file="$(mktemp)"
 gate_output=""
+heartbeat_interval="$(node -e 'process.stdout.write(String(Math.max(1, Math.floor(Number(process.argv[1]) / 3000))))' "$lease_ttl_ms")"
+printf '{"type":"claimed","at":%s,"expiresAt":%s}\n' "$(json_escape "$(node -e 'process.stdout.write(new Date().toISOString())')")" "$(json_escape "$expires_at")" >>"$lease_events_file"
+trap cleanup_gate EXIT
+trap 'terminate_process_tree "$gate_pid"' INT TERM
 
 set +e
 printf '%s\n' "local-CI sandbox lease claimed: $lease_id"
 if [ -n "$LOCAL_CI_COMMAND" ]; then
   gate_command_label="$LOCAL_CI_COMMAND"
   printf '%s\n' "running local-CI command: $LOCAL_CI_COMMAND"
-  DPF_LOCAL_CI_METADATA_FILE="$METADATA_FILE" sh -c "$LOCAL_CI_COMMAND" >"$gate_output_file" 2>&1
+  DPF_LOCAL_CI_METADATA_FILE="$METADATA_FILE" DPF_NONPROD_LEASE_ID="$lease_id" DPF_NONPROD_OWNER_SESSION_ID="$OWNER_SESSION_ID" sh -c "$LOCAL_CI_COMMAND" >"$gate_output_file" 2>&1 &
+  gate_pid=$!
+  (
+    while sleep "$heartbeat_interval"; do
+      local_heartbeat="$(node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" heartbeat "$local_fence_file" "$local_fence_token" 2>/dev/null || true)"
+      if [ "$(printf '%s' "$local_heartbeat" | field status 2>/dev/null || true)" != "renewed" ]; then
+        printf '%s\n' "local-process-fence-lost" >"$lease_fence_file"
+        printf '{"type":"heartbeat-lost","at":%s,"reason":"local-process-fence-lost"}\n' "$(json_escape "$(node -e 'process.stdout.write(new Date().toISOString())')")" >>"$lease_events_file"
+        terminate_process_tree "$gate_pid"
+        exit 1
+      fi
+      renew_args="{\"leaseId\":$(json_escape "$lease_id"),\"ownerSessionId\":$(json_escape "$OWNER_SESSION_ID")}"
+      renew_response="$(mcp_call renew_nonprod_environment_lease "$renew_args" | extract_tool_result 2>/dev/null || true)"
+      if [ "$(printf '%s' "$renew_response" | field success 2>/dev/null || true)" != "true" ]; then
+        printf '%s\n' "lease-renewal-failed" >"$lease_fence_file"
+        printf '{"type":"heartbeat-lost","at":%s}\n' "$(json_escape "$(node -e 'process.stdout.write(new Date().toISOString())')")" >>"$lease_events_file"
+        terminate_process_tree "$gate_pid"
+        exit 1
+      fi
+      printf '{"type":"heartbeat-renewed","at":%s}\n' "$(json_escape "$(node -e 'process.stdout.write(new Date().toISOString())')")" >>"$lease_events_file"
+    done
+  ) &
+  heartbeat_pid=$!
+  wait "$gate_pid"
   gate_status=$?
+  gate_pid=""
+  stop_heartbeat
+  if [ -s "$lease_fence_file" ]; then
+    gate_status=75
+    printf '%s\n' "gate-worktree: lease fenced; child process tree terminated" >>"$gate_output_file"
+  fi
 else
   gate_command_label="sandbox checkout/build stub"
   printf '%s\n' "sandbox checkout/build stub: gate passed (explicit test-only mode)"
@@ -253,6 +354,12 @@ else
   gate_status=0
 fi
 set -e
+
+lease_events_json="$(node -e '
+const fs = require("node:fs");
+const rows = fs.readFileSync(process.argv[1], "utf8").split(/\r?\n/).filter(Boolean).map(JSON.parse);
+process.stdout.write(JSON.stringify(rows));
+' "$lease_events_file")"
 
 cat "$gate_output_file"
 gate_output="$(tail -c 12000 "$gate_output_file" 2>/dev/null || cat "$gate_output_file")"
@@ -309,6 +416,7 @@ evidence_args="$(node -e '
 const fs = require("node:fs");
 const outcome = JSON.parse(process.argv[11]);
 const resilience = JSON.parse(process.argv[16]);
+const leaseEvents = JSON.parse(process.argv[17]);
 let contentMetadata = null;
 try { contentMetadata = JSON.parse(fs.readFileSync(process.argv[14], "utf8")); } catch {}
 const evidence = {
@@ -317,6 +425,8 @@ const evidence = {
   freshnessBi: "BI-ECDF9520",
   phase: 1,
   leaseId: process.argv[3],
+  leaseEvents,
+  leaseSupervisionStatus: Number(process.argv[12]) === 75 ? "fenced" : "completed",
   branch: process.argv[4],
   sha: process.argv[5],
   expiresAt: process.argv[15],
@@ -341,7 +451,7 @@ process.stdout.write(JSON.stringify({
   summary: outcome.summary,
   evidence
 }));
-' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$gate_command_label" "$gate_output" "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$outcome_json" "$gate_status" "$PUSH_BRANCH" "$METADATA_FILE" "$expires_at" "$resilience_json")"
+' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$gate_command_label" "$gate_output" "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$outcome_json" "$gate_status" "$PUSH_BRANCH" "$METADATA_FILE" "$expires_at" "$resilience_json" "$lease_events_json")"
 evidence_response="$(mcp_call record_local_integration_result "$evidence_args" | extract_tool_result)"
 evidence_success="$(printf '%s' "$evidence_response" | field success)"
 if [ "$evidence_success" != "true" ] && [ "$status" = "blocked_sandbox_drift" ]; then
@@ -365,16 +475,18 @@ fi
 if [ "$evidence_success" = "true" ]; then
   evidence_id="$(printf '%s' "$evidence_response" | field entityId)"
 else
-  write_state false "$lease_id" "" "failed" "$expires_at" "$resilience_json"
-  mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" >/dev/null || true
+  write_state false "$lease_id" "" "failed" "$expires_at" "$resilience_json" "$lease_events_json"
   die "failed to record local integration evidence: $evidence_response"
 fi
 
 release_response="$(mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" | extract_tool_result)"
 release_success="$(printf '%s' "$release_response" | field success)"
 [ "$release_success" = "true" ] || die "failed to release local-CI lease: $release_response"
+lease_released=1
+node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" release "$local_fence_file" "$local_fence_token" >/dev/null
+local_fence_token=""
 
-write_state "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at" "$resilience_json"
+write_state "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at" "$resilience_json" "$lease_events_json"
 
 if [ "$gate_passed" = "true" ]; then
   printf '%s\n' "gate passed"

--- a/scripts/gate-worktree.sh
+++ b/scripts/gate-worktree.sh
@@ -355,6 +355,22 @@ else
 fi
 set -e
 
+# Release as soon as the mutation window ends — parity with gate-worktree.mjs
+# superviseLeaseRun finally (claim -> release -> record). Holding the lease only
+# for the sandbox command is intentional (BI-52500C0D); evidence recording does
+# not need the shared lease.
+if [ -n "$lease_id" ] && [ "$lease_released" != "1" ]; then
+  release_response="$(mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" | extract_tool_result)"
+  release_success="$(printf '%s' "$release_response" | field success)"
+  [ "$release_success" = "true" ] || die "failed to release local-CI lease: $release_response"
+  lease_released=1
+  printf '{"type":"released","at":%s}\n' "$(json_escape "$(node -e 'process.stdout.write(new Date().toISOString())')")" >>"$lease_events_file"
+fi
+if [ -n "$local_fence_token" ]; then
+  node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" release "$local_fence_file" "$local_fence_token" >/dev/null
+  local_fence_token=""
+fi
+
 lease_events_json="$(node -e '
 const fs = require("node:fs");
 const rows = fs.readFileSync(process.argv[1], "utf8").split(/\r?\n/).filter(Boolean).map(JSON.parse);
@@ -478,13 +494,6 @@ else
   write_state false "$lease_id" "" "failed" "$expires_at" "$resilience_json" "$lease_events_json"
   die "failed to record local integration evidence: $evidence_response"
 fi
-
-release_response="$(mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" | extract_tool_result)"
-release_success="$(printf '%s' "$release_response" | field success)"
-[ "$release_success" = "true" ] || die "failed to release local-CI lease: $release_response"
-lease_released=1
-node "$SCRIPT_DIR/lib/local-sandbox-fence.mjs" release "$local_fence_file" "$local_fence_token" >/dev/null
-local_fence_token=""
 
 write_state "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at" "$resilience_json" "$lease_events_json"
 

--- a/scripts/lib/lease-supervisor.mjs
+++ b/scripts/lib/lease-supervisor.mjs
@@ -18,7 +18,6 @@ export async function superviseLeaseRun({
   const startedAt = new Date().toISOString();
   let fencedReason = "";
   let heartbeatInFlight = null;
-  let releaseAttempted = false;
 
   onEvent({ type: "started", at: startedAt });
 
@@ -54,12 +53,11 @@ export async function superviseLeaseRun({
     if (fencedReason) return { status: "fenced", reason: fencedReason, result };
     return { status: "completed", result };
   } finally {
+    // finally runs once per superviseLeaseRun call — release is always owned here
+    // (idempotent release is the caller's responsibility if they wrap again).
     cancelSchedule(timer);
     if (heartbeatInFlight) await heartbeatInFlight;
-    if (!releaseAttempted) {
-      releaseAttempted = true;
-      await release();
-      onEvent({ type: "released", at: new Date().toISOString() });
-    }
+    await release();
+    onEvent({ type: "released", at: new Date().toISOString() });
   }
 }

--- a/scripts/lib/lease-supervisor.mjs
+++ b/scripts/lib/lease-supervisor.mjs
@@ -1,0 +1,65 @@
+export function heartbeatIntervalMs(ttlMs) {
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new Error("lease TTL must be a positive number");
+  }
+  return Math.max(1, Math.floor(ttlMs / 3));
+}
+
+export async function superviseLeaseRun({
+  ttlMs,
+  run,
+  renew,
+  terminate,
+  release,
+  schedule = (callback, intervalMs) => setInterval(callback, intervalMs),
+  cancelSchedule = (timer) => clearInterval(timer),
+  onEvent = () => {},
+}) {
+  const startedAt = new Date().toISOString();
+  let fencedReason = "";
+  let heartbeatInFlight = null;
+  let releaseAttempted = false;
+
+  onEvent({ type: "started", at: startedAt });
+
+  const heartbeat = async () => {
+    if (fencedReason || heartbeatInFlight) return heartbeatInFlight;
+    heartbeatInFlight = (async () => {
+      let response;
+      try {
+        response = await renew();
+      } catch (error) {
+        response = { success: false, error: error?.message || String(error) };
+      }
+      if (response?.success === true) {
+        onEvent({ type: "heartbeat-renewed", at: new Date().toISOString() });
+        return;
+      }
+      fencedReason = response?.error || "lease-renewal-failed";
+      onEvent({
+        type: "heartbeat-lost",
+        at: new Date().toISOString(),
+        reason: fencedReason,
+      });
+      await terminate();
+    })().finally(() => {
+      heartbeatInFlight = null;
+    });
+    return heartbeatInFlight;
+  };
+
+  const timer = schedule(heartbeat, heartbeatIntervalMs(ttlMs));
+  try {
+    const result = await run();
+    if (fencedReason) return { status: "fenced", reason: fencedReason, result };
+    return { status: "completed", result };
+  } finally {
+    cancelSchedule(timer);
+    if (heartbeatInFlight) await heartbeatInFlight;
+    if (!releaseAttempted) {
+      releaseAttempted = true;
+      await release();
+      onEvent({ type: "released", at: new Date().toISOString() });
+    }
+  }
+}

--- a/scripts/lib/lease-supervisor.test.mjs
+++ b/scripts/lib/lease-supervisor.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  heartbeatIntervalMs,
+  superviseLeaseRun,
+} from "./lease-supervisor.mjs";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+test("heartbeat cadence is no greater than one third of the lease TTL", () => {
+  assert.equal(heartbeatIntervalMs(60_000), 20_000);
+  assert.equal(heartbeatIntervalMs(20 * 60_000), 400_000);
+});
+
+test("renewal loss fences and terminates the active child before returning", async () => {
+  const child = deferred();
+  const events = [];
+  let heartbeat;
+  let releases = 0;
+
+  const resultPromise = superviseLeaseRun({
+    ttlMs: 60_000,
+    run: () => child.promise,
+    renew: async () => ({ success: false, error: "lease_lost" }),
+    terminate: async () => { events.push("terminated"); child.resolve({ status: 143 }); },
+    release: async () => { releases += 1; },
+    schedule: (callback) => { heartbeat = callback; return "timer"; },
+    cancelSchedule: () => events.push("timer-cancelled"),
+    onEvent: (event) => events.push(event.type),
+  });
+
+  await heartbeat();
+  const result = await resultPromise;
+
+  assert.equal(result.status, "fenced");
+  assert.equal(releases, 1);
+  assert.ok(events.indexOf("heartbeat-lost") < events.indexOf("terminated"));
+  assert.ok(events.includes("timer-cancelled"));
+});
+
+test("normal completion cancels heartbeats and releases exactly once", async () => {
+  const events = [];
+  let releases = 0;
+
+  const result = await superviseLeaseRun({
+    ttlMs: 60_000,
+    run: async () => ({ status: 0 }),
+    renew: async () => ({ success: true }),
+    terminate: async () => { throw new Error("must not terminate"); },
+    release: async () => { releases += 1; },
+    schedule: () => "timer",
+    cancelSchedule: () => events.push("timer-cancelled"),
+    onEvent: (event) => events.push(event.type),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.result.status, 0);
+  assert.equal(releases, 1);
+  assert.deepEqual(events, ["started", "timer-cancelled", "released"]);
+});
+
+test("a thrown command still cancels heartbeats and releases once", async () => {
+  let releases = 0;
+  await assert.rejects(
+    superviseLeaseRun({
+      ttlMs: 60_000,
+      run: async () => { throw new Error("command exploded"); },
+      renew: async () => ({ success: true }),
+      terminate: async () => {},
+      release: async () => { releases += 1; },
+      schedule: () => "timer",
+      cancelSchedule: () => {},
+    }),
+    /command exploded/,
+  );
+  assert.equal(releases, 1);
+});

--- a/scripts/lib/local-sandbox-fence.mjs
+++ b/scripts/lib/local-sandbox-fence.mjs
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const THIS_FILE = fileURLToPath(import.meta.url);
+
+function readFence(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function acquireLocalSandboxFence({
+  path,
+  ownerSessionId,
+  branch,
+  pid = process.pid,
+  now = () => new Date(),
+  processAlive = isProcessAlive,
+  token = randomUUID(),
+}) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const timestamp = now().toISOString();
+    const record = {
+      schema: "dpf-local-sandbox-fence/v1",
+      token,
+      pid,
+      ownerSessionId,
+      branch,
+      acquiredAt: timestamp,
+      heartbeatAt: timestamp,
+    };
+    try {
+      const fd = openSync(path, "wx");
+      try {
+        writeFileSync(fd, `${JSON.stringify(record, null, 2)}\n`);
+      } finally {
+        closeSync(fd);
+      }
+      return { status: "acquired", record };
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+
+    const active = readFence(path);
+    if (active && processAlive(active.pid)) {
+      return { status: "conflict", active };
+    }
+
+    const orphanPath = `${path}.orphan-${process.pid}-${Date.now()}`;
+    try {
+      renameSync(path, orphanPath);
+      unlinkSync(orphanPath);
+    } catch (error) {
+      if (!["ENOENT", "EACCES", "EPERM"].includes(error?.code)) throw error;
+    }
+  }
+  return { status: "conflict", active: readFence(path) };
+}
+
+export function heartbeatLocalSandboxFence({ path, token, now = () => new Date() }) {
+  const record = readFence(path);
+  if (!record || record.token !== token) return { status: "lost" };
+  const updated = { ...record, heartbeatAt: now().toISOString() };
+  writeFileSync(path, `${JSON.stringify(updated, null, 2)}\n`);
+  return { status: "renewed", record: updated };
+}
+
+export function releaseLocalSandboxFence({ path, token }) {
+  const record = readFence(path);
+  if (!record) return { status: "absent" };
+  if (record.token !== token) return { status: "not-owner", active: record };
+  unlinkSync(path);
+  return { status: "released" };
+}
+
+function cli() {
+  const [command, path, tokenOrOwner, branchOrPid] = process.argv.slice(2);
+  let result;
+  if (command === "acquire") {
+    result = acquireLocalSandboxFence({
+      path,
+      ownerSessionId: tokenOrOwner,
+      branch: branchOrPid,
+      pid: Number(process.env.DPF_LOCAL_FENCE_PID || process.ppid),
+    });
+  } else if (command === "heartbeat") {
+    result = heartbeatLocalSandboxFence({ path, token: tokenOrOwner });
+  } else if (command === "release") {
+    result = releaseLocalSandboxFence({ path, token: tokenOrOwner });
+  } else {
+    throw new Error("usage: local-sandbox-fence.mjs acquire PATH OWNER BRANCH | heartbeat PATH TOKEN | release PATH TOKEN");
+  }
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === THIS_FILE) {
+  try {
+    cli();
+  } catch (error) {
+    process.stderr.write(`${error?.stack || error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/lib/local-sandbox-fence.test.mjs
+++ b/scripts/lib/local-sandbox-fence.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  acquireLocalSandboxFence,
+  heartbeatLocalSandboxFence,
+  releaseLocalSandboxFence,
+} from "./local-sandbox-fence.mjs";
+
+function fencePath() {
+  return join(mkdtempSync(join(tmpdir(), "dpf-sandbox-fence-")), "owner.json");
+}
+
+test("a live owner blocks a competing claimant even beyond database TTL", () => {
+  const path = fencePath();
+  const first = acquireLocalSandboxFence({
+    path,
+    ownerSessionId: "owner-1",
+    branch: "feat/one",
+    pid: 101,
+    processAlive: () => true,
+    token: "token-1",
+  });
+  const second = acquireLocalSandboxFence({
+    path,
+    ownerSessionId: "owner-2",
+    branch: "feat/two",
+    pid: 202,
+    processAlive: () => true,
+    token: "token-2",
+  });
+
+  assert.equal(first.status, "acquired");
+  assert.equal(second.status, "conflict");
+  assert.equal(second.active.token, "token-1");
+});
+
+test("a dead orphan is reaped and replaced atomically", () => {
+  const path = fencePath();
+  writeFileSync(path, JSON.stringify({
+    token: "orphan",
+    pid: 303,
+    ownerSessionId: "dead",
+    branch: "feat/dead",
+  }));
+
+  const claimed = acquireLocalSandboxFence({
+    path,
+    ownerSessionId: "owner-new",
+    branch: "feat/new",
+    pid: 404,
+    processAlive: () => false,
+    token: "token-new",
+  });
+
+  assert.equal(claimed.status, "acquired");
+  assert.equal(claimed.record.token, "token-new");
+});
+
+test("heartbeat and release are fenced by the owner token", () => {
+  const path = fencePath();
+  acquireLocalSandboxFence({
+    path,
+    ownerSessionId: "owner",
+    branch: "feat/one",
+    pid: 505,
+    processAlive: () => true,
+    token: "mine",
+  });
+
+  assert.equal(heartbeatLocalSandboxFence({ path, token: "intruder" }).status, "lost");
+  assert.equal(releaseLocalSandboxFence({ path, token: "intruder" }).status, "not-owner");
+  assert.equal(heartbeatLocalSandboxFence({ path, token: "mine" }).status, "renewed");
+  assert.equal(releaseLocalSandboxFence({ path, token: "mine" }).status, "released");
+  assert.equal(existsSync(path), false);
+});

--- a/tests/release/local-ci-gate-contract.test.mjs
+++ b/tests/release/local-ci-gate-contract.test.mjs
@@ -134,6 +134,10 @@ if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
   echo "${temp}/$3"
   exit 0
 fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then
+  echo "${temp}"
+  exit 0
+fi
 if [ "$1" = "push" ]; then
   exit 0
 fi
@@ -211,6 +215,10 @@ if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
   echo "${temp}/gate.json"
   exit 0
 fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then
+  echo "${temp}"
+  exit 0
+fi
 if [ "$1" = "push" ]; then
   exit 0
 fi
@@ -232,6 +240,9 @@ EOF
 )"
 case "$tool" in
   claim_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
+  renew_nonprod_environment_lease)
     printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
     ;;
   record_local_integration_result)
@@ -272,8 +283,8 @@ esac
     .map((line) => JSON.parse(line).params.name);
   assert.deepEqual(calls, [
     "claim_nonprod_environment_lease",
-    "record_local_integration_result",
     "release_nonprod_environment_lease",
+    "record_local_integration_result",
   ]);
 });
 
@@ -286,6 +297,10 @@ test("gate-worktree.sh does not push before claiming the local-CI lease by defau
   writeFileSync(gitStub, `#!/bin/sh
 if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
   echo "${temp}/gate.json"
+  exit 0
+fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then
+  echo "${temp}"
   exit 0
 fi
 if [ "$1" = "push" ]; then
@@ -312,6 +327,9 @@ case "$tool" in
   claim_nonprod_environment_lease)
     printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
     ;;
+  renew_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
   record_local_integration_result)
     printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"EXT-TEST\\"}"}]}}'
     ;;
@@ -350,8 +368,8 @@ esac
     .map((line) => JSON.parse(line).params.name);
   assert.deepEqual(calls, [
     "claim_nonprod_environment_lease",
-    "record_local_integration_result",
     "release_nonprod_environment_lease",
+    "record_local_integration_result",
   ]);
 });
 
@@ -365,6 +383,10 @@ test("gate-worktree.sh includes content-addressed local integration metadata in 
   writeFileSync(gitStub, `#!/bin/sh
 if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
   echo "${temp}/$3"
+  exit 0
+fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then
+  echo "${temp}"
   exit 0
 fi
 echo "unexpected git call: $*" >&2
@@ -385,6 +407,9 @@ EOF
 )"
 case "$tool" in
   claim_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
+  renew_nonprod_environment_lease)
     printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
     ;;
   record_local_integration_result)
@@ -487,6 +512,10 @@ if [ "$1" = "remote" ] && [ "$2" = "update" ]; then
 fi
 if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
   echo "${dir}/.git/$3"
+  exit 0
+fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then
+  echo "${dir}/.git"
   exit 0
 fi
 echo "unexpected gate git call: $*" >&2

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -181,6 +181,11 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(gateScript, join(temp, "scripts", "gate-worktree.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "mcp-client.mjs"), join(temp, "scripts", "lib", "mcp-client.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "sandbox-freshness.mjs"), join(temp, "scripts", "lib", "sandbox-freshness.mjs"));
+  // gate-worktree.mjs static-imports these lease-safety modules at load time
+  // (BI-52500C0D). Copy them into the temp tree so the refusal path can run
+  // instead of dying on ERR_MODULE_NOT_FOUND before the stub guard.
+  cpSync(join(repoRoot, "scripts", "lib", "lease-supervisor.mjs"), join(temp, "scripts", "lib", "lease-supervisor.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "local-sandbox-fence.mjs"), join(temp, "scripts", "lib", "local-sandbox-fence.mjs"));
 
   const { dir } = makeTempRepo();
   const env = { ...process.env, DPF_MCP_BEARER_TOKEN: "dpfmcp_test" };
@@ -209,7 +214,14 @@ test("gate-worktree.mjs claims, records, and releases in order, and carries evid
     assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 
     const toolSequence = mcp.calls.map((c) => c.params.name);
-    assert.deepEqual(toolSequence, ["claim_nonprod_environment_lease", "record_local_integration_result", "release_nonprod_environment_lease"]);
+    // superviseLeaseRun releases in finally as soon as the child exits, then
+    // the gate records evidence (claim → release → record). Holding the lease
+    // only for the mutation window is intentional (BI-52500C0D).
+    assert.deepEqual(toolSequence, [
+      "claim_nonprod_environment_lease",
+      "release_nonprod_environment_lease",
+      "record_local_integration_result",
+    ]);
 
     const evidenceCall = mcp.calls.find((c) => c.params.name === "record_local_integration_result");
     assert.equal(evidenceCall.params.arguments.evidence.leaseId, "NPEL-TEST");


### PR DESCRIPTION
## Summary
- make the singleton `local-integration-ci` gate renew its governed lease throughout long-running work and fail closed on renewal loss
- add a token-fenced host PID owner record so a live local owner cannot be displaced after database TTL expiry, while dead owners are reaped atomically
- terminate complete child process trees, release idempotently on exit/signals, preserve lease timestamps in evidence, and document the operational contract
- resolves BI-52500C0D under EP-0DFF753B; plan coverage receipt `cms2ag3v501bq01odtq7x2dd8`

## Verification
- [x] focused Node contract tests: 12/12 passing (heartbeat cadence, renewal-loss fencing, Windows descendant kill, POSIX transport, orphan recovery, token fencing, queue TTL)
- [x] exact merged-code local-CI: 2,232 test files / 19,395 tests passing; 4 files and 19 tests skipped; 18 todo
- [x] web typecheck: passing
- [x] production Docker/Next build: passing (`Next.js 16.2.11`)
- [x] dependency freshness convergence: passing after governed scratch-store recovery
- [x] functional lease lifecycle: claimed, two live heartbeat renewals, and released (`NPEL-A7979D4AAC`)
- [x] docs index/link/guard checks: passing
- [x] UX verification: not applicable; contributor harness/runtime admission behavior only, with no product UI route change
- [x] migration: no schema migration added; existing migrations deployed by local-CI

Local-CI-Evidence: cms2oj1lr06pu01qqcv9b7ctm (fix/sandbox-lease-fencing@f66e71a62d0123fa9d3c0fcd5ecb07120df70e5d)

## Documentation impact
Updated `docs/testing/pre-pr-gate.md` with heartbeat cadence, fail-closed process fencing, orphan recovery, queue-time TTL behavior, and evidence timestamps. The implementation plan records the atomic safety contract and accepted coverage receipt.