### PR TITLE
fix(ci): hand off pregate freshness evidence (BI-5E4EFA22)

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -211,6 +211,14 @@ Node's experimental host web-storage disabled so Node 26 cannot shadow the
 `localStorage` and `sessionStorage` implementations owned by jsdom. This is a
 test-runner compatibility setting, not a change to application runtime policy.
 
+The candidate wrapper owns the freshness-evidence handoff path. Before each
+run it removes any prior report from the candidate gitdir and passes
+`DPF_LOCAL_CI_FRESHNESS_REPORT_FILE` through the runner to the freshness
+preflight in the scratch integration worktree. The preflight writes there and
+the wrapper reads that exact path. This prevents the two linked worktrees'
+different gitdirs from turning a green preflight into `freshness: unknown`, and
+prevents a stale prior report from classifying a new run.
+
 The sandbox-freshness step checks the load-bearing runtime and gate packages,
 including the Vitest runner used by the next step. Vitest is checked for both
 locked version and runnable entrypoint imports, so an incomplete package cannot

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -10,7 +10,7 @@
 // between POSIX and Windows contributor surfaces.
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mcpCall } from "./lib/mcp-client.mjs";
@@ -209,6 +209,11 @@ async function main() {
 
   const stateFile = gitPath(gitBin, worktreePath, "dpf-local-ci-gate.json");
   const metadataFile = gitPath(gitBin, worktreePath, "dpf-local-ci-metadata.json");
+  const freshnessReportFile = gitPath(
+    gitBin,
+    worktreePath,
+    "dpf-sandbox-freshness.json",
+  );
   const gitCommonDir = resolvePath(
     worktreePath,
     gitOrEmpty(gitBin, ["rev-parse", "--git-common-dir"], worktreePath),
@@ -222,6 +227,7 @@ async function main() {
     process.stdout.write("gate-worktree dry-run\n");
     process.stdout.write(`branch=${branch}\nsha=${sha}\nworktree=${worktreePath}\nremote=${options.remote}\nmcpUrl=${options.mcpUrl}\n`);
     process.stdout.write(`metadataFile=${metadataFile}\n`);
+    process.stdout.write(`freshnessReportFile=${freshnessReportFile}\n`);
     process.stdout.write(`pushBeforeLease=${options.pushBranch}\n`);
     if (commandSpec) {
       process.stdout.write(`localCiCommand=${commandSpec.label}\n`);
@@ -266,6 +272,17 @@ async function main() {
       continue;
     }
     localFenceToken = localFence.record.token;
+    // Only the local fence owner may mutate shared-run evidence. Clearing
+    // earlier lets a queued waiter delete the active owner's fresh report.
+    // Do this before the remote lease claim so a filesystem error cannot
+    // strand a governed lease.
+    try {
+      rmSync(freshnessReportFile, { force: true });
+    } catch (error) {
+      releaseLocalSandboxFence({ path: localFencePath, token: localFenceToken });
+      localFenceToken = "";
+      throw error;
+    }
     expiresAt = new Date(Date.now() + leaseTtlMs).toISOString();
     const claimResponse = await mcpCall("claim_nonprod_environment_lease", {
       environmentKey: "local-integration-ci",
@@ -299,11 +316,16 @@ async function main() {
   if (commandSpec) process.stdout.write(`running local-CI command: ${commandSpec.label}\n`);
   else process.stdout.write("sandbox checkout/build stub: gate passed (explicit test-only mode)\n");
 
+  // The preflight executes in the shared scratch integration worktree, whose
+  // gitdir differs from this candidate worktree's gitdir. Give the descendant
+  // process one explicit handoff path so the wrapper reads evidence from the
+  // same location the preflight writes.
   const gateCommand = createGateCommand(commandSpec, {
     cwd: worktreePath,
     env: {
       ...process.env,
       DPF_LOCAL_CI_METADATA_FILE: metadataFile,
+      DPF_LOCAL_CI_FRESHNESS_REPORT_FILE: freshnessReportFile,
       DPF_NONPROD_LEASE_ID: leaseId,
       DPF_NONPROD_OWNER_SESSION_ID: ownerSessionId,
     },
@@ -372,9 +394,10 @@ async function main() {
 
   let freshnessReport = null;
   try {
-    freshnessReport = JSON.parse(readFileSync(gitPath(gitBin, worktreePath, "dpf-sandbox-freshness.json"), "utf8"));
+    freshnessReport = JSON.parse(readFileSync(freshnessReportFile, "utf8"));
   } catch {
-    // no report produced — classifyGateOutcome treats an empty verdict as "not green".
+    // No report produced; the command exit code remains authoritative and the
+    // evidence records freshness as unknown.
   }
   const outcome = classifyGateOutcome({
     freshnessVerdict: freshnessReport ? freshnessReport.verdict : "",

--- a/scripts/sandbox-freshness-preflight.mjs
+++ b/scripts/sandbox-freshness-preflight.mjs
@@ -72,6 +72,7 @@ if (!fs.existsSync(path.join(rootDir, "pnpm-lock.yaml"))) {
 }
 
 let reportPath = valueAfter("--report");
+if (!reportPath) reportPath = process.env.DPF_LOCAL_CI_FRESHNESS_REPORT_FILE || "";
 if (!reportPath) {
   const gitPath = git(rootDir, ["rev-parse", "--git-path", "dpf-sandbox-freshness.json"]);
   reportPath = gitPath ? path.resolve(rootDir, gitPath) : path.join(rootDir, ".dpf-sandbox-freshness.json");

--- a/scripts/sandbox-freshness-preflight.test.mjs
+++ b/scripts/sandbox-freshness-preflight.test.mjs
@@ -6,7 +6,7 @@
 // reserved exit codes.
 // node --test scripts/sandbox-freshness-preflight.test.mjs — pure node, no docker.
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -148,6 +148,36 @@ test("green when workspace links match the lockfile", () => {
   assert.equal(next.lockedVersion, "16.2.9");
   assert.equal(next.resolvedVersion, "16.2.9");
   rmSync(root, { recursive: true, force: true });
+});
+
+test("writes the report to the gate-owned handoff path when --report is omitted", () => {
+  const root = scaffold();
+  const handoffDir = mkdtempSync(join(tmpdir(), "dpf-freshness-handoff-"));
+  const reportPath = join(handoffDir, "candidate-gitdir", "dpf-sandbox-freshness.json");
+  const result = spawnSync(
+    "node",
+    [cli, "--dir", root, "--skip-install-scan"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DPF_LOCAL_CI_FRESHNESS_REPORT_FILE: reportPath,
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(readFileSync(reportPath, "utf8"));
+  assert.equal(report.verdict, "green");
+  assert.equal(report.dir, root);
+  assert.equal(
+    existsSync(join(root, ".dpf-sandbox-freshness.json")),
+    false,
+    "the scratch checkout must not retain a second implicit report",
+  );
+
+  rmSync(root, { recursive: true, force: true });
+  rmSync(handoffDir, { recursive: true, force: true });
 });
 
 test("detects the incident: stale next@16.2.7 store link while lockfile requires 16.2.9", () => {

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -9,7 +9,7 @@
 // tests/release/local-ci-gate-contract.test.mjs, unchanged.
 
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, cpSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, cpSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
@@ -243,15 +243,142 @@ test("gate-worktree.mjs claims, records, and releases in order, and carries evid
   }
 });
 
+test("gate-worktree.mjs hands the scratch command a clean candidate-gitdir freshness path (BI-5E4EFA22)", async () => {
+  const { dir } = makeTempRepo();
+  const reportPath = join(dir, ".git", "dpf-sandbox-freshness.json");
+  writeFileSync(
+    reportPath,
+    JSON.stringify({
+      schema: "dpf-sandbox-freshness/v1",
+      verdict: "sandbox_drift",
+      generatedAt: "stale-from-a-prior-run",
+      failures: [{ kind: "stale_fixture", message: "must be removed before the gate" }],
+      packages: [],
+    }),
+  );
+
+  const temp = mkdtempSync(join(tmpdir(), "dpf-node-gate-freshness-handoff-"));
+  const writerScript = join(temp, "write-freshness.mjs");
+  writeFileSync(writerScript, `
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const out = process.env.DPF_LOCAL_CI_FRESHNESS_REPORT_FILE;
+if (!out) process.exit(40);
+if (existsSync(out)) process.exit(41);
+mkdirSync(dirname(out), { recursive: true });
+writeFileSync(out, JSON.stringify({
+  schema: "dpf-sandbox-freshness/v1",
+  generatedAt: "fresh-from-this-run",
+  verdict: "green",
+  failures: [],
+  packages: [{
+    name: "next",
+    lockedVersion: "16.2.11",
+    resolvedVersion: "16.2.11"
+  }],
+  convergence: null,
+  handoffPath: out
+}) + "\\n");
+`);
+
+  const mcp = await startMockMcp({
+    claim_nonprod_environment_lease: () => ({ success: true, entityId: "NPEL-HANDOFF" }),
+    record_local_integration_result: () => ({ success: true, entityId: "EXT-HANDOFF" }),
+    release_nonprod_environment_lease: () => ({ success: true }),
+  });
+  try {
+    const result = await runGateAsync(
+      ["--branch", "feat/freshness-handoff", "--sha", "candidate-sha", "--worktree", dir, "--no-push", "--mcp-url", mcp.url],
+      {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+        DPF_LOCAL_CI_COMMAND: `"${process.execPath}" "${writerScript}"`,
+      },
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report.generatedAt, "fresh-from-this-run");
+    assert.equal(report.handoffPath, reportPath);
+
+    const evidenceCall = mcp.calls.find((c) => c.params.name === "record_local_integration_result");
+    assert.equal(evidenceCall.params.arguments.evidence.freshness.verdict, "green");
+    assert.deepEqual(evidenceCall.params.arguments.evidence.freshness.packages, [{
+      name: "next",
+      locked: "16.2.11",
+      resolved: "16.2.11",
+    }]);
+  } finally {
+    await mcp.close();
+    rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("gate-worktree.mjs does not clear freshness evidence until it owns the local sandbox fence (BI-5E4EFA22)", async () => {
+  const { dir } = makeTempRepo();
+  const reportPath = join(dir, ".git", "dpf-sandbox-freshness.json");
+  const activeReport = {
+    schema: "dpf-sandbox-freshness/v1",
+    verdict: "green",
+    generatedAt: "active-owner-run",
+    failures: [],
+    packages: [],
+  };
+  writeFileSync(reportPath, `${JSON.stringify(activeReport)}\n`);
+  writeFileSync(
+    join(dir, ".git", "dpf-local-ci-owner.json"),
+    `${JSON.stringify({
+      schema: "dpf-local-sandbox-fence/v1",
+      token: "active-owner-token",
+      pid: process.pid,
+      ownerSessionId: "active-owner",
+      branch: "feat/active-owner",
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    })}\n`,
+  );
+
+  const result = await runGateAsync(
+    [
+      "--branch", "feat/queued-waiter",
+      "--sha", "candidate-sha",
+      "--worktree", dir,
+      "--no-push",
+      "--lease-wait-seconds", "0",
+    ],
+    {
+      ...process.env,
+      DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+      DPF_ALLOW_LOCAL_CI_STUB: "1",
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /sandbox owner process is still live/);
+  assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), activeReport);
+});
+
 test("gate-worktree.mjs records blocked_sandbox_drift (exit 3), not a product failure, when the freshness report is red", async () => {
   const { dir } = makeTempRepo();
-  writeFileSync(join(dir, ".git", "dpf-sandbox-freshness.json"), JSON.stringify({
+  const temp = mkdtempSync(join(tmpdir(), "dpf-node-gate-freshness-drift-"));
+  const writerScript = join(temp, "write-freshness-drift.mjs");
+  writeFileSync(writerScript, `
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const out = process.env.DPF_LOCAL_CI_FRESHNESS_REPORT_FILE;
+if (!out) process.exit(40);
+mkdirSync(dirname(out), { recursive: true });
+writeFileSync(out, JSON.stringify({
     schema: "dpf-sandbox-freshness/v1",
     verdict: "sandbox_drift",
     failures: [{ kind: "version_drift", message: "next resolves to 16.2.7 but pnpm-lock.yaml requires 16.2.9" }],
     packages: [{ name: "next", lockedVersion: "16.2.9", resolvedVersion: "16.2.7" }],
     convergence: { attempted: true, command: "pnpm install --frozen-lockfile", exitCode: 1 },
-  }));
+}) + "\\n");
+process.exit(3);
+`);
 
   const mcp = await startMockMcp({
     claim_nonprod_environment_lease: () => ({ success: true, entityId: "NPEL-DRIFT" }),
@@ -261,7 +388,7 @@ test("gate-worktree.mjs records blocked_sandbox_drift (exit 3), not a product fa
   try {
     const result = await runGateAsync(
       ["--branch", "feat/x", "--sha", "abc123", "--worktree", dir, "--no-push", "--mcp-url", mcp.url],
-      { ...process.env, DPF_MCP_BEARER_TOKEN: "dpfmcp_test", DPF_LOCAL_CI_COMMAND: `"${process.execPath}" -e "process.exit(3)"` },
+      { ...process.env, DPF_MCP_BEARER_TOKEN: "dpfmcp_test", DPF_LOCAL_CI_COMMAND: `"${process.execPath}" "${writerScript}"` },
     );
     assert.equal(result.status, 3, `${result.stdout}\n${result.stderr}`);
     assert.match(result.stderr, /BLOCKED \(sandbox drift\)/);
@@ -277,6 +404,7 @@ test("gate-worktree.mjs records blocked_sandbox_drift (exit 3), not a product fa
     assert.equal(state.status, "blocked_sandbox_drift");
   } finally {
     await mcp.close();
+    rmSync(temp, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- hand the Node-native scratch pregate an explicit candidate-owned freshness report path
- keep freshness classification fail-closed for missing/red reports and deferred evidence publication
- clear stale freshness evidence only after acquiring the local sandbox fence, preserving active-owner evidence
- document the cross-gitdir handoff contract

## Evidence
- exact head: `9bfd4ef7393301836fbaec76c84a2c58558be84b`
- accepted base: `ab2c1bfee3f8bdfbadcd33063337372dd50fe1cd`
- governed local-CI: PASSED, lease `NPEL-9AA0FFB59B`, evidence `cms2yyikg037w01l79w599v5a`
- full web Vitest: 2,255 files passed / 19,550 tests passed
- web typecheck and production Docker build passed
- Prisma generate + all 448 migrations current; docs/links/guards passed
- focused contracts: 11/11 freshness preflight; 15/15 applicable Node-native pregate contracts (the native-sh-only path is unavailable on this Windows/no-sh host and remains covered on Linux CI)

## Risk and rollback
- narrow CI harness change; no product routing, schema, or user-facing behavior changes
- rollback reverts this PR, restoring the prior candidate/scratch gitdir mismatch

## Documentation impact
- updated `docs/testing/pre-pr-gate.md`; no user-guide, public-site, or UX documentation applies

## UX / migration
- UX: not applicable (CI harness only)
- migration: not applicable

Closes BI-5E4EFA22