### PR TITLE
fix(decision): enforce polarity coherence on profession-local axis projections (BI-72E8FF05)

### DIFF
--- a/docs/professions/ux-design/wiki/critique-calibration-gate.md
+++ b/docs/professions/ux-design/wiki/critique-calibration-gate.md
@@ -71,7 +71,7 @@ WSID craft decisions are weighed through `evaluate_profession_decision`, which g
 
 The short version: vectors make this gate's *reasoning* legible and its *promotions* auditable. They do not move where the authority sits.
 
-**Profession-local axes are deliberately not declared yet.** The vector design lets a profession declare its own axes — typed `benefit`/`cost`, each projecting onto at least one spine axis so the decision still rolls up when it leaves the profession, and each carrying a cited source. UX design is the design's own worked example: `hierarchy_clarity` projecting onto `human_cognitive_load`.
+**Profession-local axes are deliberately not declared yet.** The vector design lets a profession declare its own axes — typed `benefit`/`cost`, each projecting onto at least one spine axis so the decision still rolls up when it leaves the profession, and each carrying a cited source. UX design is the design's own worked example: `hierarchy_flatness` — cost-framed, scoring the deficit — projecting onto `human_cognitive_load`, a cost spine axis. An axis's kind must match its projection targets' polarity (BI-72E8FF05); a benefit-framed axis on a cost target would score backwards.
 
 The obvious candidates here are already named by the craft pages — hierarchy clarity, content density, disclosure quality, and perceptual coherence (the deterministic family), each of which would project onto cognitive load and, for the last, onto aesthetic judgment.
 

--- a/docs/superpowers/plans/2026-07-24-profession-local-decision-axes.md
+++ b/docs/superpowers/plans/2026-07-24-profession-local-decision-axes.md
@@ -53,3 +53,16 @@ The founder-kernel evolution discipline (`2026-05-24`) requires an orthogonality
 ## Acceptance
 
 A profession declares a local axis end-to-end — typed, sourced, projected, scored at full resolution within the profession, correctly rolled up when the decision crosses professions; an unsourced or unprojected axis fails to publish (integrity assertion + provenance gate).
+
+## Addendum (2026-07-29, BI-72E8FF05): polarity coherence invariant
+
+`projectLocalAxisVector` rolls values through sign-preserved and un-inverted, so an axis's
+`kind` must match the polarity of every spine axis it projects onto — a benefit-framed axis
+landing on a cost axis (the original worked example: `hierarchy_clarity` →
+`human_cognitive_load`) asserts the opposite of what its scorer said and the decision still
+returns a confident ledger. `assertProfessionLocalAxisIntegrity` now enforces this at test
+time against `PRINCIPLE_COST_DIMENSIONS` (the same list the kernel sign guard uses;
+exposed as `spineDimensionKind`). Consequence for axis authors (incl. BI-F405AC58): an axis
+projecting onto a cost axis must score the deficit — `hierarchy_flatness`, `disclosure_debt`,
+`perceptual_clutter` — never the goodness. Mixed-polarity projection targets are rejected
+outright: one axis cannot be both.

--- a/docs/superpowers/specs/2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md
+++ b/docs/superpowers/specs/2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md
@@ -130,7 +130,7 @@ Reduction is by *demotion, not deletion* — an axis used by ≤6% of principles
 A profession may declare its own axes, in its own corpus, subject to three rules:
 
 1. **Typed** — `benefit` or `cost`, with a `highMeans` statement, matching `DimensionGuidance`.
-2. **Projected** — every local axis declares a weight onto ≥1 spine axis. `hierarchy_clarity` projects onto `human_cognitive_load`. This is what preserves cross-profession commensurability: inside the profession the decision is scored at full resolution; when it leaves, it rolls up.
+2. **Projected** — every local axis declares a weight onto ≥1 spine axis, with kind matching each target's polarity (BI-72E8FF05: values roll through un-inverted, so `hierarchy_flatness`, cost-framed, projects onto the cost axis `human_cognitive_load`; the original benefit-framed `hierarchy_clarity` example scored backwards). This is what preserves cross-profession commensurability: inside the profession the decision is scored at full resolution; when it leaves, it rolls up.
 3. **Sourced** — same provenance invariant WSID already enforces: a local axis without a cited source cannot publish.
 
 This is the direct answer to *"add more vectors where there are more criteria to consider."* Vectors multiply **inside** a profession, where the criteria actually live, without inflating the shared space every profession must reason over.

--- a/docs/superpowers/specs/2026-07-25-job-specific-decision-vector-inventory-design.md
+++ b/docs/superpowers/specs/2026-07-25-job-specific-decision-vector-inventory-design.md
@@ -103,7 +103,7 @@ proposing anything.
   BI-106C2585) — the mechanism for a profession to declare a *net-new* axis
   inside its own corpus, namespaced so it can never collide with the spine. It
   **ships empty** (`profession-local-axes.ts:65-71`); the only worked axis
-  (`ux-design/hierarchy_clarity`) lives in a test. Phases 2–3 (thread the
+  (`ux-design/hierarchy_flatness`, cost-framed per BI-72E8FF05) lives in a test. Phases 2–3 (thread the
   caller's profession into `principle_decide`; validate + score the namespaced
   key) are **not built** (`plan 2026-07-24-profession-local-decision-axes.md:39-48`).
 - **Revealed-preference inference** (`weight-inference.ts`, BI-D88DFEEA): built,

--- a/packages/db/src/profession-local-axes.test.ts
+++ b/packages/db/src/profession-local-axes.test.ts
@@ -26,13 +26,16 @@ const REGISTRY_PROFESSIONS: ReadonlySet<string> = new Set(
 
 // A worked example — NOT added to the shipped registry (which stays empty until
 // a real corpus scores an axis), but exercised here so the machinery is proven
-// end-to-end. `hierarchy_clarity` is the spec's own example: a ux-design axis
-// that rolls up onto human_cognitive_load.
+// end-to-end. Cost-framed (BI-72E8FF05): it projects onto human_cognitive_load,
+// a COST spine axis, so the local axis must score the deficit — how much the
+// hierarchy resists parsing — never the clarity. The earlier benefit-framed
+// `hierarchy_clarity` version rolled 0.9 "clearer" through as 0.9 "more
+// cognitive load" and scored exactly backwards.
 const EXAMPLE: ProfessionLocalAxis = {
   profession: "ux-design",
-  key: "ux-design/hierarchy_clarity",
-  kind: "benefit",
-  highMeans: "the option makes the visual hierarchy easier to parse at a glance",
+  key: "ux-design/hierarchy_flatness",
+  kind: "cost",
+  highMeans: "the option makes the visual hierarchy HARDER to parse at a glance",
   projectsOnto: ["human_cognitive_load"],
   source: "nng/visual-hierarchy",
 };
@@ -62,11 +65,11 @@ describe("assertProfessionLocalAxisIntegrity — the rules that keep axes commen
   });
 
   it("rejects a bare (non-namespaced) key", () => {
-    expect(() => check({ key: "hierarchy_clarity" })).toThrow(/namespaced/);
+    expect(() => check({ key: "hierarchy_flatness" })).toThrow(/namespaced/);
   });
 
   it("rejects a key namespaced under a different profession than it claims", () => {
-    expect(() => check({ key: "finance/hierarchy_clarity" })).toThrow(/namespaced/);
+    expect(() => check({ key: "finance/hierarchy_flatness" })).toThrow(/namespaced/);
   });
 
   it("rejects shadowing a spine axis name", () => {
@@ -91,6 +94,32 @@ describe("assertProfessionLocalAxisIntegrity — the rules that keep axes commen
       assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS, [EXAMPLE, EXAMPLE]),
     ).toThrow(/Duplicate/);
   });
+
+  // BI-72E8FF05: projection preserves sign, so kind must match every target's
+  // polarity — otherwise a scorer's 0.9 "more of a good thing" arrives on a
+  // cost axis asserting 0.9 "more of a bad thing", silently backwards.
+  it("rejects a benefit axis projecting onto a cost spine axis", () => {
+    expect(() =>
+      check({
+        key: "ux-design/hierarchy_clarity",
+        kind: "benefit",
+        highMeans: "the option makes the visual hierarchy easier to parse",
+        projectsOnto: ["human_cognitive_load"],
+      }),
+    ).toThrow(/declared "benefit" but projects onto "human_cognitive_load", a cost/);
+  });
+
+  it("rejects a cost axis projecting onto a benefit spine axis", () => {
+    expect(() =>
+      check({ projectsOnto: ["long_term_maintainability"] }),
+    ).toThrow(/declared "cost" but projects onto "long_term_maintainability", a benefit/);
+  });
+
+  it("rejects mixed-polarity projection targets — one axis cannot be both", () => {
+    expect(() =>
+      check({ projectsOnto: ["human_cognitive_load", "long_term_maintainability"] }),
+    ).toThrow(/Polarity must match/);
+  });
 });
 
 describe("projectLocalAxisVector — roll-up onto the spine", () => {
@@ -103,7 +132,7 @@ describe("projectLocalAxisVector — roll-up onto the spine", () => {
   });
 
   it("rolls a local axis onto its declared spine target", () => {
-    expect(projectLocalAxisVector("ux-design", { "ux-design/hierarchy_clarity": 0.8 }, reg)).toEqual({
+    expect(projectLocalAxisVector("ux-design", { "ux-design/hierarchy_flatness": 0.8 }, reg)).toEqual({
       human_cognitive_load: 0.8,
     });
   });
@@ -111,21 +140,23 @@ describe("projectLocalAxisVector — roll-up onto the spine", () => {
   it("sums when a local axis and its spine target are both scored", () => {
     const out = projectLocalAxisVector(
       "ux-design",
-      { human_cognitive_load: 0.3, "ux-design/hierarchy_clarity": 0.4 },
+      { human_cognitive_load: 0.3, "ux-design/hierarchy_flatness": 0.4 },
       reg,
     );
     expect(out.human_cognitive_load).toBeCloseTo(0.7);
   });
 
   it("splits weight across targets so roll-up cannot amplify a principle", () => {
+    // Both targets are cost spine axes, matching the axis's cost kind — the
+    // polarity-coherence invariant holds for multi-target projections too.
     const multi: ProfessionLocalAxis = {
       ...EXAMPLE,
-      key: "ux-design/legibility",
-      projectsOnto: ["human_cognitive_load", "long_term_maintainability"],
+      key: "ux-design/interaction_drag",
+      projectsOnto: ["human_cognitive_load", "blast_radius"],
     };
-    const out = projectLocalAxisVector("ux-design", { "ux-design/legibility": 0.6 }, [multi]);
+    const out = projectLocalAxisVector("ux-design", { "ux-design/interaction_drag": 0.6 }, [multi]);
     expect(out.human_cognitive_load).toBeCloseTo(0.3);
-    expect(out.long_term_maintainability).toBeCloseTo(0.3);
+    expect(out.blast_radius).toBeCloseTo(0.3);
     expect(Object.values(out).reduce((a, b) => a + b, 0)).toBeCloseTo(0.6);
   });
 
@@ -143,7 +174,7 @@ describe("projectLocalAxisVector — roll-up onto the spine", () => {
   it("drops a local axis that belongs to a DIFFERENT profession", () => {
     // Commensurability boundary: another profession's axis is not in scope, so
     // it does not silently leak into this profession's roll-up.
-    expect(projectLocalAxisVector("finance", { "ux-design/hierarchy_clarity": 0.9 }, reg)).toEqual({});
+    expect(projectLocalAxisVector("finance", { "ux-design/hierarchy_flatness": 0.9 }, reg)).toEqual({});
   });
 
   it("ignores keys that are neither spine nor a known local axis", () => {
@@ -153,7 +184,7 @@ describe("projectLocalAxisVector — roll-up onto the spine", () => {
 
 describe("helpers", () => {
   it("localAxisKey namespaces consistently", () => {
-    expect(localAxisKey("ux-design", "hierarchy_clarity")).toBe("ux-design/hierarchy_clarity");
+    expect(localAxisKey("ux-design", "hierarchy_flatness")).toBe("ux-design/hierarchy_flatness");
   });
 
   it("localAxesFor returns only the named profession's axes", () => {

--- a/packages/db/src/profession-local-axes.ts
+++ b/packages/db/src/profession-local-axes.ts
@@ -25,6 +25,7 @@
 // substrate-only and enforced entirely at compile + test time.
 
 import {
+  PRINCIPLE_COST_DIMENSIONS,
   PRINCIPLE_DIMENSIONS,
   isPrincipleDimension,
   type PrincipleDimension,
@@ -33,6 +34,13 @@ import { isSpineDimension } from "./dimension-scope";
 
 /** benefit = higher is better; cost = higher is worse (negative weight). */
 export type ProfessionLocalAxisKind = "benefit" | "cost";
+
+const COST_DIMENSION_SET: ReadonlySet<string> = new Set(PRINCIPLE_COST_DIMENSIONS);
+
+/** The spine's own polarity for a dimension, from the one cost list the sign guard enforces. */
+export function spineDimensionKind(dimension: PrincipleDimension): ProfessionLocalAxisKind {
+  return COST_DIMENSION_SET.has(dimension) ? "cost" : "benefit";
+}
 
 export type ProfessionLocalAxis = {
   /** professionKey from docs/professions/registry.json that owns this axis. */
@@ -88,7 +96,9 @@ export function localAxesFor(
  * spine. Spine axes pass through; a local axis contributes its weight to each
  * spine axis it declares, split evenly so a demotion/roll-up can never amplify a
  * principle beyond its authored magnitude. Sign is preserved, so a cost axis
- * stays a cost after roll-up. A namespaced key that is not a known local axis
+ * stays a cost after roll-up — and because values roll through un-inverted,
+ * integrity enforces that an axis's kind matches every projection target's
+ * polarity (BI-72E8FF05). A namespaced key that is not a known local axis
  * for this profession is dropped rather than invented — mirroring
  * projectVectorOntoSpine's treatment of non-dimension keys.
  *
@@ -190,6 +200,22 @@ export function assertProfessionLocalAxisIntegrity(
         throw new Error(
           `Profession-local axis "${axis.key}" projects onto "${target}", which is ` +
             `itself profession-local. Projections must terminate on the spine in one hop.`,
+        );
+      }
+      // Polarity coherence (BI-72E8FF05): projection rolls the raw value through
+      // with sign preserved, so a benefit axis landing on a cost spine axis
+      // asserts the OPPOSITE of what its scorer said (0.9 "clearer hierarchy"
+      // arrives as 0.9 "more cognitive load") — and the decision still returns a
+      // confident ledger. Fail loud here instead of inverting silently in the
+      // scoring path.
+      const targetKind = spineDimensionKind(target);
+      if (targetKind !== axis.kind) {
+        throw new Error(
+          `Profession-local axis "${axis.key}" is declared "${axis.kind}" but projects ` +
+            `onto "${target}", a ${targetKind} spine axis. Polarity must match: reframe ` +
+            `the axis so a HIGH score means more of what the target measures (e.g. score ` +
+            `the deficit — "clutter", not "clarity" — to land on a cost axis), or project ` +
+            `onto a ${axis.kind} spine axis instead.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

`projectLocalAxisVector` rolls values through sign-preserved and un-inverted, so a benefit-framed local axis projecting onto a cost spine axis scores exactly backwards — 0.9 "clearer hierarchy" arrives as 0.9 "more cognitive load" — while the decision still returns a confident contribution ledger. Latent while `PROFESSION_LOCAL_AXES` ships empty; it would have bitten silently the moment BI-F405AC58 lands the first real axes (all four of its candidate axes project onto the cost axis `human_cognitive_load`).

Fix shape (a) from the BI: `assertProfessionLocalAxisIntegrity` now requires `axis.kind` to match every projection target's polarity, sourced from `PRINCIPLE_COST_DIMENSIONS` — the same single list the kernel dimension-vector sign guard enforces (exposed as `spineDimensionKind`). Mixed-polarity targets are rejected outright. The worked example re-frames cost-side (`hierarchy_flatness` — score the deficit), and the three docs teaching the inverted example are corrected in-PR.

## Design grounding

Implements the polarity invariant against `docs/superpowers/specs/2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md` §2.2 (corrected in this PR); plan addendum in `docs/superpowers/plans/2026-07-24-profession-local-decision-axes.md`. Fails loud at test time; the scoring path stays free of hidden transforms.

## Verification

- `profession-local-axes.test.ts` 23/23 (three new polarity-rejection cases), plus adjacent `dimension-scope` and `seed-decision-perspective` suites green.
- `pnpm run pregate` (Docker CI-equivalent incl. production build) passed for 61efdc24a7.

Backlog: BI-72E8FF05 (triaged build/small, in-progress). Downstream consumer: BI-F405AC58 must declare its axes cost-framed (`hierarchy_flatness`, `disclosure_debt`, `perceptual_clutter`; `content_density` already correct) — noted in the plan addendum.

Seed-Fit-Decision: not-applicable — no seed, provider, or model-profile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)