### PR TITLE
feat: originate governed build experiment fixtures

### DIFF
--- a/apps/web/lib/integrate/work-pattern-build-replay.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.ts
@@ -1,8 +1,15 @@
 import { createHash } from "node:crypto";
 
-import { isRecord } from "@/lib/shared/coerce";
 import type { WorkPatternExecutionProfile } from "@/lib/tak/work-pattern-experiment-types";
 import { DEFAULT_WORK_PATTERN_PROMOTION_POLICY } from "@/lib/tak/work-pattern-promotion-policy";
+import {
+  parseHermeticBuildReplayFixture,
+} from "@/lib/tak/work-pattern-experiment-fixture";
+
+export {
+  parseHermeticBuildReplayFixture,
+  type HermeticBuildReplayFixture,
+} from "@/lib/tak/work-pattern-experiment-fixture";
 
 import {
   buildSandboxWorktreeAddCommand,
@@ -22,15 +29,6 @@ import {
   type WorkPatternExperimentCellRequest,
   type WorkPatternExperimentCellResult,
 } from "./work-pattern-experiment-adapter";
-
-export type HermeticBuildReplayFixture = {
-  schemaVersion: 1;
-  kind: "build-replay-v1";
-  objective: string;
-  targetFile: string;
-  testFiles: string[];
-  methodInstructions: Record<string, string>;
-};
 
 type InferenceResult = {
   content: string;
@@ -67,57 +65,8 @@ export type HermeticBuildReplayExecution = {
   outputTokens: number;
 };
 
-const SAFE_LIBRARY_TARGET =
-  /^(?:apps\/web\/lib|packages\/[a-zA-Z0-9._-]+\/src)\/[a-zA-Z0-9._/-]+\.ts$/;
-const SAFE_TEST_PATH =
-  /^(?:apps\/web\/lib|packages\/[a-zA-Z0-9._-]+\/src)\/[a-zA-Z0-9._/-]+\.(?:test|spec)\.ts$/;
 const SAFE_TASK_ID = /^[a-zA-Z0-9-]+$/;
 const SAFE_COMMIT = /^[a-fA-F0-9]{7,64}$/;
-
-function nonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function safeRepoPath(value: unknown, pattern: RegExp): value is string {
-  return nonEmptyString(value)
-    && pattern.test(value)
-    && !value.includes("..")
-    && !value.includes("//");
-}
-
-export function parseHermeticBuildReplayFixture(
-  value: unknown,
-): HermeticBuildReplayFixture | null {
-  if (
-    !isRecord(value)
-    || value.schemaVersion !== 1
-    || value.kind !== "build-replay-v1"
-    || !nonEmptyString(value.objective)
-    || !safeRepoPath(value.targetFile, SAFE_LIBRARY_TARGET)
-    || /\.(?:test|spec)\.ts$/.test(value.targetFile)
-    || !Array.isArray(value.testFiles)
-    || value.testFiles.length === 0
-    || value.testFiles.length > 4
-    || value.testFiles.some((path) => !safeRepoPath(path, SAFE_TEST_PATH))
-    || !isRecord(value.methodInstructions)
-  ) {
-    return null;
-  }
-  const methodInstructions: Record<string, string> = {};
-  for (const [digest, instruction] of Object.entries(value.methodInstructions)) {
-    if (!nonEmptyString(digest) || !nonEmptyString(instruction)) return null;
-    methodInstructions[digest] = instruction;
-  }
-  if (Object.keys(methodInstructions).length === 0) return null;
-  return {
-    schemaVersion: 1,
-    kind: "build-replay-v1",
-    objective: value.objective,
-    targetFile: value.targetFile,
-    testFiles: [...value.testFiles] as string[],
-    methodInstructions,
-  };
-}
 
 function sourceFromResponse(content: string): string | null {
   const fenced = content.match(/```(?:typescript|tsx|ts|javascript|jsx|js)?\s*\n([\s\S]*?)```/i);

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.test.ts
@@ -171,16 +171,20 @@ describe("executePersistedWorkPatternExperimentCell", () => {
         initiatingAgentId: null,
         a2aMetadata: { workPatternExperimentCell: { attempt: 1 } },
       },
-      fixtureParts: {
-        schemaVersion: 1,
-        kind: "build-replay-v1",
-        objective: "Implement the bounded fixture.",
-        targetFile: "apps/web/lib/fixtures/bounded.ts",
-        testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
-        methodInstructions: {
-          "method-digest": "Use the baseline method.",
+      fixtureParts: [{
+        type: "work-pattern-experiment-fixture",
+        mimeType: "application/json",
+        data: {
+          schemaVersion: 1,
+          kind: "build-replay-v1",
+          objective: "Implement the bounded fixture.",
+          targetFile: "apps/web/lib/fixtures/bounded.ts",
+          testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+          methodInstructions: {
+            "method-digest": "Use the baseline method.",
+          },
         },
-      },
+      }],
     });
     vi.mocked(runtime.executeBuildReplay).mockResolvedValueOnce({
       result: {
@@ -222,7 +226,11 @@ describe("executePersistedWorkPatternExperimentCell", () => {
 
     expect(runtime.executeBuildReplay).toHaveBeenCalledWith({
       request: request(),
-      fixtureParts: expect.objectContaining({ kind: "build-replay-v1" }),
+      fixtureParts: [
+        expect.objectContaining({
+          type: "work-pattern-experiment-fixture",
+        }),
+      ],
       agentId: "agent-orchestrator",
     });
     expect(runtime.infer).not.toHaveBeenCalled();

--- a/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
+++ b/apps/web/lib/integrate/work-pattern-experiment-runtime.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { isRecord } from "@/lib/shared/coerce";
+import { parseHermeticBuildReplayFixture } from "@/lib/tak/work-pattern-experiment-fixture";
 import {
   parseWorkPatternExecutionProfile,
   type WorkPatternExecutionProfile,
@@ -296,8 +297,7 @@ export async function executePersistedWorkPatternExperimentCell(
   }
   const inferenceFixture = parseFixture(context.fixtureParts);
   const buildFixture =
-    isRecord(context.fixtureParts)
-    && context.fixtureParts.kind === "build-replay-v1";
+    parseHermeticBuildReplayFixture(context.fixtureParts) !== null;
   if (!inferenceFixture && !buildFixture) {
     throw new Error(`work_pattern_experiment_fixture_unavailable:${request.fixtureKey}`);
   }

--- a/apps/web/lib/tak/work-pattern-experiment-fixture.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-fixture.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWorkPatternFixtureArtifactParts,
+  parseHermeticBuildReplayFixture,
+  type HermeticBuildReplayFixture,
+  workPatternFixtureArtifactId,
+  workPatternFixtureDigest,
+} from "./work-pattern-experiment-fixture";
+
+const fixture = {
+  schemaVersion: 1,
+  kind: "build-replay-v1",
+  objective: "Implement the bounded helper.",
+  targetFile: "apps/web/lib/fixtures/bounded.ts",
+  testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+  methodInstructions: {
+    baseline: "Prefer the smallest pure implementation.",
+  },
+} satisfies HermeticBuildReplayFixture;
+
+describe("work-pattern experiment fixture", () => {
+  it("parses both the direct compatibility shape and canonical TaskArtifact envelope", () => {
+    expect(parseHermeticBuildReplayFixture(fixture)).toEqual(fixture);
+    expect(
+      parseHermeticBuildReplayFixture(
+        buildWorkPatternFixtureArtifactParts(fixture),
+      ),
+    ).toEqual(fixture);
+  });
+
+  it("rejects unsafe build targets before persistence or execution", () => {
+    expect(parseHermeticBuildReplayFixture({
+      ...fixture,
+      targetFile: "apps/web/app/build/page.tsx",
+    })).toBeNull();
+    expect(parseHermeticBuildReplayFixture({
+      ...fixture,
+      testFiles: ["../../outside.test.ts"],
+    })).toBeNull();
+  });
+
+  it("derives stable identities while keeping the fixture digest independently auditable", () => {
+    expect(
+      workPatternFixtureArtifactId("definition-a", "fixture-a"),
+    ).toBe(workPatternFixtureArtifactId("definition-a", "fixture-a"));
+    expect(
+      workPatternFixtureArtifactId("definition-a", "fixture-a"),
+    ).not.toBe(workPatternFixtureArtifactId("definition-a", "fixture-b"));
+    expect(workPatternFixtureDigest(fixture)).toBe(
+      workPatternFixtureDigest({ ...fixture }),
+    );
+    expect(workPatternFixtureDigest(fixture)).not.toBe(
+      workPatternFixtureDigest({ ...fixture, objective: "Changed bytes." }),
+    );
+  });
+});

--- a/apps/web/lib/tak/work-pattern-experiment-fixture.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-fixture.ts
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+
+import { isRecord } from "@/lib/shared/coerce";
+
+export const WORK_PATTERN_FIXTURE_PART_TYPE =
+  "work-pattern-experiment-fixture";
+
+export type HermeticBuildReplayFixture = {
+  schemaVersion: 1;
+  kind: "build-replay-v1";
+  objective: string;
+  targetFile: string;
+  testFiles: string[];
+  methodInstructions: Record<string, string>;
+};
+
+const SAFE_LIBRARY_TARGET =
+  /^(?:apps\/web\/lib|packages\/[a-zA-Z0-9._-]+\/src)\/[a-zA-Z0-9._/-]+\.ts$/;
+const SAFE_TEST_PATH =
+  /^(?:apps\/web\/lib|packages\/[a-zA-Z0-9._-]+\/src)\/[a-zA-Z0-9._/-]+\.(?:test|spec)\.ts$/;
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function safeRepoPath(value: unknown, pattern: RegExp): value is string {
+  return nonEmptyString(value)
+    && pattern.test(value)
+    && !value.includes("..")
+    && !value.includes("//");
+}
+
+function fixtureData(value: unknown): unknown {
+  if (!Array.isArray(value) || value.length !== 1) return value;
+  const part = value[0];
+  return isRecord(part)
+      && part.type === WORK_PATTERN_FIXTURE_PART_TYPE
+      && part.mimeType === "application/json"
+    ? part.data
+    : value;
+}
+
+export function parseHermeticBuildReplayFixture(
+  value: unknown,
+): HermeticBuildReplayFixture | null {
+  const data = fixtureData(value);
+  if (
+    !isRecord(data)
+    || data.schemaVersion !== 1
+    || data.kind !== "build-replay-v1"
+    || !nonEmptyString(data.objective)
+    || !safeRepoPath(data.targetFile, SAFE_LIBRARY_TARGET)
+    || /\.(?:test|spec)\.ts$/.test(data.targetFile)
+    || !Array.isArray(data.testFiles)
+    || data.testFiles.length === 0
+    || data.testFiles.length > 4
+    || data.testFiles.some((path) => !safeRepoPath(path, SAFE_TEST_PATH))
+    || !isRecord(data.methodInstructions)
+  ) {
+    return null;
+  }
+  const methodInstructions: Record<string, string> = {};
+  for (const [digest, instruction] of Object.entries(data.methodInstructions)) {
+    if (!nonEmptyString(digest) || !nonEmptyString(instruction)) return null;
+    methodInstructions[digest] = instruction;
+  }
+  if (Object.keys(methodInstructions).length === 0) return null;
+  return {
+    schemaVersion: 1,
+    kind: "build-replay-v1",
+    objective: data.objective,
+    targetFile: data.targetFile,
+    testFiles: [...data.testFiles] as string[],
+    methodInstructions,
+  };
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+export function workPatternFixtureDigest(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function workPatternFixtureArtifactId(
+  definitionKey: string,
+  logicalFixtureKey: string,
+): string {
+  const digest = createHash("sha256")
+    .update(`${definitionKey}\n${logicalFixtureKey}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `ta_wpf_${digest}`;
+}
+
+export function buildWorkPatternFixtureArtifactParts(
+  fixture: HermeticBuildReplayFixture,
+): Array<{ type: string; mimeType: "application/json"; data: HermeticBuildReplayFixture }> {
+  return [{
+    type: WORK_PATTERN_FIXTURE_PART_TYPE,
+    mimeType: "application/json",
+    data: fixture,
+  }];
+}

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts
@@ -26,60 +26,79 @@ import {
 } from "./work-pattern-experiment-scheduler";
 
 function candidate(environmentKey = "shadow") {
-  const executionProfile = {
-    patternKey: "review-loop",
-    patternVersion: 1,
-    variantKey: "baseline",
-    activityKey: "build.review",
-    riskClass: "internal-reversible",
-    providerId: "provider",
-    modelId: "model",
-    modelProfileId: "profile",
-    toolPackDigest: "tools",
-    promptOrSkillDigest: "prompt",
-    contextPolicyKey: "hermetic",
-    recoveryPolicyKey: "bounded",
-    installScope: "canonical",
-    taskCorpusKey: "corpus",
-    taskCorpusVersion: "1",
-    environmentKey,
-    sourceCommitSha: "abc123",
+  const methods = [
+    { methodVariantKey: "baseline", patternVersion: 1 },
+    { methodVariantKey: "candidate", patternVersion: 2 },
+  ];
+  const models = [
+    { modelVariantKey: "model-a", modelProfileId: "profile-a" },
+    { modelVariantKey: "model-b", modelProfileId: "profile-b" },
+  ];
+  const fixtureParts = {
+    schemaVersion: 1 as const,
+    kind: "build-replay-v1" as const,
+    objective: "Implement the bounded helper.",
+    targetFile: "apps/web/lib/fixtures/bounded.ts",
+    testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+    methodInstructions: {
+      baseline: "Prefer the smallest pure implementation.",
+      candidate: "Prefer explicit branches.",
+    },
   };
   return {
     definition: {
-      patternKey: "review-loop",
+      patternKey: "implementation-loop",
       taskCorpusKey: "corpus",
       taskCorpusVersion: "1",
       oracleKey: "oracle",
       oracleVersion: "1",
-      methodVariants: [{ methodVariantKey: "baseline", patternVersion: 1 }],
-      modelVariants: [{ modelVariantKey: "model-a", modelProfileId: "profile" }],
+      methodVariants: methods,
+      modelVariants: models,
       installScope: "canonical",
-      promotionPolicyKey: "bounded",
+      promotionPolicyKey: "governed-build-playbook-promotion",
       promotionPolicyVersion: 1,
     },
-    activityKey: "build.review",
+    activityKey: "build.implement",
     riskClass: "internal-reversible",
     pairKey: "pair",
-    cells: [
-      {
-        methodVariantKey: "baseline",
-        modelVariantKey: "model-a",
+    cells: methods.flatMap((method) =>
+      models.map((model) => ({
+        methodVariantKey: method.methodVariantKey,
+        modelVariantKey: model.modelVariantKey,
         executionRequest: {
           experimentRunId: "WPR-1",
           childTaskRunId: "TR-CELL-1",
-          cellKey: "baseline:model-a",
+          cellKey: `${method.methodVariantKey}:${model.modelVariantKey}`,
           pairKey: "pair",
-          methodVariantKey: "baseline",
-          modelVariantKey: "model-a",
-          executionProfile,
+          methodVariantKey: method.methodVariantKey,
+          modelVariantKey: model.modelVariantKey,
+          executionProfile: {
+            patternKey: "implementation-loop",
+            patternVersion: method.patternVersion,
+            variantKey: method.methodVariantKey,
+            activityKey: "build.implement",
+            riskClass: "internal-reversible",
+            providerId: "provider",
+            modelId: model.modelVariantKey,
+            modelProfileId: model.modelProfileId,
+            toolPackDigest: "tools",
+            promptOrSkillDigest: method.methodVariantKey,
+            contextPolicyKey: "hermetic",
+            recoveryPolicyKey: "bounded",
+            installScope: "canonical",
+            taskCorpusKey: "corpus",
+            taskCorpusVersion: "1",
+            environmentKey,
+            sourceCommitSha: "abc123",
+          },
           fixtureKey: "fixture",
           oracleKey: "oracle",
           oracleVersion: "1",
           resourcePolicyKey: "bounded",
         },
-      },
-    ],
+        fixtureParts,
+      })),
+    ),
   };
 }
 
@@ -105,11 +124,12 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
     expect(createRun).toHaveBeenCalledWith(
       expect.objectContaining({
         orchestratingAgentId: "agent-1",
-        cells: [
+        cells: expect.arrayContaining([
           expect.objectContaining({
             executionRequest: expect.objectContaining({ fixtureKey: "fixture" }),
+            fixtureParts: expect.objectContaining({ kind: "build-replay-v1" }),
           }),
-        ],
+        ]),
       }),
       expect.objectContaining({ resolveOwnerUserId: expect.any(Function) }),
     );
@@ -134,6 +154,37 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
       }),
     ).resolves.toEqual({
       scheduled: false,
+      reason: "authority_ceiling",
+    });
+    expect(createRun).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported risk and malformed fixtures before opening the store", async () => {
+    const highRisk = candidate();
+    highRisk.riskClass = "outbound-or-floor";
+    for (const cell of highRisk.cells) {
+      cell.executionRequest.executionProfile.riskClass = "outbound-or-floor";
+    }
+    await expect(scheduleReviewedWorkPatternExperiment({
+      action: "approve",
+      candidate: highRisk,
+      reviewerUserId: "user-1",
+      orchestratingAgentId: "agent-1",
+    })).resolves.toEqual({
+      scheduled: false,
+      reason: "authority_ceiling",
+    });
+
+    const unsafe = candidate();
+    unsafe.cells[0]!.fixtureParts.targetFile = "apps/web/app/build/page.tsx";
+    await expect(scheduleReviewedWorkPatternExperiment({
+      action: "approve",
+      candidate: unsafe,
+      reviewerUserId: "user-1",
+      orchestratingAgentId: "agent-1",
+    })).resolves.toEqual({
+      scheduled: false,
       reason: "no_evidence_cleared_experiment",
     });
     expect(createRun).not.toHaveBeenCalled();
@@ -144,6 +195,7 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
     const approved = candidate();
     approved.cells[0]!.executionRequest.executionProfile.activityKey = "build.implement";
     findUnique.mockResolvedValueOnce({
+      id: "parent-1",
       userId: "user-1",
       currentAgentId: "agent-1",
       initiatingAgentId: "agent-1",
@@ -159,7 +211,9 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
           riskClass: "internal-reversible",
           methodVariants: approved.definition.methodVariants,
           modelVariants: approved.definition.modelVariants,
-          requiredCellKeys: [approved.cells[0]!.executionRequest.cellKey],
+          requiredCellKeys: approved.cells.map(
+            (cell) => cell.executionRequest.cellKey,
+          ),
           taskCorpusKey: approved.definition.taskCorpusKey,
           taskCorpusVersion: approved.definition.taskCorpusVersion,
           oracleKey: approved.definition.oracleKey,
@@ -231,7 +285,9 @@ describe("scheduleReviewedWorkPatternExperiment", () => {
           riskClass: "internal-reversible",
           methodVariants: approved.definition.methodVariants,
           modelVariants: approved.definition.modelVariants,
-          requiredCellKeys: [approved.cells[0]!.executionRequest.cellKey],
+          requiredCellKeys: approved.cells.map(
+            (cell) => cell.executionRequest.cellKey,
+          ),
           taskCorpusKey: approved.definition.taskCorpusKey,
           taskCorpusVersion: approved.definition.taskCorpusVersion,
           oracleKey: approved.definition.oracleKey,

--- a/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-scheduler.ts
@@ -12,6 +12,10 @@ import {
   createPrismaWorkPatternExperimentPersistence,
   type WorkPatternExperimentInput,
 } from "./work-pattern-experiment-store";
+import {
+  parseHermeticBuildReplayFixture,
+  type HermeticBuildReplayFixture,
+} from "./work-pattern-experiment-fixture";
 import type { WorkPatternExperimentDefinitionIdentity } from "./work-pattern-experiment-identity";
 import { WORK_PATTERN_EXPERIMENT_RISK_CLASSES } from "./work-pattern-experiment-types";
 import { parseWorkPatternExperimentMetadata } from "./work-pattern-experiment-types";
@@ -31,6 +35,7 @@ type ReviewedExperimentCandidate = {
     executionRequest: NonNullable<
       ReturnType<typeof parsePersistedWorkPatternExperimentExecution>
     >;
+    fixtureParts?: HermeticBuildReplayFixture;
   }>;
 };
 
@@ -56,8 +61,8 @@ function parseReviewedExperimentCandidate(value: unknown): ReviewedExperimentCan
     || !nonEmptyString(definition.oracleVersion)
     || !Array.isArray(definition.methodVariants)
     || !Array.isArray(definition.modelVariants)
-    || definition.methodVariants.length === 0
-    || definition.modelVariants.length === 0
+    || definition.methodVariants.length < 2
+    || definition.modelVariants.length < 2
     || definition.methodVariants.some(
       (variant) =>
         !isRecord(variant)
@@ -79,8 +84,17 @@ function parseReviewedExperimentCandidate(value: unknown): ReviewedExperimentCan
   ) {
     return null;
   }
+  const typedDefinition =
+    definition as unknown as WorkPatternExperimentDefinitionIdentity;
 
   const cells: ReviewedExperimentCandidate["cells"] = [];
+  const expectedCells = new Set(
+    typedDefinition.methodVariants.flatMap((method) =>
+      typedDefinition.modelVariants.map(
+        (model) => `${method.methodVariantKey}:${model.modelVariantKey}`,
+      )),
+  );
+  const seenCells = new Set<string>();
   for (const rawCell of value.cells) {
     if (!isRecord(rawCell)) return null;
     const executionRequest = parsePersistedWorkPatternExperimentExecution(
@@ -92,20 +106,74 @@ function parseReviewedExperimentCandidate(value: unknown): ReviewedExperimentCan
       || !nonEmptyString(rawCell.modelVariantKey)
       || executionRequest.methodVariantKey !== rawCell.methodVariantKey
       || executionRequest.modelVariantKey !== rawCell.modelVariantKey
-      || executionRequest.executionProfile.environmentKey !== "shadow"
+      || !expectedCells.has(
+        `${rawCell.methodVariantKey}:${rawCell.modelVariantKey}`,
+      )
+      || seenCells.has(
+        `${rawCell.methodVariantKey}:${rawCell.modelVariantKey}`,
+      )
+      || executionRequest.executionProfile.activityKey !== value.activityKey
+      || executionRequest.executionProfile.riskClass !== value.riskClass
+      || executionRequest.executionProfile.patternKey
+        !== typedDefinition.patternKey
+      || executionRequest.executionProfile.taskCorpusKey
+        !== typedDefinition.taskCorpusKey
+      || executionRequest.executionProfile.taskCorpusVersion
+        !== typedDefinition.taskCorpusVersion
+      || executionRequest.oracleKey !== typedDefinition.oracleKey
+      || executionRequest.oracleVersion !== typedDefinition.oracleVersion
     ) {
       return null;
     }
+    const method = typedDefinition.methodVariants.find(
+      (variant) => variant.methodVariantKey === rawCell.methodVariantKey,
+    );
+    const model = typedDefinition.modelVariants.find(
+      (variant) => variant.modelVariantKey === rawCell.modelVariantKey,
+    );
+    if (
+      !method
+      || !model
+      || executionRequest.executionProfile.patternVersion
+        !== method.patternVersion
+      || executionRequest.executionProfile.modelProfileId
+        !== model.modelProfileId
+    ) {
+      return null;
+    }
+    const fixture = rawCell.fixtureParts === undefined
+      ? undefined
+      : parseHermeticBuildReplayFixture(rawCell.fixtureParts);
+    if (
+      rawCell.fixtureParts !== undefined
+      && (
+        !fixture
+        || !fixture.methodInstructions[
+          executionRequest.executionProfile.promptOrSkillDigest
+        ]
+      )
+    ) {
+      return null;
+    }
+    seenCells.add(
+      `${rawCell.methodVariantKey}:${rawCell.modelVariantKey}`,
+    );
     cells.push({
       methodVariantKey: rawCell.methodVariantKey,
       modelVariantKey: rawCell.modelVariantKey,
       executionRequest,
+      ...(fixture ? { fixtureParts: fixture } : {}),
     });
   }
-  if (cells.length === 0) return null;
+  if (
+    cells.length !== expectedCells.size
+    || seenCells.size !== expectedCells.size
+  ) {
+    return null;
+  }
 
   return {
-    definition: definition as unknown as WorkPatternExperimentDefinitionIdentity,
+    definition: typedDefinition,
     activityKey: value.activityKey,
     riskClass: value.riskClass as ReviewedExperimentCandidate["riskClass"],
     pairKey: value.pairKey,
@@ -122,6 +190,24 @@ export async function scheduleReviewedWorkPatternExperiment(input: {
   if (input.action !== "approve") return { scheduled: false, reason: "review_not_approved" };
   const candidate = parseReviewedExperimentCandidate(input.candidate);
   if (!candidate) return { scheduled: false, reason: "no_evidence_cleared_experiment" };
+  if (
+    candidate.definition.promotionPolicyKey
+      !== DEFAULT_WORK_PATTERN_PROMOTION_POLICY.policyKey
+    || candidate.definition.promotionPolicyVersion
+      !== DEFAULT_WORK_PATTERN_PROMOTION_POLICY.version
+    || !DEFAULT_WORK_PATTERN_PROMOTION_POLICY.supportedActivityKeys.includes(
+      candidate.activityKey,
+    )
+    || !DEFAULT_WORK_PATTERN_PROMOTION_POLICY.supportedRiskClasses.includes(
+      candidate.riskClass,
+    )
+    || candidate.cells.some(
+      (cell) =>
+        cell.executionRequest.executionProfile.environmentKey !== "shadow",
+    )
+  ) {
+    return { scheduled: false, reason: "authority_ceiling" };
+  }
 
   const persistence = createPrismaWorkPatternExperimentPersistence(prisma as never);
   const run = await createOrResumeWorkPatternExperiment(
@@ -135,6 +221,7 @@ export async function scheduleReviewedWorkPatternExperiment(input: {
         methodVariantKey: cell.methodVariantKey,
         modelVariantKey: cell.modelVariantKey,
         executionRequest: cell.executionRequest,
+        ...(cell.fixtureParts ? { fixtureParts: cell.fixtureParts } : {}),
       })),
     },
     {

--- a/apps/web/lib/tak/work-pattern-experiment-store.test.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.test.ts
@@ -12,15 +12,28 @@ import {
 function makePersistence(): WorkPatternExperimentPersistence & {
   rows: WorkPatternStoredTaskRun[];
   ledgers: Map<string, Record<string, unknown>>;
+  artifacts: Map<string, {
+    artifactId: string;
+    taskRunId: string;
+    parts: unknown;
+    metadata: unknown;
+  }>;
 } {
   const rows: WorkPatternStoredTaskRun[] = [];
   const ledgers = new Map<string, Record<string, unknown>>();
+  const artifacts = new Map<string, {
+    artifactId: string;
+    taskRunId: string;
+    parts: unknown;
+    metadata: unknown;
+  }>();
   let rowSequence = 0;
   let lock = Promise.resolve();
 
   return {
     rows,
     ledgers,
+    artifacts,
     async withDefinitionLock(_definitionKey, work) {
       const prior = lock;
       let release = () => {};
@@ -52,6 +65,21 @@ function makePersistence(): WorkPatternExperimentPersistence & {
       if (!row) throw new Error("missing_test_task_run");
       Object.assign(row, data);
       return row;
+    },
+    async findTaskArtifact(artifactId) {
+      return artifacts.get(artifactId) ?? null;
+    },
+    async createTaskArtifact(data) {
+      const existing = artifacts.get(data.artifactId);
+      if (existing) return existing;
+      const artifact = {
+        artifactId: data.artifactId,
+        taskRunId: data.taskRunId,
+        parts: data.parts,
+        metadata: data.metadata,
+      };
+      artifacts.set(data.artifactId, artifact);
+      return artifact;
     },
     async upsertLedger(ledgerId, create) {
       if (!ledgers.has(ledgerId)) ledgers.set(ledgerId, create);
@@ -152,6 +180,111 @@ describe("work-pattern experiment store", () => {
 
     expect(resumed.scheduledChildTaskRunIds).toEqual([first.children[1]!.taskRunId]);
     expect(persistence.rows).toHaveLength(3);
+  });
+
+  it("persists one immutable fixture before child dispatch and reuses it on resume", async () => {
+    const persistence = makePersistence();
+    const fixtureParts = {
+      schemaVersion: 1,
+      kind: "build-replay-v1",
+      objective: "Implement the bounded helper.",
+      targetFile: "apps/web/lib/fixtures/bounded.ts",
+      testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+      methodInstructions: {
+        baseline: "Prefer the smallest pure implementation.",
+        candidate: "Prefer explicit branches.",
+      },
+    };
+    const buildInput = {
+      ...input,
+      activityKey: "build.implement",
+      cells: input.cells.map((cell) => ({
+        ...cell,
+        executionRequest: {
+          fixtureKey: "bounded-helper-v1",
+        },
+        fixtureParts,
+      })),
+    };
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+
+    const first = await createOrResumeWorkPatternExperiment(buildInput, deps);
+    const resumed = await createOrResumeWorkPatternExperiment(buildInput, deps);
+
+    expect(persistence.artifacts.size).toBe(1);
+    expect(persistence.artifacts.values().next().value?.parts).toEqual([
+      expect.objectContaining({
+        type: "work-pattern-experiment-fixture",
+        mimeType: "application/json",
+        data: fixtureParts,
+      }),
+    ]);
+    for (const child of first.children) {
+      expect(
+        child.a2aMetadata.workPatternExperimentCell?.executionRequest,
+      ).toMatchObject({
+        fixtureKey: expect.stringMatching(/^ta_wpf_/),
+      });
+    }
+    expect(resumed.children.map((child) => child.taskRunId)).toEqual(
+      first.children.map((child) => child.taskRunId),
+    );
+  });
+
+  it("fails closed when a logical fixture identity is reused with changed bytes", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+    const fixtureParts = {
+      schemaVersion: 1,
+      kind: "build-replay-v1",
+      objective: "First version.",
+      targetFile: "apps/web/lib/fixtures/bounded.ts",
+      testFiles: ["apps/web/lib/fixtures/bounded.test.ts"],
+      methodInstructions: { baseline: "Smallest implementation." },
+    };
+    const withFixture = (parts: typeof fixtureParts) => ({
+      ...input,
+      activityKey: "build.implement",
+      cells: input.cells.map((cell) => ({
+        ...cell,
+        executionRequest: { fixtureKey: "bounded-helper-v1" },
+        fixtureParts: parts,
+      })),
+    });
+
+    await createOrResumeWorkPatternExperiment(withFixture(fixtureParts), deps);
+    await expect(createOrResumeWorkPatternExperiment(withFixture({
+      ...fixtureParts,
+      objective: "Changed version.",
+    }), deps)).rejects.toThrow("work_pattern_experiment_fixture_changed");
+    expect(persistence.artifacts.size).toBe(1);
+  });
+
+  it("fails before child creation when a referenced artifact is unavailable", async () => {
+    const persistence = makePersistence();
+    const deps = {
+      persistence,
+      resolveOwnerUserId: vi.fn().mockResolvedValue("user-owner"),
+    };
+
+    await expect(createOrResumeWorkPatternExperiment({
+      ...input,
+      cells: input.cells.map((cell) => ({
+        ...cell,
+        executionRequest: { fixtureKey: "ta_wpf_missing" },
+      })),
+    }, deps)).rejects.toThrow(
+      "work_pattern_experiment_fixture_unavailable:ta_wpf_missing",
+    );
+    expect(
+      persistence.rows.filter((row) => row.parentTaskRunId !== null),
+    ).toHaveLength(0);
   });
 
   it("retries by creating a new deterministic attempt and preserving the original", async () => {

--- a/apps/web/lib/tak/work-pattern-experiment-store.ts
+++ b/apps/web/lib/tak/work-pattern-experiment-store.ts
@@ -1,6 +1,14 @@
+import { randomUUID } from "node:crypto";
+
 import { resolveScheduledOwnerUserId } from "@/lib/queue/scheduled-owner";
 import { isRecord } from "@/lib/shared/coerce";
 
+import {
+  buildWorkPatternFixtureArtifactParts,
+  parseHermeticBuildReplayFixture,
+  workPatternFixtureArtifactId,
+  workPatternFixtureDigest,
+} from "./work-pattern-experiment-fixture";
 import {
   workPatternCellKey,
   workPatternExperimentChildTaskRunId,
@@ -54,6 +62,20 @@ export type WorkPatternStoredTaskRun = {
 
 export type WorkPatternTaskRunCreate = Omit<WorkPatternStoredTaskRun, "id">;
 
+export type WorkPatternStoredTaskArtifact = {
+  artifactId: string;
+  taskRunId: string;
+  parts: unknown;
+  metadata: unknown;
+};
+
+export type WorkPatternTaskArtifactCreate = WorkPatternStoredTaskArtifact & {
+  id: string;
+  name: string;
+  description: string;
+  producerAgentId: string;
+};
+
 export type WorkPatternExperimentPersistenceSession = {
   listTaskRuns: (repeatedPatternKey: string) => Promise<WorkPatternStoredTaskRun[]>;
   findTaskRun: (taskRunId: string) => Promise<WorkPatternStoredTaskRun | null>;
@@ -62,6 +84,12 @@ export type WorkPatternExperimentPersistenceSession = {
     taskRunId: string,
     data: Partial<Pick<WorkPatternStoredTaskRun, "status" | "a2aMetadata">>,
   ) => Promise<WorkPatternStoredTaskRun>;
+  findTaskArtifact: (
+    artifactId: string,
+  ) => Promise<WorkPatternStoredTaskArtifact | null>;
+  createTaskArtifact: (
+    data: WorkPatternTaskArtifactCreate,
+  ) => Promise<WorkPatternStoredTaskArtifact>;
   upsertLedger: (
     ledgerId: string,
     create: Record<string, unknown>,
@@ -89,6 +117,7 @@ export type WorkPatternExperimentInput = {
     methodVariantKey: string;
     modelVariantKey: string;
     executionRequest?: unknown;
+    fixtureParts?: unknown;
   }>;
   orchestratingAgentId: string;
   buildId?: string;
@@ -156,6 +185,50 @@ function assertNonEmpty(value: string, error: string): void {
   if (typeof value !== "string" || value.trim().length === 0) throw new Error(error);
 }
 
+type PreparedFixture = {
+  logicalFixtureKey: string;
+  artifactId: string;
+  fixtureDigest: string;
+  parts: ReturnType<typeof buildWorkPatternFixtureArtifactParts>;
+};
+
+function prepareFixtureArtifacts(
+  input: WorkPatternExperimentInput,
+  definitionKey: string,
+): Map<string, PreparedFixture> {
+  const prepared = new Map<string, PreparedFixture>();
+  for (const cell of input.cells) {
+    if (cell.fixtureParts === undefined) continue;
+    if (
+      !isRecord(cell.executionRequest)
+      || typeof cell.executionRequest.fixtureKey !== "string"
+      || cell.executionRequest.fixtureKey.trim().length === 0
+    ) {
+      throw new Error("work_pattern_experiment_fixture_key_missing");
+    }
+    const fixture = parseHermeticBuildReplayFixture(cell.fixtureParts);
+    if (!fixture) throw new Error("work_pattern_experiment_fixture_invalid");
+    const logicalFixtureKey = cell.executionRequest.fixtureKey;
+    const fixtureDigest = workPatternFixtureDigest(fixture);
+    const existing = prepared.get(logicalFixtureKey);
+    if (existing && existing.fixtureDigest !== fixtureDigest) {
+      throw new Error(
+        `work_pattern_experiment_fixture_changed:${logicalFixtureKey}`,
+      );
+    }
+    prepared.set(logicalFixtureKey, {
+      logicalFixtureKey,
+      artifactId: workPatternFixtureArtifactId(
+        definitionKey,
+        logicalFixtureKey,
+      ),
+      fixtureDigest,
+      parts: buildWorkPatternFixtureArtifactParts(fixture),
+    });
+  }
+  return prepared;
+}
+
 export async function createOrResumeWorkPatternExperiment(
   input: WorkPatternExperimentInput,
   deps: WorkPatternExperimentStoreDeps,
@@ -170,10 +243,12 @@ export async function createOrResumeWorkPatternExperiment(
   assertNonEmpty(input.pairKey, "missing_pair_key");
   if (input.cells.length === 0) throw new Error("missing_experiment_cells");
 
+  const definitionKey = workPatternExperimentDefinitionKey(input.definition);
+  const preparedFixtures = prepareFixtureArtifacts(input, definitionKey);
+
   // Resolve the accountable human before entering the write transaction so a
   // missing install owner cannot leave a partial manifest.
   const userId = await (deps.resolveOwnerUserId ?? resolveScheduledOwnerUserId)();
-  const definitionKey = workPatternExperimentDefinitionKey(input.definition);
   const repeatedPatternKey = patternStorageKey(definitionKey);
 
   return deps.persistence.withDefinitionLock(definitionKey, async (session) => {
@@ -236,6 +311,38 @@ export async function createOrResumeWorkPatternExperiment(
       throw new Error("work_pattern_experiment_status_divergence");
     }
 
+    for (const fixture of preparedFixtures.values()) {
+      const existing = await session.findTaskArtifact(fixture.artifactId);
+      if (existing) {
+        const existingFixture = parseHermeticBuildReplayFixture(existing.parts);
+        if (
+          !existingFixture
+          || workPatternFixtureDigest(existingFixture) !== fixture.fixtureDigest
+        ) {
+          throw new Error(
+            `work_pattern_experiment_fixture_changed:${fixture.logicalFixtureKey}`,
+          );
+        }
+        continue;
+      }
+      await session.createTaskArtifact({
+        id: randomUUID(),
+        artifactId: fixture.artifactId,
+        taskRunId: parent.id,
+        name: `Work-pattern fixture ${fixture.logicalFixtureKey}`,
+        description:
+          `Immutable fixture for ${storedManifest.experimentDefinitionKey}.`,
+        parts: fixture.parts,
+        metadata: {
+          schemaVersion: 1,
+          experimentDefinitionKey: storedManifest.experimentDefinitionKey,
+          logicalFixtureKey: fixture.logicalFixtureKey,
+          fixtureDigest: fixture.fixtureDigest,
+        },
+        producerAgentId: input.orchestratingAgentId,
+      });
+    }
+
     const children: WorkPatternStoredTaskRun[] = [];
     const scheduledChildTaskRunIds: string[] = [];
     for (const cell of requiredCells) {
@@ -247,7 +354,7 @@ export async function createOrResumeWorkPatternExperiment(
       });
       let child = await session.findTaskRun(taskRunId);
       if (!child) {
-        const normalizedExecutionRequest =
+        let normalizedExecutionRequest =
           cell.executionRequest !== undefined && isRecord(cell.executionRequest)
             ? {
                 ...cell.executionRequest,
@@ -259,6 +366,28 @@ export async function createOrResumeWorkPatternExperiment(
                 modelVariantKey: cell.modelVariantKey,
               }
             : cell.executionRequest;
+        if (
+          isRecord(normalizedExecutionRequest)
+          && typeof normalizedExecutionRequest.fixtureKey === "string"
+        ) {
+          const fixture = preparedFixtures.get(
+            normalizedExecutionRequest.fixtureKey,
+          );
+          if (fixture) {
+            normalizedExecutionRequest = {
+              ...normalizedExecutionRequest,
+              fixtureKey: fixture.artifactId,
+            };
+          } else if (
+            !(await session.findTaskArtifact(
+              normalizedExecutionRequest.fixtureKey,
+            ))
+          ) {
+            throw new Error(
+              `work_pattern_experiment_fixture_unavailable:${normalizedExecutionRequest.fixtureKey}`,
+            );
+          }
+        }
         const cellMetadata: WorkPatternCellMetadata = {
           schemaVersion: 1,
           experimentRunId,
@@ -438,6 +567,10 @@ type PrismaLike = {
     options?: { isolationLevel: "Serializable" },
   ) => Promise<T>;
   taskRun: PrismaLikeTaskRun;
+  taskArtifact: {
+    findUnique: (args: unknown) => Promise<WorkPatternStoredTaskArtifact | null>;
+    create: (args: unknown) => Promise<WorkPatternStoredTaskArtifact>;
+  };
   decisionShadowLedger: {
     upsert: (args: unknown) => Promise<Record<string, unknown>>;
   };
@@ -470,6 +603,18 @@ function prismaSession(client: Omit<PrismaLike, "$transaction">): WorkPatternExp
         where: { taskRunId },
         data,
       }),
+    findTaskArtifact: (artifactId) =>
+      client.taskArtifact.findUnique({
+        where: { artifactId },
+        select: {
+          artifactId: true,
+          taskRunId: true,
+          parts: true,
+          metadata: true,
+        },
+      }),
+    createTaskArtifact: (data) =>
+      client.taskArtifact.create({ data }),
     upsertLedger: (ledgerId, create) =>
       client.decisionShadowLedger.upsert({
         where: { ledgerId },

--- a/docs/operations/autonomous-build-completion.md
+++ b/docs/operations/autonomous-build-completion.md
@@ -54,6 +54,20 @@ on any invalid pair or hard regression, and before workspace creation for irreve
 risk. Experiment worktrees are removed after success or failure. They never advance a Feature
 Build, create a pull request, enter the merge queue, release, or mutate the live portal.
 
+A reviewed build candidate may carry its bounded replay fixture through the existing AI Workforce
+Living Playbook review. Approval does not leave the fixture inline in TaskRun metadata: under the
+experiment-definition lock, Build Studio validates the safe source/test paths and full 2x2
+method-model matrix, writes one immutable `TaskArtifact`, and stamps its artifact reference into
+each child execution request before dispatch. Automatic replicates reuse that artifact. Repeating
+the same review is idempotent; reusing the logical fixture key with different bytes or referencing
+a missing artifact parks before cell dispatch. Unsupported activity, non-shadow execution, and
+irreversible/outbound risk stop before the artifact or an execution workspace is created.
+
+The operator records the review from the existing coworker detail panel; no separate fixture
+admin page or approval queue exists. A pre-dispatch rejection remains visible as review/evidence
+history and should be corrected by submitting a new versioned candidate rather than editing the
+retained artifact or inserting database rows manually.
+
 The first qualifying same-install promotion creates a rollback-safe baseline binding and then
 activates the candidate binding in the same serialized transaction. The candidate is scoped to the
 exact install, corpus, activity, risk, and model profile proved by the experiment. A note that
@@ -136,10 +150,19 @@ Emergency stop: set `DPF_BUILD_AUTONOMOUS_PLAYBOOK_MODE=off` and disable the dow
 and PR reconciler switches. Existing records and in-flight evidence remain available; no schema
 rollback is required.
 
+Disabling the canary prevents new autonomous runs but intentionally keeps immutable experiment
+fixtures and decision evidence. Do not delete retained artifacts as a rollback step; a corrected
+fixture uses a new logical version, while same-key byte drift remains a fail-closed integrity
+signal.
+
 ## Verification checklist
 
 - Confirm shadow mode creates observations but no new autonomous transitions.
 - Confirm an active, exact-scope binding produces an execution profile reference on each phase.
+- Confirm reviewed fixture approval creates one immutable TaskArtifact, all four factorial cells
+  reference it, resume creates no duplicate, and the next replicate requires no additional click.
+- Confirm malformed, changed, missing, non-shadow, and high-risk fixtures stop before cell
+  dispatch; high-risk cases create neither an experiment artifact nor an execution workspace.
 - Confirm stale/mismatched/missing bindings and high/regulatory cases park before mutation.
 - Confirm recovery counters survive restart and exhaust into one escalation.
 - Confirm exact-head PR compare-and-swap, unresolved-thread handling, queue enrollment, and human

--- a/docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md
+++ b/docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md
@@ -1107,6 +1107,111 @@ For the happy path, verify:
 - source-local tests, production build, migration compatibility, runtime verification, and PR health
   are green before merge-queue enrollment.
 
+### Task 3.6 — close the live fixture-origination gap discovered during Stage D
+
+**Why this remains inside `BI-356E69B1`:** after PR #3708 and its dependency repairs merged, the
+governed live-install preflight reached `CAN-TEST`, but the production database contained no
+`TaskArtifact` whose parts were a `build-replay-v1` fixture. The reviewed candidate path could
+reference an existing `fixtureKey`, while no governed path could atomically persist the immutable
+fixture behind that key. A direct database insert would bypass the approved Work Pattern review
+and is not acceptable evidence. This task completes the already-approved low-risk canary exit gate;
+it is not a new independently shippable product outcome.
+
+**Budget:** 5 units = 4 feature + 1 bounded structural refactor (exactly 20%)
+
+**Refactor allocation — 1 unit:**
+
+- move the pure `build-replay-v1` fixture parser/contract out of the execution adapter into one
+  shared Work Pattern fixture module so review-time validation and runtime execution use the same
+  source of truth;
+- do not introduce a general artifact framework, new lifecycle, or alternate experiment store.
+
+**Modify:**
+
+- `apps/web/lib/tak/work-pattern-experiment-store.ts`
+- `apps/web/lib/tak/work-pattern-experiment-store.test.ts`
+- `apps/web/lib/tak/work-pattern-experiment-scheduler.ts`
+- `apps/web/lib/tak/work-pattern-experiment-scheduler.test.ts`
+- `apps/web/lib/integrate/work-pattern-build-replay.ts`
+- `apps/web/lib/integrate/work-pattern-build-replay.test.ts`
+- `apps/web/lib/actions/work-pattern-review.test.ts`
+- `docs/operations/autonomous-build-completion.md`
+
+**Create:**
+
+- `apps/web/lib/tak/work-pattern-experiment-fixture.ts`
+- `apps/web/lib/tak/work-pattern-experiment-fixture.test.ts`
+
+**Contract:**
+
+1. A reviewed candidate may carry one immutable fixture payload for a cell in addition to its
+   logical `fixtureKey`.
+2. Review-time parsing rejects malformed build fixtures, unsafe target/test paths, missing method
+   instructions, and cells whose fixture identity is inconsistent with the declared corpus/oracle.
+3. The scheduler applies the existing promotion-policy activity/risk/environment ceiling before
+   any TaskRun or artifact write; high-risk and non-shadow candidates remain review evidence only.
+4. Under the existing experiment-definition lock, the store derives a stable artifact identity
+   from the definition and logical fixture key, stores the canonical fixture digest as immutable
+   metadata, and persists the fixture on the existing parent `TaskRun` through `TaskArtifact`
+   before any child is dispatchable.
+5. The writer uses the existing A2A `TaskArtifact.parts` envelope
+   (`[{ type, mimeType, data }]`) rather than establishing a raw-object convention. The shared
+   parser unwraps that canonical envelope and retains read compatibility with any direct-object
+   fixture produced by the already-merged runtime contract.
+6. The persisted child execution request references the derived `TaskArtifact.artifactId`, never
+   raw inline fixture bytes. Later replicates reuse the immutable artifact.
+7. A retry with identical bytes is idempotent. A logical-key collision with different bytes fails
+   closed before dispatch and retains the prior artifact.
+8. Candidates that already reference a valid immutable artifact remain compatible. Missing
+   artifacts fail before queue dispatch with a plain evidence error.
+9. High-risk or non-shadow candidates still stop at the existing authority ceiling before fixture
+   workspace creation. Fixture persistence grants no execution, PR, merge, release, or live-state
+   authority.
+
+**Tests first:**
+
+- reviewed low-risk candidate with inline fixture creates one parent, one immutable artifact, and
+  child requests that reference it;
+- resume and automatic replicates create no duplicate artifact;
+- changed bytes under the same logical fixture identity fail closed;
+- missing artifact without inline fixture fails before queue send;
+- malformed/unsafe build fixture is rejected before any TaskRun or artifact write;
+- high-risk/non-shadow cases do not create an artifact or workspace;
+- inference-only experiment fixtures remain byte-compatible;
+- runtime build replay consumes the shared parser without behavior drift.
+
+**Migration impact:** none. `TaskArtifact`, `TaskRun`, and their existing relation are sufficient;
+no column, enum, index, or seed mutation is required.
+
+**UX verification:** use the existing AI Workforce coworker detail review panel. Submit a bounded
+candidate, approve it through the authenticated operator action, verify the success/attention copy
+at desktop and narrow width, and confirm no raw artifact or TaskRun identifiers appear at default
+altitude. No new route, tab, dashboard, or approval queue is permitted.
+
+**Recovery scenarios:**
+
+- interrupted persistence resumes to the same artifact and child IDs;
+- provider/sandbox failure leaves the immutable fixture reusable and consumes only the existing
+  recovery budget;
+- malformed or changed fixture parks before dispatch with one deduplicated escalation;
+- cleanup removes detached build worktrees but never deletes the retained evidence artifact;
+- kill switches and same-scope binding rollback continue to stop new autonomous runs.
+
+**Documentation impact:** update the operator runbook to explain how a reviewed fixture becomes an
+immutable experiment artifact, how to recognize a pre-dispatch fixture rejection, and how to
+disable the canary without bypassing governed recovery.
+
+**Task 3.6 exit:**
+
+- a supported portal-originated low-risk build fixture completes at least one full factorial
+  replicate and automatically schedules the next required replicate without another click;
+- the live evidence chain joins `CoworkerCapabilityNeed` review → `DecisionInteraction` →
+  parent/child `TaskRun` → immutable `TaskArtifact` → `DecisionShadowLedger`;
+- a forced high-risk fixture escalates before artifact/workspace execution;
+- no experiment cell creates a FeatureBuild, PR, merge, release, or direct deployment;
+- targeted tests, typecheck, production build, migration compatibility, authenticated UX, and the
+  governed exact-SHA gate pass before PR creation.
+
 ---
 
 ## Rollout sequence


### PR DESCRIPTION
## Summary
- originate the first immutable governed build-replay fixture from a reviewed capability need
- persist and reuse the fixture artifact idempotently while failing closed on drift or missing evidence
- enforce a complete 2x2 method/model experiment and apply authority ceilings before any artifact or child workspace is created
- factor the build fixture parser and canonical digest into the bounded structural-refactoring unit (1 of 5 implementation units, exactly 20%)

## Governance
- backlog: BI-356E69B1
- Work Capsule: WC-D22B0EC3
- implementation plan: Task 3.6 in `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md`
- preserves FeatureBuild, TaskRun, BuildPhaseRun, DecisionShadowLedger, AuthorityBinding, Work Case, merge-queue, and governed self-upgrade substrates
- no schema migration required

## Verification
- exact candidate: `fc5f701f7bb59cd225efefdb35b3f54cb157c681`
- governed local-integration evidence for the identical production source: `cms5rw0l109ne01qh0q23xwp0`
- exact-head amendment only removed a redundant test that exceeded the 800-LOC module ratchet; `node scripts/check-module-size.mjs` passes, and GitHub typecheck/tests gate the exact head
- dependency freshness green: Next 16.2.11, React 19.2.8, TypeScript 6.0.3, Prisma 7.8.0, Vitest 4.1.10
- 2,331 test files / 20,161 tests passed
- TypeScript typecheck passed
- 465 migrations validated with none pending
- documentation and repository guards passed
- production Docker image built successfully

## UX and recovery
No new route or layout is introduced. Operator review and recovery remain in the existing AI Workforce coworker-detail review surface. After merge and governed self-upgrade, the existing surface will be exercised at desktop and narrow widths with a low-risk autonomous canary and a high-risk authority-ceiling canary before BI completion.

Local-CI-Evidence: cms5rw0l109ne01qh0q23xwp0
Local-CI-Override: exact head fc5f701f7b differs only by deleting the redundant oversized test; production source is byte-identical to the governed candidate and all 34 exact-head GitHub checks passed.