### PR TITLE
fix(coworkers): make the tool-attachment cap total-inclusive so a budgeted surface can actually serve locally (BI-CAP-F2D39F8F)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1340,7 +1340,7 @@ export async function sendMessage(input: {
     roleGrants,
     pageActionNames: new Set([...pageActions.map((t) => t.name), ...routeDomainToolNames, ...brokeredToolNames]),
     alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
-    cap: toolCap,
+    cap: availableTools.length > toolCap ? Math.max(1, toolCap - 1) : toolCap,
     // BI-ACE1EBA4 — when the cap forces deferral, keep the tools most relevant to
     // this turn's intent within each priority tier.
     intentQuery: trimmedContent,

--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -139,7 +139,10 @@ describe("capSkillCatalog", () => {
 });
 
 describe("selectCoworkerToolBudget", () => {
-  it("always attaches tier-0 (load_tools + page actions) even past the cap", () => {
+  it("bounds the TOTAL attached surface — essentials take priority within the cap, not on top of it", () => {
+    // BI-CAP-F2D39F8F follow-through: essentials riding on top of the cap made
+    // the attached set exceed the routing layer's local-fallback gate (cap 15 +
+    // route tools + load_tools = 20 → local serving disqualified).
     const tools = [
       tool("wiki_query"),
       tool("create_backlog_item"),
@@ -152,22 +155,22 @@ describe("selectCoworkerToolBudget", () => {
       roleGrants: ["backlog_write"],
       pageActionNames: new Set(["page_action_x"]),
       alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
-      cap: 2,
+      cap: 3,
     });
     const names = attached.map((t) => t.name);
+    // Total stays within the cap; tier-0 wins the first slots, then tier-1.
+    expect(attached).toHaveLength(3);
     expect(names).toContain(LOAD_TOOLS_TOOL_NAME);
     expect(names).toContain("page_action_x");
-    // cap=2 fills with role (tier1) then core (tier2); the tier-3 tail defers.
     expect(names).toContain("create_backlog_item");
-    expect(names).toContain("search_code_graph");
-    expect(deferred.map((t) => t.name)).toEqual(["wiki_query"]);
+    expect(deferred.map((t) => t.name)).toEqual(["wiki_query", "search_code_graph"]);
   });
 
-  it("forces route domain tools into tier-0 so route-relevant tools survive the cap (BI-B5C358B1)", () => {
-    // Reproduces the Scrum Master incident shape: the backlog tools do not
-    // lexically match "pressing/issues/resolved", so the intent ranker scores them
-    // 0 and, under a tight local cap, they would be deferred. Forcing the route's
-    // domainTools into tier-0 (as agent-coworker now does) guarantees they attach.
+  it("keeps route domain tools first under the cap so route-relevant tools survive (BI-B5C358B1)", () => {
+    // The Scrum Master incident shape: the backlog tools do not lexically match
+    // "pressing/issues/resolved", so the intent ranker scores them 0 and, under a
+    // tight local cap, they would be deferred. Tier-0 priority (as agent-coworker
+    // passes route domainTools) attaches them ahead of everything else.
     const tools = [
       tool("wiki_query", "wiki"),
       tool("search_code_graph", "code graph"),
@@ -180,13 +183,39 @@ describe("selectCoworkerToolBudget", () => {
       roleGrants: ["backlog_read"],
       pageActionNames: new Set(["query_backlog", "get_backlog_item"]), // route domainTools
       alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
-      cap: 1,
+      cap: 2,
       intentQuery,
     });
     const names = attached.map((t) => t.name);
+    expect(attached).toHaveLength(2);
     expect(names).toContain("query_backlog");
     expect(names).toContain("get_backlog_item");
     expect(deferred.map((t) => t.name)).not.toContain("query_backlog");
+  });
+
+  it("never exceeds the local-fallback gate: cap-15 + route tools + load_tools attach ≤ 15 total", () => {
+    // Regression for the live TR-SCHED-7044CD4F miss: 115 authorized, cap 15,
+    // 4 route domain tools + load_tools rode on top → attached=20 → routing
+    // skipped the local fallback ("20 tools > 15 threshold") and the run died
+    // on exhausted cloud pools. Total-inclusive budgeting keeps the surface
+    // servable locally.
+    const surface = [
+      tool(LOAD_TOOLS_TOOL_NAME),
+      ...Array.from({ length: 4 }, (_, i) => tool(`storefront_action_${i}`)),
+      ...Array.from({ length: 110 }, (_, i) => tool(`breadth_${i}`, "misc")),
+    ];
+    const { attached, deferred } = selectCoworkerToolBudget({
+      tools: surface,
+      roleGrants: [],
+      pageActionNames: new Set(["storefront_action_0", "storefront_action_1", "storefront_action_2", "storefront_action_3"]),
+      alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+      cap: 15,
+    });
+    expect(attached.length).toBeLessThanOrEqual(15);
+    const names = attached.map((t) => t.name);
+    expect(names).toContain(LOAD_TOOLS_TOOL_NAME);
+    for (let i = 0; i < 4; i++) expect(names).toContain(`storefront_action_${i}`);
+    expect(attached.length + deferred.length).toBe(surface.length);
   });
 
   it("prefers role tools over core, and core over the breadth tail, when the cap bites", () => {

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -25,14 +25,16 @@ import { CORE_MCP_TOOL_NAMES } from "@/lib/mcp/tool-tier";
 import { LOCAL_TOOL_SELECTION_CLIFF } from "@/lib/tak/context-economy-metrics";
 
 /**
- * Default ceiling on the NON-essential (role/core/breadth) tool schemas attached
- * per coworker turn; the few essential tools (load_tools + route page actions)
- * ride on top. Chosen to keep the serialized tool block comfortably inside a
- * budget local model's served context with room for the system prompt,
- * conversation history, and the reply: ~48 tools * ~330 tok ≈ ~16k tok of schemas,
- * leaving ~16k of a 32k window for everything else. Deferred tools remain
- * authorized and loadable on demand, so this caps cost, never capability. Tune
- * per install as served context grows.
+ * Default ceiling on the TOTAL tool schemas attached per coworker turn —
+ * essentials (load_tools + route page actions) take top priority within it,
+ * they do not ride on top (the local selection cliff and the routing-layer
+ * local-fallback gate both judge the whole attached set). Chosen to keep the
+ * serialized tool block comfortably inside a budget local model's served
+ * context with room for the system prompt, conversation history, and the
+ * reply: ~48 tools * ~330 tok ≈ ~16k tok of schemas, leaving ~16k of a 32k
+ * window for everything else. Deferred tools remain authorized and loadable on
+ * demand, so this caps cost, never capability. Tune per install as served
+ * context grows.
  */
 export const MAX_COWORKER_ATTACHED_TOOLS = 48;
 
@@ -311,16 +313,23 @@ export function selectCoworkerToolBudget(params: {
 
   const attached: Array<{ t: ToolDefinition; i: number }> = [];
   const deferred: Array<{ t: ToolDefinition; i: number }> = [];
-  // tier-0 (load_tools + page actions) is essential and always attached; it does
-  // NOT consume the cap. The cap bounds the non-essential (role/core/breadth)
-  // tools, filled in priority order.
-  let nonEssentialCount = 0;
+  // The cap bounds the TOTAL attached surface (BI-CAP-F2D39F8F follow-through):
+  // the local selection cliff and the routing-layer local-fallback gate both
+  // judge the WHOLE tool set the model sees, so essentials riding on top of the
+  // cap silently disqualified local serving (live repro: cap 15 + 4 route tools
+  // + load_tools = 20 attached → "Skipping local fallback (20 tools > 15)").
+  // Tier-0 (page actions) keeps top PRIORITY within the cap rather than a free
+  // pass past it; with the real cap floor (12) route domain tools always fit.
+  // The always-include set (load_tools — the escape hatch that reaches every
+  // deferred tool) attaches unconditionally and counts toward the cap.
+  let attachedCount = 0;
   for (const entry of ranked) {
-    if (entry.tier === 0) {
+    if (always.has(entry.t.name)) {
       attached.push(entry);
-    } else if (nonEssentialCount < cap) {
+      attachedCount++;
+    } else if (attachedCount < cap) {
       attached.push(entry);
-      nonEssentialCount++;
+      attachedCount++;
     } else {
       deferred.push(entry);
     }

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -3,6 +3,7 @@
  * and fallback chain. Replaces callWithFailover's dispatch loop.
  */
 import { callProvider, InferenceError } from "@/lib/ai-inference";
+import { LOCAL_TOOL_SELECTION_CLIFF } from "@/lib/tak/context-economy-metrics";
 import type { ChatMessage } from "@/lib/ai-inference";
 import { prisma } from "@dpf/db";
 import type { RouteDecision } from "./types";
@@ -254,8 +255,10 @@ export async function callWithFallbackChain(
   // phase-filtered tools), routing local as a fallback turns the agentic loop
   // into a 200-iteration spin. Skip local fallbacks above the threshold; the
   // selected primary endpoint is still tried regardless. See FB-71FB3A53
-  // thread, 2026-05-22.
-  const LOCAL_FALLBACK_MAX_TOOLS = 15;
+  // thread, 2026-05-22. The threshold IS the shared selection cliff — the
+  // coworker-tool-budget caps its total attachment to the same constant, so a
+  // budgeted surface is never disqualified here by an off-by-essentials gap.
+  const LOCAL_FALLBACK_MAX_TOOLS = LOCAL_TOOL_SELECTION_CLIFF;
   const skipLocalFallback = (tools?.length ?? 0) > LOCAL_FALLBACK_MAX_TOOLS;
 
   for (let i = 0; i < chain.length; i++) {

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -75,8 +75,9 @@ describe("resolveAutonomousWorkTools — attachment budget (BI-CAP-F2D39F8F)", (
       intentQuery: "Review today's storefront orders and propose restocking.",
     });
 
-    // 24,576-token cliff-prone local window → 15-tool cap + load_tools rides on top.
-    expect(result.tools.length).toBeLessThanOrEqual(16);
+    // 24,576-token cliff-prone local window → 15-tool cap TOTAL, load_tools
+    // included — the same threshold as the routing layer's local-fallback gate.
+    expect(result.tools.length).toBeLessThanOrEqual(15);
     expect(result.tools.some((t) => t.name === "load_tools")).toBe(true);
     expect(result.deferredTools.length).toBe(115 - (result.tools.length - 1));
     expect(result.toolsForProvider.length).toBe(result.tools.length);

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -242,12 +242,16 @@ export async function resolveAutonomousWorkTools(input: {
       routeDomainToolNames = resolveRouteContext(input.routeContext).domainTools ?? [];
     }
 
+    // When the surface will be deferred, load_tools is prepended below — reserve
+    // its slot so the TOTAL (incl. load_tools) never exceeds the cap, which is
+    // also the routing layer's local-fallback gate.
+    const effectiveCap = authorized.length > cap ? Math.max(1, cap - 1) : cap;
     const { attached, deferred } = selectCoworkerToolBudget({
       tools: authorized,
       roleGrants,
       pageActionNames: new Set(routeDomainToolNames),
       alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
-      cap,
+      cap: effectiveCap,
       intentQuery: input.intentQuery,
     });
     const tools = deferred.length > 0 ? [LOAD_TOOLS_TOOL, ...attached] : attached;


### PR DESCRIPTION
Follow-through on #3733, from its live acceptance run (TR-SCHED-7044CD4F): the budget worked (115 authorized → 20 attached, 96 deferred) but essentials rode ON TOP of the 15-cap (4 route domain tools + load_tools), and the routing layer's local-fallback gate judges the TOTAL surface — `Skipping local fallback (20 tools > 15 threshold)` — so local was disqualified and the run died on exhausted cloud pools.

## What changed
- `selectCoworkerToolBudget` cap now bounds the **TOTAL** attached surface: tier-0 (route/page actions) keeps top *priority* within the cap instead of a free pass past it (with the real cap floor of 12, route domain tools always fit); `load_tools` attaches unconditionally and counts.
- Both call sites (interactive chat + the autonomous seam) reserve `load_tools`' prepend slot before budgeting, so the prepend can't overflow by one.
- `fallback.ts` now derives `LOCAL_FALLBACK_MAX_TOOLS` from the shared `LOCAL_TOOL_SELECTION_CLIFF` constant instead of a private 15 — the two contracts can't drift again.
- Regression test encodes the exact incident: cap-15 + 4 route tools + load_tools attaches ≤ 15 total.

## Design grounding
Specs reviewed: docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md and docs/architecture/context-engineering-standards.md (selection-cliff rationale). Code substrate reviewed: apps/web/lib/actions/coworker-tool-budget.ts (operator decision 2026-06-22 'cap + load on demand'), apps/web/lib/routing/fallback.ts local-fallback gate (FB-71FB3A53, 2026-05-22), apps/web/lib/actions/agent-coworker.ts, apps/web/lib/tak/autonomous-work-run.ts. Decision: reconcile two existing enforcement contracts onto the shared cliff constant; no new artifact.

## Verification
Local-CI pregate green at head SHA. Live acceptance: the storefront restocking task is retrying on the assertive cadence (its 16:25 retry still attached 20 and failed honestly — the #3725 semantics working); after this deploys the same retry should attach ≤ 15 and be admitted to the local model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)