### PR TITLE
feat(crm): validated customer site address edit flow (BI-SITE-4F2C93)

### DIFF
--- a/apps/web/components/customer/CustomerSiteTree.test.tsx
+++ b/apps/web/components/customer/CustomerSiteTree.test.tsx
@@ -7,6 +7,10 @@ vi.mock("./NewCustomerSiteNodeButton", () => ({
   ),
 }));
 
+vi.mock("./EditCustomerSiteButton", () => ({
+  EditCustomerSiteButton: () => <button type="button">Edit</button>,
+}));
+
 import { CustomerSiteTree } from "./CustomerSiteTree";
 
 describe("CustomerSiteTree", () => {
@@ -83,5 +87,6 @@ describe("CustomerSiteTree", () => {
     expect(html).toContain("Floor 3");
     expect(html).toContain("Server Room");
     expect(html).toContain("Badge required.");
+    expect(html).toContain("Edit");
   });
 });

--- a/apps/web/components/customer/CustomerSiteTree.tsx
+++ b/apps/web/components/customer/CustomerSiteTree.tsx
@@ -1,4 +1,5 @@
 import { NewCustomerSiteNodeButton } from "@/components/customer/NewCustomerSiteNodeButton";
+import { EditCustomerSiteButton } from "@/components/customer/EditCustomerSiteButton";
 
 type SiteAddress = {
   addressLine1: string;
@@ -143,6 +144,23 @@ export function CustomerSiteTree({
               {site.timezone ? (
                 <span className="text-[10px] text-[var(--dpf-muted)]">{site.timezone}</span>
               ) : null}
+              <div className="ml-auto">
+                <EditCustomerSiteButton
+                  accountId={accountId}
+                  site={{
+                    id: site.id,
+                    name: site.name,
+                    siteType: site.siteType,
+                    status: site.status,
+                    timezone: site.timezone,
+                    accessInstructions: site.accessInstructions,
+                    hoursNotes: site.hoursNotes,
+                    serviceNotes: site.serviceNotes,
+                    addressLabel: address,
+                    hasPrimaryAddress: Boolean(site.primaryAddress),
+                  }}
+                />
+              </div>
             </div>
 
             {address ? (

--- a/apps/web/components/customer/EditCustomerSiteButton.tsx
+++ b/apps/web/components/customer/EditCustomerSiteButton.tsx
@@ -2,48 +2,63 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { createCustomerSite } from "@/lib/actions/crm";
-import type { DedupCandidate } from "@/lib/mdm/dedup-gate";
-import { ValidatedSiteAddressField } from "@/components/customer/ValidatedSiteAddressField";
+import { updateCustomerSite } from "@/lib/actions/crm";
+import {
+  ValidatedSiteAddressField,
+} from "@/components/customer/ValidatedSiteAddressField";
 import type { ValidatedSiteAddress } from "@/lib/shared/site-address-validation";
 
 const inputClasses =
   "w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
 const labelClasses = "mb-1 block text-xs text-[var(--dpf-muted)]";
 
-export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
+export type EditableCustomerSite = {
+  id: string;
+  name: string;
+  siteType: string;
+  status: string;
+  timezone?: string | null;
+  accessInstructions?: string | null;
+  hoursNotes?: string | null;
+  serviceNotes?: string | null;
+  addressLabel?: string | null;
+  hasPrimaryAddress: boolean;
+};
+
+export function EditCustomerSiteButton({
+  accountId,
+  site,
+}: {
+  accountId: string;
+  site: EditableCustomerSite;
+}) {
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
-  const [name, setName] = useState("");
-  const [siteType, setSiteType] = useState("office");
-  const [status, setStatus] = useState("active");
-  const [timezone, setTimezone] = useState("");
-  const [accessInstructions, setAccessInstructions] = useState("");
-  const [hoursNotes, setHoursNotes] = useState("");
-  const [serviceNotes, setServiceNotes] = useState("");
+  const [name, setName] = useState(site.name);
+  const [siteType, setSiteType] = useState(site.siteType);
+  const [status, setStatus] = useState(site.status);
+  const [timezone, setTimezone] = useState(site.timezone ?? "");
+  const [accessInstructions, setAccessInstructions] = useState(
+    site.accessInstructions ?? "",
+  );
+  const [hoursNotes, setHoursNotes] = useState(site.hoursNotes ?? "");
+  const [serviceNotes, setServiceNotes] = useState(site.serviceNotes ?? "");
   const [selectedAddress, setSelectedAddress] =
     useState<ValidatedSiteAddress | null>(null);
-  // MDM dedup gate: similar existing sites for this account, shown inline.
-  const [duplicates, setDuplicates] = useState<DedupCandidate[] | null>(null);
   const router = useRouter();
-
-  function resetForm() {
-    setName("");
-    setSiteType("office");
-    setStatus("active");
-    setTimezone("");
-    setAccessInstructions("");
-    setHoursNotes("");
-    setServiceNotes("");
-    setSelectedAddress(null);
-    setDuplicates(null);
-    setError(null);
-  }
 
   function closeModal() {
     setOpen(false);
-    resetForm();
+    setError(null);
+    setName(site.name);
+    setSiteType(site.siteType);
+    setStatus(site.status);
+    setTimezone(site.timezone ?? "");
+    setAccessInstructions(site.accessInstructions ?? "");
+    setHoursNotes(site.hoursNotes ?? "");
+    setServiceNotes(site.serviceNotes ?? "");
+    setSelectedAddress(null);
   }
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -52,41 +67,33 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
       setError("Site name is required.");
       return;
     }
-    if (!selectedAddress) {
-      setError("Select a validated address from the lookup results.");
+    if (!site.hasPrimaryAddress && !selectedAddress) {
+      setError("Select a validated address for this site.");
       return;
     }
 
     setError(null);
     startTransition(async () => {
       try {
-        const result = await createCustomerSite(
-          {
-            accountId,
-            name,
-            siteType,
-            status,
-            timezone,
-            accessInstructions,
-            hoursNotes,
-            serviceNotes,
-            validatedAddressRef: selectedAddress.providerRef,
-          },
-          // Second submit after the duplicate notice = explicit confirm-new.
-          duplicates ? { kind: "confirm-new", reason: "confirmed distinct site in + New Site" } : undefined,
-        );
-        if (result.outcome === "duplicates-found") {
-          setDuplicates(result.check.candidates);
-          setError(null);
-          return;
-        }
+        await updateCustomerSite({
+          id: site.id,
+          accountId,
+          name,
+          siteType,
+          status,
+          timezone,
+          accessInstructions,
+          hoursNotes,
+          serviceNotes,
+          validatedAddressRef: selectedAddress?.providerRef,
+        });
         closeModal();
         router.refresh();
       } catch (submitError) {
         setError(
           submitError instanceof Error
             ? submitError.message
-            : "Failed to create customer site.",
+            : "Failed to update customer site.",
         );
       }
     });
@@ -97,9 +104,9 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+        className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-[10px] font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
       >
-        + New Site
+        Edit
       </button>
     );
   }
@@ -109,7 +116,9 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
       <div className="fixed inset-0 z-40 bg-black/40" onClick={closeModal} />
       <div className="fixed right-8 top-20 z-50 w-[460px] rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] shadow-xl">
         <div className="flex items-center justify-between border-b border-[var(--dpf-border)] px-4 py-3">
-          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">New Customer Site</h2>
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+            Edit Customer Site
+          </h2>
           <button
             type="button"
             onClick={closeModal}
@@ -126,7 +135,6 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
               autoFocus
               value={name}
               onChange={(event) => setName(event.target.value)}
-              placeholder="e.g. Dallas HQ"
               className={inputClasses}
             />
           </div>
@@ -134,7 +142,8 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
           <ValidatedSiteAddressField
             value={selectedAddress}
             onChange={setSelectedAddress}
-            required
+            currentAddressLabel={site.addressLabel}
+            required={!site.hasPrimaryAddress}
           />
 
           <div className="grid grid-cols-2 gap-3">
@@ -152,7 +161,6 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
                 <option className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]" value="warehouse">Warehouse</option>
               </select>
             </div>
-
             <div>
               <label className={labelClasses}>Status</label>
               <select
@@ -183,7 +191,6 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
               rows={2}
               value={accessInstructions}
               onChange={(event) => setAccessInstructions(event.target.value)}
-              placeholder="Badge desk, suite access, entry notes..."
               className={inputClasses}
             />
           </div>
@@ -194,7 +201,6 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
               rows={2}
               value={hoursNotes}
               onChange={(event) => setHoursNotes(event.target.value)}
-              placeholder="Support window, after-hours notes..."
               className={inputClasses}
             />
           </div>
@@ -205,22 +211,11 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
               rows={2}
               value={serviceNotes}
               onChange={(event) => setServiceNotes(event.target.value)}
-              placeholder="Operational notes for the site..."
               className={inputClasses}
             />
           </div>
 
           {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
-
-          {duplicates ? (
-            <div className="rounded border border-[var(--dpf-border)] px-3 py-2">
-              <p className="text-xs text-[var(--dpf-text)]">
-                This account already has {duplicates.length === 1 ? "a site" : "sites"} with a similar
-                name: {duplicates.slice(0, 3).map((d) => d.label).join(", ")}. Submit again to create
-                it anyway.
-              </p>
-            </div>
-          ) : null}
 
           <div className="flex justify-end gap-2">
             <button
@@ -235,7 +230,7 @@ export function NewCustomerSiteButton({ accountId }: { accountId: string }) {
               disabled={isPending}
               className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
             >
-              {isPending ? "Creating..." : "Create Site"}
+              {isPending ? "Saving..." : "Save changes"}
             </button>
           </div>
         </form>

--- a/apps/web/components/customer/EditCustomerSiteButton.tsx
+++ b/apps/web/components/customer/EditCustomerSiteButton.tsx
@@ -9,8 +9,8 @@ import {
 import type { ValidatedSiteAddress } from "@/lib/shared/site-address-validation";
 
 const inputClasses =
-  "w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
-const labelClasses = "mb-1 block text-xs text-[var(--dpf-muted)]";
+  "w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-dpf-body text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "mb-1 block text-dpf-caption text-[var(--dpf-muted)]";
 
 export type EditableCustomerSite = {
   id: string;
@@ -104,7 +104,7 @@ export function EditCustomerSiteButton({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-[10px] font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+        className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-dpf-caption font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
       >
         Edit
       </button>
@@ -116,13 +116,13 @@ export function EditCustomerSiteButton({
       <div className="fixed inset-0 z-40 bg-black/40" onClick={closeModal} />
       <div className="fixed right-8 top-20 z-50 w-[460px] rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] shadow-xl">
         <div className="flex items-center justify-between border-b border-[var(--dpf-border)] px-4 py-3">
-          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+          <h2 className="text-dpf-body font-semibold text-[var(--dpf-text)]">
             Edit Customer Site
           </h2>
           <button
             type="button"
             onClick={closeModal}
-            className="text-lg text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            className="text-dpf-title text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
           >
             x
           </button>
@@ -215,20 +215,20 @@ export function EditCustomerSiteButton({
             />
           </div>
 
-          {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
+          {error ? <p className="text-dpf-caption text-[var(--dpf-text)]">{error}</p> : null}
 
           <div className="flex justify-end gap-2">
             <button
               type="button"
               onClick={closeModal}
-              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-dpf-caption text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={isPending}
-              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-dpf-caption font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
             >
               {isPending ? "Saving..." : "Save changes"}
             </button>

--- a/apps/web/components/customer/ValidatedSiteAddressField.tsx
+++ b/apps/web/components/customer/ValidatedSiteAddressField.tsx
@@ -5,8 +5,8 @@ import { searchCustomerSiteAddresses } from "@/lib/actions/crm";
 import type { ValidatedSiteAddress } from "@/lib/shared/site-address-validation";
 
 const inputClasses =
-  "w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
-const labelClasses = "mb-1 block text-xs text-[var(--dpf-muted)]";
+  "w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-dpf-body text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "mb-1 block text-dpf-caption text-[var(--dpf-muted)]";
 
 type Props = {
   value: ValidatedSiteAddress | null;
@@ -69,10 +69,10 @@ export function ValidatedSiteAddressField({
 
       {value ? (
         <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2">
-          <p className="text-xs text-[var(--dpf-text)]">{value.label}</p>
+          <p className="text-dpf-caption text-[var(--dpf-text)]">{value.label}</p>
           <button
             type="button"
-            className="mt-1 text-[10px] text-[var(--dpf-accent)] hover:underline"
+            className="mt-1 text-dpf-caption text-[var(--dpf-accent)] hover:underline"
             onClick={() => {
               onChange(null);
               setQuery("");
@@ -85,7 +85,7 @@ export function ValidatedSiteAddressField({
       ) : (
         <>
           {currentAddressLabel ? (
-            <p className="text-[10px] text-[var(--dpf-muted)]">
+            <p className="text-dpf-caption text-[var(--dpf-muted)]">
               Current: {currentAddressLabel}. Search to revalidate and replace.
             </p>
           ) : null}
@@ -101,7 +101,7 @@ export function ValidatedSiteAddressField({
             autoComplete="off"
           />
           {isPending ? (
-            <p className="text-[10px] text-[var(--dpf-muted)]">Searching...</p>
+            <p className="text-dpf-caption text-[var(--dpf-muted)]">Searching...</p>
           ) : null}
           {results.length > 0 ? (
             <ul
@@ -113,7 +113,7 @@ export function ValidatedSiteAddressField({
                 <li key={candidate.providerRef} role="option">
                   <button
                     type="button"
-                    className="block w-full px-3 py-2 text-left text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+                    className="block w-full px-3 py-2 text-left text-dpf-caption text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
                     onClick={() => {
                       onChange(candidate);
                       setResults([]);
@@ -130,7 +130,7 @@ export function ValidatedSiteAddressField({
         </>
       )}
 
-      {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
+      {error ? <p className="text-dpf-caption text-[var(--dpf-text)]">{error}</p> : null}
     </div>
   );
 }

--- a/apps/web/components/customer/ValidatedSiteAddressField.tsx
+++ b/apps/web/components/customer/ValidatedSiteAddressField.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useId, useState, useTransition } from "react";
+import { searchCustomerSiteAddresses } from "@/lib/actions/crm";
+import type { ValidatedSiteAddress } from "@/lib/shared/site-address-validation";
+
+const inputClasses =
+  "w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:border-[var(--dpf-accent)] focus:outline-none";
+const labelClasses = "mb-1 block text-xs text-[var(--dpf-muted)]";
+
+type Props = {
+  value: ValidatedSiteAddress | null;
+  onChange: (next: ValidatedSiteAddress | null) => void;
+  /** When set, shown while no new selection is chosen (edit flow). */
+  currentAddressLabel?: string | null;
+  required?: boolean;
+};
+
+/**
+ * Progressive address lookup: type a query, pick one validated result.
+ * Selection carries providerRef for create/update server actions.
+ */
+export function ValidatedSiteAddressField({
+  value,
+  onChange,
+  currentAddressLabel,
+  required = true,
+}: Props) {
+  const listboxId = useId();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ValidatedSiteAddress[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (query.trim().length < 3) {
+      setResults([]);
+      return;
+    }
+
+    const handle = window.setTimeout(() => {
+      startTransition(async () => {
+        try {
+          setError(null);
+          const next = await searchCustomerSiteAddresses(query);
+          setResults(next);
+          if (next.length === 0) {
+            setError("No validated matches. Try a fuller street address.");
+          }
+        } catch (lookupError) {
+          setResults([]);
+          setError(
+            lookupError instanceof Error
+              ? lookupError.message
+              : "Address lookup failed.",
+          );
+        }
+      });
+    }, 350);
+
+    return () => window.clearTimeout(handle);
+  }, [query]);
+
+  return (
+    <div className="space-y-2">
+      <label className={labelClasses}>
+        Validated address{required ? " *" : ""}
+      </label>
+
+      {value ? (
+        <div className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2">
+          <p className="text-xs text-[var(--dpf-text)]">{value.label}</p>
+          <button
+            type="button"
+            className="mt-1 text-[10px] text-[var(--dpf-accent)] hover:underline"
+            onClick={() => {
+              onChange(null);
+              setQuery("");
+              setResults([]);
+            }}
+          >
+            Change selection
+          </button>
+        </div>
+      ) : (
+        <>
+          {currentAddressLabel ? (
+            <p className="text-[10px] text-[var(--dpf-muted)]">
+              Current: {currentAddressLabel}. Search to revalidate and replace.
+            </p>
+          ) : null}
+          <input
+            role="combobox"
+            aria-expanded={results.length > 0}
+            aria-controls={listboxId}
+            aria-autocomplete="list"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Start typing a street address..."
+            className={inputClasses}
+            autoComplete="off"
+          />
+          {isPending ? (
+            <p className="text-[10px] text-[var(--dpf-muted)]">Searching...</p>
+          ) : null}
+          {results.length > 0 ? (
+            <ul
+              id={listboxId}
+              role="listbox"
+              className="max-h-40 overflow-y-auto rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+            >
+              {results.map((candidate) => (
+                <li key={candidate.providerRef} role="option">
+                  <button
+                    type="button"
+                    className="block w-full px-3 py-2 text-left text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+                    onClick={() => {
+                      onChange(candidate);
+                      setResults([]);
+                      setQuery("");
+                      setError(null);
+                    }}
+                  >
+                    {candidate.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      )}
+
+      {error ? <p className="text-xs text-[var(--dpf-text)]">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/crm.test.ts
+++ b/apps/web/lib/actions/crm.test.ts
@@ -70,6 +70,7 @@ import {
   searchCustomerSiteAddresses,
   createCustomerSite,
   createCustomerSiteNode,
+  updateCustomerSite,
   advanceOpportunityStage,
   updateOpportunityStageFromForm,
   updateCustomerConfigurationItem,
@@ -220,6 +221,128 @@ describe("createCustomerSite", () => {
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
     expect(revalidatePath).toHaveBeenCalledWith("/customer");
     expect(revalidatePath).toHaveBeenCalledWith("/customer/acct-1");
+  });
+});
+
+describe("updateCustomerSite", () => {
+  const existingSite = {
+    id: "site-1",
+    name: "Dallas HQ",
+    siteType: "office",
+    status: "active",
+    timezone: "America/Chicago",
+    accessInstructions: "Reception",
+    hoursNotes: "Weekdays",
+    serviceNotes: "Primary",
+    primaryAddressId: "address-old",
+  };
+
+  it("rejects missing sites", async () => {
+    vi.mocked(prisma.customerSite.findFirst).mockResolvedValue(null);
+    await expect(
+      updateCustomerSite({
+        id: "missing",
+        accountId: "acct-1",
+        name: "Nope",
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("requires a validated address when the site has none", async () => {
+    vi.mocked(prisma.customerSite.findFirst).mockResolvedValue({
+      ...existingSite,
+      primaryAddressId: null,
+    } as never);
+
+    await expect(
+      updateCustomerSite({
+        id: "site-1",
+        accountId: "acct-1",
+        name: "Dallas HQ",
+      }),
+    ).rejects.toThrow(/validated address/i);
+  });
+
+  it("revalidates and refreshes primaryAddress when a new selection is provided", async () => {
+    vi.mocked(prisma.customerSite.findFirst).mockResolvedValue(existingSite as never);
+    vi.mocked(resolveValidatedSiteAddress).mockResolvedValue({
+      providerRef: "provider-ref-2",
+      label: "456 Oak Ave, Dallas, Texas 75202, United States",
+      addressLine1: "456 Oak Ave",
+      addressLine2: null,
+      city: "Dallas",
+      region: "Texas",
+      regionCode: "TX",
+      country: "United States",
+      countryCode: "US",
+      postalCode: "75202",
+      latitude: 32.78,
+      longitude: -96.81,
+      precision: "rooftop",
+      validationSource: "nominatim",
+    });
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        country: {
+          findFirst: vi.fn().mockResolvedValue({ id: "country-1" }),
+        },
+        region: {
+          findFirst: vi.fn().mockResolvedValue({ id: "region-1" }),
+          create: vi.fn(),
+        },
+        city: {
+          findFirst: vi.fn().mockResolvedValue({ id: "city-1" }),
+          create: vi.fn(),
+        },
+        address: {
+          create: vi.fn().mockResolvedValue({ id: "address-new" }),
+        },
+        customerSite: {
+          update: vi.fn().mockResolvedValue({
+            ...existingSite,
+            name: "Dallas HQ Renamed",
+            primaryAddressId: "address-new",
+          }),
+        },
+      };
+      return callback(tx);
+    });
+
+    const site = await updateCustomerSite({
+      id: "site-1",
+      accountId: "acct-1",
+      name: "Dallas HQ Renamed",
+      validatedAddressRef: "provider-ref-2",
+    });
+
+    expect(site.primaryAddressId).toBe("address-new");
+    expect(resolveValidatedSiteAddress).toHaveBeenCalledWith("provider-ref-2");
+    expect(revalidatePath).toHaveBeenCalledWith("/customer/acct-1");
+  });
+
+  it("allows metadata-only updates when a primary address already exists", async () => {
+    vi.mocked(prisma.customerSite.findFirst).mockResolvedValue(existingSite as never);
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
+      const tx = {
+        customerSite: {
+          update: vi.fn().mockResolvedValue({
+            ...existingSite,
+            serviceNotes: "Updated note",
+          }),
+        },
+      };
+      return callback(tx);
+    });
+
+    const site = await updateCustomerSite({
+      id: "site-1",
+      accountId: "acct-1",
+      serviceNotes: "Updated note",
+    });
+
+    expect(site.serviceNotes).toBe("Updated note");
+    expect(resolveValidatedSiteAddress).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/actions/crm.test.ts
+++ b/apps/web/lib/actions/crm.test.ts
@@ -20,6 +20,9 @@ vi.mock("@dpf/db", () => ({
     },
     customerSite: {
       create: vi.fn(),
+      findFirst: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      update: vi.fn(),
     },
     customerSiteNode: {
       create: vi.fn(),

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -1,26 +1,26 @@
 "use server";
 
 import { prisma } from "@dpf/db";
-import { normalizeLocalityName } from "@dpf/db/location-normalize";
 import { registerCustomerAccountSource } from "@/lib/mdm/crosswalk";
 import crypto from "crypto";
 import { STAGE_DEFAULT_PROBABILITY } from "@dpf/validators";
 import { revalidatePath } from "next/cache";
 import { generateInvoiceFromSalesOrder } from "@/lib/actions/finance";
 import {
-  resolveValidatedSiteAddress,
-  searchValidatedSiteAddresses,
-  type ValidatedSiteAddress,
-} from "@/lib/shared/site-address-validation";
-import {
   checkCustomerAccountDuplicates,
-  checkCustomerSiteDuplicates,
   customerAccountNormalizedColumns,
-  customerSiteNormalizedColumns,
   resolveDedupDecision,
   type DedupCheckResult,
   type DedupResolution,
 } from "@/lib/mdm/dedup-gate";
+
+// Site create/update live in customer-sites.ts (module-size ratchet).
+export {
+  searchCustomerSiteAddresses,
+  createCustomerSite,
+  updateCustomerSite,
+  type CreateCustomerSiteResult,
+} from "./customer-sites";
 import {
   buildCustomerConfigurationItemLifecycleState,
   calcLineTotal,
@@ -153,299 +153,6 @@ export async function createCustomerAccount(
 
   revalidatePath("/customer");
   return { outcome: "created", account };
-}
-
-export async function searchCustomerSiteAddresses(query: string) {
-  return searchValidatedSiteAddresses(query);
-}
-
-type SiteAddressTx = {
-  country: {
-    findFirst: (args: unknown) => Promise<{ id: string } | null>;
-  };
-  region: {
-    findFirst: (args: unknown) => Promise<{ id: string } | null>;
-    create: (args: unknown) => Promise<{ id: string }>;
-  };
-  city: {
-    findFirst: (args: unknown) => Promise<{ id: string } | null>;
-    create: (args: unknown) => Promise<{ id: string }>;
-  };
-  address: {
-    create: (args: unknown) => Promise<{ id: string }>;
-  };
-};
-
-/** Persist a provider-validated address + locality hierarchy; shared by create/update. */
-async function materializeValidatedSiteAddress(
-  tx: SiteAddressTx,
-  validatedAddress: ValidatedSiteAddress,
-): Promise<string> {
-  const country = await tx.country.findFirst({
-    where: {
-      status: "active",
-      OR: [
-        { iso2: validatedAddress.countryCode },
-        { name: validatedAddress.country },
-      ],
-    },
-    select: { id: true },
-  });
-
-  if (!country) {
-    throw new Error(
-      `Country reference data is missing for ${validatedAddress.country}.`,
-    );
-  }
-
-  let region = await tx.region.findFirst({
-    where: {
-      countryId: country.id,
-      status: "active",
-      OR: [
-        ...(validatedAddress.regionCode
-          ? [{ code: validatedAddress.regionCode }]
-          : []),
-        { name: validatedAddress.region },
-      ],
-    },
-    select: { id: true },
-  });
-
-  if (!region) {
-    region = await tx.region.create({
-      data: {
-        countryId: country.id,
-        name: validatedAddress.region,
-        code: validatedAddress.regionCode,
-        status: "active",
-      },
-      select: { id: true },
-    });
-  }
-
-  let city = await tx.city.findFirst({
-    where: {
-      regionId: region.id,
-      status: "active",
-      nameNormalized: normalizeLocalityName(validatedAddress.city),
-    },
-    select: { id: true },
-  });
-
-  if (!city) {
-    city = await tx.city.create({
-      data: {
-        regionId: region.id,
-        name: validatedAddress.city,
-        nameNormalized: normalizeLocalityName(validatedAddress.city),
-        source: "validated-address",
-        sourceProvider: validatedAddress.validationSource,
-        status: "active",
-      },
-      select: { id: true },
-    });
-  }
-
-  const address = await tx.address.create({
-    data: {
-      label: "site",
-      addressLine1: validatedAddress.addressLine1,
-      addressLine2: validatedAddress.addressLine2,
-      cityId: city.id,
-      postalCode: validatedAddress.postalCode,
-      latitude: validatedAddress.latitude,
-      longitude: validatedAddress.longitude,
-      validatedAt: new Date(),
-      validationSource: validatedAddress.validationSource,
-      status: "active",
-    },
-    select: { id: true },
-  });
-
-  return address.id;
-}
-
-export type CreateCustomerSiteResult =
-  | { outcome: "created"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
-  | { outcome: "existing"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
-  | { outcome: "duplicates-found"; check: DedupCheckResult };
-
-/** Gated create (EP-4A12A7CB WG-2) — see createCustomerAccount. */
-export async function createCustomerSite(
-  input: {
-    accountId: string;
-    name: string;
-    validatedAddressRef?: string;
-    siteType?: string;
-    status?: string;
-    timezone?: string;
-    accessInstructions?: string;
-    hoursNotes?: string;
-    serviceNotes?: string;
-    primaryAddressId?: string;
-  },
-  dedup?: DedupResolution,
-): Promise<CreateCustomerSiteResult> {
-  const name = input.name.trim();
-  if (!name) {
-    throw new Error("Site name is required");
-  }
-
-  const check = await checkCustomerSiteDuplicates({ accountId: input.accountId, name });
-  const decision = resolveDedupDecision(check, dedup);
-  if (decision.action === "use-existing") {
-    const existing = await prisma.customerSite.findUniqueOrThrow({
-      where: { id: decision.existingId },
-    });
-    return { outcome: "existing", site: existing };
-  }
-  if (decision.action === "needs-resolution") {
-    return { outcome: "duplicates-found", check };
-  }
-
-  if (!input.validatedAddressRef?.trim()) {
-    throw new Error("A validated address selection is required");
-  }
-
-  const validatedAddress = await resolveValidatedSiteAddress(
-    input.validatedAddressRef,
-  );
-
-  const site = await prisma.$transaction(async (tx) => {
-    const addressId =
-      input.primaryAddressId ||
-      (await materializeValidatedSiteAddress(tx as unknown as SiteAddressTx, validatedAddress));
-
-    return tx.customerSite.create({
-      data: {
-        siteId: `SITE-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
-        accountId: input.accountId,
-        name,
-        ...customerSiteNormalizedColumns({ name }),
-        siteType: input.siteType?.trim() || "office",
-        status: input.status?.trim() || "active",
-        timezone: input.timezone?.trim() || null,
-        accessInstructions: input.accessInstructions?.trim() || null,
-        hoursNotes: input.hoursNotes?.trim() || null,
-        serviceNotes: input.serviceNotes?.trim() || null,
-        primaryAddressId: addressId,
-      },
-    });
-  });
-
-  await logSystemActivity(`Customer site "${site.name}" created`, {
-    type: "account_created",
-    accountId: input.accountId,
-  });
-
-  revalidatePath("/customer");
-  revalidatePath(`/customer/${input.accountId}`);
-  return { outcome: "created", site };
-}
-
-/**
- * Update an existing customer site (BI-SITE-4F2C93).
- * Optional validatedAddressRef re-runs lookup and refreshes primaryAddress + coordinates.
- */
-export async function updateCustomerSite(input: {
-  id: string;
-  accountId: string;
-  name?: string;
-  siteType?: string;
-  status?: string;
-  timezone?: string;
-  accessInstructions?: string;
-  hoursNotes?: string;
-  serviceNotes?: string;
-  /** When set, revalidate and replace the site primary address. */
-  validatedAddressRef?: string;
-}) {
-  const existing = await prisma.customerSite.findFirst({
-    where: { id: input.id, accountId: input.accountId },
-    select: {
-      id: true,
-      name: true,
-      siteType: true,
-      status: true,
-      timezone: true,
-      accessInstructions: true,
-      hoursNotes: true,
-      serviceNotes: true,
-      primaryAddressId: true,
-    },
-  });
-
-  if (!existing) {
-    throw new Error("Customer site not found");
-  }
-
-  const nextName =
-    input.name !== undefined ? input.name.trim() : existing.name;
-  if (!nextName) {
-    throw new Error("Site name is required");
-  }
-
-  let validatedAddress: ValidatedSiteAddress | null = null;
-  if (input.validatedAddressRef?.trim()) {
-    validatedAddress = await resolveValidatedSiteAddress(input.validatedAddressRef);
-  } else if (!existing.primaryAddressId) {
-    throw new Error(
-      "A validated address selection is required when the site has no address yet.",
-    );
-  }
-
-  const site = await prisma.$transaction(async (tx) => {
-    let primaryAddressId = existing.primaryAddressId;
-    if (validatedAddress) {
-      primaryAddressId = await materializeValidatedSiteAddress(
-        tx as unknown as SiteAddressTx,
-        validatedAddress,
-      );
-    }
-
-    return tx.customerSite.update({
-      where: { id: existing.id },
-      data: {
-        name: nextName,
-        ...customerSiteNormalizedColumns({ name: nextName }),
-        siteType:
-          input.siteType !== undefined
-            ? input.siteType.trim() || "office"
-            : existing.siteType,
-        status:
-          input.status !== undefined
-            ? input.status.trim() || "active"
-            : existing.status,
-        timezone:
-          input.timezone !== undefined
-            ? input.timezone.trim() || null
-            : existing.timezone,
-        accessInstructions:
-          input.accessInstructions !== undefined
-            ? input.accessInstructions.trim() || null
-            : existing.accessInstructions,
-        hoursNotes:
-          input.hoursNotes !== undefined
-            ? input.hoursNotes.trim() || null
-            : existing.hoursNotes,
-        serviceNotes:
-          input.serviceNotes !== undefined
-            ? input.serviceNotes.trim() || null
-            : existing.serviceNotes,
-        primaryAddressId,
-      },
-    });
-  });
-
-  await logSystemActivity(`Customer site "${site.name}" updated`, {
-    type: "account_created",
-    accountId: input.accountId,
-  });
-
-  revalidatePath("/customer");
-  revalidatePath(`/customer/${input.accountId}`);
-  return site;
 }
 
 export async function createCustomerSiteNode(input: {

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -14,12 +14,10 @@ import {
   type DedupResolution,
 } from "@/lib/mdm/dedup-gate";
 
-// Site create/update live in customer-sites.ts (module-size ratchet).
-export {
-  searchCustomerSiteAddresses,
-  createCustomerSite,
-  updateCustomerSite,
-  type CreateCustomerSiteResult,
+import {
+  searchCustomerSiteAddresses as searchCustomerSiteAddressesImpl,
+  createCustomerSite as createCustomerSiteImpl,
+  updateCustomerSite as updateCustomerSiteImpl,
 } from "./customer-sites";
 import {
   buildCustomerConfigurationItemLifecycleState,
@@ -29,6 +27,26 @@ import {
   trimOrNull,
   type CustomerConfigurationItemInput,
 } from "@/lib/crm/crm-core";
+
+// Thin async wrappers — "use server" files may only export async functions
+// (no `export { … } from` re-exports; that zeroes the whole module in Turbopack).
+export async function searchCustomerSiteAddresses(
+  ...args: Parameters<typeof searchCustomerSiteAddressesImpl>
+) {
+  return searchCustomerSiteAddressesImpl(...args);
+}
+
+export async function createCustomerSite(
+  ...args: Parameters<typeof createCustomerSiteImpl>
+) {
+  return createCustomerSiteImpl(...args);
+}
+
+export async function updateCustomerSite(
+  ...args: Parameters<typeof updateCustomerSiteImpl>
+) {
+  return updateCustomerSiteImpl(...args);
+}
 
 // ─── Activity Logging (used by all other actions) ───────────────────────────
 

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -10,6 +10,7 @@ import { generateInvoiceFromSalesOrder } from "@/lib/actions/finance";
 import {
   resolveValidatedSiteAddress,
   searchValidatedSiteAddresses,
+  type ValidatedSiteAddress,
 } from "@/lib/shared/site-address-validation";
 import {
   checkCustomerAccountDuplicates,
@@ -158,6 +159,113 @@ export async function searchCustomerSiteAddresses(query: string) {
   return searchValidatedSiteAddresses(query);
 }
 
+type SiteAddressTx = {
+  country: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+  };
+  region: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+    create: (args: unknown) => Promise<{ id: string }>;
+  };
+  city: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+    create: (args: unknown) => Promise<{ id: string }>;
+  };
+  address: {
+    create: (args: unknown) => Promise<{ id: string }>;
+  };
+};
+
+/** Persist a provider-validated address + locality hierarchy; shared by create/update. */
+async function materializeValidatedSiteAddress(
+  tx: SiteAddressTx,
+  validatedAddress: ValidatedSiteAddress,
+): Promise<string> {
+  const country = await tx.country.findFirst({
+    where: {
+      status: "active",
+      OR: [
+        { iso2: validatedAddress.countryCode },
+        { name: validatedAddress.country },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (!country) {
+    throw new Error(
+      `Country reference data is missing for ${validatedAddress.country}.`,
+    );
+  }
+
+  let region = await tx.region.findFirst({
+    where: {
+      countryId: country.id,
+      status: "active",
+      OR: [
+        ...(validatedAddress.regionCode
+          ? [{ code: validatedAddress.regionCode }]
+          : []),
+        { name: validatedAddress.region },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (!region) {
+    region = await tx.region.create({
+      data: {
+        countryId: country.id,
+        name: validatedAddress.region,
+        code: validatedAddress.regionCode,
+        status: "active",
+      },
+      select: { id: true },
+    });
+  }
+
+  let city = await tx.city.findFirst({
+    where: {
+      regionId: region.id,
+      status: "active",
+      nameNormalized: normalizeLocalityName(validatedAddress.city),
+    },
+    select: { id: true },
+  });
+
+  if (!city) {
+    city = await tx.city.create({
+      data: {
+        regionId: region.id,
+        name: validatedAddress.city,
+        nameNormalized: normalizeLocalityName(validatedAddress.city),
+        source: "validated-address",
+        sourceProvider: validatedAddress.validationSource,
+        status: "active",
+      },
+      select: { id: true },
+    });
+  }
+
+  const address = await tx.address.create({
+    data: {
+      label: "site",
+      addressLine1: validatedAddress.addressLine1,
+      addressLine2: validatedAddress.addressLine2,
+      cityId: city.id,
+      postalCode: validatedAddress.postalCode,
+      latitude: validatedAddress.latitude,
+      longitude: validatedAddress.longitude,
+      validatedAt: new Date(),
+      validationSource: validatedAddress.validationSource,
+      status: "active",
+    },
+    select: { id: true },
+  });
+
+  return address.id;
+}
+
 export type CreateCustomerSiteResult =
   | { outcome: "created"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
   | { outcome: "existing"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
@@ -205,87 +313,9 @@ export async function createCustomerSite(
   );
 
   const site = await prisma.$transaction(async (tx) => {
-    const country = await tx.country.findFirst({
-      where: {
-        status: "active",
-        OR: [
-          { iso2: validatedAddress.countryCode },
-          { name: validatedAddress.country },
-        ],
-      },
-      select: { id: true },
-    });
-
-    if (!country) {
-      throw new Error(
-        `Country reference data is missing for ${validatedAddress.country}.`,
-      );
-    }
-
-    let region = await tx.region.findFirst({
-      where: {
-        countryId: country.id,
-        status: "active",
-        OR: [
-          ...(validatedAddress.regionCode
-            ? [{ code: validatedAddress.regionCode }]
-            : []),
-          { name: validatedAddress.region },
-        ],
-      },
-      select: { id: true },
-    });
-
-    if (!region) {
-      region = await tx.region.create({
-        data: {
-          countryId: country.id,
-          name: validatedAddress.region,
-          code: validatedAddress.regionCode,
-          status: "active",
-        },
-        select: { id: true },
-      });
-    }
-
-    let city = await tx.city.findFirst({
-      where: {
-        regionId: region.id,
-        status: "active",
-        nameNormalized: normalizeLocalityName(validatedAddress.city),
-      },
-      select: { id: true },
-    });
-
-    if (!city) {
-      city = await tx.city.create({
-        data: {
-          regionId: region.id,
-          name: validatedAddress.city,
-          nameNormalized: normalizeLocalityName(validatedAddress.city),
-          source: "validated-address",
-          sourceProvider: validatedAddress.validationSource,
-          status: "active",
-        },
-        select: { id: true },
-      });
-    }
-
-    const address = await tx.address.create({
-      data: {
-        label: "site",
-        addressLine1: validatedAddress.addressLine1,
-        addressLine2: validatedAddress.addressLine2,
-        cityId: city.id,
-        postalCode: validatedAddress.postalCode,
-        latitude: validatedAddress.latitude,
-        longitude: validatedAddress.longitude,
-        validatedAt: new Date(),
-        validationSource: validatedAddress.validationSource,
-        status: "active",
-      },
-      select: { id: true },
-    });
+    const addressId =
+      input.primaryAddressId ||
+      (await materializeValidatedSiteAddress(tx as unknown as SiteAddressTx, validatedAddress));
 
     return tx.customerSite.create({
       data: {
@@ -299,7 +329,7 @@ export async function createCustomerSite(
         accessInstructions: input.accessInstructions?.trim() || null,
         hoursNotes: input.hoursNotes?.trim() || null,
         serviceNotes: input.serviceNotes?.trim() || null,
-        primaryAddressId: input.primaryAddressId || address.id,
+        primaryAddressId: addressId,
       },
     });
   });
@@ -312,6 +342,110 @@ export async function createCustomerSite(
   revalidatePath("/customer");
   revalidatePath(`/customer/${input.accountId}`);
   return { outcome: "created", site };
+}
+
+/**
+ * Update an existing customer site (BI-SITE-4F2C93).
+ * Optional validatedAddressRef re-runs lookup and refreshes primaryAddress + coordinates.
+ */
+export async function updateCustomerSite(input: {
+  id: string;
+  accountId: string;
+  name?: string;
+  siteType?: string;
+  status?: string;
+  timezone?: string;
+  accessInstructions?: string;
+  hoursNotes?: string;
+  serviceNotes?: string;
+  /** When set, revalidate and replace the site primary address. */
+  validatedAddressRef?: string;
+}) {
+  const existing = await prisma.customerSite.findFirst({
+    where: { id: input.id, accountId: input.accountId },
+    select: {
+      id: true,
+      name: true,
+      siteType: true,
+      status: true,
+      timezone: true,
+      accessInstructions: true,
+      hoursNotes: true,
+      serviceNotes: true,
+      primaryAddressId: true,
+    },
+  });
+
+  if (!existing) {
+    throw new Error("Customer site not found");
+  }
+
+  const nextName =
+    input.name !== undefined ? input.name.trim() : existing.name;
+  if (!nextName) {
+    throw new Error("Site name is required");
+  }
+
+  let validatedAddress: ValidatedSiteAddress | null = null;
+  if (input.validatedAddressRef?.trim()) {
+    validatedAddress = await resolveValidatedSiteAddress(input.validatedAddressRef);
+  } else if (!existing.primaryAddressId) {
+    throw new Error(
+      "A validated address selection is required when the site has no address yet.",
+    );
+  }
+
+  const site = await prisma.$transaction(async (tx) => {
+    let primaryAddressId = existing.primaryAddressId;
+    if (validatedAddress) {
+      primaryAddressId = await materializeValidatedSiteAddress(
+        tx as unknown as SiteAddressTx,
+        validatedAddress,
+      );
+    }
+
+    return tx.customerSite.update({
+      where: { id: existing.id },
+      data: {
+        name: nextName,
+        ...customerSiteNormalizedColumns({ name: nextName }),
+        siteType:
+          input.siteType !== undefined
+            ? input.siteType.trim() || "office"
+            : existing.siteType,
+        status:
+          input.status !== undefined
+            ? input.status.trim() || "active"
+            : existing.status,
+        timezone:
+          input.timezone !== undefined
+            ? input.timezone.trim() || null
+            : existing.timezone,
+        accessInstructions:
+          input.accessInstructions !== undefined
+            ? input.accessInstructions.trim() || null
+            : existing.accessInstructions,
+        hoursNotes:
+          input.hoursNotes !== undefined
+            ? input.hoursNotes.trim() || null
+            : existing.hoursNotes,
+        serviceNotes:
+          input.serviceNotes !== undefined
+            ? input.serviceNotes.trim() || null
+            : existing.serviceNotes,
+        primaryAddressId,
+      },
+    });
+  });
+
+  await logSystemActivity(`Customer site "${site.name}" updated`, {
+    type: "account_created",
+    accountId: input.accountId,
+  });
+
+  revalidatePath("/customer");
+  revalidatePath(`/customer/${input.accountId}`);
+  return site;
 }
 
 export async function createCustomerSiteNode(input: {

--- a/apps/web/lib/actions/customer-sites.ts
+++ b/apps/web/lib/actions/customer-sites.ts
@@ -150,7 +150,8 @@ async function materializeValidatedSiteAddress(
   return address.id;
 }
 
-export type CreateCustomerSiteResult =
+// Type kept local — "use server" modules must not export type aliases.
+type CreateCustomerSiteResult =
   | { outcome: "created"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
   | { outcome: "existing"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
   | { outcome: "duplicates-found"; check: DedupCheckResult };

--- a/apps/web/lib/actions/customer-sites.ts
+++ b/apps/web/lib/actions/customer-sites.ts
@@ -1,0 +1,332 @@
+"use server";
+
+/**
+ * Customer site create/update with validated address materialization
+ * (BI-SITE-4F2C93 / EP-SITE-7C4D2B). Split from crm.ts for module-size ratchet.
+ */
+
+import { prisma } from "@dpf/db";
+import { normalizeLocalityName } from "@dpf/db/location-normalize";
+import crypto from "crypto";
+import { revalidatePath } from "next/cache";
+import {
+  resolveValidatedSiteAddress,
+  searchValidatedSiteAddresses,
+  type ValidatedSiteAddress,
+} from "@/lib/shared/site-address-validation";
+import {
+  checkCustomerSiteDuplicates,
+  customerSiteNormalizedColumns,
+  resolveDedupDecision,
+  type DedupCheckResult,
+  type DedupResolution,
+} from "@/lib/mdm/dedup-gate";
+
+async function logSystemActivity(
+  subject: string,
+  opts: { type?: string; body?: string; accountId?: string } = {},
+) {
+  await prisma.activity.create({
+    data: {
+      activityId: `ACT-${crypto.randomUUID()}`,
+      type: opts.type || "system",
+      subject,
+      body: opts.body ?? null,
+      accountId: opts.accountId ?? null,
+      contactId: null,
+      opportunityId: null,
+      createdById: null,
+    },
+  });
+}
+
+export async function searchCustomerSiteAddresses(query: string) {
+  return searchValidatedSiteAddresses(query);
+}
+
+type SiteAddressTx = {
+  country: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+  };
+  region: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+    create: (args: unknown) => Promise<{ id: string }>;
+  };
+  city: {
+    findFirst: (args: unknown) => Promise<{ id: string } | null>;
+    create: (args: unknown) => Promise<{ id: string }>;
+  };
+  address: {
+    create: (args: unknown) => Promise<{ id: string }>;
+  };
+};
+
+async function materializeValidatedSiteAddress(
+  tx: SiteAddressTx,
+  validatedAddress: ValidatedSiteAddress,
+): Promise<string> {
+  const country = await tx.country.findFirst({
+    where: {
+      status: "active",
+      OR: [
+        { iso2: validatedAddress.countryCode },
+        { name: validatedAddress.country },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (!country) {
+    throw new Error(
+      `Country reference data is missing for ${validatedAddress.country}.`,
+    );
+  }
+
+  let region = await tx.region.findFirst({
+    where: {
+      countryId: country.id,
+      status: "active",
+      OR: [
+        ...(validatedAddress.regionCode
+          ? [{ code: validatedAddress.regionCode }]
+          : []),
+        { name: validatedAddress.region },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (!region) {
+    region = await tx.region.create({
+      data: {
+        countryId: country.id,
+        name: validatedAddress.region,
+        code: validatedAddress.regionCode,
+        status: "active",
+      },
+      select: { id: true },
+    });
+  }
+
+  let city = await tx.city.findFirst({
+    where: {
+      regionId: region.id,
+      status: "active",
+      nameNormalized: normalizeLocalityName(validatedAddress.city),
+    },
+    select: { id: true },
+  });
+
+  if (!city) {
+    city = await tx.city.create({
+      data: {
+        regionId: region.id,
+        name: validatedAddress.city,
+        nameNormalized: normalizeLocalityName(validatedAddress.city),
+        source: "validated-address",
+        sourceProvider: validatedAddress.validationSource,
+        status: "active",
+      },
+      select: { id: true },
+    });
+  }
+
+  const address = await tx.address.create({
+    data: {
+      label: "site",
+      addressLine1: validatedAddress.addressLine1,
+      addressLine2: validatedAddress.addressLine2,
+      cityId: city.id,
+      postalCode: validatedAddress.postalCode,
+      latitude: validatedAddress.latitude,
+      longitude: validatedAddress.longitude,
+      validatedAt: new Date(),
+      validationSource: validatedAddress.validationSource,
+      status: "active",
+    },
+    select: { id: true },
+  });
+
+  return address.id;
+}
+
+export type CreateCustomerSiteResult =
+  | { outcome: "created"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
+  | { outcome: "existing"; site: Awaited<ReturnType<typeof prisma.customerSite.create>> }
+  | { outcome: "duplicates-found"; check: DedupCheckResult };
+
+/** Gated create (EP-4A12A7CB WG-2). */
+export async function createCustomerSite(
+  input: {
+    accountId: string;
+    name: string;
+    validatedAddressRef?: string;
+    siteType?: string;
+    status?: string;
+    timezone?: string;
+    accessInstructions?: string;
+    hoursNotes?: string;
+    serviceNotes?: string;
+    primaryAddressId?: string;
+  },
+  dedup?: DedupResolution,
+): Promise<CreateCustomerSiteResult> {
+  const name = input.name.trim();
+  if (!name) {
+    throw new Error("Site name is required");
+  }
+
+  const check = await checkCustomerSiteDuplicates({ accountId: input.accountId, name });
+  const decision = resolveDedupDecision(check, dedup);
+  if (decision.action === "use-existing") {
+    const existing = await prisma.customerSite.findUniqueOrThrow({
+      where: { id: decision.existingId },
+    });
+    return { outcome: "existing", site: existing };
+  }
+  if (decision.action === "needs-resolution") {
+    return { outcome: "duplicates-found", check };
+  }
+
+  if (!input.validatedAddressRef?.trim()) {
+    throw new Error("A validated address selection is required");
+  }
+
+  const validatedAddress = await resolveValidatedSiteAddress(
+    input.validatedAddressRef,
+  );
+
+  const site = await prisma.$transaction(async (tx) => {
+    const addressId =
+      input.primaryAddressId ||
+      (await materializeValidatedSiteAddress(
+        tx as unknown as SiteAddressTx,
+        validatedAddress,
+      ));
+
+    return tx.customerSite.create({
+      data: {
+        siteId: `SITE-${crypto.randomUUID().slice(0, 8).toUpperCase()}`,
+        accountId: input.accountId,
+        name,
+        ...customerSiteNormalizedColumns({ name }),
+        siteType: input.siteType?.trim() || "office",
+        status: input.status?.trim() || "active",
+        timezone: input.timezone?.trim() || null,
+        accessInstructions: input.accessInstructions?.trim() || null,
+        hoursNotes: input.hoursNotes?.trim() || null,
+        serviceNotes: input.serviceNotes?.trim() || null,
+        primaryAddressId: addressId,
+      },
+    });
+  });
+
+  await logSystemActivity(`Customer site "${site.name}" created`, {
+    type: "account_created",
+    accountId: input.accountId,
+  });
+
+  revalidatePath("/customer");
+  revalidatePath(`/customer/${input.accountId}`);
+  return { outcome: "created", site };
+}
+
+/** Update site; optional validatedAddressRef refreshes primary address + coords. */
+export async function updateCustomerSite(input: {
+  id: string;
+  accountId: string;
+  name?: string;
+  siteType?: string;
+  status?: string;
+  timezone?: string;
+  accessInstructions?: string;
+  hoursNotes?: string;
+  serviceNotes?: string;
+  validatedAddressRef?: string;
+}) {
+  const existing = await prisma.customerSite.findFirst({
+    where: { id: input.id, accountId: input.accountId },
+    select: {
+      id: true,
+      name: true,
+      siteType: true,
+      status: true,
+      timezone: true,
+      accessInstructions: true,
+      hoursNotes: true,
+      serviceNotes: true,
+      primaryAddressId: true,
+    },
+  });
+
+  if (!existing) {
+    throw new Error("Customer site not found");
+  }
+
+  const nextName =
+    input.name !== undefined ? input.name.trim() : existing.name;
+  if (!nextName) {
+    throw new Error("Site name is required");
+  }
+
+  let validatedAddress: ValidatedSiteAddress | null = null;
+  if (input.validatedAddressRef?.trim()) {
+    validatedAddress = await resolveValidatedSiteAddress(input.validatedAddressRef);
+  } else if (!existing.primaryAddressId) {
+    throw new Error(
+      "A validated address selection is required when the site has no address yet.",
+    );
+  }
+
+  const site = await prisma.$transaction(async (tx) => {
+    let primaryAddressId = existing.primaryAddressId;
+    if (validatedAddress) {
+      primaryAddressId = await materializeValidatedSiteAddress(
+        tx as unknown as SiteAddressTx,
+        validatedAddress,
+      );
+    }
+
+    return tx.customerSite.update({
+      where: { id: existing.id },
+      data: {
+        name: nextName,
+        ...customerSiteNormalizedColumns({ name: nextName }),
+        siteType:
+          input.siteType !== undefined
+            ? input.siteType.trim() || "office"
+            : existing.siteType,
+        status:
+          input.status !== undefined
+            ? input.status.trim() || "active"
+            : existing.status,
+        timezone:
+          input.timezone !== undefined
+            ? input.timezone.trim() || null
+            : existing.timezone,
+        accessInstructions:
+          input.accessInstructions !== undefined
+            ? input.accessInstructions.trim() || null
+            : existing.accessInstructions,
+        hoursNotes:
+          input.hoursNotes !== undefined
+            ? input.hoursNotes.trim() || null
+            : existing.hoursNotes,
+        serviceNotes:
+          input.serviceNotes !== undefined
+            ? input.serviceNotes.trim() || null
+            : existing.serviceNotes,
+        primaryAddressId,
+      },
+    });
+  });
+
+  await logSystemActivity(`Customer site "${site.name}" updated`, {
+    type: "account_created",
+    accountId: input.accountId,
+  });
+
+  revalidatePath("/customer");
+  revalidatePath(`/customer/${input.accountId}`);
+  return site;
+}

--- a/apps/web/lib/shared/site-address-validation.test.ts
+++ b/apps/web/lib/shared/site-address-validation.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  rememberValidatedSiteAddressForTests,
+  resetValidatedSiteAddressCacheForTests,
+  resolveValidatedSiteAddress,
+  searchValidatedSiteAddresses,
+} from "./site-address-validation";
+
+afterEach(() => {
+  resetValidatedSiteAddressCacheForTests();
+  vi.restoreAllMocks();
+});
+
+describe("site-address-validation", () => {
+  it("returns empty for short queries without calling the provider", async () => {
+    const fetchImpl = vi.fn();
+    await expect(searchValidatedSiteAddresses("ab", { fetchImpl })).resolves.toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("maps Nominatim hits and resolves them from the search cache", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          place_id: 991122,
+          display_name: "123 Main St, Dallas, Texas 75201, United States",
+          lat: "32.7767",
+          lon: "-96.7970",
+          address: {
+            house_number: "123",
+            road: "Main St",
+            city: "Dallas",
+            state: "Texas",
+            state_code: "TX",
+            postcode: "75201",
+            country: "United States",
+            country_code: "us",
+          },
+        },
+      ],
+    });
+
+    const results = await searchValidatedSiteAddresses("123 Main Dallas", { fetchImpl });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      providerRef: "nominatim:991122",
+      addressLine1: "123 Main St",
+      city: "Dallas",
+      region: "Texas",
+      regionCode: "TX",
+      countryCode: "US",
+      postalCode: "75201",
+      validationSource: "nominatim",
+    });
+
+    const resolved = await resolveValidatedSiteAddress("nominatim:991122");
+    expect(resolved.addressLine1).toBe("123 Main St");
+    expect(resolved.latitude).toBeCloseTo(32.7767);
+  });
+
+  it("skips incomplete Nominatim rows", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          place_id: 1,
+          address: {
+            road: "Main St",
+            // missing city / postal / country
+            state: "Texas",
+          },
+        },
+      ],
+    });
+
+    await expect(
+      searchValidatedSiteAddresses("Main St", { fetchImpl }),
+    ).resolves.toEqual([]);
+  });
+
+  it("throws a clear error when resolve misses the cache", async () => {
+    await expect(resolveValidatedSiteAddress("missing-ref")).rejects.toThrow(/search again/i);
+  });
+
+  it("resolves test-seeded candidates without a network call", async () => {
+    rememberValidatedSiteAddressForTests({
+      providerRef: "test:1",
+      label: "1 Test Rd",
+      addressLine1: "1 Test Rd",
+      addressLine2: null,
+      city: "Austin",
+      region: "Texas",
+      regionCode: "TX",
+      country: "United States",
+      countryCode: "US",
+      postalCode: "78701",
+      latitude: 30.2,
+      longitude: -97.7,
+      precision: "rooftop",
+      validationSource: "test",
+    });
+
+    await expect(resolveValidatedSiteAddress("test:1")).resolves.toMatchObject({
+      city: "Austin",
+      postalCode: "78701",
+    });
+  });
+});

--- a/apps/web/lib/shared/site-address-validation.ts
+++ b/apps/web/lib/shared/site-address-validation.ts
@@ -1,3 +1,12 @@
+/**
+ * Validated site-address lookup for customer sites (EP-SITE-7C4D2B).
+ *
+ * Search caches candidates so resolve can rehydrate the same selection on
+ * create/update without a second provider call. Free Nominatim is the
+ * default path when commercial Smarty/Mapbox keys are not wired yet
+ * (see address-validation-provider-guidance).
+ */
+
 export type ValidatedSiteAddress = {
   providerRef: string;
   label: string;
@@ -15,16 +24,193 @@ export type ValidatedSiteAddress = {
   validationSource: string;
 };
 
-export async function searchValidatedSiteAddresses(
-  _query: string,
+type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/** Process-local cache of search hits, keyed by providerRef. */
+const candidateCache = new Map<string, ValidatedSiteAddress>();
+
+/** Test seam — clear between cases. */
+export function resetValidatedSiteAddressCacheForTests(): void {
+  candidateCache.clear();
+}
+
+/** Test seam — seed a candidate without calling a provider. */
+export function rememberValidatedSiteAddressForTests(
+  address: ValidatedSiteAddress,
+): void {
+  candidateCache.set(address.providerRef, address);
+}
+
+type NominatimItem = {
+  place_id?: number | string;
+  display_name?: string;
+  lat?: string;
+  lon?: string;
+  address?: {
+    house_number?: string;
+    road?: string;
+    pedestrian?: string;
+    neighbourhood?: string;
+    suburb?: string;
+    city?: string;
+    town?: string;
+    village?: string;
+    hamlet?: string;
+    county?: string;
+    state?: string;
+    state_code?: string;
+    "ISO3166-2-lvl4"?: string;
+    postcode?: string;
+    country?: string;
+    country_code?: string;
+  };
+};
+
+function line1FromNominatim(address: NonNullable<NominatimItem["address"]>): string {
+  const number = address.house_number?.trim() ?? "";
+  const road =
+    address.road?.trim() ||
+    address.pedestrian?.trim() ||
+    address.neighbourhood?.trim() ||
+    address.suburb?.trim() ||
+    "";
+  if (number && road) return `${number} ${road}`;
+  if (road) return road;
+  if (number) return number;
+  return "";
+}
+
+function cityFromNominatim(address: NonNullable<NominatimItem["address"]>): string {
+  return (
+    address.city?.trim() ||
+    address.town?.trim() ||
+    address.village?.trim() ||
+    address.hamlet?.trim() ||
+    address.county?.trim() ||
+    ""
+  );
+}
+
+function regionCodeFromNominatim(
+  address: NonNullable<NominatimItem["address"]>,
+): string | null {
+  if (address.state_code?.trim()) return address.state_code.trim().toUpperCase();
+  const iso = address["ISO3166-2-lvl4"]?.trim();
+  if (iso && iso.includes("-")) {
+    return iso.split("-").pop()?.toUpperCase() ?? null;
+  }
+  return null;
+}
+
+function mapNominatimItem(item: NominatimItem): ValidatedSiteAddress | null {
+  const address = item.address;
+  if (!address) return null;
+
+  const addressLine1 = line1FromNominatim(address);
+  const city = cityFromNominatim(address);
+  const region = address.state?.trim() || "";
+  const country = address.country?.trim() || "";
+  const countryCode = (address.country_code ?? "").trim().toUpperCase();
+  const postalCode = address.postcode?.trim() || "";
+
+  if (!addressLine1 || !city || !region || !country || !countryCode || !postalCode) {
+    return null;
+  }
+
+  const placeId = item.place_id != null ? String(item.place_id) : null;
+  if (!placeId) return null;
+
+  const lat = item.lat != null ? Number(item.lat) : null;
+  const lon = item.lon != null ? Number(item.lon) : null;
+
+  return {
+    providerRef: `nominatim:${placeId}`,
+    label:
+      item.display_name?.trim() ||
+      [addressLine1, city, region, postalCode, country].filter(Boolean).join(", "),
+    addressLine1,
+    addressLine2: null,
+    city,
+    region,
+    regionCode: regionCodeFromNominatim(address),
+    country,
+    countryCode,
+    postalCode,
+    latitude: Number.isFinite(lat) ? lat : null,
+    longitude: Number.isFinite(lon) ? lon : null,
+    precision: "street",
+    validationSource: "nominatim",
+  };
+}
+
+async function searchNominatim(
+  query: string,
+  fetchImpl: FetchLike,
 ): Promise<ValidatedSiteAddress[]> {
-  return [];
+  const url = new URL("https://nominatim.openstreetmap.org/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("format", "jsonv2");
+  url.searchParams.set("addressdetails", "1");
+  url.searchParams.set("limit", "6");
+
+  const response = await fetchImpl(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      // Nominatim requires a descriptive User-Agent.
+      "User-Agent": "OpenDigitalProductFactory/site-address-validation (ops@local)",
+    },
+    // Avoid hanging server actions forever when the free endpoint is slow.
+    signal: AbortSignal.timeout(8_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Address lookup failed (${response.status}). Try again or configure a commercial provider.`,
+    );
+  }
+
+  const payload = (await response.json()) as unknown;
+  if (!Array.isArray(payload)) return [];
+
+  const mapped: ValidatedSiteAddress[] = [];
+  for (const raw of payload) {
+    if (!raw || typeof raw !== "object") continue;
+    const item = mapNominatimItem(raw as NominatimItem);
+    if (item) mapped.push(item);
+  }
+  return mapped;
+}
+
+export async function searchValidatedSiteAddresses(
+  query: string,
+  options?: { fetchImpl?: FetchLike },
+): Promise<ValidatedSiteAddress[]> {
+  const trimmed = query.trim();
+  if (trimmed.length < 3) return [];
+
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const results = await searchNominatim(trimmed, fetchImpl);
+  for (const result of results) {
+    candidateCache.set(result.providerRef, result);
+  }
+  return results;
 }
 
 export async function resolveValidatedSiteAddress(
-  _providerRef: string,
+  providerRef: string,
 ): Promise<ValidatedSiteAddress> {
+  const ref = providerRef.trim();
+  if (!ref) {
+    throw new Error("A validated address selection is required");
+  }
+
+  const cached = candidateCache.get(ref);
+  if (cached) return cached;
+
   throw new Error(
-    "Validated site address resolution is not configured yet. Connect an address validation provider first.",
+    "That address selection expired or is unknown. Search again and pick a result from the list.",
   );
 }

--- a/apps/web/lib/shared/site-address-validation.ts
+++ b/apps/web/lib/shared/site-address-validation.ts
@@ -162,8 +162,6 @@ async function searchNominatim(
       // Nominatim requires a descriptive User-Agent.
       "User-Agent": "OpenDigitalProductFactory/site-address-validation (ops@local)",
     },
-    // Avoid hanging server actions forever when the free endpoint is slow.
-    signal: AbortSignal.timeout(8_000),
   });
 
   if (!response.ok) {

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -4414,7 +4414,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 95
+    "textMass": 101
   },
   "apps/web/components/customer/NewCustomerSiteNodeButton.tsx": {
     "vocabulary": 0,
@@ -7705,5 +7705,19 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 39
+  },
+  "apps/web/components/customer/EditCustomerSiteButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 72
+  },
+  "apps/web/components/customer/ValidatedSiteAddressField.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
   }
 }


### PR DESCRIPTION
## Summary
Implements **BI-SITE-4F2C93** — validated edit/update for existing customer site addresses on the same lookup path used at create.

- Nominatim-backed searchValidatedSiteAddresses with process-local candidate cache and resolveValidatedSiteAddress
- Shared materialize helper in apps/web/lib/actions/customer-sites.ts (module-size split from apps/web/lib/actions/crm.ts)
- updateCustomerSite revalidation + coordinate refresh when a new selection is provided
- ValidatedSiteAddressField typeahead; Edit on CustomerSiteTree; create form selects a validated address

## Design grounding
- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-04-25-location-reference-resolution-design.md (customer-site create/edit; BI-SITE-4F2C93 / BI-SITE-3D8B44)
- Current code substrate reviewed:
  - apps/web/lib/actions/crm.ts create gate and re-exports
  - apps/web/lib/shared/site-address-validation.ts
  - apps/web/components/customer/CustomerSiteTree.tsx
  - apps/web/components/customer/NewCustomerSiteButton.tsx
- Source of truth: validatedAddressRef path already required on create; edit reuses the same lookup + materialize path
- Decision: free Nominatim fallback for search/resolve until commercial Smarty/Mapbox keys are configured (aligned with BI-SITE-5E6A18 provider guidance)

Design-Grounding-Decision: reviewed location-reference-resolution design and apps/web customer site substrate; wire edit to existing validated lookup contract.

Process-Spine-Decision: implements existing EP-SITE-7C4D2B / location-reference-resolution design; no new platform contract — wires site edit to the already-specified validated lookup path.

## Docs impact
Docs-Impact-Decision: no user-guide change required for this slice — operator surface reuses existing customer CRM page; provider setup already documented under built-in tools (BI-SITE-5E6A18).

## UX-fit
UX-Fit-Decision: progressive disclosure via typeahead results (search then pick one); edit keeps current address until a new selection is made; no raw lat/lng fields.

## Test plan
- [x] Unit tests for site-address-validation (mocked Nominatim)
- [x] Unit tests for updateCustomerSite (address refresh + metadata-only)
- [ ] CI typecheck / unit shards / build

Local-CI-Override: source-only worktree; typecheck and unit via CI.