### PR TITLE
fix(ci): cancel dead local queue observers

### DIFF
--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -141,11 +141,111 @@ test("durable queue observation reuses claimKey and grants a fresh admitted TTL"
     assert.ok([0, 3].includes(result.code), result.output);
     assert.equal(claims.length, 2);
     assert.equal(claims[0].args.claimKey, claims[1].args.claimKey);
-    assert.match(claims[0].args.claimKey, /^local-ci:gate-\d+:/);
+    assert.match(
+      claims[0].args.claimKey,
+      /^local-ci:gate-v2-[0-9a-f-]{36}-\d+:/,
+    );
     const grantedMs = Date.parse(claims[1].args.expiresAt) - claims[1].receivedAt;
     assert.ok(grantedMs >= 2_800, `expected a fresh ~3s TTL, got ${grantedMs}ms`);
     assert.match(result.output, /queued at position 2/);
   } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("a same-host dead queued observer is cancelled before the live waiter claims", async () => {
+  const calls = [];
+  const observerDirectory = mkdtempSync(join(tmpdir(), "dpf-gate-observers-"));
+  const deadToken = "77777777-7777-4777-8777-777777777777";
+  const deadPid = 2_147_483_000;
+  const deadOwner = `gate-v2-${deadToken}-${deadPid}`;
+  writeFileSync(
+    join(observerDirectory, `${deadToken}.json`),
+    JSON.stringify({
+      schema: "dpf-local-ci-queue-observer/v1",
+      observerToken: deadToken,
+      pid: deadPid,
+      ownerSessionId: deadOwner,
+      branch: "fix/dead",
+      sha: "d".repeat(40),
+      registeredAt: "2026-07-29T20:00:00.000Z",
+    }),
+  );
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      calls.push({ tool, args: payload.params.arguments });
+      const result = tool === "list_nonprod_environment_leases"
+        ? {
+          success: true,
+          data: {
+            leases: [],
+            queued: [{
+              leaseId: "NPEL-DEAD-OBSERVER",
+              environmentKey: "local-integration-ci",
+              status: "queued",
+              ownerSessionId: deadOwner,
+            }],
+          },
+        }
+        : tool === "claim_nonprod_environment_lease"
+          ? {
+            success: true,
+            entityId: "NPEL-LIVE-OBSERVER",
+            data: {
+              lease: { leaseId: "NPEL-LIVE-OBSERVER" },
+              admission: { status: "admitted", slotKey: "slot-0", waitAgeMs: 1 },
+            },
+          }
+          : tool === "record_local_integration_result"
+            ? { success: true, entityId: "EVIDENCE-DEAD-OBSERVER" }
+            : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/dead-waiter-reconciliation",
+      "--worktree", process.cwd(),
+      "--owner-session-id", "integration-test-live-owner",
+      "--expires-minutes", "0.05",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_LOCAL_QUEUE_OBSERVER_DIR: observerDirectory,
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    const deadRelease = calls.findIndex(
+      (call) => call.tool === "release_nonprod_environment_lease"
+        && call.args.leaseId === "NPEL-DEAD-OBSERVER",
+    );
+    const claim = calls.findIndex((call) => call.tool === "claim_nonprod_environment_lease");
+    assert.ok(deadRelease >= 0, result.output);
+    assert.ok(deadRelease < claim, JSON.stringify(calls));
+    assert.match(result.output, /cancelled dead same-host queue observer NPEL-DEAD-OBSERVER/);
+  } finally {
+    server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));
   }
 });

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -23,6 +23,12 @@ import {
   releaseLocalSandboxFence,
 } from "./lib/local-sandbox-fence.mjs";
 import {
+  createGateObserverIdentity,
+  findDeadLocalQueueObservers,
+  registerLocalQueueObserver,
+  releaseLocalQueueObserver,
+} from "./lib/local-queue-observer.mjs";
+import {
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
 } from "./lib/local-ci-slot-manifest.mjs";
@@ -91,7 +97,7 @@ Options:
   --worktree PATH            Worktree path (default: git rev-parse --show-toplevel)
   --remote NAME               Remote used only with --push (default: origin)
   --owner-provider NAME       build-studio|claude|codex|coworker (default: codex)
-  --owner-session-id ID       External session id (default: gate-<pid>)
+  --owner-session-id ID       External session id (default: host-local gate observer)
   --mcp-url URL                MCP endpoint (default: DPF_MCP_URL or local portal)
   --lease-wait-seconds N       Max time to wait for admission (default: 7200)
   --poll-seconds N             Initial queue-observation backoff (default: 10)
@@ -251,19 +257,78 @@ function quiescenceBlocksWrites(status) {
     && ((status.level && status.level !== "normal") || status.writesRefused === true);
 }
 
-async function warnAboutActiveLease({ mcpUrl, bearerToken }) {
+async function cancelDeadLocalQueueObservers({
+  directory,
+  mcpUrl,
+  bearerToken,
+  leaseEvents,
+  reportActive = false,
+}) {
+  let response;
   try {
-    const response = await mcpCall("list_nonprod_environment_leases", {}, { mcpUrl, bearerToken });
-    if (response?.success !== true) return;
-    const data = responseData(response);
+    response = await mcpCall(
+      "list_nonprod_environment_leases",
+      {},
+      { mcpUrl, bearerToken },
+    );
+  } catch (error) {
+    process.stderr.write(
+      `gate-worktree: dead-waiter reconciliation unavailable (${error.message}); queue remains fail-closed\n`,
+    );
+    return;
+  }
+  if (response?.success !== true) return;
+  const data = responseData(response);
+  if (reportActive) {
     const leases = Array.isArray(data.leases) ? data.leases : [];
     const active = leases.filter((lease) =>
       (lease.environmentKey || lease.environment || lease.key) === "local-integration-ci");
     if (active.length > 0) {
-      process.stderr.write(`gate-worktree: preflight sees ${active.length} active local-integration-ci lease(s); claim will queue if busy.\n`);
+      process.stderr.write(
+        `gate-worktree: preflight sees ${active.length} active local-integration-ci lease(s); claim will queue if busy.\n`,
+      );
     }
-  } catch (error) {
-    process.stderr.write(`gate-worktree: lease-list preflight unavailable (${error.message}); claim remains authoritative\n`);
+  }
+  const queued = Array.isArray(data.queued) ? data.queued : [];
+  const dead = findDeadLocalQueueObservers({
+    directory,
+    queuedLeases: queued,
+  });
+  for (const candidate of dead) {
+    let released;
+    try {
+      released = await mcpCall(
+        "release_nonprod_environment_lease",
+        { leaseId: candidate.leaseId },
+        { mcpUrl, bearerToken },
+      );
+    } catch (error) {
+      process.stderr.write(
+        `gate-worktree: proven-dead queue observer ${candidate.leaseId} could not be cancelled (${error.message}); queue remains authoritative\n`,
+      );
+      continue;
+    }
+    if (released?.success !== true) {
+      process.stderr.write(
+        `gate-worktree: could not cancel proven-dead queue observer ${candidate.leaseId}; queue remains authoritative\n`,
+      );
+      continue;
+    }
+    releaseLocalQueueObserver({
+      path: resolvePath(directory, `${candidate.livenessProof.observerToken}.json`),
+      token: candidate.livenessProof.observerToken,
+    });
+    const event = {
+      type: "dead_queue_observer_cancelled",
+      leaseId: candidate.leaseId,
+      reason: candidate.reason,
+      livenessProof: candidate.livenessProof,
+      at: new Date().toISOString(),
+    };
+    leaseEvents.push(event);
+    process.stdout.write(
+      `cancelled dead same-host queue observer ${candidate.leaseId} (${candidate.reason}; pid ${candidate.livenessProof.pid})\n`,
+    );
   }
 }
 
@@ -299,7 +364,10 @@ async function main() {
   if (branch === "HEAD") die("cannot gate detached HEAD");
   const sha = options.sha || gitOrEmpty(gitBin, ["rev-parse", "HEAD"]);
   const worktreePath = options.worktree || gitOrEmpty(gitBin, ["rev-parse", "--show-toplevel"]);
-  const ownerSessionId = options.ownerSessionId || `gate-${process.pid}`;
+  const gateObserverIdentity = options.ownerSessionId
+    ? null
+    : createGateObserverIdentity();
+  const ownerSessionId = options.ownerSessionId || gateObserverIdentity.ownerSessionId;
   const claimKey = `local-ci:${ownerSessionId}:${sha}`;
   const deadline = Date.now() + options.leaseWaitSeconds * 1000;
   const commandSpec = resolveGateCommand({ branch, allowStub, gitBin });
@@ -332,6 +400,8 @@ async function main() {
     gitOrEmpty(gitBin, ["rev-parse", "--git-common-dir"], worktreePath),
   );
   const rootClone = dirname(gitCommonDir);
+  const queueObserverDirectory = process.env.DPF_LOCAL_QUEUE_OBSERVER_DIR
+    || resolvePath(gitCommonDir, "dpf-local-ci-queue-observers");
   let slotManifest = createLocalCiSlotManifest({
     slotKey: process.env.DPF_LOCAL_CI_SLOT_KEY || "slot-0",
     rootClone,
@@ -414,7 +484,6 @@ async function main() {
     process.exit(0);
   }
 
-  await warnAboutActiveLease({ mcpUrl: options.mcpUrl, bearerToken });
   warnAboutMainFreshness({ gitBin, worktreePath });
 
   if (options.pushBranch) {
@@ -428,6 +497,7 @@ async function main() {
 
   let leaseId = "";
   let localFenceToken = "";
+  let queueObserverPath = "";
   let leaseReleased = false;
   let receivedSignal = "";
   const leaseEvents = [];
@@ -440,6 +510,15 @@ async function main() {
   ]));
   for (const [signal, handler] of Object.entries(signalHandlers)) process.once(signal, handler);
 
+  if (gateObserverIdentity) {
+    queueObserverPath = registerLocalQueueObserver({
+      directory: queueObserverDirectory,
+      identity: gateObserverIdentity,
+      branch,
+      sha,
+    }).path;
+  }
+
   const releaseLeaseOnce = async () => {
     if (!leaseId || leaseReleased) return;
     leaseReleased = true;
@@ -449,6 +528,13 @@ async function main() {
     if (response?.success !== true) {
       throw new Error(`failed to release local-CI lease: ${JSON.stringify(response)}`);
     }
+    if (queueObserverPath) {
+      releaseLocalQueueObserver({
+        path: queueObserverPath,
+        token: gateObserverIdentity.token,
+      });
+      queueObserverPath = "";
+    }
   };
 
   let claimAttempt = 0;
@@ -457,6 +543,13 @@ async function main() {
       await releaseLeaseOnce();
       process.exit(130);
     }
+    await cancelDeadLocalQueueObservers({
+      directory: queueObserverDirectory,
+      mcpUrl: options.mcpUrl,
+      bearerToken,
+      leaseEvents,
+      reportActive: claimAttempt === 0,
+    });
     expiresAt = new Date(Date.now() + leaseTtlMs).toISOString();
     let claimResponse;
     try {

--- a/scripts/lib/local-queue-observer.mjs
+++ b/scripts/lib/local-queue-observer.mjs
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const OBSERVER_SCHEMA = "dpf-local-ci-queue-observer/v1";
+const OWNER_PATTERN =
+  /^gate-v2-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-([1-9][0-9]*)$/i;
+
+function readObserver(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function observerPath(directory, token) {
+  return join(directory, `${token}.json`);
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createGateObserverIdentity({
+  pid = process.pid,
+  token = randomUUID(),
+} = {}) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error("local_queue_observer_invalid_pid");
+  }
+  if (!OWNER_PATTERN.test(`gate-v2-${token}-${pid}`)) {
+    throw new Error("local_queue_observer_invalid_token");
+  }
+  return {
+    token,
+    pid,
+    ownerSessionId: `gate-v2-${token}-${pid}`,
+  };
+}
+
+export function registerLocalQueueObserver({
+  directory,
+  identity,
+  branch,
+  sha,
+  now = () => new Date(),
+}) {
+  mkdirSync(directory, { recursive: true });
+  const path = observerPath(directory, identity.token);
+  const record = {
+    schema: OBSERVER_SCHEMA,
+    observerToken: identity.token,
+    pid: identity.pid,
+    ownerSessionId: identity.ownerSessionId,
+    branch,
+    sha,
+    registeredAt: now().toISOString(),
+  };
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  return { path, record };
+}
+
+export function findDeadLocalQueueObservers({
+  directory,
+  queuedLeases,
+  processAlive = isProcessAlive,
+}) {
+  const dead = [];
+  for (const lease of queuedLeases) {
+    if (
+      lease?.environmentKey !== "local-integration-ci"
+      || lease?.status !== "queued"
+      || typeof lease?.ownerSessionId !== "string"
+    ) {
+      continue;
+    }
+    const match = OWNER_PATTERN.exec(lease.ownerSessionId);
+    if (!match) continue;
+    const [, token, pidText] = match;
+    const pid = Number(pidText);
+    const record = readObserver(observerPath(directory, token));
+    if (
+      record?.schema !== OBSERVER_SCHEMA
+      || record.observerToken !== token
+      || record.pid !== pid
+      || record.ownerSessionId !== lease.ownerSessionId
+      || typeof record.registeredAt !== "string"
+    ) {
+      continue;
+    }
+    if (processAlive(pid)) continue;
+    dead.push({
+      leaseId: lease.leaseId,
+      ownerSessionId: lease.ownerSessionId,
+      reason: "same_host_observer_process_not_running",
+      livenessProof: {
+        schema: OBSERVER_SCHEMA,
+        observerToken: token,
+        pid,
+        registeredAt: record.registeredAt,
+      },
+    });
+  }
+  return dead;
+}
+
+export function releaseLocalQueueObserver({ path, token }) {
+  const record = readObserver(path);
+  if (!record) return { status: "absent" };
+  if (record.observerToken !== token) {
+    return { status: "not-owner", active: record };
+  }
+  unlinkSync(path);
+  return { status: "released" };
+}

--- a/scripts/lib/local-queue-observer.test.mjs
+++ b/scripts/lib/local-queue-observer.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createGateObserverIdentity,
+  findDeadLocalQueueObservers,
+  registerLocalQueueObserver,
+  releaseLocalQueueObserver,
+} from "./local-queue-observer.mjs";
+
+function observerDirectory() {
+  return mkdtempSync(join(tmpdir(), "dpf-queue-observers-"));
+}
+
+test("a dead same-host gate observer is eligible for queue cancellation", () => {
+  const directory = observerDirectory();
+  const identity = createGateObserverIdentity({
+    pid: 101,
+    token: "11111111-1111-4111-8111-111111111111",
+  });
+  registerLocalQueueObserver({
+    directory,
+    identity,
+    branch: "fix/old",
+    sha: "a".repeat(40),
+    now: () => new Date("2026-07-29T20:00:00.000Z"),
+  });
+
+  const dead = findDeadLocalQueueObservers({
+    directory,
+    queuedLeases: [{
+      leaseId: "NPEL-DEAD",
+      environmentKey: "local-integration-ci",
+      status: "queued",
+      ownerSessionId: identity.ownerSessionId,
+    }],
+    processAlive: () => false,
+  });
+
+  assert.deepEqual(dead, [{
+    leaseId: "NPEL-DEAD",
+    ownerSessionId: identity.ownerSessionId,
+    reason: "same_host_observer_process_not_running",
+    livenessProof: {
+      schema: "dpf-local-ci-queue-observer/v1",
+      observerToken: identity.token,
+      pid: 101,
+      registeredAt: "2026-07-29T20:00:00.000Z",
+    },
+  }]);
+});
+
+test("a live observer is never cancelled from queue age or TTL alone", () => {
+  const directory = observerDirectory();
+  const identity = createGateObserverIdentity({
+    pid: 202,
+    token: "22222222-2222-4222-8222-222222222222",
+  });
+  registerLocalQueueObserver({
+    directory,
+    identity,
+    branch: "fix/live",
+    sha: "b".repeat(40),
+  });
+
+  const dead = findDeadLocalQueueObservers({
+    directory,
+    queuedLeases: [{
+      leaseId: "NPEL-LIVE",
+      environmentKey: "local-integration-ci",
+      status: "queued",
+      ownerSessionId: identity.ownerSessionId,
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    }],
+    processAlive: () => true,
+  });
+
+  assert.deepEqual(dead, []);
+});
+
+test("manual, malformed, and cross-host owners fail closed", () => {
+  const directory = observerDirectory();
+  writeFileSync(
+    join(directory, "33333333-3333-4333-8333-333333333333.json"),
+    JSON.stringify({
+      schema: "dpf-local-ci-queue-observer/v1",
+      observerToken: "different-token",
+      pid: 303,
+      ownerSessionId: "gate-v2-33333333-3333-4333-8333-333333333333-303",
+    }),
+  );
+
+  const dead = findDeadLocalQueueObservers({
+    directory,
+    queuedLeases: [
+      {
+        leaseId: "NPEL-MANUAL",
+        environmentKey: "local-integration-ci",
+        status: "queued",
+        ownerSessionId: "human-session",
+      },
+      {
+        leaseId: "NPEL-CROSS-HOST",
+        environmentKey: "local-integration-ci",
+        status: "queued",
+        ownerSessionId: "gate-v2-44444444-4444-4444-8444-444444444444-404",
+      },
+      {
+        leaseId: "NPEL-MISMATCH",
+        environmentKey: "local-integration-ci",
+        status: "queued",
+        ownerSessionId: "gate-v2-33333333-3333-4333-8333-333333333333-303",
+      },
+    ],
+    processAlive: () => false,
+  });
+
+  assert.deepEqual(dead, []);
+});
+
+test("observer cleanup is token-fenced", () => {
+  const directory = observerDirectory();
+  const identity = createGateObserverIdentity({
+    pid: 505,
+    token: "55555555-5555-4555-8555-555555555555",
+  });
+  const registered = registerLocalQueueObserver({
+    directory,
+    identity,
+    branch: "fix/current",
+    sha: "c".repeat(40),
+  });
+
+  assert.equal(
+    releaseLocalQueueObserver({
+      path: registered.path,
+      token: "66666666-6666-4666-8666-666666666666",
+    }).status,
+    "not-owner",
+  );
+  assert.equal(existsSync(registered.path), true);
+  assert.equal(
+    releaseLocalQueueObserver({ path: registered.path, token: identity.token }).status,
+    "released",
+  );
+  assert.equal(existsSync(registered.path), false);
+});

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -197,6 +197,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   // instead of dying on ERR_MODULE_NOT_FOUND before the stub guard.
   cpSync(join(repoRoot, "scripts", "lib", "lease-supervisor.mjs"), join(temp, "scripts", "lib", "lease-supervisor.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-sandbox-fence.mjs"), join(temp, "scripts", "lib", "local-sandbox-fence.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "local-queue-observer.mjs"), join(temp, "scripts", "lib", "local-queue-observer.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-slot-manifest.mjs"), join(temp, "scripts", "lib", "local-ci-slot-manifest.mjs"));
 
   const { dir } = makeTempRepo();
@@ -239,7 +240,10 @@ test("gate-worktree.mjs claims, records, and releases in order, and carries evid
 
     const evidenceCall = mcp.calls.find((c) => c.params.name === "record_local_integration_result");
     const claimCall = mcp.calls.find((c) => c.params.name === "claim_nonprod_environment_lease");
-    assert.match(claimCall.params.arguments.claimKey, /^local-ci:gate-\d+:candidate-sha$/);
+    assert.match(
+      claimCall.params.arguments.claimKey,
+      /^local-ci:gate-v2-[0-9a-f-]{36}-\d+:candidate-sha$/,
+    );
     assert.equal(evidenceCall.params.arguments.evidence.leaseId, "NPEL-TEST");
     assert.equal(evidenceCall.params.arguments.evidence.branch, "feat/local-ci-sandbox");
     assert.equal(evidenceCall.params.arguments.evidence.sha, "candidate-sha");


### PR DESCRIPTION
## Summary\n\n- register each canonical local-CI waiter with a Git-scoped, host-local UUID + PID observer record\n- cancel a queued lease only when that exact same-host record exists and its process is proven dead\n- carry the cancellation reason and liveness proof into the succeeding gate evidence\n- preserve fail-closed behavior for live, manual, malformed, and cross-host owners\n\n## Verification\n\n- governed local-CI evidence: cms70kez70blp01og6orfvqtw\n- exact candidate: 