### PR TITLE
feat(build): recover PR delivery through merge queue (BI-7C4FDBF5)

### DIFF
--- a/apps/web/components/build/BuildCustomerStatusBand.test.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.test.tsx
@@ -25,6 +25,27 @@ describe("BuildCustomerStatusBand", () => {
     expect(html).toContain("Work in progress");
   });
 
+  it("keeps technical PR evidence behind progressive disclosure", () => {
+    const html = renderToStaticMarkup(
+      <BuildCustomerStatusBand
+        status={{
+          whatIsBeingBuilt: "Recover delivery",
+          lifecyclePosition: "Merge queued",
+          worker: "Repository merge queue",
+          evidence: "Build Studio checked the current delivery state.",
+          technicalEvidence: "PR #42 · head abc123 · observations 2",
+          nextAction: "wait for the protected merge queue to finish.",
+          owner: "Build Studio",
+          needsYou: false,
+        }}
+      />,
+    );
+    expect(html).toContain("<details");
+    expect(html).not.toContain("<details open");
+    expect(html).toContain("Technical delivery details");
+    expect(html).toContain("PR #42");
+  });
+
   it("renders evidence, next action, and owner for operational closeout", () => {
     const html = renderToStaticMarkup(<BuildCustomerStatusBand status={status()} />);
     expect(html).toContain("Evidence:");

--- a/apps/web/components/build/BuildCustomerStatusBand.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.tsx
@@ -30,6 +30,12 @@ export function BuildCustomerStatusBand({ status }: { status: BuildStudioCustome
           <p className="m-0 mt-0.5 text-[11px] leading-relaxed text-[var(--dpf-muted)]">
             Owner: {status.owner}
           </p>
+          {status.technicalEvidence && (
+            <details className="mt-1 text-[11px] text-[var(--dpf-muted)]">
+              <summary className="cursor-pointer text-[var(--dpf-accent)]">Technical delivery details</summary>
+              <p className="m-0 mt-1 font-mono leading-relaxed">{status.technicalEvidence}</p>
+            </details>
+          )}
         </div>
         {status.needsYou && (
           <span className={NEEDS_YOU_PILL} data-testid="build-customer-status-needs-you">

--- a/apps/web/components/build/BuildCustomerStatusBand.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.tsx
@@ -31,7 +31,7 @@ export function BuildCustomerStatusBand({ status }: { status: BuildStudioCustome
             Owner: {status.owner}
           </p>
           {status.technicalEvidence && (
-            <details className="mt-1 text-[11px] text-[var(--dpf-muted)]">
+            <details className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">
               <summary className="cursor-pointer text-[var(--dpf-accent)]">Technical delivery details</summary>
               <p className="m-0 mt-1 font-mono leading-relaxed">{status.technicalEvidence}</p>
             </details>

--- a/apps/web/lib/assurance/remediation-merge-live.ts
+++ b/apps/web/lib/assurance/remediation-merge-live.ts
@@ -17,21 +17,20 @@ import {
   resolveRepoIdentity,
 } from "@/lib/contributor-change-lanes/github-rest-reader";
 import { createPlatformIssueReport } from "@/lib/quality/platform-issue-reports";
+import {
+  enablePullRequestAutoMerge,
+  resolvePullRequestNodeId,
+} from "@/lib/integrate/github-pr-readiness";
 import { ASSURANCE_ORIGIN_MARKER } from "./remediation-teeup";
 import type { MergeGateAdapters, PrReadiness, ReadyRemediationPR } from "./remediation-merge-orchestrator";
 
 const NPM_REGISTRY_BASE = process.env.NPM_REGISTRY_BASE ?? "https://registry.npmjs.org";
 const OSV_BASE = process.env.OSV_BASE_URL ?? "https://api.osv.dev";
-const GITHUB_GRAPHQL = "https://api.github.com/graphql";
 
 /** Release-age cooldown for an auto-mergeable bump (hijacked-release guard; mirrors
  *  the Dependabot patch cooldown). The bumped release must be at least this old. */
 export const ASSURANCE_REMEDIATION_COOLDOWN_DAYS = 3;
 
-const PR_ID_QUERY =
-  "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id}}}";
-const ENABLE_AUTOMERGE_MUTATION =
-  "mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id}){pullRequest{number}}}";
 
 // ─── pure helpers ─────────────────────────────────────────────────────────────
 
@@ -121,29 +120,6 @@ export async function fetchOsvClean(
   } catch {
     return false;
   }
-}
-
-async function githubGraphql(
-  fetchImpl: typeof fetch,
-  token: string,
-  query: string,
-  variables: Record<string, unknown>,
-): Promise<Record<string, unknown> | null> {
-  const res = await fetchImpl(GITHUB_GRAPHQL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-      "User-Agent": "dpf-assurance-merge-gate",
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-  if (!res.ok) throw new Error(`GitHub GraphQL HTTP ${res.status}`);
-  const json = (await res.json()) as { data?: Record<string, unknown>; errors?: unknown[] };
-  if (Array.isArray(json.errors) && json.errors.length > 0) {
-    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(json.errors).slice(0, 200)}`);
-  }
-  return json.data ?? null;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -250,16 +226,14 @@ export async function createLiveMergeGateAdapters(deps: LiveMergeGateDeps): Prom
         throw new Error("assurance auto-merge: no GitHub token (github-pr-sync credential not active)");
       }
       const repo = await resolveRepoIdentity(tokenPrisma);
-      const idData = await githubGraphql(fetchImpl, token, PR_ID_QUERY, {
+      const nodeId = await resolvePullRequestNodeId({
+        fetchImpl,
+        token,
         owner: repo.owner,
-        name: repo.name,
-        number: pr.prNumber,
+        repo: repo.name,
+        prNumber: pr.prNumber,
       });
-      const nodeId = (idData as { repository?: { pullRequest?: { id?: unknown } } } | null)?.repository?.pullRequest?.id;
-      if (typeof nodeId !== "string" || !nodeId) {
-        throw new Error(`assurance auto-merge: could not resolve node id for PR #${pr.prNumber}`);
-      }
-      await githubGraphql(fetchImpl, token, ENABLE_AUTOMERGE_MUTATION, { id: nodeId });
+      await enablePullRequestAutoMerge({ fetchImpl, token, nodeId });
     },
 
     escalate: async (pr, reason): Promise<void> => {

--- a/apps/web/lib/build-flow-state.test.ts
+++ b/apps/web/lib/build-flow-state.test.ts
@@ -8,6 +8,7 @@ vi.mock("@dpf/db", () => ({
     buildActivity:     { findFirst: vi.fn() },
     productVersion:    { findMany: vi.fn() },
     changePromotion:   { updateMany: vi.fn() },
+    workCapsule:       { findFirst: vi.fn() },
   },
 }));
 
@@ -22,6 +23,7 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 import { prisma } from "@dpf/db";
 import { isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import { getBuildFlowState, reconcileBuildCompletion, completeLocalDeliveryBuild } from "./build-flow-state";
+import { createBuildPrDeliveryState, writeBuildPrDeliveryState } from "./build/build-pr-delivery-state";
 
 // ─── Fixture helpers ────────────────────────────────────────────────────────
 
@@ -76,6 +78,23 @@ function mockDevConfig(mode: "fork_only" | "selective" | "contribute_all" = "sel
 
 function mockPack(pack: { packId: string; prUrl: string | null; prNumber: number | null; manifest?: unknown } | null): void {
   vi.mocked(prisma.featurePack.findFirst).mockResolvedValue(pack as never);
+  const manifest = pack?.manifest as { prUrl?: string; prNumber?: number } | undefined;
+  const resolvedPrUrl = pack?.prUrl ?? manifest?.prUrl ?? null;
+  const resolvedPrNumber = pack?.prNumber ?? manifest?.prNumber ?? null;
+  vi.mocked(prisma.workCapsule.findFirst).mockResolvedValue(
+    resolvedPrUrl
+      ? ({
+          workspaceState: writeBuildPrDeliveryState({}, {
+            ...createBuildPrDeliveryState({
+              repository: "org/repo",
+              prNumber: resolvedPrNumber ?? 1,
+              prUrl: resolvedPrUrl,
+            }),
+            status: "awaiting-release",
+          }),
+        } as never)
+      : null,
+  );
 }
 
 function mockActivity(summary: string | null): void {
@@ -189,6 +208,21 @@ describe("getBuildFlowState — upstream PR fork", () => {
     expect(state!.upstream.state).toBe("shipped");
     expect(state!.upstream.prUrl).toBe("https://github.com/org/repo/pull/42");
     expect(state!.upstream.prNumber).toBe(42);
+  });
+
+  it("is still in progress when the PR exists but is only queued", async () => {
+    mockBuild({ phase: "ship" });
+    const prUrl = "https://github.com/org/repo/pull/42";
+    mockPack({ packId: "FP-1", prUrl, prNumber: 42 });
+    vi.mocked(prisma.workCapsule.findFirst).mockResolvedValue({
+      workspaceState: writeBuildPrDeliveryState({}, {
+        ...createBuildPrDeliveryState({ repository: "org/repo", prNumber: 42, prUrl }),
+        status: "queued",
+      }),
+    } as never);
+    const state = await getBuildFlowState("FB-TEST-001");
+    expect(state!.upstream.state).toBe("in_progress");
+    expect(state!.allApplicableForksTerminal).toBe(false);
   });
 
   it("reads prUrl from manifest when the top-level column is null (post-A2)", async () => {

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -15,6 +15,7 @@ import type { BuildPhase } from "@/lib/feature-build-types";
 import { PHASE_LABELS } from "@/lib/feature-build-types";
 import { isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import { recordReadyDependentsAfterCompletion } from "@/lib/build/feature-build-dependencies";
+import { readBuildPrDeliveryState } from "@/lib/build/build-pr-delivery-state";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -332,7 +333,28 @@ async function deriveUpstreamFork(
   }
 
   if (prUrl) {
-    return { state: "shipped", prUrl, prNumber, packId: pack.packId, errorMessage: null };
+    const capsule = await prisma.workCapsule.findFirst({
+      where: {
+        featureBuildId: buildRowId,
+        ...(prNumber ? { pullRequestNumber: prNumber } : {}),
+      },
+      orderBy: { updatedAt: "desc" },
+      select: { workspaceState: true },
+    });
+    const delivery = readBuildPrDeliveryState(capsule?.workspaceState);
+    if (delivery?.status === "awaiting-release" || delivery?.status === "deployed") {
+      return { state: "shipped", prUrl, prNumber, packId: pack.packId, errorMessage: null };
+    }
+    if (delivery?.status === "escalated" || delivery?.status === "closed") {
+      return {
+        state: "errored",
+        prUrl,
+        prNumber,
+        packId: pack.packId,
+        errorMessage: delivery.lastError ?? "Pull request delivery needs a human decision",
+      };
+    }
+    return { state: "in_progress", prUrl, prNumber, packId: pack.packId, errorMessage: null };
   }
 
   // Pack exists but no prUrl — check BuildActivity for a failure record on

--- a/apps/web/lib/build/build-pr-delivery-reconciler.test.ts
+++ b/apps/web/lib/build/build-pr-delivery-reconciler.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { decideBuildPrDeliveryAction } from "./build-pr-delivery-reconciler";
+import { createBuildPrDeliveryState } from "./build-pr-delivery-state";
+
+const state = createBuildPrDeliveryState({
+  repository: "o/r",
+  prNumber: 42,
+  prUrl: "https://github.com/o/r/pull/42",
+});
+
+describe("decideBuildPrDeliveryAction", () => {
+  it("queues an evidence-cleared exact head once", () => {
+    expect(decideBuildPrDeliveryAction({
+      state,
+      readiness: { kind: "ready", headSha: "abc" },
+    })).toEqual({ kind: "queue", headSha: "abc" });
+    expect(decideBuildPrDeliveryAction({
+      state: { ...state, lastActuatedHeadSha: "abc", status: "queued" },
+      readiness: { kind: "ready", headSha: "abc" },
+    })).toEqual({ kind: "wait", status: "queued", headSha: "abc", reason: "already-actuated" });
+  });
+
+  it("updates a stale head within budget and escalates when exhausted", () => {
+    expect(decideBuildPrDeliveryAction({
+      state,
+      readiness: { kind: "behind", headSha: "abc" },
+    })).toEqual({ kind: "update-branch", headSha: "abc" });
+    expect(decideBuildPrDeliveryAction({
+      state: { ...state, staleUpdateAttempts: 2 },
+      readiness: { kind: "behind", headSha: "abc" },
+    })).toEqual({ kind: "escalate", status: "escalated", headSha: "abc", reason: "stale-update-budget-exhausted" });
+  });
+
+  it("never auto-edits conflicts and honors closure", () => {
+    expect(decideBuildPrDeliveryAction({
+      state,
+      readiness: { kind: "conflict", headSha: "abc" },
+    })).toEqual({ kind: "escalate", status: "escalated", headSha: "abc", reason: "true-merge-conflict" });
+    expect(decideBuildPrDeliveryAction({
+      state,
+      readiness: { kind: "closed", headSha: "abc" },
+    })).toEqual({ kind: "escalate", status: "closed", headSha: "abc", reason: "pull-request-closed-unmerged" });
+  });
+
+  it("keeps merge distinct from governed deployment", () => {
+    expect(decideBuildPrDeliveryAction({
+      state,
+      readiness: { kind: "merged", headSha: "abc" },
+    })).toEqual({ kind: "wait", status: "awaiting-release", headSha: "abc", reason: "merged-awaiting-governed-release" });
+  });
+
+  it("parks checks and bounds unknown observations", () => {
+    expect(decideBuildPrDeliveryAction({
+      state,
+      readiness: { kind: "checking", headSha: "abc", reason: "checks-pending" },
+    })).toEqual({ kind: "wait", status: "checking", headSha: "abc", reason: "checks-pending" });
+    expect(decideBuildPrDeliveryAction({
+      state: { ...state, reconciliationAttempts: 6 },
+      readiness: { kind: "unknown", headSha: "abc", reason: "merge-state-unknown" },
+    })).toEqual({ kind: "escalate", status: "escalated", headSha: "abc", reason: "observation-budget-exhausted:merge-state-unknown" });
+  });
+});

--- a/apps/web/lib/build/build-pr-delivery-reconciler.ts
+++ b/apps/web/lib/build/build-pr-delivery-reconciler.ts
@@ -1,0 +1,277 @@
+import {
+  enablePullRequestAutoMerge,
+  observeGithubPullRequest,
+  projectGithubPrReadiness,
+  updatePullRequestBranch,
+  type GithubPrObservation,
+  type GithubPrReadiness,
+} from "@/lib/integrate/github-pr-readiness";
+import {
+  createBuildPrDeliveryState,
+  type BuildPrDeliveryStateV1,
+  type BuildPrDeliveryStatus,
+} from "./build-pr-delivery-state";
+import {
+  captureBuildPrOntoCapsule,
+  persistBuildPrDeliveryStateForBuild,
+  type CaptureBuildPrDeps,
+} from "./capture-build-pr";
+const MAX_STALE_UPDATES = 2;
+const MAX_UNKNOWN_OBSERVATIONS = 6;
+
+export type BuildPrDeliveryAction =
+  | { kind: "queue" | "update-branch"; headSha: string }
+  | {
+      kind: "wait" | "escalate";
+      status: BuildPrDeliveryStatus;
+      headSha: string | null;
+      reason: string;
+    };
+
+export function decideBuildPrDeliveryAction(input: {
+  state: BuildPrDeliveryStateV1;
+  readiness: GithubPrReadiness;
+}): BuildPrDeliveryAction {
+  const { state, readiness } = input;
+  switch (readiness.kind) {
+    case "merged":
+      return {
+        kind: "wait",
+        status: "awaiting-release",
+        headSha: readiness.headSha,
+        reason: "merged-awaiting-governed-release",
+      };
+    case "closed":
+      return {
+        kind: "escalate",
+        status: "closed",
+        headSha: readiness.headSha,
+        reason: "pull-request-closed-unmerged",
+      };
+    case "conflict":
+      return {
+        kind: "escalate",
+        status: "escalated",
+        headSha: readiness.headSha,
+        reason: "true-merge-conflict",
+      };
+    case "behind":
+      return state.staleUpdateAttempts < MAX_STALE_UPDATES
+        ? { kind: "update-branch", headSha: readiness.headSha }
+        : {
+            kind: "escalate",
+            status: "escalated",
+            headSha: readiness.headSha,
+            reason: "stale-update-budget-exhausted",
+          };
+    case "ready":
+      return state.lastActuatedHeadSha === readiness.headSha
+        ? {
+            kind: "wait",
+            status: "queued",
+            headSha: readiness.headSha,
+            reason: "already-actuated",
+          }
+        : { kind: "queue", headSha: readiness.headSha };
+    case "queued":
+      return {
+        kind: "wait",
+        status: "queued",
+        headSha: readiness.headSha,
+        reason: "merge-queue-enrolled",
+      };
+    case "checking":
+      return {
+        kind: "wait",
+        status: "checking",
+        headSha: readiness.headSha,
+        reason: readiness.reason,
+      };
+    case "unknown":
+      return state.reconciliationAttempts >= MAX_UNKNOWN_OBSERVATIONS
+        ? {
+            kind: "escalate",
+            status: "escalated",
+            headSha: readiness.headSha,
+            reason: `observation-budget-exhausted:${readiness.reason}`,
+          }
+        : {
+            kind: "wait",
+            status: "checking",
+            headSha: readiness.headSha,
+            reason: readiness.reason,
+          };
+  }
+}
+
+export type BuildPrReconcilerMode = "off" | "shadow" | "enforce";
+
+export function resolveBuildPrReconcilerMode(value = process.env.DPF_BUILD_PR_DELIVERY_RECONCILER_MODE): BuildPrReconcilerMode {
+  const normalized = (value ?? "shadow").trim().toLowerCase();
+  return normalized === "shadow" || normalized === "enforce" ? normalized : "off";
+}
+
+export async function executeBuildPrDeliveryAction(input: {
+  state: BuildPrDeliveryStateV1;
+  observation: GithubPrObservation;
+  readiness: GithubPrReadiness;
+  mode: BuildPrReconcilerMode;
+  token: string;
+  owner: string;
+  repo: string;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+}): Promise<{ state: BuildPrDeliveryStateV1; action: BuildPrDeliveryAction; actuated: boolean }> {
+  const action = decideBuildPrDeliveryAction({ state: input.state, readiness: input.readiness });
+  const now = (input.now ?? new Date()).toISOString();
+  let next: BuildPrDeliveryStateV1 = {
+    ...input.state,
+    reconciliationAttempts: input.state.reconciliationAttempts + 1,
+    lastObservedHeadSha: input.readiness.headSha,
+    lastReadiness: input.readiness.kind,
+    lastObservedAt: now,
+    lastError: null,
+  };
+
+  if (action.kind === "wait") {
+    next = { ...next, status: action.status };
+    return { state: next, action, actuated: false };
+  }
+  if (action.kind === "escalate") {
+    next = {
+      ...next,
+      status: action.status,
+      escalationKey: next.escalationKey ?? `build-pr-delivery:${input.state.prNumber}:${action.reason}`,
+      lastError: action.reason,
+    };
+    return { state: next, action, actuated: false };
+  }
+  if (input.mode !== "enforce") {
+    next = {
+      ...next,
+      status: "checking",
+      lastError: input.mode === "shadow" ? `shadow-proposed:${action.kind}` : "reconciler-disabled",
+    };
+    return { state: next, action, actuated: false };
+  }
+
+  if (action.kind === "update-branch") {
+    const result = await updatePullRequestBranch({
+      owner: input.owner,
+      repo: input.repo,
+      prNumber: input.state.prNumber,
+      expectedHeadSha: action.headSha,
+      token: input.token,
+      fetchImpl: input.fetchImpl,
+    });
+    next = {
+      ...next,
+      status: result === "accepted" ? "updating" : "checking",
+      staleUpdateAttempts: next.staleUpdateAttempts + (result === "accepted" ? 1 : 0),
+      lastError: result === "head-changed" ? "head-changed-during-update" : null,
+    };
+    return { state: next, action, actuated: result === "accepted" };
+  }
+
+  if (input.observation.headSha !== action.headSha) {
+    return {
+      state: { ...next, status: "checking", lastError: "head-changed-before-queue" },
+      action,
+      actuated: false,
+    };
+  }
+  await enablePullRequestAutoMerge({
+    nodeId: input.observation.nodeId,
+    token: input.token,
+    fetchImpl: input.fetchImpl,
+  });
+  next = {
+    ...next,
+    status: "queued",
+    lastActuatedHeadSha: action.headSha,
+  };
+  return { state: next, action, actuated: true };
+}
+
+/**
+ * Single PR-created choke point shared by Build Studio's portal-PR and
+ * contribute-to-hive paths. Durable state must exist before any GitHub
+ * actuation; otherwise the operation is withheld so a restart cannot strand it.
+ */
+export async function initializeAndReconcileBuildPrDelivery(input: {
+  db: CaptureBuildPrDeps;
+  featureBuildId: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  prUrl: string;
+  token: string;
+  eligible?: boolean;
+  mode?: BuildPrReconcilerMode;
+  fetchImpl?: typeof fetch;
+}): Promise<{
+  captured: number;
+  state: BuildPrDeliveryStateV1;
+  action: BuildPrDeliveryAction | null;
+  actuated: boolean;
+}> {
+  const repository = `${input.owner}/${input.repo}`;
+  const initial = createBuildPrDeliveryState({
+    repository,
+    prNumber: input.prNumber,
+    prUrl: input.prUrl,
+  });
+  const capture = await captureBuildPrOntoCapsule({
+    db: input.db,
+    featureBuildId: input.featureBuildId,
+    repository,
+    prNumber: input.prNumber,
+    prUrl: input.prUrl,
+  });
+  if (capture.captured === 0) {
+    return {
+      captured: 0,
+      state: { ...initial, lastError: "recovery-state-missing" },
+      action: null,
+      actuated: false,
+    };
+  }
+  if (input.eligible === false) {
+    const stopped: BuildPrDeliveryStateV1 = {
+      ...initial,
+      status: "escalated",
+      escalationKey: `build-pr-delivery:${input.prNumber}:local-evidence-not-cleared`,
+      lastError: "local-evidence-not-cleared",
+    };
+    await persistBuildPrDeliveryStateForBuild({
+      db: input.db,
+      featureBuildId: input.featureBuildId,
+      delivery: stopped,
+    });
+    return { captured: capture.captured, state: stopped, action: null, actuated: false };
+  }
+
+  const observation = await observeGithubPullRequest({
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    token: input.token,
+    fetchImpl: input.fetchImpl,
+  });
+  const outcome = await executeBuildPrDeliveryAction({
+    state: initial,
+    observation,
+    readiness: projectGithubPrReadiness(observation),
+    mode: input.mode ?? resolveBuildPrReconcilerMode(),
+    token: input.token,
+    owner: input.owner,
+    repo: input.repo,
+    fetchImpl: input.fetchImpl,
+  });
+  await persistBuildPrDeliveryStateForBuild({
+    db: input.db,
+    featureBuildId: input.featureBuildId,
+    delivery: outcome.state,
+  });
+  return { captured: capture.captured, ...outcome };
+}

--- a/apps/web/lib/build/build-pr-delivery-state.test.ts
+++ b/apps/web/lib/build/build-pr-delivery-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createBuildPrDeliveryState,
+  readBuildPrDeliveryState,
+  writeBuildPrDeliveryState,
+} from "./build-pr-delivery-state";
+
+describe("BuildPrDeliveryStateV1", () => {
+  it("initializes restart-safe PR identity without replacing unrelated capsule state", () => {
+    const state = createBuildPrDeliveryState({
+      repository: "o/r",
+      prNumber: 42,
+      prUrl: "https://github.com/o/r/pull/42",
+    });
+    const workspace = writeBuildPrDeliveryState({ claim: "kept" }, state);
+
+    expect(workspace.claim).toBe("kept");
+    expect(readBuildPrDeliveryState(workspace)).toEqual(state);
+    expect(state).toEqual(expect.objectContaining({
+      schemaVersion: 1,
+      status: "created",
+      repository: "o/r",
+      prNumber: 42,
+      staleUpdateAttempts: 0,
+      reconciliationAttempts: 0,
+    }));
+  });
+
+  it("fails closed for malformed and future-version state", () => {
+    expect(readBuildPrDeliveryState(null)).toBeNull();
+    expect(readBuildPrDeliveryState({ buildStudio: { delivery: { schemaVersion: 2 } } })).toBeNull();
+    expect(readBuildPrDeliveryState({ buildStudio: { delivery: { schemaVersion: 1, status: "bogus" } } })).toBeNull();
+  });
+});

--- a/apps/web/lib/build/build-pr-delivery-state.ts
+++ b/apps/web/lib/build/build-pr-delivery-state.ts
@@ -1,0 +1,106 @@
+import type { GithubPrReadiness } from "@/lib/integrate/github-pr-readiness";
+
+export const BUILD_PR_DELIVERY_STATUSES = [
+  "created",
+  "checking",
+  "updating",
+  "queued",
+  "awaiting-release",
+  "deployed",
+  "escalated",
+  "closed",
+] as const;
+
+export type BuildPrDeliveryStatus = (typeof BUILD_PR_DELIVERY_STATUSES)[number];
+
+export type BuildPrDeliveryStateV1 = {
+  schemaVersion: 1;
+  status: BuildPrDeliveryStatus;
+  repository: string;
+  prNumber: number;
+  prUrl: string;
+  lastObservedHeadSha: string | null;
+  lastActuatedHeadSha: string | null;
+  staleUpdateAttempts: number;
+  reconciliationAttempts: number;
+  lastReadiness: GithubPrReadiness["kind"] | null;
+  lastObservedAt: string | null;
+  escalationKey: string | null;
+  lastError: string | null;
+};
+
+type JsonObject = Record<string, unknown>;
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonObject) : {};
+}
+
+export function createBuildPrDeliveryState(input: {
+  repository: string;
+  prNumber: number;
+  prUrl: string;
+}): BuildPrDeliveryStateV1 {
+  return {
+    schemaVersion: 1,
+    status: "created",
+    repository: input.repository,
+    prNumber: input.prNumber,
+    prUrl: input.prUrl,
+    lastObservedHeadSha: null,
+    lastActuatedHeadSha: null,
+    staleUpdateAttempts: 0,
+    reconciliationAttempts: 0,
+    lastReadiness: null,
+    lastObservedAt: null,
+    escalationKey: null,
+    lastError: null,
+  };
+}
+
+export function readBuildPrDeliveryState(workspaceState: unknown): BuildPrDeliveryStateV1 | null {
+  const root = asObject(workspaceState);
+  const buildStudio = asObject(root.buildStudio);
+  const value = asObject(buildStudio.delivery);
+  if (value.schemaVersion !== 1) return null;
+  if (
+    typeof value.status !== "string" ||
+    !BUILD_PR_DELIVERY_STATUSES.includes(value.status as BuildPrDeliveryStatus) ||
+    typeof value.repository !== "string" ||
+    typeof value.prNumber !== "number" ||
+    !Number.isInteger(value.prNumber) ||
+    value.prNumber <= 0 ||
+    typeof value.prUrl !== "string" ||
+    !value.repository ||
+    !value.prUrl
+  ) {
+    return null;
+  }
+  const integer = (candidate: unknown) =>
+    typeof candidate === "number" && Number.isInteger(candidate) && candidate >= 0 ? candidate : 0;
+  return {
+    schemaVersion: 1,
+    status: value.status as BuildPrDeliveryStatus,
+    repository: value.repository,
+    prNumber: value.prNumber,
+    prUrl: value.prUrl,
+    lastObservedHeadSha: typeof value.lastObservedHeadSha === "string" ? value.lastObservedHeadSha : null,
+    lastActuatedHeadSha: typeof value.lastActuatedHeadSha === "string" ? value.lastActuatedHeadSha : null,
+    staleUpdateAttempts: integer(value.staleUpdateAttempts),
+    reconciliationAttempts: integer(value.reconciliationAttempts),
+    lastReadiness: typeof value.lastReadiness === "string"
+      ? value.lastReadiness as GithubPrReadiness["kind"]
+      : null,
+    lastObservedAt: typeof value.lastObservedAt === "string" ? value.lastObservedAt : null,
+    escalationKey: typeof value.escalationKey === "string" ? value.escalationKey : null,
+    lastError: typeof value.lastError === "string" ? value.lastError : null,
+  };
+}
+
+export function writeBuildPrDeliveryState(
+  workspaceState: unknown,
+  delivery: BuildPrDeliveryStateV1,
+): JsonObject {
+  const root = { ...asObject(workspaceState) };
+  root.buildStudio = { ...asObject(root.buildStudio), delivery };
+  return root;
+}

--- a/apps/web/lib/build/capture-build-pr.test.ts
+++ b/apps/web/lib/build/capture-build-pr.test.ts
@@ -7,23 +7,24 @@ function mkDb(count = 1) {
     Array.from({ length: count }, (_, index) => ({
       id: `capsule-${index + 1}`,
       workspaceState: { retained: true },
+      updatedAt: new Date("2026-07-27T00:00:00Z"),
     })),
   );
-  const update = vi.fn().mockResolvedValue({});
-  return { db: { workCapsule: { findMany, update } }, findMany, update };
+  const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+  return { db: { workCapsule: { findMany, updateMany } }, findMany, updateMany };
 }
 
 describe("captureBuildPrOntoCapsule (delivery visibility — PR capture onto the WorkCapsule)", () => {
   it("stamps url + number onto the build's capsule(s), keyed by featureBuildId (the cuid)", async () => {
-    const { db, update } = mkDb(1);
+    const { db, updateMany } = mkDb(1);
     const out = await captureBuildPrOntoCapsule({
       db,
       featureBuildId: "ckcuid123",
       prNumber: 2145,
       prUrl: "https://github.com/o/r/pull/2145",
     });
-    expect(update).toHaveBeenCalledWith({
-      where: { id: "capsule-1" },
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "capsule-1", updatedAt: new Date("2026-07-27T00:00:00Z") },
       data: expect.objectContaining({
         pullRequestUrl: "https://github.com/o/r/pull/2145",
         pullRequestNumber: 2145,

--- a/apps/web/lib/build/capture-build-pr.test.ts
+++ b/apps/web/lib/build/capture-build-pr.test.ts
@@ -3,22 +3,42 @@ import { describe, expect, it, vi } from "vitest";
 import { captureBuildPrOntoCapsule } from "./capture-build-pr";
 
 function mkDb(count = 1) {
-  const updateMany = vi.fn().mockResolvedValue({ count });
-  return { db: { workCapsule: { updateMany } }, updateMany };
+  const findMany = vi.fn().mockResolvedValue(
+    Array.from({ length: count }, (_, index) => ({
+      id: `capsule-${index + 1}`,
+      workspaceState: { retained: true },
+    })),
+  );
+  const update = vi.fn().mockResolvedValue({});
+  return { db: { workCapsule: { findMany, update } }, findMany, update };
 }
 
 describe("captureBuildPrOntoCapsule (delivery visibility — PR capture onto the WorkCapsule)", () => {
   it("stamps url + number onto the build's capsule(s), keyed by featureBuildId (the cuid)", async () => {
-    const { db, updateMany } = mkDb(1);
+    const { db, update } = mkDb(1);
     const out = await captureBuildPrOntoCapsule({
       db,
       featureBuildId: "ckcuid123",
       prNumber: 2145,
       prUrl: "https://github.com/o/r/pull/2145",
     });
-    expect(updateMany).toHaveBeenCalledWith({
-      where: { featureBuildId: "ckcuid123" },
-      data: { pullRequestUrl: "https://github.com/o/r/pull/2145", pullRequestNumber: 2145 },
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "capsule-1" },
+      data: expect.objectContaining({
+        pullRequestUrl: "https://github.com/o/r/pull/2145",
+        pullRequestNumber: 2145,
+        workspaceState: expect.objectContaining({
+          retained: true,
+          buildStudio: expect.objectContaining({
+            delivery: expect.objectContaining({
+              schemaVersion: 1,
+              status: "created",
+              repository: "o/r",
+              prNumber: 2145,
+            }),
+          }),
+        }),
+      }),
     });
     expect(out).toEqual({ captured: 1 });
   });
@@ -30,25 +50,25 @@ describe("captureBuildPrOntoCapsule (delivery visibility — PR capture onto the
   });
 
   it("is a no-op (no DB write) when featureBuildId is blank", async () => {
-    const { db, updateMany } = mkDb();
+    const { db, findMany } = mkDb();
     const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "", prNumber: 5, prUrl: "u" });
-    expect(updateMany).not.toHaveBeenCalled();
+    expect(findMany).not.toHaveBeenCalled();
     expect(out).toEqual({ captured: 0 });
   });
 
   it("is a no-op when prUrl is empty", async () => {
-    const { db, updateMany } = mkDb();
+    const { db, findMany } = mkDb();
     const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "c", prNumber: 5, prUrl: "" });
-    expect(updateMany).not.toHaveBeenCalled();
+    expect(findMany).not.toHaveBeenCalled();
     expect(out).toEqual({ captured: 0 });
   });
 
   it("is a no-op when prNumber is not a positive finite number", async () => {
-    const { db, updateMany } = mkDb();
+    const { db, findMany } = mkDb();
     for (const bad of [0, -3, Number.NaN, Number.POSITIVE_INFINITY]) {
       const out = await captureBuildPrOntoCapsule({ db, featureBuildId: "c", prNumber: bad, prUrl: "u" });
       expect(out).toEqual({ captured: 0 });
     }
-    expect(updateMany).not.toHaveBeenCalled();
+    expect(findMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/build/capture-build-pr.ts
+++ b/apps/web/lib/build/capture-build-pr.ts
@@ -23,6 +23,7 @@
 // build with no capsule yet (or missing inputs) is a non-error that returns
 // `{ captured: 0 }` rather than throwing.
 
+import type { Prisma } from "@dpf/db";
 import {
   createBuildPrDeliveryState,
   writeBuildPrDeliveryState,
@@ -40,7 +41,11 @@ export interface CaptureBuildPrDeps {
     }): Promise<Array<{ id: string; workspaceState: unknown; updatedAt: Date }>>;
     updateMany(args: {
       where: { id: string; updatedAt: Date };
-      data: { pullRequestUrl: string; pullRequestNumber: number; workspaceState: Record<string, unknown> };
+      data: {
+        pullRequestUrl: string;
+        pullRequestNumber: number;
+        workspaceState: Prisma.InputJsonValue;
+      };
     }): Promise<{ count: number }>;
   };
 }
@@ -72,7 +77,10 @@ export async function persistBuildPrDeliveryStateForBuild(input: {
       data: {
         pullRequestUrl: input.delivery.prUrl,
         pullRequestNumber: input.delivery.prNumber,
-        workspaceState: writeBuildPrDeliveryState(capsule.workspaceState, input.delivery),
+        workspaceState: writeBuildPrDeliveryState(
+          capsule.workspaceState,
+          input.delivery,
+        ) as unknown as Prisma.InputJsonValue,
       },
     }),
   ));

--- a/apps/web/lib/build/capture-build-pr.ts
+++ b/apps/web/lib/build/capture-build-pr.ts
@@ -34,12 +34,12 @@ export interface CaptureBuildPrDeps {
   workCapsule: {
     findMany: (args: {
       where: { featureBuildId: string };
-      select: { id: true; workspaceState: true };
-    }) => Promise<Array<{ id: string; workspaceState: unknown }>>;
-    update: (args: {
-      where: { id: string };
+      select: { id: true; workspaceState: true; updatedAt: true };
+    }) => Promise<Array<{ id: string; workspaceState: unknown; updatedAt: Date }>>;
+    updateMany: (args: {
+      where: { id: string; updatedAt: Date };
       data: { pullRequestUrl: string; pullRequestNumber: number; workspaceState: Record<string, unknown> };
-    }) => Promise<unknown>;
+    }) => Promise<{ count: number }>;
   };
 }
 
@@ -62,11 +62,11 @@ export async function persistBuildPrDeliveryStateForBuild(input: {
 }): Promise<number> {
   const capsules = await input.db.workCapsule.findMany({
     where: { featureBuildId: input.featureBuildId },
-    select: { id: true, workspaceState: true },
+    select: { id: true, workspaceState: true, updatedAt: true },
   });
-  await Promise.all(capsules.map((capsule) =>
-    input.db.workCapsule.update({
-      where: { id: capsule.id },
+  const writes = await Promise.all(capsules.map((capsule) =>
+    input.db.workCapsule.updateMany({
+      where: { id: capsule.id, updatedAt: capsule.updatedAt },
       data: {
         pullRequestUrl: input.delivery.prUrl,
         pullRequestNumber: input.delivery.prNumber,
@@ -74,7 +74,7 @@ export async function persistBuildPrDeliveryStateForBuild(input: {
       },
     }),
   ));
-  return capsules.length;
+  return writes.reduce((total, write) => total + write.count, 0);
 }
 
 /**

--- a/apps/web/lib/build/capture-build-pr.ts
+++ b/apps/web/lib/build/capture-build-pr.ts
@@ -23,13 +23,23 @@
 // build with no capsule yet (or missing inputs) is a non-error that returns
 // `{ captured: 0 }` rather than throwing.
 
+import {
+  createBuildPrDeliveryState,
+  writeBuildPrDeliveryState,
+  type BuildPrDeliveryStateV1,
+} from "./build-pr-delivery-state";
+
 /** The narrow slice of the Prisma client this helper needs (injectable for tests). */
 export interface CaptureBuildPrDeps {
   workCapsule: {
-    updateMany: (args: {
+    findMany: (args: {
       where: { featureBuildId: string };
-      data: { pullRequestUrl: string; pullRequestNumber: number };
-    }) => Promise<{ count: number }>;
+      select: { id: true; workspaceState: true };
+    }) => Promise<Array<{ id: string; workspaceState: unknown }>>;
+    update: (args: {
+      where: { id: string };
+      data: { pullRequestUrl: string; pullRequestNumber: number; workspaceState: Record<string, unknown> };
+    }) => Promise<unknown>;
   };
 }
 
@@ -42,6 +52,29 @@ export interface CaptureBuildPrArgs {
   featureBuildId: string;
   prNumber: number;
   prUrl: string;
+  repository?: string;
+}
+
+export async function persistBuildPrDeliveryStateForBuild(input: {
+  db: CaptureBuildPrDeps;
+  featureBuildId: string;
+  delivery: BuildPrDeliveryStateV1;
+}): Promise<number> {
+  const capsules = await input.db.workCapsule.findMany({
+    where: { featureBuildId: input.featureBuildId },
+    select: { id: true, workspaceState: true },
+  });
+  await Promise.all(capsules.map((capsule) =>
+    input.db.workCapsule.update({
+      where: { id: capsule.id },
+      data: {
+        pullRequestUrl: input.delivery.prUrl,
+        pullRequestNumber: input.delivery.prNumber,
+        workspaceState: writeBuildPrDeliveryState(capsule.workspaceState, input.delivery),
+      },
+    }),
+  ));
+  return capsules.length;
 }
 
 /**
@@ -62,9 +95,17 @@ export async function captureBuildPrOntoCapsule(
     return { captured: 0 };
   }
 
-  const res = await db.workCapsule.updateMany({
-    where: { featureBuildId },
-    data: { pullRequestUrl: prUrl, pullRequestNumber: prNumber },
-  });
-  return { captured: res.count };
+  const repository = args.repository ?? (() => {
+    try {
+      const url = new URL(prUrl);
+      return url.pathname.split("/").filter(Boolean).slice(0, 2).join("/");
+    } catch {
+      return "";
+    }
+  })();
+  if (!repository) return { captured: 0 };
+
+  const delivery = createBuildPrDeliveryState({ repository, prNumber, prUrl });
+  const captured = await persistBuildPrDeliveryStateForBuild({ db, featureBuildId, delivery });
+  return { captured };
 }

--- a/apps/web/lib/build/capture-build-pr.ts
+++ b/apps/web/lib/build/capture-build-pr.ts
@@ -32,14 +32,16 @@ import {
 /** The narrow slice of the Prisma client this helper needs (injectable for tests). */
 export interface CaptureBuildPrDeps {
   workCapsule: {
-    findMany: (args: {
+    // Method syntax keeps the real Prisma delegate assignable under
+    // strictFunctionTypes while preserving the narrow test-double contract.
+    findMany(args: {
       where: { featureBuildId: string };
       select: { id: true; workspaceState: true; updatedAt: true };
-    }) => Promise<Array<{ id: string; workspaceState: unknown; updatedAt: Date }>>;
-    updateMany: (args: {
+    }): Promise<Array<{ id: string; workspaceState: unknown; updatedAt: Date }>>;
+    updateMany(args: {
       where: { id: string; updatedAt: Date };
       data: { pullRequestUrl: string; pullRequestNumber: number; workspaceState: Record<string, unknown> };
-    }) => Promise<{ count: number }>;
+    }): Promise<{ count: number }>;
   };
 }
 

--- a/apps/web/lib/build/customer-status-loader.test.ts
+++ b/apps/web/lib/build/customer-status-loader.test.ts
@@ -8,10 +8,10 @@ const RECENT = new Date(NOW.getTime() - 5 * 60 * 1000);
 const STALE = new Date(NOW.getTime() - STALLED_BUILD_REAP_MS - 60_000);
 
 function dbWith(
-  capsuleRows: Array<{ featureBuildId: string | null; capsuleId: string; status: string }>,
+  capsuleRows: Array<{ featureBuildId: string | null; capsuleId: string; status: string; workspaceState?: unknown }>,
   activityRows: Array<{ buildId: string; _max: { createdAt: Date | null } }> = [],
 ) {
-  const findMany = vi.fn().mockResolvedValue(capsuleRows);
+  const findMany = vi.fn().mockResolvedValue(capsuleRows.map((row) => ({ workspaceState: {}, ...row })));
   const groupBy = vi.fn().mockResolvedValue(activityRows);
   return { db: { workCapsule: { findMany }, buildActivity: { groupBy } }, findMany, groupBy };
 }

--- a/apps/web/lib/build/customer-status-loader.ts
+++ b/apps/web/lib/build/customer-status-loader.ts
@@ -26,8 +26,8 @@ export interface CapsuleFindManyDelegate {
   workCapsule: {
     findMany: (args: {
       where: { featureBuildId: { in: string[] } };
-      select: { featureBuildId: true; capsuleId: true; status: true };
-    }) => Promise<Array<{ featureBuildId: string | null; capsuleId: string; status: string }>>;
+      select: { featureBuildId: true; capsuleId: true; status: true; workspaceState: true };
+    }) => Promise<Array<{ featureBuildId: string | null; capsuleId: string; status: string; workspaceState: unknown }>>;
   };
   buildActivity: {
     groupBy: (args: {
@@ -65,16 +65,20 @@ export async function loadBuildStudioCustomerStatuses(
 ): Promise<Record<string, BuildStudioCustomerStatus>> {
   const ids = Array.from(new Set(builds.map((b) => b.id)));
   const buildIds = Array.from(new Set(builds.map((b) => b.buildId)));
-  const byBuild = new Map<string, { capsuleId: string; status: string }>();
+  const byBuild = new Map<string, { capsuleId: string; status: string; workspaceState: unknown }>();
   const lastActivityByBuildId = new Map<string, Date>();
   if (ids.length > 0) {
     const capsules = await db.workCapsule.findMany({
       where: { featureBuildId: { in: ids } },
-      select: { featureBuildId: true, capsuleId: true, status: true },
+      select: { featureBuildId: true, capsuleId: true, status: true, workspaceState: true },
     });
     for (const capsule of capsules) {
       if (capsule.featureBuildId) {
-        byBuild.set(capsule.featureBuildId, { capsuleId: capsule.capsuleId, status: capsule.status });
+        byBuild.set(capsule.featureBuildId, {
+          capsuleId: capsule.capsuleId,
+          status: capsule.status,
+          workspaceState: capsule.workspaceState,
+        });
       }
     }
   }

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -2,10 +2,41 @@ import { describe, expect, it } from "vitest";
 
 import { projectBuildStudioCustomerStatus } from "./customer-status-projection";
 import { STALLED_BUILD_REAP_MS } from "./inert-build-reaper";
+import { createBuildPrDeliveryState, writeBuildPrDeliveryState } from "./build-pr-delivery-state";
 
 const build = { title: "Add a dark-mode toggle", phase: "build" as const, updatedAt: new Date("2026-07-20T00:00:00Z") };
 
 describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
+  it.each([
+    ["checking", "Checking the pull request", false],
+    ["updating", "Finalizing against the latest platform", false],
+    ["queued", "Merge queued", false],
+    ["awaiting-release", "Waiting for governed release", false],
+    ["deployed", "Deployed", false],
+    ["escalated", "Needs your decision", true],
+    ["closed", "Needs your decision", true],
+  ] as const)("projects delivery state %s honestly", (deliveryStatus, label, needsYou) => {
+    const delivery = {
+      ...createBuildPrDeliveryState({
+        repository: "o/r",
+        prNumber: 42,
+        prUrl: "https://github.com/o/r/pull/42",
+      }),
+      status: deliveryStatus,
+      lastError: deliveryStatus === "escalated" ? "true-merge-conflict" : null,
+    };
+    const status = projectBuildStudioCustomerStatus({
+      build: { ...build, phase: "ship" },
+      capsule: {
+        capsuleId: "WC-1",
+        status: "working",
+        workspaceState: writeBuildPrDeliveryState({}, delivery),
+      },
+    });
+    expect(status.lifecyclePosition).toBe(label);
+    expect(status.needsYou).toBe(needsYou);
+  });
+
   it("derives a plain customer status from the linked capsule (blocked → automated work, needs you)", () => {
     const status = projectBuildStudioCustomerStatus({
       build,

--- a/apps/web/lib/build/customer-status-projection.ts
+++ b/apps/web/lib/build/customer-status-projection.ts
@@ -36,6 +36,8 @@ export interface BuildStudioCustomerStatus {
   worker: string;
   /** Plain evidence behind the status, safe for customer/operator display. */
   evidence: string;
+  /** Contributor diagnostics, rendered only behind progressive disclosure. */
+  technicalEvidence?: string;
   /** One concrete next action that moves the work forward. */
   nextAction: string;
   /** The accountable owner for the next action. */
@@ -201,9 +203,16 @@ export function projectBuildStudioCustomerStatus(args: {
   if (delivery) {
     const base = {
       whatIsBeingBuilt: args.build.title,
-      evidence: delivery.lastObservedHeadSha
-        ? `Delivery evidence is current at ${delivery.lastObservedHeadSha.slice(0, 12)}.`
+      evidence: delivery.lastObservedAt
+        ? "Build Studio checked the current delivery state."
         : "Build Studio is gathering current delivery evidence.",
+      technicalEvidence: [
+        `PR #${delivery.prNumber}`,
+        delivery.lastObservedHeadSha ? `head ${delivery.lastObservedHeadSha.slice(0, 12)}` : null,
+        `observations ${delivery.reconciliationAttempts}`,
+        `stale updates ${delivery.staleUpdateAttempts}`,
+        delivery.lastError ? `last result ${delivery.lastError}` : null,
+      ].filter(Boolean).join(" · "),
     };
     switch (delivery.status) {
       case "created":

--- a/apps/web/lib/build/customer-status-projection.ts
+++ b/apps/web/lib/build/customer-status-projection.ts
@@ -25,6 +25,7 @@ import { projectWorkCaseState } from "@/lib/work-management/status-projection";
 import type { WorkCaseState } from "@/lib/work-management/case-types";
 import type { BuildPhase } from "@/lib/explore/feature-build-types";
 import { STALLED_BUILD_REAP_MS } from "@/lib/build/inert-build-reaper";
+import { readBuildPrDeliveryState } from "@/lib/build/build-pr-delivery-state";
 
 export interface BuildStudioCustomerStatus {
   /** Plain restatement of what is being built (the build title). */
@@ -192,10 +193,81 @@ function isActivityStale(args: {
 
 export function projectBuildStudioCustomerStatus(args: {
   build: { title: string; phase: BuildPhase; updatedAt: Date };
-  capsule: { capsuleId: string; status: string } | null;
+  capsule: { capsuleId: string; status: string; workspaceState?: unknown } | null;
   /** Activity-freshness signal (BI-46204009). Omit to skip the stall check (e.g. existing callers mid-migration). */
   activity?: { lastActivityAt: Date | null; now?: Date };
 }): BuildStudioCustomerStatus {
+  const delivery = readBuildPrDeliveryState(args.capsule?.workspaceState);
+  if (delivery) {
+    const base = {
+      whatIsBeingBuilt: args.build.title,
+      evidence: delivery.lastObservedHeadSha
+        ? `Delivery evidence is current at ${delivery.lastObservedHeadSha.slice(0, 12)}.`
+        : "Build Studio is gathering current delivery evidence.",
+    };
+    switch (delivery.status) {
+      case "created":
+      case "checking":
+        return {
+          ...base,
+          lifecyclePosition: "Checking the pull request",
+          worker: "Checking delivery evidence",
+          nextAction: "wait while current checks and review evidence finish.",
+          owner: "Build Studio",
+          needsYou: false,
+        };
+      case "updating":
+        return {
+          ...base,
+          lifecyclePosition: "Finalizing against the latest platform",
+          worker: "Updating the proposed change",
+          nextAction: "rerun checks against the updated platform.",
+          owner: "Build Studio",
+          needsYou: false,
+        };
+      case "queued":
+        return {
+          ...base,
+          lifecyclePosition: "Merge queued",
+          worker: "Repository merge queue",
+          nextAction: "wait for the protected merge queue to finish.",
+          owner: "Build Studio",
+          needsYou: false,
+        };
+      case "awaiting-release":
+        return {
+          ...base,
+          lifecyclePosition: "Waiting for governed release",
+          worker: "Governed release process",
+          nextAction: "wait for governed self-upgrade and live-version evidence.",
+          owner: "Build Studio",
+          needsYou: false,
+        };
+      case "deployed":
+        return {
+          ...base,
+          lifecyclePosition: "Deployed",
+          worker: "Finished",
+          nextAction: "review the completed result.",
+          owner: "reviewer",
+          needsYou: false,
+        };
+      case "closed":
+      case "escalated":
+        return {
+          ...base,
+          lifecyclePosition: "Needs your decision",
+          worker: "Waiting for you",
+          evidence: delivery.lastError
+            ? `Autonomous delivery stopped: ${delivery.lastError}.`
+            : "Autonomous delivery stopped safely.",
+          nextAction: "review the delivery issue and decide how to continue.",
+          owner: "human decision-maker",
+          needsYou: true,
+        };
+    }
+  }
+
   const base: BuildStudioCustomerStatus = args.capsule
     ? (() => {
         const projection = projectWorkCaseState({ capsule: args.capsule! });

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8843,7 +8843,7 @@
         "database-backups",
         "pull-requests-and-security-gates",
         "pre-pr-security-gates",
-        "auto-merge",
+        "autonomous-merge-queue-delivery",
         "configuration",
         "safety-guarantees"
       ]

--- a/apps/web/lib/integrate/github-api-commit.ts
+++ b/apps/web/lib/integrate/github-api-commit.ts
@@ -467,6 +467,7 @@ export interface PRStatus {
   mergeable: boolean | null;
   title: string;
   checksPass: boolean | null;
+  headSha: string;
 }
 
 /**
@@ -487,13 +488,14 @@ export async function getPRStatus(input: {
     merged: boolean;
     mergeable: boolean | null;
     title: string;
+    head: { sha: string };
   }>(`${apiBase}/pulls/${prNumber}`, token);
 
   // Check combined status for the head SHA
   let checksPass: boolean | null = null;
   try {
     const checks = await githubGet<{ state: string }>(
-      `${apiBase}/commits/${pr.number}/status`,
+      `${apiBase}/commits/${pr.head.sha}/status`,
       token,
     );
     checksPass = checks.state === "success";
@@ -508,6 +510,7 @@ export async function getPRStatus(input: {
     mergeable: pr.mergeable,
     title: pr.title,
     checksPass,
+    headSha: pr.head.sha,
   };
 }
 

--- a/apps/web/lib/integrate/github-pr-readiness.test.ts
+++ b/apps/web/lib/integrate/github-pr-readiness.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  projectGithubPrReadiness,
+  updatePullRequestBranch,
+  type GithubPrObservation,
+} from "./github-pr-readiness";
+
+function observed(overrides: Partial<GithubPrObservation> = {}): GithubPrObservation {
+  return {
+    nodeId: "PR_node",
+    number: 42,
+    url: "https://github.com/o/r/pull/42",
+    state: "OPEN",
+    merged: false,
+    headSha: "abc123",
+    mergeStateStatus: "CLEAN",
+    unresolvedReviewThreads: 0,
+    reviewThreadsComplete: true,
+    checksComplete: true,
+    checks: [{ name: "test", status: "COMPLETED", conclusion: "SUCCESS" }],
+    autoMergeEnabled: false,
+    mergeQueueEntry: false,
+    ...overrides,
+  };
+}
+
+describe("projectGithubPrReadiness", () => {
+  it("requires an open, current PR with terminal passing checks and no unresolved threads", () => {
+    expect(projectGithubPrReadiness(observed())).toEqual({
+      kind: "ready",
+      headSha: "abc123",
+    });
+  });
+
+  it.each([
+    [{ checks: [{ name: "test", status: "IN_PROGRESS", conclusion: null }] }, "checks-pending"],
+    [{ checks: [{ name: "test", status: "COMPLETED", conclusion: "FAILURE" }] }, "checks-failing"],
+    [{ unresolvedReviewThreads: 1 }, "review-threads-unresolved"],
+    [{ checksComplete: false }, "checks-incomplete"],
+    [{ reviewThreadsComplete: false }, "review-threads-incomplete"],
+  ] as const)("parks incomplete evidence (%s)", (overrides, reason) => {
+    expect(projectGithubPrReadiness(observed(overrides))).toEqual({
+      kind: "checking",
+      headSha: "abc123",
+      reason,
+    });
+  });
+
+  it("classifies stale heads for safe update", () => {
+    expect(projectGithubPrReadiness(observed({ mergeStateStatus: "BEHIND" }))).toEqual({
+      kind: "behind",
+      headSha: "abc123",
+    });
+  });
+
+  it("classifies true conflicts for escalation", () => {
+    expect(projectGithubPrReadiness(observed({ mergeStateStatus: "DIRTY" }))).toEqual({
+      kind: "conflict",
+      headSha: "abc123",
+    });
+  });
+
+  it("honors merged and closed-unmerged PRs", () => {
+    expect(projectGithubPrReadiness(observed({ state: "MERGED", merged: true }))).toEqual({
+      kind: "merged",
+      headSha: "abc123",
+    });
+    expect(projectGithubPrReadiness(observed({ state: "CLOSED" }))).toEqual({
+      kind: "closed",
+      headSha: "abc123",
+    });
+  });
+
+  it("recognizes queue enrollment without actuating it again", () => {
+    expect(projectGithubPrReadiness(observed({ autoMergeEnabled: true }))).toEqual({
+      kind: "queued",
+      headSha: "abc123",
+    });
+    expect(projectGithubPrReadiness(observed({ mergeQueueEntry: true }))).toEqual({
+      kind: "queued",
+      headSha: "abc123",
+    });
+  });
+
+  it("fails closed on missing identity or an unstable merge state", () => {
+    expect(projectGithubPrReadiness(observed({ headSha: "" }))).toEqual({
+      kind: "unknown",
+      headSha: null,
+      reason: "missing-head-sha",
+    });
+    expect(projectGithubPrReadiness(observed({ mergeStateStatus: "UNKNOWN" }))).toEqual({
+      kind: "unknown",
+      headSha: "abc123",
+      reason: "merge-state-unknown",
+    });
+  });
+});
+
+describe("updatePullRequestBranch", () => {
+  it("sends the expected head SHA and recognizes compare-and-swap loss", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 422 });
+    await expect(updatePullRequestBranch({
+      owner: "o",
+      repo: "r",
+      prNumber: 42,
+      expectedHeadSha: "abc123",
+      token: "secret",
+      fetchImpl: fetchImpl as never,
+    })).resolves.toBe("head-changed");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.github.com/repos/o/r/pulls/42/update-branch",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ expected_head_sha: "abc123" }),
+      }),
+    );
+  });
+
+  it("accepts only GitHub's asynchronous update response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 202 });
+    await expect(updatePullRequestBranch({
+      owner: "o",
+      repo: "r",
+      prNumber: 42,
+      expectedHeadSha: "abc123",
+      token: "secret",
+      fetchImpl: fetchImpl as never,
+    })).resolves.toBe("accepted");
+  });
+});

--- a/apps/web/lib/integrate/github-pr-readiness.test.ts
+++ b/apps/web/lib/integrate/github-pr-readiness.test.ts
@@ -39,13 +39,16 @@ describe("projectGithubPrReadiness", () => {
     [{ unresolvedReviewThreads: 1 }, "review-threads-unresolved"],
     [{ checksComplete: false }, "checks-incomplete"],
     [{ reviewThreadsComplete: false }, "review-threads-incomplete"],
-  ] as const)("parks incomplete evidence (%s)", (overrides, reason) => {
-    expect(projectGithubPrReadiness(observed(overrides))).toEqual({
-      kind: "checking",
-      headSha: "abc123",
-      reason,
-    });
-  });
+  ] satisfies Array<[Partial<GithubPrObservation>, string]>)(
+    "parks incomplete evidence (%s)",
+    (overrides, reason) => {
+      expect(projectGithubPrReadiness(observed(overrides))).toEqual({
+        kind: "checking",
+        headSha: "abc123",
+        reason,
+      });
+    },
+  );
 
   it("classifies stale heads for safe update", () => {
     expect(projectGithubPrReadiness(observed({ mergeStateStatus: "BEHIND" }))).toEqual({

--- a/apps/web/lib/integrate/github-pr-readiness.ts
+++ b/apps/web/lib/integrate/github-pr-readiness.ts
@@ -1,0 +1,292 @@
+/**
+ * Shared GitHub pull-request readiness and merge-queue actuation.
+ *
+ * Read decisions are exact-head and fail closed. Mutations are intentionally
+ * limited to update-branch (compare-and-swap) and enable-auto-merge; this module
+ * has no direct merge or force-push operation.
+ */
+
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+const GITHUB_API_VERSION = "2022-11-28";
+
+export type GithubCheckObservation = {
+  name: string;
+  status: string;
+  conclusion: string | null;
+};
+
+export type GithubPrObservation = {
+  nodeId: string;
+  number: number;
+  url: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  merged: boolean;
+  headSha: string;
+  mergeStateStatus: string | null;
+  unresolvedReviewThreads: number;
+  reviewThreadsComplete: boolean;
+  checksComplete: boolean;
+  checks: GithubCheckObservation[];
+  autoMergeEnabled: boolean;
+  mergeQueueEntry: boolean;
+};
+
+export type GithubPrReadiness =
+  | { kind: "ready" | "behind" | "conflict" | "queued" | "merged" | "closed"; headSha: string }
+  | { kind: "checking" | "unknown"; headSha: string | null; reason: string };
+
+const PASSING_CHECK_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+
+export function projectGithubPrReadiness(observation: GithubPrObservation): GithubPrReadiness {
+  const headSha = observation.headSha.trim();
+  if (!headSha) return { kind: "unknown", headSha: null, reason: "missing-head-sha" };
+  if (observation.merged || observation.state === "MERGED") return { kind: "merged", headSha };
+  if (observation.state === "CLOSED") return { kind: "closed", headSha };
+  if (observation.autoMergeEnabled || observation.mergeQueueEntry) return { kind: "queued", headSha };
+
+  const mergeState = (observation.mergeStateStatus ?? "").toUpperCase();
+  if (mergeState === "DIRTY") return { kind: "conflict", headSha };
+  if (mergeState === "BEHIND") return { kind: "behind", headSha };
+
+  if (!observation.reviewThreadsComplete) {
+    return { kind: "checking", headSha, reason: "review-threads-incomplete" };
+  }
+  if (observation.unresolvedReviewThreads > 0) {
+    return { kind: "checking", headSha, reason: "review-threads-unresolved" };
+  }
+  if (!observation.checksComplete) {
+    return { kind: "checking", headSha, reason: "checks-incomplete" };
+  }
+  if (observation.checks.some((check) => check.status.toUpperCase() !== "COMPLETED")) {
+    return { kind: "checking", headSha, reason: "checks-pending" };
+  }
+  if (
+    observation.checks.some(
+      (check) => !check.conclusion || !PASSING_CHECK_CONCLUSIONS.has(check.conclusion.toUpperCase()),
+    )
+  ) {
+    return { kind: "checking", headSha, reason: "checks-failing" };
+  }
+  if (!["CLEAN", "HAS_HOOKS", "UNSTABLE"].includes(mergeState)) {
+    return { kind: "unknown", headSha, reason: "merge-state-unknown" };
+  }
+  return { kind: "ready", headSha };
+}
+
+type GithubGraphqlEnvelope<T> = { data?: T; errors?: Array<{ message?: string }> };
+
+export async function githubGraphql<T>(input: {
+  token: string;
+  query: string;
+  variables: Record<string, unknown>;
+  fetchImpl?: typeof fetch;
+}): Promise<T> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(GITHUB_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${input.token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "dpf-github-pr-readiness",
+      "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    },
+    body: JSON.stringify({ query: input.query, variables: input.variables }),
+  });
+  if (!response.ok) throw new Error(`GitHub GraphQL HTTP ${response.status}`);
+  const envelope = (await response.json()) as GithubGraphqlEnvelope<T>;
+  if (envelope.errors?.length) {
+    throw new Error(`GitHub GraphQL error: ${envelope.errors[0]?.message ?? "unknown"}`);
+  }
+  if (!envelope.data) throw new Error("GitHub GraphQL returned no data");
+  return envelope.data;
+}
+
+const PR_OBSERVATION_QUERY = `
+query DpfPullRequestReadiness($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      id number url state merged headRefOid mergeStateStatus
+      autoMergeRequest { enabledAt }
+      mergeQueueEntry { id }
+      reviewThreads(first:100){ nodes { isResolved } pageInfo { hasNextPage } }
+      commits(last:1){
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first:100) {
+                nodes {
+                  ... on CheckRun { name status conclusion }
+                  ... on StatusContext { context state }
+                }
+                pageInfo { hasNextPage }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+type ObservationQueryData = {
+  repository?: {
+    pullRequest?: {
+      id?: string;
+      number?: number;
+      url?: string;
+      state?: "OPEN" | "CLOSED" | "MERGED";
+      merged?: boolean;
+      headRefOid?: string;
+      mergeStateStatus?: string | null;
+      autoMergeRequest?: { enabledAt?: string } | null;
+      mergeQueueEntry?: { id?: string } | null;
+      reviewThreads?: {
+        nodes?: Array<{ isResolved?: boolean } | null>;
+        pageInfo?: { hasNextPage?: boolean };
+      };
+      commits?: {
+        nodes?: Array<{
+          commit?: {
+            statusCheckRollup?: {
+              contexts?: {
+                nodes?: Array<{
+                  name?: string;
+                  status?: string;
+                  conclusion?: string | null;
+                  context?: string;
+                  state?: string;
+                } | null>;
+                pageInfo?: { hasNextPage?: boolean };
+              };
+            } | null;
+          };
+        } | null>;
+      };
+    } | null;
+  } | null;
+};
+
+export async function observeGithubPullRequest(input: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): Promise<GithubPrObservation> {
+  const data = await githubGraphql<ObservationQueryData>({
+    token: input.token,
+    query: PR_OBSERVATION_QUERY,
+    variables: { owner: input.owner, name: input.repo, number: input.prNumber },
+    fetchImpl: input.fetchImpl,
+  });
+  const pr = data.repository?.pullRequest;
+  if (!pr?.id || !pr.number || !pr.url || !pr.state || !pr.headRefOid) {
+    throw new Error(`GitHub PR #${input.prNumber} observation is incomplete`);
+  }
+
+  const contexts = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts;
+  const checks: GithubCheckObservation[] = (contexts?.nodes ?? []).flatMap((node) => {
+    if (!node) return [];
+    if (node.context) {
+      const state = node.state ?? "UNKNOWN";
+      return [{
+        name: node.context,
+        status: state === "PENDING" || state === "EXPECTED" ? "IN_PROGRESS" : "COMPLETED",
+        conclusion: state === "SUCCESS" ? "SUCCESS" : state,
+      }];
+    }
+    return [{ name: node.name ?? "unnamed-check", status: node.status ?? "UNKNOWN", conclusion: node.conclusion ?? null }];
+  });
+
+  return {
+    nodeId: pr.id,
+    number: pr.number,
+    url: pr.url,
+    state: pr.state,
+    merged: pr.merged === true,
+    headSha: pr.headRefOid,
+    mergeStateStatus: pr.mergeStateStatus ?? null,
+    unresolvedReviewThreads: (pr.reviewThreads?.nodes ?? []).filter((thread) => thread?.isResolved === false).length,
+    reviewThreadsComplete: pr.reviewThreads?.pageInfo?.hasNextPage !== true,
+    checksComplete: contexts?.pageInfo?.hasNextPage !== true,
+    checks,
+    autoMergeEnabled: Boolean(pr.autoMergeRequest),
+    mergeQueueEntry: Boolean(pr.mergeQueueEntry),
+  };
+}
+
+const ENABLE_AUTOMERGE_MUTATION = `
+mutation DpfEnableAutoMerge($id:ID!){
+  enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}) {
+    pullRequest { number }
+  }
+}`;
+
+const PR_NODE_ID_QUERY = `
+query DpfPullRequestNodeId($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){pullRequest(number:$number){id}}
+}`;
+
+export async function resolvePullRequestNodeId(input: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): Promise<string> {
+  const data = await githubGraphql<{
+    repository?: { pullRequest?: { id?: string } | null } | null;
+  }>({
+    token: input.token,
+    query: PR_NODE_ID_QUERY,
+    variables: { owner: input.owner, name: input.repo, number: input.prNumber },
+    fetchImpl: input.fetchImpl,
+  });
+  const nodeId = data.repository?.pullRequest?.id;
+  if (!nodeId) throw new Error(`Could not resolve GitHub node id for PR #${input.prNumber}`);
+  return nodeId;
+}
+
+export async function enablePullRequestAutoMerge(input: {
+  nodeId: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  await githubGraphql({
+    token: input.token,
+    query: ENABLE_AUTOMERGE_MUTATION,
+    variables: { id: input.nodeId },
+    fetchImpl: input.fetchImpl,
+  });
+}
+
+export type UpdatePullRequestBranchResult = "accepted" | "head-changed";
+
+export async function updatePullRequestBranch(input: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  expectedHeadSha: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): Promise<UpdatePullRequestBranchResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${encodeURIComponent(input.owner)}/${encodeURIComponent(input.repo)}/pulls/${input.prNumber}/update-branch`,
+    {
+      method: "PUT",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${input.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "dpf-github-pr-readiness",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+      },
+      body: JSON.stringify({ expected_head_sha: input.expectedHeadSha }),
+    },
+  );
+  if (response.status === 202) return "accepted";
+  if (response.status === 422) return "head-changed";
+  throw new Error(`GitHub update-branch HTTP ${response.status}`);
+}

--- a/apps/web/lib/mcp/build-ship-handlers.ts
+++ b/apps/web/lib/mcp/build-ship-handlers.ts
@@ -535,7 +535,7 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
   if (gateResult.requiresHumanReview) labels.push("needs-review");
   if (!typecheckPassed || testsFailed > 0) labels.push("verification-issues");
 
-  const { createBranchAndPR, mergePR, commentOnPR } = await import("@/lib/integrate/github-api-commit");
+  const { createBranchAndPR, commentOnPR } = await import("@/lib/integrate/github-api-commit");
 
   const prResult = await createBranchAndPR({
     headOwner: repoOwner,
@@ -561,75 +561,41 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
     };
   }
 
-  // Capture the PR onto the build's Work Capsule so it becomes a queryable,
-  // surfaceable fact (delivery visibility). The capsule's pullRequestUrl/
-  // Number are READ by the change-lanes projection, the runtime-target
-  // rollup, and the capsule presenters, but had no writer at PR-creation
-  // time — so a build's PR stayed invisible until a delayed branch-name-
-  // matched GitHub inventory snapshot backfilled it (or never). Migration-
-  // free + best-effort: opening the PR must never hinge on this write.
+  // Integration decision: all local gates pass + build fully verified. GitHub
+  // remains authoritative for current-head checks, review threads, branch
+  // freshness, and merge-queue policy. A PR merge is NOT deployment.
+  const fullyVerified = typecheckPassed && testsFailed === 0 && acMet === acTotal && acTotal > 0;
+  let deliveryState = "awaiting-review";
   try {
-    const { captureBuildPrOntoCapsule } = await import("@/lib/build/capture-build-pr");
-    const cap = await captureBuildPrOntoCapsule({
+    const {
+      initializeAndReconcileBuildPrDelivery,
+    } = await import("@/lib/build/build-pr-delivery-reconciler");
+    const outcome = await initializeAndReconcileBuildPrDelivery({
       db: prisma,
       featureBuildId: build.id,
-      prNumber: prResult.prNumber,
-      prUrl: prResult.prUrl,
-    });
-    if (cap.captured > 0) {
-      logBuildActivity(buildId, "create_portal_pr", `Linked PR #${prResult.prNumber} to ${cap.captured} work capsule(s).`);
-    }
-  } catch (err) {
-    console.warn("[create_portal_pr] PR-capture onto capsule failed:", err);
-  }
-
-  // Auto-merge decision: all gates pass + build fully verified
-  const fullyVerified = typecheckPassed && testsFailed === 0 && acMet === acTotal && acTotal > 0;
-  let merged = false;
-
-  if (!gateResult.requiresHumanReview && fullyVerified) {
-    // Auto-merge via squash
-    const mergeResult = await mergePR({
       owner: repoOwner,
       repo: repoName,
       prNumber: prResult.prNumber,
-      commitTitle: `${prTitle} (#${prResult.prNumber})`,
-      mergeMethod: "squash",
+      prUrl: prResult.prUrl,
       token,
+      eligible: !gateResult.requiresHumanReview && fullyVerified,
     });
-    merged = mergeResult.merged;
+    deliveryState = outcome.state.status;
+    logBuildActivity(
+      buildId,
+      "build-pr-delivery",
+      `PR #${prResult.prNumber}: ${outcome.action?.kind ?? "withheld"}; delivery state ${outcome.state.status}; actuated=${outcome.actuated}; capsules=${outcome.captured}.`,
+    );
+  } catch (err) {
+    deliveryState = "checking";
+    logBuildActivity(
+      buildId,
+      "build-pr-delivery",
+      `PR #${prResult.prNumber} recovery will retry after initial observation failed: ${String(err).slice(0, 180)}`,
+    );
+  }
 
-    if (merged) {
-      // Update lifecycle: FeatureBuild → complete, ChangePromotion → deployed
-      await prisma.featureBuild.update({
-        where: { buildId },
-        data: { phase: "complete" },
-      });
-      const { recordReadyDependentsAfterCompletion } = await import("@/lib/build/feature-build-dependencies");
-      await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
-        console.warn("[create_portal_pr] dependency readiness check failed:", err);
-      });
-
-      const promotion = build.productVersions[0]?.promotions[0];
-      if (promotion) {
-        await prisma.changePromotion.update({
-          where: { promotionId: promotion.promotionId },
-          data: { status: "deployed", deployedAt: new Date(), deploymentLog: `Auto-merged PR #${prResult.prNumber}` },
-        });
-      }
-
-      logBuildActivity(buildId, "create_portal_pr", `PR #${prResult.prNumber} auto-merged. Build complete.`);
-    } else {
-      // Merge failed — post comment explaining why
-      await commentOnPR({
-        owner: repoOwner, repo: repoName, prNumber: prResult.prNumber,
-        body: `Auto-merge failed. This PR requires manual review and merge.\n\n${formatGateReport(gateResult)}`,
-        token,
-      }).catch(() => {});
-
-      logBuildActivity(buildId, "create_portal_pr", `PR #${prResult.prNumber} created but auto-merge failed.`);
-    }
-  } else {
+  if (gateResult.requiresHumanReview || !fullyVerified) {
     // Needs human review — post gate report as comment
     const reasons: string[] = [];
     if (gateResult.requiresHumanReview) reasons.push("security gate warnings");
@@ -646,9 +612,10 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
     logBuildActivity(buildId, "create_portal_pr", `PR #${prResult.prNumber} created — needs review: ${reasons.join(", ")}`);
   }
 
-  const statusMsg = merged
-    ? `PR #${prResult.prNumber} created and auto-merged. Build is complete.`
-    : `PR #${prResult.prNumber} created and awaiting review. ${gateResult.summary}`;
+  const statusMsg =
+    !gateResult.requiresHumanReview && fullyVerified
+      ? `PR #${prResult.prNumber} created. Delivery state: ${deliveryState}.`
+      : `PR #${prResult.prNumber} created and awaiting review. ${gateResult.summary}`;
 
   return {
     success: true,
@@ -658,7 +625,8 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
       prNumber: prResult.prNumber,
       branchName,
       commitSha: prResult.commitSha,
-      merged,
+      merged: false,
+      deliveryState,
       gates: gateResult,
     },
   };

--- a/apps/web/lib/mcp/build-ship-handlers.ts
+++ b/apps/web/lib/mcp/build-ship-handlers.ts
@@ -565,7 +565,7 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
   // remains authoritative for current-head checks, review threads, branch
   // freshness, and merge-queue policy. A PR merge is NOT deployment.
   const fullyVerified = typecheckPassed && testsFailed === 0 && acMet === acTotal && acTotal > 0;
-  let deliveryState = "awaiting-review";
+  let deliveryState: string;
   try {
     const {
       initializeAndReconcileBuildPrDelivery,

--- a/apps/web/lib/mcp/contribution-hive-delivery.ts
+++ b/apps/web/lib/mcp/contribution-hive-delivery.ts
@@ -1,0 +1,77 @@
+import { prisma } from "@dpf/db";
+import { initializeAndReconcileBuildPrDelivery } from "@/lib/build/build-pr-delivery-reconciler";
+import { reconcileBuildCompletion } from "@/lib/build-flow-state";
+import { logBuildActivity } from "@/lib/mcp/build-tool-helpers";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+export async function reconcileHiveContributionDelivery(input: {
+  buildId: string;
+  prUrl: string | null;
+  token: string;
+  eligible: boolean;
+}): Promise<void> {
+  if (!input.prUrl) return;
+
+  const pullRequest = input.prUrl.match(
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/)?$/,
+  );
+  if (!pullRequest) {
+    logBuildActivity(
+      input.buildId,
+      "build-pr-delivery",
+      "Pull request recovery is waiting because the contribution URL was not recognized.",
+    );
+    return;
+  }
+
+  const prNumber = Number(pullRequest[3]);
+  try {
+    const outcome = await initializeAndReconcileBuildPrDelivery({
+      db: prisma,
+      featureBuildId: input.buildId,
+      owner: pullRequest[1],
+      repo: pullRequest[2],
+      prNumber,
+      prUrl: input.prUrl,
+      token: input.token,
+      eligible: input.eligible,
+    });
+    logBuildActivity(
+      input.buildId,
+      "build-pr-delivery",
+      `PR #${prNumber}: ${outcome.action?.kind ?? "withheld"}; delivery state ${outcome.state.status}; actuated=${outcome.actuated}; capsules=${outcome.captured}.`,
+    );
+  } catch (error) {
+    logBuildActivity(
+      input.buildId,
+      "build-pr-delivery",
+      `PR #${prNumber} recovery will retry after initial observation failed: ${getErrorMessage(error).slice(0, 180)}`,
+    );
+  }
+}
+
+export async function finalizeHiveContribution(input: {
+  buildId: string;
+  packId: string;
+  prUrl: string | null;
+  prError: string | null;
+  totalFiles: number;
+  dcoAttestation: string;
+}): Promise<void> {
+  await prisma.improvementProposal
+    .updateMany({
+      where: { buildId: input.buildId, contributionStatus: "local" },
+      data: { contributionStatus: "contributed" },
+    })
+    .catch(() => {});
+
+  logBuildActivity(
+    input.buildId,
+    "contribute_to_hive",
+    input.prUrl
+      ? `FeaturePack ${input.packId} created + PR ${input.prUrl}. ${input.totalFiles} files. DCO: ${input.dcoAttestation}`
+      : `FeaturePack ${input.packId} created but upstream PR FAILED: ${input.prError ?? "unknown"}. ${input.totalFiles} files. DCO: ${input.dcoAttestation}`,
+  );
+
+  await reconcileBuildCompletion(input.buildId).catch(() => {});
+}

--- a/apps/web/lib/mcp/packs/contribution-hive-pack.ts
+++ b/apps/web/lib/mcp/packs/contribution-hive-pack.ts
@@ -21,6 +21,10 @@ import {
   resolveActiveBuildId,
 } from "@/lib/mcp/build-tool-helpers";
 import { isLowSeverityReferenceDocProposal } from "@/lib/process-spine/reference-doc-promotion";
+import {
+  finalizeHiveContribution,
+  reconcileHiveContributionDelivery,
+} from "@/lib/mcp/contribution-hive-delivery";
 
 const definitions: ToolDefinition[] = [
   {
@@ -502,9 +506,6 @@ async function contributeToHiveHandler(
   // Anonymous identity pushes dpf/<hash>/<slug> branch directly to the upstream repo.
   // No customer fork needed — the hive token provides write access.
   let prUrl: string | null = null;
-  let prNumber: number | null = null;
-  let prOwner: string | null = null;
-  let prRepo: string | null = null;
   let prError: string | null = null;
   try {
     const upstreamUrl = devConfig?.upstreamRemoteUrl ?? "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git";
@@ -569,9 +570,6 @@ async function contributeToHiveHandler(
 
         if (prResult.prUrl) {
           prUrl = prResult.prUrl;
-          prNumber = prResult.prNumber;
-          prOwner = upstreamMatch[1];
-          prRepo = upstreamMatch[2];
           await prisma.featurePack.update({
             where: { packId },
             data: { manifest: { ...manifest, dcoAttestation, prUrl } as unknown as import("@dpf/db").Prisma.InputJsonValue },
@@ -606,61 +604,20 @@ async function contributeToHiveHandler(
     console.warn("[contribute_to_hive] upstream PR creation failed:", err);
   }
 
-  // Converge the autonomous contribution path with create_portal_pr: durable
-  // Work Capsule recovery state is established before exact-head observation
-  // or merge-queue actuation. Contribution review/security findings withhold
-  // actuation and remain a human decision.
-  if (prUrl && prNumber && prOwner && prRepo) {
-    try {
-      const { initializeAndReconcileBuildPrDelivery } = await import(
-        "@/lib/build/build-pr-delivery-reconciler"
-      );
-      const outcome = await initializeAndReconcileBuildPrDelivery({
-        db: prisma,
-        featureBuildId: build.id,
-        owner: prOwner,
-        repo: prRepo,
-        prNumber,
-        prUrl,
-        token: hiveTokenEarly,
-        eligible: securityScan.passed && !prError,
-      });
-      logBuildActivity(
-        buildId,
-        "build-pr-delivery",
-        `PR #${prNumber}: ${outcome.action?.kind ?? "withheld"}; delivery state ${outcome.state.status}; actuated=${outcome.actuated}; capsules=${outcome.captured}.`,
-      );
-    } catch (error) {
-      logBuildActivity(
-        buildId,
-        "build-pr-delivery",
-        `PR #${prNumber} recovery will retry after initial observation failed: ${getErrorMessage(error).slice(0, 180)}`,
-      );
-    }
-  }
-
-  // Update linked ImprovementProposal if exists
-  await prisma.improvementProposal.updateMany({
-    where: { buildId: build.id, contributionStatus: "local" },
-    data: { contributionStatus: "contributed" },
-  }).catch(() => {});
-
-  logBuildActivity(
+  await reconcileHiveContributionDelivery({
     buildId,
-    "contribute_to_hive",
-    prUrl
-      ? `FeaturePack ${packId} created + PR ${prUrl}. ${manifest.totalFiles} files. DCO: ${dcoAttestation}`
-      : `FeaturePack ${packId} created but upstream PR FAILED: ${prError ?? "unknown"}. ${manifest.totalFiles} files. DCO: ${dcoAttestation}`,
-  );
-
-  // Fork disposition has changed — ask the reconciler whether the build
-  // is ready to advance ship → complete. Success and failure both count
-  // as a terminal disposition for the upstream fork (errored is still
-  // terminal); the only state that blocks complete is in_progress.
-  {
-    const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
-    await reconcileBuildCompletion(buildId).catch(() => {});
-  }
+    prUrl,
+    token: hiveTokenEarly,
+    eligible: securityScan.passed && !prError,
+  });
+  await finalizeHiveContribution({
+    buildId,
+    packId,
+    prUrl,
+    prError,
+    totalFiles: manifest.totalFiles,
+    dcoAttestation,
+  });
 
   if (!prUrl) {
     return {

--- a/apps/web/lib/mcp/packs/contribution-hive-pack.ts
+++ b/apps/web/lib/mcp/packs/contribution-hive-pack.ts
@@ -502,6 +502,9 @@ async function contributeToHiveHandler(
   // Anonymous identity pushes dpf/<hash>/<slug> branch directly to the upstream repo.
   // No customer fork needed — the hive token provides write access.
   let prUrl: string | null = null;
+  let prNumber: number | null = null;
+  let prOwner: string | null = null;
+  let prRepo: string | null = null;
   let prError: string | null = null;
   try {
     const upstreamUrl = devConfig?.upstreamRemoteUrl ?? "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory.git";
@@ -566,6 +569,9 @@ async function contributeToHiveHandler(
 
         if (prResult.prUrl) {
           prUrl = prResult.prUrl;
+          prNumber = prResult.prNumber;
+          prOwner = upstreamMatch[1];
+          prRepo = upstreamMatch[2];
           await prisma.featurePack.update({
             where: { packId },
             data: { manifest: { ...manifest, dcoAttestation, prUrl } as unknown as import("@dpf/db").Prisma.InputJsonValue },
@@ -598,6 +604,39 @@ async function contributeToHiveHandler(
   } catch (err) {
     prError = getErrorMessage(err);
     console.warn("[contribute_to_hive] upstream PR creation failed:", err);
+  }
+
+  // Converge the autonomous contribution path with create_portal_pr: durable
+  // Work Capsule recovery state is established before exact-head observation
+  // or merge-queue actuation. Contribution review/security findings withhold
+  // actuation and remain a human decision.
+  if (prUrl && prNumber && prOwner && prRepo) {
+    try {
+      const { initializeAndReconcileBuildPrDelivery } = await import(
+        "@/lib/build/build-pr-delivery-reconciler"
+      );
+      const outcome = await initializeAndReconcileBuildPrDelivery({
+        db: prisma,
+        featureBuildId: build.id,
+        owner: prOwner,
+        repo: prRepo,
+        prNumber,
+        prUrl,
+        token: hiveTokenEarly,
+        eligible: securityScan.passed && !prError,
+      });
+      logBuildActivity(
+        buildId,
+        "build-pr-delivery",
+        `PR #${prNumber}: ${outcome.action?.kind ?? "withheld"}; delivery state ${outcome.state.status}; actuated=${outcome.actuated}; capsules=${outcome.captured}.`,
+      );
+    } catch (error) {
+      logBuildActivity(
+        buildId,
+        "build-pr-delivery",
+        `PR #${prNumber} recovery will retry after initial observation failed: ${getErrorMessage(error).slice(0, 180)}`,
+      );
+    }
   }
 
   // Update linked ImprovementProposal if exists

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -73,6 +73,18 @@ export interface ScheduledJobCatalogEntry {
 // Ordered roughly by operational prominence. core-locked jobs first.
 export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
+    jobId: "build-pr-delivery-reconcile",
+    inngestId: "build/pr-delivery-reconcile",
+    name: "Build Studio PR delivery reconcile",
+    purpose:
+      "Recovers Build Studio pull requests through exact-head readiness, stale-branch updates, and the protected merge queue without bypassing governed release.",
+    cron: "2,7,12,17,22,27,32,37,42,47,52,57 * * * *",
+    cadence: "Every 5 minutes, offset by 2 minutes",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: CODE_GRAPH_JOB_ID, // "code-graph-reconcile"
     inngestId: "ops/code-graph-reconcile-scheduled",
     name: "Code graph reconcile",

--- a/apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts
+++ b/apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts
@@ -103,7 +103,10 @@ export async function runBuildPrDeliveryReconcile(): Promise<{
       const saved = await prisma.workCapsule.updateMany({
         where: { id: capsule.id, updatedAt: capsule.updatedAt },
         data: {
-          workspaceState: writeBuildPrDeliveryState(capsule.workspaceState, outcome.state),
+          workspaceState: writeBuildPrDeliveryState(
+            capsule.workspaceState,
+            outcome.state,
+          ) as unknown as import("@dpf/db").Prisma.InputJsonValue,
           headSha: outcome.state.lastObservedHeadSha,
         },
       });
@@ -142,7 +145,12 @@ export async function runBuildPrDeliveryReconcile(): Promise<{
       };
       const saved = await prisma.workCapsule.updateMany({
         where: { id: capsule.id, updatedAt: capsule.updatedAt },
-        data: { workspaceState: writeBuildPrDeliveryState(capsule.workspaceState, failed) },
+        data: {
+          workspaceState: writeBuildPrDeliveryState(
+            capsule.workspaceState,
+            failed,
+          ) as unknown as import("@dpf/db").Prisma.InputJsonValue,
+        },
       });
       if (saved.count === 0) compareAndSwapLost += 1;
     }

--- a/apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts
+++ b/apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts
@@ -1,0 +1,166 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+export const BUILD_PR_DELIVERY_RECONCILE_CRON = "2,7,12,17,22,27,32,37,42,47,52,57 * * * *";
+
+export async function runBuildPrDeliveryReconcile(): Promise<{
+  observed: number;
+  actuated: number;
+  escalated: number;
+  compareAndSwapLost: number;
+}> {
+  const { prisma } = await import("@dpf/db");
+  const {
+    resolveGithubToken,
+  } = await import("@/lib/contributor-change-lanes/github-rest-reader");
+  const {
+    observeGithubPullRequest,
+    projectGithubPrReadiness,
+  } = await import("@/lib/integrate/github-pr-readiness");
+  const {
+    executeBuildPrDeliveryAction,
+    resolveBuildPrReconcilerMode,
+  } = await import("@/lib/build/build-pr-delivery-reconciler");
+  const {
+    createBuildPrDeliveryState,
+    readBuildPrDeliveryState,
+    writeBuildPrDeliveryState,
+  } = await import("@/lib/build/build-pr-delivery-state");
+
+  const mode = resolveBuildPrReconcilerMode();
+  if (mode === "off") return { observed: 0, actuated: 0, escalated: 0, compareAndSwapLost: 0 };
+
+  const token = await resolveGithubToken(
+    prisma as unknown as Parameters<typeof resolveGithubToken>[0],
+  );
+  if (!token) throw new Error("Build PR delivery reconcile: GitHub credential unavailable");
+
+  const capsules = await prisma.workCapsule.findMany({
+    where: {
+      featureBuildId: { not: null },
+      pullRequestNumber: { not: null },
+      pullRequestUrl: { not: null },
+      status: { notIn: ["complete", "abandoned", "archived"] },
+    },
+    select: {
+      id: true,
+      capsuleId: true,
+      featureBuildId: true,
+      repositoryFullName: true,
+      pullRequestNumber: true,
+      pullRequestUrl: true,
+      workspaceState: true,
+      updatedAt: true,
+    },
+    take: 25,
+    orderBy: { updatedAt: "asc" },
+  });
+
+  let observed = 0;
+  let actuated = 0;
+  let escalated = 0;
+  let compareAndSwapLost = 0;
+
+  for (const capsule of capsules) {
+    const prNumber = capsule.pullRequestNumber;
+    const prUrl = capsule.pullRequestUrl;
+    if (!prNumber || !prUrl || !capsule.featureBuildId) continue;
+    const existing = readBuildPrDeliveryState(capsule.workspaceState);
+    if (
+      existing?.status === "escalated" ||
+      existing?.status === "closed" ||
+      existing?.status === "deployed"
+    ) {
+      continue;
+    }
+    const repository = existing?.repository || capsule.repositoryFullName || (() => {
+      try {
+        return new URL(prUrl).pathname.split("/").filter(Boolean).slice(0, 2).join("/");
+      } catch {
+        return "";
+      }
+    })();
+    const [owner, repo] = repository.split("/");
+    if (!owner || !repo) continue;
+    const state = existing ?? createBuildPrDeliveryState({ repository, prNumber, prUrl });
+
+    try {
+      const observation = await observeGithubPullRequest({ owner, repo, prNumber, token });
+      observed += 1;
+      const readiness = projectGithubPrReadiness(observation);
+      const outcome = await executeBuildPrDeliveryAction({
+        state,
+        observation,
+        readiness,
+        mode,
+        token,
+        owner,
+        repo,
+      });
+      if (outcome.actuated) actuated += 1;
+
+      const saved = await prisma.workCapsule.updateMany({
+        where: { id: capsule.id, updatedAt: capsule.updatedAt },
+        data: {
+          workspaceState: writeBuildPrDeliveryState(capsule.workspaceState, outcome.state),
+          headSha: outcome.state.lastObservedHeadSha,
+        },
+      });
+      if (saved.count === 0) {
+        compareAndSwapLost += 1;
+        continue;
+      }
+
+      if (
+        outcome.action.kind === "escalate" &&
+        state.escalationKey !== outcome.state.escalationKey
+      ) {
+        const { createPlatformIssueReport } = await import("@/lib/quality/platform-issue-reports");
+        await createPlatformIssueReport({
+          type: "build-stall-escalation",
+          source: "build-studio",
+          severity: "high",
+          title: `Build Studio needs a PR delivery decision: #${prNumber}`,
+          description:
+            `Build Studio stopped autonomous PR delivery for ${capsule.capsuleId}.\n\n` +
+            `Reason: ${outcome.action.reason}\nHead: ${outcome.action.headSha ?? "unknown"}\nPR: ${prUrl}\n\n` +
+            "No direct merge, force-push, or automatic conflict edit was attempted.",
+          featureBuildId: capsule.featureBuildId,
+          triggerKind: "build-pr-delivery-reconcile",
+          dedupeKey: outcome.state.escalationKey ?? `build-pr-delivery:${prNumber}`,
+          selfFixClass: "needs-human",
+        });
+        escalated += 1;
+      }
+    } catch (error) {
+      const failed = {
+        ...state,
+        reconciliationAttempts: state.reconciliationAttempts + 1,
+        lastObservedAt: new Date().toISOString(),
+        lastError: String(error instanceof Error ? error.message : error).slice(0, 240),
+      };
+      const saved = await prisma.workCapsule.updateMany({
+        where: { id: capsule.id, updatedAt: capsule.updatedAt },
+        data: { workspaceState: writeBuildPrDeliveryState(capsule.workspaceState, failed) },
+      });
+      if (saved.count === 0) compareAndSwapLost += 1;
+    }
+  }
+
+  return { observed, actuated, escalated, compareAndSwapLost };
+}
+
+export const buildPrDeliveryReconcile = inngest.createFunction(
+  {
+    id: "build/pr-delivery-reconcile",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(BUILD_PR_DELIVERY_RECONCILE_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return step.run("reconcile-build-pr-delivery", runBuildPrDeliveryReconcile);
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -95,6 +95,7 @@ import {
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 import { demandReconciliationScheduled } from "./demand-reconciliation";
 import { workPatternExperimentRun } from "./work-pattern-experiment";
+import { buildPrDeliveryReconcile } from "./build-pr-delivery-reconcile";
 
 export const scheduledFunctions = [
   prometheusPoll,
@@ -149,6 +150,7 @@ export const scheduledFunctions = [
   memoryConsolidationNightly, // BI-907C4327: EP-8C706944 P2 autoDream — nightly batch-dedupe + expire coworker notes / user facts, 04:20
   semanticMemoryReconcileScheduled, // BI-DG-001: EP-DATA-GOVERNANCE — nightly orphan reconciliation of the semantic-memory derived copy, 05:10 (after retention sweep)
   demandReconciliationScheduled, // BI-44AA45BF: trusted-link demand projection, retry, and reconciliation every five minutes
+  buildPrDeliveryReconcile, // BI-7C4FDBF5: exact-SHA Build Studio PR readiness, queue enrollment, and restart recovery
   postmarkCallbackDispatchSweep,
 ];
 

--- a/docs/operations/autonomous-build-completion.md
+++ b/docs/operations/autonomous-build-completion.md
@@ -16,6 +16,15 @@ When enabled, a build that passes review and reaches the `ship` phase:
    the **platform self-upgrade** (the deploy you already run) — _not_ a per-build
    `dpf-promoter` deploy.
 
+Between steps 1 and 3, Build Studio now owns PR delivery recovery:
+
+- it evaluates checks and unresolved review threads at the PR's exact head SHA;
+- it safely updates a stale branch using GitHub's expected-head comparison;
+- it enrolls an evidence-cleared PR in the repository merge queue;
+- it resumes after portal restarts through versioned Work Capsule state; and
+- it escalates true conflicts, closed PRs, ambiguous state, or exhausted retry
+  budgets without direct merge or force-push.
+
 Completion is handled by a periodic reconciler that runs on boot and every ~10
 minutes (`reconcileDeployedShipBuilds`): for each build sitting at `ship` whose
 merged commit is now in the deployed runtime (`isFeatureBuildDeployed`), it marks
@@ -32,10 +41,17 @@ ideate → plan → build → review → ship → (PR merges + next self-upgrade
 
 ```
 DPF_AUTO_COMPLETE_VERIFIED_BUILDS = "1" | "true" | "on"     # default OFF
+DPF_BUILD_PR_DELIVERY_RECONCILER_MODE = "off" | "shadow" | "enforce"
 ```
 
 Set on the `dpf-portal` container's environment. Unset / anything else = OFF —
 builds reach `ship` and wait for a manual ship, exactly as before.
+
+The delivery reconciler defaults to `shadow`: it records the action it would
+take but does not mutate GitHub. Use `enforce` only after shadow evidence is
+reviewed for the install. `off` disables both observation and actuation. The
+outer autonomous-completion switch still controls whether Build Studio creates
+and resolves the autonomous ship forks.
 
 ## How to turn it on
 
@@ -56,6 +72,12 @@ builds reach `ship` and wait for a manual ship, exactly as before.
 - **Idempotent + non-throwing** — re-runs skip already-pushed PRs and
   already-registered products; any unresolved fork simply parks the build at
   `ship` for an operator.
+- **No direct merge** — the protected repository merge queue remains the
+  integration authority.
+- **Exact-head compare-and-swap** — a concurrent branch update cancels the old
+  decision and triggers a fresh observation.
+- **Merge is not deployment** — merged work displays “Waiting for governed
+  release” until self-upgrade evidence proves it live.
 - **Real artifacts only** — a build reads `complete` only when it genuinely has a
   pushed PR, a product/promotion, and its merged code live in the runtime. It
   never writes a `complete` status without those.

--- a/docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md
+++ b/docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md
@@ -1,0 +1,332 @@
+# Build Studio PR Readiness and Merge Recovery Implementation Plan
+
+**Status:** Draft — awaiting operator review and approval. Do not implement until approved.
+
+**Backlog item:** `BI-7C4FDBF5`
+
+**Work Capsule:** `WC-09CA9C58`
+
+**Branch / worktree:** `feat/build-studio-pr-recovery` / `D:\DPF-worktrees\build-studio-pr-recovery`
+
+**Plan backlog coverage:** atomic receipt `cms2q28mg0dqe01qqyggqaaem`
+
+**Architecture review:** Passed on 2026-07-27 with the conditions encoded in this plan: exact-head evidence, no direct merge or force-push, Work Capsule coordination rather than a parallel lifecycle, fail-closed ambiguity, merge distinct from deployment, and shadow-first rollout.
+
+## Outcome
+
+Build Studio hands every eligible, evidence-cleared pull request to the repository merge queue, follows it through stale-base recovery and merge, and reports an honest plain-language delivery state. It never directly merges, force-pushes a queued branch, treats PR merge as deployment, or invents a second release path. True conflicts, closed/replaced pull requests, exhausted retry budgets, ambiguous GitHub state, and authority-ceiling cases escalate through the existing human-escalation substrate.
+
+This is the prerequisite named by Delivery 3 of
+`docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`.
+The autonomous playbook consumer in `BI-356E69B1` remains blocked until this plan is implemented and verified.
+
+## Current-state correction
+
+The older design,
+`docs/superpowers/specs/2026-06-19-build-studio-pr-merge-resolution-design.md`,
+predates the repository's protected merge queue. Current `main` already has queue policy and merge automation. This BI therefore does not create a new merge substrate. It replaces Build Studio's obsolete direct-merge call with a reusable consumer of the existing queue and makes that consumer restart-safe.
+
+Current code findings:
+
+- `apps/web/lib/mcp/build-ship-handlers.ts` calls `mergePR` directly and records a terminal manual-merge message on failure.
+- `apps/web/lib/integrate/github-api-commit.ts` exposes PR status, but no caller uses it for Build Studio delivery; its combined-status lookup is keyed by PR number instead of the PR head SHA.
+- `apps/web/lib/integrate/ship-on-review-approval.ts` creates or observes the PR but does not own queue enrollment or stale-base recovery.
+- `apps/web/lib/assurance/remediation-merge-live.ts` already contains a GraphQL client and auto-merge mutation that should become shared substrate.
+- `WorkCapsule.workspaceState`, PR identity fields, capsule activity, `FeatureBuild`, and the existing bounded escalation helper are sufficient. No new table or public status enum is required.
+- The current customer status projection treats PR creation too much like shipping; it does not distinguish checks, queueing, merge, governed release, and deployment.
+
+## Standards and safety contract
+
+The implementation follows GitHub's protected-branch workflow:
+
+- Auto-merge/merge-queue enrollment is the actuation mechanism; repository checks and review policy remain authoritative.
+- Readiness is evaluated at the exact current `headRefOid`, not at a PR number or stale cached SHA.
+- A stale-branch update uses GitHub's update-branch endpoint with `expected_head_sha`; a changed head returns `422` and is re-observed rather than overwritten.
+- `mergeStateStatus` is advisory, not sufficient. Queue enrollment additionally requires every observed check to be terminal and passing and zero unresolved review threads.
+- A successful PR merge advances delivery only to “waiting for governed release.” The existing governed self-upgrade and deployed-version reconciliation remain authoritative for “deployed.”
+
+References:
+
+- https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/automatically-merging-a-pull-request
+- https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch
+
+## Preserved substrates and ownership
+
+- `FeatureBuild` remains the build lifecycle authority.
+- `TaskRun` and `BuildPhaseRun` remain execution and phase evidence.
+- `DecisionShadowLedger` and `AuthorityBinding` remain decision and authority evidence; this BI does not weaken their ceilings.
+- `WorkCase` remains the governed work record.
+- `WorkCapsule` owns durable external-delivery coordination and recovery state.
+- GitHub's protected branch and merge queue own integration.
+- Governed self-upgrade owns deployment, recovery points, health evidence, and rollback.
+- Existing `escalateBuildToHuman` owns bounded, deduplicated human escalation.
+
+## Atomic coverage decision
+
+This plan is deliberately atomic under receipt `cms2q28mg0dqe01qqyggqaaem`.
+
+| Deliverable | Dependency | Independently shippable |
+|---|---|---:|
+| Shared exact-SHA PR readiness and queue actuation | None | No |
+| Durable Build Studio delivery reconciler | Shared readiness | No |
+| Honest customer delivery projection | Reconciler | No |
+| Controlled rollout and verification | All prior work | No |
+
+Queue actuation without durable reconciliation can duplicate or strand delivery. Reconciliation without exact-SHA readiness can bypass current evidence. UI projection without authoritative state can mislead operators. Enforcement without rollout and recovery evidence is unsafe.
+
+## Effort budget
+
+Use 15 implementation units exactly:
+
+| Allocation | Units | Share |
+|---|---:|---:|
+| Product behavior, tests, UX, documentation, rollout | 12 | 80% |
+| Bounded structural refactoring | 3 | 20% |
+
+The three refactoring units are bounded to:
+
+1. Extract the assurance-only GitHub GraphQL/readiness/auto-merge code into one shared integration module (2 units).
+2. Converge Build Studio's two ship entry points on one delivery reconciler and one status projection (1 unit).
+
+Excluded refactoring: a general GitHub SDK rewrite, queue-engine redesign, schema normalization, FeatureBuild state-machine replacement, or unrelated Build Studio cleanup.
+
+## Slice 1 — Shared exact-SHA PR readiness contract
+
+**Files**
+
+- Create `apps/web/lib/integrate/github-pr-readiness.ts`.
+- Create `apps/web/lib/integrate/github-pr-readiness.test.ts`.
+- Modify `apps/web/lib/integrate/github-api-commit.ts`.
+- Modify `apps/web/lib/integrate/github-api-commit.test.ts`.
+- Modify `apps/web/lib/assurance/remediation-merge-live.ts`.
+- Modify `apps/web/lib/assurance/remediation-merge-live.test.ts`.
+
+**Tasks**
+
+1. Write failing unit tests for the pure readiness projection:
+   - open and current, all checks passing, zero unresolved threads;
+   - pending, skipped/neutral, failing, and missing check rollups;
+   - behind/stale;
+   - dirty/conflicting;
+   - closed-unmerged and merged;
+   - unknown/unstable GitHub states;
+   - head SHA changes between observation and actuation.
+2. Extract a shared typed GitHub GraphQL request helper and PR observation query returning PR node ID, state, merge state, merge/queue state where exposed, `headRefOid`, check rollup, and unresolved review-thread count.
+3. Add `updatePullRequestBranch({ expectedHeadSha })` through the documented REST endpoint. Treat `202` as accepted, `422` as compare-and-swap loss requiring re-observation, and other failures as typed recoverable or terminal errors.
+4. Move auto-merge enablement into the shared module and preserve the assurance consumer's behavior.
+5. Correct any remaining commit/check lookup to use the observed head SHA rather than PR number.
+6. Keep the existing direct merge API available only for unrelated explicit consumers; Build Studio must have no dependency on it.
+
+**Exit gate**
+
+- The readiness decision is a pure, exhaustive, unit-tested projection.
+- Every mutating GitHub call carries the observed PR identity and exact head SHA.
+- Assurance tests prove the extraction is behavior-preserving.
+- No Build Studio production path is switched yet.
+
+## Slice 2 — Durable Build Studio delivery state
+
+**Files**
+
+- Create `apps/web/lib/build/build-pr-delivery-state.ts`.
+- Create `apps/web/lib/build/build-pr-delivery-state.test.ts`.
+- Modify `apps/web/lib/build/capture-build-pr.ts`.
+- Modify `apps/web/lib/build/capture-build-pr.test.ts`.
+
+**Tasks**
+
+1. Define a versioned internal `BuildPrDeliveryStateV1` stored under
+   `WorkCapsule.workspaceState.buildStudio.delivery`.
+2. Persist only recovery-critical coordination fields:
+   - schema version;
+   - state: `created`, `checking`, `updating`, `queued`, `merged`, `awaiting-release`, `deployed`, `escalated`, or `closed`;
+   - PR number, URL, and repository;
+   - last observed and last actuated head SHA;
+   - stale-update and reconciliation counters;
+   - last readiness verdict and observation timestamp;
+   - dedupe keys for queue actuation and escalation;
+   - last recoverable error classification.
+3. Provide parse/upgrade helpers that fail closed on malformed or future-version state.
+4. Initialize delivery state when `captureBuildPullRequest` binds PR identity to the capsule.
+5. Make state transitions compare-and-swap-safe inside the existing Prisma transaction pattern so retries and overlapping observers cannot duplicate actuation.
+
+**Migration decision**
+
+No Prisma migration. Existing `WorkCapsule.workspaceState` JSON, PR fields, and activity streams are the intended durable coordination substrate. A migration would duplicate ownership and increase fleet-upgrade risk.
+
+**Exit gate**
+
+- A process restart can reconstruct the next safe action from the capsule alone plus a fresh GitHub observation.
+- Replayed writes and duplicate observations are idempotent.
+- Malformed state parks and escalates; it never actuates GitHub.
+
+## Slice 3 — Bounded delivery reconciler and recovery watcher
+
+**Files**
+
+- Create `apps/web/lib/build/build-pr-delivery-reconciler.ts`.
+- Create `apps/web/lib/build/build-pr-delivery-reconciler.test.ts`.
+- Create `apps/web/lib/queue/functions/build-pr-delivery-reconcile.ts`.
+- Create `apps/web/lib/queue/functions/build-pr-delivery-reconcile.test.ts`.
+- Modify `apps/web/lib/queue/functions/index.ts`.
+- Modify `apps/web/lib/queue/functions/index.test.ts`.
+- Modify `apps/web/lib/operate/scheduled-jobs/catalog.ts` and its parity tests.
+- Modify `apps/web/lib/mcp/build-ship-handlers.ts` and focused tests.
+- Modify `apps/web/lib/integrate/ship-on-review-approval.ts`.
+- Modify `apps/web/lib/integrate/ship-on-review-approval.test.ts`.
+
+**Tasks**
+
+1. Write failing table tests for every observation/action pair before implementation.
+2. Implement one injectable reconciler used by both ship entry points and the watcher.
+3. Apply the bounded rules:
+   - closed and unmerged: honor the human action, record `closed`, and escalate once;
+   - merged: record `awaiting-release`; do not complete or deploy the build;
+   - current with pending/failing checks or unresolved threads: record `checking` and wait;
+   - behind with update budget remaining: update once at the expected head SHA, record `updating`, and require a fresh observation/check run;
+   - dirty/conflicting: classify as a true conflict and escalate once with the PR, head SHA, and reason;
+   - evidence-cleared and current: enable auto-merge/queue enrollment exactly once per head SHA;
+   - unknown or repeatedly unstable: wait for a bounded number of observations, then escalate;
+   - changed head after observation: discard the decision and re-observe.
+4. Remove Build Studio's direct `mergePR` call and the terminal “manual review and merge” dead end.
+5. Have PR creation/review approval trigger an immediate reconciliation attempt.
+6. Add a quiescence-aware scheduled recovery pass over active ship-phase Build Studio capsules. Register it through the existing scheduled-function catalog and use a cadence no faster than the repository's allowed cron policy.
+7. Preserve `DPF_AUTO_COMPLETE_VERIFIED_BUILDS` as the outer automation kill switch and add a narrowly scoped mode:
+   `DPF_BUILD_PR_DELIVERY_RECONCILER_MODE=off|shadow|enforce`.
+   Default to `shadow` for rollout; invalid values fail closed to `off`.
+8. Emit structured activity/telemetry for observations, actions, retries, compare-and-swap losses, escalations, and latency without logging credentials or raw API payloads.
+
+**Exit gate**
+
+- No Build Studio path directly merges a PR.
+- Restarts at every side-effect boundary converge without duplicate updates, queue requests, or escalations.
+- The watcher recovers abandoned in-process work from durable state.
+- High-risk, conflicting, closed, ambiguous, and exhausted-budget cases escalate.
+- Shadow mode performs no GitHub mutation.
+
+## Slice 4 — Honest delivery projection and UX
+
+**Files**
+
+- Modify `apps/web/lib/build-flow-state.ts`.
+- Modify `apps/web/lib/build-flow-state.test.ts`.
+- Modify `apps/web/lib/build/customer-status-loader.ts`.
+- Modify `apps/web/lib/build/customer-status-loader.test.ts`.
+- Modify `apps/web/lib/build/customer-status-projection.ts`.
+- Modify `apps/web/lib/build/customer-status-projection.test.ts`.
+- Modify `apps/web/components/build/BuildCustomerStatusBand.tsx` only if its existing rendering contract cannot express the states.
+- Modify `apps/web/components/build/BuildCustomerStatusBand.test.tsx`.
+- Modify the closest existing operational-detail component and test only if needed to expose recovery diagnostics without creating a new dashboard.
+
+**Tasks**
+
+1. Project capsule delivery state through the existing customer-status band:
+   - `checking`: “Checking the pull request”
+   - `updating`: “Finalizing against the latest platform”
+   - `queued`: “Merge queued”
+   - `merged` / `awaiting-release`: “Waiting for governed release”
+   - `deployed`: “Deployed”
+   - `escalated` / `closed`: “Needs your decision”
+2. Stop projecting PR creation as shipped or deployed.
+3. Keep the first viewport customer-readable. Put SHA, retry count, last observation, and exact escalation reason in the existing engineer/operational detail surface, not in the primary status sentence.
+4. Preserve accessible status semantics, keyboard reachability, responsive wrapping, and light/dark contrast.
+
+**UX verification**
+
+Exercise the running portal in the leased `local-integration-ci` environment for:
+
+- pending checks;
+- stale-head update in progress;
+- queued;
+- merged but not yet released;
+- deployed after governed release evidence;
+- true conflict;
+- human-closed PR;
+- exhausted/ambiguous recovery.
+
+Capture desktop and mobile evidence in light and dark themes. Confirm the status is understandable without Git terminology in the primary sentence, no layout shift obscures actions, keyboard navigation remains ordered, and screen-reader status announcements are not duplicated.
+
+**Exit gate**
+
+- Operators can distinguish checking, queued, merged, released, and deployed.
+- Engineers can diagnose recovery without database access.
+- No second status band or competing delivery authority is introduced.
+
+## Slice 5 — Documentation, rollout, and completion evidence
+
+**Files**
+
+- Update `docs/superpowers/specs/2026-06-19-build-studio-pr-merge-resolution-design.md` to mark the current merge-queue correction and implementation status.
+- Update `docs/operations/autonomous-build-completion.md`.
+- Update the relevant Build Studio operator page under `docs/user-guide/`.
+- Update `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md` only after the prerequisite is merged, changing Delivery 3's prerequisite evidence from pending to delivered.
+
+**Rollout sequence**
+
+1. `off`: deploy code with no watcher actuation.
+2. `shadow`: observe and persist proposed actions; compare them with actual GitHub state and existing human outcomes.
+3. Contained canary: `enforce` for evidence-cleared Build Studio builds only; retain authority/risk escalation.
+4. General eligible-lane enforcement after canary recovery cases and UX evidence pass.
+5. Keep off/shadow as operational rollback modes. Disabling enforcement leaves PRs in GitHub's existing state and does not require schema rollback.
+
+**Verification**
+
+- Focused Vitest suites for every modified module.
+- Queue function catalog/parity and every-minute-cron guard.
+- `pnpm --filter web typecheck`.
+- `pnpm --filter web build`.
+- `pnpm run pregate` against the exact branch SHA after acquiring the shared `local-integration-ci` lease and running its freshness preflight.
+- UX cases above on the leased runtime.
+- `pnpm pr:health <PR>` before claiming merge readiness.
+- Post-merge observation that the PR entered and completed through the repository queue.
+- Governed release observation proving “deployed” appears only after the live version evidence advances.
+
+**Exit gate**
+
+- All build gates pass with exact-SHA evidence.
+- Recovery cases are captured in the PR evidence.
+- Documentation describes the real queue/recovery/release contract.
+- The BI and Work Capsule are not completed until the PR is merged and live backlog state is updated.
+
+## Explicit recovery scenarios
+
+| Scenario | Required behavior |
+|---|---|
+| Process stops before state write | Fresh observation repeats safely; no actuation was recorded or assumed |
+| Process stops after update-branch request | Re-observe head SHA; never blindly repeat against a changed head |
+| Process stops after queue enrollment | Detect queued/auto-merge state and record it; do not enqueue twice |
+| Main advances while checks run | Re-observe; update only with the exact previous head SHA |
+| Check becomes red after prior green | Park; queue policy remains authoritative; do not bypass |
+| Review thread reopens | Return to checking; do not treat previous clearance as current |
+| True merge conflict | Escalate once with evidence; no AI force-push or speculative conflict edit |
+| Human closes/replaces PR | Honor closure; never recreate automatically in this BI |
+| GitHub API rate limit/outage | Persist recoverable error and retry within budget; escalate after exhaustion |
+| Capsule state malformed/future version | Fail closed and escalate |
+| PR merged but release blocked | Remain “Waiting for governed release”; do not claim deployment |
+| Reconciler mode disabled | Preserve state and human/GitHub control; perform no mutation |
+
+## Architecture review record
+
+The plan was checked against the live code, the approved autonomous Build Studio program plan, the older merge-resolution design, and the current repository integration rules.
+
+**Verdict:** aligned and ready for operator review.
+
+**Findings resolved in this revision**
+
+1. The 2026-06-19 design assumed merge orchestration still needed to be invented. Current `main` already has a protected merge queue, so this plan makes Build Studio a governed queue consumer.
+2. The assurance domain already contains GraphQL auto-merge substrate. Extracting it prevents a second GitHub integration implementation while preserving assurance behavior.
+3. `FeatureBuild` is not the right home for transient PR recovery counters. Versioned Work Capsule state preserves lifecycle ownership and avoids a migration.
+4. GitHub merge state alone is not an evidence gate. The plan requires exact-head checks, zero unresolved review threads, and compare-and-swap branch updates.
+5. A merged PR is not a deployed feature. The UI and reconciler remain subordinate to governed self-upgrade and deployed-version evidence.
+6. Automatic conflict editing would exceed the safe scope of this prerequisite. True conflicts are evidence-rich escalation cases; future autonomous conflict repair requires a separate governed design.
+
+**Residual risks controlled by rollout**
+
+- GitHub API shape, rate limits, or merge-queue state can be incomplete or transient. Unknown observations wait within a budget and then fail closed.
+- Overlapping immediate and scheduled reconciliation can race. Durable dedupe keys and exact-head compare-and-swap semantics make replay safe.
+- A shadow decision can differ from repository policy. Shadow telemetry is compared with actual outcomes before enforcement.
+- Customer wording can imply completion too early. Runtime UX verification covers merged-but-unreleased and deployed states separately.
+
+## Approval gate
+
+Implementation may begin only after the operator approves this plan. Approval authorizes the five slices above, the exact 20% bounded refactoring allocation, the no-migration decision, and the shadow-to-enforced rollout. Any later need for a schema migration, a new public lifecycle enum, automatic AI conflict editing, force-push, direct merge, or a separate deployment path requires a new design decision and renewed approval.

--- a/docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md
+++ b/docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md
@@ -1,6 +1,6 @@
 # Build Studio PR Readiness and Merge Recovery Implementation Plan
 
-**Status:** Draft — awaiting operator review and approval. Do not implement until approved.
+**Status:** Approved by the operator on 2026-07-27; implementation in progress.
 
 **Backlog item:** `BI-7C4FDBF5`
 
@@ -329,4 +329,18 @@ The plan was checked against the live code, the approved autonomous Build Studio
 
 ## Approval gate
 
-Implementation may begin only after the operator approves this plan. Approval authorizes the five slices above, the exact 20% bounded refactoring allocation, the no-migration decision, and the shadow-to-enforced rollout. Any later need for a schema migration, a new public lifecycle enum, automatic AI conflict editing, force-push, direct merge, or a separate deployment path requires a new design decision and renewed approval.
+The operator approved this plan on 2026-07-27. Approval authorizes the five slices above, the exact 20% bounded refactoring allocation, the no-migration decision, and the shadow-to-enforced rollout. Any later need for a schema migration, a new public lifecycle enum, automatic AI conflict editing, force-push, direct merge, or a separate deployment path requires a new design decision and renewed approval.
+
+## UX fit review — Build Studio PR delivery recovery
+
+- **Decision:** fits with guardrails, now encoded in Slice 4.
+- **Owning area:** Platform.
+- **Route family:** existing `/build` Build Studio surface.
+- **Primary persona:** founder/operator monitoring autonomous delivery; technical diagnostics remain available to the contributor/platform operator.
+- **Navigation layer touched:** none; this is an existing in-page status projection.
+- **Reuse/convergence:** reuse `BuildCustomerStatusBand` and the existing customer-status loader/projection. No new dashboard, route, tab, badge family, or report component.
+- **Source truth:** versioned `WorkCapsule.workspaceState.buildStudio.delivery`, projected under `FeatureBuild` lifecycle authority.
+- **Empty/failure behavior:** missing or malformed delivery state fails closed to existing phase/capsule status; conflicts, closure, and exhausted recovery show “Needs your decision.”
+- **AI boundary:** status rendering sends no prompt and starts no coworker action.
+- **Evidence before merge:** projection/loader tests, source-truth tests, theme/style guards, desktop/mobile light/dark browser verification, keyboard and live-region review.
+- **Captured in:** this section and Slice 4.

--- a/docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md
+++ b/docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md
@@ -61,9 +61,13 @@ References:
 - Governed self-upgrade owns deployment, recovery points, health evidence, and rollback.
 - Existing `escalateBuildToHuman` owns bounded, deduplicated human escalation.
 
-## Atomic coverage decision
+## Backlog coverage
 
-This plan is deliberately atomic under receipt `cms2q28mg0dqe01qqyggqaaem`.
+- Decision: atomic
+- Parent: `BI-7C4FDBF5`
+- Receipt: `cms2xz0h4014g01l7lumlp0ge`
+- Dependencies: Shared readiness → durable reconciler → customer projection → controlled rollout and verification.
+- Rationale: Every slice is non-independently shippable. Queue actuation without durable reconciliation can strand or duplicate delivery; reconciliation without exact-SHA readiness can accept stale evidence; customer projection without authoritative state can mislead; and enforcement without controlled rollout and verification is unsafe.
 
 | Deliverable | Dependency | Independently shippable |
 |---|---|---:|

--- a/docs/superpowers/specs/2026-06-19-build-studio-pr-merge-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-19-build-studio-pr-merge-resolution-design.md
@@ -1,11 +1,26 @@
 # Build Studio PR Merge Resolution — Design
 
-- **Status:** Design / recommendation (not yet ratified). BI-7C4FDBF5, EP-BUILD-STUDIO.
+- **Status:** Ratified through the approved 2026-07-27 implementation plan; implementation in progress under BI-7C4FDBF5, EP-BUILD-STUDIO.
 - **Date:** 2026-06-19
 - **Operator prompt (Mark):** "Build Studio submits PRs that may not merge correctly (e.g. #2122, stuck on conflicts). Research how to best resolve this when the user is non-technical. Is there a precedent?"
 - **Method:** read-only audit of the BS PR path + GitHub-API commit/merge code, cross-checked against the live merge-race observed all of 2026-06-19, plus external precedent research.
 
 ---
+
+## 2026-07-27 current-state correction
+
+The repository now has a protected GitHub merge queue. Build Studio therefore
+does not create a per-portal queue and does not directly merge. The ratified
+implementation uses exact-head readiness, GitHub's compare-and-swap
+`update-branch` operation for a stale head, repository auto-merge/queue
+enrollment for evidence-cleared PRs, and a restart-safe Work Capsule reconciler.
+True textual conflicts escalate with evidence; automatic AI conflict editing is
+outside this prerequisite and requires a separate governed decision.
+
+PR merge is also distinct from deployment. A merged PR waits for governed
+self-upgrade and live-version evidence before the build can become complete.
+The detailed file-level contract and 20% bounded refactoring allocation are in
+`docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md`.
 
 ## 1. The failure mode (non-technical customer, dead-ended)
 

--- a/docs/user-guide/build-studio/deployment.md
+++ b/docs/user-guide/build-studio/deployment.md
@@ -60,7 +60,7 @@ When your feature is ready to ship, the AI Coworker runs through these steps in 
 3. **Create backlog epic** — Adds the feature to the operations backlog for visibility
 4. **Contribution assessment** — If sharing is enabled, evaluates whether the feature could benefit the wider community. You choose whether to share.
 5. **Documentation evidence** — Confirms that affected user guide, public site, architecture, install/ops, prompt, or contributor docs were updated, or that the build recorded a concrete no-docs-needed reason.
-6. **Pull request and security gates** — Creates a pull request on the codebase with automated security checks: secret detection, backdoor scanning, architecture compliance, dependency audit, and destructive operation scanning. If all checks pass and the build is fully verified, the PR auto-merges. If any check fails, the PR is flagged for human review with details of what needs attention.
+6. **Pull request and security gates** — Creates a pull request on the codebase with automated security checks: secret detection, backdoor scanning, architecture compliance, dependency audit, and destructive operation scanning. Build Studio checks the current PR evidence, safely refreshes a stale branch, and asks the protected merge queue to integrate an eligible change. It never bypasses the queue.
 7. **Deploy** — Checks the deployment window and triggers the governed deployment pipeline described above where promotion is enabled
 
 ## Database Backups
@@ -83,11 +83,22 @@ Every PR goes through four automated checks:
 3. **Architecture compliance** — Verifies files are in the correct directories and imports follow platform conventions
 4. **Dependency audit** — Flags any new packages added to the project for license and security review
 
-### Auto-Merge
+### Autonomous Merge-Queue Delivery
 
-If all four gates pass AND the build has passed TypeCheck, all tests, and all acceptance criteria, the PR is automatically merged using squash merge. The build status updates to "complete."
+If all four gates pass AND the build has passed TypeCheck, all tests, and all acceptance criteria, Build Studio watches the current PR head, waits for repository checks and review threads, and enrolls it in the protected merge queue. If the platform advances while checks run, Build Studio requests a safe branch update and waits for fresh checks.
 
-If any gate finds issues, the PR is created but not merged. The findings are posted as a comment on the PR for human review.
+Build Studio reports these states in plain language:
+
+- **Checking the pull request** — current checks or review evidence are still running
+- **Finalizing against the latest platform** — the branch is being refreshed safely
+- **Merge queued** — the protected repository queue owns the next step
+- **Waiting for governed release** — the PR merged, but the live platform has not advanced yet
+- **Deployed** — governed release evidence proves the change is live
+- **Needs your decision** — a true conflict, closed PR, or bounded recovery limit requires a person
+
+A merged pull request does not make the build complete. Completion waits for the
+governed release and live-version evidence. Build Studio does not directly
+merge, force-push, or silently edit a true conflict.
 
 ### Configuration
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -3630,7 +3630,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 2
+    "textMass": 5
   },
   "apps/web/components/build/BuildDecisionLedgerBand.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Outcome

Closes BI-7C4FDBF5 by giving Build Studio a durable, exact-head pull-request delivery loop instead of treating PR creation as completion.

- Centralizes GitHub PR readiness classification across both Build Studio PR-producing paths.
- Removes direct merge authority from Build Studio; it may update a stale branch and enter the protected merge queue, but GitHub/branch protection remains authoritative.
- Persists versioned delivery state on the existing Work Capsule workspace state using compare-and-set updates.
- Adds a scheduled reconciler with bounded recovery and fail-closed escalation.
- Keeps the build in `ship` until merge/release evidence is true; merged-but-not-released becomes `awaiting-release`, not “done.”
- Projects plain customer-facing delivery status with technical PR/SHA details behind progressive disclosure.

Work Capsule: `WC-09CA9C58`

## Architecture and substrate

Preserved and extended the existing `FeatureBuild`, `TaskRun`, `BuildPhaseRun`, `DecisionShadowLedger`, `AuthorityBinding`, Work Case / Work Capsule, merge-queue, and governed self-upgrade substrates. No new persistence model and no Prisma migration were introduced.

Exactly 20% of implementation effort was allocated to bounded structural refactoring: the shared GitHub readiness helper, shared delivery-state codec, and shared reconciler now replace divergent PR-readiness logic in the two existing producer paths.

## Verification

Local-CI-Evidence: `cms2zr0yb04ge01l780g4tx3r`

Exact candidate: `0a25858e4304cc3b630dd75374ced7ae33d54574`
Accepted gate base: `ab2c1bfee3f8bdfbadcd33063337372dd50fe1cd`
Integration commit: `5bbea53f76cb736161118a69d753dae638d5ee8c`

- Sandbox freshness: green (`next 16.2.11`, `react 19.2.8`, `typescript 6.0.3`, `prisma 7.8.0`, `vitest 4.1.10`).
- Prisma generate + migrate deploy: passed; 448 migrations present, none pending.
- Documentation index and link validation: passed.
- Repository guards: passed.
- Full web Vitest suite: passed.
- Web typecheck: passed.
- Production Docker build: passed (`sha256:7d68c2e5cf3a2849514791fe324d16ec82962abc9550181d6d9c5e4a13304155`).
- Current-main conflict preflight after later unrelated merges: `git merge-tree --write-tree origin/main HEAD` passed.

The final evidence write initially met governed portal quiescence during self-upgrade and was recovered from the completed SHA/base-bound artifacts without rerunning or weakening the gate. The discovered Node pregate scratch-gitdir bookkeeping defect is separately tracked as BI-5E4EFA22 and owned by the CI-efficiency lane.

## UX verification

Leased preview `NPEL-8EC8E638D0` exercised `/build?buildId=FB-UX-PR-RECOVERY` on the exact candidate.

- Desktop 1280×720: plain “Merge queued” lifecycle status, business-safe evidence and next action, no horizontal overflow.
- Mobile 390×844: status band remains in viewport with no horizontal overflow.
- Technical PR number/SHA/observation counters are closed by default and become visible only after opening “Technical delivery details.”
- Isolated fixture and preview container were removed; lease released.

Backlog UX evidence: `cms2x4pr51af501qqhlh07bt5`.

## Documentation and rollout

Updated the autonomous build completion operations guide, Build Studio deployment user guide, prior merge-resolution design, and the reviewed implementation plan. Rollout is additive and fail-closed: producer integration first, shared reconciler second, scheduled recovery third, customer projection last. No migration or data backfill is required.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`
  - `docs/superpowers/plans/2026-07-27-build-studio-pr-readiness-merge-recovery.md`
  - the prior merge-resolution design and governed self-upgrade / merge-queue documentation
- Current code substrate reviewed:
  - `FeatureBuild` and build-flow lifecycle handling
  - Work Capsule persistence and compare-and-set workspace state
  - both Build Studio PR-producing paths and the assurance remediation merge helper
  - the scheduled-job catalog and customer status loader/projection
- Source of truth:
  - Work Capsule delivery state plus fresh GitHub exact-head observation; governed self-upgrade remains deployment authority.
- Decision:
  - Build Studio may observe, update, and queue eligible evidence-cleared changes. Direct merge and conflict editing remain forbidden; ambiguous, high-risk, or authority-ceiling cases fail closed and escalate.


