### PR TITLE
feat(docs): improve search summaries and accessibility

### DIFF
--- a/apps/web/app/(shell)/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/docs/[[...slug]]/page.tsx
@@ -1,6 +1,15 @@
 import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
-import { loadDocPage, loadAllDocs, buildDocsIndex, extractHeadings, AREA_META, AREA_ORDER, type DocsIndex } from "@/lib/docs";
+import {
+  loadDocPage,
+  loadAllDocs,
+  buildDocsIndex,
+  buildDocSearchText,
+  extractHeadings,
+  AREA_META,
+  AREA_ORDER,
+  type DocsIndex,
+} from "@/lib/docs";
 import { DocsLayout } from "@/components/docs/DocsLayout";
 import { DocRenderer } from "@/components/docs/DocRenderer";
 import { ContextualQuickHelp } from "@/components/docs/ContextualQuickHelp";
@@ -58,12 +67,14 @@ export default async function DocsPage({ params, searchParams }: Props) {
     sidebarIndex[area] = pages.map((p) => ({ ...p, content: "" }));
   }
 
-  // Search items — truncated content for Fuse.js
+  // Prefer concise operator-readable summaries, while retaining enough cleaned
+  // body text for terms that appear later in a workflow or recovery section.
   const searchItems = allDocs.map((d) => ({
     slug: d.slug,
     title: d.title,
     area: d.area,
-    content: d.content.slice(0, 500),
+    description: d.description,
+    content: buildDocSearchText(d.content),
   }));
 
   // Arrived contextually from a specific page — demote the catalog so the

--- a/apps/web/components/docs/DocsLayout.tsx
+++ b/apps/web/components/docs/DocsLayout.tsx
@@ -7,7 +7,13 @@ import type { DocHeading, DocsIndex } from "@/lib/docs-types";
 type Props = {
   index: DocsIndex;
   currentSlug: string;
-  searchItems: Array<{ slug: string; title: string; area: string; content: string }>;
+  searchItems: Array<{
+    slug: string;
+    title: string;
+    area: string;
+    description: string;
+    content: string;
+  }>;
   headings?: DocHeading[];
   /** Demote the full area catalog into a collapsed disclosure (contextual arrival). */
   collapseCatalog?: boolean;

--- a/apps/web/components/docs/DocsSearch.test.tsx
+++ b/apps/web/components/docs/DocsSearch.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+import "@/components/build-studio/test-setup";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DocsSearch } from "./DocsSearch";

--- a/apps/web/components/docs/DocsSearch.test.tsx
+++ b/apps/web/components/docs/DocsSearch.test.tsx
@@ -26,5 +26,32 @@ describe("DocsSearch", () => {
     expect(
       screen.getByText("Create, readiness-check, publish, and verify the public portal."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("listbox", { name: "Documentation search results" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Setup And Launch/ })).toBeInTheDocument();
+  });
+
+  it("exposes an accessible combobox and closes its results with Escape", () => {
+    render(
+      <DocsSearch
+        items={[
+          {
+            slug: "storefront/setup-and-launch",
+            title: "Setup And Launch",
+            area: "storefront",
+            description: "Publish the public portal.",
+            content: "readiness verification",
+          },
+        ]}
+      />,
+    );
+
+    const search = screen.getByRole("combobox", { name: "Search documentation" });
+    expect(search).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.change(search, { target: { value: "publish" } });
+    expect(search).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.keyDown(search, { key: "Escape" });
+    expect(search).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/apps/web/components/docs/DocsSearch.test.tsx
+++ b/apps/web/components/docs/DocsSearch.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DocsSearch } from "./DocsSearch";
+
+describe("DocsSearch", () => {
+  it("searches authored descriptions and shows the result summary", () => {
+    render(
+      <DocsSearch
+        items={[
+          {
+            slug: "storefront/setup-and-launch",
+            title: "Setup And Launch",
+            area: "storefront",
+            description: "Create, readiness-check, publish, and verify the public portal.",
+            content: "URL slug sections items",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search docs..."), {
+      target: { value: "readiness" },
+    });
+
+    expect(screen.getByText("Setup And Launch")).toBeInTheDocument();
+    expect(
+      screen.getByText("Create, readiness-check, publish, and verify the public portal."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/docs/DocsSearch.tsx
+++ b/apps/web/components/docs/DocsSearch.tsx
@@ -8,6 +8,7 @@ type SearchItem = {
   slug: string;
   title: string;
   area: string;
+  description: string;
   content: string;
 };
 
@@ -23,7 +24,8 @@ export function DocsSearch({ items }: Props) {
     () =>
       new Fuse(items, {
         keys: [
-          { name: "title", weight: 2 },
+          { name: "title", weight: 3 },
+          { name: "description", weight: 2 },
           { name: "content", weight: 1 },
         ],
         threshold: 0.4,
@@ -55,6 +57,11 @@ export function DocsSearch({ items }: Props) {
             >
               <span className="text-[var(--dpf-text)] font-medium">{r.item.title}</span>
               <span className="text-[var(--dpf-muted)] ml-2">{r.item.area}</span>
+              {r.item.description && (
+                <span className="mt-1 block text-[11px] leading-4 text-[var(--dpf-muted)]">
+                  {r.item.description}
+                </span>
+              )}
             </Link>
           ))}
         </div>

--- a/apps/web/components/docs/DocsSearch.tsx
+++ b/apps/web/components/docs/DocsSearch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import Fuse from "fuse.js";
 import Link from "next/link";
 
@@ -19,6 +19,7 @@ type Props = {
 export function DocsSearch({ items }: Props) {
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
+  const resultsId = useId();
 
   const fuse = useMemo(
     () =>
@@ -44,15 +45,30 @@ export function DocsSearch({ items }: Props) {
         onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
         onFocus={() => setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 200)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") setOpen(false);
+        }}
+        role="combobox"
+        aria-label="Search documentation"
+        aria-autocomplete="list"
+        aria-controls={resultsId}
+        aria-expanded={open && query.length >= 2}
         placeholder="Search docs..."
         className="w-full px-3 py-1.5 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:outline-none focus:border-[var(--dpf-accent)]"
       />
       {open && results.length > 0 && (
-        <div className="absolute top-full left-0 right-0 mt-1 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-md shadow-lg z-50 max-h-64 overflow-y-auto">
+        <div
+          id={resultsId}
+          role="listbox"
+          aria-label="Documentation search results"
+          className="absolute top-full left-0 right-0 mt-1 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-md shadow-lg z-50 max-h-64 overflow-y-auto"
+        >
           {results.map((r) => (
             <Link
               key={r.item.slug}
               href={`/docs/${r.item.slug}`}
+              role="option"
+              aria-selected="false"
               className="block px-3 py-2 text-xs hover:bg-[var(--dpf-surface-2)] transition-colors"
             >
               <span className="text-[var(--dpf-text)] font-medium">{r.item.title}</span>
@@ -67,7 +83,11 @@ export function DocsSearch({ items }: Props) {
         </div>
       )}
       {open && query.length >= 2 && results.length === 0 && (
-        <div className="absolute top-full left-0 right-0 mt-1 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-md shadow-lg z-50 p-3">
+        <div
+          id={resultsId}
+          role="status"
+          className="absolute top-full left-0 right-0 mt-1 bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-md shadow-lg z-50 p-3"
+        >
           <p className="text-xs text-[var(--dpf-muted)]">No results found.</p>
         </div>
       )}

--- a/apps/web/components/docs/DocsSearch.tsx
+++ b/apps/web/components/docs/DocsSearch.tsx
@@ -74,7 +74,7 @@ export function DocsSearch({ items }: Props) {
               <span className="text-[var(--dpf-text)] font-medium">{r.item.title}</span>
               <span className="text-[var(--dpf-muted)] ml-2">{r.item.area}</span>
               {r.item.description && (
-                <span className="mt-1 block text-[11px] leading-4 text-[var(--dpf-muted)]">
+                <span className="mt-1 block text-dpf-caption text-[var(--dpf-muted)]">
                   {r.item.description}
                 </span>
               )}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9446,6 +9446,7 @@
       "publishedPortal": true,
       "anchors": [
         "choose-your-path",
+        "find-a-guide-quickly",
         "quick-paths-by-responsibility",
         "start-here",
         "serve-customers-and-deliver-work",

--- a/apps/web/lib/shared/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/shared/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ exports[`shared barrel export > exports all public symbols 1`] = `
   "AREA_ORDER",
   "asNumber",
   "asString",
+  "buildDocSearchText",
   "buildDocsIndex",
   "capParsedContentSize",
   "composeApprovalEmail",

--- a/apps/web/lib/shared/docs-types.ts
+++ b/apps/web/lib/shared/docs-types.ts
@@ -7,6 +7,7 @@
 export type DocPage = {
   slug: string;           // e.g. "getting-started/index"
   title: string;
+  description: string;    // authored frontmatter description or derived first prose paragraph
   area: string;           // e.g. "getting-started"
   order: number;
   content: string;        // markdown body (no frontmatter)

--- a/apps/web/lib/shared/docs.test.ts
+++ b/apps/web/lib/shared/docs.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseDocFrontmatter, buildDocsIndex, extractHeadings } from "./docs";
+import {
+  buildDocSearchText,
+  parseDocFrontmatter,
+  buildDocsIndex,
+  extractHeadings,
+} from "./docs";
 
 describe("parseDocFrontmatter", () => {
   it("extracts title, area, and order from frontmatter", () => {
@@ -34,6 +39,60 @@ Content here.`;
     expect(result.relatedSpecs).toEqual([]);
     expect(result.roles).toEqual([]);
   });
+
+  it("uses the canonical frontmatter description when present", () => {
+    const raw = `---
+title: "Storefront"
+description: "Create, verify, and publish the customer portal."
+area: storefront
+order: 1
+---
+
+## Overview
+
+Body copy that should not replace the authored description.`;
+
+    expect(parseDocFrontmatter(raw).description).toBe(
+      "Create, verify, and publish the customer portal.",
+    );
+  });
+
+  it("derives a readable description from the first prose paragraph", () => {
+    const raw = `---
+title: "Storefront"
+area: storefront
+order: 1
+---
+
+## Overview
+
+Use **Storefront** to manage [customer content](./content.md) and \`booking\` flows.
+
+## Later
+
+More detail.`;
+
+    expect(parseDocFrontmatter(raw).description).toBe(
+      "Use Storefront to manage customer content and booking flows.",
+    );
+  });
+});
+
+describe("buildDocSearchText", () => {
+  it("keeps useful terms beyond the old 500-character cutoff and removes markdown noise", () => {
+    const markdown = `## Overview
+
+${"intro ".repeat(100)}
+
+## Recovery
+
+Restore the prior configuration from the evidence ledger.`;
+
+    const result = buildDocSearchText(markdown);
+    expect(result).toContain("Recovery");
+    expect(result).toContain("evidence ledger");
+    expect(result).not.toContain("##");
+  });
 });
 
 describe("extractHeadings", () => {
@@ -51,9 +110,9 @@ describe("extractHeadings", () => {
 describe("buildDocsIndex", () => {
   it("groups docs by area and sorts by order", () => {
     const docs = [
-      { slug: "getting-started/roles", title: "Roles", area: "getting-started", order: 2, content: "", relatedSpecs: [], roles: [] },
-      { slug: "getting-started/index", title: "Overview", area: "getting-started", order: 1, content: "", relatedSpecs: [], roles: [] },
-      { slug: "compliance/index", title: "Compliance", area: "compliance", order: 1, content: "", relatedSpecs: [], roles: [] },
+      { slug: "getting-started/roles", title: "Roles", description: "", area: "getting-started", order: 2, content: "", relatedSpecs: [], roles: [] },
+      { slug: "getting-started/index", title: "Overview", description: "", area: "getting-started", order: 1, content: "", relatedSpecs: [], roles: [] },
+      { slug: "compliance/index", title: "Compliance", description: "", area: "compliance", order: 1, content: "", relatedSpecs: [], roles: [] },
     ];
     const index = buildDocsIndex(docs);
     expect(Object.keys(index)).toContain("getting-started");

--- a/apps/web/lib/shared/docs.test.ts
+++ b/apps/web/lib/shared/docs.test.ts
@@ -92,6 +92,7 @@ Restore the prior configuration from the evidence ledger.`;
     expect(result).toContain("Recovery");
     expect(result).toContain("evidence ledger");
     expect(result).not.toContain("##");
+    expect(result.length).toBeLessThanOrEqual(2_000);
   });
 });
 

--- a/apps/web/lib/shared/docs.ts
+++ b/apps/web/lib/shared/docs.ts
@@ -48,7 +48,7 @@ function deriveDocDescription(markdown: string): string {
 }
 
 /** Convert enough of a page to readable Fuse.js input without shipping raw Markdown noise. */
-export function buildDocSearchText(markdown: string, limit = 4_000): string {
+export function buildDocSearchText(markdown: string, limit = 2_000): string {
   return markdownToPlainText(markdown).slice(0, limit).trimEnd();
 }
 

--- a/apps/web/lib/shared/docs.ts
+++ b/apps/web/lib/shared/docs.ts
@@ -15,14 +15,55 @@ import type { DocPage, DocHeading, DocsIndex } from "./docs-types";
 
 // ── Frontmatter parsing ─────────────────────────────────────────────────────
 
+function markdownToPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*\d+\.\s+/gm, "")
+    .replace(/[`*_~>|]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function deriveDocDescription(markdown: string): string {
+  const prose = markdown
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "")
+    .split(/\n\s*\n/)
+    .find((block) => {
+      const trimmed = block.trim();
+      return (
+        trimmed.length > 0 &&
+        !/^(#{1,6}\s|[-*+]\s|\d+\.\s|\|)/.test(trimmed)
+      );
+    });
+
+  const description = prose ? markdownToPlainText(prose) : "";
+  return description.length > 240 ? `${description.slice(0, 237).trimEnd()}...` : description;
+}
+
+/** Convert enough of a page to readable Fuse.js input without shipping raw Markdown noise. */
+export function buildDocSearchText(markdown: string, limit = 4_000): string {
+  return markdownToPlainText(markdown).slice(0, limit).trimEnd();
+}
+
 export function parseDocFrontmatter(raw: string): DocPage {
   const { data, content } = matter(raw);
+  const normalizedContent = content.trim();
+  const authoredDescription =
+    typeof data.description === "string" ? data.description.trim() : "";
   return {
     slug: "",
     title: (data.title as string) ?? "Untitled",
+    description: authoredDescription || deriveDocDescription(normalizedContent),
     area: (data.area as string) ?? "unknown",
     order: (data.order as number) ?? 99,
-    content: content.trim(),
+    content: normalizedContent,
     relatedSpecs: (data.relatedSpecs as string[]) ?? [],
     roles: (data.roles as string[]) ?? [],
   };

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -24,6 +24,15 @@ flowchart LR
 
 **Text alternative:** New users start with Getting Started. Day-to-day operators use the job guides below. People supervising AI or platform services use the governance guides. People changing DPF use Build Studio or the contributor setup.
 
+### Find a guide quickly
+
+Use **Search docs** in the guide sidebar when you know the task or outcome but
+not its area. Search ranks page titles first, then the page summary, then the
+workflow body. Results show a short description so you can choose the right
+page before opening it. Terms from later sections such as recovery,
+verification, or evidence are searchable too; they are not limited to the
+opening paragraph.
+
 ### Quick paths by responsibility
 
 - **Owner or operator:** start with [Getting Started](getting-started/index.md), then use [Storefront](storefront/index.md), [Customers](customers/index.md), [Operations](operations/index.md), and [Finance](finance/index.md).

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -4526,7 +4526,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 13
+    "textMass": 18
   },
   "apps/web/components/docs/DocsSidebar.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary
- add authored-or-derived descriptions to the existing DocPage/frontmatter substrate
- search cleaned workflow text beyond the former 500-character raw Markdown cutoff while capping client payload at 2,000 characters per page
- show result summaries and expose accessible combobox/listbox semantics with Escape-to-close
- document the search behavior in the in-platform user guide

## Design grounding
- Existing specs/plans reviewed:
  - docs/platform-usability-standards.md (design-token and interaction conventions)
  - AGENTS.md documentation-impact and UX verification contract
- Current code substrate reviewed:
  - existing DocPage type and frontmatter parser in apps/web/lib/shared/docs-types.ts and docs.ts
  - existing DocsSearch, DocsLayout, and docs route search-item pipeline
- Source of truth:
  - user-guide Markdown frontmatter/body for summaries and searchable content; AREA_META remains the area-label catalog
- Decision:
  - extend the existing DocPage/search substrate rather than create a parallel metadata store; prefer authored descriptions, derive a readable fallback, bound the client payload, and use the established typography token scale

## Verification
- TDD red gate captured expected parser/search/UI failures before implementation
- exact-SHA merged-code pregate at 55dbb860 over main 1116ba05: PASS before the final typography-token-only CI correction
- 2,277 test files / 19,764 tests passed
- DocsSearch interaction tests passed
- Prisma migrate deploy, doc index, doc links, guards, typecheck, and production Docker build passed
- node scripts/check-style-drift.mjs: PASS after typography-token correction

## Documentation impact
User-facing behavior changes in the in-platform guide, so docs/user-guide/index.md is updated. README/public positioning are unaffected because this is an in-app search-quality improvement.

Backlog: BI-519DC022
Work Capsule: WC-A860DA9C