### PR TITLE
feat(form-kit): platform forms framework first slice + Workbooks record modal adoption

### DIFF
--- a/apps/web/components/ui/form-kit/AutoGrowTextarea.tsx
+++ b/apps/web/components/ui/form-kit/AutoGrowTextarea.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+// Platform form-kit — auto-growing text editor (EP-UX-SYSTEM, BI-C167C45E).
+// Spec: docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md
+//
+// A textarea that starts one line tall and grows with its content (clamped by
+// max-height), so free text in a form behaves like an input for short values
+// and like a document for long ones — never a truncated single line.
+
+import { useLayoutEffect, useRef } from "react";
+
+export interface AutoGrowTextareaProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  ariaLabel: string;
+  placeholder?: string;
+  className?: string;
+}
+
+export function AutoGrowTextarea({
+  value,
+  onValueChange,
+  ariaLabel,
+  placeholder,
+  className,
+}: AutoGrowTextareaProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  // Fit height to content on every value change (max-height + overflow come
+  // from the className, so very long content scrolls instead of growing forever).
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
+
+  return (
+    <textarea
+      ref={ref}
+      rows={1}
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      className={
+        className ??
+        "w-full resize-none overflow-y-auto max-h-64 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
+      }
+    />
+  );
+}

--- a/apps/web/components/ui/form-kit/RecordForm.test.tsx
+++ b/apps/web/components/ui/form-kit/RecordForm.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+//
+// Component test for the form-kit RecordForm (BI-C167C45E): the explicit
+// Save/Discard commit model (nothing persists on blur), the auto-growing text
+// editor for free text, and the hidden-fields disclosure.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { RecordForm } from "./RecordForm";
+import type { FormFieldSpec } from "@/lib/form-kit/field-controls";
+
+const FIELDS: FormFieldSpec[] = [
+  { fieldId: "title", label: "Title", fieldType: "text", editable: true },
+  { fieldId: "priority", label: "Priority", fieldType: "number", editable: true },
+  { fieldId: "id", label: "ID", fieldType: "text", editable: false },
+];
+
+const HIDDEN: FormFieldSpec[] = [
+  { fieldId: "notes", label: "Notes", fieldType: "text", editable: true },
+];
+
+function setup(onSave = vi.fn(), onDirtyChange = vi.fn()) {
+  render(
+    <RecordForm
+      fields={FIELDS}
+      hiddenFields={HIDDEN}
+      values={{ title: "Original", priority: 1, id: "BI-1", notes: null }}
+      onSave={onSave}
+      onDirtyChange={onDirtyChange}
+      renderReadOnly={(_f, v) => <span>{String(v ?? "—")}</span>}
+    />,
+  );
+  return { onSave, onDirtyChange };
+}
+
+afterEach(cleanup);
+
+describe("RecordForm commit model", () => {
+  it("renders free text in a textarea (auto-grow editor), not a single-line input", () => {
+    setup();
+    expect(screen.getByLabelText("Title").tagName).toBe("TEXTAREA");
+  });
+
+  it("does not persist on edit or blur; Save persists only the dirty subset", async () => {
+    const { onSave } = setup();
+    const title = screen.getByLabelText("Title");
+    fireEvent.change(title, { target: { value: "Changed" } });
+    fireEvent.blur(title);
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave).toHaveBeenCalledWith({ title: "Changed" });
+  });
+
+  it("Discard reverts the draft and hides the save bar", () => {
+    const { onSave, onDirtyChange } = setup();
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Changed" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
+    expect((screen.getByLabelText("Title") as HTMLTextAreaElement).value).toBe("Original");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("reverting an edit by hand clears dirty (no save bar)", () => {
+    setup();
+    const title = screen.getByLabelText("Title");
+    fireEvent.change(title, { target: { value: "Changed" } });
+    fireEvent.change(title, { target: { value: "Original" } });
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
+  });
+
+  it("number edits commit as numbers, cleared fields as null", async () => {
+    const { onSave } = setup();
+    fireEvent.change(screen.getByLabelText("Priority"), { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ priority: 3 }));
+  });
+
+  it("keeps hidden fields reachable behind the disclosure and editable there", async () => {
+    const { onSave } = setup();
+    expect(screen.getByText("1 hidden field")).toBeTruthy();
+    fireEvent.click(screen.getByText("1 hidden field"));
+    fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "From disclosure" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ notes: "From disclosure" }));
+  });
+
+  it("renders non-editable fields through the host's read-only renderer", () => {
+    setup();
+    expect(screen.getByText("BI-1")).toBeTruthy();
+    expect(screen.queryByLabelText("ID")).toBeNull();
+  });
+});

--- a/apps/web/components/ui/form-kit/RecordForm.tsx
+++ b/apps/web/components/ui/form-kit/RecordForm.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+// Platform form-kit — record editing form (EP-UX-SYSTEM, BI-C167C45E).
+// Spec: docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md
+//
+// The one record-form composition every surface reuses: label/control rows from
+// FormFieldSpec metadata, drafts held in the form-state kernel (nothing commits
+// on blur), one explicit Save/Discard bar that appears only when dirty, and a
+// disclosure section for fields the current layout hides. The host owns
+// persistence (onSave receives only the dirty subset) and read-only rendering
+// of its own complex value kinds.
+
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  dirtyValues,
+  committed,
+  discarded,
+  initFormState,
+  isFormDirty,
+  withFieldEdit,
+  type FormValues,
+} from "@/lib/form-kit/form-state";
+import {
+  inputTypeFor,
+  resolveControlKind,
+  type FormFieldSpec,
+} from "@/lib/form-kit/field-controls";
+import { AutoGrowTextarea } from "./AutoGrowTextarea";
+
+export interface RecordFormProps {
+  /** Fields shown by default, in layout order. */
+  fields: FormFieldSpec[];
+  /** Fields the current layout hides — reachable behind a disclosure, not lost. */
+  hiddenFields?: FormFieldSpec[];
+  /** The record's current values keyed by fieldId. */
+  values: FormValues;
+  /** Persist the dirty subset. Called only from the explicit Save action. */
+  onSave: (dirty: FormValues) => void | Promise<void>;
+  /** Dirty-state signal for the host (e.g. close guards). */
+  onDirtyChange?: (dirty: boolean) => void;
+  /** Host renders its own read-only value kinds (references, attachments, …). */
+  renderReadOnly: (field: FormFieldSpec, value: unknown) => ReactNode;
+}
+
+function asStr(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  return String(v);
+}
+
+const ctrl =
+  "w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+
+export function RecordForm({
+  fields,
+  hiddenFields = [],
+  values,
+  onSave,
+  onDirtyChange,
+  renderReadOnly,
+}: RecordFormProps) {
+  const [state, setState] = useState(() => initFormState(values));
+  const [saving, setSaving] = useState(false);
+  const dirty = isFormDirty(state);
+
+  const edit = (fieldId: string, value: unknown) => {
+    setState((s) => {
+      const next = withFieldEdit(s, fieldId, value);
+      onDirtyChange?.(isFormDirty(next));
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!dirty || saving) return;
+    setSaving(true);
+    try {
+      await onSave(dirtyValues(state));
+      setState((s) => committed(s));
+      onDirtyChange?.(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDiscard = () => {
+    setState((s) => discarded(s));
+    onDirtyChange?.(false);
+  };
+
+  const control = (field: FormFieldSpec) => {
+    const kind = resolveControlKind(field);
+    const value = state.draft[field.fieldId] ?? null;
+
+    switch (kind) {
+      case "readonly":
+        return renderReadOnly(field, value);
+      case "longtext":
+        return (
+          <AutoGrowTextarea
+            value={asStr(value)}
+            onValueChange={(v) => edit(field.fieldId, v === "" ? null : v)}
+            ariaLabel={field.label}
+          />
+        );
+      case "text":
+        return (
+          <input
+            type={inputTypeFor(field.fieldType)}
+            className={ctrl}
+            value={asStr(value)}
+            onChange={(e) => edit(field.fieldId, e.target.value === "" ? null : e.target.value)}
+            aria-label={field.label}
+          />
+        );
+      case "number":
+        return (
+          <input
+            type="number"
+            className={ctrl}
+            value={asStr(value)}
+            onChange={(e) =>
+              edit(field.fieldId, e.target.value === "" ? null : Number(e.target.value))
+            }
+            aria-label={field.label}
+          />
+        );
+      case "checkbox":
+        return (
+          <input
+            type="checkbox"
+            checked={value === true}
+            onChange={(e) => edit(field.fieldId, e.target.checked)}
+            aria-label={field.label}
+          />
+        );
+      case "select":
+        return (
+          <select
+            className={ctrl}
+            value={asStr(value)}
+            onChange={(e) => edit(field.fieldId, e.target.value === "" ? null : e.target.value)}
+            aria-label={field.label}
+          >
+            <option value="">—</option>
+            {(field.options ?? []).map((o) => (
+              <option key={o.key} value={o.key}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        );
+      case "date":
+      case "datetime":
+        return (
+          <input
+            type={kind === "datetime" ? "datetime-local" : "date"}
+            className={ctrl}
+            value={asStr(value).slice(0, kind === "datetime" ? 16 : 10)}
+            onChange={(e) => edit(field.fieldId, e.target.value === "" ? null : e.target.value)}
+            aria-label={field.label}
+          />
+        );
+    }
+  };
+
+  const row = (field: FormFieldSpec) => (
+    <div key={field.fieldId} className="dpf-record-modal-row">
+      <dt className="text-xs font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
+        {field.label}
+      </dt>
+      <dd>{control(field)}</dd>
+    </div>
+  );
+
+  const hiddenLabel = useMemo(
+    () =>
+      hiddenFields.length === 1 ? "1 hidden field" : `${hiddenFields.length} hidden fields`,
+    [hiddenFields.length],
+  );
+
+  return (
+    <div>
+      <dl className="dpf-record-modal-body">
+        {fields.map(row)}
+        {hiddenFields.length > 0 && (
+          <details>
+            <summary className="cursor-pointer text-xs font-medium text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
+              {hiddenLabel}
+            </summary>
+            <div className="mt-3 flex flex-col gap-3">{hiddenFields.map(row)}</div>
+          </details>
+        )}
+      </dl>
+      {dirty && (
+        <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+          <span className="text-xs text-[var(--dpf-muted)]">Unsaved changes</span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleDiscard}
+              disabled={saving}
+              className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-1)]"
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-60"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -1576,8 +1576,7 @@ export function WorkbookGrid({
               hiddenColumns={orderedColumns.filter((c) => hiddenColumns.includes(c.columnId))}
               canEdit={capabilities.canEditCell}
               onClose={() => setOpenRowId(null)}
-              onSave={onModalSave}
-            />
+              onSave={onModalSave} />
           ) : null;
         })()}
     </div>

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -1572,7 +1572,8 @@ export function WorkbookGrid({
           return openRow ? (
             <RecordDetailModal
               row={openRow}
-              columns={columns}
+              columns={visibleCols}
+              hiddenColumns={orderedColumns.filter((c) => hiddenColumns.includes(c.columnId))}
               canEdit={capabilities.canEditCell}
               onClose={() => setOpenRowId(null)}
               onSave={onModalSave}

--- a/apps/web/components/workbooks/RecordDetailModal.tsx
+++ b/apps/web/components/workbooks/RecordDetailModal.tsx
@@ -1,141 +1,92 @@
 "use client";
 
-// Universal Grid & Workbooks — record detail modal (EP-GRID-WORKBOOKS, toward
-// Airtable parity). "Expand a row" into a full-record editor: every field on its
-// own line, edited through the SAME validated dispatch as an in-grid edit (the
-// Grid passes an onSave that routes to persistCell). Presentational + self-
-// contained; the Grid owns persistence and which row is open.
+// Universal Grid & Workbooks — record detail modal (EP-GRID-WORKBOOKS,
+// BI-69371E1A). "Expand a row" into a full-record editor, now composed on the
+// platform form-kit (BI-C167C45E): edits accumulate in a draft and persist only
+// through the explicit Save action (routed field-by-field through the Grid's
+// validated persistCell dispatch), free text edits in an auto-growing editor,
+// and the field layout follows the grid view's order/visibility — hidden
+// fields stay reachable behind a disclosure.
 
-import { useEffect } from "react";
-import type { CellValue, ColumnDefinition, SelectOption } from "@/lib/workbooks/types";
+import { useCallback, useEffect, useRef } from "react";
+import type { CellValue, ColumnDefinition } from "@/lib/workbooks/types";
+import type { FormValues } from "@/lib/form-kit/form-state";
+import type { FormFieldSpec } from "@/lib/form-kit/field-controls";
+import { RecordForm } from "@/components/ui/form-kit/RecordForm";
+import { confirmDialog } from "@/components/ui/Dialog";
 import type { GridRowData } from "./cell-editors";
 import { cellSearchText } from "./grid-filter";
 
 export interface RecordDetailModalProps {
   row: GridRowData;
+  /** Fields shown by default — the grid view's ordered, visible columns. */
   columns: ColumnDefinition[];
+  /** Columns the view hides; shown behind a disclosure so nothing is lost. */
+  hiddenColumns?: ColumnDefinition[];
   canEdit: boolean;
   onClose: () => void;
   /** Persist one field; the Grid wires this to its validated persistCell path. */
   onSave: (columnId: string, value: CellValue) => void;
 }
 
-/** Field types the modal edits inline; everything else is shown read-only. */
-const INLINE_EDITABLE = new Set([
-  "text",
-  "url",
-  "email",
-  "phone",
-  "number",
-  "currency",
-  "percent",
-  "progress",
-  "rating",
-  "duration",
-  "checkbox",
-  "select",
-  "date",
-  "datetime",
-]);
-
-function asStr(v: CellValue): string {
-  if (v === null || v === undefined) return "";
-  return String(v);
+function toFieldSpec(col: ColumnDefinition, canEdit: boolean): FormFieldSpec {
+  return {
+    fieldId: col.columnId,
+    label: col.name,
+    fieldType: col.fieldType,
+    editable: canEdit && col.editable,
+    required: col.required,
+    multiline: col.config?.multiline,
+    options: col.config?.options?.map((o) => ({ key: o.key, label: o.label })),
+  };
 }
 
 export function RecordDetailModal({
   row,
   columns,
+  hiddenColumns = [],
   canEdit,
   onClose,
   onSave,
 }: RecordDetailModalProps) {
-  // Close on Escape — standard modal affordance.
+  const dirtyRef = useRef(false);
+
+  // Every close path (Escape, backdrop, ✕) runs the same unsaved-changes guard.
+  const requestClose = useCallback(async () => {
+    if (dirtyRef.current) {
+      const ok = await confirmDialog({
+        title: "Discard unsaved changes?",
+        message: "This record has edits that have not been saved.",
+        confirmLabel: "Discard",
+        tone: "danger",
+      });
+      if (!ok) return;
+    }
+    onClose();
+  }, [onClose]);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") void requestClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [requestClose]);
 
-  const ctrl =
-    "w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+  const values: FormValues = {};
+  for (const col of [...columns, ...hiddenColumns]) {
+    values[col.columnId] = row[col.columnId] ?? null;
+  }
 
-  const field = (col: ColumnDefinition) => {
-    const value = row[col.columnId] ?? null;
-    const editable = canEdit && col.editable && INLINE_EDITABLE.has(col.fieldType);
-
-    if (!editable) {
-      return (
-        <div className="truncate text-sm text-[var(--dpf-text)]" title={cellSearchText(value)}>
-          {cellSearchText(value) || <span className="text-[var(--dpf-muted)]">—</span>}
-        </div>
-      );
-    }
-
-    switch (col.fieldType) {
-      case "checkbox":
-        return (
-          <input
-            type="checkbox"
-            checked={value === true}
-            onChange={(e) => onSave(col.columnId, e.target.checked)}
-            aria-label={col.name}
-          />
-        );
-      case "select":
-        return (
-          <select
-            className={ctrl}
-            value={asStr(value)}
-            onChange={(e) => onSave(col.columnId, e.target.value || null)}
-            aria-label={col.name}
-          >
-            <option value="">—</option>
-            {(col.config?.options ?? []).map((o: SelectOption) => (
-              <option key={o.key} value={o.key}>
-                {o.label}
-              </option>
-            ))}
-          </select>
-        );
-      case "number":
-      case "currency":
-      case "percent":
-      case "progress":
-      case "rating":
-      case "duration":
-        return (
-          <input
-            type="number"
-            className={ctrl}
-            defaultValue={asStr(value)}
-            onBlur={(e) => onSave(col.columnId, e.target.value === "" ? null : Number(e.target.value))}
-            aria-label={col.name}
-          />
-        );
-      case "date":
-      case "datetime":
-        return (
-          <input
-            type={col.fieldType === "datetime" ? "datetime-local" : "date"}
-            className={ctrl}
-            defaultValue={asStr(value).slice(0, col.fieldType === "datetime" ? 16 : 10)}
-            onBlur={(e) => onSave(col.columnId, e.target.value || null)}
-            aria-label={col.name}
-          />
-        );
-      default:
-        return (
-          <input
-            className={ctrl}
-            defaultValue={asStr(value)}
-            onBlur={(e) => onSave(col.columnId, e.target.value === "" ? null : e.target.value)}
-            aria-label={col.name}
-          />
-        );
-    }
+  const renderReadOnly = (field: FormFieldSpec, value: unknown) => {
+    const text = cellSearchText(value as CellValue);
+    // Full content, wrapped — a read-only description must be readable, not
+    // truncated to one line.
+    return (
+      <div className="whitespace-pre-wrap break-words text-sm text-[var(--dpf-text)]">
+        {text || <span className="text-[var(--dpf-muted)]">—</span>}
+      </div>
+    );
   };
 
   return (
@@ -144,30 +95,34 @@ export function RecordDetailModal({
       role="dialog"
       aria-modal="true"
       aria-label="Record detail"
-      onClick={onClose}
+      onClick={() => void requestClose()}
     >
       <div className="dpf-record-modal" onClick={(e) => e.stopPropagation()}>
         <div className="dpf-record-modal-header">
           <span className="text-sm font-semibold text-[var(--dpf-text)]">Record</span>
           <button
             type="button"
-            onClick={onClose}
+            onClick={() => void requestClose()}
             aria-label="Close"
             className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
           >
             ✕
           </button>
         </div>
-        <dl className="dpf-record-modal-body">
-          {columns.map((col) => (
-            <div key={col.columnId} className="dpf-record-modal-row">
-              <dt className="text-xs font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
-                {col.name}
-              </dt>
-              <dd>{field(col)}</dd>
-            </div>
-          ))}
-        </dl>
+        <RecordForm
+          fields={columns.map((c) => toFieldSpec(c, canEdit))}
+          hiddenFields={hiddenColumns.map((c) => toFieldSpec(c, canEdit))}
+          values={values}
+          onDirtyChange={(dirty) => {
+            dirtyRef.current = dirty;
+          }}
+          onSave={(dirty) => {
+            for (const [columnId, value] of Object.entries(dirty)) {
+              onSave(columnId, value as CellValue);
+            }
+          }}
+          renderReadOnly={renderReadOnly}
+        />
       </div>
     </div>
   );

--- a/apps/web/lib/form-kit/field-controls.test.ts
+++ b/apps/web/lib/form-kit/field-controls.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { inputTypeFor, resolveControlKind, type FormFieldSpec } from "./field-controls";
+
+function field(fieldType: string, overrides: Partial<FormFieldSpec> = {}): FormFieldSpec {
+  return { fieldId: "f1", label: "Field", fieldType, editable: true, ...overrides };
+}
+
+describe("resolveControlKind", () => {
+  it("gives free text the auto-growing editor, always", () => {
+    expect(resolveControlKind(field("text"))).toBe("longtext");
+    expect(resolveControlKind(field("text", { multiline: true }))).toBe("longtext");
+  });
+
+  it("keeps semantic token fields single-line with the right input type", () => {
+    for (const t of ["url", "email", "phone"]) {
+      expect(resolveControlKind(field(t))).toBe("text");
+    }
+    expect(inputTypeFor("url")).toBe("url");
+    expect(inputTypeFor("email")).toBe("email");
+    expect(inputTypeFor("phone")).toBe("tel");
+    expect(inputTypeFor("text")).toBe("text");
+  });
+
+  it("maps the numeric family to the number control", () => {
+    for (const t of ["number", "currency", "percent", "progress", "rating", "duration"]) {
+      expect(resolveControlKind(field(t))).toBe("number");
+    }
+  });
+
+  it("maps checkbox, select, date, datetime to their controls", () => {
+    expect(resolveControlKind(field("checkbox"))).toBe("checkbox");
+    expect(resolveControlKind(field("select"))).toBe("select");
+    expect(resolveControlKind(field("date"))).toBe("date");
+    expect(resolveControlKind(field("datetime"))).toBe("datetime");
+  });
+
+  it("keeps complex and computed kinds read-only", () => {
+    for (const t of ["reference", "link", "multi_select", "image", "attachment", "formula", "lookup", "rollup"]) {
+      expect(resolveControlKind(field(t))).toBe("readonly");
+    }
+  });
+
+  it("never edits a non-editable field regardless of type", () => {
+    expect(resolveControlKind(field("text", { editable: false }))).toBe("readonly");
+  });
+});

--- a/apps/web/lib/form-kit/field-controls.ts
+++ b/apps/web/lib/form-kit/field-controls.ts
@@ -1,0 +1,68 @@
+// Platform form-kit — field→control selection (EP-UX-SYSTEM, BI-C167C45E).
+// Spec: docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md
+//
+// One deterministic mapping from a form field's declared type to the editing
+// control that renders it, so every form sizes controls to the content the same
+// way instead of forcing everything through a single-line <input>. Pure and
+// UI-library-agnostic; components consume the returned kind.
+
+/** A field as the form kernel consumes it — adapted from the owning surface's
+ * column/field metadata (e.g. a Workbooks ColumnDefinition). */
+export interface FormFieldSpec {
+  fieldId: string;
+  label: string;
+  /** Owning surface's field type (form-kit interprets the common vocabulary). */
+  fieldType: string;
+  editable: boolean;
+  required?: boolean;
+  /** Text fields: prefer a multi-line editor regardless of current length. */
+  multiline?: boolean;
+  /** select fields: the allowed options. */
+  options?: Array<{ key: string; label: string }>;
+}
+
+/** The control vocabulary form components render. */
+export type FormControlKind =
+  | "longtext" // auto-growing textarea, starts single-line
+  | "text" // single-line semantic input (url/email/phone)
+  | "number"
+  | "checkbox"
+  | "select"
+  | "date"
+  | "datetime"
+  | "readonly";
+
+/** Field types stored as plain numbers (mirrors workbooks NUMERIC_FIELD_TYPES). */
+const NUMBER_KINDS = new Set(["number", "currency", "percent", "progress", "rating", "duration"]);
+
+/** Single-line by semantics: the value is an address-like token, never prose. */
+const SINGLE_LINE_TEXT_KINDS = new Set(["url", "email", "phone"]);
+
+/**
+ * Resolve the editing control for a field. Free text always gets the
+ * auto-growing editor (a one-row textarea behaves like an input but grows with
+ * content — the Airtable/Linear record-form pattern), so long descriptions are
+ * never trapped in a truncated single line.
+ */
+export function resolveControlKind(field: FormFieldSpec): FormControlKind {
+  if (!field.editable) return "readonly";
+  if (field.fieldType === "text") return "longtext";
+  if (SINGLE_LINE_TEXT_KINDS.has(field.fieldType)) return "text";
+  if (NUMBER_KINDS.has(field.fieldType)) return "number";
+  if (field.fieldType === "checkbox") return "checkbox";
+  if (field.fieldType === "select") return "select";
+  if (field.fieldType === "date") return "date";
+  if (field.fieldType === "datetime") return "datetime";
+  // Complex kinds (reference, link, multi_select, image, attachment) and
+  // computed kinds (formula, lookup, rollup) stay read-only in forms for now;
+  // the spec's adoption path covers promoting them to real editors.
+  return "readonly";
+}
+
+/** HTML input type for the single-line semantic text kinds. */
+export function inputTypeFor(fieldType: string): string {
+  if (fieldType === "url") return "url";
+  if (fieldType === "email") return "email";
+  if (fieldType === "phone") return "tel";
+  return "text";
+}

--- a/apps/web/lib/form-kit/form-state.test.ts
+++ b/apps/web/lib/form-kit/form-state.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  committed,
+  dirtyFieldIds,
+  dirtyValues,
+  discarded,
+  formValuesEqual,
+  initFormState,
+  isFormDirty,
+  rebaselined,
+  withFieldEdit,
+} from "./form-state";
+
+describe("formValuesEqual", () => {
+  it("treats null and undefined as the same empty value", () => {
+    expect(formValuesEqual(null, undefined)).toBe(true);
+    expect(formValuesEqual(undefined, null)).toBe(true);
+    expect(formValuesEqual(null, "")).toBe(false);
+  });
+
+  it("compares primitives with Object.is and arrays structurally", () => {
+    expect(formValuesEqual("a", "a")).toBe(true);
+    expect(formValuesEqual(1, 2)).toBe(false);
+    expect(formValuesEqual(["x", "y"], ["x", "y"])).toBe(true);
+    expect(formValuesEqual(["x"], ["y"])).toBe(false);
+    expect(formValuesEqual({ referenceId: "r1" }, { referenceId: "r1" })).toBe(true);
+  });
+});
+
+describe("form draft lifecycle", () => {
+  const base = { title: "Original", priority: 1, done: false };
+
+  it("starts clean", () => {
+    const s = initFormState(base);
+    expect(isFormDirty(s)).toBe(false);
+    expect(dirtyFieldIds(s)).toEqual([]);
+  });
+
+  it("tracks edits as dirty and reverting an edit clears it", () => {
+    let s = withFieldEdit(initFormState(base), "title", "Changed");
+    expect(dirtyFieldIds(s)).toEqual(["title"]);
+    s = withFieldEdit(s, "title", "Original");
+    expect(isFormDirty(s)).toBe(false);
+  });
+
+  it("dirtyValues returns only the changed subset, undefined normalized to null", () => {
+    let s = withFieldEdit(initFormState(base), "priority", 2);
+    s = withFieldEdit(s, "done", undefined);
+    expect(dirtyValues(s)).toEqual({ priority: 2, done: null });
+  });
+
+  it("discard snaps the draft back to the baseline", () => {
+    const s = discarded(withFieldEdit(initFormState(base), "title", "Changed"));
+    expect(isFormDirty(s)).toBe(false);
+    expect(s.draft.title).toBe("Original");
+  });
+
+  it("commit makes the draft the new baseline", () => {
+    const s = committed(withFieldEdit(initFormState(base), "title", "Changed"));
+    expect(isFormDirty(s)).toBe(false);
+    expect(s.baseline.title).toBe("Changed");
+  });
+
+  it("rebaseline keeps unsaved edits but adopts outside changes elsewhere", () => {
+    const s = withFieldEdit(initFormState(base), "title", "My unsaved edit");
+    const r = rebaselined(s, { title: "Server title", priority: 9, done: true });
+    expect(r.draft.title).toBe("My unsaved edit"); // typing preserved
+    expect(r.draft.priority).toBe(9); // outside change adopted
+    expect(r.baseline.title).toBe("Server title");
+    expect(dirtyFieldIds(r)).toEqual(["title"]);
+  });
+});

--- a/apps/web/lib/form-kit/form-state.ts
+++ b/apps/web/lib/form-kit/form-state.ts
@@ -1,0 +1,90 @@
+// Platform form-kit — dirty-state kernel (EP-UX-SYSTEM, BI-C167C45E).
+// Spec: docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md
+//
+// The one commit model every record-editing form composes: edits accumulate in
+// a draft, the caller decides when the draft becomes real (Save) or is thrown
+// away (Discard). No field commits on blur. Pure and UI-library-agnostic so the
+// same kernel serves the Workbooks record modal, settings pages, and admin CRUD
+// forms without re-inventing per-surface save semantics.
+
+/** A form's values keyed by field id. Values are opaque to the kernel. */
+export type FormValues = Record<string, unknown>;
+
+export interface FormDraftState {
+  /** Last saved/loaded values — what Discard returns to. */
+  readonly baseline: FormValues;
+  /** Current on-screen values, including unsaved edits. */
+  readonly draft: FormValues;
+}
+
+/**
+ * Value equality for dirty detection. Primitives compare with Object.is;
+ * arrays/objects compare structurally (JSON round-trip — form values are plain
+ * data by contract). `undefined` and `null` are treated as the same "empty".
+ */
+export function formValuesEqual(a: unknown, b: unknown): boolean {
+  const na = a === undefined ? null : a;
+  const nb = b === undefined ? null : b;
+  if (Object.is(na, nb)) return true;
+  if (typeof na !== "object" || typeof nb !== "object" || na === null || nb === null) {
+    return false;
+  }
+  try {
+    return JSON.stringify(na) === JSON.stringify(nb);
+  } catch {
+    return false;
+  }
+}
+
+/** Start a form session from the record's current values. */
+export function initFormState(values: FormValues): FormDraftState {
+  return { baseline: { ...values }, draft: { ...values } };
+}
+
+/** Apply one field edit to the draft. Never mutates. */
+export function withFieldEdit(
+  state: FormDraftState,
+  fieldId: string,
+  value: unknown,
+): FormDraftState {
+  return { baseline: state.baseline, draft: { ...state.draft, [fieldId]: value } };
+}
+
+/** Field ids whose draft value differs from the baseline. */
+export function dirtyFieldIds(state: FormDraftState): string[] {
+  const ids = new Set([...Object.keys(state.baseline), ...Object.keys(state.draft)]);
+  return [...ids].filter((id) => !formValuesEqual(state.baseline[id], state.draft[id]));
+}
+
+export function isFormDirty(state: FormDraftState): boolean {
+  return dirtyFieldIds(state).length > 0;
+}
+
+/** The dirty subset of the draft — what Save should persist. */
+export function dirtyValues(state: FormDraftState): FormValues {
+  const out: FormValues = {};
+  for (const id of dirtyFieldIds(state)) out[id] = state.draft[id] ?? null;
+  return out;
+}
+
+/** Discard: the draft snaps back to the baseline. */
+export function discarded(state: FormDraftState): FormDraftState {
+  return { baseline: state.baseline, draft: { ...state.baseline } };
+}
+
+/** Commit: the draft becomes the new baseline (call after persistence succeeds). */
+export function committed(state: FormDraftState): FormDraftState {
+  return { baseline: { ...state.draft }, draft: { ...state.draft } };
+}
+
+/**
+ * Refresh from outside (e.g. the row re-loaded): new baseline, but unsaved
+ * edits on still-dirty fields are preserved so a background refresh cannot
+ * silently eat what the user is typing.
+ */
+export function rebaselined(state: FormDraftState, values: FormValues): FormDraftState {
+  const dirty = new Set(dirtyFieldIds(state));
+  const draft: FormValues = { ...values };
+  for (const id of dirty) draft[id] = state.draft[id];
+  return { baseline: { ...values }, draft };
+}

--- a/docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md
+++ b/docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md
@@ -1,0 +1,108 @@
+# Platform Forms & Data-Entry Framework (form-kit)
+
+- **Status:** first slice implemented
+- **Date:** 2026-07-28
+- **Epic:** `EP-UX-SYSTEM`
+- **Backlog items:** `BI-C167C45E` (framework), `BI-69371E1A` (first consumer: Workbooks record modal)
+- **Work Capsule:** `WC-624157ED`
+
+## 1. Problem
+
+DPF has a shared design-system vocabulary for *reporting* UX (`apps/web/components/ui/report-kit/`:
+`StatusBadge`, `DataTable`, `StatCard`, `FilterBar`, `Chart`) but none for *editing* UX. There is no
+form library dependency at all (`apps/web/package.json` carries no react-hook-form, Formik, or
+TanStack Form), so every editing surface hand-rolls its own form. The result, reported live by the
+operator against the Workbooks record modal (2026-07-27, BI-957970CA's record): edits commit
+per-field on blur with no way to save-or-not-save, every field renders as one uniform single-line
+input so long descriptions cannot be read, and there is no way to hide, reorder, or persist a field
+layout — for everyone or just for yourself.
+
+## 2. Decision
+
+Introduce **form-kit**: a small DPF-native forms layer with three parts —
+
+1. a pure **dirty-state kernel** (`apps/web/lib/form-kit/form-state.ts`): draft accumulates edits,
+   explicit Save persists the dirty subset, Discard reverts; nothing commits on blur;
+2. a deterministic **field→control registry** (`apps/web/lib/form-kit/field-controls.ts`): free
+   text always gets an auto-growing editor, semantic tokens (url/email/phone) stay single-line
+   with correct input types, the numeric family maps to number controls, complex/computed kinds
+   stay read-only until promoted;
+3. a **record-form composition** (`apps/web/components/ui/form-kit/RecordForm.tsx` +
+   `AutoGrowTextarea.tsx`): label/control rows from `FormFieldSpec` metadata, a Save/Discard bar
+   that appears only when dirty, and a disclosure section for fields the active layout hides.
+
+Layout customization ("hide, move things around, save for all or just me") is **not** a new
+persistence model. The first consumer proves the intended pattern: the form consumes the owning
+surface's existing view state. Workbooks already has exactly the two scopes the operator asked
+for — server-backed `WorkbookView` rows shared per custom table ("for all"), and localStorage
+per-grid state on platform grids plus any user's own named view ("just for me") — so the record
+form simply follows the active view's column order/visibility instead of inventing a parallel
+layout store.
+
+## 3. Research & Benchmarking
+
+Compared before building (data/interaction models, not feature lists):
+
+| Source | What it does | Adopted / rejected |
+| --- | --- | --- |
+| [react-hook-form](https://react-hook-form.com/) | Uncontrolled-input registration for perf; validation via resolver schemas (zod). | **Rejected as a dependency for v1.** Its core value (uncontrolled perf on large static typed forms, client-side schema validation) does not match DPF's shape: our forms are generated from dynamic field metadata and validation is server-owned (the Grid's `persistCell` dispatch; server actions). Adding it now adds supply-chain surface (EP-DEP-SOVEREIGNTY) for little leverage. Re-evaluate at the settings-forms adoption phase. |
+| [TanStack Form](https://tanstack.com/form/latest) | Headless, framework-agnostic form state with fine-grained subscriptions. | Same verdict as react-hook-form for v1; its headless state shape informed the kernel's API (init/edit/commit/discard as pure transitions). |
+| [RJSF (react-jsonschema-form)](https://rjsf-team.github.io/react-jsonschema-form/) | Generates whole forms from JSON Schema + uiSchema. | **Adopted the idea** (metadata-driven form generation — our `FormFieldSpec` plays the uiSchema role over Workbooks `ColumnDefinition`); rejected the library (schema dialect + widget theming would fight the DPF token system). |
+| Airtable / Linear record forms | "Expand a row" record detail; one-row auto-growing text fields; explicit long-text editors; field visibility follows the view. | **Adopted**: auto-grow-from-one-row free text (`AutoGrowTextarea`), record form follows the active view's field order/visibility, hidden fields reachable but de-emphasized. |
+| ServiceNow / Salesforce form layout editors | Admin-configured per-role form layouts stored server-side. | **Adopted the two-scope lesson** (org-shared default + personal override) but mapped it onto DPF's existing `WorkbookView` + localStorage view substrate instead of a new layout store; a dedicated layout editor is deferred until a surface proves the need. |
+| Retool / Appsmith form builders | Drag-drop form composition bound to queries. | Rejected for now — builder-grade composition belongs to a later phase; v1 is metadata-driven rendering. |
+
+## 4. Contract
+
+```ts
+// lib/form-kit/form-state.ts — pure kernel
+initFormState(values) -> { baseline, draft }
+withFieldEdit(state, fieldId, value)      // draft-only
+dirtyFieldIds / isFormDirty / dirtyValues // Object.is + structural equality; null≡undefined
+committed(state)   // after persistence succeeds
+discarded(state)   // revert
+rebaselined(state, fresh) // outside refresh never eats in-progress typing
+
+// lib/form-kit/field-controls.ts
+resolveControlKind(FormFieldSpec) -> longtext | text | number | checkbox | select | date | datetime | readonly
+```
+
+`RecordForm` owns rendering + the Save/Discard bar; the host owns persistence (receives only the
+dirty subset), read-only rendering of its complex value kinds, and close-guarding (via
+`onDirtyChange`, e.g. `confirmDialog` before closing a dirty modal — never a native dialog).
+
+## 5. First consumer (BI-69371E1A)
+
+`apps/web/components/workbooks/RecordDetailModal.tsx` is rebuilt on `RecordForm`:
+
+- explicit Save (loops the dirty subset through the Grid's existing validated `persistCell`
+  dispatch) and Discard; Escape/backdrop/✕ all pass a dirty-close `confirmDialog` guard;
+- free text edits in `AutoGrowTextarea`; read-only values render wrapped (`whitespace-pre-wrap`),
+  never truncated;
+- the Grid now passes its view-ordered `visibleCols` as the default layout and the view's hidden
+  columns behind the disclosure — so the existing hide/reorder/pin + named-view system (shared
+  server views on custom tables, personal localStorage/named views elsewhere) *is* the modal's
+  layout customization.
+
+## 6. Adoption path (follow-up, not this slice)
+
+1. Settings/admin CRUD forms adopt `RecordForm` (and the explicit-save model replaces ad hoc
+   per-field auto-save) — file per-surface BIs as they are touched; re-evaluate react-hook-form if
+   a surface needs client-side cross-field validation.
+2. Promote complex kinds (reference, link, multi_select, attachment) from read-only to real
+   form controls by reusing the Grid's existing editors.
+3. A dedicated layout editor / per-user overrides beyond the view system only if a surface proves
+   the view-state mapping insufficient (named invariant first, per `verify-substrate-before-proposing-new`).
+
+## 7. Verification
+
+- Unit: `lib/form-kit/form-state.test.ts`, `lib/form-kit/field-controls.test.ts`.
+- Component (jsdom): `components/ui/form-kit/RecordForm.test.tsx` — no persist on blur; Save sends
+  only the dirty subset; Discard reverts; hidden-field disclosure edits; read-only delegation.
+- Gates: typecheck, production build, module-size/style guards via the shared local-CI sandbox
+  (worktree-local runners are not runtime evidence).
+
+## 8. Non-goals
+
+- No new Prisma model, migration, or layout store; no external form library in v1; no change to
+  grid in-cell editing; no builder UI.

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7356,6 +7356,12 @@
     "longSentences": 0,
     "textMass": 7
   },
+  "apps/web/components/ui/form-kit/RecordForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
   "apps/web/components/ui/form/FormField.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
Delivers **BI-C167C45E** (Platform Forms & Data-Entry Framework, EP-UX-SYSTEM — first slice) and **BI-69371E1A** (Universal Grid record detail modal, EP-GRID-WORKBOOKS) as one concern: the framework plus the consumer that proves it. Work Capsule: WC-624157ED.

## What changed
- **form-kit kernel** (`apps/web/lib/form-kit/`): pure dirty-state model — edits accumulate in a draft; explicit Save persists only the dirty subset; Discard reverts; a background rebaseline never eats in-progress typing. Deterministic field→control registry: free text always gets an auto-growing editor, url/email/phone stay semantic single-line inputs, numeric family → number control, complex/computed kinds read-only.
- **form-kit components** (`apps/web/components/ui/form-kit/`): `AutoGrowTextarea` (grows from one line, clamped) and `RecordForm` (metadata-driven rows, Save/Discard bar shown only when dirty, hidden-fields disclosure, host-owned persistence and read-only rendering).
- **Workbooks record modal** rebuilt on form-kit: no more silent per-blur autosave; every close path (Escape/backdrop/✕) passes a dirty-close `confirmDialog` guard; long descriptions readable (wrapped read-only, auto-grow editing); the field layout now follows the grid view's order/visibility — the existing shared server views ("for all") and personal views/localStorage ("just me") are the layout scopes, no new persistence model.
- **Spec**: `docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md` with the required Research & Benchmarking (react-hook-form, TanStack Form, RJSF, Airtable/Linear, ServiceNow/Salesforce, Retool) and the no-new-dependency rationale for v1.

## Design grounding
Grounded in `docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md` (new artifact, this PR) over the existing `apps/web/` substrate: `components/workbooks/RecordDetailModal.tsx` (BI-90971F1F), Grid view state (`grid-view-options.ts`, named views, `WorkbookView`), report-kit precedent, `components/ui/Dialog` confirmDialog. Extends EP-GRID-WORKBOOKS + EP-UX-SYSTEM; no parallel form stack, no new table/enum/migration.

## Verification
- Unit + component tests added (`form-state.test.ts`, `field-controls.test.ts`, `RecordForm.test.tsx`); scoped typecheck of changed files clean in the session tree (only pre-existing environment-corruption errors elsewhere, e.g. react-data-grid types missing exports that main CI has).
- Worktree is source-only and the shared local-integration-ci sandbox fence was held by a live peer session at push time, so the pre-push gate used the recorded override; PR CI is the authoritative gate here.

Local-CI-Override: shared local-integration-ci sandbox fence held by a live peer session; source-only worktree; form-kit tests + scoped typecheck verified in session tree; full suite gated by this PR's CI and the merge queue.
UX-Fit-Decision: fits-with-guardrails - one explicit Save/Discard bar shown only when dirty replaces silent per-blur autosave; long text auto-grows instead of truncating; hidden fields behind one disclosure; no new route, tab, or dashboard; layout customization reuses the existing grid view system.
Design-Grounding-Decision: new spec docs/superpowers/specs/2026-07-28-platform-forms-framework-design.md over existing apps/web/ substrate (RecordDetailModal, grid view state, report-kit, Dialog); extends EP-GRID-WORKBOOKS + EP-UX-SYSTEM.
Docs-Impact-Decision: no documented user-facing route changed; the record modal has no user-guide page today - the new spec is the documentation artifact for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)