### PR TITLE
feat: add archetype readiness claim gate

### DIFF
--- a/docs/architecture/2026-07-27-platform-adequacy-roadmap-backlog-map.md
+++ b/docs/architecture/2026-07-27-platform-adequacy-roadmap-backlog-map.md
@@ -89,9 +89,10 @@ Recommended order:
 - Do not create a new umbrella epic unless live epic overlap is rechecked and the kernel decision is superseded.
 - Do not treat this document as the source of truth for execution state. Query the live backlog before acting.
 - Do not mark an archetype sole-platform-ready from seed/template presence alone.
+- Use `packages/storefront-templates/src/archetype-readiness.ts` as the executable source for readiness tiers and claim checks.
 - Do not bypass `EP-DATA-GOVERNANCE` for export or portability work.
 - Do not bypass Work Case, Attention Surface, or action-receipt substrate for AI business-record mutations.
-- If public-site, docs, or sales language changes before `BI-C1C706F1` ships, use a manual claim review against the matrix definitions in that BI body.
+- If public-site, docs, or sales language changes before a surface consumes the claim helper directly, use a manual claim review against `evaluateArchetypeReadinessClaim`.
 
 ## Recovery Notes
 

--- a/docs/superpowers/plans/2026-07-28-archetype-readiness-matrix.md
+++ b/docs/superpowers/plans/2026-07-28-archetype-readiness-matrix.md
@@ -1,0 +1,75 @@
+# Archetype Readiness Matrix and Sales-Claim Gate
+
+**Backlog item:** `BI-C1C706F1`
+**Work capsule:** `WC-3F1BC29F`
+**Branch:** `feat/archetype-readiness-matrix`
+**Date:** 2026-07-28
+
+## Goal
+
+Turn the platform adequacy review finding into executable substrate: a typed archetype readiness ladder and a reusable claim gate that prevents template coverage from being treated as operational, connector, regulated, or sole-platform readiness.
+
+## Current Evidence
+
+- The existing archetype taxonomy and template substrate live in `packages/storefront-templates/src/types.ts` and `packages/storefront-templates/src/archetypes/index.ts`.
+- The archetype completeness gate proves structural/template presence, not day-2 operational adequacy: `docs/superpowers/specs/2026-07-21-archetype-provisioning-playbook-design.md`.
+- The vertical backlog architecture names `BI-PSC-010` as the keystone for typed archetype contributions and sequences it ahead of broad vertical execution: `docs/superpowers/specs/2026-07-24-vertical-backlog-investment-architecture-design.md`.
+- Live backlog on 2026-07-28 shows `BI-PSC-010` is open under `EP-PLATFORM-SUBSTRATE-CONVERGENCE`.
+- Live vertical-readiness epics exist for most current archetype categories, but they are largely open; this is evidence of a readiness lane, not evidence that the category is already ready.
+
+## Scope
+
+This slice is atomic for `BI-C1C706F1`. It does not close `BI-PSC-010`, add a migration, or change public marketing surfaces in this PR. Instead, it creates the typed source of truth that those surfaces can consume, and it documents the manual gating rule until UI/public copy is wired to it.
+
+## Implementation
+
+- Add `packages/storefront-templates/src/archetype-readiness.ts`.
+- Export the readiness API from `packages/storefront-templates/src/index.ts`.
+- Define the closed tier ladder:
+  - `template-ready`
+  - `ops-ready`
+  - `connector-ready`
+  - `regulated-ready`
+  - `sole-platform-ready`
+- Define typed evidence references for backlog items, epics, specs, plans, code artifacts, and verification artifacts.
+- Define reusable tier requirements so each tier has concrete evidence expectations.
+- Build an initial category-level matrix from `ALL_ARCHETYPES`, with:
+  - `template-ready` claimable where the category exists in the shipped taxonomy.
+  - vertical-readiness epics and `BI-PSC-010` cross-referenced as readiness dependencies.
+  - higher tiers blocked unless explicit evidence is attached.
+- Add `evaluateArchetypeReadinessClaim` and `assertArchetypeReadinessClaimAllowed` helpers.
+- Add focused Vitest coverage proving:
+  - every shipped category has a readiness record.
+  - the tier ladder is ordered and closed.
+  - no category can claim `sole-platform-ready` from template evidence alone.
+  - sales/public claims above the current evidence are blocked with actionable missing evidence.
+  - `BI-PSC-010` and existing vertical readiness epics are represented as dependencies.
+- Update the architecture roadmap note with the new source file once the implementation lands.
+
+## Refactoring Reserve
+
+At least 20 percent of this slice is reserved for keeping the contract reusable and narrow: a pure module, no DB coupling, no UI-only logic, and helper functions that future public/docs/sales surfaces can consume directly instead of re-implementing claim rules.
+
+## Verification
+
+- Source-local targeted unit test: `pnpm --filter @dpf/storefront-templates exec vitest run src/archetype-readiness.test.ts`.
+- Source-local package typecheck: `pnpm --filter @dpf/storefront-templates typecheck`.
+- Production build is not expected to change behavior, but the PR still needs the normal DPF build gate before merge.
+- No migration gate is required.
+- No UX verification is required in this slice because there is no rendered UI change.
+
+## Backlog Coverage
+
+- Decision: atomic
+- Parent: `BI-C1C706F1`
+- Receipt: `cms4s3mql0t6d01rutnsjhq9l`
+- Dependencies: `BI-PSC-010`; existing vertical-readiness epics referenced by the readiness matrix
+- Rationale: the deliverables form one reusable claim-control substrate; splitting the tier constants, evidence matrix, claim helper, and tests would create non-functional partial states.
+
+Deliverables:
+
+- Typed archetype readiness tier contract.
+- Evidence-backed category readiness matrix with `BI-PSC-010` and vertical-readiness dependencies.
+- Reusable sales/public claim gate helpers.
+- Unit tests proving coverage, blocked overclaims, and dependency cross-references.
+- Roadmap/doc update pointing to the executable source of truth.

--- a/packages/storefront-templates/src/archetype-readiness.test.ts
+++ b/packages/storefront-templates/src/archetype-readiness.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  ARCHETYPE_READINESS_MATRIX,
+  ARCHETYPE_READINESS_TIERS,
+  ARCHETYPE_READINESS_TIER_REQUIREMENTS,
+  assertArchetypeReadinessClaimAllowed,
+  compareArchetypeReadinessTiers,
+  evaluateArchetypeReadinessClaim,
+  resolveArchetypeReadinessRecord,
+} from "./archetype-readiness";
+import { ALL_ARCHETYPES } from "./archetypes";
+
+describe("archetype readiness matrix", () => {
+  it("keeps the readiness ladder closed and ordered", () => {
+    expect(ARCHETYPE_READINESS_TIERS).toEqual([
+      "template-ready",
+      "ops-ready",
+      "connector-ready",
+      "regulated-ready",
+      "sole-platform-ready",
+    ]);
+    expect(compareArchetypeReadinessTiers("template-ready", "sole-platform-ready")).toBeLessThan(0);
+    expect(compareArchetypeReadinessTiers("sole-platform-ready", "template-ready")).toBeGreaterThan(0);
+    expect(compareArchetypeReadinessTiers("connector-ready", "connector-ready")).toBe(0);
+  });
+
+  it("defines evidence requirements for every tier", () => {
+    const requirementTiers = ARCHETYPE_READINESS_TIER_REQUIREMENTS.map(
+      (requirement) => requirement.tier,
+    );
+
+    expect(requirementTiers).toEqual(ARCHETYPE_READINESS_TIERS);
+    for (const requirement of ARCHETYPE_READINESS_TIER_REQUIREMENTS) {
+      expect(requirement.summary).toMatch(/./);
+      expect(requirement.requiredEvidence.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has exactly one category readiness record for every shipped archetype category", () => {
+    const categories = new Set(ALL_ARCHETYPES.map((archetype) => archetype.category));
+    const matrixCategories = ARCHETYPE_READINESS_MATRIX.map((record) => record.archetypeCategory);
+
+    expect(new Set(matrixCategories)).toEqual(categories);
+    expect(matrixCategories.length).toBe(categories.size);
+  });
+
+  it("allows template-ready claims for a shipped archetype category", () => {
+    const result = evaluateArchetypeReadinessClaim({
+      archetypeCategory: "healthcare-wellness",
+      requestedTier: "template-ready",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.highestClaimableTier).toBe("template-ready");
+  });
+
+  it("resolves readiness by leaf archetype id", () => {
+    const record = resolveArchetypeReadinessRecord({ archetypeId: "dental-practice" });
+
+    expect(record?.archetypeCategory).toBe("healthcare-wellness");
+  });
+
+  it("blocks sole-platform claims from template evidence alone", () => {
+    for (const record of ARCHETYPE_READINESS_MATRIX) {
+      const result = evaluateArchetypeReadinessClaim({
+        archetypeCategory: record.archetypeCategory,
+        requestedTier: "sole-platform-ready",
+      });
+      const blockerEvidenceIds = new Set(
+        result.blockers.flatMap((blocker) => blocker.evidence.map((evidence) => evidence.id)),
+      );
+
+      expect(result.allowed).toBe(false);
+      expect(result.highestClaimableTier).toBe("template-ready");
+      expect(blockerEvidenceIds.has("BI-903F5A94")).toBe(true);
+      expect(blockerEvidenceIds.has("BI-4C16947C")).toBe(true);
+      expect(blockerEvidenceIds.has("BI-35E9EE62")).toBe(true);
+    }
+  });
+
+  it("throws an actionable error when a claim outruns the evidence", () => {
+    expect(() =>
+      assertArchetypeReadinessClaimAllowed({
+        archetypeCategory: "banking-financial-services",
+        requestedTier: "regulated-ready",
+      }),
+    ).toThrow(/BI-PSC-010/);
+  });
+
+  it("cross-references BI-PSC-010 and existing vertical readiness epics", () => {
+    const banking = resolveArchetypeReadinessRecord({
+      archetypeCategory: "banking-financial-services",
+    });
+    const dependencyIds = new Set(banking?.dependencies.map((evidence) => evidence.id));
+
+    expect(dependencyIds.has("BI-PSC-010")).toBe(true);
+    expect(dependencyIds.has("EP-VERTICAL-BANKING")).toBe(true);
+  });
+
+  it("makes missing category-level vertical readiness lanes visible", () => {
+    const trades = evaluateArchetypeReadinessClaim({
+      archetypeCategory: "trades-maintenance",
+      requestedTier: "ops-ready",
+    });
+
+    expect(trades.allowed).toBe(false);
+    expect(trades.missingEvidence).toContain(
+      "No category-level vertical-readiness epic is mapped for this archetype category.",
+    );
+  });
+});

--- a/packages/storefront-templates/src/archetype-readiness.ts
+++ b/packages/storefront-templates/src/archetype-readiness.ts
@@ -1,0 +1,489 @@
+import { ALL_ARCHETYPES } from "./archetypes";
+import type { ArchetypeCategory } from "./types";
+
+export const ARCHETYPE_READINESS_TIERS = [
+  "template-ready",
+  "ops-ready",
+  "connector-ready",
+  "regulated-ready",
+  "sole-platform-ready",
+] as const;
+
+export type ArchetypeReadinessTier = (typeof ARCHETYPE_READINESS_TIERS)[number];
+
+export type ArchetypeReadinessEvidenceKind =
+  | "backlog-item"
+  | "epic"
+  | "spec"
+  | "plan"
+  | "code"
+  | "verification";
+
+export type ArchetypeReadinessEvidenceStatus =
+  | "planned"
+  | "open"
+  | "in-progress"
+  | "done"
+  | "merged"
+  | "required";
+
+export interface ArchetypeReadinessEvidenceRef {
+  kind: ArchetypeReadinessEvidenceKind;
+  id: string;
+  title: string;
+  status: ArchetypeReadinessEvidenceStatus;
+  path?: string;
+}
+
+export interface ArchetypeReadinessTierRequirement {
+  tier: ArchetypeReadinessTier;
+  summary: string;
+  requiredEvidence: readonly string[];
+}
+
+export interface ArchetypeReadinessBlocker {
+  tier: Exclude<ArchetypeReadinessTier, "template-ready">;
+  reason: string;
+  evidence: readonly ArchetypeReadinessEvidenceRef[];
+}
+
+export interface ArchetypeReadinessRecord {
+  scopeKind: "archetype-category";
+  archetypeCategory: ArchetypeCategory;
+  highestClaimableTier: ArchetypeReadinessTier;
+  evidenceByTier: Partial<Record<ArchetypeReadinessTier, readonly ArchetypeReadinessEvidenceRef[]>>;
+  dependencies: readonly ArchetypeReadinessEvidenceRef[];
+  blockersByTier: Partial<
+    Record<Exclude<ArchetypeReadinessTier, "template-ready">, readonly ArchetypeReadinessBlocker[]>
+  >;
+}
+
+export interface ArchetypeReadinessClaimRequest {
+  requestedTier: ArchetypeReadinessTier;
+  archetypeCategory?: ArchetypeCategory;
+  archetypeId?: string;
+  matrix?: readonly ArchetypeReadinessRecord[];
+}
+
+export interface ArchetypeReadinessClaimResult {
+  allowed: boolean;
+  requestedTier: ArchetypeReadinessTier;
+  highestClaimableTier?: ArchetypeReadinessTier;
+  archetypeCategory?: ArchetypeCategory;
+  missingEvidence: readonly string[];
+  blockers: readonly ArchetypeReadinessBlocker[];
+}
+
+export const ARCHETYPE_READINESS_TIER_REQUIREMENTS = [
+  {
+    tier: "template-ready",
+    summary: "The archetype exists in the template taxonomy and passes structural completeness.",
+    requiredEvidence: [
+      "ArchetypeCategory and ALL_ARCHETYPES coverage",
+      "Archetype Completeness Guard structural floor",
+    ],
+  },
+  {
+    tier: "ops-ready",
+    summary: "The archetype has verified owner workflows, operational records, and acceptance tests.",
+    requiredEvidence: [
+      "Completed or explicitly verified vertical-readiness lane",
+      "Typed archetype contribution registry through BI-PSC-010",
+      "Acceptance evidence for owner cockpit, request lifecycle, finance, capacity, and master data",
+    ],
+  },
+  {
+    tier: "connector-ready",
+    summary: "The archetype has its replacement boundary and connector posture proven.",
+    requiredEvidence: [
+      "Ops-ready evidence",
+      "Integration/replacement-boundary map",
+      "Tier-1 connector posture and adapter support evidence",
+    ],
+  },
+  {
+    tier: "regulated-ready",
+    summary: "The archetype has policy, audit, authority, and compliance evidence for regulated use.",
+    requiredEvidence: [
+      "Connector-ready evidence",
+      "Regulated policy pack or explicit non-regulated classification",
+      "Audit, retention, approval, and jurisdictional evidence",
+    ],
+  },
+  {
+    tier: "sole-platform-ready",
+    summary: "The archetype has enough resilience, portability, and action integrity for one-platform use.",
+    requiredEvidence: [
+      "Regulated-ready evidence where regulation applies, or connector-ready evidence for non-regulated categories",
+      "Sole-platform operational readiness evidence gate",
+      "Whole-account export and restore-grade data portability",
+      "Universal AI action envelope and reversibility evidence",
+    ],
+  },
+] as const satisfies readonly ArchetypeReadinessTierRequirement[];
+
+const PLATFORM_CONTRIBUTION_CONTRACT: ArchetypeReadinessEvidenceRef = {
+  kind: "backlog-item",
+  id: "BI-PSC-010",
+  title: "Typed archetype contribution registry across templates and seeds",
+  status: "open",
+};
+
+const ARCHETYPE_PROVISIONING_PLAYBOOK: ArchetypeReadinessEvidenceRef = {
+  kind: "spec",
+  id: "2026-07-21-archetype-provisioning-playbook-design",
+  title: "Archetype Provisioning Playbook",
+  status: "merged",
+  path: "docs/superpowers/specs/2026-07-21-archetype-provisioning-playbook-design.md",
+};
+
+const TEMPLATE_TAXONOMY: ArchetypeReadinessEvidenceRef = {
+  kind: "code",
+  id: "packages/storefront-templates/src/archetypes/index.ts",
+  title: "ALL_ARCHETYPES category taxonomy",
+  status: "merged",
+  path: "packages/storefront-templates/src/archetypes/index.ts",
+};
+
+const ECOSYSTEM_ABSORPTION: ArchetypeReadinessEvidenceRef = {
+  kind: "epic",
+  id: "EP-ECOSYSTEM-ABSORPTION-ARCH",
+  title: "Ecosystem Absorption Architecture",
+  status: "open",
+};
+
+const SOLE_PLATFORM_OPERATIONS_GATE: ArchetypeReadinessEvidenceRef = {
+  kind: "backlog-item",
+  id: "BI-903F5A94",
+  title: "Sole-platform operational readiness evidence gate",
+  status: "open",
+};
+
+const WHOLE_ACCOUNT_PORTABILITY: ArchetypeReadinessEvidenceRef = {
+  kind: "backlog-item",
+  id: "BI-4C16947C",
+  title: "Whole-account export and restore-grade data portability",
+  status: "open",
+};
+
+const ACTION_ENVELOPE_REVERSIBILITY: ArchetypeReadinessEvidenceRef = {
+  kind: "backlog-item",
+  id: "BI-35E9EE62",
+  title: "Universal AI business-record action envelope and reversibility matrix",
+  status: "open",
+};
+
+const VERTICAL_READINESS_EPICS_BY_CATEGORY: Partial<
+  Record<ArchetypeCategory, ArchetypeReadinessEvidenceRef>
+> = {
+  "asset-rental": {
+    kind: "epic",
+    id: "EP-VERTICAL-ASSET-RENTAL",
+    title: "Industry Vertical Readiness - Asset rental",
+    status: "open",
+  },
+  "automotive-services": {
+    kind: "epic",
+    id: "EP-VERTICAL-AUTOMOTIVE",
+    title: "Industry Vertical Readiness - Automotive services",
+    status: "open",
+  },
+  "banking-financial-services": {
+    kind: "epic",
+    id: "EP-VERTICAL-BANKING",
+    title: "Industry Vertical Readiness - Banking and financial services",
+    status: "open",
+  },
+  "beauty-personal-care": {
+    kind: "epic",
+    id: "EP-EB32313A",
+    title: "Industry Vertical Readiness - Beauty and personal care",
+    status: "open",
+  },
+  "education-training": {
+    kind: "epic",
+    id: "EP-VERTICAL-EDUCATION",
+    title: "Industry Vertical Readiness - Education and training",
+    status: "open",
+  },
+  "fabric-care-services": {
+    kind: "epic",
+    id: "EP-FABRIC-CARE-OPS",
+    title: "Fabric Care Operations Readiness",
+    status: "open",
+  },
+  "fitness-recreation": {
+    kind: "epic",
+    id: "EP-VERTICAL-FITNESS",
+    title: "Industry Vertical Readiness - Fitness and recreation",
+    status: "open",
+  },
+  "food-hospitality": {
+    kind: "epic",
+    id: "EP-VERTICAL-FOOD-HOSPITALITY",
+    title: "Industry Vertical Readiness - Food and hospitality",
+    status: "open",
+  },
+  "healthcare-wellness": {
+    kind: "epic",
+    id: "EP-525F29E5",
+    title: "Industry Vertical Readiness - Healthcare and wellness",
+    status: "open",
+  },
+  "hoa-property-management": {
+    kind: "epic",
+    id: "EP-VERTICAL-HOA-PROPERTY",
+    title: "Industry Vertical Readiness - HOA and property management",
+    status: "open",
+  },
+  "live-events-venues": {
+    kind: "epic",
+    id: "EP-VERTICAL-EVENTS",
+    title: "Industry Vertical Readiness - Live events and venues",
+    status: "open",
+  },
+  "media-production": {
+    kind: "epic",
+    id: "EP-VERTICAL-MEDIA",
+    title: "Industry Vertical Readiness - Media production",
+    status: "open",
+  },
+  "moving-and-logistics": {
+    kind: "epic",
+    id: "EP-VERTICAL-MOVING-LOGISTICS",
+    title: "Industry Vertical Readiness - Moving and logistics",
+    status: "open",
+  },
+  "nonprofit-community": {
+    kind: "epic",
+    id: "EP-VERTICAL-NONPROFIT",
+    title: "Industry Vertical Readiness - Nonprofit and community",
+    status: "open",
+  },
+  "pet-services": {
+    kind: "epic",
+    id: "EP-VERTICAL-PET-SERVICES",
+    title: "Industry Vertical Readiness - Pet services",
+    status: "open",
+  },
+  "professional-services": {
+    kind: "epic",
+    id: "EP-VERTICAL-PROFESSIONAL",
+    title: "Industry Vertical Readiness - Professional services",
+    status: "open",
+  },
+  "public-sector": {
+    kind: "epic",
+    id: "EP-VERTICAL-PUBLIC-SECTOR",
+    title: "Industry Vertical Readiness - Public sector and civic",
+    status: "open",
+  },
+  "real-estate-construction": {
+    kind: "epic",
+    id: "EP-VERTICAL-CONSTRUCTION",
+    title: "Industry Vertical Readiness - Real estate and construction",
+    status: "open",
+  },
+  "retail-goods": {
+    kind: "epic",
+    id: "EP-VERTICAL-RETAIL-GOODS",
+    title: "Industry Vertical Readiness - Retail and goods",
+    status: "open",
+  },
+  "security-services": {
+    kind: "epic",
+    id: "EP-VERTICAL-SECURITY",
+    title: "Industry Vertical Readiness - Security services",
+    status: "open",
+  },
+  "software-platform": {
+    kind: "epic",
+    id: "EP-VERTICAL-SOFTWARE",
+    title: "Industry Vertical Readiness - Software platform",
+    status: "open",
+  },
+  "warehousing-fulfilment": {
+    kind: "epic",
+    id: "EP-VERTICAL-WAREHOUSING",
+    title: "Industry Vertical Readiness - Warehousing and fulfilment",
+    status: "open",
+  },
+};
+
+const TIER_RANK = ARCHETYPE_READINESS_TIERS.reduce(
+  (rank, tier, index) => ({ ...rank, [tier]: index }),
+  {} as Record<ArchetypeReadinessTier, number>,
+);
+
+const ALL_ARCHETYPE_CATEGORIES = Array.from(
+  new Set(ALL_ARCHETYPES.map((archetype) => archetype.category)),
+).sort() as ArchetypeCategory[];
+
+function blockedByOpenEvidence(
+  tier: Exclude<ArchetypeReadinessTier, "template-ready">,
+  reason: string,
+  evidence: readonly ArchetypeReadinessEvidenceRef[],
+): ArchetypeReadinessBlocker {
+  return { tier, reason, evidence };
+}
+
+function buildCategoryRecord(category: ArchetypeCategory): ArchetypeReadinessRecord {
+  const verticalReadinessEpic = VERTICAL_READINESS_EPICS_BY_CATEGORY[category];
+  const dependencies = [
+    PLATFORM_CONTRIBUTION_CONTRACT,
+    ...(verticalReadinessEpic ? [verticalReadinessEpic] : []),
+    ECOSYSTEM_ABSORPTION,
+    SOLE_PLATFORM_OPERATIONS_GATE,
+    WHOLE_ACCOUNT_PORTABILITY,
+    ACTION_ENVELOPE_REVERSIBILITY,
+  ];
+
+  const opsEvidence = [
+    PLATFORM_CONTRIBUTION_CONTRACT,
+    ...(verticalReadinessEpic ? [verticalReadinessEpic] : []),
+  ];
+
+  const opsBlockers = [
+    blockedByOpenEvidence(
+      "ops-ready",
+      verticalReadinessEpic
+        ? `${verticalReadinessEpic.id} is open; close or attach accepted verification evidence before claiming ops readiness.`
+        : "No category-level vertical-readiness epic is mapped for this archetype category.",
+      opsEvidence,
+    ),
+    blockedByOpenEvidence(
+      "ops-ready",
+      "BI-PSC-010 is still open; typed archetype contributions are not yet the single enforced door.",
+      [PLATFORM_CONTRIBUTION_CONTRACT],
+    ),
+  ];
+
+  return {
+    scopeKind: "archetype-category",
+    archetypeCategory: category,
+    highestClaimableTier: "template-ready",
+    evidenceByTier: {
+      "template-ready": [TEMPLATE_TAXONOMY, ARCHETYPE_PROVISIONING_PLAYBOOK],
+      "ops-ready": opsEvidence,
+      "connector-ready": [ECOSYSTEM_ABSORPTION],
+      "sole-platform-ready": [
+        SOLE_PLATFORM_OPERATIONS_GATE,
+        WHOLE_ACCOUNT_PORTABILITY,
+        ACTION_ENVELOPE_REVERSIBILITY,
+      ],
+    },
+    dependencies,
+    blockersByTier: {
+      "ops-ready": opsBlockers,
+      "connector-ready": [
+        blockedByOpenEvidence(
+          "connector-ready",
+          "Connector readiness requires the ops-ready tier plus a completed replacement-boundary and connector-posture lane.",
+          [ECOSYSTEM_ABSORPTION],
+        ),
+      ],
+      "regulated-ready": [
+        blockedByOpenEvidence(
+          "regulated-ready",
+          "Regulated readiness requires connector readiness plus policy, audit, approval, and jurisdictional evidence.",
+          [verticalReadinessEpic ?? PLATFORM_CONTRIBUTION_CONTRACT],
+        ),
+      ],
+      "sole-platform-ready": [
+        blockedByOpenEvidence(
+          "sole-platform-ready",
+          "Sole-platform readiness requires operations, portability, and AI action integrity gates to be completed.",
+          [
+            SOLE_PLATFORM_OPERATIONS_GATE,
+            WHOLE_ACCOUNT_PORTABILITY,
+            ACTION_ENVELOPE_REVERSIBILITY,
+          ],
+        ),
+      ],
+    },
+  };
+}
+
+export const ARCHETYPE_READINESS_MATRIX =
+  ALL_ARCHETYPE_CATEGORIES.map(buildCategoryRecord) as readonly ArchetypeReadinessRecord[];
+
+export function compareArchetypeReadinessTiers(
+  left: ArchetypeReadinessTier,
+  right: ArchetypeReadinessTier,
+): number {
+  return TIER_RANK[left] - TIER_RANK[right];
+}
+
+export function resolveArchetypeReadinessRecord({
+  archetypeCategory,
+  archetypeId,
+  matrix = ARCHETYPE_READINESS_MATRIX,
+}: Omit<ArchetypeReadinessClaimRequest, "requestedTier">):
+  | ArchetypeReadinessRecord
+  | null {
+  const category =
+    archetypeCategory ??
+    ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === archetypeId)?.category;
+
+  if (!category) return null;
+
+  return matrix.find((record) => record.archetypeCategory === category) ?? null;
+}
+
+export function evaluateArchetypeReadinessClaim(
+  request: ArchetypeReadinessClaimRequest,
+): ArchetypeReadinessClaimResult {
+  const record = resolveArchetypeReadinessRecord(request);
+
+  if (!record) {
+    return {
+      allowed: false,
+      requestedTier: request.requestedTier,
+      missingEvidence: ["Known archetype category or archetype id."],
+      blockers: [],
+    };
+  }
+
+  const allowed =
+    compareArchetypeReadinessTiers(record.highestClaimableTier, request.requestedTier) >= 0;
+
+  if (allowed) {
+    return {
+      allowed: true,
+      requestedTier: request.requestedTier,
+      highestClaimableTier: record.highestClaimableTier,
+      archetypeCategory: record.archetypeCategory,
+      missingEvidence: [],
+      blockers: [],
+    };
+  }
+
+  const missingTiers = ARCHETYPE_READINESS_TIERS.filter(
+    (tier) =>
+      compareArchetypeReadinessTiers(tier, record.highestClaimableTier) > 0 &&
+      compareArchetypeReadinessTiers(tier, request.requestedTier) <= 0,
+  ) as Exclude<ArchetypeReadinessTier, "template-ready">[];
+  const blockers = missingTiers.flatMap((tier) => [...(record.blockersByTier[tier] ?? [])]);
+
+  return {
+    allowed: false,
+    requestedTier: request.requestedTier,
+    highestClaimableTier: record.highestClaimableTier,
+    archetypeCategory: record.archetypeCategory,
+    missingEvidence: blockers.map((blocker) => blocker.reason),
+    blockers,
+  };
+}
+
+export function assertArchetypeReadinessClaimAllowed(
+  request: ArchetypeReadinessClaimRequest,
+): ArchetypeReadinessClaimResult {
+  const result = evaluateArchetypeReadinessClaim(request);
+  if (!result.allowed) {
+    const scope = request.archetypeId ?? request.archetypeCategory ?? "unknown archetype";
+    throw new Error(
+      `Cannot claim ${request.requestedTier} for ${scope}: ${result.missingEvidence.join(" ")}`,
+    );
+  }
+  return result;
+}

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -15,4 +15,5 @@ export * from "./demo-business-load";
 export * from "./demo-flavor";
 export * from "./processing-activity-templates";
 export * from "./product-mix";
+export * from "./archetype-readiness";
 export * from "./sections/schemas";


### PR DESCRIPTION
## Summary
- Add a typed archetype readiness matrix that evaluates whether an archetype can support a sole-platform business claim across template, profession corpus, coworker decision, skills/tools, and owner journey dimensions.
- Export the readiness evaluator from `@dpf/storefront-templates` and cover supported, blocked, partial, and unknown archetype cases with focused tests.
- Link the roadmap backlog map to the implementation plan for the archetype coverage gap.

## Test plan
- [x] Local-CI sandbox freshness: green (`next@16.2.11`, `react@19.2.8`, `react-dom@19.2.8`, `typescript@6.0.3`, `prisma@7.8.0`, `vitest@4.1.10`)
- [x] Prisma generate and migrate deploy: clean, 456 migrations, no pending migrations
- [x] Broad Vitest: 2299 passed, 4 skipped; 19921 tests passed, 19 skipped, 18 todo
- [x] Typecheck: `pnpm --filter web typecheck` passed
- [x] Production build: `docker build --target build -t dpf-local-integration-feat-archetype-readiness-matrix-build .` passed

Local-CI-Evidence: cms4y4t2i06s401npqw1devut (feat/archetype-readiness-matrix@8c676096c7f78de84ebf13c488948b935aa96740)