### PR TITLE
fix(db): quarantine the damaged inventory unique index before the observation snapshot rewrite (BI-193D851D)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -6853,6 +6853,7 @@
         "step-3-monitor-the-chain",
         "step-4-verify-postgres-only-done-criteria",
         "if-it-fails-anyway-recovery",
+        "failure-class-migration-unique-violation-p3018-23505",
         "references"
       ]
     },

--- a/docs/data-impact/2026-07-28-quarantine-damaged-inventory-unique-index.data-impact.json
+++ b/docs/data-impact/2026-07-28-quarantine-damaged-inventory-unique-index.data-impact.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "InventoryEntity operational estate registry",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260728115800_quarantine_damaged_inventory_unique_index",
+    "backfill": "no row is inserted, updated, or deleted: when a sequential-scan probe (index access disabled) finds duplicate entityKey groups in the heap, the collation-damaged unique index InventoryEntity_entityKey_key is dropped so the 20260728115900 snapshot rewrite and the 20260728130000 repair can run; the repair migration rebuilds, REINDEXes, and amcheck-validates the index unconditionally, so damaged, healthy, already-upgraded, and fresh installs converge to the identical end state"
+  },
+  "tests": [
+    "packages/db/src/inventory-entity-index-integrity-migration.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:inventory-entity#entity-key-unique-index-quarantine",
+      "prismaModel": "InventoryEntity",
+      "lifecycleDisposition": "every row is retained untouched; only the damaged unique index object is conditionally dropped, and uniqueness enforcement is restored by the 20260728130000 repair migration after it converges the duplicate heap rows",
+      "fields": [
+        {
+          "fieldId": "data:inventory-entity#entityKey",
+          "resolution": "governed",
+          "reason": "an index that never caught the heap duplicates it was meant to forbid is already untrustworthy; quarantining it lets the ordered repair chain converge the duplicates and rebuild trustworthy uniqueness instead of wedging every self-upgrade at P3018/23505",
+          "provenance": "BI-193D851D live failure evidence (SUR-B848B86C, 2026-07-29), BI-CF4ADDAC collation-damage lineage, and the forced-non-HOT PostgreSQL migration fixture in inventory-entity-index-integrity-migration.test.ts"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -147,6 +147,41 @@ These should not occur once the promoter is rebuilt from current `main`, but for
   `bet5_pgvector_foundation` record; if you need to do it by hand,
   `docker exec ... prisma migrate resolve --rolled-back 20260714110000_bet5_pgvector_foundation`.
 
+## Failure class: migration-unique-violation (P3018 + 23505)
+
+A data migration's bulk UPDATE/INSERT hits `duplicate key value violates unique constraint` and the
+failed record then wedges ALL later upgrades via P3009. Two known producers:
+
+1. **Concurrent writer** minting rows into a partial unique index while the migration backfills
+   (SUR-859DB221, 2026-07-16).
+2. **Damaged unique index holding heap duplicates** (BI-CF4ADDAC collation damage, self-upgrade
+   2026-07-29): a bulk rewrite forces non-HOT row versions, each re-inserting into the unique index,
+   and `_bt_check_unique` rejects duplicates the damaged index never caught — before the repair
+   migration later in the batch can converge them.
+
+Recovery decision (inspect `_prisma_migrations`: `applied_steps_count`, and whether the migration's
+columns/indexes exist in the DB):
+
+- **Schema half-applied** (columns/index present): `prisma migrate resolve --applied <name>` — NOT
+  `--rolled-back`, which would re-run the `ADD COLUMN` and fail `already exists`.
+- **Nothing applied** (`applied_steps_count = 0`, no DDL landed): fix the root cause (de-duplicate,
+  or ship a corrected migration), then
+  `docker compose --project-directory <install root> run --rm -T --no-deps --entrypoint sh portal -c
+  'cd /app && pnpm --filter @dpf/db exec prisma migrate resolve --rolled-back <name>'`
+  and re-trigger the upgrade.
+
+Authoring rules that prevent the class:
+
+- A bulk data migration on a table under active writes must not re-validate a **partial** unique
+  index — lock the table (`SHARE ROW EXCLUSIVE`) for the bounded window.
+- If a later migration in the same batch treats an index as **untrustworthy** (drops/rebuilds it),
+  no earlier migration may bulk-rewrite rows of that table while the index is live — drop the
+  damaged index first (the repair rebuilds and amcheck-validates it).
+- Migration tests must model a damaged unique index as `indisunique = true` **with** committed
+  duplicates and force **non-HOT** updates (index the rewritten column); a non-unique stand-in index
+  or a single-page HOT-friendly fixture both hide the re-validation failure — that is exactly how
+  the 2026-07-29 failure escaped `inventory-entity-index-integrity-migration.test.ts`.
+
 ## References
 
 - Implementation record + all four fixes: `docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md`

--- a/packages/db/prisma/migrations/20260728115800_quarantine_damaged_inventory_unique_index/migration.sql
+++ b/packages/db/prisma/migrations/20260728115800_quarantine_damaged_inventory_unique_index/migration.sql
@@ -1,0 +1,33 @@
+-- BI-193D851D: the observation-snapshot rewrite (20260728115900) forces a
+-- non-HOT version of every InventoryEntity row, re-inserting entries into the
+-- collation-damaged unique index (BI-CF4ADDAC). _bt_check_unique then rejects
+-- heap duplicates the damaged index never caught, aborting the self-upgrade
+-- with P3018/23505 one migration BEFORE the repair (20260728130000) that
+-- converges those duplicates. When heap duplicates exist the index is already
+-- untrustworthy: drop it here so the snapshot and repair can run. The repair
+-- migration rebuilds, REINDEXes, and amcheck-validates it unconditionally, so
+-- every install ends in the identical state.
+--
+-- On installs that already applied the full 2026-07-28 inventory chain this
+-- runs later, finds no duplicates, and is a no-op. The duplicate probe must
+-- not consult the damaged index, so index access is disabled for this
+-- transaction.
+
+SET lock_timeout = '30s';
+LOCK TABLE "InventoryEntity" IN SHARE ROW EXCLUSIVE MODE;
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "InventoryEntity"
+    GROUP BY "entityKey"
+    HAVING count(*) > 1
+  ) THEN
+    DROP INDEX IF EXISTS "InventoryEntity_entityKey_key";
+  END IF;
+END $$;

--- a/packages/db/src/inventory-entity-index-integrity-migration.test.ts
+++ b/packages/db/src/inventory-entity-index-integrity-migration.test.ts
@@ -12,10 +12,16 @@ const identityRecoverySchema =
   `inventory_entity_identity_recovery_${randomUUID().replaceAll("-", "")}`;
 const legacyIdentitySchema =
   `inventory_entity_legacy_identity_${randomUUID().replaceAll("-", "")}`;
+const snapshotHazardSchema =
+  `inventory_entity_snapshot_hazard_${randomUUID().replaceAll("-", "")}`;
 let client: Client;
 
 const migrationUrl = new URL(
   "../prisma/migrations/20260728130000_repair_inventory_entity_index_integrity/migration.sql",
+  import.meta.url,
+);
+const indexQuarantineMigrationUrl = new URL(
+  "../prisma/migrations/20260728115800_quarantine_damaged_inventory_unique_index/migration.sql",
   import.meta.url,
 );
 const observationSnapshotMigrationUrl = new URL(
@@ -94,6 +100,12 @@ async function createFixture(targetSchema: string, crossScope = false): Promise<
       "customerSiteId" TEXT
     );
     CREATE INDEX "InventoryEntity_entityKey_key" ON "InventoryEntity" ("entityKey");
+    -- Indexing properties disqualifies HOT updates for the fixture's
+    -- single-page table, so every properties rewrite inserts a fresh
+    -- entityKey index entry and re-validates uniqueness — matching the
+    -- full-page non-HOT behavior of the production table.
+    CREATE INDEX "InventoryEntity_properties_hazard_idx"
+      ON "InventoryEntity" USING GIN (properties);
 
     CREATE TABLE "InventoryRelationship" (
       id TEXT PRIMARY KEY,
@@ -293,6 +305,18 @@ async function createFixture(targetSchema: string, crossScope = false): Promise<
       WHERE id = 'entity-a-new'
     `);
   }
+
+  // Reproduce the collation-damaged index faithfully: the production index is
+  // UNIQUE in the catalog yet already holds committed duplicates it failed to
+  // reject (BI-CF4ADDAC). Flipping indisunique — rather than creating a unique
+  // index, which would refuse the duplicate fixture rows — means every later
+  // non-HOT row rewrite re-validates uniqueness through _bt_check_unique,
+  // exactly as the damaged fleet index does during the self-upgrade window.
+  await client.query(`
+    UPDATE pg_index SET indisunique = true
+    WHERE indexrelid =
+      format('%I.%I', current_schema(), 'InventoryEntity_entityKey_key')::regclass
+  `);
 }
 
 describeDatabase("InventoryEntity unique-index integrity migration", () => {
@@ -309,10 +333,15 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
     await client.query(`DROP SCHEMA IF EXISTS "${retrySchema}" CASCADE`);
     await client.query(`DROP SCHEMA IF EXISTS "${identityRecoverySchema}" CASCADE`);
     await client.query(`DROP SCHEMA IF EXISTS "${legacyIdentitySchema}" CASCADE`);
+    await client.query(`DROP SCHEMA IF EXISTS "${snapshotHazardSchema}" CASCADE`);
     await client.end();
   });
 
   it("converges canonical entities and relationships without losing evidence", async () => {
+    const indexQuarantineMigration = await readFile(
+      indexQuarantineMigrationUrl,
+      "utf8",
+    );
     const observationSnapshotMigration = await readFile(
       observationSnapshotMigrationUrl,
       "utf8",
@@ -335,6 +364,7 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
       humanIdentityProvenanceMigrationUrl,
       "utf8",
     );
+    await client.query(indexQuarantineMigration);
     await client.query(observationSnapshotMigration);
     await client.query(observationSnapshotTriggerMigration);
     await client.query(migration);
@@ -488,6 +518,7 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
     const beforeSecondPass =
       JSON.stringify((await client.query(`SELECT * FROM "InventoryEntity" ORDER BY id`)).rows)
       + JSON.stringify((await client.query(`SELECT * FROM "InventoryRelationship" ORDER BY id`)).rows);
+    await client.query(indexQuarantineMigration);
     await client.query(observationSnapshotMigration);
     await client.query(observationSnapshotTriggerMigration);
     await client.query(migration);
@@ -501,8 +532,44 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
     expect(afterSecondPass).toBe(beforeSecondPass);
   });
 
+  it("applies the observation snapshot while the damaged unique index still holds duplicates", async () => {
+    await createFixture(snapshotHazardSchema);
+    const indexQuarantineMigration = await readFile(
+      indexQuarantineMigrationUrl,
+      "utf8",
+    );
+    const observationSnapshotMigration = await readFile(
+      observationSnapshotMigrationUrl,
+      "utf8",
+    );
+
+    // Regression (self-upgrade 2026-07-29): the bulk snapshot rewrite forces a
+    // non-HOT version of every row, re-inserting entries into the damaged
+    // unique index and re-validating duplicates it never rejected — which
+    // aborted `migrate deploy` with 23505 before the repair migration ran.
+    // The quarantine migration must clear the hazard first.
+    await client.query(indexQuarantineMigration);
+    await client.query(observationSnapshotMigration);
+
+    expect(await scalar(`
+      SELECT count(*)::text value
+      FROM "InventoryEntity"
+      WHERE properties ? '_dpfObservationSnapshot'
+    `)).toBe(7);
+    expect(await scalar(`
+      SELECT count(*)::text value
+      FROM pg_indexes
+      WHERE schemaname = current_schema()
+        AND indexname = 'InventoryEntity_entityKey_key'
+    `)).toBe(0);
+  });
+
   it("rolls back the entire migration when duplicate keys cross ownership scopes", async () => {
     await createFixture(conflictSchema, true);
+    const indexQuarantineMigration = await readFile(
+      indexQuarantineMigrationUrl,
+      "utf8",
+    );
     const observationSnapshotMigration = await readFile(
       observationSnapshotMigrationUrl,
       "utf8",
@@ -513,6 +580,7 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
     );
     const migration = await readFile(migrationUrl, "utf8");
 
+    await client.query(indexQuarantineMigration);
     await client.query(observationSnapshotMigration);
     await client.query(observationSnapshotTriggerMigration);
     await expect(client.query(migration)).rejects.toThrow(/scope|ownership/i);
@@ -536,6 +604,10 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
 
   it("refreshes observation snapshots across a failed repair and later retry", async () => {
     await createFixture(retrySchema, true);
+    const indexQuarantineMigration = await readFile(
+      indexQuarantineMigrationUrl,
+      "utf8",
+    );
     const observationSnapshotMigration = await readFile(
       observationSnapshotMigrationUrl,
       "utf8",
@@ -559,6 +631,7 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
       "utf8",
     );
 
+    await client.query(indexQuarantineMigration);
     await client.query(observationSnapshotMigration);
     await client.query(observationSnapshotTriggerMigration);
     await expect(client.query(migration)).rejects.toThrow(/scope|ownership/i);
@@ -599,6 +672,10 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
 
   it("preserves a later human correction across forward recovery", async () => {
     await createFixture(identityRecoverySchema);
+    const indexQuarantineMigration = await readFile(
+      indexQuarantineMigrationUrl,
+      "utf8",
+    );
     const observationSnapshotMigration = await readFile(
       observationSnapshotMigrationUrl,
       "utf8",
@@ -622,6 +699,7 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
       "utf8",
     );
 
+    await client.query(indexQuarantineMigration);
     await client.query(observationSnapshotMigration);
     await client.query(observationSnapshotTriggerMigration);
     await client.query(migration);
@@ -673,6 +751,7 @@ describeDatabase("InventoryEntity unique-index integrity migration", () => {
       WHERE "resolutionType" IN ('human_confirmed', 'human_corrected')
     `);
     const migrations = await Promise.all([
+      indexQuarantineMigrationUrl,
       observationSnapshotMigrationUrl,
       observationSnapshotTriggerMigrationUrl,
       migrationUrl,


### PR DESCRIPTION
## What

The 2026-07-29 self-upgrade died at migration `20260728115900_snapshot_inventory_observation_facts` with **P3018 / 23505** (`duplicate key value violates unique constraint "InventoryEntity_entityKey_key"`), and the failed record then wedged all future upgrades via P3009.

Root cause: the snapshot migration bulk-rewrites every `InventoryEntity` row while the collation-damaged unique index (BI-CF4ADDAC) is still live. Non-HOT rewrites re-insert index entries, and `_bt_check_unique` rejects heap duplicates the damaged index never caught — one migration **before** the `20260728130000` repair that converges exactly those duplicates. Confirmed live: two duplicate `entityKey` groups in the wedged install heap.

## Fix

New guard migration `20260728115800_quarantine_damaged_inventory_unique_index` (earlier timestamp, sorts ahead of the snapshot): when heap duplicates exist (seq-scan probe, index access disabled), it drops the already-untrustworthy index. The repair migration rebuilds, REINDEXes, and amcheck-validates it unconditionally, so damaged, healthy, already-upgraded, and fresh installs converge to the identical end state. Committed migrations are intentionally uneditable (pre-commit guard), so the earlier-timestamp guard is the paved road.

## Why the existing 700-line test missed it

The fixture modeled the damaged index as a plain **non-unique** index (uniqueness never re-validated) and used a single-page table where every rewrite goes **HOT** (no index insertion at all). The fixture now flips `indisunique` in the catalog over committed duplicates and adds a GIN index on `properties` to force non-HOT rewrites. Without the guard, all six tests reproduce the exact production 23505; with it, all six pass.

## Also

- `docs/runbooks/bet5-windows-self-upgrade.md`: documents the `migration-unique-violation` failure class, the `--applied` vs `--rolled-back` recovery decision tree, and the migration-authoring rules that prevent the class.
- Live install already recovered: `prisma migrate resolve --rolled-back 20260728115900...` (verified `applied_steps_count=0`, no DDL).

## Verification

- `packages/db` migration integrity suite: 6/6 green with the guard; 6/6 reproduce production 23505 without it.
- Governed local-CI pregate: **gate passed** (merge vs origin/main, `prisma migrate deploy` incl. the guard, targeted tests, full portal image build).

Seed-Fit-Decision: not-applicable — recovery hardening for an existing migration chain; no seed surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Local-CI-Override: commit 97ddefae9b is a docs-only data-impact manifest (no runtime change); the branch's runtime changes passed the governed local-CI pregate in the originating session as recorded above. PR CI re-validates the full surface.
