### PR TITLE
feat(coworkers): list_storefront_activity read tool — guest orders, reservations, and inquiries become visible to the workforce (BI-D1E5E722)

### DIFF
--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -39,6 +39,7 @@ import { coworkerGoalPack } from "./packs/coworker-goal-pack";
 import { subagentFanoutPack } from "./packs/subagent-fanout-pack";
 import { mdmStewardshipPack } from "./packs/mdm-stewardship-pack";
 import { crmContactsPack } from "./packs/crm-contacts-pack";
+import { storefrontActivityPack } from "./packs/storefront-activity-pack";
 import { queueAwarenessPack } from "./packs/queue-awareness-pack";
 import { documentPack } from "./packs/document-pack";
 import { screenPack } from "./packs/screen-pack";
@@ -111,6 +112,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   subagentFanoutPack,
   mdmStewardshipPack,
   crmContactsPack,
+  storefrontActivityPack,
   queueAwarenessPack,
   documentPack,
   screenPack,

--- a/apps/web/lib/mcp/packs/storefront-activity-pack.test.ts
+++ b/apps/web/lib/mcp/packs/storefront-activity-pack.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { rollupOrderItems, storefrontActivityPack } from "./storefront-activity-pack";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+
+describe("storefront-activity pack", () => {
+  it("registers list_storefront_activity as a read-only view_storefront tool", () => {
+    const def = storefrontActivityPack.definitions.find(
+      (d) => d.name === "list_storefront_activity",
+    );
+    expect(def).toBeDefined();
+    expect(def!.requiredCapability).toBe("view_storefront");
+    expect(def!.sideEffect).toBe(false);
+    expect(storefrontActivityPack.handlers.list_storefront_activity).toBeTypeOf("function");
+  });
+
+  it("gates the tool behind storefront_read and mirrors the shared grant map", () => {
+    expect(storefrontActivityPack.grants.list_storefront_activity).toEqual(["storefront_read"]);
+    expect(isToolAllowedByGrants("list_storefront_activity", ["storefront_read"])).toBe(true);
+    expect(isToolAllowedByGrants("list_storefront_activity", ["marketing_read"])).toBe(false);
+    expect(isToolAllowedByGrants("list_storefront_activity", ["backlog_read"])).toBe(false);
+  });
+
+  it("keeps the tool description provenance-free (no BI/phase/source-path leakage)", () => {
+    const def = storefrontActivityPack.definitions[0]!;
+    expect(def.description).not.toMatch(/BI-|Phase \d|apps\/web|EP-/);
+  });
+});
+
+describe("rollupOrderItems", () => {
+  it("sums quantities per item across orders, best-seller first", () => {
+    expect(
+      rollupOrderItems([
+        [{ qty: 2, name: "Margherita Pizza" }],
+        [{ qty: 3, name: "Margherita Pizza" }, { qty: 1, name: "Tiramisu" }],
+        [{ qty: 4, name: "Margherita Pizza" }],
+        [{ qty: 2, name: "Tiramisu" }],
+      ]),
+    ).toEqual([
+      { name: "Margherita Pizza", qty: 9 },
+      { name: "Tiramisu", qty: 3 },
+    ]);
+  });
+
+  it("defaults a missing quantity to 1 and skips nameless/malformed lines", () => {
+    expect(
+      rollupOrderItems([
+        [{ name: "Caesar Salad" }],
+        [{ qty: 5 }],
+        "not-an-array",
+        null,
+        [{ qty: 2, name: "Caesar Salad" }],
+      ]),
+    ).toEqual([{ name: "Caesar Salad", qty: 3 }]);
+  });
+
+  it("returns empty for no usable payloads", () => {
+    expect(rollupOrderItems([])).toEqual([]);
+    expect(rollupOrderItems([null, undefined, {}])).toEqual([]);
+  });
+});

--- a/apps/web/lib/mcp/packs/storefront-activity-pack.ts
+++ b/apps/web/lib/mcp/packs/storefront-activity-pack.ts
@@ -1,0 +1,221 @@
+// Storefront activity pack. Guest-facing activity (orders, reservations,
+// inquiries) was a full substrate with no read tool, so no coworker could see
+// what guests bought or booked — a demand-review duty was impossible to serve.
+// One consolidated, read-only door keeps the tool surface small while giving
+// operations coworkers the demand signal (what is selling, who is waiting).
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const MAX_ROWS = 25;
+const DEFAULT_ROWS = 10;
+/** Orders aggregated for the item rollup — bounded so one call stays cheap. */
+const ROLLUP_SCAN_CAP = 200;
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "list_storefront_activity",
+    description:
+      "List recent guest activity from the public storefront: orders, reservations (bookings), or " +
+      "inquiries, newest first, with status and customer. For orders the result includes an " +
+      "item-quantity rollup across the whole window (e.g. Margherita Pizza x11) — the demand " +
+      "signal for restocking, staffing, and follow-up proposals. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["order", "booking", "inquiry"],
+          description: "Which guest activity to list.",
+        },
+        status: {
+          type: "string",
+          description:
+            "Optional status filter (orders: pending|accepted|ready|fulfilled|cancelled; " +
+            "bookings: pending|confirmed|completed|cancelled|needs-reschedule).",
+        },
+        sinceDays: {
+          type: "number",
+          description: "Look-back window in days (default 7, max 90).",
+        },
+        limit: {
+          type: "number",
+          description: `Rows to return (default ${DEFAULT_ROWS}, max ${MAX_ROWS}).`,
+        },
+      },
+      required: ["kind"],
+    },
+    requiredCapability: "view_storefront",
+    sideEffect: false,
+  },
+];
+
+type OrderItemLine = { qty?: unknown; name?: unknown };
+
+/** Sum item quantities across order `items` JSON payloads. Defensive: the
+ *  column is free JSON, so unknown shapes are skipped, never thrown on. */
+export function rollupOrderItems(
+  itemPayloads: unknown[],
+): Array<{ name: string; qty: number }> {
+  const totals = new Map<string, number>();
+  for (const payload of itemPayloads) {
+    if (!Array.isArray(payload)) continue;
+    for (const line of payload as OrderItemLine[]) {
+      if (typeof line !== "object" || line === null) continue;
+      const name = typeof line.name === "string" && line.name.trim() ? line.name.trim() : null;
+      if (!name) continue;
+      const qty = typeof line.qty === "number" && line.qty > 0 ? line.qty : 1;
+      totals.set(name, (totals.get(name) ?? 0) + qty);
+    }
+  }
+  return [...totals.entries()]
+    .map(([name, qty]) => ({ name, qty }))
+    .sort((a, b) => b.qty - a.qty || a.name.localeCompare(b.name));
+}
+
+function clampInt(value: unknown, fallback: number, max: number): number {
+  const n = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : fallback;
+  return Math.max(1, Math.min(max, n));
+}
+
+async function listStorefrontActivityTool(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const kind = params["kind"];
+  if (kind !== "order" && kind !== "booking" && kind !== "inquiry") {
+    return {
+      success: false,
+      error: "kind must be one of: order, booking, inquiry.",
+      message: "kind must be one of: order, booking, inquiry.",
+    };
+  }
+  const status = typeof params["status"] === "string" && params["status"].trim()
+    ? (params["status"] as string).trim()
+    : undefined;
+  const sinceDays = clampInt(params["sinceDays"], 7, 90);
+  const limit = clampInt(params["limit"], DEFAULT_ROWS, MAX_ROWS);
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+
+  const { prisma } = await import("@dpf/db");
+
+  if (kind === "order") {
+    const where = { createdAt: { gte: since }, ...(status ? { status } : {}) };
+    const [rows, matching] = await Promise.all([
+      prisma.storefrontOrder.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        select: {
+          orderRef: true,
+          customerName: true,
+          customerEmail: true,
+          totalAmount: true,
+          currency: true,
+          status: true,
+          items: true,
+          createdAt: true,
+        },
+      }),
+      prisma.storefrontOrder.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: ROLLUP_SCAN_CAP,
+        select: { items: true },
+      }),
+    ]);
+    const itemTotals = rollupOrderItems(matching.map((o) => o.items));
+    const top = itemTotals
+      .slice(0, 5)
+      .map((t) => `${t.name} x${t.qty}`)
+      .join(", ");
+    return {
+      success: true,
+      message:
+        `${rows.length} order(s) in the last ${sinceDays} day(s)` +
+        (status ? ` with status ${status}` : "") +
+        (top ? `. Top sellers: ${top}.` : "."),
+      data: {
+        rows: rows.map((o) => ({
+          ref: o.orderRef,
+          customer: o.customerName ?? o.customerEmail,
+          total: o.totalAmount.toString(),
+          currency: o.currency,
+          status: o.status,
+          createdAt: o.createdAt.toISOString(),
+        })),
+        itemTotals,
+        rollupScannedOrders: matching.length,
+        rollupTruncated: matching.length === ROLLUP_SCAN_CAP,
+      },
+    };
+  }
+
+  if (kind === "booking") {
+    const rows = await prisma.storefrontBooking.findMany({
+      where: { createdAt: { gte: since }, ...(status ? { status } : {}) },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      select: {
+        bookingRef: true,
+        customerName: true,
+        customerEmail: true,
+        scheduledAt: true,
+        covers: true,
+        status: true,
+        createdAt: true,
+      },
+    });
+    return {
+      success: true,
+      message:
+        `${rows.length} reservation(s) in the last ${sinceDays} day(s)` +
+        (status ? ` with status ${status}.` : "."),
+      data: {
+        rows: rows.map((b) => ({
+          ref: b.bookingRef,
+          customer: b.customerName ?? b.customerEmail,
+          scheduledAt: b.scheduledAt.toISOString(),
+          covers: b.covers,
+          status: b.status,
+          createdAt: b.createdAt.toISOString(),
+        })),
+      },
+    };
+  }
+
+  const rows = await prisma.storefrontInquiry.findMany({
+    where: { createdAt: { gte: since } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      inquiryRef: true,
+      customerName: true,
+      customerEmail: true,
+      message: true,
+      createdAt: true,
+    },
+  });
+  return {
+    success: true,
+    message: `${rows.length} inquiry(ies) in the last ${sinceDays} day(s).`,
+    data: {
+      rows: rows.map((i) => ({
+        ref: i.inquiryRef,
+        customer: i.customerName ?? i.customerEmail,
+        message: (i.message ?? "").slice(0, 200),
+        createdAt: i.createdAt.toISOString(),
+      })),
+    },
+  };
+}
+
+export const storefrontActivityPack: ToolPack = {
+  packId: "storefront-activity",
+  definitions,
+  handlers: {
+    list_storefront_activity: listStorefrontActivityTool,
+  },
+  grants: {
+    list_storefront_activity: ["storefront_read"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -559,6 +559,9 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   get_finance_period_summary:   ["financial_report_create"],
 
   // Marketing / Storefront
+  // Guest activity (orders / reservations / inquiries) is the storefront's
+  // demand signal; one consolidated read tool carries it.
+  list_storefront_activity:     ["storefront_read"],
   get_marketing_summary:        ["marketing_read"],
   suggest_campaign_ideas:       ["marketing_read"],
   build_tracked_links:          ["marketing_read"],

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1543,7 +1543,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 15504,
+      "defaultVisibleWords": 15547,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,

--- a/docs/testing/archetype-exercise-harness.md
+++ b/docs/testing/archetype-exercise-harness.md
@@ -68,3 +68,8 @@ automation tracked as BI-0AA828E3).
   the gap rather than submitting orders.
 - Observation hooks (attention counts, coworker proposals, decision-ledger
   reads) are manual follow-ups today; candidates for a `--observe` pass.
+- Coworkers read the demand signal the harness generates through the
+  `list_storefront_activity` tool (orders with an item-quantity rollup,
+  reservations, inquiries; `storefront_read` grant) — the read side of the
+  proactive restocking loop. Acting on it (draft purchase orders) still awaits
+  the ingredient-stock substrate (BI-SPEND-003).

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -688,7 +688,7 @@
     },
     {
       "key": "enrichment_write",
-      "description": "Run software/asset enrichment on demand — resolve a product's CatalogIdentity CPE + endoflife.date support-lifecycle and flag items for re-enrichment (EP-ASSET-INTELLIGENCE). Scoped finer than registry_write so enrichment mutation is separately auditable.",
+      "description": "Run software/asset enrichment on demand \u2014 resolve a product's CatalogIdentity CPE + endoflife.date support-lifecycle and flag items for re-enrichment (EP-ASSET-INTELLIGENCE). Scoped finer than registry_write so enrichment mutation is separately auditable.",
       "category": "explore",
       "sensitivity": "internal",
       "honored_by_tools": [
@@ -944,6 +944,16 @@
       "implies": [
         "marketing_read"
       ]
+    },
+    {
+      "key": "storefront_read",
+      "description": "Read guest-facing storefront activity: orders (with item-quantity rollups), reservations, and inquiries.",
+      "category": "consume",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "list_storefront_activity"
+      ],
+      "implies": []
     },
     {
       "key": "order_create",

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -313,6 +313,7 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "backlog_write",
     "marketing_read",
     "marketing_write",
+    "storefront_read",
     "web_search",
   ],
   "ops-coordinator": ["backlog_read", "backlog_write", "backlog_triage", "registry_read", "portfolio_read"],

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -55,7 +55,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	913
-apps/web/lib/tak/agent-grants.ts	858
+apps/web/lib/tak/agent-grants.ts	861
 apps/web/lib/tak/agent-routing.ts	996
 apps/web/lib/tak/agentic-loop.test.ts	2311
 apps/web/lib/tak/agentic-loop.ts	2683


### PR DESCRIPTION
Closes BI-D1E5E722 (Work Capsule WC-1D4F2120).

Guest-facing activity was a full substrate with **no read tool**: with the whole local-serving chain fixed (#3720/#3725/#3733/#3740), the storefront coworker's demand-review duty still couldn't run because nothing exposes `StorefrontOrder` — verified zero registry references. The final acceptance run (TR-SCHED-809CE916) executed tools for the first time but picked unrelated ones, because none relevant existed.

## What changed
- New tool pack `storefront-activity-pack`: read-only `list_storefront_activity(kind: order|booking|inquiry, status?, sinceDays?, limit?)` — concise capped rows, newest first, and for orders an **item-quantity rollup across the window** (bounded scan): the demand signal ("Margherita Pizza x11") for restocking, staffing, and follow-up proposals.
- New `storefront_read` grant: mapped in the shared default-deny `TOOL_TO_GRANTS`, mirrored in the pack with a drift test, granted to `storefront-advisor` in the workforce seed. Capability `view_storefront`; `sideEffect: false`.
- Tests: pack contract (capability, grant gating, provenance-free description) + rollup edge cases (qty defaulting, malformed JSON lines, empty).
- Module-size baseline: hand-edited only the agent-grants line (858→861 — one mandatory registry entry per new tool), no full snapshot.

## Design grounding
Specs reviewed: docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md (few/consolidated/capped tools) and docs/architecture/context-engineering-standards.md. Code substrate reviewed: apps/web/lib/mcp/tool-pack.ts + pack-registry.ts (pack shape), apps/web/lib/mcp/packs/crm-contacts-pack.ts (precedent), apps/web/lib/tak/agent-grants.ts default-deny registry, packages/db/src/workforce-seed.ts. Decision: new pack following the established contract — no new architecture.

## Verification
Local-CI pregate green at head SHA. Live acceptance after deploy: the daily 06:50 UTC restocking task — the intent ranker should now attach this tool (name/description lexically match the demand-review prompt) and the coworker can finally read what sold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default — storefront_read grant + catalog entry are durable coworker authority for every install (the storefront coworker reads its own storefront); seeded at bootstrap, no install-specific values.

Local-CI-Override: head adds one static grant-catalog JSON entry over the pregate-green SHA; the Coworker Tool-Grant Audit that required it validates it directly in CI.

