### PR TITLE
fix: requeue capacity-limited coworker certification

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -144,6 +144,24 @@ describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => 
     expect((created.findings as Array<unknown>).length).toBe(0);
   });
 
+  it("a routed provider-capacity failure yields an INCONCLUSIVE run instead of failing the coworker", async () => {
+    const { deps, created } = makeDeps({
+      loopContent:
+        "The AI providers are momentarily busy (usually rate-limited or overloaded). " +
+        "Please try again in about 30 seconds — no setup change is needed.",
+      executedTools: [],
+    });
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.results[0].status).toBe("inconclusive");
+    expect(sweep.inconclusive).toBe(1);
+    expect(sweep.failed).toBe(0);
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("inconclusive");
+    expect(sweep.results[0].journeys.every((journey) => journey.capacityInconclusive)).toBe(true);
+    expect(created.findings).toHaveLength(0);
+  });
+
   it("a recovered oracle is absent-cleaned via updateMany scoped to the agent", async () => {
     const { deps, updateManyCalls } = makeDeps();
     await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -36,6 +36,7 @@ import {
 import { COWORKER_CERT_ADAPTER_KEY } from "./certification-status";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { isAdmissionTimeout } from "@/lib/inference/inference-admission";
+import { classifyInferenceFailure } from "@/lib/build/inference-failure";
 
 export { COWORKER_CERT_ADAPTER_KEY };
 export const COWORKER_CERT_ADAPTER_VERSION = "1.0.0";
@@ -140,6 +141,23 @@ function defaultDeps(): CertificationDeps {
   };
 }
 
+function capacityInconclusiveJourney(
+  journey: GoldenJourney,
+  startedAt: number,
+  deps: CertificationDeps,
+): JourneyResult {
+  return {
+    journeyId: journey.journeyId,
+    mode: journey.mode,
+    passed: false,
+    capacityInconclusive: true,
+    verdicts: [],
+    executedToolNames: [],
+    downgraded: false,
+    durationMs: deps.now().getTime() - startedAt,
+  };
+}
+
 async function executeJourney(
   journey: GoldenJourney,
   userContext: AutonomousWorkUserContext & { userId: string },
@@ -183,6 +201,14 @@ async function executeJourney(
       modelRequirements,
     });
 
+    // runAgenticLoop intentionally converts routing failures into operator-safe
+    // content instead of throwing. Preserve that UX contract while recognizing
+    // its canonical capacity signal here: a pool/rate-limit exhaustion means the
+    // coworker was not actually exercised and must be requeued, not failed.
+    if (classifyInferenceFailure(loop.content) === "rate-limit") {
+      return capacityInconclusiveJourney(journey, startedAt, deps);
+    }
+
     const verdicts = evaluateJourneyOracles({
       content: loop.content,
       executedTools: loop.executedTools.map((t) => ({
@@ -209,16 +235,7 @@ async function executeJourney(
     // the journey inconclusive with NO failure verdicts, so the run is requeued
     // and the coworker is never wrongly failed for a busy box.
     if (isAdmissionTimeout(error)) {
-      return {
-        journeyId: journey.journeyId,
-        mode: journey.mode,
-        passed: false,
-        capacityInconclusive: true,
-        verdicts: [],
-        executedToolNames: [],
-        downgraded: false,
-        durationMs: deps.now().getTime() - startedAt,
-      };
+      return capacityInconclusiveJourney(journey, startedAt, deps);
     }
     const message = getErrorMessage(error);
     const verdicts = evaluateJourneyOracles({
@@ -387,4 +404,3 @@ export async function runCoworkerCertificationSweep(options?: {
     inconclusive: results.filter((r) => r.status === "inconclusive").length,
   };
 }
-


### PR DESCRIPTION
## Summary
- classify the agentic loop's canonical provider rate-limit response as certification capacity backpressure
- persist capacity-limited certification as `inconclusive` so the scheduled job requeues it instead of failing the coworker
- share the inconclusive journey constructor across admission-timeout and routed-capacity paths

## Evidence
- live failure reproduced in AssuranceRun `cms4zj8a7006201mxnlbvxt8i`: Codex pool exhaustion returned through `runAgenticLoop`, then incorrectly persisted as `failed`
- exact merged-code local CI passed for `bc42b24baf5129aed2e1c79413477788df72f582` on base `83535a8bb13c99ab5fb7b63d3326df36c73d2737`
- local-CI evidence: `cms50yf4v02qz01mxmllnyhq3`, lease `NPEL-230B4B4123`
- 2,301 test files passed; 19,932 tests passed; typecheck, Prisma migrate deploy, guards, doc checks, and production Docker build passed

## Documentation impact
No user-facing documentation change: this restores the existing documented capacity-requeue behavior and does not change an operator workflow, route, or UI contract.