### PR TITLE
fix(db): repair issue report index integrity

### DIFF
--- a/docs/data-impact/2026-07-29-platform-issue-report-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-29-platform-issue-report-index-integrity.data-impact.json
@@ -1,0 +1,56 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "PlatformIssueReport operational issue ledger",
+    "PlatformIssueReport active dedupe identity projection",
+    "Contributor sanitized-clone source and destination",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260729143000_repair_platform_issue_report_index_integrity",
+    "backfill": "after governed producer quiescence, hold a write-blocking lock, discover active dedupeKey duplicates from the heap, retain the newest report as canonical, aggregate only structurally compatible recurrence counters whose total fits the existing integer field, retain incompatible or unrepresentable diagnostic payloads without aggregation, suppress every noncanonical row with typed mergedIntoId lineage and a bounded suppressionReason, then recreate and physically verify both dedupe indexes"
+  },
+  "tests": [
+    "packages/db/src/platform-issue-report-index-integrity-migration.test.ts",
+    "packages/db/src/sanitized-clone-source-integrity.test.ts",
+    "packages/db/src/sanitized-clone.postgres.test.ts",
+    "packages/db/scripts/index-integrity-guard.postgres.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:platform-issue-report#dedupe-index-integrity-repair",
+      "prismaModel": "PlatformIssueReport",
+      "lifecycleDisposition": "the newest createdAt then lexical-id report remains active; every duplicate loser remains durable with its public reportId and diagnostic payload, status suppressed, explicit mergedIntoId lineage, and a machine-readable repair reason",
+      "fields": [
+        {
+          "fieldId": "data:platform-issue-report#dedupeKey",
+          "resolution": "governed",
+          "reason": "restore one trustworthy active report per automated issue identity without deleting evidence or preventing recurrence after a terminal resolution",
+          "provenance": "BI-854A9A5C forced-heap duplicate evidence, bt_index_parent_check failure, and decisions DI-1E67EDBA1253 and DI-5B6BC9A24BBA"
+        },
+        {
+          "fieldId": "data:platform-issue-report#mergedIntoId",
+          "resolution": "governed",
+          "reason": "retain a typed path from every suppressed duplicate to the canonical active report",
+          "provenance": "decision DI-5FE9191AADBD and existing DPF merge-tombstone substrate"
+        },
+        {
+          "fieldId": "data:platform-issue-report#suppressionReason",
+          "resolution": "governed",
+          "reason": "distinguish compatible recurrence aggregation from incompatible retained suppression without rewriting diagnostic descriptions",
+          "provenance": "decisions DI-1E67EDBA1253 and DI-5B6BC9A24BBA"
+        }
+      ]
+    },
+    {
+      "kind": "projection",
+      "store": "postgres:contributor-sanitized-clone",
+      "derivedContractId": "critical-source-index-integrity-to-sanitized-contributor-preview",
+      "cleanupTest": "packages/db/src/sanitized-clone.postgres.test.ts",
+      "reconciliationTest": "packages/db/src/sanitized-clone-source-integrity.test.ts"
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-29-platform-issue-report-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-29-platform-issue-report-index-integrity.md
@@ -1,0 +1,142 @@
+# PlatformIssueReport index-integrity repair
+
+**Backlog item:** `BI-854A9A5C`  
+**Branch:** `fix/platform-issue-report-index-integrity`  
+**Work Capsule:** `WC-99E24F85`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time - one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Goal
+
+Restore trustworthy `PlatformIssueReport.dedupeKey` uniqueness on every install without deleting issue evidence or breaking public `PIR-*` references. The same release must teach the contributor sanitized-clone preflight to reject physical or semantic source corruption before it starts copying 553 tables.
+
+## Measured failure
+
+- The live heap contains six active duplicate `dedupeKey` groups, 12 rows total. A forced-heap scan found occurrence totals from 2 to 376.
+- `PlatformIssueReport_dedupeKey_open_key` is marked unique, valid, ready, and live, but `bt_index_parent_check` reports `XX002: down-link lower bound invariant violated`.
+- `20260721180000_repair_collation_drift_index_rebuild_reporting` already named this exact partial index as duplicate-blocked.
+- Historical backlog linkage is embedded through public report IDs in `BacklogItem.body`. One duplicate pair has a deferred BI on the older report and the only open BI on the newer report.
+- The contributor clone correctly failed while copying `PlatformIssueReport`; filtering the clone would conceal source corruption and leave the live writer unsafe.
+
+## Decisions
+
+- `DI-1E67EDBA1253`: merge compatible recurrence evidence and suppress retained duplicates; do not delete rows, clear identity keys, or filter the preview.
+- `DI-5FE9191AADBD`: store retained lineage in typed `mergedIntoId` and `suppressionReason` fields, following existing merge-tombstone substrate on customer, geography, and inventory models.
+- `DI-5B6BC9A24BBA`: an incompatible group must not wedge the forward-only fleet chain. Retain and suppress its noncanonical rows without aggregating their fields; preserve every diagnostic payload for later review.
+- Application writer serialization, alias-aware reads, and terminal-status single-sourcing are follow-on `BI-83446A46`, not hidden scope in this recovery PR.
+
+## Data contract
+
+Add to `PlatformIssueReport`:
+
+- `mergedIntoId`: nullable indexed self-reference to the canonical row, `onDelete: SetNull`.
+- `suppressionReason`: nullable bounded reason. This migration writes only `index-repair-duplicate` or `index-repair-incompatible-duplicate`.
+
+The survivor is the newest `createdAt`, then lexical `id`. This matches the existing P2002 recovery read, which selects the newest active report.
+
+For a compatible group, require identical values for issue identity and ownership fields: `type`, `source`, `status`, `digitalProductId`, `portfolioId`, `agentId`, `featureBuildId`, `triggerKind`, `supportSessionId`, and `upstreamIssueNumber`. Then update only the canonical row:
+
+- `occurrenceCount = SUM(occurrenceCount)`
+- `firstSeenAt = MIN(COALESCE(firstSeenAt, createdAt))`
+- `lastSeenAt = MAX(COALESCE(lastSeenAt, createdAt))`
+- `severity =` highest observed severity (`critical`, `high`, `medium`, `low`)
+- `stagedUntilPromoted = bool_and(stagedUntilPromoted)`
+
+For an incompatible group, do not aggregate. Set only the noncanonical rows to `status='suppressed'`, point `mergedIntoId` at the survivor, and record the incompatible reason. In both paths, IDs, `reportId`, title, description, stack, responder decision, timestamps, upstream fields, and all other diagnostic payloads remain on the retained rows.
+
+## Implementation
+
+### Phase 1 - Dirty-state migration test
+
+Add `packages/db/src/platform-issue-report-index-integrity-migration.test.ts`.
+
+The disposable PostgreSQL fixture must reproduce:
+
+- multiple duplicate groups and one three-row group;
+- compatible and incompatible ownership/lifecycle data;
+- null time fields, mixed severity, large occurrence counts, and existing terminal duplicates;
+- a non-unique/corrupted-index stand-in that allowed active duplicates;
+- existing `mergedIntoId` and reason columns/index/FK to prove a second execution is harmless.
+
+Expected assertions:
+
+- deterministic newest-row survivorship;
+- exact structured aggregation for compatible groups;
+- no aggregation for incompatible groups;
+- every loser retained with unchanged public/diagnostic payload and explicit lineage;
+- terminal duplicates remain allowed;
+- zero active heap duplicate groups;
+- exact lookup and partial-unique index definitions;
+- index catalog flags plus targeted `amcheck`;
+- a direct second active insert fails with `23505`;
+- running the migration a second time produces identical rows.
+
+### Phase 2 - Fleet-safe forward migration
+
+Modify `packages/db/prisma/schema.prisma` and add:
+
+`packages/db/prisma/migrations/20260729143000_repair_platform_issue_report_index_integrity/migration.sql`
+
+In one transaction:
+
+1. Add the nullable lineage fields, self-FK, and lineage index idempotently.
+2. Take a bounded write-blocking table lock so no producer can race the repair.
+3. Drop both dedupe indexes before reading, then force heap-only planning.
+4. Build a repair map for every active duplicate group, classify compatibility, and choose the deterministic survivor.
+5. Aggregate only compatible survivors; suppress and lineage-link every noncanonical row.
+6. Assert zero active heap duplicates.
+7. Recreate `PlatformIssueReport_dedupeKey_idx` and the exact partial-unique predicate from committed definitions.
+8. Assert catalog readiness and run targeted `bt_index_parent_check` with text-cast results.
+9. Abort the transaction if physical or semantic integrity is still unproven.
+
+The migration contains inline remediation before recreating `UNIQUE`, satisfying the fleet-safety guard. It never deletes rows or rewrites public identifiers.
+
+### Phase 3 - One closed preview source-integrity registry
+
+Refactor `packages/db/src/sanitized-clone-source-integrity.ts`; do not create a parallel guard.
+
+- Replace the Inventory-specific entry point with a closed registry of critical source contracts.
+- Keep the existing `InventoryEntity_entityKey_key` physical/heap check.
+- Add `PlatformIssueReport_dedupeKey_open_key` physical/heap checking through the shared `checkIndexIntegrity`.
+- Add a forced-heap semantic query that rejects any duplicate active `dedupeKey`.
+- Name the table and index in the thrown error before the clone callback runs.
+
+Add `packages/db/src/sanitized-clone-source-integrity.test.ts` and extend `packages/db/src/sanitized-clone.postgres.test.ts` to prove:
+
+- missing/corrupt PlatformIssueReport index blocks publication;
+- semantic duplicates block publication even when catalog flags look healthy;
+- a failed source guard leaves the destination empty;
+- clean PlatformIssueReport and existing InventoryEntity paths both pass.
+
+### Phase 4 - Documentation and data impact
+
+- Add `docs/data-impact/2026-07-29-platform-issue-report-index-integrity.data-impact.json`.
+- Update `docs/user-guide/contributing/dev-container.md` so a source-integrity stop is distinguished from destination clone or disposable preview-volume failure.
+- Preserve this plan as the implementation and rollback record.
+
+## Verification
+
+1. Red-green the migration fixture and source-integrity tests.
+2. Run targeted DB tests, Prisma validation/generation, DB and web typechecks, migration-safety guard, data-impact guard, and docs guards.
+3. Run the exact-SHA merged-code pregate with migrations against the governed `local-integration-ci` slot.
+4. After merge and governed self-upgrade, query the live heap with all index scan classes disabled; require zero active duplicate groups.
+5. Require both dedupe indexes to be unique/valid/ready/live as applicable and pass targeted `amcheck`.
+6. Under an `active-candidate` lease, run `dev-init` to completion, start `dev-portal`, and require `GET :3001/api/health` to succeed.
+7. Resume the Marketing coworker desktop/mobile acceptance only after that source proof is green.
+
+## Risks and rollback
+
+- **Fleet wedge:** bounded locking plus total-group remediation prevents a duplicate from aborting index creation. Incompatible groups use retained suppression instead of raising.
+- **Evidence loss:** no row or public identifier is deleted; payload fields are untouched on losers.
+- **Wrong survivor:** newest-row selection matches the existing runtime recovery rule and preserves the latest projected work.
+- **Partial repair:** heap assertions, exact index recreation, `amcheck`, and preview preflight all fail closed.
+- **Rollback:** schema additions are backward-compatible and nullable. Data recovery is forward-only: unsuppress a retained row only after deliberately resolving its canonical conflict, then rebuild the partial index. Never edit the committed migration.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-854A9A5C`
+- Receipt: `cms66j2og02i101o6le71wvc9`
+- Rationale: the migration and guard are one recovery contract. Shipping the guard first blocks affected installs; shipping the repair without the invariant leaves recurrence undetected. Typed lineage, data repair, index recreation, and preflight verification must become true in the same release and roll back together.
+- Dependencies: none
+- Follow-on: `BI-83446A46` owns writer serialization, alias-aware application reads, and terminal-status single-sourcing.

--- a/docs/superpowers/plans/2026-07-29-platform-issue-report-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-29-platform-issue-report-index-integrity.md
@@ -1,7 +1,7 @@
 # PlatformIssueReport index-integrity repair
 
-**Backlog item:** `BI-854A9A5C`  
-**Branch:** `fix/platform-issue-report-index-integrity`  
+**Backlog item:** `BI-854A9A5C`
+**Branch:** `fix/platform-issue-report-index-integrity`
 **Work Capsule:** `WC-99E24F85`
 
 > **For agentic workers:** execute this plan one independently reviewable backlog item at a time - one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.

--- a/docs/superpowers/plans/2026-07-29-platform-issue-report-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-29-platform-issue-report-index-integrity.md
@@ -42,7 +42,7 @@ For a compatible group, require identical values for issue identity and ownershi
 - `severity =` highest observed severity (`critical`, `high`, `medium`, `low`)
 - `stagedUntilPromoted = bool_and(stagedUntilPromoted)`
 
-For an incompatible group, do not aggregate. Set only the noncanonical rows to `status='suppressed'`, point `mergedIntoId` at the survivor, and record the incompatible reason. In both paths, IDs, `reportId`, title, description, stack, responder decision, timestamps, upstream fields, and all other diagnostic payloads remain on the retained rows.
+For an incompatible group, or a structurally compatible group whose recurrence total cannot fit the existing PostgreSQL `integer` field, do not aggregate. Set only the noncanonical rows to `status='suppressed'`, point `mergedIntoId` at the survivor, and record the incompatible reason. In both paths, IDs, `reportId`, title, description, stack, responder decision, timestamps, upstream fields, and all other diagnostic payloads remain on the retained rows, so an overflowed total remains derivable from the retained individual counters.
 
 ## Implementation
 
@@ -52,7 +52,7 @@ Add `packages/db/src/platform-issue-report-index-integrity-migration.test.ts`.
 
 The disposable PostgreSQL fixture must reproduce:
 
-- multiple duplicate groups and one three-row group;
+- multiple duplicate groups, one three-row group, and an integer-overflow group;
 - compatible and incompatible ownership/lifecycle data;
 - null time fields, mixed severity, large occurrence counts, and existing terminal duplicates;
 - a non-unique/corrupted-index stand-in that allowed active duplicates;
@@ -66,7 +66,7 @@ Expected assertions:
 - every loser retained with unchanged public/diagnostic payload and explicit lineage;
 - terminal duplicates remain allowed;
 - zero active heap duplicate groups;
-- exact lookup and partial-unique index definitions;
+- exact lookup and partial-unique index definitions plus self-FK actions;
 - index catalog flags plus targeted `amcheck`;
 - a direct second active insert fails with `23505`;
 - running the migration a second time produces identical rows.
@@ -80,7 +80,7 @@ Modify `packages/db/prisma/schema.prisma` and add:
 In one transaction:
 
 1. Add the nullable lineage fields, self-FK, and lineage index idempotently.
-2. Take a bounded write-blocking table lock so no producer can race the repair.
+2. Take the write-blocking table lock after the governed promoter has quiesced producers, so no producer can race the repair. Do not add a migration-local lock timeout: a timeout would turn transient contention into an unresolved Prisma migration.
 3. Drop both dedupe indexes before reading, then force heap-only planning.
 4. Build a repair map for every active duplicate group, classify compatibility, and choose the deterministic survivor.
 5. Aggregate only compatible survivors; suppress and lineage-link every noncanonical row.

--- a/docs/user-guide/contributing/dev-container.md
+++ b/docs/user-guide/contributing/dev-container.md
@@ -52,6 +52,7 @@ Login: `admin@dpf.local` / `changeme123`
 
 - The clone resets the disposable development application tables before copying. Restricted provider, credential, token, and connection records are not copied; production-derived search/vector values are omitted rather than carrying source terms or embeddings into the preview.
 - Additive source-schema differences are expected during concurrent development. Source-only columns or tables are left out of the preview, destination-only columns use their migrated defaults, and a shared column with an incompatible type stops the clone with a precise error instead of risking a corrupt preview.
+- Before copying, the clone verifies the live source's critical identity indexes and their heap semantics. A message naming `InventoryEntity_entityKey_key` or `PlatformIssueReport_dedupeKey_open_key` is a **source-integrity stop**: the live source must be repaired through a forward migration before preview can proceed. Recreating the disposable preview volume cannot repair that source condition.
 - Clone publication is fail-safe: if any table cannot be copied or sanitized, the development application tables are cleared again while Prisma migration history is retained. The Contributor preview will not start against a partially copied relational dataset. Correct the reported source/tooling error and restart the development initialization step to retry.
 
 ### Related

--- a/packages/db/prisma/migrations/20260729143000_repair_platform_issue_report_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260729143000_repair_platform_issue_report_index_integrity/migration.sql
@@ -1,0 +1,231 @@
+-- BI-854A9A5C: repair the physically corrupt, duplicate-blocked
+-- PlatformIssueReport_dedupeKey_open_key without deleting issue evidence.
+--
+-- @migration-safety: remediate-before-constraint: every active dedupeKey group
+-- is converged under a write-blocking table lock before the partial UNIQUE index
+-- is recreated. Compatible recurrence counters are aggregated into the newest
+-- report; incompatible rows are retained and suppressed without aggregation.
+
+BEGIN;
+
+LOCK TABLE "PlatformIssueReport" IN SHARE ROW EXCLUSIVE MODE;
+
+ALTER TABLE "PlatformIssueReport"
+  ADD COLUMN IF NOT EXISTS "mergedIntoId" TEXT,
+  ADD COLUMN IF NOT EXISTS "suppressionReason" VARCHAR(80);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = '"PlatformIssueReport"'::regclass
+      AND conname = 'PlatformIssueReport_mergedIntoId_fkey'
+  ) THEN
+    -- @migration-safety: data-safe: mergedIntoId is a newly added nullable
+    -- column and every existing row is null before this self-FK is created.
+    ALTER TABLE "PlatformIssueReport"
+      ADD CONSTRAINT "PlatformIssueReport_mergedIntoId_fkey"
+      FOREIGN KEY ("mergedIntoId")
+      REFERENCES "PlatformIssueReport"(id)
+      ON DELETE SET NULL
+      ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "PlatformIssueReport_mergedIntoId_idx"
+  ON "PlatformIssueReport"("mergedIntoId");
+
+-- The damaged unique index can hide committed duplicates from an index scan.
+-- Drop both dedupe indexes and force heap-only discovery before classifying data.
+DROP INDEX IF EXISTS "PlatformIssueReport_dedupeKey_open_key";
+DROP INDEX IF EXISTS "PlatformIssueReport_dedupeKey_idx";
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+CREATE TEMP TABLE "_dpf_pir_repair_map" ON COMMIT DROP AS
+WITH active AS (
+  SELECT
+    report.*,
+    row_number() OVER (
+      PARTITION BY report."dedupeKey"
+      ORDER BY report."createdAt" DESC, report.id DESC
+    ) AS survivor_rank,
+    count(*) OVER (PARTITION BY report."dedupeKey") AS group_size
+  FROM "PlatformIssueReport" report
+  WHERE report."dedupeKey" IS NOT NULL
+    AND report.status NOT IN (
+      'resolved_locally',
+      'resolved_upstream',
+      'suppressed'
+    )
+),
+compatibility AS (
+  SELECT
+    "dedupeKey",
+    count(DISTINCT ROW(
+      type,
+      source,
+      status,
+      "digitalProductId",
+      "portfolioId",
+      "agentId",
+      "featureBuildId",
+      "triggerKind",
+      "supportSessionId",
+      "upstreamIssueNumber"
+    )) = 1
+      AND sum("occurrenceCount")::bigint BETWEEN -2147483648 AND 2147483647
+      AS compatible
+  FROM active
+  WHERE group_size > 1
+  GROUP BY "dedupeKey"
+),
+survivors AS (
+  SELECT id, "dedupeKey"
+  FROM active
+  WHERE group_size > 1
+    AND survivor_rank = 1
+)
+SELECT
+  candidate.id AS "loserId",
+  survivor.id AS "survivorId",
+  candidate."dedupeKey",
+  compatibility.compatible
+FROM active candidate
+JOIN survivors survivor
+  ON survivor."dedupeKey" = candidate."dedupeKey"
+JOIN compatibility
+  ON compatibility."dedupeKey" = candidate."dedupeKey"
+WHERE candidate.group_size > 1
+  AND candidate.survivor_rank > 1;
+
+-- Compatible rows are recurrence observations of the same owned issue. Accrue
+-- their structured counters into the canonical row without rewriting its title,
+-- description, stack, public reportId, ownership, or other diagnostic payload.
+WITH compatible_groups AS (
+  SELECT DISTINCT "survivorId", "dedupeKey"
+  FROM "_dpf_pir_repair_map"
+  WHERE compatible
+),
+aggregates AS (
+  SELECT
+    group_row."survivorId",
+    sum(report."occurrenceCount")::integer AS "occurrenceCount",
+    min(coalesce(report."firstSeenAt", report."createdAt")) AS "firstSeenAt",
+    max(coalesce(report."lastSeenAt", report."createdAt")) AS "lastSeenAt",
+    bool_and(report."stagedUntilPromoted") AS "stagedUntilPromoted",
+    (array_agg(
+      report.severity
+      ORDER BY CASE report.severity
+        WHEN 'critical' THEN 4
+        WHEN 'high' THEN 3
+        WHEN 'medium' THEN 2
+        WHEN 'low' THEN 1
+        ELSE 0
+      END DESC,
+      report.severity
+    ))[1] AS severity
+  FROM compatible_groups group_row
+  JOIN "PlatformIssueReport" report
+    ON report."dedupeKey" = group_row."dedupeKey"
+   AND report.status NOT IN (
+     'resolved_locally',
+     'resolved_upstream',
+     'suppressed'
+   )
+  GROUP BY group_row."survivorId"
+)
+UPDATE "PlatformIssueReport" survivor
+SET
+  "occurrenceCount" = aggregates."occurrenceCount",
+  "firstSeenAt" = aggregates."firstSeenAt",
+  "lastSeenAt" = aggregates."lastSeenAt",
+  "stagedUntilPromoted" = aggregates."stagedUntilPromoted",
+  severity = aggregates.severity
+FROM aggregates
+WHERE survivor.id = aggregates."survivorId";
+
+UPDATE "PlatformIssueReport" loser
+SET
+  status = 'suppressed',
+  "mergedIntoId" = repair."survivorId",
+  "suppressionReason" = CASE
+    WHEN repair.compatible THEN 'index-repair-duplicate'
+    ELSE 'index-repair-incompatible-duplicate'
+  END
+FROM "_dpf_pir_repair_map" repair
+WHERE loser.id = repair."loserId";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "PlatformIssueReport"
+    WHERE "dedupeKey" IS NOT NULL
+      AND status NOT IN (
+        'resolved_locally',
+        'resolved_upstream',
+        'suppressed'
+      )
+    GROUP BY "dedupeKey"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'BI-854A9A5C: active PlatformIssueReport dedupeKey duplicates remain after repair';
+  END IF;
+END $$;
+
+CREATE INDEX "PlatformIssueReport_dedupeKey_idx"
+  ON "PlatformIssueReport"("dedupeKey");
+
+CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
+  ON "PlatformIssueReport"("dedupeKey")
+  WHERE "dedupeKey" IS NOT NULL
+    AND "status" NOT IN (
+      'resolved_locally',
+      'resolved_upstream',
+      'suppressed'
+    );
+
+CREATE EXTENSION IF NOT EXISTS amcheck;
+
+DO $$
+DECLARE
+  index_name text;
+  index_flags record;
+  check_result text;
+BEGIN
+  FOREACH index_name IN ARRAY ARRAY[
+    'PlatformIssueReport_dedupeKey_idx',
+    'PlatformIssueReport_dedupeKey_open_key'
+  ]
+  LOOP
+    SELECT i.indisvalid, i.indisready, i.indislive
+    INTO index_flags
+    FROM pg_index i
+    WHERE i.indexrelid =
+      format('%I.%I', current_schema(), index_name)::regclass;
+
+    IF NOT (
+      index_flags.indisvalid
+      AND index_flags.indisready
+      AND index_flags.indislive
+    ) THEN
+      RAISE EXCEPTION
+        'BI-854A9A5C: index % is not valid, ready, and live',
+        index_name;
+    END IF;
+
+    SELECT public.bt_index_parent_check(
+      format('%I.%I', current_schema(), index_name)::regclass,
+      true,
+      true
+    )::text
+    INTO check_result;
+  END LOOP;
+END $$;
+
+COMMIT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6121,6 +6121,11 @@ model PlatformIssueReport {
   // can't express partial-unique predicates); it lets a resolved signature
   // re-file when the problem recurs while preventing duplicate open reports.
   dedupeKey           String?
+  // BI-854A9A5C: retained issue-report merge lineage. Integrity repair keeps
+  // every reportId and diagnostic payload while suppressing duplicate active
+  // identities; mergedInto points each retained loser at the canonical report.
+  mergedIntoId        String?
+  suppressionReason   String?       @db.VarChar(80)
   // Governed Hermes learning Slice 1: link runtime issues to the thread/run
   // that produced them so reflection can avoid route/time-window heuristics.
   threadId            String?
@@ -6150,6 +6155,8 @@ model PlatformIssueReport {
   upstreamSyncedAt    DateTime?
   reportedBy          User?         @relation(fields: [reportedById], references: [id])
   featureBuild        FeatureBuild? @relation(fields: [featureBuildId], references: [id], onDelete: SetNull)
+  mergedInto          PlatformIssueReport?  @relation("PlatformIssueReportMerge", fields: [mergedIntoId], references: [id], onDelete: SetNull)
+  mergedFrom          PlatformIssueReport[] @relation("PlatformIssueReportMerge")
 
   @@unique([reportedById, supportSessionId])
   @@index([featureBuildId])
@@ -6159,6 +6166,7 @@ model PlatformIssueReport {
   @@index([errorDigest])
   // BI-5FE8656F: dedupeKey lookup powers the scanner's idempotency check.
   @@index([dedupeKey])
+  @@index([mergedIntoId])
   @@index([reportedById, supportSessionId, createdAt(sort: Desc)])
 }
 

--- a/packages/db/src/platform-issue-report-index-integrity-migration.test.ts
+++ b/packages/db/src/platform-issue-report-index-integrity-migration.test.ts
@@ -1,0 +1,386 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `platform_issue_report_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+const migrationUrl = new URL(
+  "../prisma/migrations/20260729143000_repair_platform_issue_report_index_integrity/migration.sql",
+  import.meta.url,
+);
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+async function readRows(): Promise<unknown[]> {
+  return (await client.query(`
+    SELECT
+      id, "reportId", type, severity, status, title, description, "errorStack",
+      source, "dedupeKey", "occurrenceCount", "firstSeenAt", "lastSeenAt",
+      "stagedUntilPromoted", "digitalProductId", "portfolioId", "agentId",
+      "featureBuildId", "triggerKind", "supportSessionId", "upstreamIssueNumber",
+      "mergedIntoId", "suppressionReason", "createdAt"
+    FROM "PlatformIssueReport"
+    ORDER BY id
+  `)).rows;
+}
+
+describeDatabase("PlatformIssueReport partial-unique integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}", public`);
+    await client.query(`
+      CREATE TABLE "PlatformIssueReport" (
+        id TEXT PRIMARY KEY,
+        "reportId" TEXT NOT NULL UNIQUE,
+        type TEXT NOT NULL,
+        severity TEXT NOT NULL DEFAULT 'medium',
+        status TEXT NOT NULL DEFAULT 'open',
+        title TEXT NOT NULL,
+        description TEXT,
+        "errorStack" TEXT,
+        "digitalProductId" TEXT,
+        "portfolioId" TEXT,
+        "agentId" TEXT,
+        "featureBuildId" TEXT,
+        "triggerKind" TEXT,
+        "supportSessionId" TEXT,
+        source TEXT NOT NULL DEFAULT 'manual',
+        "dedupeKey" TEXT,
+        "occurrenceCount" INTEGER NOT NULL DEFAULT 1,
+        "firstSeenAt" TIMESTAMPTZ,
+        "lastSeenAt" TIMESTAMPTZ,
+        "stagedUntilPromoted" BOOLEAN NOT NULL DEFAULT false,
+        "createdAt" TIMESTAMPTZ NOT NULL,
+        "updatedAt" TIMESTAMPTZ NOT NULL,
+        "upstreamIssueNumber" INTEGER
+      );
+      CREATE INDEX "PlatformIssueReport_dedupeKey_idx"
+        ON "PlatformIssueReport" ("dedupeKey");
+      CREATE INDEX "PlatformIssueReport_dedupeKey_open_key"
+        ON "PlatformIssueReport" ("dedupeKey")
+        WHERE "dedupeKey" IS NOT NULL
+          AND "status" NOT IN ('resolved_locally', 'resolved_upstream', 'suppressed');
+
+      INSERT INTO "PlatformIssueReport" (
+        id, "reportId", type, severity, status, title, description, "errorStack",
+        "digitalProductId", "portfolioId", "agentId", "featureBuildId",
+        "triggerKind", "supportSessionId", source, "dedupeKey",
+        "occurrenceCount", "firstSeenAt", "lastSeenAt", "stagedUntilPromoted",
+        "createdAt", "updatedAt", "upstreamIssueNumber"
+      ) VALUES
+        (
+          'compatible-old', 'PIR-COMPATIBLE-OLD', 'runtime', 'low', 'open',
+          'old payload', 'old description', 'old stack',
+          'product-1', 'portfolio-1', 'agent-1', 'build-1',
+          'log-signature', 'support-1', 'automated', 'log-sig:sandbox:compatible',
+          2, NULL, '2026-07-10', true,
+          '2026-07-01', '2026-07-10', 42
+        ),
+        (
+          'compatible-mid', 'PIR-COMPATIBLE-MID', 'runtime', 'critical', 'open',
+          'mid payload', 'mid description', 'mid stack',
+          'product-1', 'portfolio-1', 'agent-1', 'build-1',
+          'log-signature', 'support-1', 'automated', 'log-sig:sandbox:compatible',
+          5, '2026-06-20', NULL, false,
+          '2026-07-15', '2026-07-15', 42
+        ),
+        (
+          'compatible-new', 'PIR-COMPATIBLE-NEW', 'runtime', 'high', 'open',
+          'new payload', 'new description', 'new stack',
+          'product-1', 'portfolio-1', 'agent-1', 'build-1',
+          'log-signature', 'support-1', 'automated', 'log-sig:sandbox:compatible',
+          11, '2026-07-20', '2026-07-25', true,
+          '2026-07-20', '2026-07-25', 42
+        ),
+        (
+          'incompatible-old', 'PIR-INCOMPATIBLE-OLD', 'runtime', 'medium', 'open',
+          'incompatible old', 'preserve incompatible old', 'incompatible old stack',
+          'product-2', 'portfolio-2', 'agent-2', NULL,
+          'log-signature', NULL, 'automated', 'log-sig:sandbox:incompatible',
+          7, '2026-07-01', '2026-07-02', false,
+          '2026-07-01', '2026-07-02', NULL
+        ),
+        (
+          'incompatible-new', 'PIR-INCOMPATIBLE-NEW', 'runtime', 'high', 'open',
+          'incompatible new', 'preserve incompatible new', 'incompatible new stack',
+          'product-2', 'portfolio-OTHER', 'agent-2', NULL,
+          'log-signature', NULL, 'automated', 'log-sig:sandbox:incompatible',
+          13, '2026-07-20', '2026-07-21', true,
+          '2026-07-20', '2026-07-21', NULL
+        ),
+        (
+          'overflow-old', 'PIR-OVERFLOW-OLD', 'runtime', 'medium', 'open',
+          'overflow old', 'preserve overflow old', 'overflow old stack',
+          NULL, NULL, NULL, NULL, 'log-signature', NULL,
+          'automated', 'log-sig:sandbox:overflow',
+          2147483647, '2026-07-01', '2026-07-02', false,
+          '2026-07-01', '2026-07-02', NULL
+        ),
+        (
+          'overflow-new', 'PIR-OVERFLOW-NEW', 'runtime', 'medium', 'open',
+          'overflow new', 'preserve overflow new', 'overflow new stack',
+          NULL, NULL, NULL, NULL, 'log-signature', NULL,
+          'automated', 'log-sig:sandbox:overflow',
+          1, '2026-07-20', '2026-07-21', false,
+          '2026-07-20', '2026-07-21', NULL
+        ),
+        (
+          'underflow-old', 'PIR-UNDERFLOW-OLD', 'runtime', 'medium', 'open',
+          'underflow old', 'preserve underflow old', 'underflow old stack',
+          NULL, NULL, NULL, NULL, 'log-signature', NULL,
+          'automated', 'log-sig:sandbox:underflow',
+          -2147483648, '2026-07-01', '2026-07-02', false,
+          '2026-07-01', '2026-07-02', NULL
+        ),
+        (
+          'underflow-new', 'PIR-UNDERFLOW-NEW', 'runtime', 'medium', 'open',
+          'underflow new', 'preserve underflow new', 'underflow new stack',
+          NULL, NULL, NULL, NULL, 'log-signature', NULL,
+          'automated', 'log-sig:sandbox:underflow',
+          -1, '2026-07-20', '2026-07-21', false,
+          '2026-07-20', '2026-07-21', NULL
+        ),
+        (
+          'resolved-old', 'PIR-RESOLVED-OLD', 'runtime', 'low', 'resolved_locally',
+          'resolved old', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+          'automated', 'log-sig:sandbox:terminal', 1, NULL, NULL, false,
+          '2026-07-01', '2026-07-01', NULL
+        ),
+        (
+          'resolved-new', 'PIR-RESOLVED-NEW', 'runtime', 'low', 'suppressed',
+          'resolved new', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+          'automated', 'log-sig:sandbox:terminal', 1, NULL, NULL, false,
+          '2026-07-02', '2026-07-02', NULL
+        );
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("retains evidence, repairs active duplicates, and restores exact indexes", async () => {
+    const migration = await readFile(migrationUrl, "utf8");
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text value FROM "PlatformIssueReport"`)).toBe(11);
+    expect(await scalar(`
+      SELECT count(*)::text value
+      FROM (
+        SELECT "dedupeKey"
+        FROM "PlatformIssueReport"
+        WHERE "dedupeKey" IS NOT NULL
+          AND status NOT IN ('resolved_locally', 'resolved_upstream', 'suppressed')
+        GROUP BY "dedupeKey"
+        HAVING count(*) > 1
+      ) duplicates
+    `)).toBe(0);
+
+    const compatible = (await client.query(`
+      SELECT id, severity, status, title, description, "errorStack",
+             "occurrenceCount", "firstSeenAt", "lastSeenAt",
+             "stagedUntilPromoted", "mergedIntoId", "suppressionReason"
+      FROM "PlatformIssueReport"
+      WHERE id IN ('compatible-old', 'compatible-mid', 'compatible-new')
+      ORDER BY id
+    `)).rows;
+    expect(compatible).toMatchObject([
+      {
+        id: "compatible-mid",
+        status: "suppressed",
+        title: "mid payload",
+        description: "mid description",
+        errorStack: "mid stack",
+        occurrenceCount: 5,
+        mergedIntoId: "compatible-new",
+        suppressionReason: "index-repair-duplicate",
+      },
+      {
+        id: "compatible-new",
+        severity: "critical",
+        status: "open",
+        title: "new payload",
+        occurrenceCount: 18,
+        stagedUntilPromoted: false,
+        mergedIntoId: null,
+        suppressionReason: null,
+      },
+      {
+        id: "compatible-old",
+        status: "suppressed",
+        title: "old payload",
+        description: "old description",
+        errorStack: "old stack",
+        occurrenceCount: 2,
+        mergedIntoId: "compatible-new",
+        suppressionReason: "index-repair-duplicate",
+      },
+    ]);
+    expect(new Date(compatible[1]?.firstSeenAt).toISOString())
+      .toBe("2026-06-20T00:00:00.000Z");
+    expect(new Date(compatible[1]?.lastSeenAt).toISOString())
+      .toBe("2026-07-25T00:00:00.000Z");
+
+    const incompatible = (await client.query(`
+      SELECT id, status, description, "occurrenceCount", "portfolioId",
+             "mergedIntoId", "suppressionReason"
+      FROM "PlatformIssueReport"
+      WHERE id IN ('incompatible-old', 'incompatible-new')
+      ORDER BY id
+    `)).rows;
+    expect(incompatible).toEqual([
+      {
+        id: "incompatible-new",
+        status: "open",
+        description: "preserve incompatible new",
+        occurrenceCount: 13,
+        portfolioId: "portfolio-OTHER",
+        mergedIntoId: null,
+        suppressionReason: null,
+      },
+      {
+        id: "incompatible-old",
+        status: "suppressed",
+        description: "preserve incompatible old",
+        occurrenceCount: 7,
+        portfolioId: "portfolio-2",
+        mergedIntoId: "incompatible-new",
+        suppressionReason: "index-repair-incompatible-duplicate",
+      },
+    ]);
+
+    const overflow = (await client.query(`
+      SELECT id, status, "occurrenceCount", "mergedIntoId", "suppressionReason"
+      FROM "PlatformIssueReport"
+      WHERE id IN ('overflow-old', 'overflow-new')
+      ORDER BY id
+    `)).rows;
+    expect(overflow).toEqual([
+      {
+        id: "overflow-new",
+        status: "open",
+        occurrenceCount: 1,
+        mergedIntoId: null,
+        suppressionReason: null,
+      },
+      {
+        id: "overflow-old",
+        status: "suppressed",
+        occurrenceCount: 2147483647,
+        mergedIntoId: "overflow-new",
+        suppressionReason: "index-repair-incompatible-duplicate",
+      },
+    ]);
+
+    const underflow = (await client.query(`
+      SELECT id, status, "occurrenceCount", "mergedIntoId", "suppressionReason"
+      FROM "PlatformIssueReport"
+      WHERE id IN ('underflow-old', 'underflow-new')
+      ORDER BY id
+    `)).rows;
+    expect(underflow).toEqual([
+      {
+        id: "underflow-new",
+        status: "open",
+        occurrenceCount: -1,
+        mergedIntoId: null,
+        suppressionReason: null,
+      },
+      {
+        id: "underflow-old",
+        status: "suppressed",
+        occurrenceCount: -2147483648,
+        mergedIntoId: "underflow-new",
+        suppressionReason: "index-repair-incompatible-duplicate",
+      },
+    ]);
+
+    expect(await scalar(`
+      SELECT count(*)::text value
+      FROM "PlatformIssueReport"
+      WHERE "dedupeKey" = 'log-sig:sandbox:terminal'
+    `)).toBe(2);
+
+    const indexes = (await client.query(`
+      SELECT c.relname AS name, i.indisunique, i.indisvalid, i.indisready, i.indislive,
+             pg_get_indexdef(i.indexrelid) AS definition,
+             pg_get_expr(i.indpred, i.indrelid) AS predicate
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = current_schema()
+        AND c.relname IN (
+          'PlatformIssueReport_dedupeKey_idx',
+          'PlatformIssueReport_dedupeKey_open_key',
+          'PlatformIssueReport_mergedIntoId_idx'
+        )
+      ORDER BY c.relname
+    `)).rows;
+    expect(indexes).toHaveLength(3);
+    expect(indexes.find((row) => row.name === "PlatformIssueReport_dedupeKey_open_key"))
+      .toMatchObject({
+        indisunique: true,
+        indisvalid: true,
+        indisready: true,
+        indislive: true,
+      });
+    expect(indexes.find((row) => row.name === "PlatformIssueReport_dedupeKey_open_key")?.predicate)
+      .toMatch(/resolved_locally.*resolved_upstream.*suppressed/);
+
+    const foreignKey = (await client.query(`
+      SELECT confdeltype, confupdtype
+      FROM pg_constraint
+      WHERE conrelid = '"PlatformIssueReport"'::regclass
+        AND conname = 'PlatformIssueReport_mergedIntoId_fkey'
+    `)).rows[0];
+    expect(foreignKey).toEqual({ confdeltype: "n", confupdtype: "c" });
+
+    await expect(client.query(`
+      INSERT INTO "PlatformIssueReport" (
+        id, "reportId", type, severity, status, title, source, "dedupeKey",
+        "createdAt", "updatedAt"
+      ) VALUES (
+        'duplicate-after-repair', 'PIR-DUPLICATE-AFTER', 'runtime', 'medium',
+        'open', 'must fail', 'automated', 'log-sig:sandbox:compatible',
+        now(), now()
+      )
+    `)).rejects.toMatchObject({ code: "23505" });
+
+    await expect(client.query(`
+      INSERT INTO "PlatformIssueReport" (
+        id, "reportId", type, severity, status, title, source, "dedupeKey",
+        "createdAt", "updatedAt"
+      ) VALUES (
+        'triaged-duplicate-after-repair', 'PIR-TRIAGED-DUPLICATE-AFTER',
+        'runtime', 'medium', 'triaged_local', 'must also fail', 'automated',
+        'log-sig:sandbox:compatible', now(), now()
+      )
+    `)).rejects.toMatchObject({ code: "23505" });
+
+    await expect(client.query(`
+      INSERT INTO "PlatformIssueReport" (
+        id, "reportId", type, severity, status, title, source, "dedupeKey",
+        "createdAt", "updatedAt"
+      ) VALUES (
+        'resolved-upstream-after-repair', 'PIR-RESOLVED-UPSTREAM-AFTER',
+        'runtime', 'medium', 'resolved_upstream', 'terminal reuse succeeds',
+        'automated', 'log-sig:sandbox:terminal', now(), now()
+      )
+    `)).resolves.toBeDefined();
+
+    const beforeSecondPass = JSON.stringify(await readRows());
+    await client.query(migration);
+    expect(JSON.stringify(await readRows())).toBe(beforeSecondPass);
+  });
+});

--- a/packages/db/src/sanitized-clone-source-integrity.test.ts
+++ b/packages/db/src/sanitized-clone-source-integrity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertSanitizedCloneSourceIntegrity,
+  SANITIZED_CLONE_SOURCE_INDEX_CONTRACTS,
+} from "./sanitized-clone-source-integrity";
+
+class SourceFixture {
+  duplicateGroups = 0;
+  unhealthyIndex: string | null = null;
+  readonly queries: string[] = [];
+
+  async $queryRawUnsafe<T>(query: string, ...values: unknown[]): Promise<T> {
+    this.queries.push(query);
+
+    if (query.includes("FROM pg_extension")) {
+      return [{ installed: true }] as T;
+    }
+    if (query.includes("FROM pg_index")) {
+      const table = String(values[1]);
+      const index = table === "InventoryEntity"
+        ? "InventoryEntity_entityKey_key"
+        : "PlatformIssueReport_dedupeKey_open_key";
+      return [{
+        table_name: table,
+        index_name: index,
+        is_unique: true,
+        is_valid: this.unhealthyIndex !== index,
+        is_ready: true,
+        is_live: true,
+      }] as T;
+    }
+    if (query.includes("bt_index_parent_check")) {
+      return [] as T;
+    }
+    if (query.includes("TABLESAMPLE SYSTEM (100)")) {
+      return [{ duplicateGroups: this.duplicateGroups }] as T;
+    }
+    throw new Error(`Unexpected source-integrity query: ${query}`);
+  }
+}
+
+describe("sanitized clone source integrity", () => {
+  it("defines one closed registry for both critical source identities", () => {
+    expect(SANITIZED_CLONE_SOURCE_INDEX_CONTRACTS).toEqual([
+      {
+        table: "InventoryEntity",
+        requiredIndexes: [
+          { name: "InventoryEntity_entityKey_key", unique: true },
+        ],
+      },
+      {
+        table: "PlatformIssueReport",
+        requiredIndexes: [
+          { name: "PlatformIssueReport_dedupeKey_open_key", unique: true },
+        ],
+      },
+    ]);
+  });
+
+  it("accepts physically and semantically healthy source contracts", async () => {
+    const source = new SourceFixture();
+
+    await expect(assertSanitizedCloneSourceIntegrity(source)).resolves.toBeUndefined();
+
+    expect(source.queries.some((query) => query.includes("TABLESAMPLE SYSTEM (100)")))
+      .toBe(true);
+  });
+
+  it("names a physically unhealthy PlatformIssueReport index", async () => {
+    const source = new SourceFixture();
+    source.unhealthyIndex = "PlatformIssueReport_dedupeKey_open_key";
+
+    await expect(assertSanitizedCloneSourceIntegrity(source)).rejects.toThrow(
+      /PlatformIssueReport.*PlatformIssueReport_dedupeKey_open_key.*unhealthy/s,
+    );
+  });
+
+  it("rejects active heap duplicates even when index metadata is healthy", async () => {
+    const source = new SourceFixture();
+    source.duplicateGroups = 2;
+
+    await expect(assertSanitizedCloneSourceIntegrity(source)).rejects.toThrow(
+      /PlatformIssueReport_dedupeKey_open_key.*2 active dedupeKey group/s,
+    );
+  });
+});

--- a/packages/db/src/sanitized-clone-source-integrity.test.ts
+++ b/packages/db/src/sanitized-clone-source-integrity.test.ts
@@ -63,8 +63,12 @@ describe("sanitized clone source integrity", () => {
 
     await expect(assertSanitizedCloneSourceIntegrity(source)).resolves.toBeUndefined();
 
-    expect(source.queries.some((query) => query.includes("TABLESAMPLE SYSTEM (100)")))
-      .toBe(true);
+    const heapScan = source.queries.find((query) =>
+      query.includes("TABLESAMPLE SYSTEM (100)")
+    );
+    expect(heapScan).toMatch(
+      /"PlatformIssueReport"\s+AS report\s+TABLESAMPLE SYSTEM \(100\)/,
+    );
   });
 
   it("names a physically unhealthy PlatformIssueReport index", async () => {

--- a/packages/db/src/sanitized-clone-source-integrity.ts
+++ b/packages/db/src/sanitized-clone-source-integrity.ts
@@ -66,8 +66,8 @@ async function assertPlatformIssueReportDedupeSemantics(
     SELECT count(*)::integer AS "duplicateGroups"
     FROM (
       SELECT report."dedupeKey"
-      FROM ${quotedSchema}."PlatformIssueReport"
-        TABLESAMPLE SYSTEM (100) AS report
+      FROM ${quotedSchema}."PlatformIssueReport" AS report
+        TABLESAMPLE SYSTEM (100)
       WHERE report."dedupeKey" IS NOT NULL
         AND report.status NOT IN (
           'resolved_locally',

--- a/packages/db/src/sanitized-clone-source-integrity.ts
+++ b/packages/db/src/sanitized-clone-source-integrity.ts
@@ -2,26 +2,50 @@
 import { checkIndexIntegrity } from "../scripts/index-integrity-core.mjs";
 
 type RawQueryClient = {
-  $queryRawUnsafe<T>(query: string, ...values: never[]): Promise<T>;
+  $queryRawUnsafe<T>(query: string, ...values: unknown[]): Promise<T>;
 };
 
-export async function assertSourceInventoryIntegrity(
+type SourceIndexContract = {
+  table: string;
+  requiredIndexes: ReadonlyArray<{ name: string; unique: boolean }>;
+};
+
+type SourceIntegrityOptions = {
+  schema?: string;
+};
+
+export const SANITIZED_CLONE_SOURCE_INDEX_CONTRACTS: ReadonlyArray<SourceIndexContract> =
+  Object.freeze([
+    {
+      table: "InventoryEntity",
+      requiredIndexes: [
+        { name: "InventoryEntity_entityKey_key", unique: true },
+      ],
+    },
+    {
+      table: "PlatformIssueReport",
+      requiredIndexes: [
+        { name: "PlatformIssueReport_dedupeKey_open_key", unique: true },
+      ],
+    },
+  ]);
+
+async function assertIndexContract(
   source: RawQueryClient,
+  contract: SourceIndexContract,
+  schema: string,
 ): Promise<void> {
   const queryClient = {
     query: async (sql: string, params: unknown[] = []) => ({
-      rows: await source.$queryRawUnsafe<unknown[]>(
-        sql,
-        ...(params as never[]),
-      ),
+      rows: await source.$queryRawUnsafe<unknown[]>(sql, ...params),
     }),
   };
   const report = await checkIndexIntegrity(queryClient, {
     amcheckMode: "require",
-    schema: "public",
-    table: "InventoryEntity",
+    schema,
+    table: contract.table,
     uniqueOnly: false,
-    requiredIndexes: [{ name: "InventoryEntity_entityKey_key", unique: true }],
+    requiredIndexes: contract.requiredIndexes,
   });
   if (!report.failed) return;
 
@@ -29,6 +53,48 @@ export async function assertSourceInventoryIntegrity(
     .map((row: { index: string; error: string }) => `${row.index}: ${row.error}`)
     .join("; ");
   throw new Error(
-    `Production InventoryEntity source failed index/heap integrity; preview was not published. ${details}`,
+    `Production ${contract.table} source failed index/heap integrity; preview was not published. ${details}`,
   );
+}
+
+async function assertPlatformIssueReportDedupeSemantics(
+  source: RawQueryClient,
+  schema: string,
+): Promise<void> {
+  const quotedSchema = `"${schema.replaceAll('"', '""')}"`;
+  const rows = await source.$queryRawUnsafe<Array<{ duplicateGroups: number }>>(`
+    SELECT count(*)::integer AS "duplicateGroups"
+    FROM (
+      SELECT report."dedupeKey"
+      FROM ${quotedSchema}."PlatformIssueReport"
+        TABLESAMPLE SYSTEM (100) AS report
+      WHERE report."dedupeKey" IS NOT NULL
+        AND report.status NOT IN (
+          'resolved_locally',
+          'resolved_upstream',
+          'suppressed'
+        )
+      GROUP BY report."dedupeKey"
+      HAVING count(*) > 1
+    ) duplicate_groups
+  `);
+  const duplicateGroups = Number(rows[0]?.duplicateGroups ?? 0);
+  if (duplicateGroups === 0) return;
+
+  throw new Error(
+    "Production PlatformIssueReport source failed heap dedupe integrity for " +
+      "PlatformIssueReport_dedupeKey_open_key; preview was not published. " +
+      `${duplicateGroups} active dedupeKey group(s) contain duplicates.`,
+  );
+}
+
+export async function assertSanitizedCloneSourceIntegrity(
+  source: RawQueryClient,
+  options: SourceIntegrityOptions = {},
+): Promise<void> {
+  const schema = options.schema ?? "public";
+  for (const contract of SANITIZED_CLONE_SOURCE_INDEX_CONTRACTS) {
+    await assertIndexContract(source, contract, schema);
+  }
+  await assertPlatformIssueReportDedupeSemantics(source, schema);
 }

--- a/packages/db/src/sanitized-clone.postgres.test.ts
+++ b/packages/db/src/sanitized-clone.postgres.test.ts
@@ -3,6 +3,7 @@ import { Client } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { runSourceCheckedClone } from "./sanitized-clone";
+import { assertSanitizedCloneSourceIntegrity } from "./sanitized-clone-source-integrity";
 
 const databaseUrl = process.env.DATABASE_URL;
 const describeDatabase = databaseUrl ? describe : describe.skip;
@@ -16,6 +17,13 @@ async function destinationCount(): Promise<number> {
   return Number(result.rows[0]?.count ?? 0);
 }
 
+const sourceClient = {
+  async $queryRawUnsafe<T>(query: string, ...values: unknown[]): Promise<T> {
+    const result = await client.query(query, values as never[]);
+    return result.rows as T;
+  },
+};
+
 describeDatabase("sanitized clone publication with PostgreSQL", () => {
   beforeAll(async () => {
     client = new Client({ connectionString: databaseUrl });
@@ -25,7 +33,24 @@ describeDatabase("sanitized clone publication with PostgreSQL", () => {
       CREATE TABLE "${schema}"."Destination" (
         id TEXT PRIMARY KEY,
         "entityKey" TEXT NOT NULL UNIQUE
-      )
+      );
+      CREATE TABLE "${schema}"."InventoryEntity" (
+        id TEXT PRIMARY KEY,
+        "entityKey" TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX "InventoryEntity_entityKey_key"
+        ON "${schema}"."InventoryEntity" ("entityKey");
+      CREATE TABLE "${schema}"."PlatformIssueReport" (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        "dedupeKey" TEXT
+      );
+      CREATE INDEX "PlatformIssueReport_dedupeKey_idx"
+        ON "${schema}"."PlatformIssueReport" ("dedupeKey");
+      CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
+        ON "${schema}"."PlatformIssueReport" ("dedupeKey")
+        WHERE "dedupeKey" IS NOT NULL
+          AND status NOT IN ('resolved_locally', 'resolved_upstream', 'suppressed')
     `);
   });
 
@@ -57,6 +82,96 @@ describeDatabase("sanitized clone publication with PostgreSQL", () => {
     )).rejects.toMatchObject({ code: "23505" });
 
     expect(await destinationCount()).toBe(0);
+  });
+
+  it("empties the destination before a source-integrity failure blocks publication", async () => {
+    await client.query(
+      `INSERT INTO "${schema}"."Destination" (id, "entityKey")
+       VALUES ('stale-source-check', 'stale-source-check')`,
+    );
+    let cloneStarted = false;
+
+    await expect(runSourceCheckedClone(
+      async () => {
+        await client.query(`TRUNCATE TABLE "${schema}"."Destination"`);
+      },
+      async () => {
+        throw new Error(
+          "Production PlatformIssueReport source failed index/heap integrity",
+        );
+      },
+      async () => {
+        cloneStarted = true;
+      },
+    )).rejects.toThrow(/PlatformIssueReport source failed/);
+
+    expect(cloneStarted).toBe(false);
+    expect(await destinationCount()).toBe(0);
+  });
+
+  it("runs the real source guard against healthy PostgreSQL contracts", async () => {
+    await expect(assertSanitizedCloneSourceIntegrity(
+      sourceClient,
+      { schema },
+    )).resolves.toBeUndefined();
+  });
+
+  it("names a missing PlatformIssueReport source index", async () => {
+    await client.query(`
+      DROP INDEX "${schema}"."PlatformIssueReport_dedupeKey_open_key"
+    `);
+    try {
+      await expect(assertSanitizedCloneSourceIntegrity(
+        sourceClient,
+        { schema },
+      )).rejects.toThrow(
+        /PlatformIssueReport_dedupeKey_open_key: required index is missing/,
+      );
+    } finally {
+      await client.query(`
+        CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
+          ON "${schema}"."PlatformIssueReport" ("dedupeKey")
+          WHERE "dedupeKey" IS NOT NULL
+            AND status NOT IN (
+              'resolved_locally',
+              'resolved_upstream',
+              'suppressed'
+            )
+      `);
+    }
+  });
+
+  it("rejects real heap duplicates hidden by a too-narrow partial predicate", async () => {
+    await client.query(`
+      DROP INDEX "${schema}"."PlatformIssueReport_dedupeKey_open_key";
+      CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
+        ON "${schema}"."PlatformIssueReport" ("dedupeKey")
+        WHERE "dedupeKey" IS NOT NULL AND status = 'open';
+      INSERT INTO "${schema}"."PlatformIssueReport" (id, status, "dedupeKey")
+      VALUES
+        ('semantic-duplicate-a', 'triaged_local', 'semantic-duplicate'),
+        ('semantic-duplicate-b', 'triaged_local', 'semantic-duplicate');
+    `);
+    try {
+      await expect(assertSanitizedCloneSourceIntegrity(
+        sourceClient,
+        { schema },
+      )).rejects.toThrow(/1 active dedupeKey group/);
+    } finally {
+      await client.query(`
+        DELETE FROM "${schema}"."PlatformIssueReport"
+        WHERE id IN ('semantic-duplicate-a', 'semantic-duplicate-b');
+        DROP INDEX "${schema}"."PlatformIssueReport_dedupeKey_open_key";
+        CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
+          ON "${schema}"."PlatformIssueReport" ("dedupeKey")
+          WHERE "dedupeKey" IS NOT NULL
+            AND status NOT IN (
+              'resolved_locally',
+              'resolved_upstream',
+              'suppressed'
+            )
+      `);
+    }
   });
 
   it("publishes the destination when the source guard and clone both succeed", async () => {

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -65,7 +65,7 @@ export function shouldSkipTable(tableName: string): boolean {
 import { PrismaClient } from "../generated/client/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { runSourceCheckedClone } from "./sanitized-clone-cleanup";
-import { assertSourceInventoryIntegrity } from "./sanitized-clone-source-integrity";
+import { assertSanitizedCloneSourceIntegrity } from "./sanitized-clone-source-integrity";
 
 export {
   runSourceCheckedClone,
@@ -343,7 +343,7 @@ export async function runSanitizedClone(): Promise<void> {
 
     await runSourceCheckedClone(
       () => resetDestinationData(dev, destinationTables.map(({ tablename }) => tablename)),
-      () => assertSourceInventoryIntegrity(prod),
+      () => assertSanitizedCloneSourceIntegrity(prod),
       async () => {
         const tables = await listPublicTables(prod, false);
         console.log(`[sanitized-clone] Found ${tables.length} tables to process`);


### PR DESCRIPTION
## Summary
- repair corrupt PlatformIssueReport unique-index integrity with a fleet-safe, idempotent migration
- preserve compatible recurring reports through lineage-aware merges and retain incompatible reports with an explicit suppression reason
- harden sanitized-clone source repair and add real PostgreSQL migration/index checks
- document the data impact and contributor-preview behavior

## Verification
- governed local-integration-ci lease: NPEL-8CA9000D3E
- exact candidate: af1820fb6b9c41572c25996f2662bd378a3f14cf
- accepted base: abb941e8adb9430e1bd7fc32dd2e87510204cbde
- local integration evidence: cms6x1gnq03br01ogaddr7ci2
- external evidence: cms6x1ow703c001og636icpr0
- freshness and dependency graph passed
- Prisma generate and 468-migration deploy passed
- exhaustive Vitest: 20,258 passed; 19 skipped; 18 todo
- web typecheck passed
- production Docker build passed

## Migration safety
The migration remediates active duplicate keys before rebuilding constraints, uses deterministic survivor selection, preserves lineage, and is covered by real PostgreSQL upgrade-state tests.

Backlog: BI-854A9A5C

Seed-Fit-Decision: global-default

Local-CI-Evidence: cms6x1gnq03br01ogaddr7ci2
