### PR TITLE
feat(ea): add routing architecture cross-view drill-through

### DIFF
--- a/apps/web/app/(shell)/ea/page.tsx
+++ b/apps/web/app/(shell)/ea/page.tsx
@@ -5,7 +5,10 @@ import { EaTabNav } from "@/components/ea/EaTabNav";
 import { ReferenceModelSummary } from "@/components/ea/ReferenceModelSummary";
 import { CreateViewButton } from "@/components/ea/CreateViewButton";
 import { It4itConformanceCard } from "@/components/ea/It4itConformanceCard";
+import { ArchitectureProjectionActions } from "@/components/ea/ArchitectureProjectionActions";
 import { getReferenceModelsSummary, getIt4itCoverageHeatmap } from "@/lib/ea-data";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
 
 const LAYOUT_LABELS: Record<string, string> = {
   graph:    "Graph",
@@ -21,7 +24,7 @@ const SCOPE_LABELS: Record<string, string> = {
 };
 
 export default async function EaPage() {
-  const [views, models, it4itCoverage] = await Promise.all([
+  const [views, models, it4itCoverage, session] = await Promise.all([
     prisma.eaView.findMany({
       orderBy: [{ createdAt: "desc" }],
       select: {
@@ -37,7 +40,18 @@ export default async function EaPage() {
     }),
     getReferenceModelsSummary(),
     getIt4itCoverageHeatmap("it4it_v3_0_1").catch(() => null),
+    auth(),
   ]);
+  const canManageArchitecture = Boolean(
+    session?.user &&
+    can(
+      {
+        platformRole: session.user.platformRole,
+        isSuperuser: session.user.isSuperuser,
+      },
+      "manage_ea_model",
+    ),
+  );
 
   return (
     <div>
@@ -70,11 +84,15 @@ export default async function EaPage() {
 
       {it4itCoverage && <It4itConformanceCard data={it4itCoverage} />}
 
+      {canManageArchitecture ? (
+        <div className="mb-4 flex flex-wrap items-start justify-end gap-3">
+          <ArchitectureProjectionActions />
+          <CreateViewButton />
+        </div>
+      ) : null}
+
       {views.length > 0 ? (
         <>
-          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 16 }}>
-            <CreateViewButton />
-          </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {views.map((v) => (
               <Link key={v.id} href={`/ea/views/${v.id}`} style={{ textDecoration: "none" }}>
@@ -104,7 +122,11 @@ export default async function EaPage() {
           <p className="text-sm text-[var(--dpf-muted)] mb-4">
             No views yet. Create your first view to start modeling.
           </p>
-          <CreateViewButton />
+          <p className="text-xs text-[var(--dpf-muted)]">
+            {canManageArchitecture
+              ? "Use New view above, or refresh live projections to load governed architecture."
+              : "No architecture views are available for this workspace yet."}
+          </p>
         </div>
       )}
     </div>

--- a/apps/web/app/(shell)/ea/views/[id]/page.tsx
+++ b/apps/web/app/(shell)/ea/views/[id]/page.tsx
@@ -6,8 +6,15 @@ import { getEaView } from "@/lib/ea-data";
 import { prisma } from "@dpf/db";
 import { EaCanvas } from "@/components/ea/EaCanvas";
 
-export default async function EaViewPage({ params }: { params: Promise<{ id: string }> }) {
+export default async function EaViewPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ element?: string }>;
+}) {
   const { id } = await params;
+  const { element: initialFocusElementId } = await searchParams;
   const session = await auth();
   const user = session?.user;
 
@@ -44,6 +51,7 @@ export default async function EaViewPage({ params }: { params: Promise<{ id: str
         initialElements={view.elements}
         initialEdges={view.edges}
         initialCanvasState={view.canvasState}
+        initialFocusElementId={initialFocusElementId ?? null}
         isReadOnly={isReadOnly}
       />
     </div>

--- a/apps/web/components/ea/ArchitectureDrillthroughPanel.test.tsx
+++ b/apps/web/components/ea/ArchitectureDrillthroughPanel.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ArchitectureDrillthroughPanel } from "./ArchitectureDrillthroughPanel";
+
+describe("ArchitectureDrillthroughPanel", () => {
+  it("renders accessible related viewpoints and a privacy-safe decision explanation", () => {
+    const html = renderToStaticMarkup(
+      <ArchitectureDrillthroughPanel
+        drillthrough={{
+          operationsMapHref:
+            "/platform/ai/operations-map?mode=compare&focus=data-policy-gateway",
+          source: {
+            path: "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts",
+            symbol: "evaluateInferenceDispatchPolicy",
+            version: "ai-routing/v1",
+            implementationStatus: "partial",
+            href: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts",
+          },
+          relatedViews: [
+            {
+              elementId: "req-1",
+              elementName: "REQ-AIC-10 Screen before external egress",
+              viewId: "sysml-view",
+              viewName: "Requirements & Verification",
+              notationSlug: "sysml2",
+              notationName: "SysML 2",
+              relationshipPath: ["Traces", "Satisfies"],
+              distance: 2,
+              href: "/ea/views/sysml-view?element=req-1",
+            },
+          ],
+          decision: {
+            title: "What did data policy decide?",
+            technicalName: "Allow, protect, review, or deny gateway",
+            safeInputs: ["Data classes", "Purpose"],
+            outcomes: ["Allow", "Deny"],
+            sourcePath: "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts",
+            sourceSymbol: "evaluateInferenceDispatchPolicy",
+            sourceVersion: "ai-routing/v1",
+            implementationStatus: "partial",
+            latestEvidenceAt: "2026-07-27T02:00:00.000Z",
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Open operational evidence");
+    expect(html).toContain("Related viewpoints (1)");
+    expect(html).toContain("REQ-AIC-10 Screen before external egress");
+    expect(html).toContain("Safe inputs");
+    expect(html).toContain("Possible outcomes");
+    expect(html).toContain("latest record");
+    expect(html).not.toContain("prompt");
+  });
+});

--- a/apps/web/components/ea/ArchitectureDrillthroughPanel.tsx
+++ b/apps/web/components/ea/ArchitectureDrillthroughPanel.tsx
@@ -24,7 +24,7 @@ export function ArchitectureDrillthroughPanel({ drillthrough }: Props) {
     >
       <h3
         id="architecture-context-title"
-        className="m-0 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--dpf-accent)]"
+        className="m-0 text-dpf-caption font-bold uppercase tracking-[0.12em] text-[var(--dpf-accent)]"
       >
         Architecture context
       </h3>
@@ -41,7 +41,7 @@ export function ArchitectureDrillthroughPanel({ drillthrough }: Props) {
 
       {drillthrough.relatedViews.length > 0 ? (
         <details className="mt-2" open>
-          <summary className="cursor-pointer text-[11px] font-semibold text-[var(--dpf-text)]">
+          <summary className="cursor-pointer text-dpf-caption font-semibold text-[var(--dpf-text)]">
             Related viewpoints ({drillthrough.relatedViews.length})
           </summary>
           <ul className="mt-2 grid list-none gap-1.5 p-0">
@@ -52,10 +52,10 @@ export function ArchitectureDrillthroughPanel({ drillthrough }: Props) {
                   className="block min-h-11 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-2 no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
                   aria-label={`Open ${link.elementName} in ${link.viewName}, ${link.notationName}`}
                 >
-                  <span className="block text-[10px] font-semibold text-[var(--dpf-text)]">
+                  <span className="block text-dpf-caption font-semibold text-[var(--dpf-text)]">
                     {link.elementName}
                   </span>
-                  <span className="mt-0.5 block text-[9px] text-[var(--dpf-muted)]">
+                  <span className="mt-0.5 block text-dpf-caption text-[var(--dpf-muted)]">
                     {link.notationName} · {link.viewName} · {link.distance} link{link.distance === 1 ? "" : "s"} away
                   </span>
                 </Link>
@@ -67,10 +67,10 @@ export function ArchitectureDrillthroughPanel({ drillthrough }: Props) {
 
       {drillthrough.decision ? (
         <details className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2.5">
-          <summary className="cursor-pointer text-[11px] font-semibold text-[var(--dpf-text)]">
+          <summary className="cursor-pointer text-dpf-caption font-semibold text-[var(--dpf-text)]">
             Why this decision works this way
           </summary>
-          <div className="mt-2 grid gap-2 text-[10px] text-[var(--dpf-muted)]">
+          <div className="mt-2 grid gap-2 text-dpf-caption text-[var(--dpf-muted)]">
             <div>
               <p className="m-0 font-semibold text-[var(--dpf-text)]">
                 {drillthrough.decision.title}
@@ -110,7 +110,7 @@ export function ArchitectureDrillthroughPanel({ drillthrough }: Props) {
       ) : null}
 
       {drillthrough.source ? (
-        <div className="mt-2 rounded-md border border-[var(--dpf-border)] px-2.5 py-2 text-[10px]">
+        <div className="mt-2 rounded-md border border-[var(--dpf-border)] px-2.5 py-2 text-dpf-caption">
           <p className="m-0 font-semibold text-[var(--dpf-text)]">Implementation source</p>
           <a
             href={drillthrough.source.href}

--- a/apps/web/components/ea/ArchitectureDrillthroughPanel.tsx
+++ b/apps/web/components/ea/ArchitectureDrillthroughPanel.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ArchitectureDrillthrough } from "@/lib/ea/architecture-drillthrough";
+
+type Props = {
+  drillthrough: ArchitectureDrillthrough | null | undefined;
+};
+
+export function ArchitectureDrillthroughPanel({ drillthrough }: Props) {
+  if (!drillthrough) return null;
+  const hasArchitectureContext =
+    drillthrough.relatedViews.length > 0 ||
+    drillthrough.operationsMapHref != null ||
+    drillthrough.source != null ||
+    drillthrough.decision != null;
+  if (!hasArchitectureContext) return null;
+
+  return (
+    <section
+      aria-labelledby="architecture-context-title"
+      className="mt-3 border-t border-[var(--dpf-border)] pt-3"
+    >
+      <h3
+        id="architecture-context-title"
+        className="m-0 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--dpf-accent)]"
+      >
+        Architecture context
+      </h3>
+
+      {drillthrough.operationsMapHref ? (
+        <Link
+          href={drillthrough.operationsMapHref}
+          className="mt-2 flex min-h-11 items-center justify-between rounded-md border border-[var(--dpf-accent)] bg-[color-mix(in_srgb,var(--dpf-accent)_10%,transparent)] px-3 py-2 text-xs font-semibold text-[var(--dpf-accent)] no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+        >
+          <span>Open operational evidence</span>
+          <span aria-hidden="true">→</span>
+        </Link>
+      ) : null}
+
+      {drillthrough.relatedViews.length > 0 ? (
+        <details className="mt-2" open>
+          <summary className="cursor-pointer text-[11px] font-semibold text-[var(--dpf-text)]">
+            Related viewpoints ({drillthrough.relatedViews.length})
+          </summary>
+          <ul className="mt-2 grid list-none gap-1.5 p-0">
+            {drillthrough.relatedViews.map((link) => (
+              <li key={`${link.viewId}:${link.elementId}`}>
+                <Link
+                  href={link.href}
+                  className="block min-h-11 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-2 no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+                  aria-label={`Open ${link.elementName} in ${link.viewName}, ${link.notationName}`}
+                >
+                  <span className="block text-[10px] font-semibold text-[var(--dpf-text)]">
+                    {link.elementName}
+                  </span>
+                  <span className="mt-0.5 block text-[9px] text-[var(--dpf-muted)]">
+                    {link.notationName} · {link.viewName} · {link.distance} link{link.distance === 1 ? "" : "s"} away
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+
+      {drillthrough.decision ? (
+        <details className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2.5">
+          <summary className="cursor-pointer text-[11px] font-semibold text-[var(--dpf-text)]">
+            Why this decision works this way
+          </summary>
+          <div className="mt-2 grid gap-2 text-[10px] text-[var(--dpf-muted)]">
+            <div>
+              <p className="m-0 font-semibold text-[var(--dpf-text)]">
+                {drillthrough.decision.title}
+              </p>
+              <p className="mt-0.5">{drillthrough.decision.technicalName}</p>
+            </div>
+            <InspectorList
+              label="Safe inputs"
+              values={drillthrough.decision.safeInputs}
+            />
+            <InspectorList
+              label="Possible outcomes"
+              values={drillthrough.decision.outcomes}
+            />
+            <dl className="m-0 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
+              <dt>Design</dt>
+              <dd className="m-0 text-[var(--dpf-text)]">
+                {drillthrough.decision.sourceVersion}
+              </dd>
+              <dt>Status</dt>
+              <dd className="m-0 text-[var(--dpf-text)]">
+                {drillthrough.decision.implementationStatus}
+              </dd>
+              <dt>Evidence</dt>
+              <dd className="m-0 text-[var(--dpf-text)]">
+                {drillthrough.decision.latestEvidenceAt ? (
+                  <time dateTime={drillthrough.decision.latestEvidenceAt}>
+                    latest record {formatEvidenceTime(drillthrough.decision.latestEvidenceAt)}
+                  </time>
+                ) : (
+                  "No recorded route evidence"
+                )}
+              </dd>
+            </dl>
+          </div>
+        </details>
+      ) : null}
+
+      {drillthrough.source ? (
+        <div className="mt-2 rounded-md border border-[var(--dpf-border)] px-2.5 py-2 text-[10px]">
+          <p className="m-0 font-semibold text-[var(--dpf-text)]">Implementation source</p>
+          <a
+            href={drillthrough.source.href}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-1 block break-all text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            {drillthrough.source.path}
+            {drillthrough.source.symbol ? `#${drillthrough.source.symbol}` : ""}
+          </a>
+          {drillthrough.source.version || drillthrough.source.implementationStatus ? (
+            <p className="mb-0 mt-1 text-[var(--dpf-muted)]">
+              {[drillthrough.source.implementationStatus, drillthrough.source.version]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function InspectorList({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div>
+      <p className="m-0 font-semibold text-[var(--dpf-text)]">{label}</p>
+      <ul className="mb-0 mt-1 list-disc space-y-0.5 pl-4">
+        {values.map((value) => <li key={value}>{value}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+function formatEvidenceTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "at an unknown time"
+    : date.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+}

--- a/apps/web/components/ea/ArchitectureProjectionActions.tsx
+++ b/apps/web/components/ea/ArchitectureProjectionActions.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { refreshSysmlProjections } from "@/lib/actions/sysml-projections";
+
+export function ArchitectureProjectionActions() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  function refresh() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await refreshSysmlProjections();
+      if (!result.ok) {
+        setMessage(result.error);
+        return;
+      }
+      const routing = result.aiRoutingArchitecture;
+      setMessage(
+        routing.status === "skipped"
+          ? "Refresh completed, but the AI routing projection was unavailable."
+          : `Routing architecture refreshed: ${routing.created} created, ${routing.updated} updated, ${routing.crossLayerLinked} cross-view links current.`,
+      );
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      <button
+        type="button"
+        onClick={refresh}
+        disabled={isPending}
+        className="min-h-11 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs font-semibold text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)] disabled:cursor-wait disabled:opacity-60"
+      >
+        {isPending ? "Refreshing architecture…" : "Refresh live projections"}
+      </button>
+      <p aria-live="polite" className="m-0 max-w-md text-right text-[10px] text-[var(--dpf-muted)]">
+        {message ?? "Rebuilds governed BPMN, SysML, and ArchiMate views from their canonical sources."}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/ea/ArchitectureProjectionActions.tsx
+++ b/apps/web/components/ea/ArchitectureProjectionActions.tsx
@@ -38,7 +38,7 @@ export function ArchitectureProjectionActions() {
       >
         {isPending ? "Refreshing architecture…" : "Refresh live projections"}
       </button>
-      <p aria-live="polite" className="m-0 max-w-md text-right text-[10px] text-[var(--dpf-muted)]">
+      <p aria-live="polite" className="m-0 max-w-md text-right text-dpf-caption text-[var(--dpf-muted)]">
         {message ?? "Rebuilds governed BPMN, SysML, and ArchiMate views from their canonical sources."}
       </p>
     </div>

--- a/apps/web/components/ea/CreateViewButton.test.ts
+++ b/apps/web/components/ea/CreateViewButton.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { NOTATION_OPTIONS } from "./CreateViewButton";
+
+describe("CreateViewButton notation options", () => {
+  it("allows authorized authors to create SysML views", () => {
+    expect(NOTATION_OPTIONS).toContainEqual({ slug: "sysml2", label: "SysML 2" });
+  });
+});

--- a/apps/web/components/ea/CreateViewButton.tsx
+++ b/apps/web/components/ea/CreateViewButton.tsx
@@ -4,9 +4,10 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { createEaView } from "@/lib/actions/ea";
 
-const NOTATION_OPTIONS = [
+export const NOTATION_OPTIONS = [
   { slug: "archimate4", label: "ArchiMate 4" },
   { slug: "bpmn20", label: "BPMN 2.0" },
+  { slug: "sysml2", label: "SysML 2" },
 ] as const;
 
 const LAYOUT_OPTIONS = [

--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -69,7 +69,6 @@ type Props = {
   initialFocusElementId?: string | null;
   isReadOnly: boolean;
 };
-
 const MAX_LAYOUT_REVISIONS = 10;
 
 function defaultLayoutAlgo(): EaLayoutAlgorithm {
@@ -387,7 +386,6 @@ const EDGE_VARIANT_LABELS: Record<EdgeVariant, string> = {
   bezier:   "⌒ Curved",
   step:     "⌐ Angled",
 };
-
 export function EaCanvas({
   viewId, viewName, viewStatus, notationSlug, viewpoint, allElementTypes,
   initialElements, initialEdges, initialCanvasState, initialFocusElementId, isReadOnly,
@@ -446,9 +444,8 @@ export function EaCanvas({
   const initialNodeLayout = buildNodes(visibleElements, initialCanvasState, layoutEdges);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodeLayout.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(buildEdges(visibleEdges, handleDeleteEdge, edgeVariant));
-  const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(
-    () => visibleElements.find((element) => element.elementId === initialFocusElementId) ?? null,
-  );
+  const initialSelectedElement = visibleElements.find((element) => element.elementId === initialFocusElementId) ?? null;
+  const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(initialSelectedElement);
   const [isLayouting, setIsLayouting] = useState(false);
   const [revMenuOpen, setRevMenuOpen] = useState(false);
   const [layoutMenuOpen, setLayoutMenuOpen] = useState(false);

--- a/apps/web/components/ea/EaCanvas.tsx
+++ b/apps/web/components/ea/EaCanvas.tsx
@@ -66,6 +66,7 @@ type Props = {
   initialElements: SerializedViewElement[];
   initialEdges: SerializedEdge[];
   initialCanvasState: CanvasState | null;
+  initialFocusElementId?: string | null;
   isReadOnly: boolean;
 };
 
@@ -389,7 +390,7 @@ const EDGE_VARIANT_LABELS: Record<EdgeVariant, string> = {
 
 export function EaCanvas({
   viewId, viewName, viewStatus, notationSlug, viewpoint, allElementTypes,
-  initialElements, initialEdges, initialCanvasState, isReadOnly,
+  initialElements, initialEdges, initialCanvasState, initialFocusElementId, isReadOnly,
 }: Props) {
   const paletteTypes = viewpoint
     ? allElementTypes.filter((et) => viewpoint.allowedElementTypeSlugs.includes(et.slug))
@@ -445,7 +446,9 @@ export function EaCanvas({
   const initialNodeLayout = buildNodes(visibleElements, initialCanvasState, layoutEdges);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodeLayout.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(buildEdges(visibleEdges, handleDeleteEdge, edgeVariant));
-  const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(null);
+  const [selectedViewElement, setSelectedViewElement] = useState<SerializedViewElement | null>(
+    () => visibleElements.find((element) => element.elementId === initialFocusElementId) ?? null,
+  );
   const [isLayouting, setIsLayouting] = useState(false);
   const [revMenuOpen, setRevMenuOpen] = useState(false);
   const [layoutMenuOpen, setLayoutMenuOpen] = useState(false);

--- a/apps/web/components/ea/ElementInspector.tsx
+++ b/apps/web/components/ea/ElementInspector.tsx
@@ -9,6 +9,7 @@ import {
   type TraversalPatternInfo,
   type TraversalRunResult,
 } from "@/lib/actions/ea-traversal";
+import { ArchitectureDrillthroughPanel } from "./ArchitectureDrillthroughPanel";
 
 type Props = {
   selected: SerializedViewElement | null;
@@ -139,6 +140,8 @@ export function ElementInspector({ selected, notationSlug, onUpdated }: Props) {
             />
           </div>
         )}
+
+        <ArchitectureDrillthroughPanel drillthrough={selected.drillthrough} />
 
         {/* Traversal Run Panel */}
         <div style={{ borderTop: "1px solid var(--dpf-border)", marginTop: 4, paddingTop: 6 }}>

--- a/apps/web/lib/actions/sysml-projections.test.ts
+++ b/apps/web/lib/actions/sysml-projections.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/actions/shared/guards", () => ({
+  requireCapability: vi.fn(),
+}));
+vi.mock("@/lib/ea/reconcile-sysml-projections", () => ({
+  reconcileSysmlProjections: vi.fn(),
+}));
+
+import { requireCapability } from "@/lib/actions/shared/guards";
+import { reconcileSysmlProjections } from "@/lib/ea/reconcile-sysml-projections";
+import { refreshSysmlProjections } from "./sysml-projections";
+
+const summary = { status: "applied", created: 0, updated: 0, removed: 0 } as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireCapability).mockResolvedValue({ userId: "user-1" });
+  vi.mocked(reconcileSysmlProjections).mockResolvedValue({
+    mcpAuthority: { ...summary, toolCount: 2, grantCount: 3 },
+    coworkerAuthority: summary,
+    valueStreams: summary,
+    routes: summary,
+    navigation: summary,
+    codeStructure: summary,
+    processModels: summary,
+    skillToolchain: summary,
+    operationalGraph: summary,
+    networkTopology: summary,
+    integrations: summary,
+    scheduledJobs: summary,
+    it4itCoverage: summary,
+    securityPosture: summary,
+    workPatternArchitecture: summary,
+    federatedDemandArchitecture: summary,
+    aiRoutingArchitecture: {
+      ...summary,
+      updated: 4,
+      crossLayerLinked: 9,
+      crossLayerUnresolved: 0,
+      bpmn: summary,
+      sysml: summary,
+      archimate: summary,
+    },
+  });
+});
+
+describe("refreshSysmlProjections", () => {
+  it("requires architecture-management permission and reports routing cross-view refresh", async () => {
+    const result = await refreshSysmlProjections();
+
+    expect(requireCapability).toHaveBeenCalledWith("manage_ea_model");
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      aiRoutingArchitecture: expect.objectContaining({
+        updated: 4,
+        crossLayerLinked: 9,
+        crossLayerUnresolved: 0,
+      }),
+    }));
+  });
+
+  it("does not run reconciliation when permission is denied", async () => {
+    vi.mocked(requireCapability).mockRejectedValueOnce(new Error("Unauthorized"));
+
+    await expect(refreshSysmlProjections()).rejects.toThrow("Unauthorized");
+    expect(reconcileSysmlProjections).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/sysml-projections.ts
+++ b/apps/web/lib/actions/sysml-projections.ts
@@ -7,20 +7,25 @@
 // the 04:00 UTC pass. Mirrors refreshDataArchitecture.
 import { revalidatePath } from "next/cache";
 
-import { auth } from "@/lib/auth";
+import { requireCapability } from "@/lib/actions/shared/guards";
 import { reconcileSysmlProjections } from "@/lib/ea/reconcile-sysml-projections";
 
 type DomainSummary = { status: string; created: number; updated: number; removed: number };
 
 export type RefreshSysmlProjectionsResult =
-  | { ok: true; mcpAuthority: DomainSummary & { toolCount: number; grantCount: number }; coworkerAuthority: DomainSummary }
+  | {
+      ok: true;
+      mcpAuthority: DomainSummary & { toolCount: number; grantCount: number };
+      coworkerAuthority: DomainSummary;
+      aiRoutingArchitecture: DomainSummary & {
+        crossLayerLinked: number;
+        crossLayerUnresolved: number;
+      };
+    }
   | { ok: false; error: string };
 
 export async function refreshSysmlProjections(): Promise<RefreshSysmlProjectionsResult> {
-  const session = await auth();
-  if (!session?.user) {
-    return { ok: false, error: "Not authorized." };
-  }
+  await requireCapability("manage_ea_model");
 
   try {
     const result = await reconcileSysmlProjections();
@@ -40,6 +45,14 @@ export async function refreshSysmlProjections(): Promise<RefreshSysmlProjections
         created: result.coworkerAuthority.created,
         updated: result.coworkerAuthority.updated,
         removed: result.coworkerAuthority.removed,
+      },
+      aiRoutingArchitecture: {
+        status: result.aiRoutingArchitecture.status,
+        created: result.aiRoutingArchitecture.created,
+        updated: result.aiRoutingArchitecture.updated,
+        removed: result.aiRoutingArchitecture.removed,
+        crossLayerLinked: result.aiRoutingArchitecture.crossLayerLinked ?? 0,
+        crossLayerUnresolved: result.aiRoutingArchitecture.crossLayerUnresolved ?? 0,
       },
     };
   } catch (err) {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8839,7 +8839,8 @@
       "anchors": [
         "overview",
         "key-concepts",
-        "what-you-can-do"
+        "what-you-can-do",
+        "following-a-concern-across-views"
       ]
     },
     "docs/user-guide/build-studio/deployment.md": {

--- a/apps/web/lib/ea/architecture-drillthrough-data.ts
+++ b/apps/web/lib/ea/architecture-drillthrough-data.ts
@@ -1,0 +1,151 @@
+import { prisma } from "@dpf/db";
+
+import {
+  buildArchitectureDrillthrough,
+  type ArchitectureDrillthrough,
+} from "./architecture-drillthrough";
+import { AI_ROUTING_ARCHITECTURE_VERSION } from "./ai-routing-architecture-registry";
+
+export async function loadArchitectureDrillthroughForView(input: {
+  viewId: string;
+  elements: Array<{
+    id: string;
+    name: string;
+    notationSlug: string;
+    properties: Record<string, unknown>;
+  }>;
+}): Promise<Record<string, ArchitectureDrillthrough>> {
+  if (input.elements.length === 0) return {};
+
+  const selectedIds = input.elements.map((element) => element.id);
+  const routingArchitecture = hasRoutingElement(input.elements);
+  const projectedRoutingElements = routingArchitecture
+    ? await prisma.eaElement.findMany({
+        where: {
+          properties: {
+            path: ["sourceVersion"],
+            equals: AI_ROUTING_ARCHITECTURE_VERSION,
+          },
+        },
+        select: {
+          id: true,
+          name: true,
+          properties: true,
+          elementType: {
+            select: { notation: { select: { slug: true } } },
+          },
+        },
+      })
+    : [];
+  const seedElements = [
+    ...new Map(
+      [
+        ...input.elements.map((element) => ({
+          id: element.id,
+          name: element.name,
+          properties: element.properties,
+          elementType: { notation: { slug: element.notationSlug } },
+        })),
+        ...projectedRoutingElements,
+      ].map((element) => [element.id, element]),
+    ).values(),
+  ];
+  const seedIds = Array.from(new Set([...selectedIds, ...seedElements.map((element) => element.id)]));
+  const relationships = await prisma.eaRelationship.findMany({
+    where: {
+      OR: [
+        { fromElementId: { in: seedIds } },
+        { toElementId: { in: seedIds } },
+      ],
+    },
+    select: {
+      id: true,
+      fromElementId: true,
+      toElementId: true,
+      relationshipType: { select: { name: true } },
+    },
+  });
+  const discoveredIds = Array.from(new Set([
+    ...seedIds,
+    ...relationships.flatMap((relationship) => [
+      relationship.fromElementId,
+      relationship.toElementId,
+    ]),
+  ]));
+  const [elements, memberships, evidence] = await Promise.all([
+    routingArchitecture
+      ? Promise.resolve(seedElements)
+      : prisma.eaElement.findMany({
+          where: { id: { in: discoveredIds } },
+          select: {
+            id: true,
+            name: true,
+            properties: true,
+            elementType: {
+              select: { notation: { select: { slug: true } } },
+            },
+          },
+        }),
+    prisma.eaViewElement.findMany({
+      where: { elementId: { in: discoveredIds } },
+      select: {
+        elementId: true,
+        view: {
+          select: {
+            id: true,
+            name: true,
+            notation: { select: { slug: true, name: true } },
+          },
+        },
+      },
+    }),
+    routingArchitecture
+      ? prisma.routeDecisionLog.aggregate({ _max: { createdAt: true } })
+      : Promise.resolve({ _max: { createdAt: null } }),
+  ]);
+
+  return buildArchitectureDrillthrough({
+    currentViewId: input.viewId,
+    selectedElementIds: input.elements.map((element) => element.id),
+    elements: elements.map((element) => ({
+      id: element.id,
+      name: element.name,
+      notationSlug: element.elementType.notation.slug,
+      properties: asProperties(element.properties),
+    })),
+    relationships: relationships.map((relationship) => ({
+      fromElementId: relationship.fromElementId,
+      toElementId: relationship.toElementId,
+      relationshipLabel: relationship.relationshipType.name,
+    })),
+    memberships: memberships.map((membership) => ({
+      elementId: membership.elementId,
+      viewId: membership.view.id,
+      viewName: membership.view.name,
+      notationSlug: membership.view.notation.slug,
+      notationName: membership.view.notation.name,
+    })),
+    latestEvidenceAt: evidence._max.createdAt?.toISOString() ?? null,
+  });
+}
+
+function hasRoutingElement(
+  elements: Array<{ properties: Record<string, unknown> }>,
+): boolean {
+  return elements.some((element) => {
+    const sourceVersion = String(element.properties.sourceVersion ?? "");
+    const sourceKey = String(element.properties.sourceKey ?? "");
+    return (
+      typeof element.properties.registryKey === "string" ||
+      sourceVersion === AI_ROUTING_ARCHITECTURE_VERSION ||
+      sourceKey.includes("ai-routing") ||
+      sourceKey.includes("routed-inference")
+    );
+  });
+}
+
+function asProperties(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}

--- a/apps/web/lib/ea/architecture-drillthrough.test.ts
+++ b/apps/web/lib/ea/architecture-drillthrough.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildArchitectureDrillthrough,
+  inspectRoutingDecision,
+} from "./architecture-drillthrough";
+
+describe("buildArchitectureDrillthrough", () => {
+  it("derives deterministic cross-notation view links from existing relationships", () => {
+    const drillthrough = buildArchitectureDrillthrough({
+      currentViewId: "view-bpmn",
+      selectedElementIds: ["bpmn-rank"],
+      elements: [
+        {
+          id: "bpmn-rank",
+          name: "Balance quality, time, and cost",
+          notationSlug: "bpmn20",
+          properties: { registryKey: "rank-quality-time-cost" },
+        },
+        {
+          id: "arch-router",
+          name: "Route Selector and Fallback",
+          notationSlug: "archimate4",
+          properties: {},
+        },
+        {
+          id: "sysml-router",
+          name: "Route Selector",
+          notationSlug: "sysml2",
+          properties: {},
+        },
+        {
+          id: "sysml-requirement",
+          name: "REQ-AIC-1 Eligible-set routing",
+          notationSlug: "sysml2",
+          properties: {},
+        },
+        {
+          id: "sysml-verification",
+          name: "VC-AIC-ELIGIBILITY hard route exclusions",
+          notationSlug: "sysml2",
+          properties: {},
+        },
+      ],
+      relationships: [
+        {
+          fromElementId: "arch-router",
+          toElementId: "bpmn-rank",
+          relationshipLabel: "Realizes process",
+        },
+        {
+          fromElementId: "sysml-router",
+          toElementId: "arch-router",
+          relationshipLabel: "Allocates",
+        },
+        {
+          fromElementId: "sysml-router",
+          toElementId: "sysml-requirement",
+          relationshipLabel: "Satisfies",
+        },
+        {
+          fromElementId: "sysml-verification",
+          toElementId: "sysml-requirement",
+          relationshipLabel: "Verifies",
+        },
+      ],
+      memberships: [
+        {
+          elementId: "bpmn-rank",
+          viewId: "view-bpmn",
+          viewName: "AI Routing — Designed Process",
+          notationSlug: "bpmn20",
+          notationName: "BPMN 2.0",
+        },
+        {
+          elementId: "arch-router",
+          viewId: "view-arch",
+          viewName: "AI Routing — Realizing Architecture",
+          notationSlug: "archimate4",
+          notationName: "ArchiMate 4",
+        },
+        {
+          elementId: "sysml-router",
+          viewId: "view-sysml",
+          viewName: "AI Cockpit — Requirements & Verification",
+          notationSlug: "sysml2",
+          notationName: "SysML 2",
+        },
+        {
+          elementId: "sysml-requirement",
+          viewId: "view-sysml",
+          viewName: "AI Cockpit — Requirements & Verification",
+          notationSlug: "sysml2",
+          notationName: "SysML 2",
+        },
+        {
+          elementId: "sysml-verification",
+          viewId: "view-sysml",
+          viewName: "AI Cockpit — Requirements & Verification",
+          notationSlug: "sysml2",
+          notationName: "SysML 2",
+        },
+      ],
+    });
+
+    expect(drillthrough["bpmn-rank"]?.relatedViews).toEqual([
+      expect.objectContaining({
+        viewId: "view-arch",
+        elementId: "arch-router",
+        notationSlug: "archimate4",
+        distance: 1,
+        href: "/ea/views/view-arch?element=arch-router",
+      }),
+      expect.objectContaining({
+        viewId: "view-sysml",
+        elementId: "sysml-router",
+        notationSlug: "sysml2",
+        distance: 2,
+        href: "/ea/views/view-sysml?element=sysml-router",
+      }),
+      expect.objectContaining({
+        viewId: "view-sysml",
+        elementId: "sysml-requirement",
+        notationSlug: "sysml2",
+        distance: 3,
+      }),
+      expect.objectContaining({
+        viewId: "view-sysml",
+        elementId: "sysml-verification",
+        notationSlug: "sysml2",
+        distance: 4,
+      }),
+    ]);
+    expect(drillthrough["bpmn-rank"]?.operationsMapHref).toBe(
+      "/platform/ai/operations-map?mode=compare&focus=rank-quality-time-cost",
+    );
+  });
+
+  it("uses the shortest path and stable notation/view ordering", () => {
+    const drillthrough = buildArchitectureDrillthrough({
+      currentViewId: "current",
+      selectedElementIds: ["a"],
+      elements: [
+        { id: "a", name: "A", notationSlug: "bpmn20", properties: {} },
+        { id: "b", name: "B", notationSlug: "sysml2", properties: {} },
+        { id: "c", name: "C", notationSlug: "archimate4", properties: {} },
+      ],
+      relationships: [
+        { fromElementId: "a", toElementId: "b", relationshipLabel: "Traces" },
+        { fromElementId: "a", toElementId: "c", relationshipLabel: "Realizes" },
+        { fromElementId: "c", toElementId: "b", relationshipLabel: "Allocates" },
+      ],
+      memberships: [
+        {
+          elementId: "a",
+          viewId: "current",
+          viewName: "Current",
+          notationSlug: "bpmn20",
+          notationName: "BPMN",
+        },
+        {
+          elementId: "b",
+          viewId: "view-sysml",
+          viewName: "SysML",
+          notationSlug: "sysml2",
+          notationName: "SysML",
+        },
+        {
+          elementId: "c",
+          viewId: "view-arch",
+          viewName: "ArchiMate",
+          notationSlug: "archimate4",
+          notationName: "ArchiMate",
+        },
+      ],
+    });
+
+    expect(drillthrough.a?.relatedViews.map((link) => [link.notationSlug, link.distance])).toEqual([
+      ["archimate4", 1],
+      ["sysml2", 1],
+    ]);
+  });
+
+  it("links the same canonical element when it belongs to another view", () => {
+    const drillthrough = buildArchitectureDrillthrough({
+      currentViewId: "view-a",
+      selectedElementIds: ["shared"],
+      elements: [
+        { id: "shared", name: "Governed AI Routing", notationSlug: "archimate4", properties: {} },
+      ],
+      relationships: [],
+      memberships: [
+        {
+          elementId: "shared",
+          viewId: "view-a",
+          viewName: "Capability view",
+          notationSlug: "archimate4",
+          notationName: "ArchiMate 4",
+        },
+        {
+          elementId: "shared",
+          viewId: "view-b",
+          viewName: "Portfolio view",
+          notationSlug: "archimate4",
+          notationName: "ArchiMate 4",
+        },
+      ],
+    });
+
+    expect(drillthrough.shared?.relatedViews).toEqual([
+      expect.objectContaining({
+        viewId: "view-b",
+        elementId: "shared",
+        distance: 0,
+        relationshipPath: ["Same architecture element"],
+      }),
+    ]);
+  });
+});
+
+describe("inspectRoutingDecision", () => {
+  it("exposes only governed safe inputs, bounded outcomes, provenance, and freshness", () => {
+    expect(
+      inspectRoutingDecision({
+        properties: {
+          registryKey: "data-policy-gateway",
+          sourceKey:
+            "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts#evaluateInferenceDispatchPolicy",
+          sourceVersion: "ai-routing/v1",
+          implementationStatus: "partial",
+          prompt: "must never be reflected",
+        },
+        latestEvidenceAt: "2026-07-27T02:00:00.000Z",
+      }),
+    ).toEqual({
+      title: "What did data policy decide?",
+      technicalName: "Allow, protect, review, or deny gateway",
+      safeInputs: ["Data classes", "Purpose", "Actor and governed assets", "Route boundary"],
+      outcomes: ["Allow", "Allow after protection", "Review", "Deny"],
+      sourcePath: "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts",
+      sourceSymbol: "evaluateInferenceDispatchPolicy",
+      sourceVersion: "ai-routing/v1",
+      implementationStatus: "partial",
+      latestEvidenceAt: "2026-07-27T02:00:00.000Z",
+    });
+  });
+
+  it("returns null for a non-decision station", () => {
+    expect(
+      inspectRoutingDecision({
+        properties: { registryKey: "dispatch" },
+        latestEvidenceAt: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/ea/architecture-drillthrough.ts
+++ b/apps/web/lib/ea/architecture-drillthrough.ts
@@ -1,0 +1,315 @@
+import {
+  AI_ROUTING_ARCHITECTURE_VERSION,
+  AI_ROUTING_STAGES,
+} from "./ai-routing-architecture-registry";
+
+export type ArchitectureDrillthroughElement = {
+  id: string;
+  name: string;
+  notationSlug: string;
+  properties: Record<string, unknown>;
+};
+
+export type ArchitectureDrillthroughRelationship = {
+  fromElementId: string;
+  toElementId: string;
+  relationshipLabel: string;
+};
+
+export type ArchitectureViewMembership = {
+  elementId: string;
+  viewId: string;
+  viewName: string;
+  notationSlug: string;
+  notationName: string;
+};
+
+export type RelatedArchitectureView = ArchitectureViewMembership & {
+  elementName: string;
+  relationshipPath: string[];
+  distance: number;
+  href: string;
+};
+
+export type RoutingDecisionInspection = {
+  title: string;
+  technicalName: string;
+  safeInputs: string[];
+  outcomes: string[];
+  sourcePath: string;
+  sourceSymbol: string | null;
+  sourceVersion: string;
+  implementationStatus: string;
+  latestEvidenceAt: string | null;
+};
+
+export type ArchitectureDrillthrough = {
+  relatedViews: RelatedArchitectureView[];
+  operationsMapHref: string | null;
+  source: ArchitectureSourceInspection | null;
+  decision: RoutingDecisionInspection | null;
+};
+
+export type ArchitectureSourceInspection = {
+  path: string;
+  symbol: string | null;
+  version: string | null;
+  implementationStatus: string | null;
+  href: string;
+};
+
+type DecisionDescriptor = {
+  safeInputs: readonly string[];
+  outcomes: readonly string[];
+};
+
+const DECISION_DESCRIPTORS: Readonly<Record<string, DecisionDescriptor>> = {
+  "sensitive-screen": {
+    safeInputs: ["Data classes", "Purpose", "Actor and governed assets", "Payload shape"],
+    outcomes: ["Allow", "Keep local", "Block"],
+  },
+  "data-policy-decision": {
+    safeInputs: ["Data classes", "Purpose", "Actor and governed assets", "Route boundary"],
+    outcomes: ["Allow", "Allow after protection", "Review", "Deny"],
+  },
+  "data-policy-gateway": {
+    safeInputs: ["Data classes", "Purpose", "Actor and governed assets", "Route boundary"],
+    outcomes: ["Allow", "Allow after protection", "Review", "Deny"],
+  },
+  "route-eligibility": {
+    safeInputs: ["Task type", "Required capability", "Residency", "Sensitivity", "Contract family"],
+    outcomes: ["Eligible", "Excluded with safe reason code"],
+  },
+  "eligible-route-gateway": {
+    safeInputs: ["Eligible route count", "Hard exclusion reason codes"],
+    outcomes: ["Continue with eligible routes", "Defer, review, or stop"],
+  },
+  "availability-and-limits": {
+    safeInputs: ["Provider health", "Cooldown", "Quota window", "Short and long time limits"],
+    outcomes: ["Available", "Temporarily limited", "Unavailable"],
+  },
+  "availability-gateway": {
+    safeInputs: ["Preferred route availability", "Capacity state", "Limit window"],
+    outcomes: ["Use preferred route", "Find governed fallback"],
+  },
+  "fallback-gateway": {
+    safeInputs: ["Original route obligations", "Eligible fallback count", "Capacity state"],
+    outcomes: ["Use obligation-preserving fallback", "Defer, review, or stop"],
+  },
+  "rehydration-gateway": {
+    safeInputs: ["Actor", "Surface", "Action", "Readable fields", "Authorization freshness"],
+    outcomes: ["Restore protected values", "Return masked response"],
+  },
+};
+
+const MAX_RELATIONSHIP_DEPTH = 4;
+
+export function buildArchitectureDrillthrough(input: {
+  currentViewId: string;
+  selectedElementIds: string[];
+  elements: ArchitectureDrillthroughElement[];
+  relationships: ArchitectureDrillthroughRelationship[];
+  memberships: ArchitectureViewMembership[];
+  latestEvidenceAt?: string | null;
+}): Record<string, ArchitectureDrillthrough> {
+  const elementById = new Map(input.elements.map((element) => [element.id, element]));
+  const membershipsByElement = groupBy(input.memberships, (membership) => membership.elementId);
+  const adjacency = new Map<
+    string,
+    Array<{ elementId: string; relationshipLabel: string }>
+  >();
+
+  for (const relationship of input.relationships) {
+    pushMapArray(adjacency, relationship.fromElementId, {
+      elementId: relationship.toElementId,
+      relationshipLabel: relationship.relationshipLabel,
+    });
+    pushMapArray(adjacency, relationship.toElementId, {
+      elementId: relationship.fromElementId,
+      relationshipLabel: relationship.relationshipLabel,
+    });
+  }
+
+  return Object.fromEntries(
+    input.selectedElementIds.map((elementId) => {
+      const element = elementById.get(elementId);
+      const relatedViews = element
+        ? findRelatedViews({
+            root: element,
+            currentViewId: input.currentViewId,
+            adjacency,
+            elementById,
+            membershipsByElement,
+          })
+        : [];
+      const registryKey = stringValue(element?.properties.registryKey);
+      const source = inspectArchitectureSource(element?.properties ?? {});
+      return [
+        elementId,
+        {
+          relatedViews,
+          operationsMapHref:
+            registryKey || isRoutingArchitecture(element?.properties ?? {})
+              ? `/platform/ai/operations-map?mode=compare&focus=${encodeURIComponent(registryKey ?? "architecture")}`
+              : null,
+          source,
+          decision: inspectRoutingDecision({
+            properties: element?.properties ?? {},
+            latestEvidenceAt: input.latestEvidenceAt ?? null,
+          }),
+        },
+      ];
+    }),
+  );
+}
+
+export function inspectArchitectureSource(
+  properties: Record<string, unknown>,
+): ArchitectureSourceInspection | null {
+  const parsed = parseSourceKey(stringValue(properties.sourceKey));
+  if (!parsed.path) return null;
+  return {
+    path: parsed.path,
+    symbol: parsed.symbol,
+    version: stringValue(properties.sourceVersion),
+    implementationStatus: stringValue(properties.implementationStatus),
+    href: `https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/${parsed.path
+      .split("/")
+      .map(encodeURIComponent)
+      .join("/")}`,
+  };
+}
+
+export function inspectRoutingDecision(input: {
+  properties: Record<string, unknown>;
+  latestEvidenceAt: string | null;
+}): RoutingDecisionInspection | null {
+  const registryKey = stringValue(input.properties.registryKey);
+  if (!registryKey) return null;
+  const descriptor = DECISION_DESCRIPTORS[registryKey];
+  if (!descriptor) return null;
+  const stage = AI_ROUTING_STAGES.find((candidate) => candidate.id === registryKey);
+  if (!stage) return null;
+  const source = parseSourceKey(stringValue(input.properties.sourceKey));
+
+  return {
+    title: stage.ownerLabel,
+    technicalName: stage.technicalName,
+    safeInputs: [...descriptor.safeInputs],
+    outcomes: [...descriptor.outcomes],
+    sourcePath: source.path,
+    sourceSymbol: source.symbol,
+    sourceVersion: stringValue(input.properties.sourceVersion) ?? stage.source.version,
+    implementationStatus:
+      stringValue(input.properties.implementationStatus) ?? stage.source.status,
+    latestEvidenceAt: input.latestEvidenceAt,
+  };
+}
+
+function findRelatedViews(input: {
+  root: ArchitectureDrillthroughElement;
+  currentViewId: string;
+  adjacency: Map<string, Array<{ elementId: string; relationshipLabel: string }>>;
+  elementById: Map<string, ArchitectureDrillthroughElement>;
+  membershipsByElement: Map<string, ArchitectureViewMembership[]>;
+}): RelatedArchitectureView[] {
+  const queue: Array<{ elementId: string; path: string[]; distance: number }> = [
+    { elementId: input.root.id, path: [], distance: 0 },
+  ];
+  const shortestDistance = new Map<string, number>([[input.root.id, 0]]);
+  const related: RelatedArchitectureView[] = (
+    input.membershipsByElement.get(input.root.id) ?? []
+  )
+    .filter((membership) => membership.viewId !== input.currentViewId)
+    .map((membership) => ({
+      ...membership,
+      elementName: input.root.name,
+      relationshipPath: ["Same architecture element"],
+      distance: 0,
+      href: `/ea/views/${encodeURIComponent(membership.viewId)}?element=${encodeURIComponent(input.root.id)}`,
+    }));
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current.distance >= MAX_RELATIONSHIP_DEPTH) continue;
+    const neighbours = [...(input.adjacency.get(current.elementId) ?? [])].sort(
+      (left, right) =>
+        left.relationshipLabel.localeCompare(right.relationshipLabel) ||
+        left.elementId.localeCompare(right.elementId),
+    );
+
+    for (const neighbour of neighbours) {
+      const distance = current.distance + 1;
+      const previousDistance = shortestDistance.get(neighbour.elementId);
+      if (previousDistance !== undefined && previousDistance <= distance) continue;
+      shortestDistance.set(neighbour.elementId, distance);
+      const path = [...current.path, neighbour.relationshipLabel];
+      queue.push({ elementId: neighbour.elementId, path, distance });
+
+      const element = input.elementById.get(neighbour.elementId);
+      if (!element) continue;
+      for (const membership of input.membershipsByElement.get(neighbour.elementId) ?? []) {
+        if (membership.viewId === input.currentViewId) continue;
+        related.push({
+          ...membership,
+          elementName: element.name,
+          relationshipPath: path,
+          distance,
+          href: `/ea/views/${encodeURIComponent(membership.viewId)}?element=${encodeURIComponent(neighbour.elementId)}`,
+        });
+      }
+    }
+  }
+
+  return related.sort(
+    (left, right) =>
+      notationRank(left.notationSlug) - notationRank(right.notationSlug) ||
+      left.distance - right.distance ||
+      left.viewName.localeCompare(right.viewName) ||
+      left.elementName.localeCompare(right.elementName) ||
+      left.elementId.localeCompare(right.elementId),
+  );
+}
+
+function notationRank(notationSlug: string): number {
+  if (notationSlug === "archimate4") return 0;
+  if (notationSlug === "sysml2") return 1;
+  if (notationSlug === "bpmn20") return 2;
+  return 3;
+}
+
+function parseSourceKey(value: string | null): { path: string; symbol: string | null } {
+  if (!value) return { path: "", symbol: null };
+  const separator = value.indexOf("#");
+  return separator < 0
+    ? { path: value, symbol: null }
+    : { path: value.slice(0, separator), symbol: value.slice(separator + 1) || null };
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isRoutingArchitecture(properties: Record<string, unknown>): boolean {
+  const version = stringValue(properties.sourceVersion);
+  const sourceKey = stringValue(properties.sourceKey);
+  return Boolean(
+    version === AI_ROUTING_ARCHITECTURE_VERSION ||
+    version?.startsWith("ai-routing") ||
+    sourceKey?.includes("ai-routing") ||
+    sourceKey?.includes("routed-inference"),
+  );
+}
+
+function groupBy<T>(
+  values: T[],
+  key: (value: T) => string,
+): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const value of values) pushMapArray(grouped, key(value), value);
+  return grouped;
+}
+
+function pushMapArray<T>(map: Map<string, T[]>, key: string, value: T): void {
+  map.set(key, [...(map.get(key) ?? []), value]);
+}

--- a/apps/web/lib/explore/ea-data.test.ts
+++ b/apps/web/lib/explore/ea-data.test.ts
@@ -10,6 +10,9 @@ vi.mock("@dpf/db", () => ({
     eaStructureRule: { findMany: vi.fn() },
     eaConformanceIssue: { findMany: vi.fn() },
     eaRelationship: { findMany: vi.fn() },
+    eaElement: { findMany: vi.fn() },
+    eaViewElement: { findMany: vi.fn() },
+    routeDecisionLog: { aggregate: vi.fn() },
   },
 }));
 
@@ -21,6 +24,9 @@ const mockPrisma = prisma as unknown as {
   eaStructureRule: { findMany: ReturnType<typeof vi.fn> };
   eaConformanceIssue: { findMany: ReturnType<typeof vi.fn> };
   eaRelationship: { findMany: ReturnType<typeof vi.fn> };
+  eaElement: { findMany: ReturnType<typeof vi.fn> };
+  eaViewElement: { findMany: ReturnType<typeof vi.fn> };
+  routeDecisionLog: { aggregate: ReturnType<typeof vi.fn> };
 };
 
 beforeEach(() => {
@@ -74,6 +80,27 @@ beforeEach(() => {
   ]);
   mockPrisma.eaConformanceIssue.findMany.mockResolvedValue([]);
   mockPrisma.eaRelationship.findMany.mockResolvedValue([]);
+  mockPrisma.eaElement.findMany.mockResolvedValue([
+    {
+      id: "el-stream-1",
+      name: "Evaluate",
+      properties: {},
+      elementType: { notation: { slug: "it4it" } },
+    },
+  ]);
+  mockPrisma.eaViewElement.findMany.mockResolvedValue([
+    {
+      elementId: "el-stream-1",
+      view: {
+        id: "view-1",
+        name: "IT4IT value streams",
+        notation: { slug: "it4it", name: "IT4IT" },
+      },
+    },
+  ]);
+  mockPrisma.routeDecisionLog.aggregate.mockResolvedValue({
+    _max: { createdAt: null },
+  });
 });
 
 describe("getEaView", () => {

--- a/apps/web/lib/explore/ea-data.ts
+++ b/apps/web/lib/explore/ea-data.ts
@@ -7,6 +7,7 @@ import {
   type It4itStageParticipationRow,
 } from "./it4it-participation-view";
 import type { SerializedViewElement, SerializedEdge, CanvasState } from "./ea-types";
+import { loadArchitectureDrillthroughForView } from "@/lib/ea/architecture-drillthrough-data";
 import type {
   CoverageStatus,
   It4itCoverageHeatmap,
@@ -124,7 +125,7 @@ export const getEaView = cache(async (id: string) => {
       })
     : [];
 
-  const serializedElements: SerializedViewElement[] = view.viewElements.map((ve) => ({
+  const baseSerializedElements: SerializedViewElement[] = view.viewElements.map((ve) => ({
     viewElementId: ve.id,
     elementId: ve.elementId,
     mode: ve.mode as SerializedViewElement["mode"],
@@ -145,6 +146,19 @@ export const getEaView = cache(async (id: string) => {
       lifecycleStatus: ve.element.lifecycleStatus,
       properties: (ve.element.properties as Record<string, unknown> | null) ?? null,
     },
+  }));
+  const drillthrough = await loadArchitectureDrillthroughForView({
+    viewId: view.id,
+    elements: baseSerializedElements.map((entry) => ({
+      id: entry.elementId,
+      name: entry.element.name,
+      notationSlug: view.notation.slug,
+      properties: entry.element.properties ?? {},
+    })),
+  });
+  const serializedElements = baseSerializedElements.map((entry) => ({
+    ...entry,
+    drillthrough: drillthrough[entry.elementId] ?? null,
   }));
 
   const serializedEdges: SerializedEdge[] = relationships

--- a/apps/web/lib/explore/ea-types.ts
+++ b/apps/web/lib/explore/ea-types.ts
@@ -1,4 +1,5 @@
 // Shared types used by both client components and server actions for EA canvas.
+import type { ArchitectureDrillthrough } from "@/lib/ea/architecture-drillthrough";
 
 export type EaViewMode = "new" | "reference" | "propose";
 
@@ -49,6 +50,7 @@ export type SerializedViewElement = {
     lifecycleStatus: string;
     properties: Record<string, unknown> | null;
   };
+  drillthrough?: ArchitectureDrillthrough | null;
   childViewElements?: SerializedViewElement[];
   isReadOnly?: boolean;
   onMoveStructuredChild?: (input: {

--- a/docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md
+++ b/docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md
@@ -220,16 +220,39 @@ Make related BPMN, SysML, ArchiMate, source and evidence viewpoints navigable.
 
 ### Work
 
-- [ ] Derive related views from shared `EaElement` membership and existing
+- [x] Derive related views from shared `EaElement` membership and existing
       `EaRelationship`/source identities.
-- [ ] Add authorized SysML view creation/refresh to the existing architecture flow.
-- [ ] Add related-view actions to the element inspector.
-- [ ] Add a governed routing-decision inspector showing safe inputs, source/version,
+- [x] Add authorized SysML view creation/refresh to the existing architecture flow.
+- [x] Add related-view actions to the element inspector.
+- [x] Add a governed routing-decision inspector showing safe inputs, source/version,
       outcome vocabulary and evidence freshness.
-- [ ] Decide from evidence whether the inspector is sufficient or a future DMN
+- [x] Decide from evidence whether the inspector is sufficient or a future DMN
       notation BI is justified.
-- [ ] Keep SysML details behind architecture permissions and progressive disclosure.
-- [ ] Add keyboard, screen-reader and no-color-only navigation tests.
+- [x] Keep SysML details behind architecture permissions and progressive disclosure.
+- [x] Add keyboard, screen-reader and no-color-only navigation tests.
+
+### Phase 4 implementation advisory — 2026-07-27
+
+- Existing `EaElement`, `EaRelationship`, and `EaViewElement` rows are sufficient:
+  drill-through is a bounded, deterministic read projection and no canonical
+  view-link table or schema change is needed.
+- Routing views load the elements for the named architecture revision once, then
+  derive shortest relationship paths in memory. This keeps the inspector aligned
+  with the same BPMN/SysML/ArchiMate projection instead of introducing manually
+  curated links.
+- The architecture element inspector opens the exact related element in its target
+  view and links to the Operations Map Compare lens and repository source.
+- Governed business-rule tasks and gateways expose only enumerated contract inputs
+  and outcome vocabulary. Raw prompts, tool values, detected sensitive values,
+  account identifiers, and policy payloads are not queried or serialized.
+- The existing inspector is sufficient for current explainability. DMN remains a
+  future option only if operators need authorable decision tables or hit policies
+  that cannot be explained by the bounded rule-source metadata.
+- Projection refresh now requires `manage_ea_model`; technical drill-through still
+  requires `view_ea_modeler`. SysML is available in the existing New view flow.
+- UX fit: architecture context is progressive disclosure in the existing inspector,
+  exact links use keyboard-focusable controls and text labels, and operational
+  evidence remains on the canonical `/platform/ai/operations-map` route.
 
 ### Likely files
 

--- a/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
+++ b/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Approved — documentation authority and deterministic Designed EA projection implemented; Observed/Compare delivery remains |
+| Status | Approved — documentation authority, deterministic Designed EA projection, and architecture drill-through implemented; Operations Map Observed/Compare delivery remains |
 | Date | 2026-07-26 |
 | Epic | `EP-CFACFA9F` — AI Routing Architecture & Explainability |
 | Umbrella BI | `BI-3FA17F95` |
@@ -607,6 +607,28 @@ Reserve approximately 20 percent of implementation capacity:
 - **Standards:** the implementation remains within the ISO/IEC/IEEE 42010 viewpoint
   separation and existing OMG BPMN 2.0.2, SysML 2.0, and ArchiMate model-kind
   decisions in this design; no new external standard or tool was introduced.
+
+### Phase 4 implementation advisory
+
+- **Decision:** aligned with the existing EA substrate and the approved progressive
+  disclosure model.
+- **Data model:** no schema change or canonical view-link table was added. Related
+  navigation is derived from current `EaElement` membership and the existing
+  relationship graph for the applicable architecture revision.
+- **Source of truth:** BPMN, SysML, ArchiMate, implementation source, and Operations
+  Map links all originate from the deterministic projection metadata; the inspector
+  owns no independent route rules.
+- **Security:** the decision inspector serializes an explicit allowlist of
+  architecture-safe input classes and bounded outcome labels. It does not load raw
+  prompt, tool, detected-value, token-map, account, or policy payload content.
+- **Authorization:** viewing technical detail requires `view_ea_modeler`; creating
+  SysML views and refreshing deterministic projections requires `manage_ea_model`.
+- **DMN decision:** a governed inspector is sufficient for the current read-only
+  explainability need. DMN is deferred until an authorable decision-table need is
+  demonstrated; adding notation now would duplicate rule authority.
+- **Performance:** routing drill-through loads the bounded named design revision and
+  derives shortest paths in memory, avoiding repeated depth-by-depth database
+  traversal while preserving deterministic exact-element links.
 
 ## 19. Standards
 

--- a/docs/user-guide/architecture/index.md
+++ b/docs/user-guide/architecture/index.md
@@ -24,3 +24,29 @@ The EA Modeler is a canvas-based tool for building and maintaining your organiza
 - Start from reference models and tailor them to your organization
 - Map value streams to the products and capabilities that support them
 - Use the AI coworker to generate a draft architecture view from a description
+- Select an element to open its **Architecture context**, then follow the shortest
+  available links to the same concern in related ArchiMate, BPMN, or SysML views
+- For projected AI routing elements, open the matching operational evidence and
+  inspect the safe decision inputs, possible outcomes, design version, evidence
+  freshness, and implementation source
+- Use **Refresh live projections** when you are authorized to rebuild governed
+  BPMN, SysML, and ArchiMate views from their canonical sources
+
+## Following a Concern Across Views
+
+Select an element on an architecture canvas and open **Architecture context** in
+the inspector. **Related viewpoints** lists the nearest views that explain the
+same element or a directly linked concern. Each link names the notation, target
+view, and link distance so you can see why it is being suggested.
+
+AI routing elements can also offer **Open operational evidence**. This opens the
+AI Operations Map in Compare mode, focused on the same routing stage. The
+architecture remains the designed projection; the Operations Map supplies the
+observed evidence and calls out gaps rather than treating missing evidence as
+proof that the design ran.
+
+The **Why this decision works this way** section deliberately shows only safe
+metadata. It can include decision inputs such as sensitivity class or provider
+eligibility, possible outcomes, the design version, implementation status, and
+the latest evidence time. It never exposes prompt text or protected payload
+values.

--- a/docs/user-guide/platform/ai-operations.md
+++ b/docs/user-guide/platform/ai-operations.md
@@ -31,6 +31,11 @@ order: 2
   `docs/architecture/ai-routing-document-map.md`, which classifies the proposed
   owner-readable subway map, technical drill-through, target-state designs, and
   historical records.
+- Authorized architecture users can open a routing element in `/ea` and use
+  **Architecture context** to move to its related BPMN, SysML, or ArchiMate element,
+  inspect the governed decision vocabulary and source version, or open the same
+  station in the Operations Map Compare lens. The inspector shows bounded labels and
+  evidence freshness; it never shows prompt or protected-data content.
 
 ## What To Watch
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -734,6 +734,13 @@
     "longSentences": 0,
     "textMass": 60
   },
+  "apps/web/app/(shell)/ea/views/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
   "apps/web/app/(shell)/ea/views/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -4535,6 +4542,13 @@
     "longSentences": 0,
     "textMass": 10
   },
+  "apps/web/components/ea/ArchitectureDrillthroughPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
   "apps/web/components/ea/CreateViewButton.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -4547,7 +4561,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 141
+    "textMass": 146
   },
   "apps/web/components/ea/EaRelationshipEdge.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary
- add architecture cross-view drill-through from an exact EA element, including shortest related-view paths and Operations Map compare links
- add a governed routing decision inspector that exposes safe decision inputs/outcomes without sensitive prompt or payload values
- add authorized live projection refresh and SysML v2 view creation, with source and evidence-freshness provenance
- update the explainability design, implementation plan, EA guide, and operator AI Operations guide

## Architecture
- derives navigation from the existing EA element/relationship/view-membership graph; no parallel routing model or schema change
- preserves the routing projection as advisory evidence and keeps operational compare links on the existing Operations Map route
- applies `manage_ea_model` to projection mutation while read-only inspection remains available to authorized viewers

## Design grounding
- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md`
  - `docs/superpowers/plans/2026-07-26-ai-routing-architecture-explainability.md`
  - `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
- Current code substrate reviewed:
  - EA element, relationship, view-membership, canvas and inspector projection paths
  - AI routing architecture registry and routing evidence-conformance projection
- Source of truth:
  - canonical routing registry/code and policy remain design authority; EA is a deterministic designed projection; route ledgers remain operational authority
- Decision:
  - extend the existing EA graph and inspector with derived cross-view links; do not create a parallel routing model or ungoverned policy editor

## Verification
- governed local-CI **PASSED** for exact candidate `a96485559805916e8d8aac9afddafa098a60ab77`
- accepted base `0517a9544c494017d4d2157e951df4cc4f82838a`; integration commit `ff73a444d1f02cd8b9cca2c511ef62d2dabffa84`
- evidence `cms2vp13017fj01qql85nlq2i`; lease `NPEL-DB131A6973` released cleanly
- 2,254 web test files / 19,537 tests passed; web typecheck, Prisma generate/migrate deploy, docs and 24 repository guards, sandbox freshness, and production Docker build passed

## Backlog
- BI-52C015D8
- Work Capsule WC-CCDD71A0

## Documentation impact
Updated the EA user guide, architecture design and plan, plus the operator AI Operations guide because this changes contributor architecture workflows and operator-visible navigation.
