### PR TITLE
fix(inference): trust an explicit operator served-context pin above the estimated ceiling (BI-F4D3B9E9)

### DIFF
--- a/apps/web/lib/inference/local-model-context-reconcile.test.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.test.ts
@@ -47,12 +47,22 @@ describe("resolveServedContextTarget — resource-aware (BI-3E614946)", () => {
     expect(await resolveServedContextTarget()).toBe(122_880);
   });
 
-  it("clamps an over-ambitious operator override DOWN to the resource-aware ceiling (no over-commit)", async () => {
+  it("trusts an explicit operator pin ABOVE the estimated ceiling, clamped only to MAX (BI-F4D3B9E9)", async () => {
     mockPrisma.platformConfig.findUnique.mockImplementation(
       configByKey({ host_profile: HOST_4090, "local.servedContextTokens": 200_000 }),
     );
-    // 200k pinned, but a 24 GB card on the 30B can only serve ~24,576 — clamp down.
-    expect(await resolveServedContextTarget()).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+    // The weights+KV estimate says a 24 GB card on the 30B caps at the floor, but
+    // the estimate measurably under-sizes MoE models (40k serves fine on this
+    // exact host). An explicit pin is the operator's documented mechanism for
+    // going higher — honor it, bounded only by the hard MAX.
+    expect(await resolveServedContextTarget()).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+
+  it("honors a measured-realistic pin (40k on the 24 GB 4090 + 30B MoE) verbatim", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(
+      configByKey({ host_profile: HOST_4090, "local.servedContextTokens": 40_960 }),
+    );
+    expect(await resolveServedContextTarget()).toBe(40_960);
   });
 
   it("trusts an operator override up to MAX when the host is unknown", async () => {

--- a/apps/web/lib/inference/local-model-context-reconcile.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.ts
@@ -25,6 +25,7 @@ import {
   isEmbeddingModelId,
   RECOMMENDED_BUILD_CONTEXT_TOKENS,
   REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS,
+  clampServedContextTokens,
   computeServedContextCeiling,
   isLocalServedContextEligibleForReasoning,
   parseHostMemory,
@@ -65,10 +66,17 @@ export async function resolveHostMemoryProfile(): Promise<
 export const LOCAL_SERVED_CONTEXT_CONFIG_KEY = "local.servedContextTokens";
 
 /**
- * The reconcile target, RESOURCE-AWARE (BI-3E614946):
- *   - operator override present → clamped to `[floor, resource-aware ceiling]`,
- *     so a pinned value can never over-commit a known GPU (the ceiling is what the
- *     host can actually serve; unknown host → MAX, trusting the operator);
+ * The reconcile target, RESOURCE-AWARE (BI-3E614946, revised BI-F4D3B9E9):
+ *   - operator override present → clamped to `[floor, MAX_LOCAL_CONTEXT_TOKENS]`.
+ *     An EXPLICIT pin is trusted above the estimated resource ceiling — the
+ *     ceiling is a weights+KV estimate, and it measurably under-sizes MoE
+ *     models (qwen3-coder 30B-A3B serves 40k on the 24 GB host the estimate
+ *     capped at the 24k floor, hard-excluding every restricted-sensitivity
+ *     coworker turn from its only eligible endpoint). The module contract has
+ *     always named the override as "the mechanism for going higher"; when the
+ *     pin exceeds the estimate we honor it and WARN loudly so the choice stays
+ *     legible. DMR/llama.cpp degrades by offloading rather than hard-failing,
+ *     and the reconcile's deferred/unreachable statuses catch a refused load.
  *   - no override → the resource-aware default sized to the host's VRAM/RAM budget
  *     minus model weights + headroom (`recommendServedContextTokens`), which itself
  *     returns the build floor when the host is unknown — a safe degrade.
@@ -92,9 +100,15 @@ export async function resolveServedContextTarget(): Promise<number> {
           ? Number(row.value)
           : null;
     if (raw != null && Number.isFinite(raw)) {
-      // Operator override, bounded by the resource-aware ceiling (never below the
-      // build floor, never above what the host can serve).
-      return Math.min(ceiling, Math.max(RECOMMENDED_BUILD_CONTEXT_TOKENS, Math.floor(raw)));
+      const pinned = clampServedContextTokens(Math.floor(raw));
+      if (pinned > ceiling) {
+        console.warn(
+          `[local-model-context] operator pin ${pinned} tokens exceeds the estimated resource ceiling ${ceiling} ` +
+            `for this host — honoring the pin (explicit operator choice; serving may offload layers). ` +
+            `Lower ${LOCAL_SERVED_CONTEXT_CONFIG_KEY} if local inference degrades.`,
+        );
+      }
+      return pinned;
     }
   } catch {
     // best-effort — fall through to the resource-aware default


### PR DESCRIPTION
## What

On a fully-local install, a restricted-sensitivity coworker turn (e.g. the COO with its 34-tool surface) has exactly one eligible endpoint: the bundled local model. Routing demands `estimatedInput × 1.5` of context (~30k for that surface), but `resolveServedContextTarget` clamped the operator's served-context pin to the resource-aware **estimate** — which caps a 24 GB / qwen3-coder-30B host at the 24,576 floor. Result: the pin silently no-oped, the context filter excluded the only cleared endpoint, and every tool-bearing confidential/restricted turn dead-ended in "No AI model can handle this request" (BI-F4D3B9E9; the live outage behind tonight's COO failure, verified via router excludedTrace + `[turn]` telemetry).

## Why the estimate is wrong to override an explicit pin

The ceiling is weights + KV arithmetic calibrated on dense models. qwen3-coder is MoE (GQA, 4 KV heads) — measured on the exact host the estimate capped: **DMR serves 40,960 tokens on the RTX 4090 and answers inference, VRAM 23.9/24.5 GB.** The module's own contract names the operator pin as "the mechanism for going higher."

## Fix

- An explicit `PlatformConfig local.servedContextTokens` pin is clamped only to `[build floor, MAX_LOCAL_CONTEXT_TOKENS]`; exceeding the estimated ceiling logs a loud warning and is honored (llama.cpp degrades by offloading; the reconcile's deferred/unreachable statuses catch a refused load).
- The **no-pin default keeps the conservative resource-aware math** — nothing changes for installs without an operator pin.

## Verification

- `vitest run lib/inference/local-model-context-reconcile.test.ts lib/inference/local-model-policy.test.ts`: 49/49 green, including the rewritten over-ceiling-pin case and a new measured-realistic 40k pin case.
- Live install: pin set to 40,960; DMR reloaded and answering; reconcile repairs `ModelProfile.maxContextTokens` on its cycle, restoring COO routing.

Remaining scope tracked in BI-F4D3B9E9: provision the serving default at install, per-turn tool-surface budgeting (`surfaceZone=overload`), and persisting the RouteDecisionLog trace on the no-eligible-endpoints throw path.

Local-CI-Override: worktree pnpm .bin cannot execute the pregate runner; targeted suites green as above and PR CI re-validates the full surface.

Seed-Fit-Decision: not-applicable — runtime policy module + tests; no seeded content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)