### PR TITLE
feat(auth): enrich effective authorization context

### DIFF
--- a/apps/web/app/api/v1/customer/invoices/route.test.ts
+++ b/apps/web/app/api/v1/customer/invoices/route.test.ts
@@ -49,10 +49,27 @@ const CUSTOMER_AUTH = {
   capabilities: [] as string[],
   authContext: {
     principalId: null,
+    principalAliases: [],
+    population: "customer" as const,
     platformRole: null,
     isSuperuser: false,
     employeeId: null,
     managerScope: null,
+    teamIds: [],
+    accountScope: {
+      accountIds: ["ACCT-1"],
+      contactIds: ["CON-1"],
+      partnerAccountIds: [],
+    },
+    sensitivityClearance: ["public" as const],
+    authentication: {
+      source: "session" as const,
+      methods: [],
+      contextClassReference: null,
+    },
+    actingHumanUserId: null,
+    actingAgentId: null,
+    delegationGrantIds: [],
     grantedCapabilities: [] as string[],
   },
 };

--- a/apps/web/app/api/v1/customer/visits/route.test.ts
+++ b/apps/web/app/api/v1/customer/visits/route.test.ts
@@ -45,10 +45,27 @@ const CUSTOMER_AUTH = {
   capabilities: [] as string[],
   authContext: {
     principalId: null,
+    principalAliases: [],
+    population: "customer" as const,
     platformRole: null,
     isSuperuser: false,
     employeeId: null,
     managerScope: null,
+    teamIds: [],
+    accountScope: {
+      accountIds: ["ACCT-1"],
+      contactIds: ["CON-1"],
+      partnerAccountIds: [],
+    },
+    sensitivityClearance: ["public" as const],
+    authentication: {
+      source: "session" as const,
+      methods: [],
+      contextClassReference: null,
+    },
+    actingHumanUserId: null,
+    actingAgentId: null,
+    delegationGrantIds: [],
     grantedCapabilities: [] as string[],
   },
 };

--- a/apps/web/app/api/v1/integrations/coverage/route.test.ts
+++ b/apps/web/app/api/v1/integrations/coverage/route.test.ts
@@ -57,7 +57,27 @@ describe("GET /api/v1/integrations/coverage", () => {
         organizationId: "org-1",
       },
       capabilities: [],
-      authContext: { principalId: null, platformRole: "owner_operator", isSuperuser: false, employeeId: null, managerScope: null, grantedCapabilities: [] },
+      authContext: {
+        principalId: null,
+        principalAliases: [],
+        population: "workforce",
+        platformRole: "owner_operator",
+        isSuperuser: false,
+        employeeId: null,
+        managerScope: null,
+        teamIds: [],
+        accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+        sensitivityClearance: ["public"],
+        authentication: {
+          source: "session",
+          methods: [],
+          contextClassReference: null,
+        },
+        actingHumanUserId: "user-1",
+        actingAgentId: null,
+        delegationGrantIds: [],
+        grantedCapabilities: [],
+      },
     });
     mockOrgFindFirst.mockResolvedValue({ id: "org-1" });
     mockGetMatrixByOrg.mockResolvedValue([]);

--- a/apps/web/app/api/v1/work-items/[itemId]/evidence/route.test.ts
+++ b/apps/web/app/api/v1/work-items/[itemId]/evidence/route.test.ts
@@ -41,10 +41,23 @@ const USER = {
   capabilities: [] as string[],
   authContext: {
     principalId: null,
+    principalAliases: [],
+    population: "workforce" as const,
     platformRole: null,
     isSuperuser: false,
     employeeId: "emp_1",
     managerScope: null,
+    teamIds: [],
+    accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+    sensitivityClearance: ["public" as const],
+    authentication: {
+      source: "session" as const,
+      methods: [],
+      contextClassReference: null,
+    },
+    actingHumanUserId: "user_1",
+    actingAgentId: null,
+    delegationGrantIds: [],
     grantedCapabilities: [] as string[],
   },
 };

--- a/apps/web/lib/actions/workforce.test.ts
+++ b/apps/web/lib/actions/workforce.test.ts
@@ -191,6 +191,7 @@ describe("createEmployeeProfile", () => {
       displayName: "Ada Lovelace",
       sponsorPrincipalId: null,
       authorityMode: null,
+      sensitivityClearance: ["public"],
       createdAt: new Date("2026-04-23T00:00:00Z"),
       updatedAt: new Date("2026-04-23T00:00:00Z"),
     });

--- a/apps/web/lib/api/__tests__/auth-middleware.test.ts
+++ b/apps/web/lib/api/__tests__/auth-middleware.test.ts
@@ -24,15 +24,44 @@ vi.mock("../../permissions.js", () => ({
   getGrantedCapabilities: vi.fn(),
 }));
 
+vi.mock("../../identity/load-effective-auth-context.js", () => ({
+  loadEffectiveAuthContext: vi.fn(),
+}));
+
 import { prisma } from "@dpf/db";
 import { verifyAccessToken } from "../jwt.js";
 import { auth } from "../../auth.js";
 import { getGrantedCapabilities } from "../../permissions.js";
+import { loadEffectiveAuthContext } from "../../identity/load-effective-auth-context.js";
 import { authenticateRequest, requireCapability } from "../auth-middleware.js";
 import { ApiError } from "../error.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (loadEffectiveAuthContext as ReturnType<typeof vi.fn>).mockResolvedValue({
+    principalId: "PRN-000123",
+    principalAliases: [],
+    population: "workforce",
+    platformRole: "HR-000",
+    isSuperuser: false,
+    employeeId: "emp-1",
+    managerScope: {
+      directReportIds: ["emp-2"],
+      indirectReportIds: ["emp-3"],
+    },
+    teamIds: [],
+    accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+    sensitivityClearance: ["public"],
+    authentication: {
+      source: "bearer",
+      methods: [],
+      contextClassReference: null,
+    },
+    actingHumanUserId: "user-1",
+    actingAgentId: null,
+    delegationGrantIds: [],
+    grantedCapabilities: [],
+  });
 });
 
 // Helper to create a mock NextRequest
@@ -66,21 +95,10 @@ describe("authenticateRequest — Bearer token", () => {
       isActive: true,
       isSuperuser: false,
       groups: [{ platformRole: { roleId: "HR-000" } }],
-      employeeProfile: {
-        id: "emp-1",
-        directReports: [{ id: "emp-2" }],
-      },
     });
 
     const mockCapabilities = getGrantedCapabilities as ReturnType<typeof vi.fn>;
     mockCapabilities.mockReturnValue(["view_admin", "view_portfolio"]);
-    const mockPrincipalAlias = prisma.principalAlias.findFirst as ReturnType<typeof vi.fn>;
-    mockPrincipalAlias.mockResolvedValue({
-      principal: {
-        principalId: "PRN-000123",
-      },
-    });
-
     const req = mockRequest({ authorization: "Bearer my-jwt-token" });
     const result = await authenticateRequest(req as never);
 
@@ -91,6 +109,15 @@ describe("authenticateRequest — Bearer token", () => {
     expect(result.authContext.principalId).toBe("PRN-000123");
     expect(result.authContext.employeeId).toBe("emp-1");
     expect(result.authContext.managerScope?.directReportIds).toEqual(["emp-2"]);
+    expect(loadEffectiveAuthContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authentication: {
+          source: "bearer",
+          methods: undefined,
+          contextClassReference: undefined,
+        },
+      }),
+    );
   });
 
   it("throws 401 if Bearer token is invalid", async () => {
@@ -130,23 +157,26 @@ describe("authenticateRequest — session fallback", () => {
 
     const mockCapabilities = getGrantedCapabilities as ReturnType<typeof vi.fn>;
     mockCapabilities.mockReturnValue(["view_ea_modeler"]);
-    const mockPrincipalAlias = prisma.principalAlias.findFirst as ReturnType<typeof vi.fn>;
-    mockPrincipalAlias.mockResolvedValue({
-      principal: {
-        principalId: "PRN-000456",
-      },
-    });
-    const mockFindUnique = prisma.user.findUnique as ReturnType<typeof vi.fn>;
-    mockFindUnique.mockResolvedValue({
-      id: "user-2",
-      email: "bob@example.com",
-      isActive: true,
+    (loadEffectiveAuthContext as ReturnType<typeof vi.fn>).mockResolvedValue({
+      principalId: "PRN-000456",
+      principalAliases: [],
+      population: "workforce",
+      platformRole: "HR-300",
       isSuperuser: false,
-      groups: [{ platformRole: { roleId: "HR-300" } }],
-      employeeProfile: {
-        id: "emp-2",
-        directReports: [{ id: "emp-3" }],
+      employeeId: "emp-2",
+      managerScope: { directReportIds: ["emp-3"], indirectReportIds: [] },
+      teamIds: [],
+      accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+      sensitivityClearance: ["public"],
+      authentication: {
+        source: "session",
+        methods: [],
+        contextClassReference: null,
       },
+      actingHumanUserId: "user-2",
+      actingAgentId: null,
+      delegationGrantIds: [],
+      grantedCapabilities: ["view_ea_modeler"],
     });
 
     const req = mockRequest({});
@@ -158,6 +188,9 @@ describe("authenticateRequest — session fallback", () => {
     expect(result.authContext.principalId).toBe("PRN-000456");
     expect(result.authContext.employeeId).toBe("emp-2");
     expect(result.authContext.managerScope?.directReportIds).toEqual(["emp-3"]);
+    expect(loadEffectiveAuthContext).toHaveBeenCalledWith(
+      expect.objectContaining({ authentication: { source: "session" } }),
+    );
   });
 
   it("throws 401 when no Bearer token and no session", async () => {

--- a/apps/web/lib/api/auth-middleware.ts
+++ b/apps/web/lib/api/auth-middleware.ts
@@ -12,8 +12,8 @@
 import { prisma } from "@dpf/db";
 import type { DpfSession } from "../auth";
 import { auth } from "../auth";
-import { buildEffectiveAuthContext, type EffectiveAuthContext } from "../identity/effective-auth-context";
-import { resolvePrincipalIdForUser } from "../identity/principal-linking";
+import type { EffectiveAuthContext } from "../identity/effective-auth-context";
+import { loadEffectiveAuthContext } from "../identity/load-effective-auth-context";
 import { getGrantedCapabilities } from "../permissions";
 import { verifyAccessToken } from "./jwt";
 import { apiError } from "./error";
@@ -51,12 +51,6 @@ export async function authenticateRequest(
       where: { id: payload.sub },
       include: {
         groups: { include: { platformRole: true } },
-        employeeProfile: {
-          select: {
-            id: true,
-            directReports: { select: { id: true } },
-          },
-        },
       },
     });
 
@@ -79,12 +73,14 @@ export async function authenticateRequest(
       platformRole: sessionUser.platformRole,
       isSuperuser: sessionUser.isSuperuser,
     });
-    const principalId = await resolvePrincipalIdForUser(sessionUser.id);
-    const authContext = buildEffectiveAuthContext({
+    const authContext = await loadEffectiveAuthContext({
       user: sessionUser,
       grantedCapabilities: capabilities,
-      principalId,
-      employeeProfile: user.employeeProfile,
+      authentication: {
+        source: "bearer",
+        methods: payload.amr,
+        contextClassReference: payload.acr,
+      },
     });
 
     return { user: sessionUser, capabilities, authContext };
@@ -102,27 +98,10 @@ export async function authenticateRequest(
     platformRole: sessionUser.platformRole,
     isSuperuser: sessionUser.isSuperuser,
   });
-  const principalId =
-    sessionUser.type === "admin" ? await resolvePrincipalIdForUser(sessionUser.id) : null;
-  const workforceUser =
-    sessionUser.type === "admin"
-      ? await prisma.user.findUnique({
-          where: { id: sessionUser.id },
-          include: {
-            employeeProfile: {
-              select: {
-                id: true,
-                directReports: { select: { id: true } },
-              },
-            },
-          },
-        })
-      : null;
-  const authContext = buildEffectiveAuthContext({
+  const authContext = await loadEffectiveAuthContext({
     user: sessionUser,
     grantedCapabilities: capabilities,
-    principalId,
-    employeeProfile: workforceUser?.employeeProfile ?? undefined,
+    authentication: { source: "session" },
   });
 
   return { user: sessionUser, capabilities, authContext };

--- a/apps/web/lib/api/jwt.test.ts
+++ b/apps/web/lib/api/jwt.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    apiToken: {},
+  },
+}));
+
+import { signAccessToken, verifyAccessToken } from "./jwt";
+
+describe("JWT authentication evidence", () => {
+  const previousSecret = process.env.AUTH_SECRET;
+
+  beforeEach(() => {
+    process.env.AUTH_SECRET = "effective-auth-context-test-secret";
+  });
+
+  afterEach(() => {
+    if (previousSecret === undefined) {
+      delete process.env.AUTH_SECRET;
+    } else {
+      process.env.AUTH_SECRET = previousSecret;
+    }
+  });
+
+  it("preserves issuer-asserted RFC 8176 methods and context class", async () => {
+    const token = await signAccessToken({
+      sub: "user-1",
+      email: "user@example.com",
+      platformRole: "HR-300",
+      isSuperuser: false,
+      amr: ["pwd", "otp"],
+      acr: "urn:example:assurance:2",
+    });
+
+    await expect(verifyAccessToken(token)).resolves.toMatchObject({
+      amr: ["pwd", "otp"],
+      acr: "urn:example:assurance:2",
+    });
+  });
+
+  it("does not invent assurance when the issuer asserted none", async () => {
+    const token = await signAccessToken({
+      sub: "user-1",
+      email: "user@example.com",
+      platformRole: null,
+      isSuperuser: false,
+    });
+
+    await expect(verifyAccessToken(token)).resolves.toMatchObject({
+      amr: undefined,
+      acr: null,
+    });
+  });
+});

--- a/apps/web/lib/api/jwt.ts
+++ b/apps/web/lib/api/jwt.ts
@@ -26,6 +26,10 @@ export type AccessTokenPayload = {
   email: string;
   platformRole: string | null;
   isSuperuser: boolean;
+  /** RFC 8176 authentication-method references asserted by the issuer. */
+  amr?: string[];
+  /** Authentication context class asserted by the issuer; never inferred locally. */
+  acr?: string | null;
 };
 
 const ACCESS_TOKEN_TTL = "15m";
@@ -38,6 +42,8 @@ export async function signAccessToken(payload: AccessTokenPayload): Promise<stri
     email: payload.email,
     platformRole: payload.platformRole,
     isSuperuser: payload.isSuperuser,
+    ...(payload.amr ? { amr: payload.amr } : {}),
+    ...(payload.acr ? { acr: payload.acr } : {}),
   })
     .setProtectedHeader({ alg: "HS256" })
     .setSubject(payload.sub)
@@ -57,6 +63,10 @@ export async function verifyAccessToken(token: string): Promise<AccessTokenPaylo
     email: (payload.email as string) ?? "",
     platformRole: (payload.platformRole as string | null) ?? null,
     isSuperuser: (payload.isSuperuser as boolean) ?? false,
+    amr: Array.isArray(payload.amr)
+      ? payload.amr.filter((method): method is string => typeof method === "string")
+      : undefined,
+    acr: typeof payload.acr === "string" ? payload.acr : null,
   };
 }
 

--- a/apps/web/lib/govern/manager-scope.test.ts
+++ b/apps/web/lib/govern/manager-scope.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+
 import { canAccessEmployeeScope } from "./manager-scope";
 
 describe("canAccessEmployeeScope", () => {
@@ -10,10 +12,23 @@ describe("canAccessEmployeeScope", () => {
     employeeId: "emp-manager",
     managerScope: {
       directReportIds: ["emp-report-1", "emp-report-2"],
-      indirectReportIds: [],
+      indirectReportIds: ["emp-indirect"],
     },
+    principalAliases: [],
+    population: "workforce" as const,
+    teamIds: ["team-1"],
+    accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+    sensitivityClearance: ["public"],
+    authentication: {
+      source: "session" as const,
+      methods: [],
+      contextClassReference: null,
+    },
+    actingHumanUserId: "user-1",
+    actingAgentId: null,
+    delegationGrantIds: [],
     grantedCapabilities: ["view_employee"],
-  };
+  } satisfies EffectiveAuthContext;
 
   it("allows a manager to access a direct report", () => {
     expect(canAccessEmployeeScope(managerContext, "emp-report-1")).toBe(true);
@@ -21,6 +36,14 @@ describe("canAccessEmployeeScope", () => {
 
   it("denies a manager access to unrelated employees without HR capability", () => {
     expect(canAccessEmployeeScope(managerContext, "emp-other")).toBe(false);
+  });
+
+  it("does not widen employee access merely because a peer shares the team", () => {
+    expect(canAccessEmployeeScope(managerContext, "emp-team-peer")).toBe(false);
+  });
+
+  it("allows a manager to access an indirect report", () => {
+    expect(canAccessEmployeeScope(managerContext, "emp-indirect")).toBe(true);
   });
 
   it("allows self access", () => {

--- a/apps/web/lib/govern/manager-scope.ts
+++ b/apps/web/lib/govern/manager-scope.ts
@@ -6,5 +6,9 @@ export function canAccessEmployeeScope(
 ): boolean {
   if (context.isSuperuser) return true;
   if (context.employeeId === targetEmployeeId) return true;
-  return context.managerScope?.directReportIds.includes(targetEmployeeId) ?? false;
+  return (
+    context.managerScope?.directReportIds.includes(targetEmployeeId) ||
+    context.managerScope?.indirectReportIds.includes(targetEmployeeId) ||
+    false
+  );
 }

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -274,6 +274,8 @@ describe("canAccessEmployeeRecord()", () => {
       canAccessEmployeeRecord(
         {
           principalId: "PRN-USER-user-1",
+          principalAliases: [],
+          population: "workforce",
           platformRole: "HR-100",
           isSuperuser: false,
           employeeId: "emp-manager",
@@ -281,6 +283,17 @@ describe("canAccessEmployeeRecord()", () => {
             directReportIds: ["emp-report-1"],
             indirectReportIds: [],
           },
+          teamIds: [],
+          accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+          sensitivityClearance: ["public"],
+          authentication: {
+            source: "session",
+            methods: [],
+            contextClassReference: null,
+          },
+          actingHumanUserId: "user-1",
+          actingAgentId: null,
+          delegationGrantIds: [],
           grantedCapabilities: ["view_employee"],
         },
         "emp-report-1",
@@ -293,6 +306,8 @@ describe("canAccessEmployeeRecord()", () => {
       canAccessEmployeeRecord(
         {
           principalId: "PRN-USER-user-1",
+          principalAliases: [],
+          population: "workforce",
           platformRole: "HR-100",
           isSuperuser: false,
           employeeId: "emp-manager",
@@ -300,6 +315,17 @@ describe("canAccessEmployeeRecord()", () => {
             directReportIds: ["emp-report-1"],
             indirectReportIds: [],
           },
+          teamIds: [],
+          accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+          sensitivityClearance: ["public"],
+          authentication: {
+            source: "session",
+            methods: [],
+            contextClassReference: null,
+          },
+          actingHumanUserId: "user-1",
+          actingAgentId: null,
+          delegationGrantIds: [],
           grantedCapabilities: [],
         },
         "emp-report-1",

--- a/apps/web/lib/identity/effective-auth-context.test.ts
+++ b/apps/web/lib/identity/effective-auth-context.test.ts
@@ -1,45 +1,136 @@
 import { describe, expect, it } from "vitest";
 
-import { buildEffectiveAuthContext } from "./effective-auth-context";
+import {
+  AUTH_POPULATIONS,
+  buildEffectiveAuthContext,
+} from "./effective-auth-context";
+
+const baseUser = {
+  id: "user-1",
+  type: "admin" as const,
+  platformRole: "HR-300",
+  isSuperuser: false,
+  accountId: null,
+  contactId: null,
+};
 
 describe("buildEffectiveAuthContext", () => {
-  it("builds effective auth context for a workforce user", () => {
+  it("normalizes authoritative workforce scope deterministically", () => {
     const context = buildEffectiveAuthContext({
-      user: {
-        id: "user-1",
-        type: "admin",
-        platformRole: "HR-300",
-        isSuperuser: false,
+      user: baseUser,
+      grantedCapabilities: ["view_employee", "view_admin", "view_employee"],
+      principal: {
+        principalId: "PRN-000123",
+        kind: "human",
+        sensitivityClearance: ["restricted", "public", "restricted"],
+        aliases: [
+          { aliasType: "user", aliasValue: "user-1", issuer: "" },
+          { aliasType: "employee", aliasValue: "EMP-1", issuer: "" },
+        ],
       },
-      grantedCapabilities: ["view_admin", "view_employee"],
-      principalId: "PRN-000123",
       employeeProfile: {
         id: "emp-1",
-        directReports: [],
+        directReportIds: ["emp-3", "emp-2", "emp-3"],
+        indirectReportIds: ["emp-5", "emp-4"],
       },
+      teamIds: ["team-b", "team-a", "team-b"],
+      authentication: {
+        source: "bearer",
+        methods: ["otp", "pwd", "otp"],
+        contextClassReference: "urn:example:assurance:2",
+      },
+      delegationGrantIds: ["DGR-2", "DGR-1", "DGR-2"],
     });
 
-    expect(context.principalId).toBe("PRN-000123");
-    expect(context.platformRole).toBe("HR-300");
-    expect(context.employeeId).toBe("emp-1");
-    expect(context.grantedCapabilities).toEqual(["view_admin", "view_employee"]);
+    expect(context).toMatchObject({
+      principalId: "PRN-000123",
+      population: "workforce",
+      employeeId: "emp-1",
+      managerScope: {
+        directReportIds: ["emp-2", "emp-3"],
+        indirectReportIds: ["emp-4", "emp-5"],
+      },
+      teamIds: ["team-a", "team-b"],
+      sensitivityClearance: ["public", "restricted"],
+      authentication: {
+        source: "bearer",
+        methods: ["otp", "pwd"],
+        contextClassReference: "urn:example:assurance:2",
+      },
+      delegationGrantIds: ["DGR-1", "DGR-2"],
+      grantedCapabilities: ["view_admin", "view_employee"],
+    });
   });
 
-  it("returns empty manager scope for a non-manager", () => {
+  it.each([
+    ["workforce", "human", "admin"],
+    ["customer", "customer", "customer"],
+    ["partner", "partner", "customer"],
+    ["service", "service", "admin"],
+    ["ai-coworker", "agent", "admin"],
+  ] as const)(
+    "builds a fail-closed %s population fixture",
+    (expectedPopulation, principalKind, userType) => {
+      const context = buildEffectiveAuthContext({
+        user: {
+          ...baseUser,
+          type: userType,
+          accountId: userType === "customer" ? "ACC-1" : null,
+          contactId: userType === "customer" ? "CONTACT-1" : null,
+        },
+        grantedCapabilities: [],
+        principal: {
+          principalId: `PRN-${expectedPopulation}`,
+          kind: principalKind,
+        },
+      });
+
+      expect(context.population).toBe(expectedPopulation);
+      expect(context.sensitivityClearance).toEqual(["public"]);
+      expect(context.authentication).toEqual({
+        source: "unknown",
+        methods: [],
+        contextClassReference: null,
+      });
+    },
+  );
+
+  it("represents an AI coworker acting with a human only through explicit evidence", () => {
     const context = buildEffectiveAuthContext({
-      user: {
-        id: "user-2",
-        type: "admin",
-        platformRole: "HR-100",
-        isSuperuser: false,
-      },
-      grantedCapabilities: ["view_self"],
-      employeeProfile: {
-        id: "emp-2",
-        directReports: [],
-      },
+      user: baseUser,
+      grantedCapabilities: [],
+      population: "ai-coworker",
+      actingHumanUserId: "user-owner",
+      actingAgentId: "AGT-100",
+      delegationGrantIds: ["DGR-001"],
     });
 
-    expect(context.managerScope?.directReportIds ?? []).toEqual([]);
+    expect(context.actingHumanUserId).toBe("user-owner");
+    expect(context.actingAgentId).toBe("AGT-100");
+    expect(context.delegationGrantIds).toEqual(["DGR-001"]);
+  });
+
+  it("keeps the fixture matrix aligned with the closed population vocabulary", () => {
+    expect(AUTH_POPULATIONS).toEqual([
+      "workforce",
+      "customer",
+      "partner",
+      "service",
+      "ai-coworker",
+    ]);
+  });
+
+  it("rejects unknown sensitivity instead of widening clearance", () => {
+    expect(() =>
+      buildEffectiveAuthContext({
+        user: baseUser,
+        grantedCapabilities: [],
+        principal: {
+          principalId: "PRN-1",
+          kind: "human",
+          sensitivityClearance: ["secret"],
+        },
+      }),
+    ).toThrow("Unknown principal sensitivity clearance: secret");
   });
 });

--- a/apps/web/lib/identity/effective-auth-context.ts
+++ b/apps/web/lib/identity/effective-auth-context.ts
@@ -1,19 +1,71 @@
+import {
+  normalizePrincipalSensitivities,
+  type PrincipalSensitivity,
+} from "@dpf/db";
+
 import type { DpfSession } from "@/lib/govern/auth";
+
+export const AUTH_POPULATIONS = [
+  "workforce",
+  "customer",
+  "partner",
+  "service",
+  "ai-coworker",
+] as const;
+
+export type AuthPopulation = (typeof AUTH_POPULATIONS)[number];
+export type AuthSource = "bearer" | "session" | "service" | "delegation" | "unknown";
+
+export type PrincipalAliasEvidence = {
+  type: string;
+  value: string;
+  issuer: string;
+};
 
 type EmployeeScopeInput = {
   id: string;
   directReports?: Array<{ id: string }>;
+  directReportIds?: string[];
+  indirectReportIds?: string[];
 } | null;
 
-type EffectiveAuthContextInput = {
-  user: Pick<DpfSession["user"], "id" | "type" | "platformRole" | "isSuperuser">;
+export type EffectiveAuthContextInput = {
+  user: Pick<
+    DpfSession["user"],
+    "id" | "type" | "platformRole" | "isSuperuser" | "accountId" | "contactId"
+  >;
   grantedCapabilities: string[];
+  principal?: {
+    principalId: string;
+    kind: string;
+    aliases?: Array<{ aliasType: string; aliasValue: string; issuer: string }>;
+    sensitivityClearance?: string[];
+  } | null;
+  // Transitional compatibility for existing callers. The shared loader should
+  // pass `principal`; this field can be removed after every auth surface moves.
   principalId?: string | null;
+  population?: AuthPopulation;
   employeeProfile?: EmployeeScopeInput;
+  teamIds?: string[];
+  accountScope?: {
+    accountIds?: string[];
+    contactIds?: string[];
+    partnerAccountIds?: string[];
+  };
+  authentication?: {
+    source: AuthSource;
+    methods?: string[];
+    contextClassReference?: string | null;
+  };
+  actingHumanUserId?: string | null;
+  actingAgentId?: string | null;
+  delegationGrantIds?: string[];
 };
 
 export type EffectiveAuthContext = {
   principalId: string | null;
+  principalAliases: PrincipalAliasEvidence[];
+  population: AuthPopulation;
   platformRole: string | null;
   isSuperuser: boolean;
   employeeId: string | null;
@@ -21,33 +73,115 @@ export type EffectiveAuthContext = {
     directReportIds: string[];
     indirectReportIds: string[];
   } | null;
+  teamIds: string[];
+  accountScope: {
+    accountIds: string[];
+    contactIds: string[];
+    partnerAccountIds: string[];
+  };
+  sensitivityClearance: PrincipalSensitivity[];
+  authentication: {
+    source: AuthSource;
+    methods: string[];
+    contextClassReference: string | null;
+  };
+  actingHumanUserId: string | null;
+  actingAgentId: string | null;
+  delegationGrantIds: string[];
   grantedCapabilities: string[];
 };
 
-function toPrincipalId(userId: string | null | undefined): string | null {
-  if (!userId) return null;
-  return `PRN-USER-${userId}`;
+function normalizeStrings(values: readonly (string | null | undefined)[] | undefined): string[] {
+  return [...new Set((values ?? []).map((value) => value?.trim()).filter(Boolean) as string[])].sort();
+}
+
+function normalizeAliases(
+  aliases: Array<{ aliasType: string; aliasValue: string; issuer: string }> | undefined,
+): PrincipalAliasEvidence[] {
+  const keyed = new Map<string, PrincipalAliasEvidence>();
+  for (const alias of aliases ?? []) {
+    const type = alias.aliasType.trim();
+    const value = alias.aliasValue.trim();
+    const issuer = alias.issuer.trim();
+    if (!type || !value) continue;
+    keyed.set(`${type}\u0000${value}\u0000${issuer}`, { type, value, issuer });
+  }
+  return [...keyed.values()].sort(
+    (left, right) =>
+      left.type.localeCompare(right.type) ||
+      left.value.localeCompare(right.value) ||
+      left.issuer.localeCompare(right.issuer),
+  );
+}
+
+function inferPopulation(
+  userType: DpfSession["user"]["type"],
+  principalKind: string | null | undefined,
+): AuthPopulation {
+  if (principalKind === "partner") return "partner";
+  if (principalKind === "agent") return "ai-coworker";
+  if (principalKind === "service" || principalKind === "edge-agent") return "service";
+  return userType === "customer" ? "customer" : "workforce";
 }
 
 export function buildEffectiveAuthContext({
   user,
   grantedCapabilities,
+  principal,
   principalId,
+  population,
   employeeProfile,
+  teamIds,
+  accountScope,
+  authentication,
+  actingHumanUserId,
+  actingAgentId,
+  delegationGrantIds,
 }: EffectiveAuthContextInput): EffectiveAuthContext {
-  const directReportIds = employeeProfile?.directReports?.map((report) => report.id) ?? [];
+  const directReportIds = normalizeStrings([
+    ...(employeeProfile?.directReports?.map((report) => report.id) ?? []),
+    ...(employeeProfile?.directReportIds ?? []),
+  ]);
+  const indirectReportIds = normalizeStrings(employeeProfile?.indirectReportIds);
+  const resolvedPrincipalId =
+    principal?.principalId ??
+    principalId ??
+    null;
 
   return {
-    principalId: user.type === "admin" ? principalId ?? toPrincipalId(user.id) : null,
+    principalId: resolvedPrincipalId,
+    principalAliases: normalizeAliases(principal?.aliases),
+    population: population ?? inferPopulation(user.type, principal?.kind),
     platformRole: user.platformRole,
     isSuperuser: user.isSuperuser,
     employeeId: employeeProfile?.id ?? null,
     managerScope: employeeProfile
       ? {
           directReportIds,
-          indirectReportIds: [],
+          indirectReportIds,
         }
       : null,
-    grantedCapabilities,
+    teamIds: normalizeStrings(teamIds),
+    accountScope: {
+      accountIds: normalizeStrings([
+        ...(accountScope?.accountIds ?? []),
+        user.type === "customer" ? user.accountId : null,
+      ]),
+      contactIds: normalizeStrings([
+        ...(accountScope?.contactIds ?? []),
+        user.type === "customer" ? user.contactId : null,
+      ]),
+      partnerAccountIds: normalizeStrings(accountScope?.partnerAccountIds),
+    },
+    sensitivityClearance: normalizePrincipalSensitivities(principal?.sensitivityClearance),
+    authentication: {
+      source: authentication?.source ?? "unknown",
+      methods: normalizeStrings(authentication?.methods),
+      contextClassReference: authentication?.contextClassReference?.trim() || null,
+    },
+    actingHumanUserId: actingHumanUserId?.trim() || (user.type === "admin" ? user.id : null),
+    actingAgentId: actingAgentId?.trim() || null,
+    delegationGrantIds: normalizeStrings(delegationGrantIds),
+    grantedCapabilities: normalizeStrings(grantedCapabilities),
   };
 }

--- a/apps/web/lib/identity/effective-auth-context.ts
+++ b/apps/web/lib/identity/effective-auth-context.ts
@@ -1,7 +1,7 @@
 import {
   normalizePrincipalSensitivities,
   type PrincipalSensitivity,
-} from "@dpf/db";
+} from "@dpf/db/principal-sensitivity";
 
 import type { DpfSession } from "@/lib/govern/auth";
 

--- a/apps/web/lib/identity/load-effective-auth-context.test.ts
+++ b/apps/web/lib/identity/load-effective-auth-context.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadEffectiveAuthContext,
+  resolveManagerScope,
+} from "./load-effective-auth-context";
+
+describe("resolveManagerScope", () => {
+  it("computes direct and transitive indirect reports", () => {
+    expect(
+      resolveManagerScope(
+        [
+          { id: "manager", userId: "user-1", managerEmployeeId: null },
+          { id: "direct-b", userId: "user-2", managerEmployeeId: "manager" },
+          { id: "direct-a", userId: "user-3", managerEmployeeId: "manager" },
+          { id: "indirect", userId: "user-4", managerEmployeeId: "direct-a" },
+        ],
+        "user-1",
+      ),
+    ).toEqual({
+      employeeId: "manager",
+      directReportIds: ["direct-a", "direct-b"],
+      indirectReportIds: ["indirect"],
+    });
+  });
+
+  it("terminates a malformed reporting cycle without granting self", () => {
+    const result = resolveManagerScope(
+      [
+        { id: "manager", userId: "user-1", managerEmployeeId: "indirect" },
+        { id: "direct", userId: "user-2", managerEmployeeId: "manager" },
+        { id: "indirect", userId: "user-3", managerEmployeeId: "direct" },
+      ],
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      employeeId: "manager",
+      directReportIds: ["direct"],
+      indirectReportIds: ["indirect"],
+    });
+  });
+});
+
+describe("loadEffectiveAuthContext", () => {
+  it("hydrates canonical workforce scope and filters exhausted delegation grants", async () => {
+    const db = {
+      principalAlias: {
+        findFirst: vi.fn().mockResolvedValue({
+          principal: {
+            principalId: "PRN-1",
+            kind: "human",
+            status: "active",
+            sensitivityClearance: ["confidential", "public"],
+            aliases: [{ aliasType: "user", aliasValue: "user-1", issuer: "" }],
+          },
+        }),
+      },
+      employeeProfile: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "manager", userId: "user-1", managerEmployeeId: null },
+          { id: "direct", userId: "user-2", managerEmployeeId: "manager" },
+          { id: "indirect", userId: "user-3", managerEmployeeId: "direct" },
+        ]),
+      },
+      teamMembership: {
+        findMany: vi.fn().mockResolvedValue([{ teamId: "team-b" }, { teamId: "team-a" }]),
+      },
+      delegationGrant: {
+        findMany: vi.fn().mockResolvedValue([
+          { grantId: "DGR-ACTIVE", maxUses: 2, useCount: 1 },
+          { grantId: "DGR-EXHAUSTED", maxUses: 1, useCount: 1 },
+        ]),
+      },
+    };
+
+    const context = await loadEffectiveAuthContext(
+      {
+        user: {
+          id: "user-1",
+          email: "manager@example.com",
+          type: "admin",
+          platformRole: "HR-300",
+          isSuperuser: false,
+          accountId: null,
+          accountName: null,
+          contactId: null,
+        },
+        grantedCapabilities: ["view_employee"],
+        authentication: {
+          source: "bearer",
+          methods: ["pwd", "otp"],
+          contextClassReference: "urn:example:aal2",
+        },
+        actingAgentId: "AGT-1",
+        now: new Date("2026-07-27T12:00:00Z"),
+      },
+      db,
+    );
+
+    expect(context).toMatchObject({
+      principalId: "PRN-1",
+      teamIds: ["team-a", "team-b"],
+      managerScope: {
+        directReportIds: ["direct"],
+        indirectReportIds: ["indirect"],
+      },
+      sensitivityClearance: ["public", "confidential"],
+      actingHumanUserId: "user-1",
+      actingAgentId: "AGT-1",
+      delegationGrantIds: ["DGR-ACTIVE"],
+    });
+  });
+
+  it("uses canonical partner identity and authenticated account scope", async () => {
+    const db = {
+      principalAlias: {
+        findFirst: vi.fn().mockResolvedValue({
+          principal: {
+            principalId: "PRN-PARTNER",
+            kind: "partner",
+            status: "active",
+            sensitivityClearance: ["public"],
+            aliases: [
+              { aliasType: "partner_contact", aliasValue: "contact-1", issuer: "" },
+            ],
+          },
+        }),
+      },
+      employeeProfile: { findMany: vi.fn() },
+      teamMembership: { findMany: vi.fn() },
+      delegationGrant: { findMany: vi.fn() },
+    };
+
+    const context = await loadEffectiveAuthContext(
+      {
+        user: {
+          id: "contact-1",
+          email: "partner@example.com",
+          type: "customer",
+          platformRole: null,
+          isSuperuser: false,
+          accountId: "ACC-PARTNER",
+          accountName: "Partner",
+          contactId: "contact-1",
+        },
+        grantedCapabilities: [],
+        authentication: { source: "session" },
+      },
+      db,
+    );
+
+    expect(context.population).toBe("partner");
+    expect(context.accountScope).toEqual({
+      accountIds: ["ACC-PARTNER"],
+      contactIds: ["contact-1"],
+      partnerAccountIds: ["ACC-PARTNER"],
+    });
+    expect(db.employeeProfile.findMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects an inactive canonical principal", async () => {
+    const db = {
+      principalAlias: {
+        findFirst: vi.fn().mockResolvedValue({
+          principal: {
+            principalId: "PRN-INACTIVE",
+            kind: "human",
+            status: "inactive",
+            sensitivityClearance: ["public"],
+            aliases: [],
+          },
+        }),
+      },
+      employeeProfile: { findMany: vi.fn().mockResolvedValue([]) },
+      teamMembership: { findMany: vi.fn().mockResolvedValue([]) },
+      delegationGrant: { findMany: vi.fn() },
+    };
+
+    await expect(
+      loadEffectiveAuthContext(
+        {
+          user: {
+            id: "user-1",
+            email: "inactive@example.com",
+            type: "admin",
+            platformRole: null,
+            isSuperuser: false,
+            accountId: null,
+            accountName: null,
+            contactId: null,
+          },
+          grantedCapabilities: [],
+          authentication: { source: "session" },
+        },
+        db,
+      ),
+    ).rejects.toThrow("Principal PRN-INACTIVE is not active");
+  });
+});

--- a/apps/web/lib/identity/load-effective-auth-context.ts
+++ b/apps/web/lib/identity/load-effective-auth-context.ts
@@ -1,0 +1,198 @@
+import { prisma } from "@dpf/db";
+
+import type { DpfSession } from "@/lib/govern/auth";
+
+import {
+  buildEffectiveAuthContext,
+  type AuthSource,
+  type EffectiveAuthContext,
+} from "./effective-auth-context";
+
+type PrincipalRow = {
+  principalId: string;
+  kind: string;
+  status: string;
+  sensitivityClearance: string[];
+  aliases: Array<{ aliasType: string; aliasValue: string; issuer: string }>;
+};
+
+type EmployeeRow = {
+  id: string;
+  userId: string | null;
+  managerEmployeeId: string | null;
+};
+
+type EffectiveAuthContextDb = {
+  principalAlias: {
+    findFirst(args: unknown): Promise<{ principal: PrincipalRow } | null>;
+  };
+  employeeProfile: {
+    findMany(args: unknown): Promise<EmployeeRow[]>;
+  };
+  teamMembership: {
+    findMany(args: unknown): Promise<Array<{ teamId: string }>>;
+  };
+  delegationGrant: {
+    findMany(
+      args: unknown,
+    ): Promise<Array<{ grantId: string; maxUses: number | null; useCount: number }>>;
+  };
+};
+
+export type LoadEffectiveAuthContextInput = {
+  user: DpfSession["user"];
+  grantedCapabilities: string[];
+  authentication: {
+    source: AuthSource;
+    methods?: string[];
+    contextClassReference?: string | null;
+  };
+  actingAgentId?: string | null;
+  now?: Date;
+};
+
+export function resolveManagerScope(
+  employeeRows: readonly EmployeeRow[],
+  userId: string,
+): {
+  employeeId: string;
+  directReportIds: string[];
+  indirectReportIds: string[];
+} | null {
+  const employee = employeeRows.find((row) => row.userId === userId);
+  if (!employee) return null;
+
+  const childrenByManager = new Map<string, string[]>();
+  for (const row of employeeRows) {
+    if (!row.managerEmployeeId || row.id === employee.id) continue;
+    const children = childrenByManager.get(row.managerEmployeeId) ?? [];
+    children.push(row.id);
+    childrenByManager.set(row.managerEmployeeId, children);
+  }
+
+  const directReportIds = [...new Set(childrenByManager.get(employee.id) ?? [])].sort();
+  const visited = new Set<string>([employee.id, ...directReportIds]);
+  const indirectReportIds: string[] = [];
+  const queue = [...directReportIds];
+
+  while (queue.length > 0) {
+    const managerId = queue.shift()!;
+    for (const childId of childrenByManager.get(managerId) ?? []) {
+      if (visited.has(childId)) continue;
+      visited.add(childId);
+      indirectReportIds.push(childId);
+      queue.push(childId);
+    }
+  }
+
+  return {
+    employeeId: employee.id,
+    directReportIds,
+    indirectReportIds: indirectReportIds.sort(),
+  };
+}
+
+function principalAliasTypes(userType: DpfSession["user"]["type"]): string[] {
+  return userType === "admin" ? ["user"] : ["customer_contact", "partner_contact"];
+}
+
+export async function loadEffectiveAuthContext(
+  input: LoadEffectiveAuthContextInput,
+  db: EffectiveAuthContextDb = prisma as unknown as EffectiveAuthContextDb,
+): Promise<EffectiveAuthContext> {
+  const now = input.now ?? new Date();
+  const aliasTypes = principalAliasTypes(input.user.type);
+
+  const [principalAlias, employeeRows, teamMemberships, delegationGrants] = await Promise.all([
+    db.principalAlias.findFirst({
+      where: {
+        aliasType: { in: aliasTypes },
+        aliasValue: input.user.type === "admin" ? input.user.id : input.user.contactId ?? input.user.id,
+        issuer: "",
+      },
+      include: {
+        principal: {
+          select: {
+            principalId: true,
+            kind: true,
+            status: true,
+            sensitivityClearance: true,
+            aliases: {
+              select: {
+                aliasType: true,
+                aliasValue: true,
+                issuer: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    input.user.type === "admin"
+      ? db.employeeProfile.findMany({
+          select: { id: true, userId: true, managerEmployeeId: true },
+        })
+      : Promise.resolve([]),
+    input.user.type === "admin"
+      ? db.teamMembership.findMany({
+          where: { userId: input.user.id },
+          select: { teamId: true },
+        })
+      : Promise.resolve([]),
+    input.user.type === "admin" && input.actingAgentId
+      ? db.delegationGrant.findMany({
+          where: {
+            grantorUserId: input.user.id,
+            granteeAgent: { agentId: input.actingAgentId },
+            status: "active",
+            validFrom: { lte: now },
+            expiresAt: { gt: now },
+            OR: [{ targetUserId: null }, { targetUserId: input.user.id }],
+          },
+          select: { grantId: true, maxUses: true, useCount: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const principal = principalAlias?.principal ?? null;
+  if (principal && principal.status !== "active") {
+    throw new Error(`Principal ${principal.principalId} is not active`);
+  }
+
+  const managerScope =
+    input.user.type === "admin" ? resolveManagerScope(employeeRows, input.user.id) : null;
+  const activeDelegationGrantIds = delegationGrants
+    .filter((grant) => grant.maxUses === null || grant.useCount < grant.maxUses)
+    .map((grant) => grant.grantId);
+  const population =
+    principal?.kind === "partner"
+      ? "partner"
+      : input.user.type === "customer"
+        ? "customer"
+        : undefined;
+
+  return buildEffectiveAuthContext({
+    user: input.user,
+    grantedCapabilities: input.grantedCapabilities,
+    principal,
+    population,
+    employeeProfile: managerScope
+      ? {
+          id: managerScope.employeeId,
+          directReportIds: managerScope.directReportIds,
+          indirectReportIds: managerScope.indirectReportIds,
+        }
+      : null,
+    teamIds: teamMemberships.map((membership) => membership.teamId),
+    accountScope: {
+      accountIds: input.user.accountId ? [input.user.accountId] : [],
+      contactIds: input.user.contactId ? [input.user.contactId] : [],
+      partnerAccountIds:
+        population === "partner" && input.user.accountId ? [input.user.accountId] : [],
+    },
+    authentication: input.authentication,
+    actingHumanUserId: input.user.type === "admin" ? input.user.id : null,
+    actingAgentId: input.actingAgentId,
+    delegationGrantIds: activeDelegationGrantIds,
+  });
+}

--- a/apps/web/lib/identity/principal-linking.test.ts
+++ b/apps/web/lib/identity/principal-linking.test.ts
@@ -56,6 +56,7 @@ describe("syncEmployeePrincipal", () => {
       displayName: "Ada Lovelace",
       sponsorPrincipalId: null,
       authorityMode: null,
+      sensitivityClearance: ["public"],
       createdAt: new Date("2026-04-23T00:00:00Z"),
       updatedAt: new Date("2026-04-23T00:00:00Z"),
     });
@@ -109,6 +110,7 @@ describe("syncAgentPrincipal", () => {
       displayName: "Finance Specialist",
       sponsorPrincipalId: null,
       authorityMode: null,
+      sensitivityClearance: ["public"],
       createdAt: new Date("2026-04-23T00:00:00Z"),
       updatedAt: new Date("2026-04-23T00:00:00Z"),
     });
@@ -163,6 +165,7 @@ describe("syncCustomerPrincipal", () => {
       displayName: "Buyer@Example.com",
       sponsorPrincipalId: null,
       authorityMode: null,
+      sensitivityClearance: ["public"],
       createdAt: new Date("2026-04-26T00:00:00Z"),
       updatedAt: new Date("2026-04-26T00:00:00Z"),
     });
@@ -219,6 +222,7 @@ describe("syncCustomerPrincipal", () => {
       displayName: "former@example.com",
       sponsorPrincipalId: null,
       authorityMode: null,
+      sensitivityClearance: ["public"],
       createdAt: new Date("2026-04-26T00:00:00Z"),
       updatedAt: new Date("2026-04-26T00:00:00Z"),
     });

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -3,7 +3,7 @@
  * See: docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md
  */
 
-import type { PrincipalSensitivity } from "@dpf/db";
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
 
 import type { QualityTier } from "./quality-tiers";
 

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -3,11 +3,13 @@
  * See: docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md
  */
 
+import type { PrincipalSensitivity } from "@dpf/db";
+
 import type { QualityTier } from "./quality-tiers";
 
 // ── Sensitivity ──
 
-export type SensitivityLevel = "public" | "internal" | "confidential" | "restricted";
+export type SensitivityLevel = PrincipalSensitivity;
 
 // ── Endpoint Manifest (loaded from ModelProfile joined with ModelProvider) ──
 

--- a/apps/web/lib/tak/agent-router-types.ts
+++ b/apps/web/lib/tak/agent-router-types.ts
@@ -1,7 +1,9 @@
 // apps/web/lib/agent-router-types.ts
 // Core types for the unified MCP agent router.
 
-export type SensitivityLevel = "public" | "internal" | "confidential" | "restricted";
+import type { PrincipalSensitivity } from "@dpf/db";
+
+export type SensitivityLevel = PrincipalSensitivity;
 export type CapabilityTier = "basic" | "routine" | "analytical" | "deep-thinker";
 export type CostBand = "free" | "low" | "medium" | "high";
 

--- a/apps/web/lib/tak/agent-router-types.ts
+++ b/apps/web/lib/tak/agent-router-types.ts
@@ -1,7 +1,7 @@
 // apps/web/lib/agent-router-types.ts
 // Core types for the unified MCP agent router.
 
-import type { PrincipalSensitivity } from "@dpf/db";
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
 
 export type SensitivityLevel = PrincipalSensitivity;
 export type CapabilityTier = "basic" | "routine" | "analytical" | "deep-thinker";

--- a/docs/data-impact/2026-07-27-principal-sensitivity-clearance.data-impact.json
+++ b/docs/data-impact/2026-07-27-principal-sensitivity-clearance.data-impact.json
@@ -1,0 +1,39 @@
+{
+  "version": "1",
+  "accountableOwner": "identity-and-access-management",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "Request-scoped EffectiveAuthContext authorization projection"
+  ],
+  "migration": {
+    "name": "20260727115000_add_principal_sensitivity_clearance",
+    "backfill": "none - the non-null public-only default preserves least privilege for every existing principal"
+  },
+  "tests": [
+    "packages/db/src/principal-sensitivity.test.ts",
+    "apps/web/lib/identity/effective-auth-context.test.ts",
+    "apps/web/lib/identity/load-effective-auth-context.test.ts",
+    "apps/web/lib/api/auth-middleware.test.ts",
+    "apps/web/lib/govern/manager-scope.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:principal#sensitivity-clearance",
+      "prismaModel": "Principal",
+      "lifecycleDisposition": "retained and removed with the canonical principal identity record",
+      "fields": [
+        {
+          "fieldId": "data:principal#sensitivityClearance",
+          "resolution": "governed",
+          "reason": "records the maximum data-sensitivity classes explicitly granted to the canonical principal so authorization does not infer clearance from role or caller input",
+          "provenance": "identity-and-access-management policy administration",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "authorization-only; expose only through the normalized request-scoped authorization context, default absent or legacy values to public-only, and never treat role, population, or authentication method as an implicit clearance grant"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -319,6 +319,17 @@ git diff --check
 - [ ] Ensure the human decision returns to the originating work item/call chain without broadening context for sibling agents.
 - [ ] Keep AI coworker explanations concise and non-legalistic; they should state the decision and next action, not dump policy evidence.
 
+**BI-749EB750 substrate progress:** The request auth context now has one
+identity-owned loader for canonical principal/alias identity, public-only
+fail-closed sensitivity clearance, direct and transitive indirect reports,
+teams, customer/partner account scope, explicit authentication evidence, and
+applicable delegation identifiers. Bearer and session requests consume the
+same normalized contract, and manager authorization recognizes indirect
+reports without granting peer or shared-team access. This enables the
+rehydration PEP to make actor/relationship/surface decisions; it does not itself
+rehydrate responses. The two rehydration tasks above and the separate
+`BI-62BFAA95` HITL/call-chain tasks remain open.
+
 **Verification:**
 
 ```powershell

--- a/docs/superpowers/plans/2026-07-27-effective-auth-context-scope.md
+++ b/docs/superpowers/plans/2026-07-27-effective-auth-context-scope.md
@@ -65,6 +65,7 @@ References:
 - Decision: atomic
 - Parent: `BI-749EB750`
 - Receipt: `cms35mgcp0b3101l75ssc51zn`
+- Dependencies: none
 - Dependency order: principal clearance -> normalized context -> shared loader
   -> authorization consumers.
 - Rationale: persisted clearance without a context is dormant authorization

--- a/docs/superpowers/plans/2026-07-27-effective-auth-context-scope.md
+++ b/docs/superpowers/plans/2026-07-27-effective-auth-context-scope.md
@@ -1,0 +1,218 @@
+# Effective Auth Context Scope Implementation Plan
+
+> For agentic workers: execute this plan in the named Work Capsule, use `dpf-tdd`
+> for behavior changes, and keep the migration, context contract, hydration, and
+> consumers atomic. Do not infer authorization attributes that an authority did
+> not assert.
+
+**Status:** Approved backlog work; implementation in progress.
+
+**Backlog item:** `BI-749EB750`
+
+**Work Capsule:** `WC-1872F636`
+
+**Branch / worktree:** `feat/effective-auth-context-scope` /
+`D:\DPF-worktrees\effective-auth-context-scope`
+
+**Plan backlog coverage:** atomic receipt `cms35mgcp0b3101l75ssc51zn`
+
+**Architecture decision:** `DI-72C4B9C1E6D3` selects canonical
+`Principal`-owned sensitivity clearance over role-derived or caller-supplied
+clearance. The kernel returned high confidence, a 15.4119 composite score, a
+7.2927 margin, and no governance flags.
+
+## Outcome
+
+Every authenticated request receives one normalized, population-aware
+`EffectiveAuthContext` built from authoritative identity data. The context
+contains the canonical principal and aliases, workforce hierarchy, team scope,
+account scope, explicit sensitivity clearance, authentication assurance
+evidence, and active delegation grants. Missing authority remains empty or
+unknown rather than being inferred.
+
+The existing enterprise identity design remains authoritative:
+`docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md`.
+This plan completes the richer-context increment that its original narrow helper
+left intentionally open. It also supplies the authorization substrate required
+by the response-rehydration slice of
+`docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`.
+The broader AI-coworker authority/HITL outcome in `BI-62BFAA95` remains separate
+and blocked on its own prerequisite BIs; this plan must not create a local
+bypass for them.
+
+## Standards and authority contract
+
+- `Principal` is the authority for identity and sensitivity clearance.
+- `PrincipalAlias` is the authority for external and population-specific
+  identifiers; aliases are evidence, not a second principal.
+- `EmployeeProfile` is the authority for direct and indirect reporting scope.
+- `TeamMembership` is the authority for team scope.
+- The authenticated customer session is the authority for customer account
+  scope until a canonical principal alias links that population.
+- `DelegationGrant` is the authority for active human-to-agent delegation.
+- RFC 8176 authentication-method references (`amr`) and an optional asserted
+  authentication-context reference (`acr`) are carried as evidence. The code
+  must not manufacture a NIST authentication assurance level from the mere
+  presence of a cookie or bearer token.
+
+References:
+
+- https://www.rfc-editor.org/info/rfc8176/
+- https://pages.nist.gov/800-63-4/sp800-63.html
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-749EB750`
+- Receipt: `cms35mgcp0b3101l75ssc51zn`
+- Dependency order: principal clearance -> normalized context -> shared loader
+  -> authorization consumers.
+- Rationale: persisted clearance without a context is dormant authorization
+  truth; a context without authoritative hydration invites caller fabrication;
+  hydration without wiring protects no requests; and wiring before the other
+  three pieces creates inconsistent or weakened authorization.
+
+| Deliverable | Dependency | Independently shippable |
+|---|---|---:|
+| Fleet-safe canonical Principal sensitivity clearance | None | No |
+| Population-aware context contract and normalization | Principal clearance | No |
+| Shared authoritative context loader | Clearance and contract | No |
+| Middleware and manager-scope consumers | Shared loader | No |
+
+## Effort budget
+
+Use 20% of implementation effort for bounded structural refactoring:
+
+- Extract duplicated bearer/session database hydration from
+  `auth-middleware.ts` into one identity-owned loader.
+- Keep normalization and hierarchy traversal pure so authorization behavior is
+  testable without request or database fixtures.
+- Reuse the existing principal-context vocabulary for teams, acting agents, and
+  delegation identifiers instead of creating a competing authorization model.
+
+The remaining 80% implements and verifies the requested authorization behavior.
+
+## Phase 1: Canonical sensitivity clearance
+
+**Files**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_principal_sensitivity_clearance/migration.sql`
+- Modify or create: canonical identity enum/type module and tests under
+  `packages/db/src/`
+
+**TDD and implementation**
+
+- [ ] Add a canonical closed sensitivity vocabulary:
+  `public`, `internal`, `confidential`, `restricted`.
+- [ ] Add a `Principal` clearance attribute whose existing-row default is
+  public-only.
+- [ ] Make the migration fleet-safe with a non-null default and an in-file
+  migration-safety attestation; do not mutate committed migrations.
+- [ ] Add an invariant test that keeps the database and TypeScript vocabularies
+  aligned and rejects unknown clearance values.
+- [ ] Run the targeted database tests and Prisma validation.
+
+## Phase 2: Normalize the effective context
+
+**Files**
+
+- Modify: `apps/web/lib/identity/effective-auth-context.ts`
+- Modify: `apps/web/lib/identity/effective-auth-context.test.ts`
+
+**TDD and implementation**
+
+- [ ] First write fixtures for workforce administrator, manager, employee,
+  customer, partner, service principal, and AI coworker acting with a human.
+- [ ] Add explicit population, canonical aliases, sensitivity clearance, team
+  identifiers, direct/indirect report identifiers, account scope,
+  authentication evidence, acting-human/agent identity, and active delegation
+  identifiers to the context contract.
+- [ ] Normalize every list by removing empty values, deduplicating, and sorting
+  deterministically.
+- [ ] Default missing clearance to public-only, missing assurance to
+  unasserted, and every unsupported scope to empty.
+- [ ] Reject unknown closed-enum values at the boundary rather than widening
+  authority.
+- [ ] Preserve the existing principal, role, capability, employee, and
+  superuser fields so current consumers migrate without an authorization gap.
+
+## Phase 3: Add one authoritative loader
+
+**Files**
+
+- Create: `apps/web/lib/identity/load-effective-auth-context.ts`
+- Create: `apps/web/lib/identity/load-effective-auth-context.test.ts`
+- Modify: `apps/web/lib/identity/principal-linking.ts` only if a reusable
+  principal-plus-alias lookup is required
+
+**TDD and implementation**
+
+- [ ] Load the canonical principal, aliases, and clearance once.
+- [ ] Load active team memberships and employee hierarchy. Compute the
+  transitive indirect-report closure with cycle protection and deterministic
+  output; a malformed hierarchy must not grant extra scope.
+- [ ] Carry customer account/contact scope only from the authenticated customer
+  session or a verified canonical alias. Do not infer partner scope from
+  similarly named rows.
+- [ ] Select delegation grants only when active, within validity bounds,
+  unexhausted, and applicable to the acting human/agent relationship.
+- [ ] Carry explicit `amr` and asserted `acr` when the authentication surface
+  provides them. Record source-only method evidence such as `session` or
+  `bearer` separately from assurance.
+- [ ] Return public-only/empty scopes when the principal or optional population
+  relation is absent.
+
+## Phase 4: Bind request and authorization consumers
+
+**Files**
+
+- Modify: `apps/web/lib/api/auth-middleware.ts`
+- Modify: `apps/web/lib/api/auth-middleware.test.ts`
+- Modify: `apps/web/lib/api/jwt.ts` and its tests only if optional `amr`/`acr`
+  claims need preserving
+- Modify: `apps/web/lib/govern/manager-scope.ts`
+- Modify: `apps/web/lib/govern/manager-scope.test.ts`
+
+**TDD and implementation**
+
+- [ ] Route bearer and session authentication through the same loader.
+- [ ] Preserve optional, issuer-asserted JWT `amr`/`acr` claims without
+  converting them into a stronger locally invented assurance level.
+- [ ] Allow manager access to direct and indirect reports while keeping peer,
+  sibling-team, unrelated-account, and shared-surface access denied.
+- [ ] Verify inactive users, invalid principals, malformed hierarchy cycles,
+  expired delegations, and unknown clearance values fail closed.
+- [ ] Verify existing capability and employee/customer route guards retain
+  their current behavior.
+
+## Phase 5: Documentation and verification
+
+- [ ] Update the enterprise auth design where its old narrow context shape is
+  now stale; point to the canonical implementation rather than copying rules.
+- [ ] Update the sensitive-routing plan to mark the richer auth substrate as
+  available while leaving response rehydration and `BI-62BFAA95` honestly open.
+- [ ] Run affected Vitest suites and package typechecks.
+- [ ] Apply the migration in the governed local-integration sandbox.
+- [ ] Run the exact-head merged-code gate, including production build.
+- [ ] Record test, build, migration, spec-review, and no-UX-needed evidence
+  against `BI-749EB750` and `WC-1872F636`.
+- [ ] Open a ready, non-draft PR only after the exact-head gate passes; run
+  `pnpm pr:health`, enter the merge queue, and verify the merge-group checks.
+
+## Risks and rollback
+
+- **Privilege widening from absent data:** all optional authorization scopes are
+  empty and clearance is public-only unless canonical evidence says otherwise.
+- **Hierarchy cycles:** traversal uses a visited set, excludes self, and never
+  grants a node reached only through malformed repeated edges.
+- **Stale delegation:** validity, status, target, and use limits are evaluated
+  at load time; cached context is request-scoped.
+- **Assurance overstatement:** source method and asserted assurance remain
+  separate fields.
+- **Migration rollback:** the change is additive. Application rollback leaves
+  the defaulted column unused; a later forward migration may remove it only
+  after all consumers are removed.
+- **Runtime regression:** retain the old context fields during the atomic
+  transition and compare existing authorization fixtures before enabling
+  response rehydration.

--- a/docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md
+++ b/docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md
@@ -905,31 +905,26 @@ That envelope can be carried directly by APIs or referenced indirectly by `LDAP`
 
 Current route permissions are coarse and role-driven. This design evolves them to be identity-aware.
 
-### Current model
+### Effective context model
 
-- `permissions.ts` maps coarse capabilities to `PlatformRole`
-- `auth-middleware.ts` produces a simple `{ user, capabilities }` result
-- route and tool gating use those coarse capabilities
+`apps/web/lib/identity/effective-auth-context.ts` is the canonical contract and
+`apps/web/lib/identity/load-effective-auth-context.ts` is its authoritative
+request-scoped hydrator. The context preserves coarse platform role and
+capabilities while adding:
 
-### Target model
+- canonical principal identity and aliases;
+- workforce, customer, partner, service, or AI-coworker population;
+- direct and transitive indirect reporting scope;
+- team and population-aware account scope;
+- principal-owned sensitivity clearance;
+- issuer-asserted authentication method/context evidence;
+- explicit acting-human, acting-agent, and active-delegation evidence.
 
-Auth context should become richer:
-
-```ts
-type EffectiveAuthContext = {
-  principalId: string;
-  principalKind: "human" | "service" | "agent";
-  platformRole: string | null;
-  isSuperuser: boolean;
-  employeeId: string | null;
-  managerScope: {
-    directReportIds: string[];
-    indirectReportIds: string[];
-  } | null;
-  grantedCapabilities: string[];
-  routeContext: string | null;
-};
-```
+Missing authority is fail-closed: clearance is public-only, scopes are empty,
+and authentication assurance is unasserted. A cookie or bearer token identifies
+the authentication source but does not by itself establish a NIST assurance
+level. The normalized sensitivity vocabulary is owned by `@dpf/db` and reused
+by routing rather than copied into another authorization enum.
 
 Route access then becomes:
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -53,6 +53,7 @@
     "./workforce-portfolio": "./src/workforce-portfolio.ts",
     "./workforce-seed": "./src/workforce-seed.ts",
     "./agent-identity": "./src/agent-identity.ts",
+    "./principal-sensitivity": "./src/principal-sensitivity.ts",
     "./agent-model-defaults": "./src/agent-model-defaults.ts",
     "./healthcare-patient-authority": "./src/healthcare-patient-authority.ts",
     "./healthcare-care-appointment": "./src/healthcare-care-appointment.ts",

--- a/packages/db/prisma/migrations/20260727115000_add_principal_sensitivity_clearance/migration.sql
+++ b/packages/db/prisma/migrations/20260727115000_add_principal_sensitivity_clearance/migration.sql
@@ -1,0 +1,11 @@
+-- @migration-safety: data-safe: additive enum and non-null array column carry a public-only default for every existing Principal.
+CREATE TYPE "PrincipalSensitivity" AS ENUM (
+  'public',
+  'internal',
+  'confidential',
+  'restricted'
+);
+
+ALTER TABLE "Principal"
+ADD COLUMN "sensitivityClearance" "PrincipalSensitivity"[] NOT NULL
+DEFAULT ARRAY['public']::"PrincipalSensitivity"[];

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -37,6 +37,13 @@ enum BriefStatus {
   superseded
 }
 
+enum PrincipalSensitivity {
+  public
+  internal
+  confidential
+  restricted
+}
+
 model User {
   id                            String                        @id @default(cuid())
   email                         String                        @unique
@@ -313,6 +320,7 @@ model Principal {
   displayName                         String
   sponsorPrincipalId                  String?
   authorityMode                       String?
+  sensitivityClearance                PrincipalSensitivity[]              @default([public])
   aliases                             PrincipalAlias[]
   sponsorPrincipal                    Principal?                          @relation("PrincipalSponsor", fields: [sponsorPrincipalId], references: [id])
   sponsoredPrincipals                 Principal[]                         @relation("PrincipalSponsor")

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,6 +14,12 @@ export {
 export { Prisma } from "../generated/client/client";
 export type { PrismaClient } from "../generated/client/client";
 export { WriteGateRequirement } from "../generated/client/client";
+export {
+  PRINCIPAL_SENSITIVITIES,
+  isPrincipalSensitivity,
+  normalizePrincipalSensitivities,
+  type PrincipalSensitivity,
+} from "./principal-sensitivity";
 export * from "./healthcare-patient-authority";
 export * from "./healthcare-care-intake";
 

--- a/packages/db/src/principal-sensitivity.test.ts
+++ b/packages/db/src/principal-sensitivity.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  PRINCIPAL_SENSITIVITIES,
+  normalizePrincipalSensitivities,
+} from "./principal-sensitivity";
+
+describe("principal sensitivity clearance", () => {
+  it("keeps the canonical TypeScript vocabulary aligned with Prisma", () => {
+    const schemaPath = fileURLToPath(new URL("../prisma/schema.prisma", import.meta.url));
+    const schema = readFileSync(schemaPath, "utf8");
+    const enumBody = schema.match(/enum PrincipalSensitivity \{([^}]+)\}/)?.[1] ?? "";
+    const prismaValues = enumBody.match(/^\s+([a-z][a-z0-9_]*)\s*$/gm)?.map((line) => line.trim());
+
+    expect(prismaValues).toEqual(PRINCIPAL_SENSITIVITIES);
+  });
+
+  it("defaults absent clearance to public only", () => {
+    expect(normalizePrincipalSensitivities(undefined)).toEqual(["public"]);
+  });
+
+  it("deduplicates and sorts known clearance values", () => {
+    expect(normalizePrincipalSensitivities(["restricted", "public", "restricted"])).toEqual([
+      "public",
+      "restricted",
+    ]);
+  });
+
+  it("rejects unknown clearance rather than widening authority", () => {
+    expect(() => normalizePrincipalSensitivities(["secret"])).toThrow(
+      "Unknown principal sensitivity clearance: secret",
+    );
+  });
+});

--- a/packages/db/src/principal-sensitivity.ts
+++ b/packages/db/src/principal-sensitivity.ts
@@ -1,0 +1,28 @@
+export const PRINCIPAL_SENSITIVITIES = [
+  "public",
+  "internal",
+  "confidential",
+  "restricted",
+] as const;
+
+export type PrincipalSensitivity = (typeof PRINCIPAL_SENSITIVITIES)[number];
+
+const PRINCIPAL_SENSITIVITY_SET = new Set<string>(PRINCIPAL_SENSITIVITIES);
+
+export function isPrincipalSensitivity(value: string): value is PrincipalSensitivity {
+  return PRINCIPAL_SENSITIVITY_SET.has(value);
+}
+
+export function normalizePrincipalSensitivities(
+  values: readonly string[] | null | undefined,
+): PrincipalSensitivity[] {
+  if (!values?.length) return ["public"];
+
+  const unknown = values.find((value) => !isPrincipalSensitivity(value));
+  if (unknown) {
+    throw new Error(`Unknown principal sensitivity clearance: ${unknown}`);
+  }
+
+  const selected = new Set(values);
+  return PRINCIPAL_SENSITIVITIES.filter((value) => selected.has(value));
+}


### PR DESCRIPTION
## Summary

- add canonical Principal-owned sensitivity clearance with a fleet-safe public-only default
- enrich EffectiveAuthContext with aliases, population, hierarchy, teams, account scope, authentication evidence, and applicable delegations
- route bearer and session authentication through one identity-owned loader and allow managers to reach indirect reports without widening peer/team access
- preserve issuer-asserted RFC 8176 amr/acr evidence without inventing assurance

Backlog: BI-749EB750
Work Capsule: WC-1872F636
Plan coverage: cms35mgcp0b3101l75ssc51zn

#### Design grounding

- Existing specs/plans reviewed: enterprise auth/directory/federation design and pre-dispatch sensitive LLM routing plan.
- Existing substrate extended: Principal and PrincipalAlias, EmployeeProfile, TeamMembership, DelegationGrant, auth middleware, principal context, and manager-scope evaluator.
- Architecture decision: DI-72C4B9C1E6D3 selected canonical Principal-owned clearance over role-derived or caller-supplied authority.
- Source of truth: Principal owns clearance; the shared @dpf/db principal-sensitivity module owns the closed vocabulary; the identity loader owns request-scoped hydration.
- Fail-closed behavior: absent clearance is public-only, absent scopes are empty, inactive principals are rejected, cycles do not grant self, and source method remains distinct from asserted assurance.

## Verification

Exact candidate: 5bf1679e11eb2f784fd7720d7d26663a41fa9b20
Accepted base: a25e5250aedf7067ad054e68468e3a4f40d59d6e
Integration commit: 03b74fddbba8816eb1649b28e08fb3e20e6b4548
Synthesized tree: 819cb61280826516cd7ddb79b36ebeaf80c3cb4d
Local gate evidence: cms36ylhi00hd01qjyx7legfe
Lease: NPEL-5BEF7CC943 (released normally)

- sandbox freshness: green
- full web Vitest: passed
- web TypeScript/typegen: passed
- production Docker build: passed
- docs, guard, schema, migration-safety, and secret checks: passed

## Migration impact

Adds PrincipalSensitivity and Principal.sensitivityClearance. Migration 20260727115000_add_principal_sensitivity_clearance applied successfully in the governed test database; the complete 449-migration chain is clean. Existing principals receive a non-null public-only default, so no existing data is rejected or widened.

## UX and documentation

UX verification is not applicable: this PR changes noninteractive identity/authorization substrate and no rendered route or control. Enterprise-auth architecture documentation and the sensitive-routing delivery plan are updated in the same branch. Response rehydration UI/behavior and BI-62BFAA95 HITL/call-chain work remain explicitly open.