### PR TITLE
fix(ui): unmask an invalid phone number on blur instead of storing a wrong-confidence mask (BI-7639D394)

### DIFF
--- a/apps/web/components/ui/PhoneInput.tsx
+++ b/apps/web/components/ui/PhoneInput.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { forwardRef, useCallback } from "react";
-import type { ChangeEvent, InputHTMLAttributes } from "react";
+import type { ChangeEvent, FocusEvent, InputHTMLAttributes } from "react";
 
 import {
   formatPhoneAsYouType,
   isValidPhone,
   toE164,
+  unmaskInvalidPhone,
   type CountryCode,
 } from "@/lib/phone";
 import { usePhoneCountry } from "@/components/ui/PhoneCountryContext";
@@ -23,8 +24,9 @@ export type PhoneChangeInfo = {
 
 type Props = Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  "type" | "value" | "onChange"
+  "type" | "value" | "onChange" | "onBlur"
 > & {
+  onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
   /** Provide for a controlled field. Omit (use `defaultValue`/`name`) for an uncontrolled one. */
   value?: string;
   /** Receives the value formatted as-you-type. Store this. */
@@ -58,6 +60,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, Props>(function PhoneInpu
     onPhoneChange,
     inputMode,
     autoComplete,
+    onBlur,
     ...rest
   },
   ref,
@@ -85,6 +88,32 @@ export const PhoneInput = forwardRef<HTMLInputElement, Props>(function PhoneInpu
     [controlled, resolvedCountry, onValueChange, onPhoneChange],
   );
 
+  // On leaving the field, drop the mask from a number that never became valid:
+  // "555-0142" must not survive as the authoritative-looking "(555) 014-2"
+  // the guest never typed (BI-7639D394). Valid numbers keep their format.
+  const handleBlur = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      const current = e.currentTarget.value;
+      const unmasked = unmaskInvalidPhone(current, resolvedCountry);
+      if (unmasked !== current) {
+        if (controlled) {
+          onValueChange?.(unmasked);
+        } else {
+          e.currentTarget.value = unmasked;
+          onValueChange?.(unmasked);
+        }
+        onPhoneChange?.({
+          value: unmasked,
+          e164: toE164(unmasked, resolvedCountry),
+          isValid: isValidPhone(unmasked, resolvedCountry),
+          country: resolvedCountry,
+        });
+      }
+      onBlur?.(e);
+    },
+    [controlled, resolvedCountry, onValueChange, onPhoneChange, onBlur],
+  );
+
   return (
     <input
       ref={ref}
@@ -93,6 +122,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, Props>(function PhoneInpu
       autoComplete={autoComplete ?? "tel"}
       {...(controlled ? { value } : {})}
       onChange={handleChange}
+      onBlur={handleBlur}
       {...rest}
     />
   );

--- a/apps/web/lib/phone.test.ts
+++ b/apps/web/lib/phone.test.ts
@@ -4,6 +4,7 @@ import {
   coercePhoneCountry,
   formatPhoneAsYouType,
   formatPhoneDisplay,
+  unmaskInvalidPhone,
   isValidPhone,
   toE164,
 } from "./phone";
@@ -67,6 +68,27 @@ describe("coercePhoneCountry", () => {
     expect(coercePhoneCountry("")).toBeNull();
     expect(coercePhoneCountry("ZZ")).toBeNull();
     expect(coercePhoneCountry("United States")).toBeNull();
+  });
+});
+
+describe("unmaskInvalidPhone", () => {
+  it("strips the wrong-confidence mask from an incomplete number (BI-7639D394)", () => {
+    // A guest typing the local-style "555-0142" gets live-masked to
+    // "(555) 014-2" — on blur that must degrade to honest digits.
+    expect(unmaskInvalidPhone("(555) 014-2", "US")).toBe("5550142");
+  });
+
+  it("keeps a valid number formatted", () => {
+    expect(unmaskInvalidPhone("(415) 555-1234", "US")).toBe("(415) 555-1234");
+  });
+
+  it("preserves a leading + on invalid international fragments", () => {
+    expect(unmaskInvalidPhone("+44 20", "US")).toBe("+4420");
+  });
+
+  it("passes through empty and digit-free values", () => {
+    expect(unmaskInvalidPhone("", "US")).toBe("");
+    expect(unmaskInvalidPhone("ext.", "US")).toBe("ext.");
   });
 });
 

--- a/apps/web/lib/phone.ts
+++ b/apps/web/lib/phone.ts
@@ -73,6 +73,25 @@ export function isValidPhone(
 }
 
 /**
+ * Strip the as-you-type mask from a number that is NOT valid for `country`,
+ * returning just the digits (with any leading "+" preserved). A partial or
+ * local-style entry like "555-0142" would otherwise be presented as an
+ * authoritative-looking "(555) 014-2" — a wrong grouping the guest never
+ * typed. Valid numbers pass through unchanged. Pure. (BI-7639D394)
+ */
+export function unmaskInvalidPhone(
+  value: string,
+  country: CountryCode = DEFAULT_PHONE_COUNTRY,
+): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return "";
+  if (isValidPhone(trimmed, country)) return trimmed;
+  const digits = trimmed.replace(/[^\d]/g, "");
+  if (!digits) return trimmed;
+  return trimmed.startsWith("+") ? `+${digits}` : digits;
+}
+
+/**
  * Format a stored number for display (national format for in-country numbers,
  * international when a country code is present). Returns the input unchanged if
  * it cannot be parsed, so it is safe on legacy/free-form data.


### PR DESCRIPTION
Closes BI-7639D394.

PhoneInput live-masks as the user types, but a partial or local-style entry like `555-0142` persisted as the authoritative-looking `(555) 014-2` — a grouping the guest never typed — and rendered that way on the booking confirmation (reproduced live during the 2026-07-29 restaurant exercise, reservation BK-3CQYK6MV). On blur, a value that isn't a valid number for the field's country now degrades to its honest digits (leading `+` preserved); valid numbers keep their format.

- New pure helper `unmaskInvalidPhone` in `apps/web/lib/phone.ts` + 4 tests
- `PhoneInput` blur handler for both controlled and uncontrolled usage, chaining any caller `onBlur`

## Design grounding
No spec covers phone capture; substrate reviewed: `apps/web/lib/phone.ts`, `apps/web/components/ui/PhoneInput.tsx` (libphonenumber-js as-you-type contract), `docs/superpowers/specs/2026-07-22-accessible-form-submit-contract-design.md` for the storefront form context. Trivial behavioral correction — no contract change.

UX-Fit-Decision: No new control or choice; the existing field self-corrects on blur, strictly reducing wrong-confidence output for a non-technical guest.

## Verification
Local-CI pregate green at head SHA (unit tests incl. new unmaskInvalidPhone cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)