### PR TITLE
fix(build): pass autonomy rollout controls to portal

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -140,6 +140,13 @@ DPF_OPTIONAL_STARTUP_TASKS_ENABLED=
 # rollback to the old shared /workspace checkout.
 DPF_BUILD_WORKTREE_ISOLATION=
 
+# Governed autonomous Build Studio rollout controls. All remain disabled when
+# blank. Use shadow before enforce, and keep the independent completion and PR
+# delivery switches available as emergency stops.
+DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE=
+DPF_BUILD_PR_DELIVERY_RECONCILER_MODE=
+DPF_AUTO_COMPLETE_VERIFIED_BUILDS=
+
 # ─── Release-image distribution (used by docker-compose.release.yml) ──
 # Set these when consuming pre-built multi-arch GHCR images instead of
 # building locally. See docs/superpowers/specs/2026-05-09-deployment-contracts.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,6 +237,12 @@ services:
       # (which recreates from this file, not docker-compose.override.yml). See
       # docs/operations/autonomous-build-completion.md. Flip per-install via host .env.
       DPF_AUTO_COMPLETE_VERIFIED_BUILDS: ${DPF_AUTO_COMPLETE_VERIFIED_BUILDS:-0}
+      # Governed Living Playbook autonomy remains fail-closed unless an operator
+      # enables shadow or enforce mode for this install.
+      DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE: ${DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE:-off}
+      # PR observation and compare-and-swap delivery actions have an independent
+      # kill switch so rollout can stop without changing build evidence.
+      DPF_BUILD_PR_DELIVERY_RECONCILER_MODE: ${DPF_BUILD_PR_DELIVERY_RECONCILER_MODE:-off}
       # Tell Inngest's serve() the externally-reachable URL for this app so
       # sync registrations announce the Docker-DNS hostname (not the Host
       # header of the /api/inngest PUT, which would be "localhost:3000"

--- a/scripts/lib/compose-runtime-env.test.mjs
+++ b/scripts/lib/compose-runtime-env.test.mjs
@@ -31,6 +31,25 @@ test("example compose env documents background job override flags", () => {
   assert.match(envExample, /DPF_OPTIONAL_STARTUP_TASKS_ENABLED=/);
 });
 
+test("installed runtime passes through every autonomous Build Studio rollout control", () => {
+  assert.match(
+    compose,
+    /DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE:\s*\$\{DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE:-off\}/,
+  );
+  assert.match(
+    compose,
+    /DPF_BUILD_PR_DELIVERY_RECONCILER_MODE:\s*\$\{DPF_BUILD_PR_DELIVERY_RECONCILER_MODE:-off\}/,
+  );
+  assert.match(
+    compose,
+    /DPF_AUTO_COMPLETE_VERIFIED_BUILDS:\s*\$\{DPF_AUTO_COMPLETE_VERIFIED_BUILDS:-0\}/,
+  );
+
+  assert.match(envExample, /DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE=/);
+  assert.match(envExample, /DPF_BUILD_PR_DELIVERY_RECONCILER_MODE=/);
+  assert.match(envExample, /DPF_AUTO_COMPLETE_VERIFIED_BUILDS=/);
+});
+
 test("portal runtime exposes the host source mount as the git repo root for live-readiness ancestry checks", () => {
   assert.match(
     compose,


### PR DESCRIPTION
## Summary
- pass `DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE` and `DPF_BUILD_PR_DELIVERY_RECONCILER_MODE` into the installed portal container with fail-closed `off` defaults
- document all three autonomous Build Studio rollout controls in `.env.docker.example`
- add a regression guard that keeps the Compose runtime and operator template aligned
- continues BI-356E69B1 through Work Capsule WC-EB92D255

## Test plan
- [x] focused regression: `node --test --test-name-pattern "installed runtime passes through every autonomous Build Studio rollout control" scripts/lib/compose-runtime-env.test.mjs`
- [x] Compose resolution: `docker compose --env-file D:\DPF\.env config --quiet`
- [x] governed exact-SHA pregate: full repository Vitest, TypeScript, migration deploy, docs and policy guards, production Docker build
- [x] UX: not applicable; no rendered UI changes
- [x] Migration: not applicable; no schema changes

No overlapping open PR was found for this runtime pass-through concern.

Local-CI-Evidence: cms4wrdd104jk01np40y94utk (fix/build-studio-autonomy-runtime-env@e60ecc82dc355f82c896f8277633587c0be68037)