### PR TITLE
feat(coworkers): apply the interactive tool-attachment budget to every autonomous run (BI-CAP-F2D39F8F)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -365,10 +365,14 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
     // Tools are resolved in "act" mode for propose so the model can still CALL
     // them; the loop's propose-interception captures the call as a proposal.
     const boundary = proactivity.actionBoundary;
-    const { tools, toolsForProvider } = await resolveAutonomousWorkTools({
+    const { tools, toolsForProvider, deferredTools } = await resolveAutonomousWorkTools({
       userContext,
       mode: boundary === "advise" ? "advise" : "act",
       agentId: task.agentId,
+      // BI-CAP-F2D39F8F: budget the attachment to the serving model; the task
+      // prompt ranks which tools stay attached, the rest load on demand.
+      routeContext: task.routeContext,
+      intentQuery: task.prompt,
     });
 
     // Mirror the interactive coworker path (agent-coworker.sendMessage): carry the
@@ -396,6 +400,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       sensitivity: agentInfo.sensitivity ?? "internal",
       tools,
       toolsForProvider,
+      deferredTools,
       userId: task.ownerUserId,
       routeContext: task.routeContext,
       agentId: task.agentId,

--- a/apps/web/lib/actions/agent-thread-dispatcher-runtime.ts
+++ b/apps/web/lib/actions/agent-thread-dispatcher-runtime.ts
@@ -247,10 +247,15 @@ export async function runChildThreadExecution(context: ChildRuntimeContext): Pro
         ? agentInfo.agentId
         : context.agentId;
 
-    const { tools, toolsForProvider } = await resolveAutonomousWorkTools({
+    const { tools, toolsForProvider, deferredTools } = await resolveAutonomousWorkTools({
       userContext,
       agentId: resolvedAgentId,
       mode: "act",
+      // BI-CAP-F2D39F8F: budget the attachment to the serving model; the child
+      // thread's latest user turn ranks which tools stay attached.
+      routeContext: context.routeContext,
+      intentQuery: [...chatHistory].reverse().find((m) => m.role === "user" && typeof m.content === "string")
+        ?.content as string | undefined,
     });
 
     // Grant preflight: if this agent holds no grant for a single tool it was
@@ -292,6 +297,7 @@ export async function runChildThreadExecution(context: ChildRuntimeContext): Pro
         sensitivity: agentInfo.sensitivity ?? "internal",
         tools,
         toolsForProvider,
+        deferredTools,
         userId: context.userId,
         routeContext: context.routeContext,
         agentId: resolvedAgentId,

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -219,6 +219,10 @@ export async function submitRemoteCoworkerTask(input: {
     agentId: resolvedAgentId,
     mode: toolMode,
     externalAccessEnabled: true,
+    // BI-CAP-F2D39F8F: budget the attachment to the serving model; the remote
+    // task prompt ranks which tools stay attached.
+    routeContext: parsed.routeContext,
+    intentQuery: parsed.prompt,
   });
 
   try {
@@ -228,6 +232,7 @@ export async function submitRemoteCoworkerTask(input: {
       sensitivity: agent.sensitivity ?? "internal",
       tools: tools.tools,
       toolsForProvider: tools.toolsForProvider,
+      deferredTools: tools.deferredTools,
       userId: token.userId,
       routeContext: parsed.routeContext,
       agentId: resolvedAgentId,

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -30,6 +30,93 @@ vi.mock("@/lib/tak/agent-routing-server", () => ({
   resolveAgentForRouteWithPrompts: vi.fn(),
   resolveAgentByIdWithPrompts: vi.fn(),
 }));
+// BI-CAP-F2D39F8F — the attachment budget's environment probes, mocked so the
+// budget path is deterministic in tests.
+vi.mock("@/lib/tak/agent-grants", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getAgentToolGrantsAsync: vi.fn(async () => []),
+}));
+vi.mock("@/lib/inference/local-model-context-reconcile", () => ({
+  resolveLocalServedContextTokens: vi.fn(async () => 24_576),
+}));
+vi.mock("@/lib/routing/local-tool-fidelity", () => ({
+  resolveLocalToolFidelityCeiling: vi.fn(async () => null),
+}));
+
+describe("resolveAutonomousWorkTools — attachment budget (BI-CAP-F2D39F8F)", () => {
+  const fakeTool = (name: string) => ({
+    name,
+    description: `${name} does ${name.replace(/_/g, " ")}`,
+    inputSchema: { type: "object", properties: {} },
+    requiredCapability: null,
+    sideEffect: false,
+    executionMode: "immediate",
+  });
+  const userContext = { userId: "user-1", platformRole: "admin", isSuperuser: true };
+
+  beforeEach(async () => {
+    const tools = await import("@/lib/mcp-tools");
+    vi.mocked(tools.getAvailableTools).mockReset();
+    vi.mocked(tools.toolsToOpenAIFormat).mockReset();
+    vi.mocked(tools.toolsToOpenAIFormat).mockImplementation((ts: unknown[]) => ts as never);
+  });
+
+  it("caps a 115-tool surface to the local selection cliff and defers the rest behind load_tools", async () => {
+    const tools = await import("@/lib/mcp-tools");
+    const surface = Array.from({ length: 115 }, (_, i) => fakeTool(`tool_${i}`));
+    vi.mocked(tools.getAvailableTools).mockResolvedValue(surface as never);
+
+    const { resolveAutonomousWorkTools } = await import("./autonomous-work-run");
+    const result = await resolveAutonomousWorkTools({
+      userContext,
+      agentId: "storefront-advisor",
+      mode: "act",
+      routeContext: "/storefront",
+      intentQuery: "Review today's storefront orders and propose restocking.",
+    });
+
+    // 24,576-token cliff-prone local window → 15-tool cap + load_tools rides on top.
+    expect(result.tools.length).toBeLessThanOrEqual(16);
+    expect(result.tools.some((t) => t.name === "load_tools")).toBe(true);
+    expect(result.deferredTools.length).toBe(115 - (result.tools.length - 1));
+    expect(result.toolsForProvider.length).toBe(result.tools.length);
+  });
+
+  it("attaches everything (no load_tools) when the surface already fits", async () => {
+    const tools = await import("@/lib/mcp-tools");
+    const surface = Array.from({ length: 8 }, (_, i) => fakeTool(`tool_${i}`));
+    vi.mocked(tools.getAvailableTools).mockResolvedValue(surface as never);
+
+    const { resolveAutonomousWorkTools } = await import("./autonomous-work-run");
+    const result = await resolveAutonomousWorkTools({
+      userContext,
+      agentId: "storefront-advisor",
+      mode: "act",
+    });
+
+    expect(result.tools.length).toBe(8);
+    expect(result.tools.some((t) => t.name === "load_tools")).toBe(false);
+    expect(result.deferredTools).toHaveLength(0);
+  });
+
+  it("fails open to the full surface when a budget probe throws", async () => {
+    const tools = await import("@/lib/mcp-tools");
+    const surface = Array.from({ length: 40 }, (_, i) => fakeTool(`tool_${i}`));
+    vi.mocked(tools.getAvailableTools).mockResolvedValue(surface as never);
+    const ctx = await import("@/lib/inference/local-model-context-reconcile");
+    vi.mocked(ctx.resolveLocalServedContextTokens).mockRejectedValueOnce(new Error("probe down"));
+
+    const { resolveAutonomousWorkTools } = await import("./autonomous-work-run");
+    const result = await resolveAutonomousWorkTools({
+      userContext,
+      agentId: "storefront-advisor",
+      mode: "act",
+    });
+
+    expect(result.tools).toHaveLength(40);
+    expect(result.deferredTools).toHaveLength(0);
+  });
+});
 
 describe("createAutonomousWorkRun", () => {
   beforeEach(async () => {

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -433,7 +433,11 @@ describe("createAutonomousWorkRun", () => {
       mode: "act",
     });
 
-    expect(resolved).toEqual({ tools: toolList, toolsForProvider: [{ type: "function" }] });
+    expect(resolved).toEqual({
+      tools: toolList,
+      toolsForProvider: [{ type: "function" }],
+      deferredTools: [],
+    });
     expect(mcpTools.getAvailableTools).toHaveBeenCalledWith(
       { userId: "user-1", platformRole: null, isSuperuser: true },
       { mode: "act", agentId: "inventory-specialist" },

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -191,22 +191,88 @@ export async function resolveAutonomousWorkTools(input: {
   mode?: "advise" | "act";
   externalAccessEnabled?: boolean;
   unifiedMode?: boolean;
+  /** Route the autonomous work runs under; its declared domain tools are
+   *  force-attached (tier 0), mirroring the interactive path (BI-B5C358B1). */
+  routeContext?: string;
+  /** The task objective/prompt. When present, tools are ranked by relevance to
+   *  it within each priority tier so the attachment cap keeps the tools this
+   *  run actually needs (BI-ACE1EBA4). */
+  intentQuery?: string;
 }): Promise<{
   tools: ToolDefinition[];
   toolsForProvider: Array<Record<string, unknown>>;
+  /** Authorized tools held back from the schema payload; still callable via the
+   *  load_tools meta-tool. Empty when no budget applied (fail-open). */
+  deferredTools: ToolDefinition[];
 }> {
   const { getAvailableTools, toolsToOpenAIFormat } = await import("@/lib/mcp-tools");
-  const tools = await getAvailableTools(input.userContext, {
+  const authorized = await getAvailableTools(input.userContext, {
     mode: input.mode,
     externalAccessEnabled: input.externalAccessEnabled,
     unifiedMode: input.unifiedMode,
     agentId: input.agentId,
   });
 
-  return {
-    tools,
-    toolsForProvider: toolsToOpenAIFormat(tools),
-  };
+  // BI-CAP-F2D39F8F: right-size the ATTACHMENT for autonomous runs with the
+  // SAME budget the interactive path uses (coworker-tool-budget). A scheduled
+  // coworker's grants expand to ~100+ tools (~30k+ tokens of schema), which can
+  // never fit a budget local model's served window — every scheduled tick then
+  // dies on admission/overflow (live repro: TR-SCHED-B7151A4C). Authority is
+  // untouched: deferred tools stay authorized and loadable via load_tools.
+  // Fail-open — any budget error falls back to the full authorized surface.
+  try {
+    const { selectCoworkerToolBudget, deriveCoworkerToolCap, LOAD_TOOLS_TOOL, LOAD_TOOLS_TOOL_NAME } =
+      await import("@/lib/actions/coworker-tool-budget");
+    const { getAgentToolGrantsAsync } = await import("@/lib/tak/agent-grants");
+    const { resolveLocalServedContextTokens } = await import(
+      "@/lib/inference/local-model-context-reconcile"
+    );
+    const { resolveLocalToolFidelityCeiling } = await import("@/lib/routing/local-tool-fidelity");
+
+    const [roleGrants, localServedContext, measuredToolFidelityCeiling] = await Promise.all([
+      getAgentToolGrantsAsync(input.agentId),
+      resolveLocalServedContextTokens(),
+      resolveLocalToolFidelityCeiling(),
+    ]);
+    const cap = deriveCoworkerToolCap(localServedContext, { measuredToolFidelityCeiling });
+
+    let routeDomainToolNames: string[] = [];
+    if (input.routeContext) {
+      const { resolveRouteContext } = await import("@/lib/tak/route-context-map");
+      routeDomainToolNames = resolveRouteContext(input.routeContext).domainTools ?? [];
+    }
+
+    const { attached, deferred } = selectCoworkerToolBudget({
+      tools: authorized,
+      roleGrants,
+      pageActionNames: new Set(routeDomainToolNames),
+      alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+      cap,
+      intentQuery: input.intentQuery,
+    });
+    const tools = deferred.length > 0 ? [LOAD_TOOLS_TOOL, ...attached] : attached;
+    if (deferred.length > 0) {
+      console.log(
+        `[autonomous-tool-budget] agent=${JSON.stringify(input.agentId)} authorized=${authorized.length} ` +
+          `attached=${tools.length} deferred=${deferred.length} cap=${cap}`,
+      );
+    }
+    return {
+      tools,
+      toolsForProvider: toolsToOpenAIFormat(tools),
+      deferredTools: deferred,
+    };
+  } catch (err) {
+    console.warn(
+      "[autonomous-tool-budget] budget failed (fail-open to full surface):",
+      err instanceof Error ? err.message : err,
+    );
+    return {
+      tools: authorized,
+      toolsForProvider: toolsToOpenAIFormat(authorized),
+      deferredTools: [],
+    };
+  }
 }
 
 export async function executeAutonomousAgenticLoop(input: {

--- a/docs/architecture/context-engineering-standards.md
+++ b/docs/architecture/context-engineering-standards.md
@@ -47,6 +47,7 @@ The criteria apply to future changes automatically, not by memory:
 2. **CI guard (P5).** `tool-description-hygiene.test.ts` fails the build if any tool's model-facing `description` carries `Phase N` / `(BI-…)` provenance or a leaked source path. (Input-schema property descriptions may still carry format examples like `e.g. BI-E4A86393`.)
 3. **Shift-left precheck (P5/P6).** `packages/dpf-skill-pack/hooks/tool-economy-precheck.mjs` fires (Claude/Codex/Grok) when `mcp-tools.ts`, the MCP route, the agentic loop, or the budget module is edited, re-asserting these criteria before CI.
 4. **Review tie-in.** `docs/architecture/agent-standards-dpf-conformance.md` carries a Context Economy control area so spec/architecture reviews check P1–P13.
+5. **Attachment budget on every model path.** The per-turn tool-attachment budget (`apps/web/lib/actions/coworker-tool-budget.ts` — window-fit + local selection-cliff cap, `load_tools` deferral) applies to interactive chat AND to every autonomous run: scheduled tasks, dispatcher child threads, and remote MCP task submission all budget through `resolveAutonomousWorkTools` (BI-CAP-F2D39F8F). A coworker whose grants expand past the cap keeps full authority; the long tail loads on demand.
 
 ## How to apply (quick checklist when changing a model-facing surface)
 


### PR DESCRIPTION
Closes BI-CAP-F2D39F8F. Also the last blocker from the 2026-07-29 restaurant-archetype exercise: scheduled coworker runs could never serve locally.

A scheduled coworker's grants expand to 100+ tools (~30k tokens of schema) — impossible to fit a budget local model's served window, so every scheduled tick died on admission timeout with an **idle** engine (live repro TR-SCHED-B7151A4C: `toolSurface=115 surfaceZone=overload`, 33 admission timeouts in 30 min), then fell to rate-limited cloud pools. Interactive chat already solved exactly this with the coworker-tool-budget (window-fit + local selection-cliff cap, `load_tools` deferral) — the autonomous paths simply never used it.

## What changed
- `resolveAutonomousWorkTools` — the single seam for scheduled tasks, dispatcher child threads, remote MCP task submission, and certification — now applies the same budget: role grants + route domain tools + intent-ranked relevance under `deriveCoworkerToolCap`, `load_tools` attached whenever anything was deferred, deferred pool threaded to `runAgenticLoop` (which already accepts it). Fail-open to the full surface on any probe error.
- Callers pass the task prompt as `intentQuery` so the cap keeps the tools the run actually needs (the restocking review keeps order/storefront tools, defers the code graph).
- Authority untouched: deferred tools stay authorized and loadable on demand.
- 3 new unit tests (115→cap+load_tools, small-surface no-op, fail-open) + updated resolution-shape assertion.

## Design grounding
Specs reviewed: docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md and docs/architecture/context-engineering-standards.md (~15-tool local ceiling; standards doc's enforcement list updated in this PR). Code substrate reviewed: apps/web/lib/actions/coworker-tool-budget.ts (operator decision 2026-06-22 'cap + load on demand'), apps/web/lib/actions/agent-coworker.ts (interactive precedent), apps/web/lib/tak/autonomous-work-run.ts, apps/web/lib/actions/agent-task-scheduler.ts. Decision: extend the existing budget contract to the autonomous seam — no new artifact.

## Verification
Local-CI pregate green at head SHA. Post-merge: the daily storefront restocking task (06:50 UTC) is the live acceptance — with this + #3720 it should finally execute on the local model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)