### PR TITLE
feat: run bounded Build Studio experiment replicates

### DIFF
--- a/apps/web/lib/integrate/work-pattern-build-replay.test.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.test.ts
@@ -29,7 +29,7 @@ const request = {
     taskCorpusKey: "bounded-build-corpus",
     taskCorpusVersion: "1",
     environmentKey: "shadow",
-    sourceCommitSha: "abc123",
+    sourceCommitSha: "abc1234",
   },
   fixtureKey: "fixture-1",
   oracleKey: "fixture-tests",

--- a/apps/web/lib/integrate/work-pattern-build-replay.test.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeHermeticBuildReplay,
+  parseHermeticBuildReplayFixture,
+} from "./work-pattern-build-replay";
+
+const request = {
+  experimentRunId: "WPR-1",
+  childTaskRunId: "TR-CELL-1",
+  cellKey: "control",
+  pairKey: "pair",
+  methodVariantKey: "baseline",
+  modelVariantKey: "model-a",
+  executionProfile: {
+    patternKey: "implementation-loop",
+    patternVersion: 1,
+    variantKey: "baseline",
+    activityKey: "build.implement",
+    riskClass: "internal-reversible" as const,
+    providerId: "provider-a",
+    modelId: "model-a",
+    modelProfileId: "profile-a",
+    toolPackDigest: "bounded-code",
+    promptOrSkillDigest: "method-digest",
+    contextPolicyKey: "hermetic",
+    recoveryPolicyKey: "bounded",
+    installScope: "canonical" as const,
+    taskCorpusKey: "bounded-build-corpus",
+    taskCorpusVersion: "1",
+    environmentKey: "shadow",
+    sourceCommitSha: "abc123",
+  },
+  fixtureKey: "fixture-1",
+  oracleKey: "fixture-tests",
+  oracleVersion: "1",
+  resourcePolicyKey: "bounded",
+};
+
+const fixture = {
+  schemaVersion: 1,
+  kind: "build-replay-v1",
+  objective: "Implement the bounded helper.",
+  targetFile: "apps/web/lib/fixtures/bounded.ts",
+  testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+  methodInstructions: {
+    "method-digest": "Prefer the smallest pure implementation.",
+  },
+};
+
+describe("hermetic build replay", () => {
+  it("rejects traversal, shell-bearing paths, and mutable authority", () => {
+    expect(parseHermeticBuildReplayFixture({
+      ...fixture,
+      targetFile: "../../etc/passwd",
+    })).toBeNull();
+    expect(parseHermeticBuildReplayFixture({
+      ...fixture,
+      testFiles: ["apps/web/x.test.ts; touch /tmp/owned"],
+    })).toBeNull();
+  });
+
+  it("escalates a high-risk fixture before creating a workspace", async () => {
+    const exec = vi.fn();
+    await expect(executeHermeticBuildReplay({
+      request: {
+        ...request,
+        executionProfile: {
+          ...request.executionProfile,
+          riskClass: "outbound-or-floor",
+        },
+      },
+      fixtureParts: fixture,
+      agentId: "agent-1",
+      deps: {
+        containerId: "sandbox",
+        exec,
+        infer: vi.fn(),
+        runTests: vi.fn(),
+        runBuild: vi.fn(),
+      },
+    })).rejects.toThrow("work_pattern_experiment_authority_ceiling");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("uses an isolated worktree, bounded coding dispatch, scoped tests, and production build", async () => {
+    const exec = vi.fn().mockResolvedValue("");
+    const infer = vi.fn().mockResolvedValue({
+      content: "```typescript\nexport const bounded = true;\n```",
+      providerId: "provider-actual",
+      modelId: "model-actual",
+      inputTokens: 30,
+      outputTokens: 8,
+    });
+    const runTests = vi.fn().mockResolvedValue({ passed: true });
+    const runBuild = vi.fn().mockResolvedValue({
+      allPassed: true,
+      typecheck: { passed: true },
+      build: { passed: true },
+    });
+
+    const execution = await executeHermeticBuildReplay({
+      request,
+      fixtureParts: fixture,
+      agentId: "agent-1",
+      deps: {
+        containerId: "sandbox",
+        exec,
+        infer,
+        runTests,
+        runBuild,
+      },
+    });
+
+    expect(exec.mock.calls[0]?.[1]).toContain("git worktree add");
+    expect(exec.mock.calls[1]?.[1]).toContain("base64 -d");
+    expect(exec.mock.calls.at(-1)?.[1]).toContain("git worktree remove");
+    expect(infer).toHaveBeenCalledWith(expect.objectContaining({
+      profile: expect.objectContaining({
+        providerId: "provider-a",
+        modelId: "model-a",
+      }),
+      systemPrompt: expect.stringContaining("Prefer the smallest pure implementation."),
+    }));
+    expect(runTests).toHaveBeenCalledWith(
+      "sandbox",
+      expect.objectContaining({
+        changedFiles: [
+          "apps/web/lib/fixtures/bounded.ts",
+          "apps/web/lib/fixtures/bounded.test.ts",
+        ],
+      }),
+    );
+    expect(runBuild).toHaveBeenCalledWith(
+      "sandbox",
+      undefined,
+      expect.stringContaining(".builds/TR-CELL-1"),
+    );
+    expect(execution.result).toMatchObject({
+      success: true,
+      actualProviderId: "provider-actual",
+      actualModelId: "model-actual",
+      filesChanged: ["apps/web/lib/fixtures/bounded.ts"],
+      buildGate: {
+        unitTests: "pass",
+        productionBuild: "pass",
+      },
+    });
+  });
+
+  it("always removes the isolated worktree after a dispatch failure", async () => {
+    const exec = vi.fn().mockResolvedValue("");
+    await expect(executeHermeticBuildReplay({
+      request,
+      fixtureParts: fixture,
+      agentId: "agent-1",
+      deps: {
+        containerId: "sandbox",
+        exec,
+        infer: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+        runTests: vi.fn(),
+        runBuild: vi.fn(),
+      },
+    })).rejects.toThrow("provider unavailable");
+    expect(exec.mock.calls.at(-1)?.[1]).toContain("git worktree remove");
+  });
+});

--- a/apps/web/lib/integrate/work-pattern-build-replay.test.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.test.ts
@@ -58,6 +58,14 @@ describe("hermetic build replay", () => {
       ...fixture,
       testFiles: ["apps/web/x.test.ts; touch /tmp/owned"],
     })).toBeNull();
+    expect(parseHermeticBuildReplayFixture({
+      ...fixture,
+      targetFile: "apps/web/app/build/page.tsx",
+    })).toBeNull();
+    expect(parseHermeticBuildReplayFixture({
+      ...fixture,
+      targetFile: "apps/web/package.json",
+    })).toBeNull();
   });
 
   it("escalates a high-risk fixture before creating a workspace", async () => {

--- a/apps/web/lib/integrate/work-pattern-build-replay.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.ts
@@ -1,0 +1,289 @@
+import { createHash } from "node:crypto";
+
+import { isRecord } from "@/lib/shared/coerce";
+import type { WorkPatternExecutionProfile } from "@/lib/tak/work-pattern-experiment-types";
+
+import {
+  buildSandboxWorktreeAddCommand,
+  buildSandboxWorktreeRemoveCommand,
+  buildWorktreePath,
+} from "./sandbox/build-branch";
+import {
+  runSandboxTypecheckBuildGate,
+  type SandboxGateResult,
+} from "./sandbox/sandbox-verification";
+import {
+  runSandboxTests,
+  type SandboxTestResult,
+} from "./coding-agent";
+import {
+  executeWorkPatternExperimentCell,
+  type WorkPatternExperimentCellRequest,
+  type WorkPatternExperimentCellResult,
+} from "./work-pattern-experiment-adapter";
+
+export type HermeticBuildReplayFixture = {
+  schemaVersion: 1;
+  kind: "build-replay-v1";
+  objective: string;
+  targetFile: string;
+  testFiles: string[];
+  methodInstructions: Record<string, string>;
+};
+
+type InferenceResult = {
+  content: string;
+  providerId: string;
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export type HermeticBuildReplayDeps = {
+  containerId: string;
+  exec: (containerId: string, command: string) => Promise<string>;
+  infer: (input: {
+    messages: Array<{ role: "user"; content: string }>;
+    systemPrompt: string;
+    profile: WorkPatternExecutionProfile;
+    agentId: string;
+  }) => Promise<InferenceResult>;
+  runTests: (
+    containerId: string,
+    opts: { changedFiles: string[]; workdir: string },
+  ) => Promise<Pick<SandboxTestResult, "passed">>;
+  runBuild: (
+    containerId: string,
+    exec?: undefined,
+    workdir?: string,
+  ) => Promise<Pick<SandboxGateResult, "allPassed">>;
+};
+
+export type HermeticBuildReplayExecution = {
+  result: WorkPatternExperimentCellResult;
+  outputDigest: string;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+const SAFE_REPO_PATH = /^(?:apps|packages)\/[a-zA-Z0-9._/-]+\.[a-zA-Z0-9]+$/;
+const SAFE_TASK_ID = /^[a-zA-Z0-9-]+$/;
+const SAFE_COMMIT = /^[a-fA-F0-9]{7,64}$/;
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function safeRepoPath(value: unknown): value is string {
+  return nonEmptyString(value)
+    && SAFE_REPO_PATH.test(value)
+    && !value.includes("..")
+    && !value.includes("//");
+}
+
+export function parseHermeticBuildReplayFixture(
+  value: unknown,
+): HermeticBuildReplayFixture | null {
+  if (
+    !isRecord(value)
+    || value.schemaVersion !== 1
+    || value.kind !== "build-replay-v1"
+    || !nonEmptyString(value.objective)
+    || !safeRepoPath(value.targetFile)
+    || !Array.isArray(value.testFiles)
+    || value.testFiles.length === 0
+    || value.testFiles.length > 4
+    || value.testFiles.some((path) => !safeRepoPath(path))
+    || !isRecord(value.methodInstructions)
+  ) {
+    return null;
+  }
+  const methodInstructions: Record<string, string> = {};
+  for (const [digest, instruction] of Object.entries(value.methodInstructions)) {
+    if (!nonEmptyString(digest) || !nonEmptyString(instruction)) return null;
+    methodInstructions[digest] = instruction;
+  }
+  if (Object.keys(methodInstructions).length === 0) return null;
+  return {
+    schemaVersion: 1,
+    kind: "build-replay-v1",
+    objective: value.objective,
+    targetFile: value.targetFile,
+    testFiles: [...value.testFiles] as string[],
+    methodInstructions,
+  };
+}
+
+function sourceFromResponse(content: string): string | null {
+  const fenced = content.match(/```(?:typescript|tsx|ts|javascript|jsx|js)?\s*\n([\s\S]*?)```/i);
+  const source = (fenced?.[1] ?? content).trim();
+  return source.length > 0 ? `${source}\n` : null;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function productionDeps(): Promise<HermeticBuildReplayDeps> {
+  const [{ execInSandbox }, { routeAndCall }] = await Promise.all([
+    import("./sandbox/sandbox"),
+    import("@/lib/routed-inference"),
+  ]);
+  return {
+    containerId: process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1",
+    exec: execInSandbox,
+    infer: async ({ messages, systemPrompt, profile, agentId }) => {
+      const response = await routeAndCall(messages, systemPrompt, "internal", {
+        taskType: profile.activityKey,
+        preferredProviderId: profile.providerId,
+        preferredModelId: profile.modelId,
+        agentId,
+        persistDecision: true,
+      });
+      return {
+        content: response.content,
+        providerId: response.providerId,
+        modelId: response.modelId,
+        inputTokens: response.inputTokens,
+        outputTokens: response.outputTokens,
+      };
+    },
+    runTests: runSandboxTests,
+    runBuild: runSandboxTypecheckBuildGate,
+  };
+}
+
+/**
+ * Executes one immutable build fixture in a detached sandbox worktree. The
+ * surface is intentionally smaller than a FeatureBuild: one declared source
+ * file, up to four pre-existing tests, and the canonical production-build gate.
+ * It has no FeatureBuild, PR, merge, release, or live-state dependency.
+ */
+export async function executeHermeticBuildReplay(input: {
+  request: WorkPatternExperimentCellRequest;
+  fixtureParts: unknown;
+  agentId: string;
+  deps?: HermeticBuildReplayDeps;
+}): Promise<HermeticBuildReplayExecution> {
+  const fixture = parseHermeticBuildReplayFixture(input.fixtureParts);
+  if (!fixture) {
+    throw new Error(`work_pattern_experiment_fixture_unavailable:${input.request.fixtureKey}`);
+  }
+  if (
+    input.request.executionProfile.activityKey !== "build.implement"
+    || input.request.executionProfile.environmentKey !== "shadow"
+    || !["read-only", "internal-reversible"].includes(
+      input.request.executionProfile.riskClass,
+    )
+  ) {
+    throw new Error(
+      `work_pattern_experiment_authority_ceiling:${input.request.childTaskRunId}`,
+    );
+  }
+  if (
+    !SAFE_TASK_ID.test(input.request.childTaskRunId)
+    || !SAFE_COMMIT.test(input.request.executionProfile.sourceCommitSha)
+  ) {
+    throw new Error(
+      `invalid_work_pattern_build_identity:${input.request.childTaskRunId}`,
+    );
+  }
+  const instruction =
+    fixture.methodInstructions[input.request.executionProfile.promptOrSkillDigest];
+  if (!instruction) {
+    throw new Error(
+      `work_pattern_experiment_method_unavailable:${input.request.executionProfile.promptOrSkillDigest}`,
+    );
+  }
+
+  const deps = input.deps ?? await productionDeps();
+  const workdir = buildWorktreePath(input.request.childTaskRunId);
+  let generatedSource = "";
+  let inference: InferenceResult | null = null;
+
+  await deps.exec(
+    deps.containerId,
+    buildSandboxWorktreeAddCommand(
+      input.request.childTaskRunId,
+      input.request.executionProfile.sourceCommitSha,
+    ),
+  );
+  try {
+    const result = await executeWorkPatternExperimentCell(input.request, {
+      prepareWorkspace: async () => ({
+        workspaceId:
+          `${input.request.childTaskRunId}:${input.request.executionProfile.sourceCommitSha}`,
+        workdir,
+      }),
+      dispatch: async () => {
+        inference = await deps.infer({
+          messages: [{
+            role: "user",
+            content: [
+              fixture.objective,
+              `Implement only ${fixture.targetFile}.`,
+              "Return only the complete file in one fenced code block.",
+            ].join("\n"),
+          }],
+          systemPrompt: [
+            "You are executing a bounded, hermetic Build Studio implementation fixture.",
+            "Do not call tools, access networks, modify any other file, or describe delivery actions.",
+            instruction,
+          ].join("\n"),
+          profile: input.request.executionProfile,
+          agentId: input.agentId,
+        });
+        const source = sourceFromResponse(inference.content);
+        if (!source) {
+          return {
+            success: false,
+            providerId: inference.providerId,
+            modelId: inference.modelId,
+            filesChanged: [],
+            toolCalls: 1,
+            toolFailures: 1,
+            error: "empty_code_generation",
+          };
+        }
+        generatedSource = source;
+        const encoded = Buffer.from(source).toString("base64");
+        await deps.exec(
+          deps.containerId,
+          `printf %s '${encoded}' | base64 -d > ${workdir}/${fixture.targetFile}`,
+        );
+        return {
+          success: true,
+          providerId: inference.providerId,
+          modelId: inference.modelId,
+          filesChanged: [fixture.targetFile],
+          toolCalls: 2,
+          toolFailures: 0,
+        };
+      },
+      verify: async () => {
+        const tests = await deps.runTests(deps.containerId, {
+          changedFiles: [fixture.targetFile, ...fixture.testFiles],
+          workdir,
+        });
+        const build = await deps.runBuild(deps.containerId, undefined, workdir);
+        return {
+          unitTests: tests.passed ? "pass" : "fail",
+          productionBuild: build.allPassed ? "pass" : "fail",
+          uxVerification: "not-applicable",
+          migration: "not-applicable",
+        };
+      },
+    });
+    return {
+      result,
+      outputDigest: sha256(generatedSource),
+      inputTokens: inference?.inputTokens ?? 0,
+      outputTokens: inference?.outputTokens ?? 0,
+    };
+  } finally {
+    await deps.exec(
+      deps.containerId,
+      buildSandboxWorktreeRemoveCommand(input.request.childTaskRunId),
+    ).catch(() => undefined);
+  }
+}

--- a/apps/web/lib/integrate/work-pattern-build-replay.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.ts
@@ -206,7 +206,8 @@ export async function executeHermeticBuildReplay(input: {
   const deps = input.deps ?? await productionDeps();
   const workdir = buildWorktreePath(input.request.childTaskRunId);
   let generatedSource = "";
-  let inference: InferenceResult | null = null;
+  let inputTokens = 0;
+  let outputTokens = 0;
 
   await deps.exec(
     deps.containerId,
@@ -223,7 +224,7 @@ export async function executeHermeticBuildReplay(input: {
         workdir,
       }),
       dispatch: async () => {
-        inference = await deps.infer({
+        const inference = await deps.infer({
           messages: [{
             role: "user",
             content: [
@@ -240,6 +241,8 @@ export async function executeHermeticBuildReplay(input: {
           profile: input.request.executionProfile,
           agentId: input.agentId,
         });
+        inputTokens = inference.inputTokens;
+        outputTokens = inference.outputTokens;
         const source = sourceFromResponse(inference.content);
         if (!source) {
           return {
@@ -284,8 +287,8 @@ export async function executeHermeticBuildReplay(input: {
     return {
       result,
       outputDigest: sha256(generatedSource),
-      inputTokens: inference?.inputTokens ?? 0,
-      outputTokens: inference?.outputTokens ?? 0,
+      inputTokens,
+      outputTokens,
     };
   } finally {
     await deps.exec(

--- a/apps/web/lib/integrate/work-pattern-build-replay.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import { isRecord } from "@/lib/shared/coerce";
 import type { WorkPatternExecutionProfile } from "@/lib/tak/work-pattern-experiment-types";
+import { DEFAULT_WORK_PATTERN_PROMOTION_POLICY } from "@/lib/tak/work-pattern-promotion-policy";
 
 import {
   buildSandboxWorktreeAddCommand,
@@ -66,7 +67,10 @@ export type HermeticBuildReplayExecution = {
   outputTokens: number;
 };
 
-const SAFE_REPO_PATH = /^(?:apps|packages)\/[a-zA-Z0-9._/-]+\.[a-zA-Z0-9]+$/;
+const SAFE_LIBRARY_TARGET =
+  /^(?:apps\/web\/lib|packages\/[a-zA-Z0-9._-]+\/src)\/[a-zA-Z0-9._/-]+\.ts$/;
+const SAFE_TEST_PATH =
+  /^(?:apps\/web\/lib|packages\/[a-zA-Z0-9._-]+\/src)\/[a-zA-Z0-9._/-]+\.(?:test|spec)\.ts$/;
 const SAFE_TASK_ID = /^[a-zA-Z0-9-]+$/;
 const SAFE_COMMIT = /^[a-fA-F0-9]{7,64}$/;
 
@@ -74,9 +78,9 @@ function nonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function safeRepoPath(value: unknown): value is string {
+function safeRepoPath(value: unknown, pattern: RegExp): value is string {
   return nonEmptyString(value)
-    && SAFE_REPO_PATH.test(value)
+    && pattern.test(value)
     && !value.includes("..")
     && !value.includes("//");
 }
@@ -89,11 +93,12 @@ export function parseHermeticBuildReplayFixture(
     || value.schemaVersion !== 1
     || value.kind !== "build-replay-v1"
     || !nonEmptyString(value.objective)
-    || !safeRepoPath(value.targetFile)
+    || !safeRepoPath(value.targetFile, SAFE_LIBRARY_TARGET)
+    || /\.(?:test|spec)\.ts$/.test(value.targetFile)
     || !Array.isArray(value.testFiles)
     || value.testFiles.length === 0
     || value.testFiles.length > 4
-    || value.testFiles.some((path) => !safeRepoPath(path))
+    || value.testFiles.some((path) => !safeRepoPath(path, SAFE_TEST_PATH))
     || !isRecord(value.methodInstructions)
   ) {
     return null;
@@ -170,9 +175,11 @@ export async function executeHermeticBuildReplay(input: {
     throw new Error(`work_pattern_experiment_fixture_unavailable:${input.request.fixtureKey}`);
   }
   if (
-    input.request.executionProfile.activityKey !== "build.implement"
+    !DEFAULT_WORK_PATTERN_PROMOTION_POLICY.supportedActivityKeys.includes(
+      input.request.executionProfile.activityKey,
+    )
     || input.request.executionProfile.environmentKey !== "shadow"
-    || !["read-only", "internal-reversible"].includes(
+    || !DEFAULT_WORK_PATTERN_PROMOTION_POLICY.supportedRiskClasses.includes(
       input.request.executionProfile.riskClass,
     )
   ) {

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
@@ -69,6 +69,7 @@ function deps(): PersistedWorkPatternRuntimeDeps {
     markWorking: vi.fn().mockResolvedValue(undefined),
     updateTaskRun: vi.fn().mockResolvedValue(undefined),
     recordEvidence: vi.fn().mockImplementation(async (input) => input),
+    executeBuildReplay: vi.fn(),
   };
 }
 
@@ -156,5 +157,83 @@ describe("executePersistedWorkPatternExperimentCell", () => {
       executePersistedWorkPatternExperimentCell("TR-CELL-1", request(), runtime),
     ).rejects.toThrow("work_pattern_experiment_fixture_unavailable");
     expect(runtime.infer).not.toHaveBeenCalled();
+  });
+
+  it("runs a hermetic code fixture through the build adapter and records a production-build pass", async () => {
+    const runtime = deps();
+    vi.mocked(runtime.loadContext).mockResolvedValueOnce({
+      taskRun: {
+        taskRunId: "TR-CELL-1",
+        currentAgentId: "agent-orchestrator",
+        initiatingAgentId: null,
+        a2aMetadata: { workPatternExperimentCell: { attempt: 1 } },
+      },
+      fixtureParts: {
+        schemaVersion: 1,
+        kind: "build-replay-v1",
+        objective: "Implement the bounded fixture.",
+        targetFile: "apps/web/lib/fixtures/bounded.ts",
+        testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+        methodInstructions: {
+          "method-digest": "Use the baseline method.",
+        },
+      },
+    });
+    vi.mocked(runtime.executeBuildReplay).mockResolvedValueOnce({
+      result: {
+        experimentRunId: "WPR-1",
+        childTaskRunId: "TR-CELL-1",
+        cellKey: "baseline:model-a",
+        pairKey: "pair",
+        methodVariantKey: "baseline",
+        modelVariantKey: "model-a",
+        fixtureKey: "fixture-1",
+        oracleKey: "oracle",
+        oracleVersion: "1",
+        resourcePolicyKey: "bounded",
+        executionProfile: request().executionProfile,
+        workspaceId: "TR-CELL-1:abc123",
+        actualProviderId: "fallback-provider",
+        actualModelId: "fallback-model",
+        success: true,
+        filesChanged: ["apps/web/lib/fixtures/bounded.ts"],
+        toolCalls: 2,
+        toolFailures: 0,
+        buildGate: {
+          unitTests: "pass",
+          productionBuild: "pass",
+          uxVerification: "not-applicable",
+          migration: "not-applicable",
+        },
+      },
+      outputDigest: "a".repeat(64),
+      inputTokens: 25,
+      outputTokens: 10,
+    });
+
+    const result = await executePersistedWorkPatternExperimentCell(
+      "TR-CELL-1",
+      request(),
+      runtime,
+    );
+
+    expect(runtime.executeBuildReplay).toHaveBeenCalledWith({
+      request: request(),
+      fixtureParts: expect.objectContaining({ kind: "build-replay-v1" }),
+      agentId: "agent-orchestrator",
+    });
+    expect(runtime.infer).not.toHaveBeenCalled();
+    expect(result.buildGate.productionBuild).toBe("pass");
+    expect(runtime.updateTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "completed",
+        a2aMetadata: expect.objectContaining({
+          workPatternExperimentResult: expect.objectContaining({
+            outputDigest: "a".repeat(64),
+            buildGate: expect.objectContaining({ productionBuild: "pass" }),
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
@@ -4,8 +4,11 @@ import {
   executePersistedWorkPatternExperimentCell,
   type PersistedWorkPatternRuntimeDeps,
 } from "./work-pattern-experiment-runtime";
+import type { WorkPatternExperimentCellRequest } from "./work-pattern-experiment-adapter";
 
-function request(environmentKey = "shadow") {
+function request(
+  environmentKey: WorkPatternExperimentCellRequest["executionProfile"]["environmentKey"] = "shadow",
+): WorkPatternExperimentCellRequest {
   return {
     experimentRunId: "WPR-1",
     childTaskRunId: "TR-CELL-1",

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -9,6 +9,7 @@ import {
 import {
   executeWorkPatternExperimentCell,
   type WorkPatternExperimentCellRequest,
+  type WorkPatternExperimentCellResult,
 } from "./work-pattern-experiment-adapter";
 
 type ReplayMessage = {
@@ -77,6 +78,16 @@ export type PersistedWorkPatternRuntimeDeps = {
     outcome?: unknown;
     metadata?: Record<string, unknown>;
   }) => Promise<Record<string, unknown>>;
+  executeBuildReplay: (input: {
+    request: WorkPatternExperimentCellRequest;
+    fixtureParts: unknown;
+    agentId: string;
+  }) => Promise<{
+    result: WorkPatternExperimentCellResult;
+    outputDigest: string;
+    inputTokens: number;
+    outputTokens: number;
+  }>;
 };
 
 function nonEmptyString(value: unknown): value is string {
@@ -251,13 +262,19 @@ async function defaultDeps(): Promise<PersistedWorkPatternRuntimeDeps> {
     },
     recordEvidence: (input) =>
       recordWorkPatternExperimentEvidence(input, { persistence }),
+    executeBuildReplay: async (input) => {
+      const { executeHermeticBuildReplay } = await import(
+        "./work-pattern-build-replay"
+      );
+      return executeHermeticBuildReplay(input);
+    },
   };
 }
 
 /**
- * Executes the first evidence-cleared autonomous lane: immutable inference
- * replay fixtures. Mutable code workspaces and live/customer side effects are
- * outside this executor and therefore fail closed at fixture parsing.
+ * Executes immutable inference fixtures or bounded build fixtures. Build
+ * fixtures run in detached sandbox worktrees and expose no delivery/live-state
+ * operations; every other fixture kind fails closed.
  */
 export async function executePersistedWorkPatternExperimentCell(
   taskRunId: string,
@@ -274,15 +291,21 @@ export async function executePersistedWorkPatternExperimentCell(
 
   const deps = injected ?? await defaultDeps();
   const context = await deps.loadContext(taskRunId, request.fixtureKey);
-  const fixture = context ? parseFixture(context.fixtureParts) : null;
-  if (!context || !fixture) {
+  if (!context) {
+    throw new Error(`work_pattern_experiment_fixture_unavailable:${request.fixtureKey}`);
+  }
+  const inferenceFixture = parseFixture(context.fixtureParts);
+  const buildFixture =
+    isRecord(context.fixtureParts)
+    && context.fixtureParts.kind === "build-replay-v1";
+  if (!inferenceFixture && !buildFixture) {
     throw new Error(`work_pattern_experiment_fixture_unavailable:${request.fixtureKey}`);
   }
   const agentId = context.taskRun.currentAgentId ?? context.taskRun.initiatingAgentId;
   if (!agentId) throw new Error(`work_pattern_experiment_orchestrator_unavailable:${taskRunId}`);
-  const instruction =
-    fixture.methodInstructions[request.executionProfile.promptOrSkillDigest];
-  if (!instruction) {
+  const instruction = inferenceFixture
+    ?.methodInstructions[request.executionProfile.promptOrSkillDigest];
+  if (inferenceFixture && !instruction) {
     throw new Error(
       `work_pattern_experiment_method_unavailable:${request.executionProfile.promptOrSkillDigest}`,
     );
@@ -306,48 +329,64 @@ export async function executePersistedWorkPatternExperimentCell(
     proposedDecision: request,
   });
 
-  let inferenceContent = "";
+  let outputDigest = "";
   let inputTokens = 0;
   let outputTokens = 0;
   const startedAtMs = Date.now();
-  const result = await executeWorkPatternExperimentCell(request, {
-    prepareWorkspace: async () => ({
-      workspaceId: `${request.childTaskRunId}:${request.executionProfile.sourceCommitSha}`,
-      workdir: `artifact://${request.fixtureKey}`,
-    }),
-    dispatch: async () => {
-      const inference = await deps.infer({
-        messages: fixture.messages,
-        systemPrompt: `${fixture.systemPrompt}\n\n${instruction}`,
-        profile: request.executionProfile,
-        agentId,
-      });
-      inferenceContent = inference.content;
-      inputTokens = inference.inputTokens;
-      outputTokens = inference.outputTokens;
-      return {
-        success: true,
-        providerId: inference.providerId,
-        modelId: inference.modelId,
-        filesChanged: [],
-        toolCalls: 1,
-        toolFailures: 0,
-      };
-    },
-    verify: async () => ({
-      unitTests: oraclePasses(fixture, inferenceContent) ? "pass" : "fail",
-      productionBuild: "not-run",
-      uxVerification: "not-applicable",
-      migration: "not-applicable",
-    }),
-  });
+  let result: WorkPatternExperimentCellResult;
+  if (buildFixture) {
+    const build = await deps.executeBuildReplay({
+      request,
+      fixtureParts: context.fixtureParts,
+      agentId,
+    });
+    result = build.result;
+    outputDigest = build.outputDigest;
+    inputTokens = build.inputTokens;
+    outputTokens = build.outputTokens;
+  } else {
+    const fixture = inferenceFixture!;
+    let inferenceContent = "";
+    result = await executeWorkPatternExperimentCell(request, {
+      prepareWorkspace: async () => ({
+        workspaceId: `${request.childTaskRunId}:${request.executionProfile.sourceCommitSha}`,
+        workdir: `artifact://${request.fixtureKey}`,
+      }),
+      dispatch: async () => {
+        const inference = await deps.infer({
+          messages: fixture.messages,
+          systemPrompt: `${fixture.systemPrompt}\n\n${instruction}`,
+          profile: request.executionProfile,
+          agentId,
+        });
+        inferenceContent = inference.content;
+        inputTokens = inference.inputTokens;
+        outputTokens = inference.outputTokens;
+        return {
+          success: true,
+          providerId: inference.providerId,
+          modelId: inference.modelId,
+          filesChanged: [],
+          toolCalls: 1,
+          toolFailures: 0,
+        };
+      },
+      verify: async () => ({
+        unitTests: oraclePasses(fixture, inferenceContent) ? "pass" : "fail",
+        productionBuild: "not-run",
+        uxVerification: "not-applicable",
+        migration: "not-applicable",
+      }),
+    });
+    outputDigest = digest(inferenceContent);
+  }
 
   const compactResult = {
     success: result.success,
     actualProviderId: result.actualProviderId,
     actualModelId: result.actualModelId,
     workspaceId: result.workspaceId,
-    outputDigest: digest(inferenceContent),
+    outputDigest,
     inputTokens,
     outputTokens,
     buildGate: result.buildGate,

--- a/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.test.ts
@@ -63,4 +63,39 @@ describe("runWorkPatternExperiment", () => {
       transition.mock.invocationCallOrder.at(-1)!,
     );
   });
+
+  it("completes before scheduling the next bounded replicate", async () => {
+    const order: string[] = [];
+    const transition = vi.fn(async (_taskRunId, lifecycle) => {
+      order.push(lifecycle);
+    });
+    const continueReplicates = vi.fn(async () => {
+      order.push("continue");
+    });
+
+    await runWorkPatternExperiment(
+      { parentTaskRunId: "TR-PARENT" },
+      {
+        loadCells: vi.fn().mockResolvedValue([
+          { taskRunId: "TR-1", status: "completed" },
+        ]),
+        executeCell: vi.fn(),
+        analyze: vi.fn(),
+        promote: vi.fn().mockResolvedValue({
+          decisions: [{
+            decision: "continue",
+            reasons: ["minimum_valid_pairs_not_met"],
+          }],
+        }),
+        transition,
+        continueReplicates,
+      },
+    );
+
+    expect(continueReplicates).toHaveBeenCalledWith(
+      "TR-PARENT",
+      expect.objectContaining({ decisions: expect.any(Array) }),
+    );
+    expect(order).toEqual(["running", "analyzing", "completed", "continue"]);
+  });
 });

--- a/apps/web/lib/queue/functions/work-pattern-experiment.ts
+++ b/apps/web/lib/queue/functions/work-pattern-experiment.ts
@@ -16,6 +16,10 @@ export type RunWorkPatternExperimentDeps = {
   promote: (
     parentTaskRunId: string,
   ) => Promise<unknown> | unknown;
+  continueReplicates?: (
+    parentTaskRunId: string,
+    promotionResult: unknown,
+  ) => Promise<unknown> | unknown;
   transition: (
     parentTaskRunId: string,
     lifecycle: "running" | "analyzing" | "completed",
@@ -38,8 +42,9 @@ export async function runWorkPatternExperiment(
   }
   await deps.transition(input.parentTaskRunId, "analyzing");
   await deps.analyze(input.parentTaskRunId, await deps.loadCells(input.parentTaskRunId));
-  await deps.promote(input.parentTaskRunId);
+  const promotionResult = await deps.promote(input.parentTaskRunId);
   await deps.transition(input.parentTaskRunId, "completed");
+  await deps.continueReplicates?.(input.parentTaskRunId, promotionResult);
   return { executed };
 }
 
@@ -199,6 +204,15 @@ export const workPatternExperimentRun = inngest.createFunction(
               promoteCompletedWorkPatternExperiment,
             } = await import("@/lib/tak/work-pattern-experiment-promotion");
             return promoteCompletedWorkPatternExperiment(taskRunId);
+          },
+          continueReplicates: async (taskRunId, promotionResult) => {
+            const {
+              scheduleNextWorkPatternExperimentReplicate,
+            } = await import("@/lib/tak/work-pattern-experiment-scheduler");
+            return scheduleNextWorkPatternExperimentReplicate({
+              parentTaskRunId: taskRunId,
+              promotionResult,
+            });
           },
           transition: (taskRunId, lifecycle) =>
             transitionWorkPatternExperiment(taskRunId, lifecycle, { persistence }),

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createRun, send } = vi.hoisted(() => ({
+const { createRun, send, findUnique, findMany } = vi.hoisted(() => ({
   createRun: vi.fn(),
   send: vi.fn(),
+  findUnique: vi.fn(),
+  findMany: vi.fn(),
 }));
 
-vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: { findUnique, findMany },
+  },
+}));
 vi.mock("@/lib/queue/functions/work-pattern-experiment", () => ({
   enqueueWorkPatternExperiment: send,
 }));
@@ -14,7 +20,10 @@ vi.mock("./work-pattern-experiment-store", () => ({
   createOrResumeWorkPatternExperiment: createRun,
 }));
 
-import { scheduleReviewedWorkPatternExperiment } from "./work-pattern-experiment-scheduler";
+import {
+  scheduleNextWorkPatternExperimentReplicate,
+  scheduleReviewedWorkPatternExperiment,
+} from "./work-pattern-experiment-scheduler";
 
 function candidate(environmentKey = "shadow") {
   const executionProfile = {
@@ -129,5 +138,123 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
     });
     expect(createRun).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it("creates exactly the next replicate from a completed valid build run and stops at eight", async () => {
+    const approved = candidate();
+    approved.cells[0]!.executionRequest.executionProfile.activityKey = "build.implement";
+    findUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      currentAgentId: "agent-1",
+      initiatingAgentId: "agent-1",
+      status: "completed",
+      a2aMetadata: {
+        workPatternExperiment: {
+          schemaVersion: 1,
+          experimentDefinitionKey: "definition",
+          experimentRunId: "WPR-1",
+          replicate: 1,
+          patternKey: approved.definition.patternKey,
+          activityKey: "build.implement",
+          riskClass: "internal-reversible",
+          methodVariants: approved.definition.methodVariants,
+          modelVariants: approved.definition.modelVariants,
+          requiredCellKeys: [approved.cells[0]!.executionRequest.cellKey],
+          taskCorpusKey: approved.definition.taskCorpusKey,
+          taskCorpusVersion: approved.definition.taskCorpusVersion,
+          oracleKey: approved.definition.oracleKey,
+          oracleVersion: approved.definition.oracleVersion,
+          promotionPolicyKey: approved.definition.promotionPolicyKey,
+          promotionPolicyVersion: approved.definition.promotionPolicyVersion,
+          installScope: approved.definition.installScope,
+          lifecycle: "completed",
+        },
+      },
+    });
+    findMany.mockResolvedValueOnce(approved.cells.map((cell) => ({
+      a2aMetadata: {
+        workPatternExperimentCell: {
+          schemaVersion: 1,
+          experimentRunId: "WPR-1",
+          experimentDefinitionKey: "definition",
+          cellKey: cell.executionRequest.cellKey,
+          pairKey: "pair",
+          methodVariantKey: cell.methodVariantKey,
+          modelVariantKey: cell.modelVariantKey,
+          attempt: 1,
+          executionRequest: cell.executionRequest,
+        },
+      },
+    })));
+    createRun.mockResolvedValueOnce({
+      parent: { taskRunId: "TR-PARENT-2" },
+      manifest: { experimentRunId: "WPR-2" },
+    });
+
+    await expect(scheduleNextWorkPatternExperimentReplicate({
+      parentTaskRunId: "TR-PARENT-1",
+      promotionResult: {
+        decisions: [{
+          decision: "continue",
+          reasons: ["minimum_valid_pairs_not_met"],
+        }],
+      },
+    })).resolves.toEqual({
+      scheduled: true,
+      parentTaskRunId: "TR-PARENT-2",
+      replicate: 2,
+    });
+    expect(createRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replicate: 2,
+        activityKey: "build.implement",
+      }),
+      expect.any(Object),
+    );
+    expect(send).toHaveBeenCalledWith("WPR-2", "TR-PARENT-2");
+
+    findUnique.mockResolvedValueOnce({
+      id: "parent-8",
+      userId: "user-1",
+      buildId: null,
+      currentAgentId: "agent-1",
+      initiatingAgentId: "agent-1",
+      status: "completed",
+      a2aMetadata: {
+        workPatternExperiment: {
+          schemaVersion: 1,
+          experimentDefinitionKey: "definition",
+          experimentRunId: "WPR-8",
+          replicate: 8,
+          patternKey: approved.definition.patternKey,
+          activityKey: "build.implement",
+          riskClass: "internal-reversible",
+          methodVariants: approved.definition.methodVariants,
+          modelVariants: approved.definition.modelVariants,
+          requiredCellKeys: [approved.cells[0]!.executionRequest.cellKey],
+          taskCorpusKey: approved.definition.taskCorpusKey,
+          taskCorpusVersion: approved.definition.taskCorpusVersion,
+          oracleKey: approved.definition.oracleKey,
+          oracleVersion: approved.definition.oracleVersion,
+          promotionPolicyKey: approved.definition.promotionPolicyKey,
+          promotionPolicyVersion: approved.definition.promotionPolicyVersion,
+          installScope: approved.definition.installScope,
+          lifecycle: "completed",
+        },
+      },
+    });
+    await expect(scheduleNextWorkPatternExperimentReplicate({
+      parentTaskRunId: "TR-PARENT-8",
+      promotionResult: {
+        decisions: [{
+          decision: "continue",
+          reasons: ["minimum_valid_pairs_not_met"],
+        }],
+      },
+    })).resolves.toEqual({
+      scheduled: false,
+      reason: "replicate_limit_reached",
+    });
+    expect(createRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
@@ -15,8 +15,10 @@ import {
 import type { WorkPatternExperimentDefinitionIdentity } from "./work-pattern-experiment-identity";
 import { WORK_PATTERN_EXPERIMENT_RISK_CLASSES } from "./work-pattern-experiment-types";
 import { parseWorkPatternExperimentMetadata } from "./work-pattern-experiment-types";
+import { DEFAULT_WORK_PATTERN_PROMOTION_POLICY } from "./work-pattern-promotion-policy";
 
-export const MAX_AUTONOMOUS_WORK_PATTERN_REPLICATES = 8;
+export const MAX_AUTONOMOUS_WORK_PATTERN_REPLICATES =
+  DEFAULT_WORK_PATTERN_PROMOTION_POLICY.minimumValidPairCount;
 
 type ReviewedExperimentCandidate = {
   definition: WorkPatternExperimentDefinitionIdentity;

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
@@ -10,9 +10,13 @@ import { enqueueWorkPatternExperiment } from "@/lib/queue/functions/work-pattern
 import {
   createOrResumeWorkPatternExperiment,
   createPrismaWorkPatternExperimentPersistence,
+  type WorkPatternExperimentInput,
 } from "./work-pattern-experiment-store";
 import type { WorkPatternExperimentDefinitionIdentity } from "./work-pattern-experiment-identity";
 import { WORK_PATTERN_EXPERIMENT_RISK_CLASSES } from "./work-pattern-experiment-types";
+import { parseWorkPatternExperimentMetadata } from "./work-pattern-experiment-types";
+
+export const MAX_AUTONOMOUS_WORK_PATTERN_REPLICATES = 8;
 
 type ReviewedExperimentCandidate = {
   definition: WorkPatternExperimentDefinitionIdentity;
@@ -142,4 +146,145 @@ export async function scheduleReviewedWorkPatternExperiment(input: {
     run.parent.taskRunId,
   );
   return { scheduled: true, parentTaskRunId: run.parent.taskRunId };
+}
+
+function needsOnlyMoreValidPairs(value: unknown): boolean {
+  if (!isRecord(value) || !Array.isArray(value.decisions) || value.decisions.length === 0) {
+    return false;
+  }
+  return value.decisions.every((decision) =>
+    isRecord(decision)
+    && decision.decision === "continue"
+    && Array.isArray(decision.reasons)
+    && decision.reasons.length === 1
+    && decision.reasons[0] === "minimum_valid_pairs_not_met"
+  );
+}
+
+/**
+ * Continues a successful build experiment to the policy's evidence floor.
+ * The next replicate number is explicit, so a retry converges on the same run
+ * even if its child event has already started or completed.
+ */
+export async function scheduleNextWorkPatternExperimentReplicate(input: {
+  parentTaskRunId: string;
+  promotionResult: unknown;
+}): Promise<{
+  scheduled: boolean;
+  parentTaskRunId?: string;
+  replicate?: number;
+  reason?: string;
+}> {
+  if (!needsOnlyMoreValidPairs(input.promotionResult)) {
+    return { scheduled: false, reason: "promotion_did_not_request_valid_pairs" };
+  }
+  const parent = await prisma.taskRun.findUnique({
+    where: { taskRunId: input.parentTaskRunId },
+    select: {
+      id: true,
+      userId: true,
+      buildId: true,
+      currentAgentId: true,
+      initiatingAgentId: true,
+      status: true,
+      a2aMetadata: true,
+    },
+  });
+  const manifest = parseWorkPatternExperimentMetadata(
+    isRecord(parent?.a2aMetadata)
+      ? parent.a2aMetadata.workPatternExperiment
+      : null,
+  );
+  if (
+    !parent
+    || parent.status !== "completed"
+    || !manifest
+    || manifest.lifecycle !== "completed"
+    || manifest.activityKey !== "build.implement"
+  ) {
+    return { scheduled: false, reason: "source_run_not_continuable" };
+  }
+  if (manifest.replicate >= MAX_AUTONOMOUS_WORK_PATTERN_REPLICATES) {
+    return { scheduled: false, reason: "replicate_limit_reached" };
+  }
+  const orchestratingAgentId =
+    parent.currentAgentId ?? parent.initiatingAgentId;
+  if (!orchestratingAgentId) {
+    return { scheduled: false, reason: "orchestrator_unavailable" };
+  }
+
+  const childRows = await prisma.taskRun.findMany({
+    where: { parentTaskRunId: parent.id },
+    select: { a2aMetadata: true },
+    orderBy: { createdAt: "asc" },
+  });
+  const cells: WorkPatternExperimentInput["cells"] = [];
+  let pairKey: string | null = null;
+  for (const row of childRows) {
+    const metadata =
+      isRecord(row.a2aMetadata)
+      && isRecord(row.a2aMetadata.workPatternExperimentCell)
+        ? row.a2aMetadata.workPatternExperimentCell
+        : null;
+    const request = parsePersistedWorkPatternExperimentExecution(
+      metadata?.executionRequest,
+    );
+    if (!request) {
+      return { scheduled: false, reason: "source_cell_request_unavailable" };
+    }
+    pairKey ??= request.pairKey;
+    if (pairKey !== request.pairKey) {
+      return { scheduled: false, reason: "source_pair_mismatch" };
+    }
+    cells.push({
+      methodVariantKey: request.methodVariantKey,
+      modelVariantKey: request.modelVariantKey,
+      executionRequest: request,
+    });
+  }
+  if (
+    !pairKey
+    || cells.length !== manifest.requiredCellKeys.length
+  ) {
+    return { scheduled: false, reason: "source_factorial_incomplete" };
+  }
+
+  const nextReplicate = manifest.replicate + 1;
+  const persistence = createPrismaWorkPatternExperimentPersistence(prisma as never);
+  const run = await createOrResumeWorkPatternExperiment(
+    {
+      definition: {
+        patternKey: manifest.patternKey,
+        taskCorpusKey: manifest.taskCorpusKey,
+        taskCorpusVersion: manifest.taskCorpusVersion,
+        oracleKey: manifest.oracleKey,
+        oracleVersion: manifest.oracleVersion,
+        methodVariants: manifest.methodVariants,
+        modelVariants: manifest.modelVariants,
+        installScope: manifest.installScope,
+        promotionPolicyKey: manifest.promotionPolicyKey,
+        promotionPolicyVersion: manifest.promotionPolicyVersion,
+      },
+      activityKey: manifest.activityKey,
+      riskClass: manifest.riskClass,
+      pairKey,
+      cells,
+      orchestratingAgentId,
+      ...(parent.buildId ? { buildId: parent.buildId } : {}),
+      replicate: nextReplicate,
+    },
+    {
+      persistence,
+      resolveOwnerUserId: async () => parent.userId,
+    },
+  );
+  await enqueueWorkPatternExperiment(
+    run.manifest.experimentRunId,
+    run.parent.taskRunId,
+  );
+  return {
+    scheduled: true,
+    parentTaskRunId: run.parent.taskRunId,
+    replicate: nextReplicate,
+  };
 }

--- a/docs/operations/autonomous-build-completion.md
+++ b/docs/operations/autonomous-build-completion.md
@@ -45,6 +45,15 @@ regulatory human-control requirement. For `build.implement`, every qualifying pa
 passing production build; inference-only replay evidence remains useful shadow evidence but cannot
 authorize an autonomous build lane.
 
+An approved low-risk `build.implement` experiment continues itself one replicate at a time until
+the eight-pair evidence floor is reached. Each cell receives a detached worktree at the same source
+commit, may generate only the fixture's declared source file, runs only the fixture's declared
+scoped tests, and must pass the canonical production build. Continuation is idempotent: retries
+request the explicit next replicate rather than allocating an unbounded new run. It stops at eight,
+on any invalid pair or hard regression, and before workspace creation for irreversible/outbound
+risk. Experiment worktrees are removed after success or failure. They never advance a Feature
+Build, create a pull request, enter the merge queue, release, or mutate the live portal.
+
 The first qualifying same-install promotion creates a rollback-safe baseline binding and then
 activates the candidate binding in the same serialized transaction. The candidate is scoped to the
 exact install, corpus, activity, risk, and model profile proved by the experiment. A note that


### PR DESCRIPTION
## Summary

- add a bounded `build-replay-v1` experiment fixture that executes one pure TypeScript library change in an isolated Build Studio worktree
- verify every cell with scoped unit tests and the production build gate while prohibiting PR, merge, release, and live-state delivery behavior
- automatically schedule balanced `build.implement` factorial replicates until the canonical eight-valid-pair policy is satisfied or promotion policy says stop
- preserve exact provider/model assignment, token, digest, build-gate, TaskRun, ledger, and recovery evidence

## Design grounding

Implements the remaining real-producer/replicate slice of the approved governed playbook experimentation design:
`docs/superpowers/specs/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-design.md`

This extends the existing FeatureBuild, TaskRun, BuildPhaseRun, DecisionShadowLedger, AuthorityBinding, Work Case, merge-queue, and governed self-upgrade substrates. It adds no parallel delivery path and no new schema. Low/reversible shadow experiments may run autonomously; unsupported activity, non-shadow execution, high risk, invalid identity, missing method material, or failed verification remains fail-closed.

Backlog: BI-356E69B1
Work Capsule: WC-D22B0EC3

## Verification

Exact candidate: `b377fc37787f3fcb4bb395b0be0a809f7ff799ec`
Merged-code integration: `5dbcf3b295e59a1341dc5e6bc7f7b252cbdd0821`
Evidence-plan digest: `fea10675b6c54dcddf26cffd5b8c58333454b3edace52edd7ec75407c5a3c2cc`

- migrations applied cleanly (no migration added)
- documentation index and link integrity passed
- 24 repository guards passed
- Vitest: 2,321 files / 20,098 tests passed; 4 files and 19 tests skipped; 18 todo
- TypeScript `next typegen && tsc --noEmit` passed
- production Docker build passed

## UX and documentation impact

UX verification is not applicable to this slice: the fixture deliberately permits only pure `.ts` library targets and rejects UI `.tsx`, route, configuration, package, and migration targets. The operator-facing autonomous-build completion documentation is updated to explain the bounded replicate behavior and escalation boundaries.

## Recovery

Each experiment cell creates an isolated worktree from an immutable source SHA and removes it in `finally`, including dispatch failure. Failed cells record compact evidence and stop promotion; replicate continuation is idempotent by explicit next replicate number and only proceeds for the sole `minimum_valid_pairs_not_met` decision.