### PR TITLE
feat(harness): redeployable archetype exercise harness with restaurant scenario pack (BI-41D8DF5F)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 568,
+  "pageCount": 569,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -7242,6 +7242,19 @@
         "9-cross-cutting-test-matrix",
         "10-post-audit-actions",
         "appendix-a-full-open-epic-list-2026-06-10-snapshot"
+      ]
+    },
+    "docs/testing/archetype-exercise-harness.md": {
+      "publicHref": "/testing/archetype-exercise-harness/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "archetype-exercise-harness",
+        "what-it-does",
+        "usage",
+        "scenario-pack-contract",
+        "known-limits"
       ]
     },
     "docs/testing/ci-evidence.md": {

--- a/docs/testing/archetype-exercise-harness.md
+++ b/docs/testing/archetype-exercise-harness.md
@@ -1,0 +1,62 @@
+# Archetype Exercise Harness
+
+`scripts/harness/archetype-exercise.mjs` stands up a business-archetype scenario
+on a running portal and exercises it through the same HTTP surfaces the UI uses,
+so what it proves is what a non-technical staff crew would experience. It is the
+runner for redeployable archetype test packs (BI-41D8DF5F); the first pack is
+`scripts/harness/scenarios/restaurant.mjs`.
+
+## What it does
+
+1. **Signs in** as the install admin via the NextAuth `workforce` credentials
+   provider (`ADMIN_EMAIL`, default `admin@dpf.local`, + `ADMIN_PASSWORD` from
+   the install's `.env`). Plain `node` + `fetch`, no dependencies.
+2. **Optionally resets the archetype** (`--reset`) through
+   `POST /api/storefront/admin/archetype-reset`, applying the scenario's
+   identity (name/tagline). Note: reset currently leaves prior-archetype residue
+   behind — tracked as BI-B36DE9C5.
+3. **Seeds the scenario catalog** idempotently through
+   `POST /api/storefront/admin/items` (skips items that already exist by name).
+   The restaurant pack seeds 8 priced dishes with `purchase` CTAs alongside the
+   archetype's booking items.
+4. **Generates demand** from named guest personas. The demand wave is weighted
+   so one item is the clear best-seller — the signal a proactive restocking
+   coworker needs. Where a public flow has no JSON API (today: order submission
+   is a page server action), the harness records a `capability-gap` observation
+   in its report instead of faking the write.
+5. **Writes a JSON report** (`--report out.json`) of steps + observations, the
+   raw material for deficiency backlog items.
+
+## Usage
+
+```bash
+ADMIN_PASSWORD=... node scripts/harness/archetype-exercise.mjs --scenario restaurant --report report.json
+```
+
+Flags: `--portal <url>` (default `http://localhost:3000`), `--reset` (swap the
+storefront to the scenario's archetype first).
+
+## Scenario pack contract
+
+A pack at `scripts/harness/scenarios/<name>.mjs` default-exports:
+
+- `archetypeId` — StorefrontArchetype slug the scenario targets
+- `orgSlug` — the storefront's public slug
+- `identity` — optional identity applied on `--reset`
+- `catalog` — items for the admin items API (name/description/category/ctaType/price)
+- `personas` — named customers with emails and addresses
+- `demand` — ordered `{ kind: "order" | "booking", item, persona, qty }` wave
+- `stubs` — where real-world rails are stubbed or deferred (e.g. card payment is
+  order-then-settle today, so no card stub is needed at order time; supplier
+  ordering awaits an ingredient-stock substrate)
+
+Adding an archetype = adding one pack file; the runner is archetype-agnostic.
+
+## Known limits
+
+- Booking-demand driving (slot pick + contact submit) is not yet in the runner;
+  bookings were exercised manually in the 2026-07-29 restaurant session.
+- Public order submission has no JSON API; until one exists the runner reports
+  the gap rather than submitting orders.
+- Observation hooks (attention counts, coworker proposals, decision-ledger
+  reads) are manual follow-ups today; candidates for a `--observe` pass.

--- a/scripts/harness/archetype-exercise.mjs
+++ b/scripts/harness/archetype-exercise.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// scripts/harness/archetype-exercise.mjs (draft — BI-41D8DF5F)
+//
+// Redeployable archetype exercise harness. Stands up a full archetype scenario
+// on a running portal and exercises it through the REAL public + admin HTTP
+// surfaces — the same requests the UI makes — so what it proves is what a
+// non-technical staff crew would experience.
+//
+//   node scripts/harness/archetype-exercise.mjs --scenario restaurant \
+//     [--portal http://localhost:3000] [--reset] [--report out.json]
+//
+// Credentials: ADMIN_EMAIL (default admin@dpf.local) + ADMIN_PASSWORD env.
+// Scenario packs live in scripts/harness/scenarios/<name>.mjs and export:
+//   { archetypeId, identity, catalog: [items], personas: [guests],
+//     demand: [{kind: "order"|"booking", item, persona, qty|slot}, ...],
+//     stubs: {…} }
+
+import { parseArgs } from "node:util";
+
+const args = parseArgs({
+  options: {
+    scenario: { type: "string" },
+    portal: { type: "string", default: "http://localhost:3000" },
+    reset: { type: "boolean", default: false },
+    report: { type: "string" },
+  },
+}).values;
+
+if (!args.scenario) {
+  console.error("--scenario <name> is required (e.g. restaurant)");
+  process.exit(2);
+}
+
+const PORTAL = args.portal.replace(/\/$/, "");
+const EMAIL = process.env.ADMIN_EMAIL ?? "admin@dpf.local";
+const PASSWORD = process.env.ADMIN_PASSWORD;
+if (!PASSWORD) {
+  console.error("ADMIN_PASSWORD env var is required (see the install's .env)");
+  process.exit(2);
+}
+
+// ── Cookie-jar fetch (NextAuth credentials sign-in) ─────────────────────────
+const jar = new Map();
+function cookieHeader() {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+function storeCookies(res) {
+  const raw = res.headers.getSetCookie?.() ?? [];
+  for (const line of raw) {
+    const [pair] = line.split(";");
+    const eq = pair.indexOf("=");
+    if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+  }
+}
+async function http(path, init = {}) {
+  const res = await fetch(`${PORTAL}${path}`, {
+    redirect: "manual",
+    ...init,
+    headers: { cookie: cookieHeader(), ...(init.headers ?? {}) },
+  });
+  storeCookies(res);
+  return res;
+}
+
+async function login() {
+  const csrfRes = await http("/api/auth/csrf");
+  const { csrfToken } = await csrfRes.json();
+  const body = new URLSearchParams({ csrfToken, email: EMAIL, password: PASSWORD });
+  // The employee/admin credentials provider id is "workforce" (customer portal
+  // uses "customer") — see apps/web/lib/govern/auth.ts.
+  const res = await http("/api/auth/callback/workforce", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (res.status >= 400) throw new Error(`login failed: ${res.status}`);
+  const check = await http("/api/auth/session");
+  const session = await check.json().catch(() => null);
+  if (!session?.user) throw new Error("login did not establish a session");
+  console.log(`[harness] signed in as ${EMAIL}`);
+}
+
+// ── Steps ───────────────────────────────────────────────────────────────────
+const report = { scenario: args.scenario, startedAt: new Date().toISOString(), steps: [], observations: [] };
+function step(name, detail) {
+  report.steps.push({ name, detail, at: new Date().toISOString() });
+  console.log(`[harness] ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+async function resetArchetype(scenario) {
+  const res = await http("/api/storefront/admin/archetype-reset", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ targetArchetypeId: scenario.archetypeId, identity: scenario.identity }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`archetype-reset failed: ${res.status} ${JSON.stringify(body)}`);
+  step("archetype-reset", `${scenario.archetypeId}${body.result?.warnings?.length ? ` warnings=${body.result.warnings.length}` : ""}`);
+}
+
+async function seedCatalog(scenario) {
+  const existing = await (await http("/api/storefront/admin/items")).json();
+  const have = new Set(existing.map((i) => i.name));
+  let created = 0;
+  for (const item of scenario.catalog) {
+    if (have.has(item.name)) continue;
+    const res = await http("/api/storefront/admin/items", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(item),
+    });
+    if (res.status !== 201) throw new Error(`item create failed (${item.name}): ${res.status}`);
+    created++;
+  }
+  step("seed-catalog", `${created} created, ${scenario.catalog.length - created} already present`);
+}
+
+async function resolveSlugAndItems() {
+  // The public storefront page needs the org slug; items need their ITEM-* ids.
+  const items = await (await http("/api/storefront/admin/items")).json();
+  return new Map(items.map((i) => [i.name, i]));
+}
+
+async function generateDemand(scenario, itemsByName, orgSlug) {
+  let orders = 0;
+  for (const d of scenario.demand) {
+    if (d.kind !== "order") continue; // booking driver lands with the next slice
+    const item = itemsByName.get(d.item);
+    if (!item) throw new Error(`demand references unknown item ${d.item}`);
+    const p = d.persona;
+    const res = await http(`/api/storefront/${orgSlug}/order`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        itemId: item.itemId,
+        quantity: d.qty ?? 1,
+        customerName: p.name,
+        email: p.email,
+        address: p.address,
+      }),
+    });
+    // Public order submission is a server action on the page in today's build;
+    // when no JSON API exists, the harness records the gap instead of faking it.
+    if (res.status === 404 || res.status === 405) {
+      report.observations.push({
+        kind: "capability-gap",
+        detail: "No public JSON order-submission API; orders must go through the page server action.",
+      });
+      break;
+    }
+    if (!res.ok) throw new Error(`order failed (${d.item} for ${p.name}): ${res.status}`);
+    orders++;
+  }
+  step("generate-demand", `${orders} orders submitted`);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+const { default: scenario } = await import(`./scenarios/${args.scenario}.mjs`);
+await login();
+if (args.reset) await resetArchetype(scenario);
+await seedCatalog(scenario);
+const itemsByName = await resolveSlugAndItems();
+await generateDemand(scenario, itemsByName, scenario.orgSlug);
+report.finishedAt = new Date().toISOString();
+if (args.report) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(args.report, JSON.stringify(report, null, 2));
+}
+console.log(`[harness] done — ${report.steps.length} steps, ${report.observations.length} observations`);

--- a/scripts/harness/scenarios/restaurant.mjs
+++ b/scripts/harness/scenarios/restaurant.mjs
@@ -1,0 +1,49 @@
+// scripts/harness/scenarios/restaurant.mjs (draft — BI-41D8DF5F)
+// Restaurant scenario pack: menu, guest personas, one dinner-service demand wave.
+
+export default {
+  archetypeId: "restaurant",
+  orgSlug: "digital-product-factory",
+  identity: { tagline: "Neighbourhood trattoria — wood-fired, seasonal, local" },
+  catalog: [
+    { name: "Margherita Pizza", description: "San Marzano tomato, fresh mozzarella, basil", category: "Mains", ctaType: "purchase", priceType: "fixed", priceAmount: 16, ctaLabel: "Order" },
+    { name: "Spaghetti Carbonara", description: "Guanciale, pecorino, egg yolk", category: "Mains", ctaType: "purchase", priceType: "fixed", priceAmount: 18, ctaLabel: "Order" },
+    { name: "Grilled Salmon", description: "Atlantic salmon, lemon butter, seasonal vegetables", category: "Mains", ctaType: "purchase", priceType: "fixed", priceAmount: 26, ctaLabel: "Order" },
+    { name: "Ribeye Steak", description: "12oz ribeye, herb butter, fries", category: "Mains", ctaType: "purchase", priceType: "fixed", priceAmount: 34, ctaLabel: "Order" },
+    { name: "Caesar Salad", description: "Romaine, parmesan, house-made croutons", category: "Starters", ctaType: "purchase", priceType: "fixed", priceAmount: 11, ctaLabel: "Order" },
+    { name: "Bruschetta", description: "Grilled sourdough, tomato, garlic, basil", category: "Starters", ctaType: "purchase", priceType: "fixed", priceAmount: 9, ctaLabel: "Order" },
+    { name: "Tiramisu", description: "Classic mascarpone, espresso, cocoa", category: "Desserts", ctaType: "purchase", priceType: "fixed", priceAmount: 10, ctaLabel: "Order" },
+    { name: "Panna Cotta", description: "Vanilla bean, berry coulis", category: "Desserts", ctaType: "purchase", priceType: "fixed", priceAmount: 9, ctaLabel: "Order" },
+  ],
+  personas: {
+    quinn: { name: "Quinn Doyle", email: "quinn-doyle-6@example.com", address: { line1: "12 Harbor Lane", city: "Springfield", postcode: "62701" } },
+    iris: { name: "Iris Owens", email: "iris-owens-1@example.com", address: { line1: "44 Elm Street", city: "Springfield", postcode: "62702" } },
+    chloe: { name: "Chloe Haynes", email: "chloe-haynes-0@example.com", address: { line1: "7 Maple Ave", city: "Springfield", postcode: "62703" } },
+    vik: { name: "Vik Frost", email: "vik-frost-3@example.com", address: { line1: "221 Birch Road", city: "Springfield", postcode: "62704" } },
+    devan: { name: "Devan Mensah", email: "devan-mensah-4@example.com", address: { line1: "90 Cedar Court", city: "Springfield", postcode: "62705" } },
+    wren: { name: "Wren Khan", email: "wren-khan-7@example.com", address: { line1: "5 Oak Terrace", city: "Springfield", postcode: "62706" } },
+  },
+  get demand() {
+    const p = this.personas;
+    // A dinner-service wave weighted so one dish (Margherita) is the clear
+    // best-seller — the demand signal the proactive-restocking loop needs.
+    return [
+      { kind: "order", item: "Margherita Pizza", persona: p.quinn, qty: 2 },
+      { kind: "order", item: "Spaghetti Carbonara", persona: p.iris, qty: 1 },
+      { kind: "order", item: "Margherita Pizza", persona: p.chloe, qty: 3 },
+      { kind: "order", item: "Grilled Salmon", persona: p.vik, qty: 2 },
+      { kind: "order", item: "Margherita Pizza", persona: p.devan, qty: 2 },
+      { kind: "order", item: "Ribeye Steak", persona: p.wren, qty: 1 },
+      { kind: "order", item: "Margherita Pizza", persona: p.iris, qty: 4 },
+      { kind: "order", item: "Tiramisu", persona: p.vik, qty: 2 },
+    ];
+  },
+  stubs: {
+    // Card payment: storefront orders are order-then-settle today, so no card
+    // rail is needed at order time. When checkout gains a payment step, stub it
+    // here (test card token) rather than in product code.
+    cardPayment: "not-required-at-order-time",
+    // Supplier ordering: blocked on ingredient substrate (BI-SPEND-003).
+    supplierOrdering: "pending-ingredient-substrate",
+  },
+};


### PR DESCRIPTION
Closes BI-41D8DF5F.

A plain-node runner (`scripts/harness/archetype-exercise.mjs`) that signs into the portal via the `workforce` credentials provider, optionally swaps the storefront archetype through `POST /api/storefront/admin/archetype-reset`, idempotently seeds a scenario catalog through the admin items API, and generates persona demand through the public flows — recording `capability-gap` observations instead of faking writes where no JSON API exists. First scenario pack: restaurant (8 priced dishes, 6 guest personas, best-seller-weighted demand wave). Adding an archetype = adding one pack file.

Validated live against the local install during the 2026-07-29 restaurant exercise: sign-in OK, catalog seed idempotent (8 already present after the manual session), order-API gap correctly reported.

Doc: `docs/testing/archetype-exercise-harness.md` (usage, pack contract, known limits). Known blockers for clean redeploys tracked separately: BI-B36DE9C5 (archetype-reset residue).

## Verification
Local-CI pregate green at head SHA (shared sandbox lease). Runner exercised live as above; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)