### PR TITLE
fix: refresh self-upgrade UX baseline

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1312,7 +1312,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/ops/self-upgrade": {
-      "defaultVisibleWords": 394,
+      "defaultVisibleWords": 414,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,


### PR DESCRIPTION
## Summary
- refresh only `/ops/self-upgrade.defaultVisibleWords` from 394 to the reproducible current-main measurement of 414
- unblock the protected merge queue without weakening any route budget or changing product UI

## Evidence
- PR #3665's candidate-SHA UX sweep passed before `main` advanced
- merge groups `30286820346` and `30288334021` independently reproduced `394 → 414`
- official read-only fresh-baseline workflow `30289944903` passed across all 201 eligible routes and emitted 414
- the accessibility structure and every other `/ops/self-upgrade` metric are byte-for-byte unchanged

## Governed work
- Existing determinism backlog: BI-EA221325
- Work Capsule: WC-DEE28A2F

## Verification
- JSON parse and exact-entry assertion passed
- `git diff --check` passed
- exact-SHA local integration: sandbox freshness, migration chain, 2,274 test files / 19,726 tests, typecheck, and production Docker build passed

## UX and documentation impact
This changes only the frozen measured baseline to match current `main`; it does not change rendered UI, routes, navigation, copy, behavior, or user documentation. UX is verified by the official exhaustive calibration artifact. No migration applies.

Local-CI-Evidence: cms3j88lw0c1r01p5vmiw8oy1