### PR TITLE
fix: activate evidence-cleared Build Studio playbooks

### DIFF
--- a/apps/web/lib/build/autonomous-build-eligibility-reader.test.ts
+++ b/apps/web/lib/build/autonomous-build-eligibility-reader.test.ts
@@ -72,6 +72,60 @@ describe("selectActiveWorkPatternAttribution", () => {
       scopeMatches: false,
     });
   });
+
+  it("keeps same-install authority usable when the only blocker describes broader promotion", () => {
+    expect(selectActiveWorkPatternAttribution([
+      binding({
+        authorityScope: {
+          ...binding().authorityScope,
+          blockers: [
+            "broader_scope_requires_portable_corpus_or_customer_corroboration",
+          ],
+        },
+      }),
+    ], {
+      activityKey: "build-studio.delivery",
+      installScope: "dpf_dogfood",
+      taskCorpusKey: "build-studio-low-risk",
+      modelProfileId: "quality-first",
+      now: new Date("2026-07-27T13:00:00.000Z"),
+      freshnessWindowMs: 3_600_000,
+    })).toMatchObject({
+      bindingStatus: "active",
+      patternVersion: 2,
+      scopeMatches: true,
+    });
+  });
+
+  it("selects the in-scope active binding when another model lane is also active", () => {
+    const frontier = binding({
+      bindingId: "AB-frontier",
+      authorityScope: {
+        ...binding().authorityScope,
+        modelProfileIds: ["frontier-coding"],
+      },
+    });
+    const local = binding({
+      bindingId: "AB-local",
+      authorityScope: {
+        ...binding().authorityScope,
+        modelProfileIds: ["local-coding"],
+      },
+    });
+
+    expect(selectActiveWorkPatternAttribution([frontier, local], {
+      activityKey: "build-studio.delivery",
+      installScope: "dpf_dogfood",
+      taskCorpusKey: "build-studio-low-risk",
+      modelProfileId: "local-coding",
+      now: new Date("2026-07-27T13:00:00.000Z"),
+      freshnessWindowMs: 3_600_000,
+    })).toMatchObject({
+      bindingStatus: "active",
+      patternVersion: 2,
+      scopeMatches: true,
+    });
+  });
 });
 
 describe("readAutonomousBuildEligibility", () => {

--- a/apps/web/lib/build/autonomous-build-eligibility-reader.ts
+++ b/apps/web/lib/build/autonomous-build-eligibility-reader.ts
@@ -49,6 +49,29 @@ function containsOrUnscoped(
   return requested != null && declared.includes(requested);
 }
 
+const NON_BLOCKING_SCOPE_NOTES = new Set([
+  "broader_scope_requires_portable_corpus_or_customer_corroboration",
+]);
+
+function hasAuthorityBlocker(blockers: readonly string[]): boolean {
+  return blockers.some((blocker) => !NON_BLOCKING_SCOPE_NOTES.has(blocker));
+}
+
+function bindingMatchesScope(
+  binding: WorkPatternBindingRecord,
+  scope: AutonomousBuildBindingScope,
+): boolean {
+  const authority = binding.authorityScope;
+  return (
+    authority.activityKey === scope.activityKey
+    && authority.installScopes.includes(scope.installScope)
+    && containsOrUnscoped(authority.organizationIds, scope.organizationId)
+    && authority.taskCorpusKeys.includes(scope.taskCorpusKey)
+    && authority.modelProfileIds.includes(scope.modelProfileId)
+    && !hasAuthorityBlocker(authority.blockers)
+  );
+}
+
 export function selectActiveWorkPatternAttribution(
   bindings: readonly WorkPatternBindingRecord[],
   scope: AutonomousBuildBindingScope,
@@ -63,17 +86,14 @@ export function selectActiveWorkPatternBinding(
   binding: WorkPatternBindingRecord;
   attribution: AutonomousBuildAttribution;
 } | null {
-  const active = bindings.find((binding) => binding.status === "active");
+  const activeBindings = bindings.filter((binding) => binding.status === "active");
+  const active =
+    activeBindings.find((binding) => bindingMatchesScope(binding, scope))
+    ?? activeBindings[0];
   if (!active) return null;
 
   const authority = active.authorityScope;
-  const scopeMatches =
-    authority.activityKey === scope.activityKey
-    && authority.installScopes.includes(scope.installScope)
-    && containsOrUnscoped(authority.organizationIds, scope.organizationId)
-    && authority.taskCorpusKeys.includes(scope.taskCorpusKey)
-    && authority.modelProfileIds.includes(scope.modelProfileId)
-    && authority.blockers.length === 0;
+  const scopeMatches = bindingMatchesScope(active, scope);
   const nowMs = (scope.now ?? new Date()).getTime();
   const evidenceMs = Date.parse(authority.evidenceFreshnessAt);
   const evidenceFresh =

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4062,6 +4062,7 @@
         "what-the-operator-sees",
         "rollout-and-rollback",
         "verification-checklist",
+        "design-grounding",
         "related-contracts"
       ]
     },

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4056,6 +4056,7 @@
         "autonomous-build-studio-operator-runbook",
         "control-switches",
         "eligibility-contract",
+        "experiment-promotion",
         "autonomous-path",
         "bounded-recovery",
         "what-the-operator-sees",

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
@@ -99,6 +99,13 @@ describe("executePersistedWorkPatternExperimentCell", () => {
       }),
     );
     expect(runtime.recordEvidence).toHaveBeenCalledTimes(2);
+    expect(runtime.recordEvidence).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        observationKind: "assignment",
+        proposedDecision: request(),
+      }),
+    );
     expect(runtime.markWorking).toHaveBeenCalledWith({
       taskRunId: "TR-CELL-1",
       a2aMetadata: { workPatternExperimentCell: { attempt: 1 } },

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -316,6 +316,7 @@ export async function executePersistedWorkPatternExperimentCell(
   let inferenceContent = "";
   let inputTokens = 0;
   let outputTokens = 0;
+  const startedAtMs = Date.now();
   const result = await executeWorkPatternExperimentCell(request, {
     prepareWorkspace: async () => ({
       workspaceId: `${request.childTaskRunId}:${request.executionProfile.sourceCommitSha}`,
@@ -357,6 +358,36 @@ export async function executePersistedWorkPatternExperimentCell(
     inputTokens,
     outputTokens,
     buildGate: result.buildGate,
+    outcomeEvidence: {
+      completed: true,
+      buildGate: result.buildGate,
+      review: {
+        decision: result.success ? "pass" : "fail",
+        reproducedBlockingFindings: result.success ? 0 : 1,
+        nonBlockingFindings: 0,
+        reviewRounds: 1,
+      },
+      execution: {
+        toolCalls: result.toolCalls,
+        toolFailures: result.toolFailures,
+        retryCount: 0,
+        recoveryActions: [],
+        manualTouches: 0,
+        inputTokens,
+        outputTokens,
+        durationMs: Math.max(0, Date.now() - startedAtMs),
+      },
+      delivery: {
+        prCreated: false,
+        mergeQueued: false,
+        merged: false,
+        deployed: false,
+        rolledBack: false,
+      },
+      ...(!result.success
+        ? { failureClass: result.failureClass ?? "verification_failed" }
+        : {}),
+    },
   };
   await deps.recordEvidence({
     experimentRunId: request.experimentRunId,

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -303,14 +303,7 @@ export async function executePersistedWorkPatternExperimentCell(
     orchestratingAgentId: agentId,
     activityType: request.executionProfile.activityKey,
     riskClass: request.executionProfile.riskClass,
-    proposedDecision: {
-      cellKey: request.cellKey,
-      executionProfile: request.executionProfile,
-      fixtureKey: request.fixtureKey,
-      oracleKey: request.oracleKey,
-      oracleVersion: request.oracleVersion,
-      resourcePolicyKey: request.resourcePolicyKey,
-    },
+    proposedDecision: request,
   });
 
   let inferenceContent = "";

--- a/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
@@ -15,6 +15,7 @@ describe("runWorkPatternExperiment", () => {
       .mockRejectedValueOnce(new Error("interrupted"));
     const transition = vi.fn();
     const analyze = vi.fn();
+    const promote = vi.fn();
 
     await expect(
       runWorkPatternExperiment(
@@ -23,6 +24,7 @@ describe("runWorkPatternExperiment", () => {
           loadCells: vi.fn().mockResolvedValue(cells),
           executeCell,
           analyze,
+          promote,
           transition,
         },
       ),
@@ -37,6 +39,7 @@ describe("runWorkPatternExperiment", () => {
         loadCells: vi.fn().mockResolvedValue(cells),
         executeCell,
         analyze,
+        promote,
         transition,
       },
     );
@@ -45,11 +48,19 @@ describe("runWorkPatternExperiment", () => {
     expect(executeCell).toHaveBeenCalledWith(cells[2]);
     expect(analyze).toHaveBeenCalledTimes(1);
     expect(analyze).toHaveBeenCalledWith("TR-PARENT", cells);
+    expect(promote).toHaveBeenCalledTimes(1);
+    expect(promote).toHaveBeenCalledWith("TR-PARENT");
     expect(transition.mock.calls.map((call) => call[1])).toEqual([
       "running",
       "running",
       "analyzing",
       "completed",
     ]);
+    expect(analyze.mock.invocationCallOrder[0]).toBeLessThan(
+      promote.mock.invocationCallOrder[0]!,
+    );
+    expect(promote.mock.invocationCallOrder[0]).toBeLessThan(
+      transition.mock.invocationCallOrder.at(-1)!,
+    );
   });
 });

--- a/apps/web/lib/queue/functions/work-pattern-experiment.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.ts
@@ -13,6 +13,9 @@ export type RunWorkPatternExperimentDeps = {
     parentTaskRunId: string,
     cells: ExperimentQueueCell[],
   ) => Promise<unknown> | unknown;
+  promote: (
+    parentTaskRunId: string,
+  ) => Promise<unknown> | unknown;
   transition: (
     parentTaskRunId: string,
     lifecycle: "running" | "analyzing" | "completed",
@@ -35,6 +38,7 @@ export async function runWorkPatternExperiment(
   }
   await deps.transition(input.parentTaskRunId, "analyzing");
   await deps.analyze(input.parentTaskRunId, await deps.loadCells(input.parentTaskRunId));
+  await deps.promote(input.parentTaskRunId);
   await deps.transition(input.parentTaskRunId, "completed");
   return { executed };
 }
@@ -189,6 +193,12 @@ export const workPatternExperimentRun = inngest.createFunction(
                 } as never,
               },
             });
+          },
+          promote: async (taskRunId) => {
+            const {
+              promoteCompletedWorkPatternExperiment,
+            } = await import("@/lib/tak/work-pattern-experiment-promotion");
+            return promoteCompletedWorkPatternExperiment(taskRunId);
           },
           transition: (taskRunId, lifecycle) =>
             transitionWorkPatternExperiment(taskRunId, lifecycle, { persistence }),

--- a/apps/web/lib/tak/work-pattern-activation.test.ts
+++ b/apps/web/lib/tak/work-pattern-activation.test.ts
@@ -17,6 +17,7 @@ function snapshot(
   return {
     agentId: "build-specialist",
     patternKey: "build-review",
+    baselinePatternVersion: 1,
     patternVersion: 2,
     sourceExperimentTaskRunId: "TR-WPX-source",
     source: {
@@ -174,6 +175,37 @@ function request(overrides: Record<string, unknown> = {}) {
 }
 
 describe("activateWorkPattern", () => {
+  it("bootstraps the proven baseline as the first rollback target before activation", async () => {
+    const store = new MemoryActivationStore(snapshot({
+      promotionEvidence: {
+        ...snapshot().promotionEvidence,
+        rollbackBindingId: null,
+      },
+    }));
+    store.bindings.clear();
+
+    const result = await activateWorkPattern(request(), { persistence: store });
+
+    expect(result.decision).toBe("activate");
+    const bindings = [...store.bindings.values()];
+    expect(bindings).toContainEqual(expect.objectContaining({
+      status: "superseded",
+      resourceRef: "build-review@1",
+      authorityScope: expect.objectContaining({
+        patternVersion: 1,
+        priorSafeBindingId: null,
+      }),
+    }));
+    expect(bindings).toContainEqual(expect.objectContaining({
+      status: "active",
+      resourceRef: "build-review@2",
+      authorityScope: expect.objectContaining({
+        patternVersion: 2,
+        priorSafeBindingId: expect.stringMatching(/^AB-WP-/),
+      }),
+    }));
+  });
+
   it("activates exactly one evidence-bounded binding and preserves the prior safe version", async () => {
     const store = new MemoryActivationStore();
 

--- a/apps/web/lib/tak/work-pattern-activation.ts
+++ b/apps/web/lib/tak/work-pattern-activation.ts
@@ -46,6 +46,7 @@ export type WorkPatternActivationBinding = {
 export type WorkPatternActivationSnapshot = {
   agentId: string;
   patternKey: string;
+  baselinePatternVersion: number;
   patternVersion: number;
   sourceExperimentTaskRunId: string;
   source: WorkPatternActivationEvidenceScope;
@@ -135,6 +136,7 @@ export function workPatternActivationLaneKey(
     snapshot.patternKey,
     snapshot.promotionEvidence.activityKey,
     snapshot.promotionEvidence.riskClass,
+    snapshot.source.modelProfileId,
   ])}`;
 }
 
@@ -161,14 +163,28 @@ function sameAuthorizedScope(
 function bindingScopeKey(
   snapshot: WorkPatternActivationSnapshot,
   requestedScope: WorkPatternActivationRequest["requestedScope"],
+  patternVersion = snapshot.patternVersion,
 ): string {
   return `WP-SCOPE-${digest([
     snapshot.patternKey,
-    snapshot.patternVersion,
+    patternVersion,
     [...requestedScope.installScopes].sort(),
     [...requestedScope.organizationIds].sort(),
     [...requestedScope.taskCorpusKeys].sort(),
     [...requestedScope.modelProfileIds].sort(),
+  ])}`;
+}
+
+function bindingIdForVersion(
+  snapshot: WorkPatternActivationSnapshot,
+  requestedScope: WorkPatternActivationRequest["requestedScope"],
+  patternVersion: number,
+): string {
+  return `AB-WP-${digest([
+    snapshot.agentId,
+    bindingScopeKey(snapshot, requestedScope, patternVersion),
+    snapshot.patternKey,
+    patternVersion,
   ])}`;
 }
 
@@ -272,13 +288,31 @@ export async function activateWorkPattern(
       requested: request.grants,
     });
 
-    const policyVerdict = evaluateWorkPatternPromotion({
-      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
-      evidence: snapshot.promotionEvidence,
-      now: request.now,
-    });
     const bindings = await session.listBindingsForLane(activationLaneKey);
     const active = bindings.find((binding) => binding.status === "active") ?? null;
+    const mayBootstrapBaseline =
+      Number.isInteger(snapshot.baselinePatternVersion)
+      && snapshot.baselinePatternVersion > 0
+      && snapshot.baselinePatternVersion < snapshot.patternVersion;
+    const baselineBindingId = mayBootstrapBaseline
+      ? bindingIdForVersion(
+          snapshot,
+          request.requestedScope,
+          snapshot.baselinePatternVersion,
+        )
+      : null;
+    const effectiveRollbackBindingId =
+      active?.bindingId
+      ?? snapshot.promotionEvidence.rollbackBindingId
+      ?? baselineBindingId;
+    const policyVerdict = evaluateWorkPatternPromotion({
+      policy: DEFAULT_WORK_PATTERN_PROMOTION_POLICY,
+      evidence: {
+        ...snapshot.promotionEvidence,
+        rollbackBindingId: effectiveRollbackBindingId,
+      },
+      now: request.now,
+    });
 
     if (policyVerdict.decision === "rollback") {
       const rollbackId = snapshot.promotionEvidence.rollbackBindingId;
@@ -353,12 +387,11 @@ export async function activateWorkPattern(
     }
 
     const scopeKey = bindingScopeKey(snapshot, request.requestedScope);
-    const bindingId = `AB-WP-${digest([
-      snapshot.agentId,
-      scopeKey,
-      snapshot.patternKey,
+    const bindingId = bindingIdForVersion(
+      snapshot,
+      request.requestedScope,
       snapshot.patternVersion,
-    ])}`;
+    );
     const existing = await session.findBinding(bindingId);
     if (existing?.status === "active") {
       return observe(
@@ -369,11 +402,52 @@ export async function activateWorkPattern(
       );
     }
 
-    const requestedPriorSafeBindingId =
-      active?.bindingId ?? snapshot.promotionEvidence.rollbackBindingId;
-    const priorSafeBinding = requestedPriorSafeBindingId
+    const requestedPriorSafeBindingId = effectiveRollbackBindingId;
+    let priorSafeBinding = requestedPriorSafeBindingId
       ? await session.findBinding(requestedPriorSafeBindingId)
       : null;
+    if (
+      !priorSafeBinding
+      && baselineBindingId
+      && requestedPriorSafeBindingId === baselineBindingId
+    ) {
+      const baselineScopeKey = bindingScopeKey(
+        snapshot,
+        request.requestedScope,
+        snapshot.baselinePatternVersion,
+      );
+      const baselineAuthorityScope: WorkPatternAuthorityScopeV1 = {
+        schemaVersion: 1,
+        activationLaneKey,
+        bindingScopeKey: baselineScopeKey,
+        patternKey: snapshot.patternKey,
+        patternVersion: snapshot.baselinePatternVersion,
+        activityKey: snapshot.promotionEvidence.activityKey,
+        riskClass: snapshot.promotionEvidence.riskClass,
+        installScopes: [...request.requestedScope.installScopes],
+        organizationIds: [...request.requestedScope.organizationIds],
+        taskCorpusKeys: [...request.requestedScope.taskCorpusKeys],
+        modelProfileIds: [...request.requestedScope.modelProfileIds],
+        promotionPolicyKey: DEFAULT_WORK_PATTERN_PROMOTION_POLICY.policyKey,
+        promotionPolicyVersion: DEFAULT_WORK_PATTERN_PROMOTION_POLICY.version,
+        sourceExperimentTaskRunId: snapshot.sourceExperimentTaskRunId,
+        corroborationTaskRunIds: [...maximumScope.corroborationTaskRunIds],
+        priorSafeBindingId: null,
+        evidenceFreshnessAt: snapshot.promotionEvidence.freshnessAt.toISOString(),
+        evidenceOrigin: evidenceOrigin(maximumScope.ceiling),
+        scopeCeiling: maximumScope.ceiling,
+        blockers: [...maximumScope.blockers],
+      };
+      priorSafeBinding = await session.saveBinding({
+        bindingId: baselineBindingId,
+        name: `${patternLabel(snapshot.patternKey)} v${snapshot.baselinePatternVersion}`,
+        status: "active",
+        resourceRef: `${snapshot.patternKey}@${snapshot.baselinePatternVersion}`,
+        appliedAgentId: snapshot.agentId,
+        grants: request.grants,
+        authorityScope: baselineAuthorityScope,
+      });
+    }
     if (
       !priorSafeBinding
       || priorSafeBinding.authorityScope.activationLaneKey !== activationLaneKey
@@ -386,8 +460,8 @@ export async function activateWorkPattern(
       );
     }
     const priorSafeBindingId = priorSafeBinding.bindingId;
-    if (active && active.bindingId !== bindingId) {
-      await session.updateBindingStatus(active.bindingId, "superseded");
+    if (priorSafeBinding.status === "active" && priorSafeBinding.bindingId !== bindingId) {
+      await session.updateBindingStatus(priorSafeBinding.bindingId, "superseded");
     }
 
     const authorityScope: WorkPatternAuthorityScopeV1 = {

--- a/apps/web/lib/tak/work-pattern-experiment-promotion.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-promotion.test.ts
@@ -52,6 +52,48 @@ function run(
       const candidate = method.methodVariantKey === "candidate";
       const childTaskRunId =
         `${experimentRunId}-${method.methodVariantKey}-${model.modelVariantKey}`;
+      const outcome = {
+        success: true,
+        actualProviderId: "provider",
+        actualModelId: model.modelVariantKey,
+        outcomeEvidence: {
+          completed: true,
+          buildGate: {
+            unitTests: "pass",
+            productionBuild,
+            uxVerification: "not-applicable",
+            migration: "not-applicable",
+          },
+          review: {
+            decision: "pass",
+            reproducedBlockingFindings: candidate
+              ? options.candidateBlockingFindings ?? 0
+              : 0,
+            nonBlockingFindings: 0,
+            reviewRounds: 1,
+          },
+          execution: {
+            toolCalls: candidate ? 8 : 10,
+            toolFailures: 0,
+            retryCount: 0,
+            recoveryActions: [],
+            manualTouches: 0,
+            inputTokens: candidate ? 800 : 1_000,
+            outputTokens: candidate ? 400 : 500,
+            durationMs: candidate ? 80_000 : 100_000,
+          },
+          delivery: {
+            prCreated: false,
+            mergeQueued: false,
+            merged: false,
+            deployed: false,
+            rolledBack: false,
+          },
+          ...(candidate && options.candidateFailureClass
+            ? { failureClass: options.candidateFailureClass }
+            : {}),
+        },
+      };
       return {
         taskRunId: childTaskRunId,
         status: candidate
@@ -92,49 +134,19 @@ function run(
               },
             },
           },
-          workPatternExperimentResult: {
-            success: true,
-            actualProviderId: "provider",
-            actualModelId: model.modelVariantKey,
-            outcomeEvidence: {
-              completed: true,
-              buildGate: {
-                unitTests: "pass",
-                productionBuild,
-                uxVerification: "not-applicable",
-                migration: "not-applicable",
-              },
-              review: {
-                decision: "pass",
-                reproducedBlockingFindings: candidate
-                  ? options.candidateBlockingFindings ?? 0
-                  : 0,
-                nonBlockingFindings: 0,
-                reviewRounds: 1,
-              },
-              execution: {
-                toolCalls: candidate ? 8 : 10,
-                toolFailures: 0,
-                retryCount: 0,
-                recoveryActions: [],
-                manualTouches: 0,
-                inputTokens: candidate ? 800 : 1_000,
-                outputTokens: candidate ? 400 : 500,
-                durationMs: candidate ? 80_000 : 100_000,
-              },
-              delivery: {
-                prCreated: false,
-                mergeQueued: false,
-                merged: false,
-                deployed: false,
-                rolledBack: false,
-              },
-              ...(candidate && options.candidateFailureClass
-                ? { failureClass: options.candidateFailureClass }
-                : {}),
-            },
-          },
+          workPatternExperimentResult: { success: false },
         },
+        evidenceRows: [{
+          ledgerId: `DSL-${childTaskRunId}-outcome`,
+          taskRunId: childTaskRunId,
+          outcome,
+          observedAt: new Date(`2026-07-${String(10 + replicate).padStart(2, "0")}T12:00:00.000Z`),
+          metadata: {
+            experimentRunId,
+            observationKind: "outcome",
+            sequence: 1,
+          },
+        }],
       };
     }),
   );
@@ -146,7 +158,7 @@ function run(
 }
 
 describe("deriveWorkPatternPromotionCandidates", () => {
-  it("aggregates eight comparable replicates into one candidate per model scope", () => {
+  it("aggregates effective-ledger evidence into one candidate per model scope", () => {
     const candidates = deriveWorkPatternPromotionCandidates({
       sourceExperimentTaskRunId: "TR-WPR-8",
       orchestratingAgentId: "build-specialist",
@@ -175,6 +187,25 @@ describe("deriveWorkPatternPromotionCandidates", () => {
         },
       },
     });
+  });
+
+  it("fails closed when a model lane has no authoritative outcome ledger", () => {
+    const runs = Array.from({ length: 8 }, (_, index) => run(index + 1));
+    for (const experiment of runs) {
+      const localCandidate = experiment.cells.find((cell) =>
+        cell.taskRunId.endsWith("-candidate-local"));
+      if (localCandidate) localCandidate.evidenceRows = [];
+    }
+
+    const candidates = deriveWorkPatternPromotionCandidates({
+      sourceExperimentTaskRunId: "TR-WPR-8",
+      orchestratingAgentId: "build-specialist",
+      runs,
+      regulatoryHumanControlRequired: false,
+    });
+
+    expect(candidates.map((candidate) => candidate.snapshot.source.modelProfileId))
+      .toEqual(["frontier-coding"]);
   });
 
   it("does not count inference-only evidence as a qualifying build pair", () => {

--- a/apps/web/lib/tak/work-pattern-experiment-promotion.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-promotion.test.ts
@@ -52,6 +52,37 @@ function run(
       const candidate = method.methodVariantKey === "candidate";
       const childTaskRunId =
         `${experimentRunId}-${method.methodVariantKey}-${model.modelVariantKey}`;
+      const executionRequest = {
+        experimentRunId,
+        childTaskRunId,
+        cellKey: childTaskRunId,
+        pairKey: `pair-${replicate}`,
+        methodVariantKey: method.methodVariantKey,
+        modelVariantKey: model.modelVariantKey,
+        fixtureKey: `fixture-${replicate}`,
+        oracleKey: manifest.oracleKey,
+        oracleVersion: manifest.oracleVersion,
+        resourcePolicyKey: "bounded-build-v1",
+        executionProfile: {
+          patternKey: manifest.patternKey,
+          patternVersion: method.patternVersion,
+          variantKey: method.methodVariantKey,
+          activityKey: manifest.activityKey,
+          riskClass: manifest.riskClass,
+          providerId: "provider",
+          modelId: model.modelVariantKey,
+          modelProfileId: model.modelProfileId,
+          toolPackDigest: "tools",
+          promptOrSkillDigest: method.methodVariantKey,
+          contextPolicyKey: "bounded",
+          recoveryPolicyKey: "bounded",
+          installScope: manifest.installScope,
+          taskCorpusKey: manifest.taskCorpusKey,
+          taskCorpusVersion: manifest.taskCorpusVersion,
+          environmentKey: "shadow",
+          sourceCommitSha: "source-sha",
+        },
+      };
       const outcome = {
         success: true,
         actualProviderId: "provider",
@@ -100,53 +131,32 @@ function run(
           ? options.candidateStatus ?? "completed"
           : "completed",
         completedAt: new Date(`2026-07-${String(10 + replicate).padStart(2, "0")}T12:00:00.000Z`),
-        a2aMetadata: {
-          workPatternExperimentCell: {
-            executionRequest: {
+        evidenceRows: [
+          {
+            ledgerId: `DSL-${childTaskRunId}-assignment`,
+            taskRunId: childTaskRunId,
+            proposedDecision: executionRequest,
+            outcome: null,
+            observedAt: new Date(`2026-07-${String(10 + replicate).padStart(2, "0")}T11:59:00.000Z`),
+            metadata: {
               experimentRunId,
-              childTaskRunId,
-              cellKey: childTaskRunId,
-              pairKey: `pair-${replicate}`,
-              methodVariantKey: method.methodVariantKey,
-              modelVariantKey: model.modelVariantKey,
-              fixtureKey: `fixture-${replicate}`,
-              oracleKey: manifest.oracleKey,
-              oracleVersion: manifest.oracleVersion,
-              resourcePolicyKey: "bounded-build-v1",
-              executionProfile: {
-                patternKey: manifest.patternKey,
-                patternVersion: method.patternVersion,
-                variantKey: method.methodVariantKey,
-                activityKey: manifest.activityKey,
-                riskClass: manifest.riskClass,
-                providerId: "provider",
-                modelId: model.modelVariantKey,
-                modelProfileId: model.modelProfileId,
-                toolPackDigest: "tools",
-                promptOrSkillDigest: method.methodVariantKey,
-                contextPolicyKey: "bounded",
-                recoveryPolicyKey: "bounded",
-                installScope: manifest.installScope,
-                taskCorpusKey: manifest.taskCorpusKey,
-                taskCorpusVersion: manifest.taskCorpusVersion,
-                environmentKey: "shadow",
-                sourceCommitSha: "source-sha",
-              },
+              observationKind: "assignment",
+              sequence: 0,
             },
           },
-          workPatternExperimentResult: { success: false },
-        },
-        evidenceRows: [{
-          ledgerId: `DSL-${childTaskRunId}-outcome`,
-          taskRunId: childTaskRunId,
-          outcome,
-          observedAt: new Date(`2026-07-${String(10 + replicate).padStart(2, "0")}T12:00:00.000Z`),
-          metadata: {
-            experimentRunId,
-            observationKind: "outcome",
-            sequence: 1,
+          {
+            ledgerId: `DSL-${childTaskRunId}-outcome`,
+            taskRunId: childTaskRunId,
+            proposedDecision: { cellKey: childTaskRunId },
+            outcome,
+            observedAt: new Date(`2026-07-${String(10 + replicate).padStart(2, "0")}T12:00:00.000Z`),
+            metadata: {
+              experimentRunId,
+              observationKind: "outcome",
+              sequence: 1,
+            },
           },
-        }],
+        ],
       };
     }),
   );
@@ -194,7 +204,15 @@ describe("deriveWorkPatternPromotionCandidates", () => {
     for (const experiment of runs) {
       const localCandidate = experiment.cells.find((cell) =>
         cell.taskRunId.endsWith("-candidate-local"));
-      if (localCandidate) localCandidate.evidenceRows = [];
+      if (localCandidate) {
+        localCandidate.evidenceRows = localCandidate.evidenceRows.filter(
+          (row) =>
+            typeof row.metadata !== "object"
+            || row.metadata === null
+            || !("observationKind" in row.metadata)
+            || row.metadata.observationKind !== "outcome",
+        );
+      }
     }
 
     const candidates = deriveWorkPatternPromotionCandidates({

--- a/apps/web/lib/tak/work-pattern-experiment-promotion.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-promotion.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveWorkPatternPromotionCandidates,
+  type WorkPatternPromotionExperimentRun,
+} from "./work-pattern-experiment-promotion";
+
+function run(
+  replicate: number,
+  options: {
+    productionBuild?: "pass" | "not-run";
+    candidateFailureClass?: string;
+    candidateBlockingFindings?: number;
+    candidateStatus?: string;
+  } = {},
+): WorkPatternPromotionExperimentRun {
+  const productionBuild = options.productionBuild ?? "pass";
+  const experimentRunId = `WPR-${replicate}`;
+  const manifest = {
+    schemaVersion: 1 as const,
+    experimentDefinitionKey: "WPD-build-method",
+    experimentRunId,
+    replicate,
+    patternKey: "autonomous-build",
+    activityKey: "build.implement",
+    riskClass: "internal-reversible" as const,
+    methodVariants: [
+      { methodVariantKey: "baseline", patternVersion: 1 },
+      { methodVariantKey: "candidate", patternVersion: 2 },
+    ],
+    modelVariants: [
+      { modelVariantKey: "local", modelProfileId: "local-coding" },
+      { modelVariantKey: "frontier", modelProfileId: "frontier-coding" },
+    ],
+    requiredCellKeys: [
+      `${experimentRunId}-baseline-local`,
+      `${experimentRunId}-candidate-local`,
+      `${experimentRunId}-baseline-frontier`,
+      `${experimentRunId}-candidate-frontier`,
+    ],
+    taskCorpusKey: "dpf-repository",
+    taskCorpusVersion: "1",
+    oracleKey: "build-gate",
+    oracleVersion: "1",
+    promotionPolicyKey: "governed-build-playbook-promotion",
+    promotionPolicyVersion: 1,
+    installScope: "dpf_dogfood" as const,
+    lifecycle: "completed" as const,
+  };
+  const cells = manifest.modelVariants.flatMap((model) =>
+    manifest.methodVariants.map((method) => {
+      const candidate = method.methodVariantKey === "candidate";
+      const childTaskRunId =
+        `${experimentRunId}-${method.methodVariantKey}-${model.modelVariantKey}`;
+      return {
+        taskRunId: childTaskRunId,
+        status: candidate
+          ? options.candidateStatus ?? "completed"
+          : "completed",
+        completedAt: new Date(`2026-07-${String(10 + replicate).padStart(2, "0")}T12:00:00.000Z`),
+        a2aMetadata: {
+          workPatternExperimentCell: {
+            executionRequest: {
+              experimentRunId,
+              childTaskRunId,
+              cellKey: childTaskRunId,
+              pairKey: `pair-${replicate}`,
+              methodVariantKey: method.methodVariantKey,
+              modelVariantKey: model.modelVariantKey,
+              fixtureKey: `fixture-${replicate}`,
+              oracleKey: manifest.oracleKey,
+              oracleVersion: manifest.oracleVersion,
+              resourcePolicyKey: "bounded-build-v1",
+              executionProfile: {
+                patternKey: manifest.patternKey,
+                patternVersion: method.patternVersion,
+                variantKey: method.methodVariantKey,
+                activityKey: manifest.activityKey,
+                riskClass: manifest.riskClass,
+                providerId: "provider",
+                modelId: model.modelVariantKey,
+                modelProfileId: model.modelProfileId,
+                toolPackDigest: "tools",
+                promptOrSkillDigest: method.methodVariantKey,
+                contextPolicyKey: "bounded",
+                recoveryPolicyKey: "bounded",
+                installScope: manifest.installScope,
+                taskCorpusKey: manifest.taskCorpusKey,
+                taskCorpusVersion: manifest.taskCorpusVersion,
+                environmentKey: "shadow",
+                sourceCommitSha: "source-sha",
+              },
+            },
+          },
+          workPatternExperimentResult: {
+            success: true,
+            actualProviderId: "provider",
+            actualModelId: model.modelVariantKey,
+            outcomeEvidence: {
+              completed: true,
+              buildGate: {
+                unitTests: "pass",
+                productionBuild,
+                uxVerification: "not-applicable",
+                migration: "not-applicable",
+              },
+              review: {
+                decision: "pass",
+                reproducedBlockingFindings: candidate
+                  ? options.candidateBlockingFindings ?? 0
+                  : 0,
+                nonBlockingFindings: 0,
+                reviewRounds: 1,
+              },
+              execution: {
+                toolCalls: candidate ? 8 : 10,
+                toolFailures: 0,
+                retryCount: 0,
+                recoveryActions: [],
+                manualTouches: 0,
+                inputTokens: candidate ? 800 : 1_000,
+                outputTokens: candidate ? 400 : 500,
+                durationMs: candidate ? 80_000 : 100_000,
+              },
+              delivery: {
+                prCreated: false,
+                mergeQueued: false,
+                merged: false,
+                deployed: false,
+                rolledBack: false,
+              },
+              ...(candidate && options.candidateFailureClass
+                ? { failureClass: options.candidateFailureClass }
+                : {}),
+            },
+          },
+        },
+      };
+    }),
+  );
+  return {
+    parentTaskRunId: `TR-${experimentRunId}`,
+    manifest,
+    cells,
+  };
+}
+
+describe("deriveWorkPatternPromotionCandidates", () => {
+  it("aggregates eight comparable replicates into one candidate per model scope", () => {
+    const candidates = deriveWorkPatternPromotionCandidates({
+      sourceExperimentTaskRunId: "TR-WPR-8",
+      orchestratingAgentId: "build-specialist",
+      runs: Array.from({ length: 8 }, (_, index) => run(index + 1)),
+      regulatoryHumanControlRequired: false,
+    });
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map((candidate) => candidate.snapshot.source.modelProfileId))
+      .toEqual(["local-coding", "frontier-coding"]);
+    expect(candidates[0]?.snapshot).toMatchObject({
+      baselinePatternVersion: 1,
+      patternVersion: 2,
+      promotionEvidence: {
+        validPairCount: 8,
+        invalidPairCount: 0,
+        completedCellKeys: ["control", "method", "model", "interaction"],
+        rollbackBindingId: null,
+        objectiveDeltas: {
+          correctness: 0,
+          security: 0,
+          migrationSafety: 0,
+          customerImpact: 0,
+          speed: 0.2,
+          cost: 0.2,
+        },
+      },
+    });
+  });
+
+  it("does not count inference-only evidence as a qualifying build pair", () => {
+    const [candidate] = deriveWorkPatternPromotionCandidates({
+      sourceExperimentTaskRunId: "TR-WPR-8",
+      orchestratingAgentId: "build-specialist",
+      runs: Array.from({ length: 8 }, (_, index) =>
+        run(index + 1, { productionBuild: "not-run" })),
+      regulatoryHumanControlRequired: false,
+    });
+
+    expect(candidate?.snapshot.promotionEvidence).toMatchObject({
+      validPairCount: 0,
+      invalidPairCount: 8,
+    });
+  });
+
+  it("retains hard-negative evidence even when the pair is invalid", () => {
+    const [candidate] = deriveWorkPatternPromotionCandidates({
+      sourceExperimentTaskRunId: "TR-WPR-8",
+      orchestratingAgentId: "build-specialist",
+      runs: Array.from({ length: 8 }, (_, index) =>
+        run(index + 1, {
+          candidateFailureClass: "commandment_gate_regression",
+          candidateBlockingFindings: 1,
+        })),
+      regulatoryHumanControlRequired: false,
+    });
+
+    expect(candidate?.snapshot.promotionEvidence).toMatchObject({
+      validPairCount: 0,
+      invalidPairCount: 8,
+      commandmentGateRegression: true,
+      criticalFindingReproduced: true,
+    });
+  });
+
+  it("does not claim factorial completion for non-terminal cells", () => {
+    const [candidate] = deriveWorkPatternPromotionCandidates({
+      sourceExperimentTaskRunId: "TR-WPR-8",
+      orchestratingAgentId: "build-specialist",
+      runs: Array.from({ length: 8 }, (_, index) =>
+        run(index + 1, { candidateStatus: "working" })),
+      regulatoryHumanControlRequired: false,
+    });
+
+    expect(candidate?.snapshot.promotionEvidence.completedCellKeys).toEqual([]);
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-promotion.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-promotion.ts
@@ -1,0 +1,493 @@
+import type { Prisma } from "@dpf/db";
+
+import { isRecord } from "@/lib/shared/coerce";
+import {
+  parsePersistedWorkPatternExperimentExecution,
+} from "@/lib/integrate/work-pattern-experiment-runtime";
+
+import {
+  activateWorkPattern,
+  type WorkPatternActivationRequest,
+  type WorkPatternActivationSnapshot,
+} from "./work-pattern-activation";
+import {
+  parseWorkPatternExperimentMetadata,
+  type WorkPatternExperimentMetadataV1,
+} from "./work-pattern-experiment-types";
+import {
+  parseWorkPatternOutcomeEvidence,
+  type WorkPatternOutcomeEvidence,
+} from "./work-pattern-outcome-evidence";
+
+export type WorkPatternPromotionExperimentCell = {
+  taskRunId: string;
+  status: string;
+  completedAt: Date | null;
+  a2aMetadata: unknown;
+};
+
+export type WorkPatternPromotionExperimentRun = {
+  parentTaskRunId: string;
+  manifest: WorkPatternExperimentMetadataV1;
+  cells: WorkPatternPromotionExperimentCell[];
+};
+
+export type WorkPatternPromotionCandidate = {
+  snapshot: WorkPatternActivationSnapshot;
+  request: WorkPatternActivationRequest;
+};
+
+type ParsedCell = {
+  status: string;
+  completedAt: Date | null;
+  request: NonNullable<
+    ReturnType<typeof parsePersistedWorkPatternExperimentExecution>
+  >;
+  success: boolean;
+  actualProviderId: string;
+  actualModelId: string;
+  outcome: WorkPatternOutcomeEvidence;
+};
+
+type PromotionDb = {
+  taskRun: {
+    findUnique(args: object): Promise<unknown>;
+    findMany(args: object): Promise<unknown[]>;
+  };
+};
+
+const REQUIRED_FACTORIAL_CELLS = [
+  "control",
+  "method",
+  "model",
+  "interaction",
+] as const;
+
+function parseCell(cell: WorkPatternPromotionExperimentCell): ParsedCell | null {
+  if (!isRecord(cell.a2aMetadata)) return null;
+  const cellMetadata = isRecord(cell.a2aMetadata.workPatternExperimentCell)
+    ? cell.a2aMetadata.workPatternExperimentCell
+    : null;
+  const result = isRecord(cell.a2aMetadata.workPatternExperimentResult)
+    ? cell.a2aMetadata.workPatternExperimentResult
+    : null;
+  const request = parsePersistedWorkPatternExperimentExecution(
+    cellMetadata?.executionRequest,
+  );
+  const outcome = parseWorkPatternOutcomeEvidence(result?.outcomeEvidence);
+  if (
+    !request
+    || !result
+    || !outcome
+    || typeof result.success !== "boolean"
+    || typeof result.actualProviderId !== "string"
+    || typeof result.actualModelId !== "string"
+  ) {
+    return null;
+  }
+  return {
+    status: cell.status,
+    completedAt: cell.completedAt,
+    request,
+    success: result.success,
+    actualProviderId: result.actualProviderId,
+    actualModelId: result.actualModelId,
+    outcome,
+  };
+}
+
+function buildEvidenceCleared(cell: ParsedCell, activityKey: string): boolean {
+  const gate = cell.outcome.buildGate;
+  const buildGatePassed =
+    gate.unitTests === "pass"
+    && (
+      activityKey !== "build.implement"
+      || gate.productionBuild === "pass"
+    )
+    && gate.uxVerification !== "fail"
+    && gate.uxVerification !== "blocked"
+    && gate.migration !== "fail"
+    && gate.migration !== "blocked";
+  return (
+    cell.status === "completed"
+    && cell.success
+    && cell.outcome.completed
+    && cell.outcome.review.decision === "pass"
+    && cell.outcome.review.reproducedBlockingFindings === 0
+    && buildGatePassed
+    && cell.actualProviderId === cell.request.executionProfile.providerId
+    && cell.actualModelId === cell.request.executionProfile.modelId
+  );
+}
+
+function comparable(left: ParsedCell, right: ParsedCell): boolean {
+  const l = left.request;
+  const r = right.request;
+  return (
+    l.pairKey === r.pairKey
+    && l.fixtureKey === r.fixtureKey
+    && l.oracleKey === r.oracleKey
+    && l.oracleVersion === r.oracleVersion
+    && l.resourcePolicyKey === r.resourcePolicyKey
+    && l.executionProfile.sourceCommitSha === r.executionProfile.sourceCommitSha
+    && l.executionProfile.taskCorpusKey === r.executionProfile.taskCorpusKey
+    && l.executionProfile.taskCorpusVersion
+      === r.executionProfile.taskCorpusVersion
+  );
+}
+
+function costValue(outcome: WorkPatternOutcomeEvidence): number {
+  if (outcome.execution.costUsd !== undefined) return outcome.execution.costUsd;
+  if (
+    outcome.execution.inputTokens !== undefined
+    && outcome.execution.outputTokens !== undefined
+  ) {
+    return outcome.execution.inputTokens + outcome.execution.outputTokens;
+  }
+  return outcome.execution.toolCalls;
+}
+
+function relativeImprovement(baseline: number, candidate: number): number {
+  if (!Number.isFinite(baseline) || !Number.isFinite(candidate) || baseline <= 0) {
+    return 0;
+  }
+  return (baseline - candidate) / baseline;
+}
+
+function roundedMean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return Number(
+    (values.reduce((sum, value) => sum + value, 0) / values.length)
+      .toFixed(6),
+  );
+}
+
+function hasCompleteFactorial(
+  run: WorkPatternPromotionExperimentRun,
+): boolean {
+  const cells = run.cells.flatMap((cell) => {
+    const parsed = parseCell(cell);
+    return parsed ? [parsed] : [];
+  });
+  return run.manifest.methodVariants.every((method) =>
+    run.manifest.modelVariants.every((model) =>
+      cells.some((cell) =>
+        cell.status === "completed"
+        &&
+        cell.request.methodVariantKey === method.methodVariantKey
+        && cell.request.modelVariantKey === model.modelVariantKey)));
+}
+
+function latestEvidenceAt(
+  cells: readonly ParsedCell[],
+  fallback: Date,
+): Date {
+  const timestamps = cells
+    .map((cell) => cell.completedAt?.getTime())
+    .filter((value): value is number => value !== undefined && Number.isFinite(value));
+  return timestamps.length > 0 ? new Date(Math.max(...timestamps)) : fallback;
+}
+
+export function deriveWorkPatternPromotionCandidates(input: {
+  sourceExperimentTaskRunId: string;
+  orchestratingAgentId: string;
+  runs: readonly WorkPatternPromotionExperimentRun[];
+  regulatoryHumanControlRequired: boolean;
+  now?: Date;
+}): WorkPatternPromotionCandidate[] {
+  const sourceRun =
+    input.runs.find(
+      (run) => run.parentTaskRunId === input.sourceExperimentTaskRunId,
+    )
+    ?? input.runs.at(-1);
+  if (!sourceRun) return [];
+  const manifest = sourceRun.manifest;
+  const baselineMethod = manifest.methodVariants[0];
+  const candidateMethods = manifest.methodVariants.slice(1);
+  if (!baselineMethod || candidateMethods.length === 0) return [];
+
+  return candidateMethods.flatMap((candidateMethod) =>
+    manifest.modelVariants.flatMap((model) => {
+      const validPairs: Array<{
+        baseline: ParsedCell;
+        candidate: ParsedCell;
+      }> = [];
+      const observedCells: ParsedCell[] = [];
+      const observedCandidates: ParsedCell[] = [];
+      let invalidPairCount = 0;
+      for (const run of input.runs) {
+        const cells = run.cells.flatMap((cell) => {
+          const parsed = parseCell(cell);
+          return parsed ? [parsed] : [];
+        });
+        observedCells.push(...cells);
+        const baseline = cells.find((cell) =>
+          cell.request.methodVariantKey === baselineMethod.methodVariantKey
+          && cell.request.modelVariantKey === model.modelVariantKey);
+        const candidate = cells.find((cell) =>
+          cell.request.methodVariantKey === candidateMethod.methodVariantKey
+          && cell.request.modelVariantKey === model.modelVariantKey);
+        if (candidate) observedCandidates.push(candidate);
+        if (
+          !baseline
+          || !candidate
+          || !comparable(baseline, candidate)
+          || !buildEvidenceCleared(baseline, manifest.activityKey)
+          || !buildEvidenceCleared(candidate, manifest.activityKey)
+        ) {
+          invalidPairCount += 1;
+        } else {
+          validPairs.push({ baseline, candidate });
+        }
+      }
+      const sourceCell =
+        validPairs.at(-1)?.candidate
+        ?? sourceRun.cells.flatMap((cell) => {
+          const parsed = parseCell(cell);
+          return parsed
+            && parsed.request.methodVariantKey === candidateMethod.methodVariantKey
+            && parsed.request.modelVariantKey === model.modelVariantKey
+            ? [parsed]
+            : [];
+        })[0];
+      if (!sourceCell) return [];
+
+      const allFactorial = input.runs.length > 0
+        && input.runs.every(hasCompleteFactorial);
+      const speedDeltas = validPairs.map(({ baseline, candidate }) =>
+        relativeImprovement(
+          baseline.outcome.execution.durationMs,
+          candidate.outcome.execution.durationMs,
+        ));
+      const costDeltas = validPairs.map(({ baseline, candidate }) =>
+        relativeImprovement(
+          costValue(baseline.outcome),
+          costValue(candidate.outcome),
+        ));
+      const evidenceCells = validPairs.flatMap((pair) => [
+        pair.baseline,
+        pair.candidate,
+      ]);
+      const freshnessAt = latestEvidenceAt(
+        evidenceCells.length > 0 ? evidenceCells : observedCells,
+        new Date(0),
+      );
+      const snapshot: WorkPatternActivationSnapshot = {
+        agentId: input.orchestratingAgentId,
+        patternKey: manifest.patternKey,
+        baselinePatternVersion: baselineMethod.patternVersion,
+        patternVersion: candidateMethod.patternVersion,
+        sourceExperimentTaskRunId: input.sourceExperimentTaskRunId,
+        source: {
+          installScope: sourceCell.request.executionProfile.installScope,
+          ...(sourceCell.request.executionProfile.organizationId
+            ? {
+                organizationId:
+                  sourceCell.request.executionProfile.organizationId,
+              }
+            : {}),
+          taskCorpusKey: manifest.taskCorpusKey,
+          modelProfileId: model.modelProfileId,
+        },
+        portableCanonicalCorpus: null,
+        corroborations: [],
+        candidateEvidence: {
+          patternKey: manifest.patternKey,
+          patternVersion: candidateMethod.patternVersion,
+          methodVariantKey: candidateMethod.methodVariantKey,
+          modelProfileId: model.modelProfileId,
+          taskCorpusKey: manifest.taskCorpusKey,
+          taskCorpusVersion: manifest.taskCorpusVersion,
+          oracleKey: manifest.oracleKey,
+          oracleVersion: manifest.oracleVersion,
+          promotionPolicyKey: manifest.promotionPolicyKey,
+          promotionPolicyVersion: manifest.promotionPolicyVersion,
+        },
+        promotionEvidence: {
+          activityKey: manifest.activityKey,
+          riskClass: manifest.riskClass,
+          validPairCount: validPairs.length,
+          invalidPairCount,
+          completedCellKeys: allFactorial
+            ? [...REQUIRED_FACTORIAL_CELLS]
+            : [],
+          freshnessAt,
+          rollbackBindingId: null,
+          objectiveDeltas: {
+            correctness: 0,
+            security: 0,
+            migrationSafety: 0,
+            customerImpact: 0,
+            speed: roundedMean(speedDeltas),
+            cost: roundedMean(costDeltas),
+          },
+          commandmentGateRegression: observedCandidates.some(
+            (candidate) =>
+              candidate.outcome.failureClass === "commandment_gate_regression",
+          ),
+          criticalFindingReproduced: observedCandidates.some(
+            (candidate) =>
+              candidate.outcome.review.reproducedBlockingFindings > 0,
+          ),
+          regulatoryHumanControlRequired:
+            input.regulatoryHumanControlRequired,
+          activeBindingHealthRegression: false,
+        },
+        intrinsicGrantKeys: [],
+      };
+      const request: WorkPatternActivationRequest = {
+        patternKey: snapshot.patternKey,
+        patternVersion: snapshot.patternVersion,
+        sourceExperimentTaskRunId: snapshot.sourceExperimentTaskRunId,
+        requestedScope: {
+          installScopes: [snapshot.source.installScope],
+          organizationIds: snapshot.source.organizationId
+            ? [snapshot.source.organizationId]
+            : [],
+          taskCorpusKeys: [snapshot.source.taskCorpusKey],
+          modelProfileIds: [snapshot.source.modelProfileId],
+        },
+        grants: [],
+        now: input.now ?? new Date(),
+      };
+      return [{ snapshot, request }];
+    }),
+  );
+}
+
+async function loadPromotionCandidates(
+  db: PromotionDb,
+  sourceExperimentTaskRunId: string,
+  now = new Date(),
+): Promise<WorkPatternPromotionCandidate[]> {
+  const source = await db.taskRun.findUnique({
+    where: { taskRunId: sourceExperimentTaskRunId },
+    select: {
+      repeatedPatternKey: true,
+      currentAgentId: true,
+      initiatingAgentId: true,
+      a2aMetadata: true,
+    },
+  });
+  if (!isRecord(source) || typeof source.repeatedPatternKey !== "string") {
+    throw new Error("work_pattern_promotion_source_not_found");
+  }
+  const sourceManifest = parseWorkPatternExperimentMetadata(
+    isRecord(source.a2aMetadata)
+      ? source.a2aMetadata.workPatternExperiment
+      : null,
+  );
+  const orchestratingAgentId =
+    typeof source.currentAgentId === "string"
+      ? source.currentAgentId
+      : typeof source.initiatingAgentId === "string"
+        ? source.initiatingAgentId
+        : null;
+  if (!sourceManifest || !orchestratingAgentId) {
+    throw new Error("invalid_work_pattern_promotion_source");
+  }
+
+  const parentRows = await db.taskRun.findMany({
+    where: {
+      repeatedPatternKey: source.repeatedPatternKey,
+      parentTaskRunId: null,
+    },
+    select: { id: true, taskRunId: true, a2aMetadata: true },
+    orderBy: { createdAt: "asc" },
+  });
+  const runs: WorkPatternPromotionExperimentRun[] = [];
+  for (const row of parentRows) {
+    if (!isRecord(row) || typeof row.id !== "string" || typeof row.taskRunId !== "string") {
+      continue;
+    }
+    const manifest = parseWorkPatternExperimentMetadata(
+      isRecord(row.a2aMetadata)
+        ? row.a2aMetadata.workPatternExperiment
+        : null,
+    );
+    if (
+      !manifest
+      || manifest.experimentDefinitionKey
+        !== sourceManifest.experimentDefinitionKey
+    ) {
+      continue;
+    }
+    const childRows = await db.taskRun.findMany({
+      where: { parentTaskRunId: row.id },
+      select: {
+        taskRunId: true,
+        status: true,
+        completedAt: true,
+        a2aMetadata: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+    runs.push({
+      parentTaskRunId: row.taskRunId,
+      manifest,
+      cells: childRows.flatMap((child) =>
+        isRecord(child)
+        && typeof child.taskRunId === "string"
+        && typeof child.status === "string"
+          ? [{
+              taskRunId: child.taskRunId,
+              status: child.status,
+              completedAt:
+                child.completedAt instanceof Date ? child.completedAt : null,
+              a2aMetadata: child.a2aMetadata,
+            }]
+          : []),
+    });
+  }
+  const { resolveRuntimeRegulatoryAutonomyCeiling } = await import(
+    "@/lib/autonomy/regulatory-autonomy-runtime"
+  );
+  const regulatory = await resolveRuntimeRegulatoryAutonomyCeiling(
+    db as never,
+    { activityClass: sourceManifest.activityKey },
+  );
+  return deriveWorkPatternPromotionCandidates({
+    sourceExperimentTaskRunId,
+    orchestratingAgentId,
+    runs,
+    regulatoryHumanControlRequired:
+      regulatory.resolution.humanControlRequired,
+    now,
+  });
+}
+
+export async function promoteCompletedWorkPatternExperiment(
+  sourceExperimentTaskRunId: string,
+): Promise<{ decisions: Array<Awaited<ReturnType<typeof activateWorkPattern>>> }> {
+  const [{ prisma }, { createPrismaWorkPatternActivationPersistence }] =
+    await Promise.all([
+      import("@dpf/db"),
+      import("./work-pattern-activation-persistence"),
+    ]);
+  const initial = await loadPromotionCandidates(
+    prisma as unknown as PromotionDb,
+    sourceExperimentTaskRunId,
+  );
+  const decisions = [];
+  for (const candidate of initial) {
+    const modelProfileId = candidate.snapshot.source.modelProfileId;
+    const patternVersion = candidate.snapshot.patternVersion;
+    const persistence = createPrismaWorkPatternActivationPersistence(
+      async (tx: Prisma.TransactionClient) => {
+        const refreshed = await loadPromotionCandidates(
+          tx as unknown as PromotionDb,
+          sourceExperimentTaskRunId,
+        );
+        const match = refreshed.find((entry) =>
+          entry.snapshot.patternVersion === patternVersion
+          && entry.snapshot.source.modelProfileId === modelProfileId);
+        if (!match) throw new Error("work_pattern_promotion_snapshot_stale");
+        return match.snapshot;
+      },
+    );
+    decisions.push(
+      await activateWorkPattern(candidate.request, { persistence }),
+    );
+  }
+  return { decisions };
+}

--- a/apps/web/lib/tak/work-pattern-experiment-promotion.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-promotion.ts
@@ -27,10 +27,10 @@ export type WorkPatternPromotionExperimentCell = {
   taskRunId: string;
   status: string;
   completedAt: Date | null;
-  a2aMetadata: unknown;
   evidenceRows: Array<
     WorkPatternLedgerRow & {
       taskRunId: string | null;
+      proposedDecision: unknown;
       outcome: unknown;
       observedAt: Date;
     }
@@ -78,24 +78,26 @@ const REQUIRED_FACTORIAL_CELLS = [
 ] as const;
 
 function parseCell(cell: WorkPatternPromotionExperimentCell): ParsedCell | null {
-  if (!isRecord(cell.a2aMetadata)) return null;
-  const cellMetadata = isRecord(cell.a2aMetadata.workPatternExperimentCell)
-    ? cell.a2aMetadata.workPatternExperimentCell
-    : null;
-  const effectiveOutcomes = resolveEffectiveWorkPatternLedger(
-    cell.evidenceRows,
-  ).filter((row) =>
+  const effectiveRows = resolveEffectiveWorkPatternLedger(cell.evidenceRows);
+  const assignments = effectiveRows.filter((row) =>
+    row.taskRunId === cell.taskRunId
+    && isRecord(row.metadata)
+    && row.metadata.observationKind === "assignment"
+    && isRecord(row.proposedDecision)
+  );
+  const outcomes = effectiveRows.filter((row) =>
     row.taskRunId === cell.taskRunId
     && isRecord(row.metadata)
     && row.metadata.observationKind === "outcome"
     && isRecord(row.outcome)
   );
-  if (effectiveOutcomes.length !== 1) return null;
-  const effectiveOutcome = effectiveOutcomes[0];
+  if (assignments.length !== 1 || outcomes.length !== 1) return null;
+  const effectiveAssignment = assignments[0];
+  const effectiveOutcome = outcomes[0];
   const result = effectiveOutcome?.outcome;
   if (!isRecord(result)) return null;
   const request = parsePersistedWorkPatternExperimentExecution(
-    cellMetadata?.executionRequest,
+    effectiveAssignment?.proposedDecision,
   );
   const outcome = parseWorkPatternOutcomeEvidence(result?.outcomeEvidence);
   if (
@@ -441,7 +443,6 @@ async function loadPromotionCandidates(
         taskRunId: true,
         status: true,
         completedAt: true,
-        a2aMetadata: true,
       },
       orderBy: { createdAt: "asc" },
     });
@@ -459,6 +460,7 @@ async function loadPromotionCandidates(
           select: {
             ledgerId: true,
             taskRunId: true,
+            proposedDecision: true,
             outcome: true,
             metadata: true,
             observedAt: true,
@@ -477,6 +479,7 @@ async function loadPromotionCandidates(
         ? [{
             ledgerId: evidence.ledgerId,
             taskRunId: evidence.taskRunId,
+            proposedDecision: evidence.proposedDecision,
             outcome: evidence.outcome,
             metadata: evidence.metadata,
             observedAt: evidence.observedAt,
@@ -495,7 +498,6 @@ async function loadPromotionCandidates(
               status: child.status,
               completedAt:
                 child.completedAt instanceof Date ? child.completedAt : null,
-              a2aMetadata: child.a2aMetadata,
               evidenceRows: evidenceRows.filter(
                 (evidence) => evidence.taskRunId === child.taskRunId,
               ),

--- a/apps/web/lib/tak/work-pattern-experiment-promotion.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-promotion.ts
@@ -11,6 +11,10 @@ import {
   type WorkPatternActivationSnapshot,
 } from "./work-pattern-activation";
 import {
+  resolveEffectiveWorkPatternLedger,
+  type WorkPatternLedgerRow,
+} from "./work-pattern-effective-ledger";
+import {
   parseWorkPatternExperimentMetadata,
   type WorkPatternExperimentMetadataV1,
 } from "./work-pattern-experiment-types";
@@ -24,6 +28,13 @@ export type WorkPatternPromotionExperimentCell = {
   status: string;
   completedAt: Date | null;
   a2aMetadata: unknown;
+  evidenceRows: Array<
+    WorkPatternLedgerRow & {
+      taskRunId: string | null;
+      outcome: unknown;
+      observedAt: Date;
+    }
+  >;
 };
 
 export type WorkPatternPromotionExperimentRun = {
@@ -54,6 +65,9 @@ type PromotionDb = {
     findUnique(args: object): Promise<unknown>;
     findMany(args: object): Promise<unknown[]>;
   };
+  decisionShadowLedger: {
+    findMany(args: object): Promise<unknown[]>;
+  };
 };
 
 const REQUIRED_FACTORIAL_CELLS = [
@@ -68,9 +82,18 @@ function parseCell(cell: WorkPatternPromotionExperimentCell): ParsedCell | null 
   const cellMetadata = isRecord(cell.a2aMetadata.workPatternExperimentCell)
     ? cell.a2aMetadata.workPatternExperimentCell
     : null;
-  const result = isRecord(cell.a2aMetadata.workPatternExperimentResult)
-    ? cell.a2aMetadata.workPatternExperimentResult
-    : null;
+  const effectiveOutcomes = resolveEffectiveWorkPatternLedger(
+    cell.evidenceRows,
+  ).filter((row) =>
+    row.taskRunId === cell.taskRunId
+    && isRecord(row.metadata)
+    && row.metadata.observationKind === "outcome"
+    && isRecord(row.outcome)
+  );
+  if (effectiveOutcomes.length !== 1) return null;
+  const effectiveOutcome = effectiveOutcomes[0];
+  const result = effectiveOutcome?.outcome;
+  if (!isRecord(result)) return null;
   const request = parsePersistedWorkPatternExperimentExecution(
     cellMetadata?.executionRequest,
   );
@@ -87,7 +110,7 @@ function parseCell(cell: WorkPatternPromotionExperimentCell): ParsedCell | null 
   }
   return {
     status: cell.status,
-    completedAt: cell.completedAt,
+    completedAt: effectiveOutcome.observedAt,
     request,
     success: result.success,
     actualProviderId: result.actualProviderId,
@@ -422,6 +445,44 @@ async function loadPromotionCandidates(
       },
       orderBy: { createdAt: "asc" },
     });
+    const childTaskRunIds = childRows.flatMap((child) =>
+      isRecord(child) && typeof child.taskRunId === "string"
+        ? [child.taskRunId]
+        : []
+    );
+    const rawEvidenceRows = childTaskRunIds.length > 0
+      ? await db.decisionShadowLedger.findMany({
+          where: {
+            sourceKind: "work-pattern-experiment",
+            taskRunId: { in: childTaskRunIds },
+          },
+          select: {
+            ledgerId: true,
+            taskRunId: true,
+            outcome: true,
+            metadata: true,
+            observedAt: true,
+          },
+          orderBy: { observedAt: "asc" },
+        })
+      : [];
+    const evidenceRows = rawEvidenceRows.flatMap((evidence) =>
+      isRecord(evidence)
+      && typeof evidence.ledgerId === "string"
+      && (
+        typeof evidence.taskRunId === "string"
+        || evidence.taskRunId === null
+      )
+      && evidence.observedAt instanceof Date
+        ? [{
+            ledgerId: evidence.ledgerId,
+            taskRunId: evidence.taskRunId,
+            outcome: evidence.outcome,
+            metadata: evidence.metadata,
+            observedAt: evidence.observedAt,
+          }]
+        : []
+    );
     runs.push({
       parentTaskRunId: row.taskRunId,
       manifest,
@@ -435,6 +496,9 @@ async function loadPromotionCandidates(
               completedAt:
                 child.completedAt instanceof Date ? child.completedAt : null,
               a2aMetadata: child.a2aMetadata,
+              evidenceRows: evidenceRows.filter(
+                (evidence) => evidence.taskRunId === child.taskRunId,
+              ),
             }]
           : []),
     });

--- a/docs/operations/autonomous-build-completion.md
+++ b/docs/operations/autonomous-build-completion.md
@@ -140,6 +140,25 @@ rollback is required.
 - Confirm the operator band in light/dark and narrow/wide viewports, including collapsed engineer
   details and stale-heartbeat attention.
 
+## Design grounding
+
+- Existing specs/plans reviewed:
+  [governed playbook experimentation and autonomous Build Studio design](../superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md)
+  and its
+  [implementation plan](../superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md).
+- Current code substrate reviewed:
+  `work-pattern-activation`, `work-pattern-activation-persistence`,
+  `work-pattern-effective-ledger`, `work-pattern-binding-reader`,
+  `work-pattern-promotion-policy`, `work-pattern-experiment-store`,
+  `work-pattern-experiment-runtime`, the experiment queue function, and
+  `autonomous-build-eligibility-reader`.
+- Source of truth: effective, non-superseded `DecisionShadowLedger` assignment and outcome
+  evidence governs promotion; `AuthorityBinding` governs the active scope/model lane; `TaskRun`
+  supplies lifecycle and parent/child status only.
+- Decision: extend those substrates with fail-closed automatic same-install activation. Require
+  complete, fresh, comparable evidence and `productionBuild=pass` for `build.implement`; preserve
+  scoped rollback and authority-ceiling escalation; never synthesize qualifying build evidence.
+
 ## Related contracts
 
 - [Build Studio autonomous lanes](../user-guide/build-studio/autonomous-builds.md)

--- a/docs/operations/autonomous-build-completion.md
+++ b/docs/operations/autonomous-build-completion.md
@@ -35,6 +35,23 @@ Build, merge-queue, and self-upgrade records remain the owners of authority and 
 `BuildPhaseRun.executionProfileRef` and TaskRun metadata record the method version, model profile,
 provider, and model actually used.
 
+## Experiment promotion
+
+When a governed work-pattern experiment finishes, Build Studio analyzes and promotes its evidence
+before completing the parent run. Promotion is automatic only when the versioned policy clears it:
+each model lane needs at least eight comparable baseline/candidate pairs, a complete factorial
+matrix, fresh evidence, no reproduced blocking finding or commandment regression, and no
+regulatory human-control requirement. For `build.implement`, every qualifying pair must include a
+passing production build; inference-only replay evidence remains useful shadow evidence but cannot
+authorize an autonomous build lane.
+
+The first qualifying same-install promotion creates a rollback-safe baseline binding and then
+activates the candidate binding in the same serialized transaction. The candidate is scoped to the
+exact install, corpus, activity, risk, and model profile proved by the experiment. A note that
+portable or customer corroboration is required for broader scope does not block that local binding;
+it continues to block fleet or customer promotion. Separate model profiles receive separate
+activation lanes, and regulatory or authority ceilings still escalate instead of activating.
+
 ## Autonomous path
 
 ```text


### PR DESCRIPTION
## Summary

- connect completed governed work-pattern experiments to scoped `AuthorityBinding` activation
- make the effective `DecisionShadowLedger` assignment/outcome pair authoritative for promotion while retaining `TaskRun` only for lifecycle and parent/child status
- require a terminal full-factorial experiment, eight comparable replicates, hard-negative retention, fresh evidence, and `productionBuild=pass` for `build.implement`
- activate model-profile-specific lanes transactionally with deterministic baseline/rollback bindings and fail-closed eligibility
- document the automatic promotion boundary and the remaining requirement for legitimate build experiments before enforcement

Backlog: BI-356E69B1  
Work Capsule: WC-0BAD3500

## Architecture and substrate fit

This extends the existing `FeatureBuild`, `TaskRun`, `BuildPhaseRun`, `DecisionShadowLedger`, `AuthorityBinding`, Work Case, merge-queue, and governed self-upgrade substrates. It adds no parallel execution or evidence system. Independent architecture review tightened the implementation so immutable assignment and measured outcome evidence are read only from the effective ledger; superseded or incomplete evidence fails closed.

## Verification

- focused Vitest: 5 files / 23 tests passed
- exhaustive exact-SHA local-CI: 2,302 test files passed; 19,939 tests passed; 4 files skipped; 19 tests skipped; 18 todo
- type generation and TypeScript typecheck passed
- Prisma migration deploy passed; no new migration was required
- production Docker build passed
- documentation index and link validation passed
- UX verification: not applicable to this slice because no rendered route or component changed; runtime behavior is covered by queue/runtime/eligibility tests and will receive live canary verification after governed deployment

Local-CI-Evidence: cms52xc6606rq01mx7a74h4u6 (fix/autonomous-playbook-activation@bbb33a9481731117bc885ac81ae763bb9a93d1d3)

## Rollout boundary

This bridge remains fail closed. It does not fabricate `build.implement` evidence and does not turn shadow mode into enforcement by itself. After merge and governed self-upgrade, the next contained slice is the legitimate bounded build-replicate producer/continuation path, followed by an evidence-cleared low-risk canary; authority-ceiling and high-risk cases continue to escalate.
## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`
  - `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`
  - `docs/superpowers/plans/2026-06-28-governed-playbook-work-case-staging.md`
  - `docs/superpowers/plans/2026-06-28-governed-playbook-work-case-resolution.md`
- Current code substrate reviewed:
  - `apps/web/lib/tak/work-pattern-activation.ts`
  - `apps/web/lib/tak/work-pattern-activation-persistence.ts`
  - `apps/web/lib/tak/work-pattern-effective-ledger.ts`
  - `apps/web/lib/tak/work-pattern-binding-reader.ts`
  - `apps/web/lib/tak/work-pattern-promotion-policy.ts`
  - `apps/web/lib/tak/work-pattern-experiment-store.ts`
  - `apps/web/lib/integrate/work-pattern-experiment-runtime.ts`
  - `apps/web/lib/queue/functions/work-pattern-experiment.ts`
  - `apps/web/lib/build/autonomous-build-eligibility-reader.ts`
- Source of truth:
  - Effective, non-superseded `DecisionShadowLedger` assignment/outcome evidence is authoritative for experiment promotion; `AuthorityBinding` is authoritative for the active scope/model lane; `TaskRun` remains lifecycle/status evidence.
- Decision:
  - Extend the existing substrates with fail-closed automatic same-install activation. Require complete fresh comparable evidence and a passing production build for `build.implement`; retain scoped rollback and authority-ceiling escalation, and do not synthesize qualifying build evidence.
