### PR TITLE
feat(crm): customer contact notification preference fields (BI-FS-003)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -10,6 +10,7 @@ import { CustomerSiteTree } from "@/components/customer/CustomerSiteTree";
 import { NewCustomerSiteButton } from "@/components/customer/NewCustomerSiteButton";
 import { AccountLifecycleActions } from "@/components/customer/AccountLifecycleActions";
 import { AddContactButton } from "@/components/customer/AddContactButton";
+import { ContactNotificationPrefs } from "@/components/customer/ContactNotificationPrefs";
 import { MergeCustomerAccountButton } from "@/components/customer/MergeCustomerAccountButton";
 import { UnmergeCustomerAccountButton } from "@/components/customer/UnmergeCustomerAccountButton";
 import { loadCustomerEstateSummary } from "@/lib/customer-estate/account-estate-summary";
@@ -71,6 +72,8 @@ export default async function AccountDetailPage({
             jobTitle: true,
             isActive: true,
             doNotContact: true,
+            preferredNotificationChannel: true,
+            phoneType: true,
           },
           orderBy: { createdAt: "asc" },
         },
@@ -420,6 +423,11 @@ export default async function AccountDetailPage({
                       />
                     )}
                   </div>
+                  <ContactNotificationPrefs
+                    contactId={c.id}
+                    preferredNotificationChannel={c.preferredNotificationChannel}
+                    phoneType={c.phoneType}
+                  />
                 </div>
               ))}
             </div>

--- a/apps/web/app/api/v1/customer/contacts/[id]/route.ts
+++ b/apps/web/app/api/v1/customer/contacts/[id]/route.ts
@@ -126,7 +126,14 @@ export async function PATCH(
 
     const prior = await prisma.customerContact.findUnique({
       where: { id },
-      select: { firstName: true, lastName: true, jobTitle: true, phone: true },
+      select: {
+        firstName: true,
+        lastName: true,
+        jobTitle: true,
+        phone: true,
+        preferredNotificationChannel: true,
+        phoneType: true,
+      },
     });
 
     const updated = await prisma.customerContact.update({
@@ -150,8 +157,17 @@ export async function PATCH(
         lastName: updated.lastName,
         jobTitle: updated.jobTitle,
         phone: updated.phone,
+        preferredNotificationChannel: updated.preferredNotificationChannel,
+        phoneType: updated.phoneType,
       },
-      attributes: ["firstName", "lastName", "jobTitle", "phone"],
+      attributes: [
+        "firstName",
+        "lastName",
+        "jobTitle",
+        "phone",
+        "preferredNotificationChannel",
+        "phoneType",
+      ],
       source: "api-patch",
     });
 

--- a/apps/web/components/customer/ContactNotificationPrefs.tsx
+++ b/apps/web/components/customer/ContactNotificationPrefs.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateCustomerContact } from "@/lib/actions/customer-contacts";
+
+const selectClasses =
+  "bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-2 py-1 text-[10px] focus:border-[var(--dpf-accent)] focus:outline-none w-full";
+const labelClasses = "block text-[9px] text-[var(--dpf-muted)] mb-0.5";
+
+const CHANNEL_OPTIONS = [
+  { value: "", label: "Not set" },
+  { value: "sms", label: "SMS" },
+  { value: "voice", label: "Voice" },
+  { value: "email", label: "Email" },
+  { value: "none", label: "Do not notify" },
+] as const;
+
+const PHONE_TYPE_OPTIONS = [
+  { value: "", label: "Not set" },
+  { value: "mobile", label: "Mobile" },
+  { value: "landline", label: "Landline" },
+  { value: "unknown", label: "Unknown" },
+] as const;
+
+type Props = {
+  contactId: string;
+  preferredNotificationChannel: string | null;
+  phoneType: string | null;
+};
+
+/**
+ * Compact edit surface for BI-FS-003 notification preference fields on a
+ * contact card. Dropdowns only — progressive disclosure without a wizard.
+ */
+export function ContactNotificationPrefs({
+  contactId,
+  preferredNotificationChannel,
+  phoneType,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [channel, setChannel] = useState(preferredNotificationChannel ?? "");
+  const [type, setType] = useState(phoneType ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const dirty =
+    (channel || null) !== (preferredNotificationChannel ?? null) ||
+    (type || null) !== (phoneType ?? null);
+
+  function save() {
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      try {
+        const result = await updateCustomerContact({
+          contactId,
+          preferredNotificationChannel: (channel || null) as
+            | "sms"
+            | "voice"
+            | "email"
+            | "none"
+            | null,
+          phoneType: (type || null) as "mobile" | "landline" | "unknown" | null,
+        });
+        if (result.outcome === "not-found") {
+          setError("Contact not found.");
+          return;
+        }
+        setSaved(true);
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Could not save preferences.");
+      }
+    });
+  }
+
+  return (
+    <div className="mt-2 space-y-1.5 border-t border-[var(--dpf-border)] pt-2">
+      <p className="text-[9px] font-medium text-[var(--dpf-muted)]">Notification preferences</p>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={labelClasses} htmlFor={`channel-${contactId}`}>
+            Preferred channel
+          </label>
+          <select
+            id={`channel-${contactId}`}
+            className={selectClasses}
+            value={channel}
+            onChange={(e) => {
+              setChannel(e.target.value);
+              setSaved(false);
+            }}
+            disabled={isPending}
+          >
+            {CHANNEL_OPTIONS.map((opt) => (
+              <option
+                key={opt.value || "unset"}
+                value={opt.value}
+                className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+              >
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClasses} htmlFor={`phoneType-${contactId}`}>
+            Phone type
+          </label>
+          <select
+            id={`phoneType-${contactId}`}
+            className={selectClasses}
+            value={type}
+            onChange={(e) => {
+              setType(e.target.value);
+              setSaved(false);
+            }}
+            disabled={isPending}
+          >
+            {PHONE_TYPE_OPTIONS.map((opt) => (
+              <option
+                key={opt.value || "unset"}
+                value={opt.value}
+                className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+              >
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <p className="text-[8px] text-[var(--dpf-muted)]">
+        Dispatch uses these before SMS or voice. Landline phones cannot receive texts.
+      </p>
+      {error && <p className="text-[9px] text-[var(--dpf-accent)]" role="alert">{error}</p>}
+      {saved && !dirty && (
+        <p className="text-[9px] text-[var(--dpf-muted)]">Saved</p>
+      )}
+      {dirty && (
+        <button
+          type="button"
+          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+          disabled={isPending}
+          onClick={save}
+        >
+          {isPending ? "Saving…" : "Save preferences"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/customer/ContactNotificationPrefs.tsx
+++ b/apps/web/components/customer/ContactNotificationPrefs.tsx
@@ -9,15 +9,15 @@ const selectClasses =
 const labelClasses = "mb-1 block text-dpf-caption text-[var(--dpf-muted)]";
 
 const CHANNEL_OPTIONS = [
-  { value: "", label: "Not set" },
+  { value: "", label: "—" },
   { value: "sms", label: "SMS" },
   { value: "voice", label: "Voice" },
   { value: "email", label: "Email" },
-  { value: "none", label: "Do not notify" },
+  { value: "none", label: "None" },
 ] as const;
 
 const PHONE_TYPE_OPTIONS = [
-  { value: "", label: "Not set" },
+  { value: "", label: "—" },
   { value: "mobile", label: "Mobile" },
   { value: "landline", label: "Landline" },
   { value: "unknown", label: "Unknown" },
@@ -65,26 +65,23 @@ export function ContactNotificationPrefs({
           phoneType: (type || null) as "mobile" | "landline" | "unknown" | null,
         });
         if (result.outcome === "not-found") {
-          setError("Contact not found.");
+          setError("Not found.");
           return;
         }
         setSaved(true);
         router.refresh();
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Could not save preferences.");
+        setError(e instanceof Error ? e.message : "Save failed.");
       }
     });
   }
 
   return (
     <div className="mt-2 space-y-2 border-t border-[var(--dpf-border)] pt-2">
-      <p className="text-dpf-caption font-dpf-medium text-[var(--dpf-muted)]">
-        Notification preferences
-      </p>
       <div className="grid grid-cols-2 gap-2">
         <div>
           <label className={labelClasses} htmlFor={`channel-${contactId}`}>
-            Preferred channel
+            Notify via
           </label>
           <select
             id={`channel-${contactId}`}
@@ -95,6 +92,7 @@ export function ContactNotificationPrefs({
               setSaved(false);
             }}
             disabled={isPending}
+            aria-label="Preferred notification channel"
           >
             {CHANNEL_OPTIONS.map((opt) => (
               <option
@@ -109,7 +107,7 @@ export function ContactNotificationPrefs({
         </div>
         <div>
           <label className={labelClasses} htmlFor={`phoneType-${contactId}`}>
-            Phone type
+            Phone
           </label>
           <select
             id={`phoneType-${contactId}`}
@@ -120,6 +118,7 @@ export function ContactNotificationPrefs({
               setSaved(false);
             }}
             disabled={isPending}
+            aria-label="Phone type"
           >
             {PHONE_TYPE_OPTIONS.map((opt) => (
               <option
@@ -133,9 +132,6 @@ export function ContactNotificationPrefs({
           </select>
         </div>
       </div>
-      <p className="text-dpf-caption text-[var(--dpf-muted)]">
-        Dispatch uses these before SMS or voice. Landline phones cannot receive texts.
-      </p>
       {error ? (
         <p className="text-dpf-caption text-[var(--dpf-accent)]" role="alert">
           {error}
@@ -151,7 +147,7 @@ export function ContactNotificationPrefs({
           disabled={isPending}
           onClick={save}
         >
-          {isPending ? "Saving…" : "Save preferences"}
+          {isPending ? "Saving…" : "Save"}
         </button>
       ) : null}
     </div>

--- a/apps/web/components/customer/ContactNotificationPrefs.tsx
+++ b/apps/web/components/customer/ContactNotificationPrefs.tsx
@@ -5,8 +5,8 @@ import { useRouter } from "next/navigation";
 import { updateCustomerContact } from "@/lib/actions/customer-contacts";
 
 const selectClasses =
-  "bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] rounded px-2 py-1 text-[10px] focus:border-[var(--dpf-accent)] focus:outline-none w-full";
-const labelClasses = "block text-[9px] text-[var(--dpf-muted)] mb-0.5";
+  "w-full rounded-dpf-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-dpf-caption text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "mb-1 block text-dpf-caption text-[var(--dpf-muted)]";
 
 const CHANNEL_OPTIONS = [
   { value: "", label: "Not set" },
@@ -77,8 +77,10 @@ export function ContactNotificationPrefs({
   }
 
   return (
-    <div className="mt-2 space-y-1.5 border-t border-[var(--dpf-border)] pt-2">
-      <p className="text-[9px] font-medium text-[var(--dpf-muted)]">Notification preferences</p>
+    <div className="mt-2 space-y-2 border-t border-[var(--dpf-border)] pt-2">
+      <p className="text-dpf-caption font-dpf-medium text-[var(--dpf-muted)]">
+        Notification preferences
+      </p>
       <div className="grid grid-cols-2 gap-2">
         <div>
           <label className={labelClasses} htmlFor={`channel-${contactId}`}>
@@ -131,23 +133,27 @@ export function ContactNotificationPrefs({
           </select>
         </div>
       </div>
-      <p className="text-[8px] text-[var(--dpf-muted)]">
+      <p className="text-dpf-caption text-[var(--dpf-muted)]">
         Dispatch uses these before SMS or voice. Landline phones cannot receive texts.
       </p>
-      {error && <p className="text-[9px] text-[var(--dpf-accent)]" role="alert">{error}</p>}
-      {saved && !dirty && (
-        <p className="text-[9px] text-[var(--dpf-muted)]">Saved</p>
-      )}
-      {dirty && (
+      {error ? (
+        <p className="text-dpf-caption text-[var(--dpf-accent)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {saved && !dirty ? (
+        <p className="text-dpf-caption text-[var(--dpf-muted)]">Saved</p>
+      ) : null}
+      {dirty ? (
         <button
           type="button"
-          className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+          className="rounded-dpf-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-dpf-caption font-dpf-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
           disabled={isPending}
           onClick={save}
         >
           {isPending ? "Saving…" : "Save preferences"}
         </button>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/lib/actions/customer-contacts.ts
+++ b/apps/web/lib/actions/customer-contacts.ts
@@ -30,6 +30,8 @@ export async function createCustomerContact(
     phone?: string;
     jobTitle?: string;
     notes?: string;
+    preferredNotificationChannel?: "sms" | "voice" | "email" | "none" | null;
+    phoneType?: "mobile" | "landline" | "unknown" | null;
   },
   dedup?: DedupResolution,
 ): Promise<CreateCustomerContactResult> {
@@ -81,6 +83,11 @@ export async function createCustomerContact(
       nameNormalized: standardizeName(displayName),
       phone: input.phone?.trim() || null,
       jobTitle: input.jobTitle?.trim() || null,
+      preferredNotificationChannel: input.preferredNotificationChannel ?? null,
+      // Default phoneType to unknown when a phone is captured without a type (BI-FS-003).
+      phoneType:
+        input.phoneType ??
+        (input.phone?.trim() ? "unknown" : null),
       source: "manual",
     },
   });
@@ -103,4 +110,46 @@ export async function createCustomerContact(
   revalidatePath(`/customer/${input.accountId}`);
   revalidatePath("/customer");
   return { outcome: "created", contact };
+}
+
+export type UpdateCustomerContactResult =
+  | { outcome: "updated"; contact: Awaited<ReturnType<typeof prisma.customerContact.update>> }
+  | { outcome: "not-found" };
+
+/** Update notification preference fields (BI-FS-003) and other contact attributes. */
+export async function updateCustomerContact(input: {
+  contactId: string;
+  preferredNotificationChannel?: "sms" | "voice" | "email" | "none" | null;
+  phoneType?: "mobile" | "landline" | "unknown" | null;
+  phone?: string | null;
+  jobTitle?: string | null;
+}): Promise<UpdateCustomerContactResult> {
+  const existing = await prisma.customerContact.findUnique({
+    where: { id: input.contactId },
+    select: { id: true, accountId: true },
+  });
+  if (!existing) return { outcome: "not-found" };
+
+  const data: Record<string, string | null> = {};
+  if (input.preferredNotificationChannel !== undefined) {
+    data.preferredNotificationChannel = input.preferredNotificationChannel;
+  }
+  if (input.phoneType !== undefined) {
+    data.phoneType = input.phoneType;
+  }
+  if (input.phone !== undefined) {
+    data.phone = input.phone?.trim() || null;
+  }
+  if (input.jobTitle !== undefined) {
+    data.jobTitle = input.jobTitle?.trim() || null;
+  }
+
+  const contact = await prisma.customerContact.update({
+    where: { id: input.contactId },
+    data,
+  });
+
+  revalidatePath(`/customer/${existing.accountId}`);
+  revalidatePath("/customer");
+  return { outcome: "updated", contact };
 }

--- a/docs/data-impact/2026-07-27-customer-contact-notification-prefs.data-impact.json
+++ b/docs/data-impact/2026-07-27-customer-contact-notification-prefs.data-impact.json
@@ -1,0 +1,42 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Customer account contact card UI on /customer/[id]",
+    "CRM contact PATCH API attribute history",
+    "Field-service dispatcher preference reads (BI-FS-005/006 consumers)"
+  ],
+  "migration": {
+    "name": "20260727150000_customer_contact_notification_prefs",
+    "backfill": "none; both columns are nullable TEXT. Existing CustomerContact rows remain valid with NULL meaning preference not set yet. No delete, drop, or overwrite."
+  },
+  "tests": [
+    "packages/validators/src/customer-notification-preference.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:customer-contact",
+      "prismaModel": "CustomerContact",
+      "lifecycleDisposition": "contact-scoped operational preference; cleared when the contact is merged/deactivated or set to none by the operator; retained with the contact record under existing confidential contact retention",
+      "fields": [
+        {
+          "fieldId": "data:customer-contact#preferredNotificationChannel",
+          "resolution": "governed",
+          "reason": "states how the operator prefers the platform to reach this person for field-service and CRM outreach (sms|voice|email|none); drives dispatch channel selection and must not be inferred silently from free text",
+          "provenance": "BI-FS-003; docs/superpowers/specs/2026-05-19-field-service-trades-ai-dispatch-design.md; docs/superpowers/plans/2026-05-19-field-service-sprint-1.md",
+          "flags": ["subject"],
+          "fieldPolicy": "organization-operational contact preference only; not a principal, auth factor, or routing identity key; closed set enforced in packages/validators"
+        },
+        {
+          "fieldId": "data:customer-contact#phoneType",
+          "resolution": "governed",
+          "reason": "distinguishes mobile vs landline so SMS is not sent to non-SMS numbers; supports TCPA-aware dispatch without inventing a second phone table",
+          "provenance": "BI-FS-003; field-service AI dispatch design §customer notification preference",
+          "flags": ["subject"],
+          "fieldPolicy": "organization-operational contact attribute for the existing phone string; not used as identity; closed set enforced in packages/validators"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260727150000_customer_contact_notification_prefs/migration.sql
+++ b/packages/db/prisma/migrations/20260727150000_customer_contact_notification_prefs/migration.sql
@@ -1,0 +1,7 @@
+-- BI-FS-003: additive notification preference fields on CustomerContact.
+-- @migration-safety: data-safe: both columns are nullable with no NOT NULL and no UNIQUE;
+-- existing rows stay valid with NULL meaning "preference not set yet".
+
+ALTER TABLE "CustomerContact"
+ADD COLUMN "preferredNotificationChannel" TEXT,
+ADD COLUMN "phoneType" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -144,6 +144,12 @@ model CustomerContact {
   // email stays the unique identity key.
   nameNormalized   String               @default("")
   phone            String?
+  // Field-service dispatch (BI-FS-003): how to reach this contact and whether
+  // the phone is SMS-capable. Nullable = operator has not set a preference yet.
+  // Allowed values enforced in packages/validators (not a Prisma enum — closed
+  // set may grow without a DB migration).
+  preferredNotificationChannel String? // sms | voice | email | none
+  phoneType                    String? // mobile | landline | unknown
   jobTitle         String?
   linkedinUrl      String?
   source           String? // web | referral | import | manual

--- a/packages/validators/src/customer-notification-preference.test.ts
+++ b/packages/validators/src/customer-notification-preference.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTACT_PHONE_TYPES,
+  CustomerNotificationPreference,
+  PREFERRED_NOTIFICATION_CHANNELS,
+  contactPhoneTypeSchema,
+  createContactSchema,
+  preferredNotificationChannelSchema,
+  updateContactSchema,
+} from "./customer";
+
+describe("CustomerNotificationPreference (BI-FS-003)", () => {
+  it("accepts every allowed channel and phone type", () => {
+    for (const preferredNotificationChannel of PREFERRED_NOTIFICATION_CHANNELS) {
+      expect(preferredNotificationChannelSchema.parse(preferredNotificationChannel)).toBe(
+        preferredNotificationChannel,
+      );
+    }
+    for (const phoneType of CONTACT_PHONE_TYPES) {
+      expect(contactPhoneTypeSchema.parse(phoneType)).toBe(phoneType);
+    }
+    expect(
+      CustomerNotificationPreference.parse({
+        preferredNotificationChannel: "sms",
+        phoneType: "mobile",
+      }),
+    ).toEqual({ preferredNotificationChannel: "sms", phoneType: "mobile" });
+  });
+
+  it("rejects invalid channel and phone type values", () => {
+    expect(() => preferredNotificationChannelSchema.parse("fax")).toThrow();
+    expect(() => contactPhoneTypeSchema.parse("voip")).toThrow();
+    expect(() =>
+      CustomerNotificationPreference.parse({
+        preferredNotificationChannel: "carrier-pigeon",
+        phoneType: "mobile",
+      }),
+    ).toThrow();
+  });
+
+  it("allows null/omitted preference (operator has not set yet)", () => {
+    expect(CustomerNotificationPreference.parse({})).toEqual({});
+    expect(
+      CustomerNotificationPreference.parse({
+        preferredNotificationChannel: null,
+        phoneType: null,
+      }),
+    ).toEqual({ preferredNotificationChannel: null, phoneType: null });
+  });
+
+  it("accepts preference fields on create and update contact schemas", () => {
+    const created = createContactSchema.parse({
+      email: "tech@example.com",
+      accountId: "acct_1",
+      preferredNotificationChannel: "sms",
+      phoneType: "mobile",
+    });
+    expect(created.preferredNotificationChannel).toBe("sms");
+    expect(created.phoneType).toBe("mobile");
+
+    const updated = updateContactSchema.parse({
+      preferredNotificationChannel: "none",
+      phoneType: "landline",
+    });
+    expect(updated).toEqual({
+      preferredNotificationChannel: "none",
+      phoneType: "landline",
+    });
+  });
+
+  it("rejects invalid preference values on contact update", () => {
+    expect(() =>
+      updateContactSchema.parse({ preferredNotificationChannel: "telegram" }),
+    ).toThrow();
+  });
+});

--- a/packages/validators/src/customer.ts
+++ b/packages/validators/src/customer.ts
@@ -1,5 +1,26 @@
 import { z } from "zod";
 
+// BI-FS-003 — closed preference enums for field-service dispatch routing.
+// Source of truth for allowed values (DB stores free strings; validators gate writes).
+export const PREFERRED_NOTIFICATION_CHANNELS = ["sms", "voice", "email", "none"] as const;
+export type PreferredNotificationChannel = (typeof PREFERRED_NOTIFICATION_CHANNELS)[number];
+
+export const CONTACT_PHONE_TYPES = ["mobile", "landline", "unknown"] as const;
+export type ContactPhoneType = (typeof CONTACT_PHONE_TYPES)[number];
+
+export const preferredNotificationChannelSchema = z.enum(PREFERRED_NOTIFICATION_CHANNELS);
+export const contactPhoneTypeSchema = z.enum(CONTACT_PHONE_TYPES);
+
+/**
+ * CustomerNotificationPreference — used by the dispatcher (BI-FS-005/006) and
+ * CRM contact create/update paths. Null/undefined means "not set yet".
+ */
+export const CustomerNotificationPreference = z.object({
+  preferredNotificationChannel: preferredNotificationChannelSchema.nullable().optional(),
+  phoneType: contactPhoneTypeSchema.nullable().optional(),
+});
+export type CustomerNotificationPreference = z.infer<typeof CustomerNotificationPreference>;
+
 export const updateCustomerSchema = z.object({
   name: z.string().min(1).max(200).optional(),
   industry: z.string().max(100).optional(),
@@ -35,6 +56,8 @@ export const createContactSchema = z.object({
   linkedinUrl: z.string().url().max(500).optional().or(z.literal("")),
   source: z.enum(["web", "referral", "import", "manual"]).optional(),
   accountId: z.string(),
+  preferredNotificationChannel: preferredNotificationChannelSchema.optional().nullable(),
+  phoneType: contactPhoneTypeSchema.optional().nullable(),
 });
 
 export type CreateContactInput = z.infer<typeof createContactSchema>;
@@ -48,6 +71,8 @@ export const updateContactSchema = z.object({
   doNotContact: z.boolean().optional(),
   avatarUrl: z.string().url().max(500).optional().or(z.literal("")),
   isActive: z.boolean().optional(),
+  preferredNotificationChannel: preferredNotificationChannelSchema.optional().nullable(),
+  phoneType: contactPhoneTypeSchema.optional().nullable(),
 });
 
 export type UpdateContactInput = z.infer<typeof updateContactSchema>;

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -4332,6 +4332,13 @@
     "longSentences": 0,
     "textMass": 41
   },
+  "apps/web/components/customer/ContactNotificationPrefs.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
   "apps/web/components/customer/CustomerLifecycleReviewQueues.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary
Implements **BI-FS-003** (Field Service sprint-1): additive notification preference fields on `CustomerContact` so dispatch can choose SMS/voice/email and know phone type.

- Schema + fleet-safe additive migration (`preferredNotificationChannel`, `phoneType`)
- `CustomerNotificationPreference` validators + create/update contact schema fields
- Server actions + API PATCH history
- Contact-card dropdown UI on customer account page
- Data-impact manifest for the new contact fields

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-05-19-field-service-trades-ai-dispatch-design.md
  - docs/superpowers/plans/2026-05-19-field-service-sprint-1.md
- Current code substrate reviewed:
  - packages/db/prisma/schema.prisma (CustomerContact)
  - packages/validators/src/customer.ts
  - apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
  - apps/web/lib/actions/customer-contacts.ts
  - apps/web/app/api/v1/customer/contacts/[id]/route.ts
- Source of truth: CustomerContact + validators closed enums; account contact card projection
- Decision: extend existing contact model and contact-card UI; no new route or table

## Test plan
- [x] Pre-commit typecheck (web + validators)
- [x] Zod smoke validation of allowed/rejected channel and phone-type values
- [x] Local style-drift / data-impact / design-grounding scripts
- [ ] CI unit tests / migration safety
- [ ] Live: edit contact prefs on `/customer/[id]`, save, reload, confirm persistence

Local-CI-Override: source-local typecheck + zod smoke + gate scripts; full pregate via CI for additive schema/UI slice.

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-05-19-field-service-trades-ai-dispatch-design.md and docs/superpowers/plans/2026-05-19-field-service-sprint-1.md; code substrate apps/web/components/customer and packages/validators/src/customer.ts.

UX-Fit-Decision: progressive disclosure on contact cards; two plain dropdowns with Not set default; caption-scale type tokens.