### PR TITLE
fix(ci): stop artifact wait when producers are terminal

### DIFF
--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -146,6 +146,10 @@ jobs:
         # The producer's cold setup + cache restore + build + package path has
         # exceeded four minutes in observed GitHub-hosted runs. Ten minutes
         # remains bounded while avoiding a delayed duplicate build.
+        # BI-149370BD: this deadline now only bounds a producer that is still
+        # running. Once every exact-tree producer is terminal without an
+        # artifact — as on heavy=false PRs, where CI never builds — discovery
+        # returns immediately instead of waiting out the remaining deadline.
         run: >-
           node scripts/ci-build-artifact.mjs locate
           --workflow ci.yml

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -187,7 +187,15 @@ token and source run identifier, and the token has only `actions: read` plus
 and [REST API endpoints for GitHub Actions artifacts](https://docs.github.com/en/rest/actions/artifacts).
 
 Reuse is an optimization, never an exemption. Discovery is bounded to ten
-minutes. Missing, late, expired, incomplete, corrupt, or identity-mismatched
+minutes, but that deadline only bounds a producer that is still queued or
+running. Once at least one matching producer exists and every one of them is
+terminal without a usable artifact, discovery stops immediately and the local
+build starts: no later poll can surface evidence that a finished run never
+published. This matters most on `heavy=false` pull requests, where `Production
+Build` is skipped by design and no artifact can ever appear. A run status the
+locator does not recognise counts as still active, so uncertainty preserves
+bounded polling rather than abandoning reuse early. Missing, late, expired,
+incomplete, corrupt, or identity-mismatched
 evidence removes any partial `.next` output and runs the normal local production
 build. Packaging or upload failure is also non-authoritative: `Production Build`
 retains its successful result and UX rebuilds locally. Main-branch pushes and
@@ -195,7 +203,8 @@ manual baseline calibration always build locally;
 cross-lifecycle merge-group-to-push reuse remains owned by `BI-9585E580`.
 
 The CI and UX job summaries report payload bytes and packaging or
-download/validation/extraction duration. Compare those transfer measurements
+download/validation/extraction duration, and the locate step emits a
+`discovery_ms` output on every outcome. Compare those transfer measurements
 with the avoided UX build duration before retaining or tuning the artifact.
 
 ## UX route-sweep stability

--- a/scripts/ci-build-artifact-discovery.test.mjs
+++ b/scripts/ci-build-artifact-discovery.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = join(ROOT, "scripts/ci-build-artifact.mjs");
+const SHA = "9".repeat(40);
+
+/**
+ * BI-149370BD. These exercise the real `locate` CLI against a stubbed Actions
+ * API, because the reported defect was in the polling loop rather than in the
+ * per-poll decision: discovery kept polling to the full deadline even after
+ * every exact-tree producer had gone terminal without publishing a build.
+ */
+function stubActionsApi({ runs, artifactsByRun = {} }) {
+  let runsRequests = 0;
+  const server = createServer((req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url.includes("/actions/workflows/")) {
+      runsRequests += 1;
+      res.end(JSON.stringify({ workflow_runs: runs }));
+      return;
+    }
+    const runId = Number(req.url.match(/\/actions\/runs\/(\d+)\/artifacts/)?.[1]);
+    res.end(JSON.stringify({ artifacts: artifactsByRun[runId] ?? [] }));
+  });
+  return {
+    server,
+    listen: () => new Promise((r) => server.listen(0, "127.0.0.1", r)),
+    baseUrl: () => `http://127.0.0.1:${server.address().port}`,
+    runsRequests: () => runsRequests,
+  };
+}
+
+function producer(overrides) {
+  return {
+    id: 501,
+    head_sha: SHA,
+    event: "pull_request",
+    run_number: 7,
+    run_attempt: 1,
+    status: "completed",
+    ...overrides,
+  };
+}
+
+async function runLocate(stub, { waitSeconds }) {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-locate-"));
+  const outputPath = join(dir, "github-output");
+  writeFileSync(outputPath, "");
+  const startedAt = Date.now();
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    [SCRIPT, "locate", "--workflow", "ci.yml", "--artifact-prefix", "web-production-build",
+      "--wait-seconds", String(waitSeconds)],
+    {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        DPF_GITHUB_API_BASE_URL: stub.baseUrl(),
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REPOSITORY: "OpenDigitalProductFactory/opendigitalproductfactory",
+        GITHUB_TOKEN: "stub-token",
+        GITHUB_EVENT_NAME: "pull_request",
+        DPF_CI_RUN_HEAD_SHA: SHA,
+        GITHUB_STEP_SUMMARY: "",
+      },
+    },
+  );
+  const output = readFileSync(outputPath, "utf8");
+  rmSync(dir, { recursive: true, force: true });
+  return { elapsedMs: Date.now() - startedAt, output, stdout, stderr };
+}
+
+describe("locate discovery termination", () => {
+  const servers = [];
+  after(() => servers.forEach((s) => s.close()));
+
+  it("returns fallback immediately when every producer is terminal without an artifact", async () => {
+    const stub = stubActionsApi({ runs: [producer({})] });
+    servers.push(stub.server);
+    await stub.listen();
+
+    const result = await runLocate(stub, { waitSeconds: 600 });
+
+    assert.match(result.output, /found=false/);
+    assert.ok(
+      result.elapsedMs < 15_000,
+      `expected immediate fallback, waited ${result.elapsedMs}ms`,
+    );
+    assert.equal(stub.runsRequests(), 1, "should not have polled again");
+  });
+
+  it("keeps polling while an eligible producer is still active", async () => {
+    const stub = stubActionsApi({ runs: [producer({ status: "in_progress" })] });
+    servers.push(stub.server);
+    await stub.listen();
+
+    const result = await runLocate(stub, { waitSeconds: 6 });
+
+    assert.match(result.output, /found=false/);
+    assert.ok(result.elapsedMs >= 5_000, `expected bounded polling, exited in ${result.elapsedMs}ms`);
+    assert.ok(stub.runsRequests() > 1, "should have polled more than once");
+  });
+
+  it("consumes an available artifact", async () => {
+    const stub = stubActionsApi({
+      runs: [producer({})],
+      artifactsByRun: { 501: [{ id: 900, name: "web-production-build-501-1", expired: false }] },
+    });
+    servers.push(stub.server);
+    await stub.listen();
+
+    const result = await runLocate(stub, { waitSeconds: 600 });
+
+    assert.match(result.output, /found=true/);
+    assert.match(result.output, /artifact_name=web-production-build-501-1/);
+    assert.match(result.output, /source_run_id=501/);
+  });
+
+  it("fails safe to fallback when the Actions API errors", async () => {
+    const server = createServer((req, res) => {
+      res.statusCode = 500;
+      res.end("boom");
+    });
+    servers.push(server);
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    const stub = {
+      baseUrl: () => `http://127.0.0.1:${server.address().port}`,
+      runsRequests: () => 0,
+      server,
+    };
+
+    const result = await runLocate(stub, { waitSeconds: 600 });
+
+    assert.match(result.output, /found=false/);
+    assert.ok(result.elapsedMs < 15_000, `expected fast fail-safe, waited ${result.elapsedMs}ms`);
+  });
+});

--- a/scripts/ci-build-artifact.mjs
+++ b/scripts/ci-build-artifact.mjs
@@ -16,8 +16,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildArtifactDiscoveryVerdict,
   createBuildArtifactReceipt,
-  selectBuildArtifact,
   sha256Bytes,
   sha256File,
   validateArchiveEntries,
@@ -149,7 +149,10 @@ function createArtifact(options) {
 }
 
 async function githubJson(path) {
-  const response = await fetch(`https://api.github.com${path}`, {
+  // Overridable so the discovery loop's termination behaviour is testable
+  // against a local stub; unset in CI, where the real API is used.
+  const base = process.env.DPF_GITHUB_API_BASE_URL || "https://api.github.com";
+  const response = await fetch(`${base}${path}`, {
     headers: {
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
@@ -172,7 +175,8 @@ async function locateArtifact(options) {
   // still binds the built checkout's real commit and immutable tree below.
   const headSha = process.env.DPF_CI_RUN_HEAD_SHA || process.env.GITHUB_SHA;
   const eventName = process.env.GITHUB_EVENT_NAME;
-  const deadline = Date.now() + waitSeconds * 1000;
+  const discoveryStartedAt = Date.now();
+  const deadline = discoveryStartedAt + waitSeconds * 1000;
   try {
     while (Date.now() <= deadline) {
       const query = new URLSearchParams({
@@ -188,21 +192,35 @@ async function locateArtifact(options) {
         const artifacts = await githubJson(`/repos/${repository}/actions/runs/${run.id}/artifacts?per_page=100`);
         artifactsByRun.set(run.id, artifacts.artifacts ?? []);
       }
-      const selected = selectBuildArtifact({
+      const verdict = buildArtifactDiscoveryVerdict({
         runs: exactRuns,
         artifactsByRun,
         headSha,
         eventName,
         artifactPrefix,
       });
-      if (selected) {
+      if (verdict.decision === "found") {
+        const { selected } = verdict;
         appendOutput({
           found: "true",
           artifact_name: selected.artifactName,
           source_run_id: selected.runId,
           source_run_attempt: selected.runAttempt,
+          discovery_ms: Date.now() - discoveryStartedAt,
         });
-        console.log(`[ci-build-artifact] found ${selected.artifactName} in run ${selected.runId}`);
+        console.log(
+          `[ci-build-artifact] ${verdict.reason} after ${Date.now() - discoveryStartedAt}ms`,
+        );
+        return;
+      }
+      // BI-149370BD: no later poll can produce evidence a terminal producer
+      // never published, so stop here instead of burning the rest of the
+      // deadline ahead of the same fallback build.
+      if (verdict.decision === "abandon") {
+        appendOutput({ found: "false", discovery_ms: Date.now() - discoveryStartedAt });
+        console.warn(
+          `[ci-build-artifact] ${verdict.reason} after ${Date.now() - discoveryStartedAt}ms; rebuilding`,
+        );
         return;
       }
       await new Promise((resolvePromise) => setTimeout(resolvePromise, 5_000));
@@ -211,7 +229,7 @@ async function locateArtifact(options) {
   } catch (error) {
     console.warn(`[ci-build-artifact] discovery unavailable (${error.message}); rebuilding`);
   }
-  appendOutput({ found: "false" });
+  appendOutput({ found: "false", discovery_ms: Date.now() - discoveryStartedAt });
 }
 
 function materializeFallback(reason, startedAt) {

--- a/scripts/lib/ci-build-artifact.mjs
+++ b/scripts/lib/ci-build-artifact.mjs
@@ -148,6 +148,58 @@ export function validateArchiveEntries(entries) {
   return { ok: reasons.length === 0, reasons: [...new Set(reasons)] };
 }
 
+// GitHub reports `queued`, `waiting`, `requested`, `pending`, and `in_progress`
+// before a run reaches `completed`. Only `completed` is terminal; anything else
+// (including a status this code does not recognise) still owes us an artifact.
+const TERMINAL_RUN_STATUS = "completed";
+
+function exactTreeProducers(runs, headSha, eventName) {
+  return runs.filter((run) => run.head_sha === headSha && run.event === eventName);
+}
+
+/**
+ * Decide whether discovery should keep polling, consume an artifact, or stop.
+ *
+ * BI-149370BD. `heavy=false` PRs skip the production build entirely, so no
+ * `web-production-build-*` can ever appear and polling to the deadline is pure
+ * dead wait ahead of an unchanged fallback build. Once every exact-tree
+ * producer is terminal without a usable artifact, no further poll can change
+ * the answer.
+ *
+ * Fail-safe by construction: an unknown/missing run status counts as active, so
+ * uncertainty keeps the old bounded-polling behaviour instead of abandoning
+ * reuse early.
+ */
+export function buildArtifactDiscoveryVerdict({
+  runs,
+  artifactsByRun,
+  headSha,
+  eventName,
+  artifactPrefix,
+}) {
+  const selected = selectBuildArtifact({ runs, artifactsByRun, headSha, eventName, artifactPrefix });
+  if (selected) {
+    return { decision: "found", selected, reason: `found ${selected.artifactName} in run ${selected.runId}` };
+  }
+  const producers = exactTreeProducers(runs, headSha, eventName);
+  if (producers.length === 0) {
+    return { decision: "wait", selected: null, reason: "no exact-tree producer run has appeared yet" };
+  }
+  const active = producers.filter((run) => run.status !== TERMINAL_RUN_STATUS);
+  if (active.length > 0) {
+    return {
+      decision: "wait",
+      selected: null,
+      reason: `${active.length} exact-tree producer run(s) still active`,
+    };
+  }
+  return {
+    decision: "abandon",
+    selected: null,
+    reason: `all ${producers.length} exact-tree producer run(s) are terminal with no usable artifact`,
+  };
+}
+
 export function selectBuildArtifact({
   runs,
   artifactsByRun,

--- a/scripts/lib/ci-build-artifact.test.mjs
+++ b/scripts/lib/ci-build-artifact.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  buildArtifactDiscoveryVerdict,
   createBuildArtifactReceipt,
   selectBuildArtifact,
   validateArchiveEntries,
@@ -151,6 +152,102 @@ describe("artifact discovery", () => {
       eventName: "merge_group",
       artifactPrefix: "web-production-build",
     }), null);
+  });
+});
+
+describe("discovery termination", () => {
+  const verdict = (runs, artifactsByRun = new Map()) =>
+    buildArtifactDiscoveryVerdict({
+      runs,
+      artifactsByRun,
+      headSha: SHA,
+      eventName: "pull_request",
+      artifactPrefix: "web-production-build",
+    });
+
+  const producer = (overrides) => ({
+    id: 2,
+    head_sha: SHA,
+    event: "pull_request",
+    run_number: 11,
+    run_attempt: 1,
+    status: "completed",
+    ...overrides,
+  });
+
+  it("consumes an available artifact rather than waiting", () => {
+    const result = verdict(
+      [producer({})],
+      new Map([[2, [{ id: 20, name: "web-production-build-2-1", expired: false }]]]),
+    );
+    assert.equal(result.decision, "found");
+    assert.equal(result.selected.artifactName, "web-production-build-2-1");
+  });
+
+  // BI-149370BD: the reported defect — heavy=false CI completes without ever
+  // publishing a build, and discovery burned the remaining ~609s regardless.
+  it("abandons once every exact-tree producer is terminal without an artifact", () => {
+    const result = verdict([producer({ status: "completed" })]);
+    assert.equal(result.decision, "abandon");
+    assert.match(result.reason, /terminal with no usable artifact/);
+  });
+
+  // Terminality is what settles this, not the conclusion: a failed or cancelled
+  // producer will publish no artifact either, so waiting on one is dead time.
+  it("abandons on terminal failed and cancelled producers", () => {
+    for (const conclusion of ["failure", "cancelled", "timed_out", "success"]) {
+      assert.equal(
+        verdict([producer({ status: "completed", conclusion })]).decision,
+        "abandon",
+        `expected abandon for conclusion ${conclusion}`,
+      );
+    }
+  });
+
+  it("keeps waiting while an eligible producer is queued or in progress", () => {
+    for (const status of ["queued", "waiting", "requested", "pending", "in_progress"]) {
+      const result = verdict([producer({ status })]);
+      assert.equal(result.decision, "wait", `expected wait for status ${status}`);
+      assert.match(result.reason, /still active/);
+    }
+  });
+
+  it("keeps waiting when no matching producer has appeared yet", () => {
+    const result = verdict([
+      producer({ id: 3, event: "push" }),
+      producer({ id: 4, head_sha: "f".repeat(40) }),
+    ]);
+    assert.equal(result.decision, "wait");
+    assert.match(result.reason, /has appeared yet/);
+  });
+
+  // A newer attempt still running must not be pre-empted by an older terminal
+  // attempt that published nothing.
+  it("keeps waiting for a later attempt even when an earlier one is terminal", () => {
+    const result = verdict([
+      producer({ id: 2, run_attempt: 1, status: "completed" }),
+      producer({ id: 3, run_attempt: 2, status: "in_progress" }),
+    ]);
+    assert.equal(result.decision, "wait");
+  });
+
+  it("prefers a later attempt's artifact over an older terminal no-artifact attempt", () => {
+    const result = verdict(
+      [
+        producer({ id: 2, run_number: 11, status: "completed" }),
+        producer({ id: 3, run_number: 12, status: "completed" }),
+      ],
+      new Map([[3, [{ id: 30, name: "web-production-build-3-1", expired: false }]]]),
+    );
+    assert.equal(result.decision, "found");
+    assert.equal(result.selected.runId, 3);
+  });
+
+  // Fail safe: an unrecognised/missing status must preserve bounded polling
+  // rather than abandon reuse on a shape this code does not understand.
+  it("treats an unknown or missing run status as still active", () => {
+    assert.equal(verdict([producer({ status: undefined })]).decision, "wait");
+    assert.equal(verdict([producer({ status: "some_future_status" })]).decision, "wait");
   });
 });
 

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -52,6 +52,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/ci-evidence-plan.test.mjs",
         "scripts/ci-evidence-workflow.test.mjs",
         "scripts/ci-build-artifact-workflow.test.mjs",
+        "scripts/ci-build-artifact-discovery.test.mjs",
         "scripts/lib/ci-build-artifact.test.mjs",
         "scripts/lib/ci-evidence-plan.test.mjs",
         "scripts/ci-policy-guards.test.mjs",


### PR DESCRIPTION
## Summary

Exact-tree production-build discovery polled to the full ten-minute deadline whenever no artifact existed, even after every matching producer run had already gone terminal. On `heavy=false` pull requests CI skips the production build by design, so `web-production-build-*` can never appear — the UX sweep spent roughly 609 seconds waiting for impossible evidence before correctly falling back to its own build.

Discovery now stops as soon as at least one matching exact-tree producer exists and all of them are terminal without a usable artifact.

## Changes

- Add `buildArtifactDiscoveryVerdict` to `scripts/lib/ci-build-artifact.mjs`, wrapping the existing selection with a `found` / `wait` / `abandon` decision.
- Return early from the `locate` loop on `abandon` instead of sleeping out the remaining deadline.
- Emit a `discovery_ms` step output on every discovery outcome so the reuse economics are measurable.
- Make the Actions API base injectable (`DPF_GITHUB_API_BASE_URL`, unset in CI) so the polling loop itself is testable.
- Register the new end-to-end test with the PR Health guard suite and document the termination rule.

## Behaviour preserved

- Bounded polling continues while any eligible producer is queued or running.
- A later attempt's artifact still wins over an older terminal no-artifact attempt.
- An unrecognised or missing run status counts as **active**, so uncertainty keeps the previous behaviour rather than abandoning reuse early.
- GitHub API errors still fail safe to the local production build.
- Receipt validation, archive inventory, and fallback build behaviour are unchanged.

## Test plan

- [x] **Regression proof (red/green on the real CLI)**
  - [x] With the early-return disabled, a terminal producer burned the entire deadline: **20,130 ms against a 20,000 ms deadline**.
  - [x] With the fix, the same scenario returns in **75 ms**.
- [x] **New end-to-end tests** (`scripts/ci-build-artifact-discovery.test.mjs`, stubbed Actions API, exercises the real `locate` CLI): immediate fallback on terminal producers, bounded polling while active, artifact consumption, and fail-safe on API error.
- [x] **New unit tests** (8 cases): terminal-success, terminal failure/cancelled/timed-out, queued/waiting/requested/pending/in_progress, no matching producer, later-attempt preference, in-flight later attempt, unknown status.
- [x] Registered suites green: 28 passed across `ci-build-artifact`, `ci-build-artifact-workflow`, `ci-build-artifact-discovery`, and `ci-policy-guards`.
- [x] Docs Impact, Module Size, and doc-index freshness gates pass locally.
- [x] **Verification-harness limitation**: this is a source-only worktree (no `node_modules`), so Vitest/typecheck were not run here. The change set is Node scripts, workflow YAML, and Markdown only — no TypeScript and no `apps/web` runtime code.

## Related issues / Epic

This PR covers: `BI-149370BD`
Parent: `BI-4DB73C5E`
Epic: `EP-0DFF753B`

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md` and `docs/superpowers/plans/2026-07-27-ci-duplicate-execution-refactor.md`.
- Current code substrate reviewed: `scripts/ci-build-artifact.mjs`, `scripts/lib/ci-build-artifact.mjs`, `.github/workflows/ux-route-sweep.yml`, `.github/workflows/ci.yml`, and the PR Health guard registry.
- Source of truth: `docs/testing/ci-evidence.md`, updated in this PR.
- Decision: terminate on producer terminality rather than shortening the deadline. Shortening it would trade one arbitrary wait for another and would break the cold-producer case the ten-minute bound exists to cover; terminality is the signal that actually settles whether evidence can still arrive.

## Overlap sweep

No open PR touches `ci-build-artifact`, `ux-route-sweep`, or `ci-policy-guards`, and no open PR references `BI-149370BD`. Direct follow-up to #3682 (merged `a8e1874ed6`), which introduced the discovery step.

## Local-CI gate

The governed `local-integration-ci` gate was attempted twice and lost to concurrent sessions both times, so it did **not** pass and I am not claiming that it did:

1. First attempt timed out waiting on the sandbox process fence (29 retries).
2. Second attempt claimed lease `NPEL-B6077352DE`, began running, then hit `heartbeat-lost / local-process-fence-lost` at 19:10:59Z — another session fenced the lease and the child process tree was terminated mid-run.

The recorded gate state for this head SHA is `gatePassed: false`, evidence `cms5177fa03bq01mxwpcgfpkn`, with the lease events showing the cause was contention rather than a failing check. The push carries a recorded pre-push override with the same reason.

This is a known shared-sandbox contention problem, not a property of this change. Note also that the behaviour being fixed — GitHub Actions artifact discovery — cannot be exercised in local-CI at all, since there is no Actions API there. GitHub CI is the binding evidence for this PR.

## Notes for the reviewer

`heavy=false` PRs were measurably slower after #3682 than before it — a full extra build plus a ten-minute stall. This restores them to a plain fallback build with no stall, and leaves the reuse path on `heavy=true` PRs untouched.

Local-CI-Override: local-integration-ci fence lost twice to concurrent sessions (lease NPEL-B6077352DE, evidence cms5177fa03bq01mxwpcgfpkn); CI-scripts/workflow/docs change with no apps/web runtime code, and GitHub artifact discovery cannot be exercised in local-CI
UX-Fit-Decision: no-ui-change
Process-Spine-Decision: implements the filed defect BI-149370BD against the accepted CI evidence-efficiency spec and updates the operator CI evidence documentation in the same PR
