### PR TITLE
feat(ci): run guard parity preflight before pregate lease admission (BI-D35433FB)

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -165,6 +165,22 @@ From a worktree, the gate is:
 pnpm run pregate            # → node scripts/pregate.mjs
 ```
 
+**Guard parity preflight (BI-D35433FB).** Before the gate claims a
+`local-integration-ci` lease, `pregate.mjs` runs the deterministic CI policy
+guards host-natively — the same check commands CI's Policy Guards jobs run
+(module size, style drift, derived-artifact staleness, doc links, SBOM, plus
+the commit-range-driven UX-Fit and Design Grounding trailer gates), with guard
+self-tests stripped and PR-body-dependent gates (Seed-Fit, Decision Baseline)
+left to CI. A violation aborts in well under a minute **before any lease is
+claimed**, so a doomed run never occupies the contended sandbox slot. A guard
+this host cannot execute (missing isolated runtime) is reported as
+`environment-skipped` with its remedy — a warning, never a false red; CI
+remains the enforcer. Run it standalone with `pnpm run pregate:preflight`
+(`--plan` prints the guard plan without running it). Emergency skip:
+`DPF_SKIP_PREGATE_PREFLIGHT_REASON="<why>"` — printed on the gate run, and CI
+still enforces every guard. Routing probes (`--dry-run`) and evidence replays
+(`--finalize-evidence`) skip the preflight automatically.
+
 **Host-native/Node-first entry point (BI-2272D840, BI-52500C0D, BI-4BE30454).** `pregate.mjs`
 detects whether native `sh` actually works against *this* worktree — not just
 "sh is on PATH", but that it can resolve the worktree's own git state

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:prod-runtime": "docker compose up -d portal",
     "dev:sandbox": "docker compose up -d sandbox",
     "pregate": "node scripts/pregate.mjs",
+    "pregate:preflight": "node scripts/pregate-preflight.mjs",
     "build": "pnpm --filter web build",
     "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",
     "test:e2e": "playwright test",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -56,6 +56,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/ci-build-artifact.test.mjs",
         "scripts/lib/ci-evidence-plan.test.mjs",
         "scripts/ci-policy-guards.test.mjs",
+        "scripts/pregate-preflight.test.mjs",
       ),
     ]),
     guard("mobile-jest-pin-guard", "Mobile Jest Pin Guard", [

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -1,0 +1,141 @@
+// scripts/lib/pregate-preflight.mjs — host-side guard parity preflight
+// (BI-D35433FB, EP-0DFF753B).
+//
+// THE PROBLEM: the local pregate runs the full test suite, typecheck, and a
+// production build inside the leased local-integration-ci sandbox (30–60+ min),
+// but never runs the deterministic CI policy guards — module size, prose/style
+// ratchets, derived-artifact staleness, commit-trailer attestations. A 52h CI
+// failure taxonomy (2026-07-27 → 07-29) counted ~90 failed jobs in exactly that
+// class: author-fixable in seconds, discoverable only by pushing, each one
+// costing a full CI round trip and usually a lease-holding pregate first.
+//
+// THE FIX: run those same guard scripts host-native BEFORE lease admission, so
+// a doomed gate never occupies a contended sandbox slot. The preflight reuses
+// POLICY_GUARD_PROFILES verbatim — same scripts CI runs — with two deliberate
+// reductions:
+//
+//   1. Guard SELF-TESTS (`node --test …`) are stripped. They prove the guard's
+//      own logic and belong to CI's Policy Guards jobs; the preflight only
+//      needs the tree checked, and several self-tests require the isolated
+//      @dpf/repo-guard-runtime install that a source-only worktree lacks.
+//   2. Only commit-range-driven pull-request gates are included (UX-Fit,
+//      Design Grounding). Gates that read the PR body (Seed-Fit) or mutate the
+//      tree (Decision Baseline merges origin/main) cannot run honestly on a
+//      host worktree and stay CI-only.
+//
+// DEGRADATION CONTRACT: a guard that exits non-zero because the ENVIRONMENT
+// cannot run it (missing module, missing isolated pnpm graph) is reported as
+// `skipped_environment` with the guard's own remedy line — never a hard fail
+// and never silently green. CI remains the enforcer; the preflight is an
+// honest early warning, so a false local failure would erode trust faster
+// than a missed one.
+
+import { spawnSync } from "node:child_process";
+
+import { POLICY_GUARD_PROFILES, runPolicyProfile } from "./ci-policy-guards.mjs";
+
+export const PREFLIGHT_SKIP_ENV = "DPF_SKIP_PREGATE_PREFLIGHT_REASON";
+
+// Pull-request-profile gates that are commit-range-driven and therefore give a
+// truthful answer on a host worktree without PR context. Everything else in
+// that profile is excluded on purpose:
+//   - seed-fit-gate reads the PR body, which does not exist before push;
+//   - docs-impact-gate / data-impact-gate / spec-plan-doc-gate carry heavier
+//     self-test dependencies and are candidates for a later slice once their
+//     host-side behavior is proven;
+//   - decision-baseline MERGES origin/main into the branch — a tree mutation
+//     the preflight must never perform.
+export const LOCAL_SAFE_PR_GUARD_IDS = Object.freeze([
+  "ux-fit-gate",
+  "design-grounding-gate",
+]);
+
+// Exit-output signatures that mean "this host cannot run the guard", not
+// "the tree violates the guard". Kept narrow: each entry is a message Node or
+// the guard runtime itself emits for a missing execution substrate.
+export const ENVIRONMENT_FAILURE_RE =
+  /ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module|resolved outside its isolated pnpm graph/;
+
+function stripSelfTests(entries) {
+  return entries
+    .map((entry) => ({
+      ...entry,
+      commands: entry.commands.filter(
+        ([command, args]) => !(command === "node" && args[0] === "--test"),
+      ),
+    }))
+    .filter((entry) => entry.commands.length > 0);
+}
+
+export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES } = {}) {
+  const source = stripSelfTests(profiles.source);
+  const trailer = stripSelfTests(
+    profiles["pull-request"].filter((entry) =>
+      LOCAL_SAFE_PR_GUARD_IDS.includes(entry.id),
+    ),
+  );
+  return [...source, ...trailer];
+}
+
+function defaultExecute(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: "utf8",
+    shell: false,
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  if (result.status !== 0) process.stderr.write(output);
+  return { exitCode: result.status ?? 1, output };
+}
+
+/**
+ * Runs the preflight plan. Unlike runPolicyProfile, the executor returns
+ * `{ exitCode, output }` so a non-zero exit whose output matches
+ * ENVIRONMENT_FAILURE_RE can be reclassified as `skipped_environment` instead
+ * of `failed`. `ok` is false only for genuine guard failures.
+ */
+export async function runPreflight({
+  plan = buildPreflightPlan(),
+  execute = defaultExecute,
+  logger = () => {},
+  now = () => Date.now(),
+  env = process.env,
+} = {}) {
+  const skipReason = env[PREFLIGHT_SKIP_ENV];
+  if (skipReason) {
+    return { ok: true, skipped: true, skipReason, entries: [] };
+  }
+
+  const wrapped = new Map();
+  const result = await runPolicyProfile({
+    entries: plan,
+    execute: (command, args) => {
+      const { exitCode, output } = execute(command, args);
+      if (exitCode !== 0) {
+        wrapped.set(
+          [command, ...args].join(" "),
+          ENVIRONMENT_FAILURE_RE.test(output) ? "environment" : "violation",
+        );
+      }
+      return exitCode;
+    },
+    logger,
+    now,
+  });
+
+  const entries = result.entries.map((entry) => {
+    if (entry.status !== "failed") return entry;
+    const kind = wrapped.get(entry.failedCommand);
+    return kind === "environment"
+      ? { ...entry, status: "skipped_environment" }
+      : entry;
+  });
+
+  return {
+    ok: entries.every((entry) => entry.status !== "failed"),
+    skipped: false,
+    skipReason: null,
+    entries,
+  };
+}

--- a/scripts/pregate-preflight.mjs
+++ b/scripts/pregate-preflight.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// scripts/pregate-preflight.mjs — CLI for the host-side guard parity preflight
+// (BI-D35433FB). Run standalone (`pnpm run pregate:preflight`) or let
+// scripts/pregate.mjs invoke it automatically before lease admission.
+//
+//   node scripts/pregate-preflight.mjs           # run the preflight
+//   node scripts/pregate-preflight.mjs --plan    # print the plan as JSON
+//
+// Exit codes: 0 = clean (environment-skipped guards are warnings), 1 = at
+// least one guard reported a genuine violation.
+
+import { fileURLToPath } from "node:url";
+
+import {
+  PREFLIGHT_SKIP_ENV,
+  buildPreflightPlan,
+  runPreflight,
+} from "./lib/pregate-preflight.mjs";
+
+export async function main() {
+  if (process.argv.includes("--plan")) {
+    const plan = buildPreflightPlan().map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      commands: entry.commands.map(([command, args]) => [command, ...args].join(" ")),
+    }));
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  const startedAt = Date.now();
+  const result = await runPreflight({
+    // Failure lines are printed from the FINAL classified entries below —
+    // an env-degraded guard transiently looks "failed" at finish-time and
+    // must not be announced as a failure here.
+    logger(event) {
+      if (event.type === "start") {
+        process.stdout.write(`[pregate-preflight] ${event.entry.name}…\n`);
+      }
+    },
+  });
+
+  if (result.skipped) {
+    process.stdout.write(
+      `[pregate-preflight] SKIPPED — ${PREFLIGHT_SKIP_ENV}=${result.skipReason}\n`,
+    );
+    return;
+  }
+
+  const failed = result.entries.filter((entry) => entry.status === "failed");
+  const environmentSkipped = result.entries.filter(
+    (entry) => entry.status === "skipped_environment",
+  );
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  for (const entry of environmentSkipped) {
+    process.stderr.write(
+      `[pregate-preflight] WARN ${entry.name} could not run on this host (missing runtime) — CI will still enforce it. Remedy: pnpm install --frozen-lockfile --ignore-scripts --filter @dpf/repo-guard-runtime\n`,
+    );
+  }
+
+  if (failed.length > 0) {
+    process.stderr.write(
+      `[pregate-preflight] ${failed.length} guard(s) FAILED in ${elapsed}s — these are deterministic CI failures; fix them before the sandbox gate runs:\n`,
+    );
+    for (const entry of failed) {
+      process.stderr.write(`  - ${entry.name}: ${entry.failedCommand}\n`);
+    }
+    process.stderr.write(
+      `[pregate-preflight] emergency skip (recorded honesty, CI still enforces): set ${PREFLIGHT_SKIP_ENV}="<why>"\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `[pregate-preflight] OK — ${result.entries.length} guards clean in ${elapsed}s` +
+      (environmentSkipped.length > 0
+        ? ` (${environmentSkipped.length} environment-skipped, see warnings)`
+        : "") +
+      "\n",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -1,0 +1,184 @@
+// Tests for the host-side guard parity preflight (BI-D35433FB).
+//
+// The preflight's trust contract has two halves and both are load-bearing:
+// it must fail on a genuine deterministic guard violation BEFORE any lease is
+// claimed, and it must NOT fail on a host that merely cannot run a guard
+// (missing isolated runtime) — a false local red would teach contributors to
+// skip it, recreating the push-to-discover loop it exists to close.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  ENVIRONMENT_FAILURE_RE,
+  LOCAL_SAFE_PR_GUARD_IDS,
+  PREFLIGHT_SKIP_ENV,
+  buildPreflightPlan,
+  runPreflight,
+} from "./lib/pregate-preflight.mjs";
+import { shouldRunPreflight } from "./pregate.mjs";
+
+const repoRoot = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const preflightCli = join(repoRoot, "scripts", "pregate-preflight.mjs");
+const pregateCli = join(repoRoot, "scripts", "pregate.mjs");
+
+// ── plan construction ───────────────────────────────────────────────────────
+
+test("buildPreflightPlan strips guard self-tests but keeps every check command", () => {
+  const profiles = {
+    source: [
+      {
+        id: "g1",
+        legacyJobId: "g1",
+        name: "Guard One",
+        commands: [
+          ["node", ["--test", "scripts/g1.test.mjs"]],
+          ["node", ["scripts/g1.mjs"]],
+        ],
+      },
+      {
+        id: "tests-only",
+        legacyJobId: "tests-only",
+        name: "Self-Tests Only",
+        commands: [["node", ["--test", "scripts/only.test.mjs"]]],
+      },
+    ],
+    "pull-request": [],
+  };
+  const plan = buildPreflightPlan({ profiles });
+  assert.deepEqual(plan.map((entry) => entry.id), ["g1"]);
+  assert.deepEqual(plan[0].commands, [["node", ["scripts/g1.mjs"]]]);
+});
+
+test("buildPreflightPlan includes only commit-range-safe pull-request gates", () => {
+  const plan = buildPreflightPlan();
+  const ids = new Set(plan.map((entry) => entry.id));
+  for (const id of LOCAL_SAFE_PR_GUARD_IDS) {
+    assert.ok(ids.has(id), `expected local-safe gate ${id} in the plan`);
+  }
+  // PR-body-dependent and tree-mutating gates must never run host-side.
+  assert.ok(!ids.has("seed-fit-gate"), "seed-fit-gate reads the PR body");
+  assert.ok(!ids.has("decision-baseline"), "decision-baseline merges origin/main");
+});
+
+test("buildPreflightPlan contains no --test invocations at all", () => {
+  for (const entry of buildPreflightPlan()) {
+    for (const [command, args] of entry.commands) {
+      assert.ok(
+        !(command === "node" && args[0] === "--test"),
+        `${entry.id} kept a self-test: ${args.join(" ")}`,
+      );
+    }
+  }
+});
+
+// ── run + classification ────────────────────────────────────────────────────
+
+const PLAN = [
+  {
+    id: "violating",
+    legacyJobId: "violating",
+    name: "Violating Guard",
+    commands: [["node", ["scripts/violating.mjs"]]],
+  },
+  {
+    id: "env-broken",
+    legacyJobId: "env-broken",
+    name: "Env-Broken Guard",
+    commands: [["node", ["scripts/env-broken.mjs"]]],
+  },
+  {
+    id: "clean",
+    legacyJobId: "clean",
+    name: "Clean Guard",
+    commands: [["node", ["scripts/clean.mjs"]]],
+  },
+];
+
+function fakeExecute(command, args) {
+  const script = args[args.length - 1];
+  if (script.includes("violating")) return { exitCode: 1, output: "module exceeds ratchet baseline" };
+  if (script.includes("env-broken")) {
+    return {
+      exitCode: 1,
+      output: "Error: Repo guard TypeScript resolved outside its isolated pnpm graph: …",
+    };
+  }
+  return { exitCode: 0, output: "" };
+}
+
+test("runPreflight fails on a genuine guard violation", async () => {
+  const result = await runPreflight({ plan: PLAN, execute: fakeExecute, env: {} });
+  assert.equal(result.ok, false);
+  const byId = Object.fromEntries(result.entries.map((entry) => [entry.id, entry.status]));
+  assert.equal(byId.violating, "failed");
+  assert.equal(byId.clean, "passed");
+});
+
+test("runPreflight reclassifies environment failures as skipped_environment, not failed", async () => {
+  const result = await runPreflight({
+    plan: PLAN.filter((entry) => entry.id !== "violating"),
+    execute: fakeExecute,
+    env: {},
+  });
+  assert.equal(result.ok, true, "an unrunnable guard must not hard-fail the preflight");
+  const envEntry = result.entries.find((entry) => entry.id === "env-broken");
+  assert.equal(envEntry.status, "skipped_environment");
+});
+
+test("runPreflight honors the recorded emergency skip", async () => {
+  const result = await runPreflight({
+    plan: PLAN,
+    execute: () => {
+      throw new Error("must not execute anything when skipped");
+    },
+    env: { [PREFLIGHT_SKIP_ENV]: "hotfix: guard outage BI-XXXX" },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.skipReason, "hotfix: guard outage BI-XXXX");
+});
+
+test("ENVIRONMENT_FAILURE_RE matches runtime-absence signatures, not guard verdicts", () => {
+  assert.ok(ENVIRONMENT_FAILURE_RE.test("Error [ERR_MODULE_NOT_FOUND]: Cannot find package"));
+  assert.ok(ENVIRONMENT_FAILURE_RE.test("TypeScript resolved outside its isolated pnpm graph"));
+  assert.ok(!ENVIRONMENT_FAILURE_RE.test("module exceeds ratchet baseline: 1050 > 1047 lines"));
+  assert.ok(!ENVIRONMENT_FAILURE_RE.test("Missing UX-Fit-Decision trailer"));
+});
+
+// ── pregate wiring ──────────────────────────────────────────────────────────
+
+test("shouldRunPreflight: on for real gate runs, off for probes, replays, and recorded skips", () => {
+  assert.equal(shouldRunPreflight(["--branch", "feat/x"], {}), true);
+  assert.equal(shouldRunPreflight(["--dry-run", "--branch", "feat/x"], {}), false);
+  assert.equal(shouldRunPreflight(["--finalize-evidence", "--branch", "feat/x"], {}), false);
+  assert.equal(
+    shouldRunPreflight(["--branch", "feat/x"], { DPF_SKIP_PREGATE_PREFLIGHT_REASON: "why" }),
+    false,
+  );
+});
+
+test("pregate-preflight.mjs --plan emits the JSON plan without running guards", () => {
+  const result = spawnSync(process.execPath, [preflightCli, "--plan"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const plan = JSON.parse(result.stdout);
+  assert.ok(plan.length > 0);
+  assert.ok(plan.some((entry) => entry.id === "module-size-guard"));
+  assert.ok(plan.every((entry) => entry.commands.every((c) => !c.startsWith("node --test"))));
+});
+
+test("pregate.mjs --dry-run skips the preflight and still reaches gate routing", () => {
+  const result = spawnSync(
+    process.execPath,
+    [pregateCli, "--dry-run", "--branch", "feat/x", "--worktree", repoRoot],
+    { encoding: "utf8", env: { ...process.env, DPF_PREGATE_FORCE_NODE: "1" } },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /pregate-preflight/);
+  assert.match(result.stdout, /gate-worktree dry-run/);
+});

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -28,6 +28,17 @@ import { fileURLToPath } from "node:url";
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 
+// Host-side guard parity preflight (BI-D35433FB): run the deterministic CI
+// policy guards before lease admission so a doomed gate never occupies a
+// contended local-integration-ci sandbox slot. Routing probes (--dry-run) and
+// evidence replays (--finalize-evidence) change nothing about the tree and
+// skip it; DPF_SKIP_PREGATE_PREFLIGHT_REASON is the recorded emergency skip.
+export function shouldRunPreflight(args, env = process.env) {
+  if (args.includes("--dry-run") || args.includes("--finalize-evidence")) return false;
+  if (env.DPF_SKIP_PREGATE_PREFLIGHT_REASON) return false;
+  return true;
+}
+
 export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnSync } = {}) {
   if (process.env.DPF_PREGATE_FORCE_NODE === "1") return false;
   if (process.env.DPF_PREGATE_FORCE_SH === "1") return true;
@@ -41,6 +52,25 @@ export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnS
 
 function main() {
   const args = process.argv.slice(2);
+
+  if (shouldRunPreflight(args)) {
+    const preflight = spawnSync(
+      process.execPath,
+      [join(SCRIPT_DIR, "pregate-preflight.mjs")],
+      { stdio: "inherit" },
+    );
+    if (preflight.error || (preflight.status ?? 1) !== 0) {
+      process.stderr.write(
+        "pregate: guard parity preflight failed — fix the deterministic guard failures above before the sandbox gate runs (no lease was claimed).\n",
+      );
+      process.exit(preflight.status ?? 1);
+    }
+  } else if (process.env.DPF_SKIP_PREGATE_PREFLIGHT_REASON) {
+    process.stderr.write(
+      `pregate: guard parity preflight SKIPPED — DPF_SKIP_PREGATE_PREFLIGHT_REASON=${process.env.DPF_SKIP_PREGATE_PREFLIGHT_REASON}\n`,
+    );
+  }
+
   const shWorks = detectWorkingShell();
 
   let result;


### PR DESCRIPTION
## What

`pnpm run pregate` now runs the deterministic CI policy guards host-natively BEFORE claiming the contended `local-integration-ci` lease, so a doomed gate fails in ~50 seconds instead of occupying a sandbox slot for 30–60 minutes and then failing in CI anyway.

## Why

A 52h CI failure taxonomy (2026-07-27 → 07-29, 359 failed jobs analyzed) counted **~90 failed jobs that were deterministic and author-fixable in seconds** — Policy Guards (source) 24, Prose Lint 22, Policy Guards (PR) 16, Design Grounding 13, Module Size 12 — yet discoverable only by pushing, because the local pregate runs the full suite/build but none of these guards. Meanwhile the `nonprod-local-integration-ci` queue shows p95 wait 25 min and 31% abandonment. Failing fast before admission removes both the wasted CI round trips and a slice of lease arrivals.

## How

- `scripts/lib/pregate-preflight.mjs` reuses `POLICY_GUARD_PROFILES` verbatim (single source of truth — no duplicated guard list), stripping guard self-tests and including only commit-range-driven PR gates (UX-Fit, Design Grounding). PR-body gates (Seed-Fit) and tree-mutating gates (Decision Baseline) stay CI-only.
- Honest degradation: a guard the host cannot execute (missing isolated runtime) reports `environment-skipped` with its remedy line — a warning, never a false red. CI remains the enforcer.
- `scripts/pregate-preflight.mjs` CLI (`pnpm run pregate:preflight`, `--plan`); wired in `scripts/pregate.mjs`; `--dry-run`/`--finalize-evidence` skip it; `DPF_SKIP_PREGATE_PREFLIGHT_REASON` is the recorded emergency skip.
- 10 new tests in `scripts/pregate-preflight.test.mjs`, registered in the Policy Guards source profile.

## Verification

- Functional green: clean tree → 27 guards clean + 1 environment-skipped, exit 0, 49s.
- Functional red: seeded module-size baseline violation → preflight exit 1 naming the guard; `pregate` aborts with **no lease claimed**; reverted.
- `node --test` on the new suite + `ci-policy-guards.test.mjs` + `pregate-node-gate-contract.test.mjs`: 33/33 pass.
- Full exact-tree `pnpm run pregate` (governed lease, full web vitest, typecheck, production Docker build): **gate passed** — and dogfooded the preflight as its first step.

Backlog: BI-D35433FB (EP-0DFF753B). Coordinated with the sandbox-pool pilot plan (`docs/superpowers/plans/2026-07-28-local-ci-sandbox-pool-pilot.md`) — reduces lease arrivals without touching BI-4BE30454's slot plumbing.

Seed-Fit-Decision: not-applicable — no seed, fixture, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)