### PR TITLE
feat(inference): mask governed context before dispatch

### DIFF
--- a/apps/web/lib/govern/data/executable-policies.test.ts
+++ b/apps/web/lib/govern/data/executable-policies.test.ts
@@ -21,4 +21,17 @@ describe("executable policy bundle", () => {
     expect(kinds.has("mask")).toBe(true);
     expect(kinds.has("disposition-evidence")).toBe(true);
   });
+
+  it("separates raw external denial from authorized protected projection", () => {
+    const restrictedRaw = DATA_EXECUTABLE_POLICIES.find(
+      (policy) => policy.id === "restricted-external-destination",
+    );
+    const protected = DATA_EXECUTABLE_POLICIES.find(
+      (policy) => policy.id === "protected-external-projection",
+    );
+
+    expect(restrictedRaw?.match.transformations).toEqual(["none"]);
+    expect(protected?.match.transformations).toEqual(["masked", "tokenized"]);
+    expect(protected?.effect).toBe("allow");
+  });
 });

--- a/apps/web/lib/govern/data/executable-policies.test.ts
+++ b/apps/web/lib/govern/data/executable-policies.test.ts
@@ -26,12 +26,12 @@ describe("executable policy bundle", () => {
     const restrictedRaw = DATA_EXECUTABLE_POLICIES.find(
       (policy) => policy.id === "restricted-external-destination",
     );
-    const protected = DATA_EXECUTABLE_POLICIES.find(
+    const protectedPolicy = DATA_EXECUTABLE_POLICIES.find(
       (policy) => policy.id === "protected-external-projection",
     );
 
     expect(restrictedRaw?.match.transformations).toEqual(["none"]);
-    expect(protected?.match.transformations).toEqual(["masked", "tokenized"]);
-    expect(protected?.effect).toBe("allow");
+    expect(protectedPolicy?.match.transformations).toEqual(["masked", "tokenized"]);
+    expect(protectedPolicy?.effect).toBe("allow");
   });
 });

--- a/apps/web/lib/govern/data/executable-policies.ts
+++ b/apps/web/lib/govern/data/executable-policies.ts
@@ -10,6 +10,7 @@ import type {
   DataAssetId,
   DataCategory,
   DataEffect,
+  DataProtectionTransformation,
   DataSensitivity,
   DestinationClass,
   MasterDataDomainKey,
@@ -40,6 +41,7 @@ export type PolicyMatch = {
   purposes?: readonly ProcessingPurposeKey[];
   subjectRoles?: readonly SubjectRole[];
   destinations?: readonly DestinationClass[];
+  transformations?: readonly DataProtectionTransformation[];
 };
 
 export type DataExecutablePolicy = {
@@ -72,16 +74,50 @@ const POLICIES: readonly DataExecutablePolicy[] = [
       actions: ["project", "export"],
       sensitivities: ["restricted"],
       destinations: ["external-service"],
+      transformations: ["none"],
     },
     effect: "deny",
     explanationCode: "restricted-cannot-leave-boundary",
     effectiveFrom: "2026-07-17",
   },
   {
+    id: "protected-external-projection",
+    version: "1",
+    precedenceLevel: "mandatory-authority",
+    match: {
+      actions: ["export"],
+      sensitivities: ["confidential", "restricted"],
+      destinations: ["external-service"],
+      transformations: ["masked", "tokenized"],
+    },
+    effect: "allow",
+    explanationCode: "protected-projection-may-leave-boundary",
+    effectiveFrom: "2026-07-27",
+  },
+  {
+    id: "restricted-in-process-mask",
+    version: "1",
+    precedenceLevel: "mandatory-authority",
+    match: {
+      actions: ["project"],
+      sensitivities: ["restricted"],
+      destinations: ["in-process", "internal-store", "derived-index"],
+      transformations: ["none"],
+    },
+    effect: "allow-with-obligations",
+    obligations: [{ kind: "mask", profileId: "default-restricted" }],
+    explanationCode: "restricted-masked-inside-controlled-runtime",
+    effectiveFrom: "2026-07-27",
+  },
+  {
     id: "confidential-projection-mask",
     version: "1",
     precedenceLevel: "organization-policy",
-    match: { actions: ["project"], sensitivities: ["confidential"] },
+    match: {
+      actions: ["project", "export"],
+      sensitivities: ["confidential"],
+      transformations: ["none"],
+    },
     effect: "allow-with-obligations",
     obligations: [{ kind: "mask", profileId: "default-confidential" }],
     explanationCode: "confidential-masked-before-projection",

--- a/apps/web/lib/govern/data/mask-for-context.test.ts
+++ b/apps/web/lib/govern/data/mask-for-context.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import type { DataPolicyDecision } from "./policy-decision";
+import {
+  ContextMaskAuthorizationError,
+  ContextMaskMaterialityError,
+  applyContextTransform,
+  maskForContext,
+} from "./mask-for-context";
+
+function maskingDecision(): DataPolicyDecision {
+  return {
+    decisionId: "decision-mask-1",
+    organizationId: "org-test",
+    effect: "allow-with-obligations",
+    obligations: [{ kind: "mask", profileId: "default-confidential" }],
+    explanationCode: "confidential-masked-before-projection",
+    matchedPolicyVersions: ["confidential-projection-mask@1"],
+    assetVersion: "asset-v1",
+    classificationVersion: "classification-v1",
+    authorityVersion: "authority-v1",
+    inputHash: "input-hash",
+    replay: "single-use",
+  };
+}
+
+describe("applyContextTransform", () => {
+  it.each([
+    ["omit", "secret", undefined],
+    ["redact", "secret", "[REDACTED]"],
+    ["partial", "123456789", "[PARTIAL:6789]"],
+    ["aggregate", ["a", "b", "c"], "[AGGREGATED:3]"],
+    ["pass-through", "safe", "safe"],
+  ] as const)("applies %s", (transform, value, expected) => {
+    expect(applyContextTransform(value, transform)).toBe(expected);
+  });
+
+  it("uses one stable opaque token for repeated values", () => {
+    const first = applyContextTransform("ada@example.com", "tokenize");
+    const second = applyContextTransform("ada@example.com", "tokenize");
+
+    expect(first).toMatch(/^\[DPF_TOKEN_[A-F0-9]{12}\]$/);
+    expect(second).toBe(first);
+    expect(first).not.toContain("ada");
+  });
+});
+
+describe("maskForContext", () => {
+  it.each([
+    ["context-omit", undefined],
+    ["context-redact", "[REDACTED]"],
+    ["context-partial", "[PARTIAL:6789]"],
+    ["context-tokenize", expect.stringMatching(/^\[DPF_TOKEN_/)],
+    ["context-aggregate", "[AGGREGATED:9]"],
+    ["context-pass-through", "123456789"],
+  ] as const)("applies PDP profile %s at a nested classifier path", (profileId, expected) => {
+    const decision = {
+      ...maskingDecision(),
+      obligations: [{ kind: "mask" as const, profileId }],
+    };
+    const result = maskForContext(
+      { customer: { accountNumber: "123456789" } },
+      {
+        decision,
+        detailUse: "replaceable",
+        matches: [{
+          dataClass: "payments-finance",
+          path: "customer.accountNumber",
+          reason: "payment-or-finance-field",
+          confidence: "inferred",
+        }],
+      },
+    );
+    expect(result.value.customer.accountNumber).toEqual(expected);
+  });
+
+  it("transforms nested message, tool argument, tool result, schema, and system-prompt values", () => {
+    const rawEmail = "ada@example.com";
+    const rawSecret = "sk-super-secret-123456";
+    const result = maskForContext(
+      {
+        systemPrompt: `Help ${rawEmail}; never repeat ${rawSecret}`,
+        messages: [
+          { role: "user", content: `Contact ${rawEmail}` },
+          {
+            role: "assistant",
+            content: [{
+              type: "tool_use",
+              name: "lookup_customer",
+              input: { email: rawEmail, apiKey: rawSecret },
+            }],
+          },
+          {
+            role: "tool",
+            content: `{"customerEmail":"${rawEmail}","authorization":"${rawSecret}"}`,
+          },
+        ],
+        tools: [{
+          name: "lookup_customer",
+          parameters: {
+            properties: {
+              email: { example: rawEmail },
+              apiKey: { example: rawSecret },
+            },
+          },
+        }],
+      },
+      {
+        decision: maskingDecision(),
+        detailUse: "replaceable",
+        matches: [
+          { dataClass: "customer-records", path: "systemPrompt", reason: "contact-detail", confidence: "deterministic" },
+          { dataClass: "secrets-credentials", path: "systemPrompt", reason: "secret-shaped-token", confidence: "deterministic" },
+          { dataClass: "customer-records", path: "messages[0].content", reason: "contact-detail", confidence: "deterministic" },
+          { dataClass: "customer-records", path: "messages[1].content[0].input.email", reason: "contact-detail", confidence: "deterministic" },
+          { dataClass: "secrets-credentials", path: "messages[1].content[0].input.apiKey", reason: "secret-field-name", confidence: "inferred" },
+          { dataClass: "customer-records", path: "messages[2].content", reason: "contact-detail", confidence: "deterministic" },
+          { dataClass: "secrets-credentials", path: "messages[2].content", reason: "secret-shaped-token", confidence: "deterministic" },
+          { dataClass: "customer-records", path: "tools[0].parameters.properties.email.example", reason: "contact-detail", confidence: "deterministic" },
+          { dataClass: "secrets-credentials", path: "tools[0].parameters.properties.apiKey.example", reason: "secret-field-name", confidence: "inferred" },
+        ],
+      },
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(rawEmail);
+    expect(serialized).not.toContain(rawSecret);
+    expect(serialized).toContain("[DPF_TOKEN_");
+    expect(serialized).toContain("[REDACTED]");
+    expect(result.transformation).toBe("tokenized");
+    expect(result.rehydrationHandle).toMatch(/^rehydration_[a-f0-9]{24}$/);
+    expect(result).not.toHaveProperty("tokenMap");
+  });
+
+  it("refuses caller-shaped masking without a PDP mask obligation", () => {
+    const decision = { ...maskingDecision(), obligations: [] };
+    expect(() =>
+      maskForContext(
+        { email: "ada@example.com" },
+        {
+          decision,
+          detailUse: "replaceable",
+          matches: [
+            { dataClass: "customer-records", path: "email", reason: "contact-detail", confidence: "deterministic" },
+          ],
+        },
+      ),
+    ).toThrow(ContextMaskAuthorizationError);
+  });
+
+  it.each(["material", "unknown"] as const)(
+    "refuses a misleading transform when sensitive detail use is %s",
+    (detailUse) => {
+      expect(() =>
+        maskForContext(
+          { email: "ada@example.com" },
+          {
+            decision: maskingDecision(),
+            detailUse,
+            matches: [
+              { dataClass: "customer-records", path: "email", reason: "contact-detail", confidence: "deterministic" },
+            ],
+          },
+        ),
+      ).toThrow(ContextMaskMaterialityError);
+    },
+  );
+
+  it("fails closed when a sensitive classifier match has no safe transform", () => {
+    expect(() =>
+      maskForContext(
+        { notes: "Employee salary needs review" },
+        {
+          decision: maskingDecision(),
+          detailUse: "replaceable",
+          matches: [
+            { dataClass: "employee-records", path: "notes", reason: "employee-record-text", confidence: "inferred" },
+          ],
+        },
+      ),
+    ).toThrow(/no safe transform/i);
+  });
+
+  it("tokenizes finance identifiers without retaining the raw value", () => {
+    const raw = "Invoice account 4455661122";
+    const result = maskForContext(
+      { notes: raw },
+      {
+        decision: maskingDecision(),
+        detailUse: "replaceable",
+        matches: [
+          { dataClass: "payments-finance", path: "notes", reason: "payment-or-finance-text", confidence: "inferred" },
+        ],
+      },
+    );
+    expect(JSON.stringify(result)).not.toContain("4455661122");
+    expect(JSON.stringify(result)).toContain("[DPF_TOKEN_");
+  });
+});

--- a/apps/web/lib/govern/data/mask-for-context.ts
+++ b/apps/web/lib/govern/data/mask-for-context.ts
@@ -1,0 +1,366 @@
+import { createHmac, randomBytes } from "node:crypto";
+
+import type { DataPolicyDecision } from "./policy-decision";
+import type { InferencePayloadMatch } from "@/lib/inference/data-screening/types";
+
+export type ContextTransform =
+  | "omit"
+  | "redact"
+  | "partial"
+  | "tokenize"
+  | "aggregate"
+  | "pass-through";
+
+export type SensitiveDetailUse = "replaceable" | "material" | "unknown";
+
+export type ContextMaskAuthority = {
+  decision: DataPolicyDecision;
+  matches: readonly InferencePayloadMatch[];
+  detailUse: SensitiveDetailUse;
+};
+
+export type MaskedContext<T> = {
+  value: T;
+  transformation: "none" | "masked" | "tokenized";
+  transformedValueCount: number;
+  rehydrationHandle?: string;
+};
+
+export class ContextMaskAuthorizationError extends Error {
+  constructor() {
+    super("A current PDP allow-with-obligations decision with a mask obligation is required.");
+    this.name = "ContextMaskAuthorizationError";
+  }
+}
+
+export class ContextMaskMaterialityError extends Error {
+  constructor(detailUse: SensitiveDetailUse) {
+    super(
+      `Sensitive detail use is ${detailUse}; masking could make the answer misleading, so an eligible unmasked route is required.`,
+    );
+    this.name = "ContextMaskMaterialityError";
+  }
+}
+
+export class ContextMaskCoverageError extends Error {
+  constructor(paths: readonly string[]) {
+    super(`No safe transform is defined for sensitive classifier path(s): ${paths.join(", ")}`);
+    this.name = "ContextMaskCoverageError";
+  }
+}
+
+const TOKEN_KEY = randomBytes(32);
+const TOKEN_TTL_MS = 5 * 60_000;
+const MAX_TOKEN_MAPS = 1_000;
+const CONTACT_PATTERN =
+  /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/gi;
+const SECRET_PATTERN =
+  /\b(?:sk-[A-Za-z0-9_-]{10,}|dpfmcp_[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]{12,}|AKIA[0-9A-Z]{12,})\b|-----BEGIN\s+(?:RSA\s+)?PRIVATE KEY-----/gi;
+const FINANCE_IDENTIFIER_PATTERN = /\b\d[\d\s-]{5,}\d\b/g;
+
+type TokenVaultEntry = {
+  expiresAt: number;
+  tokens: ReadonlyMap<string, string>;
+};
+
+const tokenVault = new Map<string, TokenVaultEntry>();
+
+function stableToken(value: string): string {
+  const digest = createHmac("sha256", TOKEN_KEY)
+    .update(value)
+    .digest("hex")
+    .slice(0, 12)
+    .toUpperCase();
+  return `[DPF_TOKEN_${digest}]`;
+}
+
+/**
+ * Pure transform primitive. `maskForContext` owns authorization and should be
+ * used at enforcement seams; this helper exists so every transform has one
+ * deterministic implementation.
+ */
+export function applyContextTransform(
+  value: unknown,
+  transform: ContextTransform,
+): unknown {
+  switch (transform) {
+    case "omit":
+      return undefined;
+    case "redact":
+      return "[REDACTED]";
+    case "partial": {
+      const text = String(value ?? "");
+      return text.length <= 4 ? "[PARTIAL]" : `[PARTIAL:${text.slice(-4)}]`;
+    }
+    case "tokenize":
+      return stableToken(String(value ?? ""));
+    case "aggregate": {
+      const count = Array.isArray(value)
+        ? value.length
+        : value && typeof value === "object"
+          ? Object.keys(value).length
+          : typeof value === "number"
+            ? value
+            : String(value ?? "").length;
+      return `[AGGREGATED:${count}]`;
+    }
+    case "pass-through":
+      return value;
+  }
+}
+
+/**
+ * Apply the PDP-authorized default context mask profile to classifier-owned
+ * paths. Callers cannot supply transform directives: the PDP obligation and
+ * classifier reasons are the authority inputs.
+ */
+export function maskForContext<T>(
+  value: T,
+  authority: ContextMaskAuthority,
+): MaskedContext<T> {
+  assertMaskAuthorized(authority);
+  if (authority.matches.length === 0) {
+    return { value, transformation: "none", transformedValueCount: 0 };
+  }
+  if (authority.detailUse !== "replaceable") {
+    throw new ContextMaskMaterialityError(authority.detailUse);
+  }
+
+  const matchesByPath = groupMatchesByPath(authority.matches);
+  const forcedTransform = transformFromPolicyProfile(authority.decision);
+  const unsupported = authority.matches
+    .filter((match) =>
+      !forcedTransform &&
+      !isCoveredBySafeTransform(match, matchesByPath.get(match.path) ?? [])
+    )
+    .map((match) => match.path);
+  if (unsupported.length > 0) {
+    throw new ContextMaskCoverageError([...new Set(unsupported)].sort());
+  }
+
+  const tokenMap = new Map<string, string>();
+  const state = { transformedValueCount: 0 };
+  const transformed = visitContext(
+    value,
+    "",
+    matchesByPath,
+    tokenMap,
+    state,
+    forcedTransform,
+  ) as T;
+
+  const rehydrationHandle = tokenMap.size > 0
+    ? storeTokenMap(tokenMap)
+    : undefined;
+  return {
+    value: transformed,
+    transformation: tokenMap.size > 0 ? "tokenized" : state.transformedValueCount > 0 ? "masked" : "none",
+    transformedValueCount: state.transformedValueCount,
+    ...(rehydrationHandle ? { rehydrationHandle } : {}),
+  };
+}
+
+function assertMaskAuthorized(authority: ContextMaskAuthority): void {
+  const hasMaskObligation = authority.decision.obligations.some(
+    (obligation) => obligation.kind === "mask",
+  );
+  if (
+    authority.decision.effect !== "allow-with-obligations" ||
+    !hasMaskObligation
+  ) {
+    throw new ContextMaskAuthorizationError();
+  }
+}
+
+function groupMatchesByPath(
+  matches: readonly InferencePayloadMatch[],
+): ReadonlyMap<string, InferencePayloadMatch[]> {
+  const grouped = new Map<string, InferencePayloadMatch[]>();
+  for (const match of matches) {
+    const existing = grouped.get(match.path) ?? [];
+    existing.push(match);
+    grouped.set(match.path, existing);
+  }
+  return grouped;
+}
+
+function transformFromPolicyProfile(
+  decision: DataPolicyDecision,
+): ContextTransform | undefined {
+  const profileId = decision.obligations.find(
+    (obligation) => obligation.kind === "mask",
+  )?.profileId;
+  const profiles: Readonly<Record<string, ContextTransform>> = {
+    "context-omit": "omit",
+    "context-redact": "redact",
+    "context-partial": "partial",
+    "context-tokenize": "tokenize",
+    "context-aggregate": "aggregate",
+    "context-pass-through": "pass-through",
+  };
+  return profileId ? profiles[profileId] : undefined;
+}
+
+function isSafelyTransformable(match: InferencePayloadMatch): boolean {
+  return match.reason === "contact-detail" ||
+    match.reason === "secret-shaped-token" ||
+    match.reason === "secret-field-name" ||
+    match.reason === "payment-or-finance-text" ||
+    (
+      match.reason === "customer-record-field" &&
+      /(?:email|phone|address|contact)$/i.test(match.path)
+    );
+}
+
+function isCoveredBySafeTransform(
+  match: InferencePayloadMatch,
+  pathMatches: readonly InferencePayloadMatch[],
+): boolean {
+  if (isSafelyTransformable(match)) return true;
+  return match.reason === "customer-record-field" &&
+    pathMatches.some((candidate) => candidate.reason === "contact-detail");
+}
+
+function visitContext(
+  value: unknown,
+  path: string,
+  matchesByPath: ReadonlyMap<string, readonly InferencePayloadMatch[]>,
+  tokenMap: Map<string, string>,
+  state: { transformedValueCount: number },
+  forcedTransform?: ContextTransform,
+): unknown {
+  const pathMatches = matchesByPath.get(path) ?? [];
+  if (pathMatches.length > 0 && forcedTransform) {
+    return applyAuthorizedTransform(value, forcedTransform, tokenMap, state);
+  }
+  if (typeof value === "string" && pathMatches.length > 0) {
+    return transformMatchedString(value, pathMatches, tokenMap, state);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry, index) =>
+      visitContext(
+        entry,
+        appendIndex(path, index),
+        matchesByPath,
+        tokenMap,
+        state,
+        forcedTransform,
+      ),
+    );
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const childPath = appendKey(path, key);
+    const childMatches = matchesByPath.get(childPath) ?? [];
+    if (
+      (forcedTransform === "omit" && childMatches.length > 0) ||
+      (!forcedTransform && childMatches.some((match) => match.reason === "secret-field-name"))
+    ) {
+      state.transformedValueCount += 1;
+      continue;
+    }
+    output[key] = visitContext(
+      entry,
+      childPath,
+      matchesByPath,
+      tokenMap,
+      state,
+      forcedTransform,
+    );
+  }
+  return output;
+}
+
+function applyAuthorizedTransform(
+  value: unknown,
+  transform: ContextTransform,
+  tokenMap: Map<string, string>,
+  state: { transformedValueCount: number },
+): unknown {
+  if (transform === "pass-through") return value;
+  state.transformedValueCount += 1;
+  if (transform !== "tokenize") return applyContextTransform(value, transform);
+  const raw = typeof value === "string" ? value : JSON.stringify(value);
+  const token = stableToken(raw);
+  tokenMap.set(token, raw);
+  return token;
+}
+
+function transformMatchedString(
+  value: string,
+  matches: readonly InferencePayloadMatch[],
+  tokenMap: Map<string, string>,
+  state: { transformedValueCount: number },
+): string {
+  let transformed = value;
+  if (matches.some((match) => match.reason === "secret-shaped-token")) {
+    transformed = transformed.replace(SECRET_PATTERN, () => {
+      state.transformedValueCount += 1;
+      return "[REDACTED]";
+    });
+  }
+  if (matches.some((match) => match.reason === "contact-detail")) {
+    transformed = transformed.replace(CONTACT_PATTERN, (raw) => {
+      const token = stableToken(raw);
+      tokenMap.set(token, raw);
+      state.transformedValueCount += 1;
+      return token;
+    });
+  }
+  if (matches.some((match) => match.reason === "payment-or-finance-text")) {
+    transformed = transformed.replace(FINANCE_IDENTIFIER_PATTERN, (raw) => {
+      const token = stableToken(raw);
+      tokenMap.set(token, raw);
+      state.transformedValueCount += 1;
+      return token;
+    });
+  }
+  if (
+    transformed === value &&
+    matches.some((match) =>
+      match.reason === "customer-record-field" &&
+      /(?:email|phone|address|contact)$/i.test(match.path)
+    )
+  ) {
+    state.transformedValueCount += 1;
+    return String(applyContextTransform(value, "partial"));
+  }
+  if (
+    transformed === value &&
+    matches.some((match) => match.reason === "payment-or-finance-text")
+  ) {
+    throw new ContextMaskCoverageError([matches[0]?.path ?? "unknown"]);
+  }
+  return transformed;
+}
+
+function appendKey(path: string, key: string): string {
+  return path ? `${path}.${key}` : key;
+}
+
+function appendIndex(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function storeTokenMap(tokens: ReadonlyMap<string, string>): string {
+  const now = Date.now();
+  for (const [handle, entry] of tokenVault) {
+    if (entry.expiresAt <= now) tokenVault.delete(handle);
+  }
+  while (tokenVault.size >= MAX_TOKEN_MAPS) {
+    const oldest = tokenVault.keys().next().value as string | undefined;
+    if (!oldest) break;
+    tokenVault.delete(oldest);
+  }
+  const handle = `rehydration_${randomBytes(12).toString("hex")}`;
+  tokenVault.set(handle, {
+    expiresAt: now + TOKEN_TTL_MS,
+    tokens: new Map(tokens),
+  });
+  return handle;
+}

--- a/apps/web/lib/govern/data/policy-decision.test.ts
+++ b/apps/web/lib/govern/data/policy-decision.test.ts
@@ -63,6 +63,22 @@ describe("hard constraints and precedence", () => {
     expect(d.explanationCode).toBe("restricted-cannot-leave-boundary");
   });
 
+  it.each(["masked", "tokenized"] as const)(
+    "allows a PDP-authorized %s projection to leave without lowering source classification",
+    (transformation) => {
+      const d = evaluateDataPolicy(
+        ctx({
+          action: "export",
+          destination: "external-service",
+          transformation,
+          classification: { known: true, sensitivity: "restricted" },
+        }),
+      );
+      expect(d.effect).toBe("allow");
+      expect(d.explanationCode).toBe("protected-projection-may-leave-boundary");
+    },
+  );
+
   it("lets a stronger deny outrank a weaker allow regardless of array order", () => {
     const policies: DataExecutablePolicy[] = [
       {
@@ -101,6 +117,32 @@ describe("allow-with-obligations", () => {
     );
     expect(d.effect).toBe("allow-with-obligations");
     expect(d.obligations.some((o) => o.kind === "mask")).toBe(true);
+  });
+
+  it("requires the mask obligation before confidential external export", () => {
+    const d = evaluateDataPolicy(
+      ctx({
+        action: "export",
+        destination: "external-service",
+        transformation: "none",
+        classification: { known: true, sensitivity: "confidential", categories: ["content"] },
+      }),
+    );
+    expect(d.effect).toBe("allow-with-obligations");
+    expect(d.obligations).toContainEqual({ kind: "mask", profileId: "default-confidential" });
+  });
+
+  it("authorizes restricted masking only inside the controlled runtime", () => {
+    const d = evaluateDataPolicy(
+      ctx({
+        action: "project",
+        destination: "in-process",
+        transformation: "none",
+        classification: { known: true, sensitivity: "restricted" },
+      }),
+    );
+    expect(d.effect).toBe("allow-with-obligations");
+    expect(d.obligations).toContainEqual({ kind: "mask", profileId: "default-restricted" });
   });
 });
 

--- a/apps/web/lib/govern/data/policy-decision.ts
+++ b/apps/web/lib/govern/data/policy-decision.ts
@@ -15,6 +15,7 @@ import {
   type DataCategory,
   type DataEffect,
   type DataFieldId,
+  type DataProtectionTransformation,
   type DataSensitivity,
   type DestinationClass,
   type MasterDataDomainKey,
@@ -37,6 +38,7 @@ export type PolicyEvaluationContext = {
   fields?: readonly DataFieldId[];
   purpose: ProcessingPurposeKey;
   destination?: DestinationClass;
+  transformation?: DataProtectionTransformation;
   classification: {
     known: boolean;
     sensitivity?: DataSensitivity;
@@ -138,6 +140,7 @@ function policyMatches(m: PolicyMatch, ctx: PolicyEvaluationContext): boolean {
     inList(m.assets, ctx.asset) &&
     inList(m.purposes, ctx.purpose) &&
     inList(m.destinations, ctx.destination) &&
+    inList(m.transformations, ctx.transformation ?? "none") &&
     inList(m.sensitivities, ctx.classification.sensitivity) &&
     inList(m.domains, ctx.classification.masterDataDomain) &&
     anyIn(m.categories, ctx.classification.categories) &&
@@ -177,6 +180,7 @@ function decision(
       ctx.asset,
       ctx.purpose,
       ctx.destination ?? "-",
+      ctx.transformation ?? "none",
       ctx.assetVersion,
       ctx.classificationVersion,
       ctx.authorityVersion,

--- a/apps/web/lib/govern/data/taxonomy.ts
+++ b/apps/web/lib/govern/data/taxonomy.ts
@@ -188,6 +188,14 @@ export const ALL_PROJECTION_CLASSES = [
   "content",
 ] as const satisfies readonly ProjectionClass[];
 
+/** Protection already applied before a projection reaches its destination. */
+export type DataProtectionTransformation = "none" | "masked" | "tokenized";
+export const ALL_DATA_PROTECTION_TRANSFORMATIONS = [
+  "none",
+  "masked",
+  "tokenized",
+] as const satisfies readonly DataProtectionTransformation[];
+
 /** Protection profile key — a named encryption/tokenization/masking treatment. */
 export type ProtectionProfileKey =
   | "none"

--- a/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts
+++ b/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts
@@ -7,6 +7,7 @@ import {
   type DataEffect,
   type DataAssetId,
   type DataFieldId,
+  type DataProtectionTransformation,
   type DestinationClass,
   type ProcessingPurposeKey,
 } from "@/lib/govern/data/taxonomy";
@@ -53,6 +54,7 @@ export type InferencePolicyEvaluationInput = {
   authorityVersion?: string;
   policyBundleVersion?: string;
   policies?: readonly DataExecutablePolicy[];
+  transformation?: DataProtectionTransformation;
 };
 
 export type InferencePolicyEvaluation = {
@@ -142,6 +144,7 @@ function buildPolicyContext(input: InferencePolicyEvaluationInput): PolicyEvalua
     fields,
     purpose: resolvePurpose(input.purpose, governedData),
     destination: input.destinationClass,
+    transformation: input.transformation ?? "none",
     classification: {
       known: classificationKnown,
       sensitivity: input.classification.overallSensitivity,

--- a/apps/web/lib/inference/data-screening/routed-screening.test.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.test.ts
@@ -1,10 +1,75 @@
 import { describe, expect, it } from "vitest";
 import {
   createRoutedInferenceScreen,
+  rescreenRoutedInferencePayload,
   rescreenRoutedInferenceWithoutTools,
 } from "./routed-screening";
+import { screenInferencePayload } from "./screen-inference-payload";
 
 describe("routed inference screening", () => {
+  it("tokenizes replaceable contact data before routing and preserves source classification evidence", () => {
+    const raw = "ada@example.com";
+    const routed = createRoutedInferenceScreen({
+      messages: [{ role: "user", content: `Draft a greeting for ${raw}.` }],
+      systemPrompt: "Do not reveal private contact details.",
+      taskType: "draft",
+      routeContext: { sensitivity: "internal" },
+      sensitiveDetailUse: "replaceable",
+    });
+
+    expect(JSON.stringify(routed.screenInput)).not.toContain(raw);
+    expect(JSON.stringify(routed.screenInput)).toContain("[DPF_TOKEN_");
+    expect(routed.screen.receipt.transformation).toBe("tokenized");
+    expect(routed.screen.receipt.classifiedDataClasses).toContain("customer-records");
+    expect(routed.screen.receipt.obligationKinds).toContain("mask");
+    expect(routed.screen.receipt.routeEffect).toBe("allow");
+    expect(routed.rehydrationHandle).toMatch(/^rehydration_/);
+  });
+
+  it("keeps material contact data local instead of masking it into a misleading request", () => {
+    const raw = "ada@example.com";
+    const routed = createRoutedInferenceScreen({
+      messages: [{ role: "user", content: `Validate the exact address ${raw}.` }],
+      systemPrompt: "Validate exact values.",
+      taskType: "validation",
+      routeContext: { sensitivity: "internal" },
+      sensitiveDetailUse: "material",
+    });
+
+    expect(JSON.stringify(routed.screenInput)).toContain(raw);
+    expect(routed.screen.receipt.transformation).toBe("none");
+    expect(routed.screen.receipt.routeEffect).toBe("local-only");
+    expect(routed.rehydrationHandle).toBeUndefined();
+  });
+
+  it("recomputes source mask authority versions at the final dispatch screen", () => {
+    let classificationVersion = "classification-v1";
+    const routed = createRoutedInferenceScreen({
+      messages: [{ role: "user", content: "Draft for ada@example.com" }],
+      systemPrompt: "",
+      taskType: "draft",
+      routeContext: { sensitivity: "internal" },
+      sensitiveDetailUse: "replaceable",
+      policyVersionSource: () => ({
+        assetVersion: "asset-v1",
+        classificationVersion,
+        authorityVersion: "authority-v1",
+        policyBundleVersion: "bundle-v1",
+      }),
+    });
+    const routedReceipt = routed.screen.receipt;
+
+    classificationVersion = "classification-v2";
+    const dispatchReceipt = screenInferencePayload(routed.screenInput).receipt;
+
+    expect(dispatchReceipt.decisionIds).not.toEqual(routedReceipt.decisionIds);
+    expect(dispatchReceipt.decisionVersions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ classificationVersion: "classification-v2" }),
+      ]),
+    );
+  });
+
   it("issues a new receipt when a tool-stripping reroute changes the payload boundary", () => {
     const routed = createRoutedInferenceScreen({
       messages: [{ role: "user", content: "Summarize the public release." }],
@@ -28,5 +93,26 @@ describe("routed inference screening", () => {
     expect(stripped.receipt.classifiedDataClasses).not.toContain("secrets-credentials");
     expect(stripped.receipt.inputHash).not.toBe(routed.screen.receipt.inputHash);
     expect(stripped.screenInput.tools).toBeUndefined();
+  });
+
+  it("issues a new receipt when capability degradation replaces prompt and history", () => {
+    const routed = createRoutedInferenceScreen({
+      messages: [
+        { role: "assistant", content: "Earlier tool call." },
+        { role: "user", content: "Current request." },
+      ],
+      systemPrompt: "Use tools.",
+      taskType: "conversation",
+      routeContext: { sensitivity: "internal" },
+    });
+    const replaced = rescreenRoutedInferencePayload(routed.screenInput, {
+      messages: [{ role: "user", content: "Current request." }],
+      systemPrompt: "Limited mode.",
+      tools: undefined,
+    });
+
+    expect(replaced.receipt.inputHash).not.toBe(routed.screen.receipt.inputHash);
+    expect(replaced.screenInput.messages).toHaveLength(1);
+    expect(replaced.screenInput.systemPrompt).toBe("Limited mode.");
   });
 });

--- a/apps/web/lib/inference/data-screening/routed-screening.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.ts
@@ -55,7 +55,8 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
         detailUse: sensitiveDetailUse,
       },
     );
-    if (masked.transformation === "none") {
+    const transformation = masked.transformation;
+    if (transformation === "none") {
       return { screenInput, screen: rawScreen, rehydrationHandle: undefined };
     }
 
@@ -63,7 +64,7 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
     const appliedTransformation = transformationEvidence(
       authorityReceipt,
       rawScreen,
-      masked.transformation,
+      transformation,
     );
     const appliedTransformationSource = () => {
       const refreshedRaw = screenInferencePayload(screenInput);
@@ -77,7 +78,7 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
       return transformationEvidence(
         (refreshedProjection ?? refreshedRaw).receipt,
         refreshedRaw,
-        masked.transformation,
+        transformation,
       );
     };
     const transformedInput = {

--- a/apps/web/lib/inference/data-screening/routed-screening.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.ts
@@ -1,6 +1,13 @@
 import type { ChatMessage } from "@/lib/inference/ai-inference";
 import type { ActivityContract } from "@/lib/routing/activity-contract";
 import {
+  ContextMaskAuthorizationError,
+  ContextMaskCoverageError,
+  ContextMaskMaterialityError,
+  maskForContext,
+  type SensitiveDetailUse,
+} from "@/lib/govern/data/mask-for-context";
+import {
   screenInferencePayload,
   type ScreenInferencePayloadInput,
 } from "./screen-inference-payload";
@@ -13,23 +20,129 @@ type RoutedScreenInput = {
   routeContext: ScreenInferencePayloadInput["routeContext"];
   activityContract?: ActivityContract;
   policyVersionSource?: ScreenInferencePayloadInput["policyVersionSource"];
+  sensitiveDetailUse?: SensitiveDetailUse;
 };
 
+export function routedRehydrationHandle(rehydrationHandle?: string) {
+  return rehydrationHandle ? { rehydrationHandle } : {};
+}
+
 export function createRoutedInferenceScreen(input: RoutedScreenInput) {
-  const screenInput = { ...input } satisfies ScreenInferencePayloadInput;
+  const { sensitiveDetailUse = "unknown", ...baseInput } = input;
+  const screenInput = { ...baseInput } satisfies ScreenInferencePayloadInput;
+  const rawScreen = screenInferencePayload(screenInput);
+  const directMaskDecision = rawScreen.decisions.find(hasMaskObligation);
+  const projectionScreen = directMaskDecision
+    ? null
+    : screenInferencePayload({ ...screenInput, destinationClass: "in-process" });
+  const maskDecision = directMaskDecision ??
+    projectionScreen?.decisions.find(hasMaskObligation);
+
+  if (!maskDecision) {
+    return { screenInput, screen: rawScreen, rehydrationHandle: undefined };
+  }
+
+  try {
+    const masked = maskForContext(
+      {
+        messages: screenInput.messages,
+        systemPrompt: screenInput.systemPrompt,
+        tools: screenInput.tools,
+      },
+      {
+        decision: maskDecision,
+        matches: rawScreen.classification.matches,
+        detailUse: sensitiveDetailUse,
+      },
+    );
+    if (masked.transformation === "none") {
+      return { screenInput, screen: rawScreen, rehydrationHandle: undefined };
+    }
+
+    const authorityReceipt = (projectionScreen ?? rawScreen).receipt;
+    const appliedTransformation = transformationEvidence(
+      authorityReceipt,
+      rawScreen,
+      masked.transformation,
+    );
+    const appliedTransformationSource = () => {
+      const refreshedRaw = screenInferencePayload(screenInput);
+      const refreshedDirect = refreshedRaw.decisions.find(hasMaskObligation);
+      const refreshedProjection = refreshedDirect
+        ? null
+        : screenInferencePayload({ ...screenInput, destinationClass: "in-process" });
+      const refreshedDecision = refreshedDirect ??
+        refreshedProjection?.decisions.find(hasMaskObligation);
+      if (!refreshedDecision) throw new ContextMaskAuthorizationError();
+      return transformationEvidence(
+        (refreshedProjection ?? refreshedRaw).receipt,
+        refreshedRaw,
+        masked.transformation,
+      );
+    };
+    const transformedInput = {
+      ...screenInput,
+      messages: masked.value.messages,
+      systemPrompt: masked.value.systemPrompt,
+      tools: masked.value.tools,
+      appliedTransformation,
+      appliedTransformationSource,
+    } satisfies ScreenInferencePayloadInput;
+    return {
+      screenInput: transformedInput,
+      screen: screenInferencePayload(transformedInput),
+      rehydrationHandle: masked.rehydrationHandle,
+    };
+  } catch (error) {
+    if (
+      error instanceof ContextMaskAuthorizationError ||
+      error instanceof ContextMaskCoverageError ||
+      error instanceof ContextMaskMaterialityError
+    ) {
+      return { screenInput, screen: rawScreen, rehydrationHandle: undefined };
+    }
+    throw error;
+  }
+}
+
+function transformationEvidence(
+  authorityReceipt: ReturnType<typeof screenInferencePayload>["receipt"],
+  rawScreen: ReturnType<typeof screenInferencePayload>,
+  transformation: "masked" | "tokenized",
+): NonNullable<ScreenInferencePayloadInput["appliedTransformation"]> {
   return {
-    screenInput,
-    screen: screenInferencePayload(screenInput),
+    transformation,
+    decisionIds: authorityReceipt.decisionIds,
+    decisionVersions: authorityReceipt.decisionVersions,
+    classifiedDataClasses: rawScreen.receipt.classifiedDataClasses,
+    explanationCodes: [
+      ...authorityReceipt.explanationCodes,
+      "payload-transformed-before-dispatch",
+    ],
+    obligationKinds: authorityReceipt.obligationKinds,
   };
+}
+
+function hasMaskObligation(
+  decision: ReturnType<typeof screenInferencePayload>["decisions"][number],
+): boolean {
+  return decision.effect === "allow-with-obligations" &&
+    decision.obligations.some((obligation) => obligation.kind === "mask");
 }
 
 export function rescreenRoutedInferenceWithoutTools(
   input: ScreenInferencePayloadInput,
 ) {
-  const screenInput = {
-    ...input,
-    tools: undefined,
-  } satisfies ScreenInferencePayloadInput;
+  return rescreenRoutedInferencePayload(input, { tools: undefined });
+}
+
+export function rescreenRoutedInferencePayload(
+  input: ScreenInferencePayloadInput,
+  payload: Partial<Pick<ScreenInferencePayloadInput, "messages" | "systemPrompt">> & {
+    tools?: ScreenInferencePayloadInput["tools"];
+  },
+) {
+  const screenInput = { ...input, ...payload } satisfies ScreenInferencePayloadInput;
   return {
     screenInput,
     receipt: screenInferencePayload(screenInput).receipt,

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -10,6 +10,7 @@ import { classifyInferencePayload } from "./classify-payload";
 import { evaluateInferenceDispatchPolicy } from "./evaluate-inference-policy";
 import type {
   GovernedPayloadHint,
+  InferenceDataScreenReceipt,
   InferenceDataScreenResult,
   InferencePayloadSensitivity,
   InferencePolicyVersionSnapshot,
@@ -44,6 +45,19 @@ export type ScreenInferencePayloadInput = {
    * and invoked again at the final dispatch seam; it is never persisted.
    */
   policyVersionSource?: () => Partial<InferencePolicyVersionSnapshot>;
+  /** Safe evidence that a prior PDP-authorized projection transform was applied. */
+  appliedTransformation?: {
+    transformation: "masked" | "tokenized";
+    decisionIds: string[];
+    decisionVersions: InferenceDataScreenReceipt["decisionVersions"];
+    classifiedDataClasses: InferenceDataScreenReceipt["classifiedDataClasses"];
+    explanationCodes: string[];
+    obligationKinds: string[];
+  };
+  /** Recomputes the safe source-transform authority at final dispatch. */
+  appliedTransformationSource?: () => NonNullable<
+    ScreenInferencePayloadInput["appliedTransformation"]
+  >;
 };
 
 export function screenInferencePayload(
@@ -62,6 +76,7 @@ export function screenInferencePayload(
   });
   const destinationClass = input.destinationClass ?? "external-service";
   const policyVersions = input.policyVersionSource?.();
+  const prior = input.appliedTransformationSource?.() ?? input.appliedTransformation;
   const policy = evaluateInferenceDispatchPolicy({
     organizationId: input.organizationId ?? DEFAULT_ORGANIZATION_ID,
     classification,
@@ -72,11 +87,21 @@ export function screenInferencePayload(
     classificationVersion: policyVersions?.classificationVersion,
     authorityVersion: policyVersions?.authorityVersion,
     policyBundleVersion: policyVersions?.policyBundleVersion,
+    transformation: prior?.transformation ?? "none",
   });
 
   const originalSensitivity = normalizeSensitivity(input.routeContext?.sensitivity);
-  const sensitivity = strongestSensitivity(originalSensitivity, classification.overallSensitivity);
-  const routeEffect = policy.effect === "deny" || policy.effect === "review"
+  // A verified projection transform changes the payload being routed, not the
+  // source/output classification retained in the receipt. Caller sensitivity
+  // is still a floor and can never be lowered here.
+  const routedPayloadSensitivity = prior
+    ? "internal"
+    : classification.overallSensitivity;
+  const sensitivity = strongestSensitivity(originalSensitivity, routedPayloadSensitivity);
+  const maskRequired = policy.obligations.some((obligation) => obligation.kind === "mask");
+  const routeEffect = policy.effect === "deny" ||
+    policy.effect === "review" ||
+    (maskRequired && !prior)
     ? "local-only"
     : "allow";
   const residencyPolicy = routeEffect === "local-only"
@@ -101,23 +126,37 @@ export function screenInferencePayload(
     receipt: {
       schemaVersion: "inference-data-screen/v1",
       screenId: classification.receipt.screenId,
-      decisionIds: policy.decisionIds,
-      decisionVersions: policy.decisions.map((decision) => ({
-        decisionId: decision.decisionId,
-        assetVersion: decision.assetVersion,
-        classificationVersion: decision.classificationVersion,
-        authorityVersion: decision.authorityVersion,
-      })),
+      decisionIds: uniqueSorted([...(prior?.decisionIds ?? []), ...policy.decisionIds]),
+      decisionVersions: uniqueDecisionVersions([
+        ...(prior?.decisionVersions ?? []),
+        ...policy.decisions.map((decision) => ({
+          decisionId: decision.decisionId,
+          assetVersion: decision.assetVersion,
+          classificationVersion: decision.classificationVersion,
+          authorityVersion: decision.authorityVersion,
+        })),
+      ]),
       inputHash: classification.receipt.inputHash,
-      classifiedDataClasses: policy.classifiedDataClasses,
+      classifiedDataClasses: uniqueSorted([
+        ...(prior?.classifiedDataClasses ?? []),
+        ...policy.classifiedDataClasses,
+      ]),
       policyEffect: policy.effect,
       routeEffect,
       destinationClass,
-      transformation: classification.receipt.transformation,
-      explanationCodes: policy.explanationCodes,
-      obligationKinds: policy.obligations.map((obligation) => obligation.kind).sort(),
+      transformation: prior?.transformation ?? classification.receipt.transformation,
+      explanationCodes: uniqueSorted([
+        ...(prior?.explanationCodes ?? []),
+        ...policy.explanationCodes,
+      ]),
+      obligationKinds: uniqueSorted([
+        ...(prior?.obligationKinds ?? []),
+        ...policy.obligations.map((obligation) => obligation.kind),
+      ]),
       rawPayloadStored: false,
     },
+    classification,
+    decisions: policy.decisions,
   };
 }
 
@@ -176,4 +215,15 @@ function mergeGovernedHints(
 ): GovernedPayloadHint[] | undefined {
   const merged = [...(first ?? []), ...second];
   return merged.length > 0 ? merged : undefined;
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function uniqueDecisionVersions(
+  versions: InferenceDataScreenReceipt["decisionVersions"],
+): InferenceDataScreenReceipt["decisionVersions"] {
+  return [...new Map(versions.map((version) => [version.decisionId, version])).values()]
+    .sort((a, b) => a.decisionId.localeCompare(b.decisionId));
 }

--- a/apps/web/lib/inference/data-screening/types.ts
+++ b/apps/web/lib/inference/data-screening/types.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage } from "@/lib/inference/ai-inference";
 import type { DataEffect, DestinationClass } from "@/lib/govern/data/taxonomy";
 import type { RequestContract } from "@/lib/routing/request-contract";
+import type { DataPolicyDecision } from "@/lib/govern/data/policy-decision";
 
 export type InferenceDataClass =
   | "customer-records"
@@ -77,6 +78,10 @@ export type InferenceDataScreenReceipt = {
 export type InferenceDataScreenResult = {
   routeContext: InferenceDataScreenRouteContext;
   receipt: InferenceDataScreenReceipt;
+  /** Ephemeral classifier evidence used only by the enforcing transform seam. */
+  classification: InferencePayloadClassification;
+  /** Ephemeral PDP decisions; persisted evidence remains the bounded receipt. */
+  decisions: DataPolicyDecision[];
 };
 
 export type GovernedPayloadHint = {

--- a/apps/web/lib/inference/routed-inference-options.ts
+++ b/apps/web/lib/inference/routed-inference-options.ts
@@ -25,6 +25,13 @@ export interface RouteAndCallOptions {
   inferencePolicyVersionSource?: import(
     "@/lib/inference/data-screening/screen-inference-payload"
   ).ScreenInferencePayloadInput["policyVersionSource"];
+  /**
+   * Whether exact sensitive values are replaceable for this task. Unknown is
+   * fail-closed and never authorizes a transform.
+   */
+  sensitiveDetailUse?: import(
+    "@/lib/govern/data/mask-for-context"
+  ).SensitiveDetailUse;
   modelTier?: "local" | "robust";
   minimumDimensions?: Record<string, number>;
   requiredModelClass?: ModelClass;

--- a/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
+++ b/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
@@ -373,6 +373,34 @@ describe("routeAndCall activity harness overrides", () => {
     );
   });
 
+  it("never exposes replaceable sensitive canaries to contract inference or provider dispatch", async () => {
+    const rawEmail = "ada@example.com";
+    const result = await routeAndCall(
+      [{ role: "user", content: `Draft a neutral greeting for ${rawEmail}.` }],
+      "Draft a greeting without private identifiers.",
+      "internal",
+      {
+        taskType: "draft",
+        sensitiveDetailUse: "replaceable",
+        persistDecision: false,
+      },
+    );
+
+    const inferPayload = JSON.stringify(mocks.inferContract.mock.calls.at(-1));
+    const dispatchPayload = JSON.stringify(mocks.callWithFallbackChain.mock.calls.at(-1));
+    expect(inferPayload).not.toContain(rawEmail);
+    expect(dispatchPayload).not.toContain(rawEmail);
+    expect(inferPayload).toContain("[DPF_TOKEN_");
+    expect(dispatchPayload).toContain("[DPF_TOKEN_");
+    expect(result.routeDecision.inferenceDataScreenReceipt).toMatchObject({
+      transformation: "tokenized",
+      routeEffect: "allow",
+      classifiedDataClasses: expect.arrayContaining(["customer-records"]),
+      rawPayloadStored: false,
+    });
+    expect(result.rehydrationHandle).toMatch(/^rehydration_/);
+  });
+
   it("intersects screen allowlists with provider suitability and unions denials before routing", async () => {
     mocks.loadProviderSuitabilitySourceContext.mockResolvedValueOnce(localAndCloudSuitabilitySource());
 

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -44,13 +44,14 @@ import {
 import type { ScreenInferencePayloadInput } from "@/lib/inference/data-screening/screen-inference-payload";
 import {
   createRoutedInferenceScreen,
+  rescreenRoutedInferencePayload,
   rescreenRoutedInferenceWithoutTools,
+  routedRehydrationHandle,
 } from "@/lib/inference/data-screening/routed-screening";
 import { screenedLocalOnlyBlockReason } from "@/lib/inference/data-screening/blocked-route-explanation";
 import { createRoutingTraceId } from "@/lib/routing/routing-trace";
 import { AI_ROUTING_ARCHITECTURE_VERSION } from "@/lib/routing/routing-architecture-version";
 export type { RouteAndCallOptions } from "./routed-inference-options";
-
 // ─── Result type ────────────────────────────────────────────────────────────
 
 /** Unified inference result — flat token fields, V2 metadata included. */
@@ -71,12 +72,13 @@ export interface RoutedInferenceResult {
   routeDecision: RouteDecision;
   /** EP-INF-009d: Set when interactionMode is "background". Poll via pollAsyncOperation(). */
   asyncOperationId?: string;
+  /** Opaque handle for the later actor/surface-authorized rehydration gate. */
+  rehydrationHandle?: string;
   /** Resolved endpoint's context window (tokens) when known; null for local /
    *  unknown. The agentic loop learns this from the first dispatch to size
    *  compaction + the context-pressure gauge to the real window (BI-9679EB1A). */
   resolvedMaxContextTokens?: number | null;
 }
-
 // ─── Error ──────────────────────────────────────────────────────────────────
 
 export class NoEligibleEndpointsError extends Error {
@@ -110,6 +112,7 @@ interface PreparedRoute {
   taskType: string;
   /** Ephemeral, non-persisted input used to re-screen the actual dispatch payload. */
   screenInput: ScreenInferencePayloadInput;
+  rehydrationHandle?: string;
   /** EP-GOLDEN-TRIANGLE: the resolved posture applied to this route (null = none/Balanced). */
   posture: DispatchPosture | null;
   suitability: ProviderSuitabilityRuntime | null;
@@ -168,7 +171,7 @@ async function prepareRoute(
         : options?.residencyPolicy,
     requiredModelClass: options?.requiredModelClass,
   };
-  const { screenInput, screen } = createRoutedInferenceScreen({
+  const { screenInput, screen, rehydrationHandle } = createRoutedInferenceScreen({
     messages,
     systemPrompt,
     tools: options?.tools,
@@ -176,13 +179,14 @@ async function prepareRoute(
     routeContext: initialRouteContext,
     activityContract: options?.activityContract,
     policyVersionSource: options?.inferencePolicyVersionSource,
+    sensitiveDetailUse: options?.sensitiveDetailUse,
   });
 
   // 1. Infer contract
   let contract = await inferContract(
     taskType,
-    messages,
-    options?.tools,
+    screenInput.messages,
+    screenInput.tools,
     undefined, // outputSchema
     {
       ...initialRouteContext,
@@ -287,6 +291,7 @@ async function prepareRoute(
     overrides,
     taskType,
     screenInput,
+    rehydrationHandle,
     posture,
     suitability,
   };
@@ -363,6 +368,8 @@ export async function routeAndCall(
   // executionPlan is built for dispatch below.
   const prepared = await prepareRoute(messages, systemPrompt, sensitivity, options);
   const { contract, manifests, policies, overrides, taskType } = prepared;
+  messages = prepared.screenInput.messages;
+  systemPrompt = prepared.screenInput.systemPrompt;
   let decision = prepared.decision;
   let dispatchScreenInput = prepared.screenInput;
   const traceId = createRoutingTraceId();
@@ -524,6 +531,14 @@ export async function routeAndCall(
       messages = [lastUserMsg];
     }
 
+    const degradedScreen = rescreenRoutedInferencePayload(dispatchScreenInput, {
+      messages,
+      systemPrompt,
+      tools: undefined,
+    });
+    dispatchScreenInput = degradedScreen.screenInput;
+    decision.inferenceDataScreenReceipt = degradedScreen.receipt;
+
     console.log(`[routing] Tools stripped for ${name} — using degraded identity prompt`);
   }
 
@@ -606,7 +621,7 @@ export async function routeAndCall(
       decision,
       messages,
       systemPrompt,
-      toolsStripped ? undefined : options?.tools,
+      toolsStripped ? undefined : dispatchScreenInput.tools,
       decision.executionPlan,
       options?.previousResponseId,
       options?.mcpSession,
@@ -641,6 +656,7 @@ export async function routeAndCall(
         toolsStripped,
         routeDecision: decision,
         asyncOperationId: asyncOpId,
+        ...routedRehydrationHandle(prepared.rehydrationHandle),
       };
     }
 
@@ -668,6 +684,7 @@ export async function routeAndCall(
       downgradeMessage: result.downgradeMessage,
       toolsStripped,
       routeDecision: decision,
+      ...routedRehydrationHandle(prepared.rehydrationHandle),
     };
   }
 
@@ -676,7 +693,7 @@ export async function routeAndCall(
     decision,
     messages,
     systemPrompt,
-    toolsStripped ? undefined : options?.tools,
+    toolsStripped ? undefined : dispatchScreenInput.tools,
     decision.executionPlan,
     options?.previousResponseId,
     options?.mcpSession,
@@ -737,6 +754,7 @@ export async function routeAndCall(
     routeDecision: decision,
     responseId: result.responseId,
     resolvedMaxContextTokens: selectedManifest?.maxContextTokens ?? null,
+    ...routedRehydrationHandle(prepared.rehydrationHandle),
   };
 }
 

--- a/apps/web/lib/inference/semantic-memory.test.ts
+++ b/apps/web/lib/inference/semantic-memory.test.ts
@@ -290,6 +290,27 @@ describe("semantic memory storage sensitivity gate (BI-DG-001)", () => {
     expect(upsertVectors).not.toHaveBeenCalled();
   });
 
+  it("omits confidential free text when no safe field transform can be proven", async () => {
+    const { generateEmbedding } = await import("./embedding");
+    const { upsertVectors } = await import("@dpf/db");
+    const { storeConversationMemory } = await import("./semantic-memory");
+
+    await storeConversationMemory({
+      messageId: "msg-confidential-unknown",
+      content: "Discuss the selected private record.",
+      role: "user",
+      userId: "user-1",
+      agentId: "customer-agent",
+      routeContext: "/customer/private",
+      threadId: "thread-private",
+      sensitivity: "confidential",
+      operatingProfileFingerprint: "fp-1",
+    });
+
+    expect(generateEmbedding).not.toHaveBeenCalled();
+    expect(upsertVectors).not.toHaveBeenCalled();
+  });
+
   it("masks confidential content through a deterministic seam before storage", async () => {
     const { generateEmbedding } = await import("./embedding");
     const { upsertVectors } = await import("@dpf/db");

--- a/apps/web/lib/inference/semantic-memory.ts
+++ b/apps/web/lib/inference/semantic-memory.ts
@@ -16,6 +16,12 @@ import {
   semanticMemoryLatency,
 } from "@/lib/metrics";
 import type { RouteSensitivity } from "@/lib/tak/agent-sensitivity";
+import {
+  ContextMaskAuthorizationError,
+  ContextMaskCoverageError,
+  maskForContext,
+} from "@/lib/govern/data/mask-for-context";
+import { screenInferencePayload } from "@/lib/inference/data-screening/screen-inference-payload";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -46,16 +52,12 @@ const KNOWN_SENSITIVITIES: readonly RouteSensitivity[] = [
 ];
 
 /**
- * Interim deterministic masking seam for `confidential` content. It is intentionally
- * conservative and pure (same input → same output) so recall stays stable and the
- * seam is unit-testable; field-level protection policy (later BIs) replaces the body
- * without moving the call site. It never introduces randomness or timestamps.
+ * Compatibility facade over the canonical BI-DG-009 transform. The PDP and
+ * classifier select the treatment; this call site never supplies a mask list.
  */
 export function maskConfidentialContent(content: string): string {
-  return content
-    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[email]")
-    .replace(/\b[A-Za-z0-9_-]{32,}\b/g, "[token]")
-    .replace(/\d[\d\s().+-]{4,}\d/g, "[number]");
+  const disposition = resolveConfidentialMemoryMask(content);
+  return disposition.action === "store" ? disposition.storedContent : "";
 }
 
 /**
@@ -72,13 +74,61 @@ export function resolveMemoryStorageDisposition(
     return { action: "block", storedContent: "", payloadClass: "content" };
   }
   if (sensitivity === "confidential") {
-    return {
-      action: "store",
-      storedContent: maskConfidentialContent(content),
-      payloadClass: "masked-content",
-    };
+    return resolveConfidentialMemoryMask(content);
   }
   return { action: "store", storedContent: content, payloadClass: "content" };
+}
+
+function resolveConfidentialMemoryMask(
+  content: string,
+): { action: "store" | "block"; storedContent: string; payloadClass: MemoryPayloadClass } {
+  const screen = screenInferencePayload({
+    messages: [{ role: "user", content }],
+    systemPrompt: "",
+    destinationClass: "derived-index",
+    governedData: [{
+      assetId: "data:agent-conversation",
+      fieldIds: ["data:agent-conversation#content"],
+      classificationKnown: true,
+      sensitivity: "confidential",
+      purpose: SEMANTIC_MEMORY_PURPOSE,
+    }],
+  });
+  const decision = screen.decisions.find(
+    (candidate) =>
+      candidate.effect === "allow-with-obligations" &&
+      candidate.obligations.some((obligation) => obligation.kind === "mask"),
+  );
+  if (!decision) {
+    return { action: "block", storedContent: "", payloadClass: "masked-content" };
+  }
+
+  try {
+    const masked = maskForContext(
+      { messages: [{ role: "user" as const, content }], systemPrompt: "" },
+      {
+        decision,
+        matches: screen.classification.matches,
+        detailUse: "replaceable",
+      },
+    );
+    if (masked.transformation === "none") {
+      return { action: "block", storedContent: "", payloadClass: "masked-content" };
+    }
+    return {
+      action: "store",
+      storedContent: masked.value.messages[0]!.content,
+      payloadClass: "masked-content",
+    };
+  } catch (error) {
+    if (
+      error instanceof ContextMaskAuthorizationError ||
+      error instanceof ContextMaskCoverageError
+    ) {
+      return { action: "block", storedContent: "", payloadClass: "masked-content" };
+    }
+    throw error;
+  }
 }
 
 // ─── Store Conversation Memory ──────────────────────────────────────────────

--- a/apps/web/lib/tak/tool-result-budget.test.ts
+++ b/apps/web/lib/tak/tool-result-budget.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TOOL_RESULT_CHAR_CAP,
   MCP_ROUTE_TOOL_RESULT_CHAR_CAP,
 } from "./tool-result-budget";
+import type { DataPolicyDecision } from "@/lib/govern/data/policy-decision";
 
 describe("resolveToolResultCharCap", () => {
   it("returns the conservative default when the window is unknown", () => {
@@ -28,6 +29,41 @@ describe("resolveToolResultCharCap", () => {
 });
 
 describe("clampToolResultForModel", () => {
+  it("masks a governed tool result before model-facing serialization", () => {
+    const decision: DataPolicyDecision = {
+      decisionId: "decision-tool-mask",
+      organizationId: "org-test",
+      inputHash: "input",
+      effect: "allow-with-obligations",
+      obligations: [{ kind: "mask", profileId: "default-confidential" }],
+      matchedPolicyVersions: ["confidential-projection-mask@1"],
+      assetVersion: "a1",
+      classificationVersion: "c1",
+      authorityVersion: "auth1",
+      explanationCode: "confidential-masked-before-projection",
+      replay: "single-use",
+    };
+    const out = clampToolResultForModel(
+      { success: true, data: { customerEmail: "ada@example.com" } },
+      {
+        contextMask: {
+          decision,
+          detailUse: "replaceable",
+          matches: [{
+            dataClass: "customer-records",
+            path: "data.customerEmail",
+            reason: "contact-detail",
+            confidence: "deterministic",
+          }],
+        },
+      },
+    );
+
+    expect(out.text).not.toContain("ada@example.com");
+    expect(out.text).toContain("[DPF_TOKEN_");
+    expect(out.rehydrationHandle).toMatch(/^rehydration_/);
+  });
+
   it("passes through a small successful result untouched", () => {
     const out = clampToolResultForModel(
       { success: true, message: "ok", data: { a: 1 } },

--- a/apps/web/lib/tak/tool-result-budget.ts
+++ b/apps/web/lib/tak/tool-result-budget.ts
@@ -1,3 +1,8 @@
+import {
+  maskForContext,
+  type ContextMaskAuthority,
+} from "@/lib/govern/data/mask-for-context";
+
 /**
  * Tool-result token-budget guard.
  *
@@ -66,6 +71,8 @@ export type ClampedToolResult = {
   truncated: boolean;
   /** Length of the untruncated serialization (for telemetry). */
   originalChars: number;
+  /** Opaque only; raw token maps never leave the controlled runtime. */
+  rehydrationHandle?: string;
 };
 
 function buildFullText(result: ModelFacingToolResult): string {
@@ -91,12 +98,19 @@ function buildFullText(result: ModelFacingToolResult): string {
  */
 export function clampToolResultForModel(
   result: ModelFacingToolResult,
-  opts?: { maxChars?: number },
+  opts?: { maxChars?: number; contextMask?: ContextMaskAuthority },
 ): ClampedToolResult {
   const maxChars = Math.max(0, opts?.maxChars ?? DEFAULT_TOOL_RESULT_CHAR_CAP);
-  const full = buildFullText(result);
+  const masked = opts?.contextMask ? maskForContext(result, opts.contextMask) : null;
+  const full = buildFullText(masked?.value ?? result);
+  const handle = masked?.rehydrationHandle;
   if (full.length <= maxChars) {
-    return { text: full, truncated: false, originalChars: full.length };
+    return {
+      text: full,
+      truncated: false,
+      originalChars: full.length,
+      ...(handle ? { rehydrationHandle: handle } : {}),
+    };
   }
   const notice =
     `\n…[truncated ${full.length - maxChars} of ${full.length} chars — result exceeds the per-call ` +
@@ -106,5 +120,6 @@ export function clampToolResultForModel(
     text: full.slice(0, keep) + notice,
     truncated: true,
     originalChars: full.length,
+    ...(handle ? { rehydrationHandle: handle } : {}),
   };
 }

--- a/docs/data-impact/2026-07-27-inference-data-screen-receipt.data-impact.json
+++ b/docs/data-impact/2026-07-27-inference-data-screen-receipt.data-impact.json
@@ -4,7 +4,8 @@
   "affectedCopies": [
     "Prisma-to-EA current-state data-model mirror",
     "RouteDecisionLog governed dispatch evidence",
-    "RouteDecisionLog operator explanation projection"
+    "RouteDecisionLog operator explanation projection",
+    "Runtime-only bounded token maps (ephemeral and never persisted)"
   ],
   "migration": {
     "name": "20260726173000_add_inference_data_screen_receipt",
@@ -14,6 +15,9 @@
     "packages/db/src/provider-suitability-evidence-schema.test.ts",
     "apps/web/lib/inference/routed-inference.activity-overrides.test.ts",
     "apps/web/lib/inference/data-screening/routed-screening.test.ts",
+    "apps/web/lib/govern/data/mask-for-context.test.ts",
+    "apps/web/lib/inference/semantic-memory.test.ts",
+    "apps/web/lib/tak/tool-result-budget.test.ts",
     "apps/web/lib/routing/loader.test.ts",
     "apps/web/lib/routing/fallback-screened-dispatch.test.ts",
     "apps/web/lib/routing/inference-dispatch-guard.test.ts",

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -249,11 +249,13 @@ git diff --check
 - Modify: `apps/web/lib/tak/tool-result-budget.ts`
 - Modify: `apps/web/lib/inference/semantic-memory.ts`
 
-- [ ] Apply `omit`, `redact`, `partial`, `tokenize`, `aggregate`, and `pass-through` to nested messages, tool schemas, tool arguments, tool results, prompt blocks, and system prompt text.
-- [ ] Refuse masking when the exact sensitive detail is material to the task and no eligible endpoint exists.
-- [ ] Keep token maps out of route logs, memory, prompt previews, vector storage, and exception text.
-- [ ] Ensure output classification inherits from input classification and transformation state.
-- [ ] Add canary tests proving raw sensitive fixtures never reach prompt serialization, vector memory, tool-result return, or dispatch mocks.
+- [x] Apply `omit`, `redact`, `partial`, `tokenize`, `aggregate`, and `pass-through` to nested messages, tool schemas, tool arguments, tool results, prompt blocks, and system prompt text.
+- [x] Refuse masking when the exact sensitive detail is material to the task and no eligible endpoint exists.
+- [x] Keep token maps out of route logs, memory, prompt previews, vector storage, and exception text.
+- [x] Ensure output classification inherits from input classification and transformation state.
+- [x] Add canary tests proving raw sensitive fixtures never reach prompt serialization, vector memory, tool-result return, or dispatch mocks.
+
+**Slice 6 progress:** The canonical PDP now selects all six context transformations, and `maskForContext` recursively applies them before route inference or provider dispatch. Automatic masking is limited to replaceable detail; material or unknown exact-detail use fails closed. Token values live only in a bounded, five-minute in-memory vault and callers receive an opaque rehydration handle, so token maps never enter receipts, previews, logs, memory, vector storage, or exception text. The final screen preserves the source data classes and decision/version evidence alongside the applied transformation while routing on the transformed payload. Canary tests cover routed prompts, fallback dispatch, semantic/vector memory, and tool-result serialization. Rehydration remains blocked behind the actor, purpose, and surface authorization boundary in Chunk 5.
 
 **Verification:**
 

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -257,6 +257,13 @@ git diff --check
 
 **Slice 6 progress:** The canonical PDP now selects all six context transformations, and `maskForContext` recursively applies them before route inference or provider dispatch. Automatic masking is limited to replaceable detail; material or unknown exact-detail use fails closed. Token values live only in a bounded, five-minute in-memory vault and callers receive an opaque rehydration handle, so token maps never enter receipts, previews, logs, memory, vector storage, or exception text. The final screen preserves the source data classes and decision/version evidence alongside the applied transformation while routing on the transformed payload. Canary tests cover routed prompts, fallback dispatch, semantic/vector memory, and tool-result serialization. Rehydration remains blocked behind the actor, purpose, and surface authorization boundary in Chunk 5.
 
+#### Design grounding
+
+- Existing specs/plans reviewed: this plan and `docs/superpowers/plans/2026-07-17-data-management-governance-plan.md`.
+- Current code substrate reviewed: `apps/web/lib/govern/data/policy-decision.ts`, `apps/web/lib/inference/data-screening/`, `apps/web/lib/tak/tool-result-budget.ts`, and `apps/web/lib/inference/semantic-memory.ts`.
+- Source of truth: governance PDP decisions and the canonical `maskForContext` transform own masking authority; routing and provider adapters consume the screened contract.
+- Decision: extend the existing PDP/PEP and model-facing serialization seams without adding policy logic to provider adapters, routing UI, or ad hoc redaction helpers.
+
 **Verification:**
 
 ```powershell

--- a/docs/user-guide/ai-workforce/model-routing-lifecycle.md
+++ b/docs/user-guide/ai-workforce/model-routing-lifecycle.md
@@ -129,7 +129,9 @@ That means one connected provider can be available for public marketing copy and
 
 An employee's occupation focuses the explanations and recommendations they see. It does not grant data access, expand coworker or tool authority, or make a blocked provider eligible.
 
-When masking is safe, DPF can replace sensitive details with labels or stable tokens before a public or lower-cost model sees the request, then rehydrate only for the same authorized actor and surface. When the exact value is necessary for correctness, masking is not used as a workaround. The route must use an eligible internal, local, or enterprise provider, or the platform blocks the request with a short explanation and next action.
+When a caller declares that sensitive details are replaceable, the PDP can authorize DPF to omit, redact, partially reveal, tokenize, or aggregate matched values before contract inference, preview construction, memory projection, tool-result serialization, and provider dispatch. The transformed payload is screened again, while its receipt keeps the source data classes, protection state, and current policy versions. Stable tokens have an opaque, short-lived rehydration handle; the token map stays only inside the controlled runtime and is never written to route logs, memory, previews, vector storage, receipts, or exception text.
+
+If the exact value is material to correctness—or the classifier cannot prove a safe transform—DPF does not mask around the restriction. The task remains on an eligible internal, local, or enterprise route, or is blocked with a short explanation and next action. Response rehydration remains masked until the separate actor, role, purpose, and surface authorization gate approves it.
 
 ### Evidence belongs to the connected account
 


### PR DESCRIPTION
## Summary
- add the canonical PDP-authorized `maskForContext` transform with omit, redact, partial, tokenize, aggregate, and pass-through profiles
- screen and transform governed prompts, system text, tool payloads, semantic memory, and model-facing tool results before provider dispatch
- retain source classification and policy-version evidence while keeping token maps out of receipts, logs, previews, memory, vectors, and exceptions
- fail closed when exact sensitive detail is material or transformation authority changes before dispatch

## Verification
- `pnpm run pregate` on exact head `80de154876d5cf84d41f28da75e0567a0990717b`
  - sandbox freshness green
  - 2,263 test files passed; 4 skipped
  - 19,628 tests passed; 19 skipped; 18 todo
  - Prisma migrations applied
  - docs and guard suite passed
  - web TypeScript passed
  - production Docker build passed
- `pnpm security:secrets` passed
- `node scripts/check-module-size.mjs` passed
- `git diff --check` passed

## UX / migration / docs
- UX verification: not applicable; this slice changes the inference enforcement substrate and has no new interactive UI
- Migration: not applicable; no schema change
- Docs: updated model-routing lifecycle, data-impact manifest, and the implementation plan's Chunk 3 evidence

## Architecture
- policy decisions remain in the governance PDP; provider adapters and routing UI do not acquire data-policy logic
- opaque rehydration handles are intentionally not consumed yet; actor/purpose/surface authorization remains Chunk 5
## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
  - `docs/superpowers/plans/2026-07-17-data-management-governance-plan.md`
- Current code substrate reviewed:
  - `apps/web/lib/govern/data/policy-decision.ts`
  - `apps/web/lib/inference/data-screening/`
  - `apps/web/lib/tak/tool-result-budget.ts`
  - `apps/web/lib/inference/semantic-memory.ts`
- Source of truth:
  - governance PDP decisions and the canonical `maskForContext` transform own masking authority; routing and provider adapters consume the resulting screened contract
- Decision:
  - extend the existing PDP/PEP seam and model-facing serialization boundaries; do not add policy logic to provider adapters, routing UI, or ad hoc redaction helpers
