### PR TITLE
docs: design product management operating loop

### DIFF
--- a/docs/superpowers/plans/2026-07-27-product-management-operating-loop.md
+++ b/docs/superpowers/plans/2026-07-27-product-management-operating-loop.md
@@ -1,0 +1,347 @@
+# Product Management Operating Loop Implementation Plan
+
+> **For implementation agents:** Execute this plan through the live child BacklogItems under `EP-ED496EB0`. Do not implement the x-large umbrella `BI-5C5FA641` as one branch or one build. Revalidate the plan coverage receipt before starting each child.
+
+**Goal:** Give digital product managers a coherent, product-scoped loop from cited intelligence through demand, investment, roadmap communication, delivery, and measured outcomes.
+
+**Architecture:** Reuse and converge the existing product, research, battlecard, knowledge, demand, decision, scheduling, architecture, and delivery substrates behind a typed `ProductOperatingContext`. Add only optional product associations and the missing objective/outcome contract. Roadmaps and briefs are derived views, not new sources of truth.
+
+**Design:** `docs/superpowers/specs/2026-07-27-product-management-operating-loop-design.md`
+
+**Epic:** `EP-ED496EB0`
+
+**Umbrella:** `BI-5C5FA641`
+
+**Kernel decision:** `DI-8B3E5799CA59`
+
+## Delivery graph
+
+| Order | Deliverable | Backlog item | Depends on |
+| --- | --- | --- | --- |
+| 1 | Canonical product operating-context projection | `BI-AE062121` | — |
+| 2 | Product Direction workspace | `BI-C2C08E30` | `BI-AE062121` |
+| 3 | Product-scoped continuous intelligence | `BI-FB049FCD` | `BI-AE062121` |
+| 4 | Evidence-backed demand activation | `BI-9E608678` | `BI-AE062121` |
+| 5 | Product objective and outcome-learning contract | `BI-162FBDCC` | `BI-AE062121` |
+| 6 | Derived audience roadmaps | `BI-8C87657A` | `BI-9E608678`, `BI-162FBDCC` |
+| 7 | PM playbooks, portability, guidance, and adoption evidence | `BI-B7621682` | `BI-C2C08E30`, `BI-FB049FCD`, `BI-9E608678`, `BI-162FBDCC`, `BI-8C87657A` |
+
+The first deliverable is the explicit refactoring allocation. Reserve approximately 20% of total implementation capacity for query boundaries, adapters, typed contracts, removal of duplicated joins/rules, and invariant coverage. Do not consume that allocation with visible feature work.
+
+## Phase 1 — Canonical product operating context (`BI-AE062121`)
+
+### Task 1.1: Lock the projection contract with tests
+
+**Files:**
+
+- Create: `apps/web/lib/product-management/product-operating-context.ts`
+- Create: `apps/web/lib/product-management/product-operating-context.test.ts`
+- Modify: `apps/web/lib/portfolio/digital-product-view-model.ts`
+
+1. Write failing tests for a context containing product posture, evidence freshness, demand readiness, decisions, objectives, roadmap inputs, delivery changes, and scheduled playbooks.
+2. Require every projected item to carry its canonical ID, source kind, and `asOf`.
+3. Implement a pure typed assembler whose inputs are explicit query results.
+4. Refactor overlapping product-view joins into shared adapters without changing existing page behavior.
+5. Run targeted Vitest and product-page tests.
+
+### Task 1.2: Add optional product scope to research and battlecards
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_product_scope_to_research_and_battlecards/migration.sql`
+- Modify: `apps/web/lib/wiki/research-schedule.ts`
+- Modify: `apps/web/lib/wiki/research-execution.ts`
+- Modify: `apps/web/lib/marketing/battlecards.ts`
+- Modify: `apps/web/lib/mcp/packs/marketing-pack.ts`
+- Add or modify colocated tests.
+
+1. Add nullable `digitalProductId` foreign keys and indexes to `ResearchProposal` and `MarketingBattlecard`.
+2. Add inverse relations on `DigitalProduct`.
+3. Preserve all existing rows as organization-wide; do not infer product scope.
+4. Propagate proposal scope to the resulting product-linked knowledge article.
+5. Extend existing tool inputs/outputs rather than creating duplicate PM tools.
+6. Add migration safety attestation for additive nullable changes and verify clean application.
+
+### Task 1.3: Add query and authorization adapters
+
+**Files:**
+
+- Create: `apps/web/lib/product-management/product-operating-context-query.ts`
+- Create: `apps/web/lib/product-management/product-operating-context-query.test.ts`
+- Modify existing authorization helpers only where needed.
+
+1. Resolve the product and caller authorization once.
+2. Fetch each bounded context slice with explicit limits and stable ordering.
+3. Keep organization-wide evidence distinguishable from product-specific evidence.
+4. Test cross-organization isolation, partial data, stale data, and deleted references.
+5. Confirm the existing product overview and knowledge paths remain unchanged.
+
+**Phase gate:** targeted tests, production build, migration validation/apply, and read-model performance evidence.
+
+## Phase 2 — Product Direction workspace (`BI-C2C08E30`)
+
+### Task 2.1: Extend the existing product navigation
+
+**Files:**
+
+- Modify: `apps/web/components/product/ProductTabNav.tsx`
+- Modify: `apps/web/components/product/ProductTabNav.test.tsx`
+- Create: `apps/web/app/(shell)/portfolio/product/[id]/direction/layout.tsx`
+- Create: `apps/web/app/(shell)/portfolio/product/[id]/direction/page.tsx`
+- Create colocated route tests.
+
+1. Add one `Direction` family with Brief, Intelligence, Roadmap, and Outcomes subitems.
+2. Preserve current family active-state behavior and responsive SectionNav semantics.
+3. Do not add a global navigation destination.
+4. Add the action-oriented first viewport in the order defined by the design.
+5. Implement explicit loading, empty, partial, stale, failed, and unauthorized states.
+
+### Task 2.2: Build reusable direction components
+
+**Files:**
+
+- Create: `apps/web/components/product/direction/ProductDirectionBrief.tsx`
+- Create: `apps/web/components/product/direction/NeedsDecisionList.tsx`
+- Create: `apps/web/components/product/direction/EvidenceDeltaList.tsx`
+- Create: `apps/web/components/product/direction/CurrentBets.tsx`
+- Create: `apps/web/components/product/direction/OutcomePosture.tsx`
+- Create matching tests and stories/examples where the repo convention requires them.
+
+1. Reuse report-kit, knowledge, filter, staleness, and status primitives.
+2. Keep one primary action and use progressive disclosure for source detail.
+3. Show facts, calculations, and AI inferences with distinct labels.
+4. Verify keyboard flow, focus, contrast, 200% zoom, and narrow viewport behavior.
+
+### Task 2.3: Add preview-before-mutation interactions
+
+1. Build a shared preview panel for product-context coworker actions.
+2. Show read scope, proposed writes, sources, approval boundary, and schedule effect.
+3. Route mutations to existing governed tools.
+4. Add authorization and cancellation tests.
+
+**Phase gate:** targeted tests, production build, and browser verification across desktop/narrow/empty/stale/unauthorized states.
+
+## Phase 3 — Continuous intelligence (`BI-FB049FCD`)
+
+### Task 3.1: Refactor the legacy competitive-analysis path
+
+**Files:**
+
+- Modify: `skills/storefront/competitive-analysis.skill.md`
+- Modify: `apps/web/lib/wiki/market-research.ts`
+- Modify: `apps/web/lib/wiki/research-schedule.ts`
+- Modify: `apps/web/lib/wiki/research-execution.ts`
+- Modify: `apps/web/lib/marketing/battlecards.ts`
+- Modify associated tests and prompt/tool registration where verified.
+
+1. Replace guided, user-supplied-only analysis with a product-scoped workflow over existing cited research and battlecards.
+2. Preserve the approval gate before web/LLM execution and draft review before publication.
+3. Produce “changed since last reviewed run” output, not full repeated reports.
+4. Record source URLs, retrieval time, scope, and confidence.
+5. Update or resolve the stale competitive-signal backlog item if its acceptance criteria are fulfilled.
+
+### Task 3.2: Add Intelligence page and scheduling controls
+
+**Files:**
+
+- Create: `apps/web/app/(shell)/portfolio/product/[id]/direction/intelligence/page.tsx`
+- Create: `apps/web/components/product/direction/ProductIntelligence.tsx`
+- Modify existing scheduled-agent-task actions/components where reusable.
+
+1. Separate pending proposals, reviewed findings, competitive cards, and stale evidence.
+2. Support propose, preview, approve, decline, schedule, pause, and rerun.
+3. Make organization-wide vs product-scoped evidence obvious.
+4. Add useful first-run and no-source empty states.
+
+**Phase gate:** research/battlecard/schedule tests, build, and approval/publish boundary UX verification.
+
+## Phase 4 — Demand activation (`BI-9E608678`)
+
+### Task 4.1: Define and test activation rules
+
+**Files:**
+
+- Modify: `apps/web/lib/backlog.ts`
+- Modify: `apps/web/lib/actions/backlog.ts`
+- Modify: `apps/web/components/ops/DemandBoard.tsx`
+- Add targeted tests.
+
+1. Define the closed transition rules for intake, evidence readiness, scoring readiness, funding, and delivery.
+2. Require score explanations to expose value inputs, estimate provenance, confidence, and missing fields.
+3. Keep “unclassified” explicit until a deterministic migration rule is proven.
+4. Add guards so new product demand cannot silently bypass classification after activation.
+
+### Task 4.2: Remediate legacy demand fleet-safely
+
+**Files:**
+
+- Create a fleet-safe migration only if a deterministic backfill is proven.
+- Otherwise create a governed classification job and leave database values untouched until reviewed.
+- Add an invariant detector/test for new null-stage product demand.
+
+1. Analyze live categories before writing any backfill.
+2. Quarantine ambiguity into the unclassified queue rather than inventing scores.
+3. Keep the operation idempotent and auditable.
+4. Capture before/after counts and rollback/recovery behavior.
+
+### Task 4.3: Integrate product evidence and funding decisions
+
+1. Link demand to reviewed product knowledge and objective candidates.
+2. Reuse the existing funding approval decision tool.
+3. Surface funding rationale and decision history in the product context.
+4. Add activation/funnel telemetry that measures completeness, not raw clicks.
+
+**Phase gate:** targeted tests, build, migration/job evidence, and end-to-end demand-to-funding UX verification.
+
+## Phase 5 — Objectives and outcome learning (`BI-162FBDCC`)
+
+### Task 5.1: Add canonical enums and models
+
+**Files:**
+
+- Create: `apps/web/lib/product-management/outcomes.ts`
+- Create: `apps/web/lib/product-management/outcomes.test.ts`
+- Modify: `packages/db/prisma/schema.prisma`
+- Create: `packages/db/prisma/migrations/<timestamp>_add_product_objectives/migration.sql`
+- Modify MCP schema/pack files selected by code-graph verification.
+
+1. Define canonical statuses, measure kinds, source kinds, and contribution kinds.
+2. Mirror enum values exactly in MCP inputs.
+3. Add `ProductObjective`, `ProductObjectiveWork`, and append-only `ProductOutcomeObservation`.
+4. Add organization/product authorization through the product relation.
+5. Validate the schema before migration and apply the additive migration against representative data.
+
+### Task 5.2: Implement objective/outcome services and tools
+
+1. Create, update, review, close, and archive objectives with legal transitions.
+2. Link contributing backlog work without changing backlog ownership.
+3. Append observations; corrections supersede prior observations.
+4. Calculate posture against baseline/target only for compatible typed measures.
+5. Test qualitative measures, overdue reviews, missing baselines, and unauthorized products.
+
+### Task 5.3: Add Outcomes page
+
+**Files:**
+
+- Create: `apps/web/app/(shell)/portfolio/product/[id]/direction/outcomes/page.tsx`
+- Create: `apps/web/components/product/direction/ProductOutcomes.tsx`
+- Add associated tests.
+
+1. Lead with due reviews and changed outcome posture.
+2. Show contributing funded/delivered work and supporting observations.
+3. Guide creation of a first outcome without requiring an OKR vocabulary.
+4. Provide clear review, close, and “insufficient evidence” paths.
+
+**Phase gate:** enum/schema guards, targeted tests, build, migration apply, and objective-to-observation UX verification.
+
+## Phase 6 — Derived roadmaps (`BI-8C87657A`)
+
+### Task 6.1: Implement the projection contract
+
+**Files:**
+
+- Create: `apps/web/lib/product-management/product-roadmap.ts`
+- Create: `apps/web/lib/product-management/product-roadmap.test.ts`
+
+1. Derive candidates from funded demand linked to objectives.
+2. Combine release/change dates, dependency state, and architecture constraints.
+3. Compute sequence and timing confidence without inventing dates.
+4. Explain inclusion, movement, blockers, and evidence changes.
+5. Test contradictory, missing, cyclic dependency, and partially funded cases.
+
+### Task 6.2: Add roadmap views
+
+**Files:**
+
+- Create: `apps/web/app/(shell)/portfolio/product/[id]/direction/roadmap/page.tsx`
+- Create: `apps/web/components/product/direction/ProductRoadmap.tsx`
+- Create view components/tests using existing report-kit patterns.
+
+1. Implement Now/Next/Later as the default.
+2. Add timeline, outcome, and dependency views only over the same projection.
+3. Route edits back to canonical funding, dependency, objective, or delivery controls.
+4. Preserve filters in existing user preferences if substrate verification confirms fit.
+5. Verify dense, sparse, blocked, and undated roadmaps responsively.
+
+### Task 6.3: Add review and portable snapshots
+
+1. Record stakeholder review through the existing decision/audit substrate.
+2. Export a timestamped snapshot with filters, source IDs, `asOf`, and confidence.
+3. Optionally retain a reviewed narrative snapshot as product-linked knowledge.
+4. Test that exports do not become importable planning authorities.
+
+**Phase gate:** projection tests, build, multi-view UX verification, review audit, and export inspection.
+
+## Phase 7 — Playbooks, portability, and adoption (`BI-B7621682`)
+
+### Task 7.1: Package reusable PM workflows
+
+**Files:**
+
+- Create or update skills under the verified product-management skill category.
+- Modify prompt templates under `prompts/<verified-category>/`.
+- Extend existing `ScheduledAgentTask` registration/actions rather than adding a scheduler.
+- Add skill/prompt seed and contract tests.
+
+1. Package weekly intelligence, demand triage, investment preparation, roadmap refresh, and outcome review recipes.
+2. Declare inputs, tools, output contract, proposed writes, approvals, schedule, and failure behavior.
+3. Scope each run to one product and persist only canonical outputs.
+4. Trigger regeneration when relevant canonical records change, with deduplication and rate limits.
+
+### Task 7.2: Add scheduling and run visibility
+
+1. Preview first run and every changed permission/write scope.
+2. Support schedule, pause, resume, rerun, and inspect.
+3. Show partial success without presenting stale output as current.
+4. Record run provenance and correction/override outcomes.
+
+### Task 7.3: Complete guidance, export, and telemetry
+
+**Files:**
+
+- Modify relevant pages under `docs/user-guide/`.
+- Modify in-app help selected by route ownership.
+- Add telemetry/query tests in the owning analytics modules.
+
+1. Document the product-manager loop in task language.
+2. Explain evidence, score, roadmap confidence, approval, and outcome review.
+3. Add portable brief export using the same provenance contract as roadmap exports.
+4. Instrument the success and guardrail measures in the design.
+5. Review defaults after a pilot; do not enable automatic schedules globally without evidence.
+
+**Phase gate:** skill/prompt/schedule tests, build, complete recurring-workflow UX verification, export inspection, and documentation review.
+
+## Cross-cutting verification contract
+
+Every child branch must:
+
+1. use a dedicated worktree and current `origin/main`;
+2. re-run substrate verification before adding a model, enum, route, tool, or scheduler;
+3. write the failing behavior/contract test first for code changes;
+4. run targeted Vitest for affected files;
+5. run `pnpm --filter web build`;
+6. use the shared local-CI convergence sandbox for runtime-bound gates;
+7. exercise UI/agent/workflow changes in the browser, including narrow and non-happy states;
+8. validate and apply migrations against representative existing data;
+9. update the user guide, architecture history, prompts, and external-agent guidance when affected;
+10. record UX and migration disposition in completion evidence.
+
+## Plan-to-backlog coverage
+
+This plan is deliberately decomposed. The governed receipt must map every independently shippable phase to the live child item shown in the Delivery graph. Copy the receipt ID and validation result below after calling `record_plan_backlog_coverage`, then revalidate it before implementation:
+
+- **Coverage receipt:** `cms3d0fbp03mb01p585znk4zf`
+- **Validation:** decomposed; all 7 independently shippable deliverables resolve to live, build-triaged BacklogItems
+
+## Completion criteria for the epic
+
+The epic may close only when:
+
+- all seven child items are done with proportional verification evidence;
+- a manager can move through evidence → demand → funding → objective → roadmap → delivery → observation for one product;
+- the live roadmap contains no manually synchronized duplicate authority;
+- research and AI mutations preserve approval, source, freshness, and audit contracts;
+- existing organization-wide research, battlecards, backlog, and product routes remain compatible;
+- success/guardrail telemetry is queryable;
+- user and coworker guidance is current.

--- a/docs/superpowers/specs/2026-07-27-product-management-operating-loop-design.md
+++ b/docs/superpowers/specs/2026-07-27-product-management-operating-loop-design.md
@@ -1,0 +1,339 @@
+# Product Management Operating Loop
+
+**Date:** 2026-07-27
+
+**Status:** Proposed
+
+**Epic:** `EP-ED496EB0`
+
+**Umbrella backlog item:** `BI-5C5FA641`
+
+**Decision ledger:** `DI-8B3E5799CA59`
+
+**Implementation plan:** `docs/superpowers/plans/2026-07-27-product-management-operating-loop.md`
+
+## 1. Executive summary
+
+DPF already contains much of the substrate a product manager needs: digital products, product-linked backlog, market research, competitive battlecards, knowledge with revisions and staleness, demand scoring, funding decisions, architecture, releases, scheduling, and AI coworkers. The gap is not another product-management database. The gap is a coherent operating loop that keeps those capabilities product-scoped, evidence-backed, current, explainable, and easy to use.
+
+This design converges the existing capabilities behind a typed `ProductOperatingContext` projection and adds only the missing canonical outcome-learning contract. Product managers receive an action-oriented **Direction** area inside the existing Product workspace. It connects:
+
+1. cited market and customer intelligence;
+2. evidence-linked demand and investment decisions;
+3. objectives and measurable outcomes;
+4. derived, audience-appropriate roadmaps;
+5. delivery and release state; and
+6. recurring coworker-assisted review workflows.
+
+Roadmaps remain projections of canonical demand, objective, architecture, and delivery state. Research remains approval-gated and reviewable. AI actions preview their inputs and proposed mutations. The product workspace remains the owner; no second global PM cockpit is introduced.
+
+## 2. Problem
+
+The current platform has capable but fragmented product-management ingredients:
+
+- product navigation emphasizes delivery, operation, architecture, commercial, and team concerns, but not direction, intelligence, or outcomes;
+- market research and battlecards are organization-scoped rather than product-scoped;
+- the legacy competitive-analysis skill is guided work rather than a persistent, cited learning loop;
+- demand stages and scores exist, but live data showed `3,772` backlog items with no staged or scored items, including `1,345` product-linked items;
+- roadmap assembly is described in prompts, but a durable roadmap workflow is not honored by the current substrate;
+- there is no canonical product objective/outcome model connecting a bet, its measure, delivered work, and observed learning;
+- reusable scheduling exists, but the core PM cadences are not packaged as discoverable product-scoped playbooks.
+
+The result is a platform that can store and execute many parts of product work without yet making the product manager's loop feel continuous.
+
+## 3. Lessons being absorbed
+
+The Product Talk article about Claude Code highlights six durable properties: persistent context, reusable systems, parallel work, automatic regeneration, portable artifacts, and accessibility to nontechnical practitioners. DPF is already past the article's tool-centric framing; the useful lesson is to turn these properties into product behavior rather than asking managers to operate a coding agent.
+
+| Lesson | DPF interpretation |
+| --- | --- |
+| Persistent context | Assemble a durable, product-scoped operating context from canonical platform records with provenance and freshness. |
+| Reusable systems | Package recurring PM work as governed playbooks, not one-off chats or hardcoded route prompts. |
+| Parallel work | Let approved coworker tasks research, synthesize, score, and prepare views independently while preserving one auditable product context. |
+| Automatic regeneration | Recompute derived briefs and roadmap views when canonical evidence, funding, architecture, or delivery state changes. |
+| Portable artifacts | Export timestamped, source-linked briefs and roadmap snapshots while retaining the live platform view as canonical. |
+| Nontechnical accessibility | Put the workflow in the existing Product UI with plain language, useful defaults, previews, and guided empty states. |
+
+## 4. Research and benchmarking
+
+| Source | Lesson adopted | Boundary |
+| --- | --- | --- |
+| [Product Talk: Claude Code—What It Is and How It's Different](https://www.producttalk.org/claude-code-what-it-is-and-how-its-different/) | Persistent context, reusable workflows, regeneration, and portable outputs make AI work compound. | DPF exposes these as governed platform behavior, not terminal workflows. |
+| [Productboard product roadmaps](https://www.productboard.com/product-roadmap/) and [roadmapping use case](https://www.productboard.com/use-cases/product-roadmapping/) | Trace customer/market insight through prioritization to an always-current roadmap. | Do not copy a separate feature/roadmap source of truth. |
+| [Jira Product Discovery overview](https://support.atlassian.com/jira-product-discovery/docs/what-is-jira-product-discovery/) and [views guide](https://www.atlassian.com/software/jira/product-discovery/guides/views/overview) | Flexible list, matrix, board, timeline, and Now/Next/Later views serve different audiences from shared records. | Views are projections; view configuration must not become a second planning ontology. |
+| [Plane Cycles](https://plane.so/cycles) and [Operating Manual](https://plane.so/operating-manual) | Recurring cycles and progressive disclosure help teams turn a backlog into a repeatable rhythm. | DPF uses existing schedules and product lifecycle state rather than importing sprint semantics. |
+| [OpenProject work packages](https://www.openproject.org/docs/user-guide/work-packages/) | Typed work, hierarchy, timelines, and exports are valuable when they share one work graph. | DPF retains `Epic` and `BacklogItem` as the delivery graph. |
+| [Leantime strategy management](https://support.leantime.io/en/article/how-to-use-leantimes-strategy-management-software-16wm52a/) | Strategy becomes useful when goals roll up from ongoing project work. | DPF adds a minimal outcome contract, not a general-purpose strategy-document suite. |
+
+## 5. Governing architecture decision
+
+Three options were compared through the founder kernel:
+
+1. **Surface stitch** — assemble existing data in a new dashboard without changing workflow contracts.
+2. **Projected operating loop** — converge existing substrates behind a typed product projection, add only missing product associations and outcome contracts, and derive views.
+3. **Parallel PM module** — introduce new idea, insight, roadmap, and objective models with synchronization to existing records.
+
+The kernel selected **projected operating loop** with high confidence, composite score `15.5794`, and a `6.8520` margin. The strongest contributors were Research and Use Standards and Ship Real Functionality. The decision is recorded as `DI-8B3E5799CA59`.
+
+The surface stitch is too passive: it would make fragmentation more visible without activating the workflow. The parallel module violates single-source-of-truth and would require permanent synchronization with demand, delivery, architecture, and knowledge.
+
+## 6. Design principles
+
+1. **One product graph.** Evidence, demand, objectives, roadmap projections, delivery, and outcomes must resolve to a `DigitalProduct`.
+2. **Evidence before prioritization.** A score is explainable through inputs, evidence, estimates, and provenance.
+3. **Derived artifacts stay derived.** Briefs and roadmaps are read models. Exported snapshots are records of communication, not new planning authorities.
+4. **AI proposes; governed workflows decide.** Research execution, demand mutation, funding, and publishing preserve preview, approval, and audit boundaries.
+5. **Freshness is visible.** Every evidence-based conclusion exposes source, observed/retrieved time, review state, and staleness.
+6. **The first viewport is for action.** It leads with changed evidence, decisions needed, current bets, risks, and outcome posture—not a wall of counts.
+7. **Common substrate, archetype vocabulary.** The loop works across products while labels, sources, and playbooks can be configured for an archetype.
+8. **Refactor before expansion.** Roughly 20% of implementation capacity is reserved for the operating-context boundary and invariant coverage.
+
+## 7. Substrate verification ledger
+
+| Proposed concept | Existing substrate | Verdict |
+| --- | --- | --- |
+| Product context | `DigitalProduct`, `digital-product-view-model.ts`, product relations | Extend as a typed read-only `ProductOperatingContext`; do not persist another context record. |
+| Product intelligence | `ResearchProposal`, cited `market-research.ts`, research schedule/execution, `KnowledgeArticle` | Reuse. Add optional product scope to a proposal and propagate it to resulting knowledge. |
+| Competitive learning | `MarketingBattlecard`, marketing MCP pack, matrix builder | Reuse. Add optional product scope because positioning differs by product. |
+| Demand and investment | `BacklogItem.demandStage`, value inputs, score, investment bucket, estimate provenance, demand UI, funding decision tool | Activate and guard. Do not create an Idea model. |
+| Product roadmap | `Epic`, `BacklogItem`, dependencies, architecture, versions, changes | Add a projection contract and views. Do not add a canonical `Roadmap` table in the first release. |
+| Product outcome | No product objective, measure, target, observation, and review lifecycle exists. `RouteOutcome` and `DeliberationOutcome` serve unrelated domains. | Add a minimal `ProductObjective` plus append-only `ProductOutcomeObservation`. |
+| Persistent artifact | `KnowledgeArticle`, product links, revisions, review and staleness | Reuse for reviewed narrative briefs and exported snapshots when durable storage is required. |
+| Recurring workflow | `ScheduledAgentTask`, research schedule, skills/prompts | Reuse and package product-scoped PM playbooks. |
+| Audit/signoff | decision interactions, backlog activities, tool execution | Reuse for funding and stakeholder review; do not add a roadmap-approval ledger. |
+
+## 8. Target operating loop
+
+```mermaid
+flowchart LR
+    E["Evidence<br/>research, customer signals, telemetry"] --> I["Product intelligence<br/>cited, reviewed, fresh"]
+    I --> D["Demand<br/>problem, evidence, value, effort"]
+    D --> F["Investment decision<br/>fund, defer, learn"]
+    F --> O["Objective and outcome<br/>measure, baseline, target"]
+    O --> R["Roadmap projection<br/>Now / Next / Later or timeline"]
+    R --> X["Delivery and release<br/>backlog, change, version"]
+    X --> M["Outcome observation<br/>result and learning"]
+    M --> I
+    A["Architecture and dependencies"] --> F
+    A --> R
+    C["AI coworker playbooks"] -. "prepare, explain, refresh" .-> I
+    C -. "prepare, explain, refresh" .-> D
+    C -. "prepare, explain, refresh" .-> R
+    C -. "prepare, explain, refresh" .-> M
+```
+
+### 8.1 Product operating context
+
+`ProductOperatingContext` is a server-side TypeScript read model, assembled through explicit query adapters:
+
+- product identity, lifecycle, ownership, and architecture constraints;
+- new or changed intelligence with source and review metadata;
+- demand funnel counts plus top explainable items;
+- pending decisions and funding posture;
+- active objectives and overdue reviews;
+- roadmap projection and dependency confidence;
+- delivery/release changes;
+- configured PM playbooks and next runs.
+
+The context returns source IDs and `asOf` timestamps. It does not store generated prose. Narrative summaries are generated from this bounded context and can be promoted to a product-linked `KnowledgeArticle` revision when a manager chooses to retain one.
+
+### 8.2 Minimal data changes
+
+Add nullable `digitalProductId` relations to:
+
+- `ResearchProposal`: a proposal is either organization-wide or for one product. Product scope is copied into resulting knowledge links.
+- `MarketingBattlecard`: a card is either organization-wide or product-specific. Product-specific positioning may coexist with an organization-wide card.
+
+Add:
+
+```text
+ProductObjective
+  objectiveId, digitalProductId, title, problemStatement, outcomeHypothesis
+  ownerPrincipalId?, measureKind, measureDefinition, baseline?, target?
+  status, reviewCadence?, reviewAt?, createdAt, updatedAt
+
+ProductObjectiveWork
+  objectiveId, backlogItemId, contributionKind
+
+ProductOutcomeObservation
+  observationId, objectiveId, observedAt, value?, narrative?
+  sourceKind, sourceRef?, confidence?, recordedByPrincipalId?, createdAt
+```
+
+Fixed string values are canonical enums in one TypeScript module and mirrored exactly in MCP schemas. Observations are append-only; corrections supersede rather than overwrite. Qualitative outcomes remain first-class through `narrative` plus evidence references.
+
+The migration is expand-first:
+
+- new tables are additive;
+- product foreign keys on existing models are nullable;
+- no existing organization-wide research or battlecard is guessed into a product;
+- any later tightening or uniqueness rule is a separate fleet-safe contract step.
+
+### 8.3 Demand activation
+
+The current demand fields become an explicit product workflow:
+
+1. capture or link the problem and evidence;
+2. select a demand stage;
+3. capture value inputs and their confidence;
+4. use known estimate provenance or mark it unknown;
+5. calculate and explain the demand score;
+6. assign an investment bucket;
+7. route funding through the existing governed approval;
+8. link funded work to an objective before it appears as a committed roadmap bet.
+
+Legacy rows are classified, not silently invented. An idempotent migration or governed backfill may assign a neutral intake stage only when a deterministic rule exists; otherwise the UI presents an explicit “not yet classified” queue. New product demand cannot silently omit its stage after the activation release.
+
+### 8.4 Roadmap projections
+
+The roadmap query takes canonical inputs and produces:
+
+- **Now / Next / Later** for broad alignment;
+- **timeline** where dates are supported by release/change evidence;
+- **outcome view** grouped by objective;
+- **dependency view** for architecture and delivery coordination.
+
+Every card explains:
+
+- the source demand and objective;
+- funding/commitment state;
+- timing confidence;
+- dependencies or blockers;
+- the evidence change that last moved it.
+
+Managers may filter and save audience preferences. They cannot directly drag a funded item into a contradictory state; the interaction opens the canonical funding, dependency, or delivery control. A portable export records filters, source IDs, `asOf`, and confidence.
+
+### 8.5 Reusable playbooks
+
+Initial product-scoped recipes:
+
+- weekly intelligence review;
+- demand triage and score-readiness review;
+- investment decision preparation;
+- roadmap refresh and stakeholder brief;
+- monthly/quarterly outcome review.
+
+Each recipe declares inputs, read tools, proposed writes, approval requirements, schedule, output contract, and failure/staleness behavior. The product manager can preview, schedule, pause, rerun, and inspect the evidence used.
+
+## 9. UX and information architecture
+
+### 9.1 Owning area
+
+The canonical route remains `/portfolio/product/[id]`. Add a **Direction** family to `ProductTabNav`, with:
+
+- Brief (`/direction`);
+- Intelligence (`/direction/intelligence`);
+- Roadmap (`/direction/roadmap`);
+- Outcomes (`/direction/outcomes`).
+
+The product Overview remains a concise identity/posture page and may show a single “Direction needs attention” handoff. Demand stays structurally backed by the existing backlog; the Direction brief projects the relevant demand state rather than moving or duplicating it. No new top-level navigation item is added.
+
+### 9.2 First viewport
+
+The Direction brief shows, in order:
+
+1. **Needs your decision** — funding, review, stale evidence, and blocked outcome reviews;
+2. **What changed** — source-linked deltas since the manager's last review;
+3. **Current bets** — funded work grouped by outcome with confidence;
+4. **Are outcomes moving?** — latest observation against baseline/target;
+5. **Next coworker runs** — scheduled PM playbooks and clear pause/preview controls.
+
+Counts and trend charts are secondary. Empty states teach the next useful action: run or approve research, classify product demand, define the first outcome, or connect delivery work.
+
+### 9.3 Interaction and accessibility contract
+
+- Reuse `SectionNav`, report-kit components, shared filters, knowledge cards, and staleness indicators.
+- One primary action per page; secondary actions use menus or contextual links.
+- AI write actions show the context window, proposed records, sources, and approval boundary before execution.
+- Derived content is labeled with source and `asOf`; stale or incomplete content never looks authoritative.
+- Keyboard order, visible focus, semantic headings, text alternatives, contrast, touch targets, 200% zoom, and narrow-width behavior meet the platform usability standard.
+- Loading, partial-data, empty, stale, unauthorized, and failed-run states are designed explicitly.
+
+## 10. Permissions, trust, and provenance
+
+- Product visibility and mutations use existing product, backlog, knowledge, and decision authorization.
+- Research execution remains approval-gated; generated corpus entries remain drafts until reviewed.
+- Outcome observations identify source kind and optional source reference.
+- Roadmap exports carry provenance and are never accepted back as authoritative imports.
+- AI summaries separate sourced facts, calculated values, and inferences.
+- Cross-product and organization-wide evidence is visible only when the caller is authorized for both the evidence and target product.
+
+## 11. Success measures
+
+Measure the loop without turning activity into a vanity score:
+
+- percentage of active products with reviewed intelligence in the freshness window;
+- percentage of product-linked demand classified and explainably scored;
+- median time from new evidence to a recorded investment decision;
+- percentage of funded roadmap bets linked to an active objective;
+- percentage of due objective reviews completed on time;
+- percentage of released bets with a subsequent outcome observation;
+- roadmap exports generated from current state rather than manually maintained artifacts;
+- manager correction/override rate for AI-prepared summaries and scores.
+
+Guardrails:
+
+- no decrease in source/provenance completeness;
+- no automatic publishing of research;
+- no growth in duplicate roadmap or idea authorities;
+- no AI mutation without its declared approval contract.
+
+## 12. Rollout
+
+1. Establish the projection and associations behind feature flags.
+2. Add outcome contracts and API/MCP surfaces.
+3. Activate demand for a small set of products with an explicit unclassified queue.
+4. Introduce Direction views and roadmap projections.
+5. Add scheduled playbooks and exports.
+6. Expand defaults after adoption, correction, and outcome-review evidence is healthy.
+
+The rollout is product-selective before becoming an organization default. Existing organization-wide research, battlecards, backlog, and product pages continue to function throughout.
+
+## 13. Architecture review (advisory)
+
+- **Alignment summary:** Well aligned after folding the convergence, principal, enum, projection, and fleet-safe migration guardrails into this design.
+- **Data model:** The design extends `DigitalProduct`, `ResearchProposal`, `MarketingBattlecard`, `KnowledgeArticle`, and `BacklogItem`. The only new canonical entity is the outcome contract proven absent by schema audit. Objective ownership resolves through `Principal`; it does not introduce another identity string.
+- **Single source of truth:** Demand remains the idea/investment authority; knowledge remains the reviewed narrative authority; roadmap and brief content remain projections; decision interactions remain the approval/audit authority.
+- **Substrate fit:** The route stays in Products, the scheduler and research executor are reused, reporting UI composes report-kit, and product query logic converges behind one read model.
+- **Enums and contracts:** New fixed strings must have one canonical TypeScript registry and exact MCP mirrors. Hyphens are required. No new value may be used in data before both contracts land.
+- **Blast radius:** Prisma schema/migration, product inverse relations, research execution, battlecard services and MCP pack, backlog demand rules, product navigation/routes, report components, skills/prompts, scheduled tasks, exports, telemetry, user guide, and tests.
+- **Standards researched:** Product Talk, Productboard, Jira Product Discovery, Plane, OpenProject, and Leantime informed traceability, derived audience views, recurring rhythms, progressive disclosure, and outcome roll-up. Their separate idea/roadmap authorities were explicitly rejected because DPF already has canonical demand and delivery records.
+- **Escalated decision:** Surface stitch vs projected operating loop vs parallel PM module was governed through the kernel; `DI-8B3E5799CA59` selected the projected loop.
+- **Reference-doc feedback:** None. The current architecture, usability, schema-audit, and single-source-of-truth references cover the durable rules found in this review.
+- **Recommended next step:** Proceed through the decomposed child items, beginning with the operating-context refactor and re-running substrate verification in each implementation branch.
+
+## 14. UX fit review
+
+- **Decision:** `fits-with-guardrails`; the required guardrails are already folded into Sections 8.3, 8.4, 9, and the implementation plan.
+- **Owning area:** Products.
+- **Route family:** `/portfolio/product/[id]/direction` and its Intelligence, Roadmap, and Outcomes sibling views.
+- **Primary persona:** Digital product manager deciding what to learn, fund, communicate, and review without remembering which platform subsystem owns each record.
+- **Navigation layer touched:** Product section navigation plus contextual actions; no global navigation.
+- **Reuse/convergence:** `ProductTabNav`, `SectionNav`, report-kit, knowledge cards, staleness indicators, shared filters, and scheduled-task controls. New components express product-specific composition, not a new visual dialect.
+- **Source truth:** `ProductOperatingContext` projects canonical product, research, knowledge, demand, objective, decision, architecture, release, change, and schedule sources.
+- **Empty/failure behavior:** Every page provides an honest next action for fresh, partial, stale, unavailable-provider, failed-run, and unauthorized states. Empty pages do not render zero-filled dashboards.
+- **AI boundary:** Informational cards and navigation never send prompts. Research, scoring, scheduling, mutation, and publishing actions require a context/write preview and the existing confirmation or approval boundary.
+- **Design-intelligence checks:** Adopt helpful empty states, URL-addressable view/filter state, visible active/disabled states, clear focus, readable type, and minimal/direct composition. Reject decorative dashboard density, alert animation, and hardcoded style/color recommendations.
+- **Evidence before merge:** Route and component tests; source-ID/provenance assertions; theme-token scan; browser verification at desktop and narrow widths, 200% zoom, keyboard-only operation, and populated/empty/stale/unauthorized fixtures; AI preview/cancel/approve exercises.
+- **Captured in:** this design and `docs/superpowers/plans/2026-07-27-product-management-operating-loop.md`.
+
+## 15. Non-goals
+
+- replacing the canonical backlog, epic, architecture, change, release, knowledge, or decision models;
+- introducing a free-standing Idea database;
+- adding a second global dashboard or command center;
+- making AI-generated research or scores authoritative without review;
+- promising dates where delivery evidence only supports sequence or confidence;
+- building a general OKR suite unrelated to product bets and learning;
+- auto-associating legacy organization records to products using guesses.
+
+## 16. Open implementation questions
+
+These are bounded implementation decisions, not architecture forks:
+
+- whether the first outcome measure supports a small typed family (`number`, `percentage`, `currency`, `duration`, `qualitative`) or uses a unit-plus-value contract;
+- whether saved roadmap audience preferences belong in the existing user preference substrate or a small product-view configuration record;
+- the deterministic eligibility rule, if any, for initially assigning legacy product-linked backlog to the intake stage;
+- which existing decision interaction type best records stakeholder roadmap review without expanding its enum.
+
+Each question must be resolved against the verified substrate and recorded in the implementing child backlog item before migration or UI work begins.


### PR DESCRIPTION
## Summary
- designs a product-management operating loop that converges DPF's existing research, battlecard, knowledge, demand, decision, scheduling, architecture, and delivery substrates
- adds a phased implementation plan with an explicit ~20% refactoring allocation and a minimal new product outcome-learning contract
- creates and records the live governed work under epic `EP-ED496EB0`, umbrella `BI-5C5FA641`, seven build-triaged child items, decision `DI-8B3E5799CA59`, and coverage receipt `cms3d0fbp03mb01p585znk4zf`

## Architecture and UX
- keeps the canonical home inside `/portfolio/product/[id]`; no second global PM cockpit
- treats roadmap and operating briefs as derived projections, not duplicate sources of truth
- preserves approval, provenance, freshness, accessibility, progressive-disclosure, and fleet-safe migration contracts
- includes an advisory architecture review and a UX fit review with implementation guardrails

## Research
The design incorporates lessons from Product Talk, Productboard, Jira Product Discovery, Plane, OpenProject, and Leantime while rejecting their parallel idea/roadmap authorities where DPF already has canonical substrate.

## Test plan
- [x] `git diff --cached --check`: clean before commit
- [x] plan mapping check: all seven child BI IDs and the governed coverage receipt are present
- [x] `check_plan_backlog_coverage`: current and valid
- [x] live audit: umbrella and seven child items are open, linked to the epic, build-triaged, and sized
- [x] DCO: commit carries `Signed-off-by`
- [x] overlap sweep: no open PR touches these artifacts
- [x] production build: not applicable — documentation/design only
- [x] UX verification: not applicable — no UI implementation; required evidence is specified per child
- [x] migration apply: not applicable — no schema change; fleet-safe migration gates are specified per child

Local-CI-Override: documentation-only design and plan; no runtime, schema, or UI implementation changed.