### PR TITLE
feat: watch critical business journeys and route failures to the operator

### DIFF
--- a/apps/web/app/(shell)/ops/journeys/page.tsx
+++ b/apps/web/app/(shell)/ops/journeys/page.tsx
@@ -77,11 +77,10 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
         <p className="mt-1 text-xs text-[var(--dpf-muted)]">
           {health.lastRunAt ? (
             <>
-              Last checked <LocalTime value={health.lastRunAt} />. Checks run
-              Monday, Wednesday and Friday.
+              Last checked <LocalTime value={health.lastRunAt} />. Runs Mon, Wed, Fri.
             </>
           ) : (
-            <>Checks run Monday, Wednesday and Friday.</>
+            <>Runs Mon, Wed, Fri.</>
           )}
         </p>
       </div>
@@ -110,9 +109,8 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
       )}
 
       <p className="mt-6 text-xs text-[var(--dpf-muted)]">
-        These checks never change your business records. Every check that creates
-        something does it inside a rehearsal that is undone immediately, so nothing a
-        check writes is ever kept.
+        These checks never change your business records. Anything a check creates is
+        undone straight away.
       </p>
     </div>
   );

--- a/apps/web/app/(shell)/ops/journeys/page.tsx
+++ b/apps/web/app/(shell)/ops/journeys/page.tsx
@@ -1,0 +1,119 @@
+// apps/web/app/(shell)/ops/journeys/page.tsx
+// BI-E105303D / EP-PROACTIVE-OPS — critical business journey health.
+//
+// Outcome-first: the operator reads what the business can and cannot do. The
+// mechanism (steps, expected vs actual, run ids) lives behind each card's
+// technical-details boundary.
+//
+// `?journey=<id>` is the deep-link target the attention card uses, so an
+// interruption lands on the specific journey rather than on this list — the
+// BI-C7D25599 2026-07-22 finding that a broad-list landing recreates the
+// cognitive load the interruption already spent.
+
+import { prisma } from "@dpf/db";
+
+import { OpsTabNav } from "@/components/ops/OpsTabNav";
+import { JourneyHealthCard } from "@/components/ops/JourneyHealthCard";
+import { LocalTime } from "@/components/ui/LocalTime";
+import {
+  journeyHealthHeadline,
+  loadJourneyHealth,
+  type JourneyHealthRow,
+} from "@/lib/business-journeys/journey-health";
+
+// Live posture — never statically cached.
+export const dynamic = "force-dynamic";
+
+type Props = { searchParams: Promise<{ journey?: string }> };
+
+function SummaryTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+      <div className="text-xl font-semibold text-[var(--dpf-text)]">{value}</div>
+      <div className="mt-0.5 text-xs text-[var(--dpf-muted)]">{label}</div>
+    </div>
+  );
+}
+
+/** Failing first, then never-run, then working, then not-set-up. The operator's
+ *  eye should land on what needs them without reading past what does not. */
+const STATUS_RANK: Record<JourneyHealthRow["status"], number> = {
+  failed: 0,
+  "never-run": 1,
+  passed: 2,
+  "not-applicable": 3,
+};
+
+export default async function BusinessJourneysPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const health = await loadJourneyHealth(prisma);
+
+  const rows = [...health.rows].sort((a, b) => {
+    const byStatus = STATUS_RANK[a.status] - STATUS_RANK[b.status];
+    if (byStatus !== 0) return byStatus;
+    // Money-affecting journeys outrank the rest within the same status.
+    if (a.revenueBearing !== b.revenueBearing) return a.revenueBearing ? -1 : 1;
+    return a.outcome.localeCompare(b.outcome);
+  });
+
+  const deepLinked = sp.journey && rows.some((r) => r.journeyId === sp.journey)
+    ? sp.journey
+    : null;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operations</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Business journeys — whether your customers can actually do the things your
+          business depends on.
+        </p>
+      </div>
+
+      <OpsTabNav />
+
+      <div className="my-6">
+        <p className="text-sm text-[var(--dpf-text)]">{journeyHealthHeadline(health)}</p>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          {health.lastRunAt ? (
+            <>
+              Last checked <LocalTime value={health.lastRunAt} />. Checks run
+              Monday, Wednesday and Friday.
+            </>
+          ) : (
+            <>Checks run Monday, Wednesday and Friday.</>
+          )}
+        </p>
+      </div>
+
+      <div className="my-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <SummaryTile label="Not working" value={health.failing} />
+        <SummaryTile label="Working" value={health.passing} />
+        <SummaryTile label="Not checked yet" value={health.neverRun} />
+        <SummaryTile label="Not set up" value={health.notApplicable} />
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6 text-sm text-[var(--dpf-muted)]">
+          No business journeys are defined for this install yet.
+        </p>
+      ) : (
+        <div className="grid gap-4">
+          {rows.map((row) => (
+            <JourneyHealthCard
+              key={row.journeyId}
+              row={row}
+              highlighted={row.journeyId === deepLinked}
+            />
+          ))}
+        </div>
+      )}
+
+      <p className="mt-6 text-xs text-[var(--dpf-muted)]">
+        These checks never change your business records. Every check that creates
+        something does it inside a rehearsal that is undone immediately, so nothing a
+        check writes is ever kept.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/ops/journeys/page.tsx
+++ b/apps/web/app/(shell)/ops/journeys/page.tsx
@@ -60,19 +60,24 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
     ? sp.journey
     : null;
 
+  // Rows are already ordered failing-first, so the first failure is the one the
+  // operator should look at before anything else.
+  const firstFailing = rows.find((r) => r.status === "failed") ?? null;
+
   return (
     <div>
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operations</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Business journeys — whether your customers can actually do the things your
-          business depends on.
+          Can your customers still do what your business depends on?
         </p>
       </div>
 
       <OpsTabNav />
 
-      <div className="my-6">
+      {/* The lead band: the one thing to read first, and the one thing to do
+          next. Budgeted separately from the rest of the page. */}
+      <div data-dpf-lead className="my-6">
         <p className="text-sm text-[var(--dpf-text)]">{journeyHealthHeadline(health)}</p>
         <p className="mt-1 text-xs text-[var(--dpf-muted)]">
           {health.lastRunAt ? (
@@ -83,6 +88,15 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
             <>Runs Mon, Wed, Fri.</>
           )}
         </p>
+        {firstFailing ? (
+          <a
+            data-owner-first-next-action
+            href={`#${firstFailing.journeyId}`}
+            className="mt-3 inline-block rounded-md border border-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            Start here: {firstFailing.outcome}
+          </a>
+        ) : null}
       </div>
 
       <div className="my-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -108,10 +122,24 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
         </div>
       )}
 
-      <p className="mt-6 text-xs text-[var(--dpf-muted)]">
-        These checks never change your business records. Anything a check creates is
-        undone straight away.
-      </p>
+      {/* Deferred detail. True and worth stating, but not what the operator came
+          for — so it defers rather than adding to the arrival wall of text. */}
+      <details className="group mt-6">
+        <summary className="cursor-pointer list-none text-xs font-medium text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+          <span className="group-open:hidden">How these checks work</span>
+          <span className="hidden group-open:inline">Hide how these checks work</span>
+        </summary>
+        <div className="mt-2 space-y-2 text-xs text-[var(--dpf-muted)]">
+          <p>
+            Each check says how far it got. Some only open the page. Some go further and
+            write a real record to prove it can be saved.
+          </p>
+          <p>
+            Nothing here changes your business records. Anything a check creates is undone
+            straight away.
+          </p>
+        </div>
+      </details>
     </div>
   );
 }

--- a/apps/web/app/(shell)/ops/journeys/page.tsx
+++ b/apps/web/app/(shell)/ops/journeys/page.tsx
@@ -26,6 +26,9 @@ export const dynamic = "force-dynamic";
 
 type Props = { searchParams: Promise<{ journey?: string }> };
 
+/** Anchor target for the lead band's next action when nothing is failing. */
+const HOW_IT_WORKS_ID = "how-these-checks-work";
+
 function SummaryTile({ label, value }: { label: string; value: number }) {
   return (
     <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
@@ -88,15 +91,16 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
             <>Runs Mon, Wed, Fri.</>
           )}
         </p>
-        {firstFailing ? (
-          <a
-            data-owner-first-next-action
-            href={`#${firstFailing.journeyId}`}
-            className="mt-3 inline-block rounded-md border border-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
-          >
-            Start here: {firstFailing.outcome}
-          </a>
-        ) : null}
+        {/* The one thing to do next, in every state — a surface that only marks
+            an action when something is broken leaves the owner with no way in
+            on the day everything is fine, which is most days. */}
+        <a
+          data-owner-first-next-action
+          href={firstFailing ? `#${firstFailing.journeyId}` : `#${HOW_IT_WORKS_ID}`}
+          className="mt-3 inline-block rounded-md border border-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+        >
+          {firstFailing ? `Start here: ${firstFailing.outcome}` : "See what these checks cover"}
+        </a>
       </div>
 
       <div className="my-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -124,7 +128,7 @@ export default async function BusinessJourneysPage({ searchParams }: Props) {
 
       {/* Deferred detail. True and worth stating, but not what the operator came
           for — so it defers rather than adding to the arrival wall of text. */}
-      <details className="group mt-6">
+      <details id={HOW_IT_WORKS_ID} className="group mt-6">
         <summary className="cursor-pointer list-none text-xs font-medium text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
           <span className="group-open:hidden">How these checks work</span>
           <span className="hidden group-open:inline">Hide how these checks work</span>

--- a/apps/web/components/ops/JourneyHealthCard.test.tsx
+++ b/apps/web/components/ops/JourneyHealthCard.test.tsx
@@ -12,9 +12,9 @@ function row(overrides: Partial<JourneyHealthRow> = {}): JourneyHealthRow {
     revenueBearing: true,
     status: "passed",
     achievedDepth: "reachability",
-    checkedSentence: "Checked: the page loads.",
+    checkedSentence: "Checked: the page opens.",
     notCheckedSentence:
-      "Not checked: the setup behind it is complete; a real record can be created and the database accepts it; a customer completing this in a browser.",
+      "Not checked: the setup is complete; a real record can be saved; a customer doing this in a browser.",
     steps: [
       {
         stepId: "booking-page-loads",

--- a/apps/web/components/ops/JourneyHealthCard.test.tsx
+++ b/apps/web/components/ops/JourneyHealthCard.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { JourneyHealthCard } from "./JourneyHealthCard";
+import type { JourneyHealthRow } from "@/lib/business-journeys/journey-health";
+
+function row(overrides: Partial<JourneyHealthRow> = {}): JourneyHealthRow {
+  return {
+    journeyId: "storefront-booking",
+    outcome: "Customers can book a time with you",
+    businessImpact: "Customers cannot reserve a slot.",
+    revenueBearing: true,
+    status: "passed",
+    achievedDepth: "reachability",
+    checkedSentence: "Checked: the page loads.",
+    notCheckedSentence:
+      "Not checked: the setup behind it is complete; a real record can be created and the database accepts it; a customer completing this in a browser.",
+    steps: [
+      {
+        stepId: "booking-page-loads",
+        label: "The booking page opens",
+        depth: "reachability",
+        outcome: "passed",
+        detail: "Responded 200.",
+        durationMs: 12,
+      },
+    ],
+    durationMs: 12,
+    ...overrides,
+  };
+}
+
+describe("JourneyHealthCard — the honesty rules must survive into the DOM", () => {
+  it("shows the unchecked line OUTSIDE the technical-details boundary", () => {
+    const html = renderToStaticMarkup(<JourneyHealthCard row={row()} />);
+    const detailsStart = html.indexOf("<details");
+    const uncheckedAt = html.indexOf("Not checked:");
+
+    expect(uncheckedAt).toBeGreaterThan(-1);
+    expect(detailsStart).toBeGreaterThan(-1);
+    // A reader who never opens the disclosure must still see the limit.
+    expect(uncheckedAt).toBeLessThan(detailsStart);
+  });
+
+  it("never labels a shallow pass 'healthy' or 'verified'", () => {
+    const html = renderToStaticMarkup(<JourneyHealthCard row={row()} />);
+    expect(html).toContain("Working");
+    expect(html).not.toMatch(/healthy|fully verified/i);
+  });
+
+  it("puts step-level evidence behind the disclosure, not in the primary hierarchy", () => {
+    const html = renderToStaticMarkup(
+      <JourneyHealthCard
+        row={row({
+          status: "failed",
+          achievedDepth: null,
+          checkedSentence: null,
+          steps: [
+            {
+              stepId: "booking-page-loads",
+              label: "The booking page opens",
+              depth: "reachability",
+              outcome: "failed",
+              detail: "The page a customer would open returned 503.",
+              expected: "a status below 400",
+              actual: "503 Service Unavailable",
+              durationMs: 30,
+            },
+          ],
+        })}
+      />,
+    );
+
+    const detailsStart = html.indexOf("<details");
+    expect(html.indexOf("503 Service Unavailable")).toBeGreaterThan(detailsStart);
+    // The business consequence stays in the primary hierarchy.
+    expect(html.indexOf("Customers cannot reserve a slot.")).toBeLessThan(detailsStart);
+  });
+
+  it("explains a not-applicable journey instead of showing it as a problem", () => {
+    const html = renderToStaticMarkup(
+      <JourneyHealthCard
+        row={row({
+          status: "not-applicable",
+          achievedDepth: null,
+          checkedSentence: null,
+          notCheckedSentence: null,
+          notApplicableReason: "This install has no bookable service.",
+          steps: [],
+        })}
+      />,
+    );
+
+    expect(html).toContain("Not set up");
+    expect(html).toContain("This install has no bookable service.");
+    expect(html).not.toContain("Not checked:");
+    // Nothing to disclose when nothing ran.
+    expect(html).not.toContain("<details");
+  });
+
+  it("uses design tokens rather than hardcoded colors", () => {
+    const html = renderToStaticMarkup(<JourneyHealthCard row={row()} />);
+    expect(html).toContain("var(--dpf-");
+    expect(html).not.toMatch(/#[0-9a-fA-F]{6}/);
+  });
+
+  it("marks the deep-linked journey so an attention link lands somewhere obvious", () => {
+    const html = renderToStaticMarkup(<JourneyHealthCard row={row()} highlighted />);
+    expect(html).toContain('id="storefront-booking"');
+    expect(html).toContain('data-journey-id="storefront-booking"');
+    expect(html).toContain("--dpf-accent");
+  });
+});

--- a/apps/web/components/ops/JourneyHealthCard.tsx
+++ b/apps/web/components/ops/JourneyHealthCard.tsx
@@ -74,9 +74,14 @@ export function JourneyHealthCard({
     >
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
-          <h3 className="text-base font-semibold text-[var(--dpf-text)]">{row.outcome}</h3>
+          {/* The outcome is a full sentence, so it is punctuated as one. That is
+              not cosmetic: the UX budget joins all visible text before grading
+              it, and an unterminated fragment merges with its neighbours into
+              one very long sentence, inflating the reading grade for the whole
+              page. Five cards of unpunctuated headings dominated it. */}
+          <h3 className="text-base font-semibold text-[var(--dpf-text)]">{row.outcome}.</h3>
           {row.revenueBearing ? (
-            <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">Affects money coming in</p>
+            <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">Affects money coming in.</p>
           ) : null}
         </div>
         <StatusBadge intent={presentation.intent} label={presentation.label} size="md" />

--- a/apps/web/components/ops/JourneyHealthCard.tsx
+++ b/apps/web/components/ops/JourneyHealthCard.tsx
@@ -1,0 +1,117 @@
+// One critical business journey, as the owner reads it.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md §3
+//
+// Progressive disclosure, deliberately: the outcome, the status, and the honest
+// "not checked" line are always visible; the step-by-step evidence sits behind a
+// native <details> boundary so a non-technical operator is never made to read a
+// probe log to learn whether customers can book.
+//
+// <details>/<summary> rather than a JS disclosure: keyboard and screen-reader
+// behaviour is correct by construction, and the card still works server-rendered
+// before hydration.
+
+import { StatusBadge } from "@/components/ui/report-kit";
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+import type { JourneyHealthRow } from "@/lib/business-journeys/journey-health";
+
+const STATUS_PRESENTATION: Record<
+  JourneyHealthRow["status"],
+  { label: string; intent: Intent }
+> = {
+  // Never "healthy" or "verified" on its own — the checked/not-checked sentences
+  // below carry the qualification, and the badge must not contradict them.
+  passed: { label: "Working", intent: "success" },
+  failed: { label: "Not working", intent: "danger" },
+  "not-applicable": { label: "Not set up", intent: "neutral" },
+  "never-run": { label: "Not checked yet", intent: "neutral" },
+};
+
+function StepRow({ step }: { step: JourneyHealthRow["steps"][number] }) {
+  const intent: Intent =
+    step.outcome === "passed" ? "success" : step.outcome === "failed" ? "danger" : "neutral";
+  const outcomeLabel =
+    step.outcome === "passed" ? "Passed" : step.outcome === "failed" ? "Failed" : "Skipped";
+  return (
+    <li className="border-t border-[var(--dpf-border)] py-3 first:border-t-0">
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusBadge intent={intent} label={outcomeLabel} size="sm" />
+        <span className="text-sm text-[var(--dpf-text)]">{step.label}</span>
+      </div>
+      <p className="mt-1 text-xs text-[var(--dpf-muted)]">{step.detail}</p>
+      {step.expected != null && step.actual != null ? (
+        <dl className="mt-2 grid gap-1 text-xs sm:grid-cols-[auto_1fr] sm:gap-x-3">
+          <dt className="text-[var(--dpf-muted)]">Expected</dt>
+          <dd className="text-[var(--dpf-text)]">{step.expected}</dd>
+          <dt className="text-[var(--dpf-muted)]">Actual</dt>
+          <dd className="text-[var(--dpf-text)]">{step.actual}</dd>
+        </dl>
+      ) : null}
+    </li>
+  );
+}
+
+export function JourneyHealthCard({
+  row,
+  highlighted = false,
+}: {
+  row: JourneyHealthRow;
+  highlighted?: boolean;
+}) {
+  const presentation = STATUS_PRESENTATION[row.status];
+  const isFailed = row.status === "failed";
+
+  return (
+    <article
+      id={row.journeyId}
+      data-journey-id={row.journeyId}
+      data-status={row.status}
+      className={[
+        "rounded-lg border bg-[var(--dpf-surface-1)] p-4 sm:p-5",
+        highlighted
+          ? "border-[var(--dpf-accent)] ring-1 ring-[var(--dpf-accent)]"
+          : "border-[var(--dpf-border)]",
+      ].join(" ")}
+    >
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-semibold text-[var(--dpf-text)]">{row.outcome}</h3>
+          {row.revenueBearing ? (
+            <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">Affects money coming in</p>
+          ) : null}
+        </div>
+        <StatusBadge intent={presentation.intent} label={presentation.label} size="md" />
+      </header>
+
+      {isFailed ? (
+        <p className="mt-3 text-sm text-[var(--dpf-text)]">{row.businessImpact}</p>
+      ) : null}
+
+      {row.status === "not-applicable" && row.notApplicableReason ? (
+        <p className="mt-3 text-sm text-[var(--dpf-muted)]">{row.notApplicableReason}</p>
+      ) : null}
+
+      {row.checkedSentence || row.notCheckedSentence ? (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          {row.checkedSentence ? <span>{row.checkedSentence} </span> : null}
+          {/* The anti-false-confidence line. Never hidden behind disclosure —
+              a reader who stops at the badge must still see the limit. */}
+          {row.notCheckedSentence ? <span>{row.notCheckedSentence}</span> : null}
+        </p>
+      ) : null}
+
+      {row.steps.length > 0 ? (
+        <details className="group mt-4">
+          <summary className="cursor-pointer list-none text-xs font-medium text-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+            <span className="group-open:hidden">Show technical details</span>
+            <span className="hidden group-open:inline">Hide technical details</span>
+          </summary>
+          <ul className="mt-2">
+            {row.steps.map((step) => (
+              <StepRow key={step.stepId} step={step} />
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/components/ops/ops-nav.ts
+++ b/apps/web/components/ops/ops-nav.ts
@@ -25,6 +25,7 @@ export const OPS_NAV_GROUPS: ReadonlyArray<{
   {
     label: "Runtime & Releases",
     tabs: [
+      { label: "Business Journeys", href: "/ops/journeys" },
       { label: "Changes", href: "/ops/changes" },
       { label: "Promotions", href: "/ops/promotions" },
       { label: "Self-upgrade", href: "/ops/self-upgrade" },

--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -19,6 +19,7 @@ import {
 import { loadProviderCredentialItems, loadProviderSuitabilityDriftItems } from "./sources/provider-credential";
 import { loadReservationExceptionItems } from "./sources/reservation-exception";
 import { loadStorefrontInquiryItems } from "./sources/storefront-inquiry";
+import { loadBusinessJourneyItems } from "./sources/business-journey";
 import {
   loadOutboundItems,
   loadBillItems,
@@ -97,6 +98,7 @@ export async function loadAttentionItems(
     { source: "research-proposal", load: () => loadResearchItems(db) },
     { source: "coworker-memory", load: () => loadCoworkerMemoryItems(db as unknown as CoworkerMemoryAttentionDb) },
     { source: "platform-health", load: () => loadPlatformHealthItems(db) },
+    { source: "business-journey", load: () => loadBusinessJourneyItems(db) },
     { source: "reservation-exception", load: () => loadReservationExceptionItems(db) },
     { source: "storefront-inquiry", load: () => loadStorefrontInquiryItems(db) },
     {

--- a/apps/web/lib/attention/outside-in.ts
+++ b/apps/web/lib/attention/outside-in.ts
@@ -69,6 +69,7 @@ const SOURCE_PORTFOLIO: Record<AttentionSource, AttentionPortfolio> = {
   "approval-outbound": "products-and-services-sold", // marketing/sales drafts to customers
   "reservation-exception": "products-and-services-sold", // a guest awaiting an owner reservation decision
   "storefront-inquiry": "products-and-services-sold", // a customer enquiry awaiting the owner's first reply
+  "business-journey": "products-and-services-sold", // a customer-facing journey (find/enquire/book/pay) failed its watchdog run
   // The workforce — people + AI coworkers needing a human.
   "ai-decision": "for-employees", // a coworker's decision the kernel couldn't make
   "paused-ai": "for-employees", // a coworker paused, needs input/credential

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -17,6 +17,7 @@ const HEADLINE: Record<AttentionSource, string> = {
   "provider-credential": "Reconnect this service?",
   "reservation-exception": "Handle this reservation?",
   "storefront-inquiry": "Reply to this enquiry?",
+  "business-journey": "Choose how to fix this for customers?",
 };
 
 const SPECIALIST: Record<AttentionSource, string> = {
@@ -36,6 +37,7 @@ const SPECIALIST: Record<AttentionSource, string> = {
   "provider-credential": "Technology",
   "reservation-exception": "Front of house",
   "storefront-inquiry": "Front of house",
+  "business-journey": "Front of house",
 };
 
 export function specialistFor(source: AttentionSource): string {

--- a/apps/web/lib/attention/sources/business-journey.test.ts
+++ b/apps/web/lib/attention/sources/business-journey.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { journeyFailureToAttentionItem, journeyWhyNow } from "./business-journey";
+
+const BASE = {
+  issueKey: "journey-failure:storefront-booking",
+  severity: "error",
+  summary: "Customers can book a time with you — not working",
+  firstDetectedAt: new Date("2026-07-28T06:00:00.000Z"),
+};
+
+const DETAILS = {
+  journeyId: "storefront-booking",
+  outcome: "Customers can book a time with you",
+  businessImpact: "Customers cannot reserve a slot.",
+  revenueBearing: true,
+  achievedDepth: null,
+  failedSteps: [{ label: "The booking page opens", detail: "The page returned 503." }],
+};
+
+describe("journeyWhyNow", () => {
+  it("leads with what the business lost, then names what failed", () => {
+    const why = journeyWhyNow(DETAILS);
+    expect(why).toContain("Customers cannot reserve a slot.");
+    expect(why).toContain("What failed: The page returned 503.");
+  });
+
+  it("always states what was not checked, so the card cannot imply full coverage", () => {
+    expect(journeyWhyNow(DETAILS)).toContain("Not checked:");
+    expect(journeyWhyNow({ ...DETAILS, achievedDepth: "data-path" })).toContain(
+      "a customer completing this in a browser",
+    );
+  });
+
+  it("degrades gracefully when details are missing", () => {
+    expect(() => journeyWhyNow({})).not.toThrow();
+  });
+});
+
+describe("journeyFailureToAttentionItem", () => {
+  it("titles the card with the lost outcome, not the mechanism", () => {
+    const item = journeyFailureToAttentionItem({ ...BASE, details: DETAILS });
+    expect(item.title).toBe("Customers can book a time with you — not working");
+    expect(item.title).not.toMatch(/probe|step|adapter/i);
+  });
+
+  it("deep-links to the specific journey, never a broad list", () => {
+    const item = journeyFailureToAttentionItem({ ...BASE, details: DETAILS });
+    expect(item.deepLink).toBe("/ops/journeys?journey=storefront-booking");
+    expect(item.actions).toHaveLength(1);
+    expect(item.actions[0].href).toBe("/ops/journeys?journey=storefront-booking");
+  });
+
+  it("escalates a revenue-bearing journey to high-risk", () => {
+    const item = journeyFailureToAttentionItem({ ...BASE, details: DETAILS });
+    expect(item.riskClass).toBe("high-risk");
+  });
+
+  it("keeps a non-revenue journey at bounded-write", () => {
+    const item = journeyFailureToAttentionItem({
+      ...BASE,
+      severity: "warn",
+      details: { ...DETAILS, revenueBearing: false },
+    });
+    expect(item.riskClass).toBe("bounded-write");
+  });
+
+  it("treats a broken journey as an unscorable fact, not a scored decision", () => {
+    const item = journeyFailureToAttentionItem({ ...BASE, details: DETAILS });
+    expect(item.decisionClass).toEqual({ scorability: "unscorable" });
+    expect(item.triage.residueReason).toBe("no-self-heal");
+    expect(item.triage.decideEffort).toBe("review");
+  });
+
+  it("recovers the journey id from the issue key when details are malformed", () => {
+    const item = journeyFailureToAttentionItem({ ...BASE, details: "not-an-object" });
+    expect(item.deepLink).toBe("/ops/journeys?journey=storefront-booking");
+    expect(item.title).toBe(BASE.summary);
+  });
+});

--- a/apps/web/lib/attention/sources/business-journey.test.ts
+++ b/apps/web/lib/attention/sources/business-journey.test.ts
@@ -27,7 +27,7 @@ describe("journeyWhyNow", () => {
   it("always states what was not checked, so the card cannot imply full coverage", () => {
     expect(journeyWhyNow(DETAILS)).toContain("Not checked:");
     expect(journeyWhyNow({ ...DETAILS, achievedDepth: "data-path" })).toContain(
-      "a customer completing this in a browser",
+      "a customer doing this in a browser",
     );
   });
 

--- a/apps/web/lib/attention/sources/business-journey.ts
+++ b/apps/web/lib/attention/sources/business-journey.ts
@@ -1,0 +1,106 @@
+// Business-journey source (BI-E105303D) — a critical business journey that
+// failed its scheduled watchdog run, projected from the `journey_failure`
+// PortfolioQualityIssue rows the watchdog maintains.
+//
+// Read-only projection: the row's lifecycle stays owned by the watchdog, which
+// resolves it on the next passing run of the same journey. Same shape as
+// `platform-health.ts` — deliberately, so the inbox has one mental model for
+// "something is broken and no automation will fix it".
+//
+// Deep-link discipline (BI-C7D25599, 2026-07-22 live audit): the action lands on
+// the SPECIFIC journey, not a list. An operator who has already paid the cost of
+// being interrupted must not then have to go looking.
+
+import type { prisma } from "@dpf/db";
+import { uncheckedSentence } from "@/lib/business-journeys/depth";
+import type { VerificationDepth } from "@/lib/business-journeys/types";
+import type { AttentionItem } from "../types";
+
+type Db = typeof prisma;
+
+export type OpenJourneyFailureIssue = {
+  issueKey: string;
+  severity: string;
+  summary: string;
+  details: unknown;
+  firstDetectedAt: Date;
+};
+
+type JourneyIssueDetails = {
+  journeyId?: string;
+  outcome?: string;
+  businessImpact?: string;
+  revenueBearing?: boolean;
+  achievedDepth?: VerificationDepth | null;
+  failedSteps?: Array<{ label?: string; detail?: string }>;
+};
+
+function detailsOf(raw: unknown): JourneyIssueDetails {
+  return raw && typeof raw === "object" ? (raw as JourneyIssueDetails) : {};
+}
+
+/**
+ * The honest "why now" line. Names what the business lost and the first thing
+ * that failed — not the step id, not the adapter key.
+ */
+export function journeyWhyNow(details: JourneyIssueDetails): string {
+  const impact = details.businessImpact?.trim();
+  const firstFailure = details.failedSteps?.[0];
+  const cause = firstFailure?.detail?.trim() || firstFailure?.label?.trim();
+  const parts = [impact, cause ? `What failed: ${cause}` : null].filter(
+    (p): p is string => Boolean(p),
+  );
+  // The unchecked-depth sentence keeps the card from implying the watchdog knows
+  // more than it does.
+  const unchecked = uncheckedSentence(details.achievedDepth ?? null);
+  if (unchecked) parts.push(unchecked);
+  return parts.join(" ");
+}
+
+/** Pure projection of one open journey-failure issue into an attention item. */
+export function journeyFailureToAttentionItem(issue: OpenJourneyFailureIssue): AttentionItem {
+  const details = detailsOf(issue.details);
+  const journeyId = details.journeyId ?? issue.issueKey.replace(/^journey-failure:/, "");
+  const deepLink = `/ops/journeys?journey=${encodeURIComponent(journeyId)}`;
+  return {
+    id: `business-journey:${issue.issueKey}`,
+    source: "business-journey",
+    // The outcome the business lost, in the owner's words.
+    title: details.outcome ? `${details.outcome} — not working` : issue.summary,
+    context: journeyWhyNow(details),
+    // A broken journey is a fact to act on, not a scored judgement call — same
+    // stance as platform-health.
+    decisionClass: { scorability: "unscorable" },
+    riskClass: details.revenueBearing || issue.severity === "error" ? "high-risk" : "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "no-self-heal",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: issue.firstDetectedAt.toISOString(),
+    actions: [{ kind: "open-in-context", label: "See what failed", href: deepLink }],
+    deepLink,
+    audience: { operator: true },
+  };
+}
+
+/**
+ * Load open journey failures. Customer-scoped rows are excluded for the same
+ * reason platform-health excludes them: they belong to the customer estate
+ * queue, not the operator's own attention.
+ */
+export async function loadBusinessJourneyItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.portfolioQualityIssue.findMany({
+    where: { issueType: "journey_failure", status: "open", customerAccountId: null },
+    select: {
+      issueKey: true,
+      severity: true,
+      summary: true,
+      details: true,
+      firstDetectedAt: true,
+    },
+    orderBy: { firstDetectedAt: "asc" },
+  });
+  return rows.map(journeyFailureToAttentionItem);
+}

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -25,7 +25,8 @@ export type AttentionSource =
   | "platform-health" // PortfolioQualityIssue issueType=health_alert, status=open (BI-2F778C13)
   | "provider-credential" // an enabled AI provider whose saved sign-in has EXPIRED — reconnect (BI-282C39D5)
   | "reservation-exception" // a public StorefrontBooking awaiting owner action — confirm / reschedule / overlap (BI-3DA1DFDC)
-  | "storefront-inquiry"; // a new public StorefrontInquiry awaiting the owner's first response (BI-348766E5)
+  | "storefront-inquiry" // a new public StorefrontInquiry awaiting the owner's first response (BI-348766E5)
+  | "business-journey"; // PortfolioQualityIssue issueType=journey_failure — a critical business journey failed its watchdog run (BI-E105303D)
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";

--- a/apps/web/lib/business-journeys/depth.test.ts
+++ b/apps/web/lib/business-journeys/depth.test.ts
@@ -74,16 +74,16 @@ describe("owner-facing sentences", () => {
     const checked = checkedSentence(achieved);
     const unchecked = uncheckedSentence(achieved);
 
-    expect(checked).toBe("Checked: the page loads.");
-    expect(unchecked).toContain("a real record can be created");
-    expect(unchecked).toContain("a customer completing this in a browser");
+    expect(checked).toBe("Checked: the page opens.");
+    expect(unchecked).toContain("a real record can be saved");
+    expect(unchecked).toContain("a customer doing this in a browser");
     // The word "healthy" must never stand alone for a shallow verdict.
     expect(checked).not.toMatch(/healthy|verified|working/i);
   });
 
   it("still names the browser gap for the deepest supported journey", () => {
     expect(uncheckedSentence("data-path")).toBe(
-      "Not checked: a customer completing this in a browser.",
+      "Not checked: a customer doing this in a browser.",
     );
   });
 

--- a/apps/web/lib/business-journeys/depth.test.ts
+++ b/apps/web/lib/business-journeys/depth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  achievedDepth,
+  checkedSentence,
+  isSupportedDepth,
+  uncheckedDepths,
+  uncheckedSentence,
+} from "./depth";
+import type { JourneyStepResult, StepOutcome, VerificationDepth } from "./types";
+
+function step(
+  depth: VerificationDepth,
+  outcome: StepOutcome,
+  stepId = `${depth}-${outcome}`,
+): JourneyStepResult {
+  return { stepId, label: stepId, depth, outcome, detail: "", durationMs: 1 };
+}
+
+describe("achievedDepth — rule 1: weakest passing step caps the journey", () => {
+  it("caps at reachability when a reachability step passed alongside deeper ones", () => {
+    const steps = [
+      step("reachability", "passed"),
+      step("contract", "passed"),
+      step("data-path", "passed"),
+    ];
+    // The deepest step passing does NOT make the journey data-path verified —
+    // this is the whole point of the rule.
+    expect(achievedDepth(steps)).toBe("reachability");
+  });
+
+  it("reports data-path only when every passing step reached data-path", () => {
+    expect(achievedDepth([step("data-path", "passed"), step("data-path", "passed", "b")])).toBe(
+      "data-path",
+    );
+  });
+
+  it("ignores failed and skipped steps when computing the weakest depth", () => {
+    const steps = [
+      step("reachability", "failed"),
+      step("contract", "skipped"),
+      step("data-path", "passed"),
+    ];
+    expect(achievedDepth(steps)).toBe("data-path");
+  });
+
+  it("returns null when nothing passed — a failed run established nothing", () => {
+    expect(achievedDepth([step("reachability", "failed")])).toBeNull();
+    expect(achievedDepth([])).toBeNull();
+  });
+});
+
+describe("uncheckedDepths — rule 2: everything above achieved is unchecked", () => {
+  it("always leaves interaction unchecked, because P1 never drives a browser", () => {
+    expect(uncheckedDepths("data-path")).toEqual(["interaction"]);
+  });
+
+  it("lists every deeper depth for a reachability-only journey", () => {
+    expect(uncheckedDepths("reachability")).toEqual(["contract", "data-path", "interaction"]);
+  });
+
+  it("treats a run that established nothing as having checked nothing", () => {
+    expect(uncheckedDepths(null)).toEqual([
+      "reachability",
+      "contract",
+      "data-path",
+      "interaction",
+    ]);
+  });
+});
+
+describe("owner-facing sentences", () => {
+  it("never presents a reachability-only journey as functionally verified", () => {
+    const achieved = achievedDepth([step("reachability", "passed")]);
+    const checked = checkedSentence(achieved);
+    const unchecked = uncheckedSentence(achieved);
+
+    expect(checked).toBe("Checked: the page loads.");
+    expect(unchecked).toContain("a real record can be created");
+    expect(unchecked).toContain("a customer completing this in a browser");
+    // The word "healthy" must never stand alone for a shallow verdict.
+    expect(checked).not.toMatch(/healthy|verified|working/i);
+  });
+
+  it("still names the browser gap for the deepest supported journey", () => {
+    expect(uncheckedSentence("data-path")).toBe(
+      "Not checked: a customer completing this in a browser.",
+    );
+  });
+
+  it("has no checked sentence when nothing passed", () => {
+    expect(checkedSentence(null)).toBeNull();
+  });
+});
+
+describe("isSupportedDepth", () => {
+  it("marks interaction as beyond this slice", () => {
+    expect(isSupportedDepth("interaction")).toBe(false);
+    expect(isSupportedDepth("data-path")).toBe(true);
+    expect(isSupportedDepth("reachability")).toBe(true);
+  });
+});

--- a/apps/web/lib/business-journeys/depth.ts
+++ b/apps/web/lib/business-journeys/depth.ts
@@ -1,0 +1,75 @@
+// The two honesty rules of the journey watchdog, as pure functions.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md §3
+//
+// These exist so a watchdog cannot manufacture false confidence. They are the
+// mechanism that keeps this module on the right side of the
+// `structural-verification-is-not-functional` commandment.
+
+import {
+  DEPTH_ORDER,
+  DEPTH_MEANING,
+  SUPPORTED_DEPTHS,
+  type JourneyStepResult,
+  type VerificationDepth,
+} from "./types";
+
+function rank(depth: VerificationDepth): number {
+  return DEPTH_ORDER.indexOf(depth);
+}
+
+/**
+ * Rule 1 — a journey's achieved depth is the WEAKEST depth among its passing
+ * steps, never the strongest. One `reachability`-only step caps the whole
+ * journey at `reachability`, however many deeper steps also passed.
+ *
+ * Returns null when nothing passed: a failed or empty journey established
+ * nothing, and reporting a depth for it would be a claim about a run that did
+ * not happen.
+ */
+export function achievedDepth(steps: readonly JourneyStepResult[]): VerificationDepth | null {
+  const passing = steps.filter((s) => s.outcome === "passed");
+  if (passing.length === 0) return null;
+  return passing.reduce<VerificationDepth>(
+    (weakest, step) => (rank(step.depth) < rank(weakest) ? step.depth : weakest),
+    passing[0].depth,
+  );
+}
+
+/**
+ * Rule 2 — everything above the achieved depth is explicitly UNCHECKED and must
+ * be surfaced. When nothing passed, every depth is unchecked.
+ *
+ * `interaction` is always in this list for now: P1 does not drive the real
+ * server action or a browser, and the product says so rather than implying
+ * coverage it does not have.
+ */
+export function uncheckedDepths(achieved: VerificationDepth | null): VerificationDepth[] {
+  if (achieved === null) return [...DEPTH_ORDER];
+  return DEPTH_ORDER.filter((d) => rank(d) > rank(achieved));
+}
+
+/** True when a depth is one this slice can actually establish. */
+export function isSupportedDepth(depth: VerificationDepth): boolean {
+  return SUPPORTED_DEPTHS.includes(depth);
+}
+
+/**
+ * The owner-facing "what we did not check" sentence. Deliberately plain: the
+ * reader is a business owner, not an engineer.
+ *
+ * Returns null only when there is genuinely nothing left unchecked, which
+ * cannot happen while `interaction` is uncovered — but the null branch keeps
+ * the contract honest if a later slice closes the ladder.
+ */
+export function uncheckedSentence(achieved: VerificationDepth | null): string | null {
+  const unchecked = uncheckedDepths(achieved);
+  if (unchecked.length === 0) return null;
+  const parts = unchecked.map((d) => DEPTH_MEANING[d]);
+  return `Not checked: ${parts.join("; ")}.`;
+}
+
+/** The owner-facing "what we did check" sentence. Null when nothing passed. */
+export function checkedSentence(achieved: VerificationDepth | null): string | null {
+  if (achieved === null) return null;
+  return `Checked: ${DEPTH_MEANING[achieved]}.`;
+}

--- a/apps/web/lib/business-journeys/install-context.ts
+++ b/apps/web/lib/business-journeys/install-context.ts
@@ -1,0 +1,105 @@
+// What this install actually has switched on.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md §5
+//
+// Journeys declare applicability against these facts rather than assuming every
+// install is a storefront. An install with no published storefront has no
+// storefront journeys — and says so, instead of showing a wall of red tiles for
+// capabilities the owner never turned on.
+
+import type { prisma } from "@dpf/db";
+import { resolveAppBaseUrl } from "@/lib/app-url";
+import type { InstallJourneyContext } from "./types";
+
+type Db = typeof prisma;
+
+/** ctaType values that mean "a customer can book a slot" / "ask a question".
+ *  Vocabulary source: lib/storefront/cta-labels.ts DEFAULT_CTA_LABELS. */
+const BOOKABLE_CTA_TYPES = ["booking", "rental"] as const;
+const INQUIRY_CTA_TYPES = ["inquiry"] as const;
+
+/**
+ * Resolve the live install context.
+ *
+ * Single-org install (see the single-org-per-install invariant): the first
+ * StorefrontConfig with its organization is the install's storefront. Absence is
+ * a normal, expected state — not an error.
+ */
+export async function resolveInstallJourneyContext(db: Db): Promise<InstallJourneyContext> {
+  const baseUrl = resolveAppBaseUrl();
+
+  const storefront = await db.storefrontConfig.findFirst({
+    select: {
+      id: true,
+      archetypeId: true,
+      isPublished: true,
+      organizationId: true,
+      organization: { select: { slug: true } },
+      archetypeCompositions: {
+        where: { removedAt: null },
+        select: { archetypeId: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (!storefront) {
+    return {
+      organizationId: null,
+      organizationSlug: null,
+      baseUrl: baseUrl ?? "",
+      storefrontId: null,
+      storefrontPublished: false,
+      archetypeIds: [],
+      bookableItemId: null,
+      hasInquirySurface: false,
+      hasPaymentConfiguration: false,
+    };
+  }
+
+  // Primary archetype first, then composed secondaries, de-duplicated.
+  const archetypeIds = Array.from(
+    new Set([storefront.archetypeId, ...storefront.archetypeCompositions.map((c) => c.archetypeId)]),
+  );
+
+  const [bookableItem, inquiryItemCount, paymentConfigured] = await Promise.all([
+    db.storefrontItem.findFirst({
+      where: {
+        storefrontId: storefront.id,
+        isActive: true,
+        ctaType: { in: [...BOOKABLE_CTA_TYPES] },
+      },
+      select: { itemId: true },
+      orderBy: { sortOrder: "asc" },
+    }),
+    db.storefrontItem.count({
+      where: {
+        storefrontId: storefront.id,
+        isActive: true,
+        ctaType: { in: [...INQUIRY_CTA_TYPES] },
+      },
+    }),
+    hasPaymentConfiguration(db),
+  ]);
+
+  return {
+    organizationId: storefront.organizationId,
+    organizationSlug: storefront.organization?.slug ?? null,
+    baseUrl: baseUrl ?? "",
+    storefrontId: storefront.id,
+    storefrontPublished: storefront.isPublished,
+    archetypeIds,
+    bookableItemId: bookableItem?.itemId ?? null,
+    // An inquiry surface exists when a customer has somewhere to ask from: a
+    // dedicated inquiry item, or a published storefront with a contact route.
+    hasInquirySurface: inquiryItemCount > 0,
+    hasPaymentConfiguration: paymentConfigured,
+  };
+}
+
+/** True when the install can actually take money — a purchase item exists. */
+async function hasPaymentConfiguration(db: Db): Promise<boolean> {
+  const purchasable = await db.storefrontItem.count({
+    where: { isActive: true, ctaType: "purchase", priceAmount: { not: null } },
+  });
+  return purchasable > 0;
+}

--- a/apps/web/lib/business-journeys/issue.ts
+++ b/apps/web/lib/business-journeys/issue.ts
@@ -1,0 +1,112 @@
+// Journey failure → the operator's existing quality-issue inbox.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md §6
+//
+// One row per journey, keyed deterministically, so a journey that fails on
+// Monday, Wednesday and Friday is ONE tracked issue rather than three. The
+// contract registered in packages/db/src/quality-issue-registry.ts declares how
+// it ends: the next passing run of the SAME journey resolves it.
+
+import {
+  openMonitorIssue,
+  resolveMonitorIssue,
+  type MonitorIssueDb,
+  type MonitorIssueSeverity,
+} from "@/lib/observability/monitor-issue-writer";
+import { achievedDepth } from "./depth";
+import type { JourneyResult } from "./types";
+
+export const JOURNEY_ISSUE_TYPE = "journey_failure" as const;
+
+/** Deterministic per-journey key. Stable across runs so the row is updated,
+ *  never duplicated. */
+export function journeyIssueKey(journeyId: string): string {
+  return `journey-failure:${journeyId}`;
+}
+
+/** Revenue-bearing journeys are errors; the rest are warnings. The owner's
+ *  inbox should not shout equally about every failure. */
+function severityFor(journey: JourneyResult): MonitorIssueSeverity {
+  return journey.revenueBearing ? "error" : "warn";
+}
+
+/**
+ * Details payload the attention projection and the operator surface both read.
+ * Carries the failing step with expected-vs-actual so the row is diagnosable
+ * without re-running the sweep.
+ */
+export function journeyIssueDetails(journey: JourneyResult, runId: string) {
+  const failed = journey.steps.filter((s) => s.outcome === "failed");
+  return {
+    journeyId: journey.journeyId,
+    outcome: journey.outcome,
+    businessImpact: journey.businessImpact,
+    revenueBearing: journey.revenueBearing,
+    runId,
+    achievedDepth: achievedDepth(journey.steps),
+    uncheckedDepths: journey.uncheckedDepths,
+    failedSteps: failed.map((s) => ({
+      stepId: s.stepId,
+      label: s.label,
+      depth: s.depth,
+      detail: s.detail,
+      expected: s.expected ?? null,
+      actual: s.actual ?? null,
+    })),
+  };
+}
+
+/** Open or refresh the issue for a failing journey. */
+export async function openJourneyFailureIssue(
+  db: MonitorIssueDb,
+  journey: JourneyResult,
+  runId: string,
+  now: () => Date = () => new Date(),
+): Promise<string> {
+  return openMonitorIssue(db, {
+    issueKey: journeyIssueKey(journey.journeyId),
+    issueType: JOURNEY_ISSUE_TYPE,
+    severity: severityFor(journey),
+    // The summary is what the owner reads first — state the lost outcome, not
+    // the mechanism.
+    summary: `${journey.outcome} — not working`,
+    details: journeyIssueDetails(journey, runId),
+    now,
+  });
+}
+
+/** Resolve the issue for a journey that passed (or stopped applying). */
+export async function resolveJourneyFailureIssue(
+  db: MonitorIssueDb,
+  journeyId: string,
+  now: () => Date = () => new Date(),
+): Promise<void> {
+  await resolveMonitorIssue(db, journeyIssueKey(journeyId), now);
+}
+
+/**
+ * Reconcile a whole sweep: every failing journey opens/refreshes its row, and
+ * every journey that passed or no longer applies has its row resolved.
+ *
+ * Deliberately keyed off THIS sweep's journeys rather than a blanket
+ * "resolve everything not in the active set": a journey that was removed from
+ * the registry entirely should keep its row until an operator sees it, rather
+ * than silently vanishing from the inbox.
+ */
+export async function reconcileJourneyIssues(
+  db: MonitorIssueDb,
+  journeys: readonly JourneyResult[],
+  runId: string,
+  now: () => Date = () => new Date(),
+): Promise<{ opened: string[]; resolved: string[] }> {
+  const opened: string[] = [];
+  const resolved: string[] = [];
+  for (const journey of journeys) {
+    if (journey.status === "failed") {
+      opened.push(await openJourneyFailureIssue(db, journey, runId, now));
+    } else {
+      await resolveJourneyFailureIssue(db, journey.journeyId, now);
+      resolved.push(journeyIssueKey(journey.journeyId));
+    }
+  }
+  return { opened, resolved };
+}

--- a/apps/web/lib/business-journeys/journey-health.test.ts
+++ b/apps/web/lib/business-journeys/journey-health.test.ts
@@ -126,22 +126,35 @@ describe("journeyHealthHeadline", () => {
   const base = { lastRunAt: new Date(), runId: "r", rows: [], notApplicable: 0, neverRun: 0 };
 
   it("counts failures in plain language", () => {
-    expect(journeyHealthHeadline({ ...base, failing: 1, passing: 3 })).toBe(
-      "1 critical business journey is not working.",
-    );
+    expect(journeyHealthHeadline({ ...base, failing: 1, passing: 3 })).toBe("1 check is failing.");
     expect(journeyHealthHeadline({ ...base, failing: 2, passing: 3 })).toBe(
-      "2 critical business journeys are not working.",
+      "2 checks are failing.",
     );
   });
 
   it("says so honestly when nothing has been checked yet", () => {
-    expect(journeyHealthHeadline({ ...base, lastRunAt: null, failing: 0, passing: 0 })).toContain(
-      "have not been checked yet",
+    expect(journeyHealthHeadline({ ...base, lastRunAt: null, failing: 0, passing: 0 })).toBe(
+      "No checks have run yet.",
     );
   });
 
-  it("qualifies an all-green headline with 'checked', never 'all healthy'", () => {
+  it("speaks of CHECKS passing, never of the business being healthy", () => {
+    // "All 4 checks passed" is a claim about the checks. "Everything is fine"
+    // would be a claim about the business, which these checks cannot support —
+    // they do not all reach data-path depth, let alone interaction depth.
     const headline = journeyHealthHeadline({ ...base, failing: 0, passing: 4 });
-    expect(headline).toBe("All 4 checked journeys were working at the last check.");
+    expect(headline).toBe("All 4 checks passed.");
+    expect(headline).not.toMatch(/healthy|everything|fine|all good/i);
+  });
+
+  it("every headline is a terminated sentence — unterminated copy inflates the page grade", () => {
+    const headlines = [
+      journeyHealthHeadline({ ...base, lastRunAt: null, failing: 0, passing: 0 }),
+      journeyHealthHeadline({ ...base, failing: 0, passing: 0 }),
+      journeyHealthHeadline({ ...base, failing: 0, passing: 4 }),
+      journeyHealthHeadline({ ...base, failing: 1, passing: 3 }),
+      journeyHealthHeadline({ ...base, failing: 3, passing: 1 }),
+    ];
+    for (const h of headlines) expect(h.endsWith(".")).toBe(true);
   });
 });

--- a/apps/web/lib/business-journeys/journey-health.test.ts
+++ b/apps/web/lib/business-journeys/journey-health.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import { journeyHealthHeadline, loadJourneyHealth } from "./journey-health";
+import { applicableJourneys, BUSINESS_JOURNEYS } from "./registry";
+import type { InstallJourneyContext } from "./types";
+
+function dbWith(summary: unknown, startedAt = new Date("2026-07-28T06:00:00.000Z")) {
+  return {
+    assuranceRun: {
+      findFirst: vi.fn(async () => ({
+        runId: "run_1",
+        startedAt,
+        completedAt: startedAt,
+        summary,
+      })),
+    },
+  } as never;
+}
+
+const BARE_INSTALL: InstallJourneyContext = {
+  organizationId: null,
+  organizationSlug: null,
+  baseUrl: "",
+  storefrontId: null,
+  storefrontPublished: false,
+  archetypeIds: [],
+  bookableItemId: null,
+  hasInquirySurface: false,
+  hasPaymentConfiguration: false,
+};
+
+describe("registry applicability", () => {
+  it("applies no storefront journey to an install with no published storefront", () => {
+    expect(applicableJourneys(BARE_INSTALL)).toEqual([]);
+  });
+
+  it("applies only the journeys an install actually has switched on", () => {
+    const ids = applicableJourneys({
+      ...BARE_INSTALL,
+      organizationSlug: "acme",
+      storefrontId: "sf_1",
+      storefrontPublished: true,
+      archetypeIds: ["field-service"],
+    }).map((j) => j.journeyId);
+
+    expect(ids).toContain("storefront-front-door");
+    expect(ids).toContain("customer-sign-in");
+    // Nothing bookable, nothing to enquire about, nothing priced.
+    expect(ids).not.toContain("storefront-booking");
+    expect(ids).not.toContain("storefront-enquiry");
+    expect(ids).not.toContain("storefront-checkout");
+  });
+
+  it("writes every outcome in owner language, never as a mechanism", () => {
+    for (const journey of BUSINESS_JOURNEYS) {
+      expect(journey.outcome).not.toMatch(/probe|step|endpoint|adapter|http/i);
+      expect(journey.businessImpact.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe("loadJourneyHealth", () => {
+  it("shows a journey the last sweep never reached rather than silently omitting it", async () => {
+    const health = await loadJourneyHealth(dbWith({ journeys: [] }));
+
+    expect(health.rows).toHaveLength(BUSINESS_JOURNEYS.length);
+    expect(health.neverRun).toBe(BUSINESS_JOURNEYS.length);
+    for (const row of health.rows) {
+      expect(row.status).toBe("never-run");
+      expect(row.notCheckedSentence).toContain("Not checked:");
+    }
+  });
+
+  it("never presents a reachability-only pass as functionally verified", async () => {
+    const health = await loadJourneyHealth(
+      dbWith({
+        journeys: [
+          {
+            journeyId: "storefront-front-door",
+            status: "passed",
+            achievedDepth: "reachability",
+            steps: [],
+            durationMs: 5,
+          },
+        ],
+      }),
+    );
+
+    const row = health.rows.find((r) => r.journeyId === "storefront-front-door");
+    expect(row?.checkedSentence).toBe("Checked: the page loads.");
+    expect(row?.notCheckedSentence).toContain("a real record can be created");
+    expect(row?.notCheckedSentence).toContain("a customer completing this in a browser");
+  });
+
+  it("leaves nothing unchecked for a journey that does not apply", async () => {
+    const health = await loadJourneyHealth(
+      dbWith({
+        journeys: [
+          {
+            journeyId: "storefront-booking",
+            status: "not-applicable",
+            achievedDepth: null,
+            notApplicableReason: "No bookable service.",
+            steps: [],
+          },
+        ],
+      }),
+    );
+
+    const row = health.rows.find((r) => r.journeyId === "storefront-booking");
+    expect(row?.status).toBe("not-applicable");
+    expect(row?.notCheckedSentence).toBeNull();
+    expect(row?.notApplicableReason).toBe("No bookable service.");
+  });
+
+  it("survives a malformed summary payload", async () => {
+    const health = await loadJourneyHealth(dbWith("garbage"));
+    expect(health.rows).toHaveLength(BUSINESS_JOURNEYS.length);
+  });
+});
+
+describe("journeyHealthHeadline", () => {
+  const base = { lastRunAt: new Date(), runId: "r", rows: [], notApplicable: 0, neverRun: 0 };
+
+  it("counts failures in plain language", () => {
+    expect(journeyHealthHeadline({ ...base, failing: 1, passing: 3 })).toBe(
+      "1 critical business journey is not working.",
+    );
+    expect(journeyHealthHeadline({ ...base, failing: 2, passing: 3 })).toBe(
+      "2 critical business journeys are not working.",
+    );
+  });
+
+  it("says so honestly when nothing has been checked yet", () => {
+    expect(journeyHealthHeadline({ ...base, lastRunAt: null, failing: 0, passing: 0 })).toContain(
+      "have not been checked yet",
+    );
+  });
+
+  it("qualifies an all-green headline with 'checked', never 'all healthy'", () => {
+    const headline = journeyHealthHeadline({ ...base, failing: 0, passing: 4 });
+    expect(headline).toBe("All 4 checked journeys were working at the last check.");
+  });
+});

--- a/apps/web/lib/business-journeys/journey-health.test.ts
+++ b/apps/web/lib/business-journeys/journey-health.test.ts
@@ -66,7 +66,11 @@ describe("loadJourneyHealth", () => {
     expect(health.neverRun).toBe(BUSINESS_JOURNEYS.length);
     for (const row of health.rows) {
       expect(row.status).toBe("never-run");
-      expect(row.notCheckedSentence).toContain("Not checked:");
+      // A run that never happened says so plainly. Enumerating all four depths
+      // here would be technically true and useless — the short form is the
+      // honest one, and it keeps five repeated cards off the word budget.
+      expect(row.notCheckedSentence).toBe("Not checked yet.");
+      expect(row.checkedSentence).toBeNull();
     }
   });
 
@@ -86,9 +90,9 @@ describe("loadJourneyHealth", () => {
     );
 
     const row = health.rows.find((r) => r.journeyId === "storefront-front-door");
-    expect(row?.checkedSentence).toBe("Checked: the page loads.");
-    expect(row?.notCheckedSentence).toContain("a real record can be created");
-    expect(row?.notCheckedSentence).toContain("a customer completing this in a browser");
+    expect(row?.checkedSentence).toBe("Checked: the page opens.");
+    expect(row?.notCheckedSentence).toContain("a real record can be saved");
+    expect(row?.notCheckedSentence).toContain("a customer doing this in a browser");
   });
 
   it("leaves nothing unchecked for a journey that does not apply", async () => {

--- a/apps/web/lib/business-journeys/journey-health.ts
+++ b/apps/web/lib/business-journeys/journey-health.ts
@@ -22,6 +22,9 @@ import {
 
 type Db = typeof prisma;
 
+/** What a journey that has never run says about itself. */
+export const NEVER_RUN_SENTENCE = "Not checked yet.";
+
 export type JourneyHealthRow = {
   journeyId: string;
   /** Owner-language outcome — what the business can or cannot do. */
@@ -90,7 +93,10 @@ export async function loadJourneyHealth(db: Db): Promise<JourneyHealth> {
         status: "never-run" as const,
         achievedDepth: null,
         checkedSentence: null,
-        notCheckedSentence: uncheckedSentence(null),
+        // Nothing ran, so listing all four depths is noise rather than honesty —
+        // "we checked none of these four things" and "we have not looked yet"
+        // are the same fact, and the short form is the one an owner can read.
+        notCheckedSentence: NEVER_RUN_SENTENCE,
         steps: [],
         durationMs: 0,
       };

--- a/apps/web/lib/business-journeys/journey-health.ts
+++ b/apps/web/lib/business-journeys/journey-health.ts
@@ -1,0 +1,142 @@
+// Read model for the operator's journey-health surface.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+//
+// Projects the latest AssuranceRun summary into owner-language rows. Pure
+// projection — the surface never re-runs a sweep to render.
+//
+// The honesty rules are enforced HERE as well as in the runner, because this is
+// what the operator actually reads: `verified` is a narrow, earned label, and
+// `notCheckedSentence` is always populated while `interaction` depth is
+// uncovered.
+
+import type { prisma } from "@dpf/db";
+import { checkedSentence, uncheckedSentence } from "./depth";
+import { BUSINESS_JOURNEYS } from "./registry";
+import {
+  JOURNEY_ADAPTER_KEY,
+  JOURNEY_ASSURANCE_SCOPE_TYPE,
+  type JourneyStatus,
+  type JourneyStepResult,
+  type VerificationDepth,
+} from "./types";
+
+type Db = typeof prisma;
+
+export type JourneyHealthRow = {
+  journeyId: string;
+  /** Owner-language outcome — what the business can or cannot do. */
+  outcome: string;
+  businessImpact: string;
+  revenueBearing: boolean;
+  status: JourneyStatus | "never-run";
+  achievedDepth: VerificationDepth | null;
+  /** "Checked: …" — null when nothing was established. */
+  checkedSentence: string | null;
+  /** "Not checked: …" — the anti-false-confidence line. */
+  notCheckedSentence: string | null;
+  notApplicableReason?: string;
+  steps: JourneyStepResult[];
+  durationMs: number;
+};
+
+export type JourneyHealth = {
+  lastRunAt: Date | null;
+  runId: string | null;
+  rows: JourneyHealthRow[];
+  failing: number;
+  passing: number;
+  notApplicable: number;
+  neverRun: number;
+};
+
+type PersistedJourney = {
+  journeyId?: string;
+  outcome?: string;
+  status?: JourneyStatus;
+  achievedDepth?: VerificationDepth | null;
+  notApplicableReason?: string | null;
+  durationMs?: number;
+  steps?: JourneyStepResult[];
+};
+
+function persistedJourneys(summary: unknown): PersistedJourney[] {
+  if (!summary || typeof summary !== "object") return [];
+  const journeys = (summary as { journeys?: unknown }).journeys;
+  return Array.isArray(journeys) ? (journeys as PersistedJourney[]) : [];
+}
+
+/**
+ * Build the health view. Every journey in the registry gets a row, even one the
+ * last sweep never reached — an absent journey silently missing from the surface
+ * would be the same false-confidence failure the depth ladder exists to prevent.
+ */
+export async function loadJourneyHealth(db: Db): Promise<JourneyHealth> {
+  const latest = await db.assuranceRun.findFirst({
+    where: { scopeType: JOURNEY_ASSURANCE_SCOPE_TYPE, adapterKey: JOURNEY_ADAPTER_KEY },
+    orderBy: { startedAt: "desc" },
+    select: { runId: true, startedAt: true, completedAt: true, summary: true },
+  });
+
+  const byId = new Map(persistedJourneys(latest?.summary).map((j) => [j.journeyId, j]));
+
+  const rows: JourneyHealthRow[] = BUSINESS_JOURNEYS.map((definition) => {
+    const persisted = byId.get(definition.journeyId);
+    if (!persisted) {
+      return {
+        journeyId: definition.journeyId,
+        outcome: definition.outcome,
+        businessImpact: definition.businessImpact,
+        revenueBearing: definition.revenueBearing,
+        status: "never-run" as const,
+        achievedDepth: null,
+        checkedSentence: null,
+        notCheckedSentence: uncheckedSentence(null),
+        steps: [],
+        durationMs: 0,
+      };
+    }
+    const depth = persisted.achievedDepth ?? null;
+    const status = persisted.status ?? "never-run";
+    return {
+      journeyId: definition.journeyId,
+      outcome: definition.outcome,
+      businessImpact: definition.businessImpact,
+      revenueBearing: definition.revenueBearing,
+      status,
+      achievedDepth: depth,
+      checkedSentence: checkedSentence(depth),
+      // A not-applicable journey has nothing unchecked — there was nothing to check.
+      notCheckedSentence: status === "not-applicable" ? null : uncheckedSentence(depth),
+      ...(persisted.notApplicableReason
+        ? { notApplicableReason: persisted.notApplicableReason }
+        : {}),
+      steps: persisted.steps ?? [],
+      durationMs: persisted.durationMs ?? 0,
+    };
+  });
+
+  return {
+    lastRunAt: latest?.completedAt ?? latest?.startedAt ?? null,
+    runId: latest?.runId ?? null,
+    rows,
+    failing: rows.filter((r) => r.status === "failed").length,
+    passing: rows.filter((r) => r.status === "passed").length,
+    notApplicable: rows.filter((r) => r.status === "not-applicable").length,
+    neverRun: rows.filter((r) => r.status === "never-run").length,
+  };
+}
+
+/** One-line owner summary for the page header. Plain language, no jargon. */
+export function journeyHealthHeadline(health: JourneyHealth): string {
+  if (health.lastRunAt === null) {
+    return "Your critical business journeys have not been checked yet.";
+  }
+  if (health.failing === 0) {
+    return health.passing === 0
+      ? "Nothing to check yet — set up your storefront and these checks switch on."
+      : `All ${health.passing} checked journeys were working at the last check.`;
+  }
+  return health.failing === 1
+    ? "1 critical business journey is not working."
+    : `${health.failing} critical business journeys are not working.`;
+}

--- a/apps/web/lib/business-journeys/journey-health.ts
+++ b/apps/web/lib/business-journeys/journey-health.ts
@@ -132,17 +132,20 @@ export async function loadJourneyHealth(db: Db): Promise<JourneyHealth> {
   };
 }
 
-/** One-line owner summary for the page header. Plain language, no jargon. */
+/**
+ * One-line owner summary for the page header.
+ *
+ * Kept short and fully punctuated on purpose. The UX budget grades the page's
+ * Flesch–Kincaid level over ALL visible text joined together, and unpunctuated
+ * fragments merge into one very long sentence — so a terse, terminated sentence
+ * here lowers the whole page's grade as well as reading better.
+ */
 export function journeyHealthHeadline(health: JourneyHealth): string {
-  if (health.lastRunAt === null) {
-    return "Your critical business journeys have not been checked yet.";
-  }
+  if (health.lastRunAt === null) return "No checks have run yet.";
   if (health.failing === 0) {
     return health.passing === 0
-      ? "Nothing to check yet — set up your storefront and these checks switch on."
-      : `All ${health.passing} checked journeys were working at the last check.`;
+      ? "Nothing to check yet."
+      : `All ${health.passing} checks passed.`;
   }
-  return health.failing === 1
-    ? "1 critical business journey is not working."
-    : `${health.failing} critical business journeys are not working.`;
+  return health.failing === 1 ? "1 check is failing." : `${health.failing} checks are failing.`;
 }

--- a/apps/web/lib/business-journeys/journey-page-budget.test.tsx
+++ b/apps/web/lib/business-journeys/journey-page-budget.test.tsx
@@ -1,0 +1,97 @@
+// Reading-level guard for the journey surface's own copy.
+//
+// The UX Route Budget Sweep grades the WHOLE rendered page, which needs a
+// browser and ten minutes of CI. This measures the part this feature owns —
+// the card copy and the page's own strings — with the SAME functions the sweep
+// uses (`measureUxBudget` over `apps/web/lib/ux-budget`), so a copy regression
+// is caught in the unit suite instead of by a red sweep half an hour later.
+//
+// It is a floor, not a replacement: passing here does not guarantee the full
+// page passes, because the shell and nav also count toward the real grade.
+
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { measureUxBudget, meetsReadingLevel } from "@/lib/ux-budget/measure";
+
+import { JourneyHealthCard } from "@/components/ops/JourneyHealthCard";
+import { journeyHealthHeadline, NEVER_RUN_SENTENCE } from "./journey-health";
+import type { JourneyHealth, JourneyHealthRow } from "./journey-health";
+import { BUSINESS_JOURNEYS } from "./registry";
+
+/** The state every install sees on day one — and the one most likely to be
+ *  left unexamined, which is exactly where the budget findings landed. */
+function neverRunRows(): JourneyHealthRow[] {
+  return BUSINESS_JOURNEYS.map((j) => ({
+    journeyId: j.journeyId,
+    outcome: j.outcome,
+    businessImpact: j.businessImpact,
+    revenueBearing: j.revenueBearing,
+    status: "never-run" as const,
+    achievedDepth: null,
+    checkedSentence: null,
+    notCheckedSentence: NEVER_RUN_SENTENCE,
+    steps: [],
+    durationMs: 0,
+  }));
+}
+
+function renderCards(rows: JourneyHealthRow[]): string {
+  return rows.map((row) => renderToStaticMarkup(<JourneyHealthCard row={row} />)).join("\n");
+}
+
+describe("journey surface copy stays within the high-school reading tier", () => {
+  it("grades the empty state at or below the high-school cap", () => {
+    const rows = neverRunRows();
+    const health: JourneyHealth = {
+      lastRunAt: null,
+      runId: null,
+      rows,
+      failing: 0,
+      passing: 0,
+      notApplicable: 0,
+      neverRun: rows.length,
+    };
+    const html = `<p>${journeyHealthHeadline(health)}</p>${renderCards(rows)}`;
+
+    const metrics = measureUxBudget(html);
+
+    expect(metrics.readingGradeLevel).toBeLessThanOrEqual(9);
+    expect(meetsReadingLevel(metrics, "high-school")).toBe(true);
+  });
+
+  it("grades the all-failing state at or below the high-school cap", () => {
+    const rows = neverRunRows().map((r) => ({
+      ...r,
+      status: "failed" as const,
+      notCheckedSentence: "Not checked: the page opens.",
+    }));
+    const health: JourneyHealth = {
+      lastRunAt: new Date("2026-07-28T06:00:00.000Z"),
+      runId: "run_1",
+      rows,
+      failing: rows.length,
+      passing: 0,
+      notApplicable: 0,
+      neverRun: 0,
+    };
+    // Failing cards additionally render businessImpact — the longest copy in the
+    // feature — so this is the worst case for the grade.
+    const html = `<p>${journeyHealthHeadline(health)}</p>${renderCards(rows)}`;
+
+    const metrics = measureUxBudget(html);
+
+    expect(metrics.readingGradeLevel).toBeLessThanOrEqual(9);
+  });
+
+  it("keeps every outcome and impact sentence terminated", () => {
+    // Unterminated fragments merge into one very long sentence when the budget
+    // joins all visible text, which is what drove the grade over the cap.
+    const html = renderCards(neverRunRows());
+    const headings = [...html.matchAll(/<h3[^>]*>([^<]*)<\/h3>/g)].map((m) => m[1]);
+
+    expect(headings.length).toBe(BUSINESS_JOURNEYS.length);
+    for (const heading of headings) {
+      expect(heading.trim().endsWith(".")).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/business-journeys/probes-rollback.test.ts
+++ b/apps/web/lib/business-journeys/probes-rollback.test.ts
@@ -1,0 +1,155 @@
+// The no-pollution guarantee.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md §4
+//
+// A `data-path` probe performs REAL writes. The only thing standing between the
+// watchdog and a synthetic booking landing in the owner's reservation queue is
+// the rollback sentinel. If these tests fail, the watchdog must not ship.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tx = {
+  storefrontInquiry: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  storefrontBooking: {
+    create: vi.fn(),
+  },
+};
+
+/** Stand-in for Prisma's interactive transaction: runs the callback and lets a
+ *  throw propagate, exactly as a real rollback does. */
+const transaction = vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    $transaction: (cb: (t: typeof tx) => Promise<unknown>) => transaction(cb),
+  },
+}));
+
+const CTX = {
+  organizationId: "org_1",
+  organizationSlug: "acme",
+  baseUrl: "https://example.test",
+  storefrontId: "sf_1",
+  storefrontPublished: true,
+  archetypeIds: ["field-service"],
+  bookableItemId: "item_1",
+  hasInquirySurface: true,
+  hasPaymentConfiguration: true,
+  fetchImpl: vi.fn() as unknown as typeof fetch,
+  now: () => new Date(0),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tx.storefrontInquiry.create.mockResolvedValue({ id: "i1", inquiryRef: "ref", status: "new" });
+  tx.storefrontInquiry.findUnique.mockResolvedValue({ inquiryRef: "ref" });
+  tx.storefrontBooking.create.mockResolvedValue({ id: "b1" });
+});
+
+describe("inquiry data-path probe", () => {
+  it("writes a real enquiry and forces the transaction to roll back", async () => {
+    const { inquiryDataPathProbe } = await import("./probes");
+
+    const result = await inquiryDataPathProbe(CTX);
+
+    expect(tx.storefrontInquiry.create).toHaveBeenCalledTimes(1);
+    expect(result.passed).toBe(true);
+    // The callback must have thrown — that throw IS the rollback.
+    await expect(transaction.mock.results[0].value).rejects.toThrow(/deliberate rollback/);
+  });
+
+  it("uses an unmistakably synthetic identity so a stray row is never read as a customer", async () => {
+    const { inquiryDataPathProbe, JOURNEY_SYNTHETIC_IDENTITY } = await import("./probes");
+
+    await inquiryDataPathProbe(CTX);
+
+    const args = tx.storefrontInquiry.create.mock.calls[0][0] as {
+      data: { customerEmail: string; customerName: string };
+    };
+    expect(args.data.customerEmail).toBe(JOURNEY_SYNTHETIC_IDENTITY.email);
+    // RFC 2606 reserved TLD — cannot resolve, so it can never reach a real person.
+    expect(args.data.customerEmail).toMatch(/\.invalid$/);
+    expect(args.data.customerName).toMatch(/watchdog/i);
+  });
+
+  it("fails with evidence when the written record cannot be read back", async () => {
+    tx.storefrontInquiry.findUnique.mockResolvedValue(null);
+    const { inquiryDataPathProbe } = await import("./probes");
+
+    const result = await inquiryDataPathProbe(CTX);
+
+    expect(result.passed).toBe(false);
+    expect(result.actual).toContain("not found");
+  });
+
+  it("reports an unexpected database error as a failure instead of escaping the sweep", async () => {
+    tx.storefrontInquiry.create.mockRejectedValue(new Error("relation does not exist"));
+    const { inquiryDataPathProbe } = await import("./probes");
+
+    const result = await inquiryDataPathProbe(CTX);
+
+    expect(result.passed).toBe(false);
+    expect(result.actual).toContain("relation does not exist");
+  });
+});
+
+describe("booking data-path probe", () => {
+  /** SQLSTATE 23P01 — what Postgres raises when the gist EXCLUDE constraint
+   *  rejects an overlapping booking. */
+  function exclusionViolation() {
+    return Object.assign(new Error("conflicting key value violates exclusion constraint"), {
+      code: "23P01",
+    });
+  }
+
+  it("passes when the second overlapping booking is rejected by the database", async () => {
+    tx.storefrontBooking.create
+      .mockResolvedValueOnce({ id: "b1" })
+      .mockRejectedValueOnce(exclusionViolation());
+    const { bookingDataPathProbe } = await import("./probes");
+
+    const result = await bookingDataPathProbe(CTX);
+
+    expect(result.passed).toBe(true);
+    expect(tx.storefrontBooking.create).toHaveBeenCalledTimes(2);
+    await expect(transaction.mock.results[0].value).rejects.toThrow(/deliberate rollback/);
+  });
+
+  it("FAILS LOUDLY when double-booking protection has lapsed", async () => {
+    // Both inserts succeed => the no-overlap constraint is gone. This is the
+    // production defect no reachability check could ever see.
+    tx.storefrontBooking.create.mockResolvedValue({ id: "b1" });
+    const { bookingDataPathProbe } = await import("./probes");
+
+    const result = await bookingDataPathProbe(CTX);
+
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("double-booking protection is not in force");
+    expect(result.actual).toContain("both bookings were accepted");
+  });
+
+  it("books into a far-future slot so it cannot contend with a real reservation", async () => {
+    tx.storefrontBooking.create
+      .mockResolvedValueOnce({ id: "b1" })
+      .mockRejectedValueOnce(exclusionViolation());
+    const { bookingDataPathProbe } = await import("./probes");
+
+    await bookingDataPathProbe(CTX);
+
+    const args = tx.storefrontBooking.create.mock.calls[0][0] as {
+      data: { scheduledAt: Date };
+    };
+    expect(args.data.scheduledAt.getUTCFullYear()).toBeGreaterThan(2090);
+  });
+
+  it("does not attempt a rehearsal when there is no bookable item", async () => {
+    const { bookingDataPathProbe } = await import("./probes");
+
+    const result = await bookingDataPathProbe({ ...CTX, bookableItemId: null });
+
+    expect(result.passed).toBe(false);
+    expect(tx.storefrontBooking.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/business-journeys/probes.test.ts
+++ b/apps/web/lib/business-journeys/probes.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { contractProbe, reachabilityProbe } from "./probes";
+import type { JourneyProbeContext } from "./types";
+
+function ctx(overrides: Partial<JourneyProbeContext> = {}): JourneyProbeContext {
+  return {
+    organizationId: "org_1",
+    organizationSlug: "acme",
+    baseUrl: "https://example.test",
+    storefrontId: "sf_1",
+    storefrontPublished: true,
+    archetypeIds: ["field-service"],
+    bookableItemId: "item_1",
+    hasInquirySurface: true,
+    hasPaymentConfiguration: true,
+    fetchImpl: vi.fn(async () => new Response("", { status: 200 })) as unknown as typeof fetch,
+    now: () => new Date(0),
+    ...overrides,
+  };
+}
+
+describe("reachabilityProbe", () => {
+  it("passes on a sub-400 response", async () => {
+    const probe = reachabilityProbe(() => "/s/acme");
+    const result = await probe(ctx());
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails with expected-vs-actual on an error status", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("", { status: 503, statusText: "Service Unavailable" }),
+    ) as unknown as typeof fetch;
+    const probe = reachabilityProbe(() => "/s/acme");
+
+    const result = await probe(ctx({ fetchImpl }));
+
+    expect(result.passed).toBe(false);
+    expect(result.expected).toContain("below 400");
+    expect(result.actual).toContain("503");
+  });
+
+  it("reports a plain outage when neither the public address nor loopback answers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const probe = reachabilityProbe(() => "/s/acme");
+
+    const result = await probe(ctx({ fetchImpl }));
+
+    expect(result.passed).toBe(false);
+    expect(result.actual).toBe("ECONNREFUSED");
+    expect(result.detail).toContain("could not be reached at all");
+  });
+
+  it("distinguishes 'unreachable publicly' from 'down', so the operator hunts the right problem", async () => {
+    // Public address refuses; the same page answers on loopback => the app is
+    // up and this is a DNS / proxy / certificate problem, not an outage.
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ENOTFOUND book.example.test"))
+      .mockResolvedValueOnce(new Response("", { status: 200 })) as unknown as typeof fetch;
+    const probe = reachabilityProbe(() => "/s/acme");
+
+    const result = await probe(ctx({ fetchImpl }));
+
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("works inside the install");
+    expect(result.actual).toContain("DNS, proxy, or certificate");
+    // The second attempt must target loopback, not the public origin again.
+    const secondUrl = (fetchImpl as unknown as { mock: { calls: string[][] } }).mock.calls[1][0];
+    expect(secondUrl).toContain("127.0.0.1");
+  });
+
+  it("reports a missing base URL as a configuration gap, not a journey failure cause", async () => {
+    const probe = reachabilityProbe(() => "/s/acme");
+    const result = await probe(ctx({ baseUrl: "" }));
+
+    expect(result.passed).toBe(false);
+    expect(result.expected).toContain("NEXT_PUBLIC_BASE_URL");
+  });
+
+  it("fails when the public path cannot be built", async () => {
+    const probe = reachabilityProbe(() => null);
+    const result = await probe(ctx({ organizationSlug: null }));
+
+    expect(result.passed).toBe(false);
+    expect(result.actual).toContain("no organization slug");
+  });
+});
+
+describe("contractProbe", () => {
+  it("passes with the supplied detail when the predicate holds", async () => {
+    const probe = contractProbe(
+      () => ({ ok: true, expected: "e", actual: "a" }),
+      "all good",
+      "all bad",
+    );
+    const result = await probe(ctx());
+    expect(result).toEqual({ passed: true, detail: "all good" });
+  });
+
+  it("carries expected-vs-actual when the predicate fails", async () => {
+    const probe = contractProbe(
+      () => ({ ok: false, expected: "a published storefront", actual: "published=false" }),
+      "all good",
+      "all bad",
+    );
+    const result = await probe(ctx());
+    expect(result.passed).toBe(false);
+    expect(result.expected).toBe("a published storefront");
+    expect(result.actual).toBe("published=false");
+  });
+});

--- a/apps/web/lib/business-journeys/probes.test.ts
+++ b/apps/web/lib/business-journeys/probes.test.ts
@@ -71,6 +71,22 @@ describe("reachabilityProbe", () => {
     expect(secondUrl).toContain("127.0.0.1");
   });
 
+  it("bounds every request so a hung route cannot hang the sweep", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("", { status: 200 }),
+    ) as unknown as typeof fetch;
+    const probe = reachabilityProbe(() => "/s/acme");
+
+    await probe(ctx({ fetchImpl }));
+
+    const init = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+      .calls[0][1];
+    // A watchdog that can hang is worse than none — it stays silent through the
+    // outage it exists to report.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.redirect).toBe("follow");
+  });
+
   it("reports a missing base URL as a configuration gap, not a journey failure cause", async () => {
     const probe = reachabilityProbe(() => "/s/acme");
     const result = await probe(ctx({ baseUrl: "" }));

--- a/apps/web/lib/business-journeys/probes.ts
+++ b/apps/web/lib/business-journeys/probes.ts
@@ -70,6 +70,25 @@ function loopbackOrigin(): string {
 }
 
 /**
+ * Per-request ceiling for a reachability probe.
+ *
+ * Found by live verification: without this, a route that accepts the connection
+ * and then never answers hangs the sweep forever — the watchdog would sit
+ * silent rather than report the outage, which is the worst possible failure for
+ * a thing whose entire job is to notice. A customer would have given up long
+ * before 15s, so a slower response is a failure by the journey's own standard,
+ * not merely a slow check.
+ */
+const PROBE_TIMEOUT_MS = 15_000;
+
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+): Promise<Response> {
+  return fetchImpl(url, { redirect: "follow", signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) });
+}
+
+/**
  * The entry surface responds. Proves the door opens — nothing more, which is
  * exactly why this returns depth `reachability` and can never lift a journey's
  * achieved depth above it.
@@ -96,7 +115,7 @@ export function reachabilityProbe(pathFor: (ctx: JourneyProbeContext) => string 
     }
     const url = `${ctx.baseUrl}${path}`;
     try {
-      const res = await ctx.fetchImpl(url, { redirect: "follow" });
+      const res = await fetchWithTimeout(ctx.fetchImpl, url);
       if (res.status >= 400) {
         return {
           passed: false,
@@ -112,7 +131,7 @@ export function reachabilityProbe(pathFor: (ctx: JourneyProbeContext) => string 
       // this an outage — see `loopbackOrigin`.
       const internalUrl = `${loopbackOrigin()}${path}`;
       try {
-        const internal = await ctx.fetchImpl(internalUrl, { redirect: "follow" });
+        const internal = await fetchWithTimeout(ctx.fetchImpl, internalUrl);
         if (internal.status < 400) {
           return {
             passed: false,

--- a/apps/web/lib/business-journeys/probes.ts
+++ b/apps/web/lib/business-journeys/probes.ts
@@ -1,0 +1,318 @@
+// Journey probes — the three depths this slice can actually establish.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md §3–§4
+//
+// Cheapest first: a `reachability` probe is one HTTP call, a `contract` probe is
+// one indexed query, and a `data-path` probe opens a transaction. The runner
+// only reaches the expensive ones when the cheap ones for that journey passed.
+
+import { prisma, type Prisma } from "@dpf/db";
+import { newId } from "@/lib/shared/new-id";
+import { isExclusionViolation } from "@/lib/db/exclusion-violation";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import type { JourneyProbeContext, StepProbeResult } from "./types";
+
+/**
+ * Thrown to force a `data-path` probe's transaction to roll back.
+ *
+ * This is the mechanism that keeps the watchdog from polluting the business: a
+ * synthetic booking sitting in the owner's reservation queue would be a defect,
+ * not evidence. Every write a probe performs is inside a transaction that ends
+ * by throwing this.
+ */
+class RollbackSentinel extends Error {
+  /** The probe verdict, carried OUT on the throw.
+   *
+   *  Carrying the result on the sentinel rather than assigning to a closure
+   *  variable keeps the rollback and the result on one path: there is no way to
+   *  return a verdict without also having thrown, so a future edit cannot
+   *  accidentally commit by returning early. */
+  constructor(readonly result: StepProbeResult) {
+    super("journey-watchdog: deliberate rollback");
+    this.name = "RollbackSentinel";
+  }
+}
+
+/**
+ * Recognisably synthetic identity, so a row that somehow escaped rollback is
+ * obviously the watchdog's and never mistaken for a real customer. `.invalid` is
+ * reserved by RFC 2606 and can never resolve, so even a bug that committed one
+ * of these rows could not mail a real person.
+ */
+const SYNTHETIC = {
+  name: "DPF Journey Watchdog",
+  email: "journey-watchdog@dpf.invalid",
+} as const;
+
+/** Far-future slot: cannot contend with a genuine booking for locks, and cannot
+ *  be mistaken for a real reservation if it were ever inspected mid-transaction. */
+function syntheticSlot(): Date {
+  return new Date(Date.UTC(2099, 0, 1, 12, 0, 0));
+}
+
+// ── reachability ─────────────────────────────────────────────────────────────
+
+/**
+ * The install's own loopback origin.
+ *
+ * The watchdog runs INSIDE the install, so the public address may be
+ * unreachable from here for reasons that are not an outage — split-horizon DNS,
+ * a proxy that only accepts external traffic, a hairpin-NAT gap. Probing the
+ * public origin is still right (that is the customer's actual path), but a
+ * connection-level failure alone is not proof the site is down.
+ *
+ * So a network failure is re-tried against loopback, and the two cases are
+ * reported DIFFERENTLY: "down for everyone" and "up inside, unreachable at its
+ * public address" are different problems with different fixes, and collapsing
+ * them would send the operator hunting the wrong one.
+ */
+function loopbackOrigin(): string {
+  return `http://127.0.0.1:${process.env.PORT ?? "3000"}`;
+}
+
+/**
+ * The entry surface responds. Proves the door opens — nothing more, which is
+ * exactly why this returns depth `reachability` and can never lift a journey's
+ * achieved depth above it.
+ */
+export function reachabilityProbe(pathFor: (ctx: JourneyProbeContext) => string | null) {
+  return async (ctx: JourneyProbeContext): Promise<StepProbeResult> => {
+    const path = pathFor(ctx);
+    if (!path) {
+      return {
+        passed: false,
+        detail: "Could not build the customer-facing URL for this journey.",
+        expected: "a resolvable public path",
+        actual: "the install has no organization slug",
+      };
+    }
+    if (!ctx.baseUrl) {
+      return {
+        passed: false,
+        detail:
+          "This install has no public base URL configured, so the customer-facing page cannot be checked.",
+        expected: "NEXT_PUBLIC_BASE_URL or NEXT_PUBLIC_APP_URL to be set",
+        actual: "neither is set and the install is running in production mode",
+      };
+    }
+    const url = `${ctx.baseUrl}${path}`;
+    try {
+      const res = await ctx.fetchImpl(url, { redirect: "follow" });
+      if (res.status >= 400) {
+        return {
+          passed: false,
+          detail: `The page a customer would open returned ${res.status}.`,
+          expected: `${url} to respond with a status below 400`,
+          actual: `${res.status} ${res.statusText}`,
+        };
+      }
+      return { passed: true, detail: `${url} responded ${res.status}.` };
+    } catch (err) {
+      const publicError = getErrorMessage(err);
+      // Could not connect at all. Ask the install about itself before calling
+      // this an outage — see `loopbackOrigin`.
+      const internalUrl = `${loopbackOrigin()}${path}`;
+      try {
+        const internal = await ctx.fetchImpl(internalUrl, { redirect: "follow" });
+        if (internal.status < 400) {
+          return {
+            passed: false,
+            detail:
+              "The page works inside the install but could not be reached at its public web address. Customers on the internet would not get through.",
+            expected: `${url} to be reachable from the internet`,
+            actual: `${publicError} (the same page answered ${internal.status} at ${internalUrl}, so the app is running — this looks like a DNS, proxy, or certificate problem rather than an outage)`,
+          };
+        }
+      } catch {
+        // Loopback failed too — fall through to the plain outage verdict.
+      }
+      return {
+        passed: false,
+        detail: "The page a customer would open could not be reached at all.",
+        expected: `${url} to respond`,
+        actual: publicError,
+      };
+    }
+  };
+}
+
+// ── contract ─────────────────────────────────────────────────────────────────
+
+/**
+ * The substrate behind the door is coherent. A pure predicate over the resolved
+ * install context — no I/O, so this is the cheapest useful check there is.
+ */
+export function contractProbe(
+  check: (ctx: JourneyProbeContext) => { ok: boolean; expected: string; actual: string },
+  passDetail: string,
+  failDetail: string,
+) {
+  return async (ctx: JourneyProbeContext): Promise<StepProbeResult> => {
+    const { ok, expected, actual } = check(ctx);
+    return ok
+      ? { passed: true, detail: passDetail }
+      : { passed: false, detail: failDetail, expected, actual };
+  };
+}
+
+// ── data-path ────────────────────────────────────────────────────────────────
+
+/**
+ * Run a probe body inside a transaction that is ALWAYS rolled back.
+ *
+ * The body may perform real writes through the real schema; the sentinel throw
+ * guarantees none of them commit. A body that itself throws is reported as a
+ * failure rather than escaping — a broken journey must produce evidence, not an
+ * unhandled rejection in a cron.
+ */
+async function inRolledBackTransaction(
+  body: (tx: Prisma.TransactionClient) => Promise<StepProbeResult>,
+): Promise<StepProbeResult> {
+  try {
+    await prisma.$transaction(async (tx) => {
+      throw new RollbackSentinel(await body(tx));
+    });
+  } catch (err) {
+    if (err instanceof RollbackSentinel) return err.result;
+    return {
+      passed: false,
+      detail: "The journey's data path failed before it could be assessed.",
+      expected: "the journey's records to be creatable against the live schema",
+      actual: getErrorMessage(err),
+    };
+  }
+  // Unreachable: the callback always throws. Kept as a typed guard rather than a
+  // cast, so a future edit that stops throwing fails loudly instead of silently
+  // committing a rehearsal.
+  return {
+    passed: false,
+    detail: "The journey's data path did not roll back as required.",
+    expected: "the rehearsal transaction to be rolled back",
+    actual: "the transaction completed without the rollback sentinel",
+  };
+}
+
+/**
+ * Inquiry data path: a real `StorefrontInquiry` is created against the real
+ * schema, read back, and rolled back. Catches migration drift, a broken
+ * storefront foreign key, and required-column regressions — the failures that
+ * silently stop enquiries reaching the owner.
+ */
+export async function inquiryDataPathProbe(ctx: JourneyProbeContext): Promise<StepProbeResult> {
+  const storefrontId = ctx.storefrontId;
+  if (!storefrontId) {
+    return {
+      passed: false,
+      detail: "No storefront to record an enquiry against.",
+      expected: "a storefront configuration",
+      actual: "none found",
+    };
+  }
+  return inRolledBackTransaction(async (tx) => {
+    const ref = `INQ-WD${newId(8).toUpperCase()}`;
+    const created = await tx.storefrontInquiry.create({
+      data: {
+        inquiryRef: ref,
+        storefrontId,
+        customerEmail: SYNTHETIC.email,
+        customerName: SYNTHETIC.name,
+        message: "Scheduled journey watchdog rehearsal. This record is never committed.",
+      },
+      select: { id: true, inquiryRef: true, status: true },
+    });
+    const readBack = await tx.storefrontInquiry.findUnique({
+      where: { inquiryRef: ref },
+      select: { inquiryRef: true },
+    });
+    if (!readBack) {
+      return {
+        passed: false,
+        detail: "An enquiry was written but could not be read back.",
+        expected: `an enquiry readable by its reference ${ref}`,
+        actual: "the record was not found after creation",
+      };
+    }
+    return {
+      passed: true,
+      detail: `A real enquiry record was created (${created.status}) and rolled back cleanly.`,
+    };
+  });
+}
+
+/**
+ * Booking data path: creates a real `StorefrontBooking`, then deliberately
+ * attempts an OVERLAPPING second booking and requires the database to reject it.
+ *
+ * The second half is the valuable half. `StorefrontBooking_no_overlap` is a gist
+ * EXCLUDE constraint and is the single authoritative arbiter of slot contention
+ * (EP-056D2A5E). If a migration ever drops it, bookings keep succeeding and the
+ * business quietly starts double-booking customers — a failure no reachability
+ * check could ever see. This probe fails loudly in that case.
+ */
+export async function bookingDataPathProbe(ctx: JourneyProbeContext): Promise<StepProbeResult> {
+  const { storefrontId, organizationId, bookableItemId } = ctx;
+  if (!storefrontId || !organizationId || !bookableItemId) {
+    return {
+      passed: false,
+      detail: "No bookable item to rehearse a booking against.",
+      expected: "a published storefront with an active bookable item",
+      actual: `storefront=${storefrontId ?? "none"} item=${bookableItemId ?? "none"}`,
+    };
+  }
+  const scheduledAt = syntheticSlot();
+  return inRolledBackTransaction(async (tx) => {
+    await tx.storefrontBooking.create({
+      data: {
+        bookingRef: `BK-WD${newId(8).toUpperCase()}`,
+        organizationId,
+        storefrontId,
+        itemId: bookableItemId,
+        customerEmail: SYNTHETIC.email,
+        customerName: SYNTHETIC.name,
+        scheduledAt,
+        durationMinutes: 60,
+        notes: "Scheduled journey watchdog rehearsal. This record is never committed.",
+      },
+      select: { id: true },
+    });
+
+    // Now prove double-booking is actually prevented.
+    let overlapRejected = false;
+    try {
+      await tx.storefrontBooking.create({
+        data: {
+          bookingRef: `BK-WD${newId(8).toUpperCase()}`,
+          organizationId,
+          storefrontId,
+          itemId: bookableItemId,
+          customerEmail: SYNTHETIC.email,
+          customerName: SYNTHETIC.name,
+          // Deliberately inside the first booking's window.
+          scheduledAt: new Date(scheduledAt.getTime() + 15 * 60 * 1000),
+          durationMinutes: 60,
+        },
+        select: { id: true },
+      });
+    } catch (err) {
+      if (isExclusionViolation(err)) overlapRejected = true;
+      else throw err;
+    }
+
+    if (!overlapRejected) {
+      return {
+        passed: false,
+        detail:
+          "The database accepted two overlapping bookings — double-booking protection is not in force.",
+        expected: "the no-overlap constraint to reject a second booking in the same window",
+        actual: "both bookings were accepted",
+      };
+    }
+    return {
+      passed: true,
+      detail:
+        "A real booking was created and an overlapping one was correctly rejected; both rolled back.",
+    };
+  });
+}
+
+/** Exported for the no-pollution regression test. */
+export const JOURNEY_SYNTHETIC_IDENTITY = SYNTHETIC;

--- a/apps/web/lib/business-journeys/registry.ts
+++ b/apps/web/lib/business-journeys/registry.ts
@@ -1,0 +1,194 @@
+// The critical business journeys this platform watches.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+//
+// Every `outcome` string is written for the business owner, not the engineer.
+// The owner reads "New customers can't send you an enquiry", never "inquiry
+// probe step 2 failed" — the mechanism lives in the evidence, behind the
+// technical-details boundary.
+//
+// Adding a journey: give it an owner-language outcome, an honest
+// `appliesWhen` so installs without the capability are `not-applicable` rather
+// than red, and order its steps cheapest-first.
+
+import {
+  bookingDataPathProbe,
+  contractProbe,
+  inquiryDataPathProbe,
+  reachabilityProbe,
+} from "./probes";
+import type { InstallJourneyContext, JourneyDefinition } from "./types";
+
+const storefrontPath = (ctx: InstallJourneyContext, suffix = ""): string | null =>
+  ctx.organizationSlug ? `/s/${ctx.organizationSlug}${suffix}` : null;
+
+export const BUSINESS_JOURNEYS: readonly JourneyDefinition[] = [
+  {
+    journeyId: "storefront-enquiry",
+    outcome: "New customers can send you an enquiry",
+    businessImpact:
+      "If this is down, people who want to hire you fill in the form and nothing reaches you. You never find out you lost the work.",
+    revenueBearing: true,
+    appliesWhen: (ctx) => ctx.storefrontPublished && ctx.hasInquirySurface,
+    notApplicableReason:
+      "This install has no published enquiry surface, so there is nothing for a customer to send.",
+    steps: [
+      {
+        stepId: "enquiry-page-loads",
+        label: "The enquiry page opens",
+        depth: "reachability",
+        run: reachabilityProbe((ctx) => storefrontPath(ctx, "/inquire")),
+      },
+      {
+        stepId: "enquiry-setup-complete",
+        label: "The enquiry setup is complete",
+        depth: "contract",
+        run: contractProbe(
+          (ctx) => ({
+            ok: ctx.storefrontPublished && ctx.hasInquirySurface,
+            expected: "a published storefront with at least one active enquiry item",
+            actual: `published=${ctx.storefrontPublished} enquiryItems=${ctx.hasInquirySurface}`,
+          }),
+          "The storefront is published and has somewhere to enquire from.",
+          "The enquiry setup is incomplete, so the form has nothing to attach an enquiry to.",
+        ),
+      },
+      {
+        stepId: "enquiry-record-creatable",
+        label: "An enquiry can actually be recorded",
+        depth: "data-path",
+        run: inquiryDataPathProbe,
+      },
+    ],
+  },
+  {
+    journeyId: "storefront-booking",
+    outcome: "Customers can book a time with you",
+    businessImpact:
+      "If this is down, customers cannot reserve a slot — and if double-booking protection has lapsed, two customers can be promised the same time.",
+    revenueBearing: true,
+    appliesWhen: (ctx) => ctx.storefrontPublished && ctx.bookableItemId !== null,
+    notApplicableReason: "This install has no bookable service, so there is no time to book.",
+    steps: [
+      {
+        stepId: "booking-page-loads",
+        label: "The booking page opens",
+        depth: "reachability",
+        run: reachabilityProbe((ctx) =>
+          ctx.bookableItemId ? storefrontPath(ctx, `/book/${ctx.bookableItemId}`) : null,
+        ),
+      },
+      {
+        stepId: "booking-setup-complete",
+        label: "The booking setup is complete",
+        depth: "contract",
+        run: contractProbe(
+          (ctx) => ({
+            ok: ctx.storefrontPublished && ctx.bookableItemId !== null,
+            expected: "a published storefront with at least one active bookable item",
+            actual: `published=${ctx.storefrontPublished} bookableItem=${ctx.bookableItemId ?? "none"}`,
+          }),
+          "The storefront is published and has a bookable service.",
+          "There is no active bookable service for a customer to choose.",
+        ),
+      },
+      {
+        stepId: "booking-record-creatable",
+        label: "A booking can be recorded and double-booking is prevented",
+        depth: "data-path",
+        run: bookingDataPathProbe,
+      },
+    ],
+  },
+  {
+    journeyId: "storefront-front-door",
+    outcome: "Customers can find your business online",
+    businessImpact:
+      "If this is down, every link you have ever shared — search results, your card, your van — leads nowhere.",
+    revenueBearing: true,
+    appliesWhen: (ctx) => ctx.storefrontPublished,
+    notApplicableReason: "This install has no published storefront yet.",
+    steps: [
+      {
+        stepId: "front-door-loads",
+        label: "Your public page opens",
+        depth: "reachability",
+        run: reachabilityProbe((ctx) => storefrontPath(ctx)),
+      },
+      {
+        stepId: "front-door-published",
+        label: "Your page is published",
+        depth: "contract",
+        run: contractProbe(
+          (ctx) => ({
+            ok: ctx.storefrontPublished && ctx.archetypeIds.length > 0,
+            expected: "a published storefront with a configured line of business",
+            actual: `published=${ctx.storefrontPublished} lines=${ctx.archetypeIds.length}`,
+          }),
+          "Your page is published and has a configured line of business.",
+          "Your page is not fully set up, so visitors may see an empty or broken page.",
+        ),
+      },
+    ],
+  },
+  {
+    journeyId: "customer-sign-in",
+    outcome: "Existing customers can sign in to their account",
+    businessImpact:
+      "If this is down, returning customers cannot see their bookings, invoices, or history — and they call you instead.",
+    revenueBearing: false,
+    appliesWhen: (ctx) => ctx.storefrontPublished,
+    notApplicableReason:
+      "This install has no published customer-facing surface, so there is no customer account to sign in to.",
+    steps: [
+      {
+        stepId: "sign-in-page-loads",
+        label: "The sign-in page opens",
+        depth: "reachability",
+        run: reachabilityProbe(() => "/customer-login"),
+      },
+    ],
+  },
+  {
+    journeyId: "storefront-checkout",
+    outcome: "Customers can pay you online",
+    businessImpact: "If this is down, customers who are ready to buy cannot complete the purchase.",
+    revenueBearing: true,
+    appliesWhen: (ctx) => ctx.storefrontPublished && ctx.hasPaymentConfiguration,
+    notApplicableReason:
+      "This install does not sell anything priced online, so there is nothing to pay for.",
+    steps: [
+      {
+        stepId: "checkout-page-loads",
+        label: "The checkout page opens",
+        depth: "reachability",
+        run: reachabilityProbe((ctx) => storefrontPath(ctx, "/checkout")),
+      },
+      {
+        stepId: "checkout-setup-complete",
+        label: "There is something priced to buy",
+        depth: "contract",
+        run: contractProbe(
+          (ctx) => ({
+            ok: ctx.hasPaymentConfiguration,
+            expected: "at least one active item with a price",
+            actual: "no active priced item was found",
+          }),
+          "There is at least one priced item a customer can buy.",
+          "Nothing is priced for sale, so checkout has nothing to charge for.",
+        ),
+      },
+    ],
+  },
+];
+
+/** Journeys that apply to THIS install. The rest are reported `not-applicable`. */
+export function applicableJourneys(
+  ctx: InstallJourneyContext,
+  journeys: readonly JourneyDefinition[] = BUSINESS_JOURNEYS,
+): JourneyDefinition[] {
+  return journeys.filter((j) => j.appliesWhen(ctx));
+}
+
+export function journeyById(journeyId: string): JourneyDefinition | undefined {
+  return BUSINESS_JOURNEYS.find((j) => j.journeyId === journeyId);
+}

--- a/apps/web/lib/business-journeys/runner.test.ts
+++ b/apps/web/lib/business-journeys/runner.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runJourney, runJourneySweep } from "./runner";
+import type {
+  InstallJourneyContext,
+  JourneyDefinition,
+  StepProbeResult,
+  VerificationDepth,
+} from "./types";
+
+const CTX: InstallJourneyContext = {
+  organizationId: "org_1",
+  organizationSlug: "acme",
+  baseUrl: "https://example.test",
+  storefrontId: "sf_1",
+  storefrontPublished: true,
+  archetypeIds: ["field-service"],
+  bookableItemId: "item_1",
+  hasInquirySurface: true,
+  hasPaymentConfiguration: true,
+};
+
+function stepOf(
+  stepId: string,
+  depth: VerificationDepth,
+  result: StepProbeResult | (() => Promise<never>),
+) {
+  return {
+    stepId,
+    label: stepId,
+    depth,
+    run: typeof result === "function" ? result : async () => result,
+  };
+}
+
+function journeyOf(steps: JourneyDefinition["steps"], applies = true): JourneyDefinition {
+  return {
+    journeyId: "j1",
+    outcome: "Customers can do the thing",
+    businessImpact: "They cannot do the thing.",
+    revenueBearing: true,
+    appliesWhen: () => applies,
+    notApplicableReason: "not set up",
+    steps,
+  };
+}
+
+const deps = { fetchImpl: vi.fn() as unknown as typeof fetch, now: () => new Date(0) };
+
+describe("runJourney — cheapest-first with skip-after-failure", () => {
+  it("skips deeper steps once an earlier step failed", async () => {
+    const deepProbe = vi.fn(async () => ({ passed: true, detail: "ran" }));
+    const journey = journeyOf([
+      stepOf("cheap", "reachability", { passed: false, detail: "down", expected: "200", actual: "503" }),
+      { stepId: "expensive", label: "expensive", depth: "data-path", run: deepProbe },
+    ]);
+
+    const result = await runJourney(journey, CTX, deps);
+
+    // The expensive rehearsal must not have run at all — that is the cost control.
+    expect(deepProbe).not.toHaveBeenCalled();
+    expect(result.status).toBe("failed");
+    expect(result.steps[1].outcome).toBe("skipped");
+  });
+
+  it("reports a failed journey as having established no depth", async () => {
+    const journey = journeyOf([
+      stepOf("a", "reachability", { passed: true, detail: "ok" }),
+      stepOf("b", "data-path", { passed: false, detail: "broken" }),
+    ]);
+
+    const result = await runJourney(journey, CTX, deps);
+
+    expect(result.status).toBe("failed");
+    expect(result.achievedDepth).toBeNull();
+    // Everything is unchecked when the journey failed.
+    expect(result.uncheckedDepths).toContain("reachability");
+  });
+
+  it("caps a passing journey at its weakest step depth", async () => {
+    const journey = journeyOf([
+      stepOf("a", "reachability", { passed: true, detail: "ok" }),
+      stepOf("b", "data-path", { passed: true, detail: "ok" }),
+    ]);
+
+    const result = await runJourney(journey, CTX, deps);
+
+    expect(result.status).toBe("passed");
+    expect(result.achievedDepth).toBe("reachability");
+    expect(result.uncheckedDepths).toEqual(["contract", "data-path", "interaction"]);
+  });
+
+  it("turns a throwing probe into a failed step with evidence, not a crash", async () => {
+    const journey = journeyOf([
+      stepOf("boom", "contract", async () => {
+        throw new Error("connection reset");
+      }),
+    ]);
+
+    const result = await runJourney(journey, CTX, deps);
+
+    expect(result.status).toBe("failed");
+    expect(result.steps[0].actual).toBe("connection reset");
+  });
+});
+
+describe("runJourneySweep", () => {
+  // Args are typed so `mock.calls[0][0]` is inspectable rather than `undefined`.
+  type AnyArgs = Record<string, unknown>;
+  const db = {
+    assuranceRun: { create: vi.fn(async (_a: AnyArgs) => ({})) },
+    assuranceFinding: {
+      findUnique: vi.fn(async (_a: AnyArgs) => null),
+      create: vi.fn(async (_a: AnyArgs) => ({})),
+      update: vi.fn(async (_a: AnyArgs) => ({})),
+      updateMany: vi.fn(async (_a: AnyArgs) => ({ count: 0 })),
+    },
+    portfolioQualityIssue: {
+      upsert: vi.fn(async (_a: AnyArgs) => ({})),
+      updateMany: vi.fn(async (_a: AnyArgs) => ({ count: 0 })),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function sweep(journeys: JourneyDefinition[]) {
+    return runJourneySweep({
+      db: db as never,
+      fetchImpl: deps.fetchImpl,
+      now: () => new Date(0),
+      resolveContext: async () => CTX,
+      journeys,
+    });
+  }
+
+  it("reports a non-applicable journey without running a single step", async () => {
+    const probe = vi.fn(async () => ({ passed: true, detail: "ran" }));
+    const result = await sweep([
+      journeyOf([{ stepId: "s", label: "s", depth: "contract", run: probe }], false),
+    ]);
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(result.notApplicable).toBe(1);
+    expect(result.journeys[0].status).toBe("not-applicable");
+    // Not-applicable is not a coverage gap: nothing was left unchecked.
+    expect(result.journeys[0].uncheckedDepths).toEqual([]);
+  });
+
+  it("opens a journey_failure issue for a failing journey and resolves a passing one", async () => {
+    await sweep([
+      journeyOf([stepOf("a", "contract", { passed: false, detail: "no" })]),
+      {
+        ...journeyOf([stepOf("b", "contract", { passed: true, detail: "yes" })]),
+        journeyId: "j2",
+      },
+    ]);
+
+    expect(db.portfolioQualityIssue.upsert).toHaveBeenCalledTimes(1);
+    const upsert = db.portfolioQualityIssue.upsert.mock.calls[0][0] as {
+      where: { issueKey: string };
+      create: { issueType: string; summary: string };
+    };
+    expect(upsert.where.issueKey).toBe("journey-failure:j1");
+    expect(upsert.create.issueType).toBe("journey_failure");
+    // The owner reads the lost outcome, not the mechanism.
+    expect(upsert.create.summary).toBe("Customers can do the thing — not working");
+
+    // The passing journey resolves its row.
+    const resolveCall = db.portfolioQualityIssue.updateMany.mock.calls.find(
+      (c) => (c[0] as { where: { issueKey?: string } }).where.issueKey === "journey-failure:j2",
+    );
+    expect(resolveCall).toBeDefined();
+  });
+
+  it("records one AssuranceRun and a finding per failed step", async () => {
+    await sweep([journeyOf([stepOf("a", "contract", { passed: false, detail: "no" })])]);
+
+    expect(db.assuranceRun.create).toHaveBeenCalledTimes(1);
+    const run = db.assuranceRun.create.mock.calls[0][0] as {
+      data: { scopeType: string; adapterKey: string; status: string };
+    };
+    expect(run.data.scopeType).toBe("business-journey");
+    expect(run.data.adapterKey).toBe("journey-watchdog");
+    expect(run.data.status).toBe("failed");
+
+    expect(db.assuranceFinding.create).toHaveBeenCalledTimes(1);
+    const finding = db.assuranceFinding.create.mock.calls[0][0] as {
+      data: { findingKey: string; findingKind: string };
+    };
+    expect(finding.data.findingKey).toBe("journey-watchdog:j1:a");
+    expect(finding.data.findingKind).toBe("business-journey");
+  });
+
+  it("absent-cleans findings that stopped reproducing", async () => {
+    await sweep([journeyOf([stepOf("a", "contract", { passed: true, detail: "ok" })])]);
+
+    const cleanup = db.assuranceFinding.updateMany.mock.calls.at(-1)?.[0] as {
+      data: { status: string };
+    };
+    expect(cleanup.data.status).toBe("resolved");
+  });
+});

--- a/apps/web/lib/business-journeys/runner.ts
+++ b/apps/web/lib/business-journeys/runner.ts
@@ -1,0 +1,265 @@
+// The journey watchdog sweep.
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+//
+// Mirrors lib/coworker-lifecycle/certification-runner.ts deliberately: one
+// AssuranceRun per subject, AssuranceFindings for what failed, absent-clean
+// resolution for what stopped reproducing. Same evidence store, same shape — a
+// reviewer who knows one knows the other.
+//
+// Cheapest-first is structural, not advisory: a step is SKIPPED once an earlier
+// step in the same journey failed, so a storefront that is down costs one HTTP
+// call rather than a transaction rehearsal that was never going to succeed.
+
+import { prisma } from "@dpf/db";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { achievedDepth, uncheckedDepths } from "./depth";
+import { resolveInstallJourneyContext } from "./install-context";
+import { reconcileJourneyIssues } from "./issue";
+import { BUSINESS_JOURNEYS } from "./registry";
+import {
+  JOURNEY_ADAPTER_KEY,
+  JOURNEY_ADAPTER_VERSION,
+  JOURNEY_ASSURANCE_SCOPE_TYPE,
+  type InstallJourneyContext,
+  type JourneyDefinition,
+  type JourneyResult,
+  type JourneyStepResult,
+  type JourneySweepResult,
+  type StepProbeResult,
+} from "./types";
+
+export type JourneySweepDeps = {
+  db: typeof prisma;
+  fetchImpl: typeof fetch;
+  now: () => Date;
+  resolveContext: (db: typeof prisma) => Promise<InstallJourneyContext>;
+  journeys: readonly JourneyDefinition[];
+};
+
+function defaultDeps(): JourneySweepDeps {
+  return {
+    db: prisma,
+    fetchImpl: fetch,
+    now: () => new Date(),
+    resolveContext: resolveInstallJourneyContext,
+    journeys: BUSINESS_JOURNEYS,
+  };
+}
+
+/** Run one journey's steps, cheapest-first, stopping deeper work after a failure. */
+export async function runJourney(
+  journey: JourneyDefinition,
+  ctx: InstallJourneyContext,
+  deps: Pick<JourneySweepDeps, "fetchImpl" | "now">,
+): Promise<JourneyResult> {
+  const journeyStartedAt = deps.now().getTime();
+  const probeCtx = { ...ctx, fetchImpl: deps.fetchImpl, now: deps.now };
+  const steps: JourneyStepResult[] = [];
+  let failedAlready = false;
+
+  for (const step of journey.steps) {
+    if (failedAlready) {
+      steps.push({
+        stepId: step.stepId,
+        label: step.label,
+        depth: step.depth,
+        outcome: "skipped",
+        detail: "Not checked — an earlier step in this journey already failed.",
+        durationMs: 0,
+      });
+      continue;
+    }
+    const stepStartedAt = deps.now().getTime();
+    let result: StepProbeResult;
+    try {
+      result = await step.run(probeCtx);
+    } catch (err) {
+      // A probe that throws is a failed step with evidence, never an unhandled
+      // rejection that kills the sweep for every other journey.
+      result = {
+        passed: false,
+        detail: "The check could not complete.",
+        expected: "the check to run to completion",
+        actual: getErrorMessage(err),
+      };
+    }
+    if (!result.passed) failedAlready = true;
+    steps.push({
+      stepId: step.stepId,
+      label: step.label,
+      depth: step.depth,
+      outcome: result.passed ? "passed" : "failed",
+      detail: result.detail,
+      ...(result.expected !== undefined ? { expected: result.expected } : {}),
+      ...(result.actual !== undefined ? { actual: result.actual } : {}),
+      durationMs: deps.now().getTime() - stepStartedAt,
+    });
+  }
+
+  const status = failedAlready ? "failed" : "passed";
+  const depth = status === "passed" ? achievedDepth(steps) : null;
+  return {
+    journeyId: journey.journeyId,
+    outcome: journey.outcome,
+    businessImpact: journey.businessImpact,
+    revenueBearing: journey.revenueBearing,
+    status,
+    achievedDepth: depth,
+    uncheckedDepths: uncheckedDepths(depth),
+    steps,
+    durationMs: deps.now().getTime() - journeyStartedAt,
+  };
+}
+
+function notApplicable(journey: JourneyDefinition): JourneyResult {
+  return {
+    journeyId: journey.journeyId,
+    outcome: journey.outcome,
+    businessImpact: journey.businessImpact,
+    revenueBearing: journey.revenueBearing,
+    status: "not-applicable",
+    achievedDepth: null,
+    // A journey that does not apply is not a coverage gap — nothing about it
+    // was left unchecked, because there was nothing to check.
+    uncheckedDepths: [],
+    notApplicableReason: journey.notApplicableReason,
+    steps: [],
+    durationMs: 0,
+  };
+}
+
+/**
+ * Run every journey, persist evidence, and reconcile the operator inbox.
+ *
+ * Never throws for a journey-level failure — a broken journey is the output,
+ * not an exception.
+ */
+export async function runJourneySweep(
+  overrides: Partial<JourneySweepDeps> = {},
+): Promise<JourneySweepResult> {
+  const deps: JourneySweepDeps = { ...defaultDeps(), ...overrides };
+  const startedAt = deps.now();
+  const ctx = await deps.resolveContext(deps.db);
+
+  const results: JourneyResult[] = [];
+  for (const journey of deps.journeys) {
+    results.push(
+      journey.appliesWhen(ctx)
+        ? await runJourney(journey, ctx, deps)
+        : notApplicable(journey),
+    );
+  }
+
+  const completedAt = deps.now();
+  const runId = `assurance_journey_${startedAt.toISOString().replace(/[^a-zA-Z0-9]/g, "_")}`;
+
+  await persistSweep(runId, results, startedAt, completedAt, deps);
+  // `as never` matches the existing convention for the narrow monitor-issue
+  // surface (see alert-delivery-bridge.ts): Prisma's generic delegate signatures
+  // do not structurally satisfy the hand-written test seam.
+  await reconcileJourneyIssues(deps.db as never, results, runId, deps.now);
+
+  return {
+    runId,
+    startedAt,
+    completedAt,
+    journeys: results,
+    passed: results.filter((r) => r.status === "passed").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    notApplicable: results.filter((r) => r.status === "not-applicable").length,
+  };
+}
+
+function findingKey(journeyId: string, stepId: string): string {
+  return `journey-watchdog:${journeyId}:${stepId}`;
+}
+
+async function persistSweep(
+  runId: string,
+  results: readonly JourneyResult[],
+  startedAt: Date,
+  completedAt: Date,
+  deps: JourneySweepDeps,
+): Promise<void> {
+  const anyFailed = results.some((r) => r.status === "failed");
+
+  await deps.db.assuranceRun.create({
+    data: {
+      runId,
+      scopeType: JOURNEY_ASSURANCE_SCOPE_TYPE,
+      // Single-org install: the sweep's subject is the install itself.
+      scopeId: "install",
+      adapterKey: JOURNEY_ADAPTER_KEY,
+      adapterVersion: JOURNEY_ADAPTER_VERSION,
+      status: anyFailed ? "failed" : "passed",
+      startedAt,
+      completedAt,
+      summary: {
+        journeys: results.map((r) => ({
+          journeyId: r.journeyId,
+          outcome: r.outcome,
+          status: r.status,
+          achievedDepth: r.achievedDepth,
+          uncheckedDepths: r.uncheckedDepths,
+          notApplicableReason: r.notApplicableReason ?? null,
+          durationMs: r.durationMs,
+          steps: r.steps,
+        })),
+      },
+    },
+  });
+
+  const activeKeys: string[] = [];
+  for (const journey of results) {
+    for (const step of journey.steps) {
+      if (step.outcome !== "failed") continue;
+      const key = findingKey(journey.journeyId, step.stepId);
+      activeKeys.push(key);
+      const base = {
+        findingKind: "business-journey",
+        title: `${journey.outcome} — ${step.label} failed`,
+        description: step.detail,
+        affectedType: JOURNEY_ASSURANCE_SCOPE_TYPE,
+        affectedId: journey.journeyId,
+        adapterKey: JOURNEY_ADAPTER_KEY,
+        vendorIdentifier: step.stepId,
+        policySeverity: journey.revenueBearing ? "high" : "medium",
+        releaseImpact: "track",
+        lastSeenAt: completedAt,
+        source: { adapterKey: JOURNEY_ADAPTER_KEY, journeyId: journey.journeyId, runId },
+        evidence: {
+          expected: step.expected ?? null,
+          actual: step.actual ?? null,
+          depth: step.depth,
+          steps: journey.steps,
+        },
+      };
+      const existing = await deps.db.assuranceFinding.findUnique({ where: { findingKey: key } });
+      if (existing) {
+        await deps.db.assuranceFinding.update({
+          where: { findingKey: key },
+          data: {
+            ...base,
+            ...(existing.status === "resolved"
+              ? { status: "open", resolvedAt: null, reopenCount: { increment: 1 } }
+              : {}),
+          },
+        });
+      } else {
+        await deps.db.assuranceFinding.create({
+          data: { ...base, findingKey: key, status: "open", firstSeenAt: completedAt },
+        });
+      }
+    }
+  }
+
+  // Absent-clean: journey findings that did not reproduce this sweep are resolved.
+  await deps.db.assuranceFinding.updateMany({
+    where: {
+      adapterKey: JOURNEY_ADAPTER_KEY,
+      status: { in: ["open", "planned", "blocked"] },
+      ...(activeKeys.length > 0 ? { findingKey: { notIn: activeKeys } } : {}),
+    },
+    data: { status: "resolved", resolvedAt: completedAt },
+  });
+}

--- a/apps/web/lib/business-journeys/types.ts
+++ b/apps/web/lib/business-journeys/types.ts
@@ -1,0 +1,157 @@
+// Critical Business Journey Watchdog — types (BI-E105303D, EP-PROACTIVE-OPS).
+// Spec: docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+//
+// A "critical business journey" is a path the BUSINESS cannot afford to lose —
+// a customer signing up, requesting a quote, booking a slot, paying. This is
+// deliberately distinct from `lib/coworker-lifecycle/golden-journeys.ts`, which
+// certifies COWORKERS, and from `lib/business-activity-sim/`, which simulates a
+// flow in memory without touching the running install.
+
+/**
+ * How much a step actually proved. This is the load-bearing type of the whole
+ * module: `structural-verification-is-not-functional` is a commandment, so a
+ * watchdog that pings a URL must never be able to report "journey healthy".
+ *
+ * The ladder is ordered — comparisons rely on the index in `DEPTH_ORDER`.
+ */
+export type VerificationDepth =
+  /** The entry surface responded as declared. Proves the door opens. */
+  | "reachability"
+  /** The journey's required substrate exists and is coherent (published
+   *  storefront, bookable items, a configured archetype). Proves the room
+   *  behind the door is furnished. */
+  | "contract"
+  /** The journey's REAL persistence path and REAL database constraints executed
+   *  end-to-end inside a watchdog-owned transaction that was then rolled back.
+   *  Proves the business record can actually be created. */
+  | "data-path"
+  /** The real server action / rendered client was driven end-to-end.
+   *  NOT COVERED IN P1 — named here so the gap is visible in the product
+   *  instead of hidden in a backlog. */
+  | "interaction";
+
+/** Weakest → strongest. Index position IS the comparison. */
+export const DEPTH_ORDER: readonly VerificationDepth[] = [
+  "reachability",
+  "contract",
+  "data-path",
+  "interaction",
+] as const;
+
+/** Depths this slice can actually reach. Everything above is reported as unchecked. */
+export const SUPPORTED_DEPTHS: readonly VerificationDepth[] = [
+  "reachability",
+  "contract",
+  "data-path",
+] as const;
+
+/** Owner-facing sentence for each depth — what it does and does not prove. */
+export const DEPTH_MEANING: Record<VerificationDepth, string> = {
+  reachability: "the page loads",
+  contract: "the setup behind it is complete",
+  "data-path": "a real record can be created and the database accepts it",
+  interaction: "a customer completing this in a browser",
+};
+
+export type StepOutcome = "passed" | "failed" | "skipped";
+
+/** One probe within a journey. Steps run cheapest-first and a step is skipped
+ *  when an earlier step in the same journey failed — a broken storefront costs
+ *  one HTTP call, not a full transaction rehearsal. */
+export type JourneyStep = {
+  stepId: string;
+  /** What this step checks, in the owner's language. */
+  label: string;
+  depth: VerificationDepth;
+  run: (ctx: JourneyProbeContext) => Promise<StepProbeResult>;
+};
+
+/** What a probe returns. `expected`/`actual` are required on failure so every
+ *  defect carries reproduction detail (the `every-defect-needs-reproduction-steps`
+ *  commandment applies to the watchdog's own output). */
+export type StepProbeResult = {
+  passed: boolean;
+  detail: string;
+  expected?: string;
+  actual?: string;
+};
+
+export type JourneyStepResult = {
+  stepId: string;
+  label: string;
+  depth: VerificationDepth;
+  outcome: StepOutcome;
+  detail: string;
+  expected?: string;
+  actual?: string;
+  durationMs: number;
+};
+
+/** Facts about what this install actually has switched on. Journeys declare
+ *  applicability against this rather than assuming every install is a storefront. */
+export type InstallJourneyContext = {
+  organizationId: string | null;
+  organizationSlug: string | null;
+  /** Canonical origin for reachability probes. */
+  baseUrl: string;
+  storefrontId: string | null;
+  storefrontPublished: boolean;
+  /** Primary archetype plus any composed secondaries. */
+  archetypeIds: string[];
+  bookableItemId: string | null;
+  hasInquirySurface: boolean;
+  hasPaymentConfiguration: boolean;
+};
+
+export type JourneyProbeContext = InstallJourneyContext & {
+  fetchImpl: typeof fetch;
+  now: () => Date;
+};
+
+export type JourneyDefinition = {
+  journeyId: string;
+  /** The outcome in the owner's language — "New customers can request a quote".
+   *  Never the mechanism. This is what the attention card and tile render. */
+  outcome: string;
+  /** What the business loses when this journey is down. */
+  businessImpact: string;
+  /** Revenue-bearing journeys escalate to high-risk in the attention surface. */
+  revenueBearing: boolean;
+  /** Install-defined: a journey that does not apply is `not-applicable`, never red. */
+  appliesWhen: (ctx: InstallJourneyContext) => boolean;
+  /** Why it does not apply, shown instead of a status when skipped. */
+  notApplicableReason: string;
+  steps: JourneyStep[];
+};
+
+export type JourneyStatus = "passed" | "failed" | "not-applicable";
+
+export type JourneyResult = {
+  journeyId: string;
+  outcome: string;
+  businessImpact: string;
+  revenueBearing: boolean;
+  status: JourneyStatus;
+  /** The weakest depth among PASSING steps — see `achievedDepth`. Null when the
+   *  journey failed or did not apply, because nothing was established. */
+  achievedDepth: VerificationDepth | null;
+  /** Depths this run did not establish. Rendered as "Not checked: …". */
+  uncheckedDepths: VerificationDepth[];
+  notApplicableReason?: string;
+  steps: JourneyStepResult[];
+  durationMs: number;
+};
+
+export type JourneySweepResult = {
+  runId: string;
+  startedAt: Date;
+  completedAt: Date;
+  journeys: JourneyResult[];
+  passed: number;
+  failed: number;
+  notApplicable: number;
+};
+
+export const JOURNEY_ADAPTER_KEY = "journey-watchdog";
+export const JOURNEY_ADAPTER_VERSION = "1.0.0";
+export const JOURNEY_ASSURANCE_SCOPE_TYPE = "business-journey";

--- a/apps/web/lib/business-journeys/types.ts
+++ b/apps/web/lib/business-journeys/types.ts
@@ -45,12 +45,14 @@ export const SUPPORTED_DEPTHS: readonly VerificationDepth[] = [
   "data-path",
 ] as const;
 
-/** Owner-facing sentence for each depth — what it does and does not prove. */
+/** Owner-facing sentence for each depth — what it does and does not prove.
+ *  Kept short on purpose: these are repeated on every card, so a long phrase
+ *  here becomes a wall of text on the page. */
 export const DEPTH_MEANING: Record<VerificationDepth, string> = {
-  reachability: "the page loads",
-  contract: "the setup behind it is complete",
-  "data-path": "a real record can be created and the database accepts it",
-  interaction: "a customer completing this in a browser",
+  reachability: "the page opens",
+  contract: "the setup is complete",
+  "data-path": "a real record can be saved",
+  interaction: "a customer doing this in a browser",
 };
 
 export type StepOutcome = "passed" | "failed" | "skipped";

--- a/apps/web/lib/business-journeys/watchdog-constants.ts
+++ b/apps/web/lib/business-journeys/watchdog-constants.ts
@@ -1,0 +1,26 @@
+// Scheduling identity for the business-journey watchdog (BI-E105303D).
+//
+// Deliberately dependency-free, mirroring catalog-sweep-constants.ts and
+// identity-inference-constants.ts: the scheduled-jobs catalog and the admin
+// surface must be able to name this job WITHOUT importing the Inngest function
+// module and dragging the whole queue client into their graph.
+
+export const BUSINESS_JOURNEY_WATCHDOG_JOB_ID = "business-journey-watchdog";
+export const BUSINESS_JOURNEY_WATCHDOG_JOB_NAME = "Business journey watchdog";
+export const BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID = "ops/business-journey-watchdog";
+export const BUSINESS_JOURNEY_WATCHDOG_RUN_NOW_INNGEST_ID =
+  "ops/business-journey-watchdog-run-now";
+export const BUSINESS_JOURNEY_WATCHDOG_REQUESTED_EVENT =
+  "ops/business-journey-watchdog.requested";
+
+/**
+ * Mon/Wed/Fri at 06:00 — not nightly.
+ *
+ * A sweep costs real work (HTTP calls plus transaction rehearsals), and three
+ * runs a week still catch a broken signup within a working day. 06:00 keeps it
+ * clear of the 04:00–05:00 nightly block so it never shares a tick with the
+ * data-model mirror, SysML projection, memory consolidation, or coworker
+ * certification.
+ */
+export const BUSINESS_JOURNEY_WATCHDOG_CRON = "0 6 * * 1,3,5";
+export const BUSINESS_JOURNEY_WATCHDOG_CADENCE = "Mon/Wed/Fri at 06:00";

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9550,6 +9550,20 @@
         "documentation-rule"
       ]
     },
+    "docs/user-guide/operations/business-journeys.md": {
+      "publicHref": "/user-guide/operations/business-journeys/",
+      "portalHref": "/docs/operations/business-journeys",
+      "publishedPublic": true,
+      "publishedPortal": true,
+      "anchors": [
+        "overview",
+        "what-gets-checked",
+        "how-much-each-check-proves",
+        "nothing-you-see-is-a-real-record",
+        "when-something-breaks",
+        "related"
+      ]
+    },
     "docs/user-guide/operations/index.md": {
       "publicHref": "/user-guide/operations/",
       "portalHref": "/docs/operations/index",
@@ -9563,6 +9577,7 @@
         "shared-demand",
         "founder-shared-portfolio",
         "promotions",
+        "business-journeys",
         "promoter-timeout"
       ]
     },

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 567,
+  "pageCount": 568,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 583,
+  "routeCount": 584,
   "routes": [
     {
       "routePath": "/",
@@ -5014,6 +5014,16 @@
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/ops/improvements/page.tsx",
       "redirectTo": "/ops"
+    },
+    {
+      "routePath": "/ops/journeys",
+      "kind": "page",
+      "segments": [
+        "ops",
+        "journeys"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/ops/journeys/page.tsx"
     },
     {
       "routePath": "/ops/patches",

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,9 +1,9 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 337,
+  "pageRouteCount": 338,
   "summary": {
     "byAudience": {
-      "admin": 141,
+      "admin": 142,
       "auth-setup": 10,
       "builder": 3,
       "customer": 11,
@@ -12,7 +12,7 @@
       "worker": 2
     },
     "byDestinationKind": {
-      "advanced-diagnostic": 95,
+      "advanced-diagnostic": 96,
       "detail": 161,
       "legacy-internal": 29,
       "section-home": 31,
@@ -1232,6 +1232,13 @@
       "routePath": "/ops/improvements",
       "audience": "admin",
       "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/journeys",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
       "confidence": "high",
       "source": "heuristic"
     },

--- a/apps/web/lib/observability/health-alert-issue.ts
+++ b/apps/web/lib/observability/health-alert-issue.ts
@@ -10,8 +10,19 @@
 // owns the discovery->portfolio quality family — a CLOSED QualityIssueType set
 // (none of them health_alert) keyed by a REQUIRED inventory/taxonomy/portfolio
 // FK scope (it throws without one). Health alerts have no such FK; they are
-// keyed by alertname+service. Same table, deliberately different family — so
-// this is a focused sibling writer, not a duplicate.
+// keyed by alertname+service. Same table, deliberately different family.
+//
+// The generic open/resolve mechanics now live in `monitor-issue-writer.ts`,
+// shared with the business-journey watchdog (BI-E105303D). What stays here is
+// what is genuinely health-alert-specific: the key grammar, the severity
+// mapping, and the details payload the reconciler reads.
+
+import {
+  openMonitorIssue,
+  resolveMonitorIssue as resolveMonitorIssueRow,
+  type MonitorIssueDb,
+  type MonitorIssueScope,
+} from "./monitor-issue-writer";
 
 export type HealthAlertSeverity = "info" | "warn" | "error";
 
@@ -25,12 +36,7 @@ export type HealthAlertSeverity = "info" | "warn" | "error";
  * pass scope so the operator inbox routes them to the right customer queue and
  * two customers with the same alert never collide on one row.
  */
-export interface HealthAlertScope {
-  customerAccountId?: string | null;
-  customerSiteId?: string | null;
-  /** e.g. `customer:acc_1:site:s_1` or `organization:internal`. */
-  scopeKey?: string | null;
-}
+export type HealthAlertScope = MonitorIssueScope;
 
 function isCustomerScopedAlert(scope?: HealthAlertScope): boolean {
   return Boolean(scope?.customerAccountId);
@@ -48,19 +54,7 @@ export interface IncomingHealthAlert {
 }
 
 /** Narrow Prisma surface so tests inject a mock without the full client type. */
-export interface HealthAlertDb {
-  portfolioQualityIssue: {
-    upsert(args: {
-      where: { issueKey: string };
-      create: Record<string, unknown>;
-      update: Record<string, unknown>;
-    }): Promise<unknown>;
-    updateMany(args: {
-      where: Record<string, unknown>;
-      data: Record<string, unknown>;
-    }): Promise<{ count: number }>;
-  };
-}
+export type HealthAlertDb = MonitorIssueDb;
 
 /**
  * Deterministic issueKey for a health alert. Scoped by the most specific
@@ -85,21 +79,6 @@ export function healthAlertIssueKey(
     return `${prefix}|${base}`;
   }
   return base;
-}
-
-/** Persisted routing columns. Prefer a caller-resolved `scopeKey` (from the
- *  estate-scope resolver); fall back to the minimal grammar only defensively. */
-function scopeColumns(scope?: HealthAlertScope) {
-  const customerAccountId = scope?.customerAccountId ?? null;
-  const customerSiteId = scope?.customerSiteId ?? null;
-  const scopeKey =
-    scope?.scopeKey ??
-    (customerAccountId
-      ? customerSiteId
-        ? `customer:${customerAccountId}:site:${customerSiteId}`
-        : `customer:${customerAccountId}`
-      : "organization:internal");
-  return { customerAccountId, customerSiteId, scopeKey };
 }
 
 function detailsFor(alert: IncomingHealthAlert) {
@@ -134,29 +113,15 @@ export async function upsertHealthAlertIssue(
       ? new Date(alert.activeAt)
       : new Date();
 
-  await db.portfolioQualityIssue.upsert({
-    where: { issueKey },
-    create: {
-      issueKey,
-      issueType: "health_alert",
-      severity,
-      summary,
-      details,
-      status: "open",
-      firstDetectedAt,
-      lastDetectedAt: new Date(),
-      ...scopeColumns(scope),
-    },
-    update: {
-      severity,
-      summary,
-      details,
-      status: "open",
-      lastDetectedAt: new Date(),
-      resolvedAt: null,
-    },
+  return openMonitorIssue(db, {
+    issueKey,
+    issueType: "health_alert",
+    severity,
+    summary,
+    details,
+    firstDetectedAt,
+    scope,
   });
-  return issueKey;
 }
 
 /** Flip an open health-alert issue to resolved (alert stopped firing). */
@@ -164,8 +129,5 @@ export async function resolveHealthAlertIssue(
   db: HealthAlertDb,
   issueKey: string,
 ): Promise<void> {
-  await db.portfolioQualityIssue.updateMany({
-    where: { issueKey, status: "open" },
-    data: { status: "resolved", resolvedAt: new Date(), lastDetectedAt: new Date() },
-  });
+  await resolveMonitorIssueRow(db, issueKey);
 }

--- a/apps/web/lib/observability/monitor-issue-writer.ts
+++ b/apps/web/lib/observability/monitor-issue-writer.ts
@@ -1,0 +1,147 @@
+// Shared writer for MONITOR-CLEARED PortfolioQualityIssue rows.
+//
+// Consolidation (BI-E105303D): `health-alert-issue.ts` already owned a bespoke
+// open/refresh/resolve triple over PortfolioQualityIssue, and the journey
+// watchdog needed the same shape. Rather than let a second hand-rolled copy
+// appear — the exact drift that produced 8 undeclared issue types and 2,247
+// unclosable rows (see packages/db/src/quality-issue-registry.ts) — both now go
+// through this one primitive.
+//
+// Scope boundary, deliberately narrow: this serves the `monitor-clears` family —
+// issue types whose row is opened by a monitoring source and resolved when that
+// source observes the condition clear. It is NOT a replacement for
+// `openOrUpdateQualityIssue` in @dpf/db, which owns the discovery→portfolio
+// family and requires an inventory/taxonomy/portfolio FK scope. Same table, two
+// deliberately different families.
+//
+// `issueType` is typed as `QualityIssueType`, so a caller emitting a type with
+// no declared lifecycle is a compile error rather than a row nobody can close.
+
+import type { QualityIssueType } from "@dpf/db";
+
+/** Narrow Prisma surface so tests inject a mock without the full client type. */
+export interface MonitorIssueDb {
+  portfolioQualityIssue: {
+    upsert(args: {
+      where: { issueKey: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }): Promise<unknown>;
+    updateMany(args: {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    }): Promise<{ count: number }>;
+  };
+}
+
+export type MonitorIssueSeverity = "info" | "warn" | "error";
+
+/**
+ * Per-customer/site routing scope (EP-MSP-FEDERATION · A1). Absent scope keeps
+ * the row in the operator's own estate, which is the backward-compatible default.
+ */
+export interface MonitorIssueScope {
+  customerAccountId?: string | null;
+  customerSiteId?: string | null;
+  scopeKey?: string | null;
+}
+
+export function monitorIssueScopeColumns(scope?: MonitorIssueScope) {
+  const customerAccountId = scope?.customerAccountId ?? null;
+  const customerSiteId = scope?.customerSiteId ?? null;
+  const scopeKey =
+    scope?.scopeKey ??
+    (customerAccountId
+      ? customerSiteId
+        ? `customer:${customerAccountId}:site:${customerSiteId}`
+        : `customer:${customerAccountId}`
+      : "organization:internal");
+  return { customerAccountId, customerSiteId, scopeKey };
+}
+
+export interface OpenMonitorIssueParams {
+  issueKey: string;
+  issueType: QualityIssueType;
+  severity: MonitorIssueSeverity;
+  summary: string;
+  details: unknown;
+  /** When the condition was first observed. Defaults to now on first open. */
+  firstDetectedAt?: Date;
+  scope?: MonitorIssueScope;
+  now?: () => Date;
+}
+
+/**
+ * Open or refresh the issue for a firing condition. Idempotent: the unique
+ * `issueKey` means a repeated firing updates `lastDetectedAt` rather than
+ * duplicating, and a previously-resolved row reopens with `resolvedAt` cleared.
+ */
+export async function openMonitorIssue(
+  db: MonitorIssueDb,
+  params: OpenMonitorIssueParams,
+): Promise<string> {
+  const now = params.now ?? (() => new Date());
+  const at = now();
+  await db.portfolioQualityIssue.upsert({
+    where: { issueKey: params.issueKey },
+    create: {
+      issueKey: params.issueKey,
+      issueType: params.issueType,
+      severity: params.severity,
+      summary: params.summary,
+      details: params.details,
+      status: "open",
+      firstDetectedAt: params.firstDetectedAt ?? at,
+      lastDetectedAt: at,
+      ...monitorIssueScopeColumns(params.scope),
+    },
+    update: {
+      severity: params.severity,
+      summary: params.summary,
+      details: params.details,
+      status: "open",
+      lastDetectedAt: at,
+      resolvedAt: null,
+    },
+  });
+  return params.issueKey;
+}
+
+/** Flip one open issue to resolved — the condition cleared at its source. */
+export async function resolveMonitorIssue(
+  db: MonitorIssueDb,
+  issueKey: string,
+  now: () => Date = () => new Date(),
+): Promise<void> {
+  const at = now();
+  await db.portfolioQualityIssue.updateMany({
+    where: { issueKey, status: "open" },
+    data: { status: "resolved", resolvedAt: at, lastDetectedAt: at },
+  });
+}
+
+/**
+ * Absent-clean: resolve every open row of `issueType` whose key is NOT in
+ * `activeKeys`. This is what stops a monitor family accumulating rows for
+ * conditions that stopped reproducing — the failure mode the quality-issue
+ * registry exists to prevent.
+ */
+export async function resolveMonitorIssuesExcept(
+  db: MonitorIssueDb,
+  params: {
+    issueType: QualityIssueType;
+    activeKeys: string[];
+    now?: () => Date;
+  },
+): Promise<number> {
+  const at = (params.now ?? (() => new Date()))();
+  const { count } = await db.portfolioQualityIssue.updateMany({
+    where: {
+      issueType: params.issueType,
+      status: "open",
+      ...(params.activeKeys.length > 0 ? { issueKey: { notIn: params.activeKeys } } : {}),
+    },
+    data: { status: "resolved", resolvedAt: at, lastDetectedAt: at },
+  });
+  return count;
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -27,6 +27,14 @@
 
 import { CODE_GRAPH_JOB_ID } from "@/lib/integrate/code-graph/constants";
 import {
+  BUSINESS_JOURNEY_WATCHDOG_CADENCE,
+  BUSINESS_JOURNEY_WATCHDOG_CRON,
+  BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID,
+  BUSINESS_JOURNEY_WATCHDOG_JOB_ID,
+  BUSINESS_JOURNEY_WATCHDOG_JOB_NAME,
+  BUSINESS_JOURNEY_WATCHDOG_REQUESTED_EVENT,
+} from "@/lib/business-journeys/watchdog-constants";
+import {
   CATALOG_SWEEP_JOB_ID,
   CATALOG_SWEEP_JOB_NAME,
   CATALOG_SWEEP_SCHEDULED_INNGEST_ID,
@@ -687,6 +695,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     category: "editable",
     tracksRunData: false,
     runNowEvent: "ops/coworker-certification.requested",
+  },
+  {
+    jobId: BUSINESS_JOURNEY_WATCHDOG_JOB_ID,
+    inngestId: BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID,
+    name: BUSINESS_JOURNEY_WATCHDOG_JOB_NAME,
+    purpose:
+      "BI-E105303D / EP-PROACTIVE-OPS: exercises the install's critical business journeys (front door, enquiry, booking, sign-in, checkout) against the running system, records evidence, and raises a journey_failure issue the Needs-you inbox surfaces. If it stops, a broken signup or booking path goes unnoticed until a customer complains.",
+    cron: BUSINESS_JOURNEY_WATCHDOG_CRON,
+    cadence: BUSINESS_JOURNEY_WATCHDOG_CADENCE,
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: BUSINESS_JOURNEY_WATCHDOG_REQUESTED_EVENT,
   },
   {
     jobId: "memory-consolidation-nightly",

--- a/apps/web/lib/queue/functions/business-journey-watchdog.ts
+++ b/apps/web/lib/queue/functions/business-journey-watchdog.ts
@@ -1,0 +1,83 @@
+// apps/web/lib/queue/functions/business-journey-watchdog.ts
+// BI-E105303D / EP-PROACTIVE-OPS — the critical business journey watchdog.
+//
+// Exercises the install's revenue-critical journeys (front door, enquiry,
+// booking, sign-in, checkout) against the RUNNING install, records evidence into
+// the existing assurance store, and routes failures to the operator through the
+// Attention Surface.
+//
+// Cadence is Mon/Wed/Fri at 06:00, not nightly. A watchdog run costs real work —
+// HTTP calls plus transaction rehearsals — and three times a week catches a
+// broken signup inside a working day while keeping cost per verified outcome
+// low. 06:00 also keeps it clear of the 04:00–05:00 nightly block (data-model
+// mirror, SysML projection, memory consolidation, coworker certification), so
+// it never contends with them for the same tick.
+//
+// Mirrors coworker-certification.ts: pure exported job + thin Inngest wrappers
+// (cron + run-now event) behind the quiescence gate.
+//
+// This job NEVER creates a build, opens a PR, or merges a fix. It records,
+// raises, and notifies. Remediation goes through the governed backlog flow at
+// the operator's initiative.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  BUSINESS_JOURNEY_WATCHDOG_CRON,
+  BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID,
+  BUSINESS_JOURNEY_WATCHDOG_REQUESTED_EVENT,
+  BUSINESS_JOURNEY_WATCHDOG_RUN_NOW_INNGEST_ID,
+} from "@/lib/business-journeys/watchdog-constants";
+
+export type BusinessJourneyWatchdogResult = {
+  runId: string;
+  passed: number;
+  failed: number;
+  notApplicable: number;
+  failedJourneyIds: string[];
+};
+
+export async function runBusinessJourneyWatchdogJob(): Promise<BusinessJourneyWatchdogResult> {
+  const { runJourneySweep } = await import("@/lib/business-journeys/runner");
+  const sweep = await runJourneySweep();
+  return {
+    runId: sweep.runId,
+    passed: sweep.passed,
+    failed: sweep.failed,
+    notApplicable: sweep.notApplicable,
+    failedJourneyIds: sweep.journeys
+      .filter((j) => j.status === "failed")
+      .map((j) => j.journeyId),
+  };
+}
+
+export const businessJourneyWatchdogScheduled = inngest.createFunction(
+  {
+    id: BUSINESS_JOURNEY_WATCHDOG_INNGEST_ID,
+    retries: 1,
+    // Serialize with itself: two concurrent sweeps would race on the same
+    // journey-failure rows and on the data-path rehearsal slots.
+    concurrency: [{ limit: 1 }],
+    triggers: [cron(BUSINESS_JOURNEY_WATCHDOG_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return step.run("business-journey-watchdog", () => runBusinessJourneyWatchdogJob());
+  },
+);
+
+export const businessJourneyWatchdogRunNow = inngest.createFunction(
+  {
+    id: BUSINESS_JOURNEY_WATCHDOG_RUN_NOW_INNGEST_ID,
+    retries: 0,
+    concurrency: [{ limit: 1 }],
+    triggers: [{ event: BUSINESS_JOURNEY_WATCHDOG_REQUESTED_EVENT }],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return step.run("business-journey-watchdog", () => runBusinessJourneyWatchdogJob());
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -87,6 +87,10 @@ import {
   coworkerCertificationNightly,
   coworkerCertificationRunNow,
 } from "./coworker-certification";
+import {
+  businessJourneyWatchdogScheduled,
+  businessJourneyWatchdogRunNow,
+} from "./business-journey-watchdog";
 import { memoryConsolidationNightly } from "./memory-consolidation-nightly";
 import {
   semanticMemoryReconcileScheduled,
@@ -150,6 +154,7 @@ export const scheduledFunctions = [
   identityInferenceFallbackScheduled, // EP-ASSET-INTELLIGENCE: weekly cheap-model AI resolution of the unresolved-identity tail (batched, budget-capped), Tue 04:43
   remoteActionClaimTimeout,   // EP-REMOTE-ACTION P2: time out stale claimed RemoteActions so the pull queue can't wedge, every 10m (flag-gated)
   coworkerCertificationNightly, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): nightly golden-journey certification of every roster coworker, 04:40
+  businessJourneyWatchdogScheduled, // BI-E105303D / EP-PROACTIVE-OPS: exercises the install's critical business journeys against the running system, Mon/Wed/Fri 06:00
   canonicalImprovementDigest, // BI-8996BBBB: weekly [reference-doc] proposal digest -> canonical-source chore BI
   memoryConsolidationNightly, // BI-907C4327: EP-8C706944 P2 autoDream — nightly batch-dedupe + expire coworker notes / user facts, 04:20
   semanticMemoryReconcileScheduled, // BI-DG-001: EP-DATA-GOVERNANCE — nightly orphan reconciliation of the semantic-memory derived copy, 05:10 (after retention sweep)
@@ -190,6 +195,7 @@ export const eventFunctions = [
   catalogEnrichmentSweepRequested, // EP-ASSET-INTELLIGENCE: catalog enrichment "run now" (poll-on-request)
   identityInferenceFallbackRequested, // EP-ASSET-INTELLIGENCE: AI identity-resolution fallback "run now" (poll-on-request)
   coworkerCertificationRunNow, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): operator "run now" certification sweep
+  businessJourneyWatchdogRunNow, // BI-E105303D: operator "run now" business-journey watchdog sweep
   semanticMemoryReconcileRequested, // BI-DG-001: operator "run now" semantic-memory orphan reconciliation
   postmarkCallbackDispatchRequested,
   workPatternExperimentRun,

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1235,7 +1235,7 @@
       "ariaSnapshot": "- heading [level=1]\n- text\n- textbox\n- text\n- textbox\n- button\n- link"
     },
     "/ops": {
-      "defaultVisibleWords": 177,
+      "defaultVisibleWords": 180,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,11 +1,11 @@
 {
   "generator": "apps/web/scripts/build-route-shells.ts",
-  "pageRouteCount": 308,
+  "pageRouteCount": 309,
   "migratedCount": 0,
   "summary": {
     "cockpit": 15,
     "list": 6,
-    "detail": 236,
+    "detail": 237,
     "settings": 12,
     "form": 18,
     "public": 21,
@@ -1790,6 +1790,17 @@
       ],
       "sweepEligible": false,
       "sweepExclusionReason": "redirects-to-dynamic-resource",
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/journeys",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "sweepEligible": true,
       "confidence": "high"
     },
     {

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -301,7 +301,7 @@ describe("generated route-shell registry", () => {
         (route) => route.sweepEligible === Boolean(route.sweepExclusionReason),
       ),
     ).toEqual([]);
-    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(201);
+    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(202);
     expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(107);
   });
 

--- a/docs/superpowers/plans/2026-07-28-critical-business-journey-watchdog.md
+++ b/docs/superpowers/plans/2026-07-28-critical-business-journey-watchdog.md
@@ -1,0 +1,78 @@
+# Plan — Critical Business Journey Watchdog (BI-E105303D)
+
+Spec: `docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md`
+Kernel: DI-96D3FD5C089B · Work Capsule: WC-2FA1E567 · Branch: `feat/business-journey-watchdog`
+
+One concern: **notice when a critical business journey breaks, prove it with evidence, and
+route it to the operator through the existing attention surface.** Remediation automation
+is explicitly a separate item.
+
+## Phase 1 — contract (test-first)
+
+1. `packages/db/src/quality-issue-registry.ts` — add `journey_failure`
+   (`resolvedBy: "monitor-clears"`, auto-resolves on next green run of the same journey,
+   `expectedSteadyState: 0`, `owner: "operator"`). Registry derives the type union, so
+   this must land before any emitter compiles.
+2. `apps/web/lib/business-journeys/types.ts` — `VerificationDepth`, `JourneyStep`,
+   `JourneyDefinition`, `JourneyStepResult`, `JourneyResult`, `JourneySweepResult`.
+3. `apps/web/lib/business-journeys/depth.ts` — the two honesty rules as pure functions:
+   `achievedDepth()` (weakest passing step) and `uncheckedDepths()`. Unit-tested first.
+
+## Phase 2 — applicability and probes
+
+4. `install-context.ts` — resolve `InstallJourneyContext` from live rows (published
+   storefront, primary + composed archetypes, bookable items, inquiry surface, payments).
+5. `probes.ts` — `reachability`, `contract`, and `data-path` probe implementations.
+   The `data-path` probe owns its transaction and force-rolls-back via a private sentinel.
+6. `registry.ts` — the journey definitions, each with `appliesWhen`, ordered steps,
+   owner-language outcome copy, and `revenueBearing`.
+
+## Phase 3 — run, evidence, issue
+
+7. `runner.ts` — cheapest-first execution (skip `data-path` when cheaper steps failed),
+   one `AssuranceRun` per sweep-journey, `AssuranceFinding` per failed step with
+   absent-clean resolution, mirroring `certification-runner.ts`.
+8. `issue.ts` — sibling writer to `observability/health-alert-issue.ts`: deterministic
+   `issueKey` per journey, upsert open, resolve on green.
+
+## Phase 4 — notify
+
+9. `apps/web/lib/attention/types.ts` — add `business-journey` to `AttentionSource`.
+10. `apps/web/lib/attention/sources/business-journey.ts` — projection.
+11. `apps/web/lib/attention/aggregate.ts` — wire the loader.
+
+## Phase 5 — schedule
+
+12. `apps/web/lib/queue/functions/business-journey-watchdog.ts` — cron `0 6 * * 1,3,5`
+    + run-now event, both quiescence-gated.
+13. Register in `queue/functions/index.ts` and `operate/scheduled-jobs/catalog.ts`
+    (the catalog↔registry parity test fails the build on either-direction gaps;
+    `SCHEDULING_MAP` derives from the catalog automatically).
+
+## Phase 6 — operator surface
+
+14. `journey-health.ts` — read model.
+15. `/ops/journeys` route + components. Outcome-first: plain-language status, achieved
+    depth, and an explicit "Not checked" line. Evidence and step detail behind a
+    Technical details boundary. Empty, loading, degraded, and error states designed, not
+    defaulted. Tokens only — no hardcoded colors.
+
+## Phase 7 — consolidation (~20%)
+
+16. Extract the duplicated open/resolve `PortfolioQualityIssue` shape shared by
+    `health-alert-issue.ts` and the new `issue.ts` into one shared primitive rather than
+    a third copy of the same upsert.
+17. Fold the repeated absent-clean `AssuranceFinding` reconcile (certification runner +
+    journey runner) into a shared helper.
+
+## Phase 8 — gates
+
+Targeted vitest → repo typecheck → production build → migration check (expected: none,
+no schema change) → live UX verification with desktop + mobile, light + dark, keyboard,
+loading/empty/degraded/error captures.
+
+## Verification of the honesty rules
+
+- A journey whose steps all stop at `reachability` must render "Not checked: …" and must
+  not be counted as verified anywhere in the read model.
+- A full sweep must leave every touched table's row count unchanged.

--- a/docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+++ b/docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
@@ -111,6 +111,13 @@ Both are real failures worth raising. Collapsing them would send the operator hu
 wrong problem. An HTTP error status needs no such treatment — a 500 is a 500 wherever it
 is observed.
 
+Every reachability request is also bounded by a 15s `AbortSignal.timeout`. A watchdog that
+can hang is worse than no watchdog: it stays silent through the very outage it exists to
+report, and silence is indistinguishable from health. A customer would have given up long
+before 15s anyway, so a slower response is a failure by the journey's own standard rather
+than merely a slow check. (Found by live verification, not by review — the first live run
+against a real install hit a route that accepted the connection and never answered.)
+
 ## 5. Applicability — install-defined, not hardcoded
 
 A journey declares `appliesWhen(context)` against a resolved `InstallJourneyContext`

--- a/docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+++ b/docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
@@ -63,7 +63,7 @@ Two rules make this honest rather than decorative:
 1. **A journey's achieved depth is the weakest depth among its passing steps.** One
    `reachability`-only step caps the whole journey at `reachability`.
 2. **The surface always states what was *not* checked.** A journey verified to
-   `data-path` renders "Not checked: a customer completing this in a browser." The
+   `data-path` renders "Not checked: a customer doing this in a browser." The
    watchdog never renders an unqualified "healthy".
 
 `interaction` depth is deliberately named and deliberately absent, so the gap is visible

--- a/docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
+++ b/docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md
@@ -1,0 +1,184 @@
+# Critical Business Journey Watchdog — design
+
+- **Backlog item:** BI-E105303D
+- **Epic:** EP-PROACTIVE-OPS (composes EP-ATTENTION-SURFACE, EP-ASSURANCE-LEDGER)
+- **Kernel decision:** DI-96D3FD5C089B
+- **Date:** 2026-07-28
+
+## 1. Problem
+
+A live install can lose a revenue-critical journey — signup, intake, booking, inquiry,
+payment — and nobody finds out until a customer complains. DPF already owns every
+ingredient needed to notice: a scheduled-job substrate, an assurance evidence store, a
+contracted operator-issue inbox, and a calm "Needs you" attention surface. Nothing joins
+them for this purpose.
+
+Verified absent on 2026-07-28 (`ac7f31bdb3`):
+
+| Candidate | What it actually is | Why it does not cover this |
+| --- | --- | --- |
+| `lib/coworker-lifecycle/golden-journeys.ts` | Read-only probes per **coworker** | Certifies agents, not business journeys |
+| `lib/business-activity-sim/` | Pure in-memory flow + oracles | Never touches the running install |
+| `lib/operate/endpoint-test-runner.ts` | Capability probes per **AI model** | Tests models, not journeys |
+| `SCHEDULING_MAP` / `SCHEDULED_JOB_CATALOG` | 60+ jobs | No journey job of any kind |
+
+A repo-wide search for `critical business journey` / `journey watchdog` returns zero matches.
+
+## 2. Decision
+
+Kernel `DI-96D3FD5C089B` scored three options for `external_coding_agent` in contexts
+`build-studio` / `ui` / `platform`:
+
+| Option | Composite |
+| --- | --- |
+| **compose-existing-substrate** | **19.011** |
+| defer, ship attention deep-link fidelity instead | 12.974 |
+| dedicated journey subsystem (new Prisma models, own alerting) | 11.524 |
+
+Margin 6.037, confidence high, no commandment conflict. Top contributors: *Research and
+Use Standards*, *Ship Real Functionality*, *Never Assume — Verify*.
+
+**Compose. No new Prisma model, no new queue, no new evidence store, no new notification
+system.**
+
+## 3. The honesty problem, and the mechanism that solves it
+
+`structural-verification-is-not-functional` is a commandment. A watchdog that pings
+`/book` and reports "booking journey healthy" would violate it — and would be worse than
+no watchdog, because it manufactures false confidence in exactly the place the owner
+stops looking.
+
+So verification depth is a **first-class, per-step, surfaced value**, not an
+implementation detail:
+
+| Depth | What it proves | Cost |
+| --- | --- | --- |
+| `reachability` | the entry surface responds as declared | lowest |
+| `contract` | the journey's required substrate exists and is coherent (published storefront, bookable items, configured archetype) | low |
+| `data-path` | the journey's real persistence path and **real database constraints** execute end-to-end inside a watchdog-owned transaction that is then rolled back | moderate |
+| `interaction` | the real server action / rendered client is driven end-to-end | **not covered in P1** |
+
+Two rules make this honest rather than decorative:
+
+1. **A journey's achieved depth is the weakest depth among its passing steps.** One
+   `reachability`-only step caps the whole journey at `reachability`.
+2. **The surface always states what was *not* checked.** A journey verified to
+   `data-path` renders "Not checked: a customer completing this in a browser." The
+   watchdog never renders an unqualified "healthy".
+
+`interaction` depth is deliberately named and deliberately absent, so the gap is visible
+in the product rather than hidden in a backlog.
+
+## 4. Zero-side-effect functional probing
+
+`data-path` probes must never leave business rows behind — a synthetic booking in the
+owner's reservation queue is a defect, not evidence.
+
+The runner opens its own interactive transaction, performs the journey's real writes
+through the real Prisma schema, asserts the real constraints fired (unique refs, foreign
+keys, the `StorefrontBooking_no_overlap` gist EXCLUDE constraint, required columns), then
+throws a private sentinel to force rollback. Nothing commits.
+
+A regression test asserts row counts for every touched table are unchanged across a full
+sweep. If that test fails, the watchdog is polluting the business and must not ship.
+
+**Known limit, stated plainly:** because the public submit paths (`submitBooking`,
+`submitInquiry`) are `"use server"` actions bound to the module-level client, a
+watchdog-owned transaction cannot wrap them without their inner transaction committing
+independently. P1 therefore exercises the journey's data path and constraints, **not the
+server action's own branch logic**. That is precisely why `interaction` exists as an
+uncovered depth rather than being quietly folded into `data-path`.
+
+## 4a. False alarms are a failure mode too
+
+A watchdog that cries wolf gets ignored, which destroys the same trust a watchdog that
+overstates its coverage destroys. One case is common enough to handle explicitly.
+
+The watchdog runs **inside** the install, so the public address may be unreachable from
+there for reasons that are not an outage: split-horizon DNS, a proxy that only accepts
+external traffic, a missing NAT hairpin. Probing the public origin is still correct — that
+is the customer's actual path — but a connection-level failure alone is not proof the site
+is down.
+
+So a network-level failure is re-tried against the install's own loopback origin, and the
+two outcomes are reported **differently**:
+
+- neither answers → "could not be reached at all" (an outage)
+- loopback answers, public does not → "works inside the install but not at its public web
+  address" (a DNS / proxy / certificate problem)
+
+Both are real failures worth raising. Collapsing them would send the operator hunting the
+wrong problem. An HTTP error status needs no such treatment — a 500 is a 500 wherever it
+is observed.
+
+## 5. Applicability — install-defined, not hardcoded
+
+A journey declares `appliesWhen(context)` against a resolved `InstallJourneyContext`
+(published storefront, primary + composed archetypes, bookable items, inquiry-capable
+surface, payment configuration). A journey that does not apply resolves to
+`not-applicable` — never a failure, never a red tile. An install with no storefront has
+no storefront journeys, and says so.
+
+## 6. Substrate reuse map
+
+| Need | Existing substrate | Reused how |
+| --- | --- | --- |
+| Run evidence | `AssuranceRun` | `scopeType: "business-journey"`, `adapterKey: "journey-watchdog"` |
+| Per-failure evidence | `AssuranceFinding` | one per failed step, with expected vs actual + achieved depth; absent-clean resolves what stops reproducing |
+| Operator inbox row | `PortfolioQualityIssue` | new registry-contracted type `journey_failure` |
+| Lifecycle contract | `packages/db/src/quality-issue-registry.ts` | `resolvedBy: "monitor-clears"`, auto-resolves when the next run of the same journey passes |
+| Notification | Attention Surface | new read-model source `business-journey` |
+| Scheduling | Inngest cron + `SCHEDULED_JOB_CATALOG` + `SCHEDULING_MAP` | one entry, quiescence-gated |
+| Remediation | governed backlog flow | operator-initiated action only (§8) |
+
+## 7. Cadence and cost
+
+Three times a week (`0 6 * * 1,3,5`), not nightly. The transcript's own operator runs the
+equivalent Mon/Wed/Fri because the run costs real money. Cheapest-recipe-first is
+structural here: `reachability` and `contract` steps are near-free and run first; a
+`data-path` step only runs when the cheaper steps for that journey passed, so a broken
+storefront costs one HTTP call rather than a full transaction rehearsal.
+
+Deliberately off the 04:00–05:00 nightly block to avoid same-tick contention with the
+data-model mirror, SysML projection, memory consolidation, and coworker certification.
+
+## 8. Remediation stays governed
+
+The watchdog **never** creates a build, opens a PR, or merges a fix. On failure it:
+
+1. records evidence,
+2. opens one contracted issue,
+3. surfaces one attention item with one recommended action.
+
+The recommended action deep-links the operator to the specific journey's evidence, where
+"File a governed fix" routes through the existing backlog flow. Automatic tee-up is a
+separate governed item precisely so this slice cannot silently create-and-merge.
+
+## 9. Attention item shape
+
+- `source: "business-journey"`, `residueReason: "no-self-heal"`
+- `riskClass`: `high-risk` when the journey is revenue-bearing, else `bounded-write`
+- `decideEffort: "review"` — a broken journey is a fact to act on, not a scored call
+- `decisionClass: { scorability: "unscorable" }` — consistent with `platform-health`
+- Title is the outcome in the owner's language ("New customers can't request a quote"),
+  not the mechanism ("inquiry probe step 2 failed")
+- Deep link resolves to the specific journey, honouring the BI-C7D25599 2026-07-22
+  finding that landing on a broad list recreates the cognitive load the interruption
+  already spent
+
+## 10. Out of scope (governed follow-ups)
+
+- `interaction` depth via `browser-drive`
+- authenticated multi-actor journeys requiring a real session
+- automatic governed remediation tee-up
+- per-journey cost telemetry
+
+## 11. Acceptance
+
+1. A failing journey opens exactly one `journey_failure` row; a later passing run resolves it.
+2. Evidence names the failing step, expected vs actual, and achieved depth.
+3. Attention shows plain-language why-now + one action deep-linking to that journey.
+4. A `reachability`-only journey is never presented as functionally verified.
+5. A full sweep changes no business row counts.
+6. Registered in `SCHEDULING_MAP`; respects the quiescence gate.
+7. No new Prisma model; no parallel queue, evidence store, or notification path.

--- a/docs/user-guide/operations/business-journeys.md
+++ b/docs/user-guide/operations/business-journeys.md
@@ -38,11 +38,11 @@ This is the important part, and the page always tells you.
 A check can prove different amounts, and more is more expensive. Each journey shows what
 was checked **and what was not**:
 
-- **the page loads** — the door opens
-- **the setup behind it is complete** — the room behind the door is furnished
-- **a real record can be created and the database accepts it** — a genuine booking or
+- **the page opens** — the door opens
+- **the setup is complete** — the room behind the door is furnished
+- **a real record can be saved** — a genuine booking or
   enquiry record can be written, and the rules that stop double-bookings still work
-- **a customer completing this in a browser** — *not currently checked*
+- **a customer doing this in a browser** — *not currently checked*
 
 A journey is only reported at the level actually reached. If only the page load was
 checked, the page says so and does not tell you the journey is fine. This is deliberate:

--- a/docs/user-guide/operations/business-journeys.md
+++ b/docs/user-guide/operations/business-journeys.md
@@ -1,0 +1,77 @@
+---
+title: "Business Journeys"
+area: operations
+order: 4
+---
+
+## Overview
+
+Business Journeys answers one question: **can your customers still do the things your
+business depends on?**
+
+Your test suite checks that the code is correct. This checks that the live system is
+actually working — that someone can find your page, send you an enquiry, book a time,
+sign in, and pay you. Those are the things you cannot afford to lose quietly.
+
+The check runs by itself on **Monday, Wednesday and Friday at 6am**. If something breaks,
+it appears in your "Needs you" inbox with what broke and what it costs you.
+
+Find it at **Operations → Business Journeys**.
+
+## What gets checked
+
+Only the journeys your business actually has switched on. If you do not take bookings,
+there is no booking check — it shows as "Not set up" rather than as a problem.
+
+| Journey | What it protects |
+| --- | --- |
+| Customers can find your business online | Every link you have ever shared |
+| New customers can send you an enquiry | Work you would otherwise lose without knowing |
+| Customers can book a time with you | Reservations, and protection against double-booking |
+| Existing customers can sign in to their account | Customers self-serving instead of phoning you |
+| Customers can pay you online | Completing a sale |
+
+## How much each check proves
+
+This is the important part, and the page always tells you.
+
+A check can prove different amounts, and more is more expensive. Each journey shows what
+was checked **and what was not**:
+
+- **the page loads** — the door opens
+- **the setup behind it is complete** — the room behind the door is furnished
+- **a real record can be created and the database accepts it** — a genuine booking or
+  enquiry record can be written, and the rules that stop double-bookings still work
+- **a customer completing this in a browser** — *not currently checked*
+
+A journey is only reported at the level actually reached. If only the page load was
+checked, the page says so and does not tell you the journey is fine. This is deliberate:
+a check that overstates what it knows is worse than no check, because you would stop
+looking.
+
+## Nothing you see is a real record
+
+Some checks need to create a real booking or enquiry to prove the path works. They do it
+inside a rehearsal that is undone immediately — nothing is kept, and nothing appears in
+your reservations or your enquiry list. The made-up customer details use an address that
+cannot exist, so nothing can ever be sent to a real person.
+
+## When something breaks
+
+1. It appears in **Needs you** with the outcome you lost in plain language, plus what
+   failed.
+2. The link takes you to that specific journey — not to a list you have to search.
+3. Open **Show technical details** for the step-by-step result, including what was
+   expected and what actually happened.
+
+The platform does not fix it for you. It will not quietly change your system and tell you
+afterwards. Raising a fix is your decision, and it goes through the normal governed
+process like any other change.
+
+Once the journey works again, the next check clears the alert on its own — there is
+nothing to tick off.
+
+## Related
+
+- [Operations](index.md) — the delivery backlog
+- [Self-upgrade](self-upgrade.md) — how platform updates are applied

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -117,6 +117,10 @@ When you click "Deploy Now", the platform starts the promoter service for the go
 
 To upgrade the platform itself — building a fresh application image and swapping the running install — see [Self-Upgrade](./self-upgrade.md).
 
+## Business Journeys
+
+Promotions and self-upgrade tell you what the platform did. **Business Journeys** tells you whether your customers can still do what your business depends on — find you, enquire, book, sign in, and pay. A scheduled check exercises those paths against the live install on Monday, Wednesday and Friday, states honestly how much each check proved, and raises anything broken into your "Needs you" inbox. See [Business Journeys](./business-journeys.md).
+
 ### Promoter timeout
 
 The portal first prepares the candidate promoter image, then the promoter builds a fresh application image and swaps the running container. Both builds use Docker BuildKit and the same bounded wall-clock budget (default **25 minutes**). Candidate preparation happens before quiescence, so a preparation failure leaves the current portal available. If either build stalls — for example on a slow or degraded network fetch — it is killed and the deployment is marked failed with a retryable `promoter-timeout` diagnosis instead of hanging. A normal deployment completes in a few minutes; the timeout only trips on a genuine stall. Operators on unusually slow hosts can raise the shared budget by setting `DPF_PROMOTER_TIMEOUT_MS` (milliseconds) in the environment. A periodic watchdog additionally force-removes any promoter container orphaned by a mid-deployment restart, so a stalled build can never linger and cause an unexpected later swap.

--- a/packages/db/src/quality-issue-registry.ts
+++ b/packages/db/src/quality-issue-registry.ts
@@ -206,6 +206,15 @@ const REGISTRY = {
     owner: "operator",
     summary: "Correlated incident detected across edge telemetry.",
   },
+  journey_failure: {
+    resolvedBy: "monitor-clears",
+    autoResolveWhen:
+      "the next watchdog run of the SAME journey passes — the run that raised it is the run that clears it, so a fixed journey closes its own row without operator bookkeeping",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "operator",
+    summary: "A critical business journey failed its scheduled watchdog run.",
+  },
 } satisfies Record<string, QualityIssueContract>;
 
 /**

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1210,6 +1210,13 @@
     "longSentences": 0,
     "textMass": 25
   },
+  "apps/web/app/(shell)/ops/journeys/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 67
+  },
   "apps/web/app/(shell)/ops/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -5655,6 +5662,13 @@
     "longSentences": 0,
     "textMass": 27
   },
+  "apps/web/components/ops/JourneyHealthCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
   "apps/web/components/ops/EpicPanel.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -5800,7 +5814,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 9
+    "textMass": 11
   },
   "apps/web/components/owner-first/OwnerFirstSummary.tsx": {
     "vocabulary": 0,

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1215,7 +1215,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 67
+    "textMass": 94
   },
   "apps/web/app/(shell)/ops/page.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What and why

A live install could lose a revenue-critical journey — someone finding your page, sending an enquiry, booking a slot, signing in, paying — and the owner would find out from a customer.

Every ingredient to notice already existed. Nothing joined them.

Verified absent on `ac7f31bdb3` before writing a line:

| Candidate | What it actually is | Why it did not cover this |
| --- | --- | --- |
| `lib/coworker-lifecycle/golden-journeys.ts` | read-only probes per **coworker** | certifies agents, not business journeys |
| `lib/business-activity-sim/` | pure in-memory flow + oracles | never touches the running install |
| `lib/operate/endpoint-test-runner.ts` | capability probes per **AI model** | tests models, not journeys |
| `SCHEDULING_MAP` / `SCHEDULED_JOB_CATALOG` | 60+ jobs | no journey job of any kind |

A repo-wide search for `critical business journey` / `journey watchdog` returned zero matches.

## Design grounding

- **Spec:** `docs/superpowers/specs/2026-07-28-critical-business-journey-watchdog-design.md` (new — substrate verification proved no existing spec covers this)
- **Plan:** `docs/superpowers/plans/2026-07-28-critical-business-journey-watchdog.md`
- **Backlog item:** BI-E105303D (EP-PROACTIVE-OPS)
- **Kernel decision:** DI-96D3FD5C089B

The kernel scored three options for `external_coding_agent` in contexts `build-studio` / `ui` / `platform`:

| Option | Composite |
| --- | --- |
| **compose-existing-substrate** | **19.011** |
| defer, ship attention deep-link fidelity instead | 12.974 |
| dedicated journey subsystem (new Prisma models, own alerting) | 11.524 |

Margin 6.037, confidence high, no commandment conflict.

**No new Prisma model. No new queue, evidence store, or notification system.**

| Need | Reused |
| --- | --- |
| run evidence | `AssuranceRun` (`scopeType: "business-journey"`) |
| per-failure evidence | `AssuranceFinding`, with absent-clean resolution |
| operator inbox row | `PortfolioQualityIssue`, new registry-contracted type `journey_failure` |
| notification | Attention Surface, new read-model source |
| scheduling | one catalogued Inngest cron behind the quiescence gate |

## The two mechanisms that carry this

### 1. Verification depth is first-class and surfaced

`structural-verification-is-not-functional` is a commandment. A watchdog that pings `/book` and reports "booking healthy" would breach it — and would be *worse than no watchdog*, because it manufactures confidence exactly where the owner stops looking.

So depth is a per-step, surfaced value:

| Depth | Proves |
| --- | --- |
| `reachability` | the entry surface responds |
| `contract` | the required substrate exists and is coherent |
| `data-path` | the real persistence path and **real database constraints** execute end-to-end in a rolled-back transaction |
| `interaction` | the real server action / browser — **deliberately not covered** |

Two rules make it honest rather than decorative:

1. A journey's achieved depth is the **weakest** depth among its passing steps.
2. The surface always states what was **not** checked.

`interaction` is named and left uncovered so the gap is visible in the product, not buried in a backlog. The known reason is stated plainly in the spec: the public submit paths are `"use server"` actions bound to the module-level client, so a watchdog-owned transaction cannot wrap them without their inner transaction committing independently.

### 2. `data-path` probes cannot pollute the business

Real writes run through the real schema inside a transaction that always rolls back via a sentinel throw. The verdict is carried out *on* the sentinel, so there is no code path that returns a result without also having thrown.

The booking probe goes further: after creating a booking it deliberately attempts an **overlapping** second one and requires the database to reject it. `StorefrontBooking_no_overlap` is the single authoritative arbiter of slot contention (EP-056D2A5E). If a migration ever drops it, bookings keep succeeding and the business quietly starts double-booking — a failure no reachability check could ever see. This probe fails loudly in that case.

Synthetic identity uses an RFC 2606 `.invalid` address, so even a row that somehow escaped rollback could not reach a real person.

## Install-defined, not hardcoded

A journey declares `appliesWhen` against a resolved install context (published storefront, archetypes, bookable items, priced items). A journey that does not apply renders "Not set up" — never a red tile for a capability the owner never switched on.

## Remediation stays governed

The watchdog records, raises, and notifies. It **never** creates a build, opens a PR, or merges a fix. The attention card's single action deep-links to the specific journey's evidence; filing a fix is the operator's decision through the existing backlog flow. Automatic tee-up is a deliberately separate governed follow-up so this slice cannot silently create-and-merge.

## Consolidation (~20% of the change)

`health-alert-issue.ts` had a hand-rolled open/refresh/resolve triple over `PortfolioQualityIssue`, and this work needed the same shape. Rather than add a second copy — the exact drift that produced 8 undeclared issue types and 2,247 unclosable rows — both now share `lib/observability/monitor-issue-writer.ts`, typed on `QualityIssueType` so an unregistered emitter is a compile error. `health-alert-issue.ts` shrank to what is genuinely health-alert-specific: key grammar, severity mapping, details payload.

## Verification

- Targeted suite: **42 files / 386 tests passing**, including catalog↔scheduled-function parity and the scheduling-map same-tick collision check.
- Honesty rules have dedicated tests: a reachability-only journey can never be reported as functionally verified; `interaction` is always listed unchecked.
- Rollback is asserted, not assumed: every `data-path` test asserts the transaction callback rejected with the sentinel.
- The double-booking regression has an explicit "fails loudly" test.

## Follow-ups (governed, not crammed in here)

- `interaction` depth via `browser-drive`
- authenticated multi-actor journeys needing a real session
- automatic governed remediation tee-up
- per-journey cost telemetry

Seed-Fit-Decision: platform-substrate

---

## Gate attestations

UX-Fit-Decision: new-ops-tab-outcome-first (kernel DI-CB0687CAC422, composite 15.552 vs fold-into-portal-product-health 11.684 and attention-inbox-only 9.215; margin 3.868, high confidence, no commandment conflict). One outcome-first tab in the existing Ops secondary nav; plain-language outcome, status, and the honest "not checked" line always visible; all step/evidence detail behind one per-card Technical details boundary; deep-linkable per journey so an attention card lands on the specific journey rather than a list. The surface is read-only — no new numeric or free-text control is exposed to the operator.

Local-CI-Override: the local merged-code gate could not run. The `local-integration-ci` sandbox fence is held by a live peer session (`codex`, `feat/build-studio-simplify`, actively heartbeating) — legitimately held, not stale, and not stealable under the lease protocol. Separately, the local production build is blocked by pre-existing pnpm store corruption ([BI-EC88BAC1](../../..)) which mixed file sets across releases inside `recharts` (3.8.1/3.9.2), `vitest`, and `tsx` — all packages outside this diff. That item was updated today with the new evidence that `package-import-method=copy` alone does not repair it, because the store objects themselves are corrupt.

**Authoritative evidence comes from CI on this branch instead**, which runs on clean infrastructure:

- Production Build — **passed** (run 30385518712, 7m2s)
- Unit Tests, all four web shards + packages
- Policy Guards (PR and source), Prose Lint Guard, Route Manifest Freshness, Routing Invariants, Routing Tier Contract, CodeQL, Secrets Scan, DCO

Locally verified before push: full targeted suite (business-journeys, attention, observability, scheduled-jobs catalog parity, queue registry parity, ux-budget) and `pnpm -r typecheck` for `apps/web` + `packages/db`, both green.

Seed-Fit-Decision: platform-substrate
