### PR TITLE
fix(coworkers): fail a scheduled run that produced only a provider-failure apology instead of completing it quietly (BI-E0F27E0E)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -17,6 +17,7 @@ import { computeNextCronRun, isOneShotCron } from "@/lib/operate/cron-next-run";
 import { extractScheduledTaskSummary } from "./agent-task-scheduler-summary";
 import {
   createTaskRunForScheduledTask,
+  detectScheduledRunInferenceFailure,
   type ScheduledTaskRunRef,
 } from "@/lib/tak/scheduled-task-runs";
 import { createTaskMessage } from "@/lib/tak/task-records";
@@ -447,6 +448,21 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
           });
         }
       }
+    }
+
+    // BI-E0F27E0E: every endpoint failing leaves the loop returning ONLY a
+    // friendly provider-failure apology with zero executed tools (live repro:
+    // TR-SCHED-B7151A4C). That run did no work — throw so the catch below
+    // records status=failed and the BI-754C9E82 retry cadence takes over,
+    // instead of completing quietly with a healthy lastStatus.
+    const inferenceFailure = detectScheduledRunInferenceFailure({
+      executedToolCount: executedTools.length,
+      content: result.content,
+    });
+    if (inferenceFailure) {
+      throw new Error(
+        `Scheduled run produced no work — AI endpoints failed (${inferenceFailure}). ${result.content ?? ""}`.trim(),
+      );
     }
 
     const scheduledSummary = extractScheduledTaskSummary(executedTools);

--- a/apps/web/lib/tak/scheduled-task-runs.test.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.test.ts
@@ -10,6 +10,54 @@ vi.mock("@dpf/db", () => {
 
 vi.mock("@/lib/platform-runtime/work-admission", () => ({ admitRuntimeGuardedWork: vi.fn() }));
 
+describe("detectScheduledRunInferenceFailure", () => {
+  it("flags the live-reproduced all-endpoints-failed apology as a failed run (BI-E0F27E0E)", async () => {
+    const { detectScheduledRunInferenceFailure } = await import("./scheduled-task-runs");
+    expect(
+      detectScheduledRunInferenceFailure({
+        executedToolCount: 0,
+        content:
+          "The AI providers are momentarily busy (usually rate-limited or overloaded). Please try again in about 30 seconds — no setup change is needed.",
+      }),
+    ).toBe("rate-limit");
+  });
+
+  it("flags config-gap and connection apologies too", async () => {
+    const { detectScheduledRunInferenceFailure } = await import("./scheduled-task-runs");
+    expect(
+      detectScheduledRunInferenceFailure({
+        executedToolCount: 0,
+        content: "No AI providers are configured for this workspace.",
+      }),
+    ).toBe("config");
+    expect(
+      detectScheduledRunInferenceFailure({ executedToolCount: 0, content: "fetch failed" }),
+    ).toBe("connection");
+  });
+
+  it("never flags a run that executed tools, whatever the closing text", async () => {
+    const { detectScheduledRunInferenceFailure } = await import("./scheduled-task-runs");
+    expect(
+      detectScheduledRunInferenceFailure({
+        executedToolCount: 2,
+        content: "The AI providers are momentarily busy (usually rate-limited or overloaded).",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for real content and empty output", async () => {
+    const { detectScheduledRunInferenceFailure } = await import("./scheduled-task-runs");
+    expect(
+      detectScheduledRunInferenceFailure({
+        executedToolCount: 0,
+        content: "Reviewed 8 orders; Margherita Pizza is trending at 11 units.",
+      }),
+    ).toBeNull();
+    expect(detectScheduledRunInferenceFailure({ executedToolCount: 0, content: null })).toBeNull();
+    expect(detectScheduledRunInferenceFailure({ executedToolCount: 0, content: "" })).toBeNull();
+  });
+});
+
 describe("createTaskRunForScheduledTask", () => {
   beforeEach(async () => {
     const { prisma } = await import("@dpf/db");

--- a/apps/web/lib/tak/scheduled-task-runs.ts
+++ b/apps/web/lib/tak/scheduled-task-runs.ts
@@ -4,8 +4,27 @@ import {
 } from "@/lib/tak/autonomous-work-run";
 import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 import type { ResolvedDelegatedPosture } from "@/lib/proactivity/delegated-posture";
+import {
+  classifyInferenceFailure,
+  type InferenceFailureKind,
+} from "@/lib/build/inference-failure";
 
 export type ScheduledTaskRunRef = AutonomousWorkRunRef;
+
+/**
+ * A scheduled run whose loop executed zero tools and produced only a
+ * provider-failure apology did no work: it must fail (and enter the
+ * BI-754C9E82 retry cadence), not complete quietly with a healthy lastStatus.
+ * Returns the failure kind for such a run, or null for a real result. Pure.
+ * (BI-E0F27E0E)
+ */
+export function detectScheduledRunInferenceFailure(input: {
+  executedToolCount: number;
+  content: string | null | undefined;
+}): InferenceFailureKind | null {
+  if (input.executedToolCount > 0) return null;
+  return classifyInferenceFailure(input.content);
+}
 
 export async function createTaskRunForScheduledTask(input: {
   taskId: string;


### PR DESCRIPTION
Closes BI-E0F27E0E.

Live repro during the 2026-07-29 restaurant exercise (runs TR-SCHED-B7151A4C and TR-SCHED-AE805406): every inference endpoint failed — local engine admission timeout ×8 with an idle engine, then codex pool exhausted — the agentic loop returned the friendly *"AI providers are momentarily busy"* copy with **zero executed tools**, and the scheduler recorded `status=completed`, `lastStatus=ok`, attempts reset, no retry, no attention item. The owner's daily autonomous duty (a proactive restocking review) silently never happened, twice.

## What changed
- New pure helper `detectScheduledRunInferenceFailure` in `apps/web/lib/tak/scheduled-task-runs.ts`, reusing the canonical `classifyInferenceFailure` matchers (`apps/web/lib/build/inference-failure.ts`): a run with zero executed tools whose only content classifies as an inference failure is a failed run.
- `executeScheduledAgentTask` now throws on that condition before the success path, so the existing catch records `status=failed` with the error payload and the **already-enforced BI-754C9E82 retry cadence** (`followUpCadenceMinutes`/`maxAttempts` from the proactivity plan) takes over.
- Runs that executed tools are never flagged; real content passes through untouched. 4 new unit tests including the exact live-reproduced apology string.

## Design grounding
Specs reviewed: docs/superpowers/specs/2026-06-29-ai-coworker-proactivity-policy-design.md (the proactivity plan whose followUpCadenceMinutes/maxAttempts ARE the retry policy this fix routes into, per BI-754C9E82) and docs/superpowers/specs/2026-07-03-coworker-limitation-response-contract-design.md (the friendly-failure copy contract the classifier recognizes). Code substrate reviewed: apps/web/lib/actions/agent-task-scheduler.ts success/catch paths, apps/web/lib/tak/agentic-loop.ts `friendlyRouteErrorMessage`, apps/web/lib/tak/autonomous-work-run.ts, apps/web/lib/build/inference-failure.ts. Decision: extend the existing retry contract — corrective wiring only, no new artifact, capability, or surface.

## Verification
Local-CI pregate green at head SHA (unit tests incl. the 4 new cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: attestation-only empty commit b57e0604c8 on top of pregate-green 0c765e7adc; runtime tree unchanged — local-CI evidence for 0c765e7adc covers this head.
