### PR TITLE
fix(kernel): reject principle payload on non-principle pages instead of dropping it

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1785,6 +1785,7 @@
         "1-the-shape",
         "2-add-a-new-wiki-page-in-60-seconds",
         "3-frontmatter-shape",
+        "the-principle-payload-is-pagekind-principle-only",
         "4-wikilinks",
         "5-add-a-raw-source",
         "6-publish-flow",

--- a/docs/founder-kernel/AUTHORING.md
+++ b/docs/founder-kernel/AUTHORING.md
@@ -61,7 +61,7 @@ That&#39;s the loop.
 ```yaml
 ---
 title: Plain English Title          # required, shown in the viewer header
-pageKind: stance                    # required — entity | stance | heuristic | decision | runbook | summary | index
+pageKind: stance                    # required — entity | stance | heuristic | principle | decision | runbook | summary | index
 status: published                   # optional, default published. Other values: draft | review-needed | archived
 abstract: One paragraph summary.    # optional but recommended (shown under title in viewer)
 sources:                            # optional list of raw-source slugs that back this page
@@ -69,6 +69,29 @@ sources:                            # optional list of raw-source slugs that bac
   - articles/portfolio-as-anchor
 ---
 ```
+
+### The principle payload is `pageKind: principle` only
+
+The `principle*` frontmatter keys — `principleTier`, `principleDirection`,
+`principleWeight`, `principleWeightRationale`, `principleDimensionVector`,
+`principleDimensions`, `principleAppliesTo`, `principleRingScope`,
+`principleConsumerArchetype`, `principleConsumerContexts`, `principlePublic`,
+`principlePublicRationale`, `principleRuntimeEnforcement` — are read **only**
+from a `pageKind: principle` page. Structured option scoring reads the
+principle's dimensions, principle recall selects on the kind, and every
+`principle-*` lint detector filters to it.
+
+Declaring any of them on a `heuristic`, `stance`, `entity`, `summary`,
+`decision`, `runbook`, or `index` page is a **seed-time error** — the seeder
+names the file and the offending keys and refuses to seed. It does not
+silently drop them.
+
+This is deliberate, not a gap. A `heuristic` is defeasible by construction
+(*"prefer 3NF until a measured read-path needs denormalization"*); a
+`principle` carries a tier and a direction that move a decision verdict. If a
+rule is meant to move verdicts, author it as a `principle`. If it is genuinely
+a rule of thumb, keep it as prose and let it inform the reader rather than
+outvote the ledger.
 
 Fields are parsed by the YAML subset shared with `seed-skills.ts` and `seed-prompt-templates.ts`. Scalars, inline arrays (`[a, b]`), and block-style lists (`- item`) all work. **No nested objects.** Quotes are optional; surrounding `"`/`'` are stripped.
 
@@ -225,6 +248,7 @@ Customers will be able to override kernel pages with their own takes via the `ke
 | `Missing YAML frontmatter delimiters (---)` | File doesn&#39;t open with `---\n…\n---\n` | Add the frontmatter block at the top. |
 | `pageKind: summary` page flagged `stance-extraction-needed` | Summary lacks a `[[stances/…]]` or `[[heuristics/…]]` wikilink | Extract a stance or heuristic as its own page and link to it from the summary body. |
 | `dangling-xref` error blocks publish | A `[[wikilink]]` target doesn&#39;t exist | Create the target page first, or remove/fix the link. |
+| Seed fails: `has pageKind "heuristic" but declares principle-only frontmatter` | A non-`principle` page declares `principleDimensionVector`, `principleTier`, or another `principle*` key. Those are read only from `pageKind: principle`. | Change `pageKind` to `principle` if the page is meant to move decision verdicts, or drop the `principle*` keys if it is a rule of thumb. See §3. |
 | Page doesn&#39;t appear at `/wiki/<slug>` after seed | Slug mismatch | Check the file path. Slug is `<path-under-wiki-without-ext>` unless overridden. |
 | Same page seeds with `version=1` every time | Body actually unchanged between runs | Expected behaviour — revision chain only advances on body change. |
 | Qdrant upsert returns `qdrant=no-sidecar` | `embeddings.jsonl` missing | Run `tsx scripts/build-kernel-embeddings.ts` to generate it. The seed still writes Postgres rows even without it. |

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -1941,7 +1941,7 @@ export async function seedProfessionCorpus(
       archetypeCoverage,
     );
 
-    const principlePayload = extractPrinciplePayload(frontmatter);
+    const principlePayload = extractPrinciplePayload(frontmatter, file);
 
     // Persist the validated WSID variant axes into WikiPage.metadata so the
     // HRIS coverage helper, the runtime retrieval service, and the gate variant

--- a/packages/db/src/seed-wiki-kernel.test.ts
+++ b/packages/db/src/seed-wiki-kernel.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { resolve } from "path";
 import { describe, expect, it } from "vitest";
 import {
@@ -7,6 +7,7 @@ import {
   extractPrinciplePayload,
   extractWikilinks,
   parseFrontmatter,
+  PRINCIPLE_ONLY_FRONTMATTER_KEYS,
   type SeedablePage,
   type WikiPageFrontmatter,
 } from "./seed-wiki-kernel";
@@ -389,15 +390,17 @@ describe("seed-wiki-kernel: extractPrinciplePayload", () => {
     expect(payload.principleAppliesTo).toEqual(["human"]);
   });
 
-  it("does not forward consumer-archetype keys on non-principle pages", () => {
-    const payload = extractPrinciplePayload({
-      title: "Edge Node",
-      pageKind: "entity",
-      // These would be invalid on an entity but the helper must short-circuit
-      // before any coherence check fires.
-      principleConsumerArchetype: "route-domain-specific" as never,
-    });
-    expect(payload).toEqual({});
+  it("rejects consumer-archetype keys on non-principle pages", () => {
+    // Previously this short-circuited to {}: the archetype was dropped and the
+    // author never learned. The kind mismatch must be what surfaces here — not
+    // the "route-domain-specific requires a context" coherence check.
+    expect(() =>
+      extractPrinciplePayload({
+        title: "Edge Node",
+        pageKind: "entity",
+        principleConsumerArchetype: "route-domain-specific" as never,
+      }),
+    ).toThrow(/principleConsumerArchetype/);
   });
 
   // ─── Ring-scope axis (spec 2026-05-24-founder-kernel-evolution-discipline) ───
@@ -442,13 +445,136 @@ describe("seed-wiki-kernel: extractPrinciplePayload", () => {
     expect(payload.principleRingScope).toEqual(["universal-ring"]);
   });
 
-  it("does not forward principleRingScope on non-principle pages", () => {
-    const payload = extractPrinciplePayload({
-      title: "Edge Node",
-      pageKind: "entity",
-      principleRingScope: ["ring-1-coworker"] as never,
+  it("rejects principleRingScope on non-principle pages", () => {
+    expect(() =>
+      extractPrinciplePayload({
+        title: "Edge Node",
+        pageKind: "entity",
+        principleRingScope: ["ring-1-coworker"] as never,
+      }),
+    ).toThrow(/principleRingScope/);
+  });
+
+  // ─── Principle payload on the wrong pageKind ─────────────────────────────
+  // Regression cover for the silent drop found while building BI-D65E044E
+  // Phase 1: a decision-bearing vector authored on a `heuristic` page seeded
+  // as prose with the entire payload discarded — no vector, so it contributed
+  // nothing to structured option scoring and could not move a verdict. The
+  // principle lint detectors select on `pageKind === "principle"`, so nothing
+  // downstream could catch it either. `make-silent-failures-observable`
+  // requires the author to learn at authoring time.
+
+  it("throws when a heuristic page declares a principle dimension vector", () => {
+    expect(() =>
+      extractPrinciplePayload({
+        title: "Prefer 3NF Until Measured",
+        pageKind: "heuristic",
+        principleDimensionVector: { schema_grounding: 1.0 },
+      }),
+    ).toThrow(/principleDimensionVector/);
+  });
+
+  it("names every declared principle-only key, and the file, in the message", () => {
+    expect(() =>
+      extractPrinciplePayload(
+        {
+          title: "Prefer 3NF Until Measured",
+          pageKind: "heuristic",
+          principleTier: "core",
+          principleDirection: "Normalize first.",
+          principleDimensionVector: { schema_grounding: 1.0 },
+        },
+        "docs/professions/data-architect/wiki/prefer-3nf.md",
+      ),
+    ).toThrow(/principleTier, principleDirection, principleDimensionVector/);
+
+    // The path is what makes this actionable inside a many-hundred-page seed.
+    expect(() =>
+      extractPrinciplePayload(
+        {
+          title: "Prefer 3NF Until Measured",
+          pageKind: "heuristic",
+          principleDimensionVector: { schema_grounding: 1.0 },
+        },
+        "docs/professions/data-architect/wiki/prefer-3nf.md",
+      ),
+    ).toThrow(/prefer-3nf\.md/);
+  });
+
+  it("rejects principle payload on every non-principle kind", () => {
+    for (const kind of [
+      "heuristic",
+      "stance",
+      "entity",
+      "summary",
+      "decision",
+      "runbook",
+      "index",
+    ] as const) {
+      expect(() =>
+        extractPrinciplePayload({
+          title: "T",
+          pageKind: kind,
+          principleDimensionVector: { schema_grounding: 1.0 },
+        }),
+      ).toThrow(/pageKind: principle ONLY/);
+    }
+  });
+
+  it("fires on real authored markdown, not just object literals", () => {
+    // End-to-end from the raw file shape an author actually writes: the
+    // reported case was a profession-corpus page authored exactly like this.
+    const raw = `---
+title: Prefer 3NF Until Measured
+pageKind: heuristic
+principleDimensionVector: {"schema_grounding": 1.0}
+principleDirection: Normalize first; denormalize on measured read pressure.
+---
+
+Prefer 3NF until a measured read-path needs denormalization.`;
+
+    const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(raw);
+    expect(frontmatter.principleDimensionVector).toEqual({
+      schema_grounding: 1.0,
     });
-    expect(payload).toEqual({});
+
+    expect(() =>
+      extractPrinciplePayload(frontmatter, "docs/professions/x/wiki/y.md"),
+    ).toThrow(/principleDirection, principleDimensionVector|principleDimensionVector/);
+  });
+
+  it("still returns {} for a non-principle page that declares no payload", () => {
+    // The guard must not turn every ordinary corpus page into a seed failure.
+    expect(
+      extractPrinciplePayload({ title: "Edge Node", pageKind: "heuristic" }),
+    ).toEqual({});
+  });
+
+  it("keeps the guard key list in sync with the payload builder", () => {
+    // Every key the builder forwards must also be a key the guard rejects on
+    // the wrong kind. If the two drift, a newly added principle field silently
+    // escapes the check — reintroducing exactly this bug for that field.
+    const full: WikiPageFrontmatter = {
+      title: "T",
+      pageKind: "principle",
+      principleTier: "core",
+      principleDirection: "D",
+      principleWeight: 0.5,
+      principleWeightRationale: "R",
+      principleDimensionVector: { schema_grounding: 1.0 },
+      principleDimensions: ["schema_grounding"],
+      principleAppliesTo: ["human", "in_platform_coworker"],
+      principleRingScope: ["ring-1-coworker"],
+      principleConsumerArchetype: "universal",
+      principleConsumerContexts: ["data-model"],
+      principlePublic: true,
+      principlePublicRationale: "PR",
+    };
+
+    const guarded = new Set<string>(PRINCIPLE_ONLY_FRONTMATTER_KEYS);
+    for (const key of Object.keys(extractPrinciplePayload(full))) {
+      expect(guarded.has(key)).toBe(true);
+    }
   });
 });
 
@@ -475,6 +601,54 @@ describe("founder-kernel principle frontmatter", () => {
     }
 
     expect(missing).toEqual([]);
+  });
+
+  it("no authored page declares principle payload on a non-principle kind", () => {
+    // The seeder guard only fires when the seed actually runs (which needs a
+    // DB). This sweep is the cheap CI-time equivalent, so an author learns at
+    // PR time instead of at deploy time. Covers both corpora: the founder
+    // kernel and every profession corpus under docs/professions/*/wiki/.
+    const repoRoot = resolve(process.cwd(), "../..");
+
+    const walk = (dir: string): string[] => {
+      if (!existsSync(dir)) return [];
+      const out: string[] = [];
+      for (const entry of readdirSync(dir)) {
+        const full = resolve(dir, entry);
+        if (statSync(full).isDirectory()) out.push(...walk(full));
+        else if (entry.endsWith(".md") && !entry.startsWith("README"))
+          out.push(full);
+      }
+      return out;
+    };
+
+    const files = [
+      ...walk(resolve(repoRoot, "docs/founder-kernel/wiki")),
+      ...walk(resolve(repoRoot, "docs/professions")),
+    ];
+    // Guard the guard: if the corpus paths ever move, this test must fail
+    // loudly rather than silently sweep zero files and report success.
+    expect(files.length).toBeGreaterThan(50);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const { frontmatter } = parseFrontmatter<WikiPageFrontmatter>(
+        readFileSync(file, "utf8"),
+      );
+      if (frontmatter.pageKind === "principle") continue;
+
+      const declared = PRINCIPLE_ONLY_FRONTMATTER_KEYS.filter(
+        (key) => frontmatter[key] !== undefined,
+      );
+      if (declared.length > 0) {
+        offenders.push(
+          `${file.slice(repoRoot.length + 1).replace(/\\/g, "/")} ` +
+            `[pageKind: ${frontmatter.pageKind}] declares ${declared.join(", ")}`,
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/packages/db/src/seed-wiki-kernel.ts
+++ b/packages/db/src/seed-wiki-kernel.ts
@@ -82,11 +82,36 @@ function readManifest(): Manifest {
 // ─── Principle Payload Extractor ───────────────────────────────────────────
 
 /**
+ * Every frontmatter key that only a `pageKind: principle` page may carry.
+ *
+ * Kept as one list so the "wrong kind" guard below cannot drift out of sync
+ * with the payload builder at the bottom of `extractPrinciplePayload` — the
+ * two must cover the same key set or a field silently escapes the check.
+ */
+export const PRINCIPLE_ONLY_FRONTMATTER_KEYS = [
+  "principleTier",
+  "principleDirection",
+  "principleWeight",
+  "principleWeightRationale",
+  "principleDimensionVector",
+  "principleDimensions",
+  "principleAppliesTo",
+  "principleRingScope",
+  "principleConsumerArchetype",
+  "principleConsumerContexts",
+  "principlePublic",
+  "principlePublicRationale",
+  "principleRuntimeEnforcement",
+] as const satisfies readonly (keyof WikiPageFrontmatter)[];
+
+/**
  * Pull the principle-only fields out of a `WikiPageFrontmatter` and shape
  * them for `upsertWikiPage`'s `WikiPagePrincipleInput`.
  *
  * - Returns `{}` for non-principle pages so callers can spread the result
- *   unconditionally without leaking principle keys onto other kinds.
+ *   unconditionally without leaking principle keys onto other kinds. A
+ *   non-principle page that *declares* principle payload is a hard error
+ *   rather than a silent `{}` — see the guard below.
  * - Validates every key in `principleDimensionVector` and every entry in
  *   `principleDimensions` against the `PRINCIPLE_DIMENSIONS` registry.
  *   Throws with a clear message naming the offending key — per
@@ -100,8 +125,36 @@ function readManifest(): Manifest {
  */
 export function extractPrinciplePayload(
   frontmatter: WikiPageFrontmatter,
+  sourcePath?: string,
 ): WikiPagePrincipleInput {
   if (frontmatter.pageKind !== "principle") {
+    // A non-principle page that declares principle payload used to seed as
+    // prose with the whole payload dropped on the floor: no vector, no tier,
+    // no contribution to structured option scoring, and no way for the author
+    // to find out — the principle lint detectors only ever see
+    // `pageKind === "principle"` pages, so nothing downstream could catch it
+    // either. That is precisely the failure mode
+    // `make-silent-failures-observable` forbids, so fail at authoring time.
+    const declared = PRINCIPLE_ONLY_FRONTMATTER_KEYS.filter(
+      (key) => frontmatter[key] !== undefined,
+    );
+    if (declared.length > 0) {
+      const where = sourcePath ? ` (${sourcePath})` : "";
+      throw new Error(
+        `Page "${frontmatter.title}"${where} has pageKind ` +
+          `"${frontmatter.pageKind}" but declares principle-only frontmatter: ` +
+          `${declared.join(", ")}. The principle payload (tier, direction, ` +
+          `dimension vector, applies-to, ring scope, …) is carried by ` +
+          `pageKind: principle ONLY — spec ` +
+          `2026-06-09-wsid-coworker-professional-corpus-design.md §4.6 makes ` +
+          `"principle" the decision-bearing kind, and option scoring, ` +
+          `principle recall, and the principle lint detectors all select on ` +
+          `it. Declared here, the payload would be silently discarded. ` +
+          `Fix one of: (a) change pageKind to "principle" if this page is ` +
+          `meant to move decision verdicts; or (b) drop the listed field(s) ` +
+          `if this is a defeasible rule of thumb that should stay prose.`,
+      );
+    }
     return {};
   }
 
@@ -401,7 +454,7 @@ async function seedWikiPages(
     const slug = frontmatter.slug ?? deriveSlug(file, wikiDir);
     const status = frontmatter.status ?? "published";
 
-    const principlePayload = extractPrinciplePayload(frontmatter);
+    const principlePayload = extractPrinciplePayload(frontmatter, file);
 
     const upserted = (await upsertWikiPage(prisma, {
       slug,


### PR DESCRIPTION
## Problem

`extractPrinciplePayload` returned `{}` for any frontmatter whose `pageKind` was not `"principle"`. A page authored as `heuristic` / `stance` / `entity` / `summary` that declared `principleDimensionVector`, `principleTier`, `principleDirection`, `principleAppliesTo`, or `principleRingScope` seeded as prose with the **entire payload discarded** — no vector, so it contributed nothing to structured option scoring and could not move a decision verdict.

Nothing downstream could catch it. `principle-lint-detectors.ts` filters to `pageKind === "principle"`, as do golden decisions and principle recall, so a dropped payload was invisible at every layer — the page looked fine and scored nothing. That is the failure mode `make-silent-failures-observable` forbids.

Found while building BI-D65E044E Phase 1, which worked around it by authoring all seven new pages as `pageKind: principle`.

## Decision: the payload stays principle-only

The question raised was whether `heuristic` should be allowed to carry the principle payload. It should not:

- Spec `2026-06-09-wsid-coworker-professional-corpus-design.md` §4.6 attaches "decision-bearing rules" to `principle` **alone**, and lists `heuristic` among page kinds "used as-is".
- `AUTHORING.md` §2 already called `principle` "the heaviest of the three — it carries tier, applies-to scope, and a decision vector".
- A heuristic is defeasible by construction (*"prefer 3NF **until** a measured read-path needs denormalization"*). A kind that carries a tier and a direction into verdict aggregation is a different thing. Conflating them is what #3717 just untangled for profession commandments.
- The kind gate is not one line: `golden-decisions.ts:68`, `principle-lint-detectors.ts:67`, and principle recall all select on it. Widening the contract is a cross-cutting semantic change, and demand is currently zero.

So this makes the mistake **loud** rather than widening the contract.

## Changes

- `extractPrinciplePayload` throws when a non-principle page declares any principle-only key, naming the file, the `pageKind`, and every offending key, and spelling out both remedies (change the kind, or drop the fields).
- Driven off one exported `PRINCIPLE_ONLY_FRONTMATTER_KEYS` list, with a test that fails if the guard drifts from the payload builder — otherwise a newly added principle field silently escapes the check and reintroduces this bug for that field.
- Both seeders (`seed-wiki-kernel.ts`, `seed-profession-corpus.ts`) pass the source path so the error is actionable inside a many-hundred-page seed run.
- A corpus sweep test walks `docs/founder-kernel/wiki` and `docs/professions`, so this fails at PR time — the seeder guard only fires when a seed actually runs, which needs a DB.
- `AUTHORING.md` documents the rule, the reasoning, and the error text. Its `pageKind` enum comment was also missing `principle` entirely.

**Two existing tests asserted the silent drop as correct behavior and are inverted.** The bug was tested in, which is why it survived.

## Scope note

The report that five pages under `docs/professions/` were already affected did not reproduce. Zero non-principle pages declare any principle-only key — verified on this branch, on the root clone at `main`, and on the BI-D65E044E branch itself. Those five were most likely Phase 1 drafts before the `pageKind: principle` workaround was applied. The new sweep test is green across both corpora, and now keeps it that way.

## Verification

- `packages/db` full suite: 1626 passed. 5 pre-existing failures, all `Cannot find package '@dpf/storefront-templates'` from a source-only worktree with no `node_modules` — none related to this change.
- The sweep test was proven non-vacuous: planted a real offending page, watched it fail naming the file and keys, then pass on removal.
- `tsc --noEmit` clean on both changed TypeScript files.
- `pnpm run pregate` — gate passed, `evidenceTier: exhaustive`, `fullSuite: true`, against `origin/main@5961ca5409`.

Seed-Fit-Decision: global-default

The guard is a correctness invariant of the kernel/profession seeders themselves, not seeded content that varies by archetype or vertical. It applies identically to every install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
