### PR TITLE
Fix public guide diagrams and oversized homepage type

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -39,31 +39,15 @@
 </main>
 
 <!--
-  Mermaid rendering (EP-DOCS-SYSTEM Phase 2, WWMD DI-5C7B16CA4472).
-  Kramdown+Rouge emit ```mermaid fences as <div class="language-mermaid …"> raw
-  code. Diagrams are pre-rendered at build time to committed static SVGs
-  (scripts/render-doc-diagrams.mjs), so this shim just swaps each fence for its
-  committed asset by ORDINAL — the Nth diagram on the page → assets/diagrams/
-  <page-slug>/<N>.svg. No external CDN and no Mermaid runtime download (the
-  reason build-time won the kernel decision over the old cdn.jsdelivr.net shim).
+  User-guide Mermaid fences are replaced with committed build-time SVGs. The
+  source path is the stable key: public pretty URLs cannot distinguish
+  index.md from a sibling Markdown page. No Mermaid runtime or CDN is needed.
 -->
-<script>
-  (function () {
-    var blocks = document.querySelectorAll("div.language-mermaid");
-    if (!blocks.length) return;
-    var m = location.pathname.match(/^\/user-guide\/(.*?)\/?$/);
-    if (!m) return;
-    var slug = m[1];
-    for (var i = 0; i < blocks.length; i++) {
-      var img = document.createElement("img");
-      img.src = "/user-guide/assets/diagrams/" + slug + "/" + i + ".svg";
-      img.alt = "Diagram";
-      img.className = "doc-diagram";
-      img.loading = "lazy";
-      blocks[i].replaceWith(img);
-    }
-  })();
-</script>
+<script
+  src="{{ '/assets/js/doc-diagrams.js' | relative_url }}"
+  data-source-path="{{ page.path | escape }}"
+  defer
+></script>
 
 <footer class="site-footer">
   <div class="wrap">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -43,11 +43,10 @@
   source path is the stable key: public pretty URLs cannot distinguish
   index.md from a sibling Markdown page. No Mermaid runtime or CDN is needed.
 -->
-<script
-  src="{{ '/assets/js/doc-diagrams.js' | relative_url }}"
-  data-source-path="{{ page.path | escape }}"
-  defer
-></script>
+<script src="{{ '/assets/js/doc-diagrams.js' | relative_url }}"></script>
+<script>
+  DPFDocDiagrams.renderDocDiagrams(document, {{ page.path | jsonify }});
+</script>
 
 <footer class="site-footer">
   <div class="wrap">

--- a/docs/assets/js/doc-diagrams.js
+++ b/docs/assets/js/doc-diagrams.js
@@ -1,0 +1,60 @@
+(function (global) {
+  "use strict";
+
+  var MERMAID_BLOCK_SELECTOR =
+    "div.language-mermaid, pre > code.language-mermaid";
+
+  function diagramSlugFromSourcePath(sourcePath) {
+    var normalized = String(sourcePath || "").replace(/\\/g, "/");
+    normalized = normalized.replace(/^docs\//, "");
+    if (normalized.indexOf("user-guide/") !== 0) return null;
+    return normalized
+      .replace(/^user-guide\//, "")
+      .replace(/\.md$/, "");
+  }
+
+  function diagramPublicHref(slug, index) {
+    return "/user-guide/assets/diagrams/" + slug + "/" + index + ".svg";
+  }
+
+  function replacementTarget(block) {
+    if (
+      block.tagName === "CODE" &&
+      block.parentElement &&
+      block.parentElement.tagName === "PRE"
+    ) {
+      return block.parentElement;
+    }
+    return block;
+  }
+
+  function renderDocDiagrams(root, sourcePath) {
+    var slug = diagramSlugFromSourcePath(sourcePath);
+    if (!slug) return 0;
+
+    var blocks = root.querySelectorAll(MERMAID_BLOCK_SELECTOR);
+    for (var i = 0; i < blocks.length; i++) {
+      var img = root.createElement("img");
+      img.src = diagramPublicHref(slug, i);
+      img.alt = "Diagram";
+      img.className = "doc-diagram";
+      img.loading = "lazy";
+      replacementTarget(blocks[i]).replaceWith(img);
+    }
+    return blocks.length;
+  }
+
+  global.DPFDocDiagrams = Object.freeze({
+    MERMAID_BLOCK_SELECTOR: MERMAID_BLOCK_SELECTOR,
+    diagramSlugFromSourcePath: diagramSlugFromSourcePath,
+    diagramPublicHref: diagramPublicHref,
+    replacementTarget: replacementTarget,
+    renderDocDiagrams: renderDocDiagrams,
+  });
+
+  if (typeof document !== "undefined") {
+    var script = document.currentScript;
+    var sourcePath = script && script.getAttribute("data-source-path");
+    renderDocDiagrams(document, sourcePath);
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/docs/assets/js/doc-diagrams.js
+++ b/docs/assets/js/doc-diagrams.js
@@ -7,14 +7,25 @@
   function diagramSlugFromSourcePath(sourcePath) {
     var normalized = String(sourcePath || "").replace(/\\/g, "/");
     normalized = normalized.replace(/^docs\//, "");
-    if (normalized.indexOf("user-guide/") !== 0) return null;
+    if (
+      !/^user-guide\/[A-Za-z0-9][A-Za-z0-9_/-]*\.md$/.test(normalized) ||
+      normalized.indexOf("//") !== -1
+    ) {
+      return null;
+    }
     return normalized
       .replace(/^user-guide\//, "")
       .replace(/\.md$/, "");
   }
 
   function diagramPublicHref(slug, index) {
-    return "/user-guide/assets/diagrams/" + slug + "/" + index + ".svg";
+    var encodedSlug = String(slug)
+      .split("/")
+      .map(function (segment) {
+        return encodeURIComponent(segment);
+      })
+      .join("/");
+    return "/user-guide/assets/diagrams/" + encodedSlug + "/" + index + ".svg";
   }
 
   function replacementTarget(block) {
@@ -51,10 +62,4 @@
     replacementTarget: replacementTarget,
     renderDocDiagrams: renderDocDiagrams,
   });
-
-  if (typeof document !== "undefined") {
-    var script = document.currentScript;
-    var sourcePath = script && script.getAttribute("data-source-path");
-    renderDocDiagrams(document, sourcePath);
-  }
 })(typeof globalThis !== "undefined" ? globalThis : this);

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,8 @@
     --radius: 18px;
     --radius-lg: 28px;
     --page: 1180px;
+    --type-display: clamp(2.25rem, 3.2vw, 3rem);
+    --type-section: clamp(1.6rem, 2vw, 2rem);
   }
 
   @media (prefers-color-scheme: light) {
@@ -133,13 +135,13 @@
   h1 {
     max-width: 920px;
     margin: 0;
-    font-size: clamp(2.55rem, 7vw, 5.6rem);
+    font-size: var(--type-display);
   }
 
   h2 {
     max-width: 780px;
     margin: 0 0 18px;
-    font-size: clamp(2rem, 4.5vw, 3.6rem);
+    font-size: var(--type-section);
   }
 
   h3 {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "docs:impact:test": "node --test scripts/check-docs-impact.test.mjs scripts/gen-doc-impact.test.mjs",
     "docs:impact:graph": "node scripts/gen-doc-impact.mjs",
     "docs:impact:graph:check": "node scripts/gen-doc-impact.mjs --check",
-    "check:doc-links": "node scripts/gen-doc-index.mjs --check && node scripts/check-doc-links.mjs && node --test scripts/check-doc-links.test.mjs && node scripts/render-doc-diagrams.mjs --check",
+    "check:doc-links": "node scripts/gen-doc-index.mjs --check && node scripts/check-doc-links.mjs && node --test scripts/check-doc-links.test.mjs scripts/public-docs-rendering.test.mjs && node scripts/render-doc-diagrams.mjs --check",
     "security:secrets": "node scripts/security/run-gitleaks-local.mjs --tree",
     "security:secrets:staged": "node scripts/security/run-gitleaks-local.mjs --staged",
     "docs:tak": "node docs/architecture/generate-tak-docx.mjs",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -21,7 +21,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     ]),
     guard("docs-link-integrity", "Docs Link Integrity", [
       node("scripts/gen-doc-index.mjs", "--check"),
-      node("--test", "scripts/check-doc-links.test.mjs"),
+      node(
+        "--test",
+        "scripts/check-doc-links.test.mjs",
+        "scripts/public-docs-rendering.test.mjs",
+      ),
       node("scripts/check-doc-links.mjs"),
       node("scripts/render-doc-diagrams.mjs", "--check"),
     ]),

--- a/scripts/public-docs-rendering.test.mjs
+++ b/scripts/public-docs-rendering.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const scriptSource = fs.readFileSync(
+  path.join(repoRoot, "docs", "assets", "js", "doc-diagrams.js"),
+  "utf8",
+);
+
+function executeDiagramScript(sourcePath, blocks) {
+  const created = [];
+  const document = {
+    currentScript: {
+      getAttribute(name) {
+        return name === "data-source-path" ? sourcePath : null;
+      },
+    },
+    querySelectorAll(selector) {
+      assert.equal(
+        selector,
+        "div.language-mermaid, pre > code.language-mermaid",
+      );
+      return blocks;
+    },
+    createElement(tagName) {
+      assert.equal(tagName, "img");
+      const element = {};
+      created.push(element);
+      return element;
+    },
+  };
+  const context = { document };
+  context.globalThis = context;
+  vm.runInNewContext(scriptSource, context);
+  return { api: context.DPFDocDiagrams, created };
+}
+
+test("public user-guide root swaps Kramdown code output for the index SVG", () => {
+  let replacement;
+  const pre = {
+    tagName: "PRE",
+    replaceWith(value) {
+      replacement = value;
+    },
+  };
+  const code = { tagName: "CODE", parentElement: pre };
+
+  const { created } = executeDiagramScript("user-guide/index.md", [code]);
+
+  assert.equal(created.length, 1);
+  assert.equal(
+    replacement.src,
+    "/user-guide/assets/diagrams/index/0.svg",
+  );
+  assert.equal(replacement.className, "doc-diagram");
+  assert.equal(replacement.loading, "lazy");
+});
+
+test("nested index pages retain index in the committed diagram slug", () => {
+  const { api } = executeDiagramScript("architecture/platform-overview.md", []);
+
+  assert.equal(
+    api.diagramSlugFromSourcePath("docs/user-guide/customers/index.md"),
+    "customers/index",
+  );
+  assert.equal(
+    api.diagramPublicHref("customers/index", 0),
+    "/user-guide/assets/diagrams/customers/index/0.svg",
+  );
+});
+
+test("Jekyll layout passes the source path to the shared diagram renderer", () => {
+  const layout = fs.readFileSync(
+    path.join(repoRoot, "docs", "_layouts", "default.html"),
+    "utf8",
+  );
+
+  assert.match(layout, /assets\/js\/doc-diagrams\.js/);
+  assert.match(
+    layout,
+    /data-source-path="\{\{\s*page\.path\s*\|\s*escape\s*\}\}"/,
+  );
+  assert.doesNotMatch(layout, /querySelectorAll\("div\.language-mermaid"\)/);
+});
+
+test("homepage headings use the compact shared type scale", () => {
+  const homepage = fs.readFileSync(
+    path.join(repoRoot, "docs", "index.html"),
+    "utf8",
+  );
+
+  assert.match(
+    homepage,
+    /--type-display:\s*clamp\(2\.25rem,\s*3\.2vw,\s*3rem\)/,
+  );
+  assert.match(
+    homepage,
+    /--type-section:\s*clamp\(1\.6rem,\s*2vw,\s*2rem\)/,
+  );
+  assert.match(homepage, /h1\s*\{[^}]*font-size:\s*var\(--type-display\)/s);
+  assert.match(homepage, /h2\s*\{[^}]*font-size:\s*var\(--type-section\)/s);
+});

--- a/scripts/public-docs-rendering.test.mjs
+++ b/scripts/public-docs-rendering.test.mjs
@@ -17,11 +17,6 @@ const scriptSource = fs.readFileSync(
 function executeDiagramScript(sourcePath, blocks) {
   const created = [];
   const document = {
-    currentScript: {
-      getAttribute(name) {
-        return name === "data-source-path" ? sourcePath : null;
-      },
-    },
     querySelectorAll(selector) {
       assert.equal(
         selector,
@@ -39,6 +34,7 @@ function executeDiagramScript(sourcePath, blocks) {
   const context = { document };
   context.globalThis = context;
   vm.runInNewContext(scriptSource, context);
+  context.DPFDocDiagrams.renderDocDiagrams(document, sourcePath);
   return { api: context.DPFDocDiagrams, created };
 }
 
@@ -76,7 +72,20 @@ test("nested index pages retain index in the committed diagram slug", () => {
   );
 });
 
-test("Jekyll layout passes the source path to the shared diagram renderer", () => {
+test("diagram paths reject traversal and markup-bearing source paths", () => {
+  const { api } = executeDiagramScript("architecture/platform-overview.md", []);
+
+  assert.equal(
+    api.diagramSlugFromSourcePath("user-guide/../../index.md"),
+    null,
+  );
+  assert.equal(
+    api.diagramSlugFromSourcePath("user-guide/<img>/index.md"),
+    null,
+  );
+});
+
+test("Jekyll passes its build-time source path without reading DOM text", () => {
   const layout = fs.readFileSync(
     path.join(repoRoot, "docs", "_layouts", "default.html"),
     "utf8",
@@ -85,8 +94,10 @@ test("Jekyll layout passes the source path to the shared diagram renderer", () =
   assert.match(layout, /assets\/js\/doc-diagrams\.js/);
   assert.match(
     layout,
-    /data-source-path="\{\{\s*page\.path\s*\|\s*escape\s*\}\}"/,
+    /renderDocDiagrams\(document,\s*\{\{\s*page\.path\s*\|\s*jsonify\s*\}\}\)/,
   );
+  assert.doesNotMatch(layout, /data-source-path/);
+  assert.doesNotMatch(scriptSource, /currentScript|getAttribute/);
   assert.doesNotMatch(layout, /querySelectorAll\("div\.language-mermaid"\)/);
 });
 


### PR DESCRIPTION
## Summary

- render committed Mermaid SVGs on the public user guide instead of exposing `flowchart` source
- reduce the homepage hero maximum from 89.6px to 48px and section headings from 57.6px to 32px
- extract the fragile inline diagram swap into a shared, testable public-docs renderer
- add regression coverage to the existing Docs Link Integrity gate

## Root cause

The live Jekyll output emits Mermaid fences as `<pre><code class="language-mermaid">`, while the layout only searched for `div.language-mermaid`. It also derived diagram slugs from pretty URLs, which cannot distinguish `index.md`; `/user-guide/` therefore could not map to the committed `assets/diagrams/index/0.svg` even with the selector corrected.

The homepage used global clamps capped at `5.6rem` and `3.6rem`, producing 89.6px and 57.6px headings at the reported desktop viewport.

## User impact

The public guide now shows the intended accessible static diagram with its existing visible text alternative. The landing page retains its hierarchy but reads as a compact editorial page rather than oversized display typography.

## Verification

- live reproduction at `https://opendigitalproductfactory.com/user-guide/`: Mermaid code block present, zero diagram SVGs, no Mermaid runtime
- live reproduction at `https://opendigitalproductfactory.com/` at 2065px: hero 89.6px; section headings 57.6px
- `node --test scripts/public-docs-rendering.test.mjs` — 4/4 passed in the source-only worktree
- `pnpm check:doc-links` — 20/20 tests passed; 76 guide pages scanned; 12 committed diagrams fresh
- `git diff --check` — passed
- pre-commit Gitleaks scan — passed

Local-CI-Override: The shared `local-integration-ci` sandbox was starved by successive pre-existing and duplicate gate leases after an extended governed wait. No production build is claimed from the source-only worktree; normal GitHub CI is authoritative before merge.

UX-Fit-Decision: fits-with-guardrails; compact editorial scale selected after live reproduction and governed decision DI-097D55DC52DE. No navigation or component-family change.

Design-Grounding-Decision: reviewed `docs/superpowers/specs/2026-07-16-documentation-system-design.md`, `docs/platform-usability-standards.md`, `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`, `docs/_layouts/default.html`, and `apps/web/lib/docs/diagram-assets.mjs`.

Docs-Impact-Decision: this PR directly updates the public documentation layout and homepage; no separate operator-guide prose change is needed.

Process-Spine-Decision: focused public-site defect slice with live reproduction, shared-renderer refactor, and CI regression coverage.
