### PR TITLE
fix(db): make amcheck success Prisma-safe

### DIFF
--- a/packages/db/scripts/index-integrity-core.mjs
+++ b/packages/db/scripts/index-integrity-core.mjs
@@ -113,7 +113,7 @@ function quoteRegclassPart(value) {
 async function checkIndex(client, schema, indexName) {
   try {
     await client.query(
-      "SELECT public.bt_index_parent_check($1::regclass, true, true)",
+      "SELECT public.bt_index_parent_check($1::regclass, true, true)::text AS check_result",
       [`${quoteRegclassPart(schema)}.${quoteRegclassPart(indexName)}`],
     );
     return null;

--- a/packages/db/scripts/index-integrity-guard.postgres.test.ts
+++ b/packages/db/scripts/index-integrity-guard.postgres.test.ts
@@ -1,0 +1,44 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaClient } from "../generated/client/client";
+// @ts-expect-error -- importable runtime guard is plain .mjs by design
+import { checkIndexIntegrity } from "./index-integrity-core.mjs";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+let db: PrismaClient;
+
+describeDatabase("index integrity guard with Prisma and PostgreSQL", () => {
+  beforeAll(async () => {
+    const adapter = new PrismaPg({ connectionString: databaseUrl! });
+    db = new PrismaClient({ adapter });
+    await db.$connect();
+  });
+
+  afterAll(async () => {
+    await db?.$disconnect();
+  });
+
+  it("deserializes a successful amcheck result through Prisma", async () => {
+    const queryClient = {
+      query: async (sql: string, params: unknown[] = []) => ({
+        rows: await db.$queryRawUnsafe<unknown[]>(
+          sql,
+          ...(params as never[]),
+        ),
+      }),
+    };
+
+    const report = await checkIndexIntegrity(queryClient, {
+      amcheckMode: "require",
+      schema: "public",
+      table: "PlatformConfig",
+      uniqueOnly: true,
+      requiredIndexes: [{ name: "PlatformConfig_pkey", unique: true }],
+    });
+
+    expect(report.failed).toBe(false);
+    expect(report.corrupted).toEqual([]);
+  });
+});

--- a/packages/db/scripts/index-integrity-guard.test.ts
+++ b/packages/db/scripts/index-integrity-guard.test.ts
@@ -138,7 +138,7 @@ describe("checkIndexIntegrity", () => {
     expect(queries.some(({ sql }) => /\bCREATE\b/i.test(sql))).toBe(false);
     expect(queries[1]?.params).toEqual([false, "InventoryEntity", "public"]);
     expect(queries[2]?.sql).toContain(
-      "public.bt_index_parent_check($1::regclass, true, true)",
+      "public.bt_index_parent_check($1::regclass, true, true)::text AS check_result",
     );
     expect(queries[2]?.params).toEqual([
       '"public"."InventoryEntity_entityKey_key"',


### PR DESCRIPTION
## Summary
- make PostgreSQL amcheck success results Prisma-safe by casting the void result to text
- retain the existing corruption/error failure semantics
- add SQL-contract and real Prisma/Postgres regression coverage

## Verification
- governed local-integration-ci lease: NPEL-26866F2834
- exact candidate: 68f3d8a9915ccb238ccc125cbfa58e1085560dc2
- evidence: cms6jqaf80c1p01l24tyin63i
- freshness, Prisma generate, and 465 migrations passed
- exhaustive Vitest: 20,212 passed; 19 skipped; 18 todo
- web typecheck passed
- production Docker build passed

## Documentation
No user-facing documentation change is required: this corrects an internal integrity-check query serialization defect without changing operator workflow or UI.

Backlog: BI-D599EE20