### PR TITLE
fix(ci): make route sweep accounting deterministic (BI-EA221325)

### DIFF
--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -17,6 +17,11 @@ on:
         description: "Measure and emit a fresh route-budget-baseline.json artifact to arm the ratchet"
         type: boolean
         default: false
+      workers:
+        description: "Bounded route workers (use 1/2/4 to run the reliability experiment)"
+        type: choice
+        options: ["1", "2", "4"]
+        default: "2"
 
 concurrency:
   group: ux-route-sweep-${{ github.ref }}
@@ -45,12 +50,11 @@ concurrency:
 # visibility, so computed-invisible nodes are pruned in the page before measuring.
 #
 # BOOTSTRAP: route-budget-baseline.json ships with `bootstrapped: false`, so the sweep
-# REPORTS without blocking until a measured baseline is committed. Arming it is one
-# mechanical step, not a calibration debate:
-#   pnpm --filter web ux:sweep -- --update-baseline   # against a running portal
-#   git add apps/web/lib/ux-budget/route-budget-baseline.json && commit
-# The set of routes present at that moment defines "pre-existing"; anything added later
-# is net-new and meets the absolutes.
+# REPORTS without blocking until a reproducible measured baseline is committed. Arm it
+# only after two same-SHA freezes are identical, both account for every eligible route,
+# an enforcing run reports zero regressions, and the 1/2/4 worker experiment has selected
+# the reliable default. See docs/testing/ci-evidence.md. The set of routes in the accepted
+# freeze defines "pre-existing"; anything added later is net-new and meets the absolutes.
 
 jobs:
   sweep:
@@ -76,6 +80,7 @@ jobs:
       NEXTAUTH_SECRET: ci_sweep_secret
       NEXTAUTH_URL: http://localhost:3000
       UX_SWEEP_BASE_URL: http://localhost:3000
+      UX_SWEEP_WORKERS: ${{ github.event.inputs.workers || '2' }}
 
     steps:
       - uses: actions/checkout@v7
@@ -136,7 +141,7 @@ jobs:
 
       - name: Run the sweep
         if: ${{ github.event.inputs.update_baseline != 'true' }}
-        run: pnpm --filter web ux:sweep
+        run: pnpm --filter web ux:sweep -- --workers "$UX_SWEEP_WORKERS"
 
       # Manual arming path: measure the running portal and emit the baseline as an
       # artifact for a human to commit via PR. Deliberately NOT committed from CI —
@@ -144,7 +149,7 @@ jobs:
       # contents permission.
       - name: Measure and emit a fresh baseline
         if: ${{ github.event.inputs.update_baseline == 'true' }}
-        run: pnpm --filter web ux:sweep -- --update-baseline
+        run: pnpm --filter web ux:sweep -- --workers "$UX_SWEEP_WORKERS" --update-baseline
 
       - name: Upload the fresh baseline
         if: ${{ github.event.inputs.update_baseline == 'true' }}
@@ -159,5 +164,17 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ux-route-budget-report
-          path: apps/web/lib/ux-budget/route-budget-report.json
+          path: |
+            apps/web/lib/ux-budget/route-budget-report.json
+            apps/web/test-results/ux-route-sweep/route-sweep-execution.json
+          if-no-files-found: warn
+
+      # Screenshots exist only for failed eligible routes. Keeping them out of green
+      # artifacts avoids paying storage and download cost for 201 healthy surfaces.
+      - name: Upload failure-only route diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ux-route-sweep-failure-diagnostics
+          path: apps/web/test-results/ux-route-sweep/screenshots
           if-no-files-found: ignore

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -7187,6 +7187,7 @@
         "standards-grounding",
         "scheduled-calibration",
         "activation-gate-later-waves",
+        "ux-route-sweep-stability",
         "baseline-snapshot"
       ]
     },

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -20,6 +20,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -30,6 +31,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -40,6 +42,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -50,6 +54,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -60,6 +65,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -70,6 +76,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -80,6 +87,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -90,6 +98,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -100,6 +109,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -110,6 +120,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -120,6 +131,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -130,6 +142,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -140,6 +153,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -150,6 +164,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -160,6 +175,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -170,6 +186,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -180,6 +197,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -190,6 +208,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -200,6 +219,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -210,6 +231,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -220,6 +242,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -230,6 +253,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -240,6 +264,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -250,6 +275,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -260,6 +287,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -270,6 +298,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -280,6 +309,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -290,6 +320,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -300,6 +332,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -310,6 +343,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -320,6 +355,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -330,6 +366,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -340,6 +378,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -350,6 +389,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -360,6 +401,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -370,6 +412,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -380,6 +423,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -390,6 +435,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -400,6 +446,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -410,6 +457,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -420,6 +469,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -430,6 +480,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -440,6 +491,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -450,6 +503,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -460,6 +514,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -470,6 +525,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -480,6 +537,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -490,6 +548,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -500,6 +560,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -510,6 +571,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -520,6 +583,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -530,6 +594,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -540,6 +606,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -550,6 +617,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -560,6 +629,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -570,6 +640,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -580,6 +652,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -590,6 +664,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -600,6 +675,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -610,6 +686,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -620,6 +698,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -630,6 +709,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -640,6 +720,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -650,6 +731,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -660,6 +742,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -670,6 +753,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -680,6 +764,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -690,6 +776,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -700,6 +788,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -710,6 +799,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -720,6 +810,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -730,6 +821,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -740,6 +832,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -750,6 +843,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -760,6 +854,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -770,6 +865,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -780,6 +876,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -790,6 +888,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -800,6 +899,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -810,6 +911,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -820,6 +922,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -830,6 +933,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -840,6 +945,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -850,6 +956,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -860,6 +967,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -870,6 +978,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -880,6 +989,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -890,6 +1001,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -900,6 +1012,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -910,6 +1023,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -920,6 +1035,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -930,6 +1046,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -940,6 +1057,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -950,6 +1068,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -960,6 +1080,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -970,6 +1091,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -980,6 +1102,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -990,6 +1114,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1000,6 +1126,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1010,6 +1138,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1020,6 +1149,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1030,6 +1160,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1040,6 +1171,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1050,6 +1183,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1060,6 +1194,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1070,6 +1205,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1080,6 +1216,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1090,6 +1227,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1100,6 +1239,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -1110,6 +1251,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1120,6 +1262,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1130,6 +1274,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1140,6 +1285,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1150,6 +1296,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1160,6 +1307,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1170,6 +1318,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1180,6 +1329,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1190,6 +1340,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1200,6 +1352,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1210,6 +1363,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1220,6 +1374,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1230,6 +1386,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1240,6 +1397,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1250,6 +1408,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1260,6 +1419,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1270,6 +1430,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1280,6 +1441,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1290,6 +1452,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1300,6 +1463,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1310,6 +1474,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1320,6 +1485,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1330,6 +1496,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1340,6 +1507,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1350,6 +1518,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1360,6 +1529,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1370,6 +1540,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1380,6 +1551,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1390,6 +1562,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1400,6 +1573,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1410,6 +1584,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1420,6 +1595,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1430,6 +1606,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1440,6 +1618,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1450,6 +1629,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1460,6 +1640,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -1470,6 +1652,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -1480,6 +1664,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1490,6 +1675,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1500,6 +1687,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1510,6 +1698,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1520,6 +1710,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1530,6 +1721,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1540,6 +1732,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -1550,6 +1744,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1560,6 +1755,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1570,6 +1766,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1580,6 +1777,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1590,6 +1788,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "redirects-to-dynamic-resource",
       "confidence": "high"
     },
     {
@@ -1600,6 +1800,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1610,6 +1811,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1620,6 +1822,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1630,6 +1833,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1640,6 +1844,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1650,6 +1855,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1660,6 +1867,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1670,6 +1878,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1680,6 +1890,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1690,6 +1901,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1700,6 +1912,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1710,6 +1923,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1720,6 +1934,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1730,6 +1945,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1740,6 +1957,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1750,6 +1968,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1760,6 +1979,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1770,6 +1990,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1780,6 +2001,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1790,6 +2012,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1800,6 +2023,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1810,6 +2034,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -1820,6 +2046,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1830,6 +2057,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1840,6 +2068,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1850,6 +2079,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1860,6 +2090,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1870,6 +2101,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1880,6 +2112,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1890,6 +2123,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1900,6 +2134,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1910,6 +2145,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1920,6 +2156,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1930,6 +2167,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1940,6 +2178,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1950,6 +2189,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1960,6 +2200,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1970,6 +2211,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1980,6 +2222,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -1990,6 +2233,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2000,6 +2244,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2010,6 +2255,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2020,6 +2267,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2030,6 +2278,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2040,6 +2289,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2050,6 +2300,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2060,6 +2311,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2070,6 +2322,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2080,6 +2333,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2090,6 +2345,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2100,6 +2356,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2110,6 +2367,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2120,6 +2378,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2130,6 +2389,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2140,6 +2400,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2150,6 +2411,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2160,6 +2422,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2170,6 +2433,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2180,6 +2444,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2190,6 +2455,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2200,6 +2466,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2210,6 +2477,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2220,6 +2488,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2230,6 +2499,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2240,6 +2510,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2250,6 +2521,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2260,6 +2532,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2270,6 +2543,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2280,6 +2554,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2290,6 +2565,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2300,6 +2576,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2310,6 +2587,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2320,6 +2598,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2330,6 +2609,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2340,6 +2621,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2350,6 +2632,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2360,6 +2644,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2370,6 +2656,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2380,6 +2668,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2390,6 +2680,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2400,6 +2692,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2410,6 +2704,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2420,6 +2716,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2430,6 +2728,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2440,6 +2739,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2450,6 +2751,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "customer-session-required",
       "confidence": "high"
     },
     {
@@ -2460,6 +2763,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2470,6 +2775,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2480,6 +2787,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2490,6 +2799,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2500,6 +2811,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2510,6 +2823,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2520,6 +2835,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2530,6 +2847,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2540,6 +2859,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2550,6 +2871,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2560,6 +2883,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2570,6 +2895,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2580,6 +2907,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2590,6 +2919,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -2600,6 +2931,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2610,6 +2942,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2620,6 +2954,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2630,6 +2966,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2640,6 +2978,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2650,6 +2990,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2660,6 +3002,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2670,6 +3014,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2680,6 +3026,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2690,6 +3038,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2700,6 +3050,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2710,6 +3062,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2720,6 +3074,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2730,6 +3086,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2740,6 +3098,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2750,6 +3110,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2760,6 +3122,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2770,6 +3134,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2780,6 +3146,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2790,6 +3158,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -2800,6 +3170,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2810,6 +3181,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "fixture-capability-unavailable",
       "confidence": "high"
     },
     {
@@ -2820,6 +3193,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "setup-phase-only",
       "confidence": "high"
     },
     {
@@ -2830,6 +3205,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2840,6 +3216,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2850,6 +3228,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2860,6 +3239,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2870,6 +3251,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2880,6 +3262,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2890,6 +3274,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2900,6 +3286,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2910,6 +3298,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2920,6 +3309,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2930,6 +3320,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2940,6 +3331,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2950,6 +3342,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2960,6 +3354,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -2970,6 +3365,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "storefront-setup-required",
       "confidence": "high"
     },
     {
@@ -2980,6 +3377,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "setup-phase-only",
       "confidence": "high"
     },
     {
@@ -2990,6 +3389,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -3000,6 +3401,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -3010,6 +3412,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -3020,6 +3424,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -3030,6 +3436,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -3040,6 +3447,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -3050,6 +3458,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -3060,6 +3470,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -3070,6 +3481,8 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": false,
+      "sweepExclusionReason": "dynamic-fixture-required",
       "confidence": "high"
     },
     {
@@ -3080,6 +3493,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {
@@ -3090,6 +3504,7 @@
         "next-action-marker",
         "lead-band"
       ],
+      "sweepEligible": true,
       "confidence": "high"
     }
   ]

--- a/apps/web/lib/ux-budget/route-shells.ts
+++ b/apps/web/lib/ux-budget/route-shells.ts
@@ -62,6 +62,61 @@ export const MIGRATED_ROUTES: ReadonlySet<string> = new Set<string>([]);
 export const PRE_MIGRATION_EXEMPT_CHECKS = ["next-action-marker", "lead-band"] as const;
 export type ExemptCheck = (typeof PRE_MIGRATION_EXEMPT_CHECKS)[number];
 
+export const ROUTE_SWEEP_EXCLUSION_REASONS = [
+  "dynamic-fixture-required",
+  "customer-session-required",
+  "storefront-setup-required",
+  "setup-phase-only",
+  "fixture-capability-unavailable",
+  "redirects-to-dynamic-resource",
+] as const;
+export type RouteSweepExclusionReason =
+  (typeof ROUTE_SWEEP_EXCLUSION_REASONS)[number];
+
+/**
+ * Static routes the owner-fixture sweep cannot measure honestly.
+ *
+ * This is policy layered on the canonical route inventory, not a second inventory:
+ * the generated registry below includes every route and records either measurable or
+ * one explicit reason. These 26 routes were confirmed across repeated same-SHA CI
+ * runs. They need a different authenticated/fixture context, intentionally redirect,
+ * or depend on a capability the generic fixture does not provision.
+ *
+ * Keep this list shrink-only where possible. A route becomes eligible in the same PR
+ * that adds its honest fixture context.
+ */
+export const ROUTE_SWEEP_EXCLUSIONS = {
+  "/admin/backups": "fixture-capability-unavailable",
+  "/finance/funds": "fixture-capability-unavailable",
+  "/governance": "fixture-capability-unavailable",
+  "/governance/records-requests": "fixture-capability-unavailable",
+  "/member-equity": "fixture-capability-unavailable",
+  "/rental": "fixture-capability-unavailable",
+  "/service-requests": "fixture-capability-unavailable",
+
+  "/customer-login": "customer-session-required",
+  "/portal": "customer-session-required",
+  "/portal/account": "customer-session-required",
+  "/portal/cases": "customer-session-required",
+  "/portal/health": "customer-session-required",
+  "/portal/orders": "customer-session-required",
+  "/portal/services": "customer-session-required",
+  "/portal/sign-up": "customer-session-required",
+  "/portal/support": "customer-session-required",
+
+  "/storefront/animals": "storefront-setup-required",
+  "/storefront/inbox": "storefront-setup-required",
+  "/storefront/items": "storefront-setup-required",
+  "/storefront/sections": "storefront-setup-required",
+  "/storefront/settings": "storefront-setup-required",
+  "/storefront/tables": "storefront-setup-required",
+  "/storefront/units": "storefront-setup-required",
+
+  "/setup": "setup-phase-only",
+  "/welcome": "setup-phase-only",
+  "/ops/health": "redirects-to-dynamic-resource",
+} as const satisfies Record<string, RouteSweepExclusionReason>;
+
 export type RouteShellPolicy = {
   routePath: string;
   shell: UxShell;
@@ -69,14 +124,23 @@ export type RouteShellPolicy = {
   migrated: boolean;
   /** Checks waived while the route is pre-migration — recorded baseline debt. */
   exemptChecks: readonly ExemptCheck[];
+  /** Whether the generic owner fixture can measure this route honestly. */
+  sweepEligible: boolean;
+  /** Why the route remains in inventory but outside this fixture context. */
+  sweepExclusionReason?: RouteSweepExclusionReason;
 };
 
 export function shellPolicyFor(routePath: string, c: ShellClassifiable): RouteShellPolicy {
   const migrated = MIGRATED_ROUTES.has(routePath);
+  const sweepExclusionReason = routePath.includes("[")
+    ? "dynamic-fixture-required"
+    : ROUTE_SWEEP_EXCLUSIONS[routePath as keyof typeof ROUTE_SWEEP_EXCLUSIONS];
   return {
     routePath,
     shell: shellForRoute(c),
     migrated,
     exemptChecks: migrated ? [] : PRE_MIGRATION_EXEMPT_CHECKS,
+    sweepEligible: sweepExclusionReason === undefined,
+    ...(sweepExclusionReason ? { sweepExclusionReason } : {}),
   };
 }

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -22,6 +22,7 @@ import {
   UX_SHELLS,
 } from "./index";
 import { countWords } from "../owner-first/ux-audit";
+import { ROUTE_SWEEP_EXCLUSIONS } from "./route-shells";
 
 describe("disclosure scoping — collapsed detail is excised, never taxed", () => {
   it("does not count words inside a collapsed <details>", () => {
@@ -253,7 +254,14 @@ describe("generated route-shell registry", () => {
     pageRouteCount: number;
     migratedCount: number;
     summary: Record<string, number>;
-    routes: { routePath: string; shell: string; migrated: boolean; exemptChecks: string[] }[];
+    routes: {
+      routePath: string;
+      shell: string;
+      migrated: boolean;
+      exemptChecks: string[];
+      sweepEligible: boolean;
+      sweepExclusionReason?: string;
+    }[];
   };
 
   const manifest = JSON.parse(
@@ -285,6 +293,30 @@ describe("generated route-shell registry", () => {
     const sum = Object.values(registry.summary).reduce((a, b) => a + b, 0);
     expect(sum).toBe(registry.pageRouteCount);
     expect(registry.pageRouteCount).toBe(registry.routes.length);
+  });
+
+  it("accounts for every route as measurable or explicitly excluded", () => {
+    expect(
+      registry.routes.filter(
+        (route) => route.sweepEligible === Boolean(route.sweepExclusionReason),
+      ),
+    ).toEqual([]);
+    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(201);
+    expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(107);
+  });
+
+  it("keeps contextual sweep exclusions explicit, valid, and non-stale", () => {
+    const manifestRoutes = new Set(registry.routes.map((route) => route.routePath));
+    expect(
+      Object.keys(ROUTE_SWEEP_EXCLUSIONS).filter((routePath) => !manifestRoutes.has(routePath)),
+    ).toEqual([]);
+
+    for (const [routePath, reason] of Object.entries(ROUTE_SWEEP_EXCLUSIONS)) {
+      expect(registry.routes.find((route) => route.routePath === routePath)).toMatchObject({
+        sweepEligible: false,
+        sweepExclusionReason: reason,
+      });
+    }
   });
 
   it("the committed registry is in sync with its generator", async () => {

--- a/apps/web/scripts/ux-route-sweep-runner.ts
+++ b/apps/web/scripts/ux-route-sweep-runner.ts
@@ -1,0 +1,213 @@
+import { performance } from "node:perf_hooks";
+
+/**
+ * Pure coordination for the UX route sweep.
+ *
+ * The browser driver owns navigation and measurement; this module owns bounded
+ * scheduling, deterministic result ordering, and exact inventory accounting. Keeping
+ * those concerns browser-free makes the failure contract cheap to test and prevents
+ * the CLI from growing another ad-hoc worker loop.
+ */
+
+export const SUPPORTED_SWEEP_WORKER_COUNTS = [1, 2, 4] as const;
+export type SweepWorkerCount = (typeof SUPPORTED_SWEEP_WORKER_COUNTS)[number];
+
+type RouteRow = { routePath: string };
+
+export type SemanticStructureNode = {
+  role: string | null;
+  attributes?: string[];
+  children?: SemanticStructureNode[];
+};
+
+/**
+ * Serialise the browser-resolved semantic DOM projection the ratchet consumes.
+ *
+ * Null-role wrappers are flattened. That mirrors the accessibility tree's treatment
+ * of generic layout divs while keeping semantic descendants and their nesting.
+ */
+export function serialiseSemanticStructure(
+  nodes: readonly SemanticStructureNode[],
+): string {
+  if (nodes.length === 0) throw new Error("empty semantic structure");
+  const lines: string[] = [];
+
+  const visit = (node: SemanticStructureNode, depth: number): void => {
+    const childDepth = node.role ? depth + 1 : depth;
+    if (node.role) {
+      const attrs = (node.attributes ?? []).join(" ");
+      lines.push(
+        `${"  ".repeat(depth)}- ${node.role}${attrs ? ` ${attrs}` : ""}`,
+      );
+    }
+    for (const child of node.children ?? []) visit(child, childDepth);
+  };
+
+  for (const node of nodes) visit(node, 0);
+  if (lines.length === 0) throw new Error("semantic structure has no projected nodes");
+  return lines.join("\n");
+}
+
+export type MeasuredRouteOutcome<T> = {
+  routePath: string;
+  status: "measured";
+  value: T;
+  durationMs: number;
+};
+
+export type FailedRouteOutcome = {
+  routePath: string;
+  status: "failed";
+  reason: string;
+  durationMs: number;
+};
+
+export type RouteOutcome<T> = MeasuredRouteOutcome<T> | FailedRouteOutcome;
+
+export type RouteAccounting = {
+  complete: boolean;
+  expectedRouteCount: number;
+  measuredRouteCount: number;
+  failedRoutes: string[];
+  missingRoutes: string[];
+  duplicateRoutes: string[];
+  unexpectedRoutes: string[];
+};
+
+export type RouteWorkResult<T> = {
+  workerCount: SweepWorkerCount;
+  durationMs: number;
+  outcomes: RouteOutcome<T>[];
+  accounting: RouteAccounting;
+};
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message.split(/\r?\n/)[0] || error.name;
+  return String(error);
+}
+
+export function parseSweepWorkerCount(value: string | undefined): SweepWorkerCount {
+  const parsed = Number(value ?? "2");
+  if (
+    !Number.isInteger(parsed) ||
+    !SUPPORTED_SWEEP_WORKER_COUNTS.includes(parsed as SweepWorkerCount)
+  ) {
+    throw new Error(
+      `Unsupported UX sweep worker count ${JSON.stringify(value)}; supported values are 1, 2, or 4.`,
+    );
+  }
+  return parsed as SweepWorkerCount;
+}
+
+function duplicates(values: readonly string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([value]) => value)
+    .sort();
+}
+
+/**
+ * Reconcile terminal outcomes against the route inventory.
+ *
+ * This is deliberately independent of the worker implementation: a future scheduler
+ * or shard combiner still has to prove the same no-missing/no-duplicate contract.
+ */
+export function reconcileRouteAccounting(
+  expectedRoutes: readonly string[],
+  outcomes: readonly Pick<RouteOutcome<unknown>, "routePath" | "status">[],
+): RouteAccounting {
+  const expectedSet = new Set(expectedRoutes);
+  const outcomeRoutes = outcomes.map((outcome) => outcome.routePath);
+  const outcomeSet = new Set(outcomeRoutes);
+  const failedRoutes = outcomes
+    .filter((outcome) => outcome.status === "failed")
+    .map((outcome) => outcome.routePath)
+    .sort();
+  const missingRoutes = expectedRoutes.filter((routePath) => !outcomeSet.has(routePath)).sort();
+  const duplicateRoutes = duplicates(outcomeRoutes);
+  const unexpectedRoutes = [...outcomeSet]
+    .filter((routePath) => !expectedSet.has(routePath))
+    .sort();
+  const measuredRouteCount = outcomes.filter((outcome) => outcome.status === "measured").length;
+
+  return {
+    complete:
+      expectedRoutes.length > 0 &&
+      duplicates(expectedRoutes).length === 0 &&
+      failedRoutes.length === 0 &&
+      missingRoutes.length === 0 &&
+      duplicateRoutes.length === 0 &&
+      unexpectedRoutes.length === 0 &&
+      measuredRouteCount === expectedRoutes.length,
+    expectedRouteCount: expectedRoutes.length,
+    measuredRouteCount,
+    failedRoutes,
+    missingRoutes,
+    duplicateRoutes,
+    unexpectedRoutes,
+  };
+}
+
+/**
+ * Run one operation per route with bounded concurrency.
+ *
+ * Work completion order is intentionally discarded: outcomes retain the canonical
+ * inventory order so JSON artifacts are byte-stable apart from measured values and
+ * durations. An operation failure is one route outcome, not a worker crash; remaining
+ * routes still run so the failure artifact is complete.
+ */
+export async function runBoundedRouteWork<TRow extends RouteRow, TValue>(
+  rows: readonly TRow[],
+  workerCount: SweepWorkerCount,
+  operation: (row: TRow, workerIndex: number) => Promise<TValue>,
+): Promise<RouteWorkResult<TValue>> {
+  const routePaths = rows.map((row) => row.routePath);
+  const duplicateInputs = duplicates(routePaths);
+  if (duplicateInputs.length > 0) {
+    throw new Error(`Duplicate eligible UX routes: ${duplicateInputs.join(", ")}`);
+  }
+
+  const startedAt = performance.now();
+  const outcomes = new Array<RouteOutcome<TValue>>(rows.length);
+  let nextIndex = 0;
+
+  const workers = Array.from(
+    { length: Math.min(workerCount, Math.max(rows.length, 1)) },
+    async (_, workerIndex) => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= rows.length) return;
+
+        const row = rows[index];
+        const routeStartedAt = performance.now();
+        try {
+          outcomes[index] = {
+            routePath: row.routePath,
+            status: "measured",
+            value: await operation(row, workerIndex),
+            durationMs: Math.round(performance.now() - routeStartedAt),
+          };
+        } catch (error) {
+          outcomes[index] = {
+            routePath: row.routePath,
+            status: "failed",
+            reason: errorMessage(error),
+            durationMs: Math.round(performance.now() - routeStartedAt),
+          };
+        }
+      }
+    },
+  );
+
+  await Promise.all(workers);
+  const accounting = reconcileRouteAccounting(routePaths, outcomes);
+  return {
+    workerCount,
+    durationMs: Math.round(performance.now() - startedAt),
+    outcomes,
+    accounting,
+  };
+}

--- a/apps/web/scripts/ux-route-sweep.test.ts
+++ b/apps/web/scripts/ux-route-sweep.test.ts
@@ -1,6 +1,61 @@
 import { describe, expect, it } from "vitest";
 
-import { withIsolatedSweepPage } from "./ux-route-sweep";
+import {
+  BROWSER_EVALUATION_RUNTIME,
+  DOM_SETTLE_EXPRESSION,
+  captureAccessibilityStructure,
+  waitForRouteDomToSettle,
+  withIsolatedSweepPage,
+} from "./ux-route-sweep";
+import {
+  parseSweepWorkerCount,
+  reconcileRouteAccounting,
+  runBoundedRouteWork,
+  serialiseSemanticStructure,
+} from "./ux-route-sweep-runner";
+
+describe("serialiseSemanticStructure", () => {
+  it("keeps role hierarchy and structural state while dropping names", () => {
+    expect(
+      serialiseSemanticStructure([
+        {
+          role: "main",
+          children: [
+            { role: "heading", attributes: ["[level=1]"] },
+            { role: "button", attributes: ["[expanded]"] },
+          ],
+        },
+      ]),
+    ).toBe(
+      [
+        "- main",
+        "  - heading [level=1]",
+        "  - button [expanded]",
+      ].join("\n"),
+    );
+  });
+
+  it("flattens generic wrappers without dropping their structural children", () => {
+    expect(
+      serialiseSemanticStructure([
+        {
+          role: null,
+          children: [
+            {
+              role: null,
+              children: [
+                {
+                  role: "navigation",
+                  children: [{ role: "link" }],
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+    ).toBe(["- navigation", "  - link"].join("\n"));
+  });
+});
 
 describe("withIsolatedSweepPage", () => {
   it("gives each route a fresh page and closes it after measurement", async () => {
@@ -58,5 +113,132 @@ describe("withIsolatedSweepPage", () => {
     ).rejects.toThrow("measurement failed");
 
     expect(closed).toBe(true);
+  });
+});
+
+describe("captureAccessibilityStructure", () => {
+  it("installs the cross-realm transpiler helper before evaluating the DOM projection", async () => {
+    const evaluations: unknown[] = [];
+    const page = {
+      evaluate: async (expression: unknown) => {
+        evaluations.push(expression);
+        if (typeof expression === "string") return undefined;
+        return [{ role: "main", children: [{ role: "heading", attributes: ["[level=1]"] }] }];
+      },
+    };
+
+    await expect(
+      captureAccessibilityStructure(page as never),
+    ).resolves.toBe(["- main", "  - heading [level=1]"].join("\n"));
+    expect(evaluations).toHaveLength(2);
+    expect(evaluations[0]).toBe(BROWSER_EVALUATION_RUNTIME);
+    expect(BROWSER_EVALUATION_RUNTIME).toContain("globalThis.__name");
+    expect(typeof evaluations[1]).toBe("function");
+  });
+});
+
+describe("waitForRouteDomToSettle", () => {
+  it("uses a self-contained, bounded browser expression", async () => {
+    const evaluations: unknown[] = [];
+    const page = {
+      evaluate: async (expression: unknown) => {
+        evaluations.push(expression);
+      },
+    };
+
+    await waitForRouteDomToSettle(page as never);
+
+    expect(evaluations).toEqual([DOM_SETTLE_EXPRESSION]);
+    expect(DOM_SETTLE_EXPRESSION).toContain("new MutationObserver");
+    expect(DOM_SETTLE_EXPRESSION).toContain("deadlineMs = 5000");
+    expect(DOM_SETTLE_EXPRESSION).not.toContain("__name");
+  });
+});
+
+describe("route sweep coordination", () => {
+  it("runs bounded workers while preserving inventory order", async () => {
+    const routes = ["/slow", "/fast", "/last"].map((routePath) => ({ routePath }));
+    let active = 0;
+    let maxActive = 0;
+
+    const result = await runBoundedRouteWork(routes, 2, async (row) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, row.routePath === "/slow" ? 20 : 1));
+      active -= 1;
+      return `${row.routePath}:measured`;
+    });
+
+    expect(maxActive).toBe(2);
+    expect(result.outcomes.map((outcome) => outcome.routePath)).toEqual([
+      "/slow",
+      "/fast",
+      "/last",
+    ]);
+    expect(result.outcomes.map((outcome) => outcome.status)).toEqual([
+      "measured",
+      "measured",
+      "measured",
+    ]);
+    expect(result.accounting.complete).toBe(true);
+  });
+
+  it("records a route failure, completes the remaining inventory, and fails accounting", async () => {
+    const routes = ["/a", "/broken", "/c"].map((routePath) => ({ routePath }));
+
+    const result = await runBoundedRouteWork(routes, 2, async (row) => {
+      if (row.routePath === "/broken") throw new Error("navigation interrupted");
+      return row.routePath;
+    });
+
+    expect(result.outcomes).toHaveLength(3);
+    expect(result.outcomes.find((outcome) => outcome.routePath === "/broken")).toMatchObject({
+      status: "failed",
+      reason: "navigation interrupted",
+    });
+    expect(result.accounting).toMatchObject({
+      complete: false,
+      expectedRouteCount: 3,
+      measuredRouteCount: 2,
+      failedRoutes: ["/broken"],
+      missingRoutes: [],
+      duplicateRoutes: [],
+      unexpectedRoutes: [],
+    });
+  });
+
+  it("detects duplicate, missing, and unexpected result rows", () => {
+    expect(
+      reconcileRouteAccounting(
+        ["/a", "/b", "/c"],
+        [
+          { routePath: "/a", status: "measured" },
+          { routePath: "/a", status: "measured" },
+          { routePath: "/outside", status: "measured" },
+        ],
+      ),
+    ).toMatchObject({
+      complete: false,
+      missingRoutes: ["/b", "/c"],
+      duplicateRoutes: ["/a"],
+      unexpectedRoutes: ["/outside"],
+    });
+  });
+
+  it("rejects a silently empty eligible inventory", () => {
+    expect(reconcileRouteAccounting([], [])).toMatchObject({
+      complete: false,
+      expectedRouteCount: 0,
+      measuredRouteCount: 0,
+    });
+  });
+
+  it("accepts only the measured 1/2/4 worker experiment values", () => {
+    expect(parseSweepWorkerCount(undefined)).toBe(2);
+    expect(parseSweepWorkerCount("1")).toBe(1);
+    expect(parseSweepWorkerCount("2")).toBe(2);
+    expect(parseSweepWorkerCount("4")).toBe(4);
+    expect(() => parseSweepWorkerCount("3")).toThrow(/supported values are 1, 2, or 4/i);
+    expect(() => parseSweepWorkerCount("many")).toThrow(/supported values are 1, 2, or 4/i);
   });
 });

--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -18,9 +18,14 @@
  *   pnpm --filter web ux:sweep -- --base-url http://localhost:3000
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { chromium, type Browser, type Page } from "@playwright/test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
 import { measureUxBudget } from "../lib/ux-budget/measure";
@@ -33,7 +38,17 @@ import {
   type RouteMeasurement,
 } from "../lib/ux-budget/ratchet";
 import type { UxShell } from "../lib/ux-budget/budgets";
-import type { ExemptCheck } from "../lib/ux-budget/route-shells";
+import type {
+  ExemptCheck,
+  RouteSweepExclusionReason,
+} from "../lib/ux-budget/route-shells";
+import {
+  parseSweepWorkerCount,
+  runBoundedRouteWork,
+  serialiseSemanticStructure,
+  type SemanticStructureNode,
+  type RouteWorkResult,
+} from "./ux-route-sweep-runner";
 
 function repoRoot(): string {
   let dir = process.cwd();
@@ -48,13 +63,20 @@ const ROOT = repoRoot();
 const SHELLS_REL = "apps/web/lib/ux-budget/route-shells.generated.json";
 const BASELINE_REL = "apps/web/lib/ux-budget/route-budget-baseline.json";
 const REPORT_REL = "apps/web/lib/ux-budget/route-budget-report.json";
+const EXECUTION_REL =
+  "apps/web/test-results/ux-route-sweep/route-sweep-execution.json";
+const DIAGNOSTICS_REL = "apps/web/test-results/ux-route-sweep/screenshots";
+const MAX_FAILURE_SCREENSHOTS = 12;
 const GENERATOR = "apps/web/scripts/ux-route-sweep.ts";
+let failureScreenshotCount = 0;
 
 type ShellRow = {
   routePath: string;
   shell: UxShell;
   migrated: boolean;
   exemptChecks: ExemptCheck[];
+  sweepEligible: boolean;
+  sweepExclusionReason?: RouteSweepExclusionReason;
 };
 
 function arg(name: string, fallback: string): string {
@@ -88,9 +110,6 @@ function pruneInvisible(): string {
   return doc.querySelector("body")?.innerHTML ?? "";
 }
 
-/** Why a route produced no measurement — reported, never silently dropped. */
-export type SkipReason = { routePath: string; reason: string };
-
 /**
  * Give one route exclusive ownership of one page.
  *
@@ -114,12 +133,218 @@ export async function withIsolatedSweepPage<
   }
 }
 
+function captureSemanticStructureFromDom(): SemanticStructureNode[] {
+  const named = (element: Element): boolean =>
+    element.hasAttribute("aria-label") ||
+    element.hasAttribute("aria-labelledby");
+
+  const implicitRole = (element: Element): string | null => {
+    const tag = element.tagName.toLowerCase();
+    if (tag === "a" && element.hasAttribute("href")) return "link";
+    if (tag === "button" || tag === "summary") return "button";
+    if (/^h[1-6]$/.test(tag)) return "heading";
+    if (tag === "main") return "main";
+    if (tag === "nav") return "navigation";
+    if (tag === "header") {
+      return element.closest("article, aside, main, nav, section")
+        ? null
+        : "banner";
+    }
+    if (tag === "footer") {
+      return element.closest("article, aside, main, nav, section")
+        ? null
+        : "contentinfo";
+    }
+    if (tag === "aside") return "complementary";
+    if (tag === "form") return named(element) ? "form" : null;
+    if (tag === "section") return named(element) ? "region" : null;
+    if (tag === "dialog") return "dialog";
+    if (tag === "details" || tag === "fieldset") return "group";
+    if (tag === "table") return "table";
+    if (tag === "thead" || tag === "tbody" || tag === "tfoot") return "rowgroup";
+    if (tag === "tr") return "row";
+    if (tag === "th") {
+      return element.getAttribute("scope") === "row"
+        ? "rowheader"
+        : "columnheader";
+    }
+    if (tag === "td") return "cell";
+    if (tag === "ul" || tag === "ol") return "list";
+    if (tag === "li") return "listitem";
+    if (tag === "select") {
+      const select = element as HTMLSelectElement;
+      return select.multiple || select.size > 1 ? "listbox" : "combobox";
+    }
+    if (tag === "option") return "option";
+    if (tag === "textarea") return "textbox";
+    if (tag === "input") {
+      const input = element as HTMLInputElement;
+      if (["button", "submit", "reset", "image"].includes(input.type)) return "button";
+      if (input.type === "checkbox") return "checkbox";
+      if (input.type === "radio") return "radio";
+      if (input.type === "number") return "spinbutton";
+      if (input.type === "range") return "slider";
+      if (input.type === "search") return "searchbox";
+      if (input.type === "hidden") return null;
+      return "textbox";
+    }
+    if (tag === "img") {
+      return element.getAttribute("alt") === "" ? null : "img";
+    }
+    if (tag === "hr") return "separator";
+    if (tag === "progress") return "progressbar";
+    if (tag === "meter") return "meter";
+    if (tag === "p") return "paragraph";
+    if (tag === "code") return "code";
+    if (tag === "strong") return "strong";
+    return null;
+  };
+
+  const structuralAttributes = (element: Element, role: string): string[] => {
+    const attributes: string[] = [];
+    if (role === "heading") {
+      const level =
+        element.getAttribute("aria-level") ??
+        (/^h[1-6]$/i.test(element.tagName) ? element.tagName.slice(1) : null);
+      if (level) attributes.push(`[level=${level}]`);
+    }
+    for (const state of ["pressed", "checked", "expanded", "selected", "disabled"]) {
+      const value = element.getAttribute(`aria-${state}`);
+      if (value === "true") attributes.push(`[${state}]`);
+      else if (value && value !== "false") attributes.push(`[${state}=${value}]`);
+    }
+    const control = element as HTMLInputElement | HTMLSelectElement | HTMLOptionElement;
+    if ("checked" in control && control.checked && !attributes.includes("[checked]")) {
+      attributes.push("[checked]");
+    }
+    if ("selected" in control && control.selected && !attributes.includes("[selected]")) {
+      attributes.push("[selected]");
+    }
+    if ("disabled" in control && control.disabled && !attributes.includes("[disabled]")) {
+      attributes.push("[disabled]");
+    }
+    if (element instanceof HTMLDetailsElement && element.open) {
+      attributes.push("[expanded]");
+    }
+    return attributes;
+  };
+
+  const nameFromContentRoles = new Set([
+    "button",
+    "checkbox",
+    "columnheader",
+    "heading",
+    "link",
+    "listitem",
+    "option",
+    "radio",
+    "rowheader",
+    "tab",
+  ]);
+
+  const walk = (node: Node, suppressText = false): SemanticStructureNode[] => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return !suppressText && node.textContent?.trim()
+        ? [{ role: "text" }]
+        : [];
+    }
+    if (!(node instanceof Element)) return [];
+    if (
+      node.hasAttribute("hidden") ||
+      node.getAttribute("aria-hidden") === "true"
+    ) {
+      return [];
+    }
+    const style = getComputedStyle(node);
+    if (style.display === "none" || style.visibility === "hidden") return [];
+
+    const explicitRole = node
+      .getAttribute("role")
+      ?.trim()
+      .split(/\s+/)[0]
+      ?.toLowerCase();
+    const role =
+      explicitRole === "none" || explicitRole === "presentation"
+        ? null
+        : explicitRole || implicitRole(node);
+    const children = [...node.childNodes].flatMap((child) =>
+      walk(child, role ? nameFromContentRoles.has(role) : false),
+    );
+    if (!role) return children;
+    return [{
+      role,
+      attributes: structuralAttributes(node, role),
+      children,
+    }];
+  }
+
+  return walk(document.body);
+}
+
+/**
+ * tsx/esbuild preserves nested function names by referencing its `__name` helper.
+ * Playwright serialises only the callback passed to page.evaluate, so that helper is
+ * outside the browser realm unless we install the matching runtime primitive there.
+ *
+ * Keep this as a string expression: compiling another callback to install the helper
+ * would recreate the same cross-realm dependency we are repairing.
+ */
+export const BROWSER_EVALUATION_RUNTIME =
+  "globalThis.__name = (target, value) => Object.defineProperty(target, 'name', { value, configurable: true })";
+
+/**
+ * Resolve after the hydrated DOM has been mutation-free for a short interval.
+ *
+ * `networkidle` is invalid for this portal because event streams and polling are
+ * intentionally long-lived. Capturing immediately after `load` is also invalid:
+ * client-populated cards then race the measurement and move word counts by a row or
+ * status label between identical runs. The hard deadline keeps a genuinely live DOM
+ * from hanging the sweep.
+ *
+ * This remains a string expression for the same cross-realm reason as the transpiler
+ * runtime above: nested callbacks compiled by tsx would otherwise depend on `__name`.
+ */
+export const DOM_SETTLE_EXPRESSION = `(() => new Promise((resolve) => {
+  const quietMs = 300;
+  const deadlineMs = 5000;
+  let quietTimer;
+  let deadlineTimer;
+  const observer = new MutationObserver(() => armQuietTimer());
+  const finish = () => {
+    clearTimeout(quietTimer);
+    clearTimeout(deadlineTimer);
+    observer.disconnect();
+    resolve(undefined);
+  };
+  const armQuietTimer = () => {
+    clearTimeout(quietTimer);
+    quietTimer = setTimeout(finish, quietMs);
+  };
+  observer.observe(document.body, {
+    attributes: true,
+    childList: true,
+    characterData: true,
+    subtree: true
+  });
+  deadlineTimer = setTimeout(finish, deadlineMs);
+  armQuietTimer();
+}))()`;
+
+export async function waitForRouteDomToSettle(page: Page): Promise<void> {
+  await page.evaluate(DOM_SETTLE_EXPRESSION);
+}
+
+export async function captureAccessibilityStructure(page: Page): Promise<string> {
+  await page.evaluate(BROWSER_EVALUATION_RUNTIME);
+  const structure = await page.evaluate(captureSemanticStructureFromDom);
+  return serialiseSemanticStructure(structure);
+}
+
 async function measureRoute(
   page: Page,
   row: ShellRow,
   baseUrl: string,
-  skipped: SkipReason[],
-): Promise<RouteMeasurement | null> {
+): Promise<RouteMeasurement> {
   // NOT networkidle: this portal holds long-lived connections (activity streams,
   // polling), so networkidle never settles and every route would time out.
   const response = await page.goto(`${baseUrl}${row.routePath}`, {
@@ -128,32 +353,33 @@ async function measureRoute(
   });
   // Give client components a beat to hydrate; the whole point is the served DOM.
   await page.waitForLoadState("load", { timeout: 15_000 }).catch(() => {});
+  await waitForRouteDomToSettle(page);
 
   // A route that errors or redirects to auth is not a surface to budget; recording a
   // measurement for it would freeze a login page as the route's baseline.
   if (!response) {
-    skipped.push({ routePath: row.routePath, reason: "no response" });
-    return null;
+    throw new Error("no response");
   }
   if (response.status() >= 400) {
-    skipped.push({ routePath: row.routePath, reason: `http ${response.status()}` });
-    return null;
+    throw new Error(`http ${response.status()}`);
   }
   const landed = new URL(page.url()).pathname.replace(/\/$/, "") || "/";
   const wanted = row.routePath.replace(/\/$/, "") || "/";
   if (landed !== wanted) {
-    skipped.push({ routePath: row.routePath, reason: `redirected to ${landed}` });
-    return null;
+    throw new Error(`redirected to ${landed}`);
   }
 
   const html = await page.evaluate(pruneInvisible);
   if (typeof html !== "string" || html.length === 0) {
     // Never hand an empty/undefined document to the measurer: it would score as a
     // perfectly compliant zero-word surface and freeze that as the route's baseline.
-    skipped.push({ routePath: row.routePath, reason: "empty document after pruning" });
-    return null;
+    throw new Error("empty document after pruning");
   }
-  const ariaSnapshot = await page.locator("body").ariaSnapshot({ timeout: 15_000 });
+  // Project the browser-resolved semantic DOM to role/nesting/state only. The
+  // ratchet deliberately ignores accessible names, so asking Playwright or CDP to
+  // serialise the full named AX tree first is both wasted work and unbounded on
+  // large data-owner pages such as /admin/reference-data.
+  const ariaSnapshot = await captureAccessibilityStructure(page);
 
   // Necessary, never sufficient — axe green is not "accessible" (spec §5.4).
   // A failing SCAN must not cost us the whole route's budget measurement: axe threw
@@ -185,75 +411,162 @@ function loadBaseline(path: string): BaselineFile {
   return JSON.parse(readFileSync(path, "utf8")) as BaselineFile;
 }
 
+function routeArtifactSlug(routePath: string): string {
+  return (
+    routePath
+      .replace(/^\/+/, "")
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "root"
+  );
+}
+
+async function captureFailureScreenshot(page: Page, routePath: string): Promise<void> {
+  if (failureScreenshotCount >= MAX_FAILURE_SCREENSHOTS) return;
+  failureScreenshotCount += 1;
+  const diagnosticsDir = join(ROOT, DIAGNOSTICS_REL);
+  mkdirSync(diagnosticsDir, { recursive: true });
+  await page
+    .screenshot({
+      path: join(diagnosticsDir, `${routeArtifactSlug(routePath)}.png`),
+      fullPage: true,
+      animations: "disabled",
+      timeout: 10_000,
+    })
+    .catch(() => {});
+}
+
+function executionOutcome<T>(
+  outcome: RouteWorkResult<T>["outcomes"][number],
+): {
+  routePath: string;
+  status: "measured" | "failed";
+  durationMs: number;
+  reason?: string;
+} {
+  return outcome.status === "measured"
+    ? {
+        routePath: outcome.routePath,
+        status: outcome.status,
+        durationMs: outcome.durationMs,
+      }
+    : {
+        routePath: outcome.routePath,
+        status: outcome.status,
+        durationMs: outcome.durationMs,
+        reason: outcome.reason,
+      };
+}
+
 async function main(): Promise<void> {
   const baseUrl = arg("base-url", process.env.UX_SWEEP_BASE_URL ?? "http://localhost:3000");
   const storageState = arg("storage-state", "e2e/.auth/state.json");
+  const workerCount = parseSweepWorkerCount(
+    arg("workers", process.env.UX_SWEEP_WORKERS ?? "2"),
+  );
   const updateBaseline = process.argv.includes("--update-baseline");
 
-  const rows = (
+  const inventory = (
     JSON.parse(readFileSync(join(ROOT, SHELLS_REL), "utf8")) as { routes: ShellRow[] }
-  ).routes
-    // Dynamic routes need per-route fixtures to be meaningful; they join when the
-    // fixture org can supply real ids. Recorded as skipped rather than silently dropped.
-    .filter((r) => !r.routePath.includes("["));
+  ).routes;
+  const rows = inventory.filter((row) => row.sweepEligible);
+  const excluded = inventory
+    .filter((row) => !row.sweepEligible)
+    .map((row) => ({
+      routePath: row.routePath,
+      reason: row.sweepExclusionReason ?? "missing-generated-exclusion-reason",
+    }));
 
   const statePath = join(ROOT, storageState);
   let browser: Browser | undefined;
-  const measurements: RouteMeasurement[] = [];
-  const skipped: SkipReason[] = [];
+  let contexts: BrowserContext[] = [];
+  let routeRun: RouteWorkResult<RouteMeasurement> | undefined;
   if (!existsSync(statePath)) {
-    console.error(`[ux-sweep] WARNING: no storage state at ${storageState} — every authenticated route will redirect to login and be skipped.`);
+    console.error(
+      `[ux-sweep] WARNING: no storage state at ${storageState} — authenticated route measurement will fail.`,
+    );
   }
 
   try {
     browser = await chromium.launch();
-    const context = await browser.newContext({
-      viewport: { width: 1280, height: 900 },
-      ...(existsSync(statePath) ? { storageState: statePath } : {}),
-    });
+    contexts = await Promise.all(
+      Array.from({ length: workerCount }, () =>
+        browser!.newContext({
+          viewport: { width: 1280, height: 900 },
+          ...(existsSync(statePath) ? { storageState: statePath } : {}),
+        }),
+      ),
+    );
 
-    for (const row of rows) {
-      try {
-        const m = await withIsolatedSweepPage(context, (page) =>
-          measureRoute(page, row, baseUrl, skipped),
-        );
-        if (m) measurements.push(m);
-      } catch (err) {
-        // One unreachable route must not abort the sweep; it is reported as skipped.
-        const first = (err as Error).message.split(/\r?\n/)[0];
-        skipped.push({ routePath: row.routePath, reason: `error: ${first}` });
-      }
-    }
+    routeRun = await runBoundedRouteWork(
+      rows,
+      workerCount,
+      async (row, workerIndex) =>
+        withIsolatedSweepPage(contexts[workerIndex], async (page) => {
+          try {
+            return await measureRoute(page, row, baseUrl);
+          } catch (error) {
+            await captureFailureScreenshot(page, row.routePath);
+            throw error;
+          }
+        }),
+    );
   } finally {
+    await Promise.all(contexts.map((context) => context.close().catch(() => {})));
     await browser?.close();
   }
 
-  console.error(`[ux-sweep] measured ${measurements.length} routes, skipped ${skipped.length}`);
-  if (skipped.length) {
-    const byReason = new Map<string, string[]>();
-    for (const s of skipped) {
-      const key = s.reason.replace(/\d+/g, "N");
-      byReason.set(key, [...(byReason.get(key) ?? []), s.routePath]);
-    }
-    for (const [reason, routes] of [...byReason].sort((a, b) => b[1].length - a[1].length)) {
-      console.error(`[ux-sweep]   ${routes.length}x ${reason} — e.g. ${routes.slice(0, 5).join(", ")}`);
-    }
-  }
+  if (!routeRun) throw new Error("route worker orchestration did not produce a result");
+  const measurements = routeRun.outcomes.flatMap((outcome) =>
+    outcome.status === "measured" ? [outcome.value] : [],
+  );
+  const executionReport = {
+    schemaVersion: 1,
+    sourceSha: process.env.GITHUB_SHA ?? process.env.UX_SWEEP_SOURCE_SHA ?? "unknown",
+    workerCount,
+    durationMs: routeRun.durationMs,
+    inventory: {
+      totalRouteCount: inventory.length,
+      eligibleRouteCount: rows.length,
+      excludedRouteCount: excluded.length,
+      excluded,
+    },
+    accounting: routeRun.accounting,
+    routes: routeRun.outcomes.map(executionOutcome),
+  };
+  const executionPath = join(ROOT, EXECUTION_REL);
+  mkdirSync(dirname(executionPath), { recursive: true });
+  writeFileSync(
+    executionPath,
+    `${JSON.stringify(executionReport, null, 2)}\n`,
+    "utf8",
+  );
 
-  // CAPABILITY PROBE (spec §6 L5): a checker that measures nothing must be RED.
-  // A sweep that skips every route and reports OK is the silent-empty failure this
-  // epic exists to remove — it would sit green forever while measuring no UX at all.
-  // The threshold is deliberately blunt: any run that cannot measure a majority of
-  // the routes it was asked to measure has not done its job.
-  const attempted = measurements.length + skipped.length;
-  if (measurements.length === 0 || measurements.length * 2 < attempted) {
+  console.error(
+    `[ux-sweep] measured ${measurements.length}/${rows.length} eligible routes with ${workerCount} worker(s); ${excluded.length} explicitly excluded from this fixture context`,
+  );
+  if (!routeRun.accounting.complete) {
+    for (const outcome of routeRun.outcomes) {
+      if (outcome.status === "failed") {
+        console.error(`[ux-sweep] FAILED ${outcome.routePath}: ${outcome.reason}`);
+      }
+    }
+    if (routeRun.accounting.missingRoutes.length > 0) {
+      console.error(
+        `[ux-sweep] missing results: ${routeRun.accounting.missingRoutes.join(", ")}`,
+      );
+    }
+    if (routeRun.accounting.duplicateRoutes.length > 0) {
+      console.error(
+        `[ux-sweep] duplicate results: ${routeRun.accounting.duplicateRoutes.join(", ")}`,
+      );
+    }
+    if (routeRun.accounting.unexpectedRoutes.length > 0) {
+      console.error(
+        `[ux-sweep] unexpected results: ${routeRun.accounting.unexpectedRoutes.join(", ")}`,
+      );
+    }
     console.error(
-      [
-        "",
-        `[ux-sweep] FAILED CAPABILITY PROBE — measured ${measurements.length} of ${attempted} routes.`,
-        "A sweep that cannot see the portal is not evidence of a healthy portal.",
-        `Check the authenticated session (${storageState}) and that ${baseUrl} is serving.`,
-      ].join("\n"),
+      `[ux-sweep] FAILED COMPLETENESS CONTRACT — see ${EXECUTION_REL} and failure-only screenshots.`,
     );
     process.exit(1);
   }

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -106,6 +106,60 @@ Before any PR suite-skipping activates (BI-4527C1DA and dependents):
 
 Until then, exhaustive PR and merge-group execution remains the default.
 
+## UX route-sweep stability
+
+Workflow: `.github/workflows/ux-route-sweep.yml` (`UX Route Budget Sweep`)
+
+The sweep keeps the canonical 308-route inventory and gives every route one
+generated disposition in
+`apps/web/lib/ux-budget/route-shells.generated.json`:
+
+- **201 eligible routes** must each produce exactly one measurement;
+- **81 dynamic routes** remain visible as `dynamic-fixture-required`;
+- **26 contextual routes** carry an explicit customer-session, storefront,
+  setup-phase, fixture-capability, or dynamic-redirect exclusion.
+
+There is no percentage-based capability threshold. A missing, duplicate,
+unexpected, or failed eligible route makes the check red after the remaining
+inventory finishes. The always-uploaded
+`route-sweep-execution.json` records the source SHA, worker count, duration,
+full eligibility accounting, and route outcomes in deterministic inventory
+order. Up to 12 failure screenshots are uploaded only when eligible routes
+fail; the execution record still reports every failure.
+
+Hierarchy capture reads the browser-resolved semantic DOM and projects it
+directly to implicit/explicit role, nesting, heading level, and structural
+control state. Accessible names are never serialised into the comparison: the
+ratchet does not consume them, and doing so made large data-owner routes spend
+tens of seconds producing values that were immediately discarded.
+
+The runner waits for 300 ms of DOM mutation quiet, capped at 5 seconds, before
+capture. This is the deterministic hydration boundary: `networkidle` is not
+valid for a portal with long-lived streams, while measuring immediately after
+`load` races client-populated rows and status labels.
+
+Manual workflow dispatch accepts a bounded worker count of `1`, `2`, or `4`;
+the measured default is **2**. On candidate `37e848084f`, all three settings
+completed 201/201 routes with zero failures: worker 1 took 865,504 ms, worker 2
+took 696,589 ms, and worker 4 took 765,651 ms. Four workers added load without
+improving the critical path because `/admin/reference-data` alone consumed
+roughly 11-13 minutes; that product defect is tracked as `BI-CC7CA516`.
+Each worker owns an authenticated browser context and each route owns a fresh
+page, so route teardown cannot interrupt the next navigation.
+
+The checked-in route-budget ratchet may move from `bootstrapped:false` to
+`bootstrapped:true` only after:
+
+1. two baseline artifacts from consecutive runs on the same SHA are identical;
+2. both runs measure all 201 eligible routes with zero failures;
+3. an enforcing run against the accepted baseline reports zero regressions;
+4. the 1/2/4-worker experiment records completion, variance, failures, and
+   sweep duration.
+
+Functional UX journeys remain separate evidence. This sweep measures structural
+and cognitive-load budgets; it does not prove login, persistence, or workflow
+outcomes.
+
 ## Baseline snapshot
 
 Checked-in seed report (structure only; metrics fill from calibration runs):


### PR DESCRIPTION
## Summary
- account explicitly for all 308 discovered routes: 201 eligible, 81 dynamic exclusions, 26 contextual exclusions
- replace shared-page crawling with bounded 1/2/4-worker scheduling, one authenticated context per worker, and one fresh page per route
- fail closed on every missing, duplicate, unexpected, or failed eligible route while preserving deterministic result ordering
- add failure-only screenshot diagnostics and an always-uploaded execution record
- document the same-SHA reproducibility and worker-selection contract; keep the ratchet unarmed until evidence proves it stable

## Evidence
- exact head: `45cd1dd2b11b80554036e54fea2a284fe6ae1f49`
- accepted base: `2c70291b6c5c0a7612cfc02818af4447fa162f58`
- governed local-CI: PASSED, lease `NPEL-EAFB359F9A`, evidence `cms313ufz061p01l7bn0d3lf0`
- full web Vitest: 2,257 files / 19,569 tests passed
- typecheck, Prisma generation/migrations, docs/guards, and production Docker build passed
- manual same-SHA 1/2/4 worker experiments will be attached before queue enrollment

## Safety
- the checked-in route-budget baseline remains `bootstrapped:false`; this PR does not claim reproducibility before the same-SHA experiment finishes
- any incomplete route inventory is a red check, not a percentage threshold or silent skip
- screenshots are failure-only and capped; every outcome remains in the machine-readable execution artifact

## Documentation impact
- updates `docs/testing/ci-evidence.md` and the generated doc index

## UX / migration
- UX: verification harness change; functional user journeys are unchanged
- migration: not applicable

Closes BI-EA221325