### PR TITLE
feat(inference): authorize masked response rehydration

### DIFF
--- a/apps/web/lib/ea/ai-routing-architecture-extract.test.ts
+++ b/apps/web/lib/ea/ai-routing-architecture-extract.test.ts
@@ -86,7 +86,9 @@ describe("buildAiRoutingArchitectureModels", () => {
     expect(status.get("compile-request-contract")).toBe("partial");
     expect(status.get("eligible-fallback")).toBe("partial");
     expect(status.get("record-safe-receipt")).toBe("partial");
-    expect(status.get("rehydration-gateway")).toBe("proposed");
+    expect(status.get("rehydration-gateway")).toBe("implemented");
+    expect(status.get("return-masked-response")).toBe("implemented");
+    expect(status.get("return-authorized-response")).toBe("implemented");
 
     const sensitiveScreen = AI_ROUTING_STAGES.find(
       (stage) => stage.id === "sensitive-screen",

--- a/apps/web/lib/ea/ai-routing-architecture-registry.ts
+++ b/apps/web/lib/ea/ai-routing-architecture-registry.ts
@@ -233,7 +233,10 @@ export const AI_ROUTING_STAGES: readonly AiRoutingStage[] = [
     technicalName: "Fresh response-rehydration authorization",
     lane: "response-authorization",
     bpmnTypeSlug: "bpmn_exclusive_gateway",
-    source: PROPOSED_SENSITIVE_ROUTING("Masking And Rehydration"),
+    source: IMPLEMENTED(
+      "apps/web/lib/govern/data/response-rehydration.ts",
+      "rehydrateResponse",
+    ),
   },
   {
     id: "return-masked-response",
@@ -241,7 +244,10 @@ export const AI_ROUTING_STAGES: readonly AiRoutingStage[] = [
     technicalName: "Protected response",
     lane: "response-authorization",
     bpmnTypeSlug: "bpmn_end_event",
-    source: PROPOSED_SENSITIVE_ROUTING("Masking And Rehydration"),
+    source: IMPLEMENTED(
+      "apps/web/lib/govern/data/response-rehydration.ts",
+      "rehydrateResponse",
+    ),
   },
   {
     id: "return-authorized-response",
@@ -249,7 +255,10 @@ export const AI_ROUTING_STAGES: readonly AiRoutingStage[] = [
     technicalName: "Authorized response delivery",
     lane: "response-authorization",
     bpmnTypeSlug: "bpmn_end_event",
-    source: PROPOSED_SENSITIVE_ROUTING("Masking And Rehydration"),
+    source: IMPLEMENTED(
+      "apps/web/lib/govern/data/response-rehydration.ts",
+      "rehydrateResponse",
+    ),
   },
 ];
 

--- a/apps/web/lib/govern/data/mask-for-context.test.ts
+++ b/apps/web/lib/govern/data/mask-for-context.test.ts
@@ -7,6 +7,8 @@ import {
   applyContextTransform,
   maskForContext,
 } from "./mask-for-context";
+import { readRehydrationTokenMap } from "./rehydration-token-vault";
+import type { RehydrationAuthorizationBinding } from "./rehydration-token-vault";
 
 function maskingDecision(): DataPolicyDecision {
   return {
@@ -195,5 +197,67 @@ describe("maskForContext", () => {
     );
     expect(JSON.stringify(result)).not.toContain("4455661122");
     expect(JSON.stringify(result)).toContain("[DPF_TOKEN_");
+  });
+
+  it("keeps a legacy token map unbound and therefore non-rehydratable", () => {
+    const result = maskForContext(
+      { email: "ada@example.com" },
+      {
+        decision: maskingDecision(),
+        detailUse: "replaceable",
+        matches: [
+          { dataClass: "customer-records", path: "email", reason: "contact-detail", confidence: "deterministic" },
+        ],
+      },
+    );
+    const read = readRehydrationTokenMap(result.rehydrationHandle ?? "");
+
+    expect(read.status).toBe("available");
+    if (read.status !== "available") return;
+    expect([...read.tokens.values()][0]?.bindings).toEqual([]);
+  });
+
+  it("marks a repeated token non-rehydratable when any occurrence lacks a path binding", () => {
+    const raw = "ada@example.com";
+    const binding: RehydrationAuthorizationBinding = {
+      expectedActor: {
+        principalId: "PRN-1",
+        actingHumanUserId: "user-1",
+        actingAgentId: null,
+        delegationGrantId: null,
+      },
+      purpose: "customer-support",
+      surface: "private-customer",
+      subject: { kind: "account", id: "account-1" },
+      sensitivity: "confidential",
+      decisionVersions: [{
+        decisionId: "decision-mask-1",
+        assetVersion: "asset-v1",
+        classificationVersion: "classification-v1",
+        authorityVersion: "authority-v1",
+      }],
+      dataClasses: ["customer-records"],
+      pathPrefixes: ["customer"],
+    };
+    const result = maskForContext(
+      { customer: { email: raw }, unrelated: { email: raw } },
+      {
+        decision: maskingDecision(),
+        detailUse: "replaceable",
+        rehydrationBindings: [binding],
+        matches: [
+          { dataClass: "customer-records", path: "customer.email", reason: "contact-detail", confidence: "deterministic" },
+          { dataClass: "customer-records", path: "unrelated.email", reason: "contact-detail", confidence: "deterministic" },
+        ],
+      },
+    );
+    const read = readRehydrationTokenMap(result.rehydrationHandle ?? "");
+
+    expect(read.status).toBe("available");
+    if (read.status !== "available") return;
+    expect([...read.tokens.values()][0]).toMatchObject({
+      bindings: [binding],
+      hasUnboundOccurrence: true,
+    });
   });
 });

--- a/apps/web/lib/govern/data/mask-for-context.ts
+++ b/apps/web/lib/govern/data/mask-for-context.ts
@@ -1,7 +1,11 @@
-import { createHmac, randomBytes } from "node:crypto";
-
 import type { DataPolicyDecision } from "./policy-decision";
 import type { InferencePayloadMatch } from "@/lib/inference/data-screening/types";
+import {
+  createRehydrationToken,
+  storeRehydrationTokenMap,
+  type RehydrationAuthorizationBinding,
+  type StoredRehydrationToken,
+} from "./rehydration-token-vault";
 
 export type ContextTransform =
   | "omit"
@@ -17,6 +21,7 @@ export type ContextMaskAuthority = {
   decision: DataPolicyDecision;
   matches: readonly InferencePayloadMatch[];
   detailUse: SensitiveDetailUse;
+  rehydrationBindings?: readonly RehydrationAuthorizationBinding[];
 };
 
 export type MaskedContext<T> = {
@@ -49,30 +54,11 @@ export class ContextMaskCoverageError extends Error {
   }
 }
 
-const TOKEN_KEY = randomBytes(32);
-const TOKEN_TTL_MS = 5 * 60_000;
-const MAX_TOKEN_MAPS = 1_000;
 const CONTACT_PATTERN =
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/gi;
 const SECRET_PATTERN =
   /\b(?:sk-[A-Za-z0-9_-]{10,}|dpfmcp_[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]{12,}|AKIA[0-9A-Z]{12,})\b|-----BEGIN\s+(?:RSA\s+)?PRIVATE KEY-----/gi;
 const FINANCE_IDENTIFIER_PATTERN = /\b\d[\d\s-]{5,}\d\b/g;
-
-type TokenVaultEntry = {
-  expiresAt: number;
-  tokens: ReadonlyMap<string, string>;
-};
-
-const tokenVault = new Map<string, TokenVaultEntry>();
-
-function stableToken(value: string): string {
-  const digest = createHmac("sha256", TOKEN_KEY)
-    .update(value)
-    .digest("hex")
-    .slice(0, 12)
-    .toUpperCase();
-  return `[DPF_TOKEN_${digest}]`;
-}
 
 /**
  * Pure transform primitive. `maskForContext` owns authorization and should be
@@ -93,7 +79,7 @@ export function applyContextTransform(
       return text.length <= 4 ? "[PARTIAL]" : `[PARTIAL:${text.slice(-4)}]`;
     }
     case "tokenize":
-      return stableToken(String(value ?? ""));
+      return createRehydrationToken(String(value ?? ""));
     case "aggregate": {
       const count = Array.isArray(value)
         ? value.length
@@ -138,7 +124,7 @@ export function maskForContext<T>(
     throw new ContextMaskCoverageError([...new Set(unsupported)].sort());
   }
 
-  const tokenMap = new Map<string, string>();
+  const tokenMap = new Map<string, StoredRehydrationToken>();
   const state = { transformedValueCount: 0 };
   const transformed = visitContext(
     value,
@@ -147,10 +133,11 @@ export function maskForContext<T>(
     tokenMap,
     state,
     forcedTransform,
+    authority.rehydrationBindings,
   ) as T;
 
   const rehydrationHandle = tokenMap.size > 0
-    ? storeTokenMap(tokenMap)
+    ? storeRehydrationTokenMap(tokenMap)
     : undefined;
   return {
     value: transformed,
@@ -225,16 +212,29 @@ function visitContext(
   value: unknown,
   path: string,
   matchesByPath: ReadonlyMap<string, readonly InferencePayloadMatch[]>,
-  tokenMap: Map<string, string>,
+  tokenMap: Map<string, StoredRehydrationToken>,
   state: { transformedValueCount: number },
   forcedTransform?: ContextTransform,
+  rehydrationBindings?: readonly RehydrationAuthorizationBinding[],
 ): unknown {
   const pathMatches = matchesByPath.get(path) ?? [];
   if (pathMatches.length > 0 && forcedTransform) {
-    return applyAuthorizedTransform(value, forcedTransform, tokenMap, state);
+    return applyAuthorizedTransform(
+      value,
+      forcedTransform,
+      tokenMap,
+      state,
+      bindingsForPath(path, rehydrationBindings),
+    );
   }
   if (typeof value === "string" && pathMatches.length > 0) {
-    return transformMatchedString(value, pathMatches, tokenMap, state);
+    return transformMatchedString(
+      value,
+      pathMatches,
+      tokenMap,
+      state,
+      bindingsForPath(path, rehydrationBindings),
+    );
   }
 
   if (Array.isArray(value)) {
@@ -246,6 +246,7 @@ function visitContext(
         tokenMap,
         state,
         forcedTransform,
+        rehydrationBindings,
       ),
     );
   }
@@ -271,6 +272,7 @@ function visitContext(
       tokenMap,
       state,
       forcedTransform,
+      rehydrationBindings,
     );
   }
   return output;
@@ -279,23 +281,25 @@ function visitContext(
 function applyAuthorizedTransform(
   value: unknown,
   transform: ContextTransform,
-  tokenMap: Map<string, string>,
+  tokenMap: Map<string, StoredRehydrationToken>,
   state: { transformedValueCount: number },
+  rehydrationBindings: readonly RehydrationAuthorizationBinding[],
 ): unknown {
   if (transform === "pass-through") return value;
   state.transformedValueCount += 1;
   if (transform !== "tokenize") return applyContextTransform(value, transform);
   const raw = typeof value === "string" ? value : JSON.stringify(value);
-  const token = stableToken(raw);
-  tokenMap.set(token, raw);
+  const token = createRehydrationToken(raw);
+  addStoredToken(tokenMap, token, raw, rehydrationBindings);
   return token;
 }
 
 function transformMatchedString(
   value: string,
   matches: readonly InferencePayloadMatch[],
-  tokenMap: Map<string, string>,
+  tokenMap: Map<string, StoredRehydrationToken>,
   state: { transformedValueCount: number },
+  rehydrationBindings: readonly RehydrationAuthorizationBinding[],
 ): string {
   let transformed = value;
   if (matches.some((match) => match.reason === "secret-shaped-token")) {
@@ -306,16 +310,16 @@ function transformMatchedString(
   }
   if (matches.some((match) => match.reason === "contact-detail")) {
     transformed = transformed.replace(CONTACT_PATTERN, (raw) => {
-      const token = stableToken(raw);
-      tokenMap.set(token, raw);
+      const token = createRehydrationToken(raw);
+      addStoredToken(tokenMap, token, raw, rehydrationBindings);
       state.transformedValueCount += 1;
       return token;
     });
   }
   if (matches.some((match) => match.reason === "payment-or-finance-text")) {
     transformed = transformed.replace(FINANCE_IDENTIFIER_PATTERN, (raw) => {
-      const token = stableToken(raw);
-      tokenMap.set(token, raw);
+      const token = createRehydrationToken(raw);
+      addStoredToken(tokenMap, token, raw, rehydrationBindings);
       state.transformedValueCount += 1;
       return token;
     });
@@ -347,20 +351,51 @@ function appendIndex(path: string, index: number): string {
   return `${path}[${index}]`;
 }
 
-function storeTokenMap(tokens: ReadonlyMap<string, string>): string {
-  const now = Date.now();
-  for (const [handle, entry] of tokenVault) {
-    if (entry.expiresAt <= now) tokenVault.delete(handle);
+function addStoredToken(
+  tokenMap: Map<string, StoredRehydrationToken>,
+  token: string,
+  value: string,
+  bindings: readonly RehydrationAuthorizationBinding[],
+): void {
+  const existing = tokenMap.get(token);
+  if (!existing) {
+    tokenMap.set(token, {
+      value,
+      bindings: [...bindings],
+      ...(bindings.length === 0 ? { hasUnboundOccurrence: true } : {}),
+    });
+    return;
   }
-  while (tokenVault.size >= MAX_TOKEN_MAPS) {
-    const oldest = tokenVault.keys().next().value as string | undefined;
-    if (!oldest) break;
-    tokenVault.delete(oldest);
+  // A repeated raw value can occur at multiple governed paths. Every binding is
+  // retained, and the response PEP requires their intersection before release.
+  if (bindings.length === 0) {
+    existing.hasUnboundOccurrence = true;
+    return;
   }
-  const handle = `rehydration_${randomBytes(12).toString("hex")}`;
-  tokenVault.set(handle, {
-    expiresAt: now + TOKEN_TTL_MS,
-    tokens: new Map(tokens),
-  });
-  return handle;
+  for (const binding of bindings) {
+    if (!existing.bindings.some((candidate) => sameBinding(candidate, binding))) {
+      existing.bindings.push(binding);
+    }
+  }
+}
+
+function bindingsForPath(
+  path: string,
+  bindings: readonly RehydrationAuthorizationBinding[] | undefined,
+): RehydrationAuthorizationBinding[] {
+  return (bindings ?? []).filter((binding) =>
+    !binding.pathPrefixes ||
+    binding.pathPrefixes.some((prefix) =>
+      path === prefix ||
+      path.startsWith(`${prefix}.`) ||
+      path.startsWith(`${prefix}[`)
+    )
+  );
+}
+
+function sameBinding(
+  left: RehydrationAuthorizationBinding,
+  right: RehydrationAuthorizationBinding,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/apps/web/lib/govern/data/rehydration-token-vault.test.ts
+++ b/apps/web/lib/govern/data/rehydration-token-vault.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createRehydrationToken,
+  readRehydrationTokenMap,
+  storeRehydrationTokenMap,
+  type StoredRehydrationToken,
+} from "./rehydration-token-vault";
+
+const binding = {
+  expectedActor: {
+    principalId: "PRN-manager",
+    actingHumanUserId: "user-manager",
+    actingAgentId: null,
+    delegationGrantId: null,
+  },
+  purpose: "coworker-assistance" as const,
+  surface: "private-employee" as const,
+  subject: { kind: "employee" as const, id: "emp-report" },
+  sensitivity: "confidential" as const,
+  decisionVersions: [{
+    decisionId: "ddp_employee",
+    assetVersion: "asset-v1",
+    classificationVersion: "classification-v1",
+    authorityVersion: "authority-v1",
+  }],
+  dataClasses: ["employee-records" as const],
+};
+
+describe("rehydration token vault", () => {
+  it("stores immutable token bindings behind an opaque bounded handle", () => {
+    const raw = "ada@example.com";
+    const token = createRehydrationToken(raw);
+    const stored: StoredRehydrationToken = {
+      value: raw,
+      bindings: [binding],
+    };
+    const tokens = new Map([[token, stored]]);
+
+    const handle = storeRehydrationTokenMap(tokens, { now: 1_000 });
+    stored.value = "mutated@example.com";
+    stored.bindings.length = 0;
+
+    expect(handle).toMatch(/^rehydration_[a-f0-9]{24}$/);
+    expect(readRehydrationTokenMap(handle, { now: 1_001 })).toEqual({
+      status: "available",
+      tokens: new Map([[
+        token,
+        {
+          value: raw,
+          bindings: [binding],
+        },
+      ]]),
+    });
+  });
+
+  it("fails closed after expiry without exposing why a handle is unavailable", () => {
+    const token = createRehydrationToken("555-867-5309");
+    const handle = storeRehydrationTokenMap(
+      new Map([[token, { value: "555-867-5309", bindings: [binding] }]]),
+      { now: 2_000, ttlMs: 25 },
+    );
+
+    expect(readRehydrationTokenMap(handle, { now: 2_026 })).toEqual({
+      status: "unavailable",
+    });
+    expect(readRehydrationTokenMap("rehydration_missing", { now: 2_026 })).toEqual({
+      status: "unavailable",
+    });
+  });
+});

--- a/apps/web/lib/govern/data/rehydration-token-vault.ts
+++ b/apps/web/lib/govern/data/rehydration-token-vault.ts
@@ -1,0 +1,159 @@
+import { createHmac, randomBytes } from "node:crypto";
+
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+
+import type { ProcessingPurposeKey } from "./taxonomy";
+import type {
+  InferenceDataClass,
+  InferencePolicyDecisionVersion,
+} from "@/lib/inference/data-screening/types";
+
+export const RESPONSE_SURFACES = [
+  "private-user",
+  "private-employee",
+  "private-customer",
+  "private-partner",
+  "shared-team",
+  "public",
+] as const;
+
+export type ResponseSurface = (typeof RESPONSE_SURFACES)[number];
+
+export type RehydrationSubject =
+  | { kind: "employee"; id: string }
+  | { kind: "account"; id: string }
+  | { kind: "contact"; id: string }
+  | { kind: "partner-account"; id: string }
+  | { kind: "principal"; id: string }
+  | { kind: "team"; id: string };
+
+export type RehydrationExpectedActor = {
+  principalId: string;
+  actingHumanUserId: string | null;
+  actingAgentId: string | null;
+  delegationGrantId: string | null;
+};
+
+export type RehydrationAuthorizationBinding = {
+  expectedActor: RehydrationExpectedActor;
+  purpose: ProcessingPurposeKey;
+  surface: ResponseSurface;
+  subject: RehydrationSubject;
+  sensitivity: PrincipalSensitivity;
+  decisionVersions: InferencePolicyDecisionVersion[];
+  dataClasses: InferenceDataClass[];
+  pathPrefixes?: string[];
+};
+
+/** Caller-owned identity/surface intent. Sensitivity and policy evidence are
+ * deliberately absent: the screening seam derives those from the PDP receipt. */
+export type RehydrationRouteBinding = Pick<
+  RehydrationAuthorizationBinding,
+  "expectedActor" | "purpose" | "surface" | "subject"
+> & {
+  pathPrefixes?: string[];
+};
+
+export type StoredRehydrationToken = {
+  value: string;
+  bindings: RehydrationAuthorizationBinding[];
+  hasUnboundOccurrence?: true;
+};
+
+type TokenVaultEntry = {
+  expiresAt: number;
+  tokens: ReadonlyMap<string, StoredRehydrationToken>;
+};
+
+export type RehydrationTokenMapRead =
+  | {
+      status: "available";
+      tokens: ReadonlyMap<string, StoredRehydrationToken>;
+    }
+  | { status: "unavailable" };
+
+const TOKEN_KEY = randomBytes(32);
+const DEFAULT_TOKEN_TTL_MS = 5 * 60_000;
+const MAX_TOKEN_MAPS = 1_000;
+const tokenVault = new Map<string, TokenVaultEntry>();
+
+export function createRehydrationToken(value: string): string {
+  const digest = createHmac("sha256", TOKEN_KEY)
+    .update(value)
+    .digest("hex")
+    .slice(0, 12)
+    .toUpperCase();
+  return `[DPF_TOKEN_${digest}]`;
+}
+
+export function storeRehydrationTokenMap(
+  tokens: ReadonlyMap<string, StoredRehydrationToken>,
+  options: { now?: number; ttlMs?: number } = {},
+): string {
+  const now = options.now ?? Date.now();
+  removeExpiredEntries(now);
+  while (tokenVault.size >= MAX_TOKEN_MAPS) {
+    const oldest = tokenVault.keys().next().value as string | undefined;
+    if (!oldest) break;
+    tokenVault.delete(oldest);
+  }
+
+  const handle = `rehydration_${randomBytes(12).toString("hex")}`;
+  tokenVault.set(handle, {
+    expiresAt: now + (options.ttlMs ?? DEFAULT_TOKEN_TTL_MS),
+    tokens: cloneTokenMap(tokens),
+  });
+  return handle;
+}
+
+export function readRehydrationTokenMap(
+  handle: string,
+  options: { now?: number } = {},
+): RehydrationTokenMapRead {
+  const now = options.now ?? Date.now();
+  const entry = tokenVault.get(handle);
+  if (!entry || entry.expiresAt <= now) {
+    if (entry) tokenVault.delete(handle);
+    return { status: "unavailable" };
+  }
+  return {
+    status: "available",
+    tokens: cloneTokenMap(entry.tokens),
+  };
+}
+
+function removeExpiredEntries(now: number): void {
+  for (const [handle, entry] of tokenVault) {
+    if (entry.expiresAt <= now) tokenVault.delete(handle);
+  }
+}
+
+function cloneTokenMap(
+  tokens: ReadonlyMap<string, StoredRehydrationToken>,
+): ReadonlyMap<string, StoredRehydrationToken> {
+  return new Map(
+    [...tokens].map(([token, stored]) => [
+      token,
+      {
+        value: stored.value,
+        bindings: stored.bindings.map((binding) => ({
+          expectedActor: { ...binding.expectedActor },
+          purpose: binding.purpose,
+          surface: binding.surface,
+          subject: { ...binding.subject },
+          sensitivity: binding.sensitivity,
+          decisionVersions: binding.decisionVersions.map((version) => ({
+            ...version,
+          })),
+          dataClasses: [...binding.dataClasses],
+          ...(binding.pathPrefixes
+            ? { pathPrefixes: [...binding.pathPrefixes] }
+            : {}),
+        })),
+        ...(stored.hasUnboundOccurrence
+          ? { hasUnboundOccurrence: true as const }
+          : {}),
+      },
+    ]),
+  );
+}

--- a/apps/web/lib/govern/data/response-rehydration.test.ts
+++ b/apps/web/lib/govern/data/response-rehydration.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from "vitest";
+
+import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+
+import {
+  createRehydrationToken,
+  storeRehydrationTokenMap,
+  type RehydrationAuthorizationBinding,
+} from "./rehydration-token-vault";
+import { rehydrateResponse } from "./response-rehydration";
+
+const versions = {
+  assetVersion: "asset-v1",
+  classificationVersion: "classification-v1",
+  authorityVersion: "authority-v1",
+};
+
+const managerContext: EffectiveAuthContext = {
+  principalId: "PRN-manager",
+  principalAliases: [],
+  population: "workforce",
+  platformRole: "HR-100",
+  isSuperuser: false,
+  employeeId: "emp-manager",
+  managerScope: {
+    directReportIds: ["emp-direct"],
+    indirectReportIds: ["emp-indirect"],
+  },
+  teamIds: ["team-a"],
+  accountScope: {
+    accountIds: [],
+    contactIds: [],
+    partnerAccountIds: [],
+  },
+  sensitivityClearance: ["public", "confidential"],
+  authentication: {
+    source: "session",
+    methods: ["pwd"],
+    contextClassReference: null,
+  },
+  actingHumanUserId: "user-manager",
+  actingAgentId: null,
+  delegationGrantIds: [],
+  grantedCapabilities: ["view_employee"],
+};
+
+function employeeBinding(
+  employeeId: string,
+  overrides: Partial<RehydrationAuthorizationBinding> = {},
+): RehydrationAuthorizationBinding {
+  return {
+    expectedActor: {
+      principalId: "PRN-manager",
+      actingHumanUserId: "user-manager",
+      actingAgentId: null,
+      delegationGrantId: null,
+    },
+    purpose: "coworker-assistance",
+    surface: "private-employee",
+    subject: { kind: "employee", id: employeeId },
+    sensitivity: "confidential",
+    decisionVersions: [{
+      decisionId: "ddp_employee",
+      ...versions,
+    }],
+    dataClasses: ["employee-records"],
+    ...overrides,
+  };
+}
+
+function vault(
+  entries: Array<{ raw: string; binding?: RehydrationAuthorizationBinding }>,
+  now = 1_000,
+) {
+  const tokens = new Map(
+    entries.map(({ raw, binding }) => [
+      createRehydrationToken(raw),
+      {
+        value: raw,
+        bindings: binding ? [binding] : [],
+      },
+    ]),
+  );
+  return {
+    handle: storeRehydrationTokenMap(tokens, { now }),
+    tokens: entries.map(({ raw }) => createRehydrationToken(raw)),
+  };
+}
+
+describe("response rehydration PEP", () => {
+  it.each(["emp-direct", "emp-indirect"])(
+    "allows a cleared manager to receive authorized detail for %s",
+    (employeeId) => {
+      const raw = `${employeeId}@example.com`;
+      const stored = vault([{ raw, binding: employeeBinding(employeeId) }]);
+
+      const result = rehydrateResponse({
+        value: `Contact ${stored.tokens[0]}`,
+        rehydrationHandle: stored.handle,
+        authContext: managerContext,
+        purpose: "coworker-assistance",
+        surface: "private-employee",
+        currentVersions: versions,
+        now: 1_001,
+      });
+
+      expect(result.value).toBe(`Contact ${raw}`);
+      expect(result.evidence).toEqual({
+        outcome: "rehydrated",
+        authorizedTokenCount: 1,
+        deniedTokenCount: 0,
+        explanationCodes: ["response-rehydration-authorized"],
+        rawValuesStored: false,
+      });
+    },
+  );
+
+  it("keeps peer and unrelated employee details tokenized", () => {
+    const raw = "peer@example.com";
+    const stored = vault([{ raw, binding: employeeBinding("emp-peer") }]);
+
+    const result = rehydrateResponse({
+      value: stored.tokens[0],
+      rehydrationHandle: stored.handle,
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 1_001,
+    });
+
+    expect(result.value).toBe(stored.tokens[0]);
+    expect(result.evidence.outcome).toBe("masked");
+    expect(result.evidence.explanationCodes).toContain("response-subject-not-authorized");
+  });
+
+  it("denies shared surfaces even when the viewer can access the employee directly", () => {
+    const raw = "direct@example.com";
+    const stored = vault([{ raw, binding: employeeBinding("emp-direct") }]);
+
+    const result = rehydrateResponse({
+      value: stored.tokens[0],
+      rehydrationHandle: stored.handle,
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "shared-team",
+      currentVersions: versions,
+      now: 1_001,
+    });
+
+    expect(result.value).toBe(stored.tokens[0]);
+    expect(result.evidence.explanationCodes).toContain("response-surface-not-authorized");
+  });
+
+  it("rehydrates mixed output token by token without one allow unlocking a sibling", () => {
+    const allowedRaw = "direct@example.com";
+    const deniedRaw = "peer@example.com";
+    const stored = vault([
+      { raw: allowedRaw, binding: employeeBinding("emp-direct") },
+      { raw: deniedRaw, binding: employeeBinding("emp-peer") },
+    ]);
+    const value = {
+      allowed: `${stored.tokens[0]} / ${stored.tokens[0]}`,
+      denied: stored.tokens[1],
+    };
+
+    const result = rehydrateResponse({
+      value,
+      rehydrationHandle: stored.handle,
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 1_001,
+    });
+
+    expect(result.value).toEqual({
+      allowed: `${allowedRaw} / ${allowedRaw}`,
+      denied: stored.tokens[1],
+    });
+    expect(result.evidence).toMatchObject({
+      outcome: "partially-rehydrated",
+      authorizedTokenCount: 1,
+      deniedTokenCount: 1,
+    });
+  });
+
+  it.each([
+    {
+      name: "insufficient clearance",
+      authContext: { ...managerContext, sensitivityClearance: ["public"] as const },
+      currentVersions: versions,
+      purpose: "coworker-assistance" as const,
+      surface: "private-employee" as const,
+      explanation: "response-clearance-insufficient",
+    },
+    {
+      name: "policy-version drift",
+      authContext: managerContext,
+      currentVersions: { ...versions, authorityVersion: "authority-v2" },
+      purpose: "coworker-assistance" as const,
+      surface: "private-employee" as const,
+      explanation: "response-policy-version-stale",
+    },
+    {
+      name: "purpose mismatch",
+      authContext: managerContext,
+      currentVersions: versions,
+      purpose: "platform-operations" as const,
+      surface: "private-employee" as const,
+      explanation: "response-purpose-not-authorized",
+    },
+  ])("fails closed for $name", (scenario) => {
+    const raw = "direct@example.com";
+    const stored = vault([{ raw, binding: employeeBinding("emp-direct") }]);
+
+    const result = rehydrateResponse({
+      value: stored.tokens[0],
+      rehydrationHandle: stored.handle,
+      authContext: scenario.authContext as EffectiveAuthContext,
+      purpose: scenario.purpose,
+      surface: scenario.surface,
+      currentVersions: scenario.currentVersions,
+      now: 1_001,
+    });
+
+    expect(result.value).toBe(stored.tokens[0]);
+    expect(result.evidence.explanationCodes).toContain(scenario.explanation);
+  });
+
+  it("requires matching acting-agent and active delegation evidence", () => {
+    const raw = "direct@example.com";
+    const binding = employeeBinding("emp-direct", {
+      expectedActor: {
+        principalId: "PRN-manager",
+        actingHumanUserId: "user-manager",
+        actingAgentId: "AGT-1",
+        delegationGrantId: "DGR-1",
+      },
+    });
+    const stored = vault([{ raw, binding }]);
+    const agentContext: EffectiveAuthContext = {
+      ...managerContext,
+      population: "ai-coworker",
+      actingAgentId: "AGT-1",
+      delegationGrantIds: [],
+    };
+
+    const result = rehydrateResponse({
+      value: stored.tokens[0],
+      rehydrationHandle: stored.handle,
+      authContext: agentContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 1_001,
+    });
+
+    expect(result.value).toBe(stored.tokens[0]);
+    expect(result.evidence.explanationCodes).toContain("response-delegation-not-authorized");
+  });
+
+  it("requires the authenticated customer account scope for customer detail", () => {
+    const raw = "customer@example.com";
+    const stored = vault([{
+      raw,
+      binding: employeeBinding("unused", {
+        purpose: "customer-support",
+        surface: "private-customer",
+        subject: { kind: "account", id: "account-allowed" },
+        dataClasses: ["customer-records"],
+      }),
+    }]);
+    const customerContext: EffectiveAuthContext = {
+      ...managerContext,
+      population: "customer",
+      employeeId: null,
+      managerScope: null,
+      accountScope: {
+        accountIds: ["account-other"],
+        contactIds: [],
+        partnerAccountIds: [],
+      },
+      grantedCapabilities: [],
+    };
+
+    const result = rehydrateResponse({
+      value: stored.tokens[0],
+      rehydrationHandle: stored.handle,
+      authContext: customerContext,
+      purpose: "customer-support",
+      surface: "private-customer",
+      currentVersions: versions,
+      now: 1_001,
+    });
+
+    expect(result.value).toBe(stored.tokens[0]);
+    expect(result.evidence.explanationCodes).toContain("response-subject-not-authorized");
+  });
+
+  it("preserves unknown and malformed token text without treating it as vault evidence", () => {
+    const stored = vault([{
+      raw: "direct@example.com",
+      binding: employeeBinding("emp-direct"),
+    }]);
+    const value = `${stored.tokens[0]} [DPF_TOKEN_NOT_A_TOKEN]`;
+
+    const result = rehydrateResponse({
+      value,
+      rehydrationHandle: stored.handle,
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 1_001,
+    });
+
+    expect(result.value).toBe("direct@example.com [DPF_TOKEN_NOT_A_TOKEN]");
+    expect(result.evidence.authorizedTokenCount).toBe(1);
+  });
+
+  it("treats missing, expired, and unbound vault state identically and leaks no raw value", () => {
+    const raw = "never-log@example.com";
+    const unbound = vault([{ raw }], 2_000);
+    const expired = rehydrateResponse({
+      value: unbound.tokens[0],
+      rehydrationHandle: unbound.handle,
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 2_000 + 5 * 60_000 + 1,
+    });
+
+    expect(expired.value).toBe(unbound.tokens[0]);
+    expect(JSON.stringify(expired.evidence)).not.toContain(raw);
+    expect(JSON.stringify(expired.evidence)).not.toContain(unbound.handle);
+
+    const missing = rehydrateResponse({
+      value: unbound.tokens[0],
+      rehydrationHandle: "rehydration_missing",
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 2_001,
+    });
+    expect(missing.evidence).toEqual(expired.evidence);
+
+    const unboundResult = rehydrateResponse({
+      value: unbound.tokens[0],
+      rehydrationHandle: unbound.handle,
+      authContext: managerContext,
+      purpose: "coworker-assistance",
+      surface: "private-employee",
+      currentVersions: versions,
+      now: 2_001,
+    });
+    expect(unboundResult.evidence).toEqual(expired.evidence);
+  });
+});

--- a/apps/web/lib/govern/data/response-rehydration.ts
+++ b/apps/web/lib/govern/data/response-rehydration.ts
@@ -1,0 +1,293 @@
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+
+import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+import { canAccessEmployeeRecord } from "@/lib/govern/permissions";
+import {
+  isDecisionVersionSnapshotStillFresh,
+  type DecisionVersionSnapshot,
+} from "./policy-enforcement";
+import type { ProcessingPurposeKey } from "./taxonomy";
+import {
+  readRehydrationTokenMap,
+  type RehydrationAuthorizationBinding,
+  type RehydrationSubject,
+  type ResponseSurface,
+} from "./rehydration-token-vault";
+
+export type ResponseRehydrationExplanationCode =
+  | "response-rehydration-authorized"
+  | "response-rehydration-unavailable"
+  | "response-actor-not-authorized"
+  | "response-delegation-not-authorized"
+  | "response-purpose-not-authorized"
+  | "response-surface-not-authorized"
+  | "response-subject-not-authorized"
+  | "response-clearance-insufficient"
+  | "response-policy-version-stale";
+
+export type ResponseRehydrationEvidence = {
+  outcome: "rehydrated" | "partially-rehydrated" | "masked";
+  authorizedTokenCount: number;
+  deniedTokenCount: number;
+  explanationCodes: ResponseRehydrationExplanationCode[];
+  rawValuesStored: false;
+};
+
+export type ResponseRehydrationInput<T> = {
+  value: T;
+  rehydrationHandle: string;
+  authContext: EffectiveAuthContext;
+  purpose: ProcessingPurposeKey;
+  surface: ResponseSurface;
+  currentVersions: DecisionVersionSnapshot;
+  now?: number;
+};
+
+export function rehydrateResponse<T>(
+  input: ResponseRehydrationInput<T>,
+): { value: T; evidence: ResponseRehydrationEvidence } {
+  const read = readRehydrationTokenMap(input.rehydrationHandle, {
+    now: input.now,
+  });
+  if (read.status === "unavailable") {
+    return unavailableResult(input.value);
+  }
+  if (
+    [...read.tokens.values()].every((stored) =>
+      stored.bindings.length === 0 || stored.hasUnboundOccurrence
+    )
+  ) {
+    return unavailableResult(input.value);
+  }
+
+  const decisions = new Map<
+    string,
+    { authorized: boolean; value: string; codes: ResponseRehydrationExplanationCode[] }
+  >();
+  for (const [token, stored] of read.tokens) {
+    if (stored.bindings.length === 0 || stored.hasUnboundOccurrence) {
+      decisions.set(token, {
+        authorized: false,
+        value: stored.value,
+        codes: ["response-rehydration-unavailable"],
+      });
+      continue;
+    }
+    const codes = uniqueCodes(
+      stored.bindings.flatMap((binding) => bindingDenials(binding, input)),
+    );
+    decisions.set(token, {
+      authorized: codes.length === 0,
+      value: stored.value,
+      codes,
+    });
+  }
+
+  const encountered = new Set<string>();
+  const authorized = new Set<string>();
+  const denied = new Set<string>();
+  const explanationCodes = new Set<ResponseRehydrationExplanationCode>();
+  const value = visitValue(input.value, (text) =>
+    replaceTokens(text, decisions, {
+      encountered,
+      authorized,
+      denied,
+      explanationCodes,
+    })
+  ) as T;
+
+  if (encountered.size === 0) {
+    return unavailableResult(input.value);
+  }
+  if (authorized.size > 0) {
+    explanationCodes.add("response-rehydration-authorized");
+  }
+
+  return {
+    value,
+    evidence: {
+      outcome: authorized.size === 0
+        ? "masked"
+        : denied.size === 0
+          ? "rehydrated"
+          : "partially-rehydrated",
+      authorizedTokenCount: authorized.size,
+      deniedTokenCount: denied.size,
+      explanationCodes: [...explanationCodes].sort(),
+      rawValuesStored: false,
+    },
+  };
+}
+
+function unavailableResult<T>(
+  value: T,
+): { value: T; evidence: ResponseRehydrationEvidence } {
+  return {
+    value,
+    evidence: {
+      outcome: "masked",
+      authorizedTokenCount: 0,
+      deniedTokenCount: 0,
+      explanationCodes: ["response-rehydration-unavailable"],
+      rawValuesStored: false,
+    },
+  };
+}
+
+function bindingDenials(
+  binding: RehydrationAuthorizationBinding,
+  input: Omit<ResponseRehydrationInput<unknown>, "value" | "rehydrationHandle">,
+): ResponseRehydrationExplanationCode[] {
+  const codes: ResponseRehydrationExplanationCode[] = [];
+  if (!actorMatches(binding, input.authContext)) {
+    codes.push(
+      binding.expectedActor.delegationGrantId ||
+          binding.expectedActor.actingAgentId
+        ? "response-delegation-not-authorized"
+        : "response-actor-not-authorized",
+    );
+  }
+  if (binding.purpose !== input.purpose) {
+    codes.push("response-purpose-not-authorized");
+  }
+  if (
+    binding.surface !== input.surface ||
+    input.surface === "shared-team" ||
+    input.surface === "public"
+  ) {
+    codes.push("response-surface-not-authorized");
+  }
+  if (!canAccessSubject(input.authContext, binding.subject)) {
+    codes.push("response-subject-not-authorized");
+  }
+  if (!hasClearance(input.authContext, binding.sensitivity)) {
+    codes.push("response-clearance-insufficient");
+  }
+  if (
+    binding.decisionVersions.length === 0 ||
+    !binding.decisionVersions.every((version) =>
+      isDecisionVersionSnapshotStillFresh(version, input.currentVersions)
+    )
+  ) {
+    codes.push("response-policy-version-stale");
+  }
+  return codes;
+}
+
+function actorMatches(
+  binding: RehydrationAuthorizationBinding,
+  context: EffectiveAuthContext,
+): boolean {
+  const expected = binding.expectedActor;
+  if (
+    context.principalId !== expected.principalId ||
+    context.actingHumanUserId !== expected.actingHumanUserId ||
+    context.actingAgentId !== expected.actingAgentId
+  ) {
+    return false;
+  }
+  if (context.population === "ai-coworker" && !expected.actingAgentId) {
+    return false;
+  }
+  return expected.delegationGrantId === null ||
+    context.delegationGrantIds.includes(expected.delegationGrantId);
+}
+
+function canAccessSubject(
+  context: EffectiveAuthContext,
+  subject: RehydrationSubject,
+): boolean {
+  switch (subject.kind) {
+    case "employee":
+      return canAccessEmployeeRecord(context, subject.id);
+    case "account":
+      return canAccessCustomerScope(
+        context,
+        context.accountScope.accountIds,
+        subject.id,
+      );
+    case "contact":
+      return canAccessCustomerScope(
+        context,
+        context.accountScope.contactIds,
+        subject.id,
+      );
+    case "partner-account":
+      return canAccessCustomerScope(
+        context,
+        context.accountScope.partnerAccountIds,
+        subject.id,
+      );
+    case "principal":
+      return context.principalId === subject.id;
+    case "team":
+      return context.teamIds.includes(subject.id);
+  }
+}
+
+function canAccessCustomerScope(
+  context: EffectiveAuthContext,
+  ids: readonly string[],
+  subjectId: string,
+): boolean {
+  if (!ids.includes(subjectId)) return false;
+  return context.population === "customer" ||
+    context.population === "partner" ||
+    context.grantedCapabilities.includes("view_customer");
+}
+
+function hasClearance(
+  context: EffectiveAuthContext,
+  sensitivity: PrincipalSensitivity,
+): boolean {
+  return context.sensitivityClearance.includes(sensitivity);
+}
+
+function visitValue(value: unknown, transform: (value: string) => string): unknown {
+  if (typeof value === "string") return transform(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => visitValue(entry, transform));
+  }
+  if (!value || typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      visitValue(entry, transform),
+    ]),
+  );
+}
+
+function replaceTokens(
+  text: string,
+  decisions: ReadonlyMap<
+    string,
+    { authorized: boolean; value: string; codes: ResponseRehydrationExplanationCode[] }
+  >,
+  state: {
+    encountered: Set<string>;
+    authorized: Set<string>;
+    denied: Set<string>;
+    explanationCodes: Set<ResponseRehydrationExplanationCode>;
+  },
+): string {
+  return text.replace(/\[DPF_TOKEN_[A-F0-9]{12}\]/g, (token) => {
+    const decision = decisions.get(token);
+    if (!decision) return token;
+    state.encountered.add(token);
+    if (decision.authorized) {
+      state.authorized.add(token);
+      return decision.value;
+    } else {
+      state.denied.add(token);
+      decision.codes.forEach((code) => state.explanationCodes.add(code));
+      return token;
+    }
+  });
+}
+
+function uniqueCodes(
+  codes: readonly ResponseRehydrationExplanationCode[],
+): ResponseRehydrationExplanationCode[] {
+  return [...new Set(codes)].sort();
+}

--- a/apps/web/lib/inference/data-screening/routed-screening.test.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.test.ts
@@ -5,6 +5,7 @@ import {
   rescreenRoutedInferenceWithoutTools,
 } from "./routed-screening";
 import { screenInferencePayload } from "./screen-inference-payload";
+import { readRehydrationTokenMap } from "@/lib/govern/data/rehydration-token-vault";
 
 describe("routed inference screening", () => {
   it("tokenizes replaceable contact data before routing and preserves source classification evidence", () => {
@@ -24,6 +25,55 @@ describe("routed inference screening", () => {
     expect(routed.screen.receipt.obligationKinds).toContain("mask");
     expect(routed.screen.receipt.routeEffect).toBe("allow");
     expect(routed.rehydrationHandle).toMatch(/^rehydration_/);
+  });
+
+  it("binds tokens to caller-owned actor/subject intent and screen-owned governance evidence", () => {
+    const raw = "ada@example.com";
+    const routed = createRoutedInferenceScreen({
+      messages: [{ role: "user", content: `Draft a greeting for ${raw}.` }],
+      systemPrompt: "",
+      taskType: "draft",
+      routeContext: { sensitivity: "public" },
+      sensitiveDetailUse: "replaceable",
+      policyVersionSource: () => ({
+        assetVersion: "asset-v1",
+        classificationVersion: "classification-v1",
+        authorityVersion: "authority-v1",
+        policyBundleVersion: "bundle-v1",
+      }),
+      responseRehydration: {
+        expectedActor: {
+          principalId: "PRN-1",
+          actingHumanUserId: "user-1",
+          actingAgentId: null,
+          delegationGrantId: null,
+        },
+        purpose: "coworker-assistance",
+        surface: "private-customer",
+        subject: { kind: "account", id: "account-1" },
+        pathPrefixes: ["messages"],
+      },
+    });
+
+    const read = readRehydrationTokenMap(routed.rehydrationHandle ?? "");
+    expect(read.status).toBe("available");
+    if (read.status !== "available") return;
+    const stored = [...read.tokens.values()][0];
+    expect(stored?.bindings).toEqual([
+      expect.objectContaining({
+        purpose: "coworker-assistance",
+        surface: "private-customer",
+        subject: { kind: "account", id: "account-1" },
+        pathPrefixes: ["messages"],
+        sensitivity: "confidential",
+        dataClasses: expect.arrayContaining(["customer-records"]),
+        decisionVersions: expect.arrayContaining([
+          expect.objectContaining({
+            classificationVersion: "classification-v1",
+          }),
+        ]),
+      }),
+    ]);
   });
 
   it("keeps material contact data local instead of masking it into a misleading request", () => {

--- a/apps/web/lib/inference/data-screening/routed-screening.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.ts
@@ -7,6 +7,10 @@ import {
   maskForContext,
   type SensitiveDetailUse,
 } from "@/lib/govern/data/mask-for-context";
+import type {
+  RehydrationAuthorizationBinding,
+  RehydrationRouteBinding,
+} from "@/lib/govern/data/rehydration-token-vault";
 import {
   screenInferencePayload,
   type ScreenInferencePayloadInput,
@@ -21,15 +25,31 @@ type RoutedScreenInput = {
   activityContract?: ActivityContract;
   policyVersionSource?: ScreenInferencePayloadInput["policyVersionSource"];
   sensitiveDetailUse?: SensitiveDetailUse;
+  responseRehydration?: RehydrationRouteBinding | readonly RehydrationRouteBinding[];
 };
+
+export class ResponseRehydrationBindingError extends Error {
+  constructor() {
+    super("Response rehydration bindings must share one actor, purpose, and surface.");
+    this.name = "ResponseRehydrationBindingError";
+  }
+}
 
 export function routedRehydrationHandle(rehydrationHandle?: string) {
   return rehydrationHandle ? { rehydrationHandle } : {};
 }
 
 export function createRoutedInferenceScreen(input: RoutedScreenInput) {
-  const { sensitiveDetailUse = "unknown", ...baseInput } = input;
-  const screenInput = { ...baseInput } satisfies ScreenInferencePayloadInput;
+  const {
+    sensitiveDetailUse = "unknown",
+    responseRehydration,
+    ...baseInput
+  } = input;
+  const routeBindings = normalizeRouteBindings(responseRehydration);
+  const screenInput = {
+    ...baseInput,
+    ...(routeBindings[0] ? { purpose: routeBindings[0].purpose } : {}),
+  } satisfies ScreenInferencePayloadInput;
   const rawScreen = screenInferencePayload(screenInput);
   const directMaskDecision = rawScreen.decisions.find(hasMaskObligation);
   const projectionScreen = directMaskDecision
@@ -43,6 +63,7 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
   }
 
   try {
+    const authorityReceipt = (projectionScreen ?? rawScreen).receipt;
     const masked = maskForContext(
       {
         messages: screenInput.messages,
@@ -53,6 +74,15 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
         decision: maskDecision,
         matches: rawScreen.classification.matches,
         detailUse: sensitiveDetailUse,
+        ...(routeBindings.length > 0
+          ? {
+              rehydrationBindings: bindingsFromScreen(
+                routeBindings,
+                rawScreen,
+                authorityReceipt,
+              ),
+            }
+          : {}),
       },
     );
     const transformation = masked.transformation;
@@ -60,7 +90,6 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
       return { screenInput, screen: rawScreen, rehydrationHandle: undefined };
     }
 
-    const authorityReceipt = (projectionScreen ?? rawScreen).receipt;
     const appliedTransformation = transformationEvidence(
       authorityReceipt,
       rawScreen,
@@ -104,6 +133,41 @@ export function createRoutedInferenceScreen(input: RoutedScreenInput) {
     }
     throw error;
   }
+}
+
+function bindingsFromScreen(
+  routeBindings: readonly RehydrationRouteBinding[],
+  rawScreen: ReturnType<typeof screenInferencePayload>,
+  authorityReceipt: ReturnType<typeof screenInferencePayload>["receipt"],
+): RehydrationAuthorizationBinding[] {
+  return routeBindings.map((binding) => ({
+    ...binding,
+    sensitivity: rawScreen.classification.overallSensitivity,
+    decisionVersions: authorityReceipt.decisionVersions.map((version) => ({
+      ...version,
+    })),
+    dataClasses: [...rawScreen.receipt.classifiedDataClasses],
+  }));
+}
+
+function normalizeRouteBindings(
+  input: RehydrationRouteBinding | readonly RehydrationRouteBinding[] | undefined,
+): RehydrationRouteBinding[] {
+  if (!input) return [];
+  const bindings = Array.isArray(input) ? [...input] : [input];
+  const first = bindings[0];
+  if (!first) return [];
+  const actorKey = JSON.stringify(first.expectedActor);
+  if (
+    bindings.some((binding) =>
+      binding.purpose !== first.purpose ||
+      binding.surface !== first.surface ||
+      JSON.stringify(binding.expectedActor) !== actorKey
+    )
+  ) {
+    throw new ResponseRehydrationBindingError();
+  }
+  return bindings;
 }
 
 function transformationEvidence(

--- a/apps/web/lib/inference/routed-inference-options.ts
+++ b/apps/web/lib/inference/routed-inference-options.ts
@@ -32,6 +32,16 @@ export interface RouteAndCallOptions {
   sensitiveDetailUse?: import(
     "@/lib/govern/data/mask-for-context"
   ).SensitiveDetailUse;
+  /**
+   * Immutable actor/subject/final-surface intent for a later response PEP.
+   * Screening derives sensitivity and decision versions; this never authorizes
+   * automatic rehydration inside the routing or provider-dispatch boundary.
+   */
+  responseRehydration?: import(
+    "@/lib/govern/data/rehydration-token-vault"
+  ).RehydrationRouteBinding | readonly import(
+    "@/lib/govern/data/rehydration-token-vault"
+  ).RehydrationRouteBinding[];
   modelTier?: "local" | "robust";
   minimumDimensions?: Record<string, number>;
   requiredModelClass?: ModelClass;

--- a/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
+++ b/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
@@ -4,6 +4,7 @@ import {
   ACTIVITY_HARNESS_CONFIDENCE_OVERRIDE_ACTION,
   activityHarnessProposalParameters,
 } from "@/lib/routing/activity-harness-approval-source";
+import { readRehydrationTokenMap } from "@/lib/govern/data/rehydration-token-vault";
 
 const mocks = vi.hoisted(() => ({
   routeEndpointV2: vi.fn(),
@@ -382,6 +383,17 @@ describe("routeAndCall activity harness overrides", () => {
       {
         taskType: "draft",
         sensitiveDetailUse: "replaceable",
+        responseRehydration: {
+          expectedActor: {
+            principalId: "PRN-user",
+            actingHumanUserId: "user-1",
+            actingAgentId: null,
+            delegationGrantId: null,
+          },
+          purpose: "coworker-assistance",
+          surface: "private-customer",
+          subject: { kind: "account", id: "account-1" },
+        },
         persistDecision: false,
       },
     );
@@ -399,6 +411,15 @@ describe("routeAndCall activity harness overrides", () => {
       rawPayloadStored: false,
     });
     expect(result.rehydrationHandle).toMatch(/^rehydration_/);
+    const stored = readRehydrationTokenMap(result.rehydrationHandle ?? "");
+    expect(stored.status).toBe("available");
+    if (stored.status === "available") {
+      expect([...stored.tokens.values()][0]?.bindings[0]).toMatchObject({
+        purpose: "coworker-assistance",
+        surface: "private-customer",
+        subject: { kind: "account", id: "account-1" },
+      });
+    }
   });
 
   it("intersects screen allowlists with provider suitability and unions denials before routing", async () => {

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -180,6 +180,7 @@ async function prepareRoute(
     activityContract: options?.activityContract,
     policyVersionSource: options?.inferencePolicyVersionSource,
     sensitiveDetailUse: options?.sensitiveDetailUse,
+    responseRehydration: options?.responseRehydration,
   });
 
   // 1. Infer contract

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -53,7 +53,6 @@ import { createRoutingTraceId } from "@/lib/routing/routing-trace";
 import { AI_ROUTING_ARCHITECTURE_VERSION } from "@/lib/routing/routing-architecture-version";
 export type { RouteAndCallOptions } from "./routed-inference-options";
 // ─── Result type ────────────────────────────────────────────────────────────
-
 /** Unified inference result — flat token fields, V2 metadata included. */
 export interface RoutedInferenceResult {
   providerId: string;

--- a/apps/web/lib/routing/routing-architecture-version.ts
+++ b/apps/web/lib/routing/routing-architecture-version.ts
@@ -1,2 +1,2 @@
 /** Revision of the governed AI-routing design projected into EA/BPMN. */
-export const AI_ROUTING_ARCHITECTURE_VERSION = "2026-07-26.1";
+export const AI_ROUTING_ARCHITECTURE_VERSION = "2026-07-27.1";

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -21,7 +21,7 @@
   - `inference-pep` -> `BI-DG-012`, depends on `classifier-contract`
   - `mask-before-dispatch` -> `BI-DG-009`, depends on `classifier-contract` and `inference-pep`
   - `routing-binding` -> `BI-3D210AF8`, depends on `inference-pep` and `mask-before-dispatch`
-  - `response-rehydration-authz` -> `BI-749EB750`, depends on `inference-pep` and `mask-before-dispatch`
+  - `response-rehydration-authz` -> `BI-6A8B3910`, depends on `inference-pep`, `mask-before-dispatch`, and `BI-749EB750`
   - `employee-surface-authorization` -> `BI-62BFAA95`, depends on `inference-pep` and `mask-before-dispatch`
   - `vertical-policy-packs` -> `BI-F6018DB3`, depends on `classifier-contract` and `inference-pep`
   - `provider-onboarding-ux` -> `BI-ECBD6924`, depends on `classifier-contract` and `inference-pep`
@@ -303,7 +303,7 @@ pnpm --filter web exec vitest run lib/inference/routed-inference.activity-overri
 git diff --check
 ```
 
-### Chunk 5: BI-749EB750 / BI-62BFAA95 - Human And Employee Visibility
+### Chunk 5: BI-6A8B3910 / BI-749EB750 / BI-62BFAA95 - Human And Employee Visibility
 
 **Files:**
 

--- a/docs/superpowers/plans/2026-07-27-response-rehydration-authorization.md
+++ b/docs/superpowers/plans/2026-07-27-response-rehydration-authorization.md
@@ -1,0 +1,165 @@
+# Authorized Response Rehydration Implementation Plan
+
+> Execute this plan in `WC-2F922A0B` with test-first behavior changes. Keep
+> plaintext confined to the bounded vault and the final authorized return value.
+> A missing or ambiguous fact preserves the tokenized response.
+
+**Status:** Approved backlog work; implementation in progress.
+
+**Backlog item:** `BI-6A8B3910`
+
+**Work Capsule:** `WC-07BB587B`
+
+**Branch / worktree:** `feat/response-rehydration-authz` /
+`D:\DPF-worktrees\response-rehydration-authz`
+
+**Plan backlog coverage:** atomic receipt `cms398qau038001qjk2t1cr3y`
+
+**Architecture decision:** `DI-CCC427A3EF51` selected a dedicated
+response-rehydration PEP over inline masking-module authorization or
+surface-owned rehydration. WWMD returned high confidence, a 9.706 composite
+score, a 3.826 margin, and no commandment conflict.
+
+## Outcome
+
+DPF can restore tokenized model-output values only through one reusable,
+fail-closed response gateway. The gateway combines immutable dispatch-time
+binding with the current `EffectiveAuthContext`, validates purpose and surface,
+checks employee/customer/partner relationships and explicit sensitivity
+clearance, and re-reads policy versions immediately before disclosure. Denied
+tokens remain tokens; raw values never enter evidence, logs, memory, shared
+surfaces, or exception text.
+
+This plan implements only response disclosure. New human-approval and nested
+agent call-chain semantics remain owned by `BI-62BFAA95`.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-6A8B3910`
+- Receipt: `cms398qau038001qjk2t1cr3y`
+- Dependencies: completed `BI-DG-009`, `BI-DG-012`, and `BI-749EB750`, plus
+  the merged classifier and routing-binding slices of `BI-3D210AF8`
+- Dependency order: bound token vault -> response PEP -> routing binding ->
+  conformance and documentation.
+- Rationale: a vault lookup without the PEP exposes plaintext, a PEP without
+  immutable dispatch-time binding trusts rehydration-time caller assertions,
+  and route propagation without both creates an unsafe or unusable handle.
+  The four phases form one security boundary and are not independently
+  shippable.
+
+| Deliverable | Dependency | Independently shippable |
+|---|---|---:|
+| Bound token vault | None | No |
+| Response-rehydration PEP | Bound token vault | No |
+| Routing binding and handle propagation | Vault and PEP | No |
+| Conformance tests and documentation | All behavior phases | No |
+
+## Effort budget
+
+Use 20% of implementation effort for bounded refactoring:
+
+- Extract token generation, expiry, capacity eviction, and lookup from
+  `mask-for-context.ts` into one data-governance vault module.
+- Keep the authorization evaluator pure and inject the clock/version reader so
+  TOCTOU and expiry behavior are deterministic.
+- Propagate one optional rehydration descriptor instead of adding
+  surface-specific lookup helpers.
+
+The remaining 80% implements and verifies the response security boundary.
+
+## Phase 1: Define the authorization contract test-first
+
+**Files**
+
+- Create: `apps/web/lib/govern/data/response-rehydration.ts`
+- Create: `apps/web/lib/govern/data/response-rehydration.test.ts`
+
+**Behavior**
+
+- Define closed private and shared/public response-surface values.
+- Define explicit employee, account, contact, partner-account, and principal
+  subject references; do not infer subjects from response text or route names.
+- Require a closed processing purpose, an expected viewer principal, acting
+  human/agent identity when applicable, minimum sensitivity, and privacy-safe
+  policy decision versions.
+- Permit employee disclosure only through the canonical employee capability
+  plus self/direct/indirect manager scope.
+- Permit customer and partner disclosure only through canonical account scope.
+- Require exact explicit sensitivity clearance; superuser status does not
+  silently override clearance.
+- Reject shared/public surfaces, unknown values, identity mismatch, missing
+  delegation evidence for an acting agent, and any policy-version drift.
+
+## Phase 2: Extract and bind the token vault
+
+**Files**
+
+- Create: `apps/web/lib/govern/data/rehydration-token-vault.ts`
+- Create: `apps/web/lib/govern/data/rehydration-token-vault.test.ts`
+- Modify: `apps/web/lib/govern/data/mask-for-context.ts`
+- Modify: `apps/web/lib/govern/data/mask-for-context.test.ts`
+
+**Behavior**
+
+- Move the keyed stable-token primitive and bounded five-minute vault behind a
+  narrow module.
+- Store each token map with an immutable response-authorization binding.
+- Preserve existing opaque handle format and masking behavior.
+- Keep unbound legacy handles non-rehydratable rather than widening them.
+- Return only generic missing/expired/unauthorized outcomes; errors and
+  evidence must not include handles, tokens, or raw values.
+
+## Phase 3: Add the response PEP and routing binding
+
+**Files**
+
+- Modify: `apps/web/lib/inference/routed-inference-options.ts`
+- Modify: `apps/web/lib/inference/data-screening/routed-screening.ts`
+- Modify: `apps/web/lib/inference/routed-inference.ts`
+- Modify affected routed-inference and screening tests
+
+**Behavior**
+
+- Accept an optional server-owned response-authorization binding with the
+  route request and attach it to tokenization.
+- Preserve the opaque handle through the routed result without exposing the
+  token map.
+- Rehydrate string and structured response values token-by-token only after a
+  fresh PEP allow.
+- Preserve denied and malformed tokens unchanged, including mixed allow/deny
+  output.
+- Ensure AI-coworker acting identity can only narrow the authenticated human's
+  authority.
+
+## Phase 4: Conformance, architecture, and verification
+
+**Files**
+
+- Modify:
+  `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
+- Modify: `apps/web/lib/ea/ai-routing-architecture-registry.ts`
+- Modify related architecture extraction tests
+
+**Behavior and evidence**
+
+- Mark the rehydration gateway and masked/authorized response branches as
+  implemented only after their source anchors exist.
+- Test manager allow, peer deny, unrelated manager deny, shared-surface deny,
+  account mismatch, insufficient clearance, expired handle, missing binding,
+  malformed/repeated tokens, acting-agent mismatch, and TOCTOU drift.
+- Add plaintext canaries for logs, receipts, memory, and returned denied output.
+- Run affected Vitest suites, web typecheck, exact-head merged-code local
+  integration, production build, PR health, and merge-group verification.
+
+## Risks and rollback
+
+- **Caller fabrication:** response-time callers cannot supply or replace the
+  stored subject, purpose, surface, actor, or version binding.
+- **Handle theft:** an opaque handle is useless to another principal or surface.
+- **Privilege widening:** missing clearance, relationship, delegation, version,
+  or surface evidence returns the tokenized response.
+- **Partial disclosure:** authorization is evaluated per stored token binding;
+  one allowed token cannot unlock a denied sibling.
+- **Rollback:** the change is in-memory and additive. Removing the gateway
+  leaves tokenized responses intact and stores no schema or migration state.


### PR DESCRIPTION
## Summary

- extract the bounded token vault from context masking and bind tokens immutably to actor, purpose, private response surface, governed subject, sensitivity, policy versions, data classes, and classifier paths
- add a reusable fail-closed response PEP that rehydrates per token only when EffectiveAuthContext, relationship/account scope, explicit clearance, active delegation, purpose, surface, and current policy versions all authorize disclosure
- preserve legacy/unbound, expired, missing, malformed, shared/public, and mixed-authority responses as masked output with privacy-safe evidence
- propagate optional server-owned response bindings through routed inference without automatically rehydrating inside provider dispatch or persistence
- advance the governed AI-routing architecture projection and correct the parent-plan backlog mapping to BI-6A8B3910

## Verification

- exact candidate: `3c4e81bc966663abc965b6702e35de87ebb0f155`
- accepted base: `c900ec3dfe4732b12ed9052ef594a0b9636686e9`
- local integration evidence: `cms3b3fr8010i01p5vuqqylhm`
- released lease: `NPEL-06D3AFF733`
- integration commit: `c00ceb57a0044e8c0fb3088f07e7cc60151f4370`
- synthesized tree: `fb8252f5862193e94ddab893f0c171f79f499676`
- 2,267 test files / 19,663 tests passed
- web typecheck passed
- 449 migrations current; no pending migration
- docs index/link integrity and repository guards passed
- production Docker build passed; manifest `sha256:cee033ba77a03001697ce87adfac4bedccfa3921d0d02d2a1a0f56102a3ac274`

## Documentation impact

Architecture and contributor-facing plans are updated in this PR. No operator user-guide change is needed because this slice adds a server-side authorization primitive and routing contract; no end-user surface invokes it yet. Broader employee/HITL surface integration remains BI-62BFAA95.

Backlog: BI-6A8B3910
Work Capsule: WC-07BB587B
Decision: DI-CCC427A3EF51

Local-CI-Evidence: cms3b3fr8010i01p5vuqqylhm

