### PR TITLE
refactor(ci): hand UX sweep the same-run build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 # CodeQL actions/missing-workflow-permissions: least-privilege default
-# applied at workflow level. All CI jobs only need to read the source.
+# applied at workflow level. UX also reads same-run build artifacts.
 permissions:
+  actions: read
   contents: read
 
 on:
@@ -382,9 +383,7 @@ jobs:
       # the payload checksum to the immutable Git tree, planner, and toolchain.
       - name: Package exact-tree production build
         id: package-build
-        if: >-
-          needs.changes.outputs.heavy == 'true' &&
-          (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+        if: needs.changes.outputs.heavy == 'true'
         continue-on-error: true
         env:
           DPF_CI_PLANNER_DIGEST: ${{ needs.changes.outputs.evidence_plan_digest }}
@@ -393,7 +392,6 @@ jobs:
       - name: Upload exact-tree production build
         if: >-
           needs.changes.outputs.heavy == 'true' &&
-          (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
           steps.package-build.outcome == 'success'
         continue-on-error: true
         uses: actions/upload-artifact@v7
@@ -402,6 +400,38 @@ jobs:
           path: ${{ runner.temp }}/web-production-build
           if-no-files-found: error
           retention-days: 1
+
+  # BI-D9E8B8CB. The route runtime is a reusable workflow so manual baseline
+  # calibration and blocking CI share one behavioral definition. `needs: build`
+  # replaces cross-workflow Actions API polling with a direct producer edge.
+  ux-route-sweep-runtime:
+    name: UX Route Sweep Runtime
+    needs: [changes, build]
+    uses: ./.github/workflows/ux-route-sweep.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      reuse_current_run_build: ${{ needs.changes.outputs.heavy == 'true' }}
+      workers: "2"
+
+  # Preserve the stable branch-protection context even though the runtime now
+  # lives in a reusable workflow. `always()` converts dependency skip/failure
+  # into an explicit red check instead of leaving merge queue status ambiguous.
+  ux-route-sweep:
+    name: UX Route Budget Sweep
+    runs-on: ubuntu-latest
+    if: always()
+    needs: ux-route-sweep-runtime
+    steps:
+      - name: Assert the route runtime passed
+        env:
+          RUNTIME_RESULT: ${{ needs.ux-route-sweep-runtime.result }}
+        run: |
+          if [ "$RUNTIME_RESULT" != "success" ]; then
+            echo "::error::UX Route Sweep Runtime concluded $RUNTIME_RESULT"
+            exit 1
+          fi
 
   dockerfile-node-version:
     name: Dockerfile Node Version
@@ -510,6 +540,8 @@ jobs:
       - test-packages
       - unit-tests
       - build
+      - ux-route-sweep-runtime
+      - ux-route-sweep
       - dockerfile-node-version
       - compose-image-pins
       - adp-integration-tests

--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -6,12 +6,23 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
+    inputs:
+      update_baseline:
+        description: "Measure and emit a fresh route-budget baseline"
+        required: false
+        type: boolean
+        default: false
+      reuse_current_run_build:
+        description: "Consume the canonical Production Build artifact from this caller run"
+        required: false
+        type: boolean
+        default: false
+      workers:
+        description: "Bounded route workers"
+        required: false
+        type: string
+        default: "2"
   workflow_dispatch:
     inputs:
       update_baseline:
@@ -60,7 +71,7 @@ concurrency:
 
 jobs:
   sweep:
-    name: UX Route Budget Sweep
+    name: UX Route Sweep Runtime
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -82,7 +93,7 @@ jobs:
       NEXTAUTH_SECRET: ci_sweep_secret
       NEXTAUTH_URL: http://localhost:3000
       UX_SWEEP_BASE_URL: http://localhost:3000
-      UX_SWEEP_WORKERS: ${{ github.event.inputs.workers || '2' }}
+      UX_SWEEP_WORKERS: ${{ inputs.workers || '2' }}
 
     steps:
       - uses: actions/checkout@v7
@@ -132,57 +143,30 @@ jobs:
           git -C "$fixture_root" commit --allow-empty -m "fixture"
           echo "DPF_WORK_CONTROL_REPO_ROOT=$fixture_root" >> "$GITHUB_ENV"
 
-      # BI-959F4F38. The CI workflow publishes the exact tree's successful
-      # production output. Discovery is bounded: any unavailable, late,
-      # mismatched, expired, or corrupt evidence falls through to the local
-      # build below. Push and manual calibration deliberately remain standalone
-      # so this change does not activate cross-lifecycle evidence reuse.
-      - name: Find exact-tree CI production build
-        id: find-build
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          # Actions indexes pull_request workflow runs by the PR head SHA,
-          # while GITHUB_SHA identifies the synthetic merge checkout.
-          DPF_CI_RUN_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        # The producer's cold setup + cache restore + build + package path has
-        # exceeded four minutes in observed GitHub-hosted runs. Ten minutes
-        # remains bounded while avoiding a delayed duplicate build.
-        # BI-149370BD: this deadline now only bounds a producer that is still
-        # running. Once every exact-tree producer is terminal without an
-        # artifact — as on heavy=false PRs, where CI never builds — discovery
-        # returns immediately instead of waiting out the remaining deadline.
-        run: >-
-          node scripts/ci-build-artifact.mjs locate
-          --workflow ci.yml
-          --artifact-prefix web-production-build
-          --wait-seconds 600
-
+      # BI-D9E8B8CB. PR and merge-group callers depend directly on the canonical
+      # Production Build job, so its artifact is already terminal in this run.
+      # Heavy CI callers, including main pushes, reuse the same-run artifact;
+      # manual calibration keeps the independent local-build path.
       - name: Start production-build transfer timer
-        if: steps.find-build.outputs.found == 'true'
+        if: inputs.reuse_current_run_build == true
         run: echo "DPF_BUILD_ARTIFACT_TRANSFER_STARTED_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
 
       - name: Download exact-tree production build
         id: download-build
-        if: steps.find-build.outputs.found == 'true'
+        if: inputs.reuse_current_run_build == true
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: ${{ steps.find-build.outputs.artifact_name }}
+          name: web-production-build-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/web-production-build
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.find-build.outputs.source_run_id }}
 
       - name: Verify and materialize exact-tree production build
         id: materialize-build
-        if: >-
-          steps.find-build.outputs.found == 'true' &&
-          steps.download-build.outcome == 'success'
+        if: inputs.reuse_current_run_build == true && steps.download-build.outcome == 'success'
         run: >-
           node scripts/ci-build-artifact.mjs consume
           --input-dir "$RUNNER_TEMP/web-production-build"
-          --source-run-id "${{ steps.find-build.outputs.source_run_id }}"
+          --source-run-id "${{ github.run_id }}"
 
       - name: Build the portal
         if: steps.materialize-build.outputs.reused != 'true'
@@ -225,7 +209,7 @@ jobs:
         run: pnpm exec tsx e2e/auth-only.ts
 
       - name: Run the sweep
-        if: ${{ github.event.inputs.update_baseline != 'true' }}
+        if: ${{ inputs.update_baseline != true }}
         run: pnpm --filter web ux:sweep -- --workers "$UX_SWEEP_WORKERS"
 
       # Manual arming path: measure the running portal and emit the baseline as an
@@ -233,11 +217,11 @@ jobs:
       # the baseline is a reviewed engineering act, and this job has read-only
       # contents permission.
       - name: Measure and emit a fresh baseline
-        if: ${{ github.event.inputs.update_baseline == 'true' }}
+        if: ${{ inputs.update_baseline == true }}
         run: pnpm --filter web ux:sweep -- --workers "$UX_SWEEP_WORKERS" --update-baseline
 
       - name: Upload the fresh baseline
-        if: ${{ github.event.inputs.update_baseline == 'true' }}
+        if: ${{ inputs.update_baseline == true }}
         uses: actions/upload-artifact@v7
         with:
           name: ux-route-budget-baseline

--- a/config/merge-readiness-policy.json
+++ b/config/merge-readiness-policy.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "branch": "main",
   "strict": false,
   "requiredContexts": [
@@ -13,6 +13,8 @@
   },
   "aggregateJobId": "merge-readiness",
   "aggregateJobName": "Merge Readiness",
-  "uxJobId": "sweep",
-  "uxJobName": "UX Route Budget Sweep"
+  "uxJobId": "ux-route-sweep",
+  "uxJobName": "UX Route Budget Sweep",
+  "uxRuntimeJobId": "sweep",
+  "uxRuntimeJobName": "UX Route Sweep Runtime"
 }

--- a/docs/superpowers/plans/2026-07-29-ci-ux-same-run-build-handoff.md
+++ b/docs/superpowers/plans/2026-07-29-ci-ux-same-run-build-handoff.md
@@ -1,0 +1,227 @@
+---
+title: CI UX same-run production-build handoff
+date: 2026-07-29
+status: active
+backlog: BI-D9E8B8CB
+epic: EP-0DFF753B
+spec: docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
+coverage_receipt: cms5dxini0b6901qw5fr2ipzo
+---
+
+# CI UX same-run production-build handoff
+
+## Outcome
+
+Remove the UX route sweep's cross-workflow production-build discovery tail
+without reducing its 202-route semantic, structure, word-budget, or WCAG
+coverage. Pull-request, merge-group, and main-push UX verification will
+consume the canonical CI build through a direct job dependency and same-run
+artifact transfer. Manual baseline calibration remains independently
+dispatchable and builds locally.
+
+**For agentic workers:** execute this plan one independently reviewable backlog
+item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+implementation, `dpf-local-merge-ci-before-push` plus the plan's completion
+gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Evidence and prior-design reconciliation
+
+The existing architecture is sound in two important ways and must be retained:
+
+- `BI-959F4F38` / PR #3682 created one checksummed exact-tree/toolchain
+  production artifact and made UX validate it before materialization. It
+  removed a second 216-second portal compilation.
+- `BI-149370BD` / PR #3699 made discovery abandon immediately when every
+  matching producer is terminal without an artifact. It correctly preserves
+  bounded polling while a valid producer is still queued or running.
+
+The residual latency is therefore not an artifact-integrity or terminality
+defect. It is an orchestration defect: `.github/workflows/ci.yml` and
+`.github/workflows/ux-route-sweep.yml` start independently, so the consumer can
+only poll the Actions API until `Production Build` packages and uploads its
+artifact.
+
+Recent exact runs establish the current critical path:
+
+- merge-group run `30384206549`: about 4m40 waiting for the exact-tree build,
+  then about 3m08 sweeping all routes;
+- PR-head run `30411380083`: about five minutes waiting for the build, then
+  about three minutes sweeping 202 routes;
+- earlier run `30407144235`: about 9m30 waiting for the build, then about 3m13
+  sweeping routes.
+
+Four same-runner sweep workers improved the crawl by only about 8.4 seconds
+over two workers on the same SHA, so worker multiplication is not the material
+optimization.
+
+GitHub's supported contract is direct: artifacts pass files between jobs in
+one workflow, and `needs` makes the consumer wait for the producer. Cross-run
+download requires the token and source-run identifier that forced the current
+polling locator. Merge-queue required checks must still trigger on
+`merge_group`.
+
+This plan extends:
+
+- `docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md`;
+- `docs/superpowers/plans/2026-07-26-ci-evidence-efficiency.md`;
+- `docs/superpowers/plans/2026-07-27-ci-duplicate-execution-refactor.md`;
+- `docs/testing/ci-evidence.md`.
+
+It does not activate `BI-9585E580` cross-lifecycle merge-group-to-push evidence
+reuse, change affected-test policy, broaden cache keys, or weaken the UX
+baseline contract.
+
+## Architecture
+
+```text
+pull_request / merge_group / push
+        |
+        v
+CI workflow
+  changes ----------+
+        |            |
+        v            |
+  Production Build  |
+        |            |
+        | exact-tree receipt + archive
+        v            |
+  UX Route Budget Sweep
+        |
+        +-- same-run download + consume
+        +-- immediate local build fallback when artifact is absent/invalid
+
+workflow_dispatch (baseline calibration)
+        |
+        v
+standalone UX workflow -> local build -> explicit baseline artifact
+```
+
+The stable check name remains `UX Route Budget Sweep`. The CI workflow owns
+that check for pull requests, merge groups, and main pushes. The standalone
+workflow keeps manual calibration only. This is same-run reuse and does not
+consume merge-group evidence on the later push, so `BI-9585E580` remains
+separate. Shared sweep steps may be extracted into a composite action if that
+is the smallest way to avoid YAML duplication, but no new evidence identity
+or runtime contract is introduced.
+
+## Implementation phases
+
+### Phase 1 — Red workflow-contract tests
+
+Deliverable:
+
+- add failing source-level conformance assertions that PR and merge-group UX:
+  - are owned by the CI workflow;
+  - depend on `build` and the change classifier;
+  - download the current run's exact artifact without a token, source run id,
+    Actions API locator, or polling deadline;
+  - preserve the stable check name and `merge_group` trigger;
+  - fall back immediately when build output is skipped, missing, or invalid;
+  - leave standalone manual baseline calibration runnable.
+
+Likely files:
+
+- `scripts/check-ci-build-artifact.test.mjs`;
+- workflow guard/conformance fixtures already registered by `check-guards`.
+
+Verification:
+
+- targeted Node tests fail for the current cross-workflow locator topology and
+  pass only after Phase 2.
+
+### Phase 2 — Same-run producer/consumer topology
+
+Deliverable:
+
+- move the PR/merge-group UX job into `.github/workflows/ci.yml`;
+- add explicit `needs` edges to `changes` and `build`;
+- download `web-production-build-${{ github.run_id }}-${{
+  github.run_attempt }}` from the current run;
+- retain `scripts/ci-build-artifact.mjs consume` as the exact
+  tree/toolchain/checksum gate;
+- skip download when the heavy build is intentionally absent and start the
+  existing local build immediately;
+- keep the standalone UX workflow for `workflow_dispatch` baseline
+  calibration only;
+- extract shared setup/sweep steps if necessary to keep one behavioral
+  definition.
+
+Verification:
+
+- workflow-contract tests;
+- YAML parse and repository guard suite;
+- injected missing/corrupt artifact fixtures prove immediate local fallback;
+- check-name inventory proves `UX Route Budget Sweep` still reports for
+  `pull_request` and `merge_group`.
+
+### Phase 3 — Documentation and timing evidence
+
+Deliverable:
+
+- update `docs/testing/ci-evidence.md` and `docs/testing/pr-health.md` to name
+  CI as the PR/merge-group UX owner and manual dispatch as the standalone
+  calibration path;
+- remove the active-flow ten-minute locator description while retaining the
+  exact receipt and fail-safe materialization contract;
+- record artifact transfer time, total UX wall time, and runner-minutes on one
+  PR-head and one merge-group run.
+
+Verification:
+
+- documentation index/link checks;
+- GitHub PR-head workflow shows no `Find exact-tree CI production build` step;
+- all 202 routes pass with unchanged baselines, tolerances, exclusions,
+  semantic assertions, and WCAG/axe coverage;
+- merge-group required check passes under the same name.
+
+## Completion gate
+
+- targeted artifact/workflow tests pass;
+- `node scripts/check-guards.mjs` passes;
+- documentation index and links pass;
+- governed exact-SHA local pregate passes;
+- PR-head CI and `UX Route Budget Sweep` are terminal green;
+- merge-group CI and `UX Route Budget Sweep` are terminal green;
+- measured artifact wait is zero; any remaining delay is classified as direct
+  producer build time, transfer/materialization, portal startup, or route
+  crawl.
+
+## Risks and rollback
+
+| Risk | Mitigation |
+| --- | --- |
+| Required UX check disappears or is skipped after a dependency failure | Keep the exact job name, trigger CI on `merge_group`, and use a terminal aggregate shape that reports failure rather than silently skipping where GitHub requires `always()` |
+| Heavy=false PR waits on or downloads an artifact that cannot exist | Gate same-run download on the change-plan output and run the existing local build immediately |
+| Artifact publication fails while the canonical build itself succeeds | Keep upload non-authoritative and preserve immediate local build fallback |
+| Same-run transfer bypasses receipt verification | Continue using the existing `consume` command; artifact proximity never substitutes for tree/toolchain/checksum proof |
+| Manual baseline workflow drifts from blocking behavior | Share the behavioral steps through one composite action or a guarded source block and enforce conformance in tests |
+| Workflow move changes route coverage | Make route baseline/projection files out of scope and require unchanged 202-route PR and merge-group evidence |
+
+Rollback is one PR: restore the PR/merge-group triggers and locator block in
+the standalone UX workflow, remove the CI-owned UX job, and retain the existing
+exact-tree artifact producer/consumer contract. No schema rollback or baseline
+change is involved.
+
+## Backlog coverage
+
+Decision: `atomic`.
+
+Coverage receipt: `cms5dxini0b6901qw5fr2ipzo`.
+
+Parent BI: `BI-D9E8B8CB`.
+
+| Deliverable | Backlog item | Depends on | Independently shippable |
+| --- | --- | --- | --- |
+| Same-run build handoff and required-check topology transition | `BI-D9E8B8CB` | none | no |
+
+Atomic rationale: adding the CI-owned UX check before removing the separate
+PR/merge-group workflow duplicates binding evidence; removing the separate
+trigger first can omit the required check. Dependency wiring, fallback,
+conformance tests, and documentation are one rollback boundary.
+
+## Standards references
+
+- [GitHub Actions workflow artifacts](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflow-artifacts)
+- [Store and share data with workflow artifacts](https://docs.github.com/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts)
+- [GitHub merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+- [Troubleshooting required status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -188,10 +188,12 @@ recall conditions above.
 
 ## Exact-tree production-build reuse
 
-For pull-request and merge-group events, the `Production Build` job packages
-the deploy-equivalent standalone runtime plus static assets after a successful
-`pnpm --filter web build` and publishes it for the matching
-`UX Route Budget Sweep`. The one-day artifact contains a
+For pull-request, merge-group, push, and CI workflow-dispatch events, the
+`Production Build` job packages the deploy-equivalent standalone runtime plus
+static assets after a successful `pnpm --filter web build`. The CI workflow
+then calls the reusable UX runtime through an explicit `needs: build` edge and
+passes that same-run artifact to the stable `UX Route Budget Sweep` check. The
+one-day artifact contains a
 versioned receipt and a compressed payload. The receipt binds the payload to:
 
 - repository, commit SHA, and immutable Git tree SHA;
@@ -201,10 +203,10 @@ versioned receipt and a compressed payload. The receipt binds the payload to:
 - payload byte count and SHA-256 checksum; and
 - the successful production-build command plus creation/expiry times.
 
-The UX workflow finds only a `CI` run with the same event and Actions run-head
-identity (the PR head SHA for pull requests; `GITHUB_SHA` otherwise). The
-receipt separately binds the synthetic merge checkout and its immutable tree.
-After download, `scripts/ci-build-artifact.mjs consume` independently recomputes
+The UX runtime downloads only the artifact named for its current Actions run
+and attempt. It does not search other workflow runs or poll the Actions API.
+The receipt separately binds the synthetic merge checkout and its immutable
+tree. After download, `scripts/ci-build-artifact.mjs consume` independently recomputes
 the current tree, toolchain, payload checksum, byte count, archive inventory,
 and expiry before replacing `apps/web/.next`. The archive must contain only the
 `.next` root and must include the standalone runtime's `BUILD_ID` and canonical
@@ -213,30 +215,25 @@ assets to the standalone layout, then starts the same `apps/web/server.js`
 entry point used by the production container. Development-only server output
 and source maps are not transported.
 
-This follows GitHub's cross-run artifact contract: a consumer supplies both a
-token and source run identifier, and the token has only `actions: read` plus
-`contents: read`. See [Store and share data with workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data)
-and [REST API endpoints for GitHub Actions artifacts](https://docs.github.com/en/rest/actions/artifacts).
+This follows GitHub's same-run artifact contract: the producer uploads a named
+workflow artifact and a dependent job downloads it in the same run. The
+workflow retains only `actions: read` plus `contents: read`. See
+[Store and share data with workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data).
 
-Reuse is an optimization, never an exemption. Discovery is bounded to ten
-minutes, but that deadline only bounds a producer that is still queued or
-running. Once at least one matching producer exists and every one of them is
-terminal without a usable artifact, discovery stops immediately and the local
-build starts: no later poll can surface evidence that a finished run never
-published. This matters most on `heavy=false` pull requests, where `Production
-Build` is skipped by design and no artifact can ever appear. A run status the
-locator does not recognise counts as still active, so uncertainty preserves
-bounded polling rather than abandoning reuse early. Missing, late, expired,
+Reuse is an optimization, never an exemption. On `heavy=false` changes, or
+when packaging/upload does not produce a usable artifact, the reusable runtime
+starts the normal local production build immediately. Missing, expired,
 incomplete, corrupt, or identity-mismatched
 evidence removes any partial `.next` output and runs the normal local production
 build. Packaging or upload failure is also non-authoritative: `Production Build`
-retains its successful result and UX rebuilds locally. Main-branch pushes and
-manual baseline calibration always build locally;
-cross-lifecycle merge-group-to-push reuse remains owned by `BI-9585E580`.
+retains its successful result and UX rebuilds locally. Manual baseline
+calibration invokes the reusable workflow directly and always builds locally.
+The retained cross-run locator is not used by the blocking PR, merge-group, or
+push path; cross-lifecycle merge-group-to-push reuse remains owned by
+`BI-9585E580`.
 
 The CI and UX job summaries report payload bytes and packaging or
-download/validation/extraction duration, and the locate step emits a
-`discovery_ms` output on every outcome. Compare those transfer measurements
+download/validation/extraction duration. Compare those transfer measurements
 with the avoided UX build duration before retaining or tuning the artifact.
 
 ## UX route-sweep stability

--- a/docs/testing/pr-health.md
+++ b/docs/testing/pr-health.md
@@ -35,11 +35,14 @@ Branch protection uses the smaller, versioned contract in
 [`config/merge-readiness-policy.json`](../../config/merge-readiness-policy.json):
 
 - **Merge Readiness** aggregates every job in `.github/workflows/ci.yml`;
-- **UX Route Budget Sweep** owns the separate browser/Postgres runtime; and
+- **UX Route Budget Sweep** is the stable aggregate for the reusable
+  browser/Postgres runtime called by CI; and
 - **DCO** proves commit sign-off.
 
-Both repository workflows run for `pull_request` and `merge_group`. The repo guard fails if a CI job
-is not included in the aggregate or either workflow loses merge-group coverage. Use
+CI runs for `pull_request` and `merge_group`, while the UX implementation is a
+reusable workflow that CI calls after its exact-tree production build. The repo
+guard fails if a CI job is not included in the aggregate, CI loses merge-group
+coverage, or the UX workflow loses its callable contract. Use
 `pnpm merge-policy:check` for local conformance and `pnpm merge-policy:audit` to compare the
 manifest with live `main` protection. `pnpm merge-policy:apply` changes only required status
 checks; use it after new contexts have proven green on `main`, never before.

--- a/scripts/check-no-merge-readiness-policy-drift.test.mjs
+++ b/scripts/check-no-merge-readiness-policy-drift.test.mjs
@@ -8,12 +8,31 @@ test("guard rejects a workflow that loses merge-group coverage", () => {
     workflows: { ci: "ci.yml", ux: "ux.yml" },
     aggregateJobId: "merge-readiness",
     aggregateJobName: "Merge Readiness",
-    uxJobId: "sweep",
+    uxJobId: "ux-route-sweep",
     uxJobName: "UX Route Budget Sweep",
+    uxRuntimeJobId: "sweep",
+    uxRuntimeJobName: "UX Route Sweep Runtime",
   };
-  const ci = `on:\n  pull_request:\njobs:\n  build:\n  merge-readiness:\n    name: Merge Readiness\n    needs:\n      - build\n`;
-  const ux = `on:\n  merge_group:\njobs:\n  sweep:\n    name: UX Route Budget Sweep\n`;
+  const ci = `on:\n  pull_request:\njobs:\n  build:\n  ux-route-sweep:\n    name: UX Route Budget Sweep\n  merge-readiness:\n    name: Merge Readiness\n    needs:\n      - build\n      - ux-route-sweep\n`;
+  const ux = `on:\n  workflow_call:\njobs:\n  sweep:\n    name: UX Route Sweep Runtime\n`;
   assert.deepEqual(validateWorkflowConformance({ manifest, ciSource: ci, uxSource: ux }), [
     "ci.yml must handle merge_group",
+  ]);
+});
+
+test("guard requires the UX implementation to remain reusable", () => {
+  const manifest = {
+    workflows: { ci: "ci.yml", ux: "ux.yml" },
+    aggregateJobId: "merge-readiness",
+    aggregateJobName: "Merge Readiness",
+    uxJobId: "ux-route-sweep",
+    uxJobName: "UX Route Budget Sweep",
+    uxRuntimeJobId: "sweep",
+    uxRuntimeJobName: "UX Route Sweep Runtime",
+  };
+  const ci = `on:\n  merge_group:\njobs:\n  ux-route-sweep:\n    name: UX Route Budget Sweep\n  merge-readiness:\n    name: Merge Readiness\n    needs:\n      - ux-route-sweep\n`;
+  const ux = `on:\n  workflow_dispatch:\njobs:\n  sweep:\n    name: UX Route Sweep Runtime\n`;
+  assert.deepEqual(validateWorkflowConformance({ manifest, ciSource: ci, uxSource: ux }), [
+    "ux.yml must handle workflow_call",
   ]);
 });

--- a/scripts/ci-build-artifact-workflow.test.mjs
+++ b/scripts/ci-build-artifact-workflow.test.mjs
@@ -17,20 +17,48 @@ describe("production-build artifact workflow wiring", () => {
     assert.match(ci, /steps\.package-build\.outcome == 'success'/);
   });
 
-  it("reuses only PR and merge-group artifacts and retains a fail-safe build", () => {
-    assert.match(ux, /github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group'/);
-    assert.match(ux, /node scripts\/ci-build-artifact\.mjs locate/);
-    assert.match(ux, /DPF_CI_RUN_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
-    assert.match(ux, /--wait-seconds 600/);
+  it("hands PR and merge-group builds to UX through a same-run dependency", () => {
+    assert.match(ci, /ux-route-sweep-runtime:[\s\S]*?needs: \[changes, build\]/);
+    assert.match(ci, /uses: \.\/\.github\/workflows\/ux-route-sweep\.yml/);
+    assert.match(
+      ci,
+      /reuse_current_run_build: \$\{\{ needs\.changes\.outputs\.heavy == 'true' \}\}/,
+    );
+    assert.match(ux, /workflow_call:/);
+    assert.doesNotMatch(ux, /^\s{2}pull_request:/m);
+    assert.doesNotMatch(ux, /^\s{2}merge_group:/m);
+    assert.doesNotMatch(ux, /node scripts\/ci-build-artifact\.mjs locate/);
+    assert.doesNotMatch(ux, /--wait-seconds 600/);
     assert.match(ux, /uses: actions\/download-artifact@v8/);
+    assert.match(
+      ux,
+      /name: web-production-build-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
+    );
+    assert.doesNotMatch(ux, /github-token:/);
+    assert.doesNotMatch(ux, /run-id:/);
     assert.match(ux, /node scripts\/ci-build-artifact\.mjs consume/);
+    assert.match(ux, /--source-run-id "\$\{\{ github\.run_id \}\}"/);
     assert.match(ux, /if: steps\.materialize-build\.outputs\.reused != 'true'/);
     assert.match(ux, /run: pnpm --filter web build/);
     assert.match(ux, /DPF_REUSED_BUILD: \$\{\{ steps\.materialize-build\.outputs\.reused \}\}/);
     assert.match(ux, /cd apps\/web\/\.next\/standalone[\s\S]*?node apps\/web\/server\.js/);
   });
 
+  it("preserves the stable required check and manual calibration path", () => {
+    assert.match(
+      ci,
+      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep\s*\n\s+runs-on: ubuntu-latest\s*\n\s+if: always\(\)\s*\n\s+needs: ux-route-sweep-runtime/,
+    );
+    assert.match(ci, /needs\.ux-route-sweep-runtime\.result/);
+    assert.match(ci, /merge_group:/);
+    assert.match(ux, /workflow_dispatch:/);
+    assert.doesNotMatch(ux, /^\s{2}push:/m);
+    assert.match(ux, /update_baseline:/);
+    assert.match(ux, /--update-baseline/);
+  });
+
   it("grants only read access to workflow artifacts", () => {
+    assert.match(ci, /permissions:[\s\S]*?actions: read[\s\S]*?contents: read/);
     assert.match(ux, /permissions:[\s\S]*?actions: read[\s\S]*?contents: read/);
     assert.doesNotMatch(ux, /actions: write/);
   });

--- a/scripts/merge-readiness-policy.mjs
+++ b/scripts/merge-readiness-policy.mjs
@@ -33,6 +33,11 @@ export function workflowHasMergeGroup(source) {
   return beforeJobs.some((line) => /^  merge_group:\s*(?:\{\})?$/.test(line));
 }
 
+export function workflowIsCallable(source) {
+  const beforeJobs = source.split(/\r?\n/).slice(0, source.split(/\r?\n/).findIndex((line) => line === "jobs:"));
+  return beforeJobs.some((line) => /^  workflow_call:\s*(?:\{\})?$/.test(line));
+}
+
 export function parseAggregate(source, aggregateJobId) {
   const lines = source.split(/\r?\n/);
   const start = lines.findIndex((line) => line === `  ${aggregateJobId}:`);
@@ -56,7 +61,7 @@ export function parseAggregate(source, aggregateJobId) {
 export function validateWorkflowConformance({ manifest, ciSource, uxSource }) {
   const errors = [];
   if (!workflowHasMergeGroup(ciSource)) errors.push(`${manifest.workflows.ci} must handle merge_group`);
-  if (!workflowHasMergeGroup(uxSource)) errors.push(`${manifest.workflows.ux} must handle merge_group`);
+  if (!workflowIsCallable(uxSource)) errors.push(`${manifest.workflows.ux} must handle workflow_call`);
 
   const jobs = parseWorkflowJobIds(ciSource);
   const aggregate = parseAggregate(ciSource, manifest.aggregateJobId);
@@ -67,11 +72,17 @@ export function validateWorkflowConformance({ manifest, ciSource, uxSource }) {
   if (aggregate.name !== manifest.aggregateJobName) {
     errors.push(`aggregate name must be ${manifest.aggregateJobName}`);
   }
-  const uxJob = parseAggregate(uxSource, manifest.uxJobId);
+  const uxJob = parseAggregate(ciSource, manifest.uxJobId);
   if (!uxJob) {
     errors.push(`missing UX job ${manifest.uxJobId}`);
   } else if (uxJob.name !== manifest.uxJobName) {
     errors.push(`UX job name must be ${manifest.uxJobName}`);
+  }
+  const uxRuntimeJob = parseAggregate(uxSource, manifest.uxRuntimeJobId);
+  if (!uxRuntimeJob) {
+    errors.push(`missing UX runtime job ${manifest.uxRuntimeJobId}`);
+  } else if (uxRuntimeJob.name !== manifest.uxRuntimeJobName) {
+    errors.push(`UX runtime job name must be ${manifest.uxRuntimeJobName}`);
   }
   const expected = jobs.filter((jobId) => jobId !== manifest.aggregateJobId).sort();
   const actual = [...aggregate.needs].sort();


### PR DESCRIPTION
## Summary
- make CI own the blocking UX route sweep while preserving concurrent Production Build, fixture provisioning, and browser setup
- replace cross-workflow event/SHA/source-run discovery with a one-second rendezvous against the exact artifact name in the current Actions run
- stop promptly when the known producer is terminal without evidence; preserve exact-tree receipt verification, immediate local-build fallback, manual calibration, and every route assertion

## Backlog
- BI-D9E8B8CB
- Work Capsule WC-2D899C4C

## Measured design correction
- prior #3726 PR UX run 30443177209: route crawl started 7m06s after workflow start; the old cross-workflow locator overlapped fixture setup with Production Build
- first #3729 experiment: direct `needs: build` removed the visible poll but serialized setup, so crawl started 7m58s after workflow start (52s slower); the PR was closed rather than queueing a timing regression
- corrected topology starts setup with `needs: changes`, moves Chromium installation ahead of the rendezvous, and queries only `github.run_id` plus the exact current-run artifact name

## Verification
- governed exact-SHA local integration passed for `292151fdf2857977ebc28ebdf7a90b24ad604ef1` on current base `1ba332f92343aaf8544f529234087aec88ca4b9c`
- freshness green; migrations, documentation, and policy guards passed
- exhaustive Vitest and TypeScript passed
- production Docker build passed: `sha256:7f0c0ef5fc7a11b282d6758e3df84e5cb1f178117cf85d1cf3503bd298176708`
- focused artifact/workflow/policy contracts: 13/13 passed; both workflows parse successfully

UX verification: CI topology only; product routes, baselines, tolerances, exclusions, semantic projections, word budgets, and WCAG assertions are unchanged. PR-head and merge-group sweeps must prove both unchanged coverage and non-regressed crawl-start timing before queue/merge.

Documentation updated with the measured rejected design, current-run rendezvous, overlap invariant, fallback behavior, and manual calibration path.

Local-CI-Evidence: cms64l4uh08zh01msoaiurlly (refactor/ci-ux-same-run-build-handoff@292151fdf2857977ebc28ebdf7a90b24ad604ef1)