### PR TITLE
fix(ci): make UX route sweep fixtures deterministic

### DIFF
--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -111,11 +111,6 @@ jobs:
       - name: Seed the fixture organisation
         run: pnpm --filter @dpf/db seed
 
-      # The seed alone leaves isFirstRun() true, so every authenticated surface
-      # redirects to /setup and the sweep measures nothing (proved: 208/226 routes).
-      - name: Mark platform setup complete for the fixture org
-        run: pnpm --filter web ux:sweep-fixture
-
       # Work Control inventories the host clone's worktrees. GitHub checks out a
       # named branch for workflow_dispatch but a detached ref for pull_request,
       # so scanning the ambient checkout made /build/work change structure for
@@ -207,6 +202,13 @@ jobs:
             sleep 2
           done
           echo "portal did not become ready within 120s"; exit 1
+
+      # Run this after the portal is live. Besides clearing first-run setup, the
+      # fixture timestamps the running root portal at the moment it is actually
+      # available. Doing this before artifact discovery/build made valid slower
+      # jobs cross the change-lanes route's ten-minute stale-heartbeat boundary.
+      - name: Converge the authenticated UX fixture
+        run: pnpm --filter web ux:sweep-fixture
 
       # Reuses the existing e2e login bootstrap verbatim so the sweep measures real
       # owner surfaces instead of freezing the login page as every route's baseline.

--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -111,6 +111,13 @@ jobs:
       - name: Seed the fixture organisation
         run: pnpm --filter @dpf/db seed
 
+      # Complete first-run setup before the portal starts. Starting the server
+      # against an incomplete install lets startup reconciliation observe and
+      # reshape transient fixture state, which makes DB-backed decision routes
+      # differ from the frozen authenticated baseline.
+      - name: Mark platform setup complete for the fixture org
+        run: pnpm --filter web ux:sweep-fixture
+
       # Work Control inventories the host clone's worktrees. GitHub checks out a
       # named branch for workflow_dispatch but a detached ref for pull_request,
       # so scanning the ambient checkout made /build/work change structure for
@@ -203,11 +210,12 @@ jobs:
           done
           echo "portal did not become ready within 120s"; exit 1
 
-      # Run this after the portal is live. Besides clearing first-run setup, the
-      # fixture timestamps the running root portal at the moment it is actually
-      # available. Doing this before artifact discovery/build made valid slower
-      # jobs cross the change-lanes route's ten-minute stale-heartbeat boundary.
-      - name: Converge the authenticated UX fixture
+      # Refresh the runtime heartbeat after the portal is live. The earlier
+      # convergence establishes setup state before startup; this idempotent
+      # second pass timestamps the running root portal at actual availability,
+      # after artifact discovery/build, so slower valid jobs cannot cross the
+      # change-lanes route's ten-minute stale-heartbeat boundary.
+      - name: Refresh the authenticated UX runtime heartbeat
         run: pnpm --filter web ux:sweep-fixture
 
       # Reuses the existing e2e login bootstrap verbatim so the sweep measures real

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -25,6 +25,7 @@ import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveHomePhoneCountry } from "@/lib/phone-country.server";
 import { PhoneCountryProvider } from "@/components/ui/PhoneCountryContext";
 import { NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
+import { UxInitialLoadBoundary } from "@/components/shell/UxInitialLoadBoundary";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
   // First-run check — redirect to setup if no org exists.
@@ -249,7 +250,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
                   style={{ maxWidth: "var(--shell-page-content-max-width, none)" }}
                 >
                   {shellNavSections.length > 0 && <ShellBreadcrumb />}
-                  {children}
+                  <UxInitialLoadBoundary>{children}</UxInitialLoadBoundary>
                 </div>
               </div>
             </div>

--- a/apps/web/components/ops/ChangesClient.test.tsx
+++ b/apps/web/components/ops/ChangesClient.test.tsx
@@ -42,6 +42,24 @@ function jsonResponse(data: unknown) {
 }
 
 describe("ChangesClient expandable RFC details", () => {
+  it("keeps the UX sweep pending until the initial RFC list settles", async () => {
+    let resolveList!: (response: Response) => void;
+    const listRequest = new Promise<Response>((resolve) => {
+      resolveList = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn(() => listRequest));
+
+    const { container } = render(<ChangesClient />);
+    expect(container.querySelector('[data-dpf-ux-settle="pending"]')).not.toBeNull();
+
+    resolveList({ ok: true, json: async () => ({ data: [] }) } as Response);
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-dpf-ux-settle]")).toBeNull();
+    });
+    expect(screen.getByText('No changes with status "active".')).toBeTruthy();
+  });
+
   it("keeps one summary, shows in-panel loading, and reveals connected detail", async () => {
     let resolveDetail!: (response: Response) => void;
     const detailRequest = new Promise<Response>((resolve) => {

--- a/apps/web/components/ops/ChangesClient.tsx
+++ b/apps/web/components/ops/ChangesClient.tsx
@@ -194,7 +194,12 @@ export default function ChangesClient() {
 
   if (loading) {
     return (
-      <div className="text-center py-12 text-[var(--dpf-muted)]">Loading changes...</div>
+      <div
+        className="text-center py-12 text-[var(--dpf-muted)]"
+        data-dpf-ux-settle="pending"
+      >
+        Loading changes...
+      </div>
     );
   }
 

--- a/apps/web/components/shell/UxInitialLoadBoundary.test.tsx
+++ b/apps/web/components/shell/UxInitialLoadBoundary.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UxInitialLoadBoundary } from "./UxInitialLoadBoundary";
+
+describe("UxInitialLoadBoundary", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("keeps server markup pending until the route tree hydrates", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <UxInitialLoadBoundary>
+        <p>Route content</p>
+      </UxInitialLoadBoundary>,
+    );
+    document.body.append(container);
+
+    expect(container.querySelector('[data-dpf-ux-settle="pending"]')).not.toBeNull();
+
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <UxInitialLoadBoundary>
+          <p>Route content</p>
+        </UxInitialLoadBoundary>,
+      );
+    });
+
+    expect(container.querySelector("[data-dpf-ux-settle]")).toBeNull();
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/apps/web/components/shell/UxInitialLoadBoundary.test.tsx
+++ b/apps/web/components/shell/UxInitialLoadBoundary.test.tsx
@@ -1,42 +1,37 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
-import { hydrateRoot } from "react-dom/client";
-import { renderToString } from "react-dom/server";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UxInitialLoadBoundary } from "./UxInitialLoadBoundary";
 
 describe("UxInitialLoadBoundary", () => {
   afterEach(() => {
-    document.body.innerHTML = "";
+    cleanup();
   });
 
   it("keeps server markup pending until the route tree hydrates", async () => {
     const container = document.createElement("div");
-    container.innerHTML = renderToString(
-      <UxInitialLoadBoundary>
-        <p>Route content</p>
-      </UxInitialLoadBoundary>,
-    );
+    container.innerHTML =
+      '<div data-dpf-ux-settle="pending"><p>Route content</p></div>';
     document.body.append(container);
 
     expect(container.querySelector('[data-dpf-ux-settle="pending"]')).not.toBeNull();
 
-    let root: ReturnType<typeof hydrateRoot> | undefined;
-    await act(async () => {
-      root = hydrateRoot(
+    const result = render(
+      <UxInitialLoadBoundary>
+        <p>Route content</p>
+      </UxInitialLoadBoundary>,
+      {
         container,
-        <UxInitialLoadBoundary>
-          <p>Route content</p>
-        </UxInitialLoadBoundary>,
-      );
+        hydrate: true,
+      },
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-dpf-ux-settle]")).toBeNull();
     });
 
-    expect(container.querySelector("[data-dpf-ux-settle]")).toBeNull();
-
-    await act(async () => {
-      root?.unmount();
-    });
+    result.unmount();
   });
 });

--- a/apps/web/components/shell/UxInitialLoadBoundary.tsx
+++ b/apps/web/components/shell/UxInitialLoadBoundary.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Declare the shell's initial hydration boundary to the UX route sweep.
+ *
+ * Server HTML is intentionally pending. The marker clears after React has
+ * hydrated the route tree, so the sweep cannot capture a mixture of server
+ * markup and client state. Components that start additional initial-load work
+ * still own their narrower pending markers.
+ */
+export function UxInitialLoadBoundary({ children }: { children: React.ReactNode }) {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return (
+    <div data-dpf-ux-settle={hydrated ? undefined : "pending"}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/workspace/WorkspaceCalendar.tsx
+++ b/apps/web/components/workspace/WorkspaceCalendar.tsx
@@ -99,7 +99,10 @@ export function WorkspaceCalendar({
     anchorRect: { top: number; left: number; width: number; height: number };
   } | null>(null);
   const [liveEvents, setLiveEvents] = useState<CalendarEventView[]>(initialEvents);
-  const [fetching, setFetching] = useState(false);
+  // FullCalendar always resolves its visible range after mount and asks for a
+  // range-density refresh. Treat that first request as initial-load work so
+  // automated UX measurement cannot race the server events and refreshed set.
+  const [fetching, setFetching] = useState(true);
 
   function toggleCategory(cat: string) {
     const next = new Set(hiddenCategories);
@@ -218,7 +221,10 @@ export function WorkspaceCalendar({
   );
 
   return (
-    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+    <div
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+      data-dpf-ux-settle={fetching ? "pending" : undefined}
+    >
       {/* Filter toolbar */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
         <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest mr-2">Filter:</span>

--- a/apps/web/lib/voice/readiness.test.ts
+++ b/apps/web/lib/voice/readiness.test.ts
@@ -99,6 +99,30 @@ describe("getSpeechToTextReadiness", () => {
     expect(result.reason).toMatch(/http:\/\/dpf-stt:8000/);
   });
 
+  it("does not expose runner-specific network errors in operator readiness copy", async () => {
+    mocks.fetch.mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND dpf-stt"));
+    mocks.findFirstPerf.mockResolvedValueOnce({
+      endpointId: "profile-cuid",
+      blocked: false,
+    });
+    mocks.findProfile.mockResolvedValueOnce({
+      providerId: "speaches",
+      modelId: "base",
+      modelStatus: "active",
+      provider: {
+        name: "Local STT (whisper-server)",
+        baseUrl: "http://dpf-stt:8000",
+        authMethod: "none",
+        status: "active",
+      },
+    });
+
+    const result = await getSpeechToTextReadiness();
+
+    expect(result.reason).toContain("health probe failed: endpoint unavailable");
+    expect(result.reason).not.toContain("ENOTFOUND");
+  });
+
   it("returns 'unhealthy' when the local sidecar does not advertise the selected model", async () => {
     mocks.fetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ data: [{ id: "tiny.en" }] }), { status: 200 }),

--- a/apps/web/lib/voice/readiness.ts
+++ b/apps/web/lib/voice/readiness.ts
@@ -10,7 +10,6 @@
  */
 
 import { prisma } from "@dpf/db";
-import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 /**
  * Readiness status surfaced in the admin Communications hub card.
@@ -62,9 +61,12 @@ async function probeLocalTranscriptionEndpoint(
           .filter((id): id is string => id !== null)
       : [];
     return { ok: true, modelIds };
-  } catch (err) {
-    const message = getErrorMessage(err);
-    return { ok: false, reason: `health probe failed: ${message}` };
+  } catch {
+    // Node/undici surfaces DNS, connection, and timeout failures with
+    // platform-specific strings. Those internals are not useful operator copy
+    // and made identical UX sweeps vary by runner networking. Keep the
+    // actionable category stable; the provider URL is added by the caller.
+    return { ok: false, reason: "health probe failed: endpoint unavailable" };
   }
 }
 

--- a/apps/web/scripts/ux-sweep-fixture-core.mjs
+++ b/apps/web/scripts/ux-sweep-fixture-core.mjs
@@ -1,0 +1,43 @@
+/**
+ * Converge the database state required by the authenticated UX route sweep.
+ *
+ * The root-portal heartbeat is deliberately refreshed here, after the portal
+ * has started. Seeding happens before artifact discovery and production build,
+ * so using the seed timestamp makes the change-lanes route cross its ten-minute
+ * stale threshold on slower-but-valid CI paths.
+ *
+ * @param {{
+ *   platformSetupProgress: {
+ *     findFirst(args: object): Promise<{id: string} | null>,
+ *     create(args: object): Promise<{id: string}>,
+ *   },
+ *   runtimeTarget: {
+ *     updateMany(args: object): Promise<{count: number}>,
+ *   },
+ * }} db
+ * @param {Date} now
+ */
+export async function convergeUxSweepFixture(db, now = new Date()) {
+  const existingSetup = await db.platformSetupProgress.findFirst({
+    where: { completedAt: { not: null } },
+    select: { id: true },
+  });
+
+  const setupProgress =
+    existingSetup ??
+    (await db.platformSetupProgress.create({
+      data: { currentStep: "complete", completedAt: now },
+      select: { id: true },
+    }));
+
+  const heartbeat = await db.runtimeTarget.updateMany({
+    where: { targetId: "RT-ROOT-PORTAL", status: "running" },
+    data: { lastHeartbeatAt: now },
+  });
+
+  return {
+    setupChanged: existingSetup === null,
+    setupProgressId: setupProgress.id,
+    refreshedRuntimeTargets: heartbeat.count,
+  };
+}

--- a/apps/web/scripts/ux-sweep-fixture-core.test.mjs
+++ b/apps/web/scripts/ux-sweep-fixture-core.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { convergeUxSweepFixture } from "./ux-sweep-fixture-core.mjs";
+
+const NOW = new Date("2026-07-28T19:30:00.000Z");
+
+function fixtureDb({ setupComplete }) {
+  const calls = {
+    create: [],
+    updateMany: [],
+  };
+
+  return {
+    calls,
+    db: {
+      platformSetupProgress: {
+        async findFirst() {
+          return setupComplete ? { id: "setup-existing" } : null;
+        },
+        async create(args) {
+          calls.create.push(args);
+          return { id: "setup-created" };
+        },
+      },
+      runtimeTarget: {
+        async updateMany(args) {
+          calls.updateMany.push(args);
+          return { count: 1 };
+        },
+      },
+    },
+  };
+}
+
+test("refreshes the running root portal heartbeat even when setup is already complete", async () => {
+  const fixture = fixtureDb({ setupComplete: true });
+
+  const result = await convergeUxSweepFixture(fixture.db, NOW);
+
+  assert.deepEqual(fixture.calls.create, []);
+  assert.deepEqual(fixture.calls.updateMany, [
+    {
+      where: { targetId: "RT-ROOT-PORTAL", status: "running" },
+      data: { lastHeartbeatAt: NOW },
+    },
+  ]);
+  assert.deepEqual(result, {
+    setupChanged: false,
+    setupProgressId: "setup-existing",
+    refreshedRuntimeTargets: 1,
+  });
+});
+
+test("completes first-run setup and refreshes the heartbeat in one fixture convergence", async () => {
+  const fixture = fixtureDb({ setupComplete: false });
+
+  const result = await convergeUxSweepFixture(fixture.db, NOW);
+
+  assert.deepEqual(fixture.calls.create, [
+    {
+      data: { currentStep: "complete", completedAt: NOW },
+      select: { id: true },
+    },
+  ]);
+  assert.equal(fixture.calls.updateMany.length, 1);
+  assert.deepEqual(result, {
+    setupChanged: true,
+    setupProgressId: "setup-created",
+    refreshedRuntimeTargets: 1,
+  });
+});

--- a/apps/web/scripts/ux-sweep-fixture.ts
+++ b/apps/web/scripts/ux-sweep-fixture.ts
@@ -20,23 +20,19 @@
  */
 import { prisma } from "@dpf/db";
 
+import { convergeUxSweepFixture } from "./ux-sweep-fixture-core.mjs";
+
 void (async () => {
   try {
-    const alreadyComplete = await prisma.platformSetupProgress.findFirst({
-      where: { completedAt: { not: null } },
-      select: { id: true },
-    });
-
-    if (alreadyComplete) {
-      console.error("[ux-sweep-fixture] platform setup already complete — nothing to do");
-      return;
-    }
-
-    const row = await prisma.platformSetupProgress.create({
-      data: { currentStep: "complete", completedAt: new Date() },
-      select: { id: true },
-    });
-    console.error(`[ux-sweep-fixture] marked platform setup complete (${row.id})`);
+    const result = await convergeUxSweepFixture(prisma);
+    console.error(
+      result.setupChanged
+        ? `[ux-sweep-fixture] marked platform setup complete (${result.setupProgressId})`
+        : `[ux-sweep-fixture] platform setup already complete (${result.setupProgressId})`,
+    );
+    console.error(
+      `[ux-sweep-fixture] refreshed ${result.refreshedRuntimeTargets} running root-portal heartbeat(s)`,
+    );
   } catch (err) {
     console.error("[ux-sweep-fixture] failed:", err);
     process.exit(1);

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -244,7 +244,8 @@ The marker is an explicit component-owned readiness contract, not a route-name
 exception in the test harness. The authenticated shell owns the initial React
 hydration marker for every route. Components that start additional first-load
 work own narrower markers; the business calendar, for example, remains pending
-until FullCalendar's visible-range event refresh completes.
+until FullCalendar's visible-range event refresh completes, and Operations
+Changes remains pending until its initial RFC list request settles.
 
 The sweep also supplies `/build/work` with a deterministic one-branch Git
 repository through `DPF_WORK_CONTROL_REPO_ROOT`. GitHub's named

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -241,7 +241,10 @@ quiet, capped at 10 seconds, before capture. This is the deterministic hydration
 boundary: `networkidle` is not valid for a portal with long-lived streams, while
 measuring immediately after `load` races client-populated rows and status labels.
 The marker is an explicit component-owned readiness contract, not a route-name
-exception in the test harness.
+exception in the test harness. The authenticated shell owns the initial React
+hydration marker for every route. Components that start additional first-load
+work own narrower markers; the business calendar, for example, remains pending
+until FullCalendar's visible-range event refresh completes.
 
 The sweep also supplies `/build/work` with a deterministic one-branch Git
 repository through `DPF_WORK_CONTROL_REPO_ROOT`. GitHub's named
@@ -249,6 +252,20 @@ repository through `DPF_WORK_CONTROL_REPO_ROOT`. GitHub's named
 produce different "Adoptable work" structures for identical source. Production
 continues to resolve the real host clone from `DPF_REPO_ROOT`; the narrow
 override exists only for the route-sweep fixture.
+
+The authenticated database fixture converges only after the production portal
+is serving. It both clears first-run setup and refreshes the seeded running
+root-portal heartbeat at that real availability boundary. Artifact discovery
+and fallback builds can legitimately take longer than the change-lanes
+projection's ten-minute stale-heartbeat threshold; retaining the earlier seed
+timestamp would therefore make the same source alternate between a healthy
+lane and a five-word stale-heartbeat blocker.
+
+Fixture-facing health copy must also be semantically stable. The Communications
+speech-to-text card classifies transport failures as `endpoint unavailable`
+instead of rendering Node/undici's platform-specific DNS or socket error text.
+The operator still sees the affected provider URL and actionable recovery path,
+while identical source no longer gains or loses words with runner networking.
 
 Manual workflow dispatch accepts a bounded worker count of `1`, `2`, or `4`;
 the measured default is **2**. Before `BI-CC7CA516`, all three settings

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -253,13 +253,14 @@ produce different "Adoptable work" structures for identical source. Production
 continues to resolve the real host clone from `DPF_REPO_ROOT`; the narrow
 override exists only for the route-sweep fixture.
 
-The authenticated database fixture converges only after the production portal
-is serving. It both clears first-run setup and refreshes the seeded running
-root-portal heartbeat at that real availability boundary. Artifact discovery
-and fallback builds can legitimately take longer than the change-lanes
-projection's ten-minute stale-heartbeat threshold; retaining the earlier seed
-timestamp would therefore make the same source alternate between a healthy
-lane and a five-word stale-heartbeat blocker.
+The authenticated database fixture converges setup state before the production
+portal starts, then runs an idempotent second pass after the portal is serving
+to refresh the seeded running root-portal heartbeat. The ordering is part of the
+fixture contract: startup must not observe an incomplete first-run install, and
+artifact discovery or a fallback build can legitimately take longer than the
+change-lanes projection's ten-minute stale-heartbeat threshold. Retaining only
+the earlier seed timestamp would make the same source alternate between a
+healthy lane and a five-word stale-heartbeat blocker.
 
 Fixture-facing health copy must also be semantically stable. The Communications
 speech-to-text card classifies transport failures as `endpoint unavailable`


### PR DESCRIPTION
## Outcome

Makes the authenticated UX route sweep deterministic at initial-load boundaries without weakening semantic assertions, tolerances, route scope, or baselines. This repairs the proven same-head PR-pass / merge-group-fail behavior tracked by BI-EA221325 and the change-lanes slice BI-D23E3EDC.

## What changed

- converges the setup fixture before portal startup, then refreshes the seeded root-runtime heartbeat after the portal is actually available
- adds a shell-level hydration settle marker that clears only after React hydration
- marks the calendar pending during its initial visible-range refetch
- marks `/ops/changes` pending until its initial RFC list request resolves
- maps environment-dependent voice probe transport failures to stable operator-facing copy instead of leaking runner-specific DNS/socket text
- documents the deterministic settle contract and preserves every existing route assertion and baseline

No UX baseline, semantic projection, word tolerance, or route exclusion changed.

## Verification

Governed exact-SHA local integration passed on the final head:

- candidate: `42b5b26db948d34761b6d533b6297d10f3ce4c9a`
- base: `f9d18b187946005b6862de877941e843c6b4e363`
- integration: `832585ac72461a2b51cb1208f03a75fecd86166f`
- synthesized tree: `56ee6169aac2a9ea2a0e7e83371ddc119286182e`
- lease: `NPEL-D7B5948D99`
- evidence: `cms5dly3q0amx01qwussu37o1`
- freshness: green (Next 16.2.11, React 19.2.8, React DOM 19.2.8, TypeScript 6.0.3, Prisma 7.8.0, Vitest 4.1.10)
- migrations: passed on isolated PostgreSQL `:54329`
- docs and guards: passed
- tests: 2,327 files / 20,113 tests passed; declared skips/todos only
- typecheck: passed
- production Docker build: passed

Final PR-head UX Route Budget Sweep run `30411380083` passed all 202 routes. It is the first independent same-head runtime verification; the merge-group sweep is the required second run. The repair intentionally does not rebaseline.

## Design grounding

- Existing route sweep, baseline policy, settle-marker contract, prior BI-EA221325 completion evidence, and the portal UX simplification spine were reviewed.
- Three unchanged merge-group runs produced changing pre-existing route sets while the PR-head run passed, proving readiness nondeterminism rather than a content delta.
- The repair extends the existing `data-dpf-ux-settle="pending"` contract at the actual asynchronous boundaries instead of introducing a second wait mechanism.

## Root-cause sequence

PR-head sweep run `30409891642` proved the global readiness markers removed the original four volatile routes, but moving setup completion after portal startup exposed partial first-run DB state on three decision routes. Four prior ephemeral runs consistently measured `/coworker-decisions`, perspectives, and stance at 279/431/897 words with unchanged structure; the failed run measured 282/415/546. The final head restores setup convergence before startup and retains the post-start idempotent heartbeat refresh.

Follow-up run `30410694945` restored those decision routes and isolated `/ops/changes`, which was captured during its unmarked initial RFC fetch. The final route-local marker is covered by a pending-to-resolved component test, and run `30411380083` then passed all 202 routes.

## Docs and migration impact

- Docs updated: `docs/testing/ci-evidence.md` defines the shell hydration, calendar refetch, operations RFC fetch, and stable transport-error contracts.
- Migration: not applicable; no schema or stored-data change.

## UX fit review

- Decision: fits
- Owning area: Platform (cross-route verification substrate)
- Primary persona: founder/operator; no new concept, control, route, or navigation layer
- Reuse/convergence: extends the existing component-owned `data-dpf-ux-settle` readiness contract
- Empty/failure behavior: unchanged except runner-specific transport internals become stable operator copy
- AI boundary: no prompt send

## Related work

- Parent: BI-EA221325
- Slice: BI-D23E3EDC
- Capsule: WC-B32DFE8A
- Unblocks FIFO admission PR #3709, then blocked PR #3708.

Seed-Fit-Decision: global-default
UX-Fit-Decision: fits — invisible component-owned readiness markers add no route, navigation, control, or cognitive burden; stable transport classification improves existing failure copy without hiding its recovery path.