### PR TITLE
feat(authority): govern coworker tool execution

### DIFF
--- a/apps/web/app/api/mcp/call/route.test.ts
+++ b/apps/web/app/api/mcp/call/route.test.ts
@@ -115,4 +115,62 @@ describe("POST /api/mcp/call", () => {
     );
     expect(res.status).toBe(403);
   });
+
+  it("maps a unified coworker authority denial to 403", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "authority_denied",
+      message: "The current human cannot act on the selected record.",
+      governance: {
+        rejected: "authority_denied",
+        authorityReason: "subject-scope-denied",
+      },
+    });
+    const res = await POST(
+      makeRequest({ name: "read_employee", agentId: "AGT-100" }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 202 with the bounded envelope when approval is required", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "approval_required",
+      message: "Human approval is required.",
+      data: { envelopeId: "ENV-1" },
+      governance: {
+        rejected: "approval_required",
+        authorityReason: "approval-required",
+      },
+    });
+    const res = await POST(
+      makeRequest({ name: "create_backlog_item", agentId: "AGT-100" }),
+    );
+    expect(res.status).toBe(202);
+    await expect(res.json()).resolves.toMatchObject({
+      data: { envelopeId: "ENV-1" },
+    });
+  });
+
+  it("returns 503 when required authority evidence cannot be recorded", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u1", platformRole: "ceo", isSuperuser: true },
+    });
+    govMock.mockResolvedValue({
+      success: false,
+      error: "authority_evidence_unavailable",
+      message: "Authority evidence could not be recorded.",
+      governance: { rejected: "authority_evidence_unavailable" },
+    });
+    const res = await POST(
+      makeRequest({ name: "query_backlog", agentId: "AGT-100" }),
+    );
+    expect(res.status).toBe(503);
+  });
 });

--- a/apps/web/app/api/mcp/call/route.ts
+++ b/apps/web/app/api/mcp/call/route.ts
@@ -48,9 +48,16 @@ export async function POST(request: Request) {
   }
   if (
     result.governance?.rejected === "forbidden_capability" ||
-    result.governance?.rejected === "forbidden_grant"
+    result.governance?.rejected === "forbidden_grant" ||
+    result.governance?.rejected === "authority_denied"
   ) {
     return Response.json(result, { status: 403 });
+  }
+  if (result.governance?.rejected === "approval_required") {
+    return Response.json(result, { status: 202 });
+  }
+  if (result.governance?.rejected === "authority_evidence_unavailable") {
+    return Response.json(result, { status: 503 });
   }
 
   return Response.json(result);

--- a/apps/web/lib/coworker/authority-approval-envelope.test.ts
+++ b/apps/web/lib/coworker/authority-approval-envelope.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CoworkerApprovalBinding } from "@/lib/govern/authority/coworker-authority-decision";
+
+import {
+  ensureAuthorityApprovalEnvelope,
+  findApprovedAuthorityEnvelope,
+  resumeAuthorityApprovalTask,
+} from "./authority-approval-envelope";
+
+const BINDING: CoworkerApprovalBinding = {
+  actingHumanUserId: "user-1",
+  actingAgentId: "AGT-1",
+  chainId: "CHAIN-1",
+  taskRunId: "TASK-1",
+  toolName: "create_backlog_item",
+  subject: { kind: "platform", id: "dpf" },
+  routeContext: "/ops",
+  inputFingerprint: "input-fingerprint",
+  sensitivity: "internal",
+  decisionVersionFingerprint: "policy-fingerprint",
+};
+
+function db() {
+  return {
+    coworkerActionEnvelope: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    taskRun: {
+      updateMany: vi.fn(),
+    },
+  };
+}
+
+describe("authority approval envelopes", () => {
+  it("creates one privacy-safe envelope and pauses only the exact task", async () => {
+    const mockDb = db();
+    mockDb.coworkerActionEnvelope.findFirst.mockResolvedValue(null);
+    mockDb.coworkerActionEnvelope.create.mockResolvedValue({
+      id: "ENV-1",
+      status: "proposed",
+      expiresAt: new Date("2026-07-27T11:15:00Z"),
+    });
+
+    const result = await ensureAuthorityApprovalEnvelope(
+      {
+        binding: BINDING,
+        authorityDecisionId: "AUTH-1",
+        threadId: "THREAD-1",
+        explanation: "Approval is required.",
+        now: new Date("2026-07-27T11:00:00Z"),
+      },
+      mockDb,
+    );
+
+    expect(result.id).toBe("ENV-1");
+    expect(mockDb.coworkerActionEnvelope.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        taskRunId: "TASK-1",
+        delegationChainId: "CHAIN-1",
+        authorityDecisionId: "AUTH-1",
+        inputFingerprint: "input-fingerprint",
+        manifestActionId: "create_backlog_item",
+        argsJson: { approvalBinding: BINDING },
+      }),
+    });
+    expect(
+      JSON.stringify(mockDb.coworkerActionEnvelope.create.mock.calls),
+    ).not.toContain("private title");
+    expect(mockDb.taskRun.updateMany).toHaveBeenCalledWith({
+      where: {
+        taskRunId: "TASK-1",
+        status: { in: ["submitted", "working"] },
+      },
+      data: { status: "input-required" },
+    });
+  });
+
+  it("reuses the active envelope for an identical binding", async () => {
+    const mockDb = db();
+    mockDb.coworkerActionEnvelope.findFirst.mockResolvedValue({
+      id: "ENV-EXISTING",
+      status: "proposed",
+      expiresAt: new Date("2026-07-27T11:15:00Z"),
+    });
+
+    const result = await ensureAuthorityApprovalEnvelope(
+      {
+        binding: BINDING,
+        authorityDecisionId: "AUTH-2",
+        threadId: "THREAD-1",
+        explanation: "Approval is required.",
+        now: new Date("2026-07-27T11:00:00Z"),
+      },
+      mockDb,
+    );
+
+    expect(result.id).toBe("ENV-EXISTING");
+    expect(mockDb.coworkerActionEnvelope.create).not.toHaveBeenCalled();
+  });
+
+  it("returns only an approved, unexpired envelope with its exact binding", async () => {
+    const mockDb = db();
+    mockDb.coworkerActionEnvelope.findFirst.mockResolvedValue({
+      id: "ENV-APPROVED",
+      status: "approved",
+      expiresAt: new Date("2026-07-27T11:15:00Z"),
+      argsJson: { approvalBinding: BINDING },
+    });
+
+    await expect(
+      findApprovedAuthorityEnvelope(
+        BINDING,
+        new Date("2026-07-27T11:00:00Z"),
+        mockDb,
+      ),
+    ).resolves.toEqual({
+      envelopeId: "ENV-APPROVED",
+      status: "approved",
+      expiresAt: new Date("2026-07-27T11:15:00Z"),
+      binding: BINDING,
+    });
+  });
+
+  it("resumes only the task bound to the approved envelope", async () => {
+    const markWorking = vi.fn().mockResolvedValue(undefined);
+    await resumeAuthorityApprovalTask("TASK-1", markWorking);
+    expect(markWorking).toHaveBeenCalledWith("TASK-1");
+  });
+});

--- a/apps/web/lib/coworker/authority-approval-envelope.ts
+++ b/apps/web/lib/coworker/authority-approval-envelope.ts
@@ -1,0 +1,210 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+
+import {
+  fingerprintCoworkerApprovalBinding,
+  type CoworkerApprovalBinding,
+} from "@/lib/govern/authority/coworker-authority-decision";
+import { markTaskRunWorking } from "@/lib/observability/heartbeat";
+
+const APPROVAL_TTL_MS = 15 * 60 * 1000;
+
+type EnvelopeSummary = {
+  id: string;
+  status: string;
+  expiresAt: Date | null;
+  argsJson?: unknown;
+};
+
+type AuthorityApprovalDb = {
+  coworkerActionEnvelope: {
+    findFirst(args: unknown): Promise<EnvelopeSummary | null>;
+    create(args: unknown): Promise<EnvelopeSummary>;
+    updateMany(args: unknown): Promise<unknown>;
+  };
+  taskRun: { updateMany(args: unknown): Promise<unknown> };
+};
+
+type MarkTaskWorking = (taskRunId: string) => Promise<void>;
+
+function activeEnvelopeWhere(
+  approvalBindingFingerprint: string,
+  now: Date,
+) {
+  return {
+    approvalBindingFingerprint,
+    status: { in: ["proposed", "approved"] },
+    expiresAt: { gt: now },
+  };
+}
+
+async function findActiveEnvelope(
+  approvalBindingFingerprint: string,
+  now: Date,
+  db: AuthorityApprovalDb,
+): Promise<EnvelopeSummary | null> {
+  return db.coworkerActionEnvelope.findFirst({
+    where: activeEnvelopeWhere(approvalBindingFingerprint, now),
+    orderBy: { createdAt: "desc" },
+    select: { id: true, status: true, expiresAt: true, argsJson: true },
+  });
+}
+
+async function pauseBoundTask(
+  taskRunId: string | null,
+  db: AuthorityApprovalDb,
+): Promise<void> {
+  if (!taskRunId) return;
+  await db.taskRun.updateMany({
+    where: {
+      taskRunId,
+      status: { in: ["submitted", "working"] },
+    },
+    data: { status: "input-required" },
+  });
+}
+
+export async function ensureAuthorityApprovalEnvelope(
+  input: {
+    binding: CoworkerApprovalBinding;
+    authorityDecisionId: string;
+    threadId: string | null;
+    explanation: string;
+    now?: Date;
+  },
+  db: AuthorityApprovalDb = prisma as unknown as AuthorityApprovalDb,
+): Promise<EnvelopeSummary> {
+  const now = input.now ?? new Date();
+  const approvalBindingFingerprint =
+    fingerprintCoworkerApprovalBinding(input.binding);
+
+  // Free the active-binding uniqueness slot when an abandoned proposal has
+  // expired. This is a legal proposed|approved -> cancelled transition.
+  await db.coworkerActionEnvelope.updateMany({
+    where: {
+      approvalBindingFingerprint,
+      status: { in: ["proposed", "approved"] },
+      expiresAt: { lte: now },
+    },
+    data: { status: "cancelled", resolvedAt: now },
+  });
+
+  const existing = await findActiveEnvelope(
+    approvalBindingFingerprint,
+    now,
+    db,
+  );
+  if (existing) {
+    await pauseBoundTask(input.binding.taskRunId, db);
+    return existing;
+  }
+
+  const expiresAt = new Date(now.getTime() + APPROVAL_TTL_MS);
+  let created: EnvelopeSummary;
+  try {
+    created = await db.coworkerActionEnvelope.create({
+      data: {
+        coworkerAgentId: input.binding.actingAgentId,
+        delegatingUserId: input.binding.actingHumanUserId,
+        threadId:
+          input.threadId
+          ?? (input.binding.taskRunId
+            ? `task:${input.binding.taskRunId}`
+            : `authority:${input.binding.actingAgentId}`),
+        manifestActionId: input.binding.toolName,
+        // Never persist raw tool arguments in the universal authority
+        // envelope. The exact-call fingerprint and bounded binding are enough
+        // to prove what the human approved.
+        argsJson: { approvalBinding: input.binding },
+        rationale: input.explanation,
+        taskRunId: input.binding.taskRunId,
+        delegationChainId: input.binding.chainId,
+        authorityDecisionId: input.authorityDecisionId,
+        inputFingerprint: input.binding.inputFingerprint,
+        approvalBindingFingerprint,
+        expiresAt,
+      },
+    });
+  } catch (err) {
+    // The partial unique index arbitrates concurrent identical proposals.
+    // A losing writer reuses the winner instead of surfacing a duplicate card.
+    const winner = await findActiveEnvelope(
+      approvalBindingFingerprint,
+      now,
+      db,
+    );
+    if (!winner) throw err;
+    created = winner;
+  }
+
+  await pauseBoundTask(input.binding.taskRunId, db);
+  return created;
+}
+
+export async function findApprovedAuthorityEnvelope(
+  binding: CoworkerApprovalBinding,
+  now: Date = new Date(),
+  db: AuthorityApprovalDb = prisma as unknown as AuthorityApprovalDb,
+): Promise<{
+  envelopeId: string;
+  status: "approved";
+  expiresAt: Date;
+  binding: CoworkerApprovalBinding;
+} | null> {
+  const approvalBindingFingerprint =
+    fingerprintCoworkerApprovalBinding(binding);
+  const row = await db.coworkerActionEnvelope.findFirst({
+    where: {
+      approvalBindingFingerprint,
+      status: "approved",
+      expiresAt: { gt: now },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, status: true, expiresAt: true, argsJson: true },
+  });
+  if (!row?.expiresAt) return null;
+
+  const args =
+    row.argsJson && typeof row.argsJson === "object"
+      ? (row.argsJson as Record<string, unknown>)
+      : null;
+  const storedBinding = args?.approvalBinding;
+  if (
+    !storedBinding
+    || typeof storedBinding !== "object"
+    || fingerprintCoworkerApprovalBinding(
+      storedBinding as CoworkerApprovalBinding,
+    ) !== approvalBindingFingerprint
+  ) {
+    return null;
+  }
+
+  return {
+    envelopeId: row.id,
+    status: "approved",
+    expiresAt: row.expiresAt,
+    binding,
+  };
+}
+
+export async function resumeAuthorityApprovalTask(
+  taskRunId: string,
+  markWorking: MarkTaskWorking = markTaskRunWorking,
+): Promise<void> {
+  await markWorking(taskRunId);
+}
+
+export async function finalizeAuthorityApprovalEnvelope(
+  envelopeId: string,
+  success: boolean,
+  db: AuthorityApprovalDb = prisma as unknown as AuthorityApprovalDb,
+): Promise<void> {
+  await db.coworkerActionEnvelope.updateMany({
+    where: { id: envelopeId, status: "approved" },
+    data: {
+      status: success ? "executed" : "failed",
+      resolvedAt: new Date(),
+    },
+  });
+}

--- a/apps/web/lib/govern/authority/authority-subject.ts
+++ b/apps/web/lib/govern/authority/authority-subject.ts
@@ -1,0 +1,57 @@
+import { canAccessEmployeeRecord } from "@/lib/govern/permissions";
+import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+
+export type AuthoritySubject =
+  | { kind: "employee"; id: string }
+  | { kind: "account"; id: string }
+  | { kind: "contact"; id: string }
+  | { kind: "partner-account"; id: string }
+  | { kind: "principal"; id: string }
+  | { kind: "team"; id: string }
+  | { kind: "platform"; id: string };
+
+function canAccessCustomerScope(
+  context: EffectiveAuthContext,
+  ids: readonly string[],
+  subjectId: string,
+): boolean {
+  if (!ids.includes(subjectId)) return false;
+  return (
+    context.population === "customer" ||
+    context.population === "partner" ||
+    context.grantedCapabilities.includes("view_customer")
+  );
+}
+
+export function canAccessAuthoritySubject(
+  context: EffectiveAuthContext,
+  subject: AuthoritySubject | null | undefined,
+): boolean {
+  if (!subject || subject.kind === "platform") return true;
+  switch (subject.kind) {
+    case "employee":
+      return canAccessEmployeeRecord(context, subject.id);
+    case "account":
+      return canAccessCustomerScope(
+        context,
+        context.accountScope.accountIds,
+        subject.id,
+      );
+    case "contact":
+      return canAccessCustomerScope(
+        context,
+        context.accountScope.contactIds,
+        subject.id,
+      );
+    case "partner-account":
+      return canAccessCustomerScope(
+        context,
+        context.accountScope.partnerAccountIds,
+        subject.id,
+      );
+    case "principal":
+      return context.principalId === subject.id;
+    case "team":
+      return context.teamIds.includes(subject.id);
+  }
+}

--- a/apps/web/lib/govern/authority/coworker-authority-decision.test.ts
+++ b/apps/web/lib/govern/authority/coworker-authority-decision.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+
+import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+
+import {
+  buildCoworkerApprovalBinding,
+  evaluateCoworkerAuthority,
+  type CoworkerAuthorityInput,
+} from "./coworker-authority-decision";
+
+function auth(
+  overrides: Partial<EffectiveAuthContext> = {},
+): EffectiveAuthContext {
+  return {
+    principalId: "PRN-HUMAN",
+    principalAliases: [],
+    population: "workforce",
+    platformRole: "HR-200",
+    isSuperuser: false,
+    employeeId: "EMP-MANAGER",
+    managerScope: {
+      directReportIds: ["EMP-REPORT"],
+      indirectReportIds: [],
+    },
+    teamIds: ["TEAM-OPS"],
+    accountScope: {
+      accountIds: ["ACCOUNT-1"],
+      contactIds: [],
+      partnerAccountIds: [],
+    },
+    sensitivityClearance: ["public", "internal", "confidential"],
+    authentication: {
+      source: "session",
+      methods: ["pwd", "mfa"],
+      contextClassReference: "urn:dpf:mfa",
+    },
+    actingHumanUserId: "USER-1",
+    actingAgentId: "AGT-CHILD",
+    delegationGrantIds: ["DG-1"],
+    grantedCapabilities: ["view_employee", "manage_employee"],
+    ...overrides,
+  };
+}
+
+function base(
+  overrides: Partial<CoworkerAuthorityInput> = {},
+): CoworkerAuthorityInput {
+  return {
+    authContext: auth(),
+    action: {
+      toolName: "update_employee",
+      requiredCapability: "manage_employee",
+      agentGrantAllowed: true,
+      sideEffect: true,
+      executionMode: "immediate",
+      routeContext: "/people",
+      approvalPolicy: "side-effects",
+    },
+    subject: { kind: "employee", id: "EMP-REPORT" },
+    delegation: {
+      chainId: "CHAIN-1",
+      status: "active",
+      originUserId: "USER-1",
+      currentAgentId: "AGT-CHILD",
+      authorityScope: ["manage_employee"],
+    },
+    integration: { required: false, state: "not-required" },
+    dataPolicy: {
+      sensitivity: "confidential",
+      maskingRequired: false,
+      maskingSatisfied: true,
+      decisionVersionsCurrent: true,
+    },
+    task: {
+      taskRunId: "TASK-CHILD",
+      parentTaskRunId: "TASK-PARENT",
+    },
+    rawParams: { employeeId: "EMP-REPORT", title: "Lead" },
+    ...overrides,
+  };
+}
+
+describe("evaluateCoworkerAuthority", () => {
+  it("allows an authorized low-impact read without manufacturing approval work", () => {
+    const decision = evaluateCoworkerAuthority(
+      base({
+        action: {
+          toolName: "query_employee",
+          requiredCapability: "view_employee",
+          agentGrantAllowed: true,
+          sideEffect: false,
+          executionMode: "immediate",
+          routeContext: "/people",
+          approvalPolicy: "side-effects",
+        },
+        delegation: {
+          chainId: "CHAIN-1",
+          status: "active",
+          originUserId: "USER-1",
+          currentAgentId: "AGT-CHILD",
+          authorityScope: ["view_employee"],
+        },
+        rawParams: { employeeId: "EMP-REPORT" },
+      }),
+    );
+
+    expect(decision).toMatchObject({
+      outcome: "allow",
+      reasonCode: "authorized",
+      nextAction: "execute",
+    });
+  });
+
+  it.each<[string, Partial<EffectiveAuthContext>, string]>([
+    ["missing human", { actingHumanUserId: null }, "human-identity-missing"],
+    ["missing agent", { actingAgentId: null }, "agent-identity-missing"],
+    [
+      "human capability",
+      { grantedCapabilities: ["view_employee"] },
+      "human-capability-denied",
+    ],
+  ])("denies when %s authority is absent", (_label, context, reasonCode) => {
+    const decision = evaluateCoworkerAuthority(
+      base({ authContext: auth(context) }),
+    );
+
+    expect(decision).toMatchObject({
+      outcome: "deny",
+      reasonCode,
+      nextAction: "request-authority",
+    });
+  });
+
+  it("denies when the coworker grant does not authorize the tool", () => {
+    const decision = evaluateCoworkerAuthority(
+      base({
+        action: { ...base().action, agentGrantAllowed: false },
+      }),
+    );
+
+    expect(decision).toMatchObject({
+      outcome: "deny",
+      reasonCode: "agent-grant-denied",
+    });
+  });
+
+  it.each([
+    [
+      "inactive chain",
+      { status: "completed" as const },
+      "delegation-inactive",
+    ],
+    [
+      "wrong human root",
+      { originUserId: "USER-OTHER" },
+      "delegation-origin-mismatch",
+    ],
+    [
+      "wrong child",
+      { currentAgentId: "AGT-SIBLING" },
+      "delegation-agent-mismatch",
+    ],
+    [
+      "narrowed scope",
+      { authorityScope: ["view_employee"] },
+      "delegation-scope-denied",
+    ],
+  ])("denies a %s", (_label, delegationOverride, reasonCode) => {
+    const decision = evaluateCoworkerAuthority(
+      base({
+        delegation: {
+          ...base().delegation!,
+          ...delegationOverride,
+        },
+      }),
+    );
+
+    expect(decision).toMatchObject({ outcome: "deny", reasonCode });
+  });
+
+  it("allows a manager subject but denies a peer even when they share a team", () => {
+    expect(evaluateCoworkerAuthority(base()).outcome).toBe("require-approval");
+
+    const peer = evaluateCoworkerAuthority(
+      base({
+        subject: { kind: "employee", id: "EMP-PEER" },
+        authContext: auth({ teamIds: ["TEAM-OPS"] }),
+      }),
+    );
+    expect(peer).toMatchObject({
+      outcome: "deny",
+      reasonCode: "subject-scope-denied",
+    });
+  });
+
+  it.each([
+    [
+      "disconnected integration",
+      { integration: { required: true, state: "disconnected" as const } },
+      "integration-unavailable",
+    ],
+    [
+      "insufficient clearance",
+      {
+        authContext: auth({
+          sensitivityClearance: ["public", "internal"],
+        }),
+      },
+      "sensitivity-clearance-denied",
+    ],
+    [
+      "unmet masking",
+      {
+        dataPolicy: {
+          ...base().dataPolicy,
+          maskingRequired: true,
+          maskingSatisfied: false,
+        },
+      },
+      "masking-obligation-unmet",
+    ],
+    [
+      "stale policy",
+      {
+        dataPolicy: {
+          ...base().dataPolicy,
+          decisionVersionsCurrent: false,
+        },
+      },
+      "policy-version-stale",
+    ],
+  ])("denies for %s", (_label, override, reasonCode) => {
+    expect(
+      evaluateCoworkerAuthority(base(override as Partial<CoworkerAuthorityInput>)),
+    ).toMatchObject({ outcome: "deny", reasonCode });
+  });
+
+  it("does not let provider fallback, prompt content, or caller sensitivity lower policy", () => {
+    const decision = evaluateCoworkerAuthority(
+      base({
+        untrustedClaims: {
+          promptRequestedApprovalBypass: true,
+          providerFallbackRequested: true,
+          callerSensitivity: "public",
+        },
+        dataPolicy: {
+          ...base().dataPolicy,
+          sensitivity: "restricted",
+        },
+      }),
+    );
+
+    expect(decision).toMatchObject({
+      outcome: "deny",
+      reasonCode: "sensitivity-clearance-denied",
+    });
+  });
+
+  it("requires approval for an authorized side effect and returns a privacy-safe binding", () => {
+    const decision = evaluateCoworkerAuthority(base());
+
+    expect(decision).toMatchObject({
+      outcome: "require-approval",
+      reasonCode: "approval-required",
+      nextAction: "request-approval",
+      approvalBinding: {
+        actingHumanUserId: "USER-1",
+        actingAgentId: "AGT-CHILD",
+        chainId: "CHAIN-1",
+        taskRunId: "TASK-CHILD",
+        toolName: "update_employee",
+        subject: { kind: "employee", id: "EMP-REPORT" },
+        routeContext: "/people",
+      },
+    });
+    expect(decision.explanation).not.toContain("Lead");
+    expect(JSON.stringify(decision)).not.toContain("employeeId");
+  });
+
+  it("allows the exact active approval binding", () => {
+    const input = base();
+    const binding = buildCoworkerApprovalBinding(input);
+
+    const decision = evaluateCoworkerAuthority({
+      ...input,
+      approval: {
+        status: "approved",
+        expiresAt: new Date(Date.now() + 60_000),
+        binding,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      outcome: "allow",
+      reasonCode: "authorized",
+      nextAction: "execute",
+    });
+  });
+
+  it.each([
+    ["tool", { toolName: "delete_employee" }],
+    ["route", { routeContext: "/finance" }],
+    ["child task", { taskRunId: "TASK-SIBLING" }],
+    ["delegation chain", { chainId: "CHAIN-OTHER" }],
+  ])("denies approval replay for another %s", (_label, bindingOverride) => {
+    const input = base();
+    const binding = {
+      ...buildCoworkerApprovalBinding(input),
+      ...bindingOverride,
+    };
+
+    const decision = evaluateCoworkerAuthority({
+      ...input,
+      approval: {
+        status: "approved",
+        expiresAt: new Date(Date.now() + 60_000),
+        binding,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      outcome: "deny",
+      reasonCode: "approval-binding-mismatch",
+    });
+  });
+
+  it("denies expired approval and changed parameters", () => {
+    const input = base();
+    const binding = buildCoworkerApprovalBinding(input);
+
+    expect(
+      evaluateCoworkerAuthority({
+        ...input,
+        approval: {
+          status: "approved",
+          expiresAt: new Date(Date.now() - 1),
+          binding,
+        },
+      }),
+    ).toMatchObject({
+      outcome: "deny",
+      reasonCode: "approval-expired",
+    });
+
+    expect(
+      evaluateCoworkerAuthority({
+        ...input,
+        rawParams: { employeeId: "EMP-REPORT", title: "Director" },
+        approval: {
+          status: "approved",
+          expiresAt: new Date(Date.now() + 60_000),
+          binding,
+        },
+      }),
+    ).toMatchObject({
+      outcome: "deny",
+      reasonCode: "approval-binding-mismatch",
+    });
+  });
+});

--- a/apps/web/lib/govern/authority/coworker-authority-decision.ts
+++ b/apps/web/lib/govern/authority/coworker-authority-decision.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+
+import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
+
+import {
+  canAccessAuthoritySubject,
+  type AuthoritySubject,
+} from "./authority-subject";
+
+export const COWORKER_AUTHORITY_OUTCOMES = [
+  "allow",
+  "deny",
+  "require-approval",
+] as const;
+
+export type CoworkerAuthorityOutcome =
+  (typeof COWORKER_AUTHORITY_OUTCOMES)[number];
+
+export type CoworkerAuthoritySubject = AuthoritySubject;
+
+export type CoworkerApprovalPolicy = "none" | "side-effects" | "all";
+
+export type CoworkerAuthorityReasonCode =
+  | "authorized"
+  | "human-identity-missing"
+  | "agent-identity-missing"
+  | "human-capability-denied"
+  | "agent-grant-denied"
+  | "delegation-inactive"
+  | "delegation-origin-mismatch"
+  | "delegation-agent-mismatch"
+  | "delegation-scope-denied"
+  | "delegation-chain-required"
+  | "route-scope-denied"
+  | "subject-scope-denied"
+  | "integration-unavailable"
+  | "sensitivity-clearance-denied"
+  | "masking-obligation-unmet"
+  | "policy-version-stale"
+  | "approval-required"
+  | "approval-expired"
+  | "approval-binding-mismatch"
+  | "approval-not-active";
+
+export type CoworkerApprovalBinding = {
+  actingHumanUserId: string;
+  actingAgentId: string;
+  chainId: string | null;
+  taskRunId: string | null;
+  toolName: string;
+  subject: CoworkerAuthoritySubject | null;
+  routeContext: string | null;
+  inputFingerprint: string;
+  sensitivity: PrincipalSensitivity;
+  decisionVersionFingerprint: string;
+};
+
+export type CoworkerAuthorityInput = {
+  authContext: EffectiveAuthContext;
+  action: {
+    toolName: string;
+    requiredCapability: string | null;
+    agentGrantAllowed: boolean;
+    sideEffect: boolean;
+    executionMode: "proposal" | "immediate";
+    routeContext: string | null;
+    allowedRouteContexts?: readonly string[];
+    approvalPolicy: CoworkerApprovalPolicy;
+    requiresDelegationChain?: boolean;
+  };
+  subject?: CoworkerAuthoritySubject | null;
+  delegation?: {
+    chainId: string;
+    status: string;
+    originUserId: string;
+    currentAgentId: string;
+    authorityScope: readonly string[];
+  } | null;
+  integration: {
+    required: boolean;
+    state: "connected" | "disconnected" | "unknown" | "not-required";
+  };
+  dataPolicy: {
+    sensitivity: PrincipalSensitivity;
+    maskingRequired: boolean;
+    maskingSatisfied: boolean;
+    decisionVersionsCurrent: boolean;
+    decisionVersionIds?: readonly string[];
+  };
+  task?: {
+    taskRunId: string;
+    parentTaskRunId?: string | null;
+  } | null;
+  rawParams: Record<string, unknown>;
+  approval?: {
+    envelopeId?: string;
+    status:
+      | "proposed"
+      | "approved"
+      | "declined"
+      | "executed"
+      | "failed"
+      | "cancelled";
+    expiresAt: Date;
+    binding: CoworkerApprovalBinding;
+  } | null;
+  now?: Date;
+  /**
+   * Untrusted model/caller claims are deliberately not consulted by the
+   * evaluator. Carrying them makes that non-authority boundary explicit and
+   * lets regression tests prove prompt/fallback text cannot widen access.
+   */
+  untrustedClaims?: {
+    promptRequestedApprovalBypass?: boolean;
+    providerFallbackRequested?: boolean;
+    callerSensitivity?: PrincipalSensitivity;
+  };
+};
+
+type CoworkerAuthorityAllowDecision = {
+  outcome: "allow";
+  reasonCode: "authorized";
+  explanation: string;
+  nextAction: "execute";
+};
+
+type CoworkerAuthorityDenyDecision = {
+  outcome: "deny";
+  reasonCode: Exclude<
+    CoworkerAuthorityReasonCode,
+    "authorized" | "approval-required"
+  >;
+  explanation: string;
+  nextAction: "request-authority" | "correct-context";
+};
+
+type CoworkerAuthorityApprovalDecision = {
+  outcome: "require-approval";
+  reasonCode: "approval-required";
+  explanation: string;
+  nextAction: "request-approval";
+  approvalBinding: CoworkerApprovalBinding;
+};
+
+export type CoworkerAuthorityDecision =
+  | CoworkerAuthorityAllowDecision
+  | CoworkerAuthorityDenyDecision
+  | CoworkerAuthorityApprovalDecision;
+
+const EXPLANATIONS: Record<CoworkerAuthorityReasonCode, string> = {
+  authorized: "The current human and coworker authority permits this action.",
+  "human-identity-missing":
+    "A verified human authority root is required before this coworker can act.",
+  "agent-identity-missing":
+    "The executing coworker identity could not be verified.",
+  "human-capability-denied":
+    "The current human does not have authority for this action.",
+  "agent-grant-denied":
+    "This coworker is not assigned the tool authority required for this action.",
+  "delegation-inactive": "The delegated authority chain is no longer active.",
+  "delegation-origin-mismatch":
+    "The delegated action is not rooted in the current human authority.",
+  "delegation-agent-mismatch":
+    "The delegated action belongs to a different coworker.",
+  "delegation-scope-denied":
+    "The delegated authority was narrowed before reaching this action.",
+  "delegation-chain-required":
+    "This delegated action has no verifiable chain back to a human.",
+  "route-scope-denied":
+    "This action is not authorized from the current workspace.",
+  "subject-scope-denied":
+    "The current human cannot act on the selected record.",
+  "integration-unavailable":
+    "The required connection is not currently authorized and available.",
+  "sensitivity-clearance-denied":
+    "The current authority does not permit this data sensitivity.",
+  "masking-obligation-unmet":
+    "Required data protection was not completed before this action.",
+  "policy-version-stale":
+    "The governing policy changed; the action must be evaluated again.",
+  "approval-required":
+    "This action is authorized to proceed only after human approval.",
+  "approval-expired": "The prior approval expired; request a new decision.",
+  "approval-binding-mismatch":
+    "The prior approval belongs to different work or action details.",
+  "approval-not-active":
+    "The prior approval is not active and cannot authorize execution.",
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)]),
+  );
+}
+
+function fingerprint(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)))
+    .digest("hex");
+}
+
+function normalize(value: string | null | undefined): string | null {
+  return value?.trim() || null;
+}
+
+export function buildCoworkerApprovalBinding(
+  input: CoworkerAuthorityInput,
+): CoworkerApprovalBinding {
+  const humanId = normalize(input.authContext.actingHumanUserId);
+  const agentId = normalize(input.authContext.actingAgentId);
+  if (!humanId || !agentId) {
+    throw new Error(
+      "Cannot bind coworker approval without human and agent identities.",
+    );
+  }
+
+  return {
+    actingHumanUserId: humanId,
+    actingAgentId: agentId,
+    chainId: normalize(input.delegation?.chainId),
+    taskRunId: normalize(input.task?.taskRunId),
+    toolName: input.action.toolName.trim(),
+    subject: input.subject ?? null,
+    routeContext: normalize(input.action.routeContext),
+    inputFingerprint: fingerprint(input.rawParams),
+    sensitivity: input.dataPolicy.sensitivity,
+    decisionVersionFingerprint: fingerprint(
+      [...(input.dataPolicy.decisionVersionIds ?? [])].sort(),
+    ),
+  };
+}
+
+function deny(
+  reasonCode: CoworkerAuthorityDenyDecision["reasonCode"],
+  nextAction: CoworkerAuthorityDenyDecision["nextAction"] = "correct-context",
+): CoworkerAuthorityDenyDecision {
+  return {
+    outcome: "deny",
+    reasonCode,
+    explanation: EXPLANATIONS[reasonCode],
+    nextAction,
+  };
+}
+
+function requiresApproval(input: CoworkerAuthorityInput): boolean {
+  if (input.action.approvalPolicy === "all") return true;
+  if (input.action.executionMode === "proposal") return true;
+  return (
+    input.action.approvalPolicy === "side-effects" &&
+    input.action.sideEffect
+  );
+}
+
+function sameBinding(
+  left: CoworkerApprovalBinding,
+  right: CoworkerApprovalBinding,
+): boolean {
+  return (
+    fingerprintCoworkerApprovalBinding(left)
+    === fingerprintCoworkerApprovalBinding(right)
+  );
+}
+
+export function fingerprintCoworkerApprovalBinding(
+  binding: CoworkerApprovalBinding,
+): string {
+  return fingerprint(binding);
+}
+
+export function evaluateCoworkerAuthority(
+  input: CoworkerAuthorityInput,
+): CoworkerAuthorityDecision {
+  const humanId = normalize(input.authContext.actingHumanUserId);
+  if (!humanId) return deny("human-identity-missing", "request-authority");
+
+  const agentId = normalize(input.authContext.actingAgentId);
+  if (!agentId) return deny("agent-identity-missing", "request-authority");
+
+  const capability = normalize(input.action.requiredCapability);
+  if (
+    capability &&
+    !input.authContext.grantedCapabilities.includes(capability)
+  ) {
+    return deny("human-capability-denied", "request-authority");
+  }
+
+  if (!input.action.agentGrantAllowed) {
+    return deny("agent-grant-denied", "request-authority");
+  }
+
+  const delegation = input.delegation;
+  if (input.action.requiresDelegationChain && !delegation) {
+    return deny("delegation-chain-required", "request-authority");
+  }
+  if (delegation) {
+    if (delegation.status !== "active") return deny("delegation-inactive");
+    if (delegation.originUserId !== humanId) {
+      return deny("delegation-origin-mismatch");
+    }
+    if (delegation.currentAgentId !== agentId) {
+      return deny("delegation-agent-mismatch");
+    }
+    if (
+      capability &&
+      !delegation.authorityScope.includes(capability)
+    ) {
+      return deny("delegation-scope-denied", "request-authority");
+    }
+  }
+
+  const allowedRoutes = input.action.allowedRouteContexts;
+  if (
+    allowedRoutes?.length &&
+    !allowedRoutes.includes(input.action.routeContext ?? "")
+  ) {
+    return deny("route-scope-denied");
+  }
+
+  if (!canAccessAuthoritySubject(input.authContext, input.subject)) {
+    return deny("subject-scope-denied", "request-authority");
+  }
+
+  if (
+    input.integration.required &&
+    input.integration.state !== "connected"
+  ) {
+    return deny("integration-unavailable");
+  }
+
+  if (
+    !input.authContext.sensitivityClearance.includes(
+      input.dataPolicy.sensitivity,
+    )
+  ) {
+    return deny("sensitivity-clearance-denied", "request-authority");
+  }
+  if (
+    input.dataPolicy.maskingRequired &&
+    !input.dataPolicy.maskingSatisfied
+  ) {
+    return deny("masking-obligation-unmet");
+  }
+  if (!input.dataPolicy.decisionVersionsCurrent) {
+    return deny("policy-version-stale");
+  }
+
+  if (!requiresApproval(input)) {
+    return {
+      outcome: "allow",
+      reasonCode: "authorized",
+      explanation: EXPLANATIONS.authorized,
+      nextAction: "execute",
+    };
+  }
+
+  const currentBinding = buildCoworkerApprovalBinding(input);
+  if (!input.approval) {
+    return {
+      outcome: "require-approval",
+      reasonCode: "approval-required",
+      explanation: EXPLANATIONS["approval-required"],
+      nextAction: "request-approval",
+      approvalBinding: currentBinding,
+    };
+  }
+  if (input.approval.status !== "approved") {
+    return deny("approval-not-active");
+  }
+  if (input.approval.expiresAt.getTime() <= (input.now ?? new Date()).getTime()) {
+    return deny("approval-expired");
+  }
+  if (!sameBinding(input.approval.binding, currentBinding)) {
+    return deny("approval-binding-mismatch");
+  }
+
+  return {
+    outcome: "allow",
+    reasonCode: "authorized",
+    explanation: EXPLANATIONS.authorized,
+    nextAction: "execute",
+  };
+}

--- a/apps/web/lib/govern/authority/coworker-tool-authority-gate.ts
+++ b/apps/web/lib/govern/authority/coworker-tool-authority-gate.ts
@@ -1,0 +1,326 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+import { randomUUID } from "crypto";
+
+import type {
+  GovernedExecuteArgs,
+  GovernedExecuteRejection,
+} from "@/lib/mcp-governed-execute";
+import type { ToolDefinition } from "@/lib/mcp-tools";
+
+import {
+  evaluateCoworkerAuthority,
+  type CoworkerAuthorityDecision,
+  type CoworkerAuthorityInput,
+} from "./coworker-authority-decision";
+
+export type CoworkerAuthorityInputResolver = (args: {
+  execution: GovernedExecuteArgs;
+  tool: ToolDefinition;
+  agentGrantAllowed: boolean;
+}) => Promise<CoworkerAuthorityInput>;
+
+export type AuthorizationDecisionCreate = (
+  data: Record<string, unknown>,
+) => Promise<unknown>;
+
+export type AuthorityApprovalEnvelopeCreate = (input: {
+  binding: Extract<
+    CoworkerAuthorityDecision,
+    { outcome: "require-approval" }
+  >["approvalBinding"];
+  authorityDecisionId: string;
+  threadId: string | null;
+  explanation: string;
+}) => Promise<{ id: string; status: string; expiresAt: Date | null }>;
+
+export type AuthorityApprovalTaskResume = (taskRunId: string) => Promise<void>;
+
+export type AuthorityApprovalEnvelopeFinalize = (
+  envelopeId: string,
+  success: boolean,
+) => Promise<void>;
+
+type AuthorityGateOverrides = {
+  resolveCoworkerAuthorityInput?: CoworkerAuthorityInputResolver | null;
+  authorizationDecisionCreate?: AuthorizationDecisionCreate | null;
+  authorityApprovalEnvelopeCreate?: AuthorityApprovalEnvelopeCreate | null;
+  authorityApprovalTaskResume?: AuthorityApprovalTaskResume | null;
+  authorityApprovalEnvelopeFinalize?: AuthorityApprovalEnvelopeFinalize | null;
+};
+
+export type CoworkerToolAuthorityGateResult =
+  | {
+      outcome: "allow";
+      approvedEnvelopeId: string | null;
+    }
+  | {
+      outcome: "reject";
+      rejection: Extract<
+        GovernedExecuteRejection,
+        | "authority_denied"
+        | "approval_required"
+        | "authority_evidence_unavailable"
+      >;
+      message: string;
+      authorityReason?: CoworkerAuthorityDecision["reasonCode"];
+      data?: {
+        approvalBinding: Extract<
+          CoworkerAuthorityDecision,
+          { outcome: "require-approval" }
+        >["approvalBinding"];
+        envelopeId: string;
+        expiresAt: string | null;
+      };
+    };
+
+let overrides: AuthorityGateOverrides = {};
+
+export function setCoworkerToolAuthorityOverridesForTests(
+  next: AuthorityGateOverrides,
+): void {
+  if ("resolveCoworkerAuthorityInput" in next) {
+    overrides.resolveCoworkerAuthorityInput =
+      next.resolveCoworkerAuthorityInput ?? null;
+  }
+  if ("authorizationDecisionCreate" in next) {
+    overrides.authorizationDecisionCreate =
+      next.authorizationDecisionCreate ?? null;
+  }
+  if ("authorityApprovalEnvelopeCreate" in next) {
+    overrides.authorityApprovalEnvelopeCreate =
+      next.authorityApprovalEnvelopeCreate ?? null;
+  }
+  if ("authorityApprovalTaskResume" in next) {
+    overrides.authorityApprovalTaskResume =
+      next.authorityApprovalTaskResume ?? null;
+  }
+  if ("authorityApprovalEnvelopeFinalize" in next) {
+    overrides.authorityApprovalEnvelopeFinalize =
+      next.authorityApprovalEnvelopeFinalize ?? null;
+  }
+}
+
+async function resolveAuthorityInput(
+  execution: GovernedExecuteArgs,
+  tool: ToolDefinition,
+  agentGrantAllowed: boolean,
+): Promise<CoworkerAuthorityInput> {
+  const resolver = overrides.resolveCoworkerAuthorityInput
+    ?? (await import("./resolve-coworker-tool-authority"))
+      .resolveCoworkerToolAuthorityInput;
+  const resolved = await resolver({ execution, tool, agentGrantAllowed });
+  return {
+    ...resolved,
+    action: {
+      ...resolved.action,
+      agentGrantAllowed,
+    },
+    rawParams: execution.rawParams,
+  };
+}
+
+async function writeAuthorizationDecision(
+  input: CoworkerAuthorityInput,
+  decision: CoworkerAuthorityDecision,
+  execution: GovernedExecuteArgs,
+): Promise<string | null> {
+  const subject = input.subject
+    ? `${input.subject.kind}:${input.subject.id}`
+    : null;
+  const row = {
+    decisionId: `AUTH-${randomUUID()}`,
+    actorType: "ai-coworker",
+    actorRef:
+      input.authContext.actingAgentId
+      ?? execution.context?.agentId
+      ?? "unknown",
+    humanContextRef:
+      input.authContext.actingHumanUserId ?? execution.userId,
+    agentContextRef:
+      input.authContext.actingAgentId ?? execution.context?.agentId ?? null,
+    delegationGrantId: null,
+    organizationId: null,
+    purposeOfUse: execution.context?.workCase?.action ?? "tool-execution",
+    policyVersion: input.dataPolicy.decisionVersionIds?.join(",") || null,
+    actionKey: execution.toolName,
+    objectRef: subject,
+    decision: decision.outcome,
+    rationale: {
+      reasonCode: decision.reasonCode,
+      nextAction: decision.nextAction,
+      chainId: input.delegation?.chainId ?? null,
+      taskRunId:
+        input.task?.taskRunId ?? execution.context?.taskRunId ?? null,
+      subjectKind: input.subject?.kind ?? null,
+    },
+    endpointUsed: execution.source,
+    mode: input.action.executionMode,
+    routeContext: input.action.routeContext,
+    sensitivityLevel: input.dataPolicy.sensitivity,
+    sensitivityOverride: false,
+  };
+  try {
+    if (overrides.authorizationDecisionCreate) {
+      await overrides.authorizationDecisionCreate(row);
+    } else {
+      await prisma.authorizationDecisionLog.create({ data: row });
+    }
+    return row.decisionId;
+  } catch (error) {
+    console.error(
+      "[governed-execute] authority decision write failed tool=%s source=%s: %s",
+      JSON.stringify(execution.toolName),
+      JSON.stringify(execution.source),
+      error instanceof Error
+        ? JSON.stringify(error.message)
+        : JSON.stringify(String(error)),
+    );
+    return null;
+  }
+}
+
+async function ensureApproval(
+  input: Parameters<AuthorityApprovalEnvelopeCreate>[0],
+): Promise<Awaited<ReturnType<AuthorityApprovalEnvelopeCreate>>> {
+  if (overrides.authorityApprovalEnvelopeCreate) {
+    return overrides.authorityApprovalEnvelopeCreate(input);
+  }
+  const { ensureAuthorityApprovalEnvelope } = await import(
+    "@/lib/coworker/authority-approval-envelope"
+  );
+  return ensureAuthorityApprovalEnvelope(input);
+}
+
+async function resumeApprovedTask(taskRunId: string): Promise<void> {
+  if (overrides.authorityApprovalTaskResume) {
+    await overrides.authorityApprovalTaskResume(taskRunId);
+    return;
+  }
+  const { resumeAuthorityApprovalTask } = await import(
+    "@/lib/coworker/authority-approval-envelope"
+  );
+  await resumeAuthorityApprovalTask(taskRunId);
+}
+
+export async function finalizeCoworkerAuthorityApproval(
+  envelopeId: string,
+  success: boolean,
+): Promise<void> {
+  if (overrides.authorityApprovalEnvelopeFinalize) {
+    await overrides.authorityApprovalEnvelopeFinalize(envelopeId, success);
+    return;
+  }
+  const { finalizeAuthorityApprovalEnvelope } = await import(
+    "@/lib/coworker/authority-approval-envelope"
+  );
+  await finalizeAuthorityApprovalEnvelope(envelopeId, success);
+}
+
+export async function enforceCoworkerToolAuthority(
+  execution: GovernedExecuteArgs,
+  tool: ToolDefinition,
+  agentGrantAllowed: boolean,
+): Promise<CoworkerToolAuthorityGateResult> {
+  let input: CoworkerAuthorityInput;
+  try {
+    input = await resolveAuthorityInput(execution, tool, agentGrantAllowed);
+  } catch (error) {
+    console.error(
+      "[governed-execute] authority context unavailable tool=%s source=%s: %s",
+      JSON.stringify(execution.toolName),
+      JSON.stringify(execution.source),
+      error instanceof Error
+        ? JSON.stringify(error.message)
+        : JSON.stringify(String(error)),
+    );
+    return {
+      outcome: "reject",
+      rejection: "authority_evidence_unavailable",
+      message: "verified authority context is unavailable",
+    };
+  }
+
+  const decision = evaluateCoworkerAuthority(input);
+  const decisionId = await writeAuthorizationDecision(
+    input,
+    decision,
+    execution,
+  );
+  if (!decisionId) {
+    return {
+      outcome: "reject",
+      rejection: "authority_evidence_unavailable",
+      message: "authority evidence could not be recorded",
+    };
+  }
+
+  if (decision.outcome === "deny") {
+    return {
+      outcome: "reject",
+      rejection: "authority_denied",
+      message: decision.explanation,
+      authorityReason: decision.reasonCode,
+    };
+  }
+
+  if (decision.outcome === "require-approval") {
+    try {
+      const envelope = await ensureApproval({
+        binding: decision.approvalBinding,
+        authorityDecisionId: decisionId,
+        threadId: execution.context?.threadId ?? null,
+        explanation: decision.explanation,
+      });
+      return {
+        outcome: "reject",
+        rejection: "approval_required",
+        message: decision.explanation,
+        authorityReason: decision.reasonCode,
+        data: {
+          approvalBinding: decision.approvalBinding,
+          envelopeId: envelope.id,
+          expiresAt: envelope.expiresAt?.toISOString() ?? null,
+        },
+      };
+    } catch (error) {
+      console.error(
+        "[governed-execute] approval envelope unavailable tool=%s source=%s: %s",
+        JSON.stringify(execution.toolName),
+        JSON.stringify(execution.source),
+        error instanceof Error
+          ? JSON.stringify(error.message)
+          : JSON.stringify(String(error)),
+      );
+      return {
+        outcome: "reject",
+        rejection: "authority_evidence_unavailable",
+        message: "approval evidence could not be recorded",
+      };
+    }
+  }
+
+  const approvedEnvelopeId = input.approval?.envelopeId ?? null;
+  if (approvedEnvelopeId && input.task?.taskRunId) {
+    try {
+      await resumeApprovedTask(input.task.taskRunId);
+    } catch (error) {
+      console.error(
+        "[governed-execute] approved task resume failed task=%s tool=%s: %s",
+        JSON.stringify(input.task.taskRunId),
+        JSON.stringify(execution.toolName),
+        error instanceof Error
+          ? JSON.stringify(error.message)
+          : JSON.stringify(String(error)),
+      );
+      return {
+        outcome: "reject",
+        rejection: "authority_evidence_unavailable",
+        message: "the approved task could not be resumed",
+      };
+    }
+  }
+
+  return { outcome: "allow", approvedEnvelopeId };
+}

--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveAllowedRouteContexts,
+  deriveCoworkerApprovalPolicy,
+  deriveCoworkerAuthoritySubject,
+} from "./resolve-coworker-tool-authority";
+
+describe("deriveAllowedRouteContexts", () => {
+  it("keeps surface-agnostic and wildcard tools route-neutral", () => {
+    expect(deriveAllowedRouteContexts(undefined)).toBeUndefined();
+    expect(deriveAllowedRouteContexts("*")).toBeUndefined();
+  });
+
+  it("binds a screen-specific tool to its declared route context", () => {
+    expect(deriveAllowedRouteContexts("/platform/identity")).toEqual([
+      "/platform/identity",
+    ]);
+  });
+});
+
+describe("deriveCoworkerAuthoritySubject", () => {
+  it("derives a record subject from server-recognized identifier fields", () => {
+    expect(
+      deriveCoworkerAuthoritySubject({
+        employeeId: " EMP-100 ",
+        promptSubject: "EMP-999",
+      }),
+    ).toEqual({ kind: "employee", id: "EMP-100" });
+  });
+
+  it("does not treat unrecognized caller claims as authority scope", () => {
+    expect(
+      deriveCoworkerAuthoritySubject({
+        promptSubject: "principal:PRN-SECRET",
+        authorityOverride: true,
+      }),
+    ).toEqual({ kind: "platform", id: "dpf" });
+  });
+});
+
+describe("deriveCoworkerApprovalPolicy", () => {
+  it.each([
+    [{ hitlTierDefault: 0, hitlPolicy: "none" }, "all"],
+    [{ hitlTierDefault: 1, hitlPolicy: "none" }, "all"],
+    [{ hitlTierDefault: 2, hitlPolicy: "none" }, "side-effects"],
+    [
+      {
+        hitlTierDefault: 3,
+        hitlPolicy: "proposal_for_external_writes",
+      },
+      "side-effects",
+    ],
+    [{ hitlTierDefault: 3, hitlPolicy: "none" }, "none"],
+  ] as const)("maps %j to %s", (input, expected) => {
+    expect(deriveCoworkerApprovalPolicy(input)).toBe(expected);
+  });
+});

--- a/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
+++ b/apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts
@@ -1,0 +1,259 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+
+import { findApprovedAuthorityEnvelope } from "@/lib/coworker/authority-approval-envelope";
+import { loadEffectiveAuthContext } from "@/lib/identity/load-effective-auth-context";
+import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
+import { getGrantedCapabilities } from "@/lib/permissions";
+
+import {
+  buildCoworkerApprovalBinding,
+  type CoworkerAuthorityInput,
+  type CoworkerApprovalPolicy,
+  type CoworkerAuthoritySubject,
+} from "./coworker-authority-decision";
+import type { CoworkerAuthorityInputResolver } from "./coworker-tool-authority-gate";
+
+type AuthorityDb = {
+  agent: {
+    findFirst(args: unknown): Promise<{
+      id: string;
+      agentId: string;
+      sensitivity: string;
+      hitlTierDefault: number;
+      governanceProfile: {
+        hitlPolicy: string;
+        updatedAt: Date;
+      } | null;
+    } | null>;
+  };
+  delegationChain: {
+    findFirst(args: unknown): Promise<{
+      chainId: string;
+      status: string;
+      originUserId: string;
+      toAgentId: string;
+      authorityScope: string[];
+    } | null>;
+  };
+  taskRun: {
+    findUnique(args: unknown): Promise<{
+      taskRunId: string;
+      parentTaskRunId: string | null;
+    } | null>;
+  };
+};
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function deriveCoworkerAuthoritySubject(
+  params: Record<string, unknown>,
+): CoworkerAuthoritySubject {
+  const candidates: Array<
+    [keyof Record<string, unknown>, CoworkerAuthoritySubject["kind"]]
+  > = [
+    ["employeeId", "employee"],
+    ["accountId", "account"],
+    ["contactId", "contact"],
+    ["partnerAccountId", "partner-account"],
+    ["principalId", "principal"],
+    ["teamId", "team"],
+  ];
+  for (const [key, kind] of candidates) {
+    const id = asString(params[key]);
+    if (id) return { kind, id };
+  }
+  return { kind: "platform", id: "dpf" };
+}
+
+export function deriveCoworkerApprovalPolicy(input: {
+  hitlTierDefault: number;
+  hitlPolicy: string | null;
+}): CoworkerApprovalPolicy {
+  const policy = input.hitlPolicy?.trim().toLowerCase() ?? "";
+  if (input.hitlTierDefault <= 1 || policy === "always") return "all";
+  if (
+    input.hitlTierDefault === 2
+    || policy === "proposal_for_external_writes"
+    || policy === "side-effects"
+  ) {
+    return "side-effects";
+  }
+  return "none";
+}
+
+export function deriveAllowedRouteContexts(
+  screenSurface: string | undefined,
+): readonly string[] | undefined {
+  const surface = screenSurface?.trim();
+  return surface && surface !== "*" ? [surface] : undefined;
+}
+
+function normalizeSensitivity(
+  value: string,
+): "public" | "internal" | "confidential" | "restricted" {
+  switch (value) {
+    case "public":
+    case "internal":
+    case "confidential":
+    case "restricted":
+      return value;
+    default:
+      return "restricted";
+  }
+}
+
+function authSource(
+  context: GovernedExecuteContext | undefined,
+): "bearer" | "session" | "service" | "delegation" | "unknown" {
+  if (context?.delegationChainId) return "delegation";
+  if (context?.authSource === "pat") return "bearer";
+  if (context?.authSource === "session-jwt") return "session";
+  return "unknown";
+}
+
+/**
+ * Resolve the server-owned inputs for the pure authority evaluator. Model
+ * output and caller-provided policy claims never enter this function.
+ */
+export const resolveCoworkerToolAuthorityInput: CoworkerAuthorityInputResolver =
+  async ({ execution, tool, agentGrantAllowed }, db: AuthorityDb = prisma as unknown as AuthorityDb) => {
+    const actingAgentId = execution.context?.agentId;
+    if (!actingAgentId) {
+      throw new Error("Coworker authority resolution requires an agent identity.");
+    }
+
+    const [agent, delegation, task] = await Promise.all([
+      db.agent.findFirst({
+        where: {
+          OR: [
+            { id: actingAgentId },
+            { agentId: actingAgentId },
+            { slugId: actingAgentId },
+          ],
+          status: "active",
+          archived: false,
+        },
+        select: {
+          id: true,
+          agentId: true,
+          sensitivity: true,
+          hitlTierDefault: true,
+          governanceProfile: {
+            select: { hitlPolicy: true, updatedAt: true },
+          },
+        },
+      }),
+      execution.context?.delegationChainId
+        ? db.delegationChain.findFirst({
+            where: { chainId: execution.context.delegationChainId },
+            orderBy: { depth: "desc" },
+            select: {
+              chainId: true,
+              status: true,
+              originUserId: true,
+              toAgentId: true,
+              authorityScope: true,
+            },
+          })
+        : Promise.resolve(null),
+      execution.context?.taskRunId
+        ? db.taskRun.findUnique({
+            where: { taskRunId: execution.context.taskRunId },
+            select: { taskRunId: true, parentTaskRunId: true },
+          })
+        : Promise.resolve(null),
+    ]);
+    if (!agent) {
+      throw new Error("The executing coworker identity is not active.");
+    }
+
+    const grantedCapabilities = getGrantedCapabilities(execution.userContext);
+    const effectiveAuth = await loadEffectiveAuthContext(
+      {
+        user: {
+          id: execution.userId,
+          email: "",
+          type: "admin",
+          platformRole: execution.userContext.platformRole,
+          isSuperuser: execution.userContext.isSuperuser,
+          accountId: null,
+          accountName: null,
+          contactId: null,
+        },
+        grantedCapabilities,
+        authentication: {
+          source: authSource(execution.context),
+          methods: [],
+        },
+        actingAgentId: agent.agentId,
+      },
+      db as never,
+    );
+
+    const approvalPolicy = deriveCoworkerApprovalPolicy({
+      hitlTierDefault: agent.hitlTierDefault,
+      hitlPolicy: agent.governanceProfile?.hitlPolicy ?? null,
+    });
+    const sensitivity = normalizeSensitivity(agent.sensitivity);
+    const decisionVersionIds = [
+      "coworker-authority-v1",
+      agent.governanceProfile?.updatedAt.toISOString(),
+    ].filter((value): value is string => Boolean(value));
+
+    const input: CoworkerAuthorityInput = {
+      authContext: effectiveAuth,
+      action: {
+        toolName: execution.toolName,
+        requiredCapability: tool.requiredCapability,
+        agentGrantAllowed,
+        sideEffect: tool.sideEffect === true,
+        executionMode: tool.executionMode ?? "immediate",
+        routeContext: execution.context?.routeContext ?? null,
+        allowedRouteContexts: deriveAllowedRouteContexts(tool.screenSurface),
+        approvalPolicy,
+        requiresDelegationChain: Boolean(execution.context?.delegationChainId),
+      },
+      subject: deriveCoworkerAuthoritySubject(execution.rawParams),
+      delegation: delegation
+        ? {
+            chainId: delegation.chainId,
+            status: delegation.status,
+            originUserId: delegation.originUserId,
+            currentAgentId: delegation.toAgentId,
+            authorityScope: delegation.authorityScope,
+          }
+        : null,
+      integration: {
+        required: tool.requiresExternalAccess === true,
+        state: tool.requiresExternalAccess
+          ? execution.context?.externalAccessEnabled === true
+            ? "connected"
+            : "unknown"
+          : "not-required",
+      },
+      dataPolicy: {
+        sensitivity,
+        maskingRequired: false,
+        maskingSatisfied: true,
+        decisionVersionsCurrent: true,
+        decisionVersionIds,
+      },
+      task,
+      rawParams: execution.rawParams,
+      approval: null,
+    };
+    const binding = buildCoworkerApprovalBinding(input);
+    const approval = await findApprovedAuthorityEnvelope(
+      binding,
+      new Date(),
+      db as never,
+    );
+    return {
+      ...input,
+      approval,
+    };
+  };

--- a/apps/web/lib/govern/data/response-rehydration.ts
+++ b/apps/web/lib/govern/data/response-rehydration.ts
@@ -1,7 +1,7 @@
 import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
 
 import type { EffectiveAuthContext } from "@/lib/identity/effective-auth-context";
-import { canAccessEmployeeRecord } from "@/lib/govern/permissions";
+import { canAccessAuthoritySubject } from "@/lib/govern/authority/authority-subject";
 import {
   isDecisionVersionSnapshotStillFresh,
   type DecisionVersionSnapshot,
@@ -197,43 +197,7 @@ function canAccessSubject(
   context: EffectiveAuthContext,
   subject: RehydrationSubject,
 ): boolean {
-  switch (subject.kind) {
-    case "employee":
-      return canAccessEmployeeRecord(context, subject.id);
-    case "account":
-      return canAccessCustomerScope(
-        context,
-        context.accountScope.accountIds,
-        subject.id,
-      );
-    case "contact":
-      return canAccessCustomerScope(
-        context,
-        context.accountScope.contactIds,
-        subject.id,
-      );
-    case "partner-account":
-      return canAccessCustomerScope(
-        context,
-        context.accountScope.partnerAccountIds,
-        subject.id,
-      );
-    case "principal":
-      return context.principalId === subject.id;
-    case "team":
-      return context.teamIds.includes(subject.id);
-  }
-}
-
-function canAccessCustomerScope(
-  context: EffectiveAuthContext,
-  ids: readonly string[],
-  subjectId: string,
-): boolean {
-  if (!ids.includes(subjectId)) return false;
-  return context.population === "customer" ||
-    context.population === "partner" ||
-    context.grantedCapabilities.includes("view_customer");
+  return canAccessAuthoritySubject(context, subject);
 }
 
 function hasClearance(

--- a/apps/web/lib/mcp-governed-execute-authority.cases.ts
+++ b/apps/web/lib/mcp-governed-execute-authority.cases.ts
@@ -1,0 +1,274 @@
+import { expect, it } from "vitest";
+
+import {
+  buildCoworkerApprovalBinding,
+  type CoworkerAuthorityInput,
+} from "./govern/authority/coworker-authority-decision";
+import {
+  governedExecuteTool,
+  type _setGovernanceForTests,
+} from "./mcp-governed-execute";
+
+type AuditRow = Record<string, unknown>;
+type GovernanceOverrides = Parameters<typeof _setGovernanceForTests>[0];
+
+type AuthorityCaseHarness = {
+  applyOverrides(overrides: GovernanceOverrides): void;
+  authorityInput(
+    overrides?: Partial<CoworkerAuthorityInput>,
+  ): CoworkerAuthorityInput;
+  normalUser: {
+    platformRole: string;
+    isSuperuser: boolean;
+  };
+  executeMock(): unknown;
+  authorityRows(): AuditRow[];
+  auditRows(): AuditRow[];
+  approvalEnvelopeCreate(): unknown;
+  approvalTaskResume(): unknown;
+  approvalEnvelopeFinalize(): unknown;
+};
+
+export function registerCoworkerAuthorityCases(
+  harness: AuthorityCaseHarness,
+): void {
+  it("evaluates and records every coworker tool action at the universal seam", async () => {
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: { status: "open" },
+      userId: "user-1",
+      userContext: harness.normalUser,
+      context: { agentId: "AGT-100", routeContext: "/ops" },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(true);
+    expect(harness.executeMock()).toHaveBeenCalledOnce();
+    expect(harness.authorityRows()).toHaveLength(1);
+    expect(harness.authorityRows()[0]).toMatchObject({
+      actorType: "ai-coworker",
+      actorRef: "AGT-100",
+      humanContextRef: "user-1",
+      actionKey: "query_backlog",
+      decision: "allow",
+      routeContext: "/ops",
+      sensitivityLevel: "internal",
+    });
+  });
+
+  it("denies without executing when universal authority rejects the action", async () => {
+    harness.applyOverrides({
+      resolveCoworkerAuthorityInput: async () =>
+        harness.authorityInput({
+          authContext: {
+            ...harness.authorityInput().authContext,
+            grantedCapabilities: ["view_platform"],
+          },
+          action: {
+            ...harness.authorityInput().action,
+            toolName: "create_backlog_item",
+            requiredCapability: "manage_backlog",
+            sideEffect: true,
+            approvalPolicy: "side-effects",
+          },
+        }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "private title" },
+      userId: "user-1",
+      userContext: harness.normalUser,
+      context: { agentId: "AGT-100", routeContext: "/ops" },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "authority_denied",
+      governance: {
+        rejected: "authority_denied",
+        authorityReason: "human-capability-denied",
+      },
+    });
+    expect(harness.executeMock()).not.toHaveBeenCalled();
+    expect(harness.authorityRows().at(-1)).toMatchObject({
+      decision: "deny",
+      rationale: { reasonCode: "human-capability-denied" },
+    });
+    expect(JSON.stringify(harness.authorityRows())).not.toContain(
+      "private title",
+    );
+  });
+
+  it("rejects a missing agent grant and audits the denial", async () => {
+    harness.applyOverrides({
+      resolveAgentGrants: async () => ["registry_read"],
+      isAllowedByGrants: () => false,
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "x", type: "product", source: "user-request" },
+      userId: "u",
+      userContext: harness.normalUser,
+      context: { agentId: "AGT-100" },
+      source: "rest",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "authority_denied",
+      governance: { authorityReason: "agent-grant-denied" },
+    });
+    expect(harness.executeMock()).not.toHaveBeenCalled();
+    expect(harness.auditRows()).toHaveLength(1);
+    expect(harness.auditRows()[0]).toMatchObject({
+      success: false,
+      toolName: "create_backlog_item",
+    });
+  });
+
+  it("returns a bounded approval requirement without executing", async () => {
+    harness.applyOverrides({
+      resolveCoworkerAuthorityInput: async () =>
+        harness.authorityInput({
+          action: {
+            ...harness.authorityInput().action,
+            toolName: "create_backlog_item",
+            requiredCapability: "manage_backlog",
+            sideEffect: true,
+            approvalPolicy: "side-effects",
+          },
+          rawParams: { title: "private title" },
+        }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "private title" },
+      userId: "user-1",
+      userContext: harness.normalUser,
+      context: {
+        agentId: "AGT-100",
+        routeContext: "/ops",
+        taskRunId: "TASK-1",
+      },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "approval_required",
+      governance: {
+        rejected: "approval_required",
+        authorityReason: "approval-required",
+      },
+      data: {
+        envelopeId: "ENV-1",
+        approvalBinding: {
+          actingHumanUserId: "user-1",
+          actingAgentId: "AGT-100",
+          toolName: "create_backlog_item",
+        },
+      },
+    });
+    expect(harness.executeMock()).not.toHaveBeenCalled();
+    expect(harness.approvalEnvelopeCreate()).toHaveBeenCalledOnce();
+    expect(JSON.stringify(result)).not.toContain("private title");
+    expect(harness.authorityRows().at(-1)).toMatchObject({
+      decision: "require-approval",
+    });
+  });
+
+  it("resumes and finalizes only the exact task bound to an approved call", async () => {
+    const pending = harness.authorityInput({
+      action: {
+        ...harness.authorityInput().action,
+        toolName: "create_backlog_item",
+        requiredCapability: "manage_backlog",
+        sideEffect: true,
+        approvalPolicy: "side-effects",
+      },
+      task: { taskRunId: "TASK-1", parentTaskRunId: "TASK-PARENT" },
+      rawParams: { title: "approved title" },
+    });
+    const binding = buildCoworkerApprovalBinding(pending);
+    harness.applyOverrides({
+      resolveCoworkerAuthorityInput: async () => ({
+        ...pending,
+        approval: {
+          envelopeId: "ENV-APPROVED",
+          status: "approved",
+          expiresAt: new Date(Date.now() + 60_000),
+          binding,
+        },
+      }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "approved title" },
+      userId: "user-1",
+      userContext: harness.normalUser,
+      context: {
+        agentId: "AGT-100",
+        routeContext: "/ops",
+        taskRunId: "TASK-1",
+      },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(true);
+    expect(harness.approvalTaskResume()).toHaveBeenCalledWith("TASK-1");
+    expect(harness.approvalTaskResume()).not.toHaveBeenCalledWith(
+      "TASK-SIBLING",
+    );
+    expect(harness.approvalEnvelopeFinalize()).toHaveBeenCalledWith(
+      "ENV-APPROVED",
+      true,
+    );
+  });
+
+  it("fails closed when authority evidence cannot be recorded", async () => {
+    harness.applyOverrides({
+      authorizationDecisionCreate: async () => {
+        throw new Error("decision store unavailable");
+      },
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: harness.normalUser,
+      context: { agentId: "AGT-100" },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "authority_evidence_unavailable",
+    });
+    expect(harness.executeMock()).not.toHaveBeenCalled();
+  });
+
+  it("keeps direct human REST calls on the existing capability seam", async () => {
+    harness.applyOverrides({
+      resolveCoworkerAuthorityInput: async () => {
+        throw new Error("must not resolve coworker authority");
+      },
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: harness.normalUser,
+      source: "rest",
+    });
+
+    expect(result.success).toBe(true);
+    expect(harness.authorityRows()).toHaveLength(0);
+  });
+}

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -5,6 +5,15 @@ import {
   governedExecuteTool,
   registerToolLifecycleHook,
 } from "./mcp-governed-execute";
+import type {
+  AuthorityApprovalEnvelopeCreate,
+  AuthorityApprovalEnvelopeFinalize,
+  AuthorityApprovalTaskResume,
+} from "./mcp-governed-execute";
+import {
+  buildCoworkerApprovalBinding,
+  type CoworkerAuthorityInput,
+} from "./govern/authority/coworker-authority-decision";
 import type { ToolResult } from "./mcp-tools";
 
 type AuditRow = Record<string, unknown>;
@@ -34,11 +43,74 @@ type ExecuteFn = (
 
 let auditRows: AuditRow[];
 let receiptRows: AuditRow[];
+let authorityRows: AuditRow[];
 let executeMock: ReturnType<typeof vi.fn> & ExecuteFn;
+let approvalEnvelopeCreate: AuthorityApprovalEnvelopeCreate;
+let approvalTaskResume: AuthorityApprovalTaskResume;
+let approvalEnvelopeFinalize: AuthorityApprovalEnvelopeFinalize;
+
+function authorityInput(
+  overrides: Partial<CoworkerAuthorityInput> = {},
+): CoworkerAuthorityInput {
+  return {
+    authContext: {
+      principalId: "PRN-1",
+      principalAliases: [],
+      population: "workforce",
+      platformRole: "HR-000",
+      isSuperuser: true,
+      employeeId: "EMP-1",
+      managerScope: { directReportIds: [], indirectReportIds: [] },
+      teamIds: [],
+      accountScope: {
+        accountIds: [],
+        contactIds: [],
+        partnerAccountIds: [],
+      },
+      sensitivityClearance: [
+        "public",
+        "internal",
+        "confidential",
+        "restricted",
+      ],
+      authentication: {
+        source: "session",
+        methods: ["mfa"],
+        contextClassReference: null,
+      },
+      actingHumanUserId: "user-1",
+      actingAgentId: "AGT-100",
+      delegationGrantIds: [],
+      grantedCapabilities: ["view_platform", "view_backlog", "manage_backlog"],
+    },
+    action: {
+      toolName: "query_backlog",
+      requiredCapability: "view_platform",
+      agentGrantAllowed: true,
+      sideEffect: false,
+      executionMode: "immediate",
+      routeContext: "/ops",
+      approvalPolicy: "none",
+    },
+    subject: { kind: "platform", id: "dpf" },
+    delegation: null,
+    integration: { required: false, state: "not-required" },
+    dataPolicy: {
+      sensitivity: "internal",
+      maskingRequired: false,
+      maskingSatisfied: true,
+      decisionVersionsCurrent: true,
+    },
+    task: null,
+    rawParams: {},
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
   auditRows = [];
   receiptRows = [];
+  authorityRows = [];
   executeMock = vi.fn(
     async (): Promise<ToolResult> => ({
       success: true,
@@ -46,12 +118,24 @@ beforeEach(() => {
       entityId: "BI-FAKE",
     }),
   ) as ReturnType<typeof vi.fn> & ExecuteFn;
+  approvalEnvelopeCreate = vi.fn(async () => ({
+    id: "ENV-1",
+    status: "proposed",
+    expiresAt: new Date("2026-07-27T12:00:00Z"),
+  }));
+  approvalTaskResume = vi.fn(async () => undefined);
+  approvalEnvelopeFinalize = vi.fn(async () => undefined);
   _setGovernanceForTests({
     resolveAgentGrants: async () => ["backlog_read", "backlog_write"],
     isAllowedByGrants: () => true,
     executeTool: executeMock,
     toolExecutionCreate: captureAudit(auditRows),
     toolExecutionReceiptCreate: captureAudit(receiptRows),
+    resolveCoworkerAuthorityInput: async () => authorityInput(),
+    authorizationDecisionCreate: captureAudit(authorityRows),
+    authorityApprovalEnvelopeCreate: approvalEnvelopeCreate,
+    authorityApprovalTaskResume: approvalTaskResume,
+    authorityApprovalEnvelopeFinalize: approvalEnvelopeFinalize,
   });
 });
 
@@ -62,10 +146,252 @@ afterEach(() => {
     executeTool: null,
     toolExecutionCreate: null,
     toolExecutionReceiptCreate: null,
+    resolveCoworkerAuthorityInput: null,
+    authorizationDecisionCreate: null,
+    authorityApprovalEnvelopeCreate: null,
+    authorityApprovalTaskResume: null,
+    authorityApprovalEnvelopeFinalize: null,
   });
 });
 
 describe("governedExecuteTool — happy path", () => {
+  it("evaluates and records every coworker tool action at the universal seam", async () => {
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: { status: "open" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-100", routeContext: "/ops" },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(true);
+    expect(executeMock).toHaveBeenCalledOnce();
+    expect(authorityRows).toHaveLength(1);
+    expect(authorityRows[0]).toMatchObject({
+      actorType: "ai-coworker",
+      actorRef: "AGT-100",
+      humanContextRef: "user-1",
+      actionKey: "query_backlog",
+      decision: "allow",
+      routeContext: "/ops",
+      sensitivityLevel: "internal",
+    });
+  });
+
+  it("denies without executing when universal authority rejects the action", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_write"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      authorizationDecisionCreate: captureAudit(authorityRows),
+      resolveCoworkerAuthorityInput: async () =>
+        authorityInput({
+          authContext: {
+            ...authorityInput().authContext,
+            grantedCapabilities: ["view_platform"],
+          },
+          action: {
+            ...authorityInput().action,
+            toolName: "create_backlog_item",
+            requiredCapability: "manage_backlog",
+            sideEffect: true,
+            approvalPolicy: "side-effects",
+          },
+        }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "private title" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-100", routeContext: "/ops" },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "authority_denied",
+      governance: {
+        rejected: "authority_denied",
+        authorityReason: "human-capability-denied",
+      },
+    });
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(authorityRows.at(-1)).toMatchObject({
+      decision: "deny",
+      rationale: {
+        reasonCode: "human-capability-denied",
+      },
+    });
+    expect(JSON.stringify(authorityRows)).not.toContain("private title");
+  });
+
+  it("returns a bounded approval requirement without executing", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_write"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      authorizationDecisionCreate: captureAudit(authorityRows),
+      resolveCoworkerAuthorityInput: async () =>
+        authorityInput({
+          action: {
+            ...authorityInput().action,
+            toolName: "create_backlog_item",
+            requiredCapability: "manage_backlog",
+            sideEffect: true,
+            approvalPolicy: "side-effects",
+          },
+          rawParams: { title: "private title" },
+        }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "private title" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: {
+        agentId: "AGT-100",
+        routeContext: "/ops",
+        taskRunId: "TASK-1",
+      },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "approval_required",
+      governance: {
+        rejected: "approval_required",
+        authorityReason: "approval-required",
+      },
+      data: {
+        envelopeId: "ENV-1",
+        approvalBinding: {
+          actingHumanUserId: "user-1",
+          actingAgentId: "AGT-100",
+          toolName: "create_backlog_item",
+        },
+      },
+    });
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(approvalEnvelopeCreate).toHaveBeenCalledOnce();
+    expect(JSON.stringify(result)).not.toContain("private title");
+    expect(authorityRows.at(-1)).toMatchObject({
+      decision: "require-approval",
+    });
+  });
+
+  it("resumes and finalizes only the exact task bound to an approved call", async () => {
+    const pending = authorityInput({
+      action: {
+        ...authorityInput().action,
+        toolName: "create_backlog_item",
+        requiredCapability: "manage_backlog",
+        sideEffect: true,
+        approvalPolicy: "side-effects",
+      },
+      task: { taskRunId: "TASK-1", parentTaskRunId: "TASK-PARENT" },
+      rawParams: { title: "approved title" },
+    });
+    const binding = buildCoworkerApprovalBinding(pending);
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_write"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      toolExecutionReceiptCreate: captureAudit(receiptRows),
+      authorizationDecisionCreate: captureAudit(authorityRows),
+      authorityApprovalEnvelopeCreate: approvalEnvelopeCreate,
+      authorityApprovalTaskResume: approvalTaskResume,
+      authorityApprovalEnvelopeFinalize: approvalEnvelopeFinalize,
+      resolveCoworkerAuthorityInput: async () => ({
+        ...pending,
+        approval: {
+          envelopeId: "ENV-APPROVED",
+          status: "approved",
+          expiresAt: new Date(Date.now() + 60_000),
+          binding,
+        },
+      }),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "create_backlog_item",
+      rawParams: { title: "approved title" },
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: {
+        agentId: "AGT-100",
+        routeContext: "/ops",
+        taskRunId: "TASK-1",
+      },
+      source: "agentic-loop",
+    });
+
+    expect(result.success).toBe(true);
+    expect(approvalTaskResume).toHaveBeenCalledWith("TASK-1");
+    expect(approvalTaskResume).not.toHaveBeenCalledWith("TASK-SIBLING");
+    expect(approvalEnvelopeFinalize).toHaveBeenCalledWith(
+      "ENV-APPROVED",
+      true,
+    );
+  });
+
+  it("fails closed when authority evidence cannot be recorded", async () => {
+    _setGovernanceForTests({
+      resolveAgentGrants: async () => ["backlog_read"],
+      isAllowedByGrants: () => true,
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      resolveCoworkerAuthorityInput: async () => authorityInput(),
+      authorizationDecisionCreate: async () => {
+        throw new Error("decision store unavailable");
+      },
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      context: { agentId: "AGT-100" },
+      source: "agentic-loop",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "authority_evidence_unavailable",
+    });
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps direct human REST calls on the existing capability seam", async () => {
+    _setGovernanceForTests({
+      executeTool: executeMock,
+      toolExecutionCreate: captureAudit(auditRows),
+      resolveCoworkerAuthorityInput: async () => {
+        throw new Error("must not resolve coworker authority");
+      },
+      authorizationDecisionCreate: captureAudit(authorityRows),
+    });
+
+    const result = await governedExecuteTool({
+      toolName: "query_backlog",
+      rawParams: {},
+      userId: "user-1",
+      userContext: NORMAL_USER,
+      source: "rest",
+    });
+
+    expect(result.success).toBe(true);
+    expect(authorityRows).toHaveLength(0);
+  });
+
   it("supports registering and unregistering lifecycle hooks", async () => {
     const calls: string[] = [];
     const unregister = registerToolLifecycleHook({
@@ -348,7 +674,7 @@ describe("governedExecuteTool — rejection paths", () => {
     expect(auditRows).toHaveLength(0);
   });
 
-  it("rejects on forbidden_grant and audits the failure (executeTool never runs)", async () => {
+  it("rejects a missing grant through the unified authority decision and audits the failure", async () => {
     _setGovernanceForTests({
       resolveAgentGrants: async () => ["registry_read"], // no backlog_write
       isAllowedByGrants: () => false,
@@ -364,7 +690,10 @@ describe("governedExecuteTool — rejection paths", () => {
       source: "rest",
     });
     expect(result.success).toBe(false);
-    expect(result.error).toBe("forbidden_grant");
+    expect(result).toMatchObject({
+      error: "authority_denied",
+      governance: { authorityReason: "agent-grant-denied" },
+    });
     expect(executeMock).not.toHaveBeenCalled();
     expect(auditRows).toHaveLength(1);
     expect(auditRows[0]?.success).toBe(false);
@@ -542,7 +871,10 @@ describe("governedExecuteTool — coworker read-baseline at execution time", () 
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("forbidden_grant");
+    expect(result).toMatchObject({
+      error: "authority_denied",
+      governance: { authorityReason: "agent-grant-denied" },
+    });
     expect(executeMock).not.toHaveBeenCalled();
     expect(auditRows[0]?.success).toBe(false);
   });
@@ -566,7 +898,10 @@ describe("governedExecuteTool — coworker read-baseline at execution time", () 
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("forbidden_grant");
+    expect(result).toMatchObject({
+      error: "authority_denied",
+      governance: { authorityReason: "agent-grant-denied" },
+    });
     expect(executeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -10,25 +10,19 @@ import type {
   AuthorityApprovalEnvelopeFinalize,
   AuthorityApprovalTaskResume,
 } from "./mcp-governed-execute";
-import {
-  buildCoworkerApprovalBinding,
-  type CoworkerAuthorityInput,
-} from "./govern/authority/coworker-authority-decision";
+import type { CoworkerAuthorityInput } from "./govern/authority/coworker-authority-decision";
 import type { ToolResult } from "./mcp-tools";
-
+import { registerCoworkerAuthorityCases } from "./mcp-governed-execute-authority.cases";
 type AuditRow = Record<string, unknown>;
-
 function captureAudit(rows: AuditRow[]) {
   return async (data: AuditRow) => {
     rows.push(data);
   };
 }
-
 const NORMAL_USER = {
   platformRole: "ceo",
   isSuperuser: true,
 };
-
 type ExecuteFn = (
   toolName: string,
   params: Record<string, unknown>,
@@ -40,7 +34,6 @@ type ExecuteFn = (
     taskRunId?: string;
   },
 ) => Promise<ToolResult>;
-
 let auditRows: AuditRow[];
 let receiptRows: AuditRow[];
 let authorityRows: AuditRow[];
@@ -48,7 +41,6 @@ let executeMock: ReturnType<typeof vi.fn> & ExecuteFn;
 let approvalEnvelopeCreate: AuthorityApprovalEnvelopeCreate;
 let approvalTaskResume: AuthorityApprovalTaskResume;
 let approvalEnvelopeFinalize: AuthorityApprovalEnvelopeFinalize;
-
 function authorityInput(
   overrides: Partial<CoworkerAuthorityInput> = {},
 ): CoworkerAuthorityInput {
@@ -106,6 +98,23 @@ function authorityInput(
     ...overrides,
   };
 }
+function applyAuthorityOverrides(
+  overrides: Parameters<typeof _setGovernanceForTests>[0],
+): void {
+  _setGovernanceForTests({
+    resolveAgentGrants: async () => ["backlog_read", "backlog_write"],
+    isAllowedByGrants: () => true,
+    executeTool: executeMock,
+    toolExecutionCreate: captureAudit(auditRows),
+    toolExecutionReceiptCreate: captureAudit(receiptRows),
+    resolveCoworkerAuthorityInput: async () => authorityInput(),
+    authorizationDecisionCreate: captureAudit(authorityRows),
+    authorityApprovalEnvelopeCreate: approvalEnvelopeCreate,
+    authorityApprovalTaskResume: approvalTaskResume,
+    authorityApprovalEnvelopeFinalize: approvalEnvelopeFinalize,
+    ...overrides,
+  });
+}
 
 beforeEach(() => {
   auditRows = [];
@@ -155,243 +164,13 @@ afterEach(() => {
 });
 
 describe("governedExecuteTool — happy path", () => {
-  it("evaluates and records every coworker tool action at the universal seam", async () => {
-    const result = await governedExecuteTool({
-      toolName: "query_backlog",
-      rawParams: { status: "open" },
-      userId: "user-1",
-      userContext: NORMAL_USER,
-      context: { agentId: "AGT-100", routeContext: "/ops" },
-      source: "agentic-loop",
-    });
-
-    expect(result.success).toBe(true);
-    expect(executeMock).toHaveBeenCalledOnce();
-    expect(authorityRows).toHaveLength(1);
-    expect(authorityRows[0]).toMatchObject({
-      actorType: "ai-coworker",
-      actorRef: "AGT-100",
-      humanContextRef: "user-1",
-      actionKey: "query_backlog",
-      decision: "allow",
-      routeContext: "/ops",
-      sensitivityLevel: "internal",
-    });
+  registerCoworkerAuthorityCases({
+    applyOverrides: applyAuthorityOverrides, authorityInput,
+    normalUser: NORMAL_USER, executeMock: () => executeMock,
+    authorityRows: () => authorityRows, auditRows: () => auditRows,
+    approvalEnvelopeCreate: () => approvalEnvelopeCreate, approvalTaskResume: () => approvalTaskResume,
+    approvalEnvelopeFinalize: () => approvalEnvelopeFinalize,
   });
-
-  it("denies without executing when universal authority rejects the action", async () => {
-    _setGovernanceForTests({
-      resolveAgentGrants: async () => ["backlog_write"],
-      isAllowedByGrants: () => true,
-      executeTool: executeMock,
-      toolExecutionCreate: captureAudit(auditRows),
-      authorizationDecisionCreate: captureAudit(authorityRows),
-      resolveCoworkerAuthorityInput: async () =>
-        authorityInput({
-          authContext: {
-            ...authorityInput().authContext,
-            grantedCapabilities: ["view_platform"],
-          },
-          action: {
-            ...authorityInput().action,
-            toolName: "create_backlog_item",
-            requiredCapability: "manage_backlog",
-            sideEffect: true,
-            approvalPolicy: "side-effects",
-          },
-        }),
-    });
-
-    const result = await governedExecuteTool({
-      toolName: "create_backlog_item",
-      rawParams: { title: "private title" },
-      userId: "user-1",
-      userContext: NORMAL_USER,
-      context: { agentId: "AGT-100", routeContext: "/ops" },
-      source: "agentic-loop",
-    });
-
-    expect(result).toMatchObject({
-      success: false,
-      error: "authority_denied",
-      governance: {
-        rejected: "authority_denied",
-        authorityReason: "human-capability-denied",
-      },
-    });
-    expect(executeMock).not.toHaveBeenCalled();
-    expect(authorityRows.at(-1)).toMatchObject({
-      decision: "deny",
-      rationale: {
-        reasonCode: "human-capability-denied",
-      },
-    });
-    expect(JSON.stringify(authorityRows)).not.toContain("private title");
-  });
-
-  it("returns a bounded approval requirement without executing", async () => {
-    _setGovernanceForTests({
-      resolveAgentGrants: async () => ["backlog_write"],
-      isAllowedByGrants: () => true,
-      executeTool: executeMock,
-      toolExecutionCreate: captureAudit(auditRows),
-      authorizationDecisionCreate: captureAudit(authorityRows),
-      resolveCoworkerAuthorityInput: async () =>
-        authorityInput({
-          action: {
-            ...authorityInput().action,
-            toolName: "create_backlog_item",
-            requiredCapability: "manage_backlog",
-            sideEffect: true,
-            approvalPolicy: "side-effects",
-          },
-          rawParams: { title: "private title" },
-        }),
-    });
-
-    const result = await governedExecuteTool({
-      toolName: "create_backlog_item",
-      rawParams: { title: "private title" },
-      userId: "user-1",
-      userContext: NORMAL_USER,
-      context: {
-        agentId: "AGT-100",
-        routeContext: "/ops",
-        taskRunId: "TASK-1",
-      },
-      source: "agentic-loop",
-    });
-
-    expect(result).toMatchObject({
-      success: false,
-      error: "approval_required",
-      governance: {
-        rejected: "approval_required",
-        authorityReason: "approval-required",
-      },
-      data: {
-        envelopeId: "ENV-1",
-        approvalBinding: {
-          actingHumanUserId: "user-1",
-          actingAgentId: "AGT-100",
-          toolName: "create_backlog_item",
-        },
-      },
-    });
-    expect(executeMock).not.toHaveBeenCalled();
-    expect(approvalEnvelopeCreate).toHaveBeenCalledOnce();
-    expect(JSON.stringify(result)).not.toContain("private title");
-    expect(authorityRows.at(-1)).toMatchObject({
-      decision: "require-approval",
-    });
-  });
-
-  it("resumes and finalizes only the exact task bound to an approved call", async () => {
-    const pending = authorityInput({
-      action: {
-        ...authorityInput().action,
-        toolName: "create_backlog_item",
-        requiredCapability: "manage_backlog",
-        sideEffect: true,
-        approvalPolicy: "side-effects",
-      },
-      task: { taskRunId: "TASK-1", parentTaskRunId: "TASK-PARENT" },
-      rawParams: { title: "approved title" },
-    });
-    const binding = buildCoworkerApprovalBinding(pending);
-    _setGovernanceForTests({
-      resolveAgentGrants: async () => ["backlog_write"],
-      isAllowedByGrants: () => true,
-      executeTool: executeMock,
-      toolExecutionCreate: captureAudit(auditRows),
-      toolExecutionReceiptCreate: captureAudit(receiptRows),
-      authorizationDecisionCreate: captureAudit(authorityRows),
-      authorityApprovalEnvelopeCreate: approvalEnvelopeCreate,
-      authorityApprovalTaskResume: approvalTaskResume,
-      authorityApprovalEnvelopeFinalize: approvalEnvelopeFinalize,
-      resolveCoworkerAuthorityInput: async () => ({
-        ...pending,
-        approval: {
-          envelopeId: "ENV-APPROVED",
-          status: "approved",
-          expiresAt: new Date(Date.now() + 60_000),
-          binding,
-        },
-      }),
-    });
-
-    const result = await governedExecuteTool({
-      toolName: "create_backlog_item",
-      rawParams: { title: "approved title" },
-      userId: "user-1",
-      userContext: NORMAL_USER,
-      context: {
-        agentId: "AGT-100",
-        routeContext: "/ops",
-        taskRunId: "TASK-1",
-      },
-      source: "agentic-loop",
-    });
-
-    expect(result.success).toBe(true);
-    expect(approvalTaskResume).toHaveBeenCalledWith("TASK-1");
-    expect(approvalTaskResume).not.toHaveBeenCalledWith("TASK-SIBLING");
-    expect(approvalEnvelopeFinalize).toHaveBeenCalledWith(
-      "ENV-APPROVED",
-      true,
-    );
-  });
-
-  it("fails closed when authority evidence cannot be recorded", async () => {
-    _setGovernanceForTests({
-      resolveAgentGrants: async () => ["backlog_read"],
-      isAllowedByGrants: () => true,
-      executeTool: executeMock,
-      toolExecutionCreate: captureAudit(auditRows),
-      resolveCoworkerAuthorityInput: async () => authorityInput(),
-      authorizationDecisionCreate: async () => {
-        throw new Error("decision store unavailable");
-      },
-    });
-
-    const result = await governedExecuteTool({
-      toolName: "query_backlog",
-      rawParams: {},
-      userId: "user-1",
-      userContext: NORMAL_USER,
-      context: { agentId: "AGT-100" },
-      source: "agentic-loop",
-    });
-
-    expect(result).toMatchObject({
-      success: false,
-      error: "authority_evidence_unavailable",
-    });
-    expect(executeMock).not.toHaveBeenCalled();
-  });
-
-  it("keeps direct human REST calls on the existing capability seam", async () => {
-    _setGovernanceForTests({
-      executeTool: executeMock,
-      toolExecutionCreate: captureAudit(auditRows),
-      resolveCoworkerAuthorityInput: async () => {
-        throw new Error("must not resolve coworker authority");
-      },
-      authorizationDecisionCreate: captureAudit(authorityRows),
-    });
-
-    const result = await governedExecuteTool({
-      toolName: "query_backlog",
-      rawParams: {},
-      userId: "user-1",
-      userContext: NORMAL_USER,
-      source: "rest",
-    });
-
-    expect(result.success).toBe(true);
-    expect(authorityRows).toHaveLength(0);
-  });
-
   it("supports registering and unregistering lifecycle hooks", async () => {
     const calls: string[] = [];
     const unregister = registerToolLifecycleHook({
@@ -672,32 +451,6 @@ describe("governedExecuteTool — rejection paths", () => {
     expect(executeMock).not.toHaveBeenCalled();
     // unknown_tool is rejected before audit write
     expect(auditRows).toHaveLength(0);
-  });
-
-  it("rejects a missing grant through the unified authority decision and audits the failure", async () => {
-    _setGovernanceForTests({
-      resolveAgentGrants: async () => ["registry_read"], // no backlog_write
-      isAllowedByGrants: () => false,
-      executeTool: executeMock,
-      toolExecutionCreate: captureAudit(auditRows),
-    });
-    const result = await governedExecuteTool({
-      toolName: "create_backlog_item",
-      rawParams: { title: "x", type: "product", source: "user-request" },
-      userId: "u",
-      userContext: NORMAL_USER,
-      context: { agentId: "AGT-100" },
-      source: "rest",
-    });
-    expect(result.success).toBe(false);
-    expect(result).toMatchObject({
-      error: "authority_denied",
-      governance: { authorityReason: "agent-grant-denied" },
-    });
-    expect(executeMock).not.toHaveBeenCalled();
-    expect(auditRows).toHaveLength(1);
-    expect(auditRows[0]?.success).toBe(false);
-    expect(auditRows[0]?.toolName).toBe("create_backlog_item");
   });
 
   it("rejects on forbidden_capability and audits the failure", async () => {

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -10,6 +10,23 @@
 import { prisma } from "@dpf/db";
 import { createHash, scryptSync } from "crypto";
 import { can, type CapabilityKey, type UserContext } from "./permissions";
+import type { CoworkerAuthorityDecision } from "./govern/authority/coworker-authority-decision";
+import {
+  enforceCoworkerToolAuthority,
+  finalizeCoworkerAuthorityApproval,
+  setCoworkerToolAuthorityOverridesForTests,
+  type AuthorizationDecisionCreate,
+  type AuthorityApprovalEnvelopeCreate,
+  type AuthorityApprovalEnvelopeFinalize,
+  type AuthorityApprovalTaskResume,
+  type CoworkerAuthorityInputResolver,
+} from "./govern/authority/coworker-tool-authority-gate";
+export type {
+  AuthorityApprovalEnvelopeCreate,
+  AuthorityApprovalEnvelopeFinalize,
+  AuthorityApprovalTaskResume,
+  CoworkerAuthorityInputResolver,
+} from "./govern/authority/coworker-tool-authority-gate";
 import {
   PLATFORM_TOOLS,
   executeTool,
@@ -70,6 +87,12 @@ export type GovernedExecuteContext = {
    */
   coworkerReadBaseline?: boolean;
   /**
+   * Server-owned session permission for tools that cross the platform
+   * boundary. Callers may set this only after the tool registry has admitted
+   * the tool for the current session.
+   */
+  externalAccessEnabled?: boolean;
+  /**
    * Optional Work Case context for consequential actions flowing through the
    * governed execution seam. Existing callers omit this and retain their
    * current audit/receipt behavior.
@@ -99,12 +122,16 @@ export type GovernedExecuteRejection =
   | "unknown_tool"
   | "forbidden_capability"
   | "forbidden_grant"
-  | "hook_denied";
+  | "hook_denied"
+  | "authority_denied"
+  | "approval_required"
+  | "authority_evidence_unavailable";
 
 export type GovernedExecuteResult = ToolResult & {
   governance?: {
     rejected?: GovernedExecuteRejection;
     durationMs?: number;
+    authorityReason?: CoworkerAuthorityDecision["reasonCode"];
   };
 };
 
@@ -159,6 +186,11 @@ export function _setGovernanceForTests(overrides: {
   ) => Promise<ToolResult>) | null;
   toolExecutionCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
   toolExecutionReceiptCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
+  resolveCoworkerAuthorityInput?: CoworkerAuthorityInputResolver | null;
+  authorizationDecisionCreate?: AuthorizationDecisionCreate | null;
+  authorityApprovalEnvelopeCreate?: AuthorityApprovalEnvelopeCreate | null;
+  authorityApprovalTaskResume?: AuthorityApprovalTaskResume | null;
+  authorityApprovalEnvelopeFinalize?: AuthorityApprovalEnvelopeFinalize | null;
   lifecycleHooks?: ToolLifecycleHook[] | null;
 }): void {
   _resolveAgentGrants = overrides.resolveAgentGrants ?? null;
@@ -166,6 +198,7 @@ export function _setGovernanceForTests(overrides: {
   _executeToolOverride = overrides.executeTool ?? null;
   _toolExecutionCreateOverride = overrides.toolExecutionCreate ?? null;
   _toolExecutionReceiptCreateOverride = overrides.toolExecutionReceiptCreate ?? null;
+  setCoworkerToolAuthorityOverridesForTests(overrides);
   _lifecycleHooks = overrides.lifecycleHooks ?? [];
 }
 
@@ -438,6 +471,7 @@ async function runPostToolHooks(event: ToolLifecyclePostEvent): Promise<void> {
 export async function governedExecuteTool(
   args: GovernedExecuteArgs,
 ): Promise<GovernedExecuteResult> {
+  let approvedAuthorityEnvelopeId: string | null = null;
   const tool = findTool(args.toolName);
   if (!tool) {
     return {
@@ -461,10 +495,13 @@ export async function governedExecuteTool(
     rawParams: coerceMcpToolArgs(args.rawParams, tool.inputSchema),
   };
 
-  // Capability check — user must have the platform role required by the tool.
-  if (tool.requiredCapability) {
-    const allowed = can(args.userContext, tool.requiredCapability as CapabilityKey);
-    if (!allowed) {
+  const humanCapabilityAllowed = !tool.requiredCapability
+    || can(args.userContext, tool.requiredCapability as CapabilityKey);
+
+  // Direct human transports retain the existing capability contract. Coworker
+  // calls are evaluated below as one combined human + agent + delegation
+  // decision so every attempted action produces one complete authority record.
+  if (!args.context?.agentId && !humanCapabilityAllowed) {
       const result = rejectionResult(
         args.toolName,
         "forbidden_capability",
@@ -480,11 +517,8 @@ export async function governedExecuteTool(
         durationMs: 0,
       });
       return result;
-    }
   }
 
-  // Agent grant check — when an agentId is in the context, the agent must
-  // have a grant that authorises this tool.
   if (args.context?.agentId) {
     let grants = await resolveGrants(args.context.agentId);
     // In-portal coworker chat turns attach COWORKER_READ_BASELINE_GRANTS to the
@@ -500,24 +534,45 @@ export async function governedExecuteTool(
       const { COWORKER_READ_BASELINE_GRANTS } = await import("./tak/agent-grants");
       grants = Array.from(new Set([...grants, ...COWORKER_READ_BASELINE_GRANTS]));
     }
-    const allowed = await isAllowedByGrants(args.toolName, grants);
-    if (!allowed) {
-      const result = rejectionResult(
-        args.toolName,
-        "forbidden_grant",
-        `agent ${args.context.agentId} lacks a required grant for ${args.toolName}`,
-      );
-      await writeAudit({
-        toolName: args.toolName,
-        rawParams: args.rawParams,
-        result,
-        userId: args.userId,
-        source: args.source,
-        context: args.context,
-        durationMs: 0,
-      });
+    const agentGrantAllowed = await isAllowedByGrants(args.toolName, grants);
+
+    const authorityGate = await enforceCoworkerToolAuthority(
+      args,
+      tool,
+      agentGrantAllowed,
+    );
+    if (authorityGate.outcome === "reject") {
+      const result: GovernedExecuteResult = {
+        ...rejectionResult(
+          args.toolName,
+          authorityGate.rejection,
+          authorityGate.message,
+        ),
+        ...(authorityGate.data ? { data: authorityGate.data } : {}),
+        governance: {
+          rejected: authorityGate.rejection,
+          ...(authorityGate.authorityReason
+            ? { authorityReason: authorityGate.authorityReason }
+            : {}),
+        },
+      };
+      if (
+        authorityGate.rejection === "authority_denied"
+        || authorityGate.rejection === "approval_required"
+      ) {
+        await writeAudit({
+          toolName: args.toolName,
+          rawParams: args.rawParams,
+          result,
+          userId: args.userId,
+          source: args.source,
+          context: args.context,
+          durationMs: 0,
+        });
+      }
       return result;
     }
+    approvedAuthorityEnvelopeId = authorityGate.approvedEnvelopeId;
   }
 
   const hookRejection = await runPreToolHooks({
@@ -567,6 +622,25 @@ export async function governedExecuteTool(
     };
   }
   const durationMs = Date.now() - t0;
+
+  if (approvedAuthorityEnvelopeId) {
+    try {
+      await finalizeCoworkerAuthorityApproval(
+        approvedAuthorityEnvelopeId,
+        result.success,
+      );
+    } catch (err) {
+      // The action has already run, so this cannot fail closed without
+      // misreporting the side effect. Preserve the result and surface the
+      // evidence defect in server logs for reconciliation.
+      console.error(
+        "[governed-execute] approval envelope finalization failed envelope=%s tool=%s: %s",
+        JSON.stringify(approvedAuthorityEnvelopeId),
+        JSON.stringify(args.toolName),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+      );
+    }
+  }
 
   await runPostToolHooks({
     toolName: args.toolName,

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -2532,13 +2532,7 @@ export async function runAgenticLoop(params: {
             // time (BI-FD7E4D72) — otherwise a coworker whose own grants lack a
             // baseline read grant gets the tool attached but rejected on call.
             // Autonomous turns leave this false, so their authority is unchanged.
-            coworkerReadBaseline: interactionMode === "chat",
-            // This call already passed the server-owned available-tool check
-            // above. Mark external access connected only for a tool admitted
-            // by that registry; caller/model arguments cannot set this.
-            externalAccessEnabled: toolDef.requiresExternalAccess
-              ? true
-              : undefined,
+            coworkerReadBaseline: interactionMode === "chat", externalAccessEnabled: toolDef.requiresExternalAccess || undefined,
             // BI-F4A30FCB (Dale dogfood 2026-05-24): plumb the build the
             // user is messaging from into tool context so phase-scoped
             // tools (start_ideate_research, start_scout_research) can

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -2533,6 +2533,12 @@ export async function runAgenticLoop(params: {
             // baseline read grant gets the tool attached but rejected on call.
             // Autonomous turns leave this false, so their authority is unchanged.
             coworkerReadBaseline: interactionMode === "chat",
+            // This call already passed the server-owned available-tool check
+            // above. Mark external access connected only for a tool admitted
+            // by that registry; caller/model arguments cannot set this.
+            externalAccessEnabled: toolDef.requiresExternalAccess
+              ? true
+              : undefined,
             // BI-F4A30FCB (Dale dogfood 2026-05-24): plumb the build the
             // user is messaging from into tool context so phase-scoped
             // tools (start_ideate_research, start_scout_research) can

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -429,6 +429,7 @@ export async function executeAutonomousWorkTool(input: {
   threadId: string;
   taskRunId: string;
   apiTokenId?: string | null;
+  externalAccessEnabled?: boolean;
 }): Promise<ToolResult> {
   const { governedExecuteTool } = await import("@/lib/mcp-governed-execute");
 
@@ -444,6 +445,7 @@ export async function executeAutonomousWorkTool(input: {
       threadId: input.threadId,
       taskRunId: input.taskRunId,
       apiTokenId: input.apiTokenId ?? undefined,
+      externalAccessEnabled: input.externalAccessEnabled,
     },
   });
 }

--- a/docs/architecture/ai-agent-meta-model.md
+++ b/docs/architecture/ai-agent-meta-model.md
@@ -94,7 +94,8 @@ In the registry this is the `config_profile.model_binding` block (`model_id`, `p
 
 - **MCP servers** are first-class records: **`McpServer`** (`serverId`, `transport`, `category`, `status`, `healthStatus`, …) with discovered **`McpServerTool`** rows (`toolName`, `inputSchema`, `isEnabled`). The local DPF server (`serverId="dpf"`) exposes the platform tool catalog over JSON-RPC 2.0 at `apps/web/app/api/mcp/v1/route.ts`.
 - **Tool grants** — an agent's *permitted* surface is `AgentToolGrant` rows (`grantKey`, e.g. `registry_read`, `backlog_write`). Grants are coarse keys, not raw tool names.
-- **Enforcement** — `getAvailableTools()` (`apps/web/lib/mcp-tools.ts`) intersects **user role capability ∩ agent grants**, applies `TOOL_TO_GRANTS` + `GRANT_IMPLICATIONS` (`apps/web/lib/agent-grants.ts`), adds the `COWORKER_READ_BASELINE_GRANTS` every coworker gets, then unions in MCP server tools under the same gating. Default-deny: an unmapped tool is refused. Every call writes to the `ToolExecution` ledger (AGENTS.md §8).
+- **Attachment** — `getAvailableTools()` (`apps/web/lib/mcp-tools.ts`) intersects **user role capability ∩ agent grants**, applies `TOOL_TO_GRANTS` + `GRANT_IMPLICATIONS` (`apps/web/lib/agent-grants.ts`), adds the `COWORKER_READ_BASELINE_GRANTS` every coworker gets, then unions in MCP server tools under the same gating. Default-deny: an unmapped tool is refused.
+- **Execution-time authority** — every coworker call passes through `governedExecuteTool()`, which evaluates the current `EffectiveAuthContext`, coworker grant, `DelegationChain` attenuation, route/record scope, external-connection state, sensitivity clearance, masking obligations, policy version, and HITL policy. Prompt text, model routing fallback, and provider cost are deliberately not authority inputs. The outcome is `allow`, `deny`, or `require-approval`; every outcome writes a privacy-safe `AuthorizationDecisionLog` before execution. A missing authority context or failed decision-log write fails closed.
 
 In the registry this is `config_profile.tool_grants` and `execution_runtime`.
 
@@ -115,7 +116,8 @@ Three prompt sources compose into the system context:
 
 - **`AgentGovernanceProfile`** (schema ~line 2015) — `autonomyLevel`, `hitlPolicy`, `allowDelegation`, `maxDelegationRiskBand`, plus FKs to `AgentCapabilityClass` and `DirectivePolicyClass`.
 - **HITL tier** (`hitlTierDefault` 0–3) — the autonomy dial.
-- **Delegation & authority** — `DelegationGrant` and `AuthorityBinding` carry scoped, time-boxed, risk-banded authority; effectful actions pass through a `CoworkerActionEnvelope` approval gate.
+- **Delegation & authority** — `DelegationGrant` and `AuthorityBinding` carry scoped, time-boxed, risk-banded authority. `DelegationChain` narrows capability scope hop by hop and preserves the human origin at execution.
+- **HITL call-chain return** — an execution-time `require-approval` decision creates or reuses a privacy-safe `CoworkerActionEnvelope` bound to the exact human, coworker, task, delegation chain, tool, subject, route, input fingerprint, sensitivity, and policy-version fingerprint. Only that `TaskRun` moves to `input-required`; an approved re-entry resumes and finalizes only the matching call. Changed inputs or stale policy require a new decision.
 - **Accountability spine** — `humanSupervisorId` (sponsor) + `escalatesTo` (escalation target). The SysML current-state model of these invariants lives in `packages/db/src/seed-ea-sysml-agent-authority.ts` (default-deny, dual-gate, HITL, token-scope, audit, dual-principal, grant-narrowing).
 
 ### 3.7 Lifecycle & performance — *the agent over time*
@@ -213,9 +215,9 @@ Identity and config are static; the live agent is *assembled* per request. `getA
 | MCP servers & tools | `McpServer`, `McpServerTool`, `AgentToolGrant`; `apps/web/app/api/mcp/v1/route.ts`; `apps/web/lib/mcp-tools.ts`; `apps/web/lib/agent-grants.ts` |
 | Prompts | `prompts/<category>/<slug>.prompt.md`; `PromptTemplate`; `AgentPromptContext`; `apps/web/lib/integrate/build-agent-prompts.ts` |
 | Skills | `SkillDefinition`, `SkillAssignment`; `packages/dpf-skill-pack/skills/<slug>/SKILL.md` |
-| Governance & authority | `AgentGovernanceProfile`, `DelegationGrant`, `AuthorityBinding`, `CoworkerActionEnvelope`; `packages/db/src/seed-ea-sysml-agent-authority.ts`; AGENTS.md §8 |
+| Governance & authority | `AgentGovernanceProfile`, `DelegationGrant`, `DelegationChain`, `AuthorityBinding`, `CoworkerActionEnvelope`; `apps/web/lib/govern/authority/`; `apps/web/lib/mcp-governed-execute.ts`; `packages/db/src/seed-ea-sysml-agent-authority.ts`; AGENTS.md §8 |
 | Lifecycle & performance | `Agent.status/lifecycleStage`, `AgentPerformance`, `CoworkerSelfAssessment`, `CoworkerCapabilityNeed` |
-| Audit ledger | `ToolExecution` (`/platform/ai/authority`) |
+| Audit ledger | `AuthorizationDecisionLog` (why authority allowed/denied/paused) + `ToolExecution` (what ran), surfaced at `/platform/ai/authority` |
 
 ---
 

--- a/docs/data-impact/2026-07-27-coworker-authority-envelope-binding.data-impact.json
+++ b/docs/data-impact/2026-07-27-coworker-authority-envelope-binding.data-impact.json
@@ -1,0 +1,78 @@
+{
+  "version": "1",
+  "accountableOwner": "identity-and-access-management",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "Coworker approval attention and decision projections",
+    "AuthorizationDecisionLog and ToolExecution evidence joins"
+  ],
+  "migration": {
+    "name": "20260727160000_bind_coworker_authority_envelopes",
+    "backfill": "none - every new binding is nullable and historical envelopes remain explicitly unbound rather than receiving fabricated authority evidence"
+  },
+  "tests": [
+    "apps/web/lib/coworker/authority-approval-envelope.test.ts",
+    "apps/web/lib/govern/authority/coworker-authority-decision.test.ts",
+    "apps/web/lib/govern/authority/resolve-coworker-tool-authority.test.ts",
+    "apps/web/lib/mcp-governed-execute.test.ts",
+    "apps/web/app/api/mcp/call/route.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:coworker-action-envelope#authority-binding",
+      "prismaModel": "CoworkerActionEnvelope",
+      "lifecycleDisposition": "retained and resolved with the canonical coworker approval envelope; terminal envelopes follow the existing approval-evidence lifecycle",
+      "fields": [
+        {
+          "fieldId": "data:coworker-action-envelope#taskRunId",
+          "resolution": "governed",
+          "reason": "binds approval pause and resume to the exact originating task node",
+          "provenance": "server-resolved governed execution context",
+          "flags": ["sensitive"],
+          "fieldPolicy": "authorization evidence only; never accept from model output and expose only through bounded approval/task projections"
+        },
+        {
+          "fieldId": "data:coworker-action-envelope#delegationChainId",
+          "resolution": "governed",
+          "reason": "prevents approval reuse outside the active narrowing chain of custody",
+          "provenance": "server-resolved active DelegationChain",
+          "flags": ["sensitive"],
+          "fieldPolicy": "authorization evidence only; never use the identifier itself to widen authority"
+        },
+        {
+          "fieldId": "data:coworker-action-envelope#authorityDecisionId",
+          "resolution": "governed",
+          "reason": "joins the approval lifecycle to the exact privacy-safe authorization decision",
+          "provenance": "AuthorizationDecisionLog writer at the universal execution seam",
+          "flags": ["sensitive"],
+          "fieldPolicy": "opaque evidence reference only; do not project decision internals or raw parameters"
+        },
+        {
+          "fieldId": "data:coworker-action-envelope#inputFingerprint",
+          "resolution": "governed",
+          "reason": "detects changed arguments without persisting the governed input payload",
+          "provenance": "server-side canonical input fingerprinting",
+          "flags": ["sensitive"],
+          "fieldPolicy": "one-way fingerprint only; prohibit raw arguments, secrets, employee data, customer data, and reversible encodings"
+        },
+        {
+          "fieldId": "data:coworker-action-envelope#approvalBindingFingerprint",
+          "resolution": "governed",
+          "reason": "provides idempotency and exact-match replay protection across the full approval binding",
+          "provenance": "server-side canonical approval-binding fingerprinting",
+          "flags": ["sensitive"],
+          "fieldPolicy": "one-way fingerprint only; use for exact lookup and active-envelope uniqueness, never as an authorization grant by itself"
+        },
+        {
+          "fieldId": "data:coworker-action-envelope#expiresAt",
+          "resolution": "governed",
+          "reason": "bounds the period during which an exact human approval may be re-evaluated for execution",
+          "provenance": "server-owned approval policy TTL",
+          "flags": [],
+          "fieldPolicy": "server-owned timestamp; expired approvals fail closed and cannot be revived by callers"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-27-coworker-authority-universal-seam.md
+++ b/docs/superpowers/plans/2026-07-27-coworker-authority-universal-seam.md
@@ -8,9 +8,11 @@
 
 ## Backlog Coverage
 
-- Decision: `atomic`
+- Decision: atomic
 - Receipt: `cms3cwgnq03kq01p5c89v774q`
-- Parent BI: `BI-62BFAA95`
+- Parent: `BI-62BFAA95`
+- Dependencies: none
+- Rationale: The evaluator, universal enforcement seam, approval return path, and regression proof are mutually dependent parts of one safe release; shipping any phase alone would either enforce nothing or dead-end approved work.
 - Delivery graph:
   - `authority-decision-contract` -> `BI-62BFAA95`
   - `universal-execution-seam` -> `BI-62BFAA95`, depends on `authority-decision-contract`
@@ -18,6 +20,19 @@
   - `consumer-and-regression-tests` -> `BI-62BFAA95`, depends on all preceding phases
 
 The phases are internal sequencing, not independently safe releases. A chain-only release would improve provenance while still allowing actions that should require approval. An evaluator without the universal seam would not enforce anything. A `require-approval` result without a return path to the originating `TaskRun`/envelope would dead-end work. The complete seam must therefore land as one PR.
+
+## Design Grounding
+
+- Existing specs/plans reviewed:
+  - `docs/superpowers/specs/2026-07-17-coworker-authority-model-completion-design.md`
+  - `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
+  - this atomic plan and its live backlog-coverage receipt
+- Current code substrate reviewed:
+  - `apps/web/lib/mcp-governed-execute.ts` as the universal enforcement point
+  - `apps/web/lib/identity/load-effective-auth-context.ts` as the verified human-context loader
+  - `apps/web/lib/tak/delegation-authority.ts`, `CoworkerActionEnvelope`, and `TaskRun` as the existing chain, approval, and return-path substrate
+- Source of truth: the deterministic authority evaluator owns the decision, `AuthorizationDecisionLog` owns decision evidence, `CoworkerActionEnvelope` owns approval lifecycle, and `ToolExecution` owns execution outcome.
+- Decision: extend those existing contracts at the universal seam and keep caller routes thin; do not create a parallel authority store, caller-specific policy branch, or prompt-owned approval path.
 
 ## Architecture Decision
 

--- a/docs/superpowers/plans/2026-07-27-coworker-authority-universal-seam.md
+++ b/docs/superpowers/plans/2026-07-27-coworker-authority-universal-seam.md
@@ -1,0 +1,186 @@
+# Coworker Authority Universal Seam Implementation Plan
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+**Backlog item:** `BI-62BFAA95`  
+**Work Capsule:** `WC-6D367D6F`  
+**Goal:** Make every AI-coworker tool action pass one fail-closed authority decision that intersects the human, coworker, delegation chain, route, object scope, connection state, and data policy; return approval decisions to the exact originating task node without widening sibling context.
+
+## Backlog Coverage
+
+- Decision: `atomic`
+- Receipt: `cms3cwgnq03kq01p5c89v774q`
+- Parent BI: `BI-62BFAA95`
+- Delivery graph:
+  - `authority-decision-contract` -> `BI-62BFAA95`
+  - `universal-execution-seam` -> `BI-62BFAA95`, depends on `authority-decision-contract`
+  - `hitl-call-chain-return` -> `BI-62BFAA95`, depends on `universal-execution-seam`
+  - `consumer-and-regression-tests` -> `BI-62BFAA95`, depends on all preceding phases
+
+The phases are internal sequencing, not independently safe releases. A chain-only release would improve provenance while still allowing actions that should require approval. An evaluator without the universal seam would not enforce anything. A `require-approval` result without a return path to the originating `TaskRun`/envelope would dead-end work. The complete seam must therefore land as one PR.
+
+## Architecture Decision
+
+WWMD ledger `DI-5965306B6BF9` compared:
+
+1. combined chain-of-custody and impact-gated approval at `governedExecuteTool`;
+2. chain propagation first, approval later;
+3. separate checks at individual caller surfaces.
+
+The kernel selected the combined universal seam with high confidence (composite `17.159`, margin `3.347`, no commandment conflict). The choice accepts a larger immediate blast radius in exchange for one reusable PEP, one decision receipt, and no interval where audit completeness can be mistaken for authorization completeness.
+
+This extends, rather than duplicates:
+
+- `apps/web/lib/mcp-governed-execute.ts` as the universal tool PEP;
+- `apps/web/lib/identity/effective-auth-context.ts` and its loader as the human/relationship scope;
+- `apps/web/lib/tak/delegation-authority.ts` and `DelegationChain` as the narrowing call-chain;
+- `CoworkerActionEnvelope` plus `apps/web/lib/coworker/envelope-state-machine.ts` as the approve/decline/execute lifecycle;
+- `TaskRun.parentTaskRunId`, `authorityScope`, `a2aMetadata`, and `input-required` as the originating-node return path;
+- `AuthorizationDecisionLog` as the canonical allow/deny/require-approval evidence row;
+- `DecisionInteraction` only where a governed judgment is required, not as a second authorization log.
+
+No new Prisma model or status vocabulary is planned. The schema audit shows that
+the existing `CoworkerActionEnvelope` needs nullable, indexed bindings for the
+originating `TaskRun`, delegation chain, authority decision, input fingerprint,
+and expiry. Extend that canonical model with an expand-only migration; do not
+hide stable authority relationships inside `argsJson` or create a parallel
+approval table.
+
+## Standards Grounding
+
+- NIST SP 800-207: keep policy decision separate from enforcement, evaluate each request using subject/resource context, and apply least privilege.
+- OWASP LLM06:2025 Excessive Agency: execute actions in the user's authorization scope and require human approval for high-impact actions.
+- DPF Pseudo-User Contract: an AI coworker never becomes the human principal; effective authority is the intersection of human authority and narrower coworker/delegation grants.
+
+The evaluator is deterministic application code. Prompt text, model output, routing fallback, provider cost, and caller-supplied approval claims are evidence inputs at most; none can broaden authority.
+
+## Phase 1: Pure Authority Decision Contract
+
+**Create:**
+
+- `apps/web/lib/govern/authority/coworker-authority-decision.ts`
+- `apps/web/lib/govern/authority/coworker-authority-decision.test.ts`
+
+**Refactor:**
+
+- extract decision construction and privacy-safe explanation formatting from `mcp-governed-execute.ts`;
+- keep execution, persistence, and hook orchestration outside the pure evaluator.
+
+Define a closed result:
+
+- `allow`
+- `deny`
+- `require-approval`
+
+Inputs must be server-owned or server-resolved: effective human context, agent grants, tool action metadata, route context, object/account/employee scope, active delegation grant and chain, integration connection state, data sensitivity/masking obligations, and any already-approved envelope reference.
+
+Fail closed when identity, object scope, delegation lineage, connection ownership, policy version, or approval binding is absent or stale. Produce concise user-readable reason and next action while keeping raw parameters, tokens, secrets, employee data, and policy internals out of evidence.
+
+**TDD cases:**
+
+- human capability and coworker grant must both authorize;
+- a delegation may narrow but never widen authority;
+- peer/shared-team scope cannot borrow manager scope;
+- prompt content, provider fallback, and caller-supplied sensitivity cannot lower a restriction;
+- reversible low-impact reads can allow;
+- unauthorized actions deny;
+- consequential authorized actions require approval unless the exact active envelope binds actor, action, object, task node, and parameter fingerprint;
+- expired/replayed/mismatched approval denies.
+
+## Phase 2: Universal PEP and Decision Evidence
+
+**Modify:**
+
+- `apps/web/lib/mcp-governed-execute.ts`
+- `apps/web/lib/mcp-governed-execute.test.ts`
+- `apps/web/lib/identity/load-effective-auth-context.ts`
+- `apps/web/lib/tak/delegation-authority.ts`
+
+Load or accept a server-resolved `EffectiveAuthContext` at the universal seam. Resolve the executing agent's grants and the active narrowing chain before tool execution. Invoke the pure evaluator after argument coercion but before lifecycle hooks and `executeTool`.
+
+Persist one `AuthorizationDecisionLog` for each evaluated agent action:
+
+- actor and human context references;
+- agent and delegation references;
+- action key, route, bounded object reference, sensitivity, policy version;
+- `allow`, `deny`, or `require-approval`;
+- privacy-safe rationale codes and decision version.
+
+Join the resulting `ToolExecution` to the same delegation chain and decision reference. Audit-write failure for a denied or approval-required action must not permit execution. Successful allow evidence must remain observable without storing raw sensitive arguments.
+
+Keep the existing human capability and agent grant checks as inputs to the new evaluator during refactoring, then remove duplicate branches only after parity tests prove the unified decision owns them.
+
+## Phase 3: HITL Pause and Exact Call-Chain Resume
+
+**Modify:**
+
+- `apps/web/lib/coworker/envelope-actions.ts`
+- `apps/web/lib/coworker/envelope-state-machine.ts`
+- `apps/web/lib/tak/subagent-fanout.ts`
+- `apps/web/lib/mcp/packs/screen-pack.ts`
+- `packages/db/prisma/schema.prisma`
+- `packages/db/prisma/migrations/<timestamp>_bind_coworker_envelopes_to_authority_chain/migration.sql`
+- the agentic-loop caller that supplies `GovernedExecuteContext`
+
+On `require-approval`:
+
+1. create or reuse an idempotent `CoworkerActionEnvelope` bound to the exact action, args fingerprint, human, coworker, `TaskRun.taskRunId`, delegation chain, authority decision, and expiry;
+2. set only the originating `TaskRun` to `input-required`;
+3. expose a bounded decision through the existing attention/decision surface;
+4. on approval, re-enter `governedExecuteTool` with the envelope id;
+5. re-evaluate current authority and policy before executing;
+6. resume the exact originating task node and preserve sibling tasks unchanged;
+7. on decline, expiry, cancellation, or mismatch, terminate the envelope without executing.
+
+Do not copy full parent context into child/sibling tasks. Pass stable ids and bounded authority scope; loaders resolve current state at the decision and execution boundaries.
+
+**TDD cases:**
+
+- a tertiary child pause points to its own task and preserves the root human;
+- approval resumes that child only;
+- sibling task authority/context does not change;
+- parent cancellation invalidates a pending child approval;
+- approval cannot be replayed for another tool, object, parameter set, route, agent, or policy version;
+- a changed grant, manager relation, connection state, sensitivity, or delegation chain forces a new decision.
+
+## Phase 4: Consumers, Architecture Projection, and Completion Gate
+
+Wire the current coworker chat, delegated subagent, autonomous task, and external MCP paths through the same context builder. No consumer may synthesize `allow` or treat `require-approval` as success.
+
+Update:
+
+- `docs/superpowers/specs/2026-07-17-coworker-authority-model-completion-design.md`
+- `docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md`
+- relevant EA architecture projection/registry entries if the authority seam is represented there.
+
+No operator documentation is required unless this slice changes the visible approval or denial experience. If visible copy or controls change, run `dpf-ux-fit-review` and update the relevant `docs/user-guide/` page in the same PR.
+
+**Targeted verification:**
+
+```powershell
+pnpm --filter web exec vitest run `
+  lib/govern/authority/coworker-authority-decision.test.ts `
+  lib/mcp-governed-execute.test.ts `
+  lib/coworker/envelope-state-machine.test.ts `
+  lib/tak/subagent-fanout.test.ts `
+  lib/identity/load-effective-auth-context.test.ts `
+  lib/work-management/policy-envelope.test.ts
+git diff --check
+```
+
+**Completion gate:**
+
+1. exact candidate passes the shared local-integration CI gate against current accepted `main`;
+2. all web unit tests and production build pass;
+3. the expand-only envelope-binding migration passes the migration-safety guard and applies cleanly against existing envelope rows;
+4. functional tests prove allow, deny, require-approval, exact child resume, sibling isolation, stale-policy denial, and replay denial;
+5. `pnpm pr:health <pr>` reports every check terminal and green with zero unresolved threads;
+6. merge-group CI passes before BI and Work Capsule completion.
+
+## Risks and Rollback
+
+- **Universal-seam regression:** a bad evaluator can block every coworker tool call. Mitigate with parity characterization tests before removing old checks and a single feature-local module that can be reverted with the PR.
+- **Approval replay or confused deputy:** an envelope could authorize a different action or child. Bind actor, human, action, object, args fingerprint, task node, chain, route, and policy versions; re-evaluate at execution.
+- **Audit leaks:** authority evidence could capture sensitive parameters. Persist bounded references, reason codes, versions, and fingerprints only.
+- **Duplicate sources of truth:** `AuthorizationDecisionLog`, `DecisionInteraction`, `CoworkerActionEnvelope`, and `ToolExecution` could overlap. Keep authorization result in `AuthorizationDecisionLog`, human judgment in `DecisionInteraction`, approval lifecycle in `CoworkerActionEnvelope`, and execution outcome in `ToolExecution`.
+- **Rollback:** squash-revert the PR. The nullable envelope-binding columns may remain harmlessly unused during rollback or be removed in a later contract migration; existing capability/grant checks remain behaviorally characterized so rollback restores the prior universal seam without data repair.

--- a/docs/user-guide/platform/identity-and-access.md
+++ b/docs/user-guide/platform/identity-and-access.md
@@ -21,8 +21,17 @@ order: 4
 2. Check group and authorization posture before editing the principal directly.
 3. Validate downstream effect on route access, tool grants, and coworker authority.
 
+Coworker actions are re-evaluated when the tool actually runs. The platform
+intersects the current human authority, coworker grant, delegated scope,
+record scope, connection state, data sensitivity, and HITL policy. A denial is
+returned as a plain-language explanation; an action that needs judgment pauses
+the originating task and creates one approval envelope. Approving that envelope
+does not approve a different task or changed action.
+
 ## What To Watch
 
 - direct fixes that bypass the canonical identity model
 - role changes that accidentally widen access
 - drift between directory records and effective authorization
+- assuming a prompt, model fallback, or cheaper provider can widen authority
+- approving a coworker action without checking the named action and record scope

--- a/packages/db/prisma/migrations/20260727160000_bind_coworker_authority_envelopes/migration.sql
+++ b/packages/db/prisma/migrations/20260727160000_bind_coworker_authority_envelopes/migration.sql
@@ -1,0 +1,35 @@
+-- Expand-only authority envelope binding. Every new column is nullable so
+-- existing envelopes remain valid and no fleet data can violate the change.
+-- @migration-safety: data-safe: nullable columns and indexes only; the optional
+-- unique fingerprint has no pre-existing non-null values.
+ALTER TABLE "CoworkerActionEnvelope"
+  ADD COLUMN "taskRunId" TEXT,
+  ADD COLUMN "delegationChainId" TEXT,
+  ADD COLUMN "authorityDecisionId" TEXT,
+  ADD COLUMN "inputFingerprint" TEXT,
+  ADD COLUMN "approvalBindingFingerprint" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP(3);
+
+CREATE INDEX "CoworkerActionEnvelope_approvalBindingFingerprint_idx"
+  ON "CoworkerActionEnvelope"("approvalBindingFingerprint");
+CREATE UNIQUE INDEX "CoworkerActionEnvelope_active_approval_binding_key"
+  ON "CoworkerActionEnvelope"("approvalBindingFingerprint")
+  WHERE "status" IN ('proposed', 'approved');
+CREATE INDEX "CoworkerActionEnvelope_taskRunId_idx"
+  ON "CoworkerActionEnvelope"("taskRunId");
+CREATE INDEX "CoworkerActionEnvelope_delegationChainId_idx"
+  ON "CoworkerActionEnvelope"("delegationChainId");
+CREATE INDEX "CoworkerActionEnvelope_authorityDecisionId_idx"
+  ON "CoworkerActionEnvelope"("authorityDecisionId");
+CREATE INDEX "CoworkerActionEnvelope_expiresAt_idx"
+  ON "CoworkerActionEnvelope"("expiresAt");
+
+ALTER TABLE "CoworkerActionEnvelope"
+  ADD CONSTRAINT "CoworkerActionEnvelope_taskRunId_fkey"
+  FOREIGN KEY ("taskRunId") REFERENCES "TaskRun"("taskRunId")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "CoworkerActionEnvelope"
+  ADD CONSTRAINT "CoworkerActionEnvelope_authorityDecisionId_fkey"
+  FOREIGN KEY ("authorityDecisionId") REFERENCES "AuthorizationDecisionLog"("decisionId")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3009,6 +3009,7 @@ model AuthorizationDecisionLog {
   patientSubjectPrincipal   Principal?               @relation("PatientAuthorizationSubject", fields: [patientSubjectPrincipalId], references: [id], onDelete: SetNull)
   patientAuthority          PatientAuthority?        @relation(fields: [patientAuthorityId], references: [id], onDelete: SetNull)
   patientConsentDirective   PatientConsentDirective? @relation(fields: [patientConsentDirectiveId], references: [id], onDelete: SetNull)
+  actionEnvelopes           CoworkerActionEnvelope[]
 
   @@index([decision])
   @@index([createdAt])
@@ -5534,24 +5535,37 @@ model ToolExecution {
 // ToolExecution.agentId convention; Principal convergence is via
 // PrincipalAlias lookup at query time (AGENTS.md §11), not a direct FK.
 model CoworkerActionEnvelope {
-  id               String    @id @default(cuid())
-  coworkerAgentId  String
-  delegatingUserId String
-  threadId         String
-  chatMessageId    String?
-  manifestActionId String
-  argsJson         Json
-  rationale        String
-  status           String    @default("proposed")
-  createdAt        DateTime  @default(now())
-  resolvedAt       DateTime?
+  id                         String    @id @default(cuid())
+  coworkerAgentId            String
+  delegatingUserId           String
+  threadId                   String
+  chatMessageId              String?
+  manifestActionId           String
+  argsJson                   Json
+  rationale                  String
+  status                     String    @default("proposed")
+  taskRunId                  String?
+  delegationChainId          String?
+  authorityDecisionId        String?
+  inputFingerprint           String?
+  approvalBindingFingerprint String?
+  expiresAt                  DateTime?
+  createdAt                  DateTime  @default(now())
+  resolvedAt                 DateTime?
 
-  toolExecutions ToolExecution[]
+  toolExecutions    ToolExecution[]
+  taskRun           TaskRun?                  @relation(fields: [taskRunId], references: [taskRunId], onDelete: SetNull)
+  authorityDecision AuthorizationDecisionLog? @relation(fields: [authorityDecisionId], references: [decisionId], onDelete: SetNull)
 
   @@index([threadId, createdAt(sort: Desc)])
   @@index([coworkerAgentId, createdAt(sort: Desc)])
   @@index([status])
   @@index([chatMessageId])
+  @@index([taskRunId])
+  @@index([delegationChainId])
+  @@index([authorityDecisionId])
+  @@index([approvalBindingFingerprint])
+  @@index([expiresAt])
 }
 
 model ToolExecutionReceipt {
@@ -6878,6 +6892,7 @@ model TaskRun {
   deliberationRuns     DeliberationRun[]
   decisionInteractions DecisionInteraction[]
   stallEvents          StallEvent[]
+  actionEnvelopes      CoworkerActionEnvelope[]
 
   @@index([userId, status])
   @@index([threadId])


### PR DESCRIPTION
## Summary
- enforce one universal `allow | deny | require-approval` authority decision for every AI-coworker tool execution while preserving the existing direct-human capability contract
- bind human approval to the exact task, delegation chain, authority decision, input fingerprint, policy context, and expiry; resume through the canonical task heartbeat transition and fail closed when evidence cannot be loaded or recorded
- persist privacy-safe authorization evidence, add a fleet-safe expand migration, and document the operator and architecture contracts
- linked work: BI-62BFAA95; Work Capsule WC-6D367D6F

## Test plan
- [x] exact local merged-code gate on `origin/main@f25bac69d3`: passed for `d96671586a`
- [x] repo guard loop: 24/24 guards passed
- [x] full web Vitest: 2,274 files / 19,721 tests passed (4 files and 19 tests skipped; 18 todo)
- [x] web typecheck: `next typegen && tsc --noEmit` passed
- [x] production build: Docker `build` target / Next.js production build passed
- [x] migration verification: Prisma generate and deploy passed; migration chain current after exact migration application
- [x] docs: index freshness and user-guide link scan passed
- [x] UX verification: n/a — no rendered UI surface changed; governed execution and REST response behavior are covered by route and authority tests

## Design grounding
- extends the existing universal `mcp-governed-execute` seam, proposal/approval substrate, task-run heartbeat contract, capability registry, and authorization evidence model
- introduces no parallel execution path: authority persistence and approval orchestration are extracted behind the existing governed seam
- direct-human capability execution remains unchanged; the new evaluation applies to AI-coworker subjects and fails closed when policy evidence is unavailable

## Delivery notes
- Sandbox freshness: green (`next@16.2.11`, `react@19.2.8`, `react-dom@19.2.8`, `typescript@6.0.3`, `prisma@7.8.0`, `vitest@4.1.10`)
- Overlap sweep: no open PR overlaps this authority/HITL concern; PR #3662 independently touches Prisma schema for CRM notification preferences
- Refactoring: authority persistence and approval orchestration were extracted from the universal execution seam; substrate complexity remains within the module-size ratchet

Local-CI-Evidence: cms3fweab07u201p5r1c8zrra (feat/coworker-authority-evaluator@d96671586ab13dbdc0484bb96d02c6074ba034f6)