### PR TITLE
fix: cap WSL crash-dump retention in the installer

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -858,6 +858,47 @@ if ((Test-StepDone "wsl2_partial") -and -not (Test-StepDone "wsl2")) {
     Save-Progress "wsl2"
 }
 
+# Cap WSL2's built-in crash-dump collector (Microsoft Learn: "Advanced settings
+# configuration in WSL", maxCrashDumpCount under [wsl2]). Left uncapped, every
+# ephemeral process that aborts inside a WSL-backed Docker container writes a
+# dump to %LOCALAPPDATA%\Temp\wsl-crashes with no automatic cleanup -- observed
+# reaching 60GB+ and filling the system drive on a dev box running many
+# parallel containerized builds. Runs on every install/reinstall pass (not
+# gated behind Test-StepDone) so it backfills existing installs whose
+# .wslconfig predates this fix, but never overwrites an operator's own
+# explicit choice for this key.
+$wslConfigPath = Join-Path $env:USERPROFILE ".wslconfig"
+$crashDumpCap = 2
+$wslConfigChanged = $false
+if (Test-Path $wslConfigPath) {
+    $wslConfigLines = @(Get-Content -LiteralPath $wslConfigPath)
+    # NOTE: "-notmatch" against an array filters to non-matching elements (almost
+    # always truthy) rather than testing "no element matches" -- use a positive
+    # -match filter and check its Count instead.
+    if (@($wslConfigLines -match "^\s*maxCrashDumpCount\s*=").Count -eq 0) {
+        if (@($wslConfigLines -match "^\s*\[wsl2\]\s*$").Count -gt 0) {
+            # Insert right after the [wsl2] section header.
+            $newLines = New-Object System.Collections.Generic.List[string]
+            foreach ($line in $wslConfigLines) {
+                $newLines.Add($line)
+                if ($line -match "^\s*\[wsl2\]\s*$") {
+                    $newLines.Add("maxCrashDumpCount=$crashDumpCap")
+                }
+            }
+            Set-Content -LiteralPath $wslConfigPath -Value $newLines
+        } else {
+            Add-Content -LiteralPath $wslConfigPath -Value @("", "[wsl2]", "maxCrashDumpCount=$crashDumpCap")
+        }
+        $wslConfigChanged = $true
+    }
+} else {
+    Set-Content -LiteralPath $wslConfigPath -Value @("[wsl2]", "maxCrashDumpCount=$crashDumpCap")
+    $wslConfigChanged = $true
+}
+if ($wslConfigChanged) {
+    Write-OK "Capped WSL crash-dump retention (maxCrashDumpCount=$crashDumpCap) in .wslconfig"
+}
+
 # --- Step 3: Docker Desktop ---------------------------------------------------
 
 Write-Step 3 10 "Installing Docker Desktop..."


### PR DESCRIPTION
## Summary
- WSL2's built-in crash-dump collector (`core_pattern` -> `wsl-capture-crash`) writes a dump to `%LOCALAPPDATA%\Temp\wsl-crashes` for every process that aborts inside any WSL distro, with no automatic cleanup. On a dev box running many parallel containerized builds, ephemeral test/build containers abort routinely (postgres, node, and the prisma engine were all observed) and this reached 60GB+, filling the system drive.
- `dmesg` showed zero OOM kills and zero kernel panics — this is Microsoft's own crash collector working exactly as designed, not a sign of host/kernel instability. The fix is retention, not root-causing every individual ephemeral container abort.
- Adds `maxCrashDumpCount=2` to `.wslconfig` during the installer's WSL2 setup step, per [Microsoft Learn's documented setting](https://learn.microsoft.com/en-us/windows/wsl/wsl-config), so every future install — not just this dev machine — is capped from the start.
- Runs on every install/reinstall pass (not gated behind `Test-StepDone`) so it backfills existing installs whose `.wslconfig` predates this fix, but never overwrites an operator's own explicit value for this key if one already exists.

## Test plan
- [x] PowerShell tokenizer parse check: no syntax errors.
- [x] ASCII-only compliance check per AGENTS.md PowerShell conventions: clean.
- [x] Ran the exact merge logic against 4 fixtures: no `.wslconfig` (creates it), `[wsl2]` section present with no key (inserts after header), key already set to a different value (correctly left unchanged — no duplicate line), no `[wsl2]` section at all (appends one). Caught and fixed a real bug in the first pass: PowerShell's `-notmatch` against an array filters non-matching elements rather than returning a boolean, so the original check never actually detected an existing key.
- [x] Applied `maxCrashDumpCount=2` to this dev machine's own `.wslconfig` and ran `wsl --shutdown` to confirm it takes effect without breaking the running Ubuntu/docker-desktop distros.
- [x] gitleaks secret scan passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)