### PR TITLE
feat(process): gate-context pack — diff-driven CI constraints before generation (BI-2677A465)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8633,6 +8633,7 @@
         "why-it-exists",
         "what-it-asserts-ready-iff-all-hold",
         "observation-versus-merge-authority",
+        "know-the-constraints-before-you-write-pnpm-gatecontext",
         "tests-ci"
       ]
     },

--- a/docs/superpowers/plans/2026-07-29-gate-context-pack-plan.md
+++ b/docs/superpowers/plans/2026-07-29-gate-context-pack-plan.md
@@ -1,0 +1,89 @@
+# Gate-context pack — prevention-side constraint injection plan
+
+**Backlog item:** BI-2677A465 (EP-AGENT-INSTRUCTION-PLANE)
+
+## Problem
+
+DPF's CI gates are discovered reactively: an agent writes code, pushes, and
+learns about the module-size ratchet, a frozen route word budget, a required
+attestation trailer, or the generated route companions from a red check. The
+52h failure taxonomy (2026-07-27 → 29) counted ~90 deterministic guard
+failures in that class. The pregate guard-parity preflight (BI-D35433FB)
+moved detection from CI to pre-push seconds; this plan moves the constraint
+to BEFORE generation. External validation: AppFaktors' Architecture Context
+Engine monetizes exactly this bet (constraints in agent context
+pre-generation → their claimed 40–60% rework reduction).
+
+## Substrate verdict (sweep 2026-07-29)
+
+Nothing like a prospective diff→constraints generator exists.
+`scripts/pr-readiness` executes gates and reports pass/fail (the back half);
+`scripts/lib/ci-evidence-plan.mjs` classifies diffs for evidence selection and
+is the architecture template (pure lib + CLI + deterministic output);
+`POLICY_GUARD_PROFILES` is the canonical gate inventory. The UX-Fit and
+Spec/Plan/Doc gates kept their file-sensitivity constants module-private, and
+the dpf-skill-pack precheck hooks hand-mirror them ("Mirrors NEW_SOURCE_FILE_RE
+in …") — a real drift existed when this plan was implemented: the
+spec-plan-doc hook's mirror was missing the gate's migration-file alternative,
+found by this slice's first drift-guard run and fixed in the same change.
+
+## Deliverables
+
+1. **generator** (this slice, under the umbrella BI):
+   - `scripts/lib/gate-sensitivity.mjs` — hoisted canonical sensitivity and
+     attestation constants; `check-ux-fit-decision.mjs` and
+     `check-spec-plan-doc.mjs` import them (no behavior change).
+   - `scripts/lib/gate-context.mjs` — `buildGateContext({changedFiles,
+     addedLinesByFile})` deriving, from the same registries CI enforces:
+     required attestation trailers (spec/plan/doc, design grounding, ux-fit,
+     seed-fit, data-impact), module-size caps (baseline + absolute budgets),
+     shrink-only prose/style ratchets, derived-artifact regeneration list,
+     route budgets (net-new absolute + companions checklist; pre-existing
+     frozen word budgets), and migration immutability/safety contracts.
+     Deterministic: no timestamps, no environment probes.
+   - `scripts/gate-context.mjs` CLI (`pnpm gate:context`, `--json`,
+     `--base`): committed + staged + unstaged + untracked diff vs the merge
+     base.
+   - Drift-guards in `scripts/gate-context.test.mjs` pinning the skill-pack
+     hook mirrors' behavior to the canonical exports (the hooks keep
+     dependency-free copies because the pack is distributed outside the
+     repo).
+   - The pregate preflight's failure output points at `pnpm gate:context`.
+2. **delivery-surfaces** → BI-121DC3A3: Build Studio `BuildContext.gateContext`
+   prompt section + `get_change_gate_context` MCP tool, both consuming the
+   generator module verbatim.
+3. **pr-readiness-convergence** → BI-9652021C: `buildGatePlan()` derived from
+   `POLICY_GUARD_PROFILES`; readiness report leads with the gate-context
+   section; one trailer inventory.
+
+## Acceptance (this slice)
+
+- For a synthetic diff touching a baselined module, a design-sensitive file, a
+  new route, seed content, and a migration, the pack names the exact cap,
+  trailer, companion, and immutability constraints CI would enforce — proven
+  by unit tests against the live registries.
+- Identical inputs produce byte-identical packs.
+- Hook drift-guards fail CI when a mirror and the canonical constant diverge
+  (proven by catching the real migration-alternative drift).
+
+## Backlog coverage
+
+- Decision: decomposed
+- Parent: BI-2677A465
+- Receipt: cms6sdpei06fg01ogjis8acqw
+- Dependencies: delivery-surfaces and pr-readiness-convergence depend on the
+  generator; the generator has none.
+- Mapping: `generator` -> BI-2677A465
+- Mapping: `delivery-surfaces` -> BI-121DC3A3
+- Mapping: `pr-readiness-convergence` -> BI-9652021C
+
+## Risks
+
+- **A fourth copy of gate knowledge.** Mitigation: the pack imports checker
+  exports and reads the checked-in baselines directly; the only remaining
+  copies (skill-pack hooks) are drift-guard-pinned.
+- **Stale advice after a gate changes.** Mitigation: same-repo derivation —
+  a gate change and its pack output move in the same commit; the drift-guards
+  cover the one distribution boundary.
+- **Prospective ≠ enforcement.** The pack is advisory context; CI gates remain
+  the only authority. The pack must never claim a gate passed.

--- a/docs/testing/pr-health.md
+++ b/docs/testing/pr-health.md
@@ -47,6 +47,28 @@ coverage, or the UX workflow loses its callable contract. Use
 manifest with live `main` protection. `pnpm merge-policy:apply` changes only required status
 checks; use it after new contexts have proven green on `main`, never before.
 
+## Know the constraints before you write: `pnpm gate:context`
+
+`pr:health` and CI tell you what already failed; the **gate-context pack**
+(BI-2677A465) tells you what will be enforced, before generation or push. It
+derives — from the same registries CI runs, never a hand-written list — the
+constraints that apply to the current worktree diff (committed + staged +
+unstaged + untracked, vs the `origin/main` merge base):
+
+- required attestation trailers for this diff shape (Process-Spine, Design
+  Grounding, UX-Fit, Seed-Fit body line, Data-Impact manifest);
+- module-size caps for touched baselined files and budgets for new modules;
+- shrink-only prose/style ratchet values frozen for touched files;
+- derived artifacts to regenerate in the same change;
+- route budgets: absolute budgets + the four generated companions for
+  net-new routes, frozen word/structure budgets for pre-existing ones;
+- migration immutability and safety-attestation contracts.
+
+Run it before writing code and again before pushing; `--json` emits the
+machine-readable pack (`scripts/lib/gate-context.mjs` is the single source —
+the Build Studio prompt section and MCP tool consume the same module). The
+pack is advisory context: CI gates remain the only authority.
+
 ## Tests & CI
 
 The pure verdict (`evaluatePrHealth()`) is unit-tested in [`scripts/pr-health.test.mjs`](../../scripts/pr-health.test.mjs) and runs in CI as the **PR Health Logic** job (`node --test`). The script's GitHub I/O is exercised by running it against live PRs; it is not run in CI (it would be circular).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:sandbox": "docker compose up -d sandbox",
     "pregate": "node scripts/pregate.mjs",
     "pregate:preflight": "node scripts/pregate-preflight.mjs",
+    "gate:context": "node scripts/gate-context.mjs",
     "build": "pnpm --filter web build",
     "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",
     "test:e2e": "playwright test",

--- a/packages/dpf-skill-pack/hooks/spec-plan-doc-precheck.mjs
+++ b/packages/dpf-skill-pack/hooks/spec-plan-doc-precheck.mjs
@@ -22,9 +22,12 @@
 import { readFileSync } from "node:fs";
 
 // A NEW file under these roots is a new capability/contract worth documenting.
-// Mirrors NEW_SOURCE_FILE_RE in scripts/check-spec-plan-doc.mjs.
+// Mirrors NEW_SOURCE_FILE_RE in scripts/lib/gate-sensitivity.mjs (the pack is
+// distributed outside the repo, so this stays a dependency-free copy) —
+// scripts/gate-context.test.mjs drift-guards pin this mirror's behavior to
+// the canonical export; change them together.
 const NEW_SOURCE_FILE_RE =
-  /^(apps\/web\/lib\/.*\.(ts|tsx)|apps\/web\/app\/.*\/(page|route)\.(ts|tsx)|packages\/[^/]+\/src\/.*\.(ts|tsx))$/;
+  /^(apps\/web\/lib\/.*\.(ts|tsx)|apps\/web\/app\/.*\/(page|route)\.(ts|tsx)|packages\/[^/]+\/src\/.*\.(ts|tsx)|packages\/db\/prisma\/migrations\/.*\/migration\.sql)$/;
 const EXCLUDE_RE = /(\.(test|spec|stories)\.(ts|tsx)$|__tests__\/|\.d\.ts$|\/generated\/)/;
 
 const GUIDANCE =

--- a/scripts/check-spec-plan-doc.mjs
+++ b/scripts/check-spec-plan-doc.mjs
@@ -37,26 +37,15 @@
 
 import { execFileSync } from "node:child_process";
 import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
-
-const ATTESTATION_RE = /Process-Spine-Decision:/i;
-
-// ── What COUNTS as a substantial implementation surface (triggers the gate) ──
-// New source modules and routes are a high-signal, low-false-positive marker of
-// a new capability/contract that deserves a spec/plan/doc touch. We trigger on
-// NEW files under these roots, never on edits to existing ones (those are
-// covered by the large-rewrite threshold below).
-const NEW_SOURCE_FILE_RE =
-  /^(apps\/web\/lib\/.*\.(ts|tsx)|apps\/web\/app\/.*\/(page|route)\.(ts|tsx)|packages\/[^/]+\/src\/.*\.(ts|tsx)|packages\/db\/prisma\/migrations\/.*\/migration\.sql)$/;
-
-// A large in-place rewrite of existing source is also a substantial change even
-// with no new file. Count added non-test source lines across the diff; over the
-// threshold the gate fires. Tuned conservatively to avoid noise on small fixes.
-const ADDED_SOURCE_LINE_THRESHOLD = 120;
-const SOURCE_LINE_FILE_RE = /^(apps\/web|packages\/[^/]+\/src)\/.*\.(ts|tsx)$/;
-
-// ── What SATISFIES the gate (durable-knowledge artifact touched) ─────────────
-const DOC_ARTIFACT_RE =
-  /^(docs\/.*\.(md|html)|AGENTS\.md|.*\/AGENTS\.md|docs\/founder-kernel\/wiki\/principles\/.*\.md|packages\/dpf-skill-pack\/skills\/.*\/SKILL\.md|skills\/.*\.skill\.md)$/;
+// Canonical sensitivity constants (single source, shared with the gate-context
+// pack; the dpf-skill-pack precheck hook keeps a drift-guard-pinned copy).
+import {
+  ADDED_SOURCE_LINE_THRESHOLD,
+  DOC_ARTIFACT_RE,
+  NEW_SOURCE_FILE_RE,
+  PROCESS_SPINE_ATTESTATION_RE as ATTESTATION_RE,
+  SOURCE_LINE_FILE_RE,
+} from "./lib/gate-sensitivity.mjs";
 
 // Test/story/generated scaffolding is never "implementation surface" for this
 // gate (its own tests, fixtures, snapshots don't imply a missing spec/doc).

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -25,14 +25,14 @@
 import { execFileSync } from "node:child_process";
 import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
 
-const ATTESTATION_RE = /UX-Fit-Decision:/i;
-
-// Added lines that introduce a user-facing control the operator must understand.
-const UI_CONTROL_RE = /<input\b|<select\b|<textarea\b|type=["'](?:number|range)["']|<form\b/i;
-// A newly-added route is a new surface that deserves a fit review.
-const ROUTE_FILE_RE = /app\/.*\/page\.tsx$/;
-// Don't gate test/story scaffolding — those controls aren't user-facing.
-const EXCLUDE_RE = /\.(test|spec|stories)\.tsx$/;
+// Canonical sensitivity constants (single source, shared with the gate-context
+// pack; the dpf-skill-pack precheck hook keeps a drift-guard-pinned copy).
+import {
+  UI_CONTROL_RE,
+  UX_EXCLUDE_RE as EXCLUDE_RE,
+  UX_FIT_ATTESTATION_RE as ATTESTATION_RE,
+  UX_ROUTE_FILE_RE as ROUTE_FILE_RE,
+} from "./lib/gate-sensitivity.mjs";
 
 // Refs reach us from CI env vars (BASE_SHA) and from git's own output. Pin the
 // set of characters we accept so a forged value cannot smuggle shell metachars

--- a/scripts/gate-context.mjs
+++ b/scripts/gate-context.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// scripts/gate-context.mjs — CLI for the gate-context pack (BI-2677A465).
+//
+//   pnpm gate:context              # markdown pack for the current worktree diff
+//   node scripts/gate-context.mjs --json          # machine-readable
+//   node scripts/gate-context.mjs --base origin/main
+//
+// Diff scope: everything this worktree would ship — committed, staged, AND
+// unstaged changes plus untracked files — measured against the merge base
+// with `--base` (default origin/main). Run it BEFORE writing code (empty diff
+// still prints the verification path) and again before pushing.
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { buildGateContext, formatGateContextMarkdown } from "./lib/gate-context.mjs";
+
+// Same conservative ref/path pinning as the gate checkers
+// (js/indirect-command-line-injection): execFile arg arrays, no shell, and a
+// leading-dash guard so nothing is reinterpreted as an option.
+const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
+const PATH_RE = /^[A-Za-z0-9._\-/()[\]@]+$/;
+
+function assertSafeRef(ref) {
+  if (!REF_RE.test(ref) || ref.startsWith("-")) {
+    throw new Error(`[gate-context] refusing unsafe ref: ${JSON.stringify(ref)}`);
+  }
+  return ref;
+}
+
+function git(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function safePath(path) {
+  const normalized = String(path ?? "").trim().replace(/\\/g, "/");
+  if (!normalized || !PATH_RE.test(normalized) || normalized.startsWith("-")) return null;
+  return normalized;
+}
+
+export function collectWorktreeDiff({ base = "origin/main", cwd = process.cwd() } = {}) {
+  assertSafeRef(base);
+  const mergeBase = git(["merge-base", base, "HEAD"], cwd).trim();
+  assertSafeRef(mergeBase);
+
+  const changedFiles = [];
+  const addedLinesByFile = new Map();
+
+  for (const line of git(["diff", "--name-status", "--diff-filter=ACMRD", mergeBase], cwd).split(/\r?\n/)) {
+    // Renames arrive as "R<score>\told\tnew" — the new path is the live one.
+    const parts = line.split("\t");
+    if (parts.length < 2) continue;
+    const status = parts[0][0];
+    const path = safePath(parts[parts.length - 1]);
+    if (!path) continue;
+    changedFiles.push({ path, status: status === "C" || status === "R" ? "A" : status });
+  }
+
+  for (const line of git(["diff", "--numstat", mergeBase], cwd).split(/\r?\n/)) {
+    const match = line.match(/^(\d+)\t\d+\t(.+)$/);
+    if (!match) continue;
+    const path = safePath(match[2]);
+    if (path) addedLinesByFile.set(path, Number(match[1]));
+  }
+
+  for (const line of git(["ls-files", "--others", "--exclude-standard"], cwd).split(/\r?\n/)) {
+    const path = safePath(line);
+    if (path) changedFiles.push({ path, status: "A" });
+  }
+
+  return { base, mergeBase, changedFiles, addedLinesByFile };
+}
+
+export async function main() {
+  const args = process.argv.slice(2);
+  const baseIndex = args.indexOf("--base");
+  const base = baseIndex >= 0 ? args[baseIndex + 1] : "origin/main";
+
+  const diff = collectWorktreeDiff({ base });
+  const context = buildGateContext({
+    changedFiles: diff.changedFiles,
+    addedLinesByFile: diff.addedLinesByFile,
+  });
+
+  if (args.includes("--json")) {
+    process.stdout.write(`${JSON.stringify({ base: diff.base, mergeBase: diff.mergeBase, ...context }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${formatGateContextMarkdown(context)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/gate-context.test.mjs
+++ b/scripts/gate-context.test.mjs
@@ -1,0 +1,177 @@
+// Tests for the gate-context pack (BI-2677A465).
+//
+// Two contracts under test. (1) buildGateContext derives constraints from the
+// SAME registries CI enforces — each section fires exactly when its gate
+// would. (2) Drift-guards: the dpf-skill-pack precheck hooks keep
+// dependency-free mirrors of the canonical sensitivity constants (the pack is
+// distributed outside this repo); these tests pin the mirrors' BEHAVIOR to
+// the canonical exports so a divergence fails CI instead of silently letting
+// a gate and its warning disagree.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { buildGateContext, formatGateContextMarkdown } from "./lib/gate-context.mjs";
+import {
+  NEW_SOURCE_FILE_RE,
+  UI_CONTROL_RE,
+  UX_EXCLUDE_RE,
+} from "./lib/gate-sensitivity.mjs";
+import { decide as specPlanDocDecide } from "../packages/dpf-skill-pack/hooks/spec-plan-doc-precheck.mjs";
+import { decide as uxFitDecide } from "../packages/dpf-skill-pack/hooks/ux-fit-precheck.mjs";
+
+const repoRoot = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+
+const build = (changedFiles, extra = {}) =>
+  buildGateContext({ changedFiles, repoRoot, ...extra });
+
+// ── attestation trailers ─────────────────────────────────────────────────────
+
+test("a new apps/web/lib module without a doc touch requires the Process-Spine attestation", () => {
+  const ctx = build([{ path: "apps/web/lib/foo/new-capability.ts", status: "A" }]);
+  const gates = ctx.trailers.map((t) => t.gate);
+  assert.ok(gates.includes("Spec/Plan/Doc"), gates.join(","));
+});
+
+test("the same new module WITH a doc touch does not demand the trailer", () => {
+  const ctx = build([
+    { path: "apps/web/lib/foo/new-capability.ts", status: "A" },
+    { path: "docs/testing/foo.md", status: "M" },
+  ]);
+  assert.ok(!ctx.trailers.some((t) => t.gate === "Spec/Plan/Doc"));
+});
+
+test("design-sensitive files require Design Grounding; plain scripts do not", () => {
+  const sensitive = build([{ path: "apps/web/components/foo/Bar.tsx", status: "M" }]);
+  assert.ok(sensitive.trailers.some((t) => t.gate === "Design Grounding"));
+  const plain = build([{ path: "scripts/some-tool.mjs", status: "M" }]);
+  assert.ok(!plain.trailers.some((t) => t.gate === "Design Grounding"));
+});
+
+test("a net-new page requires UX-Fit; an edited component gets the conditional form", () => {
+  const newPage = build([{ path: "apps/web/app/things/page.tsx", status: "A" }]);
+  const required = newPage.trailers.find((t) => t.gate === "UX-Fit");
+  assert.equal(required?.level, "required");
+
+  const edited = build([{ path: "apps/web/components/things/Panel.tsx", status: "M" }]);
+  const conditional = edited.trailers.find((t) => t.gate === "UX-Fit");
+  assert.equal(conditional?.level, "conditional");
+
+  const testFile = build([{ path: "apps/web/components/things/Panel.test.tsx", status: "M" }]);
+  assert.ok(!testFile.trailers.some((t) => t.gate === "UX-Fit"));
+});
+
+test("schema changes surface the Data-Impact requirement", () => {
+  const ctx = build([{ path: "packages/db/prisma/schema.prisma", status: "M" }]);
+  assert.ok(ctx.trailers.some((t) => t.gate === "Data-Impact"));
+});
+
+// ── ratchets, artifacts, routes, migrations ──────────────────────────────────
+
+test("a baselined module reports its frozen size cap; a new .ts module gets the absolute budget", () => {
+  const ctx = build([
+    { path: "apps/web/instrumentation.ts", status: "M" },
+    { path: "apps/web/lib/foo/big-new-module.ts", status: "A" },
+  ]);
+  const baselined = ctx.moduleSize.find((m) => m.path === "apps/web/instrumentation.ts");
+  assert.ok(baselined && baselined.capLines >= 800, JSON.stringify(ctx.moduleSize));
+  const fresh = ctx.moduleSize.find((m) => m.path === "apps/web/lib/foo/big-new-module.ts");
+  assert.equal(fresh?.capLines, 800);
+});
+
+test("docs changes report the doc-index derived artifact", () => {
+  const ctx = build([{ path: "docs/testing/pre-pr-gate.md", status: "M" }]);
+  assert.ok(ctx.derivedArtifacts.some((d) => d.id === "doc-index"), JSON.stringify(ctx.derivedArtifacts));
+});
+
+test("a net-new route lists the absolute budgets and four-companion checklist", () => {
+  const ctx = build([{ path: "apps/web/app/brand-new-surface/page.tsx", status: "A" }]);
+  const route = ctx.routes.find((r) => r.route === "/brand-new-surface");
+  assert.equal(route?.status, "net-new");
+  assert.ok(route.rules.some((rule) => rule.includes("route-manifest")));
+});
+
+test("a pre-existing baselined route reports its frozen word budget", () => {
+  const ctx = build([{ path: "apps/web/app/admin/page.tsx", status: "M" }]);
+  const route = ctx.routes.find((r) => r.route === "/admin");
+  assert.equal(route?.status, "pre-existing");
+  assert.ok(route.rules.some((rule) => /≤\d+ words/.test(rule)), JSON.stringify(route));
+});
+
+test("editing a committed migration is flagged blocking; a new migration gets the safety contract", () => {
+  const edited = build([{ path: "packages/db/prisma/migrations/20260701000000_x/migration.sql", status: "M" }]);
+  assert.ok(edited.migrations.some((m) => m.severity === "blocking" && m.rule.includes("IMMUTABLE")));
+  const added = build([{ path: "packages/db/prisma/migrations/20260729000000_y/migration.sql", status: "A" }]);
+  assert.ok(added.migrations.some((m) => m.rule.includes("migration-safety guard")));
+});
+
+// ── determinism + formatting ─────────────────────────────────────────────────
+
+test("identical inputs produce byte-identical packs (no timestamps, no environment)", () => {
+  const input = [
+    { path: "apps/web/lib/foo/new-capability.ts", status: "A" },
+    { path: "packages/db/prisma/schema.prisma", status: "M" },
+  ];
+  assert.equal(JSON.stringify(build(input)), JSON.stringify(build(input)));
+});
+
+test("an empty diff still renders the verification path", () => {
+  const md = formatGateContextMarkdown(build([]));
+  assert.match(md, /No gate-sensitive surfaces detected/);
+  assert.match(md, /pregate:preflight/);
+});
+
+// ── skill-pack hook drift-guards ─────────────────────────────────────────────
+// The hooks keep local mirrors of the canonical constants (deliberate
+// distribution boundary). Pin their BEHAVIOR to the canonical exports.
+
+const SPEC_PROBES = [
+  "apps/web/lib/foo/thing.ts",
+  "apps/web/app/x/page.tsx",
+  "apps/web/app/api/x/route.ts",
+  "packages/db/src/thing.ts",
+  "packages/db/prisma/migrations/20260101000000_z/migration.sql",
+  "apps/web/components/Panel.tsx",
+  "scripts/tool.mjs",
+  "docs/testing/foo.md",
+];
+
+test("spec-plan-doc hook mirror agrees with canonical NEW_SOURCE_FILE_RE on every probe", () => {
+  for (const probe of SPEC_PROBES) {
+    const canonical = NEW_SOURCE_FILE_RE.test(probe) && !UX_EXCLUDE_RE.test(probe);
+    const hook = specPlanDocDecide("Write", { file_path: `${repoRoot}${probe}` }).remind;
+    assert.equal(hook, canonical, `drift on ${probe}: hook=${hook} canonical=${canonical} — update the hook mirror or gate-sensitivity.mjs together`);
+  }
+});
+
+const CONTROL_PROBES = [
+  { text: '<input type="text" />', file: "apps/web/components/A.tsx" },
+  { text: '<select>', file: "apps/web/components/B.tsx" },
+  { text: '<textarea rows={3}>', file: "apps/web/components/C.tsx" },
+  { text: 'type="number"', file: "apps/web/components/D.tsx" },
+  { text: "<form onSubmit={x}>", file: "apps/web/components/E.tsx" },
+  { text: "<div>plain</div>", file: "apps/web/components/F.tsx" },
+];
+
+test("ux-fit hook mirror agrees with canonical UI_CONTROL_RE on every probe", () => {
+  for (const probe of CONTROL_PROBES) {
+    const canonical = UI_CONTROL_RE.test(probe.text);
+    const hook = uxFitDecide("Edit", { file_path: probe.file, new_string: probe.text }).remind;
+    assert.equal(hook, canonical, `drift on ${JSON.stringify(probe.text)}: hook=${hook} canonical=${canonical}`);
+  }
+});
+
+// ── CLI smoke ────────────────────────────────────────────────────────────────
+
+test("gate-context CLI emits valid JSON for the live worktree", () => {
+  const result = spawnSync(process.execPath, [join(repoRoot, "scripts", "gate-context.mjs"), "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const pack = JSON.parse(result.stdout);
+  assert.equal(pack.schemaVersion, 1);
+  assert.ok(Array.isArray(pack.trailers));
+});

--- a/scripts/lib/ci-evidence-plan.mjs
+++ b/scripts/lib/ci-evidence-plan.mjs
@@ -88,7 +88,7 @@ function normalizeRecommendationPaths(value) {
   )).filter(Boolean);
 }
 
-function deriveRoute(path) {
+export function deriveRoute(path) {
   const appPrefix = "apps/web/app/";
   if (!path.startsWith(appPrefix)) return null;
   const relative = path.slice(appPrefix.length);

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -57,6 +57,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/ci-evidence-plan.test.mjs",
         "scripts/ci-policy-guards.test.mjs",
         "scripts/pregate-preflight.test.mjs",
+        "scripts/gate-context.test.mjs",
       ),
     ]),
     guard("mobile-jest-pin-guard", "Mobile Jest Pin Guard", [

--- a/scripts/lib/gate-context.mjs
+++ b/scripts/lib/gate-context.mjs
@@ -1,0 +1,329 @@
+// scripts/lib/gate-context.mjs — the gate-context pack (BI-2677A465).
+//
+// PREVENTION, not detection: CI's gates are discovered reactively — an agent
+// writes code, pushes, and learns about the module-size ratchet, a frozen
+// word budget, a required attestation trailer, or the generated route
+// companions from a red check. The 52h failure taxonomy (2026-07-27 → 29)
+// counted ~90 deterministic guard failures in exactly that class. This module
+// answers, BEFORE generation or push: "given this diff, which gate
+// constraints apply?" — derived from the same registries and checker exports
+// CI runs (never a hand-written prose list that can drift):
+//
+//   - attestation trailers   → scripts/lib/gate-sensitivity.mjs +
+//                              check-design-grounding-decision.mjs +
+//                              check-data-impact.mjs + lib/seed-fit-gate.mjs
+//   - module-size caps       → scripts/module-size-baseline.txt +
+//                              lib/module-size-scope.mjs
+//   - prose/style ratchets   → scripts/prose-lint-baseline.json +
+//                              scripts/style-drift-baseline.json
+//   - derived artifacts      → lib/derived-artifacts-registry.mjs
+//   - route budgets/companions → apps/web/lib/ux-budget/route-budget-baseline.json
+//                              + deriveRoute from lib/ci-evidence-plan.mjs
+//   - migration immutability → the pre-commit guard + migration-safety contract
+//
+// Consumers: the scripts/gate-context.mjs CLI (`pnpm gate:context`) today; an
+// MCP tool and Build Studio prompt assembly in follow-up slices (they must
+// consume THIS module so the pack stays the single source).
+//
+// Determinism contract: output depends only on the input diff and the checked-
+// in registries — no timestamps, no environment probes — so packs are
+// comparable across runs and cacheable by tree.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { classifyChangedFiles } from "../check-design-grounding-decision.mjs";
+import { classifyChangedSurfaces } from "../check-data-impact.mjs";
+import { deriveRoute } from "./ci-evidence-plan.mjs";
+import { affectedEntries } from "./derived-artifacts-registry.mjs";
+import {
+  ADDED_SOURCE_LINE_THRESHOLD,
+  DOC_ARTIFACT_RE,
+  NEW_SOURCE_FILE_RE,
+  SOURCE_LINE_FILE_RE,
+  UX_EXCLUDE_RE,
+  UX_ROUTE_FILE_RE,
+} from "./gate-sensitivity.mjs";
+import { findCanonicalSeedContentPaths } from "./seed-fit-gate.mjs";
+import {
+  MODULE_SIZE_HARD_CAP,
+  MODULE_SIZE_SOFT_CEILING,
+  isModuleSizeSource,
+} from "./module-size-scope.mjs";
+
+export const GATE_CONTEXT_SCHEMA_VERSION = 1;
+
+const MIGRATION_FILE_RE = /^packages\/db\/prisma\/migrations\/[^/]+\/migration\.sql$/;
+const PRISMA_SCHEMA_PATH = "packages/db/prisma/schema.prisma";
+
+function normalize(path) {
+  return String(path ?? "").trim().replace(/\\/g, "/");
+}
+
+function loadJson(repoRoot, relative) {
+  try {
+    return JSON.parse(readFileSync(join(repoRoot, relative), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function loadModuleSizeBaseline(repoRoot) {
+  try {
+    const text = readFileSync(join(repoRoot, "scripts/module-size-baseline.txt"), "utf8");
+    const map = new Map();
+    for (const line of text.split(/\r?\n/)) {
+      const match = line.match(/^(\S+)\t(\d+)$/);
+      if (!match) continue;
+      const cap = Number(match[2]);
+      // The checker resolves duplicate union-merge lines to the max cap.
+      map.set(match[1], Math.max(cap, map.get(match[1]) ?? 0));
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+function trailerConstraints(files, addedLinesByFile) {
+  const trailers = [];
+  const paths = files.map((f) => f.path);
+  const docsTouched = paths.some((p) => DOC_ARTIFACT_RE.test(p));
+
+  const newSubstantial = files.filter(
+    (f) => f.status === "A" && NEW_SOURCE_FILE_RE.test(f.path) && !UX_EXCLUDE_RE.test(f.path),
+  );
+  const addedSourceLines = files
+    .filter((f) => SOURCE_LINE_FILE_RE.test(f.path) && !/\.(test|spec)\.(ts|tsx)$/.test(f.path))
+    .reduce((total, f) => total + (addedLinesByFile?.get?.(f.path) ?? 0), 0);
+  if ((newSubstantial.length > 0 || addedSourceLines > ADDED_SOURCE_LINE_THRESHOLD) && !docsTouched) {
+    trailers.push({
+      gate: "Spec/Plan/Doc",
+      trailer: "Process-Spine-Decision:",
+      level: "required",
+      because: newSubstantial.length > 0
+        ? `new source module(s)/route(s): ${newSubstantial.slice(0, 5).map((f) => f.path).join(", ")}`
+        : `~${addedSourceLines} added source lines exceed the ${ADDED_SOURCE_LINE_THRESHOLD}-line substantial-change threshold`,
+      alternative: "touch the affected doc/spec/plan in the same PR (preferred over the trailer)",
+    });
+  }
+
+  const designSensitive = classifyChangedFiles(paths).designSensitive;
+  if (designSensitive.length > 0) {
+    trailers.push({
+      gate: "Design Grounding",
+      trailer: "Design-Grounding-Decision:",
+      level: "required",
+      because: `design-sensitive file(s): ${designSensitive.slice(0, 5).join(", ")}`,
+      alternative: "a '## Design grounding' section in the PR body (specs/plans reviewed + code substrate reviewed + source of truth + decision)",
+    });
+  }
+
+  const newRoutes = files.filter(
+    (f) => f.status === "A" && UX_ROUTE_FILE_RE.test(f.path) && !UX_EXCLUDE_RE.test(f.path),
+  );
+  const editedUi = files.filter(
+    (f) => /apps\/web\/.*\.tsx$/.test(f.path) && !UX_EXCLUDE_RE.test(f.path),
+  );
+  if (newRoutes.length > 0) {
+    trailers.push({
+      gate: "UX-Fit",
+      trailer: "UX-Fit-Decision:",
+      level: "required",
+      because: `net-new route page(s): ${newRoutes.map((f) => f.path).join(", ")}`,
+    });
+  } else if (editedUi.length > 0) {
+    trailers.push({
+      gate: "UX-Fit",
+      trailer: "UX-Fit-Decision:",
+      level: "conditional",
+      because: "apps/web .tsx changed — required if the diff ADDS a user-facing control (<input>, <select>, <textarea>, type=number|range, <form>)",
+    });
+  }
+
+  const seedPaths = findCanonicalSeedContentPaths(paths);
+  if (seedPaths.length > 0) {
+    trailers.push({
+      gate: "Seed Contribution Fit",
+      trailer: "Seed-Fit-Decision:",
+      level: "required",
+      because: `canonical seed content changed: ${seedPaths.slice(0, 5).join(", ")}`,
+      note: "this one goes in the PR BODY (the gate reads the push-event body, not commit trailers)",
+    });
+  }
+
+  const dataSurfaces = classifyChangedSurfaces(paths);
+  if (dataSurfaces.length > 0) {
+    trailers.push({
+      gate: "Data-Impact",
+      trailer: "Data-Impact manifest",
+      level: "required",
+      because: `persistent data surface(s) changed: ${[...new Set(dataSurfaces.map((s) => s.kind))].join(", ")}`,
+      alternative: "a data-impact manifest (or registered exception) covering migration/backfill/rollback disposition",
+    });
+  }
+
+  return trailers;
+}
+
+export function buildGateContext({
+  changedFiles = [],
+  addedLinesByFile = new Map(),
+  repoRoot = process.cwd(),
+} = {}) {
+  const files = changedFiles
+    .map((f) => (typeof f === "string" ? { path: f, status: "M" } : f))
+    .map((f) => ({ ...f, path: normalize(f.path) }))
+    .filter((f) => f.path);
+  const paths = files.map((f) => f.path);
+
+  // 1. Attestation trailers this diff shape requires.
+  const trailers = trailerConstraints(files, addedLinesByFile);
+
+  // 2. Module-size ratchet: baselined caps for touched files; absolute budget
+  //    for new source files. Baselined files may shrink, never grow.
+  const sizeBaseline = loadModuleSizeBaseline(repoRoot);
+  const moduleSize = [];
+  for (const f of files) {
+    if (f.status === "D") continue;
+    if (sizeBaseline.has(f.path)) {
+      moduleSize.push({ path: f.path, capLines: sizeBaseline.get(f.path), rule: "baselined: may shrink, never grow (guard counts lines its own way — trust the guard, not wc -l)" });
+    } else if (f.status === "A" && isModuleSizeSource(f.path)) {
+      moduleSize.push({ path: f.path, capLines: MODULE_SIZE_SOFT_CEILING, rule: `new module: keep under ${MODULE_SIZE_SOFT_CEILING} lines (hard cap ${MODULE_SIZE_HARD_CAP})` });
+    }
+  }
+
+  // 3. Prose / style shrink-only ratchets for touched files.
+  const proseBaseline = loadJson(repoRoot, "scripts/prose-lint-baseline.json") ?? {};
+  const styleBaseline = loadJson(repoRoot, "scripts/style-drift-baseline.json") ?? {};
+  const ratchets = [];
+  for (const path of paths) {
+    if (proseBaseline[path]) {
+      ratchets.push({ path, ratchet: "prose-lint", frozen: proseBaseline[path], rule: "every axis may shrink, never grow" });
+    }
+    if (styleBaseline[path] !== undefined) {
+      ratchets.push({ path, ratchet: "style-drift", frozen: styleBaseline[path], rule: "hardcoded style tokens may shrink, never grow" });
+    }
+  }
+
+  // 4. Derived artifacts whose sources this diff touches — regenerate and
+  //    commit the artifact in the SAME change (pre-commit stages registered
+  //    ones automatically; route companions are checked by their own audits).
+  const derived = affectedEntries(paths).map((entry) => ({
+    id: entry.id,
+    description: entry.description,
+    artifacts: entry.artifactPaths,
+  }));
+
+  // 5. Routes: net-new pages face absolute budgets + four generated
+  //    companions; pre-existing pages carry a frozen word/structure budget.
+  const budgetBaseline = loadJson(repoRoot, "apps/web/lib/ux-budget/route-budget-baseline.json");
+  const routes = [];
+  for (const f of files) {
+    const route = deriveRoute(f.path);
+    if (!route || UX_EXCLUDE_RE.test(f.path)) continue;
+    const frozen = budgetBaseline?.routes?.[route];
+    if (f.status === "A" && !frozen) {
+      routes.push({
+        route,
+        status: "net-new",
+        rules: [
+          "absolute UX budgets BLOCK (no legacy excuse): shell word/control/field budgets + data-dpf-lead band + owner-first next-action marker",
+          "regenerate the four companions in this change: route-manifest, route-shells, route-audience (apps/web/scripts/build-route-*.ts) and doc-index",
+          "update the hardcoded eligible-route count in apps/web/lib/ux-budget/ux-budget.test.ts",
+        ],
+      });
+    } else if (frozen) {
+      routes.push({
+        route,
+        status: "pre-existing",
+        rules: [
+          `frozen sweep baseline: ≤${frozen.defaultVisibleWords} words visible on arrival; heading/landmark structure must not change shape`,
+          "net word delta ≤ 0 on this route — the merge-group sweep enforces it against the checked-in baseline",
+        ],
+      });
+    }
+  }
+
+  // 6. Migrations: committed migrations are immutable; new ones carry the
+  //    safety-attestation and timestamp contracts.
+  const migrations = [];
+  const editedMigrations = files.filter((f) => f.status !== "A" && f.status !== "D" && MIGRATION_FILE_RE.test(f.path));
+  if (editedMigrations.length > 0) {
+    migrations.push({
+      severity: "blocking",
+      rule: `committed migrations are IMMUTABLE (pre-commit rejects the edit): ${editedMigrations.map((f) => f.path).join(", ")} — author a NEW migration (field-fixes may need an earlier timestamp) instead`,
+    });
+  }
+  if (files.some((f) => f.status === "A" && MIGRATION_FILE_RE.test(f.path))) {
+    migrations.push({
+      severity: "blocking",
+      rule: "new migration: must pass the migration-safety guard (tightening DDL needs an in-file attestation/remediation block) and the timestamp-collision guard (rebump via git mv if a concurrent PR took your timestamp)",
+    });
+  }
+  if (paths.includes(PRISMA_SCHEMA_PATH)) {
+    migrations.push({
+      severity: "advisory",
+      rule: "schema.prisma changed: a new model trips the substrate-complexity baseline (scripts/platform-substrate-baseline.json prismaModelCount) plus the new-Prisma-model gate gauntlet — update only your own baseline line",
+    });
+  }
+
+  return {
+    schemaVersion: GATE_CONTEXT_SCHEMA_VERSION,
+    changedFileCount: files.length,
+    trailers,
+    moduleSize,
+    ratchets,
+    derivedArtifacts: derived,
+    routes,
+    migrations,
+    verification: [
+      "quick host-side guard check before the sandbox gate: pnpm run pregate:preflight (~1 min, no lease)",
+      "runtime-code pushes need a passing exact-tree gate for this branch+SHA: pnpm run pregate",
+      "before merge: pnpm pr:health (and read bot REVIEW findings, not just checks)",
+    ],
+  };
+}
+
+function formatSection(title, lines) {
+  if (lines.length === 0) return [];
+  return [`## ${title}`, ...lines, ""];
+}
+
+export function formatGateContextMarkdown(context) {
+  const out = ["# Gate context — constraints CI will enforce on this diff", ""];
+  out.push(...formatSection(
+    "Required attestations",
+    context.trailers.map((t) =>
+      `- **${t.gate}** (${t.level}): \`${t.trailer}\` — ${t.because}${t.alternative ? `; alternative: ${t.alternative}` : ""}${t.note ? ` (${t.note})` : ""}`,
+    ),
+  ));
+  out.push(...formatSection(
+    "Module-size caps",
+    context.moduleSize.map((m) => `- \`${m.path}\` ≤ ${m.capLines} lines — ${m.rule}`),
+  ));
+  out.push(...formatSection(
+    "Shrink-only ratchets on touched files",
+    context.ratchets.map((r) => `- \`${r.path}\` [${r.ratchet}] frozen at ${JSON.stringify(r.frozen)} — ${r.rule}`),
+  ));
+  out.push(...formatSection(
+    "Derived artifacts to regenerate in this change",
+    context.derivedArtifacts.map((d) => `- **${d.id}**: ${d.artifacts.join(", ")}`),
+  ));
+  out.push(...formatSection(
+    "Route budgets",
+    context.routes.flatMap((r) => [`- \`${r.route}\` (${r.status}):`, ...r.rules.map((rule) => `  - ${rule}`)]),
+  ));
+  out.push(...formatSection(
+    "Migrations",
+    context.migrations.map((m) => `- [${m.severity}] ${m.rule}`),
+  ));
+  out.push(...formatSection("Verification path", context.verification.map((v) => `- ${v}`)));
+  if (
+    context.trailers.length + context.moduleSize.length + context.ratchets.length +
+    context.derivedArtifacts.length + context.routes.length + context.migrations.length === 0
+  ) {
+    out.splice(2, 0, "_No gate-sensitive surfaces detected in this diff — the always-on verification path still applies._", "");
+  }
+  return out.join("\n");
+}

--- a/scripts/lib/gate-sensitivity.mjs
+++ b/scripts/lib/gate-sensitivity.mjs
@@ -1,0 +1,42 @@
+// scripts/lib/gate-sensitivity.mjs — canonical file-sensitivity and
+// attestation constants for the UX-Fit and Spec/Plan/Doc gates (BI-2677A465).
+//
+// These regexes decide WHICH diffs each gate applies to. They used to live as
+// module-private constants inside scripts/check-ux-fit-decision.mjs and
+// scripts/check-spec-plan-doc.mjs, with hand-mirrored copies in the
+// dpf-skill-pack precheck hooks ("Mirrors NEW_SOURCE_FILE_RE in …") — three
+// copies, one drift away from a gate and its warning disagreeing. This module
+// is the single source: the gate checkers import it, the gate-context pack
+// derives prospective constraints from it, and a drift-guard test pins the
+// skill-pack hooks' local mirrors to it (the hooks keep dependency-free copies
+// because the pack is distributed outside this repo).
+
+// ── Spec/Plan/Doc gate (scripts/check-spec-plan-doc.mjs) ─────────────────────
+
+export const PROCESS_SPINE_ATTESTATION_RE = /Process-Spine-Decision:/i;
+
+// What COUNTS as a substantial implementation surface (triggers the gate):
+// NEW source modules and routes are a high-signal, low-false-positive marker
+// of a new capability/contract that deserves a spec/plan/doc touch.
+export const NEW_SOURCE_FILE_RE =
+  /^(apps\/web\/lib\/.*\.(ts|tsx)|apps\/web\/app\/.*\/(page|route)\.(ts|tsx)|packages\/[^/]+\/src\/.*\.(ts|tsx)|packages\/db\/prisma\/migrations\/.*\/migration\.sql)$/;
+
+// A large in-place rewrite of existing source is also substantial even with no
+// new file: added non-test source lines across the diff beyond this threshold.
+export const ADDED_SOURCE_LINE_THRESHOLD = 120;
+export const SOURCE_LINE_FILE_RE = /^(apps\/web|packages\/[^/]+\/src)\/.*\.(ts|tsx)$/;
+
+// What SATISFIES the gate (durable-knowledge artifact touched).
+export const DOC_ARTIFACT_RE =
+  /^(docs\/.*\.(md|html)|AGENTS\.md|.*\/AGENTS\.md|docs\/founder-kernel\/wiki\/principles\/.*\.md|packages\/dpf-skill-pack\/skills\/.*\/SKILL\.md|skills\/.*\.skill\.md)$/;
+
+// ── UX-Fit gate (scripts/check-ux-fit-decision.mjs) ──────────────────────────
+
+export const UX_FIT_ATTESTATION_RE = /UX-Fit-Decision:/i;
+
+// Added lines that introduce a user-facing control the operator must understand.
+export const UI_CONTROL_RE = /<input\b|<select\b|<textarea\b|type=["'](?:number|range)["']|<form\b/i;
+// A newly-added route is a new surface that deserves a fit review.
+export const UX_ROUTE_FILE_RE = /app\/.*\/page\.tsx$/;
+// Test/story scaffolding is never user-facing.
+export const UX_EXCLUDE_RE = /\.(test|spec|stories)\.tsx$/;

--- a/scripts/pregate-preflight.mjs
+++ b/scripts/pregate-preflight.mjs
@@ -67,6 +67,7 @@ export async function main() {
       process.stderr.write(`  - ${entry.name}: ${entry.failedCommand}\n`);
     }
     process.stderr.write(
+      `[pregate-preflight] see every constraint that applies to this diff: pnpm gate:context\n` +
       `[pregate-preflight] emergency skip (recorded honesty, CI still enforces): set ${PREFLIGHT_SKIP_ENV}="<why>"\n`,
     );
     process.exitCode = 1;


### PR DESCRIPTION
## What

`pnpm gate:context` (and `--json`) emits the CI constraints that WILL apply to the current worktree diff — before code is written or pushed: required attestation trailers for the diff shape, module-size caps and new-module budgets, shrink-only prose/style ratchet values, derived artifacts to regenerate, route budgets (net-new absolutes + four-companion checklist; pre-existing frozen word budgets), and migration immutability/safety contracts. Everything derives from the same registries and checker exports CI enforces — never a hand-written list that can drift. Deterministic by construction (no timestamps, no environment probes).

## Why

CI gates are discovered reactively; the 52h failure taxonomy (2026-07-27→29) counted ~90 deterministic guard failures that were knowable before push. BI-D35433FB (merged #3732) moved detection to pre-push seconds; this PR moves the constraint before generation — the prevention bet AppFaktors' Architecture Context Engine validates commercially. Plan: `docs/superpowers/plans/2026-07-29-gate-context-pack-plan.md` (coverage receipt cms6sdpei06fg01ogjis8acqw, decomposed).

## Single-source consolidation (and a real drift caught)

The UX-Fit and Spec/Plan/Doc gates' file-sensitivity constants hoist into `scripts/lib/gate-sensitivity.mjs`; the checkers import them (zero behavior change). New drift-guard tests pin the dpf-skill-pack precheck hooks' dependency-free mirrors to the canonical exports — and their **first run caught a live drift**: the spec-plan-doc hook was missing the gate's migration-file alternative, so new-migration authors never got the nudge the CI gate enforced. Fixed here.

## Design grounding

- Existing specs/plans reviewed: this slice's plan; `2026-07-26-ci-evidence-efficiency-design.md` (architecture template).
- Current code substrate reviewed: `scripts/pr-readiness/core.mjs` (executes gates after the fact — the back half), `scripts/lib/ci-evidence-plan.mjs` + `ci-policy-guards.mjs` (POLICY_GUARD_PROFILES inventory), the checker regexes and skill-pack hooks (hand-mirrored constants), `apps/web/lib/ux-budget/route-budget-baseline.json` (read-only consumption).
- Source of truth: checker exports + checked-in baselines; `gate-sensitivity.mjs` becomes the canonical constant home.
- Decision: extend the checkers with a shared module + prospective generator; no gate behavior change; hooks stay dependency-free with drift-guard-pinned mirrors.

## Verification

- 15 new tests (`scripts/gate-context.test.mjs`, registered in the Policy Guards source profile) + 17 existing hook tests green.
- Dogfooded on itself: the guard preflight blocked this branch's first pregate on a genuinely missing Design-Grounding attestation — which `pnpm gate:context` had predicted for this exact diff — with no sandbox lease consumed.
- Full exact-tree pregate passed at head `a271200e64` (freshness, migrations, guards, full web Vitest, typecheck, production Docker build).

## Follow-up slices (mapped in the coverage receipt)

- BI-121DC3A3 — Build Studio `BuildContext.gateContext` prompt section + `get_change_gate_context` MCP tool.
- BI-9652021C — pr-readiness derives its gate plan from POLICY_GUARD_PROFILES and leads its report with the pack.

Seed-Fit-Decision: not-applicable — no seed, fixture, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)