### PR TITLE
feat: separate Operations and business Performance

### DIFF
--- a/apps/web/app/(shell)/performance/layout.test.tsx
+++ b/apps/web/app/(shell)/performance/layout.test.tsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const { mockAuth, mockNotFound } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockNotFound: vi.fn(() => {
+    throw new Error("not-found");
+  }),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
+vi.mock("next/navigation", () => ({ notFound: mockNotFound }));
+
+import PerformanceLayout from "./layout";
+
+describe("PerformanceLayout", () => {
+  beforeEach(() => {
+    mockAuth.mockReset();
+    mockNotFound.mockClear();
+  });
+
+  it("server-denies a workforce member", async () => {
+    mockAuth.mockResolvedValue({
+      user: { platformRole: "HR-600", isSuperuser: false },
+    });
+
+    await expect(
+      PerformanceLayout({ children: <p>Private performance</p> }),
+    ).rejects.toThrow("not-found");
+    expect(mockNotFound).toHaveBeenCalledOnce();
+  });
+
+  it("renders for an authorized owner", async () => {
+    mockAuth.mockResolvedValue({
+      user: { platformRole: "HR-000", isSuperuser: false },
+    });
+
+    const result = await PerformanceLayout({
+      children: <p>Private performance</p>,
+    });
+
+    expect(renderToStaticMarkup(result)).toContain("Private performance");
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(shell)/performance/layout.tsx
+++ b/apps/web/app/(shell)/performance/layout.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+
+export default async function PerformanceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  const user = session?.user;
+
+  if (
+    !user ||
+    !can(
+      {
+        platformRole: user.platformRole,
+        isSuperuser: user.isSuperuser,
+      },
+      "view_business_performance",
+    )
+  ) {
+    notFound();
+  }
+
+  return children;
+}

--- a/apps/web/app/(shell)/performance/loading.test.tsx
+++ b/apps/web/app/(shell)/performance/loading.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import PerformanceLoading from "./loading";
+
+describe("PerformanceLoading", () => {
+  it("uses the shared skeleton grammar with an accessible page-level label", () => {
+    const html = renderToStaticMarkup(<PerformanceLoading />);
+
+    expect(html).toContain('aria-label="Loading business performance"');
+    expect(html).toContain('aria-label="Loading metrics"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).not.toContain("border-t-transparent");
+  });
+});

--- a/apps/web/app/(shell)/performance/loading.tsx
+++ b/apps/web/app/(shell)/performance/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/report-kit";
+
+export default function PerformanceLoading() {
+  return (
+    <main
+      className="mx-auto max-w-7xl space-y-6 p-4 sm:p-6"
+      aria-label="Loading business performance"
+    >
+      <header className="space-y-3">
+        <Skeleton width={180} height={24} />
+        <Skeleton width="min(42rem, 100%)" lines={2} />
+      </header>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4" aria-label="Loading metrics">
+        {Array.from({ length: 4 }, (_, index) => (
+          <Skeleton key={index} height={112} rounded="lg" />
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/(shell)/performance/page.test.tsx
+++ b/apps/web/app/(shell)/performance/page.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import PerformancePage, { metadata } from "./page";
+
+describe("PerformancePage", () => {
+  it("states its owner/manager purpose and renders a truthful setup state", async () => {
+    const html = renderToStaticMarkup(await PerformancePage());
+
+    expect(metadata.title).toBe("Performance");
+    expect(html).toContain(">Performance<");
+    expect(html).toContain("Review how the business is doing over time.");
+    expect(html).toContain("Connect a source to see performance");
+    expect(html).toContain("We will not show made-up numbers.");
+    expect(html).toContain('href="/workspace"');
+    expect(html).toContain("data-dpf-lead");
+    expect(html).toContain("data-owner-first-next-action");
+    expect(html).toContain("data-dpf-primary-action");
+    expect(html).not.toContain(">0<");
+  });
+
+  it("does not add a second primary or local navigation component", async () => {
+    const html = renderToStaticMarkup(await PerformancePage());
+
+    expect(html).not.toContain("<nav");
+    expect(html).not.toContain("data-component=\"app-rail\"");
+  });
+});

--- a/apps/web/app/(shell)/performance/page.tsx
+++ b/apps/web/app/(shell)/performance/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { EmptyState } from "@/components/ui/report-kit";
+import { loadBusinessPerformance } from "@/lib/performance/business-performance-provider";
+
+export const metadata: Metadata = {
+  title: "Performance",
+  description: "Business results, trends, and operating drivers for owners and managers.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function PerformancePage() {
+  const performance = await loadBusinessPerformance();
+
+  return (
+    <main
+      className="mx-auto max-w-7xl space-y-6 p-4 sm:p-6"
+      data-component="business-performance-home"
+      data-source={performance.source}
+    >
+      <header className="space-y-1" data-dpf-lead>
+        <h1 className="text-xl font-semibold text-[var(--dpf-text)]">Performance</h1>
+        <p className="max-w-3xl text-sm text-[var(--dpf-text-secondary)]">
+          Review how the business is doing over time.
+        </p>
+      </header>
+
+      <EmptyState
+        title="Connect a source to see performance"
+        description="No history source is connected. We will not show made-up numbers."
+        action={
+          <Link
+            href="/workspace"
+            data-dpf-primary-action
+            data-owner-first-next-action
+            className="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            Open Operations
+          </Link>
+        }
+      />
+    </main>
+  );
+}

--- a/apps/web/components/shell/AppRail.test.tsx
+++ b/apps/web/components/shell/AppRail.test.tsx
@@ -31,17 +31,27 @@ const sections: ShellNavSection[] = [
   {
     key: "workspace",
     label: "Workspace",
-    description: "Your queue, recents, and AI-guided next steps.",
+    description: "Current business work and authorized owner/manager performance.",
     items: [
       {
         key: "workspace",
-        label: "Workspace",
+        label: "Operations",
         href: "/workspace",
-        description: "See what needs attention next.",
+        description: "See the current business state and next action.",
         sectionKey: "workspace",
         capabilityKey: null,
         orgCapabilityKey: null,
         audienceModes: ["worker", "operator"],
+      },
+      {
+        key: "performance",
+        label: "Performance",
+        href: "/performance",
+        description: "Understand business results and trends.",
+        sectionKey: "workspace",
+        capabilityKey: "view_business_performance",
+        orgCapabilityKey: null,
+        audienceModes: ["operator"],
       },
     ],
   },
@@ -80,6 +90,8 @@ describe("AppRail", () => {
     const html = renderToStaticMarkup(<AppRail sections={sections} />);
 
     expect(html).toContain(">Workspace<");
+    expect(html).toContain(">Operations<");
+    expect(html).toContain(">Performance<");
     expect(html).toContain(">Business<");
     expect(html).toContain(">Finance<");
     expect(html).toContain(">Compliance<");
@@ -90,7 +102,7 @@ describe("AppRail", () => {
     pathname = "/finance";
     const html = renderToStaticMarkup(<AppRail sections={sections} />);
 
-    expect(html).not.toContain("See what needs attention next.");
+    expect(html).not.toContain("See the current business state and next action.");
     expect(html).not.toContain("Cashflow, receivables, payables, and close.");
     expect(html).not.toContain("Controls, risk, obligations, and posture.");
   });
@@ -107,6 +119,17 @@ describe("AppRail", () => {
     expect(html).not.toContain("overflow-x-auto");
     expect(html).not.toContain("min-w-max");
     expect(html).toContain("grid min-w-0 gap-3");
+    expect(html).toContain('href="/workspace"');
+    expect(html).toContain('href="/performance"');
+  });
+
+  it("marks Performance active without losing the Operations sibling", () => {
+    pathname = "/performance";
+    const html = renderToStaticMarkup(<AppRail sections={sections} />);
+
+    expect(html).toContain('href="/workspace"');
+    expect(html).toContain('href="/performance"');
+    expect(html).toContain(">Here<");
   });
 
   it("renders the worker/operator mode toggle reflecting the active mode", () => {

--- a/apps/web/lib/agent/panel-route-context.test.ts
+++ b/apps/web/lib/agent/panel-route-context.test.ts
@@ -3,7 +3,7 @@ import { resolvePanelRouteContextLabel } from "./panel-route-context";
 
 describe("resolvePanelRouteContextLabel (BI-3238AAF0)", () => {
   it("names top-level business areas from the canonical nav model", () => {
-    expect(resolvePanelRouteContextLabel("/workspace")).toBe("Workspace");
+    expect(resolvePanelRouteContextLabel("/workspace")).toBe("Operations");
     expect(resolvePanelRouteContextLabel("/finance")).toBe("Finance");
     expect(resolvePanelRouteContextLabel("/customer")).toBe("Customer");
   });

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9949,6 +9949,7 @@
       "publishedPortal": true,
       "anchors": [
         "overview",
+        "operations-and-performance",
         "key-concepts",
         "what-you-can-do"
       ]

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 584,
+  "routeCount": 585,
   "routes": [
     {
       "routePath": "/",
@@ -5064,6 +5064,15 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/ops/self-upgrade/page.tsx"
+    },
+    {
+      "routePath": "/performance",
+      "kind": "page",
+      "segments": [
+        "performance"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/performance/page.tsx"
     },
     {
       "routePath": "/platform",

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -13,6 +13,7 @@ import {
 const hr000 = { platformRole: "HR-000", isSuperuser: false };
 const hr300 = { platformRole: "HR-300", isSuperuser: false };
 const hr500 = { platformRole: "HR-500", isSuperuser: false };
+const hr600 = { platformRole: "HR-600", isSuperuser: false };
 const noRole = { platformRole: null, isSuperuser: false };
 const superuser = { platformRole: null, isSuperuser: true };
 
@@ -30,6 +31,13 @@ describe("can()", () => {
   it("HR-500 can view operations but not portfolio", () => {
     expect(can(hr500, "view_operations")).toBe(true);
     expect(can(hr500, "view_portfolio")).toBe(false);
+  });
+
+  it("grants business Performance only to owners and operations managers", () => {
+    expect(can(hr000, "view_business_performance")).toBe(true);
+    expect(can(hr500, "view_business_performance")).toBe(true);
+    expect(can(hr300, "view_business_performance")).toBe(false);
+    expect(can(hr600, "view_business_performance")).toBe(false);
   });
 
   it("HR-500 can manage_backlog", () => {
@@ -110,6 +118,31 @@ describe("getShellNavSections()", () => {
     expect(keys(worker)).not.toContain("admin");
     expect(keys(worker)).not.toContain("ai_workforce");
     expect(keys(worker)).toEqual(expect.arrayContaining(["workspace", "customer", "finance"]));
+    expect(keys(operator)).toContain("performance");
+    expect(keys(worker)).not.toContain("performance");
+  });
+
+  it("shows Operations to workforce members while server-gating Performance", () => {
+    const keys = getShellNavSections(hr600, { mode: "operator" })
+      .flatMap((section) => section.items.map((item) => item.key));
+
+    expect(keys).toContain("workspace");
+    expect(keys).not.toContain("performance");
+  });
+
+  it("presents Operations and Performance as owner/manager rail siblings", () => {
+    for (const user of [hr000, hr500]) {
+      const workspaceItems = getShellNavSections(user, { mode: "operator" })
+        .find((section) => section.key === "workspace")
+        ?.items ?? [];
+
+      expect(workspaceItems.map((item) => [item.key, item.label, item.href])).toEqual(
+        expect.arrayContaining([
+          ["workspace", "Operations", "/workspace"],
+          ["performance", "Performance", "/performance"],
+        ]),
+      );
+    }
   });
 
   it("treats no mode as the full operator rail (backward compatible)", () => {
@@ -363,6 +396,7 @@ describe("HR-600 Workforce Member base floor", () => {
       "manage_user_lifecycle",
       "manage_backlog",
       "view_operations",
+      "view_business_performance",
       "view_platform",
       "manage_platform",
       "manage_users",

--- a/apps/web/lib/govern/permissions.ts
+++ b/apps/web/lib/govern/permissions.ts
@@ -5,6 +5,7 @@ import { canAccessEmployeeScope } from "./manager-scope";
 import {
   getShellNavEntries,
   getSectionNavEntries,
+  PORTAL_SHELL_SECTIONS,
   type PortalAudienceMode,
   type PortalShellSectionKey,
 } from "../navigation/portal-navigation-model";
@@ -28,6 +29,7 @@ export type CapabilityKey =
   | "view_customer"
   | "operate_customer"
   | "view_operations"
+  | "view_business_performance"
   | "view_platform"
   | "view_admin"
   | "view_storefront"
@@ -69,6 +71,7 @@ export const PERMISSIONS: Record<CapabilityKey, Permission> = {
   // reversible records (status=draft), never external sends.
   operate_customer:            { roles: ["HR-000", "HR-200"] },
   view_operations:             { roles: ["HR-000", "HR-500"] },
+  view_business_performance:   { roles: ["HR-000", "HR-500"] },
   view_platform:               { roles: ["HR-000", "HR-200", "HR-300"] },
   view_admin:                  { roles: ["HR-000"] },
   view_storefront:             { roles: ["HR-000", "HR-200", "HR-300"] },
@@ -203,39 +206,6 @@ const ALL_TILES: WorkspaceTile[] = [
   { key: "storefront", label: "Storefront", route: "/storefront", capabilityKey: "view_storefront",  accentColor: "var(--dpf-warning)" },
 ];
 
-const SHELL_SECTIONS: Array<Pick<ShellNavSection, "key" | "label" | "description">> = [
-  {
-    key: "workspace",
-    label: "Workspace",
-    description: "Your queue, recents, and AI-guided next steps.",
-  },
-  {
-    key: "business",
-    label: "Business",
-    description: "Run customer, people, finance, compliance, and portal operations.",
-  },
-  {
-    key: "products",
-    label: "Products",
-    description: "Guide product lifecycle work from portfolio through delivery.",
-  },
-  {
-    key: "delivery",
-    label: "Delivery",
-    description: "Build, ship, and track delivery work from one operator home.",
-  },
-  {
-    key: "platform",
-    label: "Platform",
-    description: "Direct AI coworkers and operate the platform itself.",
-  },
-  {
-    key: "knowledge",
-    label: "Knowledge",
-    description: "Shared knowledge, reference, and documentation.",
-  },
-];
-
 const SHELL_ITEMS: ShellNavItem[] = getShellNavEntries().map((entry) => ({
   key: entry.key,
   label: entry.label,
@@ -320,7 +290,7 @@ export function getShellNavSections(
     const keys = typeof gate === "string" ? [gate] : gate;
     return keys.some((key) => activeOrgCapabilities.has(key));
   };
-  return SHELL_SECTIONS.map((section) => ({
+  return PORTAL_SHELL_SECTIONS.map((section) => ({
     ...section,
     items: SHELL_ITEMS.filter(
       (item) =>

--- a/apps/web/lib/navigation/business-view-routes.ts
+++ b/apps/web/lib/navigation/business-view-routes.ts
@@ -1,0 +1,35 @@
+import type { PortalNavRecord } from "./portal-navigation-model";
+
+export const BUSINESS_VIEW_ROUTES: readonly PortalNavRecord[] = [
+  {
+    key: "workspace",
+    label: "Operations",
+    path: "/workspace",
+    parentPath: "/workspace",
+    domain: "workspace",
+    audienceModes: ["worker", "operator"],
+    destinationKind: "domain-home",
+    capabilityKey: null,
+    primaryOrder: 10,
+    shellNav: {
+      sectionKey: "workspace",
+      description: "Current state and next action.",
+    },
+    sectionSiblings: ["/workspace", "/workspace/inbox", "/workspace/my-queue", "/workspace/documents"],
+  },
+  {
+    key: "performance",
+    label: "Performance",
+    path: "/performance",
+    parentPath: "/performance",
+    domain: "performance",
+    audienceModes: ["operator"],
+    destinationKind: "domain-home",
+    capabilityKey: "view_business_performance",
+    primaryOrder: 15,
+    shellNav: {
+      sectionKey: "workspace",
+      description: "Understand business results, trends, and operating drivers.",
+    },
+  },
+];

--- a/apps/web/lib/navigation/portal-navigation-model.test.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.test.ts
@@ -50,6 +50,33 @@ describe("portal navigation model", () => {
     expect(getRouteNavRecord("/workspace/cases/[caseKey]")?.destinationKind).toBe("detail");
   });
 
+  it("models Operations and Performance as distinct main-rail domain homes", () => {
+    const operations = getRouteNavRecord("/workspace");
+    const performance = getRouteNavRecord("/performance");
+
+    expect(operations).toMatchObject({
+      label: "Operations",
+      domain: "workspace",
+      destinationKind: "domain-home",
+    });
+    expect(performance).toMatchObject({
+      label: "Performance",
+      domain: "performance",
+      destinationKind: "domain-home",
+      capabilityKey: "view_business_performance",
+    });
+    expect(operations?.shellNav?.sectionKey).toBe("workspace");
+    expect(performance?.shellNav?.sectionKey).toBe("workspace");
+  });
+
+  it("keeps Performance out of the Operations section-level queue navigation", () => {
+    const operationsSections = getSectionNavEntries("/workspace").map((entry) => entry.path);
+
+    expect(operationsSections).toContain("/workspace/inbox");
+    expect(operationsSections).toContain("/workspace/my-queue");
+    expect(operationsSections).not.toContain("/performance");
+  });
+
   it("classifies legacy redirect destinations as redirects, not primary nav", () => {
     expect(getRouteNavRecord("/admin/storefront")?.destinationKind).toBe(
       "legacy-redirect",

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -2,6 +2,15 @@ import type { CapabilityKey } from "@/lib/govern/permissions";
 
 export type PortalAudienceMode = "worker" | "operator" | "customer" | "diagnostic";
 
+import type { PortalShellSectionKey } from "./portal-shell-sections";
+import { BUSINESS_VIEW_ROUTES } from "./business-view-routes";
+
+export {
+  PORTAL_SHELL_SECTIONS,
+  type PortalShellSectionDefinition,
+  type PortalShellSectionKey,
+} from "./portal-shell-sections";
+
 export type PortalDestinationKind =
   | "domain-home"
   | "section-page"
@@ -13,14 +22,13 @@ export type PortalDestinationKind =
 
 export type PortalDomain =
   | "workspace"
+  | "performance"
   | "business"
   | "delivery"
   | "platform"
   | "admin"
   | "knowledge"
   | "customer";
-
-export type PortalShellSectionKey = "workspace" | "business" | "products" | "delivery" | "platform" | "knowledge";
 
 export type PortalNavRecord = {
   key: string;
@@ -84,22 +92,7 @@ function platformAiRoute(
 }
 
 export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
-  {
-    key: "workspace",
-    label: "Workspace",
-    path: "/workspace",
-    parentPath: "/workspace",
-    domain: "workspace",
-    audienceModes: ["worker", "operator"],
-    destinationKind: "domain-home",
-    capabilityKey: null,
-    primaryOrder: 10,
-    shellNav: {
-      sectionKey: "workspace",
-      description: "See what needs attention next.",
-    },
-    sectionSiblings: ["/workspace", "/workspace/inbox", "/workspace/my-queue", "/workspace/documents"],
-  },
+  ...BUSINESS_VIEW_ROUTES,
   {
     // EP-ATTENTION-SURFACE keystone (BI-D39484E7): the "Needs you" attention inbox.
     // A workspace-section SIBLING, not a new rail destination (kernel-ratified

--- a/apps/web/lib/navigation/portal-shell-sections.ts
+++ b/apps/web/lib/navigation/portal-shell-sections.ts
@@ -1,0 +1,22 @@
+export type PortalShellSectionKey =
+  | "workspace"
+  | "business"
+  | "products"
+  | "delivery"
+  | "platform"
+  | "knowledge";
+
+export interface PortalShellSectionDefinition {
+  key: PortalShellSectionKey;
+  label: string;
+  description: string;
+}
+
+export const PORTAL_SHELL_SECTIONS: readonly PortalShellSectionDefinition[] = [
+  { key: "workspace", label: "Workspace", description: "Current business work and authorized owner/manager performance." },
+  { key: "business", label: "Business", description: "Run customer, people, finance, compliance, and portal operations." },
+  { key: "products", label: "Products", description: "Guide product lifecycle work from portfolio through delivery." },
+  { key: "delivery", label: "Delivery", description: "Build, ship, and track delivery work from one operator home." },
+  { key: "platform", label: "Platform", description: "Direct AI coworkers and operate the platform itself." },
+  { key: "knowledge", label: "Knowledge", description: "Shared knowledge, reference, and documentation." },
+];

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,13 +1,13 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 338,
+  "pageRouteCount": 339,
   "summary": {
     "byAudience": {
       "admin": 142,
       "auth-setup": 10,
       "builder": 3,
       "customer": 11,
-      "owner": 149,
+      "owner": 150,
       "public": 21,
       "worker": 2
     },
@@ -15,11 +15,11 @@
       "advanced-diagnostic": 96,
       "detail": 161,
       "legacy-internal": 29,
-      "section-home": 31,
+      "section-home": 32,
       "settings-config": 12,
       "workflow-step": 9
     },
-    "overrideCount": 5,
+    "overrideCount": 6,
     "lowConfidenceCount": 0,
     "lowConfidencePaths": []
   },
@@ -1269,6 +1269,13 @@
       "destinationKind": "advanced-diagnostic",
       "confidence": "high",
       "source": "heuristic"
+    },
+    {
+      "routePath": "/performance",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "override"
     },
     {
       "routePath": "/platform",

--- a/apps/web/lib/navigation/route-audience.test.ts
+++ b/apps/web/lib/navigation/route-audience.test.ts
@@ -24,6 +24,11 @@ describe("classifyRoute — audience", () => {
     expect(classifyRoute(route("/finance")).audience).toBe("owner");
     expect(classifyRoute(route("/compliance")).audience).toBe("owner");
     expect(classifyRoute(route("/customer")).audience).toBe("owner");
+    expect(classifyRoute(route("/performance"))).toMatchObject({
+      audience: "owner",
+      destinationKind: "section-home",
+      confidence: "high",
+    });
   });
 
   it("maps customer + public first segments", () => {

--- a/apps/web/lib/navigation/route-audience.ts
+++ b/apps/web/lib/navigation/route-audience.ts
@@ -107,6 +107,7 @@ const FIRST_SEGMENT_AUDIENCE: Record<string, RouteAudience> = {
   // Owner / operator business domains
   finance: "owner",
   workspace: "owner",
+  performance: "owner",
   compliance: "owner",
   customer: "owner", // owner-facing CRM (managing customers)
   storefront: "owner", // internal storefront management (AGENTS §2: /storefront is internal)
@@ -139,6 +140,7 @@ export const ROUTE_AUDIENCE_OVERRIDES: Record<
 > = {
   "/": { audience: "auth-setup", destinationKind: "legacy-internal" }, // redirect → /welcome
   "/workspace": { audience: "owner", destinationKind: "section-home" },
+  "/performance": { audience: "owner", destinationKind: "section-home" },
   "/workspace/my-queue": { audience: "worker", destinationKind: "detail" },
   "/workspace/inbox": { audience: "worker", destinationKind: "detail" },
   "/knowledge": { audience: "public", destinationKind: "section-home" },

--- a/apps/web/lib/performance/business-performance-provider.test.ts
+++ b/apps/web/lib/performance/business-performance-provider.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { loadBusinessPerformance } from "./business-performance-provider";
+
+describe("loadBusinessPerformance", () => {
+  it("returns an attributed setup state without fabricated metric values", async () => {
+    await expect(loadBusinessPerformance()).resolves.toEqual({
+      status: "not-configured",
+      asOf: null,
+      metricValues: [],
+      source: "business-performance-read-model",
+    });
+  });
+});

--- a/apps/web/lib/performance/business-performance-provider.ts
+++ b/apps/web/lib/performance/business-performance-provider.ts
@@ -1,0 +1,35 @@
+/**
+ * Truthful read boundary for the owner/manager Performance view.
+ *
+ * The historical read model lands in BI-PLAN-005. Until then this provider
+ * returns an explicit setup state, never fabricated zeroes or demo metrics.
+ */
+export interface UnconfiguredBusinessPerformance {
+  status: "not-configured";
+  asOf: null;
+  metricValues: readonly [];
+  source: "business-performance-read-model";
+}
+
+export type BusinessPerformanceReadModel = UnconfiguredBusinessPerformance;
+
+export interface BusinessPerformanceProvider {
+  load(): Promise<BusinessPerformanceReadModel>;
+}
+
+const unconfiguredProvider: BusinessPerformanceProvider = {
+  async load() {
+    return {
+      status: "not-configured",
+      asOf: null,
+      metricValues: [],
+      source: "business-performance-read-model",
+    };
+  },
+};
+
+export async function loadBusinessPerformance(
+  provider: BusinessPerformanceProvider = unconfiguredProvider,
+): Promise<BusinessPerformanceReadModel> {
+  return provider.load();
+}

--- a/apps/web/lib/tak/agent-routing.test.ts
+++ b/apps/web/lib/tak/agent-routing.test.ts
@@ -72,6 +72,15 @@ describe("resolveAgentForRoute", () => {
     expect(result.canAssist).toBe(true);
   });
 
+  it("routes authorized Performance questions to a metric-safe COO context", () => {
+    const result = resolveAgentForRoute("/performance", opsUser);
+
+    expect(result.agentId).toBe("coo");
+    expect(result.canAssist).toBe(true);
+    expect(result.systemPrompt).toContain("historical business performance");
+    expect(result.systemPrompt).toContain("Never invent");
+  });
+
   it("keeps the Software Engineer on /build and routes governed work to the Change Reviewer", () => {
     const build = resolveAgentForRoute("/build", superuser);
     const work = resolveAgentForRoute("/build/work/WC-123", superuser);

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -4,6 +4,7 @@ import { getRouteSensitivity } from "@/lib/agent-sensitivity";
 import { resolveRouteContext, UNIVERSAL_SKILLS } from "@/lib/route-context-map";
 import { resolveSelectedCoworkerForRoute } from "./selected-coworker-route";
 import { CHANGE_REVIEWER_ROUTE_AGENT } from "./change-reviewer-route";
+import { PERFORMANCE_ROUTE_AGENT } from "./performance-route";
 // prompt-loader is imported server-side only via agent-routing-server.ts.
 // This file stays free of @dpf/db for client component compatibility.
 
@@ -616,6 +617,7 @@ ON THIS PAGE: The user is managing the internal storefront workspace. Focus on p
       defaultBudgetClass: "balanced",
     },
   },
+  "/performance": PERFORMANCE_ROUTE_AGENT,
   "/workspace": {
     agentId: "coo",
     agentName: "COO",

--- a/apps/web/lib/tak/performance-route.ts
+++ b/apps/web/lib/tak/performance-route.ts
@@ -1,0 +1,56 @@
+import type { RouteAgentEntry } from "@/lib/agent-coworker-types";
+import type { RouteContextDef } from "./route-context-types";
+
+export const PERFORMANCE_ROUTE_AGENT: RouteAgentEntry = {
+  agentId: "coo",
+  agentName: "COO",
+  agentDescription: "Owner and manager interpretation of business results and operating drivers",
+  capability: "view_business_performance",
+  sensitivity: "confidential",
+  systemPrompt: `You are the Chief Operating Officer (COO) on the historical business performance view.
+
+PERSPECTIVE: Help owners and operations managers understand results, trends, and operating drivers. Keep this distinct from Operations, which owns current state, conflicts, queues, and next actions.
+
+DATA DISCIPLINE: The Performance read model is not connected yet. Never invent a metric, treat missing data as zero, infer a trend from an empty state, or claim that a source is configured. Explain the boundary and the exact missing source truth shown on the page.`,
+  skills: [
+    {
+      label: "Explain Performance",
+      description: "Explain what belongs here and what still needs a source",
+      capability: "view_business_performance",
+      prompt:
+        "Explain what belongs in Performance versus Operations and identify only the source gap visible on this page.",
+    },
+    {
+      label: "Report an issue",
+      description: "Report a bug or give feedback",
+      capability: null,
+      prompt: "I'd like to report an issue or give feedback.",
+    },
+  ],
+};
+
+export const PERFORMANCE_ROUTE_CONTEXT: RouteContextDef = {
+  routePrefix: "/performance",
+  domain: "Business Performance",
+  sensitivity: "confidential",
+  domainContext:
+    "This owner and operations-manager view is for historical business results, trends, and operating drivers. Its read model is not configured yet. The coworker must not invent metrics, infer that missing data is zero, or describe current operational state as historical evidence.",
+  domainTools: [],
+  docsPath: "/docs/workspace/index",
+  skills: [
+    {
+      label: "Explain Performance",
+      description: "Explain the view boundary and what still needs a metric source",
+      capability: "view_business_performance",
+      taskType: "analysis",
+      prompt:
+        "Explain what belongs in Performance versus Operations. Use only data visible on the page, and state clearly when historical metric sources are not configured.",
+    },
+    {
+      label: "Report an issue",
+      description: "Report a bug or give feedback",
+      capability: null,
+      prompt: "I'd like to report an issue or give feedback about this page.",
+    },
+  ],
+};

--- a/apps/web/lib/tak/route-context-map.test.ts
+++ b/apps/web/lib/tak/route-context-map.test.ts
@@ -93,6 +93,17 @@ describe("resolveRouteContext", () => {
     expect(ctx.sensitivity).toBe("internal");
   });
 
+  it("keeps Performance owner-focused and refuses to imply connected metrics", () => {
+    const ctx = resolveRouteContext("/performance");
+
+    expect(ctx.domain).toBe("Business Performance");
+    expect(ctx.routePrefix).toBe("/performance");
+    expect(ctx.sensitivity).toBe("confidential");
+    expect(ctx.domainContext).toContain("historical");
+    expect(ctx.domainContext).toContain("must not invent");
+    expect(ctx.domainTools).toEqual([]);
+  });
+
   it("returns correct sensitivity for /customer (confidential)", () => {
     const ctx = resolveRouteContext("/customer");
     expect(ctx.sensitivity).toBe("confidential");

--- a/apps/web/lib/tak/route-context-map.ts
+++ b/apps/web/lib/tak/route-context-map.ts
@@ -1,24 +1,11 @@
 // apps/web/lib/route-context-map.ts
 // Factual domain context definitions per route — replaces persona-based agent routing.
 
-import type { SensitivityLevel } from "./agent-router-types";
 import { resolveDocsPath } from "@/lib/docs-route-map";
 import { CHANGE_REVIEWER_ROUTE_CONTEXT } from "./change-reviewer-route";
-export type RouteContextDef = {
-  routePrefix: string;
-  domain: string;
-  sensitivity: SensitivityLevel;
-  domainContext: string;
-  domainTools: string[];
-  docsPath?: string;
-  skills: Array<{
-    label: string;
-    description: string;
-    capability: string | null;
-    prompt: string;
-    taskType?: "conversation" | "code_generation" | "analysis";
-  }>;
-};
+import { PERFORMANCE_ROUTE_CONTEXT } from "./performance-route";
+import type { RouteContextDef } from "./route-context-types";
+export type { RouteContextDef } from "./route-context-types";
 
 // Universal baseline page-interaction skills added to every route.
 export const UNIVERSAL_SKILLS: RouteContextDef["skills"] = [
@@ -1133,6 +1120,8 @@ When generating or reviewing UI code, enforce these rules:
       },
     ],
   },
+
+  "/performance": PERFORMANCE_ROUTE_CONTEXT,
 
   "/workspace": {
     routePrefix: "/workspace",

--- a/apps/web/lib/tak/route-context-types.ts
+++ b/apps/web/lib/tak/route-context-types.ts
@@ -1,0 +1,17 @@
+import type { SensitivityLevel } from "./agent-router-types";
+
+export type RouteContextDef = {
+  routePrefix: string;
+  domain: string;
+  sensitivity: SensitivityLevel;
+  domainContext: string;
+  domainTools: string[];
+  docsPath?: string;
+  skills: Array<{
+    label: string;
+    description: string;
+    capability: string | null;
+    prompt: string;
+    taskType?: "conversation" | "code_generation" | "analysis";
+  }>;
+};

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -3,7 +3,7 @@
   "generator": "apps/web/scripts/ux-route-sweep.ts",
   "routes": {
     "/admin": {
-      "defaultVisibleWords": 177,
+      "defaultVisibleWords": 178,
       "leadBandWords": 0,
       "primaryActions": 3,
       "visibleFields": 5,
@@ -14,7 +14,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=4]\n  - group\n    - button\n      - text\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - checkbox\n  - text\n  - paragraph\n    - text\n  - button\n  - heading [level=4]\n  - group\n    - button\n      - text\n    - text\n  - text\n  - combobox\n    - option [selected]\n  - button"
     },
     "/admin/archetypes": {
-      "defaultVisibleWords": 506,
+      "defaultVisibleWords": 507,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,
@@ -25,7 +25,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - button\n  - searchbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text\n  - text\n  - button [disabled]\n  - button"
     },
     "/admin/branding": {
-      "defaultVisibleWords": 233,
+      "defaultVisibleWords": 234,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 7,
@@ -36,7 +36,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - checkbox [checked]\n  - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - button"
     },
     "/admin/build-studio/stall-thresholds": {
-      "defaultVisibleWords": 211,
+      "defaultVisibleWords": 212,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 12,
@@ -47,7 +47,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n    - strong\n      - text\n    - text\n    - strong\n      - text\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - button [disabled]"
     },
     "/admin/business-models": {
-      "defaultVisibleWords": 302,
+      "defaultVisibleWords": 303,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -58,7 +58,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - button\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/admin/cockpit": {
-      "defaultVisibleWords": 265,
+      "defaultVisibleWords": 266,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -69,7 +69,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/admin/data-stewardship": {
-      "defaultVisibleWords": 270,
+      "defaultVisibleWords": 271,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 6,
@@ -80,7 +80,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button"
     },
     "/admin/diagnostics": {
-      "defaultVisibleWords": 153,
+      "defaultVisibleWords": 154,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -91,7 +91,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - checkbox\n  - text"
     },
     "/admin/hive": {
-      "defaultVisibleWords": 383,
+      "defaultVisibleWords": 384,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -102,7 +102,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - switch\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - switch [checked]\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n  - heading [level=2]\n  - paragraph\n    - text\n  - text"
     },
     "/admin/issue-reports": {
-      "defaultVisibleWords": 210,
+      "defaultVisibleWords": 211,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -113,7 +113,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - button\n  - paragraph\n    - text"
     },
     "/admin/platform-development": {
-      "defaultVisibleWords": 310,
+      "defaultVisibleWords": 311,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 5,
@@ -124,7 +124,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - radio [checked]\n  - text\n  - paragraph\n    - text\n  - radio\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - button\n  - paragraph\n    - text\n  - link\n  - text"
     },
     "/admin/reference-data": {
-      "defaultVisibleWords": 325,
+      "defaultVisibleWords": 326,
       "leadBandWords": 0,
       "primaryActions": 3,
       "visibleFields": 4,
@@ -135,7 +135,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - button [expanded]\n    - heading [level=3]\n  - text\n  - searchbox\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button\n  - navigation\n    - paragraph\n      - text\n    - text\n    - link\n  - button [expanded]\n    - heading [level=3]\n  - text\n  - combobox\n  - paragraph\n    - text\n  - button\n  - button [expanded]\n    - heading [level=3]\n  - text\n  - combobox\n  - paragraph\n    - text\n  - button\n  - button [expanded]\n    - heading [level=3]\n  - text\n  - searchbox\n  - button\n  - text\n  - button\n  - text\n  - button\n  - text\n  - button"
     },
     "/admin/research": {
-      "defaultVisibleWords": 107,
+      "defaultVisibleWords": 108,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -146,7 +146,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/admin/scheduled-jobs": {
-      "defaultVisibleWords": 2970,
+      "defaultVisibleWords": 1542,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -157,7 +157,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - text\n          - button\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - text\n          - button\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - button\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - button"
     },
     "/admin/settings": {
-      "defaultVisibleWords": 481,
+      "defaultVisibleWords": 482,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 17,
@@ -168,7 +168,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - textbox\n  - text\n  - textbox\n  - checkbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button [disabled]\n  - text\n  - textbox\n  - button [disabled]\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - paragraph\n    - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - paragraph\n    - text\n  - combobox\n    - option\n    - option [selected]\n  - button [disabled]\n  - text"
     },
     "/admin/storefront/preset": {
-      "defaultVisibleWords": 167,
+      "defaultVisibleWords": 168,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -179,7 +179,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - link\n  - text"
     },
     "/admin/twin-gallery": {
-      "defaultVisibleWords": 3830,
+      "defaultVisibleWords": 3831,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -190,7 +190,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n    - text\n  - link\n    - text\n    - paragraph\n      - text"
     },
     "/admin/twin-kit": {
-      "defaultVisibleWords": 375,
+      "defaultVisibleWords": 376,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -201,7 +201,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n    - code\n      - text\n    - text\n  - tablist\n    - tab [selected]\n      - text\n    - tab\n      - text\n  - heading [level=2]\n  - text\n  - button\n  - heading [level=4]\n  - text\n  - heading [level=4]\n  - text\n  - heading [level=4]\n  - text\n  - heading [level=4]\n  - text\n  - progressbar\n  - text\n  - progressbar\n  - text\n  - heading [level=4]\n  - text\n  - list\n    - listitem\n      - text\n  - heading [level=4]\n  - text\n  - list\n    - listitem\n      - text\n  - heading [level=4]\n  - list\n    - listitem\n      - text\n  - heading [level=4]\n  - list\n    - listitem\n      - text\n  - text\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n    - code\n      - text\n    - text"
     },
     "/admin/wiki/lint": {
-      "defaultVisibleWords": 149,
+      "defaultVisibleWords": 150,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -212,7 +212,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text"
     },
     "/build": {
-      "defaultVisibleWords": 165,
+      "defaultVisibleWords": 166,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -223,7 +223,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - button [expanded]\n    - text\n  - text\n  - textbox\n  - group\n    - button\n    - text\n    - combobox\n      - option [selected]\n      - option\n  - text\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - link [disabled]"
     },
     "/build/work": {
-      "defaultVisibleWords": 176,
+      "defaultVisibleWords": 177,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -234,7 +234,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n  - text\n  - link\n  - button\n  - text\n  - heading [level=2]\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - button\n  - region\n    - heading [level=2]\n    - text\n  - region\n    - heading [level=2]\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - cell\n            - text"
     },
     "/complaints": {
-      "defaultVisibleWords": 104,
+      "defaultVisibleWords": 105,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -245,7 +245,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - button\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text\n  - paragraph\n    - text"
     },
     "/compliance": {
-      "defaultVisibleWords": 141,
+      "defaultVisibleWords": 142,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -256,7 +256,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/compliance/actions": {
-      "defaultVisibleWords": 127,
+      "defaultVisibleWords": 128,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -267,7 +267,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/compliance/audits": {
-      "defaultVisibleWords": 112,
+      "defaultVisibleWords": 113,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -278,7 +278,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/compliance/controls": {
-      "defaultVisibleWords": 284,
+      "defaultVisibleWords": 285,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -289,7 +289,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - text\n  - link\n  - link\n    - text\n    - paragraph\n      - text"
     },
     "/compliance/evidence": {
-      "defaultVisibleWords": 123,
+      "defaultVisibleWords": 124,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -300,7 +300,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/compliance/gaps": {
-      "defaultVisibleWords": 99,
+      "defaultVisibleWords": 100,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -311,7 +311,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text"
     },
     "/compliance/incidents": {
-      "defaultVisibleWords": 121,
+      "defaultVisibleWords": 122,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -322,7 +322,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - link\n  - paragraph\n    - text"
     },
     "/compliance/licensing": {
-      "defaultVisibleWords": 406,
+      "defaultVisibleWords": 407,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 8,
@@ -333,7 +333,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - button\n  - paragraph\n    - text\n  - button\n    - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text"
     },
     "/compliance/obligations": {
-      "defaultVisibleWords": 180,
+      "defaultVisibleWords": 181,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -344,7 +344,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - text\n  - link\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text"
     },
     "/compliance/onboard": {
-      "defaultVisibleWords": 114,
+      "defaultVisibleWords": 115,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 8,
@@ -355,7 +355,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=2]\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button [disabled]"
     },
     "/compliance/policies": {
-      "defaultVisibleWords": 108,
+      "defaultVisibleWords": 109,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -366,7 +366,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text"
     },
     "/compliance/posture": {
-      "defaultVisibleWords": 132,
+      "defaultVisibleWords": 133,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 0,
@@ -377,7 +377,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/compliance/regulations": {
-      "defaultVisibleWords": 145,
+      "defaultVisibleWords": 146,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -388,7 +388,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - button\n  - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link"
     },
     "/compliance/risks": {
-      "defaultVisibleWords": 119,
+      "defaultVisibleWords": 120,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -399,7 +399,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - link\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/compliance/submissions": {
-      "defaultVisibleWords": 117,
+      "defaultVisibleWords": 118,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -410,7 +410,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/coworker-decisions": {
-      "defaultVisibleWords": 279,
+      "defaultVisibleWords": 280,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -421,7 +421,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - text\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n  - link\n    - paragraph\n      - text\n    - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - group\n    - button\n      - text\n    - heading [level=3]\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=3]\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=3]\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=3]\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n    - heading [level=4]\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text\n  - group\n    - button\n      - text\n    - list\n      - listitem\n        - link\n          - text\n          - paragraph\n            - text"
     },
     "/coworker-decisions/craft": {
-      "defaultVisibleWords": 249,
+      "defaultVisibleWords": 250,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -432,7 +432,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - list\n    - listitem\n      - link\n        - text"
     },
     "/coworker-decisions/decisions": {
-      "defaultVisibleWords": 172,
+      "defaultVisibleWords": 173,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -443,7 +443,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n  - link\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/coworker-decisions/matrix": {
-      "defaultVisibleWords": 289,
+      "defaultVisibleWords": 290,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -454,7 +454,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - navigation\n    - link\n    - text\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - paragraph\n    - text"
     },
     "/coworker-decisions/perspectives": {
-      "defaultVisibleWords": 431,
+      "defaultVisibleWords": 432,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -465,7 +465,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link"
     },
     "/coworker-decisions/proactivity": {
-      "defaultVisibleWords": 1005,
+      "defaultVisibleWords": 1006,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -476,7 +476,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n    - text\n  - list\n    - listitem\n      - paragraph\n        - text\n      - button\n        - text\n  - heading [level=2]\n    - text\n  - list\n    - listitem\n      - paragraph\n        - text\n      - button\n        - text\n  - heading [level=2]\n    - text\n  - list\n    - listitem\n      - paragraph\n        - text\n      - button\n        - text\n  - heading [level=2]\n    - text\n  - list\n    - listitem\n      - paragraph\n        - text\n      - button\n        - text"
     },
     "/coworker-decisions/review": {
-      "defaultVisibleWords": 194,
+      "defaultVisibleWords": 195,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -487,7 +487,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - list\n    - listitem\n      - text\n      - link\n      - paragraph\n        - text\n  - paragraph\n    - text\n  - link"
     },
     "/coworker-decisions/stance": {
-      "defaultVisibleWords": 897,
+      "defaultVisibleWords": 898,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
@@ -498,7 +498,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - list\n    - listitem\n      - text\n      - button\n      - paragraph\n        - text\n  - button\n  - text\n  - heading [level=2]\n  - list\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - text\n  - paragraph\n    - text\n    - link\n    - text"
     },
     "/customer": {
-      "defaultVisibleWords": 114,
+      "defaultVisibleWords": 115,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -531,7 +531,7 @@
       "ariaSnapshot": "- paragraph\n  - text\n- link"
     },
     "/customer/engagements": {
-      "defaultVisibleWords": 122,
+      "defaultVisibleWords": 123,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -542,7 +542,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - heading [level=1]\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text"
     },
     "/customer/funnel": {
-      "defaultVisibleWords": 166,
+      "defaultVisibleWords": 167,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -553,7 +553,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/marketing": {
-      "defaultVisibleWords": 234,
+      "defaultVisibleWords": 229,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -564,7 +564,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - navigation\n    - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - button\n  - paragraph\n    - text\n  - button\n    - text\n  - group\n    - button\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - link\n    - heading [level=2]\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - heading [level=2]\n    - list\n      - listitem\n    - heading [level=2]\n    - paragraph\n      - text\n    - heading [level=2]\n    - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - heading [level=2]\n    - text\n    - heading [level=2]\n    - heading [level=3]\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/marketing/automation": {
-      "defaultVisibleWords": 195,
+      "defaultVisibleWords": 196,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -575,7 +575,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - navigation\n    - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/marketing/campaigns": {
-      "defaultVisibleWords": 209,
+      "defaultVisibleWords": 210,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -586,7 +586,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - navigation\n    - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/marketing/funnel": {
-      "defaultVisibleWords": 220,
+      "defaultVisibleWords": 221,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -597,7 +597,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - navigation\n    - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/marketing/strategy": {
-      "defaultVisibleWords": 337,
+      "defaultVisibleWords": 338,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -608,7 +608,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - navigation\n    - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - button\n  - paragraph\n    - text\n  - button\n    - text\n  - heading [level=2]\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - heading [level=2]\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/opportunities": {
-      "defaultVisibleWords": 158,
+      "defaultVisibleWords": 159,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -619,7 +619,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - heading [level=1]\n  - text\n  - button\n  - link\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - complementary\n    - paragraph\n      - text\n    - heading [level=2]\n    - button\n    - paragraph\n      - text\n    - button\n      - text"
     },
     "/customer/quotes": {
-      "defaultVisibleWords": 127,
+      "defaultVisibleWords": 128,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -630,7 +630,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text"
     },
     "/customer/sales-orders": {
-      "defaultVisibleWords": 90,
+      "defaultVisibleWords": 91,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -641,7 +641,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text"
     },
     "/delivery": {
-      "defaultVisibleWords": 161,
+      "defaultVisibleWords": 162,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -652,7 +652,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - text"
     },
     "/ea": {
-      "defaultVisibleWords": 311,
+      "defaultVisibleWords": 312,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -663,7 +663,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - text\n  - button\n  - paragraph\n    - text\n  - button\n  - link\n    - paragraph\n      - text"
     },
     "/ea/capabilities": {
-      "defaultVisibleWords": 1332,
+      "defaultVisibleWords": 1333,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -674,7 +674,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n  - paragraph\n    - text\n  - group\n    - button [pressed]\n    - button\n  - region\n    - button [pressed]\n      - text\n      - heading [level=2]\n      - paragraph\n        - text\n      - text\n    - button\n      - text\n      - heading [level=3]\n      - paragraph\n        - text\n      - text\n  - region\n    - button\n      - text\n      - heading [level=2]\n      - paragraph\n        - text\n      - text\n    - button\n      - text\n      - heading [level=3]\n      - paragraph\n        - text\n      - text\n  - complementary\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - heading [level=3]\n    - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - note\n      - paragraph\n        - text\n      - text\n    - paragraph\n      - text\n    - group [expanded]\n      - button\n      - table\n        - rowgroup\n          - row\n            - columnheader\n              - text\n        - rowgroup\n          - row\n            - cell\n              - text\n  - group\n    - button\n    - heading [level=2]\n    - text\n    - textbox\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - textbox\n    - text\n    - textbox\n    - text\n    - checkbox\n    - text\n    - checkbox\n    - text\n    - checkbox\n    - text\n    - checkbox\n    - text\n    - checkbox\n    - text\n    - checkbox\n    - text\n    - checkbox\n    - text\n    - button\n    - heading [level=2]\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option\n      - option [selected]\n      - option\n    - text\n    - textbox\n    - button\n    - heading [level=2]\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option\n      - option [selected]\n      - option\n    - text\n    - textbox\n    - button"
     },
     "/ea/data-model": {
-      "defaultVisibleWords": 172,
+      "defaultVisibleWords": 173,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -685,7 +685,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - button\n  - link"
     },
     "/ea/models": {
-      "defaultVisibleWords": 122,
+      "defaultVisibleWords": 123,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -696,7 +696,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text"
     },
     "/ea/value-streams": {
-      "defaultVisibleWords": 142,
+      "defaultVisibleWords": 143,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -707,7 +707,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link"
     },
     "/ea/views": {
-      "defaultVisibleWords": 254,
+      "defaultVisibleWords": 255,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -718,7 +718,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text"
     },
     "/employee": {
-      "defaultVisibleWords": 288,
+      "defaultVisibleWords": 289,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 5,
@@ -729,7 +729,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - list\n      - listitem\n        - paragraph\n          - text\n        - link\n        - paragraph\n          - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - checkbox\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n  - paragraph\n    - text\n  - group\n    - text\n    - radio [checked]\n    - text\n    - radio\n    - text\n  - text\n  - spinbutton\n  - button\n  - group\n    - button\n      - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - combobox\n      - option [selected]\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - checkbox [checked]\n    - text\n    - paragraph\n      - text\n    - group\n      - button\n        - text\n      - text\n    - button"
     },
     "/finance": {
-      "defaultVisibleWords": 228,
+      "defaultVisibleWords": 229,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -740,7 +740,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n  - group\n    - button\n      - text\n    - link\n      - paragraph\n        - text\n      - text\n      - paragraph\n        - text\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - cell\n            - link\n            - paragraph\n              - text\n          - cell\n          - cell\n            - text\n          - cell\n            - paragraph\n              - text\n        - row\n          - cell\n            - link\n            - paragraph\n              - text\n          - cell\n            - text\n          - cell\n            - paragraph\n              - text\n    - paragraph\n      - text\n    - link\n      - text\n  - paragraph\n    - text\n  - paragraph\n    - link\n  - paragraph\n    - text\n  - paragraph\n    - link\n  - paragraph\n    - text\n  - paragraph\n    - link\n  - paragraph\n    - text\n  - paragraph\n    - link\n  - paragraph\n    - text\n  - paragraph\n    - text\n    - link\n  - group\n    - button\n      - text\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n    - paragraph\n      - text\n    - link\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/finance/assets": {
-      "defaultVisibleWords": 120,
+      "defaultVisibleWords": 121,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -751,7 +751,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - text\n  - link\n  - link\n    - text\n  - paragraph\n    - text\n  - link"
     },
     "/finance/assets/new": {
-      "defaultVisibleWords": 129,
+      "defaultVisibleWords": 130,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 11,
@@ -762,7 +762,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - button\n  - spinbutton\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - link"
     },
     "/finance/banking": {
-      "defaultVisibleWords": 117,
+      "defaultVisibleWords": 118,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -773,7 +773,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link"
     },
     "/finance/banking/new": {
-      "defaultVisibleWords": 128,
+      "defaultVisibleWords": 129,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 9,
@@ -784,7 +784,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - spinbutton\n  - paragraph\n    - text\n  - button"
     },
     "/finance/banking/rules": {
-      "defaultVisibleWords": 122,
+      "defaultVisibleWords": 123,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 6,
@@ -795,7 +795,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - textbox\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/finance/bills": {
-      "defaultVisibleWords": 116,
+      "defaultVisibleWords": 117,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -806,7 +806,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - text\n  - button [disabled]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/finance/bills/new": {
-      "defaultVisibleWords": 131,
+      "defaultVisibleWords": 132,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 11,
@@ -817,7 +817,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - text\n  - combobox\n    - option [selected]\n  - link\n  - text\n  - combobox\n    - option [selected]\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - heading [level=2]\n  - button\n  - paragraph\n    - text\n  - textbox\n  - paragraph\n    - text\n  - spinbutton\n  - paragraph\n    - text\n  - spinbutton\n  - paragraph\n    - text\n  - spinbutton\n  - paragraph\n  - paragraph\n    - text\n  - text\n  - textbox\n  - button"
     },
     "/finance/close": {
-      "defaultVisibleWords": 181,
+      "defaultVisibleWords": 182,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -828,7 +828,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/finance/configuration": {
-      "defaultVisibleWords": 192,
+      "defaultVisibleWords": 193,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -839,7 +839,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/finance/expense-claims": {
-      "defaultVisibleWords": 117,
+      "defaultVisibleWords": 118,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -850,7 +850,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - text\n  - button [disabled]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/finance/invoices": {
-      "defaultVisibleWords": 134,
+      "defaultVisibleWords": 135,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -861,7 +861,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - text\n  - button [disabled]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/finance/invoices/new": {
-      "defaultVisibleWords": 147,
+      "defaultVisibleWords": 148,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 10,
@@ -872,7 +872,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - combobox\n    - option [selected]\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - checkbox\n  - text\n  - heading [level=2]\n  - button\n  - text\n  - textbox\n  - spinbutton\n  - text\n  - button [disabled]\n  - text\n  - link\n  - button"
     },
     "/finance/my-expenses": {
-      "defaultVisibleWords": 108,
+      "defaultVisibleWords": 109,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -883,7 +883,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link"
     },
     "/finance/my-expenses/new": {
-      "defaultVisibleWords": 127,
+      "defaultVisibleWords": 128,
       "leadBandWords": 0,
       "primaryActions": 3,
       "visibleFields": 7,
@@ -894,7 +894,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - heading [level=2]\n  - button\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - textbox\n  - text\n  - textbox\n  - paragraph\n    - text\n  - text\n  - textbox\n  - button"
     },
     "/finance/payment-runs": {
-      "defaultVisibleWords": 183,
+      "defaultVisibleWords": 184,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -905,7 +905,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - button [disabled]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/finance/payments": {
-      "defaultVisibleWords": 104,
+      "defaultVisibleWords": 105,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -916,7 +916,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - link\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/finance/purchase-orders": {
-      "defaultVisibleWords": 117,
+      "defaultVisibleWords": 118,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -927,7 +927,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - text\n  - button [disabled]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/finance/purchase-orders/new": {
-      "defaultVisibleWords": 124,
+      "defaultVisibleWords": 125,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 9,
@@ -938,7 +938,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - text\n  - combobox\n    - option [selected]\n  - link\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - heading [level=2]\n  - button\n  - paragraph\n    - text\n  - textbox\n  - paragraph\n    - text\n  - spinbutton\n  - paragraph\n    - text\n  - spinbutton\n  - paragraph\n    - text\n  - spinbutton\n  - paragraph\n  - paragraph\n    - text\n  - text\n  - textbox\n  - button"
     },
     "/finance/recurring": {
-      "defaultVisibleWords": 111,
+      "defaultVisibleWords": 112,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -949,7 +949,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - text\n  - paragraph\n    - text"
     },
     "/finance/recurring/new": {
-      "defaultVisibleWords": 143,
+      "defaultVisibleWords": 144,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 12,
@@ -960,7 +960,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - combobox\n    - option [selected]\n  - text\n  - textbox\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - checkbox [checked]\n  - text\n  - heading [level=2]\n  - button\n  - text\n  - textbox\n  - spinbutton\n  - text\n  - button [disabled]\n  - text\n  - link\n  - button"
     },
     "/finance/reports": {
-      "defaultVisibleWords": 158,
+      "defaultVisibleWords": 159,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -971,7 +971,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text"
     },
     "/finance/reports/aged-creditors": {
-      "defaultVisibleWords": 87,
+      "defaultVisibleWords": 88,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -982,7 +982,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text"
     },
     "/finance/reports/aged-debtors": {
-      "defaultVisibleWords": 87,
+      "defaultVisibleWords": 88,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -993,61 +993,6 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text"
     },
     "/finance/reports/cash-flow": {
-      "defaultVisibleWords": 121,
-      "leadBandWords": 0,
-      "primaryActions": 2,
-      "visibleFields": 2,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 3,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - link"
-    },
-    "/finance/reports/general-ledger": {
-      "defaultVisibleWords": 111,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - text\n  - paragraph\n    - text"
-    },
-    "/finance/reports/outstanding": {
-      "defaultVisibleWords": 92,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link"
-    },
-    "/finance/reports/profit-loss": {
-      "defaultVisibleWords": 143,
-      "leadBandWords": 0,
-      "primaryActions": 2,
-      "visibleFields": 2,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 3,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - paragraph\n    - text\n  - link"
-    },
-    "/finance/reports/revenue-by-customer": {
-      "defaultVisibleWords": 100,
-      "leadBandWords": 0,
-      "primaryActions": 2,
-      "visibleFields": 2,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 3,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - link"
-    },
-    "/finance/reports/vat-summary": {
       "defaultVisibleWords": 122,
       "leadBandWords": 0,
       "primaryActions": 2,
@@ -1058,8 +1003,63 @@
       "axeViolations": 3,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - link"
     },
+    "/finance/reports/general-ledger": {
+      "defaultVisibleWords": 112,
+      "leadBandWords": 0,
+      "primaryActions": 1,
+      "visibleFields": 0,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 2,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - text\n  - paragraph\n    - text"
+    },
+    "/finance/reports/outstanding": {
+      "defaultVisibleWords": 93,
+      "leadBandWords": 0,
+      "primaryActions": 1,
+      "visibleFields": 0,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 2,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link"
+    },
+    "/finance/reports/profit-loss": {
+      "defaultVisibleWords": 144,
+      "leadBandWords": 0,
+      "primaryActions": 2,
+      "visibleFields": 2,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 3,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - paragraph\n    - text\n  - link"
+    },
+    "/finance/reports/revenue-by-customer": {
+      "defaultVisibleWords": 101,
+      "leadBandWords": 0,
+      "primaryActions": 2,
+      "visibleFields": 2,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 3,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - link"
+    },
+    "/finance/reports/vat-summary": {
+      "defaultVisibleWords": 123,
+      "leadBandWords": 0,
+      "primaryActions": 2,
+      "visibleFields": 2,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 3,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - link"
+    },
     "/finance/revenue": {
-      "defaultVisibleWords": 169,
+      "defaultVisibleWords": 170,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1070,7 +1070,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/finance/settings": {
-      "defaultVisibleWords": 232,
+      "defaultVisibleWords": 233,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1081,7 +1081,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - link\n  - paragraph\n    - text\n  - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - paragraph\n    - text\n  - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - link"
     },
     "/finance/settings/currency": {
-      "defaultVisibleWords": 228,
+      "defaultVisibleWords": 229,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
@@ -1092,7 +1092,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - button"
     },
     "/finance/settings/dunning": {
-      "defaultVisibleWords": 190,
+      "defaultVisibleWords": 191,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1103,7 +1103,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text"
     },
     "/finance/settings/rate-card": {
-      "defaultVisibleWords": 146,
+      "defaultVisibleWords": 147,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1114,7 +1114,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - paragraph\n    - text\n    - link"
     },
     "/finance/settings/setup": {
-      "defaultVisibleWords": 250,
+      "defaultVisibleWords": 251,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -1125,7 +1125,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - text\n  - button\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - button\n  - complementary\n    - paragraph\n      - text"
     },
     "/finance/settings/tax": {
-      "defaultVisibleWords": 908,
+      "defaultVisibleWords": 909,
       "leadBandWords": 0,
       "primaryActions": 3,
       "visibleFields": 17,
@@ -1136,7 +1136,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option\n    - option [selected]\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text"
     },
     "/finance/spend": {
-      "defaultVisibleWords": 205,
+      "defaultVisibleWords": 206,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1147,7 +1147,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/finance/spend/ai": {
-      "defaultVisibleWords": 342,
+      "defaultVisibleWords": 343,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 12,
@@ -1158,7 +1158,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n    - text\n  - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - button\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - group\n    - text\n    - checkbox [checked]\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - spinbutton\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - link\n        - cell\n          - text\n        - cell\n          - paragraph\n            - text\n        - cell\n          - text"
     },
     "/finance/suppliers": {
-      "defaultVisibleWords": 113,
+      "defaultVisibleWords": 114,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1169,7 +1169,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - link\n  - paragraph\n    - text\n  - link\n  - button\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - link\n        - cell\n          - text"
     },
     "/finance/suppliers/new": {
-      "defaultVisibleWords": 112,
+      "defaultVisibleWords": 113,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 8,
@@ -1191,7 +1191,7 @@
       "ariaSnapshot": "- heading [level=1]\n- paragraph\n  - text\n- text\n- textbox\n- button\n- paragraph\n  - text"
     },
     "/inventory": {
-      "defaultVisibleWords": 4541,
+      "defaultVisibleWords": 4543,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -1202,7 +1202,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - group\n    - button\n      - text\n    - paragraph\n      - text\n      - link\n      - text\n      - link\n      - text\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - button\n  - button\n    - text\n    - paragraph\n      - text\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - checkbox\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/knowledge": {
-      "defaultVisibleWords": 98,
+      "defaultVisibleWords": 100,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1213,7 +1213,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - link\n  - paragraph\n    - text"
     },
     "/knowledge/new": {
-      "defaultVisibleWords": 524,
+      "defaultVisibleWords": 526,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 5,
@@ -1235,7 +1235,7 @@
       "ariaSnapshot": "- heading [level=1]\n- text\n- textbox\n- text\n- textbox\n- button\n- link"
     },
     "/ops": {
-      "defaultVisibleWords": 180,
+      "defaultVisibleWords": 181,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -1246,7 +1246,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - button [expanded]\n    - heading [level=2]\n    - text\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - heading [level=2]\n    - text\n  - checkbox [checked]\n  - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n    - text\n  - heading [level=3]\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=3]\n    - text\n  - button\n  - paragraph\n    - text"
     },
     "/ops/changes": {
-      "defaultVisibleWords": 104,
+      "defaultVisibleWords": 107,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1257,7 +1257,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - button\n  - text"
     },
     "/ops/demand": {
-      "defaultVisibleWords": 268,
+      "defaultVisibleWords": 271,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1268,7 +1268,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - paragraph\n      - text\n      - link\n  - paragraph\n    - text"
     },
     "/ops/dev-loop": {
-      "defaultVisibleWords": 187,
+      "defaultVisibleWords": 190,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1278,8 +1278,19 @@
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - group\n    - button\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - cell\n            - text\n  - strong\n    - text\n  - list\n    - listitem\n      - strong\n        - text\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n    - code\n      - text\n    - text"
     },
+    "/ops/journeys": {
+      "defaultVisibleWords": 210,
+      "leadBandWords": 14,
+      "primaryActions": 1,
+      "visibleFields": 0,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 2,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - group\n    - button\n      - text\n    - paragraph\n      - text"
+    },
     "/ops/patches": {
-      "defaultVisibleWords": 148,
+      "defaultVisibleWords": 151,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -1290,7 +1301,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/ops/promotions": {
-      "defaultVisibleWords": 135,
+      "defaultVisibleWords": 138,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1301,7 +1312,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n  - button\n  - text"
     },
     "/ops/security": {
-      "defaultVisibleWords": 159,
+      "defaultVisibleWords": 162,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1312,7 +1323,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/ops/self-upgrade": {
-      "defaultVisibleWords": 414,
+      "defaultVisibleWords": 397,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -1322,8 +1333,19 @@
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - region\n    - note\n      - paragraph\n        - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - text\n    - checkbox\n    - text\n    - button\n  - group [expanded]\n    - button\n      - text\n    - text\n    - link\n    - text\n    - button\n    - text\n    - heading [level=3]\n    - paragraph\n      - text"
     },
+    "/performance": {
+      "defaultVisibleWords": 95,
+      "leadBandWords": 9,
+      "primaryActions": 1,
+      "visibleFields": 0,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 2,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - main\n    - heading [level=1]\n    - paragraph\n      - text"
+    },
     "/platform": {
-      "defaultVisibleWords": 454,
+      "defaultVisibleWords": 455,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1334,18 +1356,18 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - group\n      - button\n      - paragraph\n        - text\n      - list\n        - listitem\n          - text\n      - paragraph\n        - text\n      - list\n        - listitem\n          - text\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - columnheader\n            - link\n          - cell\n            - link\n              - text\n    - region\n      - heading [level=3]\n      - list\n        - listitem\n          - text\n          - link\n      - paragraph\n        - text"
     },
     "/platform/ai/assignments": {
-      "defaultVisibleWords": 1023,
+      "defaultVisibleWords": 1038,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 37,
-      "maxChoicesPerControl": 16,
+      "maxChoicesPerControl": 17,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 4,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n    - strong\n      - text\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n  - text\n  - radiogroup\n    - radio\n      - text\n    - radio [checked]\n      - text\n    - radio\n      - text\n  - img\n    - text\n    - slider\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - text\n  - spinbutton\n  - text\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - link\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n            - option\n        - cell\n          - combobox\n            - option [selected]\n            - option\n        - cell\n          - text\n        - cell\n          - button\n      - row\n        - cell\n          - link\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n            - option\n        - cell\n          - text\n        - cell\n          - button\n      - row\n        - cell\n          - link\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n        - cell\n          - text\n        - cell\n          - button\n      - row\n        - cell\n          - link\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n            - option\n        - cell\n          - text\n        - cell\n          - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - button\n  - text\n  - heading [level=4]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - button\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - link\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - link\n          - text\n        - cell\n          - text"
     },
     "/platform/ai/browser-sessions": {
-      "defaultVisibleWords": 169,
+      "defaultVisibleWords": 170,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 1,
@@ -1356,7 +1378,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/platform/ai/browser-sessions/setup": {
-      "defaultVisibleWords": 204,
+      "defaultVisibleWords": 205,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
@@ -1367,7 +1389,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/ai/build-studio": {
-      "defaultVisibleWords": 370,
+      "defaultVisibleWords": 371,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 6,
@@ -1378,7 +1400,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - text\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - link\n  - group\n    - button\n    - paragraph\n      - text\n  - text\n  - paragraph\n    - text\n  - button\n  - radio [checked]\n  - strong\n    - text\n  - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - radio [disabled]\n  - text\n  - radio [disabled]\n  - text\n  - link\n  - text\n  - radio [disabled]\n  - text\n  - radio [disabled]\n  - text\n  - link\n  - text\n  - radio [disabled]\n  - text\n  - link\n  - button"
     },
     "/platform/ai/capacity-continuity": {
-      "defaultVisibleWords": 313,
+      "defaultVisibleWords": 314,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1389,7 +1411,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - heading [level=2]\n  - link"
     },
     "/platform/ai/catalog": {
-      "defaultVisibleWords": 604,
+      "defaultVisibleWords": 605,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1400,7 +1422,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - complementary\n    - heading [level=2]\n    - text"
     },
     "/platform/ai/founder-review": {
-      "defaultVisibleWords": 288,
+      "defaultVisibleWords": 289,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1411,7 +1433,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - link\n    - heading [level=2]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text"
     },
     "/platform/ai/memory": {
-      "defaultVisibleWords": 217,
+      "defaultVisibleWords": 218,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1422,7 +1444,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/ai/operations-map": {
-      "defaultVisibleWords": 500,
+      "defaultVisibleWords": 501,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 7,
@@ -1433,7 +1455,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - button\n  - region\n    - paragraph\n      - text\n    - heading [level=1]\n    - paragraph\n      - text\n    - group\n      - button\n      - button [pressed]\n    - text\n    - list\n      - listitem\n        - button\n          - text\n          - heading [level=2]\n          - paragraph\n            - text\n    - paragraph\n      - text\n    - link\n  - region\n    - paragraph\n      - text\n    - heading [level=1]\n    - paragraph\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - group\n      - button [pressed]\n      - button\n    - region\n      - heading [level=3]\n      - paragraph\n        - text\n      - button\n      - paragraph\n        - text\n      - group\n        - text\n        - combobox\n          - option [selected]\n          - option\n        - text\n        - combobox\n          - option [selected]\n          - option\n        - text\n        - combobox\n          - option [selected]\n          - option\n      - group\n        - text\n        - button [pressed]\n        - text\n        - combobox\n          - option [selected]\n          - option\n        - text\n        - combobox\n          - option [selected]\n        - text\n        - combobox [disabled]\n          - option [selected]\n          - option\n      - paragraph\n        - text\n      - button [disabled]\n      - text\n      - button\n      - button [disabled]\n      - slider\n      - text\n      - group\n        - button\n          - text\n        - table\n          - rowgroup\n            - row\n              - columnheader\n                - text\n          - rowgroup\n            - row\n              - cell\n                - text\n    - region\n      - region\n        - button\n        - text\n        - button\n        - button [disabled]\n        - img\n          - text\n          - button\n            - text\n          - text\n    - group\n      - button\n        - heading [level=2]\n        - text\n      - region\n        - paragraph\n          - text\n        - heading [level=2]\n        - text\n        - button\n        - paragraph\n          - text\n        - list\n          - listitem\n            - button [pressed]\n              - text\n              - paragraph\n                - text\n          - listitem\n            - button\n              - text\n              - paragraph\n                - text\n        - region\n          - paragraph\n            - text\n          - heading [level=3]\n          - paragraph\n            - text\n          - text\n          - paragraph\n            - text\n          - text\n          - paragraph\n            - text\n          - text\n          - group\n            - button\n            - text\n            - button\n          - paragraph\n            - text\n          - list\n            - listitem\n              - text\n        - heading [level=3]\n        - paragraph\n          - text\n        - text\n        - group\n          - button\n          - text\n          - button\n        - paragraph\n          - text\n        - list\n          - listitem\n        - heading [level=3]\n        - paragraph\n          - text\n        - text\n        - group\n          - button\n          - text\n          - button\n        - paragraph\n          - text\n        - list\n          - listitem\n        - heading [level=3]\n        - paragraph\n          - text\n        - text\n        - group\n          - button\n          - text\n          - button\n        - paragraph\n          - text\n        - list\n          - listitem\n        - heading [level=3]\n        - paragraph\n          - text\n        - text\n        - group\n          - button\n          - text\n          - button\n        - paragraph\n          - text\n        - list\n          - listitem\n        - heading [level=3]\n        - paragraph\n          - text\n        - text\n        - group\n          - button\n          - text\n          - button\n        - paragraph\n          - text\n        - list\n          - listitem\n        - heading [level=3]\n        - paragraph\n          - text\n        - text\n        - group\n          - button\n          - text\n          - button\n          - text\n          - button\n          - text\n          - button\n        - paragraph\n          - text\n        - list\n          - listitem\n      - region\n        - heading [level=2]\n        - paragraph\n          - text\n        - text\n  - group\n    - button\n      - heading [level=2]\n      - paragraph\n        - text\n      - text\n    - region\n      - heading [level=3]\n      - button\n      - paragraph\n        - text\n      - button [pressed]\n      - button\n      - paragraph\n        - text\n      - button [pressed]\n      - paragraph\n        - text\n      - button [pressed]\n    - region\n      - heading [level=3]\n      - paragraph\n        - text\n      - button [pressed]\n        - heading [level=4]\n        - paragraph\n          - text\n      - button\n        - heading [level=4]\n        - paragraph\n          - text\n      - text\n    - complementary\n      - heading [level=3]\n      - heading [level=4]\n      - paragraph\n        - text"
     },
     "/platform/ai/overview": {
-      "defaultVisibleWords": 3143,
+      "defaultVisibleWords": 3144,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 5,
@@ -1444,7 +1466,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - searchbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - checkbox\n  - text\n  - button\n  - group\n    - button\n      - text\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - checkbox\n    - text\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n  - region\n    - heading [level=2]\n    - text\n    - heading [level=3]\n    - text\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n  - region\n    - heading [level=2]\n    - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - link\n  - group\n    - button\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - table\n      - rowgroup\n        - row\n          - columnheader\n            - text\n      - rowgroup\n        - row\n          - cell\n            - text"
     },
     "/platform/ai/priority/outcomes": {
-      "defaultVisibleWords": 210,
+      "defaultVisibleWords": 211,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1455,7 +1477,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - strong\n    - text\n  - paragraph\n    - text"
     },
     "/platform/ai/prompts": {
-      "defaultVisibleWords": 513,
+      "defaultVisibleWords": 514,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1466,7 +1488,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - strong\n    - text\n  - text\n  - link\n  - text\n  - paragraph\n    - text\n    - link\n    - text\n  - navigation\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n    - button [expanded]\n      - text\n    - list\n      - listitem\n        - button\n          - text\n  - text"
     },
     "/platform/ai/providers": {
-      "defaultVisibleWords": 328,
+      "defaultVisibleWords": 329,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1477,7 +1499,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - button\n    - paragraph\n      - text\n    - region\n      - paragraph\n        - text\n    - region\n      - paragraph\n        - text\n      - text\n    - paragraph\n      - text\n    - group\n      - button\n      - region\n        - heading [level=3]\n        - list\n          - listitem\n            - text\n      - region\n        - heading [level=3]\n        - paragraph\n          - text\n    - group\n      - button\n      - region\n        - paragraph\n          - text\n        - text\n      - paragraph\n        - text\n  - paragraph\n    - text\n    - link\n    - text\n  - text\n  - button\n  - button\n    - text\n  - button\n    - text\n    - button\n  - button\n    - text\n  - button\n    - text\n    - button\n  - group\n    - button\n    - text\n    - paragraph\n      - text\n      - strong\n        - text\n      - text\n    - paragraph\n      - text\n    - checkbox\n    - text\n  - group\n    - button\n    - text\n    - paragraph\n      - text\n    - button\n    - paragraph\n      - text\n    - text\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - cell\n            - text\n          - cell\n            - combobox\n              - option [selected]\n              - option\n          - cell\n            - text\n          - cell\n            - button\n        - row\n          - cell\n            - text\n          - cell\n            - combobox\n              - option\n              - option [selected]\n              - option\n          - cell\n            - text\n          - cell\n            - button\n        - row\n          - cell\n            - text\n          - cell\n            - combobox\n              - option [selected]\n              - option\n          - cell\n            - text\n          - cell\n            - button"
     },
     "/platform/ai/readiness": {
-      "defaultVisibleWords": 223,
+      "defaultVisibleWords": 224,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1488,7 +1510,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link"
     },
     "/platform/ai/runtime-health": {
-      "defaultVisibleWords": 514,
+      "defaultVisibleWords": 515,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1499,18 +1521,18 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - heading [level=2]\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - group\n    - button\n    - list\n      - listitem\n  - link\n  - text\n  - code\n    - text\n  - text"
     },
     "/platform/ai/skills": {
-      "defaultVisibleWords": 5349,
+      "defaultVisibleWords": 5362,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 4,
-      "maxChoicesPerControl": 25,
+      "maxChoicesPerControl": 26,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 3,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - strong\n    - text\n  - text\n  - link\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - link\n    - text\n  - text\n  - textbox\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - tablist\n    - tab [selected]\n      - text\n    - tab\n      - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n    - text\n  - heading [level=2]\n  - heading [level=3]\n  - paragraph\n    - text\n  - button"
     },
     "/platform/audit": {
-      "defaultVisibleWords": 202,
+      "defaultVisibleWords": 203,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1521,7 +1543,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 15517,
+      "defaultVisibleWords": 15504,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,
@@ -1532,7 +1554,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n  - group\n    - button\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - paragraph\n      - text\n    - heading [level=3]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n  - text\n  - paragraph\n    - text\n  - text"
     },
     "/platform/audit/journal": {
-      "defaultVisibleWords": 132,
+      "defaultVisibleWords": 133,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,
@@ -1543,7 +1565,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - combobox\n    - option [selected]\n    - option\n  - textbox\n  - text"
     },
     "/platform/audit/ledger": {
-      "defaultVisibleWords": 130,
+      "defaultVisibleWords": 131,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -1554,7 +1576,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - combobox\n    - option [selected]\n    - option\n  - combobox\n    - option [selected]\n  - text"
     },
     "/platform/audit/metrics": {
-      "defaultVisibleWords": 143,
+      "defaultVisibleWords": 144,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1565,7 +1587,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text"
     },
     "/platform/audit/operations": {
-      "defaultVisibleWords": 119,
+      "defaultVisibleWords": 120,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1576,7 +1598,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text"
     },
     "/platform/audit/routes": {
-      "defaultVisibleWords": 139,
+      "defaultVisibleWords": 140,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1587,7 +1609,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text"
     },
     "/platform/development/change-lanes": {
-      "defaultVisibleWords": 316,
+      "defaultVisibleWords": 317,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1598,7 +1620,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - region\n    - heading [level=2]\n    - text\n    - paragraph\n      - text\n    - text\n    - heading [level=3]\n    - list\n      - listitem\n        - text\n    - heading [level=3]\n    - list\n      - listitem\n        - text\n  - button\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n        - columnheader\n          - text\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - link\n        - cell\n          - text"
     },
     "/platform/device-catalog": {
-      "defaultVisibleWords": 385,
+      "defaultVisibleWords": 386,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1609,7 +1631,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - strong\n      - text\n    - text\n    - strong\n      - text\n    - text\n    - code\n      - text\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/platform/edge-nodes": {
-      "defaultVisibleWords": 232,
+      "defaultVisibleWords": 233,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 5,
@@ -1620,7 +1642,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - strong\n      - text\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n  - text\n  - combobox [disabled]\n    - option [selected]\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/federation-links": {
-      "defaultVisibleWords": 396,
+      "defaultVisibleWords": 397,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 6,
@@ -1631,7 +1653,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - button\n      - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n    - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button [disabled]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text"
     },
     "/platform/federation-proposals": {
-      "defaultVisibleWords": 116,
+      "defaultVisibleWords": 117,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1642,7 +1664,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/platform/identity": {
-      "defaultVisibleWords": 298,
+      "defaultVisibleWords": 299,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1653,7 +1675,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - paragraph\n    - text"
     },
     "/platform/identity/agents": {
-      "defaultVisibleWords": 4519,
+      "defaultVisibleWords": 4520,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1664,7 +1686,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text"
     },
     "/platform/identity/applications": {
-      "defaultVisibleWords": 253,
+      "defaultVisibleWords": 254,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1675,18 +1697,18 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text"
     },
     "/platform/identity/authorization": {
-      "defaultVisibleWords": 1917,
+      "defaultVisibleWords": 1949,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
-      "maxChoicesPerControl": 16,
+      "maxChoicesPerControl": 17,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - button\n  - heading [level=4]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - button\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - link\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - link\n          - text\n        - cell\n          - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - text"
     },
     "/platform/identity/directory": {
-      "defaultVisibleWords": 273,
+      "defaultVisibleWords": 274,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1697,7 +1719,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/identity/federation": {
-      "defaultVisibleWords": 331,
+      "defaultVisibleWords": 332,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1708,7 +1730,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text"
     },
     "/platform/identity/groups": {
-      "defaultVisibleWords": 315,
+      "defaultVisibleWords": 316,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1719,7 +1741,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text"
     },
     "/platform/identity/principals": {
-      "defaultVisibleWords": 128,
+      "defaultVisibleWords": 129,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1730,7 +1752,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text"
     },
     "/platform/schedule": {
-      "defaultVisibleWords": 335,
+      "defaultVisibleWords": 331,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1741,7 +1763,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - button\n  - group\n    - button\n  - button\n    - img\n  - button [disabled]\n  - heading [level=2]\n  - button [pressed]\n  - button\n  - grid\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - gridcell\n          - text\n  - text\n  - button"
     },
     "/platform/service-desk": {
-      "defaultVisibleWords": 120,
+      "defaultVisibleWords": 121,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1752,7 +1774,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/platform/tools": {
-      "defaultVisibleWords": 317,
+      "defaultVisibleWords": 318,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1763,7 +1785,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - paragraph\n    - text"
     },
     "/platform/tools/built-ins": {
-      "defaultVisibleWords": 277,
+      "defaultVisibleWords": 278,
       "leadBandWords": 37,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -1774,7 +1796,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - group\n      - button\n      - paragraph\n        - text\n      - list\n        - listitem\n          - text\n          - paragraph\n            - text\n    - paragraph\n      - text\n      - link\n      - text\n      - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - textbox\n  - button [disabled]"
     },
     "/platform/tools/catalog": {
-      "defaultVisibleWords": 907,
+      "defaultVisibleWords": 908,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 5,
@@ -1785,7 +1807,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - text\n  - link\n  - text\n  - searchbox\n  - combobox\n    - option [selected]\n    - option\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - heading [level=3]\n    - text\n    - paragraph\n      - text\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - heading [level=3]\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - heading [level=3]\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/tools/catalog/sync": {
-      "defaultVisibleWords": 200,
+      "defaultVisibleWords": 201,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -1796,7 +1818,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n            - option\n        - cell\n          - text\n        - cell\n          - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup"
     },
     "/platform/tools/discovery": {
-      "defaultVisibleWords": 4562,
+      "defaultVisibleWords": 4564,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -1807,7 +1829,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - group\n    - button\n      - text\n    - paragraph\n      - text\n      - link\n      - text\n      - link\n      - text\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - button\n  - button\n    - text\n    - paragraph\n      - text\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - button\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - checkbox\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/tools/discovery/promotion-audit": {
-      "defaultVisibleWords": 147,
+      "defaultVisibleWords": 148,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1818,7 +1840,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - main"
     },
     "/platform/tools/integrations": {
-      "defaultVisibleWords": 1869,
+      "defaultVisibleWords": 1870,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1829,7 +1851,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - paragraph\n            - text\n        - cell\n          - text\n        - cell\n          - paragraph\n            - text\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - paragraph\n    - text"
     },
     "/platform/tools/integrations/adp": {
-      "defaultVisibleWords": 290,
+      "defaultVisibleWords": 291,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 6,
@@ -1840,7 +1862,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - group\n    - text\n    - radio [checked]\n    - text\n    - radio\n    - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem\n      - listitem\n        - code\n          - text\n      - listitem\n      - listitem\n        - link"
     },
     "/platform/tools/integrations/communications": {
-      "defaultVisibleWords": 294,
+      "defaultVisibleWords": 295,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1851,7 +1873,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - main\n    - text\n    - heading [level=1]\n    - paragraph\n      - text\n    - region\n      - paragraph\n        - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - region\n      - heading [level=2]\n      - paragraph\n        - text\n      - text\n      - paragraph\n        - text\n      - region\n        - paragraph\n          - text\n        - button [disabled]\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/tools/integrations/email-postmark": {
-      "defaultVisibleWords": 347,
+      "defaultVisibleWords": 348,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
@@ -1862,7 +1884,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - paragraph\n    - text\n    - code\n      - text\n  - button\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem\n        - code\n          - text\n      - listitem\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem\n        - code\n          - text\n      - listitem\n        - text\n      - listitem\n      - listitem\n        - code\n          - text\n      - listitem"
     },
     "/platform/tools/integrations/facebook-lead-ads": {
-      "defaultVisibleWords": 287,
+      "defaultVisibleWords": 288,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -1873,7 +1895,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/facebook-pages": {
-      "defaultVisibleWords": 290,
+      "defaultVisibleWords": 291,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -1884,7 +1906,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/google-business-profile": {
-      "defaultVisibleWords": 344,
+      "defaultVisibleWords": 345,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 5,
@@ -1895,7 +1917,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/google-marketing-intelligence": {
-      "defaultVisibleWords": 327,
+      "defaultVisibleWords": 328,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 5,
@@ -1906,7 +1928,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/hubspot": {
-      "defaultVisibleWords": 258,
+      "defaultVisibleWords": 259,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 1,
@@ -1917,7 +1939,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/instagram-business": {
-      "defaultVisibleWords": 268,
+      "defaultVisibleWords": 269,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -1928,7 +1950,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/linkedin-personal-social": {
-      "defaultVisibleWords": 317,
+      "defaultVisibleWords": 318,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -1939,7 +1961,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem\n        - text\n      - listitem\n        - code\n          - text\n      - listitem\n        - text\n        - code\n          - text\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem\n        - code\n          - text\n      - listitem\n        - text\n      - listitem"
     },
     "/platform/tools/integrations/mailchimp": {
-      "defaultVisibleWords": 263,
+      "defaultVisibleWords": 264,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 2,
@@ -1950,7 +1972,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/microsoft365-communications": {
-      "defaultVisibleWords": 300,
+      "defaultVisibleWords": 301,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
@@ -1961,7 +1983,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/quickbooks": {
-      "defaultVisibleWords": 905,
+      "defaultVisibleWords": 906,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 6,
@@ -1972,7 +1994,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - group\n    - text\n    - radio [checked]\n    - text\n    - radio\n    - text\n  - button\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - heading [level=3]\n  - list\n    - listitem\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/stripe": {
-      "defaultVisibleWords": 256,
+      "defaultVisibleWords": 257,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 1,
@@ -1983,7 +2005,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/integrations/whatsapp-business": {
-      "defaultVisibleWords": 289,
+      "defaultVisibleWords": 290,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 3,
@@ -1994,7 +2016,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - link\n  - complementary\n    - heading [level=2]\n    - list\n      - listitem"
     },
     "/platform/tools/inventory": {
-      "defaultVisibleWords": 1441,
+      "defaultVisibleWords": 1442,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,
@@ -2005,7 +2027,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - searchbox\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/platform/tools/services": {
-      "defaultVisibleWords": 173,
+      "defaultVisibleWords": 174,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2016,7 +2038,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - link\n    - text\n  - heading [level=2]\n  - link\n    - text\n  - heading [level=2]\n  - link\n    - text"
     },
     "/platform/tools/services/activate": {
-      "defaultVisibleWords": 148,
+      "defaultVisibleWords": 149,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 7,
@@ -2060,7 +2082,7 @@
       "ariaSnapshot": "- text\n- heading [level=2]\n- paragraph\n  - text"
     },
     "/storefront": {
-      "defaultVisibleWords": 187,
+      "defaultVisibleWords": 188,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2071,7 +2093,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - navigation\n    - link\n  - text\n  - paragraph\n    - text\n  - list\n    - listitem\n      - text\n  - link"
     },
     "/storefront/dispatch": {
-      "defaultVisibleWords": 83,
+      "defaultVisibleWords": 84,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2082,7 +2104,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - text\n  - link\n  - text"
     },
     "/storefront/intake": {
-      "defaultVisibleWords": 95,
+      "defaultVisibleWords": 96,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2093,7 +2115,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - note\n    - paragraph\n      - text\n    - text"
     },
     "/storefront/settings/business": {
-      "defaultVisibleWords": 569,
+      "defaultVisibleWords": 570,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 15,
@@ -2104,7 +2126,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - textbox\n  - text\n  - button\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - button\n  - checkbox\n  - text\n  - button\n  - text\n  - button\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - button"
     },
     "/storefront/settings/capabilities": {
-      "defaultVisibleWords": 112,
+      "defaultVisibleWords": 113,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2115,7 +2137,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text"
     },
     "/storefront/settings/operations": {
-      "defaultVisibleWords": 1461,
+      "defaultVisibleWords": 1462,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 11,
@@ -2126,7 +2148,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - paragraph\n    - text\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch\n  - text\n  - switch\n  - text\n  - button"
     },
     "/storefront/setup": {
-      "defaultVisibleWords": 460,
+      "defaultVisibleWords": 461,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -2137,7 +2159,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - heading [level=2]\n  - searchbox\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text\n  - text\n  - button\n    - text"
     },
     "/storefront/team": {
-      "defaultVisibleWords": 83,
+      "defaultVisibleWords": 84,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2148,7 +2170,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - text\n  - link\n  - text"
     },
     "/workbooks": {
-      "defaultVisibleWords": 96,
+      "defaultVisibleWords": 97,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2159,7 +2181,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text"
     },
     "/workspace": {
-      "defaultVisibleWords": 198,
+      "defaultVisibleWords": 199,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2170,7 +2192,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - region\n    - paragraph\n      - text\n    - link\n  - heading [level=2]\n  - link\n  - paragraph\n    - text\n  - complementary\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - link\n      - paragraph\n        - text\n    - paragraph\n      - text\n    - link\n      - paragraph\n        - text\n      - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - link\n    - list\n      - listitem\n        - paragraph\n          - text\n        - list\n          - listitem\n            - text\n  - paragraph\n    - text\n  - button\n    - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - button"
     },
     "/workspace/calendar": {
-      "defaultVisibleWords": 245,
+      "defaultVisibleWords": 246,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2181,7 +2203,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n  - text\n  - button\n  - group\n    - button\n  - button\n    - img\n  - button [disabled]\n  - heading [level=2]\n  - button [pressed]\n  - button\n  - grid\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - gridcell\n          - text\n  - text\n  - button"
     },
     "/workspace/documents": {
-      "defaultVisibleWords": 108,
+      "defaultVisibleWords": 109,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 4,
@@ -2192,7 +2214,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - textbox\n  - combobox\n    - option [selected]\n  - button\n  - link\n  - text"
     },
     "/workspace/inbox": {
-      "defaultVisibleWords": 140,
+      "defaultVisibleWords": 141,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2203,7 +2225,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - list\n      - listitem"
     },
     "/workspace/my-queue": {
-      "defaultVisibleWords": 115,
+      "defaultVisibleWords": 116,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,9 +1,9 @@
 {
   "generator": "apps/web/scripts/build-route-shells.ts",
-  "pageRouteCount": 309,
+  "pageRouteCount": 310,
   "migratedCount": 0,
   "summary": {
-    "cockpit": 15,
+    "cockpit": 16,
     "list": 6,
     "detail": 237,
     "settings": 12,
@@ -1839,6 +1839,17 @@
     {
       "routePath": "/ops/self-upgrade",
       "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "sweepEligible": true,
+      "confidence": "high"
+    },
+    {
+      "routePath": "/performance",
+      "shell": "cockpit",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -301,7 +301,7 @@ describe("generated route-shell registry", () => {
         (route) => route.sweepEligible === Boolean(route.sweepExclusionReason),
       ),
     ).toEqual([]);
-    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(202);
+    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(203);
     expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(107);
   });
 

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -64,7 +64,7 @@ Down the left side is a rail, grouped by the kind of work rather than by screen.
 
 | Group | What lives there | Who uses it most |
 |---|---|---|
-| **Workspace** | Your queue, recent items, and AI-suggested next steps | Everyone, every day |
+| **Workspace** | Operations for current work; Performance for authorized owners and managers | Everyone daily; managers for trends |
 | **Business** | Customers, people, money, compliance, and your public portal | Owners and managers |
 | **Knowledge** | Shared reference, documents, and this guide | Everyone |
 | **Products** | Portfolio, backlog, and architecture | Businesses that build a product |
@@ -75,7 +75,10 @@ Down the left side is a rail, grouped by the kind of work rather than by screen.
 
 You only ever see what your role allows and what your business type actually turned on. An empty group is not a fault — it means that part does not apply to you.
 
-The three groups most owners live in are **Workspace**, **Business**, and **Knowledge**. If you run a business rather than build software, you may never need Products or Delivery at all.
+The three groups most owners live in are **Workspace**, **Business**, and
+**Knowledge**. In Workspace, choose **Operations** for what needs attention now
+and **Performance** for results and trends. If you run a business rather than
+build software, you may never need Products or Delivery at all.
 
 ## Your AI Coworker
 
@@ -103,4 +106,5 @@ If you are a developer working on the platform's source code, that is a differen
 - [Roles & Access](roles-and-access.md) — who on your team can see and do what.
 - [Storefront](../storefront/index.md) — your public front door: sections, items, booking, and enquiries.
 - [Customers](../customers/index.md) — accounts, enquiries, pipeline, and marketing.
-- [Workspace](../workspace/index.md) — your daily board and personal queue.
+- [Operations and Performance](../workspace/index.md) — current business work
+  versus owner/manager results and trends.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -35,8 +35,10 @@ opening paragraph.
 
 ### Quick paths by responsibility
 
-- **Owner or operator:** start with [Getting Started](getting-started/index.md), then use [Storefront](storefront/index.md), [Customers](customers/index.md), [Operations](operations/index.md), and [Finance](finance/index.md).
-- **Team, product, or architecture lead:** begin in [My Workspace](workspace/index.md), then move to [Product Inventory](products/index.md), [Portfolios](portfolios/index.md), [Enterprise Architecture](architecture/index.md), or the domain guide for the work you own.
+- **Owner or operator:** start with [Getting Started](getting-started/index.md),
+  then use [Business Operations](workspace/index.md), [Storefront](storefront/index.md),
+  [Customers](customers/index.md), and [Finance](finance/index.md).
+- **Team, product, or architecture lead:** begin in [Business Operations](workspace/index.md), then move to [Product Inventory](products/index.md), [Portfolios](portfolios/index.md), [Enterprise Architecture](architecture/index.md), or the domain guide for the work you own.
 - **Administrator or AI supervisor:** use [AI Workforce](ai-workforce/index.md), [Platform](platform/index.md), [Security Operations](security/index.md), and [Admin](admin/index.md).
 - **Builder or contributor:** choose [Build Studio](build-studio/index.md) for the governed intake-to-ship workflow, or [Contributing & Dev Setup](contributing/index.md) when working directly with source control and an external development environment.
 
@@ -54,9 +56,11 @@ Changing DPF's own source code is a separate job with a separate setup. Use [Con
 
 Use these guides when the work begins with a customer need and ends with a delivered product, service, or operating outcome.
 
-- [My Workspace](workspace/index.md) — manage personal work, documents, and activity that crosses business domains.
+- [Business Operations](workspace/index.md) — manage current work, documents,
+  and activity, then use Performance for authorized owner/manager trends.
 - [Customers](customers/index.md) — work with customer accounts, the sales pipeline, and marketing.
-- [Operations](operations/index.md) — manage the delivery backlog, infrastructure discovery, and value-stream operations.
+- [Platform Operations](operations/index.md) — manage the delivery backlog,
+  infrastructure discovery, and value-stream operations.
 - [Storefront](storefront/index.md) — configure the public-facing storefront, catalog, inbox, fulfilment, and operating settings.
 
 ## Run the company

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -1,12 +1,31 @@
 ---
-title: "My Workspace"
+title: "Business Operations"
 area: workspace
 order: 1
 ---
 
 ## Overview
 
-My Workspace is your personal home base inside the platform. It gives you a cross-cutting view of what's happening across all areas without having to navigate into each one individually. It also hosts managed documents when an operator needs the maintained copy of a guide, note, policy, or imported source.
+**Operations** is the day-to-day business home inside the platform. Its stable
+address remains `/workspace`, so existing bookmarks continue to work. It gives
+you a cross-cutting view of what is happening now without requiring you to open
+every business area. It also hosts managed documents when an operator needs the
+maintained copy of a guide, note, policy, or imported source.
+
+## Operations and Performance
+
+The main rail separates two different decisions:
+
+- **Operations** answers “what is happening now, what conflicts exist, and what
+  should happen next?” It contains current work, queues, and immediate actions.
+- **Performance** answers “how is the business doing over time, and what is
+  driving the result?” It is available only to authorized owners and operations
+  managers. If historical sources are not configured, it says so instead of
+  displaying placeholder zeroes.
+
+Performance is a separate main destination, not a tab inside Operations. Simple
+navigation keeps the day-to-day Operations surface and hides the manager view;
+Full navigation exposes both when the signed-in role is permitted.
 
 ## Key Concepts
 
@@ -18,7 +37,7 @@ My Workspace is your personal home base inside the platform. It gives you a cros
 
 ## What You Can Do
 
-- See a consolidated health snapshot across portfolios, compliance, HR, and operations from one screen
+- See a consolidated current-state snapshot across the business from one screen
 - Click a tile to jump directly into the relevant area
 - Review recent activity from colleagues and digital coworkers without leaving your workspace
 - Access your calendar for today's events and upcoming deadlines

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1252,6 +1252,20 @@
     "longSentences": 0,
     "textMass": 29
   },
+  "apps/web/app/(shell)/performance/loading.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(shell)/performance/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
   "apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary
- relabel the stable `/workspace` business-current-state destination as **Operations**
- add **Performance** as a separate primary owner/manager destination at `/performance`
- capability-gate Performance to HR-000/HR-500 roles and preserve worker access to Operations
- add a truthful Performance read boundary and explicit unconfigured state instead of fabricated zero metrics
- centralize shell-section definitions in the canonical navigation model and update TAK/COO route context
- update operator docs and all route, audience, shell, and docs generated artifacts

## Architecture / UX
- Operations and Performance are sibling main-nav destinations, not tabs or section siblings
- `/workspace` remains the stable operational route; only its visible business label changes
- `/performance` is an operator domain home with an independent loading boundary
- no fake metric values are rendered before BI-PLAN-005 lands the historical read model
- route/render, AppRail, mobile navigation, permission, audience, and agent-context tests cover the split

## Verification
- governed merged-code local CI passed on `d57ea9011cd664041f11888b5b86dad27d72d9b1` against accepted base `e5ad544839b216d4dada1cbcc3ba3d3966d53347`
- 2,324 test files / 20,105 tests passed; 19 skipped; 18 todo
- 24 policy guards passed
- TypeScript and Next route generation passed
- all 465 Prisma migrations deployed cleanly to the isolated local-CI database
- production Docker / Next.js build passed
- sandbox dependency freshness was green: Next 16.2.11, React 19.2.8, TypeScript 6.0.3, Prisma 7.8.0, Vitest 4.1.10
- local-CI evidence: `cms5ajfke070v01qwdhvdjg4f`
- two exact-SHA UX calibration runs (30405680284, 30406252971) produced identical semantic snapshots across all 203 eligible routes; the committed conservative envelope adds /performance without relaxing semantic-structure or control-size axes
- GitHub UX Route Budget Sweep must pass before merge and includes 203 eligible routes / 310 total page routes, including `/performance`

## Documentation and migration
- updated the getting-started, user-guide index, and Workspace/Operations guide language
- no schema change or migration added

Backlog: BI-E12431C3

## Design grounding
- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md`
  - `docs/superpowers/plans/2026-07-28-business-operations-and-performance-views-plan.md`
- Current code substrate reviewed:
  - `apps/web/lib/navigation/portal-navigation-model.ts`
  - `apps/web/components/shell/AppRail.tsx`
  - `apps/web/lib/govern/permissions.ts`
  - `apps/web/lib/navigation/route-audience.ts`
  - `apps/web/lib/tak/route-context-map.ts`
- Source of truth:
  - the canonical portal navigation model owns labels, destination kinds, audiences, and capabilities; `/workspace` remains the stable Operations route and `/performance` is a distinct operator domain home
- Decision:
  - expose Operations and Performance as separate primary destinations; keep Performance truthful and unconfigured until the historical read model lands

UX-Fit-Decision: separate-primary-destinations-with-truthful-progressive-disclosure



