### PR TITLE
feat(wsid): promote profession craft pages to PerspectiveMaterial so the profession gate can confirm (BI-3B02FF9C)

### DIFF
--- a/apps/web/lib/actions/wiki-publish.test.ts
+++ b/apps/web/lib/actions/wiki-publish.test.ts
@@ -10,6 +10,8 @@ vi.mock("@dpf/db", () => ({
       update: vi.fn(),
     },
     wikiPageRevision: { create: vi.fn(), findFirst: vi.fn() },
+    decisionPerspectiveProfile: { findUnique: vi.fn() },
+    perspectiveMaterial: { findUnique: vi.fn(), upsert: vi.fn() },
   },
 }));
 
@@ -31,6 +33,9 @@ beforeEach(() => {
     id: "org_test",
   });
   (prisma.wikiPageRevision.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  (prisma.decisionPerspectiveProfile.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  (prisma.perspectiveMaterial.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  (prisma.perspectiveMaterial.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({});
 });
 
 // ─── Auth + validation ──────────────────────────────────────────────────────
@@ -211,6 +216,92 @@ describe("publishWikiOverlayPages — batch flow", () => {
       expect(r.published.map((p) => p.pageId)).toEqual(["wp_ok"]);
       expect(r.rejected.map((r) => r.pageId)).toEqual(["wp_kernel"]);
     }
+  });
+});
+
+// ─── WSID craft promotion on publish (BI-3B02FF9C) ──────────────────────────
+
+describe("publishWikiOverlayPages — craft override promotion", () => {
+  const CRAFT_ROW = {
+    id: "wp_craft",
+    slug: "craft/enterprise-architecture/verify-the-substrate-first",
+    title: "Verify the substrate first",
+    body: "Check the live schema before proposing new substrate.",
+    status: "draft",
+    isKernel: false,
+    organizationId: "org_test",
+    pageKind: "heuristic",
+    abstract: "Substrate check precedes new-concept proposals.",
+  };
+
+  it("publishing a craft/<professionKey>/ page promotes owner-confirmed gate-live material", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([CRAFT_ROW]);
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "rev" });
+    (prisma.decisionPerspectiveProfile.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      profileId: "wsid-enterprise-architecture",
+      currentVersionId: "wsid-enterprise-architecture-v1",
+    });
+
+    const r = await publishWikiOverlayPages({ pageIds: ["wp_craft"] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    expect(r.craftPromotions).toHaveLength(1);
+    expect(r.craftPromotions[0]).toMatchObject({
+      pageId: "wp_craft",
+      professionKey: "enterprise-architecture",
+      gateLive: true,
+    });
+    // EA craft doctrine answers architecture-tradeoff consults first.
+    expect(prisma.perspectiveMaterial.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { materialId: `wsid-enterprise-architecture:${CRAFT_ROW.slug}` },
+        create: expect.objectContaining({
+          domainClass: "architecture-tradeoff",
+          evidenceGrade: "A",
+          confidenceWeight: 0.9,
+          reviewStatus: "approved",
+          promotionState: "promoted",
+        }),
+      }),
+    );
+  });
+
+  it("promotion failure never fails the page publish", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([CRAFT_ROW]);
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "rev" });
+    (prisma.decisionPerspectiveProfile.findUnique as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("db down"),
+    );
+
+    const r = await publishWikiOverlayPages({ pageIds: ["wp_craft"] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.published).toHaveLength(1);
+    expect(r.craftPromotions).toEqual([]);
+  });
+
+  it("does not promote for non-craft slugs or non-published target status", async () => {
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { ...CRAFT_ROW, id: "wp_stance", slug: "stances/b", pageKind: "stance" },
+    ]);
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "rev" });
+
+    const stancePublish = await publishWikiOverlayPages({ pageIds: ["wp_stance"] });
+    expect(stancePublish.ok).toBe(true);
+    if (stancePublish.ok) expect(stancePublish.craftPromotions).toEqual([]);
+
+    (prisma.wikiPage.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([CRAFT_ROW]);
+    const reviewNeeded = await publishWikiOverlayPages({
+      pageIds: ["wp_craft"],
+      targetStatus: "review-needed",
+    });
+    expect(reviewNeeded.ok).toBe(true);
+    if (reviewNeeded.ok) expect(reviewNeeded.craftPromotions).toEqual([]);
+    expect(prisma.perspectiveMaterial.upsert).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/actions/wiki-publish.ts
+++ b/apps/web/lib/actions/wiki-publish.ts
@@ -21,8 +21,13 @@ import {
   appendRevision,
   type WikiPageStatus,
 } from "@dpf/db/wiki-store";
+import {
+  parseProfessionPageSlug,
+  promoteProfessionPageMaterial,
+} from "@dpf/db/profession-material-promotion";
 import { revalidatePath } from "next/cache";
 import { requireUser } from "@/lib/actions/shared/guards";
+import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -44,6 +49,15 @@ export type PublishedRow = {
   newStatus: WikiPageStatus;
 };
 
+export type CraftPromotionRow = {
+  pageId: string;
+  slug: string;
+  professionKey: string;
+  /** True when the material rows are approved+promoted (gate-visible). */
+  gateLive: boolean;
+  materialIds: string[];
+};
+
 export type RejectedRow = {
   pageId: string;
   reason: "not-found" | "kernel" | "cross-org" | "already-target-status";
@@ -54,6 +68,12 @@ export type PublishWikiOverlayPagesResult =
       ok: true;
       published: PublishedRow[];
       rejected: RejectedRow[];
+      /**
+       * WSID craft overrides that went gate-live with this publish
+       * (BI-3B02FF9C): publishing a craft/<professionKey>/ page also promotes
+       * owner-confirmed PerspectiveMaterial on the profession's wsid profile.
+       */
+      craftPromotions: CraftPromotionRow[];
     }
   | { ok: false; error: string };
 
@@ -107,6 +127,8 @@ export async function publishWikiOverlayPages(
         status: true,
         isKernel: true,
         organizationId: true,
+        pageKind: true,
+        abstract: true,
       },
     })) as Array<{
       id: string;
@@ -116,11 +138,14 @@ export async function publishWikiOverlayPages(
       status: WikiPageStatus;
       isKernel: boolean;
       organizationId: string | null;
+      pageKind: string;
+      abstract: string | null;
     }>;
 
     const foundIds = new Set(rows.map((r) => r.id));
     const published: PublishedRow[] = [];
     const rejected: RejectedRow[] = [];
+    const craftPromotions: CraftPromotionRow[] = [];
 
     for (const id of input.pageIds) {
       if (!foundIds.has(id)) {
@@ -160,11 +185,56 @@ export async function publishWikiOverlayPages(
         previousStatus,
         newStatus: targetStatus,
       });
+
+      // WSID Phase 6 (BI-3B02FF9C): publishing a craft override is the owner's
+      // approval, so it becomes gate-live doctrine — the profession sibling of
+      // publishBusinessStance's promoteStanceMaterial call. Promotion failure
+      // never rolls back the page publish: the page flip already happened and
+      // the seed backfill converges any missed material on its next run.
+      const slugInfo =
+        targetStatus === "published" ? parseProfessionPageSlug(row.slug) : null;
+      if (slugInfo?.corpus === "org-override") {
+        try {
+          const family = PROFESSION_REGISTRY.families.find(
+            (f) => f.professionKey === slugInfo.professionKey,
+          );
+          const promoted = await promoteProfessionPageMaterial({
+            db: prisma,
+            professionKey: slugInfo.professionKey,
+            contextSlugs: family?.contextSlugs ?? [],
+            page: {
+              id: row.id,
+              slug: row.slug,
+              title: row.title,
+              pageKind: row.pageKind,
+              abstract: row.abstract,
+            },
+            tier: "confirmed",
+          });
+          if (promoted.ok) {
+            craftPromotions.push({
+              pageId: row.id,
+              slug: row.slug,
+              professionKey: slugInfo.professionKey,
+              gateLive: promoted.gateLive,
+              materialIds: promoted.materialIds,
+            });
+          } else {
+            console.warn(
+              `[wiki-publish] craft promotion skipped for ${row.slug}: ${promoted.error}`,
+            );
+          }
+        } catch (promotionError) {
+          console.warn(
+            `[wiki-publish] craft promotion failed for ${row.slug}: ${(promotionError as Error).message}`,
+          );
+        }
+      }
       revalidatePath(`/coworker-decisions/${row.slug}`);
     }
     revalidatePath("/coworker-decisions");
 
-    return { ok: true, published, rejected };
+    return { ok: true, published, rejected, craftPromotions };
   } catch (err) {
     return {
       ok: false,

--- a/apps/web/lib/decision-perspective/profession-gate.test.ts
+++ b/apps/web/lib/decision-perspective/profession-gate.test.ts
@@ -228,6 +228,86 @@ describe("evaluateProfessionDecisionGate", () => {
   });
 });
 
+// ─── WSID Phase 6 acceptance (BI-3B02FF9C) ──────────────────────────────────
+// The BI's concrete acceptance, in miniature: after the craft-material
+// promotion backfills the corpus and the owner publishes the two EA craft
+// overrides (confirmed A/0.9, architecture-tradeoff primary — the exact rows
+// promoteProfessionPageMaterial writes), an architecture-tradeoff consult on
+// wsid-enterprise-architecture returns recommend with
+// professionProfileSelected=true instead of the 64-deferral coverage gap.
+describe("evaluateProfessionDecisionGate — EA architecture-tradeoff acceptance", () => {
+  function promotedCraftRow(slug: string) {
+    return {
+      materialId: `wsid-enterprise-architecture:${slug}`,
+      profileId: "wsid-enterprise-architecture",
+      sourceType: "heuristic",
+      sourceRef: { slug, professionKey: "enterprise-architecture", corpus: "org-override" },
+      summary: "s",
+      domainClass: "architecture-tradeoff",
+      direction: "support",
+      domains: ["architecture-tradeoff"],
+      freshness: "current",
+      evidenceGrade: "A",
+      confidenceWeight: 0.9,
+      reviewStatus: "approved",
+      promotionState: "promoted",
+      lastValidatedAt: null,
+    };
+  }
+
+  it("recommends from the EA profile once the published craft overrides are gate-live", async () => {
+    const db = {
+      decisionInteraction: {
+        create: vi
+          .fn()
+          .mockImplementation(async (args: { data: Record<string, unknown> }) => ({ id: "row-1", ...args.data })),
+      },
+      decisionPerspectiveProfile: {
+        findUnique: vi.fn().mockImplementation(async (args: { where: { profileId: string } }) =>
+          args.where.profileId === "wsid-enterprise-architecture"
+            ? {
+                profileId: "wsid-enterprise-architecture",
+                name: "Enterprise Architecture",
+                kind: "profession",
+                scope: { professionKey: "enterprise-architecture" },
+                fallbackProfileId: null,
+                defaultResolver: null,
+                autonomyPolicy: null,
+                currentVersion: { versionId: "wsid-enterprise-architecture-v1", versionNumber: 1 },
+              }
+            : null,
+        ),
+      },
+      perspectiveMaterial: {
+        findMany: vi.fn().mockResolvedValue([
+          promotedCraftRow("craft/enterprise-architecture/architecture-review-verdicts"),
+          promotedCraftRow("craft/enterprise-architecture/verify-the-substrate-first"),
+        ]),
+      },
+    };
+
+    const result = await evaluateProfessionDecisionGate({
+      db: db as never,
+      // ea-architect is bound to the enterprise-architecture family in
+      // docs/professions/registry.json.
+      agentIdentity: { slugId: "ea-architect" },
+      question: "Introduce a read replica or denormalize the reporting tables?",
+      options: ["Read replica", "Denormalize"],
+      domainClass: "architecture-tradeoff",
+      riskTier: "low",
+      routeContext: "/coworker",
+    });
+
+    expect(result.professionKey).toBe("enterprise-architecture");
+    expect(result.professionProfileSelected).toBe(true);
+    expect(result.evaluation.outcomeType).toBe("recommend");
+    expect(result.allowed).toBe(true);
+    expect(result.evaluation.coverageGap).toBe(false);
+    // Two confirmed A/0.9 rows → mean effective weight 0.9, low risk → 0.9.
+    expect(result.evaluation.confidenceScore).toBeCloseTo(0.9, 5);
+  });
+});
+
 describe("resolveProfileMaterialForProfession", () => {
   function materialRow(profileId: string) {
     return {

--- a/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
+++ b/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
@@ -521,3 +521,55 @@ decision classes (mapped `domainClass`, dimension vectors present) that the gate
 recommend or arbitrate on the family's routine consult shapes instead of deferring —
 verified against the family's own recent deferral questions, not hypotheticals. Depth
 beyond the pack is pulled by gap capture (§4.7), not pushed speculatively.
+
+## 12. Addendum (2026-07-29) — Phase 6 implementation record: craft pages become gate-live material (BI-3B02FF9C)
+
+**Why this phase is load-bearing.** Phase 6 is the decisive step of the weaning
+ladder (founder → WWMD → WWWD/WSID): until corpus pages produce
+`PerspectiveMaterial`, every profession decision borrows WWMD via the fallback
+chain and every wsid-* consult defers. The demand signal fired exactly as §4.11
+rule 2 designed — 64 unresolved `architecture-tradeoff` deferrals on
+`wsid-enterprise-architecture` put that family at the front of the rollout.
+
+**What shipped.** The profession sibling of the WWWD stance promotion
+(`stance-promotion.ts`), one shared write path used by both the runtime and the
+seed: `packages/db/src/profession-material-promotion.ts` (exported as
+`@dpf/db/profession-material-promotion`).
+
+1. **Publish hook** — `publishWikiOverlayPages` (the overlay draft review
+   surface's publish click) promotes any published `craft/<professionKey>/`
+   page to owner-confirmed material on `wsid-<professionKey>`, exactly as
+   `publishBusinessStance` promotes an org stance. Promotion failure never
+   rolls back the page publish; the seed backfill converges misses.
+2. **Backfill** — `backfillProfessionCraftMaterials`, run as the
+   `professionCraftMaterials` seed step after `seedProfessionCorpus`:
+   published `professions/<key>/` platform pages enter at the derived tier,
+   already-published `craft/<key>/` overrides at the confirmed tier.
+   Idempotent; loud on anomalies.
+3. **Tier ladder** (aligned with the §4.6 trust ladder and the stance ladder):
+   `derived` B/0.6 (platform distillation of a standard), `confirmed` A/0.9
+   (owner published a craft override), `ruled` A/1.0 (human ruled on a real
+   decision). Never downgrades — neither tier nor an approved review status.
+4. **Tier-aware domain-class mapping.** Only decision-bearing page kinds
+   promote (`principle`, `heuristic`, `stance`, `decision`; `entity`/`summary`/
+   `runbook` stay retrieval-only per §4.6). Derived material is context-grade
+   and enters `professional-practice` only; confirmed/ruled material carries
+   the family's decision classes — for `enterprise-architecture`,
+   `architecture-tradeoff` primary + `professional-practice`. Rationale: gate
+   confidence is the *mean* of applicable effective weights, so a derived row
+   (0.45 effective) sharing a class with confirmed rows (0.9) would dilute the
+   mean below the 0.7 recommend band — human confirmation is what promotes a
+   page's doctrine into tradeoff authority.
+5. **Risk tiering** (competence-flywheel §5.5, BI-BE9C95D9): families whose
+   registry contextSlugs touch `finance` or `compliance` (finance,
+   legal-compliance, hr-people-ops, security today) are high-stakes — their
+   derived-tier rows land `draft`/`candidate`, auditable but invisible to the
+   gate, until a human approves. Confirmed/ruled tiers are human actions and go
+   gate-live everywhere.
+
+**Acceptance trace.** With the backfill plus the two published EA craft
+overrides (`craft/enterprise-architecture/architecture-review-verdicts-…`,
+`…/verify-the-substrate-first-…`), an `architecture-tradeoff` consult on
+`wsid-enterprise-architecture` resolves 2 confirmed materials → confidence 0.9
+at low risk → `recommend` with `professionProfileSelected=true` instead of the
+coverage-gap defer (regression-locked in `profession-gate.test.ts`).

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -48,6 +48,7 @@
     "./profession-local-axes": "./src/profession-local-axes.ts",
     "./wiki-store": "./src/wiki-store.ts",
     "./wiki-frontmatter": "./src/wiki-frontmatter.ts",
+    "./profession-material-promotion": "./src/profession-material-promotion.ts",
     "./capability-maturity": "./src/capability-maturity.ts",
     "./business-capability-perspectives": "./src/business-capability-perspectives.ts",
     "./workforce-portfolio": "./src/workforce-portfolio.ts",

--- a/packages/db/src/profession-material-promotion.test.ts
+++ b/packages/db/src/profession-material-promotion.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  backfillProfessionCraftMaterials,
+  DECISION_BEARING_PAGE_KINDS,
+  isHighStakesProfession,
+  parseProfessionPageSlug,
+  PROFESSION_MATERIAL_TIERS,
+  professionDomainClasses,
+  professionMaterialId,
+  promoteProfessionPageMaterial,
+  type ProfessionCraftBackfillClient,
+} from "./profession-material-promotion";
+
+type Row = Record<string, any>;
+
+function makeFakeDb(opts: { profiles?: Row[]; materials?: Row[]; pages?: Row[] }) {
+  const materials: Row[] = opts.materials ?? [];
+  const profiles: Row[] = opts.profiles ?? [];
+  const db: ProfessionCraftBackfillClient = {
+    decisionPerspectiveProfile: {
+      findUnique: vi.fn(async (args: any) => {
+        return profiles.find((p) => p.profileId === args.where.profileId) ?? null;
+      }),
+    },
+    perspectiveMaterial: {
+      findUnique: vi.fn(async (args: any) => {
+        return materials.find((m) => m.materialId === args.where.materialId) ?? null;
+      }),
+      upsert: vi.fn(async (args: any) => {
+        const found = materials.find((m) => m.materialId === args.where.materialId);
+        if (found) {
+          Object.assign(found, args.update);
+          return found;
+        }
+        const row = { ...args.create };
+        materials.push(row);
+        return row;
+      }),
+    },
+    wikiPage: {
+      findMany: vi.fn(async () => opts.pages ?? []),
+    },
+  };
+  return { db, materials };
+}
+
+const EA_PROFILE = {
+  profileId: "wsid-enterprise-architecture",
+  currentVersionId: "wsid-enterprise-architecture-v1",
+};
+const FINANCE_PROFILE = { profileId: "wsid-finance", currentVersionId: "wsid-finance-v1" };
+
+const EA_PAGE = {
+  id: "wp_adr",
+  slug: "professions/enterprise-architecture/record-decisions-as-adrs",
+  title: "Record decisions as ADRs",
+  pageKind: "principle",
+  abstract: "Every consequential architecture decision gets an ADR.",
+};
+
+describe("registry helpers", () => {
+  it("parses both profession slug namespaces and rejects others", () => {
+    expect(parseProfessionPageSlug(EA_PAGE.slug)).toEqual({
+      professionKey: "enterprise-architecture",
+      corpus: "platform",
+    });
+    expect(parseProfessionPageSlug("craft/enterprise-architecture/verify-the-substrate-first")).toEqual({
+      professionKey: "enterprise-architecture",
+      corpus: "org-override",
+    });
+    expect(parseProfessionPageSlug("stances/customer-goodwill")).toBeNull();
+    expect(parseProfessionPageSlug("professions/")).toBeNull();
+    expect(parseProfessionPageSlug("craft/x")).toBeNull();
+  });
+
+  it("maps human-vouched EA tiers to architecture-tradeoff primary; derived stays context-grade", () => {
+    expect(professionDomainClasses("enterprise-architecture", "confirmed")).toEqual([
+      "architecture-tradeoff",
+      "professional-practice",
+    ]);
+    expect(professionDomainClasses("enterprise-architecture", "ruled")).toEqual([
+      "architecture-tradeoff",
+      "professional-practice",
+    ]);
+    // Derived B/0.6 rows score 0.45 effective — letting them share the
+    // tradeoff class would dilute confirmed rows below the recommend band.
+    expect(professionDomainClasses("enterprise-architecture", "derived")).toEqual([
+      "professional-practice",
+    ]);
+    expect(professionDomainClasses("marketing", "confirmed")).toEqual(["professional-practice"]);
+  });
+
+  it("flags finance/compliance context slugs as high-stakes", () => {
+    expect(isHighStakesProfession(["finance"])).toBe(true);
+    expect(isHighStakesProfession(["data-security", "compliance"])).toBe(true);
+    expect(isHighStakesProfession(["engineering-flow"])).toBe(false);
+  });
+
+  it("tier ladder matches the stance ladder shape (derived is the B rung)", () => {
+    expect(PROFESSION_MATERIAL_TIERS.derived).toEqual({ evidenceGrade: "B", confidenceWeight: 0.6 });
+    expect(PROFESSION_MATERIAL_TIERS.confirmed).toEqual({ evidenceGrade: "A", confidenceWeight: 0.9 });
+    expect(PROFESSION_MATERIAL_TIERS.ruled).toEqual({ evidenceGrade: "A", confidenceWeight: 1.0 });
+  });
+
+  it("materialId scheme mirrors stanceMaterialId (primary keeps the short id)", () => {
+    expect(professionMaterialId("wsid-x", "professions/x/p", "architecture-tradeoff", true)).toBe(
+      "wsid-x:professions/x/p",
+    );
+    expect(professionMaterialId("wsid-x", "professions/x/p", "professional-practice", false)).toBe(
+      "wsid-x:professions/x/p:professional-practice",
+    );
+  });
+});
+
+describe("promoteProfessionPageMaterial", () => {
+  it("returns no-profession-profile when the wsid profile is not seeded", async () => {
+    const { db } = makeFakeDb({ profiles: [] });
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "enterprise-architecture",
+      contextSlugs: ["engineering-flow"],
+      page: EA_PAGE,
+      tier: "derived",
+    });
+    expect(result).toEqual({ ok: false, error: "no-profession-profile" });
+  });
+
+  it("refuses context-only page kinds (entity/summary stay retrieval-only)", async () => {
+    const { db, materials } = makeFakeDb({ profiles: [EA_PROFILE] });
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "enterprise-architecture",
+      contextSlugs: ["engineering-flow"],
+      page: { ...EA_PAGE, pageKind: "entity" },
+      tier: "derived",
+    });
+    expect(result).toEqual({ ok: false, error: "not-decision-bearing" });
+    expect(materials).toHaveLength(0);
+  });
+
+  it("writes a gate-live B/0.6 professional-practice row for a platform-seeded EA principle", async () => {
+    const { db, materials } = makeFakeDb({ profiles: [EA_PROFILE] });
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "enterprise-architecture",
+      contextSlugs: ["engineering-flow"],
+      page: EA_PAGE,
+      tier: "derived",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.gateLive).toBe(true);
+    expect(result.heldForReview).toBe(false);
+    expect(materials).toHaveLength(1);
+    expect(materials[0]).toMatchObject({
+      materialId: `wsid-enterprise-architecture:${EA_PAGE.slug}`,
+      profileId: "wsid-enterprise-architecture",
+      domainClass: "professional-practice",
+      sourceType: "principle",
+      evidenceGrade: "B",
+      confidenceWeight: 0.6,
+      reviewStatus: "approved",
+      promotionState: "promoted",
+      direction: "support",
+      summary: EA_PAGE.abstract,
+    });
+    expect(materials[0].sourceRef).toMatchObject({
+      wikiPageId: EA_PAGE.id,
+      professionKey: "enterprise-architecture",
+      corpus: "platform",
+    });
+  });
+
+  it("writes confirmed A/0.9 gate-live rows for a published org craft override, tradeoff-primary", async () => {
+    const { db, materials } = makeFakeDb({ profiles: [EA_PROFILE] });
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "enterprise-architecture",
+      contextSlugs: ["engineering-flow"],
+      page: {
+        id: "wp_craft",
+        slug: "craft/enterprise-architecture/verify-the-substrate-first",
+        title: "Verify the substrate first",
+        pageKind: "heuristic",
+        abstract: null,
+      },
+      tier: "confirmed",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.gateLive).toBe(true);
+    expect(materials).toHaveLength(2);
+    expect(materials[0]).toMatchObject({
+      materialId: "wsid-enterprise-architecture:craft/enterprise-architecture/verify-the-substrate-first",
+      domainClass: "architecture-tradeoff",
+      evidenceGrade: "A",
+      confidenceWeight: 0.9,
+      reviewStatus: "approved",
+      promotionState: "promoted",
+      // No abstract → the title carries the summary.
+      summary: "Verify the substrate first",
+    });
+    expect(materials[1]).toMatchObject({ domainClass: "professional-practice" });
+    expect(materials[0].sourceRef).toMatchObject({ corpus: "org-override" });
+  });
+
+  it("holds high-stakes derived material out of the gate (draft/candidate)", async () => {
+    const { db, materials } = makeFakeDb({ profiles: [FINANCE_PROFILE] });
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "finance",
+      contextSlugs: ["finance"],
+      page: {
+        id: "wp_gaap",
+        slug: "professions/finance/revenue-recognized-when-earned",
+        title: "Revenue is recognized when earned",
+        pageKind: "principle",
+      },
+      tier: "derived",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.gateLive).toBe(false);
+    expect(result.heldForReview).toBe(true);
+    expect(materials[0]).toMatchObject({
+      evidenceGrade: "B",
+      confidenceWeight: 0.6,
+      reviewStatus: "draft",
+      promotionState: "candidate",
+    });
+  });
+
+  it("high-stakes CONFIRMED tier goes gate-live (a human published it)", async () => {
+    const { db, materials } = makeFakeDb({ profiles: [FINANCE_PROFILE] });
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "finance",
+      contextSlugs: ["finance"],
+      page: {
+        id: "wp_fin_craft",
+        slug: "craft/finance/close-on-the-fifth",
+        title: "Close on the fifth",
+        pageKind: "heuristic",
+      },
+      tier: "confirmed",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.gateLive).toBe(true);
+    expect(materials[0]).toMatchObject({ reviewStatus: "approved", promotionState: "promoted" });
+  });
+
+  it("NEVER downgrades: a confirmed row survives a later derived re-seed", async () => {
+    const existing = {
+      materialId: `wsid-enterprise-architecture:${EA_PAGE.slug}`,
+      evidenceGrade: "A",
+      confidenceWeight: 0.9,
+      reviewStatus: "approved",
+      promotionState: "promoted",
+    };
+    const { db, materials } = makeFakeDb({ profiles: [EA_PROFILE], materials: [existing] });
+
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "enterprise-architecture",
+      contextSlugs: ["engineering-flow"],
+      page: EA_PAGE,
+      tier: "derived",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.keptHigherTier).toContain(existing.materialId);
+    expect(materials[0].confidenceWeight).toBe(0.9);
+  });
+
+  it("never pulls an already-approved row back behind the high-stakes hold", async () => {
+    const approved = {
+      materialId: "wsid-finance:professions/finance/revenue-recognized-when-earned",
+      evidenceGrade: "B",
+      confidenceWeight: 0.6,
+      reviewStatus: "approved",
+      promotionState: "promoted",
+    };
+    const { db, materials } = makeFakeDb({ profiles: [FINANCE_PROFILE], materials: [approved] });
+
+    const result = await promoteProfessionPageMaterial({
+      db,
+      professionKey: "finance",
+      contextSlugs: ["finance"],
+      page: {
+        id: "wp_gaap",
+        slug: "professions/finance/revenue-recognized-when-earned",
+        title: "Revenue is recognized when earned",
+        pageKind: "principle",
+      },
+      tier: "derived",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(materials[0].reviewStatus).toBe("approved");
+    expect(materials[0].promotionState).toBe("promoted");
+  });
+});
+
+describe("backfillProfessionCraftMaterials", () => {
+  const families = [
+    { professionKey: "enterprise-architecture", contextSlugs: ["engineering-flow"] },
+    { professionKey: "finance", contextSlugs: ["finance"] },
+  ];
+
+  it("promotes platform pages at derived, craft overrides at confirmed, and counts context pages", async () => {
+    const { db, materials } = makeFakeDb({
+      profiles: [EA_PROFILE, FINANCE_PROFILE],
+      pages: [
+        { ...EA_PAGE, organizationId: null, abstract: EA_PAGE.abstract },
+        {
+          id: "wp_entity",
+          slug: "professions/enterprise-architecture/togaf-adm-phases",
+          title: "TOGAF ADM phases",
+          pageKind: "entity",
+          abstract: null,
+          organizationId: null,
+        },
+        {
+          id: "wp_craft",
+          slug: "craft/enterprise-architecture/architecture-review-verdicts",
+          title: "Architecture review verdicts",
+          pageKind: "heuristic",
+          abstract: null,
+          organizationId: "org_1",
+        },
+        {
+          id: "wp_gaap",
+          slug: "professions/finance/revenue-recognized-when-earned",
+          title: "Revenue recognized when earned",
+          pageKind: "principle",
+          abstract: null,
+          organizationId: null,
+        },
+        {
+          id: "wp_unknown",
+          slug: "professions/underwater-basket-weaving/knots",
+          title: "Knots",
+          pageKind: "principle",
+          abstract: null,
+          organizationId: null,
+        },
+      ],
+    });
+
+    const result = await backfillProfessionCraftMaterials(db, { loadFamilies: () => families });
+
+    expect(result.scanned).toBe(5);
+    expect(result.promoted).toBe(3);
+    expect(result.gateLive).toBe(2); // EA platform + EA craft
+    expect(result.heldForReview).toBe(1); // finance platform page held
+    expect(result.notDecisionBearing).toBe(1);
+    expect(result.skipped).toEqual([
+      {
+        slug: "professions/underwater-basket-weaving/knots",
+        reason: expect.stringContaining("underwater-basket-weaving"),
+      },
+    ]);
+
+    const craftRow = materials.find(
+      (m) => m.materialId === "wsid-enterprise-architecture:craft/enterprise-architecture/architecture-review-verdicts",
+    );
+    expect(craftRow).toMatchObject({
+      domainClass: "architecture-tradeoff",
+      evidenceGrade: "A",
+      confidenceWeight: 0.9,
+    });
+  });
+
+  it("re-running is idempotent and reports keptHigherTier for converged pages", async () => {
+    const pages = [{ ...EA_PAGE, organizationId: null, abstract: EA_PAGE.abstract }];
+    const { db } = makeFakeDb({ profiles: [EA_PROFILE], pages });
+
+    const first = await backfillProfessionCraftMaterials(db, { loadFamilies: () => families });
+    expect(first.promoted).toBe(1);
+
+    // Second run rewrites at the same tier — still counted as promoted (upsert),
+    // not keptHigherTier, because derived == derived is not a downgrade.
+    const second = await backfillProfessionCraftMaterials(db, { loadFamilies: () => families });
+    expect(second.promoted).toBe(1);
+    expect(second.skipped).toHaveLength(0);
+  });
+
+  it("the decision-bearing kind registry stays closed", () => {
+    expect(DECISION_BEARING_PAGE_KINDS).toEqual(["principle", "heuristic", "stance", "decision"]);
+  });
+});

--- a/packages/db/src/profession-material-promotion.ts
+++ b/packages/db/src/profession-material-promotion.ts
@@ -1,0 +1,441 @@
+// Profession craft-material promotion (WSID Phase 6, BI-3B02FF9C).
+//
+// The WSID sibling of the org stance promotion in
+// apps/web/lib/decision-perspective/stance-promotion.ts: a profession corpus
+// WikiPage alone is a body-of-knowledge document; only an approved+promoted
+// PerspectiveMaterial row on the profession's wsid-<professionKey> profile in
+// the right domainClass changes what the profession decision gate
+// (evaluateProfessionDecisionGate) can confirm. Until this write path existed,
+// every wsid-* profile had ZERO material rows and every craft consult
+// deferred — the demand signal seedProfessionProfiles deliberately created.
+//
+// Three authority tiers, aligned with the stance confirmation ladder
+// (2026-06-09 WSID spec §4.6 + the stance-onboarding design §5):
+//
+//   derived    B / 0.6  — platform-seeded distillation of a standard; DPF's
+//                          *reading* of DMBOK/TOGAF/GAAP, not first-party fact
+//   confirmed  A / 0.9  — the org's owner published a craft override
+//   ruled      A / 1.0  — a human ruled on a real decision in this class
+//
+// Never downgrades: a ruled row survives a later confirmed write, a confirmed
+// row survives a later derived re-seed, and an approved review status is never
+// pulled back to draft by a re-run.
+//
+// Risk tiering (competence-flywheel design §5.5, BI-BE9C95D9): high-stakes
+// families — those whose registry contextSlugs touch finance or compliance —
+// do NOT get gate-live material from an unattended platform seed. Their
+// derived-tier rows land as reviewStatus "draft" / promotionState "candidate",
+// visible for audit but invisible to the gate (which requires
+// approved+promoted), until a human approves them. Confirmed/ruled tiers are
+// human actions by definition and go gate-live everywhere.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Profession material only ever occupies these two decision classes. The
+// closed platform registry lives in apps/web/lib/decision-perspective/types.ts
+// (DECISION_DOMAIN_CLASSES); this local subset exists because packages/db
+// cannot import from apps/web (same precedent: PLAN_READINESS_DOMAIN_CLASS in
+// seed-decision-perspective.ts).
+export const PROFESSION_DOMAIN_CLASSES = ["professional-practice", "architecture-tradeoff"] as const;
+export type ProfessionDomainClass = (typeof PROFESSION_DOMAIN_CLASSES)[number];
+
+export const PROFESSION_MATERIAL_TIERS = {
+  derived: { evidenceGrade: "B", confidenceWeight: 0.6 },
+  confirmed: { evidenceGrade: "A", confidenceWeight: 0.9 },
+  ruled: { evidenceGrade: "A", confidenceWeight: 1.0 },
+} as const;
+
+export type ProfessionMaterialTier = keyof typeof PROFESSION_MATERIAL_TIERS;
+
+/** Rank for the never-downgrade guard. */
+const TIER_RANK: Record<ProfessionMaterialTier, number> = { derived: 0, confirmed: 1, ruled: 2 };
+
+function tierOf(row: { evidenceGrade: string; confidenceWeight: number }): ProfessionMaterialTier {
+  if (row.evidenceGrade === "A" && row.confidenceWeight >= 1.0) return "ruled";
+  if (row.evidenceGrade === "A" && row.confidenceWeight >= 0.9) return "confirmed";
+  return "derived";
+}
+
+/**
+ * The decision-bearing subset of the corpus (WSID spec §4.6): pages that
+ * encode rules, trade-off heuristics, positions, or recorded decisions.
+ * Context kinds (entity, summary, runbook) stay retrieval-only — they ground
+ * prompts, not gate verdicts.
+ */
+export const DECISION_BEARING_PAGE_KINDS = ["principle", "heuristic", "stance", "decision"] as const;
+
+export function isDecisionBearingPageKind(pageKind: string): boolean {
+  return (DECISION_BEARING_PAGE_KINDS as readonly string[]).includes(pageKind);
+}
+
+/**
+ * High-stakes families require human approval before platform-seeded material
+ * goes gate-live (competence-flywheel §5.5 names legal, compliance, finance,
+ * healthcare). Derived from the registry's contextSlugs rather than a
+ * hardcoded family list so a new regulated family inherits the hold
+ * automatically: finance + legal-compliance + hr-people-ops + security all
+ * carry one of these slugs today.
+ */
+export const HIGH_STAKES_CONTEXT_SLUGS = ["finance", "compliance"] as const;
+
+export function isHighStakesProfession(contextSlugs: readonly string[]): boolean {
+  return contextSlugs.some((slug) =>
+    (HIGH_STAKES_CONTEXT_SLUGS as readonly string[]).includes(slug),
+  );
+}
+
+/**
+ * Which decision classes a profession's craft material occupies; the first
+ * entry is the primary class (its material row keeps the short id). Every
+ * family governs `professional-practice`; enterprise-architecture review and
+ * practice doctrine additionally answers `architecture-tradeoff` consults —
+ * the class whose 64 deferrals on wsid-enterprise-architecture are the
+ * demand signal this promotion exists to serve. Extend per family as the
+ * next defer clusters fire.
+ *
+ * The mapping is TIER-AWARE by design: the gate's confidence is the MEAN of
+ * applicable effective weights (evaluator.ts scoreProfileCoverage), so a
+ * derived B/0.6 row scores 0.45 effective and arithmetically dilutes any
+ * confirmed A/0.9 row sharing its domain class below the 0.7 recommend band.
+ * Derived platform distillations therefore stay context-grade
+ * (professional-practice only); human-vouched tiers (confirmed/ruled) carry
+ * the family's decision classes and are what actually clear a tradeoff
+ * consult. Confirming a platform page (BI-BE9C95D9's review surface)
+ * upgrades its tier and thereby promotes it into the tradeoff class.
+ */
+const PROFESSION_DOMAIN_CLASS_MAP: Record<string, readonly ProfessionDomainClass[]> = {
+  "enterprise-architecture": ["architecture-tradeoff", "professional-practice"],
+};
+
+export function professionDomainClasses(
+  professionKey: string,
+  tier: ProfessionMaterialTier,
+): readonly ProfessionDomainClass[] {
+  if (tier === "derived") return ["professional-practice"];
+  return PROFESSION_DOMAIN_CLASS_MAP[professionKey] ?? ["professional-practice"];
+}
+
+/** materialId scheme, mirroring stanceMaterialId: primary keeps the short id. */
+export function professionMaterialId(
+  profileId: string,
+  slug: string,
+  domainClass: string,
+  isPrimary: boolean,
+): string {
+  return isPrimary ? `${profileId}:${slug}` : `${profileId}:${slug}:${domainClass}`;
+}
+
+export type ProfessionPageSlugInfo = {
+  professionKey: string;
+  /** platform = seeded professions/<key>/ baseline; org-override = craft/<key>/ overlay. */
+  corpus: "platform" | "org-override";
+};
+
+/**
+ * Recognize the two profession corpus slug namespaces:
+ *   professions/<professionKey>/<page>  — platform-seeded baseline
+ *   craft/<professionKey>/<page>        — org craft override (CraftOverrideForm)
+ * Returns null for every other slug shape.
+ */
+export function parseProfessionPageSlug(slug: string): ProfessionPageSlugInfo | null {
+  const match = /^(professions|craft)\/([a-z0-9-]+)\/.+/.exec(slug);
+  if (!match) return null;
+  return {
+    professionKey: match[2],
+    corpus: match[1] === "professions" ? "platform" : "org-override",
+  };
+}
+
+// ─── DB client surfaces (structural, satisfied by PrismaClient and fakes) ────
+
+export type ProfessionMaterialPromotionClient = {
+  decisionPerspectiveProfile: {
+    findUnique(args: unknown): Promise<unknown>;
+  };
+  perspectiveMaterial: {
+    findUnique(args: unknown): Promise<unknown>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+};
+
+export type ProfessionCraftBackfillClient = ProfessionMaterialPromotionClient & {
+  wikiPage: {
+    findMany(args: unknown): Promise<unknown>;
+  };
+};
+
+// ─── Promotion ───────────────────────────────────────────────────────────────
+
+export type PromoteProfessionPageMaterialInput = {
+  db: ProfessionMaterialPromotionClient;
+  professionKey: string;
+  /** The family's registry contextSlugs — drives the high-stakes hold. */
+  contextSlugs: readonly string[];
+  page: {
+    id: string;
+    slug: string;
+    title: string;
+    pageKind: string;
+    abstract?: string | null;
+  };
+  tier: ProfessionMaterialTier;
+};
+
+export type PromoteProfessionPageMaterialResult =
+  | {
+      ok: true;
+      profileId: string;
+      /** materialIds written (or already at an equal/higher tier). */
+      materialIds: string[];
+      /** materialIds left untouched because they already sat at a higher tier. */
+      keptHigherTier: string[];
+      /** True when the written rows are approved+promoted (visible to the gate). */
+      gateLive: boolean;
+      /** True when the high-stakes hold kept the rows out of the gate. */
+      heldForReview: boolean;
+    }
+  | { ok: false; error: "no-profession-profile" | "not-decision-bearing" };
+
+/**
+ * Upsert the page's material rows on the profession's wsid-<professionKey>
+ * profile across its domain-class bundle. Idempotent; never downgrades tier
+ * or review status.
+ */
+export async function promoteProfessionPageMaterial(
+  input: PromoteProfessionPageMaterialInput,
+): Promise<PromoteProfessionPageMaterialResult> {
+  if (!isDecisionBearingPageKind(input.page.pageKind)) {
+    return { ok: false, error: "not-decision-bearing" };
+  }
+
+  const profileId = `wsid-${input.professionKey}`;
+  const profile = (await input.db.decisionPerspectiveProfile.findUnique({
+    where: { profileId },
+    select: { profileId: true, currentVersionId: true },
+  })) as { profileId: string; currentVersionId: string | null } | null;
+
+  if (!profile) {
+    return { ok: false, error: "no-profession-profile" };
+  }
+
+  const tier = PROFESSION_MATERIAL_TIERS[input.tier];
+  // The high-stakes hold applies only to unattended platform seeds; confirmed
+  // and ruled tiers exist because a human acted, which IS the approval.
+  const held = input.tier === "derived" && isHighStakesProfession(input.contextSlugs);
+
+  const domainClasses = professionDomainClasses(input.professionKey, input.tier);
+  const summary = input.page.abstract?.trim() || input.page.title;
+  const materialIds: string[] = [];
+  const keptHigherTier: string[] = [];
+
+  for (const [index, domainClass] of domainClasses.entries()) {
+    const materialId = professionMaterialId(profileId, input.page.slug, domainClass, index === 0);
+    materialIds.push(materialId);
+
+    const existing = (await input.db.perspectiveMaterial.findUnique({
+      where: { materialId },
+      select: { evidenceGrade: true, confidenceWeight: true, reviewStatus: true, promotionState: true },
+    })) as {
+      evidenceGrade: string;
+      confidenceWeight: number;
+      reviewStatus: string;
+      promotionState: string;
+    } | null;
+
+    if (existing && TIER_RANK[tierOf(existing)] > TIER_RANK[input.tier]) {
+      keptHigherTier.push(materialId);
+      continue;
+    }
+
+    // Never pull an already-approved row back behind the review hold.
+    const reviewStatus = held && existing?.reviewStatus !== "approved" ? "draft" : "approved";
+    const promotionState =
+      held && existing?.promotionState !== "promoted" ? "candidate" : "promoted";
+
+    const sourceRef = {
+      wikiPageId: input.page.id,
+      slug: input.page.slug,
+      professionKey: input.professionKey,
+      corpus: input.tier === "derived" ? "platform" : "org-override",
+    };
+
+    await input.db.perspectiveMaterial.upsert({
+      where: { materialId },
+      update: {
+        sourceType: input.page.pageKind,
+        sourceRef,
+        scope: { domains: [domainClass] },
+        domainClass,
+        domains: [domainClass],
+        summary,
+        freshness: "current",
+        evidenceGrade: tier.evidenceGrade,
+        confidenceWeight: tier.confidenceWeight,
+        reviewStatus,
+        promotionState,
+        lastValidatedAt: new Date(),
+      },
+      create: {
+        materialId,
+        profileId: profile.profileId,
+        profileVersionId: profile.currentVersionId ?? `${profile.profileId}-v1`,
+        sourceType: input.page.pageKind,
+        sourceRef,
+        scope: { domains: [domainClass] },
+        domainClass,
+        direction: "support",
+        domains: [domainClass],
+        freshness: "current",
+        evidenceGrade: tier.evidenceGrade,
+        confidenceWeight: tier.confidenceWeight,
+        reviewStatus,
+        promotionState,
+        summary,
+        lastValidatedAt: new Date(),
+      },
+    });
+  }
+
+  return {
+    ok: true,
+    profileId: profile.profileId,
+    materialIds,
+    keptHigherTier,
+    gateLive: !held,
+    heldForReview: held,
+  };
+}
+
+// ─── Backfill ────────────────────────────────────────────────────────────────
+
+export type ProfessionFamilyContext = {
+  professionKey: string;
+  contextSlugs: string[];
+};
+
+function loadProfessionFamilyContexts(): ProfessionFamilyContext[] {
+  const registryPath = join(__dirname, "../../../docs/professions/registry.json");
+  const raw = readFileSync(registryPath, "utf-8");
+  const data = JSON.parse(raw) as {
+    families: Array<{ professionKey: string; contextSlugs?: string[] }>;
+  };
+  return data.families.map((family) => ({
+    professionKey: family.professionKey,
+    contextSlugs: family.contextSlugs ?? [],
+  }));
+}
+
+export type BackfillProfessionCraftMaterialsResult = {
+  /** Published corpus/override pages examined. */
+  scanned: number;
+  /** Pages whose material rows were written this run. */
+  promoted: number;
+  /** Pages whose rows are approved+promoted (gate-visible). */
+  gateLive: number;
+  /** Pages held as draft/candidate by the high-stakes hold. */
+  heldForReview: number;
+  /** Pages skipped because their rows already sat at a higher tier. */
+  keptHigherTier: number;
+  /** Context-only pages (entity/summary/runbook) — not decision-bearing. */
+  notDecisionBearing: number;
+  /** Real anomalies worth a loud log line. */
+  skipped: Array<{ slug: string; reason: string }>;
+};
+
+/**
+ * One-shot idempotent backfill for the existing published corpus: every
+ * professions/<key>/ platform page enters at the derived tier, every
+ * craft/<key>/ org override that a human already published enters at the
+ * confirmed tier. Runs from the seed (fresh installs get materials with their
+ * corpus; existing installs converge on the next seed run).
+ */
+export async function backfillProfessionCraftMaterials(
+  db: ProfessionCraftBackfillClient,
+  options?: { loadFamilies?: () => ProfessionFamilyContext[] },
+): Promise<BackfillProfessionCraftMaterialsResult> {
+  const families = (options?.loadFamilies ?? loadProfessionFamilyContexts)();
+  const familyByKey = new Map(families.map((family) => [family.professionKey, family]));
+
+  const pages = (await db.wikiPage.findMany({
+    where: {
+      status: "published",
+      OR: [
+        { slug: { startsWith: "professions/" }, organizationId: null },
+        { slug: { startsWith: "craft/" } },
+      ],
+    },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      pageKind: true,
+      abstract: true,
+      organizationId: true,
+    },
+    orderBy: { slug: "asc" },
+  })) as Array<{
+    id: string;
+    slug: string;
+    title: string;
+    pageKind: string;
+    abstract: string | null;
+    organizationId: string | null;
+  }>;
+
+  const result: BackfillProfessionCraftMaterialsResult = {
+    scanned: pages.length,
+    promoted: 0,
+    gateLive: 0,
+    heldForReview: 0,
+    keptHigherTier: 0,
+    notDecisionBearing: 0,
+    skipped: [],
+  };
+
+  for (const page of pages) {
+    const slugInfo = parseProfessionPageSlug(page.slug);
+    if (!slugInfo) {
+      result.skipped.push({ slug: page.slug, reason: "unparseable profession slug" });
+      continue;
+    }
+
+    const family = familyByKey.get(slugInfo.professionKey);
+    if (!family) {
+      result.skipped.push({
+        slug: page.slug,
+        reason: `professionKey "${slugInfo.professionKey}" is not in docs/professions/registry.json`,
+      });
+      continue;
+    }
+
+    if (!isDecisionBearingPageKind(page.pageKind)) {
+      result.notDecisionBearing++;
+      continue;
+    }
+
+    const promoted = await promoteProfessionPageMaterial({
+      db,
+      professionKey: slugInfo.professionKey,
+      contextSlugs: family.contextSlugs,
+      page,
+      tier: slugInfo.corpus === "platform" ? "derived" : "confirmed",
+    });
+
+    if (!promoted.ok) {
+      result.skipped.push({ slug: page.slug, reason: promoted.error });
+      continue;
+    }
+
+    if (promoted.keptHigherTier.length === promoted.materialIds.length) {
+      result.keptHigherTier++;
+      continue;
+    }
+
+    result.promoted++;
+    if (promoted.heldForReview) result.heldForReview++;
+    else result.gateLive++;
+  }
+
+  return result;
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -56,6 +56,7 @@ import { seedSkills } from "./seed-skills.js";
 import { seedWikiKernel } from "./seed-wiki-kernel.js";
 import { seedDecisionPerspective, seedProfessionProfiles } from "./seed-decision-perspective.js";
 import { seedProfessionCorpus } from "./seed-profession-corpus.js";
+import { backfillProfessionCraftMaterials } from "./profession-material-promotion.js";
 import { seedPlatformVoice } from "./seed-platform-voice.js";
 import {
   SPEACHES_PROVIDER_ID,
@@ -2575,6 +2576,21 @@ async function main(): Promise<void> {
           `jurisdiction[${fmt(result.jurisdictionCoverage)}] ` +
           `competency[${fmt(result.competencyCoverage)}]`,
       );
+    }
+  });
+  // WSID Phase 6 (BI-3B02FF9C): the corpus pages above become decision-bearing
+  // PerspectiveMaterial on their wsid-* profiles, so the profession gate can
+  // confirm instead of deferring. Idempotent; never downgrades a tier.
+  await step("professionCraftMaterials", async () => {
+    const result = await backfillProfessionCraftMaterials(prisma);
+    console.log(
+      `  profession-craft-materials: scanned=${result.scanned} promoted=${result.promoted} ` +
+        `gate-live=${result.gateLive} held-for-review=${result.heldForReview} ` +
+        `kept-higher-tier=${result.keptHigherTier} context-only=${result.notDecisionBearing} ` +
+        `skipped=${result.skipped.length}`,
+    );
+    for (const skip of result.skipped) {
+      console.warn(`  [profession-craft-materials] SKIP ${skip.slug}: ${skip.reason}`);
     }
   });
   // BI-2535D6F4: ship the founder's recorded seed voice on the platform profile.


### PR DESCRIPTION
## Summary

WSID Phase 6 (spec §4.6, designed 2026-06-09, never implemented until now): the ~186 published `professions/<family>/` corpus pages and `craft/<professionKey>/` org overrides stopped at WikiPage, so every wsid-* profile had ZERO PerspectiveMaterial rows and every profession consult deferred — 64 `architecture-tradeoff` deferrals on `wsid-enterprise-architecture` were the demand signal (§11 addendum, #3735).

- **`packages/db/src/profession-material-promotion.ts`** — the profession sibling of `stance-promotion.ts`, shared by runtime + seed (exported as `@dpf/db/profession-material-promotion`). Tier ladder `derived` B/0.6 → `confirmed` A/0.9 → `ruled` A/1.0; never downgrades tier or an approved review status.
- **Tier-aware domainClass mapping** — derived platform distillations stay `professional-practice` (context-grade: a 0.45-effective row sharing a class would dilute the mean-based gate confidence below the 0.7 recommend band); confirmed/ruled enterprise-architecture material is `architecture-tradeoff` primary. Human confirmation is what promotes a page's doctrine into tradeoff authority.
- **Risk tiering** (competence-flywheel §5.5, BI-BE9C95D9) — families whose registry contextSlugs touch finance/compliance (finance, legal-compliance, hr-people-ops, security) hold derived rows `draft`/`candidate` — auditable, gate-invisible — until a human approves. Confirmed/ruled tiers are human actions and go gate-live everywhere.
- **Publish hook** — `publishWikiOverlayPages` (the overlay review publish click) promotes a published `craft/<key>/` page at confirmed tier, mirroring `publishBusinessStance`; promotion failure never rolls back the page publish.
- **Seed backfill** — new `professionCraftMaterials` step after `seedProfessionCorpus`: platform pages at derived, already-published craft overrides at confirmed. Idempotent, loud on anomalies.
- **Spec** — §12 implementation-record addendum on the WSID design (complements Mark's §11 priming addendum from #3735).

## Acceptance

Regression-locked in `profession-gate.test.ts`: with the two published EA craft overrides gate-live (confirmed A/0.9, architecture-tradeoff primary — the exact rows the promotion writes), an `architecture-tradeoff` consult on `wsid-enterprise-architecture` returns **recommend at 0.9 confidence with `professionProfileSelected=true`** instead of the coverage-gap defer. On the live install: run the seed (backfill), then publish the two draft EA craft overrides at `craft/enterprise-architecture/*` — the publish click itself promotes them gate-live.

## Verification

- `pnpm run pregate` — shared local-CI convergence sandbox, merged with `origin/main` @ e8512d5c33: **gate passed** (typecheck + unit tests + production Docker build).
- Targeted vitest (worktree, junctions): promotion module 16/16; wiki-publish + profession-gate + stance-promotion 31/31; material + resolve-profession-profile + profession-corpus-wiring 33/33.
- `packages/db/src/seed.test.ts`: 13/14 — the 1 failure (`seedEaReferenceModels` barrel check) fails identically on `main` in the root clone (pre-existing `@dpf/storefront-templates` workspace-link resolution gap in hollow node_modules); covered by the CI Unit Tests job.

Seed-Fit-Decision: global-default
Seed-fit rationale: platform substrate for every install — an additive, idempotent seed step deriving PerspectiveMaterial from already-seeded published corpus pages; no runtime patching, no data destruction, existing installs converge on their next seed run per seed-is-bootstrap-calibration-is-runtime.
UX-Fit-Decision: no UI surface added or changed — server-side promotion write path, seed step, and an additive server-action result field only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Local-CI-Override: head 6547d7f298287fa6b2412731a1091b6c99bb85b0 is an empty retrigger commit (Seed-Fit-Decision trailer fix only); its tree is byte-identical to the SHA that passed `pnpm run pregate` on the shared local-CI sandbox merged with origin/main e8512d5c33 (gate passed: typecheck + unit tests + production Docker build).
