### PR TITLE
feat(decisions): plain-language "what do I do about this?" help for escalated/deferred decisions (BI-404E9BEA)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
@@ -10,6 +10,7 @@ import { prisma } from "@dpf/db";
 import { StatusBadge } from "@/components/ui/report-kit";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { TIER_LABELS, tierForRow } from "@/lib/wiki/decision-audit";
+import { buildDecisionHelp } from "@/lib/wiki/decision-help";
 
 export const dynamic = "force-dynamic";
 
@@ -238,18 +239,46 @@ export default async function DecisionRecordPage({ params }: { params: Params })
             Deferred — {row.deferralCapture.gapReason}. The perspective lacks material to answer;
             adding stance/principle coverage closes this gap.
           </p>
-        ) : row.outcomeType === "escalate" || row.outcomeType === "defer" ? (
-          <p className="text-sm text-[var(--dpf-muted)]">
-            Awaiting human review — see{" "}
-            <Link href="/coworker-decisions/review" className="text-[var(--dpf-accent)] hover:underline">
-              Review &amp; adjust
-            </Link>
-            .
-          </p>
         ) : (
-          <p className="text-sm text-[var(--dpf-muted)]">
-            None needed — the recommendation stood on its own.
-          </p>
+          // Plain-language "what do I do about this?" guidance (BI-404E9BEA) —
+          // deterministic, so it holds even when the model runtime is down.
+          (() => {
+            const help = buildDecisionHelp({
+              outcomeType: row.outcomeType,
+              tier,
+              riskTier: row.riskTier,
+              principleConflict: row.principleConflict,
+              insufficientSignal,
+              hasBuild: Boolean(row.buildId),
+              resolved: row.humanOutcome !== null,
+            });
+            const needsAction = help.steps.length > 0;
+            return (
+              <div
+                className={`rounded-lg border p-3 text-sm ${
+                  needsAction ? "border-[var(--dpf-accent)]" : "border-[var(--dpf-border)]"
+                }`}
+              >
+                <p className="text-[var(--dpf-text)]">{help.meaning}</p>
+                <p className="mt-2 text-[var(--dpf-muted)]">{help.urgency}</p>
+                {needsAction ? (
+                  <ol className="mt-3 space-y-1.5 list-decimal pl-5">
+                    {help.steps.map((step) => (
+                      <li key={step.label} className="text-[var(--dpf-text)]">
+                        {step.href ? (
+                          <Link href={step.href} className="text-[var(--dpf-accent)] hover:underline">
+                            {step.label}
+                          </Link>
+                        ) : (
+                          step.label
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                ) : null}
+              </div>
+            );
+          })()
         )}
       </section>
     </div>

--- a/apps/web/app/(shell)/coworker-decisions/decisions/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/page.tsx
@@ -10,6 +10,7 @@ import { prisma } from "@dpf/db";
 import { StatCard } from "@/components/ui/report-kit";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { DecisionAuditTable } from "@/components/wiki/DecisionAuditTable";
+import { DecisionAwaitingHelp } from "@/components/wiki/DecisionAwaitingHelp";
 import {
   DECISION_AUDIT_TIERS,
   buildCallerStats,
@@ -157,6 +158,9 @@ export default async function DecisionLogPage({
           />
         ))}
       </div>
+
+      {/* What the awaiting-review load means and where to act on it (BI-404E9BEA). */}
+      <DecisionAwaitingHelp stats={tierStatRaw} />
 
       {/* Who consults — a client working outside this list never consulted
           the kernel at all, which is itself the finding. */}

--- a/apps/web/components/wiki/DecisionAwaitingHelp.tsx
+++ b/apps/web/components/wiki/DecisionAwaitingHelp.tsx
@@ -1,0 +1,58 @@
+// BI-404E9BEA — the "what do I do about this?" header for the Decision log.
+// Server-rendered; the disclosure is a native <details> so the explainer costs
+// no client JS and no inference (deterministic copy from decision-help.ts).
+
+import Link from "next/link";
+
+import { buildAwaitingDigest } from "@/lib/wiki/decision-help";
+import type { DecisionTierStats } from "@/lib/wiki/decision-audit";
+
+export function DecisionAwaitingHelp({ stats }: { stats: DecisionTierStats[] }) {
+  const digest = buildAwaitingDigest(stats);
+  if (!digest) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <p className="text-sm font-medium text-[var(--dpf-text)]">
+          {digest.headline}
+          <span className="text-[var(--dpf-muted)]"> — {digest.fragments.join(", ")}</span>
+        </p>
+        <Link
+          href="/coworker-decisions/review"
+          data-owner-first-next-action
+          className="rounded-md border border-[var(--dpf-accent)] px-2.5 py-1 text-xs font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)] shrink-0"
+        >
+          Work through them on Review &amp; adjust →
+        </Link>
+      </div>
+      <details data-dpf-disclosure className="mt-2 group">
+        <summary className="cursor-pointer text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] list-none [&::-webkit-details-marker]:hidden">
+          <span className="underline decoration-dotted underline-offset-2">
+            What does &ldquo;awaiting review&rdquo; mean — do I have to act?
+          </span>
+        </summary>
+        <div className="mt-2 space-y-2 text-xs text-[var(--dpf-muted)] max-w-2xl">
+          <p>
+            <span className="font-medium text-[var(--dpf-text)]">Escalated</span> means your AI
+            stopped short of making a call alone — the decision was risky, its confidence was low,
+            or two of your principles disagreed.{" "}
+            <span className="font-medium text-[var(--dpf-text)]">Deferred</span> means it found
+            nothing recorded that answers the question, so it declined to guess.
+          </p>
+          <p>
+            Nothing on this page is silently stuck: the coworker that asked handled its moment
+            (usually by taking the safest option or asking in its own session) and moved on. The
+            one exception is a Build Studio build waiting at a decision gate — its own record says
+            so.
+          </p>
+          <p>
+            You do not work this log line by line. Review &amp; adjust rolls these rows into a
+            short list of themes — answer a theme once, or add a stance that covers it, and your AI
+            stops needing to ask.
+          </p>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/apps/web/components/wiki/DecisionAwaitingHelp.tsx
+++ b/apps/web/components/wiki/DecisionAwaitingHelp.tsx
@@ -35,21 +35,19 @@ export function DecisionAwaitingHelp({ stats }: { stats: DecisionTierStats[] }) 
         <div className="mt-2 space-y-2 text-xs text-[var(--dpf-muted)] max-w-2xl">
           <p>
             <span className="font-medium text-[var(--dpf-text)]">Escalated</span> means your AI
-            stopped short of making a call alone — the decision was risky, its confidence was low,
-            or two of your principles disagreed.{" "}
-            <span className="font-medium text-[var(--dpf-text)]">Deferred</span> means it found
-            nothing recorded that answers the question, so it declined to guess.
+            stopped short of deciding alone — the call was risky, confidence was low, or two
+            principles disagreed.{" "}
+            <span className="font-medium text-[var(--dpf-text)]">Deferred</span> means it found no
+            recorded guidance, so it declined to guess.
           </p>
           <p>
-            Nothing on this page is silently stuck: the coworker that asked handled its moment
-            (usually by taking the safest option or asking in its own session) and moved on. The
-            one exception is a Build Studio build waiting at a decision gate — its own record says
-            so.
+            Nothing here is silently stuck. The coworker that asked already handled its moment and
+            moved on. The one exception, a build paused at a decision gate, says so on its own
+            record.
           </p>
           <p>
-            You do not work this log line by line. Review &amp; adjust rolls these rows into a
-            short list of themes — answer a theme once, or add a stance that covers it, and your AI
-            stops needing to ask.
+            You do not work this log line by line. Review &amp; adjust groups these rows into a
+            few themes. Answer a theme once — or add a stance — and your AI stops needing to ask.
           </p>
         </div>
       </details>

--- a/apps/web/lib/docs-quick-help.ts
+++ b/apps/web/lib/docs-quick-help.ts
@@ -314,6 +314,23 @@ const QUICK_HELP_MAP: QuickHelpEntry[] = [
         "A mis-entered requirement can be edited or removed; submitted filings are corrected with the receiving body. Full guidance is in Compliance below.",
     },
   },
+  // ── BI-404E9BEA: the decision-governance surface answers the stuck-reader
+  // questions too — an "awaiting review" ledger reads as homework without this.
+  {
+    routePrefix: "/coworker-decisions",
+    help: {
+      whatThisPageIs:
+        "How your AI decides — the questions it consulted your governance on, what it recommended, and the calls it put in front of a human (escalated or deferred).",
+      actionNow:
+        "Use Review & adjust: it rolls the waiting decisions into a few themes. Answer a theme once, or add a stance covering it, and your AI stops needing to ask.",
+      ifNothingDone:
+        "Work does not silently stall — only a build paused at a decision gate waits, and says so. But unanswered themes keep escalating, so the waiting count keeps growing.",
+      reversible:
+        "Reading changes nothing. Answers and stances you record can be edited or retired later; they steer future decisions rather than rewriting past ones.",
+      recovery:
+        "If an answer taught your AI the wrong thing, edit or retire that stance and the next decisions follow the correction. Full guidance is below.",
+    },
+  },
   {
     routePrefix: "/compliance/licensing",
     help: {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9918,6 +9918,7 @@
         "authoritative-state",
         "ai-coworker-support",
         "reading-the-decision-log",
+        "escalated-and-deferred-decisions-what-to-do",
         "review-adjust-findings",
         "what-to-watch"
       ]

--- a/apps/web/lib/wiki/decision-help.test.ts
+++ b/apps/web/lib/wiki/decision-help.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAwaitingDigest, buildDecisionHelp, type DecisionHelpInput } from "./decision-help";
+import { buildTierStats } from "./decision-audit";
+
+function input(overrides: Partial<DecisionHelpInput> = {}): DecisionHelpInput {
+  return {
+    outcomeType: "escalate",
+    tier: "wwmd",
+    riskTier: "medium",
+    principleConflict: false,
+    insufficientSignal: false,
+    hasBuild: false,
+    resolved: false,
+    ...overrides,
+  };
+}
+
+describe("buildDecisionHelp", () => {
+  it("explains an insufficient-signal escalation without decision-engine jargon", () => {
+    const help = buildDecisionHelp(input({ insufficientSignal: true }));
+    expect(help.meaning).toContain("without scoreable options");
+    expect(help.meaning).not.toMatch(/composite|feature vector|contribution/i);
+    expect(help.steps.length).toBeGreaterThan(0);
+  });
+
+  it("names the principle conflict when the gate flagged one", () => {
+    const help = buildDecisionHelp(input({ principleConflict: true }));
+    expect(help.meaning).toContain("opposite directions");
+  });
+
+  it("explains high-risk escalations as policy, not as a failure", () => {
+    const help = buildDecisionHelp(input({ riskTier: "high" }));
+    expect(help.meaning).toContain("high-risk");
+    expect(help.meaning).toContain("always routes");
+  });
+
+  it("tells the reader nothing is stuck for a fire-and-forget consult", () => {
+    const help = buildDecisionHelp(input());
+    expect(help.urgency).toContain("Nothing is stuck");
+  });
+
+  it("says a build is paused — and leads with the Build Studio step — when the consult came from a build gate", () => {
+    const help = buildDecisionHelp(input({ hasBuild: true }));
+    expect(help.urgency).toContain("paused");
+    expect(help.steps[0]?.href).toBe("/build");
+  });
+
+  it("routes each tier's follow-up to its own authoring surface", () => {
+    const wwmd = buildDecisionHelp(input({ tier: "wwmd" }));
+    const wsid = buildDecisionHelp(input({ tier: "wsid", outcomeType: "defer" }));
+    const wwwd = buildDecisionHelp(input({ tier: "wwwd", outcomeType: "defer" }));
+    expect(wwmd.steps.map((s) => s.href)).toContain("/coworker-decisions/stance");
+    expect(wsid.steps.map((s) => s.href)).toContain("/coworker-decisions/craft");
+    // WWWD is answerable inline on the review surface — one step, no stance editor detour.
+    expect(wwwd.steps).toHaveLength(1);
+    expect(wwwd.steps[0]?.href).toBe("/coworker-decisions/review");
+  });
+
+  it("describes a defer as a coverage gap, not a refusal", () => {
+    const help = buildDecisionHelp(input({ outcomeType: "defer", tier: "wsid" }));
+    expect(help.meaning).toContain("declined to guess");
+    expect(help.meaning).toContain("craft playbook");
+  });
+
+  it("collapses to a no-action read once a human resolved it", () => {
+    const help = buildDecisionHelp(input({ resolved: true }));
+    expect(help.urgency).toContain("Resolved");
+    expect(help.steps).toHaveLength(0);
+  });
+
+  it("gives recommend and arbitrate rows a nothing-needed read", () => {
+    for (const outcomeType of ["recommend", "arbitrate"]) {
+      const help = buildDecisionHelp(input({ outcomeType }));
+      expect(help.urgency).toContain("Nothing is needed from you");
+      expect(help.steps).toHaveLength(0);
+    }
+  });
+});
+
+describe("buildAwaitingDigest", () => {
+  const stats = (unresolved: [number, number, number]) =>
+    (["wwmd", "wwwd", "wsid"] as const).map((tier, i) =>
+      buildTierStats({
+        tier,
+        total: 100,
+        last7d: 5,
+        last30d: 20,
+        unresolved: unresolved[i]!,
+        lastDecisionAt: null,
+      }));
+
+  it("returns null when nothing is waiting so the panel disappears", () => {
+    expect(buildAwaitingDigest(stats([0, 0, 0]))).toBeNull();
+  });
+
+  it("totals across tiers and only names the tiers that have load", () => {
+    const digest = buildAwaitingDigest(stats([29, 0, 45]));
+    expect(digest?.headline).toBe("74 decisions are waiting on a human");
+    expect(digest?.fragments).toEqual([
+      "29 platform doctrine (WWMD)",
+      "45 role craft (WSID)",
+    ]);
+  });
+
+  it("uses the singular headline for a single waiting decision", () => {
+    expect(buildAwaitingDigest(stats([1, 0, 0]))?.headline).toBe(
+      "1 decision is waiting on a human",
+    );
+  });
+});

--- a/apps/web/lib/wiki/decision-help.ts
+++ b/apps/web/lib/wiki/decision-help.ts
@@ -1,0 +1,193 @@
+// BI-404E9BEA — plain-language "what do I do about this?" guidance for the
+// decision ledger, aimed at the non-technical operator staring at an
+// ESCALATE/DEFER row.
+//
+// Pure and deterministic by design: the local model runtime must never be a
+// dependency of the help that explains the ledger, so every sentence here is
+// derived from recorded fields (outcome, tier, risk, flags), not inference.
+// The pages do the Prisma I/O and pass shaped inputs in, mirroring
+// decision-audit.ts.
+
+import type { DecisionAuditTierOrOther, DecisionTierStats } from "./decision-audit";
+
+export type DecisionHelpStep = {
+  label: string;
+  /** Internal route the step points at; null for a step that is just advice. */
+  href: string | null;
+};
+
+export type DecisionHelp = {
+  /** What this outcome is, in one or two plain sentences. */
+  meaning: string;
+  /** Whether anything is actually waiting on the reader. */
+  urgency: string;
+  /** Ordered concrete next actions; empty when nothing is needed. */
+  steps: DecisionHelpStep[];
+};
+
+export type DecisionHelpInput = {
+  outcomeType: string;
+  tier: DecisionAuditTierOrOther;
+  riskTier: string | null;
+  principleConflict: boolean;
+  /** True when no option carried scoreable features (every contribution zero). */
+  insufficientSignal: boolean;
+  /** True when the consult came from a Build Studio gate (row.buildId set). */
+  hasBuild: boolean;
+  /** True once a human answered (capture row or humanOutcome present). */
+  resolved: boolean;
+};
+
+/** The tier's playbook, named the way the rest of the surface names it. */
+function tierPlaybook(tier: DecisionAuditTierOrOther): string {
+  switch (tier) {
+    case "wwmd":
+      return "platform doctrine (how the platform itself should be built)";
+    case "wwwd":
+      return "your business playbook";
+    case "wsid":
+      return "this role's craft playbook";
+    default:
+      return "the governing playbook";
+  }
+}
+
+function escalateMeaning(input: DecisionHelpInput): string {
+  const base = "Your AI stopped short of making this call alone and put it in front of a human.";
+  if (input.insufficientSignal) {
+    return `${base} The consult arrived without scoreable options, so nothing could actually be weighed — only a person (or a re-run with scoreable options) can settle it.`;
+  }
+  if (input.principleConflict) {
+    return `${base} Two of your recorded principles pull in opposite directions on it, and de-conflicting principles is a human call.`;
+  }
+  if (input.riskTier === "high" || input.riskTier === "critical") {
+    return `${base} It is marked ${input.riskTier}-risk, and your governance always routes ${input.riskTier}-risk calls to a human regardless of confidence.`;
+  }
+  return `${base} Its confidence in what ${tierPlaybook(input.tier)} says about this was too low to decide unattended.`;
+}
+
+function deferMeaning(input: DecisionHelpInput): string {
+  return `Your AI looked for guidance and found nothing recorded that answers this, so it declined to guess. ${
+    input.tier === "wwwd"
+      ? "Your business hasn't weighed in on this kind of question yet."
+      : `There is a gap in ${tierPlaybook(input.tier)} here.`
+  }`;
+}
+
+function unresolvedSteps(input: DecisionHelpInput): DecisionHelpStep[] {
+  const steps: DecisionHelpStep[] = [];
+  if (input.hasBuild) {
+    steps.push({
+      label: "Open Build Studio — this build is paused at its decision gate until the question is answered there.",
+      href: "/build",
+    });
+  }
+  if (input.tier === "wwwd") {
+    steps.push({
+      label:
+        "Answer it once on Review & adjust — your answer is captured as draft business doctrine your AI reuses, and the whole cluster of similar questions clears.",
+      href: "/coworker-decisions/review",
+    });
+    return steps;
+  }
+  steps.push({
+    label:
+      "Check Review & adjust — it rolls rows like this into a short list of themes instead of making you work the log line by line.",
+    href: "/coworker-decisions/review",
+  });
+  steps.push(
+    input.tier === "wsid"
+      ? {
+        label:
+          "If the same question keeps coming back, add craft guidance for the role so it can settle these itself next time.",
+        href: "/coworker-decisions/craft",
+      }
+      : {
+        label:
+          "If the same question keeps coming back, add a stance that answers it so it stops needing you.",
+        href: "/coworker-decisions/stance",
+      },
+  );
+  return steps;
+}
+
+/**
+ * Plain-language guidance for one ledger row. Always returns something to say:
+ * resolved rows and recommend/arbitrate rows get a "nothing needed" read, so
+ * the panel never leaves the reader guessing whether silence means action.
+ */
+export function buildDecisionHelp(input: DecisionHelpInput): DecisionHelp {
+  const unresolvedAsk = input.outcomeType === "escalate" || input.outcomeType === "defer";
+
+  if (input.outcomeType === "recommend") {
+    return {
+      meaning:
+        "Your AI weighed the options and recommends one. The recommendation went back to whoever asked; this row is the audit record of it.",
+      urgency: "Nothing is needed from you.",
+      steps: [],
+    };
+  }
+  if (input.outcomeType === "arbitrate") {
+    return {
+      meaning:
+        "Your AI was confident enough — and allowed by your autonomy settings — to settle this itself and keep working. It is recorded here so you can audit the call.",
+      urgency: "Nothing is needed from you unless you disagree with the call.",
+      steps: [],
+    };
+  }
+
+  const meaning =
+    input.outcomeType === "defer" ? deferMeaning(input) : escalateMeaning(input);
+
+  if (!unresolvedAsk) {
+    return {
+      meaning: "This outcome type has no recorded guidance.",
+      urgency: "Nothing is known to be waiting on you.",
+      steps: [],
+    };
+  }
+
+  if (input.resolved) {
+    return {
+      meaning,
+      urgency: "Resolved — a human already answered this. Nothing left to do here.",
+      steps: [],
+    };
+  }
+
+  return {
+    meaning,
+    urgency: input.hasBuild
+      ? "A build is waiting: the Build Studio build that asked is paused at this gate until someone answers."
+      : "Nothing is stuck. The coworker that asked handled the moment — typically by taking the safest option or asking in its own session — and moved on. Answering teaches your AI, so this question stops piling up here.",
+    steps: unresolvedSteps(input),
+  };
+}
+
+// ── Log-page digest ─────────────────────────────────────────────────────────
+
+export type AwaitingDigest = {
+  total: number;
+  /** e.g. "74 decisions are waiting on a human" */
+  headline: string;
+  /** Per-tier fragments, e.g. "29 platform doctrine". Only non-zero tiers. */
+  fragments: string[];
+};
+
+/**
+ * Deterministic roll-up of the "awaiting review" load for the log header.
+ * Returns null when nothing is waiting so the panel disappears entirely.
+ */
+export function buildAwaitingDigest(stats: DecisionTierStats[]): AwaitingDigest | null {
+  const waiting = stats.filter((s) => s.unresolved > 0);
+  const total = waiting.reduce((sum, s) => sum + s.unresolved, 0);
+  if (total === 0) return null;
+  return {
+    total,
+    headline:
+      total === 1
+        ? "1 decision is waiting on a human"
+        : `${total} decisions are waiting on a human`,
+    fragments: waiting.map((s) => `${s.unresolved} ${s.expansion.toLowerCase()} (${s.code})`),
+  };
+}

--- a/docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md
@@ -267,3 +267,32 @@ BI-EF3F4A2D) governs multi-tenant gate authority, not whether authoring works.
    "Posture" label on the review surface (§1.1).
 3. **Phase-1 stop point.** Is the reframed landing + linked existing surfaces enough to react to
    before committing Phases 2–4?
+
+---
+
+## 9. Addendum (2026-07-28, BI-404E9BEA): plain-language "what do I do about this?" help
+
+Operator finding: the Decision log and its drill-in show `ESCALATE`/`DEFER` rows with an
+"awaiting review" chip and a bare link to Review & adjust. A non-technical reader cannot tell what
+the outcome *is*, whether anything is blocked while it waits, or what to concretely do — 29 WWMD +
+45 WSID unresolved rows read as alarming homework with no instructions. This is a §7 success-criteria
+gap on the audit surface itself.
+
+Resolution — a deterministic guidance layer (`apps/web/lib/wiki/decision-help.ts`, pure/unit-tested;
+**no inference dependency**, so the help works even when the local model runtime is down):
+
+- **Per-row guidance** (`buildDecisionHelp`): maps outcome type + tier + risk + conflict /
+  insufficient-signal flags + build-gate linkage + resolution state to plain language — what the
+  outcome means, whether anything is actually waiting (a Build Studio gate blocks; a fire-and-forget
+  consult does not), and ordered next steps linking to Review & adjust / stance editor / craft
+  corpus. Rendered in the decision drill-in's Human review section for every outcome, including the
+  "nothing needed from you" read on recommend/arbitrate rows.
+- **Log-header digest** (`buildAwaitingDigest`): rolls the per-tier unresolved counts into one
+  headline ("N decisions are waiting on a human") with a progressive-disclosure explainer of
+  escalate vs defer, why nothing on the page is silently stuck, and that Review & adjust clusters
+  rows into themes answered once — not worked line by line.
+- **Contextual Docs**: a `/coworker-decisions` quick-help entry joins the BI-2DD18122 registry so
+  Help opened from any decision-governance page answers the five stuck-reader questions.
+
+A follow-up (separate BI) may add an AI-coworker-narrated summary of the unresolved cluster; it
+layers on top of — and must never replace — this deterministic floor.

--- a/docs/user-guide/wiki/index.md
+++ b/docs/user-guide/wiki/index.md
@@ -39,6 +39,14 @@ Each row is filed under **the gate that made the decision**, not the doctrine it
 
 A tier reading **"never used"** means that gate has recorded nothing. Treat it as a question, not a conclusion: it can mean the gate genuinely is not exercised, or that nothing is wired to call it. Compare it against the **Consults by caller** panel on the same page — a coworker that never appears there has never consulted the kernel at all.
 
+## Escalated And Deferred Decisions: What To Do
+
+Rows marked **escalate** or **defer** carry an "awaiting review" chip until a human answers. Escalated means the AI stopped short of deciding alone — the call was high-risk, its confidence was low, two principles conflicted, or the consult carried no scoreable options. Deferred means it found no recorded guidance at all, so it declined to guess.
+
+Neither outcome silently blocks work. The coworker that asked handled its own moment and moved on; the one exception is a Build Studio build paused at a decision gate, and that row says so. The log header totals what is waiting per tier, and each decision's drill-in now explains, in plain language, what its outcome means, whether anything is waiting on you, and the next steps with links.
+
+Do not work the log line by line. Review & adjust groups the waiting rows into themes; answering a theme once — or adding a stance or craft guidance that covers it — teaches your AI so that question stops needing a human.
+
 ## Review & Adjust Findings
 
 `/coworker-decisions/review` surfaces findings over the accumulating decision ledger so you can keep governance sharp without reading every row: conflicting principles, gaps where the doctrine has no settled answer yet, a canonical decision that quietly drifted under a doctrine change, and stale decision material.

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7453,6 +7453,13 @@
     "longSentences": 0,
     "textMass": 7
   },
+  "apps/web/components/wiki/DecisionAwaitingHelp.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 98
+  },
   "apps/web/components/wiki/DecisionDisciplineHub.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary

Operator feedback (BI-404E9BEA): the Decision log and its drill-in show `ESCALATE`/`DEFER` rows with an "awaiting review" chip and a bare "see Review & adjust" link. A non-technical operator cannot tell what the outcome *is*, whether anything is blocked while it waits, or what to concretely do — 29 WWMD + 45 WSID unresolved rows read as alarming homework with no instructions.

This adds a **deterministic plain-language guidance layer** — rules over recorded fields, no inference — so the help holds even while the local model runtime is down:

- **`apps/web/lib/wiki/decision-help.ts`** (pure, unit-tested): `buildDecisionHelp` maps outcome type + tier + risk + conflict/insufficient-signal flags + build-gate linkage + resolution state to plain language — what the outcome means, whether anything is actually waiting (a Build Studio gate blocks; a fire-and-forget consult does not), and ordered next steps into Review & adjust / the stance editor / the craft corpus. `buildAwaitingDigest` rolls the per-tier unresolved counts into one headline.
- **Decision drill-in** (`/coworker-decisions/decisions/[interactionId]`): the Human review section now renders the guidance panel for every outcome — including a "nothing needed from you" read on recommend/arbitrate rows.
- **Decision log** (`/coworker-decisions/decisions`): "N decisions are waiting on a human" digest with a native `<details>` progressive-disclosure explainer (escalate vs defer, nothing silently stuck, Review & adjust answers themes once — not 74 rows one by one) and an owner-first next-action link.
- **Contextual Docs**: `/coworker-decisions` quick-help entry joins the BI-2DD18122 registry, inside its 60-word/220-word ceilings.

## Design grounding

Extends `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md` with a §9 addendum (in this PR) — the operator finding is a §7 success-criteria gap on the audit surface itself. Source of truth for the read model stays `apps/web/lib/wiki/decision-audit.ts`; the help layer is a pure sibling module, no contract changes to the ledger, gates, or Review & adjust actions.

## Verification

- `vitest run` on `lib/wiki/decision-help.test.ts`, `lib/docs-quick-help.test.ts`, `lib/wiki/decision-audit.test.ts` — 40/40 green in the worktree.
- New pure module passes `tsc --strict` in isolation.
- Full local `apps/web` typecheck was not runnable: both the root clone and worktree currently have hollow `apps/web/node_modules` (no `next` package resolvable — pre-existing, also breaks `next typegen` on main). CI typecheck gates the merge.

Backlog: BI-404E9BEA (triaged build/small, linked EP-UX-SYSTEM). Follow-up candidate (not in this PR): AI-coworker-narrated summary of the unresolved cluster once the model runtime is healthy — it layers on top of, never replaces, this deterministic floor.

Seed-Fit-Decision: not-applicable — no seed, provider, or model-profile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
