### PR TITLE
feat(ci): add shadow evidence impact planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       heavy: ${{ steps.decide.outputs.heavy }}
+      evidence_plan_digest: ${{ steps.decide.outputs.evidence_plan_digest }}
+      evidence_tier: ${{ steps.decide.outputs.evidence_tier }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -46,24 +48,25 @@ jobs:
         id: decide
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "Non-PR event ($EVENT_NAME) -> full CI."
-            echo "heavy=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          PLAN_PATH="$RUNNER_TEMP/ci-evidence-plan.json"
           git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
-          if ! changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null)"; then
-            echo "Could not compute diff -- failing safe to full CI."
-            echo "heavy=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Changed files:"
-          printf '%s\n' "$changed"
-          printf '%s\n' "$changed" | node scripts/ci-change-scope.mjs --github-output "$GITHUB_OUTPUT"
+          node scripts/ci-evidence-plan.mjs \
+            --event "$EVENT_NAME" \
+            --base "${BASE_SHA:-origin/main}" \
+            --head "${HEAD_SHA:-HEAD}" \
+            --output "$PLAN_PATH" \
+            --github-output "$GITHUB_OUTPUT"
+      - name: Upload shadow evidence plan
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ci-evidence-plan.json
+          if-no-files-found: error
+          retention-days: 30
 
   typecheck:
     name: Typecheck
@@ -201,6 +204,10 @@ jobs:
           scripts/ci-observation.test.mjs
           scripts/ci-shadow-selection.test.mjs
           scripts/ci-coverage-config.test.mjs
+          scripts/ci-change-scope.test.mjs
+          scripts/ci-evidence-plan.test.mjs
+          scripts/ci-evidence-workflow.test.mjs
+          scripts/lib/ci-evidence-plan.test.mjs
 
   mobile-jest-pin-guard:
     name: Mobile Jest Pin Guard

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -7217,6 +7217,7 @@
         "standards-grounding",
         "scheduled-calibration",
         "activation-gate-later-waves",
+        "impact-planner-shadow-mode",
         "ux-route-sweep-stability",
         "baseline-snapshot"
       ]

--- a/config/ci-evidence-policy.json
+++ b/config/ci-evidence-policy.json
@@ -1,0 +1,128 @@
+{
+  "schemaVersion": 1,
+  "policyVersion": "2026-07-27.1",
+  "plannerVersion": "1.0.0-shadow",
+  "mode": "shadow",
+  "selectionThresholdPercent": 70,
+  "graphAdviceSchemaVersion": 1,
+  "requiredGraphRelationships": [
+    "DEFINES",
+    "IMPORTS",
+    "IMPLEMENTS_ROUTE",
+    "EXPOSES_TOOL",
+    "TESTED_BY"
+  ],
+  "exhaustiveEvents": [
+    "merge_group",
+    "push",
+    "workflow_dispatch",
+    "schedule"
+  ],
+  "globalGuards": [
+    "derived-artifacts",
+    "docs-integrity",
+    "repo-guards",
+    "secrets"
+  ],
+  "patterns": {
+    "docs": [
+      "(^|/)docs/",
+      "(^|/)README\\.md$",
+      "\\.mdx?$"
+    ],
+    "tests": [
+      "(^|/)(__tests__)(/|$)",
+      "\\.(test|spec)\\.[cm]?[jt]sx?$"
+    ],
+    "production": [
+      "^(apps|packages)/.*\\.[cm]?[jt]sx?$",
+      "^packages/db/prisma/schema\\.prisma$"
+    ],
+    "mobile": [
+      "^apps/mobile/",
+      "^packages/(api-client|types|validators)/"
+    ],
+    "mobileOnly": [
+      "^apps/mobile/"
+    ]
+  },
+  "packageRoots": {
+    "apps/mobile": "mobile",
+    "apps/web": "web",
+    "packages/api-client": "@dpf/api-client",
+    "packages/bootstrap": "@dpf/bootstrap",
+    "packages/db": "@dpf/db",
+    "packages/types": "@dpf/types",
+    "packages/validators": "@dpf/validators"
+  },
+  "riskRules": [
+    {
+      "code": "workflow",
+      "patterns": [
+        "^\\.github/",
+        "^config/merge-readiness-policy\\.json$"
+      ]
+    },
+    {
+      "code": "lockfile",
+      "patterns": [
+        "(^|/)pnpm-lock\\.yaml$",
+        "(^|/)pnpm-workspace\\.yaml$",
+        "(^|/)package\\.json$"
+      ]
+    },
+    {
+      "code": "migration",
+      "patterns": [
+        "^packages/db/prisma/(schema\\.prisma|migrations/)"
+      ]
+    },
+    {
+      "code": "test-config",
+      "patterns": [
+        "(^|/)(vitest|vite|playwright|jest)(\\.|-).*config",
+        "^apps/.*/vitest\\.config\\.",
+        "^tests/.*/setup\\."
+      ]
+    },
+    {
+      "code": "auth",
+      "patterns": [
+        "^apps/web/(lib|app)/.*(auth|proxy|session)(/|\\.|-)"
+      ]
+    },
+    {
+      "code": "routing-shell",
+      "patterns": [
+        "^apps/web/app/(layout|not-found|global-error)\\.",
+        "^apps/web/(proxy|middleware)\\.",
+        "^apps/web/components/(shell|navigation)/"
+      ]
+    },
+    {
+      "code": "install-seed",
+      "patterns": [
+        "^scripts/(seed|install|dpf-bootstrap|setup)",
+        "^packages/db/src/seed",
+        "^docker-compose",
+        "^Dockerfile"
+      ]
+    },
+    {
+      "code": "generated-contract",
+      "patterns": [
+        "\\.generated\\.",
+        "^apps/web/lib/ea/route-manifest\\.json$",
+        "^apps/web/lib/docs/doc-index\\.generated\\.json$"
+      ]
+    },
+    {
+      "code": "shared-setup",
+      "patterns": [
+        "^scripts/(pregate|gate-worktree|local-ci-runner)",
+        "^scripts/lib/(local-integration-ci|sandbox-freshness)",
+        "^apps/web/(instrumentation|vitest\\.setup)\\."
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-27-ci-evidence-impact-planner.md
+++ b/docs/superpowers/plans/2026-07-27-ci-evidence-impact-planner.md
@@ -1,0 +1,206 @@
+---
+title: CI evidence impact planner — shadow-mode implementation
+date: 2026-07-27
+status: active
+backlog: BI-A4EC0EA6
+epic: EP-CODE-GRAPH
+spec: docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
+coverage_receipt: cms3ocv0p0i3f01p5hjqigijf
+---
+
+# CI evidence impact planner
+
+**For agentic workers:** execute this plan one independently reviewable backlog
+item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+implementation, `dpf-local-merge-ci-before-push` plus the plan's completion
+gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+Implement the shared, deterministic evidence planner from
+`BI-A4EC0EA6` in shadow mode. Local-CI and GitHub CI will produce the same
+versioned semantic plan for the same base tree, head tree, policy, and advice
+inputs. Existing exhaustive test, typecheck, build, migration, guard, and merge
+queue execution remains unchanged in this slice.
+
+The plan recommends impacted tests, packages, routes, UX mode, and global
+guards. Any missing, stale, dirty, incompatible, ambiguous, or unmapped input
+expands the recommendation to exhaustive evidence. `unknown` never means
+`skip`.
+
+## Design grounding and architecture review
+
+The merged umbrella spec and plan were reconciled with:
+
+- `scripts/ci-change-scope.mjs`, the current GitHub change classifier;
+- `scripts/lib/local-integration-ci.mjs`, the canonical local merged-code plan;
+- `apps/web/lib/integrate/code-graph-access.ts` and
+  `apps/web/lib/integrate/code-graph/graph-queries.ts`, the existing graph
+  freshness and `TESTED_BY` contracts;
+- the existing route manifest and route-family registries;
+- the merge-readiness contract, which keeps `merge_group` exhaustive.
+
+Architecture review: **aligned with guardrails**.
+
+1. Code-graph advice is a versioned planner input, not a hidden runtime
+   dependency. It is trusted only when the graph is `ready`, clean,
+   structurally healthy, and indexed at the exact head SHA. GitHub may omit
+   the advice input; runtime-source changes then expand to exhaustive evidence.
+2. The digest covers semantic inputs and output only. Timestamps, host paths,
+   logs, and other volatile diagnostics live outside the digested plan.
+3. Every changed production file receives an explicit disposition:
+   `mapped-tests`, `global-risk`, `coverage-observation`, or `unmapped`.
+   `unmapped` selects exhaustive evidence and is visible in the report.
+4. The current docs-only exemption is preserved because it does not narrow
+   runtime evidence. Missing graph data does not turn a documentation-only
+   change into a full web build. Runtime-source selection still fails safe.
+5. Route ownership reuses committed route/manifest substrate; the planner does
+   not create a second route registry.
+
+Standards reviewed:
+
+- Vitest `related` / `--changed`: static import relationships are useful seeds,
+  but dynamic imports require explicit full-run triggers.
+- Nx affected: use the Git diff plus dependency ownership and reverse
+  dependencies, with explicit base/head identities.
+- GitHub merge queues: required workflows must run on `merge_group`; DPF keeps
+  that event exhaustive.
+- The merged DPF design's Launchable/Develocity benchmark: shadow observation
+  and an exhaustive safety net precede any skipping.
+
+## Backlog coverage
+
+- Decision: `atomic`
+- Parent: `BI-A4EC0EA6`
+- Receipt: `cms3ocv0p0i3f01p5hjqigijf`
+- Rationale: the versioned core plus both local and GitHub consumers must land
+  together. A core without both adapters is dead competing substrate; one
+  adapter without the other violates parity.
+- `planner-contract` — not independently shippable; dependencies: none.
+- `surface-adapters` — not independently shippable; depends on
+  `planner-contract`.
+- `shadow-evidence` — not independently shippable; depends on both prior
+  phases.
+
+## Phase 1 — test-drive the planner contract
+
+Create:
+
+- `config/ci-evidence-policy.json`
+- `scripts/lib/ci-evidence-plan.mjs`
+- `scripts/lib/ci-evidence-plan.test.mjs`
+- `scripts/fixtures/ci-evidence/`
+
+Red tests define:
+
+- stable schema version, policy version, and canonical SHA-256 digest;
+- byte-stable semantic output regardless of input ordering;
+- docs-only, mobile-only, web leaf, route, test-only, package, and DB inputs;
+- package ownership, colocated tests, supplied Vitest-related tests, supplied
+  graph `TESTED_BY` recommendations, and route families;
+- exact-head/clean/ready graph trust;
+- exhaustive expansion for missing/stale/dirty/incompatible graph on runtime
+  source, workflow/security/migration/lockfile/test-config/auth/routing-shell/
+  shared-setup/install/seed/generated-contract changes, unmapped production
+  files, planner errors, and selection-size thresholds;
+- merge-group and non-PR events always exhaustive;
+- explicit per-file dispositions and missing-test-update observations;
+- timestamps and host paths do not affect the semantic digest.
+
+Implement only enough pure Node logic to make those contracts green. The core
+accepts already-resolved file lists and advice; it does not call Git, Vitest,
+Neo4j, MCP, or GitHub.
+
+## Phase 2 — one CLI and compatibility adapter
+
+Create `scripts/ci-evidence-plan.mjs` to:
+
+- resolve base/head commits and immutable tree SHAs;
+- read changed paths from Git or newline-delimited stdin;
+- load the checked-in policy and optional versioned advice JSON;
+- emit canonical JSON to a file/stdout and a concise human summary;
+- write GitHub outputs when requested.
+
+Refactor `scripts/ci-change-scope.mjs` into a compatibility adapter over the
+planner. Preserve its `heavy` and `mobile` outputs for existing jobs; remove its
+duplicate path classification rules. Keep `classifyChangedFiles` as a stable
+adapter export until all callers migrate.
+
+Red-green verification:
+
+- existing `ci-change-scope` tests remain green;
+- local and GitHub CLI fixtures produce the same plan bytes and digest;
+- malformed policy/advice/diff input returns a valid exhaustive plan, not an
+  empty plan or an unhandled selector error;
+- docs-only output remains light and non-runtime.
+
+## Phase 3 — shadow consumers
+
+Update `.github/workflows/ci.yml`:
+
+- the existing `changes` job invokes the planner;
+- publish plan JSON/digest/selection summary as shadow evidence;
+- retain all current execution decisions except the already-existing docs and
+  mobile compatibility outputs;
+- force merge-group/non-PR plans to exhaustive.
+
+Update `scripts/lib/local-integration-ci.mjs` and its tests:
+
+- add the same planner command before exhaustive Vitest/typecheck/build;
+- bind the plan to the exact integration tree and policy digest;
+- keep the actual local-CI command list exhaustive.
+
+The local/GitHub consumers must not duplicate risk rules. Workflow YAML and the
+local integration plan only pass identities and consume the planner output.
+
+## Phase 4 — reporting, docs, and refactor
+
+Create/update:
+
+- `docs/testing/ci-evidence.md`
+- `docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md`
+- relevant contract tests for CI workflow wiring.
+
+Document the schema, graph-advice envelope, fail-safe reasons, digest boundary,
+shadow-only semantics, and the future activation gate owned by `BI-4527C1DA`.
+No operator-facing portal docs or UX changes are required.
+
+The required 20% refactoring allocation is spent inside this slice:
+
+- replace the duplicate `ci-change-scope` classifier with one adapter;
+- centralize stable JSON/digest code in the planner;
+- centralize risk rules in policy plus one evaluator;
+- keep workflow/local surfaces as thin consumers.
+
+Do not refactor shard balancing, build reuse, TypeScript duplication, policy
+jobs, or CodeQL here; those remain `BI-4DB73C5E`.
+
+## Completion gate
+
+1. Planner and scope-adapter Node tests pass, including every expansion rule.
+2. The same fixture produces byte-identical semantic output and digest through
+   local and GitHub CLI modes.
+3. Missing/stale/dirty graph, unknown files, and planner errors produce
+   exhaustive plans.
+4. Merge-group and push plans remain exhaustive.
+5. GitHub and local-CI continue running their current exhaustive evidence; no
+   test is skipped because of this PR.
+6. The full governed `pnpm run pregate` passes for the exact candidate SHA,
+   including typecheck, migrations/guards/docs, full tests, and production
+   build.
+7. `pnpm pr:health` reports every GitHub check terminal/pass, mergeable, and
+   zero unresolved threads before queue enrollment.
+8. Documentation impact is recorded. UX and migration are not applicable:
+   this is CI developer tooling with no UI or schema change.
+
+## Risks and rollback
+
+| Risk | Prevention | Rollback |
+| --- | --- | --- |
+| Planner silently narrows on bad input | exhaustive result is the error value; table-driven tests | switch the `changes` job back to the adapter's previous full behavior |
+| Local/GitHub drift | one pure core, canonical serializer, parity fixtures | remove both thin consumers together |
+| Volatile digest | semantic/diagnostic split and ordering tests | bump schema and invalidate observations |
+| Graph advice from wrong tree | exact head SHA + clean/ready/relationship checks | omit graph advice and run exhaustive |
+| Docs-only regression | compatibility fixture preserves current exemption | restore the prior adapter while planner remains shadow-only |
+| Missing test ownership is hidden | explicit per-file dispositions and unmapped list | exhaustive evidence plus a visible observation |
+

--- a/docs/superpowers/plans/2026-07-27-ci-evidence-impact-planner.md
+++ b/docs/superpowers/plans/2026-07-27-ci-evidence-impact-planner.md
@@ -44,7 +44,7 @@ Architecture review: **aligned with guardrails**.
 
 1. Code-graph advice is a versioned planner input, not a hidden runtime
    dependency. It is trusted only when the graph is `ready`, clean,
-   structurally healthy, and indexed at the exact head SHA. GitHub may omit
+   structurally healthy, and indexed at the exact head SHA and tree. GitHub may omit
    the advice input; runtime-source changes then expand to exhaustive evidence.
 2. The digest covers semantic inputs and output only. Timestamps, host paths,
    logs, and other volatile diagnostics live outside the digested plan.
@@ -98,7 +98,7 @@ Red tests define:
 - docs-only, mobile-only, web leaf, route, test-only, package, and DB inputs;
 - package ownership, colocated tests, supplied Vitest-related tests, supplied
   graph `TESTED_BY` recommendations, and route families;
-- exact-head/clean/ready graph trust;
+- exact-head-and-tree/clean/ready graph trust;
 - exhaustive expansion for missing/stale/dirty/incompatible graph on runtime
   source, workflow/security/migration/lockfile/test-config/auth/routing-shell/
   shared-setup/install/seed/generated-contract changes, unmapped production
@@ -200,7 +200,6 @@ jobs, or CodeQL here; those remain `BI-4DB73C5E`.
 | Planner silently narrows on bad input | exhaustive result is the error value; table-driven tests | switch the `changes` job back to the adapter's previous full behavior |
 | Local/GitHub drift | one pure core, canonical serializer, parity fixtures | remove both thin consumers together |
 | Volatile digest | semantic/diagnostic split and ordering tests | bump schema and invalidate observations |
-| Graph advice from wrong tree | exact head SHA + clean/ready/relationship checks | omit graph advice and run exhaustive |
+| Graph advice from wrong tree | exact head SHA and tree + clean/ready/relationship checks | omit graph advice and run exhaustive |
 | Docs-only regression | compatibility fixture preserves current exemption | restore the prior adapter while planner remains shadow-only |
 | Missing test ownership is hidden | explicit per-file dispositions and unmapped list | exhaustive evidence plus a visible observation |
-

--- a/docs/superpowers/plans/2026-07-27-ci-evidence-impact-planner.md
+++ b/docs/superpowers/plans/2026-07-27-ci-evidence-impact-planner.md
@@ -44,7 +44,9 @@ Architecture review: **aligned with guardrails**.
 
 1. Code-graph advice is a versioned planner input, not a hidden runtime
    dependency. It is trusted only when the graph is `ready`, clean,
-   structurally healthy, and indexed at the exact head SHA and tree. GitHub may omit
+   structurally healthy, and indexed at the exact head tree. Commit SHAs remain
+   provenance but do not invalidate advice when a synthetic merge commit has
+   the same tree. GitHub may omit
    the advice input; runtime-source changes then expand to exhaustive evidence.
 2. The digest covers semantic inputs and output only. Timestamps, host paths,
    logs, and other volatile diagnostics live outside the digested plan.
@@ -98,7 +100,7 @@ Red tests define:
 - docs-only, mobile-only, web leaf, route, test-only, package, and DB inputs;
 - package ownership, colocated tests, supplied Vitest-related tests, supplied
   graph `TESTED_BY` recommendations, and route families;
-- exact-head-and-tree/clean/ready graph trust;
+- exact-tree/clean/ready graph trust;
 - exhaustive expansion for missing/stale/dirty/incompatible graph on runtime
   source, workflow/security/migration/lockfile/test-config/auth/routing-shell/
   shared-setup/install/seed/generated-contract changes, unmapped production
@@ -200,6 +202,6 @@ jobs, or CodeQL here; those remain `BI-4DB73C5E`.
 | Planner silently narrows on bad input | exhaustive result is the error value; table-driven tests | switch the `changes` job back to the adapter's previous full behavior |
 | Local/GitHub drift | one pure core, canonical serializer, parity fixtures | remove both thin consumers together |
 | Volatile digest | semantic/diagnostic split and ordering tests | bump schema and invalidate observations |
-| Graph advice from wrong tree | exact head SHA and tree + clean/ready/relationship checks | omit graph advice and run exhaustive |
+| Graph advice from wrong tree | exact head tree + clean/ready/relationship checks | omit graph advice and run exhaustive |
 | Docs-only regression | compatibility fixture preserves current exemption | restore the prior adapter while planner remains shadow-only |
 | Missing test ownership is hidden | explicit per-file dispositions and unmapped list | exhaustive evidence plus a visible observation |

--- a/docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
+++ b/docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
@@ -146,7 +146,7 @@ This is an architecture umbrella, not a competing implementation:
 | `BI-EA221325` | Deterministic, stable route sweep and honest ratchet arming |
 | `BI-72AEDE8B` | Windows local-CI timeout/harness stabilization |
 
-The code graph is currently low-trust for CI selection: its live index is stale/dirty and exposes no trustworthy structural relationships. It may recommend tests after it meets freshness and recall requirements, but it must not yet be a sole blocking selector. Planner advice is therefore a versioned optional envelope bound to both the exact head commit and immutable tree. Missing, dirty, stale, schema-incompatible, or structurally incomplete advice is an exhaustive-evidence signal, never an empty selection. The plan digest excludes volatile timestamps, host paths, and logs so local-CI and GitHub can compare the same semantic recommendation.
+The code graph is currently low-trust for CI selection: its live index is stale/dirty and exposes no trustworthy structural relationships. It may recommend tests after it meets freshness and recall requirements, but it must not yet be a sole blocking selector. Planner advice is therefore a versioned optional envelope bound to the exact immutable head tree. Commit SHAs remain provenance but do not change the digest because local-CI retries synthesize different merge commits for byte-identical trees. Missing, dirty, stale, schema-incompatible, or structurally incomplete advice is an exhaustive-evidence signal, never an empty selection. The plan digest also excludes volatile timestamps, host paths, and logs so local-CI and GitHub can compare the same semantic recommendation.
 
 ## Prior-design reconciliation
 

--- a/docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
+++ b/docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
@@ -146,7 +146,7 @@ This is an architecture umbrella, not a competing implementation:
 | `BI-EA221325` | Deterministic, stable route sweep and honest ratchet arming |
 | `BI-72AEDE8B` | Windows local-CI timeout/harness stabilization |
 
-The code graph is currently low-trust for CI selection: its live index is stale/dirty and exposes no trustworthy structural relationships. It may recommend tests after it meets freshness and recall requirements, but it must not yet be a sole blocking selector.
+The code graph is currently low-trust for CI selection: its live index is stale/dirty and exposes no trustworthy structural relationships. It may recommend tests after it meets freshness and recall requirements, but it must not yet be a sole blocking selector. Planner advice is therefore a versioned optional envelope bound to both the exact head commit and immutable tree. Missing, dirty, stale, schema-incompatible, or structurally incomplete advice is an exhaustive-evidence signal, never an empty selection. The plan digest excludes volatile timestamps, host paths, and logs so local-CI and GitHub can compare the same semantic recommendation.
 
 ## Prior-design reconciliation
 

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -106,6 +106,51 @@ Before any PR suite-skipping activates (BI-4527C1DA and dependents):
 
 Until then, exhaustive PR and merge-group execution remains the default.
 
+## Impact planner (shadow mode)
+
+`scripts/ci-evidence-plan.mjs` is the shared planner for GitHub CI and the
+governed local-integration runner. It emits a canonical schema-versioned JSON
+document and SHA-256 digest for the base/head commits and trees, changed files,
+policy, and supplied advice. GitHub uploads the document as
+`ci-evidence-plan-<run>-<attempt>`; local-CI writes
+`dpf-ci-evidence-plan.json` beside its run metadata and records the digest in
+that metadata.
+
+The planner recommends:
+
+- affected workspace packages, including transitive reverse dependencies;
+- changed, colocated, supplied Vitest-related, and trusted graph-recommended
+  tests;
+- Next.js routes, route families, UX mode, and global repository guards;
+- an explicit disposition for every changed file and visible missing-test
+  observations.
+
+The digest covers semantic data only. Generation time, runner path, logs, and
+other host-specific diagnostics are intentionally excluded so the same
+immutable inputs produce the same digest on GitHub and local-CI.
+
+Code-graph advice is optional and is never a hidden live dependency. Advice is
+trusted only when its schema matches policy, the index is `ready`, the
+workspace is clean, both the indexed commit and tree match the candidate, and
+the required `DEFINES`, `IMPORTS`, `IMPLEMENTS_ROUTE`, `EXPOSES_TOOL`, and
+`TESTED_BY` relationships are populated. Missing, stale, dirty, structurally
+incomplete, or malformed advice expands runtime-source evidence to exhaustive.
+Supplied Vitest static relationships and co-located tests remain independent
+recommendation inputs.
+
+Other exhaustive reasons include workflow, lockfile, migration, test-config,
+authentication, routing-shell, install/seed, generated-contract, or shared
+setup changes; unmapped source; planner input errors; empty diffs; selections
+above the policy threshold; and every `merge_group`, `push`,
+`workflow_dispatch`, or scheduled event. The docs-only compatibility exemption
+remains unchanged because it does not narrow runtime evidence.
+
+This is observation only. The planner continues to emit the existing `heavy`
+and `mobile` compatibility outputs, but it does not skip any test, typecheck,
+build, migration, guard, or merge-queue proof. Activation is owned by
+`BI-4527C1DA` and still requires the calibration and 100% observed-failure
+recall conditions above.
+
 ## UX route-sweep stability
 
 Workflow: `.github/workflows/ux-route-sweep.yml` (`UX Route Budget Sweep`)

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -125,13 +125,16 @@ The planner recommends:
 - an explicit disposition for every changed file and visible missing-test
   observations.
 
-The digest covers semantic data only. Generation time, runner path, logs, and
-other host-specific diagnostics are intentionally excluded so the same
-immutable inputs produce the same digest on GitHub and local-CI.
+The digest covers semantic data and exact base/head tree identities. Commit
+SHAs remain in the document as provenance but are excluded from the digest
+because local-CI synthesizes a new merge commit on every retry even when its
+tree is byte-identical. Generation time, runner path, logs, and other
+host-specific diagnostics are also excluded so the same immutable content
+produces the same digest on GitHub and local-CI.
 
 Code-graph advice is optional and is never a hidden live dependency. Advice is
 trusted only when its schema matches policy, the index is `ready`, the
-workspace is clean, both the indexed commit and tree match the candidate, and
+workspace is clean, the indexed tree matches the candidate exactly, and
 the required `DEFINES`, `IMPORTS`, `IMPLEMENTS_ROUTE`, `EXPOSES_TOOL`, and
 `TESTED_BY` relationships are populated. Missing, stale, dirty, structurally
 incomplete, or malformed advice expands runtime-source evidence to exhaustive.

--- a/scripts/ci-change-scope.mjs
+++ b/scripts/ci-change-scope.mjs
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 import { appendFileSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import {
+  createEvidencePlan,
+  loadEvidencePolicy,
+} from "./lib/ci-evidence-plan.mjs";
 
-const DOC_PATTERN = /(^docs\/|\.mdx?$)/;
-const MOBILE_APP_PATTERN = /^apps\/mobile\//;
-const MOBILE_SHARED_PATTERNS = [
-  /^packages\/api-client\//,
-  /^packages\/types\//,
-  /^packages\/validators\//,
-];
+const policy = loadEvidencePolicy();
 
 export function classifyChangedFiles(files) {
   const changedFiles = files.map((file) => file.trim()).filter(Boolean);
@@ -16,22 +14,25 @@ export function classifyChangedFiles(files) {
   if (changedFiles.length === 0) {
     return { heavy: true, mobile: true, docsOnly: false, mobileOnly: false };
   }
-
-  const docsOnly = changedFiles.every((file) => DOC_PATTERN.test(file));
-  if (docsOnly) {
-    return { heavy: false, mobile: false, docsOnly: true, mobileOnly: false };
-  }
-
-  const mobileOnly = changedFiles.every((file) => DOC_PATTERN.test(file) || MOBILE_APP_PATTERN.test(file));
-  const mobile = changedFiles.some(
-    (file) => MOBILE_APP_PATTERN.test(file) || MOBILE_SHARED_PATTERNS.some((pattern) => pattern.test(file)),
-  );
-
+  const plan = createEvidencePlan({
+    eventName: "pull_request",
+    baseSha: "scope-adapter-base",
+    headSha: "scope-adapter-head",
+    baseTreeSha: "scope-adapter-base-tree",
+    headTreeSha: "scope-adapter-head-tree",
+    changedFiles,
+    knownTests: [],
+    relatedTestsBySource: {},
+    routeAdviceBySource: {},
+    codeGraphAdvice: null,
+    totalTestCount: 0,
+    policy,
+  });
   return {
-    heavy: !mobileOnly,
-    mobile,
-    docsOnly: false,
-    mobileOnly,
+    heavy: plan.scope.heavy,
+    mobile: plan.scope.mobile,
+    docsOnly: plan.scope.docsOnly,
+    mobileOnly: plan.scope.mobileOnly,
   };
 }
 

--- a/scripts/ci-evidence-plan.mjs
+++ b/scripts/ci-evidence-plan.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  canonicalJson,
+  createEvidencePlan,
+  loadEvidencePolicy,
+} from "./lib/ci-evidence-plan.mjs";
+
+function parseArgs(args) {
+  const values = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      values[key] = true;
+    } else {
+      values[key] = value;
+      index += 1;
+    }
+  }
+  return values;
+}
+
+function git(args, cwd = process.cwd()) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function readOptionalJson(path, label, inputErrors) {
+  if (!path) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    inputErrors.push(`${label}-invalid`);
+    return null;
+  }
+}
+
+function readPolicy(path, inputErrors) {
+  if (!path) return loadEvidencePolicy();
+  try {
+    return loadEvidencePolicy(resolve(path));
+  } catch {
+    inputErrors.push("policy-invalid");
+    return loadEvidencePolicy();
+  }
+}
+
+function resolveRevision(ref, inputErrors, label) {
+  try {
+    return git(["rev-parse", "--verify", ref]);
+  } catch {
+    inputErrors.push(`${label}-revision-unresolved`);
+    return ref;
+  }
+}
+
+function resolveTree(ref, inputErrors, label) {
+  try {
+    return git(["rev-parse", "--verify", `${ref}^{tree}`]);
+  } catch {
+    inputErrors.push(`${label}-tree-unresolved`);
+    return "unknown";
+  }
+}
+
+function changedFiles(baseSha, headSha, inputErrors) {
+  try {
+    return git(["diff", "--name-only", baseSha, headSha])
+      .split(/\r?\n/)
+      .filter(Boolean);
+  } catch {
+    inputErrors.push("git-diff-failed");
+    return [];
+  }
+}
+
+function knownTestsAt(headSha, policy, inputErrors) {
+  try {
+    const patterns = policy.patterns.tests.map((pattern) => new RegExp(pattern));
+    return git(["ls-tree", "-r", "--name-only", headSha])
+      .split(/\r?\n/)
+      .filter((path) => path && patterns.some((pattern) => pattern.test(path)));
+  } catch {
+    inputErrors.push("test-inventory-failed");
+    return [];
+  }
+}
+
+function packageDependenciesAt(headSha, policy, inputErrors) {
+  const rootsByPackage = new Map(
+    Object.entries(policy.packageRoots).map(([root, packageName]) => [packageName, root]),
+  );
+  const result = {};
+  for (const [packageName, root] of rootsByPackage) {
+    try {
+      const manifest = JSON.parse(git(["show", `${headSha}:${root}/package.json`]));
+      const dependencyNames = new Set([
+        ...Object.keys(manifest.dependencies ?? {}),
+        ...Object.keys(manifest.devDependencies ?? {}),
+        ...Object.keys(manifest.optionalDependencies ?? {}),
+        ...Object.keys(manifest.peerDependencies ?? {}),
+      ]);
+      result[packageName] = [...dependencyNames]
+        .filter((dependency) => rootsByPackage.has(dependency))
+        .sort((left, right) => left.localeCompare(right));
+    } catch {
+      // Some configured roots intentionally have no independent manifest.
+      // Ownership still works; only malformed existing manifests are unsafe.
+      try {
+        git(["cat-file", "-e", `${headSha}:${root}/package.json`]);
+        inputErrors.push(`package-manifest-invalid:${packageName}`);
+      } catch {
+        result[packageName] = [];
+      }
+    }
+  }
+  return result;
+}
+
+function writeText(path, contents) {
+  mkdirSync(dirname(resolve(path)), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+function writeGitHubOutputs(path, plan) {
+  if (!path) return;
+  appendFileSync(path, [
+    `heavy=${plan.scope.heavy}`,
+    `mobile=${plan.scope.mobile}`,
+    `evidence_tier=${plan.evidenceTier}`,
+    `evidence_plan_digest=${plan.digest}`,
+    `evidence_selected_percentage=${plan.selection.selectedPercentage}`,
+    "",
+  ].join("\n"));
+}
+
+export function runEvidencePlannerCli(args = process.argv.slice(2)) {
+  const options = parseArgs(args);
+  const inputErrors = [];
+  const eventName = String(options.event ?? process.env.GITHUB_EVENT_NAME ?? "local-ci");
+  const baseRef = String(options.base ?? process.env.CI_EVIDENCE_BASE_SHA ?? "origin/main");
+  const headRef = String(options.head ?? process.env.CI_EVIDENCE_HEAD_SHA ?? "HEAD");
+  const baseSha = resolveRevision(baseRef, inputErrors, "base");
+  const headSha = resolveRevision(headRef, inputErrors, "head");
+  const policy = readPolicy(options.policy, inputErrors);
+  const codeGraphAdvice = readOptionalJson(
+    options["graph-advice"],
+    "graph-advice",
+    inputErrors,
+  );
+  const relatedTestsBySource = readOptionalJson(
+    options["related-tests"],
+    "related-tests",
+    inputErrors,
+  ) ?? {};
+  const routeAdviceBySource = readOptionalJson(
+    options["route-advice"],
+    "route-advice",
+    inputErrors,
+  ) ?? {};
+  const knownTests = options["known-tests"]
+    ? readOptionalJson(options["known-tests"], "known-tests", inputErrors) ?? []
+    : knownTestsAt(headSha, policy, inputErrors);
+  const files = changedFiles(baseSha, headSha, inputErrors);
+  const plan = createEvidencePlan({
+    eventName,
+    baseSha,
+    headSha,
+    baseTreeSha: resolveTree(baseSha, inputErrors, "base"),
+    headTreeSha: resolveTree(headSha, inputErrors, "head"),
+    changedFiles: files,
+    knownTests,
+    relatedTestsBySource,
+    codeGraphAdvice,
+    routeAdviceBySource,
+    packageDependencies: packageDependenciesAt(headSha, policy, inputErrors),
+    totalTestCount: knownTests.length,
+    inputErrors,
+    policy,
+  });
+  const json = canonicalJson(plan);
+  if (options.output) writeText(options.output, json);
+  else process.stdout.write(json);
+  writeGitHubOutputs(options["github-output"], plan);
+  process.stderr.write(
+    `[ci-evidence-plan] ${plan.evidenceTier}; ${plan.affectedTests.length}/`
+    + `${plan.selection.totalTestCount} tests recommended; digest=${plan.digest.slice(0, 12)}\n`,
+  );
+  return plan;
+}
+
+const thisFile = resolve(fileURLToPath(import.meta.url));
+if (process.argv[1] && resolve(process.argv[1]) === thisFile) {
+  try {
+    runEvidencePlannerCli();
+  } catch (error) {
+    console.error(
+      `[ci-evidence-plan] fatal planner error: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci-evidence-plan.test.mjs
+++ b/scripts/ci-evidence-plan.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, before, describe, it } from "node:test";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const cliPath = join(repoRoot, "scripts", "ci-evidence-plan.mjs");
+let fixture;
+let baseSha;
+let headSha;
+
+function git(...args) {
+  return execFileSync("git", args, { cwd: fixture, encoding: "utf8" }).trim();
+}
+
+function write(path, contents) {
+  const absolute = join(fixture, path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, contents);
+}
+
+function runCli(extraArgs = []) {
+  const result = spawnSync(process.execPath, [
+    cliPath,
+    "--event", "pull_request",
+    "--base", baseSha,
+    "--head", headSha,
+    ...extraArgs,
+  ], {
+    cwd: fixture,
+    encoding: "utf8",
+  });
+  return result;
+}
+
+before(() => {
+  fixture = mkdtempSync(join(tmpdir(), "dpf-ci-evidence-plan-"));
+  git("init");
+  git("config", "user.email", "ci-planner@example.invalid");
+  git("config", "user.name", "CI Planner Test");
+  write("apps/web/lib/orders.ts", "export const orders = [];\n");
+  write(
+    "apps/web/lib/orders.test.ts",
+    "import { orders } from './orders';\nvoid orders;\n",
+  );
+  git("add", ".");
+  git("commit", "-m", "base");
+  baseSha = git("rev-parse", "HEAD");
+  write("apps/web/lib/orders.ts", "export const orders = ['changed'];\n");
+  git("add", ".");
+  git("commit", "-m", "head");
+  headSha = git("rev-parse", "HEAD");
+});
+
+after(() => {
+  if (fixture) rmSync(fixture, { recursive: true, force: true });
+});
+
+describe("ci-evidence-plan CLI", () => {
+  it("derives immutable tree identities and writes deterministic plan JSON", () => {
+    const firstPath = join(fixture, "first-plan.json");
+    const secondPath = join(fixture, "second-plan.json");
+    const first = runCli(["--output", firstPath]);
+    const second = runCli(["--output", secondPath]);
+
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(second.status, 0, second.stderr);
+    const firstText = readFileSync(firstPath, "utf8");
+    const secondText = readFileSync(secondPath, "utf8");
+    assert.equal(firstText, secondText);
+
+    const plan = JSON.parse(firstText);
+    assert.equal(plan.baseSha, baseSha);
+    assert.equal(plan.headSha, headSha);
+    assert.equal(plan.baseTreeSha, git("rev-parse", `${baseSha}^{tree}`));
+    assert.equal(plan.headTreeSha, git("rev-parse", `${headSha}^{tree}`));
+    assert.deepEqual(plan.changedFiles, ["apps/web/lib/orders.ts"]);
+    assert.deepEqual(plan.affectedTests, ["apps/web/lib/orders.test.ts"]);
+    assert.equal(plan.fullSuite, true);
+    assert.ok(plan.escalations.some((entry) => entry.code === "graph-missing"));
+  });
+
+  it("writes stable GitHub outputs without embedding plan JSON in workflow expressions", () => {
+    const githubOutput = join(fixture, "github-output.txt");
+    const outputPath = join(fixture, "github-plan.json");
+    const result = runCli([
+      "--output", outputPath,
+      "--github-output", githubOutput,
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = readFileSync(githubOutput, "utf8");
+    assert.match(output, /^heavy=true$/m);
+    assert.match(output, /^mobile=false$/m);
+    assert.match(output, /^evidence_tier=exhaustive$/m);
+    assert.match(output, /^evidence_plan_digest=[a-f0-9]{64}$/m);
+  });
+
+  it("turns malformed optional advice into exhaustive evidence instead of aborting", () => {
+    const advicePath = join(fixture, "bad-graph-advice.json");
+    const outputPath = join(fixture, "fallback-plan.json");
+    writeFileSync(advicePath, "{not-json");
+    const result = runCli([
+      "--graph-advice", advicePath,
+      "--output", outputPath,
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const plan = JSON.parse(readFileSync(outputPath, "utf8"));
+    assert.equal(plan.fullSuite, true);
+    assert.ok(
+      plan.escalations.some((entry) => entry.code === "planner-input-error"),
+    );
+  });
+});

--- a/scripts/ci-evidence-workflow.test.mjs
+++ b/scripts/ci-evidence-workflow.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
+
+describe("CI evidence planner workflow wiring", () => {
+  it("uses the shared planner as the change-scope authority", () => {
+    assert.match(
+      workflow,
+      /node scripts\/ci-evidence-plan\.mjs[\s\S]*--github-output "\$GITHUB_OUTPUT"/,
+    );
+    assert.doesNotMatch(
+      workflow,
+      /node scripts\/ci-change-scope\.mjs --github-output/,
+    );
+  });
+
+  it("publishes the shadow plan without changing stable required contexts", () => {
+    assert.match(workflow, /name: Upload shadow evidence plan/);
+    assert.match(workflow, /uses: actions\/upload-artifact@v7/);
+    assert.match(workflow, /name: ci-evidence-plan-/);
+    assert.match(workflow, /evidence_plan_digest/);
+    assert.match(workflow, /evidence_tier/);
+    assert.match(workflow, /name: Typecheck/);
+    assert.match(workflow, /name: Production Build/);
+    assert.match(workflow, /name: Unit Tests/);
+  });
+});

--- a/scripts/lib/ci-evidence-plan.mjs
+++ b/scripts/lib/ci-evidence-plan.mjs
@@ -114,9 +114,6 @@ function graphVerdict(advice, input, policy) {
   }
   if (advice.indexStatus !== "ready") return { trusted: false, code: "graph-not-ready" };
   if (advice.workspaceDirty) return { trusted: false, code: "graph-dirty" };
-  if (advice.indexedHeadSha !== input.headSha) {
-    return { trusted: false, code: "graph-head-mismatch" };
-  }
   if (advice.indexedTreeSha !== input.headTreeSha) {
     return { trusted: false, code: "graph-tree-mismatch" };
   }
@@ -357,6 +354,10 @@ export function createEvidencePlan(input) {
       thresholdPercentage: policy.selectionThresholdPercent,
     },
   };
-  const digest = createHash("sha256").update(canonicalJson(semanticPlan)).digest("hex");
+  // Local-CI synthesizes a fresh merge commit on every retry. Commit SHAs are
+  // valuable provenance, but the Git tree is the immutable content identity:
+  // two commits with the same tree require the same evidence recommendation.
+  const { baseSha: _baseSha, headSha: _headSha, ...digestPlan } = semanticPlan;
+  const digest = createHash("sha256").update(canonicalJson(digestPlan)).digest("hex");
   return { ...semanticPlan, digest };
 }

--- a/scripts/lib/ci-evidence-plan.mjs
+++ b/scripts/lib/ci-evidence-plan.mjs
@@ -1,0 +1,362 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export const CI_EVIDENCE_PLAN_SCHEMA_VERSION = 1;
+const DEFAULT_POLICY_PATH = fileURLToPath(
+  new URL("../../config/ci-evidence-policy.json", import.meta.url),
+);
+
+function sortedUnique(values) {
+  return [...new Set(values.filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizePath(value) {
+  return String(value ?? "").trim().replaceAll("\\", "/").replace(/^\.\/+/, "");
+}
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort((left, right) => left.localeCompare(right))
+        .map((key) => [key, stableValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return `${JSON.stringify(stableValue(value), null, 2)}\n`;
+}
+
+export function loadEvidencePolicy(path = DEFAULT_POLICY_PATH) {
+  const policy = JSON.parse(readFileSync(path, "utf8"));
+  if (policy.schemaVersion !== CI_EVIDENCE_PLAN_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported CI evidence policy schema ${String(policy.schemaVersion)}; `
+      + `expected ${CI_EVIDENCE_PLAN_SCHEMA_VERSION}.`,
+    );
+  }
+  return policy;
+}
+
+function compilePatterns(patterns) {
+  return (patterns ?? []).map((pattern) => new RegExp(pattern));
+}
+
+function matchesAny(path, patterns) {
+  return patterns.some((pattern) => pattern.test(path));
+}
+
+function classifyPath(path, compiled) {
+  if (matchesAny(path, compiled.docs)) return "docs";
+  if (matchesAny(path, compiled.tests)) return "test";
+  if (matchesAny(path, compiled.production)) return "production";
+  return "other";
+}
+
+function packageOwner(path, packageRoots) {
+  return Object.entries(packageRoots)
+    .sort(([left], [right]) => right.length - left.length)
+    .find(([root]) => path === root || path.startsWith(`${root}/`))?.[1] ?? null;
+}
+
+function testStem(path) {
+  return path.replace(/\.[cm]?[jt]sx?$/, "");
+}
+
+function colocatedTests(path, knownTests) {
+  const stem = testStem(path);
+  const basename = stem.split("/").at(-1);
+  const directory = stem.includes("/") ? stem.slice(0, stem.lastIndexOf("/")) : "";
+  return knownTests.filter((testPath) => (
+    testPath.startsWith(`${stem}.test.`)
+    || testPath.startsWith(`${stem}.spec.`)
+    || (
+      basename
+      && testPath.startsWith(`${directory ? `${directory}/` : ""}__tests__/${basename}.`)
+    )
+  ));
+}
+
+function normalizeRecommendationPaths(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => (
+    typeof entry === "string" ? normalizePath(entry) : normalizePath(entry?.path)
+  )).filter(Boolean);
+}
+
+function deriveRoute(path) {
+  const appPrefix = "apps/web/app/";
+  if (!path.startsWith(appPrefix)) return null;
+  const relative = path.slice(appPrefix.length);
+  if (!/(^|\/)(page|route)\.[cm]?[jt]sx?$/.test(relative)) return null;
+  const segments = relative
+    .replace(/\/(page|route)\.[cm]?[jt]sx?$/, "")
+    .replace(/^(page|route)\.[cm]?[jt]sx?$/, "")
+    .split("/")
+    .filter((segment) => segment && !(segment.startsWith("(") && segment.endsWith(")")));
+  return `/${segments.join("/")}` || "/";
+}
+
+function routeFamily(route) {
+  if (route === "/") return "/";
+  const first = route.split("/").filter(Boolean)[0];
+  return first ? `/${first}` : "/";
+}
+
+function graphVerdict(advice, input, policy) {
+  if (!advice) return { trusted: false, code: "graph-missing" };
+  if (advice.schemaVersion !== policy.graphAdviceSchemaVersion) {
+    return { trusted: false, code: "graph-schema-mismatch" };
+  }
+  if (advice.indexStatus !== "ready") return { trusted: false, code: "graph-not-ready" };
+  if (advice.workspaceDirty) return { trusted: false, code: "graph-dirty" };
+  if (advice.indexedHeadSha !== input.headSha) {
+    return { trusted: false, code: "graph-head-mismatch" };
+  }
+  if (advice.indexedTreeSha !== input.headTreeSha) {
+    return { trusted: false, code: "graph-tree-mismatch" };
+  }
+  const missing = policy.requiredGraphRelationships.filter(
+    (relationship) => Number(advice.relationshipCounts?.[relationship] ?? 0) <= 0,
+  );
+  if (missing.length > 0) {
+    return {
+      trusted: false,
+      code: "graph-relationships-missing",
+      missingRelationships: missing,
+    };
+  }
+  return { trusted: true, code: null };
+}
+
+function expandAffectedPackages(seedPackages, packageDependencies = {}) {
+  const affected = new Set(seedPackages);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [consumer, dependencies] of Object.entries(packageDependencies)) {
+      if (
+        !affected.has(consumer)
+        && (dependencies ?? []).some((dependency) => affected.has(dependency))
+      ) {
+        affected.add(consumer);
+        changed = true;
+      }
+    }
+  }
+  return affected;
+}
+
+function riskCodesForPath(path, riskRules) {
+  return riskRules
+    .filter((rule) => matchesAny(path, rule.patterns))
+    .map((rule) => rule.code);
+}
+
+function addEscalation(escalations, code, detail = undefined) {
+  if (escalations.some((entry) => entry.code === code)) return;
+  escalations.push(detail === undefined ? { code } : { code, detail });
+}
+
+export function createEvidencePlan(input) {
+  const policy = input.policy ?? loadEvidencePolicy();
+  const changedFiles = sortedUnique((input.changedFiles ?? []).map(normalizePath));
+  const knownTests = sortedUnique((input.knownTests ?? []).map(normalizePath));
+  const compiled = {
+    docs: compilePatterns(policy.patterns.docs),
+    tests: compilePatterns(policy.patterns.tests),
+    production: compilePatterns(policy.patterns.production),
+    mobile: compilePatterns(policy.patterns.mobile),
+    mobileOnly: compilePatterns(policy.patterns.mobileOnly),
+  };
+  const riskRules = policy.riskRules.map((rule) => ({
+    code: rule.code,
+    patterns: compilePatterns(rule.patterns),
+  }));
+  const kinds = new Map(changedFiles.map((path) => [path, classifyPath(path, compiled)]));
+  const productionFiles = changedFiles.filter((path) => kinds.get(path) === "production");
+  const changedTests = changedFiles.filter((path) => kinds.get(path) === "test");
+  const docsOnly = changedFiles.length > 0
+    && changedFiles.every((path) => kinds.get(path) === "docs");
+  const mobileOnly = !docsOnly
+    && changedFiles.length > 0
+    && changedFiles.every((path) => (
+      kinds.get(path) === "docs" || matchesAny(path, compiled.mobileOnly)
+    ));
+  const graph = graphVerdict(input.codeGraphAdvice, input, policy);
+  const escalations = [];
+  const affectedTests = new Set(changedTests);
+  const affectedRoutes = new Set();
+  const affectedPackages = new Set();
+  const fileDispositions = [];
+  const missingTestUpdates = [];
+
+  for (const path of changedFiles) {
+    const kind = kinds.get(path);
+    const owner = packageOwner(path, policy.packageRoots);
+    if (owner) affectedPackages.add(owner);
+    const risks = riskCodesForPath(path, riskRules);
+    for (const code of risks) addEscalation(escalations, `risk:${code}`, path);
+
+    if (kind === "docs") {
+      fileDispositions.push({
+        path,
+        kind,
+        disposition: "docs-only",
+        tests: [],
+        routes: [],
+      });
+      continue;
+    }
+    if (kind === "test") {
+      fileDispositions.push({
+        path,
+        kind,
+        disposition: "changed-test",
+        tests: [path],
+        routes: [],
+      });
+      continue;
+    }
+
+    const deterministicTests = normalizeRecommendationPaths(
+      input.relatedTestsBySource?.[path],
+    );
+    const graphTests = graph.trusted
+      ? normalizeRecommendationPaths(input.codeGraphAdvice?.recommendations?.[path])
+      : [];
+    const tests = sortedUnique([
+      ...deterministicTests,
+      ...graphTests,
+      ...colocatedTests(path, knownTests),
+    ]).filter((testPath) => knownTests.length === 0 || knownTests.includes(testPath));
+    tests.forEach((testPath) => affectedTests.add(testPath));
+
+    const routes = sortedUnique([
+      deriveRoute(path),
+      ...normalizeRecommendationPaths(input.routeAdviceBySource?.[path]),
+    ]);
+    routes.forEach((route) => affectedRoutes.add(route));
+
+    if (risks.length > 0) {
+      fileDispositions.push({
+        path,
+        kind,
+        disposition: "global-risk",
+        tests,
+        routes,
+      });
+    } else if (kind === "production" && tests.length > 0) {
+      fileDispositions.push({
+        path,
+        kind,
+        disposition: "mapped-tests",
+        tests,
+        routes,
+      });
+    } else if (kind === "production") {
+      fileDispositions.push({
+        path,
+        kind,
+        disposition: "unmapped",
+        tests: [],
+        routes,
+      });
+      addEscalation(escalations, "unmapped-production", path);
+    } else {
+      fileDispositions.push({
+        path,
+        kind,
+        disposition: "unmapped",
+        tests: [],
+        routes,
+      });
+      addEscalation(escalations, "unmapped-file", path);
+    }
+
+    if (
+      kind === "production"
+      && !changedTests.some((testPath) => tests.includes(testPath))
+    ) {
+      missingTestUpdates.push(path);
+    }
+  }
+
+  if (productionFiles.length > 0 && !graph.trusted) {
+    addEscalation(escalations, graph.code, graph.missingRelationships);
+  }
+  if (changedFiles.length === 0) addEscalation(escalations, "empty-diff");
+  for (const inputError of sortedUnique(input.inputErrors ?? [])) {
+    addEscalation(escalations, "planner-input-error", inputError);
+  }
+  if (policy.exhaustiveEvents.includes(input.eventName)) {
+    addEscalation(escalations, "event-exhaustive", input.eventName);
+  }
+
+  const selectedTests = sortedUnique([...affectedTests]);
+  const totalTestCount = Math.max(
+    Number(input.totalTestCount ?? knownTests.length),
+    selectedTests.length,
+  );
+  const selectedPercentage = totalTestCount > 0
+    ? Number(((selectedTests.length / totalTestCount) * 100).toFixed(2))
+    : 0;
+  if (selectedPercentage > policy.selectionThresholdPercent) {
+    addEscalation(escalations, "selection-threshold", {
+      selectedPercentage,
+      thresholdPercentage: policy.selectionThresholdPercent,
+    });
+  }
+
+  const routes = sortedUnique([...affectedRoutes]);
+  const semanticPlan = {
+    schemaVersion: CI_EVIDENCE_PLAN_SCHEMA_VERSION,
+    plannerVersion: policy.plannerVersion,
+    policyVersion: policy.policyVersion,
+    mode: policy.mode,
+    eventName: input.eventName,
+    baseSha: input.baseSha,
+    headSha: input.headSha,
+    baseTreeSha: input.baseTreeSha,
+    headTreeSha: input.headTreeSha,
+    changedFiles,
+    scope: {
+      docsOnly,
+      mobileOnly,
+      mobile: changedFiles.some((path) => matchesAny(path, compiled.mobile)),
+      heavy: !docsOnly && !mobileOnly,
+    },
+    graph: {
+      graphKey: input.codeGraphAdvice?.graphKey ?? "source-code",
+      trusted: graph.trusted,
+      verdict: graph.code ?? "trusted",
+    },
+    affectedPackages: sortedUnique([
+      ...expandAffectedPackages(affectedPackages, input.packageDependencies),
+    ]),
+    affectedTests: selectedTests,
+    affectedRoutes: routes,
+    routeFamilies: sortedUnique(routes.map(routeFamily)),
+    globalGuards: sortedUnique(policy.globalGuards),
+    uxMode: routes.length > 0 ? "changed-routes" : "none",
+    fullSuite: escalations.length > 0,
+    evidenceTier: escalations.length > 0 ? "exhaustive" : "affected",
+    escalations: escalations.sort((left, right) => left.code.localeCompare(right.code)),
+    fileDispositions: fileDispositions.sort((left, right) => left.path.localeCompare(right.path)),
+    observations: {
+      missingTestUpdates: sortedUnique(missingTestUpdates),
+    },
+    selection: {
+      selectedTestCount: selectedTests.length,
+      totalTestCount,
+      selectedPercentage,
+      thresholdPercentage: policy.selectionThresholdPercent,
+    },
+  };
+  const digest = createHash("sha256").update(canonicalJson(semanticPlan)).digest("hex");
+  return { ...semanticPlan, digest };
+}

--- a/scripts/lib/ci-evidence-plan.test.mjs
+++ b/scripts/lib/ci-evidence-plan.test.mjs
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CI_EVIDENCE_PLAN_SCHEMA_VERSION,
+  canonicalJson,
+  createEvidencePlan,
+  loadEvidencePolicy,
+} from "./ci-evidence-plan.mjs";
+
+const policy = loadEvidencePolicy();
+
+function input(overrides = {}) {
+  return {
+    eventName: "pull_request",
+    baseSha: "base-commit",
+    headSha: "head-commit",
+    baseTreeSha: "base-tree",
+    headTreeSha: "head-tree",
+    changedFiles: [],
+    knownTests: [],
+    relatedTestsBySource: {},
+    codeGraphAdvice: null,
+    routeAdviceBySource: {},
+    packageDependencies: {},
+    totalTestCount: 100,
+    policy,
+    ...overrides,
+  };
+}
+
+function trustedGraph(recommendations = {}) {
+  return {
+    schemaVersion: 1,
+    graphKey: "source-code",
+    indexStatus: "ready",
+    indexedHeadSha: "head-commit",
+    indexedTreeSha: "head-tree",
+    workspaceDirty: false,
+    relationshipCounts: {
+      DEFINES: 10,
+      IMPORTS: 20,
+      IMPLEMENTS_ROUTE: 5,
+      EXPOSES_TOOL: 5,
+      TESTED_BY: 8,
+    },
+    recommendations,
+  };
+}
+
+function escalationCodes(plan) {
+  return plan.escalations.map((entry) => entry.code);
+}
+
+describe("createEvidencePlan", () => {
+  it("emits a versioned deterministic semantic plan and digest", () => {
+    const first = createEvidencePlan(input({
+      changedFiles: [
+        "apps/web/lib/orders.test.ts",
+        "apps/web/lib/orders.ts",
+      ],
+      knownTests: ["apps/web/lib/orders.test.ts"],
+      codeGraphAdvice: trustedGraph({
+        "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+      }),
+      generatedAt: "2026-07-27T01:00:00Z",
+      hostPath: "D:/one",
+    }));
+    const second = createEvidencePlan(input({
+      changedFiles: [
+        "apps/web/lib/orders.ts",
+        "apps/web/lib/orders.test.ts",
+      ],
+      knownTests: ["apps/web/lib/orders.test.ts"],
+      codeGraphAdvice: trustedGraph({
+        "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+      }),
+      generatedAt: "2026-07-28T02:00:00Z",
+      hostPath: "/tmp/two",
+    }));
+
+    assert.equal(first.schemaVersion, CI_EVIDENCE_PLAN_SCHEMA_VERSION);
+    assert.equal(first.digest.length, 64);
+    assert.equal(canonicalJson(first), canonicalJson(second));
+    assert.deepEqual(first.changedFiles, [
+      "apps/web/lib/orders.test.ts",
+      "apps/web/lib/orders.ts",
+    ]);
+  });
+
+  it("preserves the existing docs-only exemption without graph input", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: [
+        "README.md",
+        "docs/testing/ci-evidence.md",
+      ],
+    }));
+
+    assert.equal(plan.scope.docsOnly, true);
+    assert.equal(plan.scope.heavy, false);
+    assert.equal(plan.fullSuite, false);
+    assert.equal(plan.uxMode, "none");
+    assert.deepEqual(plan.escalations, []);
+  });
+
+  it("recommends deterministic related tests but expands runtime source when graph input is missing", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/orders.ts"],
+      knownTests: ["apps/web/lib/orders.test.ts"],
+      relatedTestsBySource: {
+        "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+      },
+    }));
+
+    assert.deepEqual(plan.affectedTests, ["apps/web/lib/orders.test.ts"]);
+    assert.equal(plan.fullSuite, true);
+    assert.ok(escalationCodes(plan).includes("graph-missing"));
+  });
+
+  it("uses exact-tree clean graph TESTED_BY advice without making it the sole selector", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/orders.ts"],
+      knownTests: [
+        "apps/web/lib/orders.contract.test.ts",
+        "apps/web/lib/orders.test.ts",
+      ],
+      relatedTestsBySource: {
+        "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+      },
+      codeGraphAdvice: trustedGraph({
+        "apps/web/lib/orders.ts": ["apps/web/lib/orders.contract.test.ts"],
+      }),
+    }));
+
+    assert.deepEqual(plan.affectedTests, [
+      "apps/web/lib/orders.contract.test.ts",
+      "apps/web/lib/orders.test.ts",
+    ]);
+    assert.equal(plan.graph.trusted, true);
+    assert.equal(plan.fullSuite, false);
+  });
+
+  for (const [name, advice, code] of [
+    ["stale head", { ...trustedGraph(), indexedHeadSha: "other-head" }, "graph-head-mismatch"],
+    ["dirty workspace", { ...trustedGraph(), workspaceDirty: true }, "graph-dirty"],
+    ["incompatible schema", { ...trustedGraph(), schemaVersion: 2 }, "graph-schema-mismatch"],
+    ["stale tree", { ...trustedGraph(), indexedTreeSha: "other-tree" }, "graph-tree-mismatch"],
+    ["missing TESTED_BY facts", {
+      ...trustedGraph(),
+      relationshipCounts: { ...trustedGraph().relationshipCounts, TESTED_BY: 0 },
+    }, "graph-relationships-missing"],
+  ]) {
+    it(`fails safe for ${name}`, () => {
+      const plan = createEvidencePlan(input({
+        changedFiles: ["apps/web/lib/orders.ts"],
+        knownTests: ["apps/web/lib/orders.test.ts"],
+        relatedTestsBySource: {
+          "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+        },
+        codeGraphAdvice: advice,
+      }));
+
+      assert.equal(plan.fullSuite, true);
+      assert.ok(escalationCodes(plan).includes(code));
+    });
+  }
+
+  for (const [path, code] of [
+    ["pnpm-lock.yaml", "lockfile"],
+    [".github/workflows/ci.yml", "workflow"],
+    ["packages/db/prisma/schema.prisma", "migration"],
+    ["apps/web/lib/auth/session.ts", "auth"],
+    ["apps/web/app/layout.tsx", "routing-shell"],
+    ["apps/web/vitest.config.ts", "test-config"],
+    ["scripts/seed-fixtures.mjs", "install-seed"],
+    ["apps/web/lib/docs/doc-index.generated.json", "generated-contract"],
+    ["scripts/lib/local-integration-ci.mjs", "shared-setup"],
+  ]) {
+    it(`selects exhaustive evidence for ${code} risk`, () => {
+      const plan = createEvidencePlan(input({
+        changedFiles: [path],
+        codeGraphAdvice: trustedGraph(),
+      }));
+
+      assert.equal(plan.fullSuite, true);
+      assert.ok(escalationCodes(plan).includes(`risk:${code}`));
+    });
+  }
+
+  for (const eventName of ["merge_group", "push", "workflow_dispatch", "schedule"]) {
+    it(`keeps ${eventName} exhaustive`, () => {
+      const plan = createEvidencePlan(input({
+        eventName,
+        changedFiles: ["apps/web/lib/orders.ts"],
+        knownTests: ["apps/web/lib/orders.test.ts"],
+        relatedTestsBySource: {
+          "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+        },
+        codeGraphAdvice: trustedGraph(),
+      }));
+
+      assert.equal(plan.fullSuite, true);
+      assert.ok(escalationCodes(plan).includes("event-exhaustive"));
+    });
+  }
+
+  it("marks an unmapped production file and expands to exhaustive evidence", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/unowned-behavior.ts"],
+      codeGraphAdvice: trustedGraph(),
+    }));
+
+    assert.equal(plan.fullSuite, true);
+    assert.ok(escalationCodes(plan).includes("unmapped-production"));
+    assert.deepEqual(plan.fileDispositions, [{
+      path: "apps/web/lib/unowned-behavior.ts",
+      kind: "production",
+      disposition: "unmapped",
+      tests: [],
+      routes: [],
+    }]);
+    assert.deepEqual(plan.observations.missingTestUpdates, [
+      "apps/web/lib/unowned-behavior.ts",
+    ]);
+  });
+
+  it("expands when the selected test percentage exceeds policy", () => {
+    const selected = Array.from({ length: 71 }, (_, index) => `apps/web/lib/t${index}.test.ts`);
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/orders.ts"],
+      knownTests: selected,
+      relatedTestsBySource: {
+        "apps/web/lib/orders.ts": selected,
+      },
+      codeGraphAdvice: trustedGraph(),
+      totalTestCount: 100,
+    }));
+
+    assert.equal(plan.selection.selectedPercentage, 71);
+    assert.equal(plan.fullSuite, true);
+    assert.ok(escalationCodes(plan).includes("selection-threshold"));
+  });
+
+  it("selects a directly changed test without requiring graph advice", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/orders.test.ts"],
+      knownTests: ["apps/web/lib/orders.test.ts"],
+    }));
+
+    assert.deepEqual(plan.affectedTests, ["apps/web/lib/orders.test.ts"]);
+    assert.equal(plan.fullSuite, false);
+    assert.deepEqual(plan.escalations, []);
+  });
+
+  it("derives Next route paths and route families from page ownership", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/app/(shell)/ops/self-upgrade/page.tsx"],
+      knownTests: ["apps/web/app/(shell)/ops/self-upgrade/page.test.tsx"],
+      relatedTestsBySource: {
+        "apps/web/app/(shell)/ops/self-upgrade/page.tsx": [
+          "apps/web/app/(shell)/ops/self-upgrade/page.test.tsx",
+        ],
+      },
+      codeGraphAdvice: trustedGraph(),
+    }));
+
+    assert.deepEqual(plan.affectedRoutes, ["/ops/self-upgrade"]);
+    assert.deepEqual(plan.routeFamilies, ["/ops"]);
+    assert.equal(plan.uxMode, "changed-routes");
+  });
+
+  it("expands affected packages through transitive workspace consumers", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["packages/types/src/order.ts"],
+      knownTests: ["packages/types/src/order.test.ts"],
+      relatedTestsBySource: {
+        "packages/types/src/order.ts": ["packages/types/src/order.test.ts"],
+      },
+      packageDependencies: {
+        "@dpf/types": [],
+        "@dpf/api-client": ["@dpf/types"],
+        "web": ["@dpf/api-client"],
+        "mobile": ["@dpf/api-client"],
+      },
+      codeGraphAdvice: trustedGraph(),
+    }));
+
+    assert.deepEqual(plan.affectedPackages, [
+      "@dpf/api-client",
+      "@dpf/types",
+      "mobile",
+      "web",
+    ]);
+  });
+});

--- a/scripts/lib/ci-evidence-plan.test.mjs
+++ b/scripts/lib/ci-evidence-plan.test.mjs
@@ -87,6 +87,23 @@ describe("createEvidencePlan", () => {
     ]);
   });
 
+  it("keeps the digest stable across synthetic merge commits with identical trees", () => {
+    const first = createEvidencePlan(input({
+      baseSha: "accepted-base-commit",
+      headSha: "local-merge-one",
+      changedFiles: ["docs/testing/ci-evidence.md"],
+    }));
+    const second = createEvidencePlan(input({
+      baseSha: "other-ref-to-the-same-base-tree",
+      headSha: "local-merge-two",
+      changedFiles: ["docs/testing/ci-evidence.md"],
+    }));
+
+    assert.notEqual(first.headSha, second.headSha);
+    assert.equal(first.headTreeSha, second.headTreeSha);
+    assert.equal(first.digest, second.digest);
+  });
+
   it("preserves the existing docs-only exemption without graph input", () => {
     const plan = createEvidencePlan(input({
       changedFiles: [
@@ -139,8 +156,23 @@ describe("createEvidencePlan", () => {
     assert.equal(plan.fullSuite, false);
   });
 
+  it("accepts a different commit alias when graph advice matches the exact tree", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/orders.ts"],
+      knownTests: ["apps/web/lib/orders.test.ts"],
+      codeGraphAdvice: {
+        ...trustedGraph({
+          "apps/web/lib/orders.ts": ["apps/web/lib/orders.test.ts"],
+        }),
+        indexedHeadSha: "candidate-before-synthetic-merge",
+      },
+    }));
+
+    assert.equal(plan.graph.trusted, true);
+    assert.equal(plan.fullSuite, false);
+  });
+
   for (const [name, advice, code] of [
-    ["stale head", { ...trustedGraph(), indexedHeadSha: "other-head" }, "graph-head-mismatch"],
     ["dirty workspace", { ...trustedGraph(), workspaceDirty: true }, "graph-dirty"],
     ["incompatible schema", { ...trustedGraph(), schemaVersion: 2 }, "graph-schema-mismatch"],
     ["stale tree", { ...trustedGraph(), indexedTreeSha: "other-tree" }, "graph-tree-mismatch"],

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -139,11 +139,26 @@ export function createLocalIntegrationPlan(input) {
     // `env VAR=… cmd` keeps the plan a plain argv (no shell) — host-next is
     // POSIX-only by construction (Windows defaults to docker-build above).
     : ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "next", "build"];
+  const evidencePlanCommand = [
+    "node",
+    "scripts/ci-evidence-plan.mjs",
+    "--event",
+    "local-ci",
+    "--base",
+    baseRef,
+    "--head",
+    "HEAD",
+    ...(input.evidencePlanOutput ? ["--output", input.evidencePlanOutput] : []),
+  ];
   const commands = [
     ...(input.fetchBase ? [["git", "fetch", "origin", "main"]] : []),
     ["git", "checkout", "-B", branch, baseRef],
     ["git", "merge", "--no-ff", "--no-edit", input.candidateBranch],
     ...input.siblingBranches.map((sibling) => ["git", "merge", "--no-ff", "--no-edit", sibling]),
+    // Generate the same versioned, digest-bound evidence recommendation used
+    // by GitHub after the exact integration tree exists. Shadow mode records
+    // advice only; the exhaustive gate below remains the execution authority.
+    evidencePlanCommand,
     // Step-zero sandbox freshness gate (BI-ECDF9520): after the merge changes
     // pnpm-lock.yaml, node_modules must be proven to match it before any
     // test/build result counts as product evidence. Exits 3/4 (sandbox drift /

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -60,6 +60,7 @@ describe("createLocalIntegrationPlan", () => {
     assert.deepEqual(plan.commands.map((command) => command.join(" ")), [
       "git checkout -B local-integration/doc-build-studio-decision-skill-packs origin/main",
       "git merge --no-ff --no-edit doc/build-studio-decision-skill-packs",
+      "node scripts/ci-evidence-plan.mjs --event local-ci --base origin/main --head HEAD",
       "node scripts/sandbox-freshness-preflight.mjs --converge --branch local-integration/doc-build-studio-decision-skill-packs",
       "pnpm --filter @dpf/db exec prisma generate",
       "node scripts/gen-doc-index.mjs --check",
@@ -141,10 +142,27 @@ describe("createLocalIntegrationPlan", () => {
     });
     const commands = plan.commands.map((command) => command.join(" "));
     const preflightIndex = commands.findIndex((c) => c.includes("sandbox-freshness-preflight.mjs"));
+    const evidencePlanIndex = commands.findIndex((c) => c.includes("ci-evidence-plan.mjs"));
     const lastMergeIndex = commands.map((c, i) => (c.startsWith("git merge") ? i : -1)).reduce((a, b) => Math.max(a, b), -1);
     const firstGateIndex = commands.findIndex((c) => c.includes("vitest run"));
+    assert.ok(evidencePlanIndex > lastMergeIndex);
+    assert.ok(evidencePlanIndex < preflightIndex);
     assert.ok(preflightIndex > lastMergeIndex);
     assert.ok(preflightIndex < firstGateIndex);
+  });
+
+  it("writes the shadow plan beside governed local-CI metadata when requested", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "feat/x",
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "linux",
+      evidencePlanOutput: "artifacts/dpf-ci-evidence-plan.json",
+    });
+
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
+      "node scripts/ci-evidence-plan.mjs --event local-ci --base origin/main --head HEAD --output artifacts/dpf-ci-evidence-plan.json",
+    ));
   });
 
   it("runs fast PR guard parity before the expensive test/build gates", () => {

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
   collectToolchainFingerprint,
   createLocalIntegrationPlan,
@@ -18,6 +19,8 @@ const baseRef = valueAfter("--base-ref") || "origin/main";
 const candidateSha = valueAfter("--candidate-sha");
 const baseSha = valueAfter("--base-sha");
 const metadataOut = valueAfter("--metadata-out");
+const evidencePlanOut = valueAfter("--evidence-plan-out")
+  || (metadataOut ? join(dirname(metadataOut), "dpf-ci-evidence-plan.json") : "");
 const mode = valueAfter("--mode") || "single-branch";
 const buildStrategy = valueAfter("--build-strategy");
 const fetchBase = process.argv.includes("--fetch-base");
@@ -26,7 +29,7 @@ const siblingBranches = process.argv
   .map((arg) => arg.slice("--sibling=".length));
 
 if (!candidateBranch) {
-  console.error("Usage: node scripts/local-integration-ci.mjs --candidate BRANCH [--base-ref REF] [--candidate-sha SHA] [--base-sha SHA] [--metadata-out PATH] [--fetch-base] [--mode single-branch|sibling-set|post-merge-main] [--sibling=BRANCH] [--migrate-deploy]");
+  console.error("Usage: node scripts/local-integration-ci.mjs --candidate BRANCH [--base-ref REF] [--candidate-sha SHA] [--base-sha SHA] [--metadata-out PATH] [--evidence-plan-out PATH] [--fetch-base] [--mode single-branch|sibling-set|post-merge-main] [--sibling=BRANCH] [--migrate-deploy]");
   process.exit(2);
 }
 
@@ -37,6 +40,7 @@ const plan = createLocalIntegrationPlan({
   siblingBranches,
   buildStrategy: buildStrategy || undefined,
   fetchBase,
+  evidencePlanOutput: evidencePlanOut || undefined,
   includeMigrateDeploy: process.argv.includes("--migrate-deploy"),
 });
 const startedAt = new Date().toISOString();
@@ -51,6 +55,9 @@ for (const command of plan.commands) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 if (metadataOut) {
+  const evidencePlan = evidencePlanOut
+    ? JSON.parse(readFileSync(evidencePlanOut, "utf8"))
+    : null;
   const payload = {
     schemaVersion: 1,
     bi: "BI-76551B2D",
@@ -64,6 +71,14 @@ if (metadataOut) {
     integrationCommitSha: resolveGitRevision("HEAD"),
     synthesizedTreeSha: resolveGitRevision("HEAD^{tree}"),
     buildStrategy: plan.buildStrategy,
+    evidencePlan: evidencePlan ? {
+      path: evidencePlanOut,
+      digest: evidencePlan.digest,
+      plannerVersion: evidencePlan.plannerVersion,
+      policyVersion: evidencePlan.policyVersion,
+      evidenceTier: evidencePlan.evidenceTier,
+      fullSuite: evidencePlan.fullSuite,
+    } : null,
     ...collectToolchainFingerprint({ buildStrategy: plan.buildStrategy }),
     commands: plan.commands.map((command) => command.join(" ")),
     startedAt,


### PR DESCRIPTION
## Summary
- add a versioned, deterministic CI evidence planner that maps changed files to affected packages, tests, routes, UX mode, and global guards
- consume the same planner from GitHub CI and governed local-CI while preserving current exhaustive execution and stable required-check names
- fail safe on missing/stale graph advice, global-risk changes, unmapped source, and large selections; keep merge-group and non-PR events exhaustive
- refactor the legacy change-scope classifier into a compatibility adapter over the shared policy/core
- document the shadow schema, exact-tree digest boundary, activation gate, and prior-design reconciliation

Linked backlog: BI-A4EC0EA6

## Test plan
- [x] planner, CLI, compatibility, workflow, and local integration contracts: 58 passing
- [x] governed exact-SHA local-CI: 2,275 test files / 19,734 tests passed
- [x] web typecheck: passed
- [x] Prisma migrate deploy: passed, no pending migrations
- [x] docs index, link integrity, and repository guards: passed
- [x] production Docker build: passed (`sha256:794c9f09c1ecdbdf811f5385018e7af21c655e910483ca4be0e00e426bdb4878`)
- [x] UX verification: not applicable; CI developer tooling has no UI behavior change

The planner is shadow-only in this PR: no tests, builds, migrations, guards, or merge-queue proof are skipped. Activation remains owned by BI-4527C1DA after calibrated recall evidence.

Local-CI-Evidence: cms3pcjnf0je301p5xg66b7da (feat/ci-evidence-impact-planner@332545998438bc8e5cc986b6c8e38598ec0a6762)