### PR TITLE
feat(storefront): order fulfilment lane in the owner inbox (BI-115E0D1F)

### DIFF
--- a/apps/web/app/(shell)/storefront/inbox/page.tsx
+++ b/apps/web/app/(shell)/storefront/inbox/page.tsx
@@ -4,6 +4,7 @@ import { StorefrontInbox } from "@/components/storefront-admin/StorefrontInbox";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import { formatReservationWhen, nextActionForReservation } from "@/lib/storefront/booking-summary";
+import { nextActionForOrder, summarizeOrderItems } from "@/lib/storefront/order-lifecycle";
 
 export default async function InboxPage() {
   const config = await prisma.storefrontConfig.findFirst({ select: { id: true, timezone: true } });
@@ -48,8 +49,11 @@ export default async function InboxPage() {
       select: {
         id: true,
         orderRef: true,
+        customerName: true,
         customerEmail: true,
         totalAmount: true,
+        items: true,
+        status: true,
         createdAt: true,
       },
     }),
@@ -169,17 +173,25 @@ export default async function InboxPage() {
         nextAction: nextActionForReservation(booking.status),
       };
     }),
-    ...orders.map((order) => ({
-      id: order.id,
-      ref: order.orderRef,
-      name: null,
-      email: order.customerEmail,
-      type: "order",
-      detail: `${currencySymbol}${order.totalAmount.toString()}`,
-      createdAt: order.createdAt.toISOString(),
-      providerName: null,
-      status: "",
-    })),
+    ...orders.map((order) => {
+      // Fulfilment handoff (BI-115E0D1F): the owner sees who ordered, what, the
+      // order's lane status, and the exact next action — same contract as
+      // reservations.
+      const itemSummary = summarizeOrderItems(order.items);
+      return {
+        id: order.id,
+        ref: order.orderRef,
+        name: order.customerName,
+        email: order.customerEmail,
+        type: "order",
+        detail: `${currencySymbol}${order.totalAmount.toString()}`,
+        createdAt: order.createdAt.toISOString(),
+        providerName: null,
+        status: order.status,
+        itemName: itemSummary,
+        nextAction: nextActionForOrder(order.status),
+      };
+    }),
     ...donations.map((donation) => ({
       id: donation.id,
       ref: donation.donationRef,

--- a/apps/web/app/api/storefront/orders/[id]/status/route.ts
+++ b/apps/web/app/api/storefront/orders/[id]/status/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { canTransitionOrder, isOrderStatus } from "@/lib/storefront/order-lifecycle";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const body = (await req.json().catch(() => ({}))) as { status?: unknown };
+  if (!isOrderStatus(body.status)) {
+    return NextResponse.json({ error: "A valid target status is required" }, { status: 400 });
+  }
+
+  const order = await prisma.storefrontOrder.findUnique({
+    where: { id },
+    select: { id: true, status: true },
+  });
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+
+  if (!canTransitionOrder(order.status, body.status)) {
+    return NextResponse.json(
+      { error: `An order that is ${order.status} cannot become ${body.status}` },
+      { status: 409 },
+    );
+  }
+
+  await prisma.storefrontOrder.update({
+    where: { id },
+    data: { status: body.status },
+  });
+
+  return NextResponse.json({ success: true, status: body.status });
+}

--- a/apps/web/app/api/storefront/orders/[id]/status/route.ts
+++ b/apps/web/app/api/storefront/orders/[id]/status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
+import { apiErrorResponse } from "@/lib/api/error";
 import { canTransitionOrder, isOrderStatus } from "@/lib/storefront/order-lifecycle";
 
 export async function POST(
@@ -9,14 +10,14 @@ export async function POST(
 ) {
   const session = await auth();
   if (!session?.user || (session.user as { type?: string }).type !== "admin") {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
   }
 
   const { id } = await params;
 
   const body = (await req.json().catch(() => ({}))) as { status?: unknown };
   if (!isOrderStatus(body.status)) {
-    return NextResponse.json({ error: "A valid target status is required" }, { status: 400 });
+    return apiErrorResponse("INVALID_STATUS", "A valid target status is required", 400);
   }
 
   const order = await prisma.storefrontOrder.findUnique({
@@ -24,13 +25,14 @@ export async function POST(
     select: { id: true, status: true },
   });
   if (!order) {
-    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+    return apiErrorResponse("NOT_FOUND", "Order not found", 404);
   }
 
   if (!canTransitionOrder(order.status, body.status)) {
-    return NextResponse.json(
-      { error: `An order that is ${order.status} cannot become ${body.status}` },
-      { status: 409 },
+    return apiErrorResponse(
+      "INVALID_TRANSITION",
+      `An order that is ${order.status} cannot become ${body.status}`,
+      409,
     );
   }
 

--- a/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
@@ -302,7 +302,10 @@ describe("StorefrontInbox — order rows", () => {
   });
 
   it("surfaces a failed transition as a retryable error", async () => {
-    stubFetch({ ok: false, body: { error: "An order that is fulfilled cannot become accepted" } });
+    stubFetch({
+      ok: false,
+      body: { code: "INVALID_TRANSITION", message: "An order that is fulfilled cannot become accepted" },
+    });
     render(<StorefrontInbox entries={[order()]} defaultDigitalProduct={defaultDigitalProduct} />);
 
     fireEvent.click(screen.getByRole("button", { name: /accept order ORD-0001/i }));

--- a/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
@@ -223,6 +223,94 @@ describe("StorefrontInbox — booking confirm/cancel result states", () => {
   });
 });
 
+// ── Order fulfilment lane (BI-115E0D1F) ─────────────────────────────────────
+function order(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "ord_1",
+    ref: "ORD-0001",
+    name: "Quinn Doyle",
+    email: "quinn@example.com",
+    type: "order",
+    detail: "$32",
+    createdAt: "2026-07-29T10:00:00.000Z",
+    providerName: null,
+    status: "pending",
+    backlogItemId: null,
+    itemName: "2× Margherita Pizza",
+    nextAction: "Accept this order to start preparing it",
+    ...overrides,
+  };
+}
+
+describe("StorefrontInbox — order rows", () => {
+  it("shows the customer name, contents, status, and next action", () => {
+    render(<StorefrontInbox entries={[order()]} defaultDigitalProduct={defaultDigitalProduct} />);
+    expect(screen.getByText(/quinn doyle · quinn@example\.com/i)).toBeTruthy();
+    expect(screen.getByText(/2× margherita pizza/i)).toBeTruthy();
+    expect(screen.getByText("pending")).toBeTruthy();
+    expect(screen.getByText(/next: accept this order to start preparing it/i)).toBeTruthy();
+  });
+
+  it("advances a pending order to accepted and shows the result", async () => {
+    const fetchMock = stubFetch({ ok: true });
+    render(<StorefrontInbox entries={[order()]} defaultDigitalProduct={defaultDigitalProduct} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /accept order ORD-0001/i }));
+
+    await waitFor(() => expect(screen.getByText(/accepted — it's now in preparation\./i)).toBeTruthy());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/storefront/orders/ord_1/status",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ status: "accepted" }) }),
+    );
+    // The row's forward action follows the new status without a reload.
+    expect(screen.getByRole("button", { name: /mark ready ORD-0001/i })).toBeTruthy();
+  });
+
+  it("offers Mark ready then Mark fulfilled along the lane", () => {
+    render(
+      <StorefrontInbox
+        entries={[order({ id: "ord_a", ref: "ORD-A", status: "accepted" }), order({ id: "ord_r", ref: "ORD-R", status: "ready" })]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /mark ready ORD-A/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /mark fulfilled ORD-R/i })).toBeTruthy();
+  });
+
+  it("confirms before cancelling and hides all actions on terminal orders", async () => {
+    dialogMocks.confirmDialog.mockResolvedValue(true);
+    const fetchMock = stubFetch({ ok: true });
+    render(
+      <StorefrontInbox
+        entries={[order(), order({ id: "ord_f", ref: "ORD-F", status: "fulfilled" })]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+
+    // Terminal order: no advance, no cancel.
+    expect(screen.queryByRole("button", { name: /cancel order ORD-F/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel order ORD-0001/i }));
+    await waitFor(() => expect(screen.getByText(/cancelled — this order won't be prepared\./i)).toBeTruthy());
+    expect(dialogMocks.confirmDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/ORD-0001 for Quinn Doyle/i) }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/storefront/orders/ord_1/status",
+      expect.objectContaining({ body: JSON.stringify({ status: "cancelled" }) }),
+    );
+  });
+
+  it("surfaces a failed transition as a retryable error", async () => {
+    stubFetch({ ok: false, body: { error: "An order that is fulfilled cannot become accepted" } });
+    render(<StorefrontInbox entries={[order()]} defaultDigitalProduct={defaultDigitalProduct} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /accept order ORD-0001/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/cannot become accepted/i));
+  });
+});
+
 // ── Filter announcement + labelled provider select (BI-F0B389C9 residue) ─────
 describe("StorefrontInbox — filter chips and provider select", () => {
   it("marks the active filter chip and announces the result count", () => {

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -107,7 +107,12 @@ export function StorefrontInbox({
       const res = await opts.request();
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        throw new Error(typeof body.error === "string" ? body.error : opts.failureMessage);
+        // Booking routes return { error }; envelope routes return { message }.
+        const detail =
+          typeof body.error === "string" ? body.error
+          : typeof body.message === "string" ? body.message
+          : opts.failureMessage;
+        throw new Error(detail);
       }
       setStatusOverride((s) => ({ ...s, [e.id]: opts.successStatus }));
       setBookingAction((s) => ({ ...s, [e.id]: { phase: "done", message: opts.successMessage } }));

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -336,7 +336,7 @@ export function StorefrontInbox({
               </span>
             </div>
             <div style={{ fontSize: 13 }}>{e.name ?? "Anonymous"} · {e.email}</div>
-            {e.type === "booking" ? (
+            {e.type === "booking" && (
               <div style={{ marginTop: 4, display: "flex", flexDirection: "column", gap: 2 }}>
                 <div style={{ fontSize: 13, fontWeight: 600 }}>
                   {e.itemName ?? "Reservation"}
@@ -356,7 +356,8 @@ export function StorefrontInbox({
                   </div>
                 )}
               </div>
-            ) : e.type === "order" ? (
+            )}
+            {e.type === "order" && (
               <div style={{ marginTop: 4, display: "flex", flexDirection: "column", gap: 2 }}>
                 <div style={{ fontSize: 13, fontWeight: 600 }}>
                   {e.itemName ?? "Order"}
@@ -368,8 +369,9 @@ export function StorefrontInbox({
                   </div>
                 )}
               </div>
-            ) : (
-              e.detail && <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 2 }}>{e.detail}</div>
+            )}
+            {e.type !== "booking" && e.type !== "order" && e.detail && (
+              <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 2 }}>{e.detail}</div>
             )}
             {e.type === "inquiry" && (() => {
               // A successful send stores the created itemId (BI-…); anything

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { confirmDialog, promptDialog } from "@/components/ui/Dialog";
 import { reservationActionLabel } from "@/lib/storefront/booking-summary";
+import { type OrderStatus } from "@/lib/storefront/order-lifecycle";
 
 type Entry = {
   id: string;
@@ -36,6 +37,17 @@ const STATUS_STYLES: Record<string, { background: string; color: string }> = {
   completed: { background: "rgba(79,70,229,0.15)", color: "var(--dpf-accent)" },
   cancelled: { background: "color-mix(in srgb, var(--dpf-error) 15%, transparent)", color: "var(--dpf-error)" },
   "needs-reschedule": { background: "rgba(249,115,22,0.15)", color: "#f97316" },
+  // Order fulfilment lane (BI-115E0D1F).
+  accepted: { background: "rgba(79,70,229,0.15)", color: "var(--dpf-accent)" },
+  ready: { background: "color-mix(in srgb, var(--dpf-success) 15%, transparent)", color: "var(--dpf-success)" },
+  fulfilled: { background: "rgba(79,70,229,0.15)", color: "var(--dpf-accent)" },
+};
+
+// The owner-facing verb that moves an order forward from each lane status.
+const ORDER_ADVANCE: Record<string, { to: OrderStatus; verb: string; done: string } | undefined> = {
+  pending: { to: "accepted", verb: "Accept order", done: "Accepted — it's now in preparation." },
+  accepted: { to: "ready", verb: "Mark ready", done: "Ready — hand it over and mark it fulfilled." },
+  ready: { to: "fulfilled", verb: "Mark fulfilled", done: "Fulfilled — this order is complete." },
 };
 
 function StatusBadge({ status }: { status: string }) {
@@ -149,6 +161,32 @@ export function StorefrontInbox({
       failureMessage: "Couldn't confirm the booking.",
       request: () => fetch(`/api/storefront/bookings/${e.id}/confirm`, { method: "POST" }),
     });
+  }
+
+  async function advanceOrder(e: Entry, to: OrderStatus, doneMessage: string) {
+    await runBookingAction(e, {
+      pendingMessage: "Updating…",
+      successStatus: to,
+      successMessage: doneMessage,
+      failureMessage: "Couldn't update the order.",
+      request: () =>
+        fetch(`/api/storefront/orders/${e.id}/status`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: to }),
+        }),
+    });
+  }
+
+  async function cancelOrder(e: Entry) {
+    const ok = await confirmDialog({
+      title: `Cancel order ${e.ref}`,
+      message: `Order ${e.ref}${e.name ? ` for ${e.name}` : ""}. The order becomes cancelled and won't be prepared.`,
+      confirmLabel: "Cancel order",
+      cancelLabel: "Keep order",
+    });
+    if (!ok) return;
+    await advanceOrder(e, "cancelled", "Cancelled — this order won't be prepared.");
   }
 
   async function sendInquiryToProductBacklog(id: string) {
@@ -280,7 +318,7 @@ export function StorefrontInbox({
                 </span>
               )}
               <span style={{ fontSize: 12, fontFamily: "monospace" }}>{e.ref}</span>
-              {e.type === "booking" && (statusOverride[e.id] ?? e.status) && (
+              {(e.type === "booking" || e.type === "order") && (statusOverride[e.id] ?? e.status) && (
                 <StatusBadge status={statusOverride[e.id] ?? e.status} />
               )}
               {e.type === "booking" && e.providerName && (
@@ -307,6 +345,18 @@ export function StorefrontInbox({
                     Dietary: {e.dietaryNotes}
                   </div>
                 )}
+                {e.nextAction && (
+                  <div style={{ fontSize: 12, color: "var(--dpf-accent)" }}>
+                    Next: {e.nextAction}
+                  </div>
+                )}
+              </div>
+            ) : e.type === "order" ? (
+              <div style={{ marginTop: 4, display: "flex", flexDirection: "column", gap: 2 }}>
+                <div style={{ fontSize: 13, fontWeight: 600 }}>
+                  {e.itemName ?? "Order"}
+                  {e.detail && <span className="text-[var(--dpf-muted)]" style={{ fontWeight: 400 }}> · {e.detail}</span>}
+                </div>
                 {e.nextAction && (
                   <div style={{ fontSize: 12, color: "var(--dpf-accent)" }}>
                     Next: {e.nextAction}
@@ -383,6 +433,70 @@ export function StorefrontInbox({
                     <p className="text-[var(--dpf-muted)]" style={{ fontSize: 11, margin: 0 }}>
                       Creates an internal work item for your team to follow up. The customer isn&apos;t notified.
                     </p>
+                  )}
+                </div>
+              );
+            })()}
+            {e.type === "order" && (() => {
+              const status = statusOverride[e.id] ?? e.status;
+              const action = bookingAction[e.id];
+              const busy = action?.phase === "pending";
+              const advance = ORDER_ADVANCE[status];
+              const cancellable = status !== "fulfilled" && status !== "cancelled";
+              return (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }}>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    {advance && (
+                      <button
+                        onClick={() => advanceOrder(e, advance.to, advance.done)}
+                        disabled={busy}
+                        aria-label={`${advance.verb} ${e.ref}`}
+                        className="dpf-tap-target border border-[var(--dpf-success)] text-[var(--dpf-success)]"
+                        style={{
+                          padding: "3px 12px",
+                          borderRadius: 4,
+                          background: "none",
+                          cursor: busy ? "wait" : "pointer",
+                          fontSize: 12,
+                          opacity: busy ? 0.6 : 1,
+                        }}
+                      >
+                        {busy ? "Working…" : advance.verb}
+                      </button>
+                    )}
+                    {cancellable && (
+                      <button
+                        onClick={() => cancelOrder(e)}
+                        disabled={busy}
+                        aria-label={`Cancel order ${e.ref}`}
+                        className="dpf-tap-target border border-[var(--dpf-error)] text-[var(--dpf-error)]"
+                        style={{
+                          padding: "3px 12px",
+                          borderRadius: 4,
+                          background: "none",
+                          cursor: busy ? "wait" : "pointer",
+                          fontSize: 12,
+                          opacity: busy ? 0.6 : 1,
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                  {action && (
+                    <span
+                      role={action.phase === "error" ? "alert" : "status"}
+                      className={
+                        action.phase === "error"
+                          ? "text-[var(--dpf-error)]"
+                          : action.phase === "done"
+                            ? "text-[var(--dpf-success)]"
+                            : "text-[var(--dpf-muted)]"
+                      }
+                      style={{ fontSize: 12 }}
+                    >
+                      {action.message}
+                    </span>
                   )}
                 </div>
               );

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9849,6 +9849,7 @@
         "use-this-doc-for",
         "workflow",
         "reservations",
+        "orders",
         "what-to-watch"
       ]
     },

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 585,
+  "routeCount": 586,
   "routes": [
     {
       "routePath": "/",
@@ -1604,6 +1604,21 @@
         "id"
       ],
       "file": "apps/web/app/api/storefront/bookings/[id]/confirm/route.ts"
+    },
+    {
+      "routePath": "/api/storefront/orders/[id]/status",
+      "kind": "route",
+      "segments": [
+        "api",
+        "storefront",
+        "orders",
+        "[id]",
+        "status"
+      ],
+      "dynamicParams": [
+        "id"
+      ],
+      "file": "apps/web/app/api/storefront/orders/[id]/status/route.ts"
     },
     {
       "routePath": "/api/storefront/sign-up",

--- a/apps/web/lib/storefront/order-lifecycle.test.ts
+++ b/apps/web/lib/storefront/order-lifecycle.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ORDER_STATUSES,
+  ORDER_TRANSITIONS,
+  canTransitionOrder,
+  isOrderStatus,
+  nextActionForOrder,
+  summarizeOrderItems,
+} from "./order-lifecycle";
+
+describe("order status vocabulary", () => {
+  it("recognises every canonical status and rejects strangers", () => {
+    for (const status of ORDER_STATUSES) expect(isOrderStatus(status)).toBe(true);
+    expect(isOrderStatus("shipped")).toBe(false);
+    expect(isOrderStatus("")).toBe(false);
+    expect(isOrderStatus(null)).toBe(false);
+  });
+
+  it("keeps terminal states terminal", () => {
+    expect(ORDER_TRANSITIONS.fulfilled).toHaveLength(0);
+    expect(ORDER_TRANSITIONS.cancelled).toHaveLength(0);
+  });
+});
+
+describe("canTransitionOrder", () => {
+  it("walks the happy lane pending → accepted → ready → fulfilled", () => {
+    expect(canTransitionOrder("pending", "accepted")).toBe(true);
+    expect(canTransitionOrder("accepted", "ready")).toBe(true);
+    expect(canTransitionOrder("ready", "fulfilled")).toBe(true);
+  });
+
+  it("allows cancel from every non-terminal state only", () => {
+    expect(canTransitionOrder("pending", "cancelled")).toBe(true);
+    expect(canTransitionOrder("accepted", "cancelled")).toBe(true);
+    expect(canTransitionOrder("ready", "cancelled")).toBe(true);
+    expect(canTransitionOrder("fulfilled", "cancelled")).toBe(false);
+    expect(canTransitionOrder("cancelled", "cancelled")).toBe(false);
+  });
+
+  it("refuses skips, reversals, and unknown states", () => {
+    expect(canTransitionOrder("pending", "ready")).toBe(false);
+    expect(canTransitionOrder("pending", "fulfilled")).toBe(false);
+    expect(canTransitionOrder("ready", "accepted")).toBe(false);
+    expect(canTransitionOrder("shipped", "fulfilled")).toBe(false);
+    expect(canTransitionOrder("pending", "shipped")).toBe(false);
+  });
+});
+
+describe("nextActionForOrder", () => {
+  it("gives a concrete owner instruction per status", () => {
+    expect(nextActionForOrder("pending")).toMatch(/accept/i);
+    expect(nextActionForOrder("accepted")).toMatch(/ready/i);
+    expect(nextActionForOrder("ready")).toMatch(/fulfilled/i);
+    expect(nextActionForOrder("fulfilled")).toMatch(/no action needed/i);
+    expect(nextActionForOrder("cancelled")).toMatch(/no action needed/i);
+  });
+
+  it("degrades to a generic review line for unknown status", () => {
+    expect(nextActionForOrder("mystery")).toBe("Review this order");
+  });
+});
+
+describe("summarizeOrderItems", () => {
+  it("summarises a single line item with quantity", () => {
+    expect(summarizeOrderItems([{ qty: 2, name: "Margherita Pizza", unitPrice: 16 }])).toBe(
+      "2× Margherita Pizza",
+    );
+  });
+
+  it("collapses extra lines into a +N more suffix", () => {
+    expect(
+      summarizeOrderItems([
+        { qty: 1, name: "Caesar Salad" },
+        { qty: 2, name: "Tiramisu" },
+        { qty: 1, name: "Bruschetta" },
+      ]),
+    ).toBe("Caesar Salad +2 more");
+  });
+
+  it("returns null for empty or malformed items JSON", () => {
+    expect(summarizeOrderItems([])).toBeNull();
+    expect(summarizeOrderItems(null)).toBeNull();
+    expect(summarizeOrderItems("not-an-array")).toBeNull();
+    expect(summarizeOrderItems([{ qty: 3 }])).toBeNull();
+  });
+});

--- a/apps/web/lib/storefront/order-lifecycle.ts
+++ b/apps/web/lib/storefront/order-lifecycle.ts
@@ -58,7 +58,7 @@ export function summarizeOrderItems(items: unknown): string | null {
     .filter((it): it is { qty?: unknown; name?: unknown } => typeof it === "object" && it !== null)
     .map((it) => {
       const name = typeof it.name === "string" && it.name.trim() ? it.name.trim() : null;
-      const qty = typeof it.qty === "number" && it.qty > 0 ? it.qty : null;
+      const qty = typeof it.qty === "number" && it.qty > 1 ? it.qty : null;
       if (!name) return null;
       return qty ? `${qty}× ${name}` : name;
     })

--- a/apps/web/lib/storefront/order-lifecycle.ts
+++ b/apps/web/lib/storefront/order-lifecycle.ts
@@ -1,0 +1,69 @@
+// Order fulfilment handoff — the pure, shared vocabulary that turns a public
+// storefront order into a traceable owner-facing fulfilment task (BI-115E0D1F).
+//
+// Mirrors booking-summary.ts for reservations: dependency-free (no prisma, no
+// React) so the same lane backs the inbox rows, the status API's transition
+// guard, and any future attention source without drift.
+
+/** Canonical StorefrontOrder.status values. `pending` is the create-time
+ *  default; everything else is owner-driven. Hyphenless single words, matching
+ *  the reservation lane's style. */
+export const ORDER_STATUSES = ["pending", "accepted", "ready", "fulfilled", "cancelled"] as const;
+export type OrderStatus = (typeof ORDER_STATUSES)[number];
+
+export function isOrderStatus(value: unknown): value is OrderStatus {
+  return typeof value === "string" && (ORDER_STATUSES as readonly string[]).includes(value);
+}
+
+/** Legal forward transitions. Cancel is allowed from any non-terminal state;
+ *  fulfilled/cancelled are terminal. */
+export const ORDER_TRANSITIONS: Record<OrderStatus, readonly OrderStatus[]> = {
+  pending: ["accepted", "cancelled"],
+  accepted: ["ready", "cancelled"],
+  ready: ["fulfilled", "cancelled"],
+  fulfilled: [],
+  cancelled: [],
+};
+
+export function canTransitionOrder(from: string, to: string): boolean {
+  if (!isOrderStatus(from) || !isOrderStatus(to)) return false;
+  return ORDER_TRANSITIONS[from].includes(to);
+}
+
+/** The exact next action for an order at a given status — the "what to do"
+ *  line for a non-technical owner, matching nextActionForReservation. Pure. */
+export function nextActionForOrder(status: string): string {
+  switch (status) {
+    case "pending":
+      return "Accept this order to start preparing it";
+    case "accepted":
+      return "In preparation — mark it ready when it's done";
+    case "ready":
+      return "Ready — hand it over, then mark it fulfilled";
+    case "fulfilled":
+      return "Fulfilled — no action needed";
+    case "cancelled":
+      return "Cancelled — no action needed";
+    default:
+      return "Review this order";
+  }
+}
+
+/** One-line order contents summary for the inbox row, e.g.
+ *  "2× Margherita Pizza" or "2× Tiramisu +1 more". Pure and defensive: the
+ *  items column is free JSON, so unknown shapes degrade to a count. */
+export function summarizeOrderItems(items: unknown): string | null {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  const lines = items
+    .filter((it): it is { qty?: unknown; name?: unknown } => typeof it === "object" && it !== null)
+    .map((it) => {
+      const name = typeof it.name === "string" && it.name.trim() ? it.name.trim() : null;
+      const qty = typeof it.qty === "number" && it.qty > 0 ? it.qty : null;
+      if (!name) return null;
+      return qty ? `${qty}× ${name}` : name;
+    })
+    .filter((line): line is string => line !== null);
+  if (lines.length === 0) return null;
+  const [first, ...rest] = lines;
+  return rest.length > 0 ? `${first} +${rest.length} more` : first;
+}

--- a/docs/user-guide/storefront/inbox-and-enquiries.md
+++ b/docs/user-guide/storefront/inbox-and-enquiries.md
@@ -39,6 +39,26 @@ needs a new time, or a double-booking to untangle) also appear in your workspace
 New customer enquiries that haven't been replied to or routed yet appear there too
 ("Reply to …"), so a waiting lead is never visible only in this inbox.
 
+## Orders
+
+Order entries show who ordered, what they ordered (for example "2× Margherita
+Pizza"), the total, and the order's current stage. Every order moves through one
+simple lane:
+
+**pending → accepted → ready → fulfilled** (or **cancelled** at any point before
+it's fulfilled).
+
+- a **Next** line states the one action the order needs (for example "Accept this
+  order to start preparing it");
+- one button moves the order forward — **Accept order**, then **Mark ready**, then
+  **Mark fulfilled** — and **Cancel** is available until the order is fulfilled;
+- cancelling always shows you the exact order first and explains that it won't be
+  prepared.
+
+As with reservations, each action shows a short working state, then a green note
+on success or a red note on failure (the order is unchanged and you can try
+again).
+
 ## What To Watch
 
 - enquiries that never get converted into owned follow-up work


### PR DESCRIPTION
Closes BI-115E0D1F (Work Capsule WC-22B42410).

Storefront inbox order rows showed "Anonymous" (customerName was never selected — hardcoded `name: null`) and offered no lifecycle action at all: the dashboard said "8 orders to fulfil — waiting to be actioned" while the inbox gave a cook nothing to click, so `StorefrontOrder.status` stayed `pending` forever. Found during the 2026-07-29 live restaurant-archetype exercise after placing 8 real orders through the public storefront.

## What changed

- **`apps/web/lib/storefront/order-lifecycle.ts`** (new, pure): canonical `ORDER_STATUSES` (`pending → accepted → ready → fulfilled | cancelled`), transition guard, `nextActionForOrder()`, `summarizeOrderItems()` — the order twin of `booking-summary.ts`.
- **`POST /api/storefront/orders/[id]/status`** (new): admin-authed, transition-guarded status move using the canonical `apiErrorResponse` envelope; mirrors `bookings/[id]/confirm`.
- **Inbox page**: orders now select + surface `customerName`, `items`, `status`; rows carry a contents summary ("2× Margherita Pizza"), a status badge, and the "Next:" line.
- **`StorefrontInbox`**: order rows get one forward action per stage (Accept order / Mark ready / Mark fulfilled) plus confirm-dialog Cancel, with the same in-flight/success/error row feedback bookings have.
- **Docs**: `docs/user-guide/storefront/inbox-and-enquiries.md` gains an Orders section.
- Tests: `order-lifecycle.test.ts` (vocabulary, transitions, summaries) + 5 new `StorefrontInbox` order-row tests.

## Design grounding

Extends the reservation handoff contract (BI-3DA1DFDC, `docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md`) to orders. Code substrate reviewed: `apps/web/lib/storefront/booking-summary.ts`, `apps/web/components/storefront-admin/StorefrontInbox.tsx`, `apps/web/app/api/storefront/bookings/[id]/confirm/route.ts`. No existing spec covers order fulfilment; the lane deliberately mirrors the booking pattern rather than introducing a new artifact. Relates to BI-0E4A1228 (F&H request lifecycle) as the generic common slice it can build on.

## Verification

- Local-CI pregate (shared sandbox lease): unit tests + guards green at head SHA (record attached by the gate).
- UX path: component tests cover render + all transitions; live-portal walkthrough deferred to post-merge self-upgrade (this worktree is source-only; the live portal runs the pre-change image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
