### PR TITLE
docs(proactivity): align level label to shipped UI copy — "Quiet", not "Reactive" (BI-334A0D73)

### DIFF
--- a/apps/web/lib/attention/owner-routing.ts
+++ b/apps/web/lib/attention/owner-routing.ts
@@ -53,7 +53,7 @@ export function classifyOwnerAttentionLane(
   }
   if (item.source === "research-proposal") {
     return appliedLevel === "quiet"
-      ? decision("needs-you-now", "Reactive mode asks before low-risk research.", false, appliedLevel)
+      ? decision("needs-you-now", "Quiet mode asks before low-risk research.", false, appliedLevel)
       : decision("weekly-digest", "Low-urgency research can be reviewed together.", false, appliedLevel);
   }
   if (item.source === "coworker-memory") {

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -118,7 +118,8 @@ export type AttentionTechnicalMetadata = {
 };
 
 /** Proactivity evidence carried by a coworker-owned source. The existing closed
- * level union remains canonical; the owner UI calls `quiet` “Reactive”. */
+ * level union remains canonical; owner-facing labels come from
+ * PROACTIVITY_LEVEL_COPY (`quiet` renders as “Quiet”). */
 export type AttentionProactivity = {
   level: import("@/lib/proactivity/proactivity-types").ProactivityLevel;
   actorId?: string;

--- a/docs/user-guide/ai-workforce/coworker-proactivity.md
+++ b/docs/user-guide/ai-workforce/coworker-proactivity.md
@@ -18,7 +18,7 @@ You don't start from a blank slate. Each coworker's default level is **derived f
 
 ## The Levels
 
-- **Reactive** — asks you before most things. You see the most.
+- **Quiet** — asks you before most things. You see the most.
 - **Balanced** — handles routine work and logs it; brings real business choices to you.
 - **Assertive** — acts and tells you after. You see the least.
 


### PR DESCRIPTION
## Summary

Live terminology divergence: the coworker proactivity enum is `["quiet", "balanced", "assertive"]` and the shipped UI copy (`apps/web/lib/proactivity/proactivity-copy.ts`) renders the first level as **"Quiet"** on every surface — level picker (`ProactivityLevelControl`), coworker profile setting, attention proposal copy, governance action-proposal presentation. The user guide (`docs/user-guide/ai-workforce/coworker-proactivity.md`) still labeled the levels **"Reactive / Balanced / Assertive"** — the label the 2026-07-17 redesign plan proposed but which never shipped.

Canonical owner-facing label = **"Quiet"** (the term users already see). Changes:

- `docs/user-guide/ai-workforce/coworker-proactivity.md` — "Reactive" → "Quiet"
- `apps/web/lib/attention/owner-routing.ts` — the one rendered straggler: "Reactive mode asks before low-risk research." → "Quiet mode asks before low-risk research."
- `apps/web/lib/attention/types.ts` — fix the stale comment claiming the owner UI calls `quiet` "Reactive"

Dated design artifacts under `docs/superpowers/specs/` keep their historical wording; the living user guide and rendered copy are what must agree.

## Design grounding

Design-Grounding-Decision: trivial copy-alignment, no contract change. Specs/plans reviewed: `docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md` and `docs/superpowers/plans/2026-07-17-needs-you-cognitive-load-redesign.md` proposed "Reactive" as owner copy; the shipped code substrate (`apps/web/lib/proactivity/proactivity-copy.ts`, consumed by `apps/web/components/proactivity/ProactivityLevelControl.tsx` and `apps/web/components/platform/coworker-record/CoworkerProactivitySetting.tsx`) renders "Quiet". The label follows what is already rendered to users.

## Verification

- `apps/web` attention + proactivity vitest suites: 28 files / 219 tests green locally
- `pnpm run check:doc-links` green (link check, rendering tests, diagram check)
- doc-index / doc-impact regenerated with no content change
- Local gate runs green: design-grounding, docs-impact, module-size
- Typecheck deferred to CI (source-only worktree)

Local-CI-Override: source-only worktree (no runnable `.bin`) cannot execute the sandbox pregate; scoped verification above is green and required CI checks gate this merge.
Seed-Fit-Decision: no seed impact — owner-facing label copy and docs only; no schema, seed, or fixture change.
Docs-Impact-Decision: docs/user-guide/ai-workforce/coworker-proactivity.md updated in this PR.

Backlog: BI-334A0D73

🤖 Generated with [Claude Code](https://claude.com/claude-code)