### PR TITLE
feat(db): dimension sourcing registry — how each decision axis's weight is kept honest (BI-25CCF1A4 Phase 0)

### DIFF
--- a/packages/db/src/dimension-scope.test.ts
+++ b/packages/db/src/dimension-scope.test.ts
@@ -10,6 +10,10 @@ import {
   PRINCIPLE_DIMENSION_SCOPE,
   PRINCIPLE_SPINE_DIMENSIONS,
   PRINCIPLE_LOCAL_DIMENSIONS,
+  PRINCIPLE_DIMENSION_SOURCING,
+  PRINCIPLE_DIMENSION_SOURCINGS,
+  dimensionSourcing,
+  dimensionsBySourcing,
   assertDimensionScopeIntegrity,
   isSpineDimension,
   projectVectorOntoSpine,
@@ -190,5 +194,39 @@ describe("dimension scope — the judgement calls are pinned deliberately", () =
   it("leaves a spine that is smaller than the full registry but not degenerate", () => {
     expect(PRINCIPLE_SPINE_DIMENSIONS.length).toBeLessThan(PRINCIPLE_DIMENSIONS.length);
     expect(PRINCIPLE_SPINE_DIMENSIONS.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+// BI-25CCF1A4 Phase 0 — dimension sourcing. Sourcing (how a weight is kept
+// honest) is orthogonal to scope (which population owns the vocabulary). These
+// pin the honest baseline and the schema-honesty invariant: no axis is labelled
+// with a source it does not yet actually draw its weight from.
+describe("dimension sourcing — every axis is sourcing-classified", () => {
+  it("labels every dimension with a known sourcing class", () => {
+    for (const d of PRINCIPLE_DIMENSIONS) {
+      expect(PRINCIPLE_DIMENSION_SOURCING[d], `${d} has no sourcing class`).toBeDefined();
+      expect(PRINCIPLE_DIMENSION_SOURCINGS).toContain(dimensionSourcing(d));
+    }
+  });
+
+  it("ships the HONEST baseline: every axis is `basic` (uniformly hand-authored) — that uniformity is the gap the inventory repairs", () => {
+    // Schema-honesty: an axis is reclassified ONLY when its weight actually
+    // comes from that source. Until the per-job inventory wires corpus
+    // derivation / revealed inference / external lookup, everything is basic.
+    for (const d of PRINCIPLE_DIMENSIONS) {
+      expect(dimensionSourcing(d), `${d} claims a source it is not yet wired to`).toBe("basic");
+    }
+    expect(dimensionsBySourcing("basic")).toHaveLength(PRINCIPLE_DIMENSIONS.length);
+    for (const s of ["corpus-derived", "revealed", "external"] as const) {
+      expect(dimensionsBySourcing(s), `${s} must stay empty until an axis is wired to it`).toHaveLength(0);
+    }
+  });
+
+  it("dimensionsBySourcing partitions the registry (every axis in exactly one class)", () => {
+    const counted = PRINCIPLE_DIMENSION_SOURCINGS.reduce(
+      (sum, s) => sum + dimensionsBySourcing(s).length,
+      0,
+    );
+    expect(counted).toBe(PRINCIPLE_DIMENSIONS.length);
   });
 });

--- a/packages/db/src/dimension-scope.ts
+++ b/packages/db/src/dimension-scope.ts
@@ -295,3 +295,74 @@ export function assertDimensionScopeIntegrity(
     throw new Error("The spine cannot be empty — it is the commensurability layer.");
   }
 }
+
+// ---------------------------------------------------------------------------
+// Dimension SOURCING (BI-25CCF1A4 Phase 0) — how each axis's weight is kept
+// honest. This is the code analogue of the tier-rebalance spec's §1.4
+// epistemology taxonomy (measured / policy / revealed-preference / predictive),
+// which shipped as prose with no substrate.
+//
+// Sourcing is ORTHOGONAL to scope: scope (spine vs profession-local) says which
+// population owns the vocabulary; sourcing says where the weight comes from and
+// how it is refreshed. It is deliberately a label per axis (spec §8 Q2 proposed
+// per-axis to start; revisit only if a real conflict appears).
+// ---------------------------------------------------------------------------
+
+export const PRINCIPLE_DIMENSION_SOURCINGS = [
+  "basic", // hand-scored, stable doctrine. Refresh: PR + ratification.
+  "corpus-derived", // meaning derived from a profession's WSID corpus. Refresh: corpus change.
+  "revealed", // weight learned from rulings via weight-inference.ts (proposal ladder, human-ruled).
+  "external", // a live looked-up signal, validated-against-outcome before it scores (JSI §4.3).
+] as const;
+export type PrincipleDimensionSourcing =
+  (typeof PRINCIPLE_DIMENSION_SOURCINGS)[number];
+
+/**
+ * Every axis, sourcing-labelled. `satisfies Record<PrincipleDimension, …>` makes
+ * an unlabelled new axis a compile error, exactly like the scope registry above.
+ *
+ * HONEST BASELINE: every axis is `basic` today — uniformly hand-authored via
+ * `principleDimensionVector` (tier-rebalance §1.4). That uniformity IS the gap
+ * the per-job decision-vector inventory repairs (spec
+ * docs/superpowers/specs/2026-07-25-job-specific-decision-vector-inventory-design.md).
+ * An axis is reclassified here ONLY when its weight actually comes from that
+ * source — never on intent (schema-honesty-over-aspirational-naming). So this
+ * ships all-`basic` and grows by evidence as the inventory wires corpus
+ * derivation, revealed inference, or external lookup for a specific axis.
+ */
+export const PRINCIPLE_DIMENSION_SOURCING = {
+  long_term_maintainability: "basic",
+  blast_radius: "basic",
+  reusability: "basic",
+  evidence_density: "basic",
+  human_cognitive_load: "basic",
+  capacity_utilization: "basic",
+  governance_compliance: "basic",
+  public_safety: "basic",
+  speed_to_value: "basic",
+  schema_grounding: "basic",
+  operational_independence: "basic",
+  data_privacy: "basic",
+  cost_efficiency: "basic",
+  vendor_lock_in: "basic",
+  reversibility: "basic",
+  evidence_confidence: "basic",
+  customer_consent_state: "basic",
+  business_disruption: "basic",
+  operator_effort: "basic",
+  legibility_of_consequence: "basic",
+} as const satisfies Record<PrincipleDimension, PrincipleDimensionSourcing>;
+
+/** The sourcing class of one axis. */
+export function dimensionSourcing(dimension: PrincipleDimension): PrincipleDimensionSourcing {
+  return PRINCIPLE_DIMENSION_SOURCING[dimension];
+}
+
+/** Every axis currently sourced a given way (drives the per-job inventory's reclassification work). */
+export function dimensionsBySourcing(
+  sourcing: PrincipleDimensionSourcing,
+): readonly PrincipleDimension[] {
+  return PRINCIPLE_DIMENSIONS.filter(
+    (dimension) => PRINCIPLE_DIMENSION_SOURCING[dimension] === sourcing,
+  ) as readonly PrincipleDimension[];
+}


### PR DESCRIPTION
**BI-25CCF1A4 Phase 0** — first substrate slice of the job-specific decision-vector inventory ([spec PR #3711](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3711)). Additive, no behavior change.

## What
`PRINCIPLE_DIMENSION_SOURCING` alongside the existing scope registry — a per-axis label (`basic | corpus-derived | revealed | external`) that is the **code analogue of the tier-rebalance spec's §1.4 epistemology taxonomy** (which shipped as prose, no substrate). Sourcing is **orthogonal to scope**: scope says which population owns the vocabulary, sourcing says where the weight comes from and how it's refreshed. Compile-enforced (`satisfies Record<PrincipleDimension, …>`) so a new axis must declare its sourcing. Helpers: `dimensionSourcing()`, `dimensionsBySourcing()`.

## Honest baseline (schema-honesty)
All 20 axes ship **`basic`**. Every `principleDimensionVector` is uniformly hand-authored today, and that uniformity **is** the gap the per-job inventory repairs. An axis is reclassified only when its weight **actually** comes from that source — never on intent — so `corpus-derived`/`revealed`/`external` ship empty and grow by evidence as the inventory wires each. Mirrors how `profession-local-axes.ts` shipped "empty but proven."

## Verification
21 tests pass (3 new: every axis classified; the all-`basic` honest-baseline + empty-non-basic invariant; the partition invariant). `dimension-scope.ts` type-clean after client regen (remaining local tsc noise is missing `@dpf/*` workspace deps in a fresh worktree, not this file).

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
