### PR TITLE
fix(db): recover inventory snapshot migration safely

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -345,6 +345,31 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
       expect(dryRunResult.stdout).toContain("step=migrate");
     });
 
+    it("guards the known inventory snapshot failure before normal migration deploy", () => {
+      const scriptSource = readFileSync(join(REPO_ROOT, "scripts", "promote.sh"), "utf8");
+      const recoveryCommand =
+        "node packages/db/scripts/recover-inventory-snapshot-migration.mjs";
+      const resolveCommand =
+        "prisma migrate resolve --rolled-back 20260728115900_snapshot_inventory_observation_facts";
+      const verifyCommand =
+        "recover-inventory-snapshot-migration.mjs --verify-rolled-back";
+      const deployCommand =
+        "-c 'cd /app && pnpm --filter @dpf/db exec prisma migrate deploy'";
+
+      expect(scriptSource).toContain(recoveryCommand);
+      expect(scriptSource).toContain(resolveCommand);
+      expect(scriptSource.indexOf(recoveryCommand)).toBeLessThan(
+        scriptSource.indexOf(resolveCommand),
+      );
+      expect(scriptSource.indexOf(resolveCommand)).toBeLessThan(
+        scriptSource.indexOf(verifyCommand),
+      );
+      expect(scriptSource.indexOf(verifyCommand)).toBeLessThan(
+        scriptSource.indexOf(deployCommand),
+      );
+      expect(scriptSource).not.toContain(`${resolveCommand}' >/dev/null 2>&1 || true`);
+    });
+
     it("emits docker-up step", () => {
       expect(dryRunResult.stdout).toContain("step=docker-up");
     });

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -88,6 +88,15 @@ for arg in "$@"; do
 done
 [ -n "$DOCKER_LOG" ] && printf '%s\\n' "$*" >> "$DOCKER_LOG"
 case "$*" in
+  *"recover-inventory-snapshot-migration.mjs --verify-rolled-back"*) printf "verified" ;;
+  *"recover-inventory-snapshot-migration.mjs"*)
+    [ "\${DPF_TEST_RECOVERY_DECISION:-not-needed}" = "blocked" ] && exit 1
+    if [ "\${DPF_TEST_RECOVERY_DECISION:-not-needed}" = "recover" ]; then
+      printf "recover:11111111-1111-4111-8111-111111111111"
+    else
+      printf "not-needed"
+    fi
+    ;;
   *"up -d --no-deps --force-recreate portal"*|*"up -d --no-deps --force-recreate sandbox"*)
     service=
     for service in "$@"; do :; done
@@ -119,6 +128,7 @@ function runPromote(opts: {
   fakeBin: string;
   composeEnvFile?: string;
   dockerLog?: string;
+  recoveryDecision?: "recover" | "not-needed" | "blocked";
 }): { status: number | null; stdout: string; stderr: string } {
   const stateDir = join(opts.backup, "state");
   const secret = "s".repeat(32);
@@ -155,6 +165,9 @@ function runPromote(opts: {
     `export DPF_INSTALL_STATE_MIGRATION_SIGNATURE=${shellQuote(signature)}`,
     "export PROMOTE_HEALTH_URL='http://127.0.0.1:9/api/health'",
     "export PROMOTE_COMPOSE_PROJECT='dpf-functest'",
+    ...(opts.recoveryDecision
+      ? [`export DPF_TEST_RECOVERY_DECISION=${shellQuote(opts.recoveryDecision)}`]
+      : []),
     ...(opts.composeEnvFile
       ? [`export PROMOTE_COMPOSE_ENV_FILE=${shellQuote(toBashPath(opts.composeEnvFile))}`]
       : []),
@@ -290,7 +303,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       mkdirSync(emptyShaBin, { recursive: true });
       writeFileSync(
         join(emptyShaBin, "docker"),
-        '#!/bin/sh\ncase "$*" in\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+        '#!/bin/sh\ncase "$*" in\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
       );
       // /sha → empty (the bug); other probes → ok.
       writeFileSync(
@@ -350,6 +363,60 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     }
   }, PROMOTE_TEST_TIMEOUT_MS);
 
+  it("resolves the allowlisted snapshot failure before normal migrate deploy", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({
+        source,
+        backup,
+        targetSha: head,
+        fakeBin,
+        dockerLog,
+        recoveryDecision: "recover",
+      });
+
+      expect(r.status).toBe(0);
+      const calls = readFileSync(dockerLog, "utf8");
+      const check = calls.indexOf("recover-inventory-snapshot-migration.mjs");
+      const resolve = calls.indexOf(
+        "prisma migrate resolve --rolled-back 20260728115900_snapshot_inventory_observation_facts",
+      );
+      const deploy = calls.indexOf("prisma migrate deploy");
+      expect(check).toBeGreaterThanOrEqual(0);
+      expect(resolve).toBeGreaterThan(check);
+      expect(deploy).toBeGreaterThan(resolve);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
+  it("fails before migrate deploy when snapshot recovery cannot prove safety", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({
+        source,
+        backup,
+        targetSha: head,
+        fakeBin,
+        dockerLog,
+        recoveryDecision: "blocked",
+      });
+
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain(
+        "inventory snapshot migration recovery did not prove a safe state",
+      );
+      const calls = readFileSync(dockerLog, "utf8");
+      expect(calls).toContain("recover-inventory-snapshot-migration.mjs");
+      expect(calls).not.toContain("prisma migrate deploy");
+      expect(calls).not.toContain("up -d --no-deps --force-recreate portal");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
   // BI-A8686CFC: a sandbox rebuild that fails AFTER the portal is verified must
   // NOT fail the whole promotion (the portal swap already happened and the
   // orchestrator died with it) — it emits a loud sandbox-refresh-failed marker
@@ -363,7 +430,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       mkdirSync(bin, { recursive: true });
       writeFileSync(
         join(bin, "docker"),
-        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"build sandbox"*) exit 1 ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *"build sandbox"*) exit 1 ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
       );
       writeFileSync(
         join(bin, "curl"),
@@ -399,7 +466,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       // present ("1"); everything else behaves like the default fake.
       writeFileSync(
         join(bin, "docker"),
-        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *pg_available_extensions*) printf "1" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *pg_available_extensions*) printf "1" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
       );
       writeFileSync(
         join(bin, "curl"),

--- a/docs/data-impact/2026-07-28-inventory-entity-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-28-inventory-entity-index-integrity.data-impact.json
@@ -10,11 +10,13 @@
     "Contributor sanitized-clone source and destination"
   ],
   "migration": {
-    "name": "20260728115900_snapshot_inventory_observation_facts through 20260728181500_restore_human_identity_tuple_provenance",
-    "backfill": "forced-heap entity and relationship convergence: retain the earliest deterministic canonical identity, repoint hard and registered soft references, preserve the newest coherent observation and human-confirmed identity facts, retain entity and relationship collision losers as inactive superseded tombstones with mergedIntoId lineage, retain merge-created relationship self loops as inactive tombstones with an explicit repair reason and no fabricated survivor, rebuild the unique entityKey index, and provision read-only amcheck verification; no row or primary key is deleted"
+    "name": "20260728115800_quarantine_damaged_inventory_unique_index through 20260728130000_repair_inventory_entity_index_integrity",
+    "backfill": "quarantine the untrustworthy entityKey index before any whole-table update, snapshot each duplicate row's mutable observation facts, then perform forced-heap entity and relationship convergence: retain the earliest deterministic canonical identity, repoint hard and registered soft references, preserve the newest coherent observation and human-confirmed identity facts, retain entity and relationship collision losers as inactive superseded tombstones with mergedIntoId lineage, retain merge-created relationship self loops as inactive tombstones with an explicit repair reason and no fabricated survivor, rebuild the unique entityKey index, and provision read-only amcheck verification; the exact historical 12:00 repair identity is restored for installs that already applied it, and no row or primary key is deleted"
   },
   "tests": [
     "packages/db/src/inventory-entity-index-integrity-migration.test.ts",
+    "packages/db/src/inventory-migration-history.test.ts",
+    "packages/db/src/inventory-snapshot-migration-recovery.test.ts",
     "packages/db/src/inventory-entity-merge-references.test.ts",
     "packages/db/src/inventory-entity-canonical-read-completeness.test.ts",
     "packages/db/src/discovery-sync.integrity.test.ts",
@@ -46,7 +48,7 @@
           "fieldId": "data:inventory-entity#observation-and-identity-facts",
           "resolution": "governed",
           "reason": "preserve the newest coherent discovery observation and any later human-confirmed identity correction across a failed or retried repair",
-          "provenance": "snapshot, retry, and identity-ledger migration fixtures under BI-CF4ADDAC"
+          "provenance": "pre-snapshot, retry, and identity-ledger migration fixtures under BI-CF4ADDAC and BI-B92CFED7"
         }
       ]
     },

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -162,6 +162,14 @@ failed record then wedges ALL later upgrades via P3009. Two known producers:
 Recovery decision (inspect `_prisma_migrations`: `applied_steps_count`, and whether the migration's
 columns/indexes exist in the DB):
 
+- **Exact inventory snapshot failure** (`20260728115900_snapshot_inventory_observation_facts`):
+  the promoter automatically marks the row rolled back only when it is the sole unresolved
+  migration in the entire Prisma ledger, its checksum matches the committed migration bytes, its
+  database row id is a valid UUID, and the log names SQLSTATE `23505` and
+  `InventoryEntity_entityKey_key`, `applied_steps_count = 0`, no durable
+  `_dpfObservationSnapshot` exists, and the candidate carries the exact committed `11:58`
+  quarantine migration. It verifies that same row after resolution before normal deploy. Any
+  mismatch fails closed before the portal swap and requires the evidence-led decision below.
 - **Schema half-applied** (columns/index present): `prisma migrate resolve --applied <name>` — NOT
   `--rolled-back`, which would re-run the `ADD COLUMN` and fail `already exists`.
 - **Nothing applied** (`applied_steps_count = 0`, no DDL landed): fix the root cause (de-duplicate,

--- a/docs/superpowers/plans/2026-07-28-inventory-migration-p3018-recovery.md
+++ b/docs/superpowers/plans/2026-07-28-inventory-migration-p3018-recovery.md
@@ -1,0 +1,200 @@
+# Inventory migration P3018 recovery plan
+
+**Backlog item:** BI-B92CFED7
+**Parent incident:** BI-CF4ADDAC / PR #3706 / self-upgrade SUR-B848B86C
+**Decision ledger:** DI-C34A1675FF13, DI-29BB02FE8F5C
+
+## Outcome
+
+Every supported migration-history population advances through the governed
+self-upgrade path without deleting inventory evidence:
+
+1. the canonical install whose
+   `20260728115900_snapshot_inventory_observation_facts` attempt failed with
+   SQLSTATE `23505`;
+2. installs that already applied the repair as
+   `20260728120000_repair_inventory_entity_index_integrity`;
+3. installs that applied the merged
+   `20260728130000_repair_inventory_entity_index_integrity`; and
+4. clean installs.
+
+The canonical portal must remain on its healthy prior image until the complete
+forward repair passes migration, health, inventory integrity, and contributor
+preview acceptance.
+
+## Evidence
+
+- `SelfUpgradeRun.runId=SUR-B848B86C` failed before the portal swap while
+  advancing `7618827d28a2...` to merged PR #3706.
+- `_prisma_migrations` records the failed migration as
+  `20260728115900_snapshot_inventory_observation_facts`, SQLSTATE `23505`,
+  constraint `InventoryEntity_entityKey_key`.
+- Forced heap scans show five rows across two duplicate `entityKey` groups;
+  the index remains marked unique, valid, ready, and live.
+- The failed snapshot statement was atomic: zero rows contain
+  `_dpfObservationSnapshot`.
+- Shared `:5433` and `:54329` databases record the former `12:00` repair
+  checksum `84704a50...`; merged main contains only the renamed `13:00` repair
+  checksum `49751a53...`.
+
+## Architecture decision
+
+The kernel consultation strongly favored the forward-history option over a
+runtime SQL workaround or rewriting committed migrations. The tool currently
+omits option ids in its response, so the auditable basis is the ordered
+contribution ledger: the first option scored `5.890`, margin `4.530`, with
+`Never Assume - Verify`, `Architecture Over Shortcuts`, `Research and Use
+Standards`, and `Single Source of Truth` as the strongest contributors. No
+commandment conflict was reported.
+
+The selected design is:
+
+- keep every merged migration immutable;
+- reuse the merged `11:58` damaged-index quarantine from PR #3716, which sorts
+  before the failing snapshot and is already the source-owned repair boundary;
+- restore the former `12:00` migration using its exact applied bytes and
+  checksum so already-applied histories remain first-class;
+- add a narrowly allowlisted promoter recovery for only the known failed
+  `11:59` statement, after proving it has no durable effects; and
+- resume ordinary `prisma migrate deploy` after the failed row is marked
+  rolled back.
+
+No direct live SQL repair, migration edit, database reset, emergency override,
+or ungoverned portal rebuild is permitted.
+
+## Implementation
+
+### Phase 1 - Regression contracts
+
+Touch:
+
+- `apps/web/lib/self-upgrade/promote-script-contract.test.ts`
+- `apps/web/lib/self-upgrade/promote-script-functional.test.ts`
+- a focused migration-history/recovery test when the existing suites do not
+  cover all four populations.
+
+Prove red:
+
+- the merged quarantine guard sorts before the snapshot;
+- the former applied `12:00` migration is absent from source;
+- the promoter does not recover the exact failed, effect-free snapshot row;
+- a different failure or a partially applied snapshot is never auto-resolved.
+
+### Phase 2 - Forward migration history
+
+Touch:
+
+- restored
+  `20260728120000_repair_inventory_entity_index_integrity/migration.sql`.
+
+PR #3716 owns the pre-snapshot quarantine and its PostgreSQL damaged-index
+fixture. This branch does not duplicate or supersede that work. Restoring the
+former migration uses the exact bytes whose SHA-256 is
+`84704a50ad127a0a4823074956f8041cd99f647accbcb39ce17c856fa1f13d90`.
+The committed `11:58`, `11:59`, and `13:00` migrations remain byte-for-byte
+unchanged.
+
+### Phase 3 - Guarded failed-history recovery
+
+Touch:
+
+- `scripts/promote.sh`;
+- a small source-owned recovery helper if needed to keep shell orchestration
+  legible and testable.
+
+Before normal deploy, inspect the exact `11:59` migration row. Mark it rolled
+back only when all of these are true:
+
+- it is failed and unfinished;
+- its log names SQLSTATE `23505` and
+  `InventoryEntity_entityKey_key`;
+- `applied_steps_count=0`;
+- no `_dpfObservationSnapshot` effect exists; and
+- exactly one unresolved migration exists in the entire Prisma ledger;
+- the failed snapshot checksum matches the committed `11:59` bytes; and
+- the candidate pre-snapshot quarantine checksum matches its committed bytes.
+
+Any ambiguity fails closed and leaves the prior portal serving.
+After Prisma marks the migration rolled back, verify the authorized database
+row ID and prove no unresolved row with that migration name remains.
+
+### Phase 4 - Verification and delivery
+
+1. Run schema validation and migration safety/data-impact guards.
+2. Run targeted unit and PostgreSQL migration tests.
+3. Exercise all four migration-history populations in the governed shared
+   local-CI sandbox.
+4. Run the full exact-SHA merged-code pregate and production build.
+5. Obtain independent architecture/data review.
+6. Open a ready PR, pass `pnpm pr:health`, and merge through the queue.
+7. Advance the canonical install only through `/ops/self-upgrade`.
+8. Re-run live preflight, forced heap/index checks, and contributor-preview
+   acceptance.
+
+## Risks and rollback
+
+- **Incorrect automatic resolution:** fail closed on any mismatch; tests include
+  unrelated and partially applied failures.
+- **Migration-history drift:** preserve committed bytes and restore the exact
+  former checksum rather than synthesizing a lookalike.
+- **Repeated repair:** the inventory repair already carries a second-execution
+  no-data-change contract; prove it across the restored and current identities.
+- **Broader Prisma resolution:** inspect every unresolved row, authorize only
+  one exact row/checksum, and verify that row ID after `migrate resolve`.
+- **Already-advanced histories:** the merged `11:58` quarantine is a no-op once
+  the repaired unique index is trustworthy; restoring the exact former `12:00`
+  directory prevents Prisma history drift without replaying applied work.
+- **Historical timestamp collision:** allow only the exact former `12:00`
+  directory and checksum in the collision guard; any byte drift still fails.
+- **Live deployment failure:** the promoter applies migrations before swap and
+  retains the existing recovery point, so the healthy prior image remains
+  active.
+
+Rollback is source-level only before merge. After merge, migrations remain
+forward-only; any correction is another additive migration.
+
+## Independent review
+
+Two independent read-only reviews requested changes before the first candidate
+completed its gate:
+
+- the operations review identified the timestamp-collision guard, multi-row
+  Prisma resolve scope, and missing checksum authorization;
+- the data/architecture review identified canonical snapshots retained on
+  already-advanced histories.
+
+The first candidate passed its exact-SHA gate and both reviews after those
+findings were addressed. PR #3716 then landed a stronger pre-snapshot
+quarantine and PostgreSQL fixture on `main`. This final candidate narrows to
+the non-overlapping history restoration and exact one-row authorization with
+post-resolution verification; clean, multiple-attempt, effect-bearing, and
+already-advanced states remain covered.
+
+The final architecture re-review found that snapshot-name filtering could
+overlook an unrelated unresolved Prisma migration. The recovery now inspects
+the entire unresolved ledger, requires the snapshot to be its sole row, proves
+the ledger is globally clear after resolution, and covers both boundaries with
+PostgreSQL fixtures.
+
+A focused DB verification then caught that the recovery fixture's original
+`.test.mjs` name was outside the package's Vitest discovery pattern. The final
+fixture uses `.test.ts`, and acceptance requires it to execute against
+PostgreSQL rather than merely exist in source.
+
+## Documentation impact
+
+This changes contributor and operator deployment behavior, not a user-facing
+workflow. Update the existing BET-5 self-upgrade recovery runbook and this
+plan. No navigation, route map, prompt, archetype, or public positioning change
+is required.
+
+## Backlog coverage
+
+Receipt `cms5gy5sm044g01o62s118dl4` records this plan as atomic under
+`BI-B92CFED7`.
+
+| Deliverable | BI | Depends on | Independently shippable |
+|---|---|---|---|
+| `forward-migration-history` | `BI-B92CFED7` | none | no |
+| `guarded-failed-history-recovery` | `BI-B92CFED7` | `forward-migration-history` | no |
+| `fleet-verification` | `BI-B92CFED7` | both prior deliverables | no |

--- a/docs/superpowers/plans/2026-07-28-inventory-migration-p3018-recovery.md
+++ b/docs/superpowers/plans/2026-07-28-inventory-migration-p3018-recovery.md
@@ -190,8 +190,14 @@ is required.
 
 ## Backlog coverage
 
-Receipt `cms5gy5sm044g01o62s118dl4` records this plan as atomic under
-`BI-B92CFED7`.
+- Decision: atomic
+- Parent: `BI-B92CFED7`
+- Receipt: `cms5yvha102pc01ms7pwo4mnd`
+- Rationale: The restored historical migration identity, exact failed-ledger
+  recovery, and fleet verification are one release contract; shipping any
+  phase alone either leaves the canonical install wedged or creates an
+  unverified forward-history state.
+- Dependencies: none
 
 | Deliverable | BI | Depends on | Independently shippable |
 |---|---|---|---|

--- a/packages/db/prisma/migrations/20260728120000_repair_inventory_entity_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260728120000_repair_inventory_entity_index_integrity/migration.sql
@@ -1,0 +1,667 @@
+-- BI-CF4ADDAC - repair InventoryEntity heap/index divergence caused by the
+-- measured musl-to-glibc collation transition. The damaged unique index could
+-- miss heap rows during upsert and also fail to reject a second copy.
+--
+-- @migration-safety: remediates-existing-data: duplicate entity and projected
+-- relationship groups are converged before either unique contract is rebuilt.
+--
+-- Fleet contract:
+--   * no InventoryEntity or InventoryRelationship row is deleted;
+--   * duplicate losers remain superseded tombstones with merge lineage;
+--   * every hard and declared soft reference is repointed;
+--   * ownership/mastered-identity disagreements fail and roll back;
+--   * clean installs and a second execution change no row data.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+-- Provisioned here so every later integrity check can remain read-only.
+CREATE EXTENSION IF NOT EXISTS amcheck WITH SCHEMA public;
+
+ALTER TABLE "InventoryEntity"
+  ADD COLUMN IF NOT EXISTS "mergedIntoId" TEXT;
+ALTER TABLE "InventoryRelationship"
+  ADD COLUMN IF NOT EXISTS "mergedIntoId" TEXT;
+
+-- Fixed lock order. SHARE ROW EXCLUSIVE blocks concurrent writers while still
+-- allowing ordinary reads during the bounded self-upgrade migration window.
+LOCK TABLE
+  "ChangeItem",
+  "DiscoveredItem",
+  "DiscoveredRelationship",
+  "DiscoveredSoftwareEvidence",
+  "DiscoveryConnection",
+  "DiscoveryFingerprintObservation",
+  "DiscoveryTriageDecision",
+  "IdentityResolutionLog",
+  "InventoryEntity",
+  "InventoryRelationship",
+  "PortfolioQualityIssue",
+  "RemoteAction"
+IN SHARE ROW EXCLUSIVE MODE;
+
+-- Never let the untrustworthy comparator participate in survivor discovery.
+DROP INDEX IF EXISTS "InventoryEntity_entityKey_key";
+
+CREATE TEMP TABLE _dpf_entity_merge_map (
+  loser_id TEXT PRIMARY KEY,
+  survivor_id TEXT NOT NULL,
+  original_key TEXT NOT NULL,
+  quarantine_key TEXT
+) ON COMMIT DROP;
+
+INSERT INTO _dpf_entity_merge_map (loser_id, survivor_id, original_key)
+WITH ranked AS (
+  SELECT
+    e.id,
+    e."entityKey",
+    first_value(e.id) OVER (
+      PARTITION BY e."entityKey"
+      ORDER BY e."firstSeenAt", e.id
+    ) AS survivor_id,
+    count(*) OVER (PARTITION BY e."entityKey") AS copies
+  FROM "InventoryEntity" e
+)
+SELECT id, survivor_id, "entityKey"
+FROM ranked
+WHERE copies > 1
+  AND id <> survivor_id;
+
+-- Refuse to infer equivalence across ownership or mastered-identity boundaries.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "InventoryEntity" e
+    WHERE EXISTS (
+      SELECT 1
+      FROM _dpf_entity_merge_map m
+      WHERE m.original_key = e."entityKey"
+    )
+    GROUP BY e."entityKey"
+    HAVING
+      count(DISTINCT e."entityType") > 1
+      OR count(DISTINCT e."scopeKey")
+           + CASE WHEN bool_or(e."scopeKey" IS NULL) THEN 1 ELSE 0 END > 1
+      OR count(DISTINCT e."customerAccountId")
+           + CASE WHEN bool_or(e."customerAccountId" IS NULL) THEN 1 ELSE 0 END > 1
+      OR count(DISTINCT e."customerSiteId")
+           + CASE WHEN bool_or(e."customerSiteId" IS NULL) THEN 1 ELSE 0 END > 1
+      OR count(DISTINCT e."portfolioId") > 1
+      OR count(DISTINCT e."digitalProductId") > 1
+      OR count(DISTINCT e."taxonomyNodeId") > 1
+      OR count(DISTINCT e."catalogIdentityId") FILTER (
+        WHERE e."identityStatus" IN ('human_confirmed', 'human_corrected')
+      ) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'InventoryEntity integrity repair stopped: duplicate key crosses scope, ownership, or mastered identity';
+  END IF;
+END $$;
+
+-- Pick the first collision-free reserved key. The loser id makes candidates
+-- mutually distinct; the suffix handles a pre-existing reserved-name row.
+WITH candidates AS (
+  SELECT
+    m.loser_id,
+    candidate.quarantine_key
+  FROM _dpf_entity_merge_map m
+  CROSS JOIN LATERAL (
+    SELECT
+      '__dpf_quarantined__' || m.loser_id || '__' || m.original_key
+        || repeat('_', series.n) AS quarantine_key
+    FROM generate_series(0, 1000) AS series(n)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "InventoryEntity" existing
+      WHERE existing."entityKey" =
+        '__dpf_quarantined__' || m.loser_id || '__' || m.original_key
+          || repeat('_', series.n)
+    )
+    ORDER BY series.n
+    LIMIT 1
+  ) candidate
+)
+UPDATE _dpf_entity_merge_map m
+SET quarantine_key = candidates.quarantine_key
+FROM candidates
+WHERE candidates.loser_id = m.loser_id;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM _dpf_entity_merge_map WHERE quarantine_key IS NULL
+  ) THEN
+    RAISE EXCEPTION 'InventoryEntity integrity repair could not allocate a quarantine key';
+  END IF;
+END $$;
+
+CREATE TEMP TABLE _dpf_entity_members (
+  entity_id TEXT PRIMARY KEY,
+  survivor_id TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _dpf_entity_members (entity_id, survivor_id)
+SELECT loser_id, survivor_id FROM _dpf_entity_merge_map
+UNION
+SELECT survivor_id, survivor_id FROM _dpf_entity_merge_map;
+
+CREATE TEMP TABLE _dpf_entity_rollup ON COMMIT DROP AS
+SELECT
+  members.survivor_id,
+  min(e."firstSeenAt") AS first_seen_at,
+  max(e."lastSeenAt") AS last_seen_at,
+  (array_agg(e."lastConfirmedRunId" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."lastConfirmedRunId" IS NOT NULL))[1] AS last_confirmed_run_id,
+  (array_agg(e."technicalClass" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."technicalClass" IS NOT NULL))[1] AS technical_class,
+  (array_agg(e."iconKey" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."iconKey" IS NOT NULL))[1] AS icon_key,
+  (array_agg(e.manufacturer ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e.manufacturer IS NOT NULL))[1] AS manufacturer,
+  (array_agg(e."productModel" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."productModel" IS NOT NULL))[1] AS product_model,
+  (array_agg(e."observedVersion" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."observedVersion" IS NOT NULL))[1] AS observed_version,
+  (array_agg(e."normalizedVersion" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."normalizedVersion" IS NOT NULL))[1] AS normalized_version,
+  (array_agg(e."supportStatus" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."supportStatus" <> 'unknown'))[1] AS support_status,
+  (array_agg(e."attributionStatus" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."attributionStatus" NOT IN ('needs_review', 'unmapped')))[1]
+      AS attribution_status,
+  (array_agg(e.confidence ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e.confidence IS NOT NULL))[1] AS confidence,
+  (array_agg(e."portfolioId" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."portfolioId" IS NOT NULL))[1] AS portfolio_id,
+  (array_agg(e."taxonomyNodeId" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."taxonomyNodeId" IS NOT NULL))[1] AS taxonomy_node_id,
+  (array_agg(e."digitalProductId" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."digitalProductId" IS NOT NULL))[1] AS digital_product_id,
+  (array_agg(e."attributionMethod" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."attributionMethod" IS NOT NULL))[1] AS attribution_method,
+  (array_agg(e."attributionConfidence" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."attributionConfidence" IS NOT NULL))[1] AS attribution_confidence,
+  (array_agg(e."attributionEvidence" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."attributionEvidence" IS NOT NULL))[1] AS attribution_evidence,
+  (array_agg(e."candidateTaxonomy" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."candidateTaxonomy" IS NOT NULL))[1] AS candidate_taxonomy,
+  (array_agg(e."catalogIdentityId" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."catalogIdentityId" IS NOT NULL))[1] AS catalog_identity_id,
+  (array_agg(e."identityStatus" ORDER BY
+      (e."identityStatus" IN ('human_confirmed', 'human_corrected')) DESC,
+      e."lastSeenAt" DESC,
+      e.id DESC)
+    FILTER (WHERE e."identityStatus" IS NOT NULL))[1] AS identity_status,
+  (array_agg(e."identityConfidence" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."identityConfidence" IS NOT NULL))[1] AS identity_confidence,
+  (array_agg(e."updatePosture" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."updatePosture" <> 'unknown'))[1] AS update_posture,
+  (array_agg(e."updatePostureSource" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."updatePostureSource" IS NOT NULL))[1] AS update_posture_source,
+  (array_agg(e."updatePostureConfidence" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."updatePostureConfidence" IS NOT NULL))[1] AS update_posture_confidence,
+  (array_agg(e."latestKnownVersion" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."latestKnownVersion" IS NOT NULL))[1] AS latest_known_version,
+  (array_agg(e."supportLifecycleSource" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."supportLifecycleSource" IS NOT NULL))[1] AS support_lifecycle_source,
+  (array_agg(e."supportLifecycleConfidence" ORDER BY e."lastSeenAt" DESC, e.id DESC)
+    FILTER (WHERE e."supportLifecycleConfidence" IS NOT NULL))[1]
+      AS support_lifecycle_confidence,
+  coalesce((
+    SELECT jsonb_object_agg(
+      property.key,
+      property.value
+      ORDER BY observed."lastSeenAt", observed.id
+    )
+    FROM _dpf_entity_members nested_members
+    JOIN "InventoryEntity" observed
+      ON observed.id = nested_members.entity_id
+    CROSS JOIN LATERAL jsonb_each(observed.properties) property
+    WHERE nested_members.survivor_id = members.survivor_id
+  ), '{}'::jsonb) AS merged_properties
+FROM _dpf_entity_members members
+JOIN "InventoryEntity" e ON e.id = members.entity_id
+GROUP BY members.survivor_id;
+
+UPDATE "InventoryEntity" survivor
+SET
+  "technicalClass" = coalesce(survivor."technicalClass", rollup.technical_class),
+  "iconKey" = coalesce(survivor."iconKey", rollup.icon_key),
+  manufacturer = coalesce(survivor.manufacturer, rollup.manufacturer),
+  "productModel" = coalesce(survivor."productModel", rollup.product_model),
+  "observedVersion" = coalesce(survivor."observedVersion", rollup.observed_version),
+  "normalizedVersion" = coalesce(survivor."normalizedVersion", rollup.normalized_version),
+  "supportStatus" = CASE
+    WHEN survivor."supportStatus" <> 'unknown' THEN survivor."supportStatus"
+    ELSE coalesce(rollup.support_status, survivor."supportStatus")
+  END,
+  "attributionStatus" = CASE
+    WHEN survivor."attributionStatus" NOT IN ('needs_review', 'unmapped')
+      THEN survivor."attributionStatus"
+    ELSE coalesce(rollup.attribution_status, survivor."attributionStatus")
+  END,
+  confidence = coalesce(survivor.confidence, rollup.confidence),
+  properties = rollup.merged_properties,
+  "firstSeenAt" = rollup.first_seen_at,
+  "lastSeenAt" = rollup.last_seen_at,
+  "lastConfirmedRunId" = coalesce(rollup.last_confirmed_run_id, survivor."lastConfirmedRunId"),
+  "portfolioId" = coalesce(survivor."portfolioId", rollup.portfolio_id),
+  "taxonomyNodeId" = coalesce(survivor."taxonomyNodeId", rollup.taxonomy_node_id),
+  "digitalProductId" = coalesce(survivor."digitalProductId", rollup.digital_product_id),
+  "attributionMethod" = coalesce(survivor."attributionMethod", rollup.attribution_method),
+  "attributionConfidence" =
+    coalesce(survivor."attributionConfidence", rollup.attribution_confidence),
+  "attributionEvidence" =
+    coalesce(survivor."attributionEvidence", rollup.attribution_evidence),
+  "candidateTaxonomy" = coalesce(survivor."candidateTaxonomy", rollup.candidate_taxonomy),
+  "catalogIdentityId" = coalesce(survivor."catalogIdentityId", rollup.catalog_identity_id),
+  "identityStatus" = CASE
+    WHEN survivor."identityStatus" IN ('human_confirmed', 'human_corrected')
+      THEN survivor."identityStatus"
+    ELSE coalesce(rollup.identity_status, survivor."identityStatus")
+  END,
+  "identityConfidence" =
+    coalesce(survivor."identityConfidence", rollup.identity_confidence),
+  "updatePosture" = CASE
+    WHEN survivor."updatePosture" <> 'unknown' THEN survivor."updatePosture"
+    ELSE coalesce(rollup.update_posture, survivor."updatePosture")
+  END,
+  "updatePostureSource" =
+    coalesce(survivor."updatePostureSource", rollup.update_posture_source),
+  "updatePostureConfidence" =
+    coalesce(survivor."updatePostureConfidence", rollup.update_posture_confidence),
+  "latestKnownVersion" =
+    coalesce(survivor."latestKnownVersion", rollup.latest_known_version),
+  "supportLifecycleSource" =
+    coalesce(survivor."supportLifecycleSource", rollup.support_lifecycle_source),
+  "supportLifecycleConfidence" =
+    coalesce(survivor."supportLifecycleConfidence", rollup.support_lifecycle_confidence)
+FROM _dpf_entity_rollup rollup
+WHERE survivor.id = rollup.survivor_id;
+
+-- Build relationship projections before changing any endpoint or entity key.
+CREATE TEMP TABLE _dpf_relationship_projection ON COMMIT DROP AS
+SELECT
+  relationship.id,
+  relationship."fromEntityId" AS original_from_id,
+  relationship."toEntityId" AS original_to_id,
+  coalesce(from_map.survivor_id, relationship."fromEntityId") AS future_from_id,
+  coalesce(to_map.survivor_id, relationship."toEntityId") AS future_to_id,
+  relationship."relationshipType",
+  (
+    relationship."fromEntityId" <> relationship."toEntityId"
+    AND coalesce(from_map.survivor_id, relationship."fromEntityId")
+      = coalesce(to_map.survivor_id, relationship."toEntityId")
+  ) AS self_loop_after_merge
+FROM "InventoryRelationship" relationship
+LEFT JOIN _dpf_entity_merge_map from_map
+  ON from_map.loser_id = relationship."fromEntityId"
+LEFT JOIN _dpf_entity_merge_map to_map
+  ON to_map.loser_id = relationship."toEntityId";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM _dpf_relationship_projection projection
+    JOIN "InventoryRelationship" relationship ON relationship.id = projection.id
+    WHERE NOT projection.self_loop_after_merge
+      AND relationship."mergedIntoId" IS NULL
+      AND relationship.status <> 'superseded'
+    GROUP BY
+      projection.future_from_id,
+      projection.future_to_id,
+      projection."relationshipType"
+    HAVING
+      count(DISTINCT relationship."scopeKey")
+        + CASE WHEN bool_or(relationship."scopeKey" IS NULL) THEN 1 ELSE 0 END > 1
+      OR count(DISTINCT relationship."customerAccountId")
+        + CASE WHEN bool_or(relationship."customerAccountId" IS NULL) THEN 1 ELSE 0 END > 1
+      OR count(DISTINCT relationship."customerSiteId")
+        + CASE WHEN bool_or(relationship."customerSiteId" IS NULL) THEN 1 ELSE 0 END > 1
+  ) THEN
+    RAISE EXCEPTION
+      'InventoryRelationship integrity repair stopped: projected tuple crosses scope or ownership';
+  END IF;
+END $$;
+
+CREATE TEMP TABLE _dpf_relationship_merge_map (
+  loser_id TEXT PRIMARY KEY,
+  survivor_id TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _dpf_relationship_merge_map (loser_id, survivor_id)
+WITH ranked AS (
+  SELECT
+    relationship.id,
+    first_value(relationship.id) OVER (
+      PARTITION BY
+        projection.future_from_id,
+        projection.future_to_id,
+        projection."relationshipType"
+      ORDER BY
+        (
+          relationship."fromEntityId" = projection.future_from_id
+          AND relationship."toEntityId" = projection.future_to_id
+        ) DESC,
+        relationship."firstSeenAt",
+        relationship.id
+    ) AS survivor_id,
+    count(*) OVER (
+      PARTITION BY
+        projection.future_from_id,
+        projection.future_to_id,
+        projection."relationshipType"
+    ) AS copies
+  FROM _dpf_relationship_projection projection
+  JOIN "InventoryRelationship" relationship ON relationship.id = projection.id
+  WHERE NOT projection.self_loop_after_merge
+    AND relationship."mergedIntoId" IS NULL
+    AND relationship.status <> 'superseded'
+)
+SELECT id, survivor_id
+FROM ranked
+WHERE copies > 1
+  AND id <> survivor_id;
+
+CREATE TEMP TABLE _dpf_relationship_members (
+  relationship_id TEXT PRIMARY KEY,
+  survivor_id TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _dpf_relationship_members (relationship_id, survivor_id)
+SELECT loser_id, survivor_id FROM _dpf_relationship_merge_map
+UNION
+SELECT survivor_id, survivor_id FROM _dpf_relationship_merge_map;
+
+CREATE TEMP TABLE _dpf_relationship_rollup ON COMMIT DROP AS
+SELECT
+  members.survivor_id,
+  min(relationship."firstSeenAt") AS first_seen_at,
+  max(relationship."lastSeenAt") AS last_seen_at,
+  (array_agg(relationship."lastConfirmedRunId"
+    ORDER BY relationship."lastSeenAt" DESC, relationship.id DESC)
+    FILTER (WHERE relationship."lastConfirmedRunId" IS NOT NULL))[1]
+      AS last_confirmed_run_id,
+  (array_agg(relationship.status
+    ORDER BY relationship."lastSeenAt" DESC, relationship.id DESC))[1]
+      AS current_status,
+  (array_agg(relationship.confidence
+    ORDER BY relationship."lastSeenAt" DESC, relationship.id DESC)
+    FILTER (WHERE relationship.confidence IS NOT NULL))[1] AS confidence,
+  coalesce((
+    SELECT jsonb_object_agg(
+      property.key,
+      property.value
+      ORDER BY observed."lastSeenAt", observed.id
+    )
+    FROM _dpf_relationship_members nested_members
+    JOIN "InventoryRelationship" observed
+      ON observed.id = nested_members.relationship_id
+    CROSS JOIN LATERAL jsonb_each(coalesce(observed.properties, '{}'::jsonb)) property
+    WHERE nested_members.survivor_id = members.survivor_id
+  ), '{}'::jsonb) AS merged_properties
+FROM _dpf_relationship_members members
+JOIN "InventoryRelationship" relationship
+  ON relationship.id = members.relationship_id
+GROUP BY members.survivor_id;
+
+UPDATE "InventoryRelationship" survivor
+SET
+  status = rollup.current_status,
+  confidence = coalesce(rollup.confidence, survivor.confidence),
+  properties = rollup.merged_properties,
+  "firstSeenAt" = rollup.first_seen_at,
+  "lastSeenAt" = rollup.last_seen_at,
+  "lastConfirmedRunId" =
+    coalesce(rollup.last_confirmed_run_id, survivor."lastConfirmedRunId")
+FROM _dpf_relationship_rollup rollup
+WHERE survivor.id = rollup.survivor_id;
+
+-- Repoint all relationship-owned evidence before retiring collision losers.
+UPDATE "DiscoveredRelationship" child
+SET "inventoryRelationshipId" = map.survivor_id
+FROM _dpf_relationship_merge_map map
+WHERE child."inventoryRelationshipId" = map.loser_id;
+
+UPDATE "PortfolioQualityIssue" child
+SET "inventoryRelationshipId" = map.survivor_id
+FROM _dpf_relationship_merge_map map
+WHERE child."inventoryRelationshipId" = map.loser_id;
+
+UPDATE "InventoryRelationship" existing
+SET "mergedIntoId" = map.survivor_id
+FROM _dpf_relationship_merge_map map
+WHERE existing."mergedIntoId" = map.loser_id;
+
+UPDATE "InventoryRelationship" loser
+SET
+  status = 'superseded',
+  "mergedIntoId" = map.survivor_id,
+  properties = coalesce(loser.properties, '{}'::jsonb) || jsonb_build_object(
+    '_dpfIntegrityRepair',
+    jsonb_build_object(
+      'backlogItemId', 'BI-CF4ADDAC',
+      'reason', 'projected_tuple_collision',
+      'survivorId', map.survivor_id,
+      'version', 1
+    )
+  )
+FROM _dpf_relationship_merge_map map
+WHERE loser.id = map.loser_id;
+
+UPDATE "InventoryRelationship" relationship
+SET
+  status = 'superseded',
+  "mergedIntoId" = NULL,
+  properties = coalesce(relationship.properties, '{}'::jsonb) || jsonb_build_object(
+    '_dpfIntegrityRepair',
+    jsonb_build_object(
+      'backlogItemId', 'BI-CF4ADDAC',
+      'reason', 'self_loop_after_entity_merge',
+      'version', 1
+    )
+  )
+FROM _dpf_relationship_projection projection
+WHERE relationship.id = projection.id
+  AND projection.self_loop_after_merge
+  AND relationship."mergedIntoId" IS NULL
+  AND relationship.status <> 'superseded';
+
+-- Only canonical/surviving relationships move to canonical entity endpoints.
+UPDATE "InventoryRelationship" relationship
+SET
+  "fromEntityId" = projection.future_from_id,
+  "toEntityId" = projection.future_to_id
+FROM _dpf_relationship_projection projection
+WHERE relationship.id = projection.id
+  AND NOT projection.self_loop_after_merge
+  AND relationship."mergedIntoId" IS NULL
+  AND relationship.status <> 'superseded'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM _dpf_relationship_merge_map map
+    WHERE map.loser_id = relationship.id
+  );
+
+-- Repoint every hard entity reference and the declared RemoteAction soft ref.
+UPDATE "ChangeItem" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "DiscoveredItem" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "DiscoveredSoftwareEvidence" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "DiscoveryConnection" child
+SET "gatewayEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."gatewayEntityId" = map.loser_id;
+
+UPDATE "DiscoveryFingerprintObservation" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "DiscoveryTriageDecision" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "IdentityResolutionLog" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "PortfolioQualityIssue" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "RemoteAction" child
+SET "inventoryEntityId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE child."inventoryEntityId" = map.loser_id;
+
+UPDATE "InventoryEntity" existing
+SET "mergedIntoId" = map.survivor_id
+FROM _dpf_entity_merge_map map
+WHERE existing."mergedIntoId" = map.loser_id;
+
+UPDATE "InventoryEntity" loser
+SET
+  "entityKey" = map.quarantine_key,
+  status = 'superseded',
+  "mergedIntoId" = map.survivor_id,
+  properties = loser.properties || jsonb_build_object(
+    '_dpfIntegrityRepair',
+    jsonb_build_object(
+      'backlogItemId', 'BI-CF4ADDAC',
+      'canonicalId', map.survivor_id,
+      'originalEntityKey', map.original_key,
+      'version', 1
+    )
+  )
+FROM _dpf_entity_merge_map map
+WHERE loser.id = map.loser_id;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "InventoryEntity"
+    GROUP BY "entityKey"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'InventoryEntity integrity repair left duplicate entityKey values';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "InventoryRelationship" relationship
+    JOIN "InventoryEntity" from_entity ON from_entity.id = relationship."fromEntityId"
+    JOIN "InventoryEntity" to_entity ON to_entity.id = relationship."toEntityId"
+    WHERE relationship."mergedIntoId" IS NULL
+      AND relationship.status <> 'superseded'
+      AND (
+        from_entity."mergedIntoId" IS NOT NULL
+        OR to_entity."mergedIntoId" IS NOT NULL
+      )
+  ) THEN
+    RAISE EXCEPTION 'InventoryRelationship integrity repair left a canonical row on a tombstone endpoint';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "InventoryRelationship"
+    WHERE "mergedIntoId" IS NULL
+      AND status <> 'superseded'
+    GROUP BY "fromEntityId", "toEntityId", "relationshipType"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'InventoryRelationship integrity repair left duplicate canonical tuples';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX "InventoryEntity_entityKey_key"
+  ON "InventoryEntity" ("entityKey");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'InventoryEntity_mergedIntoId_fkey'
+      AND conrelid = '"InventoryEntity"'::regclass
+  ) THEN
+    ALTER TABLE "InventoryEntity"
+      ADD CONSTRAINT "InventoryEntity_mergedIntoId_fkey"
+      FOREIGN KEY ("mergedIntoId")
+      REFERENCES "InventoryEntity"(id)
+      ON DELETE SET NULL
+      ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'InventoryRelationship_mergedIntoId_fkey'
+      AND conrelid = '"InventoryRelationship"'::regclass
+  ) THEN
+    ALTER TABLE "InventoryRelationship"
+      ADD CONSTRAINT "InventoryRelationship_mergedIntoId_fkey"
+      FOREIGN KEY ("mergedIntoId")
+      REFERENCES "InventoryRelationship"(id)
+      ON DELETE SET NULL
+      ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "InventoryEntity_mergedIntoId_idx"
+  ON "InventoryEntity" ("mergedIntoId");
+CREATE INDEX IF NOT EXISTS "InventoryRelationship_mergedIntoId_idx"
+  ON "InventoryRelationship" ("mergedIntoId");
+
+-- The earlier fleet repair rebuilt the remaining indexes, but repeat these
+-- two small tables while their writers are locked so this migration closes
+-- with one measured heap/index truth.
+REINDEX TABLE "InventoryEntity";
+REINDEX TABLE "InventoryRelationship";
+
+DO $$
+BEGIN
+  PERFORM public.bt_index_parent_check(
+    format('%I.%I', current_schema(), 'InventoryEntity_entityKey_key')::regclass,
+    true,
+    true
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_index index_state
+    JOIN pg_class index_class ON index_class.oid = index_state.indexrelid
+    JOIN pg_namespace namespace ON namespace.oid = index_class.relnamespace
+    WHERE namespace.nspname = current_schema()
+      AND index_class.relname = 'InventoryEntity_entityKey_key'
+      AND index_state.indisunique
+      AND index_state.indisvalid
+      AND index_state.indisready
+      AND index_state.indislive
+  ) THEN
+    RAISE EXCEPTION 'InventoryEntity_entityKey_key is not unique, valid, ready, and live';
+  END IF;
+END $$;
+
+COMMIT;

--- a/packages/db/scripts/lib/inventory-snapshot-migration-recovery.mjs
+++ b/packages/db/scripts/lib/inventory-snapshot-migration-recovery.mjs
@@ -1,0 +1,55 @@
+export const INVENTORY_SNAPSHOT_MIGRATION =
+  "20260728115900_snapshot_inventory_observation_facts";
+export const INVENTORY_SNAPSHOT_SHA256 =
+  "e443357fe93a2f99ada9be0b614663e6d0885b95523a9b4d572353a657b5a77f";
+export const INDEX_QUARANTINE_SHA256 =
+  "132be99f149869db31d0266f5dfe6cb7f9923f157dbf8f567bf67ebc00f116b7";
+
+const MIGRATION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function blocked(reason) {
+  return { action: "blocked", reason };
+}
+
+export function classifyInventorySnapshotRecovery({
+  unresolvedMigrations,
+  snapshotEffectCount,
+  indexQuarantineChecksum,
+}) {
+  if (indexQuarantineChecksum !== INDEX_QUARANTINE_SHA256) {
+    return blocked("candidate pre-snapshot quarantine checksum does not match");
+  }
+  if (unresolvedMigrations.length === 0) {
+    return { action: "not-needed" };
+  }
+  if (unresolvedMigrations.length !== 1) {
+    return blocked("expected exactly one unresolved migration");
+  }
+
+  const migration = unresolvedMigrations[0];
+  if (migration.migrationName !== INVENTORY_SNAPSHOT_MIGRATION) {
+    return blocked("migration identity does not match the allowlist");
+  }
+  if (!MIGRATION_ID.test(String(migration.id ?? ""))) {
+    return blocked("migration row id is not a UUID");
+  }
+  if (migration.checksum !== INVENTORY_SNAPSHOT_SHA256) {
+    return blocked("failed migration checksum does not match");
+  }
+  if (migration.appliedStepsCount !== 0) {
+    return blocked("failed migration has applied steps");
+  }
+  if (snapshotEffectCount !== 0) {
+    return blocked("failed migration left durable snapshot effects");
+  }
+
+  const logs = String(migration.logs ?? "");
+  if (!logs.includes("23505")) {
+    return blocked("failed migration does not report SQLSTATE 23505");
+  }
+  if (!logs.includes("InventoryEntity_entityKey_key")) {
+    return blocked("failed migration does not name the allowlisted constraint");
+  }
+
+  return { action: "recover", migrationId: migration.id };
+}

--- a/packages/db/scripts/migration-timestamp-collision-guard.mjs
+++ b/packages/db/scripts/migration-timestamp-collision-guard.mjs
@@ -19,6 +19,9 @@
 // timestamp prefix is shared by any other migration in the working tree —
 // whether that other migration is pre-existing or also new. Existing pairs are
 // never "new", so the 19 legacy collisions self-baseline and are never flagged.
+// One exact-checksum exception restores a migration identity already applied by
+// an earlier branch revision; changing either its name or bytes would create
+// fleet drift, so the exception is narrower than an ordinary baseline.
 //
 // The fix for a flagged collision is always to pick a fresh, later timestamp for
 // the NEW migration BEFORE it merges (it has never been applied anywhere, so
@@ -32,11 +35,21 @@
 //   - packages/db/scripts/migration-timestamp-collision-guard.test.ts (vitest)
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MIGRATIONS_DIR = "packages/db/prisma/migrations";
 const TS_PREFIX = /^(\d{14})_/;
+
+// A former branch revision reached real databases under this exact identity
+// before the migration was renamed. Restoring those exact bytes is required to
+// preserve Prisma history; any checksum drift remains a collision failure.
+export const HISTORICAL_COLLISION_RESTORATIONS = Object.freeze({
+  "20260728120000_repair_inventory_entity_index_integrity":
+    "84704a50ad127a0a4823074956f8041cd99f647accbcb39ce17c856fa1f13d90",
+});
 
 /**
  * Given the full set of migration directory names and the subset that is NEW
@@ -45,9 +58,10 @@ const TS_PREFIX = /^(\d{14})_/;
  *
  * @param {string[]} allDirs   every migration dir name in the working tree
  * @param {Set<string>} newDirs the subset that is new since the base ref
+ * @param {Map<string, string>} migrationChecksums SHA-256 by migration dir
  * @returns {{ dir: string, timestamp: string, collidesWith: string[] }[]}
  */
-export function findCollisions(allDirs, newDirs) {
+export function findCollisions(allDirs, newDirs, migrationChecksums = new Map()) {
   const byTimestamp = new Map();
   for (const dir of allDirs) {
     const m = TS_PREFIX.exec(dir);
@@ -60,6 +74,13 @@ export function findCollisions(allDirs, newDirs) {
   const findings = [];
   for (const dir of allDirs) {
     if (!newDirs.has(dir)) continue;
+    const restorationChecksum = HISTORICAL_COLLISION_RESTORATIONS[dir];
+    if (
+      restorationChecksum
+      && migrationChecksums.get(dir) === restorationChecksum
+    ) {
+      continue;
+    }
     const m = TS_PREFIX.exec(dir);
     if (!m) continue;
     const siblings = byTimestamp.get(m[1]).filter((d) => d !== dir);
@@ -92,6 +113,14 @@ function main() {
   // Map each migration.sql path → its migration directory name.
   const dirOf = (f) => f.slice(`${MIGRATIONS_DIR}/`.length).split("/")[0];
   const allDirs = tracked.map(dirOf);
+  const migrationChecksums = new Map(
+    tracked.map((file) => [
+      dirOf(file),
+      createHash("sha256")
+        .update(readFileSync(resolve(repoRoot, file)))
+        .digest("hex"),
+    ]),
+  );
 
   const newDirs = new Set(
     tracked
@@ -106,7 +135,7 @@ function main() {
       .map(dirOf),
   );
 
-  const findings = findCollisions(allDirs, newDirs);
+  const findings = findCollisions(allDirs, newDirs, migrationChecksums);
 
   if (findings.length === 0) {
     console.log("✅ No new migration timestamp collisions.");
@@ -123,12 +152,17 @@ function main() {
   for (const f of findings) {
     console.error(`  ${f.dir}`);
     console.error(`    • timestamp ${f.timestamp} also used by: ${f.collidesWith.join(", ")}`);
+    if (HISTORICAL_COLLISION_RESTORATIONS[f.dir]) {
+      console.error(
+        `    • historical restoration must have checksum ${HISTORICAL_COLLISION_RESTORATIONS[f.dir]}`,
+      );
+      console.error(`    • observed checksum ${migrationChecksums.get(f.dir) ?? "<missing>"}`);
+    }
   }
   console.error("");
-  console.error("Fix: rename the NEW migration directory above to a fresh, later 14-digit timestamp");
-  console.error("(YYYYMMDDHHMMSS) that no other migration uses. Do NOT rename the migration it");
-  console.error("collides with — if that one has already been applied anywhere, renaming it wedges");
-  console.error("the forward-only chain.");
+  console.error("Fix an ordinary NEW migration by renaming it to a fresh timestamp before merge.");
+  console.error("Fix a listed historical restoration by restoring its exact recorded bytes.");
+  console.error("Never rename a migration identity that has already been applied anywhere.");
   console.error("");
   process.exit(1);
 }

--- a/packages/db/scripts/migration-timestamp-collision-guard.test.ts
+++ b/packages/db/scripts/migration-timestamp-collision-guard.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 // @ts-expect-error — .mjs guard, no types
-import { findCollisions } from "./migration-timestamp-collision-guard.mjs";
+import {
+  findCollisions,
+  HISTORICAL_COLLISION_RESTORATIONS,
+} from "./migration-timestamp-collision-guard.mjs";
 
 const newSet = (...dirs: string[]) => new Set(dirs);
 
@@ -66,5 +69,31 @@ describe("migration-timestamp-collision-guard", () => {
   it("ignores dirs without a 14-digit timestamp prefix", () => {
     const all = ["migration_lock.toml_notadir", "20260707120000_add_alpha"];
     expect(findCollisions(all, newSet("20260707120000_add_alpha"))).toHaveLength(0);
+  });
+
+  it("allows the exact historical inventory repair restoration", () => {
+    const restored = "20260728120000_repair_inventory_entity_index_integrity";
+    const all = [
+      "20260728120000_add_business_product_hierarchy",
+      restored,
+    ];
+    const checksums = new Map([
+      [restored, HISTORICAL_COLLISION_RESTORATIONS[restored]],
+    ]);
+    expect(findCollisions(all, newSet(restored), checksums)).toHaveLength(0);
+  });
+
+  it("rejects any byte drift in the historical restoration", () => {
+    const restored = "20260728120000_repair_inventory_entity_index_integrity";
+    const all = [
+      "20260728120000_add_business_product_hierarchy",
+      restored,
+    ];
+    const findings = findCollisions(
+      all,
+      newSet(restored),
+      new Map([[restored, "0".repeat(64)]]),
+    );
+    expect(findings).toHaveLength(1);
   });
 });

--- a/packages/db/scripts/recover-inventory-snapshot-migration.mjs
+++ b/packages/db/scripts/recover-inventory-snapshot-migration.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import pg from "pg";
+
+import {
+  classifyInventorySnapshotRecovery,
+  INVENTORY_SNAPSHOT_MIGRATION,
+} from "./lib/inventory-snapshot-migration-recovery.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexQuarantinePath = resolve(
+  here,
+  "../prisma/migrations/20260728115800_quarantine_damaged_inventory_unique_index/migration.sql",
+);
+
+function fail(message) {
+  process.stderr.write(`inventory-snapshot-recovery: ${message}\n`);
+  process.exit(1);
+}
+
+export async function inspectRecoveryState(client) {
+  let unresolvedMigrations;
+  try {
+    const result = await client.query(
+      `SELECT
+         id,
+         migration_name AS "migrationName",
+         checksum,
+         applied_steps_count AS "appliedStepsCount",
+         logs
+       FROM "_prisma_migrations"
+       WHERE finished_at IS NULL
+         AND rolled_back_at IS NULL
+       ORDER BY started_at, id`,
+    );
+    unresolvedMigrations = result.rows;
+  } catch (error) {
+    if (error?.code === "42P01") {
+      return { unresolvedMigrations: [], snapshotEffectCount: 0 };
+    }
+    throw error;
+  }
+
+  if (unresolvedMigrations.length === 0) {
+    return { unresolvedMigrations, snapshotEffectCount: 0 };
+  }
+
+  const effects = await client.query(
+    `SELECT count(*)::int AS count
+       FROM "InventoryEntity"
+      WHERE properties ? '_dpfObservationSnapshot'`,
+  );
+  return {
+    unresolvedMigrations,
+    snapshotEffectCount: Number(effects.rows[0]?.count ?? 0),
+  };
+}
+
+export async function verifyRolledBackMigration(client, migrationId) {
+  const result = await client.query(
+    `SELECT
+       count(*) FILTER (
+         WHERE id = $1
+           AND migration_name = $2
+           AND rolled_back_at IS NOT NULL
+           AND finished_at IS NULL
+       )::int AS "verifiedRows",
+       count(*) FILTER (
+         WHERE finished_at IS NULL
+           AND rolled_back_at IS NULL
+       )::int AS "unresolvedRows"
+     FROM "_prisma_migrations"`,
+    [migrationId, INVENTORY_SNAPSHOT_MIGRATION],
+  );
+  return (
+    Number(result.rows[0]?.verifiedRows ?? 0) === 1
+    && Number(result.rows[0]?.unresolvedRows ?? 0) === 0
+  );
+}
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) fail("DATABASE_URL is not set");
+
+  const client = new pg.Client({ connectionString });
+  try {
+    await client.connect();
+    const verifyIndex = process.argv.indexOf("--verify-rolled-back");
+    if (verifyIndex >= 0) {
+      const migrationId = process.argv[verifyIndex + 1];
+      if (!migrationId) fail("--verify-rolled-back requires a migration row id");
+      if (!(await verifyRolledBackMigration(client, migrationId))) {
+        fail("post-resolution verification did not match the authorized row");
+      }
+      process.stdout.write("verified\n");
+      return;
+    }
+
+    const state = await inspectRecoveryState(client);
+    const indexQuarantineChecksum = createHash("sha256")
+      .update(readFileSync(indexQuarantinePath))
+      .digest("hex");
+    const decision = classifyInventorySnapshotRecovery({
+      ...state,
+      indexQuarantineChecksum,
+    });
+    if (decision.action === "blocked") {
+      fail(decision.reason);
+    }
+    process.stdout.write(
+      decision.action === "recover"
+        ? `recover:${decision.migrationId}\n`
+        : `${decision.action}\n`,
+    );
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+const invokedDirectly =
+  process.argv[1]
+  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (invokedDirectly) {
+  main().catch((error) => fail(error.message ?? String(error)));
+}

--- a/packages/db/src/inventory-migration-history.test.ts
+++ b/packages/db/src/inventory-migration-history.test.ts
@@ -1,0 +1,41 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+const migrationsUrl = new URL("../prisma/migrations/", import.meta.url);
+const indexQuarantine =
+  "20260728115800_quarantine_damaged_inventory_unique_index";
+const snapshot = "20260728115900_snapshot_inventory_observation_facts";
+const formerRepair = "20260728120000_repair_inventory_entity_index_integrity";
+const currentRepair = "20260728130000_repair_inventory_entity_index_integrity";
+
+async function migrationChecksum(name: string): Promise<string> {
+  const bytes = await readFile(new URL(`${name}/migration.sql`, migrationsUrl));
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+describe("inventory repair migration history", () => {
+  it("quarantines a damaged index before snapshotting observation facts", async () => {
+    const names = (await readdir(migrationsUrl)).sort();
+
+    expect(names).toContain(indexQuarantine);
+    expect(names.indexOf(indexQuarantine)).toBeLessThan(names.indexOf(snapshot));
+    expect(names.indexOf(snapshot)).toBeLessThan(names.indexOf(formerRepair));
+    expect(names.indexOf(formerRepair)).toBeLessThan(names.indexOf(currentRepair));
+  });
+
+  it("preserves the failed snapshot and both repair identities at known checksums", async () => {
+    await expect(migrationChecksum(snapshot)).resolves.toBe(
+      "e443357fe93a2f99ada9be0b614663e6d0885b95523a9b4d572353a657b5a77f",
+    );
+    await expect(migrationChecksum(indexQuarantine)).resolves.toBe(
+      "132be99f149869db31d0266f5dfe6cb7f9923f157dbf8f567bf67ebc00f116b7",
+    );
+    await expect(migrationChecksum(formerRepair)).resolves.toBe(
+      "84704a50ad127a0a4823074956f8041cd99f647accbcb39ce17c856fa1f13d90",
+    );
+    await expect(migrationChecksum(currentRepair)).resolves.toBe(
+      "49751a531c643b41d169a305c51f0d2a2ece9c44b8861138d3d894cdc3a7921b",
+    );
+  });
+});

--- a/packages/db/src/inventory-snapshot-migration-recovery.test.ts
+++ b/packages/db/src/inventory-snapshot-migration-recovery.test.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+// @ts-expect-error - production helper is intentionally runtime-native ESM.
+import {
+  classifyInventorySnapshotRecovery,
+  INDEX_QUARANTINE_SHA256,
+  INVENTORY_SNAPSHOT_SHA256,
+  INVENTORY_SNAPSHOT_MIGRATION,
+} from "../scripts/lib/inventory-snapshot-migration-recovery.mjs";
+import {
+  inspectRecoveryState,
+  verifyRolledBackMigration,
+} from "../scripts/recover-inventory-snapshot-migration.mjs";
+
+const exactFailure = {
+  id: "11111111-1111-4111-8111-111111111111",
+  migrationName: INVENTORY_SNAPSHOT_MIGRATION,
+  checksum: INVENTORY_SNAPSHOT_SHA256,
+  finishedAt: null,
+  rolledBackAt: null,
+  appliedStepsCount: 0,
+  logs: [
+    "Database error code: 23505",
+    'duplicate key value violates unique constraint "InventoryEntity_entityKey_key"',
+  ].join("\n"),
+};
+
+describe("inventory snapshot migration recovery policy", () => {
+  it("recovers only the exact effect-free failed snapshot attempt", () => {
+    expect(classifyInventorySnapshotRecovery({
+      unresolvedMigrations: [exactFailure],
+      snapshotEffectCount: 0,
+      indexQuarantineChecksum: INDEX_QUARANTINE_SHA256,
+    })).toEqual({ action: "recover", migrationId: exactFailure.id });
+  });
+
+  it("does nothing when the snapshot migration has never failed", () => {
+    expect(classifyInventorySnapshotRecovery({
+      unresolvedMigrations: [],
+      snapshotEffectCount: 0,
+      indexQuarantineChecksum: INDEX_QUARANTINE_SHA256,
+    })).toEqual({ action: "not-needed" });
+  });
+
+  it.each([
+    ["different SQLSTATE", [{ ...exactFailure, logs: "Database error code: 23503" }], 0, INDEX_QUARANTINE_SHA256],
+    ["different constraint", [{ ...exactFailure, logs: "23505 Other_unique_key" }], 0, INDEX_QUARANTINE_SHA256],
+    ["wrong snapshot checksum", [{ ...exactFailure, checksum: "0".repeat(64) }], 0, INDEX_QUARANTINE_SHA256],
+    ["partially applied history", [{ ...exactFailure, appliedStepsCount: 1 }], 0, INDEX_QUARANTINE_SHA256],
+    ["multiple unresolved migrations", [exactFailure, { ...exactFailure, id: "22222222-2222-4222-8222-222222222222" }], 0, INDEX_QUARANTINE_SHA256],
+    ["durable snapshot effects", [exactFailure], 1, INDEX_QUARANTINE_SHA256],
+    ["wrong quarantine bytes", [exactFailure], 0, "0".repeat(64)],
+  ])("blocks %s", (_label, unresolvedMigrations, snapshotEffectCount, indexQuarantineChecksum) => {
+    expect(classifyInventorySnapshotRecovery({
+      unresolvedMigrations,
+      snapshotEffectCount,
+      indexQuarantineChecksum,
+    })).toMatchObject({ action: "blocked" });
+  });
+
+  it("blocks a malformed migration id before it reaches the shell", () => {
+    expect(classifyInventorySnapshotRecovery({
+      unresolvedMigrations: [{ ...exactFailure, id: "not-a-uuid" }],
+      snapshotEffectCount: 0,
+      indexQuarantineChecksum: INDEX_QUARANTINE_SHA256,
+    })).toMatchObject({ action: "blocked" });
+  });
+});
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schemas: string[] = [];
+
+async function recoveryFixture({
+  attempts = 0,
+  effects = 0,
+}: { attempts?: number; effects?: number } = {}) {
+  const schema = `inventory_snapshot_recovery_${randomUUID().replaceAll("-", "")}`;
+  schemas.push(schema);
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  await client.query(`CREATE SCHEMA "${schema}"; SET search_path TO "${schema}"`);
+  await client.query(`
+    CREATE TABLE "_prisma_migrations" (
+      id VARCHAR(36) PRIMARY KEY,
+      checksum VARCHAR(64) NOT NULL,
+      finished_at TIMESTAMPTZ,
+      migration_name VARCHAR(255) NOT NULL,
+      logs TEXT,
+      rolled_back_at TIMESTAMPTZ,
+      started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      applied_steps_count INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE "InventoryEntity" (
+      id TEXT PRIMARY KEY,
+      properties JSONB NOT NULL DEFAULT '{}'
+    );
+  `);
+  for (let index = 0; index < attempts; index += 1) {
+    await client.query(
+      `INSERT INTO "_prisma_migrations" (
+         id, checksum, migration_name, logs, applied_steps_count
+       ) VALUES ($1, $2, $3, $4, 0)`,
+      [
+        index === 0
+          ? exactFailure.id
+          : "22222222-2222-4222-8222-222222222222",
+        INVENTORY_SNAPSHOT_SHA256,
+        INVENTORY_SNAPSHOT_MIGRATION,
+        exactFailure.logs,
+      ],
+    );
+  }
+  for (let index = 0; index < effects; index += 1) {
+    await client.query(
+      `INSERT INTO "InventoryEntity" (id, properties)
+       VALUES ($1, '{"_dpfObservationSnapshot":{"version":1}}')`,
+      [`entity-${index}`],
+    );
+  }
+  return client;
+}
+
+describeDatabase("inventory snapshot recovery SQL inspection", () => {
+  afterAll(async () => {
+    if (!databaseUrl || schemas.length === 0) return;
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      for (const schema of schemas) {
+        await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      }
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("treats an absent Prisma ledger as a clean install", async () => {
+    const schema = `inventory_snapshot_recovery_${randomUUID().replaceAll("-", "")}`;
+    schemas.push(schema);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      await client.query(`CREATE SCHEMA "${schema}"; SET search_path TO "${schema}"`);
+      await expect(inspectRecoveryState(client)).resolves.toEqual({
+        unresolvedMigrations: [],
+        snapshotEffectCount: 0,
+      });
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("returns no unresolved attempts for a clean migration ledger", async () => {
+    const client = await recoveryFixture();
+    try {
+      await expect(inspectRecoveryState(client)).resolves.toEqual({
+        unresolvedMigrations: [],
+        snapshotEffectCount: 0,
+      });
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("returns every unresolved attempt and durable effect count", async () => {
+    const client = await recoveryFixture({ attempts: 2, effects: 1 });
+    try {
+      const state = await inspectRecoveryState(client);
+      expect(state.unresolvedMigrations).toHaveLength(2);
+      expect(state.snapshotEffectCount).toBe(1);
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("returns unrelated unresolved migrations so recovery fails closed", async () => {
+    const client = await recoveryFixture({ attempts: 1 });
+    try {
+      await client.query(
+        `INSERT INTO "_prisma_migrations" (
+           id, checksum, migration_name, logs, applied_steps_count
+         ) VALUES ($1, $2, $3, $4, 0)`,
+        [
+          "33333333-3333-4333-8333-333333333333",
+          "0".repeat(64),
+          "20260728123000_unrelated_failed_migration",
+          "unrelated failure",
+        ],
+      );
+      const state = await inspectRecoveryState(client);
+      expect(state.unresolvedMigrations).toHaveLength(2);
+      expect(classifyInventorySnapshotRecovery({
+        ...state,
+        indexQuarantineChecksum: INDEX_QUARANTINE_SHA256,
+      })).toMatchObject({ action: "blocked" });
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("verifies the exact row after it is marked rolled back", async () => {
+    const client = await recoveryFixture({ attempts: 1 });
+    try {
+      await client.query(
+        `UPDATE "_prisma_migrations" SET rolled_back_at = now() WHERE id = $1`,
+        [exactFailure.id],
+      );
+      await expect(
+        verifyRolledBackMigration(client, exactFailure.id),
+      ).resolves.toBe(true);
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("rejects post-resolution verification while any other migration is unresolved", async () => {
+    const client = await recoveryFixture({ attempts: 1 });
+    try {
+      await client.query(
+        `UPDATE "_prisma_migrations" SET rolled_back_at = now() WHERE id = $1`,
+        [exactFailure.id],
+      );
+      await client.query(
+        `INSERT INTO "_prisma_migrations" (
+           id, checksum, migration_name, logs, applied_steps_count
+         ) VALUES ($1, $2, $3, $4, 0)`,
+        [
+          "33333333-3333-4333-8333-333333333333",
+          "0".repeat(64),
+          "20260728123000_unrelated_failed_migration",
+          "unrelated failure",
+        ],
+      );
+      await expect(
+        verifyRolledBackMigration(client, exactFailure.id),
+      ).resolves.toBe(false);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/packages/db/src/inventory-snapshot-migration-recovery.test.ts
+++ b/packages/db/src/inventory-snapshot-migration-recovery.test.ts
@@ -2,16 +2,20 @@ import { randomUUID } from "node:crypto";
 import pg from "pg";
 import { afterAll, describe, expect, it } from "vitest";
 // @ts-expect-error - production helper is intentionally runtime-native ESM.
-import {
+import * as inventorySnapshotRecovery from "../scripts/lib/inventory-snapshot-migration-recovery.mjs";
+// @ts-expect-error - production helper is intentionally runtime-native ESM.
+import * as inventorySnapshotRecoveryRunner from "../scripts/recover-inventory-snapshot-migration.mjs";
+
+const {
   classifyInventorySnapshotRecovery,
   INDEX_QUARANTINE_SHA256,
   INVENTORY_SNAPSHOT_SHA256,
   INVENTORY_SNAPSHOT_MIGRATION,
-} from "../scripts/lib/inventory-snapshot-migration-recovery.mjs";
-import {
+} = inventorySnapshotRecovery;
+const {
   inspectRecoveryState,
   verifyRolledBackMigration,
-} from "../scripts/recover-inventory-snapshot-migration.mjs";
+} = inventorySnapshotRecoveryRunner;
 
 const exactFailure = {
   id: "11111111-1111-4111-8111-111111111111",

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -403,6 +403,38 @@ if [[ $_dry_run -eq 0 ]]; then
   docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
     "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
     -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate resolve --rolled-back 20260714110000_bet5_pgvector_foundation' >/dev/null 2>&1 || true
+
+  # BI-B92CFED7: a pre-fix self-upgrade can leave the 11:59 observation
+  # snapshot failed at its first UPDATE because a corrupted unique index still
+  # contains duplicate heap keys. The candidate-owned checker proves the exact
+  # allowlisted failure, zero applied steps, zero durable snapshot effects, and
+  # the exact pre-snapshot quarantine guard. Any mismatch aborts before the
+  # portal swap.
+  _inventory_snapshot_recovery="$(
+    docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+      "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+      -c 'cd /app && node packages/db/scripts/recover-inventory-snapshot-migration.mjs'
+  )" || {
+    printf 'error: inventory snapshot migration recovery did not prove a safe state\n' >&2
+    exit 1
+  }
+  case "$_inventory_snapshot_recovery" in
+    recover:*)
+      _inventory_snapshot_migration_id="${_inventory_snapshot_recovery#recover:}"
+      docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+        "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+        -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate resolve --rolled-back 20260728115900_snapshot_inventory_observation_facts'
+      docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+        "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+        -c 'cd /app && node packages/db/scripts/recover-inventory-snapshot-migration.mjs --verify-rolled-back "$1"' \
+        sh "$_inventory_snapshot_migration_id"
+      ;;
+    not-needed) ;;
+    *)
+      printf 'error: inventory snapshot migration recovery returned an unknown decision\n' >&2
+      exit 1
+      ;;
+  esac
 fi
 
 # --- Step 3b: migrate ---


### PR DESCRIPTION
## Summary
- restore the exact historical 20260728120000 inventory index repair migration so fleet databases with that applied identity remain upgradeable
- recover only the exact known failed 20260728115900 snapshot migration state, with fail-closed whole-ledger validation before and after resolution
- preserve PR #3716's stronger early quarantine ownership while adding migration-history, PostgreSQL, promoter-contract, and runbook coverage

## Verification
- local integration freshness: green on accepted base 991be733bc53036d74c775f89f3144d76a00de82
- Prisma generate and migrate deploy: passed across 466 migration directories
- exhaustive Vitest: 2,331 files / 20,167 tests passed; 4 files and 19 tests skipped; 18 todo
- focused PostgreSQL migration suite: 4 files / 32 tests passed with no skips
- web typecheck: passed
- production Docker build: passed
- architecture, operations, and final-delta reviews: approved
- current head d5641b8077da23374d3ac27428a5b15f006aa039 adds the canonical live backlog-coverage receipt and corrects TypeScript suppression placement in the already-executed PostgreSQL test; GitHub CI validates that exact head

Local-CI-Evidence: cms5xzs0501po01msbmisr4tn (fix/inventory-migration-p3018@a96bdd583941c56e3cd0e65f846f6e402127a7d9)

## Documentation
Updated the Windows self-upgrade runbook, migration data-impact record, and implementation plan to describe the exact fleet-history compatibility and recovery contract.