### PR TITLE
feat: simplify Build Studio around outcomes

### DIFF
--- a/apps/web/components/build/BuildOperatorOverview.test.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BuildOperatorOverview } from "./BuildOperatorOverview";
+
+describe("BuildOperatorOverview", () => {
+  it("keeps the default hierarchy outcome-first and business-safe", () => {
+    const html = renderToStaticMarkup(
+      <BuildOperatorOverview
+        title="Reduce missed invoice follow-ups"
+        outcome="Remind account owners before an invoice becomes overdue."
+        phase="review"
+        status={{
+          whatIsBeingBuilt: "Reduce missed invoice follow-ups",
+          lifecyclePosition: "Checking the work",
+          worker: "Build Studio",
+          evidence: "Implementation is complete and verification is running.",
+          technicalEvidence: "WC-123 on feat/invoice-reminders",
+          nextAction: "No action needed while checks run.",
+          owner: "Build Studio",
+          needsYou: false,
+        }}
+      />,
+    );
+
+    expect(html).toContain('data-testid="build-studio-operator-outcome"');
+    expect(html).toContain("Reduce missed invoice follow-ups");
+    expect(html).toContain("Remind account owners before an invoice becomes overdue.");
+    expect(html).toContain('data-testid="build-studio-operator-status"');
+    expect(html).toContain("Checking the work");
+    expect(html).toContain('data-testid="build-studio-operator-next-action"');
+    expect(html).toContain("No action needed while checks run.");
+    expect(html).toContain('data-testid="build-studio-activity-story"');
+    expect(html).not.toContain("WC-123");
+    expect(html).not.toContain("feat/invoice-reminders");
+  });
+
+  it("makes an operator decision visually explicit without exposing technical evidence", () => {
+    const html = renderToStaticMarkup(
+      <BuildOperatorOverview
+        title="Choose delivery policy"
+        outcome="Agree how urgent deliveries should be prioritized."
+        phase="plan"
+        status={{
+          whatIsBeingBuilt: "Choose delivery policy",
+          lifecyclePosition: "Waiting for your decision",
+          worker: "Build Studio",
+          evidence: "Two safe options are ready.",
+          nextAction: "Choose the preferred delivery policy.",
+          owner: "Operator",
+          needsYou: true,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Needs you");
+    expect(html).toContain("Choose the preferred delivery policy.");
+  });
+});

--- a/apps/web/components/build/BuildOperatorOverview.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.tsx
@@ -27,7 +27,7 @@ export function BuildOperatorOverview({
   return (
     <div className="space-y-5 px-5 py-5 sm:px-7 sm:py-6">
       <section data-testid="build-studio-operator-outcome" aria-labelledby="build-outcome-heading">
-        <p className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+        <p className="m-0 text-dpf-caption font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
           Outcome
         </p>
         <h2
@@ -52,12 +52,12 @@ export function BuildOperatorOverview({
           <div className="flex items-center justify-between gap-3">
             <p
               id="build-status-heading"
-              className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+              className="m-0 text-dpf-caption font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
             >
               Now
             </p>
             {status?.needsYou ? (
-              <span className="rounded-full border border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] px-2 py-1 text-[11px] font-semibold text-[var(--dpf-warning)]">
+              <span className="rounded-full border border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] px-2 py-1 text-dpf-caption font-semibold text-[var(--dpf-warning)]">
                 Needs you
               </span>
             ) : null}
@@ -79,7 +79,7 @@ export function BuildOperatorOverview({
         >
           <p
             id="build-next-heading"
-            className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+            className="m-0 text-dpf-caption font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
           >
             Next
           </p>
@@ -94,7 +94,7 @@ export function BuildOperatorOverview({
           <div>
             <p
               id="build-activity-heading"
-              className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+              className="m-0 text-dpf-caption font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
             >
               Activity
             </p>
@@ -112,7 +112,7 @@ export function BuildOperatorOverview({
             >
               <div className="flex items-center gap-2">
                 <span
-                  className="grid h-5 w-5 shrink-0 place-items-center rounded-full border border-current text-[10px] font-bold"
+                  className="grid h-5 w-5 shrink-0 place-items-center rounded-full border border-current text-dpf-caption font-bold"
                   aria-hidden="true"
                 >
                   {step.state === "complete" ? "✓" : step.state === "attention" ? "!" : "·"}
@@ -120,7 +120,7 @@ export function BuildOperatorOverview({
                 <span className="text-xs font-semibold leading-4">{step.label}</span>
               </div>
               {(step.state === "current" || step.state === "attention") ? (
-                <p className="m-0 mt-2 text-[11px] leading-4 text-[var(--dpf-muted)]">
+                <p className="m-0 mt-2 text-dpf-caption text-[var(--dpf-muted)]">
                   {step.detail}
                 </p>
               ) : null}

--- a/apps/web/components/build/BuildOperatorOverview.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.tsx
@@ -1,0 +1,154 @@
+import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+import type { BuildPhase } from "@/lib/feature-build-types";
+import { deriveBuildActivityStory } from "./build-studio-operator-view";
+
+const STEP_TONE = {
+  complete: "border-[var(--dpf-success)] bg-[var(--dpf-state-success)] text-[var(--dpf-success)]",
+  current: "border-[var(--dpf-accent)] bg-[var(--dpf-state-info)] text-[var(--dpf-accent)]",
+  upcoming: "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)]",
+  attention: "border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)]",
+} as const;
+
+export function BuildOperatorOverview({
+  title,
+  outcome,
+  phase,
+  status,
+}: {
+  title: string;
+  outcome: string | null | undefined;
+  phase: BuildPhase;
+  status?: BuildStudioCustomerStatus | null;
+}) {
+  const activity = deriveBuildActivityStory(phase);
+  const lifecyclePosition = status?.lifecyclePosition ?? fallbackStatus(phase);
+  const nextAction = status?.nextAction ?? fallbackNextAction(phase);
+
+  return (
+    <div className="space-y-5 px-5 py-5 sm:px-7 sm:py-6">
+      <section data-testid="build-studio-operator-outcome" aria-labelledby="build-outcome-heading">
+        <p className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+          Outcome
+        </p>
+        <h2
+          id="build-outcome-heading"
+          className="m-0 mt-1 max-w-4xl text-balance text-xl font-semibold leading-7 text-[var(--dpf-text)] sm:text-2xl"
+        >
+          {title}
+        </h2>
+        {outcome ? (
+          <p className="m-0 mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+            {outcome}
+          </p>
+        ) : null}
+      </section>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <section
+          data-testid="build-studio-operator-status"
+          className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4"
+          aria-labelledby="build-status-heading"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <p
+              id="build-status-heading"
+              className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+            >
+              Now
+            </p>
+            {status?.needsYou ? (
+              <span className="rounded-full border border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] px-2 py-1 text-[11px] font-semibold text-[var(--dpf-warning)]">
+                Needs you
+              </span>
+            ) : null}
+          </div>
+          <p className="m-0 mt-2 text-base font-semibold text-[var(--dpf-text)]">
+            {lifecyclePosition}
+          </p>
+          {status?.evidence ? (
+            <p className="m-0 mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+              {status.evidence}
+            </p>
+          ) : null}
+        </section>
+
+        <section
+          data-testid="build-studio-operator-next-action"
+          className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+          aria-labelledby="build-next-heading"
+        >
+          <p
+            id="build-next-heading"
+            className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+          >
+            Next
+          </p>
+          <p className="m-0 mt-2 text-sm font-medium leading-6 text-[var(--dpf-text)]">
+            {nextAction}
+          </p>
+        </section>
+      </div>
+
+      <section data-testid="build-studio-activity-story" aria-labelledby="build-activity-heading">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p
+              id="build-activity-heading"
+              className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+            >
+              Activity
+            </p>
+            <p className="m-0 mt-1 text-xs text-[var(--dpf-muted)]">
+              Evidence collected as Build Studio works.
+            </p>
+          </div>
+        </div>
+        <ol className="mt-3 grid gap-2 sm:grid-cols-5">
+          {activity.map((step) => (
+            <li
+              key={step.key}
+              className={`min-w-0 rounded-lg border p-3 ${STEP_TONE[step.state]}`}
+              aria-current={step.state === "current" ? "step" : undefined}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className="grid h-5 w-5 shrink-0 place-items-center rounded-full border border-current text-[10px] font-bold"
+                  aria-hidden="true"
+                >
+                  {step.state === "complete" ? "✓" : step.state === "attention" ? "!" : "·"}
+                </span>
+                <span className="text-xs font-semibold leading-4">{step.label}</span>
+              </div>
+              {(step.state === "current" || step.state === "attention") ? (
+                <p className="m-0 mt-2 text-[11px] leading-4 text-[var(--dpf-muted)]">
+                  {step.detail}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      </section>
+    </div>
+  );
+}
+
+function fallbackStatus(phase: BuildPhase): string {
+  const labels: Record<BuildPhase, string> = {
+    ideate: "Understanding the outcome",
+    plan: "Shaping the approach",
+    build: "Building the solution",
+    review: "Checking the work",
+    ship: "Preparing for release",
+    complete: "Ready to use",
+    failed: "Needs recovery",
+    abandoned: "Work stopped",
+  };
+  return labels[phase];
+}
+
+function fallbackNextAction(phase: BuildPhase): string {
+  if (phase === "failed") return "Resolve the blocker, then resume the governed build.";
+  if (phase === "abandoned") return "Resume this outcome only if it is still valuable.";
+  if (phase === "complete") return "No action needed. The evidence remains available in technical details.";
+  return "No action needed unless Build Studio asks for a decision.";
+}

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -895,6 +895,11 @@ export function BuildStudio({
                         </Link>
                       ) : null}
                     </div>
+                    {customerStatuses[activeBuild.id]?.technicalEvidence ? (
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-2 font-mono text-[11px] leading-5 text-[var(--dpf-muted)]">
+                        {customerStatuses[activeBuild.id].technicalEvidence}
+                      </div>
+                    ) : null}
                     {activeWorkWarrant !== null && activeWorkWarrant !== undefined ? (
                       <div className="border-b border-[var(--dpf-border)] px-4 py-3">
                         <BuildWorkWarrantBand warrant={activeWorkWarrant} />

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -84,7 +84,7 @@ type Props = {
   /**
    * BI-E167A8A6: whether the operator holds manage_backlog. Gates door 2 —
    * the "Work Control / Plan governed work" intake — so a non-technical
-   * operator only ever sees the plain-English "Start a new build" door.
+   * operator only ever sees the plain-English "Start a new outcome" door.
    */
   canManageGovernedWork?: boolean;
   dpfEnvironment?: string;
@@ -207,10 +207,10 @@ export function BuildStudio({
   // Operator-first altitude: process mechanics and evidence remain available
   // behind one technical-details boundary. Persist the technical user's choice.
   const BUILD_ENGINEER_VIEW_KEY = "dpf:build-studio-engineer-view";
-  const [engineerView, setEngineerView] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(BUILD_ENGINEER_VIEW_KEY) === "true";
-  });
+  // Keep the server and first client render deterministic. Reading viewport or
+  // localStorage during initial render makes a mobile or returning technical
+  // user hydrate different markup from the server response.
+  const [engineerView, setEngineerView] = useState(false);
   const [snoozedCustodianKeys, setSnoozedCustodianKeys] = useState(readCustodianSnoozes);
   const toggleEngineerView = useCallback(() => {
     setEngineerView((prev) => {
@@ -219,11 +219,14 @@ export function BuildStudio({
       return next;
     });
   }, []);
-  const [sidebarOpen, setSidebarOpen] = useState(() =>
-    shouldOpenBuildStudioSidebarByDefault(
-      typeof window === "undefined" ? undefined : window.innerWidth,
-    ),
-  );
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  useEffect(() => {
+    try {
+      setEngineerView(window.localStorage.getItem(BUILD_ENGINEER_VIEW_KEY) === "true");
+    } catch {
+      // Storage can be unavailable in hardened/private browser contexts.
+    }
+  }, []);
   useEffect(() => {
     if (!newPortfolioId && portfolioRows[0]?.id) {
       setNewPortfolioId(portfolioRows[0].id);
@@ -1614,7 +1617,7 @@ function FleetRailZone({
           <div className="text-3xl mb-3 opacity-20">&#128161;</div>
           <p className="text-sm text-[var(--dpf-muted)] mb-2">No builds yet</p>
           <p className="text-xs text-[var(--dpf-muted)] opacity-70">
-            Type a feature name above and click "Start a new build" to start.
+            Describe the outcome above and choose Continue when it is clear.
           </p>
         </div>
       </div>

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -7,7 +7,6 @@ import { confirmDialog } from "@/components/ui/Dialog";
 import { Spinner } from "@/components/ui/Spinner";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { GitBranch } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { FeatureBriefPanel } from "./FeatureBriefPanel";
 import { ReviewPanel } from "./ReviewPanel";
@@ -28,11 +27,8 @@ import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
 import { EpicRollupListItem } from "./EpicRollupListItem";
 import {
-  deriveCoworkerActivityCount,
-  deriveFleetCounts,
   deriveNeedsAttention,
   deriveQueueState,
-  formatOperatorFocusHeader,
   isOperatorFocusEntry,
 } from "./fleet-derivation";
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
@@ -41,11 +37,12 @@ import { deriveBuildStudioCustodianPrompt, type BuildStudioCustodianPrompt } fro
 import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
 import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
-import { BuildCustomerStatusBand } from "./BuildCustomerStatusBand";
 import { BuildWorkWarrantBand } from "./BuildWorkWarrantBand";
 import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
 import { projectAutonomousBuildCustody } from "@/lib/build/autonomous-build-custody";
-import { BuildOperatorHeaderDetails, BuildWorkRequestStrip, formatOperatorPhaseLabel } from "./BuildOperatorContext";
+import { BuildOperatorHeaderDetails, formatOperatorPhaseLabel } from "./BuildOperatorContext";
+import { BuildOperatorOverview } from "./BuildOperatorOverview";
+import { groupOperatorBuilds } from "./build-studio-operator-view";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
 import { deleteFeatureBuild } from "@/lib/actions/build";
 import { createBuildStudioBacklogIntake, startBacklogBuild } from "@/lib/actions/backlog-build";
@@ -198,32 +195,17 @@ export function BuildStudio({
   const [newPortfolioId, setNewPortfolioId] = useState(() => portfolioRows[0]?.id ?? "");
   const [pendingIntake, setPendingIntake] = useState<BuildStudioPendingIntake | null>(null);
   const [promotingItemId, setPromotingItemId] = useState<string | null>(null);
-  // Tab selector removed per spec §1 + §9 #11 — the workflow graph is the
-  // always-visible primary surface of the active-build pane. Progress /
-  // Brief / Review / Sandbox / BS-Queue evidence migrates into the
-  // DetailsDrawer accordion (PR #912's DetailsDrawer + this slice).
+  const [intakeOpen, setIntakeOpen] = useState(() => buildRows.length === 0);
+  // One evidence drawer remains authoritative for progress, brief, review,
+  // runtime, and queue diagnostics. The operator overview stays primary;
+  // the graph and drawer mount only inside Technical details.
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerInitialSectionId, setDrawerInitialSectionId] = useState<string | null>(null);
-  // BI-63EAD801: keep internal IDs / git branch chip behind Engineer view so
-  // end-users (Dale) don't see FB-*, WC-*, and raw branch names in the header.
-  const BUILD_DETAILS_KEY = "dpf:build-studio-header-details-expanded";
-  const [headerDetailsExpanded, setHeaderDetailsExpanded] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(BUILD_DETAILS_KEY) === "true";
-  });
-  const toggleHeaderDetails = useCallback(() => {
-    setHeaderDetailsExpanded((prev) => {
-      const next = !prev;
-      try { window.localStorage.setItem(BUILD_DETAILS_KEY, String(next)); } catch { /* ignore */ }
-      return next;
-    });
-  }, []);
   // Assurance + code-intel cards collapse so the workflow graph stays the
   // primary surface (spec §1 + §9 #11). Operators can re-expand on demand.
   const [assuranceRowExpanded, setAssuranceRowExpanded] = useState(false);
-  // Overseer altitude flip (BI-90670010): the plain "Solution & Oversight" bands
-  // are the default first-viewport; the engineer-grade ProcessGraph + evidence
-  // demote behind this single toggle. Persisted so an engineer's choice sticks.
+  // Operator-first altitude: process mechanics and evidence remain available
+  // behind one technical-details boundary. Persist the technical user's choice.
   const BUILD_ENGINEER_VIEW_KEY = "dpf:build-studio-engineer-view";
   const [engineerView, setEngineerView] = useState(() => {
     if (typeof window === "undefined") return false;
@@ -644,28 +626,6 @@ export function BuildStudio({
 
         {/* Left: Build List */}
         <div className={getBuildStudioSidebarClassName(sidebarOpen)}>
-          {/* BI-E167A8A6: door 2 (Work Control / governed engineering work) is
-              only surfaced to operators who can actually create it
-              (manage_backlog). Non-technical operators see just the
-              plain-English "Start a new build" door below — no second intake to
-              guess between. Where both are shown, the subtitle states the
-              relationship so it is clear which door does what. */}
-          {canManageGovernedWork && (
-            <div className="border-b border-[var(--dpf-border)] p-3">
-              <Link
-                href="/build/work"
-                className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
-              >
-                <GitBranch className="h-4 w-4" aria-hidden="true" />
-                <span>Work Control</span>
-              </Link>
-              <p className="mt-1.5 text-[10px] leading-snug text-[var(--dpf-muted)]">
-                Governed engineering work — git branches &amp; worktrees. To
-                describe a feature in plain English instead, use{" "}
-                <span className="font-medium text-[var(--dpf-text)]">Start a new build</span> below.
-              </p>
-            </div>
-          )}
           {isDevEnvironment ? (
             <div className="p-3 border-b border-[var(--dpf-border)]">
               <div className="px-3 py-2 text-sm bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded-md text-[var(--dpf-muted)]">
@@ -673,102 +633,111 @@ export function BuildStudio({
               </div>
             </div>
           ) : (
-            // D12 (2026-05-23): multiline textarea instead of single-line input.
-            // The prior <input> truncated longer descriptions to a tail-only
-            // view (e.g. "...driving back to the warehouse" with no way to see
-            // the start) — looked like the platform had eaten half the text.
-            // Now: auto-resizing textarea with visible char count; Enter inserts
-            // a newline (multiline field), Cmd/Ctrl+Enter submits to preserve
-            // keyboard flow without losing the multiline capability.
-            <div className="p-3 border-b border-[var(--dpf-border)]">
-              {/* BI-E167A8A6: name door 1 and state its purpose so it reads as
-                  the primary, plain-English intake — distinct from governed
-                  Work Control above. */}
-              <div className="mb-2">
-                <p className="text-xs font-semibold text-[var(--dpf-text)]">Start a new build</p>
-                <p className="mt-0.5 text-[10px] leading-snug text-[var(--dpf-muted)]">
-                  Describe a feature in plain English — your AI Coworker designs, builds, and ships it for you.
-                </p>
-              </div>
-              <textarea
-                placeholder="Describe a new feature in plain English — say what you want to do, who it's for, and any details that matter."
-                value={newTitle}
-                onChange={(e) => setNewTitle(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                    e.preventDefault();
-                    handleCreate();
-                  }
-                }}
-                rows={3}
-                className="w-full px-3 py-2 text-sm bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] rounded-md text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)] resize-y min-h-[72px] max-h-[200px] leading-snug"
-              />
-              <label className="mt-2 block text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
-                Portfolio
-                <select
-                  value={newPortfolioId}
-                  onChange={(e) => setNewPortfolioId(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm normal-case tracking-normal text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
-                >
-                  {portfolioRows.length === 0 ? (
-                    <option value="">No portfolios available</option>
+            <div className="border-b border-[var(--dpf-border)]">
+              <button
+                type="button"
+                onClick={() => setIntakeOpen((open) => !open)}
+                aria-expanded={intakeOpen}
+                className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left transition-colors hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+              >
+                <span>
+                  <span className="block text-sm font-semibold text-[var(--dpf-text)]">
+                    Start a new outcome
+                  </span>
+                  {!intakeOpen ? (
+                    <span className="mt-0.5 block text-[11px] text-[var(--dpf-muted)]">
+                      Describe what should be different.
+                    </span>
                   ) : null}
-                  {portfolioRows.map((portfolio) => (
-                    <option key={portfolio.id} value={portfolio.id}>
-                      {portfolio.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              {/* BI-950FE085 (D??): the prior "New" label gave Dale no signal
-                  about what he was creating. "Start a new build" is explicit —
-                  it names the action, the artifact, and the intent. */}
-              <div className="flex items-center justify-between mt-2 gap-2">
-                <div className="text-[10px] text-[var(--dpf-muted)] leading-tight">
-                  Press Cmd/Ctrl+Enter to file.
-                  {newTitle.length > 0 ? ` ${newTitle.length} characters.` : ""}
-                </div>
-                <button
-                  onClick={handleCreate}
-                  disabled={creating || !newTitle.trim() || !newPortfolioId}
-                  className="px-4 py-2 text-sm font-semibold bg-[var(--dpf-accent)] text-white border-none rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:opacity-90 transition-opacity flex items-center gap-1.5"
-                >
-                  {creating && <Spinner size="xs" tone="current" presentational />}
-                  {creating ? "Filing..." : "File backlog item"}
-                </button>
-              </div>
-              {pendingIntake && (
-                <div className="mt-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-                    Ready to promote
+                </span>
+                <span aria-hidden="true" className="text-[var(--dpf-muted)]">
+                  {intakeOpen ? "−" : "+"}
+                </span>
+              </button>
+              {intakeOpen ? (
+                <div className="px-3 pb-3">
+                  <label className="block text-[11px] font-medium text-[var(--dpf-muted)]">
+                    What outcome do you want?
+                    <textarea
+                      placeholder="Describe what should be different, who it helps, and any constraint that matters."
+                      value={newTitle}
+                      onChange={(e) => setNewTitle(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          handleCreate();
+                        }
+                      }}
+                      rows={4}
+                      className="mt-1 w-full min-h-[92px] max-h-[220px] resize-y rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm leading-5 text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
+                    />
+                  </label>
+                  {portfolioRows.length > 1 ? (
+                    <details className="mt-2">
+                      <summary className="cursor-pointer text-[11px] font-medium text-[var(--dpf-muted)]">
+                        Choose business area
+                      </summary>
+                      <label className="mt-2 block text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
+                        Business area
+                        <select
+                          value={newPortfolioId}
+                          onChange={(e) => setNewPortfolioId(e.target.value)}
+                          className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm normal-case tracking-normal text-[var(--dpf-text)] outline-none focus:border-[var(--dpf-accent)]"
+                        >
+                          {portfolioRows.map((portfolio) => (
+                            <option key={portfolio.id} value={portfolio.id}>
+                              {portfolio.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </details>
+                  ) : null}
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <span className="text-[10px] leading-tight text-[var(--dpf-muted)]">
+                      {newTitle.length > 0 ? `${newTitle.length} characters` : "Plain language is enough"}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleCreate}
+                      disabled={creating || !newTitle.trim() || !newPortfolioId}
+                      className="inline-flex items-center gap-1.5 rounded-md border-none bg-[var(--dpf-accent)] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {creating && <Spinner size="xs" tone="current" presentational />}
+                      {creating ? "Saving..." : "Continue"}
+                    </button>
                   </div>
-                  <div className="mt-1 text-sm font-medium text-[var(--dpf-text)]">
-                    {pendingIntake.itemId}
-                  </div>
-                  <p className="mt-1 text-xs leading-snug text-[var(--dpf-muted)]">
-                    {pendingIntake.title} · {pendingIntake.portfolioName}
-                  </p>
-                  <button
-                    type="button"
-                    onClick={handlePromotePendingIntake}
-                    disabled={promotingItemId === pendingIntake.itemId}
-                    className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[var(--dpf-accent)] px-3 py-2 text-sm font-semibold text-[var(--dpf-accent)] transition-colors hover:bg-[var(--dpf-accent)] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {promotingItemId === pendingIntake.itemId && (
-                      <Spinner size="xs" tone="current" presentational />
-                    )}
-                    {promotingItemId === pendingIntake.itemId ? "Promoting..." : "Promote to Feature Build"}
-                  </button>
+                  {pendingIntake ? (
+                    <div className="mt-3 rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-state-info)] p-3">
+                      <p className="m-0 text-[10px] font-semibold uppercase tracking-wide text-[var(--dpf-accent)]">
+                        Outcome captured
+                      </p>
+                      <p className="m-0 mt-1 text-sm font-medium text-[var(--dpf-text)]">
+                        {pendingIntake.title}
+                      </p>
+                      <p className="m-0 mt-1 text-xs text-[var(--dpf-muted)]">
+                        {pendingIntake.portfolioName}
+                      </p>
+                      <button
+                        type="button"
+                        onClick={handlePromotePendingIntake}
+                        disabled={promotingItemId === pendingIntake.itemId}
+                        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-semibold text-[var(--dpf-accent)] transition-colors hover:bg-[var(--dpf-accent)] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {promotingItemId === pendingIntake.itemId && (
+                          <Spinner size="xs" tone="current" presentational />
+                        )}
+                        {promotingItemId === pendingIntake.itemId ? "Starting..." : "Start governed build"}
+                      </button>
+                    </div>
+                  ) : null}
+                  {createError ? (
+                    <div role="alert" className="mt-2 text-[11px] leading-snug text-[var(--dpf-danger)]">
+                      {createError}
+                    </div>
+                  ) : null}
                 </div>
-              )}
-              {createError && (
-                <div
-                  role="alert"
-                  className="mt-2 text-[11px] text-[var(--dpf-danger)] leading-snug"
-                >
-                  {createError}
-                </div>
-              )}
+              ) : null}
             </div>
           )}
 
@@ -804,6 +773,7 @@ export function BuildStudio({
               });
             }}
             onOpenQueueDrawer={() => {
+              setEngineerView(true);
               setDrawerInitialSectionId("bs-queue");
               setDrawerOpen(true);
             }}
@@ -811,7 +781,7 @@ export function BuildStudio({
         </div>
 
         {/* Right: Preview or Brief */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-[var(--dpf-surface-1)]">
+        <div className="flex min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-[var(--dpf-surface-1)]">
           <PortalContextStrip
             envelope={portalContext ?? null}
             contextLabel="Build context"
@@ -819,57 +789,16 @@ export function BuildStudio({
           />
           {activeBuild ? (
             <>
-              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-3">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h2
-                      title={activeBuild.title}
-                      className="m-0 max-h-[3rem] min-w-0 overflow-hidden break-words text-base font-bold leading-6 text-[var(--dpf-text)] line-clamp-2"
-                    >
-                      {activeBuild.title}
-                    </h2>
-                    <ClaimBadge agentId={activeBuild.claimedByAgentId ?? null} claimStatus={activeBuild.claimStatus ?? null} claimedAt={activeBuild.claimedAt ?? null} />
-                  </div>
-                  {/* BI-63EAD801 (D13): Internal IDs and git branch chip are
-                      hidden from the operator view — end-users (Dale) have no
-                      use for FB-*, WC-*, or raw branch names. Engineer view is
-                      the explicit opt-in for those details. */}
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--dpf-muted)]">
-                    <button
-                      type="button"
-                      aria-expanded={headerDetailsExpanded}
-                      aria-controls="build-studio-header-details"
-                      onClick={toggleHeaderDetails}
-                      className="inline-flex items-center gap-1 rounded px-1 py-0.5 text-[var(--dpf-muted)] transition-colors hover:bg-[var(--dpf-surface-2)] hover:text-[var(--dpf-text)]"
-                    >
-                      <span aria-hidden="true">{headerDetailsExpanded ? "▾" : "▸"}</span>
-                      Details
-                    </button>
-                    {headerDetailsExpanded && (
-                      <span
-                        id="build-studio-header-details"
-                        className="flex flex-wrap items-center gap-2"
-                        data-testid="build-studio-header-details"
-                      >
-                        <BuildOperatorHeaderDetails
-                          build={activeBuild}
-                          branchBadge={branchBadge}
-                          engineerView={engineerView}
-                        />
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* BI-BB13B599: plain customer-mode status band — the first-viewport
-                  "wife-test" line. Reads the capsule projection so external
-                  Claude/Codex/Grok work is reflected in one plain lifecycle
-                  status, never a raw phase or executor name. Always visible
-                  (not behind engineer view). */}
-              {customerStatuses[activeBuild.id] && (
-                <BuildCustomerStatusBand status={customerStatuses[activeBuild.id]} />
-              )}
+              <BuildOperatorOverview
+                title={activeBuild.title}
+                outcome={
+                  activeBuild.designDoc?.problemStatement
+                  ?? activeBuild.description
+                  ?? activeBuild.originator?.resolution
+                }
+                phase={activeBuild.phase}
+                status={customerStatuses[activeBuild.id]}
+              />
 
               {/* Error banner for failed builds */}
               {activeBuild.phase === "failed" && (
@@ -877,18 +806,6 @@ export function BuildStudio({
               )}
 
               <div className="flex min-h-0 flex-1 flex-col">
-                <BuildWorkRequestStrip
-                  build={activeBuild}
-                  onOpenWorkRequest={() => {
-                    setDrawerInitialSectionId("canonical-doc");
-                    setDrawerOpen(true);
-                  }}
-                />
-                {activeWorkWarrant !== null && activeWorkWarrant !== undefined && (
-                  <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-                    <BuildWorkWarrantBand warrant={activeWorkWarrant} />
-                  </div>
-                )}
                 {activeBuild && activeBuild.phase === "ship" && (
                   <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
                     <ReleaseDecisionPanel
@@ -935,139 +852,165 @@ export function BuildStudio({
                     )}
                   </div>
                 )}
-                {(activeBuild.designDoc?.problemStatement || activeBuild.designDoc?.proposedApproach || activeBuild.description || autonomousCustody) && (
-                  <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-                    <BuildSolutionSummaryBand
-                      problemStatement={activeBuild.designDoc?.problemStatement ?? null}
-                      proposedApproach={activeBuild.designDoc?.proposedApproach ?? null}
-                      fallbackIntent={activeBuild.description}
-                      custody={autonomousCustody}
-                    />
-                  </div>
-                )}
-                {changeNarrative && (
-                  <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-                    <BuildChangeSummaryBand narrative={changeNarrative} />
-                  </div>
-                )}
-                {decisionLedger.length > 0 && (
-                  <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-                    <BuildDecisionLedgerBand entries={decisionLedger} engineerView={engineerView} />
-                  </div>
-                )}
-                {/* Workflow graph — always-visible primary surface of the
-                    active-build pane. The tab selector (Progress/Workflow/
-                    Details/Preview) is gone; evidence migrates into the
-                    DetailsDrawer below. See spec §1 + §9 #11. */}
-                <div
-                  className={`${getBuildStudioGraphPanelClassName()} relative`}
-                  data-testid={BUILD_STUDIO_TEST_IDS.graphPanel}
-                >
-                  {/* Overseer altitude flip (BI-90670010): the plain bands above
-                      are the default; the engineer-grade graph + evidence demote
-                      behind this toggle. The phase rail keeps liveness visible
-                      even when the graph is hidden; the Details drawer (below)
-                      stays as the bands' dive-in either way. */}
-                  <div className="flex items-center justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-2">
-                    <PhaseMiniRail currentPhase={toRailPhase(activeBuild.phase)} />
-                    <button
-                      type="button"
-                      onClick={toggleEngineerView}
-                      aria-pressed={engineerView}
-                      data-testid="build-studio-engineer-view-toggle"
-                      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-xs font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
-                    >
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                        <path d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
-                      </svg>
-                      {engineerView ? "Hide engineer view" : "Engineer view"}
-                    </button>
-                  </div>
-                  {engineerView && (
-                    <>
-                  <AssuranceRow
-                    expanded={assuranceRowExpanded}
-                    onToggle={() => setAssuranceRowExpanded((p) => !p)}
-                    freshness={codeGraphFreshness}
-                    buildId={activeBuild.buildId}
-                    bomSummary={bomSummary}
-                    findings={assuranceFindings}
-                  />
-                  <AgentActivityStrip build={activeBuild} />
-                  <div className="border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
-                    Select any stage or task to inspect — or open Details on the right for progress, brief, review, sandbox, and BS Queue evidence.
-                  </div>
-                  <ProcessGraph
-                    build={activeBuild}
-                    workflowLabel={activeLifecycleLabel}
-                    governedBacklogEnabled={governedBacklogEnabled}
-                    progressVisibility={progressVisibility}
-                    onNodeClick={(info) => {
-                      setSelectedNodeClick((prev) =>
-                        prev?.nodeId === info.nodeId ? null : info,
-                      );
-                    }}
-                  />
-                  {selectedNodeClick && (
-                    <NodeInspector
-                      nodeId={selectedNodeClick.nodeId}
-                      title={resolveInspectorTitle(selectedNodeClick)}
-                      anchorRect={selectedNodeClick.anchorRect}
-                      containerRect={selectedNodeClick.containerRect}
-                      containerScrollTop={selectedNodeClick.containerScrollTop}
-                      onClose={() => setSelectedNodeClick(null)}
-                      onAskCoworker={() => {
-                        const prefill = buildCoworkerPrefill(selectedNodeClick, activeBuild.buildId);
-                        document.dispatchEvent(
-                          new CustomEvent("open-agent-panel", {
-                            detail: { autoMessage: prefill, targetBuildId: activeBuild.buildId },
-                          }),
-                        );
-                      }}
-                    >
-                      <NodeInspectorBody info={selectedNodeClick} />
-                    </NodeInspector>
-                  )}
-                    </>
-                  )}
-                  <DetailsDrawerPill
-                    isOpen={drawerOpen}
-                    onClick={() => {
-                      setDrawerOpen((p) => !p);
-                      setDrawerInitialSectionId(null);
-                    }}
-                  />
-                  <DetailsDrawer
-                    isOpen={drawerOpen}
-                    onClose={() => setDrawerOpen(false)}
-                    sections={buildDetailsDrawerSections(
-                      activeBuild,
-                      progressVisibility,
-                      drawerInitialSectionId,
-                      supervisedBuildRows,
-                      changeNarrative,
-                      engineerView,
-                    )}
-                  />
+                <div className="border-t border-[var(--dpf-border)] px-4 py-3">
+                  <button
+                    type="button"
+                    onClick={toggleEngineerView}
+                    aria-expanded={engineerView}
+                    aria-controls="build-studio-technical-details"
+                    data-testid="build-studio-engineer-view-toggle"
+                    className="inline-flex items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+                  >
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                      <path d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+                    </svg>
+                    {engineerView ? "Hide technical details" : "Technical details"}
+                  </button>
                 </div>
+                {engineerView ? (
+                  <section
+                    id="build-studio-technical-details"
+                    className="border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+                    data-testid="build-studio-technical-details"
+                  >
+                    <div className="flex flex-wrap items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-3">
+                      <ClaimBadge
+                        agentId={activeBuild.claimedByAgentId ?? null}
+                        claimStatus={activeBuild.claimStatus ?? null}
+                        claimedAt={activeBuild.claimedAt ?? null}
+                      />
+                      <span data-testid="build-studio-header-details" className="flex flex-wrap items-center gap-2">
+                        <BuildOperatorHeaderDetails
+                          build={activeBuild}
+                          branchBadge={branchBadge}
+                          engineerView
+                        />
+                      </span>
+                      {canManageGovernedWork ? (
+                        <Link
+                          href="/build/work"
+                          className="ml-auto text-xs font-medium text-[var(--dpf-accent)] hover:underline"
+                        >
+                          Open Work Control
+                        </Link>
+                      ) : null}
+                    </div>
+                    {activeWorkWarrant !== null && activeWorkWarrant !== undefined ? (
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+                        <BuildWorkWarrantBand warrant={activeWorkWarrant} />
+                      </div>
+                    ) : null}
+                    {(activeBuild.designDoc?.proposedApproach || activeBuild.description || autonomousCustody) ? (
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+                        <BuildSolutionSummaryBand
+                          problemStatement={activeBuild.designDoc?.problemStatement ?? null}
+                          proposedApproach={activeBuild.designDoc?.proposedApproach ?? null}
+                          fallbackIntent={activeBuild.description}
+                          custody={autonomousCustody}
+                        />
+                      </div>
+                    ) : null}
+                    {changeNarrative ? (
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+                        <BuildChangeSummaryBand narrative={changeNarrative} />
+                      </div>
+                    ) : null}
+                    {decisionLedger.length > 0 ? (
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+                        <BuildDecisionLedgerBand entries={decisionLedger} engineerView />
+                      </div>
+                    ) : null}
+                    <div
+                      className={`${getBuildStudioGraphPanelClassName()} relative`}
+                      data-testid={BUILD_STUDIO_TEST_IDS.graphPanel}
+                    >
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-2">
+                        <PhaseMiniRail currentPhase={toRailPhase(activeBuild.phase)} />
+                      </div>
+                      <AssuranceRow
+                        expanded={assuranceRowExpanded}
+                        onToggle={() => setAssuranceRowExpanded((p) => !p)}
+                        freshness={codeGraphFreshness}
+                        buildId={activeBuild.buildId}
+                        bomSummary={bomSummary}
+                        findings={assuranceFindings}
+                      />
+                      <AgentActivityStrip build={activeBuild} />
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
+                        Select a stage or task to inspect it. Open evidence for canonical documents, review, runtime, and queue diagnostics.
+                      </div>
+                      <ProcessGraph
+                        build={activeBuild}
+                        workflowLabel={activeLifecycleLabel}
+                        governedBacklogEnabled={governedBacklogEnabled}
+                        progressVisibility={progressVisibility}
+                        onNodeClick={(info) => {
+                          setSelectedNodeClick((prev) =>
+                            prev?.nodeId === info.nodeId ? null : info,
+                          );
+                        }}
+                      />
+                      {selectedNodeClick ? (
+                        <NodeInspector
+                          nodeId={selectedNodeClick.nodeId}
+                          title={resolveInspectorTitle(selectedNodeClick)}
+                          anchorRect={selectedNodeClick.anchorRect}
+                          containerRect={selectedNodeClick.containerRect}
+                          containerScrollTop={selectedNodeClick.containerScrollTop}
+                          onClose={() => setSelectedNodeClick(null)}
+                          onAskCoworker={() => {
+                            const prefill = buildCoworkerPrefill(selectedNodeClick, activeBuild.buildId);
+                            document.dispatchEvent(
+                              new CustomEvent("open-agent-panel", {
+                                detail: { autoMessage: prefill, targetBuildId: activeBuild.buildId },
+                              }),
+                            );
+                          }}
+                        >
+                          <NodeInspectorBody info={selectedNodeClick} />
+                        </NodeInspector>
+                      ) : null}
+                      <DetailsDrawerPill
+                        isOpen={drawerOpen}
+                        onClick={() => {
+                          setDrawerOpen((open) => !open);
+                          setDrawerInitialSectionId(null);
+                        }}
+                      />
+                      <DetailsDrawer
+                        isOpen={drawerOpen}
+                        onClose={() => setDrawerOpen(false)}
+                        sections={buildDetailsDrawerSections(
+                          activeBuild,
+                          progressVisibility,
+                          drawerInitialSectionId,
+                          supervisedBuildRows,
+                          changeNarrative,
+                          true,
+                        )}
+                      />
+                    </div>
+                  </section>
+                ) : null}
               </div>
             </>
           ) : (
             <div className="grid flex-1 place-items-center">
-              <div className="text-center max-w-md px-8">
-                <div className="text-5xl mb-4 opacity-20">&#128736;</div>
-                <h2 className="text-lg font-bold text-[var(--dpf-text)] mb-3">Product Development Studio</h2>
-                <p className="text-sm text-[var(--dpf-muted)] leading-relaxed mb-6">
-                  Build features without writing code. Describe what you want, and your AI Coworker will design, build, and deploy it.
+              <div className="max-w-lg px-8 text-center">
+                <div className="mx-auto grid h-12 w-12 place-items-center rounded-2xl bg-[var(--dpf-state-info)] text-2xl text-[var(--dpf-accent)]" aria-hidden="true">
+                  ✦
+                </div>
+                <h2 className="mb-2 mt-4 text-xl font-semibold text-[var(--dpf-text)]">
+                  What should be different?
+                </h2>
+                <p className="m-0 text-sm leading-6 text-[var(--dpf-muted)]">
+                  Start a new outcome in plain language. Build Studio will shape the approach,
+                  build the change, collect evidence, and return when a meaningful decision needs you.
                 </p>
-                <div className="text-left bg-[var(--dpf-surface-2)] rounded-lg border border-[var(--dpf-border)] p-4 shadow-dpf-md">
-                  <p className="text-xs font-semibold text-[var(--dpf-text)] mb-3 uppercase tracking-wider">How it works</p>
-                  <div className="flex flex-col gap-2.5">
-                    <Step n={1} text={'Type a feature name in the sidebar and click “Start a new build”'} />
-                    <Step n={2} text="Your AI Coworker will open and guide you through the process" />
-                    <Step n={3} text="Review the live preview as it builds" />
-                    <Step n={4} text="Approve and deploy when you're happy" />
-                  </div>
+                <div className="mt-6 grid gap-2 text-left sm:grid-cols-3">
+                  <Step n={1} text="Describe the outcome" />
+                  <Step n={2} text="Follow one clear status" />
+                  <Step n={3} text="Decide only when needed" />
                 </div>
               </div>
             </div>
@@ -1539,6 +1482,16 @@ function FleetRailZone({
       governedBacklogEnabled,
     }),
   }));
+  const operatorGroups = groupOperatorBuilds(
+    entries.map((entry) => ({
+      id: entry.build.id,
+      buildId: entry.build.buildId,
+      title: entry.build.title,
+      phase: entry.build.phase,
+      updatedAt: entry.build.updatedAt,
+      needsYou: entry.needsAttention,
+    })),
+  );
 
   // Sort: running → blocked → queued (by position) → idle. Stable tie-break
   // by buildId so render order doesn't flicker across re-renders.
@@ -1556,14 +1509,15 @@ function FleetRailZone({
   // Split entries into focus work, parked coworker-custody work, and completed
   // history. Quiet ideation/planning probes stay out of the operator's default
   // list until they run, block, ask for a decision, or are selected.
-  const nonCompletedEntries = sorted.filter((e) => e.build.phase !== "complete");
+  const nonCompletedEntries = sorted.filter(
+    (entry) => entry.build.phase !== "complete" && entry.build.phase !== "abandoned",
+  );
   const focusEntries = nonCompletedEntries.filter((entry) =>
     isOperatorFocusEntry(entry, activeBuildId),
   );
-  const parkedEntries = nonCompletedEntries.filter((entry) =>
-    !isOperatorFocusEntry(entry, activeBuildId),
+  const completedEntries = sorted.filter(
+    (entry) => entry.build.phase === "complete" || entry.build.phase === "abandoned",
   );
-  const completedEntries = sorted.filter((e) => e.build.phase === "complete");
   const isFocusRollup = (rollup: EpicRollupView) => {
     if (rollup.status === "complete") return false;
     if (rollup.status === "needs-attention" || rollup.status === "blocked") return true;
@@ -1571,45 +1525,20 @@ function FleetRailZone({
     return rollup.children.some((child) => child.phase === "build" || child.phase === "review");
   };
   const focusEpicRollups = epicRollups.filter(isFocusRollup);
-  const parkedEpicRollups = epicRollups.filter((rollup) =>
-    rollup.status !== "complete" && !isFocusRollup(rollup),
-  );
   const completedEpicRollups = epicRollups.filter((rollup) => rollup.status === "complete");
-  const completedItemCount = completedEntries.length + completedEpicRollups.length;
+  const completedItemCount =
+    (operatorGroups.find((group) => group.key === "recent")?.builds.length ?? 0)
+    + completedEpicRollups.length;
   const [showCompleted, setShowCompleted] = useState(false);
   const [showAllFocus, setShowAllFocus] = useState(false);
 
-  // BI-5939B62F: a build can be BOTH needs-attention and running (e.g. a plan
-  // build with a failed review — its phase now derives to "running"). Such a
-  // build belongs in the "Needs you" bucket only; deriving working/waiting over
-  // the non-attention entries keeps it from being double-counted as "Working"
-  // (blockedCount below already applies the same !needsAttention guard).
-  const counts = deriveFleetCounts(
-    focusEntries.filter((e) => !e.needsAttention).map((e) => e.queueState),
-  );
-  const parkedItemCount = parkedEntries.length + parkedEpicRollups.length;
   const needsYouCount =
-    focusEntries.filter((entry) => entry.needsAttention).length
+    (operatorGroups.find((group) => group.key === "needs-you")?.builds.length ?? 0)
     + focusEpicRollups.filter((rollup) => rollup.status === "needs-attention").length;
-  const blockedCount =
-    focusEntries.filter((entry) => !entry.needsAttention && entry.queueState.kind === "blocked").length
-    + focusEpicRollups.filter((rollup) => rollup.status === "blocked").length;
-  const workingEpicCount = focusEpicRollups.filter((rollup) =>
-    rollup.status === "in-progress"
-    && rollup.children.some((child) => child.phase === "build" || child.phase === "review"),
-  ).length;
-  // Coworker-custody work (ideate/plan) is off the operator focus rail by design,
-  // so it never shows in "Working". Surface it as a distinct "Coworker" count so
-  // the header reflects that the coworker is active, not that nothing is happening.
-  const coworkerCount = deriveCoworkerActivityCount(buildRows);
-  const focusHeaderLabel = formatOperatorFocusHeader({
-    needsYouCount,
-    workingCount: counts.runningCount + workingEpicCount,
-    blockedCount,
-    queuedCount: counts.queuedCount,
-    coworkerCount,
-    parkedCount: parkedItemCount,
-  });
+  const activeCount =
+    (operatorGroups.find((group) => group.key === "in-progress")?.builds.length ?? 0)
+    + needsYouCount
+    + epicRollups.filter((rollup) => rollup.status !== "complete").length;
   const totalFocusItemCount = focusEpicRollups.length + focusEntries.length;
   const shouldCollapseFocus = totalFocusItemCount > MAX_OPERATOR_FLEET_ITEMS && !showAllFocus;
 
@@ -1689,14 +1618,21 @@ function FleetRailZone({
         onClick={onOpenQueueDrawer}
         role="status"
         aria-live="polite"
-        aria-label={`Open build details drawer - queue section. ${focusHeaderLabel}`}
+        aria-label="Open technical build queue details"
         data-testid="build-studio-fleet-header"
         className="flex w-full shrink-0 cursor-pointer items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-text)] transition-colors hover:bg-[var(--dpf-surface-3)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
       >
-        <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-1">
-          <span className="truncate">
-            {focusHeaderLabel}
-          </span>
+        <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-2">
+          <span>Builds</span>
+          {needsYouCount > 0 ? (
+            <span className="rounded-full bg-[var(--dpf-state-warning)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-warning)]">
+              {needsYouCount} need{needsYouCount === 1 ? "s" : ""} you
+            </span>
+          ) : activeCount > 0 ? (
+            <span className="text-[10px] font-normal text-[var(--dpf-muted)]">
+              {activeCount} active
+            </span>
+          ) : null}
         </span>
         <span aria-hidden="true" className="text-[var(--dpf-muted)]">›</span>
       </button>
@@ -1731,18 +1667,7 @@ function FleetRailZone({
         ))}
         {visibleFocusEpicRollups.length === 0 && visibleFocusEntries.length === 0 && (
           <li className="px-3 py-6 text-center text-[11px] text-[var(--dpf-muted)]">
-            Nothing needs you right now. AI Coworker is watching the build queue.
-          </li>
-        )}
-        {parkedItemCount > 0 && (
-          <li>
-            <button
-              type="button"
-              onClick={onOpenQueueDrawer}
-              className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-left text-[11px] leading-snug text-[var(--dpf-muted)] transition-colors hover:bg-[var(--dpf-surface-3)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
-            >
-              AI Coworker is watching {parkedItemCount} parked build{parkedItemCount === 1 ? "" : "s"}. Open details for the full queue.
-            </button>
+            Nothing needs you right now.
           </li>
         )}
         {totalFocusItemCount > MAX_OPERATOR_FLEET_ITEMS && (

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -1224,7 +1224,15 @@ function BsQueueSection({ builds }: { builds: readonly FeatureBuildRow[] }) {
     }
     return a.build.buildId.localeCompare(b.build.buildId);
   });
-  const counts = deriveFleetCounts(entries.map((e) => e.queueState));
+  const counts = entries.reduce(
+    (acc, entry) => {
+      if (entry.queueState.kind === "running") acc.runningCount += 1;
+      if (entry.queueState.kind === "blocked") acc.blockedCount += 1;
+      if (entry.queueState.kind === "queued") acc.queuedCount += 1;
+      return acc;
+    },
+    { runningCount: 0, blockedCount: 0, queuedCount: 0 },
+  );
   const labelForQueueState = (entry: (typeof entries)[number]) => {
     if (entry.needsAttention) return "Needs you";
     if (entry.queueState.kind === "running") return "Working";

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -648,7 +648,7 @@ export function BuildStudio({
                     Start a new outcome
                   </span>
                   {!intakeOpen ? (
-                    <span className="mt-0.5 block text-[11px] text-[var(--dpf-muted)]">
+                    <span className="mt-0.5 block text-dpf-caption text-[var(--dpf-muted)]">
                       Describe what should be different.
                     </span>
                   ) : null}
@@ -659,7 +659,7 @@ export function BuildStudio({
               </button>
               {intakeOpen ? (
                 <div className="px-3 pb-3">
-                  <label className="block text-[11px] font-medium text-[var(--dpf-muted)]">
+                  <label className="block text-dpf-caption font-medium text-[var(--dpf-muted)]">
                     What outcome do you want?
                     <textarea
                       placeholder="Describe what should be different, who it helps, and any constraint that matters."
@@ -677,10 +677,10 @@ export function BuildStudio({
                   </label>
                   {portfolioRows.length > 1 ? (
                     <details className="mt-2">
-                      <summary className="cursor-pointer text-[11px] font-medium text-[var(--dpf-muted)]">
+                      <summary className="cursor-pointer text-dpf-caption font-medium text-[var(--dpf-muted)]">
                         Choose business area
                       </summary>
-                      <label className="mt-2 block text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
+                      <label className="mt-2 block text-dpf-caption font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
                         Business area
                         <select
                           value={newPortfolioId}
@@ -697,7 +697,7 @@ export function BuildStudio({
                     </details>
                   ) : null}
                   <div className="mt-2 flex items-center justify-between gap-2">
-                    <span className="text-[10px] leading-tight text-[var(--dpf-muted)]">
+                    <span className="text-dpf-caption text-[var(--dpf-muted)]">
                       {newTitle.length > 0 ? `${newTitle.length} characters` : "Plain language is enough"}
                     </span>
                     <button
@@ -712,7 +712,7 @@ export function BuildStudio({
                   </div>
                   {pendingIntake ? (
                     <div className="mt-3 rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-state-info)] p-3">
-                      <p className="m-0 text-[10px] font-semibold uppercase tracking-wide text-[var(--dpf-accent)]">
+                      <p className="m-0 text-dpf-caption font-semibold uppercase tracking-wide text-[var(--dpf-accent)]">
                         Outcome captured
                       </p>
                       <p className="m-0 mt-1 text-sm font-medium text-[var(--dpf-text)]">
@@ -735,7 +735,7 @@ export function BuildStudio({
                     </div>
                   ) : null}
                   {createError ? (
-                    <div role="alert" className="mt-2 text-[11px] leading-snug text-[var(--dpf-danger)]">
+                    <div role="alert" className="mt-2 text-dpf-caption text-[var(--dpf-danger)]">
                       {createError}
                     </div>
                   ) : null}
@@ -899,7 +899,7 @@ export function BuildStudio({
                       ) : null}
                     </div>
                     {customerStatuses[activeBuild.id]?.technicalEvidence ? (
-                      <div className="border-b border-[var(--dpf-border)] px-4 py-2 font-mono text-[11px] leading-5 text-[var(--dpf-muted)]">
+                      <div className="border-b border-[var(--dpf-border)] px-4 py-2 font-mono text-dpf-caption text-[var(--dpf-muted)]">
                         {customerStatuses[activeBuild.id].technicalEvidence}
                       </div>
                     ) : null}
@@ -1641,11 +1641,11 @@ function FleetRailZone({
         <span data-testid="fleet-header-label" className="inline-flex min-w-0 items-center gap-2">
           <span>Builds</span>
           {needsYouCount > 0 ? (
-            <span className="rounded-full bg-[var(--dpf-state-warning)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-warning)]">
+            <span className="rounded-full bg-[var(--dpf-state-warning)] px-1.5 py-0.5 text-dpf-caption text-[var(--dpf-warning)]">
               {needsYouCount} need{needsYouCount === 1 ? "s" : ""} you
             </span>
           ) : activeCount > 0 ? (
-            <span className="text-[10px] font-normal text-[var(--dpf-muted)]">
+            <span className="text-dpf-caption font-normal text-[var(--dpf-muted)]">
               {activeCount} active
             </span>
           ) : null}

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -662,7 +662,7 @@ export function BuildStudio({
                   <label className="block text-dpf-caption font-medium text-[var(--dpf-muted)]">
                     What outcome do you want?
                     <textarea
-                      placeholder="Describe what should be different, who it helps, and any constraint that matters."
+                      placeholder="Say what should change, who it helps, and what must stay the same."
                       value={newTitle}
                       onChange={(e) => setNewTitle(e.target.value)}
                       onKeyDown={(e) => {
@@ -698,7 +698,7 @@ export function BuildStudio({
                   ) : null}
                   <div className="mt-2 flex items-center justify-between gap-2">
                     <span className="text-dpf-caption text-[var(--dpf-muted)]">
-                      {newTitle.length > 0 ? `${newTitle.length} characters` : "Plain language is enough"}
+                      {newTitle.length > 0 ? `${newTitle.length} characters` : "Plain words are enough"}
                     </span>
                     <button
                       type="button"
@@ -1012,13 +1012,13 @@ export function BuildStudio({
                   What should be different?
                 </h2>
                 <p className="m-0 text-sm leading-6 text-[var(--dpf-muted)]">
-                  Start a new outcome in plain language. Build Studio will shape the approach,
-                  build the change, collect evidence, and return when a meaningful decision needs you.
+                  Tell Build Studio what should change. It will plan the work, build it,
+                  check it, and ask you only when it needs a choice.
                 </p>
                 <div className="mt-6 grid gap-2 text-left sm:grid-cols-3">
-                  <Step n={1} text="Describe the outcome" />
-                  <Step n={2} text="Follow one clear status" />
-                  <Step n={3} text="Decide only when needed" />
+                  <Step n={1} text="Say what should change" />
+                  <Step n={2} text="See one clear status" />
+                  <Step n={3} text="Choose only when asked" />
                 </div>
               </div>
             </div>

--- a/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+++ b/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
@@ -14,7 +14,7 @@
 import "../build-studio/test-setup";
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BuildStudio } from "./BuildStudio";
 import { BUILD_STUDIO_TEST_IDS } from "./build-studio-layout";
@@ -24,6 +24,10 @@ import {
 } from "@/lib/feature-build-types";
 
 afterEach(cleanup);
+
+beforeEach(() => {
+  window.localStorage.setItem("dpf:build-studio-engineer-view", "true");
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), replace: vi.fn() }),

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -442,6 +442,39 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).toMatch(/data-testid="build-studio-details-drawer"[^>]*data-open="false"/);
   });
 
+  it("presents one outcome, one status, one next action, and one activity story before technical details", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[makeBuild({ phase: "review" })]}
+        portfolios={[]}
+        governedBacklogEnabled
+        canManageGovernedWork
+        projectBranch="main"
+        submissionBranchShortId="fb8783b9"
+        customerStatuses={{
+          "build-row-1": {
+            whatIsBeingBuilt: "Fix Build Studio header/content overlap in workflow view",
+            lifecyclePosition: "Checking the work",
+            worker: "Build Studio",
+            evidence: "Implementation finished and verification evidence is arriving.",
+            nextAction: "No action needed while checks run.",
+            owner: "Build Studio",
+            needsYou: false,
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain('data-testid="build-studio-operator-outcome"');
+    expect(html).toContain('data-testid="build-studio-operator-status"');
+    expect(html).toContain('data-testid="build-studio-operator-next-action"');
+    expect(html).toContain('data-testid="build-studio-activity-story"');
+    expect(html).toContain(">Technical details<");
+    expect(html).not.toContain(">Engineer view<");
+    expect(html).not.toContain(">Work Control<");
+    expect(html).not.toContain('data-testid="process-graph"');
+  });
+
   it("renders the build assurance gate next to code intelligence (engineer view)", () => {
     // These engineer-grade surfaces live behind the "Engineer view" toggle after
     // the reframe (BI-90670010); render with it enabled to verify them.

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { BuildStudio } from "@/components/build/BuildStudio";
+import { BuildStudio } from "./BuildStudio";
 import {
   normalizeHappyPathState,
   type FeatureBuildRow,
@@ -225,9 +225,7 @@ describe("BuildStudio active-build header layout", () => {
     vi.clearAllMocks();
   });
 
-  it("intake CTA is labelled 'Start a new build' not just 'New' (BI-950FE085)", () => {
-    // Regression guard: Dale had no idea what "New" created. The CTA must
-    // name the action + artifact so it's discoverable without training.
+  it("names the intake around the operator's outcome", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[]}
@@ -237,7 +235,8 @@ describe("BuildStudio active-build header layout", () => {
         submissionBranchShortId="fb8783b9"
       />,
     );
-    expect(html).toContain("Start a new build");
+    expect(html).toContain("Start a new outcome");
+    expect(html).toContain("What outcome do you want?");
     expect(html).not.toContain(">New<");
   });
 
@@ -262,13 +261,10 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    fireEvent.change(screen.getByPlaceholderText(/Describe a new feature/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Describe what should be different/i), {
       target: { value: "Improve customer onboarding" },
     });
-    fireEvent.change(screen.getByLabelText("Portfolio"), {
-      target: { value: "portfolio-foundational" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "File backlog item" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => {
       expect(backlogBuildMocks.createBuildStudioBacklogIntake).toHaveBeenCalledWith({
@@ -276,8 +272,9 @@ describe("BuildStudio active-build header layout", () => {
         portfolioId: "portfolio-foundational",
       });
     });
-    expect(await screen.findByText("BI-NEW1234")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Promote to Feature Build" })).toBeTruthy();
+    expect(await screen.findByText("Improve customer onboarding")).toBeTruthy();
+    expect(screen.queryByText("BI-NEW1234")).toBeNull();
+    expect(screen.getByRole("button", { name: "Start governed build" })).toBeTruthy();
     expect(backlogBuildMocks.startBacklogBuild).not.toHaveBeenCalled();
   });
 
@@ -292,7 +289,7 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Product Development Studio");
+    expect(html).toContain("What should be different?");
     expect(html).toContain("No builds yet");
   });
 
@@ -315,7 +312,7 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain("Low-stock surfacing");
   });
 
-  it("keeps the active-build title and metadata lane shrinkable for long submission branches", () => {
+  it("keeps the active outcome in a bounded readable lane", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[makeBuild()]}
@@ -326,8 +323,9 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toMatch(/<div class=\"min-w-0 flex-1\">/);
-    expect(html).toMatch(/class=\"mt-1 flex flex-wrap items-center gap-2 text-xs text-\[var\(--dpf-muted\)\]\"/);
+    expect(html).toContain('data-testid="build-studio-operator-outcome"');
+    expect(html).toContain("max-w-4xl");
+    expect(html).not.toMatch(/dpf\/fb8783b9\//);
   });
 
   it("opens the build requested by the buildId deep link", () => {
@@ -346,7 +344,7 @@ describe("BuildStudio active-build header layout", () => {
     );
 
     expect(html).toContain("Backlog launched build");
-    expect(html).not.toContain("First build</h2>");
+    expect(html).not.toContain(">First build</h2>");
   });
 
   it("URL-backs the selected default build when /build has no buildId", async () => {
@@ -379,16 +377,12 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain(`title="${longTitle}"`);
-    expect(html).toMatch(/class=\"m-0 max-h-\[3rem\] min-w-0 overflow-hidden break-words text-base font-bold leading-6 text-\[var\(--dpf-text\)\] line-clamp-2\"/);
+    expect(html).toContain(longTitle);
+    expect(html).toContain("text-balance");
+    expect(html).toContain("max-w-4xl");
   });
 
-  it("hides submission branch badge by default (BI-63EAD801); Details toggle is rendered instead", () => {
-    // BI-63EAD801: git branch names are internal plumbing — hidden by default.
-    // The branch chip is only visible when the operator expands Details.
-    // This replaces the old "truncating wrapper" assertion which tested that
-    // the chip rendered at all; the chip now only renders after Details is
-    // expanded, which requires an interactive test (see the BI-63EAD801 suite).
+  it("hides submission branch plumbing behind Technical details", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[makeBuild()]}
@@ -399,19 +393,12 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    // Details toggle button is present
     expect(html).toContain("aria-expanded=\"false\"");
-    expect(html).toContain(">Details<");
-    // Branch chip is NOT in the static HTML (hidden by default)
+    expect(html).toContain(">Technical details<");
     expect(html).not.toMatch(/dpf\/fb8783b9\//);
   });
 
-  it("defaults to the plain overseer bands; the engineer graph is behind the Engineer view toggle (BI-90670010)", () => {
-    // Overseer altitude flip: the plain "Solution & Oversight" bands are the
-    // default first-viewport; the global tab selector is gone (spec §1/§9 #11);
-    // and the engineer-grade ProcessGraph + assurance cards demote behind a
-    // single "Engineer view" toggle (default off). The DetailsDrawer accordion
-    // stays mounted as the bands' dive-in.
+  it("does not mount engineering or evidence surfaces before Technical details opens", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[makeBuild()]}
@@ -422,24 +409,14 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    // No global tab list / tab buttons.
     expect(html).not.toMatch(/role="tablist"[^>]*aria-label="Workflow view tabs"/);
-    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Progress<\/button>/);
-    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Workflow<\/button>/);
-    expect(html).not.toMatch(/<button[^>]*role="tab"[^>]*>Details<\/button>/);
-
-    // The graph-panel container + the Engineer view toggle are mounted, but the
-    // engineer-grade ProcessGraph + assurance cards are NOT rendered by default
-    // (they appear only after toggling Engineer view on).
-    expect(html).toContain('data-testid="build-studio-graph-panel"');
     expect(html).toContain('data-testid="build-studio-engineer-view-toggle"');
+    expect(html).not.toContain('data-testid="build-studio-technical-details"');
+    expect(html).not.toContain('data-testid="build-studio-graph-panel"');
     expect(html).not.toContain('data-testid="code-intelligence-status-card"');
     expect(html).not.toContain('data-testid="process-graph"');
-
-    // DetailsDrawer + Pill are mounted; drawer starts closed.
-    expect(html).toContain('data-testid="build-studio-details-drawer-pill"');
-    expect(html).toContain('data-testid="build-studio-details-drawer"');
-    expect(html).toMatch(/data-testid="build-studio-details-drawer"[^>]*data-open="false"/);
+    expect(html).not.toContain('data-testid="build-studio-details-drawer-pill"');
+    expect(html).not.toContain('data-testid="build-studio-details-drawer"');
   });
 
   it("presents one outcome, one status, one next action, and one activity story before technical details", () => {
@@ -537,7 +514,7 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain(">Review with coworker<");
   });
 
-  it("presents backlog context as a short work request, not an internal canonical record", () => {
+  it("presents the requested outcome without canonical-record terminology", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[makeBuild()]}
@@ -548,8 +525,8 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Work request");
-    expect(html).toContain("Why it matters:");
+    expect(html).toContain(">Outcome<");
+    expect(html).toContain("A real keeper bugfix for the governed Build Studio flow.");
     expect(html).not.toContain("Canonical backlog item");
     expect(html).not.toContain("Triage:");
     expect(html).not.toContain("Decision:");
@@ -607,14 +584,17 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Needs you: 1 · Working: 2 · Coworker: 6 · Parked: 5");
+    expect(html).toContain(">Builds<");
+    expect(html).toContain("1 needs you");
+    expect(html).not.toContain("Coworker:");
+    expect(html).not.toContain("Parked:");
     expect(html).not.toContain("WIP slots");
     expect(html).toContain("Review customer entry gate");
     expect(html).toContain("Ship provider readiness check");
     expect(html).toContain("Choose recovery path for failed review");
     expect(html).not.toContain("Parked research build 1");
     expect(html).not.toContain("Parked research build 5");
-    expect(html).toContain("AI Coworker is watching 5 parked builds");
+    expect(html).not.toContain("AI Coworker is watching 5 parked builds");
     expect(html).not.toContain("Show 5 more builds");
   });
 
@@ -783,12 +763,12 @@ describe("BuildStudio active-build header layout", () => {
   });
 });
 
-describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", () => {
+describe("BuildStudio progressive technical disclosure", () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it("AC1: default view shows feature title but hides the build ID chip", () => {
+  it("shows the outcome while hiding technical identifiers by default", () => {
     const { getAllByText, queryByTestId, getByRole } = render(
       <BuildStudio
         builds={[makeBuild({ buildId: "FB-DALE01" })]}
@@ -800,18 +780,15 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
         submissionBranchShortId="aabbccdd"
       />,
     );
-    // Feature title always visible (may appear multiple times — in header + fleet rail)
     const titleElements = getAllByText("Fix Build Studio header/content overlap in workflow view");
     expect(titleElements.length).toBeGreaterThan(0);
-    // Details toggle shown, details panel hidden by default
-    const btn = getByRole("button", { name: /Details/ });
+    const btn = getByRole("button", { name: "Technical details" });
     expect(btn.getAttribute("aria-expanded")).toBe("false");
-    // Build ID hidden by default
     expect(queryByTestId("build-studio-build-id")).toBeNull();
     expect(queryByTestId("build-studio-header-details")).toBeNull();
   });
 
-  it("clicking Details keeps internal IDs hidden in operator mode", async () => {
+  it("reveals IDs, branch, and evidence only after Technical details opens", async () => {
     const { getByRole, findByTestId, queryByTestId } = render(
       <BuildStudio
         builds={[makeBuild({ buildId: "FB-DALE02" })]}
@@ -823,21 +800,20 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
         submissionBranchShortId="aabbccdd"
       />,
     );
-    const detailsBtn = getByRole("button", { name: /Details/ });
+    const detailsBtn = getByRole("button", { name: "Technical details" });
     expect(detailsBtn.getAttribute("aria-expanded")).toBe("false");
 
     detailsBtn.click();
 
     const details = await findByTestId("build-studio-header-details");
     expect(details).toBeDefined();
-    expect(details.textContent).toContain("AI Coworker is handling");
-    expect(details.textContent).not.toContain("FB-DALE02");
-    expect(details.textContent).not.toContain("BI-5B839D74");
-    expect(details.textContent).not.toContain("dpf/");
-    expect(queryByTestId("build-studio-build-id")).toBeNull();
+    expect(details.textContent).toContain("FB-DALE02");
+    expect(details.textContent).toContain("BI-5B839D74");
+    expect(details.textContent).toContain("dpf/aabbccdd/");
+    expect(queryByTestId("build-studio-build-id")).not.toBeNull();
   });
 
-  it("clicking Details again collapses the panel", async () => {
+  it("collapses the complete technical region with the same control", async () => {
     const { getByRole, queryByTestId } = render(
       <BuildStudio
         builds={[makeBuild({ buildId: "FB-DALE03" })]}
@@ -849,14 +825,15 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
         submissionBranchShortId="aabbccdd"
       />,
     );
-    const btn = getByRole("button", { name: /Details/ });
+    const btn = getByRole("button", { name: "Technical details" });
     btn.click();
-    await waitFor(() => expect(queryByTestId("build-studio-header-details")).not.toBeNull());
-    btn.click();
-    await waitFor(() => expect(queryByTestId("build-studio-header-details")).toBeNull());
+    await waitFor(() => expect(queryByTestId("build-studio-technical-details")).not.toBeNull());
+    const closeButton = getByRole("button", { name: "Hide technical details" });
+    closeButton.click();
+    await waitFor(() => expect(queryByTestId("build-studio-technical-details")).toBeNull());
   });
 
-  it("persists expanded state to localStorage", async () => {
+  it("persists the technical user's disclosure preference", async () => {
     const { getByRole } = render(
       <BuildStudio
         builds={[makeBuild()]}
@@ -868,14 +845,14 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
         submissionBranchShortId="aabbccdd"
       />,
     );
-    getByRole("button", { name: /Details/ }).click();
+    getByRole("button", { name: "Technical details" }).click();
     await waitFor(() =>
-      expect(localStorage.getItem("dpf:build-studio-header-details-expanded")).toBe("true"),
+      expect(localStorage.getItem("dpf:build-studio-engineer-view")).toBe("true"),
     );
   });
 
-  it("restores expanded state from localStorage on mount", async () => {
-    localStorage.setItem("dpf:build-studio-header-details-expanded", "true");
+  it("restores Technical details when a technical user opted in previously", async () => {
+    localStorage.setItem("dpf:build-studio-engineer-view", "true");
     const { findByTestId } = render(
       <BuildStudio
         builds={[makeBuild({ buildId: "FB-RESTORED" })]}
@@ -888,32 +865,11 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
       />,
     );
     const details = await findByTestId("build-studio-header-details");
-    expect(details.textContent).toContain("AI Coworker is handling");
-    expect(details.textContent).not.toContain("FB-RESTORED");
+    expect(details.textContent).toContain("FB-RESTORED");
   });
 
-  it("reveals IDs and branch only when Engineer view is enabled", async () => {
+  it("keeps WorkWarrant governance in Technical details", () => {
     localStorage.setItem("dpf:build-studio-engineer-view", "true");
-    const { getByRole, findByTestId } = render(
-      <BuildStudio
-        builds={[makeBuild({ buildId: "FB-ENGINEER" })]}
-        epicRollups={[]}
-        portfolios={[]}
-        governedBacklogEnabled
-        portalContext={makePortalContextEnvelope()}
-        projectBranch="main"
-        submissionBranchShortId="aabbccdd"
-      />,
-    );
-
-    getByRole("button", { name: /Details/ }).click();
-    const details = await findByTestId("build-studio-header-details");
-    expect(details.textContent).toContain("FB-ENGINEER");
-    expect(details.textContent).toContain("BI-5B839D74");
-    expect(details.textContent).toContain("dpf/aabbccdd/");
-  });
-
-  it("surfaces the active build WorkWarrant in plain language", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -261,7 +261,7 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    fireEvent.change(screen.getByPlaceholderText(/Describe what should be different/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Say what should change/i), {
       target: { value: "Improve customer onboarding" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -759,7 +759,7 @@ describe("BuildStudio active-build header layout", () => {
     );
 
     expect(html).toContain("release-decision-panel");
-    expect(html).toContain(">Release<");
+    expect(html).toContain("Preparing for release");
   });
 });
 

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -291,6 +291,8 @@ describe("BuildStudio active-build header layout", () => {
 
     expect(html).toContain("What should be different?");
     expect(html).toContain("No builds yet");
+    expect(html).toContain("Describe the outcome above");
+    expect(html).not.toContain("Start a new build");
   });
 
   it("renders execution epics as fleet rows even when their child builds are no longer flat rows", () => {
@@ -452,11 +454,11 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain('data-testid="process-graph"');
   });
 
-  it("renders the build assurance gate next to code intelligence (engineer view)", () => {
+  it("renders the build assurance gate next to code intelligence (engineer view)", async () => {
     // These engineer-grade surfaces live behind the "Engineer view" toggle after
     // the reframe (BI-90670010); render with it enabled to verify them.
     window.localStorage.setItem("dpf:build-studio-engineer-view", "true");
-    const html = renderToStaticMarkup(
+    const { findByTestId } = render(
       <BuildStudio
         builds={[makeBuild()]}
         portfolios={[]}
@@ -465,11 +467,10 @@ describe("BuildStudio active-build header layout", () => {
         submissionBranchShortId="fb8783b9"
       />,
     );
-    window.localStorage.removeItem("dpf:build-studio-engineer-view");
 
-    expect(html).toContain('data-testid="build-assurance-gate-card"');
-    expect(html).toContain("Assurance Gate");
-    expect(html).toContain("No BOM generated");
+    const assuranceGate = await findByTestId("build-assurance-gate-card");
+    expect(assuranceGate.textContent).toContain("Assurance Gate");
+    expect(assuranceGate.textContent).toContain("No BOM generated");
   });
 
   it("renders the portal context strip when a server envelope is provided", () => {
@@ -868,9 +869,9 @@ describe("BuildStudio progressive technical disclosure", () => {
     expect(details.textContent).toContain("FB-RESTORED");
   });
 
-  it("keeps WorkWarrant governance in Technical details", () => {
+  it("keeps WorkWarrant governance in Technical details", async () => {
     localStorage.setItem("dpf:build-studio-engineer-view", "true");
-    const html = renderToStaticMarkup(
+    const { findByTestId } = render(
       <BuildStudio
         builds={[
           makeBuild({
@@ -908,11 +909,11 @@ describe("BuildStudio progressive technical disclosure", () => {
       />,
     );
 
-    expect(html).toContain('data-testid="build-work-warrant-band"');
-    expect(html).toContain("Architecture-level work");
-    expect(html).toContain("governed review");
-    expect(html).toContain("strong model");
-    expect(html).toContain("ledger evidence");
+    const warrant = await findByTestId("build-work-warrant-band");
+    expect(warrant.textContent).toContain("Architecture-level work");
+    expect(warrant.textContent).toContain("governed review");
+    expect(warrant.textContent).toContain("strong model");
+    expect(warrant.textContent).toContain("ledger evidence");
   });
 });
 

--- a/apps/web/components/build/build-studio-operator-view.test.ts
+++ b/apps/web/components/build/build-studio-operator-view.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveBuildActivityStory,
+  groupOperatorBuilds,
+} from "./build-studio-operator-view";
+
+describe("Build Studio operator view model", () => {
+  it("groups attention first, active work second, and completed work as recent history", () => {
+    const groups = groupOperatorBuilds([
+      {
+        id: "complete",
+        buildId: "FB-COMPLETE",
+        title: "Shipped customer portal",
+        phase: "complete",
+        updatedAt: new Date("2026-07-26T12:00:00Z"),
+        needsYou: false,
+      },
+      {
+        id: "working",
+        buildId: "FB-WORKING",
+        title: "Improve invoice reminders",
+        phase: "build",
+        updatedAt: new Date("2026-07-28T10:00:00Z"),
+        needsYou: false,
+      },
+      {
+        id: "decision",
+        buildId: "FB-DECISION",
+        title: "Choose delivery policy",
+        phase: "plan",
+        updatedAt: new Date("2026-07-27T15:00:00Z"),
+        needsYou: true,
+      },
+    ]);
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "Needs you",
+      "In progress",
+      "Recent",
+    ]);
+    expect(groups[0].builds.map((build) => build.buildId)).toEqual(["FB-DECISION"]);
+    expect(groups[1].builds.map((build) => build.buildId)).toEqual(["FB-WORKING"]);
+    expect(groups[2].builds.map((build) => build.buildId)).toEqual(["FB-COMPLETE"]);
+  });
+
+  it("keeps implementation phases as a compact evidence story instead of operator instructions", () => {
+    const story = deriveBuildActivityStory("review");
+
+    expect(story.map((step) => step.label)).toEqual([
+      "Outcome understood",
+      "Approach shaped",
+      "Solution built",
+      "Quality checked",
+      "Ready to use",
+    ]);
+    expect(story.map((step) => step.state)).toEqual([
+      "complete",
+      "complete",
+      "complete",
+      "current",
+      "upcoming",
+    ]);
+    expect(story.find((step) => step.state === "current")?.detail).toMatch(
+      /evidence|checks/i,
+    );
+  });
+
+  it("treats a failed build as attention-worthy without pretending progress was lost", () => {
+    const story = deriveBuildActivityStory("failed");
+
+    expect(story.some((step) => step.state === "complete")).toBe(true);
+    expect(story.at(-1)).toMatchObject({
+      label: "Needs recovery",
+      state: "attention",
+    });
+  });
+});

--- a/apps/web/components/build/build-studio-operator-view.ts
+++ b/apps/web/components/build/build-studio-operator-view.ts
@@ -1,0 +1,116 @@
+import type { BuildPhase } from "@/lib/feature-build-types";
+
+export type OperatorBuildInput = {
+  id: string;
+  buildId: string;
+  title: string;
+  phase: BuildPhase;
+  updatedAt: Date;
+  needsYou: boolean;
+};
+
+export type OperatorBuildGroup = {
+  key: "needs-you" | "in-progress" | "recent";
+  label: "Needs you" | "In progress" | "Recent";
+  builds: OperatorBuildInput[];
+};
+
+export type BuildActivityStep = {
+  key: string;
+  label: string;
+  detail: string;
+  state: "complete" | "current" | "upcoming" | "attention";
+};
+
+const ACTIVITY_STEPS: ReadonlyArray<Omit<BuildActivityStep, "state">> = [
+  {
+    key: "understand",
+    label: "Outcome understood",
+    detail: "The requested outcome and success conditions are captured.",
+  },
+  {
+    key: "shape",
+    label: "Approach shaped",
+    detail: "The approach, constraints, risks, and plan are resolved.",
+  },
+  {
+    key: "build",
+    label: "Solution built",
+    detail: "The change is implemented in the governed workspace.",
+  },
+  {
+    key: "check",
+    label: "Quality checked",
+    detail: "Tests, review, and release evidence are being checked.",
+  },
+  {
+    key: "ready",
+    label: "Ready to use",
+    detail: "The verified change is ready for governed release.",
+  },
+];
+
+const CURRENT_STEP_BY_PHASE: Record<Exclude<BuildPhase, "complete" | "failed" | "abandoned">, number> = {
+  ideate: 0,
+  plan: 1,
+  build: 2,
+  review: 3,
+  ship: 4,
+};
+
+function newestFirst(a: OperatorBuildInput, b: OperatorBuildInput): number {
+  return b.updatedAt.getTime() - a.updatedAt.getTime();
+}
+
+export function groupOperatorBuilds(builds: OperatorBuildInput[]): OperatorBuildGroup[] {
+  const needsYou = builds.filter((build) => build.needsYou).sort(newestFirst);
+  const inProgress = builds
+    .filter(
+      (build) =>
+        !build.needsYou
+        && build.phase !== "complete"
+        && build.phase !== "abandoned",
+    )
+    .sort(newestFirst);
+  const recent = builds
+    .filter(
+      (build) =>
+        !build.needsYou
+        && (build.phase === "complete" || build.phase === "abandoned"),
+    )
+    .sort(newestFirst);
+
+  return [
+    { key: "needs-you", label: "Needs you", builds: needsYou },
+    { key: "in-progress", label: "In progress", builds: inProgress },
+    { key: "recent", label: "Recent", builds: recent },
+  ].filter((group) => group.builds.length > 0) as OperatorBuildGroup[];
+}
+
+export function deriveBuildActivityStory(phase: BuildPhase): BuildActivityStep[] {
+  if (phase === "failed" || phase === "abandoned") {
+    return [
+      { ...ACTIVITY_STEPS[0]!, state: "complete" },
+      { ...ACTIVITY_STEPS[1]!, state: "complete" },
+      {
+        key: "recovery",
+        label: phase === "failed" ? "Needs recovery" : "Work stopped",
+        detail:
+          phase === "failed"
+            ? "Build Studio preserved the evidence and needs the blocker resolved before continuing."
+            : "The evidence remains available if this outcome is resumed.",
+        state: "attention",
+      },
+    ];
+  }
+
+  if (phase === "complete") {
+    return ACTIVITY_STEPS.map((step) => ({ ...step, state: "complete" }));
+  }
+
+  const currentIndex = CURRENT_STEP_BY_PHASE[phase];
+  return ACTIVITY_STEPS.map((step, index) => ({
+    ...step,
+    state: index < currentIndex ? "complete" : index === currentIndex ? "current" : "upcoming",
+  }));
+}

--- a/apps/web/components/build/work-control/WorkControlPanel.test.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.test.tsx
@@ -79,12 +79,12 @@ describe("WorkControlPanel", () => {
     expect(html).toContain('href="/build"');
   });
 
-  it("states the relationship to the plain-English Start a new build door", () => {
+  it("states the relationship to the plain-English Start a new outcome door", () => {
     const html = renderToStaticMarkup(
       <WorkControlPanel capsules={[]} adoptable={[]} createAction={vi.fn()} canCreateGovernedWork />,
     );
 
-    expect(html).toContain("Start a new build");
+    expect(html).toContain("Start a new outcome");
     expect(html).toContain('href="/build"');
   });
 

--- a/apps/web/components/build/work-control/WorkControlPanel.tsx
+++ b/apps/web/components/build/work-control/WorkControlPanel.tsx
@@ -32,7 +32,7 @@ export function WorkControlPanel({
       </div>
 
       {/* BI-E167A8A6: state what this surface is and how it relates to the other
-          Build Studio intake ("Start a new build"). Work Control is the governed
+          Build Studio intake ("Start a new outcome"). Work Control is the governed
           engineering substrate; describing a feature in plain English lives in
           Build Studio. Making the relationship explicit is the fix for the
           dual-intake IA confusion. */}
@@ -46,7 +46,7 @@ export function WorkControlPanel({
           href="/build"
           className="font-medium text-[var(--dpf-accent)] hover:underline"
         >
-          Start a new build
+          Start a new outcome
         </Link>{" "}
         in Build Studio.
       </p>
@@ -80,7 +80,7 @@ export function WorkControlPanel({
             href="/build"
             className="font-medium text-[var(--dpf-accent)] hover:underline"
           >
-            Start a new build
+            Start a new outcome
           </Link>{" "}
           in Build Studio — your AI Coworker sets up the capsule and branch for
           you.

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8967,10 +8967,11 @@
       "publishedPortal": true,
       "anchors": [
         "overview",
+        "the-operator-workspace",
         "current-maturity",
         "key-concepts",
         "what-you-can-do",
-        "the-five-phases",
+        "what-happens-behind-the-activity-story",
         "ideate",
         "plan",
         "build",

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -212,15 +212,15 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text"
     },
     "/build": {
-      "defaultVisibleWords": 239,
+      "defaultVisibleWords": 165,
       "leadBandWords": 0,
       "primaryActions": 1,
-      "visibleFields": 2,
-      "maxChoicesPerControl": 4,
+      "visibleFields": 1,
+      "maxChoicesPerControl": 0,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - link\n    - text\n  - paragraph\n    - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - button\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - link [disabled]"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - button [expanded]\n    - text\n  - text\n  - textbox\n  - group\n    - button\n    - text\n    - combobox\n      - option [selected]\n      - option\n  - text\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - link [disabled]"
     },
     "/build/work": {
       "defaultVisibleWords": 176,

--- a/docs/superpowers/plans/2026-07-28-build-studio-outcome-first-simplification.md
+++ b/docs/superpowers/plans/2026-07-28-build-studio-outcome-first-simplification.md
@@ -1,10 +1,15 @@
 # Build Studio outcome-first simplification
 
-**Backlog:** BI-IMP-78D1A439  
-**Epic:** EP-BUILD-STUDIO-UX  
-**Work Capsule:** WC-BF66038E  
-**Branch:** `feat/build-studio-simplify`  
-**Decision evidence:** DI-88CBB559FE19  
+**Backlog:** BI-IMP-78D1A439
+
+**Epic:** EP-BUILD-STUDIO-UX
+
+**Work Capsule:** WC-BF66038E
+
+**Branch:** `feat/build-studio-simplify`
+
+**Decision evidence:** DI-88CBB559FE19
+
 **Atomic coverage receipt:** cms4s3q220t6l01ruw42p5co6
 
 ## Outcome

--- a/docs/superpowers/plans/2026-07-28-build-studio-outcome-first-simplification.md
+++ b/docs/superpowers/plans/2026-07-28-build-studio-outcome-first-simplification.md
@@ -1,0 +1,103 @@
+# Build Studio outcome-first simplification
+
+**Backlog:** BI-IMP-78D1A439  
+**Epic:** EP-BUILD-STUDIO-UX  
+**Work Capsule:** WC-BF66038E  
+**Branch:** `feat/build-studio-simplify`  
+**Decision evidence:** DI-88CBB559FE19  
+**Atomic coverage receipt:** cms4s3q220t6l01ruw42p5co6
+
+## Outcome
+
+Make `/build` understandable without delivery-process knowledge. The default experience must answer, in this order:
+
+1. What outcome did I ask for?
+2. What is happening now?
+3. Does Build Studio need a decision from me?
+4. What has happened so far?
+
+FeatureBuild, Work Capsule, review, verification, PR, merge, and release controls remain authoritative. The change is a presentation and information-architecture refactor, not a second workflow or a relaxation of governance.
+
+## Grounding
+
+- The live route currently presents intake, Work Control, fleet counts, epic rollups, raw identifiers, context, work warrant, workflow action, solution summary, phase rail, engineer controls, process graph, evidence drawer, sandbox controls, and a coworker panel in one workspace.
+- `BuildCustomerStatusBand` and `BuildStudioWorkflowActionCard` already project the canonical status and next governed action. Reuse these rather than inventing parallel state.
+- `DetailsDrawer` already owns canonical documents, progress, review evidence, queue diagnostics, and sandbox details. It is the correct progressive-disclosure destination for technical and governance evidence.
+- `/build` remains the canonical Build Studio route under Delivery. `/build/work` remains a technical secondary surface and must not compete with the plain-language intake door.
+- The 2026-07-25 governed-playbook experimentation spec and DI-88CBB559FE19 support evidence-gated phase compression: stages may remain in the audit story without becoming operator-driven ceremony.
+
+## UX-fit review
+
+**Decision:** Fits with guardrails.
+
+- **Owning area:** Platform / Delivery.
+- **Primary persona:** founder/operator or product owner who can describe an outcome but should not need to understand DPF internals.
+- **Secondary persona:** technical delivery owner who needs complete evidence and recovery controls.
+- **Navigation layer:** local page hierarchy only; add no global navigation.
+- **Source of truth:** FeatureBuild + Work Capsule + customer-status projection + derived workflow action.
+- **AI boundary:** describing an outcome does not silently execute production changes. The explicit start/promote action remains visible, and consequence-bearing actions retain their governed confirmation.
+- **Empty state:** one primary invitation to describe an outcome, with a compact explanation of what Build Studio will do.
+- **Blocked state:** one plain-language blocker and one next action; diagnostics move to technical details.
+- **Responsive/theming:** use DPF theme variables; verify desktop and narrow viewports in light and dark themes.
+
+## Atomic scope and 20% refactor allocation
+
+This is one atomic UI change because the new hierarchy, extracted presentation model, component wiring, tests, and user guidance must ship together; partial delivery would leave duplicate or contradictory Build Studio surfaces.
+
+Coverage dependency order: `presentation-contract` → `operator-workspace` → `technical-disclosure` → `guidance-verification`. None is independently shippable; receipt `cms4s3q220t6l01ruw42p5co6` records the atomic decision against BI-IMP-78D1A439.
+
+Approximately 20% of implementation effort is reserved for refactoring:
+
+- extract operator-facing build selection and activity/status derivation from the 85 KB `BuildStudio.tsx`;
+- centralize outcome-first labels and view-model rules so tests do not depend on DOM accidents;
+- converge duplicated details/engineer disclosures into one technical-details entry point;
+- remove obsolete layout helpers only when no caller remains.
+
+The remaining effort implements and verifies the new operator surface.
+
+## Deliverables
+
+### 1. Test-first presentation contract
+
+- Add unit tests for the operator view model: attention-first ordering, status copy, current/complete activity steps, and technical-detail visibility.
+- Add component tests proving the default view contains one outcome, one status, one next-action region, one compact activity story, and one technical-details control.
+- Preserve tests for workflow actions, destructive confirmations, accessibility names, and evidence drawers.
+
+### 2. Outcome-first workspace
+
+- Make plain-language outcome intake the only primary start door.
+- Replace the always-open fleet rail with a compact build switcher grouped by `Needs you`, `In progress`, and `Recent`; keep the selected build visible.
+- Make the active build header outcome-led and hide raw IDs, branch, taxonomy, warrants, and graph by default.
+- Present canonical customer status first, the governed next action second, and a compact evidence-backed activity story third.
+- Keep release decisions and blocked recovery actions prominent when applicable.
+
+### 3. Progressive technical disclosure
+
+- Provide one `Technical details` control.
+- Place process graph, work warrant, canonical documents, branch/IDs, queue diagnostics, code intelligence, assurance, review evidence, and sandbox diagnostics behind that disclosure.
+- Keep all existing controls reachable; do not fork or duplicate mutation logic.
+
+### 4. Guidance and documentation
+
+- Update the operator guide for the new `/build` mental model.
+- Record that Build Studio stages are an audit/evidence story for routine work, while human attention is reserved for consequence, uncertainty, or risk boundaries.
+- Record no migration impact: no schema or persisted-data change.
+
+## Verification
+
+1. Run affected Vitest suites for Build Studio presentation, workflow actions, details drawer, and layout.
+2. Run the web production build.
+3. Lease `local-integration-ci`, run sandbox freshness convergence, deploy the branch through the governed local-integration path, and exercise:
+   - active build with no attention needed;
+   - build needing a decision;
+   - blocked/failed build;
+   - empty state;
+   - technical-details disclosure;
+   - desktop and narrow viewport;
+   - light and dark themes.
+4. Capture screenshots and accessibility/console evidence.
+5. Run `pnpm pr:health` after the ready PR exists.
+
+## Documentation impact
+
+Update `docs/user-guide/` because the operator workflow and terminology change. The architecture substrate and database do not change; this plan is the durable contributor record, so no separate architecture document or migration is required.

--- a/docs/user-guide/build-studio/index.md
+++ b/docs/user-guide/build-studio/index.md
@@ -8,9 +8,21 @@ relatedCode:
 
 ## Overview
 
-Build Studio is the platform's feature development environment. It guides a new capability from initial idea through to a shipped, tested, documented, and deployed feature using a five-phase pipeline. AI agents assist at each phase, handling research, planning, code generation, documentation impact, verification, and deployment while keeping a human in control of decisions.
+Build Studio is the platform's guided way to turn a plain-language outcome into a tested, documented, and deployable platform change. You do not need to manage its internal delivery process. The main workspace stays focused on four questions: what you asked for, what is happening now, whether Build Studio needs a decision, and what evidence has accumulated.
 
 Build Studio is not a separate code universe. It works from the install's shared development workspace. In customizable installs, that means Build Studio and VS Code operate on the same source tree while the portal continues to own review, evidence, and governed promotion.
+
+## The operator workspace
+
+Open **Build Studio** under **Delivery**, then:
+
+1. Choose **Start a new outcome** and describe what should be different, who it helps, and any constraint that matters.
+2. Choose **Continue**, review the captured outcome, and explicitly start the governed build.
+3. Follow the plain-language status. Build Studio continues routine research, planning, implementation, and checking without asking you to operate each internal stage.
+4. Respond when the workspace says **Needs you**. Human attention is reserved for consequence, unresolved product judgment, elevated risk, or a blocked prerequisite.
+5. Open **Technical details** when you need the process graph, source branch, work warrant, canonical documents, review evidence, queue diagnostics, or build-runtime information.
+
+The compact activity story is evidence, not a wizard. It shows what Build Studio has understood, shaped, built, and checked; it does not turn each internal phase into another button the operator must click.
 
 ## Current Maturity
 
@@ -30,7 +42,8 @@ escalations.
 
 ## Key Concepts
 
-- **Phases** — The five stages every feature moves through: Ideate (define the problem), Plan (design the solution), Build (generate and test code), Review (quality gates), Ship (deploy to production).
+- **Activity story** — The operator-facing evidence trail: outcome understood, approach shaped, solution built, quality checked, and ready to use. It compresses routine internal work into a readable history.
+- **Technical phases** — Ideate, Plan, Build, Review, and Ship remain the canonical governed states. They appear in technical details and audit evidence rather than dominating the operator workspace.
 - **Feature Brief** — The structured output of the Ideate phase. It captures the problem, desired outcome, constraints, and acceptance criteria. Everything downstream is built from this.
 - **AI Coworker** — The Software Engineer agent that works with you through each phase. It searches the codebase, writes code, runs tests, and deploys features. You guide it with plain language.
 - **Change Reviewer** — An independent, read-only coworker for governed Work Capsules. It inspects committed source, tests, architecture, and evidence, but cannot edit the change, advance the build, waive findings, or publish a release. The Software Engineer remains the authoring coworker on the main Build Studio surface.
@@ -49,27 +62,26 @@ does not certify or activate a coworker.
 
 ## What You Can Do
 
-- Start a new feature by describing the idea in the conversation panel
-- Review and refine the feature brief before moving to planning
-- Approve the plan and watch the AI Coworker build and test the feature
-- See the live preview of your feature as it is being built
-- Review test results and acceptance criteria before shipping
-- Prepare the feature for governed promotion with recorded evidence, health checks, and rollback planning
-- Track active builds and their current phase from the Build Studio dashboard
+- Start a new outcome in plain language
+- See one current status and the next meaningful action
+- Respond to product, risk, or consequence decisions when Build Studio needs you
+- Follow a compact story of completed and current work
+- Open technical details for the full design, source, test, review, runtime, and promotion evidence
+- Prepare the outcome for governed promotion with recorded evidence, health checks, and rollback planning
 
-## The Five Phases
+## What happens behind the activity story
 
 ### Ideate
 
-Describe what you want in plain language. The AI Coworker searches the existing codebase for relevant patterns, then creates a design document covering the problem, approach, and acceptance criteria. You review and approve before moving on.
+Build Studio turns the requested outcome into an evidence-backed problem statement and acceptance criteria. It searches the existing codebase and platform guidance before proposing change.
 
 ### Plan
 
-The AI Coworker creates an implementation plan listing the files to create or modify, tasks to complete, tests to write, and documentation impact to handle. You see a plain-language summary. Approve the plan to start building.
+The AI Coworker creates or refines the implementation plan, including affected files, tests, documentation impact, dependencies, and risk controls. Routine plan progression can remain under coworker custody; unresolved product judgment or elevated consequence returns to you as a clear decision.
 
 ### Build
 
-The AI Coworker generates code inside the isolated Build runtime. You can see the live preview update in real time. It runs tests and typecheck after generating code. If tests fail, it attempts to fix them automatically. You can ask for changes at any time.
+The AI Coworker generates code inside the isolated Build runtime. It runs tests and typecheck, gathers concrete evidence, and can use bounded disposable spikes to answer uncertain UX or implementation questions. A spike is evidence, not production code: the normal design, review, and release gates still decide what may ship.
 
 If a task stops before it finishes, Build Studio distinguishes *why*. When the coding session died on infrastructure — a timeout, a provider outage, a rate limit, the process being killed — that is not a verdict on your feature, so the same task is re-run once automatically and you see a "retrying" note in the activity feed. When the session instead stopped because it needs something only you can supply — an unresolved product question, a contradiction in the spec — it is **not** retried, because re-running will not answer the question. That one surfaces as a blocked task for you to resolve.
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -3674,6 +3674,13 @@
     "longSentences": 0,
     "textMass": 10
   },
+  "apps/web/components/build/BuildOperatorOverview.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
   "apps/web/components/build/BuildPhaseCostCard.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -3953,6 +3960,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 51
+  },
+  "apps/web/components/build/build-studio-operator-view.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
   },
   "apps/web/components/build/build-studio-workflow-actions.ts": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

- Reframes Build Studio around the operator's desired outcome, current state, next action, and a five-step activity story.
- Compresses routine agent phases into evidence-gated execution while preserving decisions, release controls, autonomous custody, assurance, branches, phase graph, and queue diagnostics behind one Technical details disclosure.
- Replaces ticket/build-system language with plain-language intake and keeps governed build promotion explicit.
- Fixes server/client hydration drift for mobile and returning technical users by deferring viewport and local-storage restoration until after the deterministic first render.
- Updates the Build Studio user guide and records the implementation plan.

Backlog: BI-IMP-78D1A439
Decision: DI-88CBB559FE19
Work Capsule: WC-BF66038E

## Why

The reviewed Jira/Linear thesis is directionally right about obsolete handoff-heavy presentation, but not about removing context or governance. DPF should compress procedural handoffs when agents can produce evidence directly, then route human attention to consequence, uncertainty, risk, and release boundaries.

## Verification

- Local-CI merged-code gate passed against `origin/main@c127d95c8034968a1642480b43e450844050e838`.
- 24 policy guards passed.
- 2,301 test files passed; 19,931 tests passed (4 file skips, 19 test skips, 18 todos).
- Web typecheck passed.
- 456 migrations checked; none pending.
- Production Docker build passed.
- Isolated `/build` UX exercised with an active representative build at desktop and 390px mobile widths; Outcome / Now / Next / Activity remained primary and Technical details exposed the governed engineering evidence.
- Documentation index and link checks passed.
- UX Route Budget Sweep passed after a reproducible /build accessibility-baseline refresh; visible words fell 239 -> 165, fields 2 -> 1, and choices 4 -> 0.

Local-CI-Evidence: cms4zupt400yd01mxpje1xdrb (feat/build-studio-simplify@1c02438ed93463ab6abcfd2bd57e986b6d14673d)

## Documentation impact

Updated `docs/user-guide/build-studio/index.md` for the outcome-first journey, evidence-gated phase compression, bounded prototype spikes, and the retained technical/governance layer. Added the implementation plan under `docs/superpowers/plans/`.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md`
  - `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`
  - `docs/superpowers/plans/2026-07-28-build-studio-outcome-first-simplification.md`
- Current code substrate reviewed:
  - `BuildStudio`, `BuildStudioWorkflowActionCard`, `BuildSolutionSummaryBand`, `DetailsDrawer`, customer-status projection, fleet derivation, autonomous-build custody, and `/build/work`.
- Source of truth:
  - `FeatureBuild` + `WorkCapsule` + `projectBuildStudioCustomerStatus` + derived workflow action; `DetailsDrawer` remains the canonical technical-evidence destination.
- Decision:
  - Refactor presentation and information architecture around Outcome / Now / Next / Activity. Preserve the governed workflow, autonomous custody, assurance, release controls, and mutation paths; add no parallel state or route.

UX-Fit-Decision: evidence-gated progressive disclosure (DI-88CBB559FE19; outcome-first view preserves governed evidence and release controls)



