### PR TITLE
fix(build): materialize hermetic replay dependencies

### DIFF
--- a/apps/web/lib/integrate/sandbox/sandbox-verification.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-verification.test.ts
@@ -33,11 +33,22 @@ describe("SANDBOX_BUILD_COMMAND", () => {
   // prerender pass. See BI-6A1CE023.
   it("forces NODE_ENV=production for the Next production build", () => {
     expect(SANDBOX_BUILD_COMMAND).toContain("NODE_ENV=production");
-    expect(SANDBOX_BUILD_COMMAND).toMatch(/NODE_ENV=production\s+pnpm --filter web build/);
+    expect(SANDBOX_BUILD_COMMAND).toMatch(
+      /NODE_ENV=production\s+NODE_OPTIONS=--max-old-space-size=8192\s+pnpm --filter web build/,
+    );
   });
 
   it("does not leak NODE_ENV into the typecheck command", () => {
     expect(SANDBOX_TYPECHECK_COMMAND).not.toContain("NODE_ENV");
+  });
+
+  it("gives TypeScript and Next enough heap for the current portal graph", () => {
+    expect(SANDBOX_TYPECHECK_COMMAND).toContain(
+      "NODE_OPTIONS=--max-old-space-size=8192",
+    );
+    expect(SANDBOX_BUILD_COMMAND).toContain(
+      "NODE_OPTIONS=--max-old-space-size=8192",
+    );
   });
 
   it("captures the production NODE_ENV in the command issued to the sandbox exec", async () => {

--- a/apps/web/lib/integrate/sandbox/sandbox-verification.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-verification.ts
@@ -38,7 +38,7 @@ const VERIFY_WORKSPACE_DEFAULT = "/workspace";
 // worktree when isolation is on, else /workspace (default — byte-identical to the
 // prior string constants). BI-98B723C0 Phase 2c.
 export function sandboxTypecheckCommand(workdir: string = VERIFY_WORKSPACE_DEFAULT): string {
-  return `cd ${workdir} && pnpm --filter web typecheck 2>&1`;
+  return `cd ${workdir} && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck 2>&1`;
 }
 // The sandbox container ships with NODE_ENV=development so the in-container Next
 // dev server behaves like local dev. Production builds must NOT inherit that:
@@ -48,7 +48,7 @@ export function sandboxTypecheckCommand(workdir: string = VERIFY_WORKSPACE_DEFAU
 // the prerender pass. Force NODE_ENV=production for the build gate only — the
 // dev-server launch in sandbox.ts is unaffected.
 export function sandboxBuildCommand(workdir: string = VERIFY_WORKSPACE_DEFAULT): string {
-  return `cd ${workdir} && NODE_ENV=production pnpm --filter web build 2>&1`;
+  return `cd ${workdir} && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build 2>&1`;
 }
 // Back-compat string constants (default /workspace) for non-per-build callers.
 export const SANDBOX_TYPECHECK_COMMAND = sandboxTypecheckCommand();

--- a/apps/web/lib/integrate/work-pattern-build-replay.test.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildHermeticDependencyInstallCommand,
   executeHermeticBuildReplay,
   parseHermeticBuildReplayFixture,
 } from "./work-pattern-build-replay";
@@ -49,6 +50,19 @@ const fixture = {
 };
 
 describe("hermetic build replay", () => {
+  it("materializes worktree-local dependencies before Next verification", () => {
+    const command = buildHermeticDependencyInstallCommand(
+      "/workspace/.builds/TR-CELL-1",
+    );
+
+    expect(command).toContain(
+      "if [ -L /workspace/.builds/TR-CELL-1/node_modules ]; then rm",
+    );
+    expect(command).toContain("CI=true pnpm install --offline --frozen-lockfile");
+    expect(command).not.toContain("; &&");
+    expect(command).not.toContain("ln -sfn");
+  });
+
   it("rejects traversal, shell-bearing paths, and mutable authority", () => {
     expect(parseHermeticBuildReplayFixture({
       ...fixture,
@@ -121,7 +135,12 @@ describe("hermetic build replay", () => {
     });
 
     expect(exec.mock.calls[0]?.[1]).toContain("git worktree add");
-    expect(exec.mock.calls[1]?.[1]).toContain("base64 -d");
+    expect(
+      exec.mock.calls.some(([, command]) =>
+        command.includes("pnpm install --offline --frozen-lockfile"),
+      ),
+    ).toBe(true);
+    expect(exec.mock.calls.some(([, command]) => command.includes("base64 -d"))).toBe(true);
     expect(exec.mock.calls.at(-1)?.[1]).toContain("git worktree remove");
     expect(infer).toHaveBeenCalledWith(expect.objectContaining({
       profile: expect.objectContaining({

--- a/apps/web/lib/integrate/work-pattern-build-replay.ts
+++ b/apps/web/lib/integrate/work-pattern-build-replay.ts
@@ -78,6 +78,24 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+export function buildHermeticDependencyInstallCommand(workdir: string): string {
+  const linkedDependencyPaths = [
+    `${workdir}/node_modules`,
+    `${workdir}/apps/web/node_modules`,
+    `${workdir}/packages/db/node_modules`,
+    `${workdir}/packages/dpf-skill-pack/node_modules`,
+    `${workdir}/packages/dpf-bootstrap/node_modules`,
+  ];
+  const unlinkCommands = linkedDependencyPaths
+    .map((path) => `if [ -L ${path} ]; then rm ${path}; fi`)
+    .join(" && ");
+  return [
+    unlinkCommands,
+    `cd ${workdir}`,
+    "CI=true pnpm install --offline --frozen-lockfile",
+  ].join(" && ");
+}
+
 async function productionDeps(): Promise<HermeticBuildReplayDeps> {
   const [{ execInSandbox }, { routeAndCall }] = await Promise.all([
     import("./sandbox/sandbox"),
@@ -166,6 +184,10 @@ export async function executeHermeticBuildReplay(input: {
     ),
   );
   try {
+    await deps.exec(
+      deps.containerId,
+      buildHermeticDependencyInstallCommand(workdir),
+    );
     const result = await executeWorkPatternExperimentCell(input.request, {
       prepareWorkspace: async () => ({
         workspaceId:


### PR DESCRIPTION
## Summary
- materialize replay dependencies inside the isolated worktree instead of linking external node_modules paths
- keep replay install hermetic with the local pnpm store, offline mode, and the frozen lockfile
- give type generation and production builds the verified 8 GiB Node heap ceiling

This repairs the autonomous Build Studio replay path after Next.js correctly rejected an apps/web/node_modules symlink outside the replay filesystem root.

Backlog: BI-356E69B1

## Verification
- focused tests: apps/web/lib/integrate/work-pattern-build-replay.test.ts and sandbox/sandbox-verification.test.ts (20 passed)
- exact local merged-code gate: 2,340 files / 20,214 tests, typecheck, migrations/guards, production Docker build
- Local-CI-Evidence: cms6lio8m0e5001l2n79opiga (fix/work-pattern-replay-typegen-symlink@cdcb11f0e3ff0cfe071e9f9d614cab3dfdf5e9a5)

## Impact
- UX verification: not applicable; this is an internal replay harness repair with no UI change
- migrations: none; no schema change
- documentation: no user/operator or contributor workflow changed; the implementation restores the already-documented hermetic replay contract
