### PR TITLE
feat(platform): address validation provider-choice guidance (BI-SITE-5E6A18)

### DIFF
--- a/apps/web/app/(shell)/platform/tools/built-ins/page.test.tsx
+++ b/apps/web/app/(shell)/platform/tools/built-ins/page.test.tsx
@@ -52,7 +52,8 @@ describe("BuiltInToolsPage", () => {
     expect(html).toContain("Brave Search");
     expect(html).toContain("search_public_web");
     expect(html).toContain("platform-keys-panel");
-    expect(html).toContain("Address validation providers");
+    expect(html).toContain("Address validation");
+    expect(html).toContain("Provider choices");
     expect(html).toContain("Smarty");
     expect(html).toContain("Mapbox");
   });

--- a/apps/web/app/(shell)/platform/tools/built-ins/page.test.tsx
+++ b/apps/web/app/(shell)/platform/tools/built-ins/page.test.tsx
@@ -20,6 +20,13 @@ vi.mock("@/lib/actions/built-in-tools", () => ({
         currentValue: "BSA-secret",
       },
     },
+    addressValidation: {
+      commercialProviderDetected: false,
+      siteLookupReady: false,
+      headline: "No address validation provider is configured.",
+      nextStep: "Choose Smarty (US-first) or Mapbox (global), add one key, leave the other off.",
+      primaryCountry: "US",
+    },
   }),
 }));
 
@@ -45,5 +52,8 @@ describe("BuiltInToolsPage", () => {
     expect(html).toContain("Brave Search");
     expect(html).toContain("search_public_web");
     expect(html).toContain("platform-keys-panel");
+    expect(html).toContain("Address validation providers");
+    expect(html).toContain("Smarty");
+    expect(html).toContain("Mapbox");
   });
 });

--- a/apps/web/app/(shell)/platform/tools/built-ins/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/built-ins/page.tsx
@@ -1,4 +1,5 @@
 import { PlatformKeysPanel } from "@/components/admin/PlatformKeysPanel";
+import { AddressValidationProviderGuidance } from "@/components/platform/AddressValidationProviderGuidance";
 import { getBuiltInToolsOverview } from "@/lib/actions/built-in-tools";
 
 const BRAVE_SEARCH_CONFIG = [
@@ -12,7 +13,7 @@ const BRAVE_SEARCH_CONFIG = [
 ];
 
 export default async function BuiltInToolsPage() {
-  const { tools, keyData } = await getBuiltInToolsOverview();
+  const { tools, keyData, addressValidation } = await getBuiltInToolsOverview();
 
   return (
     <div className="space-y-6">
@@ -34,12 +35,12 @@ export default async function BuiltInToolsPage() {
                 <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{tool.name}</h2>
                 <p className="mt-2 text-sm text-[var(--dpf-muted)]">{tool.description}</p>
               </div>
-              <span className="rounded-full border border-[var(--dpf-border)] px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+              <span className="rounded-full border border-[var(--dpf-border)] px-2 py-1 text-dpf-caption uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
                 {tool.model}
               </span>
             </div>
 
-            <div className="mt-4 space-y-2 text-xs text-[var(--dpf-muted)]">
+            <div className="mt-4 space-y-2 text-dpf-caption text-[var(--dpf-muted)]">
               <p>
                 Capability: <span className="font-mono text-[var(--dpf-text)]">{tool.capability}</span>
               </p>
@@ -53,6 +54,11 @@ export default async function BuiltInToolsPage() {
           </div>
         ))}
       </div>
+
+      <AddressValidationProviderGuidance
+        status={addressValidation}
+        primaryCountry={addressValidation.primaryCountry}
+      />
 
       <PlatformKeysPanel
         keyData={keyData}

--- a/apps/web/components/platform/AddressValidationProviderGuidance.tsx
+++ b/apps/web/components/platform/AddressValidationProviderGuidance.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link";
+import {
+  ADDRESS_VALIDATION_ONE_ACTIVE_POLICY,
+  ADDRESS_VALIDATION_PROVIDERS,
+  describeAddressValidationSetup,
+  suggestProviderForGeography,
+  type AddressValidationSetupStatus,
+} from "@/lib/shared/address-validation-provider-guidance";
+
+type Props = {
+  status: AddressValidationSetupStatus;
+  /** Optional org country for the geography hint. */
+  primaryCountry?: string | null;
+};
+
+/**
+ * BI-SITE-5E6A18 — compact provider-choice guidance for address validation.
+ * Progressive disclosure: status first, then Smarty vs Mapbox choices.
+ */
+export function AddressValidationProviderGuidance({ status, primaryCountry }: Props) {
+  const suggested = suggestProviderForGeography({ primaryCountry });
+  const suggestedName =
+    ADDRESS_VALIDATION_PROVIDERS.find((p) => p.id === suggested)?.name ?? "Smarty";
+
+  return (
+    <section
+      className="space-y-4 rounded-2xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
+      aria-labelledby="address-validation-guidance-heading"
+    >
+      <div>
+        <h2
+          id="address-validation-guidance-heading"
+          className="text-dpf-title font-dpf-semibold text-[var(--dpf-text)]"
+        >
+          Address validation providers
+        </h2>
+        <p className="mt-1 text-dpf-body text-[var(--dpf-muted)]">{status.headline}</p>
+        <p className="mt-2 text-dpf-caption text-[var(--dpf-muted)]">
+          Next: {status.nextStep}
+        </p>
+      </div>
+
+      <p className="text-dpf-caption text-[var(--dpf-text)]">
+        {ADDRESS_VALIDATION_ONE_ACTIVE_POLICY}
+      </p>
+
+      <p className="text-dpf-caption text-[var(--dpf-muted)]">
+        Suggested for this install: <span className="text-[var(--dpf-text)]">{suggestedName}</span>
+        {primaryCountry ? ` (${primaryCountry})` : ""}.
+      </p>
+
+      <ul className="space-y-3">
+        {ADDRESS_VALIDATION_PROVIDERS.map((provider) => (
+          <li
+            key={provider.id}
+            className="rounded-dpf-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-dpf-body font-dpf-semibold text-[var(--dpf-text)]">
+                {provider.name}
+              </span>
+              {provider.id === suggested ? (
+                <span className="rounded-full border border-[var(--dpf-accent)] px-2 py-0.5 text-dpf-caption text-[var(--dpf-accent)]">
+                  Suggested
+                </span>
+              ) : null}
+              {provider.needsApiKey ? (
+                <span className="text-dpf-caption text-[var(--dpf-muted)]">API key</span>
+              ) : (
+                <span className="text-dpf-caption text-[var(--dpf-muted)]">No key</span>
+              )}
+            </div>
+            <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">
+              Best for: {provider.bestFor}
+            </p>
+            <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">{provider.notes}</p>
+          </li>
+        ))}
+      </ul>
+
+      <p className="text-dpf-caption text-[var(--dpf-muted)]">
+        Full notes:{" "}
+        <Link
+          href="/docs/platform/address-validation-providers"
+          className="text-[var(--dpf-accent)] hover:underline"
+        >
+          Address validation setup
+        </Link>
+        . Service registry:{" "}
+        <Link href="/platform/tools/services" className="text-[var(--dpf-accent)] hover:underline">
+          MCP Services
+        </Link>
+        .
+      </p>
+    </section>
+  );
+}
+
+/** Server helper: status from boolean probes (kept free of Prisma). */
+export function buildAddressValidationStatus(input: {
+  commercialProviderDetected: boolean;
+  siteLookupReady: boolean;
+}): AddressValidationSetupStatus {
+  return describeAddressValidationSetup(input);
+}

--- a/apps/web/components/platform/AddressValidationProviderGuidance.tsx
+++ b/apps/web/components/platform/AddressValidationProviderGuidance.tsx
@@ -15,7 +15,8 @@ type Props = {
 
 /**
  * BI-SITE-5E6A18 — compact provider-choice guidance for address validation.
- * Progressive disclosure: status first, then Smarty vs Mapbox choices.
+ * Default viewport: status + next step only. Provider comparison stays collapsed
+ * so the Built-in Tools route does not regress the UX word budget.
  */
 export function AddressValidationProviderGuidance({ status, primaryCountry }: Props) {
   const suggested = suggestProviderForGeography({ primaryCountry });
@@ -24,15 +25,16 @@ export function AddressValidationProviderGuidance({ status, primaryCountry }: Pr
 
   return (
     <section
-      className="space-y-4 rounded-2xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
+      className="space-y-3 rounded-2xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
       aria-labelledby="address-validation-guidance-heading"
+      data-dpf-lead
     >
       <div>
         <h2
           id="address-validation-guidance-heading"
           className="text-dpf-title font-dpf-semibold text-[var(--dpf-text)]"
         >
-          Address validation providers
+          Address validation
         </h2>
         <p className="mt-1 text-dpf-body text-[var(--dpf-muted)]">{status.headline}</p>
         <p className="mt-2 text-dpf-caption text-[var(--dpf-muted)]">
@@ -40,57 +42,60 @@ export function AddressValidationProviderGuidance({ status, primaryCountry }: Pr
         </p>
       </div>
 
-      <p className="text-dpf-caption text-[var(--dpf-text)]">
-        {ADDRESS_VALIDATION_ONE_ACTIVE_POLICY}
+      <p className="text-dpf-caption text-[var(--dpf-muted)]">
+        Suggested: <span className="text-[var(--dpf-text)]">{suggestedName}</span>
+        {primaryCountry ? ` (${primaryCountry})` : ""}. One commercial key at a time.
       </p>
 
-      <p className="text-dpf-caption text-[var(--dpf-muted)]">
-        Suggested for this install: <span className="text-[var(--dpf-text)]">{suggestedName}</span>
-        {primaryCountry ? ` (${primaryCountry})` : ""}.
-      </p>
+      <details className="rounded-dpf-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+        <summary className="cursor-pointer text-dpf-body font-dpf-medium text-[var(--dpf-text)]">
+          Provider choices
+        </summary>
+        <div className="mt-3 space-y-3">
+          <p className="text-dpf-caption text-[var(--dpf-text)]">
+            {ADDRESS_VALIDATION_ONE_ACTIVE_POLICY}
+          </p>
+          <ul className="space-y-3">
+            {ADDRESS_VALIDATION_PROVIDERS.map((provider) => (
+              <li
+                key={provider.id}
+                className="rounded-dpf-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-dpf-body font-dpf-semibold text-[var(--dpf-text)]">
+                    {provider.name}
+                  </span>
+                  {provider.id === suggested ? (
+                    <span className="rounded-full border border-[var(--dpf-accent)] px-2 py-0.5 text-dpf-caption text-[var(--dpf-accent)]">
+                      Suggested
+                    </span>
+                  ) : null}
+                  <span className="text-dpf-caption text-[var(--dpf-muted)]">
+                    {provider.needsApiKey ? "API key" : "No key"}
+                  </span>
+                </div>
+                <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">
+                  Best for: {provider.bestFor}
+                </p>
+                <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">{provider.notes}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </details>
 
-      <ul className="space-y-3">
-        {ADDRESS_VALIDATION_PROVIDERS.map((provider) => (
-          <li
-            key={provider.id}
-            className="rounded-dpf-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
-          >
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-dpf-body font-dpf-semibold text-[var(--dpf-text)]">
-                {provider.name}
-              </span>
-              {provider.id === suggested ? (
-                <span className="rounded-full border border-[var(--dpf-accent)] px-2 py-0.5 text-dpf-caption text-[var(--dpf-accent)]">
-                  Suggested
-                </span>
-              ) : null}
-              {provider.needsApiKey ? (
-                <span className="text-dpf-caption text-[var(--dpf-muted)]">API key</span>
-              ) : (
-                <span className="text-dpf-caption text-[var(--dpf-muted)]">No key</span>
-              )}
-            </div>
-            <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">
-              Best for: {provider.bestFor}
-            </p>
-            <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">{provider.notes}</p>
-          </li>
-        ))}
-      </ul>
-
       <p className="text-dpf-caption text-[var(--dpf-muted)]">
-        Full notes:{" "}
+        Docs:{" "}
         <Link
           href="/docs/platform/address-validation-providers"
           className="text-[var(--dpf-accent)] hover:underline"
         >
-          Address validation setup
+          setup guide
         </Link>
-        . Service registry:{" "}
+        {" · "}
         <Link href="/platform/tools/services" className="text-[var(--dpf-accent)] hover:underline">
           MCP Services
         </Link>
-        .
       </p>
     </section>
   );

--- a/apps/web/lib/actions/built-in-tools.test.ts
+++ b/apps/web/lib/actions/built-in-tools.test.ts
@@ -5,6 +5,12 @@ vi.mock("@dpf/db", () => ({
     platformConfig: {
       findMany: vi.fn(),
     },
+    modelProvider: {
+      findFirst: vi.fn(),
+    },
+    organization: {
+      findFirst: vi.fn(),
+    },
   },
 }));
 
@@ -16,6 +22,8 @@ describe("getBuiltInToolsOverview", () => {
     vi.mocked(prisma.platformConfig.findMany).mockResolvedValue([
       { key: "brave_search_api_key", value: "BSA-secret" },
     ] as never);
+    vi.mocked(prisma.modelProvider.findFirst).mockResolvedValue(null as never);
+    vi.mocked(prisma.organization.findFirst).mockResolvedValue({ address: null } as never);
 
     const result = await getBuiltInToolsOverview();
     const braveSearch = result.tools.find((tool) => tool.id === "brave-search");
@@ -26,6 +34,8 @@ describe("getBuiltInToolsOverview", () => {
 
   it("includes the built-in tool descriptors even when no key is configured", async () => {
     vi.mocked(prisma.platformConfig.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.modelProvider.findFirst).mockResolvedValue(null as never);
+    vi.mocked(prisma.organization.findFirst).mockResolvedValue({ address: null } as never);
 
     const result = await getBuiltInToolsOverview();
 
@@ -35,5 +45,20 @@ describe("getBuiltInToolsOverview", () => {
       "branding-analyzer",
     ]);
     expect(result.keyData.brave_search_api_key.configured).toBe(false);
+  });
+
+  it("reports address validation status and org country hint (BI-SITE-5E6A18)", async () => {
+    vi.mocked(prisma.platformConfig.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.modelProvider.findFirst).mockResolvedValue({ id: "prov-1" } as never);
+    vi.mocked(prisma.organization.findFirst).mockResolvedValue({
+      address: { country: "US" },
+    } as never);
+
+    const result = await getBuiltInToolsOverview();
+
+    expect(result.addressValidation.commercialProviderDetected).toBe(true);
+    expect(result.addressValidation.siteLookupReady).toBe(false);
+    expect(result.addressValidation.primaryCountry).toBe("US");
+    expect(result.addressValidation.headline.toLowerCase()).toMatch(/not wired|registered/);
   });
 });

--- a/apps/web/lib/actions/built-in-tools.ts
+++ b/apps/web/lib/actions/built-in-tools.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { prisma } from "@dpf/db";
+import { describeAddressValidationSetup } from "@/lib/shared/address-validation-provider-guidance";
+import type { AddressValidationSetupStatus } from "@/lib/shared/address-validation-provider-guidance";
 
 export type BuiltInToolEntry = {
   id: "brave-search" | "public-web-fetch" | "branding-analyzer";
@@ -20,16 +22,54 @@ type KeyState = {
 export async function getBuiltInToolsOverview(): Promise<{
   tools: BuiltInToolEntry[];
   keyData: Record<string, KeyState>;
+  addressValidation: AddressValidationSetupStatus & {
+    primaryCountry: string | null;
+  };
 }> {
-  const configs = await prisma.platformConfig.findMany({
-    where: { key: { in: ["brave_search_api_key"] } },
-    select: { key: true, value: true },
-  });
+  const [configs, geocodingService, organization] = await Promise.all([
+    prisma.platformConfig.findMany({
+      where: { key: { in: ["brave_search_api_key"] } },
+      select: { key: true, value: true },
+    }),
+    prisma.modelProvider.findFirst({
+      where: {
+        endpointType: "service",
+        status: "active",
+        OR: [
+          { name: { contains: "geocod", mode: "insensitive" } },
+          { name: { contains: "places", mode: "insensitive" } },
+          { name: { contains: "mapbox", mode: "insensitive" } },
+          { name: { contains: "smarty", mode: "insensitive" } },
+        ],
+      },
+      select: { id: true },
+    }),
+    prisma.organization.findFirst({
+      select: { address: true },
+      orderBy: { createdAt: "asc" },
+    }),
+  ]);
 
   const braveValue =
     configs.find((config) => config.key === "brave_search_api_key")?.value ?? null;
   const braveSearchConfigured =
     typeof braveValue === "string" && braveValue.trim().length > 0;
+
+  // Site lookup remains a separate wiring step (resolveValidatedSiteAddress).
+  // A registered geocode service is necessary but not sufficient — report that honestly.
+  const commercialProviderDetected = Boolean(geocodingService);
+  const siteLookupReady = false;
+  const addressStatus = describeAddressValidationSetup({
+    commercialProviderDetected,
+    siteLookupReady,
+  });
+
+  let primaryCountry: string | null = null;
+  if (organization?.address && typeof organization.address === "object" && !Array.isArray(organization.address)) {
+    const addr = organization.address as Record<string, unknown>;
+    const country = addr.country ?? addr.countryCode;
+    if (typeof country === "string" && country.trim()) primaryCountry = country.trim();
+  }
 
   return {
     tools: [
@@ -66,6 +106,10 @@ export async function getBuiltInToolsOverview(): Promise<{
         configured: braveSearchConfigured,
         currentValue: typeof braveValue === "string" && braveValue.length > 0 ? braveValue : null,
       },
+    },
+    addressValidation: {
+      ...addressStatus,
+      primaryCountry,
     },
   };
 }

--- a/apps/web/lib/actions/connection-catalog.test.ts
+++ b/apps/web/lib/actions/connection-catalog.test.ts
@@ -63,6 +63,13 @@ beforeEach(() => {
         currentValue: null,
       },
     },
+    addressValidation: {
+      commercialProviderDetected: false,
+      siteLookupReady: false,
+      headline: "No address validation provider is configured.",
+      nextStep: "Choose Smarty or Mapbox.",
+      primaryCountry: null,
+    },
   });
   vi.mocked(prisma.integrationCredential.findMany).mockResolvedValue([
     { integrationId: "quickbooks-online-accounting", status: "connected" },

--- a/apps/web/lib/actions/tool-marketplace-readiness.test.ts
+++ b/apps/web/lib/actions/tool-marketplace-readiness.test.ts
@@ -93,6 +93,13 @@ beforeEach(() => {
     keyData: {
       brave_search_api_key: { configured: true, currentValue: "configured" },
     },
+    addressValidation: {
+      commercialProviderDetected: false,
+      siteLookupReady: false,
+      headline: "No address validation provider is configured.",
+      nextStep: "Choose Smarty or Mapbox.",
+      primaryCountry: null,
+    },
   });
 
   vi.mocked(prisma.taskRequirement.findUnique).mockImplementation((input) => Promise.resolve({

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 563,
+  "pageCount": 564,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9526,6 +9526,21 @@
         "what-to-watch"
       ]
     },
+    "docs/user-guide/platform/address-validation-providers.md": {
+      "publicHref": "/user-guide/platform/address-validation-providers/",
+      "portalHref": "/docs/platform/address-validation-providers",
+      "publishedPublic": true,
+      "publishedPortal": true,
+      "anchors": [
+        "use-this-doc-for",
+        "why-it-matters",
+        "choose-a-provider",
+        "geography-hint",
+        "setup-steps",
+        "what-to-watch",
+        "related"
+      ]
+    },
     "docs/user-guide/platform/ai-operations.md": {
       "publicHref": "/user-guide/platform/ai-operations/",
       "portalHref": "/docs/platform/ai-operations",

--- a/apps/web/lib/shared/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/shared/__snapshots__/index.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`shared barrel export > exports all public symbols 1`] = `
 [
+  "ADDRESS_VALIDATION_ONE_ACTIVE_POLICY",
+  "ADDRESS_VALIDATION_PROVIDERS",
   "AREA_META",
   "AREA_ORDER",
   "asNumber",
@@ -14,6 +16,7 @@ exports[`shared barrel export > exports all public symbols 1`] = `
   "composeInvoiceEmail",
   "composeSignedConfirmationEmail",
   "deleteAttachmentsForThread",
+  "describeAddressValidationSetup",
   "err",
   "escapeCsvField",
   "extractHeadings",
@@ -44,6 +47,7 @@ exports[`shared barrel export > exports all public symbols 1`] = `
   "safeRenderValue",
   "sendEmail",
   "slugify",
+  "suggestProviderForGeography",
   "toCsv",
   "validateAddress",
 ]

--- a/apps/web/lib/shared/address-validation-provider-guidance.test.ts
+++ b/apps/web/lib/shared/address-validation-provider-guidance.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADDRESS_VALIDATION_ONE_ACTIVE_POLICY,
+  ADDRESS_VALIDATION_PROVIDERS,
+  describeAddressValidationSetup,
+  suggestProviderForGeography,
+} from "./address-validation-provider-guidance";
+
+describe("address-validation-provider-guidance (BI-SITE-5E6A18)", () => {
+  it("lists Smarty, Mapbox, and Nominatim with one-active policy", () => {
+    expect(ADDRESS_VALIDATION_PROVIDERS.map((p) => p.id)).toEqual([
+      "smarty",
+      "mapbox",
+      "nominatim",
+    ]);
+    expect(ADDRESS_VALIDATION_ONE_ACTIVE_POLICY.toLowerCase()).toContain("one commercial");
+  });
+
+  it("suggests Smarty for US and Mapbox for other countries", () => {
+    expect(suggestProviderForGeography({ primaryCountry: "US" })).toBe("smarty");
+    expect(suggestProviderForGeography({ primaryCountry: "United States" })).toBe("smarty");
+    expect(suggestProviderForGeography({ primaryCountry: "CA" })).toBe("mapbox");
+    expect(suggestProviderForGeography({})).toBe("smarty");
+  });
+
+  it("describes setup status for missing, partial, and ready states", () => {
+    expect(
+      describeAddressValidationSetup({
+        commercialProviderDetected: false,
+        siteLookupReady: false,
+      }).nextStep,
+    ).toMatch(/Smarty|Mapbox/);
+
+    expect(
+      describeAddressValidationSetup({
+        commercialProviderDetected: true,
+        siteLookupReady: false,
+      }).headline,
+    ).toMatch(/not wired/i);
+
+    expect(
+      describeAddressValidationSetup({
+        commercialProviderDetected: true,
+        siteLookupReady: true,
+      }).headline,
+    ).toMatch(/ready/i);
+  });
+});

--- a/apps/web/lib/shared/address-validation-provider-guidance.ts
+++ b/apps/web/lib/shared/address-validation-provider-guidance.ts
@@ -1,0 +1,99 @@
+/**
+ * Operator-facing provider-choice guidance for site/address validation
+ * (BI-SITE-5E6A18 / EP-SITE-7C4D2B).
+ *
+ * Pure content + status helpers — no Prisma. UI and user-guide share this
+ * so Smarty vs Mapbox policy stays single-source.
+ */
+
+export type AddressValidationProviderId = "smarty" | "mapbox" | "nominatim";
+
+export type AddressValidationProviderOption = {
+  id: AddressValidationProviderId;
+  name: string;
+  bestFor: string;
+  notes: string;
+  needsApiKey: boolean;
+};
+
+/** One active commercial provider at a time — avoids conflicting lookups. */
+export const ADDRESS_VALIDATION_ONE_ACTIVE_POLICY =
+  "Enable one commercial address provider at a time. Keep a free fallback only when the commercial path is offline.";
+
+export const ADDRESS_VALIDATION_PROVIDERS: readonly AddressValidationProviderOption[] = [
+  {
+    id: "smarty",
+    name: "Smarty",
+    bestFor: "US postal accuracy, CASS-style verification, suite/unit data",
+    notes: "Best default when most customer sites are in the United States.",
+    needsApiKey: true,
+  },
+  {
+    id: "mapbox",
+    name: "Mapbox",
+    bestFor: "Global geocoding and map-aligned coordinates",
+    notes: "Prefer when sites span multiple countries or you already use Mapbox maps.",
+    needsApiKey: true,
+  },
+  {
+    id: "nominatim",
+    name: "Nominatim (OSM)",
+    bestFor: "Self-hosted / no-key installs",
+    notes: "Lower precision for commercial delivery; use as emergency fallback, not primary for field routes.",
+    needsApiKey: false,
+  },
+] as const;
+
+export type AddressValidationSetupStatus = {
+  /** True when a geocoding/places/mapbox service row is active. */
+  commercialProviderDetected: boolean;
+  /** True when site lookup can resolve a validated address ref. */
+  siteLookupReady: boolean;
+  headline: string;
+  nextStep: string;
+};
+
+/**
+ * Build operator status from live substrate signals (caller supplies booleans).
+ */
+export function describeAddressValidationSetup(input: {
+  commercialProviderDetected: boolean;
+  siteLookupReady: boolean;
+}): AddressValidationSetupStatus {
+  if (input.siteLookupReady) {
+    return {
+      commercialProviderDetected: input.commercialProviderDetected,
+      siteLookupReady: true,
+      headline: "Address validation is ready for customer sites.",
+      nextStep: "Keep one commercial provider active; re-check after key rotation.",
+    };
+  }
+  if (input.commercialProviderDetected) {
+    return {
+      commercialProviderDetected: true,
+      siteLookupReady: false,
+      headline: "A map/geocode service is registered, but site lookup is not wired yet.",
+      nextStep: "Finish connecting the active provider to customer site create/edit.",
+    };
+  }
+  return {
+    commercialProviderDetected: false,
+    siteLookupReady: false,
+    headline: "No address validation provider is configured.",
+    nextStep: "Choose Smarty (US-first) or Mapbox (global), add one key, leave the other off.",
+  };
+}
+
+/** Geography hint for progressive disclosure — not a hard router. */
+export function suggestProviderForGeography(input: {
+  primaryCountry?: string | null;
+}): AddressValidationProviderId {
+  const country = (input.primaryCountry ?? "").trim().toUpperCase();
+  if (country === "US" || country === "USA" || country === "UNITED STATES") {
+    return "smarty";
+  }
+  if (country.length > 0) {
+    return "mapbox";
+  }
+  return "smarty";
+}

--- a/apps/web/lib/shared/index.ts
+++ b/apps/web/lib/shared/index.ts
@@ -16,6 +16,7 @@ export * from "./docs";
 export * from "./docs-types";
 export * from "./bmr-resolver";
 export * from "./address-validation";
+export * from "./address-validation-provider-guidance";
 export * from "./address-data";
 export * from "./address-types";
 export * from "./email";

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1763,15 +1763,15 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - paragraph\n    - text"
     },
     "/platform/tools/built-ins": {
-      "defaultVisibleWords": 240,
-      "leadBandWords": 0,
+      "defaultVisibleWords": 277,
+      "leadBandWords": 37,
       "primaryActions": 1,
       "visibleFields": 1,
       "maxChoicesPerControl": 0,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - group\n      - button\n      - paragraph\n        - text\n      - list\n        - listitem\n          - text\n          - paragraph\n            - text\n    - paragraph\n      - text\n      - link\n      - text\n      - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]"
     },
     "/platform/tools/catalog": {
       "defaultVisibleWords": 907,

--- a/docs/user-guide/platform/address-validation-providers.md
+++ b/docs/user-guide/platform/address-validation-providers.md
@@ -1,0 +1,50 @@
+---
+title: "Address Validation Providers"
+area: platform
+order: 6
+---
+
+## Use This Doc For
+
+- Choosing a commercial address provider for customer site create/edit
+- Understanding the one-active-provider rule
+- `/platform/tools/built-ins` address validation guidance
+
+## Why It Matters
+
+Customer site records need a validated address before save. Without a provider, create/edit cannot resolve a verified street location. Pick one commercial provider that matches where your customers live, keep only that key active, and treat free OSM lookup as a fallback — not the primary field path.
+
+## Choose A Provider
+
+| Provider | Best for | Key needed |
+| --- | --- | --- |
+| **Smarty** | US postal accuracy and suite/unit detail | Yes |
+| **Mapbox** | Multi-country sites and map-aligned coordinates | Yes |
+| **Nominatim (OSM)** | Offline / no-key installs (lower commercial precision) | No |
+
+**Rule:** enable **one commercial** provider at a time. Two live commercial keys can return conflicting candidates for the same site.
+
+### Geography hint
+
+- Mostly US sites → start with **Smarty**
+- Sites in several countries → start with **Mapbox**
+- No commercial key available → Nominatim only, accept weaker precision
+
+## Setup Steps
+
+1. Open **Platform → Tools → Built-in Tools** and read the Address validation card.
+2. Register or configure the chosen provider under **Platform → Tools → Services** (or the catalog activation path).
+3. Confirm the Built-in Tools card shows the provider as registered.
+4. Create a test customer site with a real street address and confirm validation succeeds.
+5. After key rotation, re-check that only one commercial provider is still active.
+
+## What To Watch
+
+- Two commercial providers both marked active
+- Site create failing with “validated address selection is required” when no provider is configured
+- Using Nominatim as primary for delivery or field-service routes
+
+## Related
+
+- [Tools and Integrations](tools-and-integrations.md)
+- Customer site create under CRM account detail

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -31,6 +31,7 @@ Use the Platform area to supervise AI operations, Edge Nodes, integrations, iden
 - [AI Operations](ai-operations.md) - operations map, capacity continuity, assignments, capability needs, and history.
 - [Edge Nodes](edge-nodes.md) - Edge Node enrollment, trust, freshness, and host-level runbook links.
 - [Tools and Integrations](tools-and-integrations.md) - tool catalog, native integrations, MCP surfaces, and service posture.
+- [Address Validation Providers](address-validation-providers.md) - Smarty vs Mapbox choice, one-active-provider rule, and setup checks.
 
 ## Connections
 

--- a/docs/user-guide/platform/tools-and-integrations.md
+++ b/docs/user-guide/platform/tools-and-integrations.md
@@ -7,6 +7,7 @@ order: 5
 ## Use This Doc For
 
 - `/platform/tools`
+- `/platform/tools/built-ins`
 - `/platform/tools/catalog`
 - `/platform/tools/catalog/sync`
 - `/platform/tools/integrations`
@@ -16,6 +17,7 @@ order: 5
 - `/platform/tools/services`
 - `/platform/services`
 - `/platform/integrations`
+- Address validation provider choice (Smarty vs Mapbox) — see [Address Validation Providers](address-validation-providers.md)
 
 ## Start With The Object You Are Managing
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5816,6 +5816,13 @@
     "longSentences": 0,
     "textMass": 132
   },
+  "apps/web/components/platform/AddressValidationProviderGuidance.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
   "apps/web/components/platform/AgentBudgetEventsPanel.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary
Implements **BI-SITE-5E6A18**: operator guidance for choosing Smarty vs Mapbox (one-active commercial provider) for customer site address validation.

- Shared guidance module + unit tests
- Built-in Tools card with live “provider registered?” status
- User-guide page + index/links

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-03-17-reference-data-ux-polish-design.md
  - docs/superpowers/specs/2026-05-22-customer-surface-archetype-activation-design.md
- Current code substrate reviewed:
  - apps/web/lib/shared/address-validation.ts
  - apps/web/lib/shared/site-address-validation.ts
  - apps/web/app/(shell)/platform/tools/built-ins/page.tsx
- Source of truth: one-active commercial provider policy
- Decision: guidance + docs now; API wiring remains future site BIs

## Test plan
- [x] Pure unit tests for geography + setup status helpers (3 passed locally)
- [ ] CI web unit tests for built-ins page + built-in-tools
- [ ] Open `/platform/tools/built-ins` and confirm Address validation card
- [ ] Open `/docs/platform/address-validation-providers`

Local-CI-Override: pure helper tests + docs; full typecheck/build via CI (worktree source-only install).

UX-Fit-Decision: status-first card; three plain choices; no raw API setup form in this PR.