### PR TITLE
feat(wsid): enterprise-architecture minimum viable decision-pack (BI-D65E044E Phase 1)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 571,
+  "pageCount": 578,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -5082,6 +5082,18 @@
         "see-also"
       ]
     },
+    "docs/professions/enterprise-architecture/wiki/anchor-changes-to-a-value-stream-stage.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/anchor-changes-to-a-value-stream-stage/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
+        "see-also"
+      ]
+    },
     "docs/professions/enterprise-architecture/wiki/archimate-three-layers.md": {
       "publicHref": "/professions/enterprise-architecture/wiki/archimate-three-layers/",
       "portalHref": null,
@@ -5107,6 +5119,18 @@
         "see-also"
       ]
     },
+    "docs/professions/enterprise-architecture/wiki/architecture-review-verdict-thresholds.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/architecture-review-verdict-thresholds/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
+        "see-also"
+      ]
+    },
     "docs/professions/enterprise-architecture/wiki/conways-law.md": {
       "publicHref": "/professions/enterprise-architecture/wiki/conways-law/",
       "portalHref": null,
@@ -5120,6 +5144,30 @@
         "see-also"
       ]
     },
+    "docs/professions/enterprise-architecture/wiki/evolve-schema-additively.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/evolve-schema-additively/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
+        "see-also"
+      ]
+    },
+    "docs/professions/enterprise-architecture/wiki/extend-canonical-models-never-fork.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/extend-canonical-models-never-fork/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
+        "see-also"
+      ]
+    },
     "docs/professions/enterprise-architecture/wiki/it4it-value-streams.md": {
       "publicHref": "/professions/enterprise-architecture/wiki/it4it-value-streams/",
       "portalHref": null,
@@ -5129,6 +5177,30 @@
         "what-this-source-is",
         "the-four-value-streams",
         "how-dpf-coworkers-use-it",
+        "see-also"
+      ]
+    },
+    "docs/professions/enterprise-architecture/wiki/minimal-proven-associations.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/minimal-proven-associations/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
+        "see-also"
+      ]
+    },
+    "docs/professions/enterprise-architecture/wiki/name-and-type-the-contract-canonically.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/name-and-type-the-contract-canonically/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
         "see-also"
       ]
     },
@@ -5153,6 +5225,18 @@
         "what-this-source-is",
         "the-adm-phases",
         "how-dpf-coworkers-use-it",
+        "see-also"
+      ]
+    },
+    "docs/professions/enterprise-architecture/wiki/verify-the-substrate-before-proposing-new.md": {
+      "publicHref": "/professions/enterprise-architecture/wiki/verify-the-substrate-before-proposing-new/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "how-to-apply",
         "see-also"
       ]
     },

--- a/docs/professions/enterprise-architecture/wiki/anchor-changes-to-a-value-stream-stage.md
+++ b/docs/professions/enterprise-architecture/wiki/anchor-changes-to-a-value-stream-stage.md
@@ -1,0 +1,51 @@
+---
+title: Anchor every change to a value-stream stage
+pageKind: principle
+status: published
+abstract: A design should name the value-stream stage it serves and the whole outcome it moves. A change that cannot name one is a local optimization — it may be individually correct and still not advance anything end to end, which is the most common non-blocking finding in architecture review.
+principleTier: contextual
+principleDirection: Require every design to name the value-stream stage it serves and the end-to-end outcome it advances; treat an unanchored change as a local optimization.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.6, "long_term_maintainability": 0.6, "reusability": 0.5, "capacity_utilization": 0.4}
+professionCompetencyLevel: practitioner
+sources:
+  - opengroup/it4it
+  - techtarget/it4it
+  - iso/42010
+---
+
+## Rule
+
+Every architecturally significant design names two things:
+
+- **The value-stream stage it serves** — in IT4IT terms, Strategy to Portfolio, Requirement to Deploy, Request to Fulfill, or Detect to Correct.
+- **The end-to-end outcome it moves** — what a user or operator can do afterwards that they could not do before, stated at the level of the whole flow rather than the component.
+
+An unanchored change is not automatically wrong. It is *unevidenced*, and that is a named adjustment on an otherwise-passing review — not a block.
+
+## Why
+
+IT4IT is a **value-stream-based** reference architecture: its organizing claim is that IT work is understood as flows that cross functions, not as a set of independently-managed components. The four value streams exist so that a change can be located in a flow and its contribution measured there.
+
+The failure this prevents is local optimization — a component improved in isolation while the flow it belongs to is unchanged or worse. It is hard to catch by inspection precisely because the component-level work is usually good; nothing in the diff looks wrong. Only the question "which stage of which flow is better because of this?" exposes it.
+
+ISO/IEC/IEEE 42010 gives the same discipline its general form: an architecture description exists to address identified stakeholder **concerns**. A change with no nameable concern behind it has no criterion by which anyone can later judge whether it worked. Anchoring is what makes the outcome falsifiable.
+
+## How To Apply
+
+1. **Name the stage explicitly in the design**, not by implication. "This serves Requirement to Deploy by removing a manual step between plan approval and build dispatch" is anchored; "this improves the build page" is not.
+2. **State the outcome end to end.** Whose flow, and what is different at the end of it.
+3. **Grade a missing anchor as minor.** It is an adjustment carried on a proceed verdict — see [[professions/enterprise-architecture/architecture-review-verdict-thresholds]] — unless the change is *only* justifiable by an anchor it cannot supply, in which case the design has no rationale at all.
+4. **Watch for the stage mismatch.** A change filed under one stage whose real effect lands in another usually means the design is solving a different problem than the one it opens with.
+5. **Where the estate is organized by archetype or vertical**, anchor to that vertical's load-bearing stage — the generic stage name alone under-specifies which flow was meant.
+
+## See Also
+
+- [[professions/enterprise-architecture/it4it-value-streams]]
+- [[professions/enterprise-architecture/architecture-review-verdict-thresholds]]
+- [[professions/enterprise-architecture/minimal-proven-associations]]

--- a/docs/professions/enterprise-architecture/wiki/architecture-review-verdict-thresholds.md
+++ b/docs/professions/enterprise-architecture/wiki/architecture-review-verdict-thresholds.md
@@ -1,0 +1,57 @@
+---
+title: Architecture review verdict thresholds
+pageKind: principle
+status: published
+abstract: An architecture review returns a verdict, not a question. Aligned-with-minor-adjustments is a pass — recommend proceeding and carry each adjustment as a named required change. Reserve revise-before-building for findings that would entrench a defect, and escalate to a human only when the review itself cannot be settled from the architecture description.
+principleTier: core
+principleDirection: Return a verdict at the severity the findings justify; only a defect-entrenching finding blocks the build, and unresolved-by-the-reviewer is the only reason to escalate.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"legibility_of_consequence": 0.7, "speed_to_value": 0.6, "governance_compliance": 0.5, "human_cognitive_load": -0.7, "operator_effort": -0.6}
+professionCompetencyLevel: expert
+sources:
+  - iso/42010
+  - opengroup/togaf
+  - nygard/adr
+  - dpf/agents-rulebook
+---
+
+## Rule
+
+An architecture review exists to **decide**, and its verdict must be graded to the worst finding it made — no higher.
+
+| Worst finding | Verdict | What travels with it |
+| --- | --- | --- |
+| None, or wording/clarity only | **Proceed** | Optional notes |
+| Minor — real, fixable inside the current design, does not change the design's shape | **Proceed** | Each adjustment named as a **required change**, with the file or contract it lands in |
+| Major — would entrench a defect if built as written (a parallel authority beside a canonical model, a contract change to a governed spine, an unenforceable invariant) | **Revise before building** | The specific defect and the smallest change that removes it |
+| The reviewer cannot settle the question from the architecture description at all | **Escalate** | The concern, the stakeholder it belongs to, and what evidence would settle it |
+
+**Aligned with minor adjustments is a pass.** The adjustments ride along as required changes; they do not convert the verdict into an open question for a human.
+
+## Why
+
+ISO/IEC/IEEE 42010 frames an architecture description as the thing that addresses identified **stakeholder concerns**. A review is therefore a check that the concerns in scope are addressed — a bounded judgment against a known set — not an open-ended invitation to find more. TOGAF's ADM places compliance review inside Phase G *Implementation Governance*, where the point is to keep delivery moving in conformance, not to halt it.
+
+Escalating a minor finding is not caution; it is a transfer of work. It converts a decision the reviewer was competent to make into human queue time, and — because the finding was minor — the human almost always returns the same answer the reviewer already held. Do that at scale and the review surface stops being a governance asset and becomes a tax on delivery, which is precisely the failure Phase G governance is meant to prevent.
+
+The named-required-change form is what makes a pass safe. Nygard's point about ADRs applies to review output too: record the **rationale**, not just the outcome. "Proceed, and these three things must change" is auditable and actionable; "looks fine" is neither.
+
+## How To Apply
+
+1. **Grade every finding before you pick a verdict.** Minor vs major is the whole decision. Ask: if this shipped as written, would it entrench a defect that a later change cannot cheaply undo? Only "yes" is major.
+2. **Name each adjustment concretely.** Which model, which route, which enum, which migration. An adjustment the author cannot locate is a question wearing a verdict's clothes.
+3. **Check the three standing major triggers first**: a new parallel authority beside an existing canonical model (see [[professions/enterprise-architecture/extend-canonical-models-never-fork]]), a contract change to a governed spine, and an invariant the database cannot actually enforce (see [[professions/enterprise-architecture/evolve-schema-additively]]).
+4. **Escalate only for an unsettled concern.** Not for risk, and not for size. A high-consequence decision you can settle from the description is still a verdict.
+5. **Record the verdict as an ADR** when the review changed the design's direction — see [[professions/enterprise-architecture/record-decisions-as-adrs]].
+
+## See Also
+
+- [[professions/enterprise-architecture/verify-the-substrate-before-proposing-new]]
+- [[professions/enterprise-architecture/extend-canonical-models-never-fork]]
+- [[professions/enterprise-architecture/minimal-proven-associations]]
+- [[professions/enterprise-architecture/togaf-adm-phases]]

--- a/docs/professions/enterprise-architecture/wiki/evolve-schema-additively.md
+++ b/docs/professions/enterprise-architecture/wiki/evolve-schema-additively.md
@@ -1,0 +1,56 @@
+---
+title: Evolve schema additively — expand, migrate, contract
+pageKind: principle
+status: published
+abstract: Schema change reaches running systems, so it is staged rather than switched. Add the new shape alongside the old, backfill and migrate consumers, and remove the old shape only once nothing reads it. An already-applied migration is never edited — a correction is a new migration — and every invariant the design claims must be one the database can actually enforce.
+principleTier: core
+principleDirection: Stage schema change as expand-migrate-contract with each step independently deployable; never edit an applied migration, and never claim an invariant the database cannot enforce.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"reversibility": 0.8, "long_term_maintainability": 0.7, "schema_grounding": 0.7, "blast_radius": -0.7, "business_disruption": -0.6}
+professionCompetencyLevel: expert
+sources:
+  - fowler/parallel-change
+  - fowler/evolutionary-database-design
+  - postgresql/data-definition
+---
+
+## Rule
+
+Three staged, independently-deployable steps — never one switch:
+
+1. **Expand.** Add the new column, table, or enum member **nullable / optional**, alongside the old shape. Old and new coexist; nothing breaks.
+2. **Migrate.** Backfill existing rows, dual-write if there are live writers, and move consumers over one at a time.
+3. **Contract.** Once nothing reads or writes the old shape, drop it — and only then tighten the new column to `NOT NULL` or add the constraint that assumes a full backfill.
+
+Two absolutes ride along:
+
+- **An applied migration is immutable.** A migration that has run anywhere is never edited. A correction is a *new* migration.
+- **An invariant is only real if the database enforces it.** If the design says "this combination is unique", there must be a constraint that makes it so.
+
+## Why
+
+Sato's *Parallel Change* is the general form: when a change is backward-incompatible and has consumers you do not control in one commit, expand/migrate/contract is what makes each phase independently releasable instead of requiring every consumer to change at the same instant. Schema is the case where this matters most, because the consumers include the currently-running application.
+
+Sadalage and Fowler's *Evolutionary Database Design* supplies the immutability half: migrations are small, sequenced scripts held in version control and applied in order to a blank database. Editing an applied migration breaks that guarantee — environments that already ran the old text and environments that will run the new text now hold *different schemas from the same version number*, and nothing detects the divergence. Their prescribed resolution for a conflict is to renumber and retest your own migration, never to rewrite history.
+
+The unenforceable-invariant failure is the one that most often survives review, because it reads as correct. The classic instance: a uniqueness rule declared over columns where one is nullable. In SQL, `NULL` is not equal to `NULL`, so a plain unique constraint permits unlimited rows whose nullable component is null — the duplicates the design was written to prevent. The design says "unique"; the database says "go ahead". Push a required-from-day-one `NOT NULL` into an expand step and you get the sibling failure: the deploy fails on existing rows, or silently fills them with a default that means nothing.
+
+## How To Apply
+
+1. **Nullable in expand, tightened in contract.** A column required by the final design starts optional. Backfill is what earns the `NOT NULL`.
+2. **Ship the migration artifact with the plan.** A plan that describes a schema change but produces no migration file is not implementable; that is a *revise-before-building* finding.
+3. **State the uniqueness key explicitly**, including its behaviour over nullable components, and pick the constraint that actually enforces it (a partial index, a sentinel value, or a non-nullable discriminator) rather than assuming a plain unique constraint covers it.
+4. **Name the backfill.** How existing rows acquire a value, and what happens to rows that cannot. "Backfill" without a rule is an unhandled case.
+5. **Order the drop last, in its own deploy.** Contract is a separate release from migrate; collapsing them reintroduces the coupling the pattern removed.
+6. **Add foreign keys instead of string references** when the relation is real — referential integrity is an invariant the database can enforce, and a string reference is one it cannot.
+
+## See Also
+
+- [[professions/enterprise-architecture/extend-canonical-models-never-fork]]
+- [[professions/enterprise-architecture/name-and-type-the-contract-canonically]]
+- [[professions/enterprise-architecture/architecture-review-verdict-thresholds]]

--- a/docs/professions/enterprise-architecture/wiki/extend-canonical-models-never-fork.md
+++ b/docs/professions/enterprise-architecture/wiki/extend-canonical-models-never-fork.md
@@ -1,0 +1,56 @@
+---
+title: Extend the canonical model; never fork it
+pageKind: principle
+status: published
+abstract: Every concept in an estate has exactly one canonical home — one model, one writer, one place the truth is defined. A change that needs more from a concept extends that home additively. A change that stands up a second table, second enum, or second writer for the same concept creates a parallel authority, which is the defect architecture review exists to catch.
+principleTier: core
+principleDirection: Extend the existing canonical model and its single writer; never introduce a second authority for a concept that already has one.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"long_term_maintainability": 1.0, "reusability": 0.8, "schema_grounding": 0.7, "blast_radius": -0.5}
+professionCompetencyLevel: expert
+sources:
+  - opengroup/togaf
+  - opengroup/archimate-3-2
+  - iso/42010
+  - dpf/agents-rulebook
+---
+
+## Rule
+
+A concept has **one canonical home**: one model that defines it, one writer that mutates it, one module the rest of the estate imports it from.
+
+- Needs another attribute? **Extend** the canonical model.
+- Needs another view of it? **Project** from the canonical model.
+- Needs different behaviour in one context? **Overlay** the canonical definition — cite it and override the specific values.
+- Needs a second table, a second enum, a second writer, or a second spec for the same concept? That is a **fork**, and it is the finding.
+
+Placement follows the same rule: a change lands in the concept's existing home, not in a new one near the caller that happens to need it.
+
+## Why
+
+TOGAF answers this at the governance layer: the Architecture Repository and the ADM's continuous requirements-management core exist so that one enterprise architecture is developed and governed, rather than a set of locally-optimal architectures that each look correct in isolation. ArchiMate answers it at the modeling layer: it is deliberately *one* model relating Business, Application, and Technology through service-orientation, with views as projections over that single model — not as independent models that happen to agree today.
+
+The failure mode is not that a fork is wrong on the day it lands. It is usually correct on that day — that is what makes it pass review. The failure is that two authorities for one concept **diverge silently**. Each acquires its own writers and its own consumers; each is updated for its own reasons; and the moment they disagree, every consumer downstream of the wrong one is wrong, with no error raised anywhere. ISO/IEC/IEEE 42010's separation of the architecture from its descriptions is the same insight: many descriptions, one architecture. Two architectures pretending to be one is the pathology.
+
+Removal cost compounds. Deleting a forked authority means finding and re-pointing every writer and reader it accumulated, then reconciling the data the two produced while they disagreed. Extending the canonical model costs a column.
+
+## How To Apply
+
+1. **Find the home before you write.** Run the sweep in [[professions/enterprise-architecture/verify-the-substrate-before-proposing-new]]; the home is what it returns.
+2. **Extend additively.** New optional attribute, new enum member, new relation — see [[professions/enterprise-architecture/evolve-schema-additively]] for doing it deploy-safely.
+3. **Prefer overlay to fork for variation.** When one context needs different values, keep the canonical definition and record the delta against it. Cite-and-override preserves a single lineage; copy-and-edit destroys it.
+4. **Keep one writer.** Read paths may be many; the mutation path must be one, so an invariant has one place to live.
+5. **Extend the navigation, route, and enum registries in place** rather than adding a parallel one beside them — a second registry is a fork of the registry concept.
+6. **When a fork is genuinely unavoidable**, record it as an ADR with its removal condition — see [[professions/enterprise-architecture/record-decisions-as-adrs]]. An undocumented fork is indistinguishable from an accident.
+
+## See Also
+
+- [[professions/enterprise-architecture/verify-the-substrate-before-proposing-new]]
+- [[professions/enterprise-architecture/name-and-type-the-contract-canonically]]
+- [[professions/enterprise-architecture/evolve-schema-additively]]
+- [[professions/enterprise-architecture/archimate-three-layers]]

--- a/docs/professions/enterprise-architecture/wiki/minimal-proven-associations.md
+++ b/docs/professions/enterprise-architecture/wiki/minimal-proven-associations.md
@@ -1,0 +1,54 @@
+---
+title: Add only the associations live data proves necessary
+pageKind: principle
+status: published
+abstract: Every relationship in a model is a permanent constraint on how the estate can change. Add an association only when live data or a named stakeholder concern requires it — and treat a structural check as insufficient evidence that it works, because a schema that compiles proves nothing about behaviour.
+principleTier: core
+principleDirection: Add an association only when live evidence or a named concern requires it, and treat structural verification as insufficient evidence of behaviour.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.9, "long_term_maintainability": 0.6, "blast_radius": -0.5, "human_cognitive_load": -0.4}
+professionCompetencyLevel: expert
+sources:
+  - iso/42010
+  - opengroup/archimate-3-2
+  - wikipedia/verification-validation
+  - dpf/agents-rulebook
+---
+
+## Rule
+
+Two halves, both about evidence:
+
+- **Minimal associations.** A relationship — a foreign key, a link table, a cross-module dependency, a new coupling between layers — is added when live data or a named stakeholder concern shows it is needed. "We will probably want to traverse this later" is not that showing.
+- **Structural verification is not functional verification.** That a model compiles, a migration applies, a type-check passes, or a page renders is evidence about *structure*. A claim about **behaviour** requires the behaviour to have been exercised.
+
+A review that asserts a design works, on structural grounds alone, has overstated its evidence.
+
+## Why
+
+ISO/IEC/IEEE 42010 ties every element of an architecture description back to a **stakeholder concern**: views exist because concerns exist. An association with no concern behind it fails that test — it is in the model because someone anticipated a need, not because a need was demonstrated.
+
+ArchiMate makes the cost concrete. Relationships are typed and load-bearing: they are what analysis traverses, what impact assessment follows, and what a change must preserve. A speculative relationship is therefore not free storage — it enlarges the blast radius of every future change to either end, and it will be traversed by tooling and by readers as though it meant something.
+
+The verification half is the standard distinction between verification and validation: verification asks whether the thing was built to specification, validation whether it does the job. Structural checks are firmly on the verification side, and they are systematically over-trusted because they are the cheap ones and they go green. A schema that applies cleanly and a schema that stores the right thing are different claims, and only the first one has been tested.
+
+Both halves fail the same way: **confident, unfalsifiable output**. A speculative association is never wrong today; an unexercised behaviour is never observed failing. Neither produces an error until something depends on it.
+
+## How To Apply
+
+1. **Demand the concern.** For each association in a design, name the stakeholder concern or the live query it serves. No answer means drop it — it can be added when a real traversal needs it.
+2. **Prefer the narrower relation.** One-to-many before many-to-many; a direct foreign key before a link table. Widening later is additive — see [[professions/enterprise-architecture/evolve-schema-additively]]; narrowing later is a migration with data loss.
+3. **Grade behavioural claims by their evidence.** In a review, separate "this compiles / is placed correctly" from "this works". Only the first can be settled by reading.
+4. **Say which check you ran.** State the verification actually performed, and do not carry a structural result across into a behavioural conclusion.
+5. **A relationship that exists only to serve a report is a projection**, not a model change — build the read path rather than the association.
+
+## See Also
+
+- [[professions/enterprise-architecture/architecture-review-verdict-thresholds]]
+- [[professions/enterprise-architecture/anchor-changes-to-a-value-stream-stage]]
+- [[professions/enterprise-architecture/archimate-three-layers]]

--- a/docs/professions/enterprise-architecture/wiki/name-and-type-the-contract-canonically.md
+++ b/docs/professions/enterprise-architecture/wiki/name-and-type-the-contract-canonically.md
@@ -1,0 +1,56 @@
+---
+title: Name and type the contract canonically
+pageKind: principle
+status: published
+abstract: A categorical value gets an enumerated type, not a free string; a shape shared by a producer and a consumer gets one typed contract both import, not two structural guesses; and a new route, job, or field is named by the convention its neighbours already follow. Naming and typing are architecture, because they are what makes drift detectable instead of silent.
+principleTier: core
+principleDirection: Give every categorical value an enumerated type and every shared shape one imported contract, and name new surfaces by the convention their neighbours already use.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"schema_grounding": 0.9, "long_term_maintainability": 0.8, "reusability": 0.6, "human_cognitive_load": -0.5}
+professionCompetencyLevel: practitioner
+sources:
+  - opengroup/archimate-3-2
+  - ietf/rfc-9110
+  - postgresql/data-definition
+  - dpf/agents-rulebook
+---
+
+## Rule
+
+Three obligations, all of them checkable in a design before a line is written:
+
+1. **Categorical values are enumerated.** A field with a closed set of legal values — a status, a kind, a basis, a period type — is declared as a type with those members, in the registry where the estate's enums live. Not a `String` with the values described in prose.
+2. **A shared shape has one contract.** When a producer and a consumer both know a structure, exactly one typed definition exists and both import it. Two independently-derived shapes that agree today are a divergence with a delay on it.
+3. **New surfaces follow the existing convention.** A route, job name, table, or field is named the way its neighbours are named. Consistency is the contract; a one-off convention is a small permanent tax on everyone who reads the estate afterwards.
+
+Route and handler layers stay thin: the handler resolves and authorizes, then delegates to the domain service that owns the behaviour.
+
+## Why
+
+ArchiMate's whole apparatus is typed elements and typed relationships — the model has meaning because a "serves" relationship means one thing everywhere, not because each diagram's author was careful. An estate whose categorical values are free strings has thrown that away: nothing distinguishes a legal value from a typo, and every consumer re-implements the same partial validation slightly differently.
+
+RFC 9110 makes the naming half explicit at the interface level: HTTP's value comes from *uniform*, generic semantics that any participant can interpret without prior negotiation. A route named against the estate's convention inherits that interpretability for free. A route named against nothing forces every future reader to check what it actually does.
+
+The database side is the same claim with teeth. PostgreSQL's DDL gives real machinery — enumerated types, check constraints, foreign keys — that turns "this must be one of four values" from documentation into an invariant. Prose in a spec constrains nothing; a type constrains everything downstream of it, including the code a future contributor has not written yet.
+
+The cost of getting this wrong is not a bug on day one. It is that drift becomes **undetectable**. A fifth status value written into a `String` column is accepted silently and read by every consumer as something it does not handle. The same value written into an enumerated type fails loudly, at the boundary, where it is cheap to fix.
+
+## How To Apply
+
+1. **Enumerate before you build.** Every categorical field in the design names its legal values and the registry they are declared in. A design that leaves them as prose is a *revise-before-building* finding — the types are load-bearing.
+2. **Point both sides at one definition.** If the plan shows a shape declared twice, that is the finding; collapse it to one import.
+3. **Check the neighbours for naming.** Read the adjacent routes, jobs, and columns first. Match them, including pluralization and casing.
+4. **Keep the handler thin.** Route → authorize → delegate. Business rules in a route handler cannot be reused, and are the usual reason a second copy appears later.
+5. **Push the constraint into the database** where it is expressible — see [[professions/enterprise-architecture/evolve-schema-additively]].
+6. **Extend the enum registry in place**; a second registry is a fork — see [[professions/enterprise-architecture/extend-canonical-models-never-fork]].
+
+## See Also
+
+- [[professions/enterprise-architecture/extend-canonical-models-never-fork]]
+- [[professions/enterprise-architecture/evolve-schema-additively]]
+- [[professions/enterprise-architecture/archimate-three-layers]]

--- a/docs/professions/enterprise-architecture/wiki/verify-the-substrate-before-proposing-new.md
+++ b/docs/professions/enterprise-architecture/wiki/verify-the-substrate-before-proposing-new.md
@@ -1,0 +1,48 @@
+---
+title: Verify the substrate before proposing anything new
+pageKind: principle
+status: published
+abstract: Before accepting or proposing a new table, enum, capability, route, or spec, sweep what already exists — the baseline architecture, the code, the live backlog, the main branch. In a dense estate the concept usually already exists under another name, and "we need a new X" is the most common reviewable claim that turns out to be false.
+principleTier: core
+principleDirection: Sweep the existing baseline for the concept before recording a need for a new one; never accept a new-X claim that no baseline sweep was run against.
+principleConsumerArchetype: specialist
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleRingScope:
+  - ring-1-coworker
+principleDimensionVector: {"evidence_density": 0.9, "reusability": 0.8, "long_term_maintainability": 0.6, "speed_to_value": -0.2}
+professionCompetencyLevel: practitioner
+sources:
+  - opengroup/togaf
+  - iso/42010
+  - dpf/agents-rulebook
+---
+
+## Rule
+
+**No new-X claim without a baseline sweep.** Before a design or plan may assert that some new table, enum, capability, model, route, service, or spec is needed, the existing estate must have been searched for it: the code, the architecture description, the live backlog, and the current main branch.
+
+The finding is recorded either way — "swept, nothing covers this" is as much a review artifact as "swept, this already exists as Y".
+
+## Why
+
+TOGAF's ADM makes this ordering structural: each architecture-domain phase (B Business, C Information Systems, D Technology) develops the **Baseline** architecture before the Target, precisely so that the gap between them is measured rather than assumed. A target proposed without a baseline is not a gap analysis; it is a guess.
+
+ISO/IEC/IEEE 42010 supplies the reason the guess is systematically wrong. The architecture description is the *record of what exists* and the concerns it addresses. An estate accumulates concepts faster than any single contributor reads them, so the honest prior in a mature system is that a plausibly-needed concept is already there — under a name the proposer did not think to search for.
+
+The cost is asymmetric, which is why this rule pays for its small delay. A sweep that finds nothing costs minutes. A sweep skipped costs a duplicate spine: two tables that mean the same thing, drifting apart, each with its own writers, each half-right — and the second one is far more expensive to remove than it would have been to never add.
+
+## How To Apply
+
+1. **Search by concept, not by your name for it.** The existing model rarely uses the word you would have chosen. Search the vocabulary of the domain, the synonyms, and the abbreviation.
+2. **Sweep four surfaces**: source, the architecture description / specs, the live backlog (someone may be building it right now), and the current main branch (it may have landed since your branch point).
+3. **Record the sweep in the design.** State what you searched and what you found. This is the evidence the reviewer grades; an unrecorded sweep is indistinguishable from no sweep.
+4. **When it exists, extend it** — see [[professions/enterprise-architecture/extend-canonical-models-never-fork]]. When it genuinely does not, say so explicitly, so the reviewer is grading a claim rather than an omission.
+5. **A structural match is not a semantic match.** Two models with the same columns can mean different things. Confirm the *concern* each one addresses before merging them conceptually.
+
+## See Also
+
+- [[professions/enterprise-architecture/extend-canonical-models-never-fork]]
+- [[professions/enterprise-architecture/architecture-review-verdict-thresholds]]
+- [[professions/enterprise-architecture/togaf-adm-phases]]

--- a/packages/db/src/enterprise-architecture-decision-pack.test.ts
+++ b/packages/db/src/enterprise-architecture-decision-pack.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { extractPrinciplePayload, parseFrontmatter } from "./seed-wiki-kernel";
+import type { WikiPageFrontmatter } from "./wiki-frontmatter";
+import { ALL_PROFESSION_EXTERNAL_SOURCES } from "./seed-profession-corpus";
+import {
+  PRINCIPLE_DIMENSIONS,
+  PRINCIPLE_TIERS,
+  PROFESSION_COMPETENCY_LEVELS,
+} from "./wiki-taxonomy";
+
+// BI-D65E044E Phase 1 — the enterprise-architecture minimum viable decision-pack.
+//
+// WHY THIS TEST EXISTS
+// The profession gate deferred 69 times on `architecture-tradeoff` while six
+// published, vectored enterprise-architecture pages sat in the corpus. Those six
+// are DESCRIPTIVE (what TOGAF / ArchiMate / IT4IT ARE); none of them carries a
+// rule a review verdict can be decided from. Spec §11.3 defines "primed" as
+// enough decision-bearing material in the family's live decision classes that
+// the gate can recommend or arbitrate on the family's ROUTINE CONSULT SHAPES —
+// "verified against the family's own recent deferral questions, not
+// hypotheticals".
+//
+// So the pack is pinned against the mined deferrals, not against a wish list.
+// CONSULT_SHAPES below is the clustering of the 69 real `defer` rows
+// (DecisionInteraction, domainClass=architecture-tradeoff, mined 2026-07-29):
+// every row arrived from reviewDesignDoc/reviewPlanDoc with the same option set
+// ["aligned", "revise-before-building"], and each row's verdict prose falls into
+// one or more of these shapes. `evidence` quotes the actual deferral text.
+//
+// If a future edit deletes or renames a pack page, the shape it covered fails
+// loudly here — which is the point: the gap this closes is invisible from the
+// page count alone.
+
+const PACK_DIR = join(
+  __dirname,
+  "../../../docs/professions/enterprise-architecture/wiki",
+);
+
+type ConsultShape = {
+  /** What the reviewer was actually being asked to settle. */
+  shape: string;
+  /** Verbatim fragment from a mined `defer` row. */
+  evidence: string;
+  /** Rows in the mined set whose verdict prose exhibits this shape. */
+  minedRows: number;
+  /** Pack page slugs that let the gate settle it. */
+  coveredBy: string[];
+};
+
+const CONSULT_SHAPES: ConsultShape[] = [
+  {
+    shape: "spec-alignment verdict where the findings are minor",
+    evidence:
+      "The plan is largely aligned with architectural standards but requires minor "
+      + "adjustments to ensure canonical API naming consistency, schema alignment, and "
+      + "progressive disclosure adherence.",
+    minedRows: 60,
+    coveredBy: ["architecture-review-verdict-thresholds"],
+  },
+  {
+    shape: "reuse-vs-new-model — is a new model justified, or does one exist?",
+    evidence:
+      "The design introduces new data models without clear alignment to canonical "
+      + "structures, lacks adherence to established job naming conventions, and does not "
+      + "reference the canonical enum registry, creating risk of architectural drift.",
+    minedRows: 12,
+    coveredBy: [
+      "verify-the-substrate-before-proposing-new",
+      "extend-canonical-models-never-fork",
+    ],
+  },
+  {
+    shape: "canonical home / single-source-of-truth ownership",
+    evidence:
+      "the main architectural edits being to keep the database model canonical in "
+      + "packages/db, extend existing navigation rather than recreate it, and make "
+      + "service-layer enforcement the explicit single authority for partner-domain mutations.",
+    minedRows: 25,
+    coveredBy: ["extend-canonical-models-never-fork"],
+  },
+  {
+    shape: "schema extension, migration safety, and database-enforced invariants",
+    evidence:
+      "portfolioId in SpendPeriodRollup must be nullable (String?) to support "
+      + "expand-contract backfill, but Task 4 defines it as required (String) ... "
+      + "SpendPeriodRollup's unique constraint is unenforceable with nullable fields.",
+    minedRows: 15,
+    coveredBy: ["evolve-schema-additively"],
+  },
+  {
+    shape: "API/naming consistency and typed-contract discipline",
+    evidence:
+      "lacks enumerated strongly-typed values for costBasis, periodType, and "
+      + "recommendation types—clarify these before implementing to maintain canonical "
+      + "data-model stewardship and API contracts.",
+    minedRows: 18,
+    coveredBy: ["name-and-type-the-contract-canonically"],
+  },
+  {
+    shape: "value-stream mapping — does the change serve a load-bearing stage?",
+    evidence:
+      "it could better articulate its connection to a load-bearing value-stream stage "
+      + "to ensure end-to-end outcome alignment.",
+    minedRows: 9,
+    coveredBy: ["anchor-changes-to-a-value-stream-stage"],
+  },
+  {
+    shape: "association justification and evidence sufficiency",
+    evidence:
+      "Spec is structurally sound but has important architectural misalignments: "
+      + "audit trail ambiguity between mutable confirmations and immutable corrections, "
+      + "... missing data integrity constraint on correction targets.",
+    minedRows: 8,
+    coveredBy: ["minimal-proven-associations"],
+  },
+];
+
+/** The pages this BI adds — the decision-bearing half of the family corpus. */
+const PACK_SLUGS = [
+  "anchor-changes-to-a-value-stream-stage",
+  "architecture-review-verdict-thresholds",
+  "evolve-schema-additively",
+  "extend-canonical-models-never-fork",
+  "minimal-proven-associations",
+  "name-and-type-the-contract-canonically",
+  "verify-the-substrate-before-proposing-new",
+];
+
+function loadPage(slug: string) {
+  const raw = readFileSync(join(PACK_DIR, `${slug}.md`), "utf8");
+  return parseFrontmatter<WikiPageFrontmatter>(raw);
+}
+
+describe("EA decision-pack — coverage of the mined deferral shapes", () => {
+  it("covers every mined consult shape with at least one pack page", () => {
+    for (const shape of CONSULT_SHAPES) {
+      expect(shape.coveredBy.length, `uncovered shape: ${shape.shape}`).toBeGreaterThan(0);
+      for (const slug of shape.coveredBy) {
+        expect(PACK_SLUGS, `${shape.shape} -> ${slug}`).toContain(slug);
+      }
+    }
+  });
+
+  it("pins every pack page to a shape — no page without mined demand", () => {
+    const covering = new Set(CONSULT_SHAPES.flatMap((s) => s.coveredBy));
+    for (const slug of PACK_SLUGS) {
+      expect(covering, `${slug} answers no mined consult shape`).toContain(slug);
+    }
+  });
+
+  it("the dominant shape (the alignment verdict itself) is decision-bearing", () => {
+    // 60 of 69 mined rows are a verdict call with options
+    // ["aligned", "revise-before-building"]. If the page that supplies the
+    // verdict rule loses its principleDirection, the gate is back to deferring.
+    const { frontmatter } = loadPage("architecture-review-verdict-thresholds");
+    expect(frontmatter.principleDirection).toBeTruthy();
+    expect(frontmatter.principleTier).toBe("core");
+  });
+});
+
+describe("EA decision-pack — frontmatter contract", () => {
+  it.each(PACK_SLUGS)("%s is published, sourced, and vectored", (slug) => {
+    const { frontmatter, body } = loadPage(slug);
+
+    expect(frontmatter.title, "title").toBeTruthy();
+    expect(frontmatter.status ?? "published").toBe("published");
+    expect(frontmatter.abstract, "abstract").toBeTruthy();
+    expect(body.trim().length).toBeGreaterThan(400);
+
+    // pageKind MUST be `principle`, and not merely because the pages read like
+    // principles: extractPrinciplePayload (seed-wiki-kernel.ts) returns `{}` for
+    // every pageKind except "principle". A `heuristic` page therefore seeds with
+    // its principleDimensionVector, principleDirection, and principleTier
+    // SILENTLY DROPPED — it persists as prose with no vector, so it cannot score
+    // and cannot move a verdict. Five vectored `heuristic` pages elsewhere in
+    // docs/professions/ are already losing their payload this way.
+    expect(frontmatter.pageKind, `${slug} must be a principle to keep its vector`).toBe(
+      "principle",
+    );
+
+    // detectUnsourcedProfessionPages is an ERROR-severity lint for any published
+    // professions/ page with zero citations — and the conduit rule requires the
+    // citation to be a source the seeder actually registers.
+    const sources = frontmatter.sources ?? [];
+    expect(sources.length, `${slug} has no sources`).toBeGreaterThan(0);
+    for (const key of sources) {
+      expect(
+        ALL_PROFESSION_EXTERNAL_SOURCES,
+        `${slug} cites unregistered source ${key}`,
+      ).toHaveProperty(key);
+    }
+
+    expect(PROFESSION_COMPETENCY_LEVELS).toContain(frontmatter.professionCompetencyLevel);
+    expect(PRINCIPLE_TIERS).toContain(frontmatter.principleTier);
+    expect(frontmatter.principleDirection, `${slug} principleDirection`).toBeTruthy();
+  });
+
+  it.each(PACK_SLUGS)("%s carries a signed, in-registry dimension vector", (slug) => {
+    const { frontmatter } = loadPage(slug);
+    const vector = frontmatter.principleDimensionVector;
+
+    // A material with no vector contributes nothing to structured option
+    // scoring (computeStructuredAlignment reads the PRINCIPLE's dimensions), so
+    // an unvectored pack page cannot move a verdict — it would promote into
+    // material that scores exactly zero.
+    expect(vector, `${slug} has no principleDimensionVector`).toBeTruthy();
+    const entries = Object.entries(vector ?? {});
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const [axis, weight] of entries) {
+      expect(PRINCIPLE_DIMENSIONS, `${slug}: unknown axis ${axis}`).toContain(axis);
+      expect(typeof weight).toBe("number");
+      expect(Math.abs(weight), `${slug}.${axis} out of range`).toBeLessThanOrEqual(1);
+      expect(weight, `${slug}.${axis} is zero — say nothing instead`).not.toBe(0);
+    }
+  });
+});
+
+describe("EA decision-pack — the seeder accepts every page", () => {
+  // extractPrinciplePayload is the seed walker's own gate: it THROWS on an
+  // unknown dimension key and on the §8A.1 archetype/population coherence
+  // violations. Running it here is what makes "the pages seed" a functional
+  // claim rather than a structural one — a page that parses but would abort
+  // `seedProfessionCorpus` on a fresh install is not shipped material.
+  it.each(PACK_SLUGS)("%s passes the seed walker's principle gate", (slug) => {
+    const { frontmatter } = loadPage(slug);
+    const payload = extractPrinciplePayload(frontmatter);
+
+    expect(payload.principleDimensionVector).toEqual(frontmatter.principleDimensionVector);
+    // principleDimensions is derived from the vector's keys when not authored;
+    // it is what retrieval filters on, so an empty derivation means the page is
+    // invisible to dimension-scoped recall.
+    expect(payload.principleDimensions?.length ?? 0).toBeGreaterThan(0);
+  });
+});
+
+describe("EA corpus — the pack lands beside the existing family pages", () => {
+  it("does not orphan a wikilink to a page that does not exist", () => {
+    const present = new Set(
+      readdirSync(PACK_DIR)
+        .filter((f) => f.endsWith(".md"))
+        .map((f) => f.replace(/\.md$/, "")),
+    );
+
+    for (const slug of PACK_SLUGS) {
+      const raw = readFileSync(join(PACK_DIR, `${slug}.md`), "utf8");
+      const links = [...raw.matchAll(/\[\[professions\/enterprise-architecture\/([^\]]+)\]\]/g)];
+      expect(links.length, `${slug} links to no sibling page`).toBeGreaterThan(0);
+      for (const [, target] of links) {
+        expect(present, `${slug} links to missing page ${target}`).toContain(target);
+      }
+    }
+  });
+
+  it("leaves the six pre-existing family pages in place", () => {
+    const present = new Set(
+      readdirSync(PACK_DIR)
+        .filter((f) => f.endsWith(".md"))
+        .map((f) => f.replace(/\.md$/, "")),
+    );
+    for (const slug of [
+      "archimate-three-layers",
+      "architecture-decision-record",
+      "conways-law",
+      "it4it-value-streams",
+      "record-decisions-as-adrs",
+      "togaf-adm-phases",
+    ]) {
+      expect(present, `pre-existing page ${slug} disappeared`).toContain(slug);
+    }
+  });
+});

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -903,6 +903,48 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
     retrievedAt: "2026-06-13",
   },
 
+  // ── Enterprise-architecture decision-pack (BI-D65E044E Phase 1) ──
+  // The six wave-6 pages above are descriptive (what TOGAF/ArchiMate/IT4IT ARE);
+  // the decision-pack pages need sources that ground REVIEW VERDICTS and schema
+  // evolution. ISO/IEC/IEEE 42010 is purchase-licensed, so — same treatment as
+  // TOGAF/ITIL/NIST above — the concept model is cited via an open summary.
+  "iso/42010": {
+    sourceType: "standard",
+    title: "ISO/IEC/IEEE 42010:2022 Architecture description (open summary)",
+    url: "https://en.wikipedia.org/wiki/ISO/IEC_42010",
+    license: "open-summary-iso-licensed",
+    abstract:
+      "Open summary of ISO/IEC/IEEE 42010:2022. Defines the architecture-description " +
+      "concept model — stakeholder, concern, viewpoint, view — and the rule that every " +
+      "view exists to address identified stakeholder concerns, with rationale recorded. " +
+      "The ISO standard itself is licensed (checklist-only).",
+    retrievedAt: "2026-07-29",
+  },
+  "fowler/parallel-change": {
+    sourceType: "web-article",
+    title: "Parallel Change (Danilo Sato, martinfowler.com)",
+    url: "https://martinfowler.com/bliki/ParallelChange.html",
+    license: "article-free-to-read",
+    abstract:
+      "The expand / migrate / contract pattern for making a backward-incompatible " +
+      "interface change safely: add the new shape alongside the old, migrate consumers " +
+      "incrementally, remove the old shape only once nothing depends on it — so every " +
+      "phase is independently releasable.",
+    retrievedAt: "2026-07-29",
+  },
+  "fowler/evolutionary-database-design": {
+    sourceType: "web-article",
+    title: "Evolutionary Database Design (Pramod Sadalage & Martin Fowler)",
+    url: "https://martinfowler.com/articles/evodb.html",
+    license: "article-free-to-read",
+    abstract:
+      "Database change as refactoring: every schema change is a small, sequenced " +
+      "migration script held in version control beside the application code, applied in " +
+      "order to a blank database. Conflicts are resolved by renumbering your own " +
+      "migration and retesting — not by editing one that has already been applied.",
+    retrievedAt: "2026-07-29",
+  },
+
   // ── IT operations / SRE family (WSID wave 6/7) ──
   // NIST SP 800-61 Rev.2 was withdrawn 2025-04-03 (superseded by Rev.3); the
   // IR-lifecycle phases are durable doctrine cited via an open secondary
@@ -1682,7 +1724,7 @@ const PROFESSION_EXTERNAL_SOURCES_GATED: Record<string, ExternalSourceEntry> = {
  * because its canonical home is a still-open sibling PR) resolve last-wins;
  * the entries are byte-identical, so there is no behavioral difference.
  */
-const ALL_PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
+export const ALL_PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
   ...PROFESSION_EXTERNAL_SOURCES,
   ...PROFESSION_EXTERNAL_SOURCES_GATED,
   ...PROVIDER_COMPLIANCE_EXTERNAL_SOURCES,


### PR DESCRIPTION
## What

Phase 1 of **BI-D65E044E** (WSID corpus priming program): the **enterprise-architecture minimum viable decision-pack**. Seven new source-cited, vectored corpus pages under `docs/professions/enterprise-architecture/wiki/`, authored against the family's own mined deferral questions.

EA is first by the demand signal, not editorially: it carries **69 unresolved `architecture-tradeoff` defers** — the largest of any family, and spec §11.3 makes the defer count the rollout order.

## Why the family was deferring (mined, not assumed)

Queried the live ledger:

```sql
SELECT question, options, "riskTier", "routeContext"
FROM "DecisionInteraction"
WHERE "domainClass" = 'architecture-tradeoff' AND "outcomeType" = 'defer';
```

69 rows, all from `reviewDesignDoc` (23) / `reviewPlanDoc` (46), all with the same option set `["aligned", "revise-before-building"]`, 63 at medium risk.

The cause is a **coverage gap, not a retrieval bug** — verified:

| profile | fallback | materials | `architecture-tradeoff` materials |
| --- | --- | --- | --- |
| `wsid-enterprise-architecture` | `mark-dpf-platform` | 0 | 0 |
| `mark-dpf-platform` | — | 6 (all `plan-readiness`) | 0 |

`evaluateDecisionPerspective` returns `defer` / `gapReason: no-applicable-material` when no profile in the chain has applicable material. Nothing in the EA chain has ever had any for this domain. Meanwhile the six published EA pages are all **descriptive** (`summary` × 3, `entity` × 1, and two ADR principles) — they say what TOGAF, ArchiMate, and IT4IT *are*. None carries a rule a verdict can be decided from. That is the gap this pack closes.

## The mined consult shapes → what was authored

Clustered the 69 verdict texts. Every page answers a shape with real demand; no page was written speculatively (pinned in `enterprise-architecture-decision-pack.test.ts`, with verbatim deferral quotes as fixtures).

| Consult shape | Rows | New page |
| --- | --- | --- |
| Alignment verdict where findings are minor | 60 | `architecture-review-verdict-thresholds` |
| Canonical home / single-source-of-truth ownership | 25 | `extend-canonical-models-never-fork` |
| API/naming consistency + typed-contract discipline | 18 | `name-and-type-the-contract-canonically` |
| Schema extension, migration safety, DB-enforced invariants | 15 | `evolve-schema-additively` |
| Reuse-vs-new-model | 12 | `verify-the-substrate-before-proposing-new` (+ `extend-canonical-…`) |
| Value-stream mapping | 9 | `anchor-changes-to-a-value-stream-stage` |
| Association justification / evidence sufficiency | 8 | `minimal-proven-associations` |

Also closes the `guardrail-and-constraint-enforcement` item on the family's `coverageChecklist` in `docs/professions/registry.json`, which had no page.

## Validation — would this material let the gate settle these rows?

Walked real deferrals against the pack:

1. *"largely aligned … requires minor adjustments to ensure canonical API naming consistency, schema alignment, and progressive disclosure adherence"* (medium) → `architecture-review-verdict-thresholds` grades this **minor**, so the verdict is `aligned` with three named required changes. Previously: defer.
2. *"introduces new data models without clear alignment to canonical structures … does not reference the canonical enum registry"* (high) → `verify-the-substrate-before-proposing-new` + `extend-canonical-models-never-fork` make "new parallel authority beside a canonical model" a **standing major trigger** → `revise-before-building`, which is what the reviewer actually meant.
3. *"portfolioId … must be nullable (String?) to support expand-contract backfill, but Task 4 defines it as required … SpendPeriodRollup's unique constraint is unenforceable with nullable fields"* (high) → `evolve-schema-additively` covers both halves directly: nullable-in-expand/tighten-in-contract, and "an invariant is only real if the database enforces it" including the `NULL != NULL` uniqueness trap.
4. *"lacks enumerated strongly-typed values for costBasis, periodType, and recommendation types"* (medium) → `name-and-type-the-contract-canonically` makes enumerating categorical values a pre-build obligation, so this is a `revise-before-building` with a concrete edit rather than a question.
5. *"could better articulate its connection to a load-bearing value-stream stage"* (medium) → `anchor-changes-to-a-value-stream-stage` grades a missing anchor as **minor** — an adjustment carried on a pass, which is exactly the row that should never have deferred.

### One honest caveat for BI-3B02FF9C — the grade threshold

Once the promotion path lands, **any** applicable positive-weight material ends the coverage gap, so these rows stop returning `defer`. Reaching `recommend` needs more than existence. With `wsid-enterprise-architecture`'s live `autonomyPolicy` (`allowArbitration: false`, medium-risk penalty `0.1`, and the `confidence < 0.9 && riskTier !== "low"` escalate branch), a medium-risk row needs mean `effectiveWeight ≈ 1.0`:

- grade **A** / weight 1.0 / approved / promoted / current → `1.0` → confidence `0.9` → **recommend**
- grade **B** / weight 1.0 → `0.75` → confidence `0.65` → escalate
- grade **B** / weight 0.6 → `0.45` → confidence `0.35` → escalate

So a purely B-graded promotion moves these rows from `defer` to `escalate` (already a real gain — a material-backed answer with citations on the Decision Canvas) but not to `recommend`. The five pages that restate **settled DPF precedent** rather than DPF's reading of an external standard — verify-substrate-first, extend-canonical-never-fork, structural-verification-is-not-functional — are `ruled`-tier by spec §11.1's own definition, and `STANCE_TIERS.ruled` is already `{ evidenceGrade: "A", confidenceWeight: 1.0 }`. Flagging this so the promotion work grades deliberately rather than defaulting everything to B. High-risk rows (5 of 69) escalate unconditionally by design and are out of scope for any grade.

## Content doctrine

Encodes established DPF precedent, not textbook filler: verify-substrate-first; extend-canonical-never-fork; minimal proven associations; aligned-with-minor-adjustments = proceed with named required changes; structural verification ≠ functional. Every page is source-cited per the conduit rule — TOGAF ADM Phase G, ISO/IEC/IEEE 42010 (concept model via open summary; the ISO standard itself stays checklist-only), ArchiMate, IT4IT, Nygard/ADR, Sato's *Parallel Change*, Sadalage & Fowler's *Evolutionary Database Design*, PostgreSQL DDL, and the DPF Agent Rulebook. Three new `RawSource` entries registered; the rest reuse existing keys.

The two org-scoped craft drafts (`craft/enterprise-architecture/*`) are the **org overlay** of the same doctrine — one-paragraph, uncited, still in draft. This pack is the **platform baseline** (`organizationId = null`, published, cited, structured) they cite and override, per §11.2's cite-and-override rule. No fork.

## Seeding

`seedProfessionCorpus` already walks `docs/professions/*/wiki/` recursively, so the pages seed on every new install with `status: published` — no loader change was needed beyond registering the three new sources. Regenerated `doc-index.generated.json` (571 → 578 pages).

## Trap found and worked around (filed separately)

`extractPrinciplePayload` (`packages/db/src/seed-wiki-kernel.ts`) returns `{}` for every `pageKind` except `principle`. A page authored as `heuristic` with a `principleDimensionVector` seeds with the **entire principle payload silently dropped** — no vector, no direction, no tier — so it can never score or move a verdict. Five vectored `heuristic` pages elsewhere under `docs/professions/` are already losing their payload this way. All seven pack pages are therefore `pageKind: principle`, and the test pins that with the reason. The underlying silent-drop is out of scope here and is filed as its own item.

## Verification

- `packages/db/src/enterprise-architecture-decision-pack.test.ts` — 26 tests, all green. Pins shape→page coverage (and the reverse: no page without mined demand), the frontmatter contract, in-registry signed dimension vectors, source keys resolving against the effective registry, no orphaned wikilinks, the six pre-existing pages surviving, and — functionally, not structurally — that `extractPrinciplePayload` accepts every page (it throws on unknown axes and §8A.1 coherence violations, so this is the seed walker's own gate, not a re-implementation of it).
- `node scripts/check-module-size.mjs` — clean.
- `pnpm run pregate` — see below.

## Scope

Phase 1 only. **BI-D65E044E stays open** for the DEPTH rollout to the remaining families (by defer count), plus the archetype (layer 2) and locale (layer 3) variation layers. Does not touch BI-3B02FF9C's scope — no changes to `material.ts`, `stance-promotion.ts`, or any promotion sibling.

Seed-Fit-Decision: global-default
