### PR TITLE
fix(ci): exclude wall-clock-collection routes from the UX sweep frozen baseline (BI-0C6C2153)

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1608,17 +1608,6 @@
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text"
     },
-    "/platform/development/change-lanes": {
-      "defaultVisibleWords": 317,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 1,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - button\n  - text\n  - region\n    - heading [level=2]\n    - text\n    - paragraph\n      - text\n    - text\n    - heading [level=3]\n    - list\n      - listitem\n        - text\n    - heading [level=3]\n    - list\n      - listitem\n        - text\n  - button\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n        - columnheader\n          - text\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - link\n        - cell\n          - text"
-    },
     "/platform/device-catalog": {
       "defaultVisibleWords": 386,
       "leadBandWords": 0,
@@ -1750,17 +1739,6 @@
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text"
-    },
-    "/platform/schedule": {
-      "defaultVisibleWords": 331,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 9,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 5,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - text\n  - button\n  - group\n    - button\n  - button\n    - img\n  - button [disabled]\n  - heading [level=2]\n  - button [pressed]\n  - button\n  - grid\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - gridcell\n          - text\n  - text\n  - button"
     },
     "/platform/service-desk": {
       "defaultVisibleWords": 121,
@@ -2190,17 +2168,6 @@
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - region\n    - paragraph\n      - text\n    - link\n  - heading [level=2]\n  - link\n  - paragraph\n    - text\n  - complementary\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - link\n      - paragraph\n        - text\n    - paragraph\n      - text\n    - link\n      - paragraph\n        - text\n      - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - link\n    - list\n      - listitem\n        - paragraph\n          - text\n        - list\n          - listitem\n            - text\n  - paragraph\n    - text\n  - button\n    - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - button"
-    },
-    "/workspace/calendar": {
-      "defaultVisibleWords": 246,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 9,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 4,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n  - text\n  - button\n  - group\n    - button\n  - button\n    - img\n  - button [disabled]\n  - heading [level=2]\n  - button [pressed]\n  - button\n  - grid\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - gridcell\n          - text\n  - text\n  - button"
     },
     "/workspace/documents": {
       "defaultVisibleWords": 109,

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -2178,7 +2178,8 @@
         "next-action-marker",
         "lead-band"
       ],
-      "sweepEligible": true,
+      "sweepEligible": false,
+      "sweepExclusionReason": "wall-clock-collection",
       "confidence": "high"
     },
     {
@@ -2333,7 +2334,8 @@
         "next-action-marker",
         "lead-band"
       ],
-      "sweepEligible": true,
+      "sweepEligible": false,
+      "sweepExclusionReason": "wall-clock-collection",
       "confidence": "high"
     },
     {
@@ -3469,7 +3471,8 @@
         "next-action-marker",
         "lead-band"
       ],
-      "sweepEligible": true,
+      "sweepEligible": false,
+      "sweepExclusionReason": "wall-clock-collection",
       "confidence": "high"
     },
     {

--- a/apps/web/lib/ux-budget/route-shells.ts
+++ b/apps/web/lib/ux-budget/route-shells.ts
@@ -69,6 +69,7 @@ export const ROUTE_SWEEP_EXCLUSION_REASONS = [
   "setup-phase-only",
   "fixture-capability-unavailable",
   "redirects-to-dynamic-resource",
+  "wall-clock-collection",
 ] as const;
 export type RouteSweepExclusionReason =
   (typeof ROUTE_SWEEP_EXCLUSION_REASONS)[number];
@@ -78,8 +79,8 @@ export type RouteSweepExclusionReason =
  *
  * This is policy layered on the canonical route inventory, not a second inventory:
  * the generated registry below includes every route and records either measurable or
- * one explicit reason. These 26 routes were confirmed across repeated same-SHA CI
- * runs. They need a different authenticated/fixture context, intentionally redirect,
+ * one explicit reason. The non-wall-clock routes here were confirmed across
+ * repeated same-SHA CI runs. They need a different authenticated/fixture context, intentionally redirect,
  * or depend on a capability the generic fixture does not provision.
  *
  * Keep this list shrink-only where possible. A route becomes eligible in the same PR
@@ -115,6 +116,18 @@ export const ROUTE_SWEEP_EXCLUSIONS = {
   "/setup": "setup-phase-only",
   "/welcome": "setup-phase-only",
   "/ops/health": "redirects-to-dynamic-resource",
+
+  // Wall-clock collections (BI-0C6C2153): these routes derive the SET of
+  // visible entities from `new Date()` — calendar windows materialize upcoming
+  // cron-run instances, change lanes bucket work by time window. The volatile-
+  // text normalizer stabilizes timestamp PHRASING but cannot stabilize a
+  // changing entity set, so an exact frozen word baseline flakes with the
+  // clock (measured: /platform/schedule 331→342 words between a 01:07 and an
+  // 03:26 run of untouched code). Exclude until the fixture can pin the
+  // app-visible clock.
+  "/platform/schedule": "wall-clock-collection",
+  "/workspace/calendar": "wall-clock-collection",
+  "/platform/development/change-lanes": "wall-clock-collection",
 } as const satisfies Record<string, RouteSweepExclusionReason>;
 
 export type RouteShellPolicy = {

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -301,8 +301,8 @@ describe("generated route-shell registry", () => {
         (route) => route.sweepEligible === Boolean(route.sweepExclusionReason),
       ),
     ).toEqual([]);
-    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(203);
-    expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(107);
+    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(200);
+    expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(110);
   });
 
   it("keeps contextual sweep exclusions explicit, valid, and non-stale", () => {


### PR DESCRIPTION
## What

The UX Route Budget Sweep (REQUIRED) is failing PRs on routes their diffs cannot touch. Tonight: `/platform/schedule` regressed 331→342 words on two same-SHA runs of PR #3716 (03:26 and 03:35 UTC) while main was green on the identical base at 01:07 — and #3716's diff contains no `apps/web` UI change at all.

## Root cause

`/platform/schedule` renders a calendar over a window derived from `new Date()`. The **set** of visible events (upcoming cron-run instances, deployment windows, task runs) moves with the clock. The volatile-text normalizer (BI-EA221325) stabilizes timestamp *phrasing*, and #3712 made fixture *data* deterministic — but nothing pins the app-visible **clock**, so a frozen exact-word baseline flakes as event instances materialize. `/workspace/calendar` (same component) and `/platform/development/change-lanes` (BI-0C6C2153's original 316→321 route; read model built from `now`) share the mechanism.

## Fix

- New typed sweep-exclusion reason `wall-clock-collection`, applied to the three routes (exclusion, not baseline re-freeze — a re-freeze would flake again at the next clock boundary).
- `route-shells.generated.json` regenerated: 200 eligible / 110 excluded; `ux-budget.test.ts` counts updated; stale baseline entries pruned.
- Path back to measurement (pinning the app-visible clock in the sweep fixture) stays tracked in BI-0C6C2153.

## Verification

- `vitest run lib/ux-budget/`: 72/72 green (registry accounting, exclusion validity/staleness, ratchet).
- This PR's own sweep run exercises the new exclusion end-to-end.

Local-CI-Override: worktree pnpm .bin cannot execute the pregate runner; ux-budget suite green as above and PR CI re-validates the full surface.

Seed-Fit-Decision: not-applicable — CI measurement policy only; no seeded content or runtime surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)