### PR TITLE
fix(ux-sweep): boot the sweep portal in measurement runtime (BI-232BA634)

### DIFF
--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -196,6 +196,11 @@ jobs:
       - name: Start the portal
         env:
           DPF_REUSED_BUILD: ${{ steps.materialize-build.outputs.reused }}
+          # Measurement-runtime boot (BI-232BA634): render-relevant boot syncs
+          # are awaited before the portal serves, and the fire-and-forget
+          # self-heal reconcilers/watchdogs that mutate operational state
+          # mid-crawl are disabled — same-tree sweeps measure the same portal.
+          DPF_MEASUREMENT_RUNTIME: "1"
         run: |
           if [ "$DPF_REUSED_BUILD" = "true" ]; then
             (cd apps/web/.next/standalone && PORT=3000 HOSTNAME=127.0.0.1 node apps/web/server.js) &

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -2,6 +2,7 @@
 // See: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
 
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
+import { isMeasurementRuntime, settleBootSync } from "@/lib/runtime/measurement-runtime";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { sweepOrphanedPromoterContainers } from "@/lib/self-upgrade/promoter-sweep";
 
@@ -980,6 +981,17 @@ export async function register() {
     // boot rather than waiting for a contribution to trip it.
     warnIfLegacyHiveTokenEnvSet();
 
+    // Measurement-runtime boot (BI-232BA634): the UX route sweep measures a
+    // frozen baseline against a live portal, so background boot writers are
+    // the nondeterminism. Under this flag, render-relevant syncs are awaited
+    // and operational self-heal maintenance is skipped entirely.
+    const measurementRuntime = isMeasurementRuntime();
+    if (measurementRuntime) {
+      console.log(
+        "[instrumentation] Measurement runtime: boot syncs awaited, background maintenance disabled (DPF_MEASUREMENT_RUNTIME)",
+      );
+    }
+
     // Plane-2 decision-routing gate (BI-B22DE548): register the server-side
     // governance hook so an in-portal coworker / Build Studio agent that takes a
     // consequential backlog decision (triage/retire) without consulting the
@@ -994,8 +1006,9 @@ export async function register() {
 
     // Mirror version.json into PlatformConfig["platform.version"] so the
     // DB-backed runtime metadata matches the canonical file. Non-fatal —
-    // logs loudly on failure but does not block startup.
-    void syncPlatformVersionOnBoot();
+    // logs loudly on failure but does not block startup (awaited under
+    // measurement runtime so routes render one consistent version).
+    await settleBootSync(measurementRuntime, syncPlatformVersionOnBoot);
 
     // DB-continuity guard (BI-B61779DB): detect a reverted/stale postgres volume
     // BEFORE any reconciler trusts the data. A monotonic epoch lives in BOTH the
@@ -1022,107 +1035,115 @@ export async function register() {
       }
     }
 
-    // Voice-service desired-state fail-loud (BI-264565A4): if narration is
-    // enabled but the TTS sidecar is down, log CRITICAL at boot — Prometheus
-    // can't scrape a /health-only sidecar, and this beats the VoiceServiceDown
-    // alert's scrape+2m delay. Non-fatal; detection only (self-heal is a
-    // separate follow-up).
-    void (async () => {
-      const { assertVoiceServiceOnBoot } = await import(
-        "@/lib/operate/voice-service-continuity"
+    // Operational self-heal maintenance (voice continuity, stuck-run
+    // reconciles, watchdog intervals, model-context re-assertion). Skipped
+    // wholesale under measurement runtime: an ephemeral sweep portal has no
+    // stuck state to heal, and these fire-and-forget writers racing the crawl
+    // are exactly the same-tree pass/fail nondeterminism BI-232BA634 removed.
+    if (!measurementRuntime) {
+      // Voice-service desired-state fail-loud (BI-264565A4): if narration is
+      // enabled but the TTS sidecar is down, log CRITICAL at boot — Prometheus
+      // can't scrape a /health-only sidecar, and this beats the VoiceServiceDown
+      // alert's scrape+2m delay. Non-fatal; detection only (self-heal is a
+      // separate follow-up).
+      void (async () => {
+        const { assertVoiceServiceOnBoot } = await import(
+          "@/lib/operate/voice-service-continuity"
+        );
+        await assertVoiceServiceOnBoot();
+      })();
+
+      // Self-heal a quiescence level left stuck by a swap that killed the
+      // coordinator mid-protocol — otherwise the portal refuses gated requests
+      // ("portal_quiescing") forever. Must run before reconciliation.
+      void resetStuckQuiescenceLevelOnBoot();
+
+      // Close the loop on any self-upgrade run whose orchestrator died mid-swap
+      // (a real upgrade recreates this very container). Records succeeded when we
+      // came up on the target SHA; fails orphans so triggers aren't blocked.
+      void reconcileSelfUpgradeRunsOnBoot();
+
+      // Periodic safety net — cron-independent (the boot reconcile above and the
+      // Inngest cron can BOTH miss this). If a swap's orchestrator dies while the
+      // portal stays UP (no reboot), the SelfUpgradeRun sits "running" forever and
+      // every future trigger silently no-ops (requestPortalSelfUpgradeAction). The
+      // June-10 run sat "running" for 4 days until a manual restart — this re-runs
+      // the reconcile in-process so a stuck run self-heals within ~20 min instead.
+      // Staleness-guarded so a legitimately in-flight upgrade is never touched.
+      setInterval(
+        () => {
+          void reconcileSelfUpgradeRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
+          // Backstop: force-remove any promoter container orphaned by a portal
+          // restart that killed runPromoter's own timeout timer (BI-3EC7FDB0).
+          void sweepOrphanedPromoterContainers({ maxAgeMs: 30 * 60 * 1000 });
+        },
+        20 * 60 * 1000,
       );
-      await assertVoiceServiceOnBoot();
-    })();
 
-    // Self-heal a quiescence level left stuck by a swap that killed the
-    // coordinator mid-protocol — otherwise the portal refuses gated requests
-    // ("portal_quiescing") forever. Must run before reconciliation.
-    void resetStuckQuiescenceLevelOnBoot();
-
-    // Close the loop on any self-upgrade run whose orchestrator died mid-swap
-    // (a real upgrade recreates this very container). Records succeeded when we
-    // came up on the target SHA; fails orphans so triggers aren't blocked.
-    void reconcileSelfUpgradeRunsOnBoot();
-
-    // Periodic safety net — cron-independent (the boot reconcile above and the
-    // Inngest cron can BOTH miss this). If a swap's orchestrator dies while the
-    // portal stays UP (no reboot), the SelfUpgradeRun sits "running" forever and
-    // every future trigger silently no-ops (requestPortalSelfUpgradeAction). The
-    // June-10 run sat "running" for 4 days until a manual restart — this re-runs
-    // the reconcile in-process so a stuck run self-heals within ~20 min instead.
-    // Staleness-guarded so a legitimately in-flight upgrade is never touched.
-    setInterval(
-      () => {
-        void reconcileSelfUpgradeRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
-        // Backstop: force-remove any promoter container orphaned by a portal
-        // restart that killed runPromoter's own timeout timer (BI-3EC7FDB0).
-        void sweepOrphanedPromoterContainers({ maxAgeMs: 30 * 60 * 1000 });
-      },
-      20 * 60 * 1000,
-    );
-
-    // Close the SAME self-swap gap for the quiescence coordinator. A succeeded
-    // upgrade whose swap kills the orchestrator leaves the coordinator to time
-    // out and falsely emit `failed`, surfacing as a bogus "Upgrade postponed,
-    // failed" banner. The surviving portal completes the swap-complete handshake
-    // here (boot), plus a periodic net for the portal-stays-up orphan case.
-    void reconcileQuiescenceRunsOnBoot();
-    setInterval(
-      () => {
-        void reconcileQuiescenceRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
-      },
-      20 * 60 * 1000,
-    );
-
-    // Same boot + periodic safety net for BackupRun rows stuck "running": a
-    // backup runner that dies mid-dump leaves a false "in progress" row forever
-    // (no other recovery), polluting the backup-health card + corruption alerts.
-    void (async () => {
-      const { reconcileStuckBackupRuns } = await import(
-        "@/lib/operate/backups/reconcile-stuck-runs"
+      // Close the SAME self-swap gap for the quiescence coordinator. A succeeded
+      // upgrade whose swap kills the orchestrator leaves the coordinator to time
+      // out and falsely emit `failed`, surfacing as a bogus "Upgrade postponed,
+      // failed" banner. The surviving portal completes the swap-complete handshake
+      // here (boot), plus a periodic net for the portal-stays-up orphan case.
+      void reconcileQuiescenceRunsOnBoot();
+      setInterval(
+        () => {
+          void reconcileQuiescenceRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
+        },
+        20 * 60 * 1000,
       );
-      await reconcileStuckBackupRuns();
-      setInterval(() => void reconcileStuckBackupRuns(), 20 * 60 * 1000);
-    })();
 
-    // Self-heal the local model's served context window. A Docker Desktop / DMR
-    // restart wipes DMR's per-model `context-size` override back to the model
-    // card default (qwen3-coder = 4k), which silently overflows EVERY local
-    // coworker turn (exceed_context_size_error: request ~24k > n_ctx 4096). The
-    // first-run bootstrap raises it once; this re-asserts it on every boot (the
-    // common case: a Docker restart restarts the portal too) plus a periodic net
-    // (a DMR-only restart while the portal stays up). Idempotent + best-effort.
-    void (async () => {
-      const { reconcileLocalModelContext } = await import(
-        "@/lib/inference/local-model-context-reconcile"
-      );
-      const logCtx = (r: Awaited<ReturnType<typeof reconcileLocalModelContext>>) => {
-        if (r.status === "raised") {
-          console.log(
-            `[local-model-context] raised ${r.modelId} ${r.before ?? "unset"} → ${r.after} tokens`,
-          );
-        } else if (r.status === "deferred") {
-          console.warn(
-            `[local-model-context] raise deferred (${r.reason ?? "unknown"}); applies on next model load`,
-          );
-        }
-      };
-      logCtx(await reconcileLocalModelContext());
-      setInterval(() => void reconcileLocalModelContext().then(logCtx), 20 * 60 * 1000);
-    })();
+      // Same boot + periodic safety net for BackupRun rows stuck "running": a
+      // backup runner that dies mid-dump leaves a false "in progress" row forever
+      // (no other recovery), polluting the backup-health card + corruption alerts.
+      void (async () => {
+        const { reconcileStuckBackupRuns } = await import(
+          "@/lib/operate/backups/reconcile-stuck-runs"
+        );
+        await reconcileStuckBackupRuns();
+        setInterval(() => void reconcileStuckBackupRuns(), 20 * 60 * 1000);
+      })();
+
+      // Self-heal the local model's served context window. A Docker Desktop / DMR
+      // restart wipes DMR's per-model `context-size` override back to the model
+      // card default (qwen3-coder = 4k), which silently overflows EVERY local
+      // coworker turn (exceed_context_size_error: request ~24k > n_ctx 4096). The
+      // first-run bootstrap raises it once; this re-asserts it on every boot (the
+      // common case: a Docker restart restarts the portal too) plus a periodic net
+      // (a DMR-only restart while the portal stays up). Idempotent + best-effort.
+      void (async () => {
+        const { reconcileLocalModelContext } = await import(
+          "@/lib/inference/local-model-context-reconcile"
+        );
+        const logCtx = (r: Awaited<ReturnType<typeof reconcileLocalModelContext>>) => {
+          if (r.status === "raised") {
+            console.log(
+              `[local-model-context] raised ${r.modelId} ${r.before ?? "unset"} → ${r.after} tokens`,
+            );
+          } else if (r.status === "deferred") {
+            console.warn(
+              `[local-model-context] raise deferred (${r.reason ?? "unknown"}); applies on next model load`,
+            );
+          }
+        };
+        logCtx(await reconcileLocalModelContext());
+        setInterval(() => void reconcileLocalModelContext().then(logCtx), 20 * 60 * 1000);
+      })();
+    }
 
     // Backfill the operational value stream (OVSM) EA view for any storefront
     // that completed setup before the #1798 generator was running on it — those
     // installs have a StorefrontConfig + archetype but no archetype_value_stream
     // EaView, so /ea/value-streams shows the empty state forever with nothing to
     // self-heal it. Cheap when already present (existence check, no projection);
-    // idempotent and non-fatal per org.
-    void (async () => {
+    // idempotent and non-fatal per org. Awaited under measurement runtime so
+    // every measured route observes the same post-backfill state.
+    await settleBootSync(measurementRuntime, async () => {
       const { backfillOperationalValueStreamsOnBoot } = await import(
         "@/lib/storefront/backfill-operational-value-streams"
       );
       await backfillOperationalValueStreamsOnBoot();
-    })();
+    });
 
     // Backfill the org WWWD corpus (BI-44526F3E Phase A) for any install that
     // completed setup before the onboarding seed chain existed — those orgs
@@ -1130,53 +1151,59 @@ export async function register() {
     // Decision Governance hub shows "no stance of your own yet" forever and
     // business decisions silently fall back to platform doctrine. Cheap when
     // already present (existence checks only); idempotent and non-fatal per org.
-    void (async () => {
+    // Awaited under measurement runtime: this backfill flips empty-state prose
+    // on governance/workspace surfaces, so racing it is measurable word drift.
+    await settleBootSync(measurementRuntime, async () => {
       const { backfillOrgWwwdOnBoot } = await import(
         "@/lib/onboarding/backfill-org-wwwd-on-boot"
       );
       await backfillOrgWwwdOnBoot();
-    })();
+    });
 
     // Build Studio engine reliability (spec §3.1 engine-first / FB-78E967D4).
-    // These run unconditionally — they are correctness reconcilers, not optional
-    // maintenance — and FIX 1 runs before FIX 2 so contradictory checkpoints are
-    // coerced/cleared before the resume pass considers them.
+    // These are correctness reconcilers, not optional maintenance — skipped
+    // only under measurement runtime (an ephemeral sweep portal runs no
+    // builds, and their FeatureBuild writes race the crawl) — and FIX 1 runs
+    // before FIX 2 so contradictory checkpoints are coerced/cleared before
+    // the resume pass considers them.
     //
     // FIX 1: auto-recover builds whose buildExecState landed in a contradictory
     // shape (was previously only escapable via the manual "Reset Build").
     // FIX 2: re-dispatch builds whose fire-and-forget pipeline was killed by a
     // portal recycle, leaving a row stranded mid-step that nothing resumes.
-    void (async () => {
-      await recoverContradictoryBuildExecStatesOnBoot();
-      await resumeStrandedBuildsOnBoot();
-      // Complete any ship-phase builds whose merged code went live in the
-      // self-upgrade that just (re)started this portal (autonomous-completion
-      // path; no-op when the flag is off).
-      await reconcileDeployedShipBuilds();
-    })();
+    if (!measurementRuntime) {
+      void (async () => {
+        await recoverContradictoryBuildExecStatesOnBoot();
+        await resumeStrandedBuildsOnBoot();
+        // Complete any ship-phase builds whose merged code went live in the
+        // self-upgrade that just (re)started this portal (autonomous-completion
+        // path; no-op when the flag is off).
+        await reconcileDeployedShipBuilds();
+      })();
 
-    // Periodic build-resume (cron-independent) — the boot reconcile above runs
-    // ONLY once at startup, so any build CREATED or STRANDED after boot (e.g. a
-    // decomposition's child builds, a fresh promote, or a phase that strands
-    // mid-pipeline) sits untouched until the next reboot. Observed live: the 3
-    // children from a decomposition stuck at zero phases 19+ min post-restart,
-    // because resumeStrandedBuildsOnBoot had already run before they existed.
-    // Re-run the SAME reconcilers on an interval so the drain is CONTINUOUS, not
-    // boot-only — mirroring the self-upgrade-reconcile and stale-slot-reclaim
-    // periodic safety nets above. Both reconcilers are idempotent; the resume
-    // uses a LONGER staleness (20 min) than the boot default (5 min) so a
-    // legitimately slow in-flight phase (an ideate dispatch can run ~14 min) is
-    // never re-dispatched out from under itself.
-    setInterval(
-      () => {
-        void (async () => {
-          await recoverContradictoryBuildExecStatesOnBoot();
-          await resumeStrandedBuildsOnBoot({ staleAfterMs: 20 * 60 * 1000 });
-          await reconcileDeployedShipBuilds();
-        })();
-      },
-      10 * 60 * 1000,
-    );
+      // Periodic build-resume (cron-independent) — the boot reconcile above runs
+      // ONLY once at startup, so any build CREATED or STRANDED after boot (e.g. a
+      // decomposition's child builds, a fresh promote, or a phase that strands
+      // mid-pipeline) sits untouched until the next reboot. Observed live: the 3
+      // children from a decomposition stuck at zero phases 19+ min post-restart,
+      // because resumeStrandedBuildsOnBoot had already run before they existed.
+      // Re-run the SAME reconcilers on an interval so the drain is CONTINUOUS, not
+      // boot-only — mirroring the self-upgrade-reconcile and stale-slot-reclaim
+      // periodic safety nets above. Both reconcilers are idempotent; the resume
+      // uses a LONGER staleness (20 min) than the boot default (5 min) so a
+      // legitimately slow in-flight phase (an ideate dispatch can run ~14 min) is
+      // never re-dispatched out from under itself.
+      setInterval(
+        () => {
+          void (async () => {
+            await recoverContradictoryBuildExecStatesOnBoot();
+            await resumeStrandedBuildsOnBoot({ staleAfterMs: 20 * 60 * 1000 });
+            await reconcileDeployedShipBuilds();
+          })();
+        },
+        10 * 60 * 1000,
+      );
+    }
 
     const optionalStartupTasksEnabled = areOptionalStartupTasksEnabled();
     if (!optionalStartupTasksEnabled) {

--- a/apps/web/lib/runtime/measurement-runtime.test.ts
+++ b/apps/web/lib/runtime/measurement-runtime.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { isMeasurementRuntime, settleBootSync } from "./measurement-runtime";
+
+describe("isMeasurementRuntime", () => {
+  it("is off by default — production and dev boots are unchanged", () => {
+    expect(isMeasurementRuntime({})).toBe(false);
+    expect(isMeasurementRuntime({ DPF_MEASUREMENT_RUNTIME: "" })).toBe(false);
+    expect(isMeasurementRuntime({ DPF_MEASUREMENT_RUNTIME: "0" })).toBe(false);
+  });
+
+  it("recognizes the standard truthy env forms", () => {
+    expect(isMeasurementRuntime({ DPF_MEASUREMENT_RUNTIME: "1" })).toBe(true);
+    expect(isMeasurementRuntime({ DPF_MEASUREMENT_RUNTIME: "true" })).toBe(true);
+    expect(isMeasurementRuntime({ DPF_MEASUREMENT_RUNTIME: "on" })).toBe(true);
+  });
+});
+
+describe("settleBootSync", () => {
+  it("awaits the task under measurement runtime so it completes before serving", async () => {
+    let completed = false;
+    await settleBootSync(true, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      completed = true;
+    });
+    expect(completed).toBe(true);
+  });
+
+  it("fire-and-forgets outside measurement runtime (pre-existing boot behavior)", async () => {
+    let started = false;
+    let completed = false;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await settleBootSync(false, async () => {
+      started = true;
+      await gate;
+      completed = true;
+    });
+    // settleBootSync returned while the task is still pending — it must not
+    // have blocked boot on the task.
+    expect(started).toBe(true);
+    expect(completed).toBe(false);
+    release();
+    await gate;
+  });
+
+  it("swallows a rejecting task under measurement runtime — boot syncs are non-fatal", async () => {
+    await expect(
+      settleBootSync(true, async () => {
+        throw new Error("boot sync failed");
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/lib/runtime/measurement-runtime.ts
+++ b/apps/web/lib/runtime/measurement-runtime.ts
@@ -1,0 +1,48 @@
+// Measurement-runtime boot mode (BI-232BA634).
+//
+// The UX route sweep boots a REAL production portal and measures every route
+// against a frozen baseline. Same-tree sweep runs have flipped pass/fail
+// (merge-group runs 30434754297 fail / 30438124151 pass shared git tree
+// 79055b61) because instrumentation's fire-and-forget boot reconcilers keep
+// WRITING operational state — self-upgrade/quiescence/backup reconciles, org
+// backfills, version sync — while the crawl is measuring the routes that
+// render that state. Which side of each write a route lands on is a race.
+//
+// Under DPF_MEASUREMENT_RUNTIME=1 the boot contract changes to "deterministic
+// by construction":
+//   - render-relevant idempotent syncs are AWAITED inside register(), so every
+//     request observes the same post-sync state (Next serves no traffic until
+//     register() resolves);
+//   - operational self-heal maintenance (stuck-run reconciles, watchdog
+//     intervals) is SKIPPED — an ephemeral measurement portal has nothing to
+//     heal, and its writes are exactly the nondeterminism being removed.
+// Production and dev boots (flag unset) are byte-for-byte unchanged.
+
+import { envFlagEnabled } from "@/lib/runtime/env-flags";
+
+export function isMeasurementRuntime(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return envFlagEnabled(env, "DPF_MEASUREMENT_RUNTIME");
+}
+
+/**
+ * Run a render-relevant idempotent boot sync. Awaited under measurement
+ * runtime so it completes before the portal serves its first request;
+ * fire-and-forget otherwise (the pre-existing production behavior). Failures
+ * never block boot in either mode — these tasks carry their own logging.
+ */
+export async function settleBootSync(
+  measurementRuntime: boolean,
+  task: () => Promise<unknown>,
+): Promise<void> {
+  if (!measurementRuntime) {
+    void task();
+    return;
+  }
+  try {
+    await task();
+  } catch {
+    // Boot syncs are non-fatal by contract; the task logs its own failure.
+  }
+}

--- a/docs/superpowers/plans/2026-07-29-ux-sweep-measurement-runtime-plan.md
+++ b/docs/superpowers/plans/2026-07-29-ux-sweep-measurement-runtime-plan.md
@@ -51,6 +51,16 @@ One flag, one chokepoint: `DPF_MEASUREMENT_RUNTIME=1`
   awaited-under-measurement, fire-and-forget otherwise, and non-fatal
   rejection handling.
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-232BA634
+- Receipt: cms6e02xl03j901l2b0y9ca2z
+- Rationale: the flag module, the instrumentation gating, and the workflow env
+  wire are one behavior — any one of them alone leaves the sweep exactly as
+  nondeterministic as before, so no phase is independently shippable.
+- Dependencies: none
+
 ## Residual risk / follow-up
 
 - Routes rendering *time itself* stay governed by the #3719 typed

--- a/docs/superpowers/plans/2026-07-29-ux-sweep-measurement-runtime-plan.md
+++ b/docs/superpowers/plans/2026-07-29-ux-sweep-measurement-runtime-plan.md
@@ -1,0 +1,62 @@
+# UX sweep measurement-runtime boot — class-level determinism plan
+
+**Backlog item:** BI-232BA634 (EP-UX-SYSTEM)
+**Predecessor:** BI-EA221325 (closed twice on per-route fixes; the class recurred)
+
+## Root cause (evidence, not hypothesis)
+
+Merge-group runs 30434754297 (fail) and 30438124151 (pass) measured the
+**identical git tree** `79055b61bdce78437a80617d638c866e2dba6828` with identical
+parents and nearly identical navigation/settle timings (~710 ms), yet disagreed
+on `/workspace` by five words, one heading, and 2.3 reading-grade points. The
+page was captured in two different *server* states, not two different codes.
+
+The sweep boots a real production portal. `apps/web/instrumentation.ts`
+`register()` fires a queue of fire-and-forget reconcilers and watchdog
+intervals that WRITE operational state after the portal starts serving:
+platform-version sync, quiescence level reset, self-upgrade/quiescence/backup
+stuck-run reconciles, local-model-context re-assertion, OVSM and org-WWWD
+backfills, Build Studio exec-state recovery. The crawl starts seconds after
+boot; which side of each write a route is measured on is a race. Per-route
+fixture fixes (#3656, #3712) and typed wall-clock exclusions (#3719) cannot
+close this class because the writers are runtime, not seed.
+
+## Remedy — deterministic by construction
+
+One flag, one chokepoint: `DPF_MEASUREMENT_RUNTIME=1`
+(`apps/web/lib/runtime/measurement-runtime.ts`), consumed by `register()`:
+
+1. **Awaited render-relevant syncs** — platform-version sync and the OVSM /
+   org-WWWD backfills complete inside `register()` before Next serves the
+   first request (`settleBootSync`). Every measured route observes the same
+   post-sync state, and it is the state production users actually see.
+2. **Skipped operational self-heal** — voice continuity, stuck-run
+   reconciles and their periodic intervals, model-context re-assertion, and
+   Build Studio recovery are skipped. An ephemeral sweep portal has no stuck
+   state to heal; these writers are the measured nondeterminism.
+3. **Unchanged production/dev boots** — the flag defaults off; when unset,
+   the boot path is byte-for-byte the prior behavior.
+
+`.github/workflows/ux-route-sweep.yml` sets the flag when starting the portal.
+
+## Acceptance
+
+- Two same-commit sweep runs (workflow_dispatch ×2 on the PR head) produce
+  byte-identical verdicts for every pre-existing route.
+- The class criterion from BI-232BA634: a change with zero route/UI surface
+  produces zero sweep regressions on pre-existing routes — validated on this
+  PR itself (instrumentation/workflow/docs-only diff) across PR and
+  merge-group sweeps.
+- Unit contract: `measurement-runtime.test.ts` proves flag default-off,
+  awaited-under-measurement, fire-and-forget otherwise, and non-fatal
+  rejection handling.
+
+## Residual risk / follow-up
+
+- Routes rendering *time itself* stay governed by the #3719 typed
+  wall-clock-collection exclusions — different class, already handled.
+- If a future boot writer is added outside the gated regions, it reintroduces
+  the race for sweeps only; the gate-context pack (BI-2677A465) and review
+  attention on `instrumentation.ts` are the guard. A structural
+  "no ungated writer" contract test is a candidate follow-up if recurrence is
+  observed.

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -295,6 +295,21 @@ change-lanes projection's ten-minute stale-heartbeat threshold. Retaining only
 the earlier seed timestamp would make the same source alternate between a
 healthy lane and a five-word stale-heartbeat blocker.
 
+The portal itself boots in **measurement runtime** (`DPF_MEASUREMENT_RUNTIME=1`,
+BI-232BA634). A production boot fires instrumentation reconcilers and watchdog
+intervals that keep writing operational state — self-upgrade/quiescence/backup
+stuck-run reconciles, build resume, model-context re-assertion, org backfills —
+while the crawl is measuring the routes that render that state; merge-group runs
+30434754297 and 30438124151 measured the identical git tree (`79055b61`) and
+flipped fail/pass on `/workspace` because of exactly such a write. Under
+measurement runtime, render-relevant idempotent boot syncs (platform version,
+OVSM and org-WWWD backfills) are awaited inside `register()` so every request
+observes the same post-sync state, and operational self-heal maintenance is
+skipped — an ephemeral sweep portal has nothing to heal, and its background
+writes are the nondeterminism. Production and dev boots (flag unset) are
+unchanged; the classification lives in `apps/web/lib/runtime/measurement-runtime.ts`
+and the gating in `apps/web/instrumentation.ts`.
+
 Fixture-facing health copy must also be semantically stable. The Communications
 speech-to-text card classifies transport failures as `endpoint unavailable`
 instead of rendering Node/undici's platform-specific DNS or socket error text.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -165,6 +165,22 @@ From a worktree, the gate is:
 pnpm run pregate            # → node scripts/pregate.mjs
 ```
 
+**Guard parity preflight (BI-D35433FB).** Before the gate claims a
+`local-integration-ci` lease, `pregate.mjs` runs the deterministic CI policy
+guards host-natively — the same check commands CI's Policy Guards jobs run
+(module size, style drift, derived-artifact staleness, doc links, SBOM, plus
+the commit-range-driven UX-Fit and Design Grounding trailer gates), with guard
+self-tests stripped and PR-body-dependent gates (Seed-Fit, Decision Baseline)
+left to CI. A violation aborts in well under a minute **before any lease is
+claimed**, so a doomed run never occupies the contended sandbox slot. A guard
+this host cannot execute (missing isolated runtime) is reported as
+`environment-skipped` with its remedy — a warning, never a false red; CI
+remains the enforcer. Run it standalone with `pnpm run pregate:preflight`
+(`--plan` prints the guard plan without running it). Emergency skip:
+`DPF_SKIP_PREGATE_PREFLIGHT_REASON="<why>"` — printed on the gate run, and CI
+still enforces every guard. Routing probes (`--dry-run`) and evidence replays
+(`--finalize-evidence`) skip the preflight automatically.
+
 **Host-native/Node-first entry point (BI-2272D840, BI-52500C0D, BI-4BE30454).** `pregate.mjs`
 detects whether native `sh` actually works against *this* worktree — not just
 "sh is on PATH", but that it can resolve the worktree's own git state

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:prod-runtime": "docker compose up -d portal",
     "dev:sandbox": "docker compose up -d sandbox",
     "pregate": "node scripts/pregate.mjs",
+    "pregate:preflight": "node scripts/pregate-preflight.mjs",
     "build": "pnpm --filter web build",
     "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",
     "test:e2e": "playwright test",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -56,6 +56,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/ci-build-artifact.test.mjs",
         "scripts/lib/ci-evidence-plan.test.mjs",
         "scripts/ci-policy-guards.test.mjs",
+        "scripts/pregate-preflight.test.mjs",
       ),
     ]),
     guard("mobile-jest-pin-guard", "Mobile Jest Pin Guard", [

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -1,0 +1,141 @@
+// scripts/lib/pregate-preflight.mjs — host-side guard parity preflight
+// (BI-D35433FB, EP-0DFF753B).
+//
+// THE PROBLEM: the local pregate runs the full test suite, typecheck, and a
+// production build inside the leased local-integration-ci sandbox (30–60+ min),
+// but never runs the deterministic CI policy guards — module size, prose/style
+// ratchets, derived-artifact staleness, commit-trailer attestations. A 52h CI
+// failure taxonomy (2026-07-27 → 07-29) counted ~90 failed jobs in exactly that
+// class: author-fixable in seconds, discoverable only by pushing, each one
+// costing a full CI round trip and usually a lease-holding pregate first.
+//
+// THE FIX: run those same guard scripts host-native BEFORE lease admission, so
+// a doomed gate never occupies a contended sandbox slot. The preflight reuses
+// POLICY_GUARD_PROFILES verbatim — same scripts CI runs — with two deliberate
+// reductions:
+//
+//   1. Guard SELF-TESTS (`node --test …`) are stripped. They prove the guard's
+//      own logic and belong to CI's Policy Guards jobs; the preflight only
+//      needs the tree checked, and several self-tests require the isolated
+//      @dpf/repo-guard-runtime install that a source-only worktree lacks.
+//   2. Only commit-range-driven pull-request gates are included (UX-Fit,
+//      Design Grounding). Gates that read the PR body (Seed-Fit) or mutate the
+//      tree (Decision Baseline merges origin/main) cannot run honestly on a
+//      host worktree and stay CI-only.
+//
+// DEGRADATION CONTRACT: a guard that exits non-zero because the ENVIRONMENT
+// cannot run it (missing module, missing isolated pnpm graph) is reported as
+// `skipped_environment` with the guard's own remedy line — never a hard fail
+// and never silently green. CI remains the enforcer; the preflight is an
+// honest early warning, so a false local failure would erode trust faster
+// than a missed one.
+
+import { spawnSync } from "node:child_process";
+
+import { POLICY_GUARD_PROFILES, runPolicyProfile } from "./ci-policy-guards.mjs";
+
+export const PREFLIGHT_SKIP_ENV = "DPF_SKIP_PREGATE_PREFLIGHT_REASON";
+
+// Pull-request-profile gates that are commit-range-driven and therefore give a
+// truthful answer on a host worktree without PR context. Everything else in
+// that profile is excluded on purpose:
+//   - seed-fit-gate reads the PR body, which does not exist before push;
+//   - docs-impact-gate / data-impact-gate / spec-plan-doc-gate carry heavier
+//     self-test dependencies and are candidates for a later slice once their
+//     host-side behavior is proven;
+//   - decision-baseline MERGES origin/main into the branch — a tree mutation
+//     the preflight must never perform.
+export const LOCAL_SAFE_PR_GUARD_IDS = Object.freeze([
+  "ux-fit-gate",
+  "design-grounding-gate",
+]);
+
+// Exit-output signatures that mean "this host cannot run the guard", not
+// "the tree violates the guard". Kept narrow: each entry is a message Node or
+// the guard runtime itself emits for a missing execution substrate.
+export const ENVIRONMENT_FAILURE_RE =
+  /ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module|resolved outside its isolated pnpm graph/;
+
+function stripSelfTests(entries) {
+  return entries
+    .map((entry) => ({
+      ...entry,
+      commands: entry.commands.filter(
+        ([command, args]) => !(command === "node" && args[0] === "--test"),
+      ),
+    }))
+    .filter((entry) => entry.commands.length > 0);
+}
+
+export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES } = {}) {
+  const source = stripSelfTests(profiles.source);
+  const trailer = stripSelfTests(
+    profiles["pull-request"].filter((entry) =>
+      LOCAL_SAFE_PR_GUARD_IDS.includes(entry.id),
+    ),
+  );
+  return [...source, ...trailer];
+}
+
+function defaultExecute(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: "utf8",
+    shell: false,
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  if (result.status !== 0) process.stderr.write(output);
+  return { exitCode: result.status ?? 1, output };
+}
+
+/**
+ * Runs the preflight plan. Unlike runPolicyProfile, the executor returns
+ * `{ exitCode, output }` so a non-zero exit whose output matches
+ * ENVIRONMENT_FAILURE_RE can be reclassified as `skipped_environment` instead
+ * of `failed`. `ok` is false only for genuine guard failures.
+ */
+export async function runPreflight({
+  plan = buildPreflightPlan(),
+  execute = defaultExecute,
+  logger = () => {},
+  now = () => Date.now(),
+  env = process.env,
+} = {}) {
+  const skipReason = env[PREFLIGHT_SKIP_ENV];
+  if (skipReason) {
+    return { ok: true, skipped: true, skipReason, entries: [] };
+  }
+
+  const wrapped = new Map();
+  const result = await runPolicyProfile({
+    entries: plan,
+    execute: (command, args) => {
+      const { exitCode, output } = execute(command, args);
+      if (exitCode !== 0) {
+        wrapped.set(
+          [command, ...args].join(" "),
+          ENVIRONMENT_FAILURE_RE.test(output) ? "environment" : "violation",
+        );
+      }
+      return exitCode;
+    },
+    logger,
+    now,
+  });
+
+  const entries = result.entries.map((entry) => {
+    if (entry.status !== "failed") return entry;
+    const kind = wrapped.get(entry.failedCommand);
+    return kind === "environment"
+      ? { ...entry, status: "skipped_environment" }
+      : entry;
+  });
+
+  return {
+    ok: entries.every((entry) => entry.status !== "failed"),
+    skipped: false,
+    skipReason: null,
+    entries,
+  };
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -14,7 +14,7 @@ apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	1015
 apps/web/components/workbooks/Grid.tsx	1585
 apps/web/instrumentation.test.ts	945
-apps/web/instrumentation.ts	1497
+apps/web/instrumentation.ts	1524
 apps/web/lib/actions/agent-coworker-external.test.ts	867
 apps/web/lib/actions/agent-coworker.ts	2759
 apps/web/lib/actions/agent-task-scheduler.test.ts	1124

--- a/scripts/pregate-preflight.mjs
+++ b/scripts/pregate-preflight.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// scripts/pregate-preflight.mjs — CLI for the host-side guard parity preflight
+// (BI-D35433FB). Run standalone (`pnpm run pregate:preflight`) or let
+// scripts/pregate.mjs invoke it automatically before lease admission.
+//
+//   node scripts/pregate-preflight.mjs           # run the preflight
+//   node scripts/pregate-preflight.mjs --plan    # print the plan as JSON
+//
+// Exit codes: 0 = clean (environment-skipped guards are warnings), 1 = at
+// least one guard reported a genuine violation.
+
+import { fileURLToPath } from "node:url";
+
+import {
+  PREFLIGHT_SKIP_ENV,
+  buildPreflightPlan,
+  runPreflight,
+} from "./lib/pregate-preflight.mjs";
+
+export async function main() {
+  if (process.argv.includes("--plan")) {
+    const plan = buildPreflightPlan().map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      commands: entry.commands.map(([command, args]) => [command, ...args].join(" ")),
+    }));
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  const startedAt = Date.now();
+  const result = await runPreflight({
+    // Failure lines are printed from the FINAL classified entries below —
+    // an env-degraded guard transiently looks "failed" at finish-time and
+    // must not be announced as a failure here.
+    logger(event) {
+      if (event.type === "start") {
+        process.stdout.write(`[pregate-preflight] ${event.entry.name}…\n`);
+      }
+    },
+  });
+
+  if (result.skipped) {
+    process.stdout.write(
+      `[pregate-preflight] SKIPPED — ${PREFLIGHT_SKIP_ENV}=${result.skipReason}\n`,
+    );
+    return;
+  }
+
+  const failed = result.entries.filter((entry) => entry.status === "failed");
+  const environmentSkipped = result.entries.filter(
+    (entry) => entry.status === "skipped_environment",
+  );
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  for (const entry of environmentSkipped) {
+    process.stderr.write(
+      `[pregate-preflight] WARN ${entry.name} could not run on this host (missing runtime) — CI will still enforce it. Remedy: pnpm install --frozen-lockfile --ignore-scripts --filter @dpf/repo-guard-runtime\n`,
+    );
+  }
+
+  if (failed.length > 0) {
+    process.stderr.write(
+      `[pregate-preflight] ${failed.length} guard(s) FAILED in ${elapsed}s — these are deterministic CI failures; fix them before the sandbox gate runs:\n`,
+    );
+    for (const entry of failed) {
+      process.stderr.write(`  - ${entry.name}: ${entry.failedCommand}\n`);
+    }
+    process.stderr.write(
+      `[pregate-preflight] emergency skip (recorded honesty, CI still enforces): set ${PREFLIGHT_SKIP_ENV}="<why>"\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `[pregate-preflight] OK — ${result.entries.length} guards clean in ${elapsed}s` +
+      (environmentSkipped.length > 0
+        ? ` (${environmentSkipped.length} environment-skipped, see warnings)`
+        : "") +
+      "\n",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -1,0 +1,184 @@
+// Tests for the host-side guard parity preflight (BI-D35433FB).
+//
+// The preflight's trust contract has two halves and both are load-bearing:
+// it must fail on a genuine deterministic guard violation BEFORE any lease is
+// claimed, and it must NOT fail on a host that merely cannot run a guard
+// (missing isolated runtime) — a false local red would teach contributors to
+// skip it, recreating the push-to-discover loop it exists to close.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  ENVIRONMENT_FAILURE_RE,
+  LOCAL_SAFE_PR_GUARD_IDS,
+  PREFLIGHT_SKIP_ENV,
+  buildPreflightPlan,
+  runPreflight,
+} from "./lib/pregate-preflight.mjs";
+import { shouldRunPreflight } from "./pregate.mjs";
+
+const repoRoot = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const preflightCli = join(repoRoot, "scripts", "pregate-preflight.mjs");
+const pregateCli = join(repoRoot, "scripts", "pregate.mjs");
+
+// ── plan construction ───────────────────────────────────────────────────────
+
+test("buildPreflightPlan strips guard self-tests but keeps every check command", () => {
+  const profiles = {
+    source: [
+      {
+        id: "g1",
+        legacyJobId: "g1",
+        name: "Guard One",
+        commands: [
+          ["node", ["--test", "scripts/g1.test.mjs"]],
+          ["node", ["scripts/g1.mjs"]],
+        ],
+      },
+      {
+        id: "tests-only",
+        legacyJobId: "tests-only",
+        name: "Self-Tests Only",
+        commands: [["node", ["--test", "scripts/only.test.mjs"]]],
+      },
+    ],
+    "pull-request": [],
+  };
+  const plan = buildPreflightPlan({ profiles });
+  assert.deepEqual(plan.map((entry) => entry.id), ["g1"]);
+  assert.deepEqual(plan[0].commands, [["node", ["scripts/g1.mjs"]]]);
+});
+
+test("buildPreflightPlan includes only commit-range-safe pull-request gates", () => {
+  const plan = buildPreflightPlan();
+  const ids = new Set(plan.map((entry) => entry.id));
+  for (const id of LOCAL_SAFE_PR_GUARD_IDS) {
+    assert.ok(ids.has(id), `expected local-safe gate ${id} in the plan`);
+  }
+  // PR-body-dependent and tree-mutating gates must never run host-side.
+  assert.ok(!ids.has("seed-fit-gate"), "seed-fit-gate reads the PR body");
+  assert.ok(!ids.has("decision-baseline"), "decision-baseline merges origin/main");
+});
+
+test("buildPreflightPlan contains no --test invocations at all", () => {
+  for (const entry of buildPreflightPlan()) {
+    for (const [command, args] of entry.commands) {
+      assert.ok(
+        !(command === "node" && args[0] === "--test"),
+        `${entry.id} kept a self-test: ${args.join(" ")}`,
+      );
+    }
+  }
+});
+
+// ── run + classification ────────────────────────────────────────────────────
+
+const PLAN = [
+  {
+    id: "violating",
+    legacyJobId: "violating",
+    name: "Violating Guard",
+    commands: [["node", ["scripts/violating.mjs"]]],
+  },
+  {
+    id: "env-broken",
+    legacyJobId: "env-broken",
+    name: "Env-Broken Guard",
+    commands: [["node", ["scripts/env-broken.mjs"]]],
+  },
+  {
+    id: "clean",
+    legacyJobId: "clean",
+    name: "Clean Guard",
+    commands: [["node", ["scripts/clean.mjs"]]],
+  },
+];
+
+function fakeExecute(command, args) {
+  const script = args[args.length - 1];
+  if (script.includes("violating")) return { exitCode: 1, output: "module exceeds ratchet baseline" };
+  if (script.includes("env-broken")) {
+    return {
+      exitCode: 1,
+      output: "Error: Repo guard TypeScript resolved outside its isolated pnpm graph: …",
+    };
+  }
+  return { exitCode: 0, output: "" };
+}
+
+test("runPreflight fails on a genuine guard violation", async () => {
+  const result = await runPreflight({ plan: PLAN, execute: fakeExecute, env: {} });
+  assert.equal(result.ok, false);
+  const byId = Object.fromEntries(result.entries.map((entry) => [entry.id, entry.status]));
+  assert.equal(byId.violating, "failed");
+  assert.equal(byId.clean, "passed");
+});
+
+test("runPreflight reclassifies environment failures as skipped_environment, not failed", async () => {
+  const result = await runPreflight({
+    plan: PLAN.filter((entry) => entry.id !== "violating"),
+    execute: fakeExecute,
+    env: {},
+  });
+  assert.equal(result.ok, true, "an unrunnable guard must not hard-fail the preflight");
+  const envEntry = result.entries.find((entry) => entry.id === "env-broken");
+  assert.equal(envEntry.status, "skipped_environment");
+});
+
+test("runPreflight honors the recorded emergency skip", async () => {
+  const result = await runPreflight({
+    plan: PLAN,
+    execute: () => {
+      throw new Error("must not execute anything when skipped");
+    },
+    env: { [PREFLIGHT_SKIP_ENV]: "hotfix: guard outage BI-XXXX" },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.skipReason, "hotfix: guard outage BI-XXXX");
+});
+
+test("ENVIRONMENT_FAILURE_RE matches runtime-absence signatures, not guard verdicts", () => {
+  assert.ok(ENVIRONMENT_FAILURE_RE.test("Error [ERR_MODULE_NOT_FOUND]: Cannot find package"));
+  assert.ok(ENVIRONMENT_FAILURE_RE.test("TypeScript resolved outside its isolated pnpm graph"));
+  assert.ok(!ENVIRONMENT_FAILURE_RE.test("module exceeds ratchet baseline: 1050 > 1047 lines"));
+  assert.ok(!ENVIRONMENT_FAILURE_RE.test("Missing UX-Fit-Decision trailer"));
+});
+
+// ── pregate wiring ──────────────────────────────────────────────────────────
+
+test("shouldRunPreflight: on for real gate runs, off for probes, replays, and recorded skips", () => {
+  assert.equal(shouldRunPreflight(["--branch", "feat/x"], {}), true);
+  assert.equal(shouldRunPreflight(["--dry-run", "--branch", "feat/x"], {}), false);
+  assert.equal(shouldRunPreflight(["--finalize-evidence", "--branch", "feat/x"], {}), false);
+  assert.equal(
+    shouldRunPreflight(["--branch", "feat/x"], { DPF_SKIP_PREGATE_PREFLIGHT_REASON: "why" }),
+    false,
+  );
+});
+
+test("pregate-preflight.mjs --plan emits the JSON plan without running guards", () => {
+  const result = spawnSync(process.execPath, [preflightCli, "--plan"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const plan = JSON.parse(result.stdout);
+  assert.ok(plan.length > 0);
+  assert.ok(plan.some((entry) => entry.id === "module-size-guard"));
+  assert.ok(plan.every((entry) => entry.commands.every((c) => !c.startsWith("node --test"))));
+});
+
+test("pregate.mjs --dry-run skips the preflight and still reaches gate routing", () => {
+  const result = spawnSync(
+    process.execPath,
+    [pregateCli, "--dry-run", "--branch", "feat/x", "--worktree", repoRoot],
+    { encoding: "utf8", env: { ...process.env, DPF_PREGATE_FORCE_NODE: "1" } },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /pregate-preflight/);
+  assert.match(result.stdout, /gate-worktree dry-run/);
+});

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -28,6 +28,17 @@ import { fileURLToPath } from "node:url";
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 
+// Host-side guard parity preflight (BI-D35433FB): run the deterministic CI
+// policy guards before lease admission so a doomed gate never occupies a
+// contended local-integration-ci sandbox slot. Routing probes (--dry-run) and
+// evidence replays (--finalize-evidence) change nothing about the tree and
+// skip it; DPF_SKIP_PREGATE_PREFLIGHT_REASON is the recorded emergency skip.
+export function shouldRunPreflight(args, env = process.env) {
+  if (args.includes("--dry-run") || args.includes("--finalize-evidence")) return false;
+  if (env.DPF_SKIP_PREGATE_PREFLIGHT_REASON) return false;
+  return true;
+}
+
 export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnSync } = {}) {
   if (process.env.DPF_PREGATE_FORCE_NODE === "1") return false;
   if (process.env.DPF_PREGATE_FORCE_SH === "1") return true;
@@ -41,6 +52,25 @@ export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnS
 
 function main() {
   const args = process.argv.slice(2);
+
+  if (shouldRunPreflight(args)) {
+    const preflight = spawnSync(
+      process.execPath,
+      [join(SCRIPT_DIR, "pregate-preflight.mjs")],
+      { stdio: "inherit" },
+    );
+    if (preflight.error || (preflight.status ?? 1) !== 0) {
+      process.stderr.write(
+        "pregate: guard parity preflight failed — fix the deterministic guard failures above before the sandbox gate runs (no lease was claimed).\n",
+      );
+      process.exit(preflight.status ?? 1);
+    }
+  } else if (process.env.DPF_SKIP_PREGATE_PREFLIGHT_REASON) {
+    process.stderr.write(
+      `pregate: guard parity preflight SKIPPED — DPF_SKIP_PREGATE_PREFLIGHT_REASON=${process.env.DPF_SKIP_PREGATE_PREFLIGHT_REASON}\n`,
+    );
+  }
+
   const shWorks = detectWorkingShell();
 
   let result;


### PR DESCRIPTION
## What

The UX Route Budget Sweep's portal now boots with `DPF_MEASUREMENT_RUNTIME=1`: render-relevant idempotent boot syncs (platform version, OVSM backfill, org-WWWD backfill) are **awaited** inside `register()` before the portal serves its first request, and operational self-heal maintenance (voice continuity, self-upgrade/quiescence/backup stuck-run reconciles and their watchdog intervals, local-model-context re-assertion, Build Studio recovery/resume) is **skipped**. Production and dev boots (flag unset) are byte-for-byte unchanged.

## Why — the class, cryptographically proven

Merge-group runs [30434754297](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/30434754297) (fail) and [30438124151](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/30438124151) (pass) measured the **identical git tree** `79055b61` (identical parents, ~710 ms settle in both) yet disagreed on `/workspace` by 5 words, one heading, and 2.3 reading-grade points. The portal's own fire-and-forget boot writers mutate the operational state that `/ops/*`, `/platform/ai/*`, and cockpit routes render, while the crawl is measuring them — which side of each write a route lands on is a race. Per-route fixes (#3656, #3712, #3719, #3736) each close one symptom; ~77% of classified sweep failures in the 52h taxonomy (2026-07-27→29) carry this signature, and one drifting route has blocked 11 unrelated branches at once. BI-EA221325 was closed twice on "two consecutive green sweeps" and the class recurred within hours both times.

Complementary to #3736 (BI-1C048B7A), which converges the pre-existing weekly-digest data sources at the fixture boundary; this PR removes the mid-crawl writers that keep creating new ones.

## Verification

- Governed exact-tree pregate: freshness, migrations, docs+guards, full web Vitest (incl. the new `measurement-runtime.test.ts` contract tests), TypeScript, production Docker build — **gate passed**.
- Guard parity preflight green (and it caught a real module-size baseline miscount during development).
- `instrumentation.ts` module-size baseline consciously bumped 1497→1524 (only that line, hand-edited).
- **Acceptance protocol**: two `workflow_dispatch` sweeps on this exact head must produce identical verdicts for every pre-existing route, and this PR itself (zero route/UI surface) must produce zero pre-existing-route regressions on its PR and merge-group sweeps. Dispatch results will be posted as a comment.

Plan: `docs/superpowers/plans/2026-07-29-ux-sweep-measurement-runtime-plan.md` · Backlog: BI-232BA634 (EP-UX-SYSTEM), successor to BI-EA221325.

Seed-Fit-Decision: not-applicable — no seed, fixture, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: full exact-tree gate passed at 281dd4a4f4 (lease-governed pregate: freshness, migrations, guards, full web Vitest, typecheck, production Docker build); the only delta to head 3c545349c7 is the plan Backlog-coverage section (docs) plus the regenerated doc-index — no runtime change since the gated tree.
