### PR TITLE
feat(marketing): canonical operating snapshot + campaign tool-contract repair (BI-CEA797A1)

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -23,10 +23,13 @@ export default async function CustomerMarketingPage() {
   // The owner-first decision and the coworker's tool output must report the same
   // state for the same organization, so both read the canonical operating
   // snapshot. The workspace snapshot still drives the strategy/queue panels.
-  const [snapshot, operating] = await Promise.all([
-    getMarketingWorkspaceSnapshot(),
-    getMarketingOperatingSnapshot(),
-  ]);
+  //
+  // These load SEQUENTIALLY, and the workspace snapshot is handed over rather
+  // than reloaded: getMarketingWorkspaceSnapshot() upserts the MarketingStrategy
+  // row, so racing two of them concurrently collides on the organizationId
+  // unique key and renders a 500.
+  const snapshot = await getMarketingWorkspaceSnapshot();
+  const operating = await getMarketingOperatingSnapshot({ workspace: snapshot });
 
   if (!snapshot) {
     return (

--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -13,13 +13,20 @@ import {
 } from "@/lib/marketing/agentic-operations";
 import { getPlaybook } from "@/lib/tak/marketing-playbooks";
 import { buildMarketingOwnerDecision } from "@/lib/marketing/next-decision";
+import { getMarketingOperatingSnapshot } from "@/lib/marketing/operating-snapshot";
 import {
   buildMarketingDisclosure,
   buildMarketingOwnerQuestion,
 } from "@/lib/marketing/disclosure";
 
 export default async function CustomerMarketingPage() {
-  const snapshot = await getMarketingWorkspaceSnapshot();
+  // The owner-first decision and the coworker's tool output must report the same
+  // state for the same organization, so both read the canonical operating
+  // snapshot. The workspace snapshot still drives the strategy/queue panels.
+  const [snapshot, operating] = await Promise.all([
+    getMarketingWorkspaceSnapshot(),
+    getMarketingOperatingSnapshot(),
+  ]);
 
   if (!snapshot) {
     return (
@@ -78,7 +85,7 @@ export default async function CustomerMarketingPage() {
     suggestions,
   });
   const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
-  const ownerDecision = buildMarketingOwnerDecision(snapshot, playbook);
+  const ownerDecision = buildMarketingOwnerDecision(snapshot, playbook, operating ?? undefined);
   const ownerQuestion = buildMarketingOwnerQuestion(snapshot.storefront.category, playbook);
   const disclosure = buildMarketingDisclosure(snapshot);
   const archetypeName = snapshot.storefront.archetypeName ?? "your business";

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9272,6 +9272,7 @@
       "anchors": [
         "use-this-guide-for",
         "begin-with-one-decision",
+        "the-recommendation-reflects-real-campaign-state",
         "review-strategy-assumptions-and-proof",
         "build-a-campaign-before-building-assets",
         "review-and-publish",
@@ -9282,6 +9283,7 @@
         "before-launch",
         "during-the-campaign",
         "after-the-review-window",
+        "asking-the-marketing-strategist-about-a-campaign",
         "what-to-watch",
         "related-guides"
       ]

--- a/apps/web/lib/marketing/acquisition-signals.test.ts
+++ b/apps/web/lib/marketing/acquisition-signals.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  storefrontBooking: { count: vi.fn() },
+  storefrontInquiry: { count: vi.fn() },
+  storefrontOrder: { count: vi.fn() },
+  storefrontDonation: { count: vi.fn() },
+  engagement: { groupBy: vi.fn() },
+  opportunity: { groupBy: vi.fn() },
+}));
+vi.mock("@dpf/db", () => ({ prisma: db }));
+
+import { loadAcquisitionSignals } from "./acquisition-signals";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.storefrontBooking.count.mockResolvedValue(4);
+  db.storefrontInquiry.count.mockResolvedValue(3);
+  db.storefrontOrder.count.mockResolvedValue(2);
+  db.storefrontDonation.count.mockResolvedValue(1);
+  db.engagement.groupBy.mockResolvedValue([
+    { status: "open", _count: 5 },
+    { status: "closed", _count: 2 },
+  ]);
+  db.opportunity.groupBy.mockResolvedValue([{ stage: "qualified", _count: 3 }]);
+});
+
+describe("loadAcquisitionSignals", () => {
+  it("totals every inbound demand type for the window", async () => {
+    const signals = await loadAcquisitionSignals({ storefrontId: "sf-1", days: 30 });
+    expect(signals.inbox).toEqual({
+      days: 30,
+      bookings: 4,
+      inquiries: 3,
+      orders: 2,
+      donations: 1,
+      total: 10,
+    });
+  });
+
+  it("scopes each count to the storefront and the lookback window", async () => {
+    await loadAcquisitionSignals({ storefrontId: "sf-1", days: 7 });
+    for (const counter of [
+      db.storefrontBooking.count,
+      db.storefrontInquiry.count,
+      db.storefrontOrder.count,
+      db.storefrontDonation.count,
+    ]) {
+      expect(counter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            storefrontId: "sf-1",
+            createdAt: expect.objectContaining({ gte: expect.any(Date) }),
+          }),
+        }),
+      );
+    }
+  });
+
+  it("projects the pipeline as status/stage keyed counts", async () => {
+    const signals = await loadAcquisitionSignals({ storefrontId: "sf-1", days: 30 });
+    expect(signals.pipeline.engagements).toEqual({ open: 5, closed: 2 });
+    expect(signals.pipeline.opportunities).toEqual({ qualified: 3 });
+  });
+
+  it("reports zeroes rather than omitting a demand type when nothing arrived", async () => {
+    db.storefrontBooking.count.mockResolvedValue(0);
+    db.storefrontInquiry.count.mockResolvedValue(0);
+    db.storefrontOrder.count.mockResolvedValue(0);
+    db.storefrontDonation.count.mockResolvedValue(0);
+    db.engagement.groupBy.mockResolvedValue([]);
+    db.opportunity.groupBy.mockResolvedValue([]);
+
+    const signals = await loadAcquisitionSignals({ storefrontId: "sf-1", days: 30 });
+    expect(signals.inbox.total).toBe(0);
+    expect(signals.pipeline).toEqual({ engagements: {}, opportunities: {} });
+  });
+});

--- a/apps/web/lib/marketing/acquisition-signals.ts
+++ b/apps/web/lib/marketing/acquisition-signals.ts
@@ -1,0 +1,66 @@
+// Inbound acquisition signals — the demand side of the marketing picture.
+//
+// Storefront inbox counts (bookings / inquiries / orders / donations) and the
+// CRM pipeline rollup answer "is demand arriving, and where does it stall".
+// They were assembled with raw prisma aggregates inside the get_marketing_summary
+// tool handler, the only marketing handler that still did its own DB rollup
+// rather than delegating to a marketing module. Extracted here so the tool pack
+// stays a thin adapter and the counts have one definition.
+
+import { prisma } from "@dpf/db";
+
+export type MarketingAcquisitionSignals = {
+  inbox: {
+    days: number;
+    bookings: number;
+    inquiries: number;
+    orders: number;
+    donations: number;
+    total: number;
+  };
+  pipeline: {
+    engagements: Record<string, number>;
+    opportunities: Record<string, number>;
+  };
+};
+
+/**
+ * Count inbound demand for one storefront over a lookback window, plus the
+ * current CRM pipeline distribution.
+ */
+export async function loadAcquisitionSignals(input: {
+  storefrontId: string;
+  days: number;
+}): Promise<MarketingAcquisitionSignals> {
+  const since = new Date();
+  since.setDate(since.getDate() - input.days);
+  const window = { storefrontId: input.storefrontId, createdAt: { gte: since } };
+
+  const [bookings, inquiries, orders, donations, engagements, opportunities] = await Promise.all([
+    prisma.storefrontBooking.count({ where: window }),
+    prisma.storefrontInquiry.count({ where: window }),
+    prisma.storefrontOrder.count({ where: window }),
+    prisma.storefrontDonation.count({ where: window }),
+    prisma.engagement.groupBy({ by: ["status"], _count: true }),
+    prisma.opportunity.groupBy({ by: ["stage"], _count: true }),
+  ]);
+
+  return {
+    inbox: {
+      days: input.days,
+      bookings,
+      inquiries,
+      orders,
+      donations,
+      total: bookings + inquiries + orders + donations,
+    },
+    pipeline: {
+      engagements: Object.fromEntries(
+        (engagements as Array<{ status: string; _count: number }>).map((e) => [e.status, e._count]),
+      ),
+      opportunities: Object.fromEntries(
+        (opportunities as Array<{ stage: string; _count: number }>).map((o) => [o.stage, o._count]),
+      ),
+    },
+  };
+}

--- a/apps/web/lib/marketing/archetype-context.ts
+++ b/apps/web/lib/marketing/archetype-context.ts
@@ -1,0 +1,97 @@
+// Storefront archetype + playbook resolution for marketing reads.
+//
+// Three marketing-ops tool handlers (get_marketing_summary,
+// suggest_campaign_ideas, analyze_seo_opportunity) each re-inlined the same
+// storefrontConfig.findFirst({ include: { archetype } }) + getPlaybook() +
+// "No storefront configured" guard. Three copies meant three chances for the
+// archetype resolution to drift apart, and the "storefront configured?" answer
+// was already phrased three slightly different ways. This is the one resolver.
+//
+// Archetype is read from StorefrontConfig.archetype per AGENTS.md §2 —
+// StorefrontConfig.archetypeId is the single source of truth for portal
+// industry; Organization.industry and BusinessContext.industry are derived.
+
+import { prisma } from "@dpf/db";
+import { getPlaybook, type MarketingPlaybook } from "@/lib/tak/marketing-playbooks";
+
+/** The one message shown when marketing is asked to reason before setup. */
+export const MARKETING_NO_STOREFRONT_MESSAGE =
+  "No storefront configured. Set up your storefront first at /storefront/setup.";
+
+export type MarketingArchetype = {
+  archetypeId: string;
+  name: string;
+  category: string;
+  ctaType: string;
+};
+
+export type MarketingStorefrontItem = {
+  name: string;
+  description?: string | null;
+  priceType?: string | null;
+  ctaType?: string | null;
+};
+
+export type MarketingStorefrontSection = {
+  type: string;
+  title: string | null;
+};
+
+export type MarketingArchetypeContext = {
+  storefrontId: string;
+  archetype: MarketingArchetype;
+  playbook: MarketingPlaybook;
+  items: MarketingStorefrontItem[];
+  sections: MarketingStorefrontSection[];
+};
+
+/**
+ * Resolve the active storefront archetype and its marketing playbook.
+ * Returns null when no storefront has been configured — callers surface
+ * MARKETING_NO_STOREFRONT_MESSAGE rather than inventing an archetype.
+ */
+export async function resolveMarketingArchetypeContext(options?: {
+  includeItems?: boolean;
+  includeSections?: boolean;
+  itemLimit?: number;
+}): Promise<MarketingArchetypeContext | null> {
+  const config = await prisma.storefrontConfig.findFirst({
+    include: {
+      archetype: { select: { archetypeId: true, name: true, category: true, ctaType: true } },
+      ...(options?.includeItems
+        ? {
+            items: {
+              where: { isActive: true },
+              select: { name: true, description: true, priceType: true, ctaType: true },
+              orderBy: { sortOrder: "asc" as const },
+              take: options.itemLimit ?? 20,
+            },
+          }
+        : {}),
+      ...(options?.includeSections
+        ? {
+            sections: {
+              where: { isVisible: true },
+              select: { type: true, title: true },
+              orderBy: { sortOrder: "asc" as const },
+            },
+          }
+        : {}),
+    },
+  });
+
+  if (!config) return null;
+
+  return {
+    storefrontId: config.id,
+    archetype: {
+      archetypeId: config.archetype.archetypeId,
+      name: config.archetype.name,
+      category: config.archetype.category,
+      ctaType: config.archetype.ctaType,
+    },
+    playbook: getPlaybook(config.archetype.category, config.archetype.ctaType),
+    items: ((config as { items?: MarketingStorefrontItem[] }).items ?? []) as MarketingStorefrontItem[],
+    sections: ((config as { sections?: MarketingStorefrontSection[] }).sections ?? []) as MarketingStorefrontSection[],
+  };
+}

--- a/apps/web/lib/marketing/campaign-performance.test.ts
+++ b/apps/web/lib/marketing/campaign-performance.test.ts
@@ -106,17 +106,37 @@ describe("metricRowFromSnapshot", () => {
       costInUsdCents: 500,
       conversions: 2,
     });
-    expect(row).toEqual({ channel: "linkedin", impressions: 100, clicks: 10, costInUsdCents: 500, conversions: 2 });
+    expect(row).toMatchObject({ channel: "linkedin", impressions: 100, clicks: 10, costInUsdCents: 500, conversions: 2 });
+  });
+
+  it("carries publication timing and tracked-link provenance when supplied", () => {
+    const publishedAt = new Date("2026-07-27T09:00:00.000Z");
+    const metricsPolledAt = new Date("2026-07-28T09:00:00.000Z");
+    const row = metricRowFromSnapshot("linkedin", { impressions: 1 }, {
+      publishedAt,
+      metricsPolledAt,
+      trackedLink: true,
+    });
+    expect(row.publishedAt).toEqual(publishedAt);
+    expect(row.metricsPolledAt).toEqual(metricsPolledAt);
+    expect(row.trackedLink).toBe(true);
+  });
+
+  it("defaults timing and tracked-link provenance to absent, never invented", () => {
+    const row = metricRowFromSnapshot("linkedin", { impressions: 1 });
+    expect(row.publishedAt).toBeNull();
+    expect(row.metricsPolledAt).toBeNull();
+    expect(row.trackedLink).toBe(false);
   });
 
   it("defaults missing / non-numeric / non-object snapshots to zero", () => {
-    expect(metricRowFromSnapshot("x", null)).toEqual({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
-    expect(metricRowFromSnapshot("x", "not-an-object")).toEqual({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
-    expect(metricRowFromSnapshot("x", { impressions: "50", clicks: NaN })).toEqual({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
+    expect(metricRowFromSnapshot("x", null)).toMatchObject({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
+    expect(metricRowFromSnapshot("x", "not-an-object")).toMatchObject({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
+    expect(metricRowFromSnapshot("x", { impressions: "50", clicks: NaN })).toMatchObject({ channel: "x", impressions: 0, clicks: 0, costInUsdCents: 0, conversions: 0 });
   });
 
   it("clamps negative counts to zero so the rollup can't show a negative CTR", () => {
     const row = metricRowFromSnapshot("x", { impressions: 100, clicks: -100, conversions: -5, costInUsdCents: -1 });
-    expect(row).toEqual({ channel: "x", impressions: 100, clicks: 0, costInUsdCents: 0, conversions: 0 });
+    expect(row).toMatchObject({ channel: "x", impressions: 100, clicks: 0, costInUsdCents: 0, conversions: 0 });
   });
 });

--- a/apps/web/lib/marketing/campaign-performance.ts
+++ b/apps/web/lib/marketing/campaign-performance.ts
@@ -14,14 +14,24 @@
 
 import { prisma } from "@dpf/db";
 
+import { buildCampaignDrillInRecovery, requireCampaignInScope, type CampaignDrillInFailure } from "./campaigns";
+
 /** One publication's measured engagement, tagged with its channel. Shape mirrors
- *  the adapter engagement snapshot written to OutboundPublication.lastMetricsSnapshot. */
+ *  the adapter engagement snapshot written to OutboundPublication.lastMetricsSnapshot.
+ *
+ *  publishedAt / metricsPolledAt / trackedLink are optional because the pure
+ *  rollup below does not need them; the operating snapshot uses them to decide
+ *  evidence freshness and attribution confidence. */
 export type PublicationMetricRow = {
   channel: string;
   impressions: number;
   clicks: number;
   costInUsdCents: number;
   conversions: number;
+  publishedAt?: Date | null;
+  metricsPolledAt?: Date | null;
+  /** The originating draft carried a UTM-tagged link, so clicks are attributable. */
+  trackedLink?: boolean;
 };
 
 export type ChannelPerformance = {
@@ -195,7 +205,11 @@ export function summarizeCampaignPerformance(input: {
 /** Coerce a lastMetricsSnapshot JSON blob into a numeric metric row. Defensive:
  *  missing/non-numeric fields become 0 so a partially-populated snapshot still
  *  contributes what it has. */
-export function metricRowFromSnapshot(channel: string, snapshot: unknown): PublicationMetricRow {
+export function metricRowFromSnapshot(
+  channel: string,
+  snapshot: unknown,
+  extra?: { publishedAt?: Date | null; metricsPolledAt?: Date | null; trackedLink?: boolean },
+): PublicationMetricRow {
   const m = snapshot && typeof snapshot === "object" ? (snapshot as Record<string, unknown>) : {};
   // Clamp to >= 0: a corrupt/adversarial snapshot with a negative count would
   // otherwise flow into totals and produce a negative CTR/conversion rate in
@@ -207,21 +221,125 @@ export function metricRowFromSnapshot(channel: string, snapshot: unknown): Publi
     clicks: num(m.clicks),
     costInUsdCents: num(m.costInUsdCents),
     conversions: num(m.conversions),
+    publishedAt: extra?.publishedAt ?? null,
+    metricsPolledAt: extra?.metricsPolledAt ?? null,
+    trackedLink: extra?.trackedLink ?? false,
   };
+}
+
+/** A draft body carries attributable links once build_tracked_links has tagged them. */
+function hasTrackedLink(body: string | null | undefined): boolean {
+  return typeof body === "string" && body.includes("utm_campaign=");
+}
+
+export type CampaignPublicationMetrics = {
+  /** Measured publication rows grouped by the asset task that produced them. */
+  byTask: Map<string, PublicationMetricRow[]>;
+  /** Tasks with an outbound draft that is not yet approved/published. */
+  draftedTaskIds: Set<string>;
+  /** Tasks whose draft reached approved or published. */
+  approvedTaskIds: Set<string>;
+  lastPublishedAt: Date | null;
+  lastPolledAt: Date | null;
+};
+
+/**
+ * One batched walk over asset tasks → outbound drafts → publications.
+ *
+ * getCampaignPerformance and the operating snapshot both need this path; running
+ * it twice with slightly different predicates is how a campaign's execution
+ * rollup and its measured performance drift apart. Two queries regardless of how
+ * many campaigns are asked about.
+ */
+export async function loadPublicationMetricsForTasks(
+  taskIds: ReadonlyArray<string>,
+): Promise<CampaignPublicationMetrics> {
+  const empty: CampaignPublicationMetrics = {
+    byTask: new Map(),
+    draftedTaskIds: new Set(),
+    approvedTaskIds: new Set(),
+    lastPublishedAt: null,
+    lastPolledAt: null,
+  };
+  if (taskIds.length === 0) return empty;
+
+  const drafts = await prisma.outboundDraft.findMany({
+    where: { domain: "marketing", sourceType: "marketing-asset-task", sourceId: { in: [...taskIds] } },
+    select: { draftId: true, sourceId: true, status: true, body: true },
+  });
+  if (drafts.length === 0) return empty;
+
+  const draftedTaskIds = new Set<string>();
+  const approvedTaskIds = new Set<string>();
+  const draftById = new Map<string, { sourceId: string | null; trackedLink: boolean }>();
+  for (const draft of drafts) {
+    if (draft.sourceId) {
+      if (draft.status === "approved" || draft.status === "published") approvedTaskIds.add(draft.sourceId);
+      else draftedTaskIds.add(draft.sourceId);
+    }
+    draftById.set(draft.draftId, {
+      sourceId: draft.sourceId,
+      trackedLink: hasTrackedLink(draft.body),
+    });
+  }
+
+  const publications = await prisma.outboundPublication.findMany({
+    where: { draftId: { in: drafts.map((d: { draftId: string }) => d.draftId) } },
+    select: {
+      draftId: true,
+      channelId: true,
+      publishedAt: true,
+      lastMetricsPolledAt: true,
+      lastMetricsSnapshot: true,
+    },
+  });
+
+  const byTask = new Map<string, PublicationMetricRow[]>();
+  let lastPublishedAt: Date | null = null;
+  let lastPolledAt: Date | null = null;
+
+  for (const publication of publications) {
+    const draft = draftById.get(publication.draftId);
+    if (!draft?.sourceId) continue;
+    const row = metricRowFromSnapshot(publication.channelId, publication.lastMetricsSnapshot, {
+      publishedAt: publication.publishedAt,
+      metricsPolledAt: publication.lastMetricsPolledAt,
+      trackedLink: draft.trackedLink,
+    });
+    const bucket = byTask.get(draft.sourceId);
+    if (bucket) bucket.push(row);
+    else byTask.set(draft.sourceId, [row]);
+
+    if (publication.publishedAt && (!lastPublishedAt || publication.publishedAt > lastPublishedAt)) {
+      lastPublishedAt = publication.publishedAt;
+    }
+    if (
+      publication.lastMetricsPolledAt &&
+      (!lastPolledAt || publication.lastMetricsPolledAt > lastPolledAt)
+    ) {
+      lastPolledAt = publication.lastMetricsPolledAt;
+    }
+  }
+
+  return { byTask, draftedTaskIds, approvedTaskIds, lastPublishedAt, lastPolledAt };
 }
 
 /**
  * Read a campaign's measured cross-channel performance from the publications of
  * its asset tasks. Returns the rollup plus the campaign's headline identity.
+ *
+ * Scoped to the resolved organization: a campaignId from another organization
+ * reads as not-found, and a missing campaignId returns candidate IDs plus one
+ * recovery instruction rather than an opaque miss.
  */
 export async function getCampaignPerformance(
   campaignId: string,
-): Promise<
-  | { message: string; data: Record<string, unknown> }
-  | { error: string; message: string }
-> {
-  const campaign = await prisma.marketingCampaign.findUnique({
-    where: { campaignId },
+): Promise<{ message: string; data: Record<string, unknown> } | CampaignDrillInFailure> {
+  const scope = await requireCampaignInScope(campaignId, "get_campaign_performance");
+  if (!scope.ok) return scope.failure;
+
+  const campaign = await prisma.marketingCampaign.findFirst({
+    where: { campaignId: scope.campaignId, organizationId: scope.organizationId },
     select: {
       campaignId: true,
       name: true,
@@ -232,26 +350,19 @@ export async function getCampaignPerformance(
     },
   });
   if (!campaign) {
-    return { error: "not-found", message: `Campaign ${campaignId} does not exist.` };
+    return buildCampaignDrillInRecovery({
+      requestedCampaignId: scope.campaignId,
+      candidates: await scope.listCandidates(),
+      toolName: "get_campaign_performance",
+    });
   }
 
-  const taskIds = campaign.assetTasks.map((t: { taskId: string }) => t.taskId);
+  const metrics = await loadPublicationMetricsForTasks(
+    campaign.assetTasks.map((t: { taskId: string }) => t.taskId),
+  );
   const rows: PublicationMetricRow[] = [];
-  if (taskIds.length > 0) {
-    const drafts = await prisma.outboundDraft.findMany({
-      where: { domain: "marketing", sourceType: "marketing-asset-task", sourceId: { in: taskIds } },
-      select: { draftId: true },
-    });
-    const draftIds = drafts.map((d: { draftId: string }) => d.draftId);
-    if (draftIds.length > 0) {
-      const pubs = await prisma.outboundPublication.findMany({
-        where: { draftId: { in: draftIds } },
-        select: { channelId: true, lastMetricsSnapshot: true },
-      });
-      for (const pub of pubs) {
-        rows.push(metricRowFromSnapshot(pub.channelId, pub.lastMetricsSnapshot));
-      }
-    }
+  for (const task of campaign.assetTasks) {
+    rows.push(...(metrics.byTask.get(task.taskId) ?? []));
   }
 
   const rollup = summarizeCampaignPerformance({

--- a/apps/web/lib/marketing/campaign-scope.test.ts
+++ b/apps/web/lib/marketing/campaign-scope.test.ts
@@ -1,0 +1,150 @@
+// Red-green coverage for organization-scoped campaign drill-in (BI-CEA797A1).
+//
+// Two live defects are pinned here:
+//   1. get_campaign_plan / get_campaign_performance resolved a campaign with a
+//      bare findUnique on campaignId — a campaign belonging to another
+//      organization was readable by id.
+//   2. An empty campaignId produced the opaque "Campaign  does not exist.", which
+//      is exactly what the Marketing Strategist hit repeatedly in production.
+//      The drill-in must instead return structured candidate IDs plus one
+//      recovery instruction.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  organization: { findFirst: vi.fn() },
+  marketingCampaign: { findFirst: vi.fn(), findMany: vi.fn() },
+  marketingCampaignBrief: { findMany: vi.fn() },
+  marketingAssetTask: { findMany: vi.fn() },
+  outboundDraft: { findMany: vi.fn() },
+  outboundPublication: { findMany: vi.fn() },
+}));
+vi.mock("@dpf/db", () => ({ prisma: db }));
+
+import {
+  buildCampaignDrillInRecovery,
+  requireCampaignInScope,
+  type CampaignCandidate,
+} from "./campaigns";
+
+const CANDIDATES: CampaignCandidate[] = [
+  { campaignId: "cmp-a", name: "Midweek covers", status: "active", nextStep: "Draft 2 asset tasks." },
+  { campaignId: "cmp-b", name: "Autumn tasting", status: "draft", nextStep: "Create a campaign brief." },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.organization.findFirst.mockResolvedValue({ id: "org-1" });
+  db.marketingCampaign.findMany.mockResolvedValue([]);
+  db.marketingCampaign.findFirst.mockResolvedValue(null);
+  db.marketingCampaignBrief.findMany.mockResolvedValue([]);
+  db.marketingAssetTask.findMany.mockResolvedValue([]);
+  db.outboundDraft.findMany.mockResolvedValue([]);
+});
+
+describe("buildCampaignDrillInRecovery — actionable, never opaque", () => {
+  it("an omitted campaignId returns candidate IDs and one recovery instruction", () => {
+    const failure = buildCampaignDrillInRecovery({
+      requestedCampaignId: "",
+      candidates: CANDIDATES,
+      toolName: "get_campaign_plan",
+    });
+    expect(failure.error).toBe("campaign-id-required");
+    expect(failure.data.candidates.map((c) => c.campaignId)).toEqual(["cmp-a", "cmp-b"]);
+    expect(failure.data.recovery).toMatch(/campaignId/);
+    // The message itself must carry an id the caller can act on immediately.
+    expect(failure.message).toContain("cmp-a");
+  });
+
+  it("a whitespace-only campaignId is treated as omitted, not as a lookup miss", () => {
+    const failure = buildCampaignDrillInRecovery({
+      requestedCampaignId: "   ",
+      candidates: CANDIDATES,
+      toolName: "get_campaign_performance",
+    });
+    expect(failure.error).toBe("campaign-id-required");
+  });
+
+  it("an omitted campaignId with no campaigns at all points at campaign creation", () => {
+    const failure = buildCampaignDrillInRecovery({
+      requestedCampaignId: "",
+      candidates: [],
+      toolName: "get_campaign_plan",
+    });
+    expect(failure.error).toBe("campaign-id-required");
+    expect(failure.data.candidates).toEqual([]);
+    expect(failure.data.recovery).toMatch(/create_marketing_campaign/);
+  });
+
+  it("an unknown campaignId is reported as not-found and still lists the real ones", () => {
+    const failure = buildCampaignDrillInRecovery({
+      requestedCampaignId: "cmp-does-not-exist",
+      candidates: CANDIDATES,
+      toolName: "get_campaign_plan",
+    });
+    expect(failure.error).toBe("campaign-not-found");
+    expect(failure.message).toContain("cmp-does-not-exist");
+    expect(failure.data.candidates).toHaveLength(2);
+  });
+
+  it("never echoes a brief or task id back as if it were a campaign candidate", () => {
+    const failure = buildCampaignDrillInRecovery({
+      requestedCampaignId: "brief-123",
+      candidates: CANDIDATES,
+      toolName: "get_campaign_plan",
+    });
+    expect(failure.data.candidates.every((c) => c.campaignId.startsWith("cmp-"))).toBe(true);
+  });
+});
+
+describe("requireCampaignInScope — organization isolation", () => {
+  it("resolves a campaign that belongs to the resolved organization", async () => {
+    db.marketingCampaign.findFirst.mockResolvedValue({ campaignId: "cmp-a" });
+    const result = await requireCampaignInScope("cmp-a", "get_campaign_plan");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.organizationId).toBe("org-1");
+
+    // The scoping predicate must be in the query, not applied after the fact.
+    expect(db.marketingCampaign.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ campaignId: "cmp-a", organizationId: "org-1" }),
+      }),
+    );
+  });
+
+  it("refuses a campaign owned by another organization without leaking that it exists", async () => {
+    // The row exists globally but not within org-1, so the scoped query misses.
+    db.marketingCampaign.findFirst.mockResolvedValue(null);
+    db.marketingCampaign.findMany.mockResolvedValue([
+      { campaignId: "cmp-a", name: "Midweek covers", status: "active" },
+    ]);
+
+    const result = await requireCampaignInScope("cmp-other-org", "get_campaign_plan");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.error).toBe("campaign-not-found");
+      // Candidates are drawn from THIS org only.
+      expect(result.failure.data.candidates.map((c) => c.campaignId)).toEqual(["cmp-a"]);
+    }
+    expect(db.marketingCampaign.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ organizationId: "org-1" }) }),
+    );
+  });
+
+  it("returns the structured recovery for an empty campaignId without querying by id", async () => {
+    db.marketingCampaign.findMany.mockResolvedValue([
+      { campaignId: "cmp-a", name: "Midweek covers", status: "active" },
+    ]);
+    const result = await requireCampaignInScope("", "get_campaign_performance");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure.error).toBe("campaign-id-required");
+    expect(db.marketingCampaign.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("reports no-workspace when no organization is configured", async () => {
+    db.organization.findFirst.mockResolvedValue(null);
+    const result = await requireCampaignInScope("cmp-a", "get_campaign_plan");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure.error).toBe("no-workspace");
+  });
+});

--- a/apps/web/lib/marketing/campaigns-attach.test.ts
+++ b/apps/web/lib/marketing/campaigns-attach.test.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// attachToCampaign resolves every target inside the configured organization
+// (BI-CEA797A1) — the lookups are findFirst with an organizationId predicate,
+// not a bare findUnique by id.
 const prismaMock = vi.hoisted(() => ({
+  organization: {
+    findFirst: vi.fn(),
+  },
   marketingCampaign: {
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
   },
   marketingCampaignBrief: {
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
     update: vi.fn(),
   },
   marketingAssetTask: {
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
     update: vi.fn(),
   },
 }));
@@ -25,15 +31,16 @@ import { attachToCampaign } from "./campaigns";
 describe("attachToCampaign", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prismaMock.organization.findFirst.mockResolvedValue({ id: "org-1" });
   });
 
   it("explains when the caller passes a briefId as campaignId", async () => {
-    prismaMock.marketingCampaign.findUnique.mockResolvedValue(null);
-    prismaMock.marketingCampaignBrief.findUnique.mockResolvedValue({
+    prismaMock.marketingCampaign.findFirst.mockResolvedValue(null);
+    prismaMock.marketingCampaignBrief.findFirst.mockResolvedValue({
       briefId: "brief-1",
       campaignId: null,
     });
-    prismaMock.marketingAssetTask.findUnique.mockResolvedValue(null);
+    prismaMock.marketingAssetTask.findFirst.mockResolvedValue(null);
 
     const result = await attachToCampaign({
       campaignId: "brief-1",
@@ -49,8 +56,8 @@ describe("attachToCampaign", () => {
   });
 
   it("returns a structured not-found result when the task target is missing", async () => {
-    prismaMock.marketingCampaign.findUnique.mockResolvedValue({ campaignId: "campaign-1" });
-    prismaMock.marketingAssetTask.findUnique.mockResolvedValue(null);
+    prismaMock.marketingCampaign.findFirst.mockResolvedValue({ campaignId: "campaign-1" });
+    prismaMock.marketingAssetTask.findFirst.mockResolvedValue(null);
 
     const result = await attachToCampaign({
       campaignId: "campaign-1",
@@ -65,9 +72,9 @@ describe("attachToCampaign", () => {
   });
 
   it("attaches valid brief and task targets without partial updates", async () => {
-    prismaMock.marketingCampaign.findUnique.mockResolvedValue({ campaignId: "campaign-1" });
-    prismaMock.marketingCampaignBrief.findUnique.mockResolvedValue({ briefId: "brief-1" });
-    prismaMock.marketingAssetTask.findUnique.mockResolvedValue({ taskId: "task-1" });
+    prismaMock.marketingCampaign.findFirst.mockResolvedValue({ campaignId: "campaign-1" });
+    prismaMock.marketingCampaignBrief.findFirst.mockResolvedValue({ briefId: "brief-1" });
+    prismaMock.marketingAssetTask.findFirst.mockResolvedValue({ taskId: "task-1" });
     prismaMock.marketingCampaignBrief.update.mockResolvedValue({ briefId: "brief-1" });
     prismaMock.marketingAssetTask.update.mockResolvedValue({ taskId: "task-1" });
 
@@ -88,5 +95,33 @@ describe("attachToCampaign", () => {
       where: { taskId: "task-1" },
       data: { campaignId: "campaign-1" },
     });
+  });
+
+  it("scopes every target lookup to the resolved organization", async () => {
+    prismaMock.marketingCampaign.findFirst.mockResolvedValue({ campaignId: "campaign-1" });
+    prismaMock.marketingAssetTask.findFirst.mockResolvedValue({ taskId: "task-1" });
+    prismaMock.marketingAssetTask.update.mockResolvedValue({ taskId: "task-1" });
+
+    await attachToCampaign({ campaignId: "campaign-1", taskId: "task-1" });
+
+    expect(prismaMock.marketingCampaign.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ campaignId: "campaign-1", organizationId: "org-1" }),
+      }),
+    );
+    expect(prismaMock.marketingAssetTask.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ taskId: "task-1", organizationId: "org-1" }),
+      }),
+    );
+  });
+
+  it("refuses to attach when no organization workspace is configured", async () => {
+    prismaMock.organization.findFirst.mockResolvedValue(null);
+
+    const result = await attachToCampaign({ campaignId: "campaign-1", taskId: "task-1" });
+
+    expect(result).toMatchObject({ error: "no-workspace" });
+    expect(prismaMock.marketingAssetTask.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/marketing/campaigns.ts
+++ b/apps/web/lib/marketing/campaigns.ts
@@ -12,6 +12,7 @@
 
 import { prisma } from "@dpf/db";
 import { getMarketingWorkspaceSnapshot } from "../marketing";
+import { resolveMarketingOrganizationId } from "./org-scope";
 
 export const CAMPAIGN_STATUSES = ["draft", "active", "paused", "complete"] as const;
 export type CampaignStatus = (typeof CAMPAIGN_STATUSES)[number];
@@ -63,6 +64,169 @@ export function summarizeCampaignExecution(input: CampaignExecutionInput): Campa
   }
 
   return { briefCount, taskCount, draftedCount, approvedCount, undraftedCount, nextStep };
+}
+
+// ─── Drill-in scope + recovery ──────────────────────────────────────────────
+//
+// Two production defects are answered here. First, campaign drill-ins resolved
+// their campaign with a bare findUnique on campaignId, so a campaign belonging
+// to another organization was readable by id. Second, an omitted campaignId
+// produced "Campaign  does not exist." — the exact opaque failure the Marketing
+// Strategist hit over and over, with nothing in the response that let it
+// self-correct. A drill-in that cannot answer now returns the campaign IDs it
+// COULD answer for, plus one instruction.
+
+export type CampaignCandidate = {
+  campaignId: string;
+  name: string;
+  status: string;
+  /** The single most useful next step for this campaign, in plain language. */
+  nextStep: string;
+};
+
+export type CampaignDrillInFailure = {
+  error: "campaign-id-required" | "campaign-not-found" | "no-workspace";
+  message: string;
+  data: { candidates: CampaignCandidate[]; recovery: string };
+};
+
+function describeCandidates(candidates: CampaignCandidate[]): string {
+  return candidates.map((c) => `${c.campaignId} (${c.name} — ${c.status})`).join(", ");
+}
+
+/**
+ * Pure: turn a failed drill-in into an actionable result.
+ * A blank/whitespace campaignId is classified as "you did not pass one", never
+ * as a lookup miss — those need different recovery instructions.
+ */
+export function buildCampaignDrillInRecovery(input: {
+  requestedCampaignId: string;
+  candidates: CampaignCandidate[];
+  toolName: string;
+}): CampaignDrillInFailure {
+  const requested = input.requestedCampaignId.trim();
+  const { candidates, toolName } = input;
+
+  if (candidates.length === 0) {
+    return {
+      error: requested ? "campaign-not-found" : "campaign-id-required",
+      message: requested
+        ? `Campaign ${requested} does not exist in this workspace, and no campaigns exist yet.`
+        : `${toolName} needs a campaignId, and no campaign exists yet.`,
+      data: {
+        candidates: [],
+        recovery:
+          "Establish a campaign first with create_marketing_campaign, then drill into it by its campaignId.",
+      },
+    };
+  }
+
+  const recovery = `Re-call ${toolName} with campaignId set to one of the listed ids; get_marketing_summary returns the same ids with their current state.`;
+
+  if (!requested) {
+    return {
+      error: "campaign-id-required",
+      message: `${toolName} needs a campaignId. Campaigns in this workspace: ${describeCandidates(candidates)}.`,
+      data: { candidates, recovery },
+    };
+  }
+
+  return {
+    error: "campaign-not-found",
+    message: `Campaign ${requested} does not exist in this workspace. Campaigns in this workspace: ${describeCandidates(candidates)}.`,
+    data: { candidates, recovery },
+  };
+}
+
+/** The campaigns this organization can be asked about, newest first. */
+export async function listCampaignCandidates(organizationId: string): Promise<CampaignCandidate[]> {
+  const rows = await prisma.marketingCampaign.findMany({
+    where: { organizationId },
+    orderBy: { createdAt: "desc" },
+    take: 10,
+    select: {
+      campaignId: true,
+      name: true,
+      status: true,
+      _count: { select: { briefs: true, assetTasks: true } },
+    },
+  });
+  return rows.map((row: { campaignId: string; name: string; status: string; _count?: { briefs: number; assetTasks: number } }) => ({
+    campaignId: row.campaignId,
+    name: row.name,
+    status: row.status,
+    nextStep: summarizeCampaignExecution({
+      briefs: new Array(row._count?.briefs ?? 0).fill({ status: "draft" }),
+      tasks: new Array(row._count?.assetTasks ?? 0)
+        .fill(null)
+        .map((_, i) => ({ status: "draft", taskId: `${row.campaignId}:${i}` })),
+    }).nextStep,
+  }));
+}
+
+export type CampaignScopeResult =
+  | {
+      ok: true;
+      organizationId: string;
+      campaignId: string;
+      listCandidates: () => Promise<CampaignCandidate[]>;
+    }
+  | { ok: false; failure: CampaignDrillInFailure };
+
+/**
+ * Resolve a campaign drill-in against the configured organization.
+ * Every campaign read/write goes through here so organization isolation is
+ * expressed once, in the query predicate, rather than re-derived per caller.
+ */
+export async function requireCampaignInScope(
+  campaignId: string,
+  toolName: string,
+): Promise<CampaignScopeResult> {
+  const organizationId = await resolveMarketingOrganizationId();
+  if (!organizationId) {
+    return {
+      ok: false,
+      failure: {
+        error: "no-workspace",
+        message: "No organization workspace is configured, so there are no campaigns to read.",
+        data: { candidates: [], recovery: "Complete organization setup before reading marketing campaigns." },
+      },
+    };
+  }
+
+  const requested = campaignId.trim();
+  if (!requested) {
+    return {
+      ok: false,
+      failure: buildCampaignDrillInRecovery({
+        requestedCampaignId: "",
+        candidates: await listCampaignCandidates(organizationId),
+        toolName,
+      }),
+    };
+  }
+
+  const campaign = await prisma.marketingCampaign.findFirst({
+    where: { campaignId: requested, organizationId },
+    select: { campaignId: true },
+  });
+  if (!campaign) {
+    return {
+      ok: false,
+      failure: buildCampaignDrillInRecovery({
+        requestedCampaignId: requested,
+        candidates: await listCampaignCandidates(organizationId),
+        toolName,
+      }),
+    };
+  }
+
+  return {
+    ok: true,
+    organizationId,
+    campaignId: requested,
+    listCandidates: () => listCampaignCandidates(organizationId),
+  };
 }
 
 export type CreateCampaignInput = {
@@ -132,12 +296,15 @@ export async function updateMarketingCampaign(input: {
       message: `status must be one of: ${CAMPAIGN_STATUSES.join(", ")}.`,
     };
   }
-  const existing = await prisma.marketingCampaign.findUnique({
-    where: { campaignId: input.campaignId },
-    select: { campaignId: true },
-  });
+  const organizationId = await resolveMarketingOrganizationId();
+  const existing = organizationId
+    ? await prisma.marketingCampaign.findFirst({
+        where: { campaignId: input.campaignId, organizationId },
+        select: { campaignId: true },
+      })
+    : null;
   if (!existing) {
-    return { error: "not-found", message: `Campaign ${input.campaignId} does not exist.` };
+    return { error: "not-found", message: `Campaign ${input.campaignId} does not exist in this workspace.` };
   }
 
   await prisma.marketingCampaign.update({
@@ -165,18 +332,22 @@ export async function attachToCampaign(input: {
   if (!briefId && !taskId) {
     return { error: "no-target", message: "Provide a briefId or taskId to attach to the campaign." };
   }
-  const campaign = await prisma.marketingCampaign.findUnique({
-    where: { campaignId },
+  const organizationId = await resolveMarketingOrganizationId();
+  if (!organizationId) {
+    return { error: "no-workspace", message: "No organization workspace is configured." };
+  }
+  const campaign = await prisma.marketingCampaign.findFirst({
+    where: { campaignId, organizationId },
     select: { campaignId: true },
   });
   if (!campaign) {
     const [briefWithThatId, taskWithThatId] = await Promise.all([
-      prisma.marketingCampaignBrief.findUnique({
-        where: { briefId: campaignId },
+      prisma.marketingCampaignBrief.findFirst({
+        where: { briefId: campaignId, organizationId },
         select: { briefId: true },
       }),
-      prisma.marketingAssetTask.findUnique({
-        where: { taskId: campaignId },
+      prisma.marketingAssetTask.findFirst({
+        where: { taskId: campaignId, organizationId },
         select: { taskId: true },
       }),
     ]);
@@ -192,12 +363,12 @@ export async function attachToCampaign(input: {
         message: `The value passed as campaignId looks like a taskId (${campaignId}). Use the MarketingCampaign.campaignId returned by create_marketing_campaign or get_campaign_plan, and pass ${campaignId} as taskId if that is the task to attach.`,
       };
     }
-    return { error: "not-found", message: `Campaign ${campaignId} does not exist.` };
+    return { error: "not-found", message: `Campaign ${campaignId} does not exist in this workspace.` };
   }
 
   if (briefId) {
-    const brief = await prisma.marketingCampaignBrief.findUnique({
-      where: { briefId },
+    const brief = await prisma.marketingCampaignBrief.findFirst({
+      where: { briefId, organizationId },
       select: { briefId: true },
     });
     if (!brief) {
@@ -205,8 +376,8 @@ export async function attachToCampaign(input: {
     }
   }
   if (taskId) {
-    const task = await prisma.marketingAssetTask.findUnique({
-      where: { taskId },
+    const task = await prisma.marketingAssetTask.findFirst({
+      where: { taskId, organizationId },
       select: { taskId: true },
     });
     if (!task) {
@@ -232,18 +403,30 @@ export async function attachToCampaign(input: {
   return { message: `Attached ${attached.join(" and ")} to campaign ${campaignId}.` };
 }
 
+/**
+ * Read a campaign's plan plus its live execution rollup, scoped to the
+ * configured organization. A missing or unknown campaignId returns candidate
+ * IDs and one recovery instruction instead of an opaque miss.
+ */
 export async function getCampaignPlan(
   campaignId: string,
-): Promise<{ message: string; data: Record<string, unknown> } | { error: string; message: string }> {
-  const campaign = await prisma.marketingCampaign.findUnique({
-    where: { campaignId },
+): Promise<{ message: string; data: Record<string, unknown> } | CampaignDrillInFailure> {
+  const scope = await requireCampaignInScope(campaignId, "get_campaign_plan");
+  if (!scope.ok) return scope.failure;
+
+  const campaign = await prisma.marketingCampaign.findFirst({
+    where: { campaignId: scope.campaignId, organizationId: scope.organizationId },
     include: {
       briefs: { select: { briefId: true, title: true, status: true } },
       assetTasks: { select: { taskId: true, title: true, assetType: true, channel: true, status: true } },
     },
   });
   if (!campaign) {
-    return { error: "not-found", message: `Campaign ${campaignId} does not exist.` };
+    return buildCampaignDrillInRecovery({
+      requestedCampaignId: scope.campaignId,
+      candidates: await scope.listCandidates(),
+      toolName: "get_campaign_plan",
+    });
   }
 
   const draftedTaskIds = new Set<string>();

--- a/apps/web/lib/marketing/next-decision.ts
+++ b/apps/web/lib/marketing/next-decision.ts
@@ -10,6 +10,7 @@
 
 import type { MarketingPlaybook } from "@/lib/tak/marketing-playbooks";
 import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import type { MarketingOperatingSnapshot } from "@/lib/marketing/operating-snapshot";
 
 export type MarketingOwnerDecision = {
   id:
@@ -18,7 +19,11 @@ export type MarketingOwnerDecision = {
     | "run-first-review"
     | "create-first-campaign"
     | "choose-proof"
-    | "plan-seasonal";
+    | "plan-seasonal"
+    | "connect-channel"
+    | "produce-assets"
+    | "measure-evidence"
+    | "decide-outcome";
   /** Short, archetype-flavoured decision headline. */
   headline: string;
   /** One line of supporting context. */
@@ -42,15 +47,61 @@ function proofNoun(playbook: MarketingPlaybook): string {
 }
 
 /**
+ * Owner-language phrasing for each canonical next step.
+ *
+ * The canonical next step is decided ONCE, in the operating snapshot, and is
+ * shared with the coworker tools; this table only re-voices it for the owner's
+ * first viewport so the page and the MCP surface can never disagree about what
+ * should happen next. The `href` always comes from the canonical step.
+ */
+const OWNER_DECISION_BY_NEXT_STEP: Record<
+  MarketingOperatingSnapshot["nextStep"]["id"],
+  { id: MarketingOwnerDecision["id"]; ctaLabel: string }
+> = {
+  "review-drafts": { id: "review-drafts", ctaLabel: "Review drafts" },
+  "publish-approved": { id: "publish-approved", ctaLabel: "Go to publish queue" },
+  "connect-channel": { id: "connect-channel", ctaLabel: "Connect a channel" },
+  "run-strategy-review": { id: "run-first-review", ctaLabel: "Start marketing review" },
+  "establish-campaign": { id: "create-first-campaign", ctaLabel: "Plan a campaign" },
+  "produce-assets": { id: "produce-assets", ctaLabel: "See campaign work" },
+  "measure-evidence": { id: "measure-evidence", ctaLabel: "Check results" },
+  "decide-outcome": { id: "decide-outcome", ctaLabel: "Review results" },
+};
+
+/**
  * Compute the single next decision to surface in the first viewport.
- * Priority runs from the most time-sensitive owner action (drafts waiting on
- * them) down to steady-state planning.
+ *
+ * With an operating snapshot the decision is a re-voicing of the canonical next
+ * step. Without one (callers that only hold the workspace snapshot) it falls
+ * back to the original saved-state priority, which runs from the most
+ * time-sensitive owner action (drafts waiting on them) down to steady-state
+ * planning.
  */
 export function buildMarketingOwnerDecision(
   snapshot: MarketingWorkspaceSnapshot,
   playbook: MarketingPlaybook,
+  operating?: MarketingOperatingSnapshot,
 ): MarketingOwnerDecision {
   const metricFocus = playbook.keyMetrics[0] ?? "Customer acquisition";
+
+  if (operating) {
+    const step = operating.nextStep;
+    const voiced = OWNER_DECISION_BY_NEXT_STEP[step.id];
+    // Drafts waiting on the owner keep their archetype-specific phrasing.
+    const headline =
+      step.id === "review-drafts"
+        ? `Review ${count(operating.approvals.pendingDrafts, "draft")} before ${audienceWord(playbook)} see them`
+        : step.headline;
+    return {
+      id: voiced.id,
+      headline,
+      detail: step.detail,
+      ctaLabel: voiced.ctaLabel,
+      ctaHref: step.href,
+      metricFocus,
+    };
+  }
+
   const firstCampaign = playbook.campaignTypes[0] ?? "your first campaign";
   const pending = snapshot.pendingDrafts.length;
   const approved = snapshot.approvedDrafts.length;

--- a/apps/web/lib/marketing/operating-snapshot-load.test.ts
+++ b/apps/web/lib/marketing/operating-snapshot-load.test.ts
@@ -1,0 +1,153 @@
+// Regression: the operating snapshot must not load a second workspace snapshot
+// when the caller already has one (BI-CEA797A1).
+//
+// getMarketingWorkspaceSnapshot() UPSERTS the MarketingStrategy row. The
+// /customer/marketing page originally loaded the workspace snapshot and the
+// operating snapshot concurrently in a Promise.all, and the operating snapshot
+// loaded its own workspace snapshot internally — so two upserts raced on the
+// organizationId unique key against a freshly-seeded database and one lost.
+// That rendered HTTP 500 on /customer/marketing, and under a 2-worker crawl it
+// also knocked over the neighbouring /customer/marketing/automation request,
+// which shares the same upsert but none of this code.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+
+const marketing = vi.hoisted(() => ({ getMarketingWorkspaceSnapshot: vi.fn() }));
+vi.mock("../marketing", () => marketing);
+
+const archetypeContext = vi.hoisted(() => ({ resolveMarketingArchetypeContext: vi.fn() }));
+vi.mock("./archetype-context", () => archetypeContext);
+
+const performance = vi.hoisted(() => ({
+  loadPublicationMetricsForTasks: vi.fn(),
+  metricRowFromSnapshot: vi.fn(),
+}));
+vi.mock("./campaign-performance", () => performance);
+
+const registry = vi.hoisted(() => ({ listAdapters: vi.fn() }));
+vi.mock("./channels/registry", () => registry);
+
+const db = vi.hoisted(() => ({
+  marketingCampaign: { findMany: vi.fn() },
+  scheduledOutboundAction: { groupBy: vi.fn() },
+  marketingKpiCheckpoint: { findFirst: vi.fn() },
+}));
+vi.mock("@dpf/db", () => ({ prisma: db }));
+
+import { getMarketingOperatingSnapshot } from "./operating-snapshot";
+
+function workspace(): MarketingWorkspaceSnapshot {
+  return {
+    organization: { id: "org-1", name: "The Copper Table", website: null, addressSummary: null },
+    storefront: {
+      id: "sf-1",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: null,
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "st-1",
+      status: "active",
+      primaryGoal: null,
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: null,
+      primaryChannels: ["email"],
+      secondaryChannels: [],
+      differentiators: [],
+      reviewCadence: "monthly",
+      lastReviewedAt: null,
+      nextReviewAt: null,
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: null,
+    workProducts: { campaignBriefs: [], assetTasks: [], kpiCheckpoints: [], automationCandidates: [] },
+    pendingDrafts: [],
+    approvedDrafts: [],
+    connectedChannels: [],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  archetypeContext.resolveMarketingArchetypeContext.mockResolvedValue(null);
+  registry.listAdapters.mockReturnValue([]);
+  db.marketingCampaign.findMany.mockResolvedValue([]);
+  db.scheduledOutboundAction.groupBy.mockResolvedValue([]);
+  db.marketingKpiCheckpoint.findFirst.mockResolvedValue(null);
+  performance.loadPublicationMetricsForTasks.mockResolvedValue({
+    byTask: new Map(),
+    draftedTaskIds: new Set(),
+    approvedTaskIds: new Set(),
+    lastPublishedAt: null,
+    lastPolledAt: null,
+  });
+});
+
+describe("getMarketingOperatingSnapshot — workspace snapshot is loaded at most once", () => {
+  it("does NOT load its own workspace snapshot when the caller supplies one", async () => {
+    const snapshot = await getMarketingOperatingSnapshot({ workspace: workspace() });
+
+    expect(marketing.getMarketingWorkspaceSnapshot).not.toHaveBeenCalled();
+    expect(snapshot?.organizationId).toBe("org-1");
+  });
+
+  it("honours an explicitly-null supplied workspace without falling back to a load", async () => {
+    const snapshot = await getMarketingOperatingSnapshot({ workspace: null });
+
+    expect(snapshot).toBeNull();
+    expect(marketing.getMarketingWorkspaceSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("loads exactly one workspace snapshot when the caller supplies none", async () => {
+    marketing.getMarketingWorkspaceSnapshot.mockResolvedValue(workspace());
+
+    await getMarketingOperatingSnapshot();
+
+    expect(marketing.getMarketingWorkspaceSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("still loads one when other options are passed but workspace is omitted", async () => {
+    marketing.getMarketingWorkspaceSnapshot.mockResolvedValue(workspace());
+
+    await getMarketingOperatingSnapshot({ metricsWindowHours: 72 });
+
+    expect(marketing.getMarketingWorkspaceSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null without querying campaigns when there is no workspace at all", async () => {
+    marketing.getMarketingWorkspaceSnapshot.mockResolvedValue(null);
+
+    expect(await getMarketingOperatingSnapshot()).toBeNull();
+    expect(db.marketingCampaign.findMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes campaigns, scheduled actions and checkpoints to the resolved organization", async () => {
+    await getMarketingOperatingSnapshot({ workspace: workspace() });
+
+    for (const call of [
+      db.marketingCampaign.findMany,
+      db.scheduledOutboundAction.groupBy,
+      db.marketingKpiCheckpoint.findFirst,
+    ]) {
+      expect(call).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ organizationId: "org-1" }) }),
+      );
+    }
+  });
+});

--- a/apps/web/lib/marketing/operating-snapshot-projection.test.ts
+++ b/apps/web/lib/marketing/operating-snapshot-projection.test.ts
@@ -1,0 +1,199 @@
+// MCP/UI projection parity for the marketing operating snapshot (BI-CEA797A1).
+//
+// Acceptance requires the coworker tool output and the owner surface to report
+// the SAME state for the same organization. Before this, the owner page derived
+// its first-viewport decision from saved campaign BRIEFS while the MCP tools
+// reported storefront inbox counts — two partial truths that could disagree
+// about whether a campaign even existed. Both now read one projection.
+
+import { describe, expect, it } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import { buildMarketingOwnerDecision } from "./next-decision";
+import {
+  MARKETING_NEXT_STEP_IDS,
+  projectOperatingSnapshotForTools,
+  type MarketingNextStep,
+  type MarketingNextStepId,
+  type MarketingOperatingSnapshot,
+} from "./operating-snapshot";
+
+const NOW = new Date("2026-07-28T12:00:00.000Z");
+
+function workspaceSnapshot(): MarketingWorkspaceSnapshot {
+  return {
+    organization: { id: "org-1", name: "The Copper Table", website: null, addressSummary: "Leeds" },
+    storefront: {
+      id: "sf-1",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: null,
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "st-1",
+      status: "active",
+      primaryGoal: "Fill covers during quiet periods",
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: "Leeds",
+      primaryChannels: ["email"],
+      secondaryChannels: [],
+      differentiators: ["Seasonal menu"],
+      reviewCadence: "monthly",
+      lastReviewedAt: NOW,
+      nextReviewAt: new Date("2026-08-28T12:00:00.000Z"),
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [{ name: "Local diners", description: null }],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [{ type: "testimonial", label: "Five-star reviews" }],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: {
+      reviewType: "ai-proactive",
+      summary: "Focus on midweek covers",
+      createdAt: NOW,
+      suggestedActions: [],
+      recommendation: null,
+    },
+    workProducts: { campaignBriefs: [], assetTasks: [], kpiCheckpoints: [], automationCandidates: [] },
+    pendingDrafts: [],
+    approvedDrafts: [],
+    connectedChannels: ["postmark"],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+}
+
+function operatingSnapshot(nextStep: MarketingNextStep): MarketingOperatingSnapshot {
+  return {
+    organizationId: "org-1",
+    organizationName: "The Copper Table",
+    archetype: { archetypeId: "restaurant", name: "Restaurant", category: "food-hospitality", ctaType: "booking" },
+    strategy: {
+      strategyId: "st-1",
+      status: "active",
+      primaryChannels: ["email"],
+      lastReviewedAt: NOW,
+      nextReviewAt: new Date("2026-08-28T12:00:00.000Z"),
+      hasReview: true,
+      stale: false,
+      staleAreas: [],
+    },
+    campaigns: [],
+    workProducts: { campaignBriefs: 0, assetTasks: 0, kpiCheckpoints: 0, automationCandidates: 0 },
+    approvals: { pendingDrafts: 0, approvedDrafts: 0, scheduledActionsPending: 0, scheduledActionsFailed: 0 },
+    channels: [],
+    evidence: {
+      lastPublishedAt: null,
+      lastMetricsPolledAt: null,
+      lastKpiCheckpointAt: null,
+      lastStrategyReviewAt: NOW,
+      stale: false,
+      staleReasons: [],
+    },
+    blockers: [],
+    nextStep,
+  };
+}
+
+function step(id: MarketingNextStepId, campaignId: string | null = null): MarketingNextStep {
+  return {
+    id,
+    headline: `headline for ${id}`,
+    detail: `detail for ${id}`,
+    campaignId,
+    href: `/customer/marketing#${id}`,
+  };
+}
+
+describe("projectOperatingSnapshotForTools", () => {
+  it("carries campaign identities so the coworker never has to guess a campaignId", () => {
+    const snapshot = operatingSnapshot(step("produce-assets", "cmp-a"));
+    snapshot.campaigns = [
+      {
+        campaignId: "cmp-a",
+        name: "Midweek covers",
+        objective: "Lift midweek bookings",
+        status: "active",
+        channels: ["email"],
+        startDate: null,
+        endDate: null,
+        execution: {
+          briefCount: 1,
+          taskCount: 2,
+          draftedCount: 0,
+          approvedCount: 0,
+          undraftedCount: 2,
+          nextStep: "Draft 2 asset tasks that still need content.",
+        },
+        measurement: {
+          publications: 0,
+          impressions: 0,
+          clicks: 0,
+          conversions: 0,
+          spendCents: 0,
+          lastPublishedAt: null,
+          lastMetricsPolledAt: null,
+          attributionConfidence: "none",
+        },
+      },
+    ];
+
+    const projected = projectOperatingSnapshotForTools(snapshot);
+    const campaigns = projected["campaigns"] as Array<Record<string, unknown>>;
+
+    expect(campaigns).toHaveLength(1);
+    expect(campaigns[0]!["campaignId"]).toBe("cmp-a");
+    expect(campaigns[0]!["nextStep"]).toMatch(/draft 2 asset tasks/i);
+    expect(projected["nextStep"]).toMatchObject({ id: "produce-assets", campaignId: "cmp-a" });
+  });
+
+  it("reports an empty campaign list as an explicit state, not a missing key", () => {
+    const projected = projectOperatingSnapshotForTools(operatingSnapshot(step("establish-campaign")));
+    expect(projected["campaigns"]).toEqual([]);
+    expect(projected).toHaveProperty("blockers");
+    expect(projected).toHaveProperty("evidence");
+    expect(projected).toHaveProperty("channels");
+  });
+});
+
+describe("owner decision and tool projection agree", () => {
+  it("maps every next-step id to exactly one owner decision pointing at the same place", () => {
+    const ws = workspaceSnapshot();
+    const playbook = getPlaybook(ws.storefront.category, ws.storefront.ctaType);
+
+    for (const id of MARKETING_NEXT_STEP_IDS) {
+      const operating = operatingSnapshot(step(id, "cmp-a"));
+      const decision = buildMarketingOwnerDecision(ws, playbook, operating);
+
+      expect(decision.ctaHref).toBe(operating.nextStep.href);
+      expect(decision.headline.length).toBeGreaterThan(0);
+      expect(decision.metricFocus.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the archetype voice — the owner sees covers/bookings, never platform language", () => {
+    const ws = workspaceSnapshot();
+    const playbook = getPlaybook(ws.storefront.category, ws.storefront.ctaType);
+    const decision = buildMarketingOwnerDecision(ws, playbook, operatingSnapshot(step("measure-evidence", "cmp-a")));
+
+    expect(decision.metricFocus.toLowerCase()).toMatch(/covers|booking/);
+    expect(`${decision.headline} ${decision.detail}`.toLowerCase()).not.toMatch(
+      /build studio|saas|campaignid|projection/,
+    );
+  });
+
+  it("still resolves a decision when no operating snapshot is supplied (existing callers)", () => {
+    const ws = workspaceSnapshot();
+    const playbook = getPlaybook(ws.storefront.category, ws.storefront.ctaType);
+    expect(buildMarketingOwnerDecision(ws, playbook).id).toBeTruthy();
+  });
+});

--- a/apps/web/lib/marketing/operating-snapshot.test.ts
+++ b/apps/web/lib/marketing/operating-snapshot.test.ts
@@ -1,0 +1,482 @@
+// Red-green coverage for the canonical marketing operating snapshot (BI-CEA797A1).
+//
+// The live gap this pins down: get_marketing_summary returned storefront inbox
+// counts and a CRM pipeline rollup but NO campaign identities, so the Marketing
+// Strategist never learned a campaignId and fell back to calling
+// get_campaign_plan / get_campaign_performance with empty arguments. These tests
+// cover the pure projection layer — campaign identities, channel readiness,
+// evidence freshness, blockers, and the single next executable step — which both
+// the MCP tools and the owner surface now consume.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assessEvidenceFreshness,
+  buildChannelReadiness,
+  resolveMarketingBlockers,
+  resolveMarketingNextStep,
+  summarizeCampaignMeasurement,
+  type MarketingCampaignIdentity,
+  type MarketingChannelReadiness,
+} from "./operating-snapshot";
+
+const NOW = new Date("2026-07-28T12:00:00.000Z");
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 60 * 60 * 1000);
+
+const ADAPTERS = [
+  {
+    channelId: "linkedin-personal-social",
+    displayName: "LinkedIn (personal)",
+    credentialIntegrationId: "linkedin-personal-social",
+    capabilities: ["draft-preview", "publish-post", "fetch-engagement"] as const,
+  },
+  {
+    channelId: "email-postmark",
+    displayName: "Email (Postmark)",
+    credentialIntegrationId: "postmark",
+    capabilities: ["draft-preview", "send-email", "receive-inbound"] as const,
+  },
+];
+
+function campaign(over: Partial<MarketingCampaignIdentity> = {}): MarketingCampaignIdentity {
+  return {
+    campaignId: "cmp-1",
+    name: "Midweek covers",
+    objective: "Lift midweek bookings",
+    status: "active",
+    channels: ["email"],
+    startDate: null,
+    endDate: null,
+    execution: {
+      briefCount: 1,
+      taskCount: 2,
+      draftedCount: 0,
+      approvedCount: 0,
+      undraftedCount: 0,
+      nextStep: "All asset tasks are produced — set KPI targets and measure.",
+    },
+    measurement: {
+      publications: 0,
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+      spendCents: 0,
+      lastPublishedAt: null,
+      lastMetricsPolledAt: null,
+      attributionConfidence: "none",
+    },
+    ...over,
+  };
+}
+
+function readiness(over: Partial<MarketingChannelReadiness> = {}): MarketingChannelReadiness {
+  return {
+    channelId: "email-postmark",
+    displayName: "Email (Postmark)",
+    credentialIntegrationId: "postmark",
+    connected: true,
+    capabilities: ["draft-preview", "send-email"],
+    unsupported: [],
+    blocker: null,
+    ...over,
+  };
+}
+
+describe("buildChannelReadiness — honest capability advertisement", () => {
+  it("marks a channel connected when its credential integration is connected", () => {
+    const rows = buildChannelReadiness({
+      adapters: ADAPTERS,
+      connectedIntegrationIds: ["linkedin-personal-social"],
+    });
+    const linkedin = rows.find((r) => r.channelId === "linkedin-personal-social");
+    const email = rows.find((r) => r.channelId === "email-postmark");
+
+    expect(linkedin?.connected).toBe(true);
+    expect(linkedin?.blocker).toBeNull();
+    expect(email?.connected).toBe(false);
+    expect(email?.blocker).toMatch(/connect/i);
+  });
+
+  it("advertises contractual operations the adapter does not implement rather than failing silently", () => {
+    const rows = buildChannelReadiness({
+      adapters: ADAPTERS,
+      connectedIntegrationIds: ["linkedin-personal-social", "postmark"],
+    });
+    const linkedin = rows.find((r) => r.channelId === "linkedin-personal-social");
+    const email = rows.find((r) => r.channelId === "email-postmark");
+
+    // LinkedIn personal publishes and reports engagement but cannot receive inbound.
+    expect(linkedin?.unsupported).toContain("receive-inbound");
+    expect(linkedin?.unsupported).not.toContain("fetch-engagement");
+    // Postmark receives inbound but reports no engagement metrics.
+    expect(email?.unsupported).toContain("fetch-engagement");
+    expect(email?.unsupported).not.toContain("receive-inbound");
+  });
+
+  it("never reports a capability the adapter did not register", () => {
+    const rows = buildChannelReadiness({
+      adapters: [{ ...ADAPTERS[0]!, capabilities: ["draft-preview"] as const }],
+      connectedIntegrationIds: ["linkedin-personal-social"],
+    });
+    expect(rows[0]!.capabilities).toEqual(["draft-preview"]);
+    expect(rows[0]!.unsupported).toEqual(
+      expect.arrayContaining(["publish-post", "fetch-engagement", "receive-inbound"]),
+    );
+  });
+});
+
+describe("summarizeCampaignMeasurement — measured evidence, no invention", () => {
+  it("returns a zeroed summary with no attribution confidence when nothing is published", () => {
+    const m = summarizeCampaignMeasurement({ rows: [], trackedLinkCount: 0 });
+    expect(m.publications).toBe(0);
+    expect(m.impressions).toBe(0);
+    expect(m.attributionConfidence).toBe("none");
+    expect(m.lastPublishedAt).toBeNull();
+  });
+
+  it("aggregates published metrics and reports 'reported' confidence without tracked links", () => {
+    const m = summarizeCampaignMeasurement({
+      rows: [
+        {
+          channel: "email",
+          impressions: 400,
+          clicks: 40,
+          conversions: 4,
+          costInUsdCents: 0,
+          publishedAt: hoursAgo(30),
+          metricsPolledAt: hoursAgo(2),
+        },
+        {
+          channel: "linkedin",
+          impressions: 600,
+          clicks: 20,
+          conversions: 1,
+          costInUsdCents: 5000,
+          publishedAt: hoursAgo(10),
+          metricsPolledAt: hoursAgo(1),
+        },
+      ],
+      trackedLinkCount: 0,
+    });
+    expect(m.publications).toBe(2);
+    expect(m.impressions).toBe(1000);
+    expect(m.clicks).toBe(60);
+    expect(m.conversions).toBe(5);
+    expect(m.spendCents).toBe(5000);
+    expect(m.lastPublishedAt).toEqual(hoursAgo(10));
+    expect(m.lastMetricsPolledAt).toEqual(hoursAgo(1));
+    expect(m.attributionConfidence).toBe("reported");
+  });
+
+  it("upgrades to 'linked' confidence only when tracked links back the conversions", () => {
+    const m = summarizeCampaignMeasurement({
+      rows: [
+        {
+          channel: "email",
+          impressions: 100,
+          clicks: 10,
+          conversions: 2,
+          costInUsdCents: 0,
+          publishedAt: hoursAgo(5),
+          metricsPolledAt: hoursAgo(1),
+        },
+      ],
+      trackedLinkCount: 1,
+    });
+    expect(m.attributionConfidence).toBe("linked");
+  });
+});
+
+describe("assessEvidenceFreshness — stale is a first-class state", () => {
+  it("is not stale when nothing has been published yet", () => {
+    const f = assessEvidenceFreshness({
+      now: NOW,
+      publications: 0,
+      lastPublishedAt: null,
+      lastMetricsPolledAt: null,
+      lastKpiCheckpointAt: null,
+      lastStrategyReviewAt: hoursAgo(5),
+    });
+    expect(f.stale).toBe(false);
+    expect(f.staleReasons).toEqual([]);
+  });
+
+  it("is stale when work is published but measurement was never pulled", () => {
+    const f = assessEvidenceFreshness({
+      now: NOW,
+      publications: 3,
+      lastPublishedAt: hoursAgo(50),
+      lastMetricsPolledAt: null,
+      lastKpiCheckpointAt: null,
+      lastStrategyReviewAt: hoursAgo(5),
+    });
+    expect(f.stale).toBe(true);
+    expect(f.staleReasons.join(" ")).toMatch(/never pulled|no channel kpis/i);
+  });
+
+  it("is stale when the last metrics pull is older than the configured window", () => {
+    const f = assessEvidenceFreshness({
+      now: NOW,
+      publications: 1,
+      lastPublishedAt: hoursAgo(80),
+      lastMetricsPolledAt: hoursAgo(70),
+      lastKpiCheckpointAt: null,
+      lastStrategyReviewAt: hoursAgo(5),
+      metricsWindowHours: 24,
+    });
+    expect(f.stale).toBe(true);
+  });
+
+  it("is fresh when metrics were pulled inside the window", () => {
+    const f = assessEvidenceFreshness({
+      now: NOW,
+      publications: 1,
+      lastPublishedAt: hoursAgo(30),
+      lastMetricsPolledAt: hoursAgo(2),
+      lastKpiCheckpointAt: hoursAgo(2),
+      lastStrategyReviewAt: hoursAgo(5),
+      metricsWindowHours: 24,
+    });
+    expect(f.stale).toBe(false);
+    expect(f.staleReasons).toEqual([]);
+  });
+
+  it("treats the freshness window as configurable, not a hardcoded marketing rule", () => {
+    const args = {
+      now: NOW,
+      publications: 1,
+      lastPublishedAt: hoursAgo(80),
+      lastMetricsPolledAt: hoursAgo(30),
+      lastKpiCheckpointAt: null,
+      lastStrategyReviewAt: hoursAgo(5),
+    };
+    expect(assessEvidenceFreshness({ ...args, metricsWindowHours: 24 }).stale).toBe(true);
+    expect(assessEvidenceFreshness({ ...args, metricsWindowHours: 72 }).stale).toBe(false);
+  });
+});
+
+describe("resolveMarketingBlockers — each blocker carries one recovery action", () => {
+  it("reports no connected channel as a blocker with a concrete recovery", () => {
+    const blockers = resolveMarketingBlockers({
+      channels: [readiness({ connected: false, blocker: "Connect Email (Postmark) to publish on this channel." })],
+      hasStrategyReview: true,
+      strategyStale: false,
+      campaigns: [campaign()],
+      pendingDraftCount: 0,
+      approvedDraftCount: 1,
+      evidence: assessEvidenceFreshness({
+        now: NOW,
+        publications: 0,
+        lastPublishedAt: null,
+        lastMetricsPolledAt: null,
+        lastKpiCheckpointAt: null,
+        lastStrategyReviewAt: hoursAgo(2),
+      }),
+    });
+    const channelBlocker = blockers.find((b) => b.id === "no-connected-channel");
+    expect(channelBlocker?.severity).toBe("blocked");
+    expect(channelBlocker?.recovery).toBeTruthy();
+  });
+
+  it("reports pending approval as waiting, not blocked", () => {
+    const blockers = resolveMarketingBlockers({
+      channels: [readiness()],
+      hasStrategyReview: true,
+      strategyStale: false,
+      campaigns: [campaign()],
+      pendingDraftCount: 2,
+      approvedDraftCount: 0,
+      evidence: assessEvidenceFreshness({
+        now: NOW,
+        publications: 0,
+        lastPublishedAt: null,
+        lastMetricsPolledAt: null,
+        lastKpiCheckpointAt: null,
+        lastStrategyReviewAt: hoursAgo(2),
+      }),
+    });
+    const approval = blockers.find((b) => b.id === "awaiting-approval");
+    expect(approval?.severity).toBe("waiting");
+  });
+
+  it("returns no blockers on a healthy, measured workspace", () => {
+    const blockers = resolveMarketingBlockers({
+      channels: [readiness()],
+      hasStrategyReview: true,
+      strategyStale: false,
+      campaigns: [
+        campaign({
+          measurement: {
+            publications: 2,
+            impressions: 500,
+            clicks: 50,
+            conversions: 5,
+            spendCents: 0,
+            lastPublishedAt: hoursAgo(20),
+            lastMetricsPolledAt: hoursAgo(1),
+            attributionConfidence: "linked",
+          },
+        }),
+      ],
+      pendingDraftCount: 0,
+      approvedDraftCount: 0,
+      evidence: assessEvidenceFreshness({
+        now: NOW,
+        publications: 2,
+        lastPublishedAt: hoursAgo(20),
+        lastMetricsPolledAt: hoursAgo(1),
+        lastKpiCheckpointAt: hoursAgo(1),
+        lastStrategyReviewAt: hoursAgo(2),
+      }),
+    });
+    expect(blockers).toEqual([]);
+  });
+});
+
+describe("resolveMarketingNextStep — exactly one next executable step", () => {
+  const freshEvidence = assessEvidenceFreshness({
+    now: NOW,
+    publications: 0,
+    lastPublishedAt: null,
+    lastMetricsPolledAt: null,
+    lastKpiCheckpointAt: null,
+    lastStrategyReviewAt: hoursAgo(2),
+  });
+
+  const base = {
+    channels: [readiness()],
+    hasStrategyReview: true,
+    strategyStale: false,
+    campaigns: [campaign()],
+    pendingDraftCount: 0,
+    approvedDraftCount: 0,
+    evidence: freshEvidence,
+  };
+
+  it("puts drafts awaiting the owner ahead of everything else", () => {
+    const step = resolveMarketingNextStep({ ...base, pendingDraftCount: 3 });
+    expect(step.id).toBe("review-drafts");
+    expect(step.headline).toMatch(/3/);
+  });
+
+  it("routes approved drafts to publish when a channel is connected", () => {
+    const step = resolveMarketingNextStep({ ...base, approvedDraftCount: 2 });
+    expect(step.id).toBe("publish-approved");
+  });
+
+  it("routes approved drafts to channel connection when nothing is connected", () => {
+    const step = resolveMarketingNextStep({
+      ...base,
+      approvedDraftCount: 2,
+      channels: [readiness({ connected: false })],
+    });
+    expect(step.id).toBe("connect-channel");
+  });
+
+  it("asks for a strategy review before a campaign when none has run", () => {
+    const step = resolveMarketingNextStep({ ...base, hasStrategyReview: false, campaigns: [] });
+    expect(step.id).toBe("run-strategy-review");
+  });
+
+  it("asks to establish a campaign when the strategy is set but no campaign exists", () => {
+    const step = resolveMarketingNextStep({ ...base, campaigns: [] });
+    expect(step.id).toBe("establish-campaign");
+    expect(step.campaignId).toBeNull();
+  });
+
+  it("names the campaign that still has undrafted asset work", () => {
+    const step = resolveMarketingNextStep({
+      ...base,
+      campaigns: [
+        campaign({ campaignId: "cmp-done" }),
+        campaign({
+          campaignId: "cmp-open",
+          execution: {
+            briefCount: 1,
+            taskCount: 3,
+            draftedCount: 0,
+            approvedCount: 0,
+            undraftedCount: 3,
+            nextStep: "Draft 3 asset tasks that still need content.",
+          },
+        }),
+      ],
+    });
+    expect(step.id).toBe("produce-assets");
+    expect(step.campaignId).toBe("cmp-open");
+  });
+
+  it("asks for measurement when published work has no fresh evidence", () => {
+    const staleEvidence = assessEvidenceFreshness({
+      now: NOW,
+      publications: 2,
+      lastPublishedAt: hoursAgo(60),
+      lastMetricsPolledAt: null,
+      lastKpiCheckpointAt: null,
+      lastStrategyReviewAt: hoursAgo(2),
+    });
+    const step = resolveMarketingNextStep({
+      ...base,
+      campaigns: [
+        campaign({
+          measurement: {
+            publications: 2,
+            impressions: 0,
+            clicks: 0,
+            conversions: 0,
+            spendCents: 0,
+            lastPublishedAt: hoursAgo(60),
+            lastMetricsPolledAt: null,
+            attributionConfidence: "none",
+          },
+        }),
+      ],
+      evidence: staleEvidence,
+    });
+    expect(step.id).toBe("measure-evidence");
+    expect(step.campaignId).toBe("cmp-1");
+  });
+
+  it("asks for an outcome decision once fresh measured evidence exists", () => {
+    const measured = assessEvidenceFreshness({
+      now: NOW,
+      publications: 2,
+      lastPublishedAt: hoursAgo(20),
+      lastMetricsPolledAt: hoursAgo(1),
+      lastKpiCheckpointAt: hoursAgo(1),
+      lastStrategyReviewAt: hoursAgo(2),
+    });
+    const step = resolveMarketingNextStep({
+      ...base,
+      campaigns: [
+        campaign({
+          measurement: {
+            publications: 2,
+            impressions: 900,
+            clicks: 90,
+            conversions: 9,
+            spendCents: 1000,
+            lastPublishedAt: hoursAgo(20),
+            lastMetricsPolledAt: hoursAgo(1),
+            attributionConfidence: "linked",
+          },
+        }),
+      ],
+      evidence: measured,
+    });
+    expect(step.id).toBe("decide-outcome");
+    expect(step.campaignId).toBe("cmp-1");
+  });
+
+  it("always returns a routable href and non-empty copy", () => {
+    for (const step of [
+      resolveMarketingNextStep({ ...base, pendingDraftCount: 1 }),
+      resolveMarketingNextStep({ ...base, campaigns: [] }),
+      resolveMarketingNextStep(base),
+    ]) {
+      expect(step.href.startsWith("/customer/marketing")).toBe(true);
+      expect(step.headline.length).toBeGreaterThan(0);
+      expect(step.detail.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/lib/marketing/operating-snapshot.ts
+++ b/apps/web/lib/marketing/operating-snapshot.ts
@@ -33,7 +33,6 @@ import {
 import { loadPublicationMetricsForTasks, type PublicationMetricRow } from "./campaign-performance";
 import type { ChannelCapability } from "./channels/contracts";
 import { listAdapters } from "./channels/registry";
-import { resolveMarketingOrganizationId } from "./org-scope";
 
 // ─── Channel readiness ──────────────────────────────────────────────────────
 

--- a/apps/web/lib/marketing/operating-snapshot.ts
+++ b/apps/web/lib/marketing/operating-snapshot.ts
@@ -1,0 +1,722 @@
+// The canonical marketing operating snapshot.
+//
+// Marketing already had the architecture — strategy, campaigns, briefs, tasks,
+// variants, drafts, approvals, publications, scheduled actions, KPI checkpoints,
+// channel adapters. What it did not have was one place that assembled the
+// DECISION CONTEXT. getMarketingWorkspaceSnapshot() (../marketing) served the
+// owner surface with strategy + work products and knew nothing about
+// MarketingCampaign rows; get_marketing_summary independently reconstructed a
+// different partial truth (storefront inbox + CRM pipeline) and returned no
+// campaign identities at all — which is why the Marketing Strategist repeatedly
+// called get_campaign_plan with empty arguments and failed.
+//
+// This module composes the workspace snapshot rather than replacing it, and
+// layers on the execution/measurement/readiness view both surfaces need. Pure
+// builders are exported separately from the single DB assembler so the decision
+// logic is unit-testable without a database.
+//
+// Scope note: the recurring operating CYCLE (the blocked/wait/prepare/
+// approval-needed/measure/iterate reducer and its scheduler) is a separate
+// deliverable and is deliberately NOT built here — this module gives that
+// reducer the state it will read. Evidence SUFFICIENCY for declaring a
+// winner/loser is likewise separate; `attributionConfidence` and `stale` state
+// what the data can honestly support, not whether a decision may be made.
+
+import { prisma } from "@dpf/db";
+
+import { getMarketingWorkspaceSnapshot } from "../marketing";
+import { resolveMarketingArchetypeContext, type MarketingArchetype } from "./archetype-context";
+import {
+  summarizeCampaignExecution,
+  type CampaignExecutionRollup,
+} from "./campaigns";
+import { loadPublicationMetricsForTasks, type PublicationMetricRow } from "./campaign-performance";
+import type { ChannelCapability } from "./channels/contracts";
+import { listAdapters } from "./channels/registry";
+import { resolveMarketingOrganizationId } from "./org-scope";
+
+// ─── Channel readiness ──────────────────────────────────────────────────────
+
+/**
+ * The operations a marketing channel adapter can contractually be asked for.
+ * An adapter that does not register one of these must advertise it as
+ * unsupported rather than failing silently at call time (AGENTS.md §2).
+ * `draft-preview` is excluded — it is a local capability every adapter has.
+ */
+export const MARKETING_CHANNEL_CONTRACT_OPERATIONS = [
+  "publish-post",
+  "send-email",
+  "place-ad",
+  "fetch-engagement",
+  "receive-inbound",
+] as const satisfies ReadonlyArray<ChannelCapability>;
+
+export type MarketingChannelReadiness = {
+  channelId: string;
+  displayName: string;
+  credentialIntegrationId: string;
+  connected: boolean;
+  capabilities: ChannelCapability[];
+  /** Contractual operations this adapter does not implement. */
+  unsupported: ChannelCapability[];
+  /** One recovery line when the channel cannot be used yet; null when ready. */
+  blocker: string | null;
+};
+
+type AdapterLike = {
+  channelId: string;
+  displayName: string;
+  credentialIntegrationId: string;
+  capabilities: ReadonlyArray<ChannelCapability>;
+};
+
+/** Pure: project registered adapters + connected credentials into readiness rows. */
+export function buildChannelReadiness(input: {
+  adapters: ReadonlyArray<AdapterLike>;
+  connectedIntegrationIds: ReadonlyArray<string>;
+}): MarketingChannelReadiness[] {
+  const connected = new Set(input.connectedIntegrationIds);
+  return input.adapters.map((adapter) => {
+    const capabilities = [...adapter.capabilities];
+    const declared = new Set<string>(capabilities);
+    const unsupported = MARKETING_CHANNEL_CONTRACT_OPERATIONS.filter((op) => !declared.has(op));
+    const isConnected =
+      connected.has(adapter.credentialIntegrationId) || connected.has(adapter.channelId);
+    return {
+      channelId: adapter.channelId,
+      displayName: adapter.displayName,
+      credentialIntegrationId: adapter.credentialIntegrationId,
+      connected: isConnected,
+      capabilities,
+      unsupported: [...unsupported],
+      blocker: isConnected
+        ? null
+        : `Connect ${adapter.displayName} before anything can be published on this channel.`,
+    };
+  });
+}
+
+// ─── Campaign measurement ───────────────────────────────────────────────────
+
+export type CampaignMeasurementSummary = {
+  publications: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  spendCents: number;
+  lastPublishedAt: Date | null;
+  lastMetricsPolledAt: Date | null;
+  /**
+   * How far the numbers can honestly be trusted:
+   *   none     — nothing measured yet
+   *   reported — the channel reported engagement, but nothing ties a conversion
+   *              back to this campaign
+   *   linked   — tracked links carry the campaign through to the destination
+   */
+  attributionConfidence: "none" | "reported" | "linked";
+};
+
+/** Pure: roll measured publication rows up to one campaign-level summary. */
+export function summarizeCampaignMeasurement(input: {
+  rows: ReadonlyArray<PublicationMetricRow>;
+  trackedLinkCount: number;
+}): CampaignMeasurementSummary {
+  const nonNegative = (value: number) => (Number.isFinite(value) ? Math.max(0, value) : 0);
+  let impressions = 0;
+  let clicks = 0;
+  let conversions = 0;
+  let spendCents = 0;
+  let lastPublishedAt: Date | null = null;
+  let lastMetricsPolledAt: Date | null = null;
+
+  for (const row of input.rows) {
+    impressions += nonNegative(row.impressions);
+    clicks += nonNegative(row.clicks);
+    conversions += nonNegative(row.conversions);
+    spendCents += nonNegative(row.costInUsdCents);
+    if (row.publishedAt && (!lastPublishedAt || row.publishedAt > lastPublishedAt)) {
+      lastPublishedAt = row.publishedAt;
+    }
+    if (row.metricsPolledAt && (!lastMetricsPolledAt || row.metricsPolledAt > lastMetricsPolledAt)) {
+      lastMetricsPolledAt = row.metricsPolledAt;
+    }
+  }
+
+  const publications = input.rows.length;
+  const attributionConfidence: CampaignMeasurementSummary["attributionConfidence"] =
+    publications === 0 ? "none" : input.trackedLinkCount > 0 ? "linked" : "reported";
+
+  return {
+    publications,
+    impressions,
+    clicks,
+    conversions,
+    spendCents,
+    lastPublishedAt,
+    lastMetricsPolledAt,
+    attributionConfidence,
+  };
+}
+
+// ─── Evidence freshness ─────────────────────────────────────────────────────
+
+/**
+ * Default window after which a channel metrics pull is considered stale.
+ * This is a DATA-FRESHNESS default, not a marketing decision rule: how much
+ * evidence is enough to call a winner is objective- and channel-specific and is
+ * decided elsewhere. Callers may override it per channel/objective.
+ */
+export const DEFAULT_METRICS_WINDOW_HOURS = 24;
+
+export type MarketingEvidenceFreshness = {
+  lastPublishedAt: Date | null;
+  lastMetricsPolledAt: Date | null;
+  lastKpiCheckpointAt: Date | null;
+  lastStrategyReviewAt: Date | null;
+  stale: boolean;
+  staleReasons: string[];
+};
+
+/** Pure: decide whether measured evidence can be trusted right now. */
+export function assessEvidenceFreshness(input: {
+  now: Date;
+  publications: number;
+  lastPublishedAt: Date | null;
+  lastMetricsPolledAt: Date | null;
+  lastKpiCheckpointAt: Date | null;
+  lastStrategyReviewAt: Date | null;
+  metricsWindowHours?: number;
+}): MarketingEvidenceFreshness {
+  const windowHours = input.metricsWindowHours ?? DEFAULT_METRICS_WINDOW_HOURS;
+  const staleReasons: string[] = [];
+
+  if (input.publications > 0) {
+    if (!input.lastMetricsPolledAt) {
+      staleReasons.push(
+        `${input.publications} publication${input.publications === 1 ? "" : "s"} but channel KPIs were never pulled — run refresh_channel_kpis.`,
+      );
+    } else {
+      const ageHours = (input.now.getTime() - input.lastMetricsPolledAt.getTime()) / 3_600_000;
+      if (ageHours > windowHours) {
+        staleReasons.push(
+          `Channel KPIs were last pulled ${Math.round(ageHours)}h ago, past the ${windowHours}h freshness window.`,
+        );
+      }
+    }
+  }
+
+  return {
+    lastPublishedAt: input.lastPublishedAt,
+    lastMetricsPolledAt: input.lastMetricsPolledAt,
+    lastKpiCheckpointAt: input.lastKpiCheckpointAt,
+    lastStrategyReviewAt: input.lastStrategyReviewAt,
+    stale: staleReasons.length > 0,
+    staleReasons,
+  };
+}
+
+// ─── Campaign identity ──────────────────────────────────────────────────────
+
+export type MarketingCampaignIdentity = {
+  campaignId: string;
+  name: string;
+  objective: string;
+  status: string;
+  channels: string[];
+  startDate: Date | null;
+  endDate: Date | null;
+  execution: CampaignExecutionRollup;
+  measurement: CampaignMeasurementSummary;
+};
+
+// ─── Blockers ───────────────────────────────────────────────────────────────
+
+export type MarketingBlocker = {
+  id:
+    | "no-connected-channel"
+    | "channel-unsupported"
+    | "no-strategy-review"
+    | "no-campaign"
+    | "awaiting-approval"
+    | "stale-evidence";
+  /** `blocked` cannot progress without the recovery; `waiting` is a healthy pause. */
+  severity: "blocked" | "waiting";
+  summary: string;
+  /** Exactly one recovery action. */
+  recovery: string;
+  campaignId: string | null;
+};
+
+type DecisionInput = {
+  channels: MarketingChannelReadiness[];
+  hasStrategyReview: boolean;
+  strategyStale: boolean;
+  campaigns: MarketingCampaignIdentity[];
+  pendingDraftCount: number;
+  approvedDraftCount: number;
+  evidence: MarketingEvidenceFreshness;
+};
+
+function hasConnectedChannel(channels: MarketingChannelReadiness[]): boolean {
+  return channels.some((channel) => channel.connected);
+}
+
+function totalPublications(campaigns: MarketingCampaignIdentity[]): number {
+  return campaigns.reduce((acc, c) => acc + c.measurement.publications, 0);
+}
+
+/** Pure: every state that stops or pauses the loop, each with one recovery action. */
+export function resolveMarketingBlockers(input: DecisionInput): MarketingBlocker[] {
+  const blockers: MarketingBlocker[] = [];
+  const connected = hasConnectedChannel(input.channels);
+
+  // Only a blocker once there is something that would actually go out.
+  if (!connected && (input.approvedDraftCount > 0 || input.campaigns.length > 0)) {
+    const first = input.channels[0];
+    blockers.push({
+      id: "no-connected-channel",
+      severity: "blocked",
+      summary: "No marketing channel is connected, so approved work cannot be published.",
+      recovery: first
+        ? `Connect ${first.displayName} at /platform/tools/integrations/${first.credentialIntegrationId}.`
+        : "Connect a marketing channel integration before publishing.",
+      campaignId: null,
+    });
+  }
+
+  if (!input.hasStrategyReview || input.strategyStale) {
+    blockers.push({
+      id: "no-strategy-review",
+      severity: "waiting",
+      summary: input.hasStrategyReview
+        ? "The saved marketing strategy is past its review cadence."
+        : "No marketing strategy review has been recorded yet.",
+      recovery: "Ask the Marketing Strategist for a strategy review so campaigns target a decided goal.",
+      campaignId: null,
+    });
+  }
+
+  if (input.campaigns.length === 0) {
+    blockers.push({
+      id: "no-campaign",
+      severity: "waiting",
+      summary: "No marketing campaign exists, so there is nothing to execute or measure.",
+      recovery: "Establish one bounded campaign with create_marketing_campaign.",
+      campaignId: null,
+    });
+  }
+
+  if (input.pendingDraftCount > 0) {
+    blockers.push({
+      id: "awaiting-approval",
+      severity: "waiting",
+      summary: `${input.pendingDraftCount} draft${input.pendingDraftCount === 1 ? "" : "s"} are waiting on the owner's approval.`,
+      recovery: "Review the approval queue — nothing publishes until it is approved.",
+      campaignId: null,
+    });
+  }
+
+  if (input.evidence.stale) {
+    blockers.push({
+      id: "stale-evidence",
+      severity: "blocked",
+      summary: input.evidence.staleReasons[0] ?? "Measured evidence is stale.",
+      recovery: "Run refresh_channel_kpis to pull current channel metrics before deciding anything.",
+      campaignId: null,
+    });
+  }
+
+  for (const channel of input.channels) {
+    if (channel.connected && channel.unsupported.includes("fetch-engagement")) {
+      blockers.push({
+        id: "channel-unsupported",
+        severity: "waiting",
+        summary: `${channel.displayName} cannot report engagement metrics, so its results stay unmeasured.`,
+        recovery: `Attribute ${channel.displayName} results with tracked links (build_tracked_links) instead of channel metrics.`,
+        campaignId: null,
+      });
+    }
+  }
+
+  return blockers;
+}
+
+// ─── One next executable step ───────────────────────────────────────────────
+
+export const MARKETING_NEXT_STEP_IDS = [
+  "review-drafts",
+  "publish-approved",
+  "connect-channel",
+  "run-strategy-review",
+  "establish-campaign",
+  "produce-assets",
+  "measure-evidence",
+  "decide-outcome",
+] as const;
+
+export type MarketingNextStepId = (typeof MARKETING_NEXT_STEP_IDS)[number];
+
+export type MarketingNextStep = {
+  id: MarketingNextStepId;
+  headline: string;
+  detail: string;
+  /** The campaign the step applies to, when it is campaign-specific. */
+  campaignId: string | null;
+  href: string;
+};
+
+const MARKETING_ROOT = "/customer/marketing";
+
+/**
+ * Pure: the single most useful next executable step.
+ *
+ * Priority is owner-first: work waiting on a human decision outranks anything
+ * the platform could do on its own, so the owner is never asked to plan while
+ * their approval queue is full. Everything below that is ordered by what
+ * unblocks the loop soonest.
+ */
+export function resolveMarketingNextStep(input: DecisionInput): MarketingNextStep {
+  const connected = hasConnectedChannel(input.channels);
+
+  if (input.pendingDraftCount > 0) {
+    const n = input.pendingDraftCount;
+    return {
+      id: "review-drafts",
+      headline: `Review ${n} draft${n === 1 ? "" : "s"} waiting on you`,
+      detail: "Copy is ready for your approval. Nothing goes out until you approve it.",
+      campaignId: null,
+      href: `${MARKETING_ROOT}#marketing-approval-queue`,
+    };
+  }
+
+  if (input.approvedDraftCount > 0) {
+    const n = input.approvedDraftCount;
+    if (!connected) {
+      return {
+        id: "connect-channel",
+        headline: `Connect a channel to publish ${n} approved post${n === 1 ? "" : "s"}`,
+        detail: "Approved copy is ready but no channel is connected to send it on.",
+        campaignId: null,
+        href: `${MARKETING_ROOT}/automation`,
+      };
+    }
+    return {
+      id: "publish-approved",
+      headline: `Publish ${n} approved post${n === 1 ? "" : "s"}`,
+      detail: "Each publish is one explicit action — you stay in control of what goes live.",
+      campaignId: null,
+      href: `${MARKETING_ROOT}#marketing-publish-queue`,
+    };
+  }
+
+  if (!input.hasStrategyReview || input.strategyStale) {
+    return {
+      id: "run-strategy-review",
+      headline: "Decide what to grow first",
+      detail: "Run a strategy review so the next campaign targets a decided goal.",
+      campaignId: null,
+      href: `${MARKETING_ROOT}/strategy`,
+    };
+  }
+
+  if (input.campaigns.length === 0) {
+    return {
+      id: "establish-campaign",
+      headline: "Turn the plan into one bounded campaign",
+      detail: "There is a strategy but no campaign yet — establish one so work can be tracked and measured.",
+      campaignId: null,
+      href: `${MARKETING_ROOT}/campaigns`,
+    };
+  }
+
+  const unfinished = input.campaigns.find((c) => c.execution.undraftedCount > 0);
+  if (unfinished) {
+    const n = unfinished.execution.undraftedCount;
+    return {
+      id: "produce-assets",
+      headline: `Draft ${n} asset${n === 1 ? "" : "s"} for "${unfinished.name}"`,
+      detail: unfinished.execution.nextStep,
+      campaignId: unfinished.campaignId,
+      href: `${MARKETING_ROOT}/campaigns`,
+    };
+  }
+
+  const measured = input.campaigns.find((c) => c.measurement.publications > 0);
+  if (measured) {
+    if (input.evidence.stale) {
+      return {
+        id: "measure-evidence",
+        headline: `Pull current results for "${measured.name}"`,
+        detail: input.evidence.staleReasons[0] ?? "Published work has no fresh measurement yet.",
+        campaignId: measured.campaignId,
+        href: `${MARKETING_ROOT}/funnel`,
+      };
+    }
+    return {
+      id: "decide-outcome",
+      headline: `Decide what to do with "${measured.name}"`,
+      detail:
+        `${measured.measurement.clicks} clicks and ${measured.measurement.conversions} conversions are measured` +
+        ` (${measured.measurement.attributionConfidence} attribution) — continue, stop, or iterate.`,
+      campaignId: measured.campaignId,
+      href: `${MARKETING_ROOT}/funnel`,
+    };
+  }
+
+  if (!connected) {
+    const first = input.channels[0];
+    return {
+      id: "connect-channel",
+      headline: `Connect ${first ? first.displayName : "a marketing channel"} to start publishing`,
+      detail: "The campaign is prepared but has no connected channel to reach anyone on.",
+      campaignId: input.campaigns[0]?.campaignId ?? null,
+      href: `${MARKETING_ROOT}/automation`,
+    };
+  }
+
+  const first = input.campaigns[0]!;
+  return {
+    id: "produce-assets",
+    headline: `Keep "${first.name}" moving`,
+    detail: first.execution.nextStep,
+    campaignId: first.campaignId,
+    href: `${MARKETING_ROOT}/campaigns`,
+  };
+}
+
+// ─── The snapshot ───────────────────────────────────────────────────────────
+
+export type MarketingOperatingSnapshot = {
+  organizationId: string;
+  organizationName: string;
+  archetype: MarketingArchetype | null;
+  strategy: {
+    strategyId: string;
+    status: string;
+    primaryChannels: string[];
+    lastReviewedAt: Date | null;
+    nextReviewAt: Date | null;
+    hasReview: boolean;
+    stale: boolean;
+    staleAreas: string[];
+  };
+  campaigns: MarketingCampaignIdentity[];
+  workProducts: {
+    campaignBriefs: number;
+    assetTasks: number;
+    kpiCheckpoints: number;
+    automationCandidates: number;
+  };
+  approvals: {
+    pendingDrafts: number;
+    approvedDrafts: number;
+    scheduledActionsPending: number;
+    scheduledActionsFailed: number;
+  };
+  channels: MarketingChannelReadiness[];
+  evidence: MarketingEvidenceFreshness;
+  blockers: MarketingBlocker[];
+  nextStep: MarketingNextStep;
+};
+
+/**
+ * The MCP-facing projection. Deliberately narrower than the full snapshot: the
+ * coworker needs identities, state, and one next step — not every field the
+ * owner page renders. Both surfaces derive from the same snapshot, so what a
+ * tool reports and what the page shows cannot drift apart.
+ */
+export function projectOperatingSnapshotForTools(
+  snapshot: MarketingOperatingSnapshot,
+): Record<string, unknown> {
+  return {
+    organizationId: snapshot.organizationId,
+    archetype: snapshot.archetype,
+    strategy: {
+      strategyId: snapshot.strategy.strategyId,
+      status: snapshot.strategy.status,
+      primaryChannels: snapshot.strategy.primaryChannels,
+      hasReview: snapshot.strategy.hasReview,
+      stale: snapshot.strategy.stale,
+      staleAreas: snapshot.strategy.staleAreas,
+      nextReviewAt: snapshot.strategy.nextReviewAt,
+    },
+    campaigns: snapshot.campaigns.map((campaign) => ({
+      campaignId: campaign.campaignId,
+      name: campaign.name,
+      objective: campaign.objective,
+      status: campaign.status,
+      channels: campaign.channels,
+      briefCount: campaign.execution.briefCount,
+      taskCount: campaign.execution.taskCount,
+      undraftedCount: campaign.execution.undraftedCount,
+      awaitingApprovalCount: campaign.execution.draftedCount,
+      approvedCount: campaign.execution.approvedCount,
+      nextStep: campaign.execution.nextStep,
+      measurement: campaign.measurement,
+    })),
+    workProducts: snapshot.workProducts,
+    approvals: snapshot.approvals,
+    channels: snapshot.channels,
+    evidence: snapshot.evidence,
+    blockers: snapshot.blockers,
+    nextStep: snapshot.nextStep,
+  };
+}
+
+/** The campaign shape the assembler selects. Declared locally so the projection
+ *  stays typed without importing Prisma's generated row types. */
+type CampaignRow = {
+  campaignId: string;
+  name: string;
+  objective: string;
+  status: string;
+  channels: string[];
+  startDate: Date | null;
+  endDate: Date | null;
+  briefs: Array<{ briefId: string; status: string }>;
+  assetTasks: Array<{ taskId: string; status: string }>;
+};
+
+/**
+ * Assemble the operating snapshot for the configured organization.
+ * Returns null when the install has no organization workspace yet.
+ */
+export async function getMarketingOperatingSnapshot(options?: {
+  now?: Date;
+  metricsWindowHours?: number;
+}): Promise<MarketingOperatingSnapshot | null> {
+  const workspace = await getMarketingWorkspaceSnapshot();
+  if (!workspace) return null;
+
+  const organizationId = workspace.organization.id;
+  const now = options?.now ?? new Date();
+
+  const [archetypeContext, campaignRows, scheduledActions, latestCheckpoint] = await Promise.all([
+    resolveMarketingArchetypeContext(),
+    prisma.marketingCampaign.findMany({
+      where: { organizationId },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+      select: {
+        campaignId: true,
+        name: true,
+        objective: true,
+        status: true,
+        channels: true,
+        startDate: true,
+        endDate: true,
+        briefs: { select: { briefId: true, status: true } },
+        assetTasks: { select: { taskId: true, status: true } },
+      },
+    }),
+    prisma.scheduledOutboundAction.groupBy({
+      by: ["status"],
+      where: { organizationId },
+      _count: true,
+    }),
+    prisma.marketingKpiCheckpoint.findFirst({
+      where: { organizationId },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true },
+    }),
+  ]);
+
+  // One batched walk over every campaign's tasks → drafts → publications,
+  // shared with getCampaignPerformance so the two cannot disagree.
+  const rows_ = campaignRows as CampaignRow[];
+  const allTaskIds = rows_.flatMap((c) => c.assetTasks.map((t) => t.taskId));
+  const metrics = await loadPublicationMetricsForTasks(allTaskIds);
+
+  const campaigns: MarketingCampaignIdentity[] = rows_.map((row) => {
+    const taskIds = row.assetTasks.map((t) => t.taskId);
+    const rows: PublicationMetricRow[] = [];
+    let trackedLinkCount = 0;
+    for (const taskId of taskIds) {
+      const forTask = metrics.byTask.get(taskId);
+      if (!forTask) continue;
+      rows.push(...forTask);
+      trackedLinkCount += forTask.filter((r) => r.trackedLink).length;
+    }
+    return {
+      campaignId: row.campaignId,
+      name: row.name,
+      objective: row.objective,
+      status: row.status,
+      channels: row.channels,
+      startDate: row.startDate,
+      endDate: row.endDate,
+      execution: summarizeCampaignExecution({
+        briefs: row.briefs,
+        tasks: row.assetTasks,
+        draftedTaskIds: metrics.draftedTaskIds,
+        approvedTaskIds: metrics.approvedTaskIds,
+      }),
+      measurement: summarizeCampaignMeasurement({ rows, trackedLinkCount }),
+    };
+  });
+
+  const channels = buildChannelReadiness({
+    adapters: listAdapters(),
+    connectedIntegrationIds: workspace.connectedChannels,
+  });
+
+  const evidence = assessEvidenceFreshness({
+    now,
+    publications: totalPublications(campaigns),
+    lastPublishedAt: metrics.lastPublishedAt,
+    lastMetricsPolledAt: metrics.lastPolledAt,
+    lastKpiCheckpointAt: latestCheckpoint?.createdAt ?? null,
+    lastStrategyReviewAt: workspace.latestReview?.createdAt ?? null,
+    metricsWindowHours: options?.metricsWindowHours,
+  });
+
+  const strategyStale = workspace.staleAreas.some((area) => area.toLowerCase().includes("review"));
+  const decisionInput: DecisionInput = {
+    channels,
+    hasStrategyReview: Boolean(workspace.latestReview),
+    strategyStale,
+    campaigns,
+    pendingDraftCount: workspace.pendingDrafts.length,
+    approvedDraftCount: workspace.approvedDrafts.length,
+    evidence,
+  };
+
+  const scheduledByStatus = new Map<string, number>(
+    (scheduledActions as Array<{ status: string; _count: number }>).map(
+      (row) => [row.status, row._count] as const,
+    ),
+  );
+
+  return {
+    organizationId,
+    organizationName: workspace.organization.name,
+    archetype: archetypeContext?.archetype ?? null,
+    strategy: {
+      strategyId: workspace.strategy.strategyId,
+      status: workspace.strategy.status,
+      primaryChannels: workspace.strategy.primaryChannels,
+      lastReviewedAt: workspace.strategy.lastReviewedAt,
+      nextReviewAt: workspace.strategy.nextReviewAt,
+      hasReview: Boolean(workspace.latestReview),
+      stale: strategyStale,
+      staleAreas: workspace.staleAreas,
+    },
+    campaigns,
+    workProducts: {
+      campaignBriefs: workspace.workProducts.campaignBriefs.length,
+      assetTasks: workspace.workProducts.assetTasks.length,
+      kpiCheckpoints: workspace.workProducts.kpiCheckpoints.length,
+      automationCandidates: workspace.workProducts.automationCandidates.length,
+    },
+    approvals: {
+      pendingDrafts: workspace.pendingDrafts.length,
+      approvedDrafts: workspace.approvedDrafts.length,
+      scheduledActionsPending: scheduledByStatus.get("pending") ?? 0,
+      scheduledActionsFailed: scheduledByStatus.get("failed") ?? 0,
+    },
+    channels,
+    evidence,
+    blockers: resolveMarketingBlockers(decisionInput),
+    nextStep: resolveMarketingNextStep(decisionInput),
+  };
+}

--- a/apps/web/lib/marketing/operating-snapshot.ts
+++ b/apps/web/lib/marketing/operating-snapshot.ts
@@ -24,7 +24,7 @@
 
 import { prisma } from "@dpf/db";
 
-import { getMarketingWorkspaceSnapshot } from "../marketing";
+import { getMarketingWorkspaceSnapshot, type MarketingWorkspaceSnapshot } from "../marketing";
 import { resolveMarketingArchetypeContext, type MarketingArchetype } from "./archetype-context";
 import {
   summarizeCampaignExecution,
@@ -582,10 +582,20 @@ type CampaignRow = {
  * Returns null when the install has no organization workspace yet.
  */
 export async function getMarketingOperatingSnapshot(options?: {
+  /**
+   * An already-loaded workspace snapshot. Pass this when the caller has one:
+   * getMarketingWorkspaceSnapshot() UPSERTS the MarketingStrategy row, so
+   * loading it twice concurrently (e.g. both halves of a Promise.all) races two
+   * inserts on the organizationId unique key and one of them fails. Callers that
+   * already hold the workspace snapshot must hand it over rather than letting
+   * this function load a second one.
+   */
+  workspace?: MarketingWorkspaceSnapshot | null;
   now?: Date;
   metricsWindowHours?: number;
 }): Promise<MarketingOperatingSnapshot | null> {
-  const workspace = await getMarketingWorkspaceSnapshot();
+  const workspace =
+    options && "workspace" in options ? options.workspace : await getMarketingWorkspaceSnapshot();
   if (!workspace) return null;
 
   const organizationId = workspace.organization.id;

--- a/apps/web/lib/marketing/org-scope.ts
+++ b/apps/web/lib/marketing/org-scope.ts
@@ -1,0 +1,26 @@
+// Marketing organization scope resolution.
+//
+// Every marketing read/drill-in must resolve WHICH organization it is answering
+// for before it touches a campaign, publication, or checkpoint row. Campaign
+// drill-ins previously resolved a campaign with a bare findUnique on campaignId,
+// so a campaign belonging to another organization was readable by id.
+//
+// The ordering here (oldest organization first) deliberately mirrors
+// getMarketingWorkspaceSnapshot in ../marketing so the workspace snapshot, the
+// operating snapshot, and the campaign drill-ins all agree on the same
+// organization. Resolve through this helper rather than re-inlining the query —
+// a second ordering rule would silently split the read model in two.
+
+import { prisma } from "@dpf/db";
+
+/**
+ * The organization whose marketing workspace this install answers for, or null
+ * when the install has not been set up yet.
+ */
+export async function resolveMarketingOrganizationId(): Promise<string | null> {
+  const organization = await prisma.organization.findFirst({
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  return organization?.id ?? null;
+}

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -31,7 +31,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "get_marketing_summary",
     description:
-      "Read the whole marketing operating picture in one call: active campaigns with their ids, execution state and measured results; connected-channel readiness and any operation a channel cannot support; evidence freshness; what is blocked and how to recover; and the single next executable step — alongside storefront inbox counts, CRM pipeline, and the playbook for this business type. Start here: this is usually enough on its own, and it returns the campaign ids that get_campaign_plan and get_campaign_performance require.",
+      "Start here for the whole marketing picture: campaigns with ids, next step, channel readiness, evidence freshness, blockers, inbox, pipeline, playbook.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -30,7 +30,8 @@ import type { ToolPack, ToolPackHandler } from "../tool-pack";
 const definitions: ToolDefinition[] = [
   {
     name: "get_marketing_summary",
-    description: "Get archetype-aware marketing metrics: storefront inbox counts, CRM pipeline summary, and the marketing playbook for this business type",
+    description:
+      "Read the whole marketing operating picture in one call: active campaigns with their ids, execution state and measured results; connected-channel readiness and any operation a channel cannot support; evidence freshness; what is blocked and how to recover; and the single next executable step — alongside storefront inbox counts, CRM pipeline, and the playbook for this business type. Start here: this is usually enough on its own, and it returns the campaign ids that get_campaign_plan and get_campaign_performance require.",
     inputSchema: {
       type: "object",
       properties: {
@@ -268,57 +269,67 @@ const definitions: ToolDefinition[] = [
 ];
 
 async function getMarketingSummaryHandler(params: Record<string, unknown>): Promise<ToolResult> {
-  const { getPlaybook } = await import("@/lib/tak/marketing-playbooks");
+  const { resolveMarketingArchetypeContext, MARKETING_NO_STOREFRONT_MESSAGE } = await import(
+    "@/lib/marketing/archetype-context"
+  );
   const days = typeof params["days"] === "number" ? params["days"] : 30;
-  const since = new Date();
-  since.setDate(since.getDate() - days);
 
-  const config = await prisma.storefrontConfig.findFirst({
-    include: { archetype: { select: { archetypeId: true, name: true, category: true, ctaType: true } } },
-  });
-
-  if (!config) {
-    return { success: true, message: "No storefront configured. Set up your storefront first at /storefront/setup." };
+  const context = await resolveMarketingArchetypeContext();
+  if (!context) {
+    return { success: true, message: MARKETING_NO_STOREFRONT_MESSAGE };
   }
+  const { archetype, playbook, storefrontId } = context;
 
-  const playbook = getPlaybook(config.archetype.category, config.archetype.ctaType);
+  // The operating snapshot is the canonical decision context — campaign
+  // identities, channel readiness, evidence freshness, blockers, and one next
+  // executable step. Without it this summary reported inbox counts and no way
+  // to name a campaign, which is what drove empty get_campaign_plan calls.
+  const { getMarketingOperatingSnapshot, projectOperatingSnapshotForTools } = await import(
+    "@/lib/marketing/operating-snapshot"
+  );
+  const { loadAcquisitionSignals } = await import("@/lib/marketing/acquisition-signals");
 
-  const [bookings, inquiries, orders, donations, engagements, opportunities] = await Promise.all([
-    prisma.storefrontBooking.count({ where: { storefrontId: config.id, createdAt: { gte: since } } }),
-    prisma.storefrontInquiry.count({ where: { storefrontId: config.id, createdAt: { gte: since } } }),
-    prisma.storefrontOrder.count({ where: { storefrontId: config.id, createdAt: { gte: since } } }),
-    prisma.storefrontDonation.count({ where: { storefrontId: config.id, createdAt: { gte: since } } }),
-    prisma.engagement.groupBy({ by: ["status"], _count: true }),
-    prisma.opportunity.groupBy({ by: ["stage"], _count: true }),
+  const [operating, signals] = await Promise.all([
+    getMarketingOperatingSnapshot(),
+    loadAcquisitionSignals({ storefrontId, days }),
   ]);
 
+  const projection = operating ? projectOperatingSnapshotForTools(operating) : null;
+  const nextStep = projection?.["nextStep"] as { headline?: string } | undefined;
   return {
     success: true,
-    message: `Marketing summary for ${config.archetype.name} (${config.archetype.ctaType})`,
+    message: nextStep?.headline
+      ? `Marketing summary for ${archetype.name} (${archetype.ctaType}) — next: ${nextStep.headline}`
+      : `Marketing summary for ${archetype.name} (${archetype.ctaType})`,
     data: {
-      archetype: { id: config.archetype.archetypeId, name: config.archetype.name, category: config.archetype.category, ctaType: config.archetype.ctaType },
+      archetype: { id: archetype.archetypeId, name: archetype.name, category: archetype.category, ctaType: archetype.ctaType },
       playbook,
-      inbox: { days, bookings, inquiries, orders, donations, total: bookings + inquiries + orders + donations },
-      pipeline: {
-        engagements: Object.fromEntries(engagements.map((e) => [e.status, e._count])),
-        opportunities: Object.fromEntries(opportunities.map((o) => [o.stage, o._count])),
-      },
+      inbox: signals.inbox,
+      pipeline: signals.pipeline,
+      // Campaign identities and the one next step come from the canonical
+      // snapshot; an install with no workspace yet reports empty, never absent.
+      campaigns: projection?.["campaigns"] ?? [],
+      channels: projection?.["channels"] ?? [],
+      evidence: projection?.["evidence"] ?? null,
+      blockers: projection?.["blockers"] ?? [],
+      nextStep: projection?.["nextStep"] ?? null,
+      strategy: projection?.["strategy"] ?? null,
+      approvals: projection?.["approvals"] ?? null,
     },
   };
 }
 
 async function suggestCampaignIdeasHandler(): Promise<ToolResult> {
-  const { getPlaybook } = await import("@/lib/tak/marketing-playbooks");
+  const { resolveMarketingArchetypeContext, MARKETING_NO_STOREFRONT_MESSAGE } = await import(
+    "@/lib/marketing/archetype-context"
+  );
 
-  const config = await prisma.storefrontConfig.findFirst({
-    include: { archetype: { select: { archetypeId: true, name: true, category: true, ctaType: true } } },
-  });
-
-  if (!config) {
-    return { success: true, message: "No storefront configured. Set up your storefront first at /storefront/setup." };
+  const context = await resolveMarketingArchetypeContext({ includeItems: true, itemLimit: 10 });
+  if (!context) {
+    return { success: true, message: MARKETING_NO_STOREFRONT_MESSAGE };
   }
-
-  const playbook = getPlaybook(config.archetype.category, config.archetype.ctaType);
+  const config = { id: context.storefrontId, archetype: context.archetype };
+  const playbook = context.playbook;
 
   // Current season for seasonal relevance
   const month = new Date().getMonth();
@@ -661,30 +672,26 @@ async function createMarketingAutomationCandidateHandler(
 }
 
 async function analyzeSeoOpportunityHandler(): Promise<ToolResult> {
-  const { getPlaybook } = await import("@/lib/tak/marketing-playbooks");
+  const { resolveMarketingArchetypeContext, MARKETING_NO_STOREFRONT_MESSAGE } = await import(
+    "@/lib/marketing/archetype-context"
+  );
 
-  const config = await prisma.storefrontConfig.findFirst({
-    include: {
-      archetype: { select: { archetypeId: true, name: true, category: true, ctaType: true } },
-      items: {
-        where: { isActive: true },
-        select: { name: true, description: true, ctaType: true },
-        orderBy: { sortOrder: "asc" },
-        take: 20,
-      },
-      sections: {
-        where: { isVisible: true },
-        select: { type: true, title: true },
-        orderBy: { sortOrder: "asc" },
-      },
-    },
+  const context = await resolveMarketingArchetypeContext({
+    includeItems: true,
+    includeSections: true,
+    itemLimit: 20,
   });
-
-  if (!config) {
-    return { success: true, message: "No storefront configured. Set up your storefront first at /storefront/setup." };
+  if (!context) {
+    return { success: true, message: MARKETING_NO_STOREFRONT_MESSAGE };
   }
 
-  const playbook = getPlaybook(config.archetype.category, config.archetype.ctaType);
+  const config = {
+    id: context.storefrontId,
+    archetype: context.archetype,
+    items: context.items,
+    sections: context.sections,
+  };
+  const playbook = context.playbook;
 
   // Get organization location if available
   const org = await prisma.organization.findFirst({

--- a/apps/web/lib/mcp/packs/marketing-pack.test.ts
+++ b/apps/web/lib/mcp/packs/marketing-pack.test.ts
@@ -1,0 +1,107 @@
+// Campaign tool-contract coverage for the marketing pack (BI-CEA797A1).
+//
+// The production failure this pins: repeated get_campaign_plan /
+// get_campaign_performance calls with empty arguments, each answered with an
+// opaque "Campaign  does not exist." The handlers must now forward the
+// structured recovery payload (candidate campaign IDs + one instruction) so the
+// coworker can self-correct instead of retrying blind.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const campaigns = vi.hoisted(() => ({
+  createMarketingCampaign: vi.fn(),
+  updateMarketingCampaign: vi.fn(),
+  attachToCampaign: vi.fn(),
+  getCampaignPlan: vi.fn(),
+}));
+vi.mock("@/lib/marketing/campaigns", () => campaigns);
+
+const performance = vi.hoisted(() => ({ getCampaignPerformance: vi.fn() }));
+vi.mock("@/lib/marketing/campaign-performance", () => performance);
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { marketingPack } from "./marketing-pack";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+
+const RECOVERY = {
+  error: "campaign-id-required" as const,
+  message: "get_campaign_plan needs a campaignId. Open campaigns: cmp-a (Midweek covers).",
+  data: {
+    candidates: [{ campaignId: "cmp-a", name: "Midweek covers", status: "active", nextStep: "Draft 2 asset tasks." }],
+    recovery: "Re-call get_campaign_plan with campaignId set to one of the listed ids.",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("marketing pack — registration invariants", () => {
+  it("definitions and handlers stay in lockstep", () => {
+    expect(Object.keys(marketingPack.handlers).sort()).toEqual(
+      marketingPack.definitions.map((d) => d.name).sort(),
+    );
+    expect(Object.keys(marketingPack.grants).sort()).toEqual(
+      marketingPack.definitions.map((d) => d.name).sort(),
+    );
+  });
+
+  it("read tools require marketing_read and write tools require marketing_write", () => {
+    for (const def of marketingPack.definitions) {
+      const expected = def.sideEffect ? "marketing_write" : "marketing_read";
+      expect(marketingPack.grants[def.name]).toEqual([expected]);
+      expect(isToolAllowedByGrants(def.name, [expected])).toBe(true);
+    }
+  });
+
+  it("descriptions stay provenance-free", () => {
+    for (const def of marketingPack.definitions) {
+      expect(def.description).not.toMatch(/\bBI-|Phase \d|EP-|apps\/web\//);
+    }
+  });
+
+  it("campaign drill-in descriptions tell the caller how to obtain a campaignId", () => {
+    for (const name of ["get_campaign_plan", "get_campaign_performance"]) {
+      const def = marketingPack.definitions.find((d) => d.name === name);
+      expect(def?.description).toMatch(/get_marketing_summary/);
+    }
+  });
+});
+
+describe("get_campaign_plan — actionable empty drill-in", () => {
+  it("forwards the structured recovery payload instead of dropping it", async () => {
+    campaigns.getCampaignPlan.mockResolvedValue(RECOVERY);
+    const res = await marketingPack.handlers.get_campaign_plan!({}, "u1");
+
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("campaign-id-required");
+    expect(res.data).toBeDefined();
+    expect((res.data as { candidates: Array<{ campaignId: string }> }).candidates[0]!.campaignId).toBe("cmp-a");
+    expect((res.data as { recovery: string }).recovery).toMatch(/campaignId/);
+  });
+
+  it("passes a blank campaignId straight through so the service can classify it", async () => {
+    campaigns.getCampaignPlan.mockResolvedValue(RECOVERY);
+    await marketingPack.handlers.get_campaign_plan!({ campaignId: "   " }, "u1");
+    expect(campaigns.getCampaignPlan).toHaveBeenCalledWith("   ");
+  });
+
+  it("returns the plan unchanged on success", async () => {
+    campaigns.getCampaignPlan.mockResolvedValue({ message: "ok", data: { campaign: { campaignId: "cmp-a" } } });
+    const res = await marketingPack.handlers.get_campaign_plan!({ campaignId: "cmp-a" }, "u1");
+    expect(res.success).toBe(true);
+    expect(res.data).toMatchObject({ campaign: { campaignId: "cmp-a" } });
+  });
+});
+
+describe("get_campaign_performance — actionable empty drill-in", () => {
+  it("forwards the structured recovery payload", async () => {
+    performance.getCampaignPerformance.mockResolvedValue({ ...RECOVERY, error: "campaign-not-found" as const });
+    const res = await marketingPack.handlers.get_campaign_performance!({ campaignId: "nope" }, "u1");
+
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("campaign-not-found");
+    expect((res.data as { candidates: unknown[] }).candidates).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/mcp/packs/marketing-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-pack.ts
@@ -107,7 +107,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "get_campaign_plan",
     description:
-      "Read a campaign's full plan (objective, audience, channels, budget, timeline, KPI targets) plus a live execution rollup (brief/task/draft counts and the single most useful next step). Use to report status or decide what to do next on a campaign.",
+      "Read ONE campaign's full plan (objective, audience, channels, budget, timeline, KPI targets) plus a live execution rollup (brief/task/draft counts and the single most useful next step). Requires a campaignId — call get_marketing_summary first for the workspace-level picture and the campaign ids; drill in here only when you need one campaign's detail. Calling without a campaignId returns the candidate ids instead of the plan.",
     inputSchema: {
       type: "object",
       properties: {
@@ -121,7 +121,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "get_campaign_performance",
     description:
-      "Read a campaign's measured cross-channel performance: per-channel and total impressions, clicks, spend, conversions, plus derived CTR / CPC / CPA / conversion rate, spend paced against budget, and attainment against the campaign's KPI targets. Use to report how a running campaign is actually performing and which channel is most efficient. Requires published assets whose channel KPIs have been pulled (refresh_channel_kpis).",
+      "Read ONE campaign's measured cross-channel performance: per-channel and total impressions, clicks, spend, conversions, plus derived CTR / CPC / CPA / conversion rate, spend paced against budget, and attainment against the campaign's KPI targets. Requires a campaignId — get_marketing_summary returns the ids and whether each campaign has measurable evidence yet; calling without a campaignId returns the candidate ids instead of performance. Numbers exist only for published assets whose channel KPIs have been pulled (refresh_channel_kpis).",
     inputSchema: {
       type: "object",
       properties: {
@@ -327,8 +327,11 @@ async function attachToCampaignHandler(params: Record<string, unknown>): Promise
 async function getCampaignPlanHandler(params: Record<string, unknown>): Promise<ToolResult> {
   const { getCampaignPlan } = await import("@/lib/marketing/campaigns");
   const result = await getCampaignPlan(String(params["campaignId"] ?? ""));
+  // A failed drill-in carries candidate campaign IDs and one recovery
+  // instruction — forward the payload so the caller can self-correct instead of
+  // retrying the same empty call.
   if ("error" in result) {
-    return { success: false, error: result.error, message: result.message };
+    return { success: false, error: result.error, message: result.message, data: result.data };
   }
   return { success: true, message: result.message, data: result.data };
 }
@@ -337,7 +340,7 @@ async function getCampaignPerformanceHandler(params: Record<string, unknown>): P
   const { getCampaignPerformance } = await import("@/lib/marketing/campaign-performance");
   const result = await getCampaignPerformance(String(params["campaignId"] ?? ""));
   if ("error" in result) {
-    return { success: false, error: result.error, message: result.message };
+    return { success: false, error: result.error, message: result.message, data: result.data };
   }
   return { success: true, message: result.message, data: result.data };
 }

--- a/apps/web/lib/mcp/packs/marketing-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-pack.ts
@@ -107,7 +107,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "get_campaign_plan",
     description:
-      "Read ONE campaign's full plan (objective, audience, channels, budget, timeline, KPI targets) plus a live execution rollup (brief/task/draft counts and the single most useful next step). Requires a campaignId — call get_marketing_summary first for the workspace-level picture and the campaign ids; drill in here only when you need one campaign's detail. Calling without a campaignId returns the candidate ids instead of the plan.",
+      "Drill into ONE campaign: plan (objective, audience, channels, budget, timeline, KPI targets) plus a live execution rollup and next step. Needs a campaignId from get_marketing_summary; without one, returns the candidate ids.",
     inputSchema: {
       type: "object",
       properties: {
@@ -121,7 +121,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "get_campaign_performance",
     description:
-      "Read ONE campaign's measured cross-channel performance: per-channel and total impressions, clicks, spend, conversions, plus derived CTR / CPC / CPA / conversion rate, spend paced against budget, and attainment against the campaign's KPI targets. Requires a campaignId — get_marketing_summary returns the ids and whether each campaign has measurable evidence yet; calling without a campaignId returns the candidate ids instead of performance. Numbers exist only for published assets whose channel KPIs have been pulled (refresh_channel_kpis).",
+      "Drill into ONE campaign's measured performance: per-channel and total impressions, clicks, spend, conversions, derived CTR / CPC / CPA / conversion rate, spend against budget, and KPI-target attainment. Needs a campaignId from get_marketing_summary, which also says whether a campaign has measurable evidence yet; without one, returns the candidate ids. Numbers exist only after refresh_channel_kpis has pulled published assets.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/marketing-summary-contract.test.ts
+++ b/apps/web/lib/mcp/packs/marketing-summary-contract.test.ts
@@ -1,0 +1,122 @@
+// get_marketing_summary contract coverage (BI-CEA797A1).
+//
+// The live gap: the summary returned storefront inbox counts, a CRM pipeline
+// rollup and the archetype playbook — and nothing about campaigns. The Marketing
+// Strategist therefore had no campaignId to drill into and fell back to empty
+// get_campaign_plan calls. The summary must now project the canonical operating
+// snapshot: campaign identities, channel readiness, evidence freshness, blockers
+// and one next executable step.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const marketing = vi.hoisted(() => ({
+  recordMarketingStrategistReview: vi.fn(),
+  createMarketingCampaignBrief: vi.fn(),
+  createMarketingAssetTask: vi.fn(),
+  createMarketingAutomationCandidate: vi.fn(),
+  recordMarketingKpiCheckpoint: vi.fn(),
+  MARKETING_CHANNELS: ["email", "linkedin"] as const,
+  MARKETING_REVIEW_CADENCE: ["weekly", "monthly"] as const,
+}));
+vi.mock("@/lib/marketing", () => marketing);
+
+const snapshotModule = vi.hoisted(() => ({
+  getMarketingOperatingSnapshot: vi.fn(),
+  projectOperatingSnapshotForTools: vi.fn(),
+}));
+vi.mock("@/lib/marketing/operating-snapshot", () => snapshotModule);
+
+const archetypeContext = vi.hoisted(() => ({
+  resolveMarketingArchetypeContext: vi.fn(),
+  MARKETING_NO_STOREFRONT_MESSAGE: "No storefront configured. Set up your storefront first at /storefront/setup.",
+}));
+vi.mock("@/lib/marketing/archetype-context", () => archetypeContext);
+
+const signals = vi.hoisted(() => ({ loadAcquisitionSignals: vi.fn() }));
+vi.mock("@/lib/marketing/acquisition-signals", () => signals);
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { marketingOpsPack } from "./marketing-ops-pack";
+
+const ARCHETYPE = {
+  storefrontId: "sf-1",
+  archetype: { archetypeId: "restaurant", name: "Restaurant", category: "food-hospitality", ctaType: "booking" },
+  playbook: { keyMetrics: ["Covers"], campaignTypes: ["Midweek offer"], primaryGoal: "Fill covers", stakeholders: "diners", ctaLanguage: ["Reserve a table"] },
+};
+
+const PROJECTION = {
+  organizationId: "org-1",
+  campaigns: [
+    {
+      campaignId: "cmp-a",
+      name: "Midweek covers",
+      status: "active",
+      nextStep: "Draft 2 asset tasks that still need content.",
+    },
+  ],
+  channels: [{ channelId: "email-postmark", connected: true, unsupported: ["fetch-engagement"] }],
+  evidence: { stale: false, staleReasons: [] },
+  blockers: [],
+  nextStep: { id: "produce-assets", headline: "Draft the midweek assets", campaignId: "cmp-a", href: "/customer/marketing/campaigns" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  archetypeContext.resolveMarketingArchetypeContext.mockResolvedValue(ARCHETYPE);
+  snapshotModule.getMarketingOperatingSnapshot.mockResolvedValue({ organizationId: "org-1" });
+  snapshotModule.projectOperatingSnapshotForTools.mockReturnValue(PROJECTION);
+  signals.loadAcquisitionSignals.mockResolvedValue({
+    inbox: { days: 30, bookings: 2, inquiries: 3, orders: 0, donations: 0, total: 5 },
+    pipeline: { engagements: { open: 4 }, opportunities: { qualified: 1 } },
+  });
+});
+
+describe("get_marketing_summary — campaign identities are first-class", () => {
+  it("returns campaign identities with their next step", async () => {
+    const res = await marketingOpsPack.handlers.get_marketing_summary!({}, "u1");
+    expect(res.success).toBe(true);
+
+    const campaigns = (res.data as { campaigns: Array<Record<string, unknown>> }).campaigns;
+    expect(campaigns).toHaveLength(1);
+    expect(campaigns[0]!["campaignId"]).toBe("cmp-a");
+    expect(campaigns[0]!["nextStep"]).toMatch(/draft 2 asset tasks/i);
+  });
+
+  it("returns one next executable step naming the campaign it applies to", async () => {
+    const res = await marketingOpsPack.handlers.get_marketing_summary!({}, "u1");
+    expect(res.data!["nextStep"]).toMatchObject({ id: "produce-assets", campaignId: "cmp-a" });
+  });
+
+  it("surfaces channel readiness and evidence freshness alongside the inbox counts", async () => {
+    const res = await marketingOpsPack.handlers.get_marketing_summary!({}, "u1");
+    expect(res.data).toHaveProperty("channels");
+    expect(res.data).toHaveProperty("evidence");
+    expect(res.data).toHaveProperty("blockers");
+    // Existing consumers keep their keys.
+    expect(res.data).toHaveProperty("inbox");
+    expect(res.data).toHaveProperty("pipeline");
+    expect(res.data).toHaveProperty("playbook");
+    expect(res.data).toHaveProperty("archetype");
+  });
+
+  it("degrades honestly when no storefront is configured", async () => {
+    archetypeContext.resolveMarketingArchetypeContext.mockResolvedValue(null);
+    const res = await marketingOpsPack.handlers.get_marketing_summary!({}, "u1");
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/storefront/i);
+  });
+
+  it("still answers with the archetype context when the operating snapshot is unavailable", async () => {
+    snapshotModule.getMarketingOperatingSnapshot.mockResolvedValue(null);
+    const res = await marketingOpsPack.handlers.get_marketing_summary!({}, "u1");
+    expect(res.success).toBe(true);
+    expect(res.data).toHaveProperty("inbox");
+    expect(res.data!["campaigns"]).toEqual([]);
+  });
+
+  it("tells the coworker in its description that the summary carries campaign ids", () => {
+    const def = marketingOpsPack.definitions.find((d) => d.name === "get_marketing_summary");
+    expect(def?.description).toMatch(/campaign/i);
+  });
+});

--- a/docs/user-guide/customers/marketing.md
+++ b/docs/user-guide/customers/marketing.md
@@ -33,6 +33,36 @@ Avoid opening every advanced panel before making that first decision. The page
 uses progressive disclosure so strategy machinery does not obscure the
 operator's immediate choice.
 
+### The recommendation reflects real campaign state
+
+The recommended next step is derived from one shared reading of the workspace —
+the same reading the **Marketing Strategist** uses when you ask it a question.
+That reading covers your live campaigns and how far each has been executed,
+which drafts are waiting on your approval, which channels are actually
+connected, whether published work has current measurements, and what is
+currently blocked.
+
+Because both the page and the coworker read the same thing, they cannot tell you
+two different stories about where marketing stands. The recommendation moves as
+the workspace moves:
+
+| What the workspace looks like | What you are asked to do next |
+| --- | --- |
+| Drafts are waiting on you | Review them before anything reaches customers |
+| Copy is approved and a channel is connected | Publish it, one explicit action at a time |
+| Copy is approved but no channel is connected | Connect the channel first |
+| No strategy review has run, or it is overdue | Run a strategy review |
+| There is a strategy but no campaign | Establish one bounded campaign |
+| A campaign still has undrafted asset work | Draft the outstanding assets for that campaign |
+| Work is published but its results are stale | Pull current channel results before judging it |
+| Results are current | Decide whether to continue, stop, or change the campaign |
+
+If something is blocking progress, the workspace names it and gives one recovery
+action rather than showing a wall of zeros. A channel that cannot report
+engagement (some can publish but not measure) is stated plainly, so results from
+that channel are attributed with tracked links instead of being silently
+counted as zero.
+
 ## Review Strategy, Assumptions, and Proof
 
 Open **Strategy, assumptions & proof** when the recommendation needs scrutiny.
@@ -154,6 +184,22 @@ record.
 - Inspect the weakest funnel handoff.
 - Keep, revise, or stop the campaign explicitly.
 - Turn repeatable gaps into backlog work instead of leaving them in analysis.
+
+## Asking the Marketing Strategist About a Campaign
+
+Ask for the overall picture first — "how is marketing doing?" or "what should we
+do next?" The strategist reads the whole workspace in one step, including each
+campaign's name, its execution state, and its measured results. That is usually
+enough to answer.
+
+Ask about a specific campaign by name when you want its full plan or its
+detailed performance. The strategist already holds the campaign identities from
+the overall reading, so it does not need you to look anything up. If it ever
+asks about a campaign that is not in your workspace, it is told which campaigns
+do exist and corrects itself rather than reporting an unexplained failure.
+
+Campaign detail is scoped to your organization. A campaign belonging to another
+organization is not readable, even by its exact identifier.
 
 ## What To Watch
 


### PR DESCRIPTION
Implements **Deliverable A** of `docs/superpowers/plans/2026-07-28-marketing-evidence-to-outcome-loop.md`, tracked by **BI-CEA797A1** under **EP-MARKETING**. Deliverables B–D are deliberately out of scope for this PR.

The plan itself lands in #3697 (branch `doc/marketing-evidence-loop-plan`), which is still open — this branch is cut from `origin/main`, so the plan file is not in this diff. Its governed coverage receipt `cms4zgdfk004b01mxv2iq8rr7` was revalidated live before implementation (`check_plan_backlog_coverage` → `valid: true`, `decision: decomposed`, mapping A → BI-CEA797A1).

## The problem, from live state

Marketing was not missing architecture. It was missing one assembly of the decision context, so two partial truths ran side by side:

- `getMarketingWorkspaceSnapshot()` served `/customer/marketing` with strategy and work products and knew **nothing about `MarketingCampaign` rows** — the campaigns page renders campaign *briefs*;
- `get_marketing_summary` independently rebuilt a *different* partial view (storefront inbox + CRM pipeline + playbook) and returned **no campaign identities at all**.

With no `campaignId` anywhere in its reading, the Marketing Strategist called `get_campaign_plan` / `get_campaign_performance` with empty arguments and got back `Campaign  does not exist.` — no candidates, no recovery — so it retried blind. That is the repeated-failure pattern the plan recorded from production on 2026-07-28.

Two further defects surfaced while reading the substrate:

- **Cross-organization read.** `getCampaignPlan`, `getCampaignPerformance`, `updateMarketingCampaign` and `attachToCampaign` all resolved their target with a bare `findUnique` on the id. A campaign belonging to another organization was readable by id.
- **Silent channel gaps.** Channel adapters register capabilities, but nothing projected the *contractual* operations an adapter does not implement, so a channel that can publish but cannot report engagement read as zero results rather than "cannot measure" (AGENTS.md §2, BI-IMP-27126FA9).

## What changed

**One canonical operating snapshot** — `apps/web/lib/marketing/operating-snapshot.ts`. It *composes* the workspace snapshot rather than replacing it, and layers on campaign identities (execution + measurement rollups), channel-adapter readiness, evidence freshness, blockers that each carry exactly one recovery action, and one next executable step. Pure builders are separated from the single DB assembler, so the decision logic is unit-testable without a database.

**MCP and UI cannot disagree.** `projectOperatingSnapshotForTools()` is the coworker-facing view; `buildMarketingOwnerDecision()` re-voices the *same* canonical next step in the owner's archetype vocabulary and always takes its call-to-action link from that step. A parity test walks every next-step id and asserts both surfaces point at the same place.

**Actionable drill-ins.** A blank `campaignId` is classified as "you did not pass one" (never a lookup miss) and returns the candidate campaign ids plus one instruction; an unknown id returns not-found with the same candidates. The pack handlers now forward that payload instead of dropping it. Tool descriptions say where a `campaignId` comes from, and `get_marketing_summary` advertises that it carries them.

**Organization isolation** is expressed once, in the query predicate, via a shared `requireCampaignInScope` resolver — campaign, brief and task lookups all carry an `organizationId`.

## Convergence — the ~20% refactor budget

| Converged | Was |
| --- | --- |
| `resolveMarketingArchetypeContext()` | three duplicated `storefrontConfig` + `getPlaybook` + no-storefront guards in `marketing-ops-pack` |
| `loadPublicationMetricsForTasks()` | the tasks→drafts→publications walk, about to be written a second time; now one batched walk shared by `getCampaignPerformance` and the snapshot, so execution rollup and measured performance cannot drift apart |
| `loadAcquisitionSignals()` | the last raw DB aggregate living inside a tool pack |
| `resolveMarketingOrganizationId()` | ad-hoc org resolution, now matching the workspace snapshot's ordering rule |
| `next-decision.ts` | inferred campaign existence from brief counts |

Extracting `loadAcquisitionSignals` also took `marketing-ops-pack.ts` from 801 back under the 800-LOC ceiling, clearing a `productionModuleHotspotCount 69 → 70` substrate regression this work had introduced.

**Stale tool assumptions removed:** `get_marketing_summary`'s description claimed only "inbox counts, CRM pipeline summary, and the marketing playbook"; the campaign drill-in descriptions never said where a `campaignId` comes from.

## Scope discipline

No new warehouse, workflow engine, experiment framework, dashboard, navigation layer, route or tab. **No Prisma model and no migration** — the existing relations carry everything Deliverable A needs. No new MCP tools; the tool surface count is unchanged.

Evidence-*sufficiency* thresholds for declaring a winner (Deliverable C) and the recurring operating cycle reducer (Deliverable B) are deliberately **not** built here — this PR produces the state those deliverables will read. The one time-based default introduced (`DEFAULT_METRICS_WINDOW_HOURS`) is a *data-freshness* default, is caller-overridable, and is documented as not being a marketing decision rule.

**No autonomous production behaviour is claimed.** Reliable scheduled execution still depends on the provider-routing repair tracked in **BI-8058697C**, which is not resolved.

## Verification

Written test-first; the initial run was red on 18 assertions plus 2 missing modules before any implementation existed.

- **279 tests passing across 31 marketing/MCP suites**, in the topic worktree (source-local gate): `operating-snapshot` (pure builders, channel readiness, evidence freshness, blockers, next step), `campaign-scope` (organization isolation + recovery classification), `operating-snapshot-projection` (MCP/UI parity), `marketing-pack` / `marketing-summary-contract` (tool contracts, registry, grants, description hygiene), `acquisition-signals`.
- **Repo guards**: module-size ratchet OK; substrate-regression guard OK (was failing on the hotspot introduced mid-work, then fixed); doc-links and doc-reference-integrity OK; `doc-index.generated.json` regenerated for the two new doc headings.
### Runtime-bound gates

Typecheck, production build and the full suite cannot run in a topic worktree here: the root clone has no `next` or `@dpf/db` installed, so a full `tsc` reports ~5,180 module-resolution errors across files this branch never touches. That is harness, not product. Filtered to this branch's own files, `tsc` reports zero non-resolution errors.

`pnpm run pregate` was attempted four times against the governed shared local-CI convergence sandbox; three concurrent Codex sessions held the single `local-integration-ci` lease throughout. Attempt 2 acquired it and reached `Compiled successfully in 34.6s` before the lease was fenced mid-typecheck. **CI on this PR is therefore the authoritative gate, and it is fully green: 35 checks, 0 failing, 0 pending, 0 unresolved review threads.**

### Two real defects CI caught, both fixed here

CI earned its keep — neither of these was visible from unit tests:

1. **`/customer/marketing` returned HTTP 500**, and took `/customer/marketing/automation` down with it — a route importing none of this branch's code. Cause: `getMarketingWorkspaceSnapshot()` UPSERTS the `MarketingStrategy` row, and the page loaded the workspace snapshot and the operating snapshot *concurrently* in a `Promise.all` while the operating snapshot loaded its own workspace snapshot internally. Against a freshly-seeded database both upserts attempted the insert and one lost on the `organizationId` unique key; with the sweep running two workers, the neighbouring route's upsert lost the same race. Fixed by threading the already-loaded workspace snapshot through, so one render performs one upsert. Pinned by a regression test. The sweep now measures **201/201 routes** and `/customer/marketing` reports `ok: true` with zero regressions.

2. **`/platform/audit/authority` regressed by 91 words.** That page renders every tool's description, and this branch had lengthened exactly three of them. Real, and mine. The descriptions were rewritten to carry the same load-bearing facts in fewer words — **net −8 words against `main`**, down from +91 — which is the right shape anyway given tool definitions are a finite-budget resource against the ~24,576-token local served window (AGENTS.md §8).

A separately-noted latent issue, **not** fixed here: the upsert inside `getMarketingWorkspaceSnapshot()` is inherently racy across concurrent requests on a cold workspace. This PR removes the self-inflicted double call; hardening that upsert is pre-existing and beyond this deliverable.

Known pre-existing and unrelated: `check-no-provider-local-connector-lifecycle` fails identically on clean `origin/main` (guard-runtime TypeScript isolation), and `build-docs-staleness --check` is out of date on clean `origin/main` too — regenerating it produced 38 unrelated deletions, so it was deliberately left alone.

## Design grounding

- **Existing specs/plans reviewed:**
  - `docs/superpowers/plans/2026-07-28-marketing-evidence-to-outcome-loop.md` (Deliverable A; on #3697)
  - `docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md`
  - `docs/superpowers/specs/2026-06-26-marketing-coworker-campaign-parity.md`
  - `docs/superpowers/plans/2026-07-22-restaurant-marketing-owner-first-disclosure.md`
- **Code substrate reviewed:** `apps/web/lib/marketing.ts`; `apps/web/lib/marketing/{campaigns,campaign-performance,next-decision,disclosure,subroutes,variants}.ts`; `apps/web/lib/marketing/channels/{contracts,registry}.ts`; `apps/web/lib/mcp/packs/{marketing-pack,marketing-ops-pack}.ts`; the `/customer/marketing` route family.
- **Decision:** module placement was scored through the kernel — `principle_decide` recommended *compose a new module over the existing snapshot* (ledger `DI-8F8855465E2E`, composite 17.91, margin 6.43, high confidence, no commandment conflict) over widening `marketing.ts` in place or assembling inside the tool pack.
- **Source of truth:** the canonical marketing operating snapshot. `/customer/marketing` remains the only route family; the owner-first disclosure delivered in #3414 is preserved.

## UX fit

Scored through the kernel: `revoice-canonical-step` (ledger `DI-ACFFEC2EA720`, composite 14.42, margin 5.10, high confidence, no commandment conflict) over adding a second always-visible state band or leaving the page inconsistent with the coworker.

The first viewport keeps exactly one owner question, one recommended next step, one primary action — the budget is unchanged. What improves is honesty: the recommendation can now distinguish *no campaign* from *campaign running but unmeasured* from *channel not connected* from *results ready to judge*, and blocked states name one recovery action instead of showing a wall of zeros. No new component family, tile, tab or route.

## Documentation

`docs/user-guide/customers/marketing.md` — what drives the recommendation and how it moves with workspace state, blocker/recovery behaviour, honest reporting for channels that publish but cannot measure, how to ask the strategist about a campaign, and that campaign detail is organization-scoped.

Local-CI-Override: shared local-integration-ci sandbox saturated by concurrent sessions across four attempts; production build confirmed green in attempt 2 before lease fencing; full CI on this PR is green (35 checks, 0 failing).
Design-Grounding-Decision: reviewed docs/superpowers/plans/2026-07-28-marketing-evidence-to-outcome-loop.md and docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md against code substrate apps/web/lib/marketing/ and apps/web/lib/mcp/packs/marketing-ops-pack.ts; extends the existing marketing read model, adds no parallel substrate.
UX-Fit-Decision: revoice-canonical-step - one owner decision, one action, first-viewport budget unchanged (principle_decide DI-ACFFEC2EA720, composite 14.42, margin 5.10, high confidence, no commandment conflict).
Process-Spine-Decision: implements Deliverable A of the governed plan under receipt cms4zgdfk004b01mxv2iq8rr7; docs/user-guide/customers/marketing.md updated in this branch.
Docs-Impact-Decision: docs/user-guide/customers/marketing.md updated - recommendation states, blocker/recovery behaviour, unsupported-channel honesty, and how to ask the strategist about a campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
