### PR TITLE
fix(attention): remove the no-op "Review this decision" button and retire dead build decision residue (BI-90B6D8C5, BI-FE034C1E)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
@@ -11,6 +11,7 @@ import { StatusBadge } from "@/components/ui/report-kit";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { TIER_LABELS, tierForRow } from "@/lib/wiki/decision-audit";
 import { buildDecisionHelp } from "@/lib/wiki/decision-help";
+import { isWithdrawnHumanOutcome } from "@/lib/quality/decision-residue-staleness";
 
 export const dynamic = "force-dynamic";
 
@@ -251,6 +252,7 @@ export default async function DecisionRecordPage({ params }: { params: Params })
               insufficientSignal,
               hasBuild: Boolean(row.buildId),
               resolved: row.humanOutcome !== null,
+              withdrawn: isWithdrawnHumanOutcome(row.humanOutcome),
             });
             const needsAction = help.steps.length > 0;
             return (

--- a/apps/web/app/(shell)/workspace/inbox/page.tsx
+++ b/apps/web/app/(shell)/workspace/inbox/page.tsx
@@ -2,8 +2,10 @@
 // EP-ATTENTION-SURFACE keystone (BI-D39484E7). A workspace-section sibling, so no
 // cross-rail teleport (EP-NAV-COHERENCE). Spec §6.
 import { prisma } from "@dpf/db";
+import { cookies } from "next/headers";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import { NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 import { loadAttentionItems, filterAttentionForAudience } from "@/lib/attention/aggregate";
 import { buildOwnerAttentionProjection } from "@/lib/attention/owner-projection";
 import { buildWeeklyDigest } from "@/lib/attention/weekly-digest";
@@ -28,9 +30,14 @@ export default async function WorkspaceInboxPage() {
   // V1 operator-view; worker scoping (own approvals only) is BI-AS-4.
   const visible = filterAttentionForAudience(items, { operator: true });
   const nowMs = Date.now();
+  // Simple/Full decides whether a card's real action can be its own button: in
+  // Full the reader asked to see builder and platform tools, so a builder-rail
+  // action IS the honest primary action (BI-90B6D8C5).
+  const audience = resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value);
   const projection = buildOwnerAttentionProjection(visible, {
     fallbackLevel: "balanced",
     nowMs,
+    audience: audience === "worker" ? "worker" : "operator",
   });
   const digest = buildWeeklyDigest(projection.weeklyDigest, nowMs);
   const digestDisposition =

--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -74,7 +74,10 @@ export default async function WorkspacePage() {
   const cockpit = (
     <>
       <WorkspaceStorefrontAttention density={simpleHome ? "simple" : "full"} />
-      <OperatorCockpit userId={session.user.id} />
+      <OperatorCockpit
+        userId={session.user.id}
+        audience={simpleHome ? "worker" : "operator"}
+      />
     </>
   );
 

--- a/apps/web/components/attention/OwnerDecisionCards.tsx
+++ b/apps/web/components/attention/OwnerDecisionCards.tsx
@@ -127,6 +127,14 @@ function DecisionActions({ entry }: { entry: OwnerAttentionEntry }) {
       />
     );
   }
+  // Nothing this reader can act on. Say so in words — the old fallback rendered a
+  // button that linked back to this same page and could only no-op (BI-90B6D8C5).
+  if (entry.card.choices.length === 0) {
+    return entry.card.handoff ? (
+      <p className="text-xs leading-relaxed text-[var(--dpf-muted)]">{entry.card.handoff}</p>
+    ) : null;
+  }
+
   return (
     <div className="flex flex-wrap gap-2">
       {entry.card.choices.map((choice, index) => (

--- a/apps/web/components/attention/WeeklyDigestPanel.test.tsx
+++ b/apps/web/components/attention/WeeklyDigestPanel.test.tsx
@@ -55,8 +55,8 @@ const entry = {
     choices: [
       {
         kind: "open-in-context",
-        label: "Review",
-        href: "/workspace/inbox?attentionId=research-proposal%3A1",
+        label: "Review proposal",
+        href: "/admin/research",
       },
     ],
     tags: [{ label: "Reversible", kind: "reversible" }],

--- a/apps/web/components/workspace-home/OperatorCockpit.tsx
+++ b/apps/web/components/workspace-home/OperatorCockpit.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@dpf/db";
 
 import { loadAttentionItems, filterAttentionForAudience } from "@/lib/attention/aggregate";
 import { buildOwnerAttentionProjection, type OwnerAttentionProjection } from "@/lib/attention/owner-projection";
+import type { OwnerDecisionAudience } from "@/lib/attention/owner-decision";
 import type { AttentionSource } from "@/lib/attention/types";
 import { OwnerDecisionCards } from "@/components/attention/OwnerDecisionCards";
 import {
@@ -84,7 +85,14 @@ export function OperatorCockpitView({
   );
 }
 
-export async function OperatorCockpit({ userId }: { userId?: string }) {
+export async function OperatorCockpit({
+  userId,
+  audience = "operator",
+}: {
+  userId?: string;
+  /** Simple/Full rail mode — see OwnerDecisionAudience (BI-90B6D8C5). */
+  audience?: OwnerDecisionAudience;
+}) {
   const { items, failedSources } = await loadAttentionItems(prisma, {
     aiReadinessUserId: userId,
   });
@@ -92,6 +100,7 @@ export async function OperatorCockpit({ userId }: { userId?: string }) {
   const projection = buildOwnerAttentionProjection(visible, {
     fallbackLevel: "balanced",
     nowMs: Date.now(),
+    audience,
   });
   return <OperatorCockpitView projection={projection} failedSources={failedSources} />;
 }

--- a/apps/web/lib/attention/owner-decision.test.ts
+++ b/apps/web/lib/attention/owner-decision.test.ts
@@ -87,7 +87,34 @@ describe("translateAttentionToOwnerDecision", () => {
     expect(card.technical.builderActions).toContainEqual(
       expect.objectContaining({ label: "Open in Operations", href: "/ops" }),
     );
-    expect(card.choices).not.toContainEqual(expect.objectContaining({ href: "/build?buildId=FB-VOICE-16" }));
+  });
+
+  it("keeps a builder route out of Simple-view owner buttons", () => {
+    const card = translateAttentionToOwnerDecision(
+      item(),
+      Date.parse("2026-07-17T18:00:00Z"),
+      "worker",
+    );
+
+    expect(card.choices).toEqual([]);
+    expect(card.technical.builderActions).toContainEqual(
+      expect.objectContaining({ href: "/build?buildId=FB-VOICE-16" }),
+    );
+  });
+
+  it("makes the builder route the primary action in Full view", () => {
+    // Full view says "showing everything, including builder and platform tools",
+    // so routing the reader to the surface that holds the record is honest.
+    const card = translateAttentionToOwnerDecision(
+      item(),
+      Date.parse("2026-07-17T18:00:00Z"),
+      "operator",
+    );
+
+    expect(card.choices).toContainEqual(
+      expect.objectContaining({ href: "/build?buildId=FB-VOICE-16" }),
+    );
+    expect(card.handoff).toBeUndefined();
   });
 
   it.each<{
@@ -139,7 +166,7 @@ describe("translateAttentionToOwnerDecision", () => {
     expect(card.technical.fields).toContainEqual({ label: "Original title", value: raw });
   });
 
-  it("keeps builder, platform, and admin routes below technical detail", () => {
+  it("keeps builder, platform, and admin routes below technical detail in Simple view", () => {
     const card = translateAttentionToOwnerDecision(
       item({
         id: "research-proposal:1",
@@ -148,13 +175,122 @@ describe("translateAttentionToOwnerDecision", () => {
         deepLink: "/admin/research",
       }),
       Date.now(),
+      "worker",
     );
 
-    expect(card.choices.map((choice) => choice.href)).toEqual([
-      "/workspace/inbox?attentionId=research-proposal%3A1",
-    ]);
+    // No owner button at all — and specifically NOT the old self-link fallback,
+    // which pointed at the page the card renders on and never did anything.
+    expect(card.choices).toEqual([]);
+    expect(card.handoff).toMatch(/technical detail/i);
     expect(card.technical.builderActions).toContainEqual(
       expect.objectContaining({ label: "Review proposal", href: "/admin/research" }),
+    );
+  });
+
+  it("never offers a choice that links back to the surface the card renders on", () => {
+    // The BI-90B6D8C5 regression guard, held for EVERY source and both views: the
+    // old fallback was `/workspace/inbox?attentionId=<id>` on a card rendered at
+    // /workspace/inbox, with no reader for the param anywhere — a guaranteed no-op.
+    const sources: AttentionSource[] = [
+      "escalation",
+      "ai-decision",
+      "business-journey",
+      "paused-ai",
+      "scheduled-task",
+      "agent-proposal",
+      "approval-outbound",
+      "approval-bill",
+      "approval-expense",
+      "compliance-submission",
+      "research-proposal",
+      "coworker-memory",
+      "ai-readiness-blocker",
+      "platform-health",
+      "provider-credential",
+      "reservation-exception",
+      "storefront-inquiry",
+    ];
+    const builderRailHrefs = [
+      "/platform/ai/decisions/DI-1",
+      "/ops/journeys?journey=storefront-booking",
+      "/build?buildId=FB-1",
+      "/admin/research",
+    ];
+
+    for (const source of sources) {
+      for (const href of builderRailHrefs) {
+        for (const audience of ["worker", "operator"] as const) {
+          const card = translateAttentionToOwnerDecision(
+            item({
+              id: `${source}:no-op-guard`,
+              source,
+              actions: [{ kind: "open-in-context", label: "Open record", href }],
+              deepLink: href,
+            }),
+            Date.parse("2026-07-29T12:00:00Z"),
+            audience,
+          );
+
+          for (const choice of card.choices) {
+            expect(choice.href).not.toMatch(/^\/workspace\/inbox\b/);
+            expect(choice.href).not.toMatch(/\battentionId=/);
+          }
+          // A card with no button always explains itself instead.
+          if (card.choices.length === 0) expect(card.handoff).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  it("names the build in the handoff when the blast radius carries one", () => {
+    const card = translateAttentionToOwnerDecision(
+      item({
+        source: "ai-decision",
+        actions: [{ kind: "open-in-context", label: "Review evidence", href: "/platform/ai/decisions/DI-1" }],
+        deepLink: "/platform/ai/decisions/DI-1",
+        triage: {
+          timeToAct: "none",
+          residueReason: "high-risk-gate",
+          blastRadius: "build FB-1DB2A3B5",
+          decideEffort: "judgment",
+          irreversible: false,
+        },
+      }),
+      Date.parse("2026-07-29T12:00:00Z"),
+      "worker",
+    );
+
+    expect(card.handoff).toMatch(/build record/i);
+    // The raw id stays below the fold, never in owner copy.
+    expect(card.handoff).not.toMatch(/FB-1DB2A3B5/);
+  });
+
+  it("recovers the feature build id from the blast radius when the deep link has no query", () => {
+    // An ai-decision deep link is /platform/ai/decisions/DI-… with no buildId
+    // param, so query-only parsing reported "Not attached" on a card whose own
+    // consequence line named the build (BI-90B6D8C5).
+    const card = translateAttentionToOwnerDecision(
+      item({
+        source: "ai-decision",
+        actions: [{ kind: "open-in-context", label: "Review evidence", href: "/platform/ai/decisions/DI-1" }],
+        deepLink: "/platform/ai/decisions/DI-1",
+        triage: {
+          timeToAct: "none",
+          residueReason: "high-risk-gate",
+          blastRadius: "build FB-1DB2A3B5",
+          decideEffort: "judgment",
+          irreversible: false,
+        },
+      }),
+      Date.parse("2026-07-29T12:00:00Z"),
+    );
+    const details = Object.fromEntries(
+      card.technical.fields.map((field) => [field.label, field.value]),
+    );
+
+    expect(details["Feature build"]).toBe("FB-1DB2A3B5");
+    expect(card.technical.builderActions).toContainEqual(
+      expect.objectContaining({ label: "Resume build", href: "/build?buildId=FB-1DB2A3B5" }),
     );
   });
 

--- a/apps/web/lib/attention/owner-decision.ts
+++ b/apps/web/lib/attention/owner-decision.ts
@@ -19,6 +19,16 @@ export type OwnerDecisionChoice = AttentionAction & { href: string };
 
 export type OwnerTechnicalField = { label: string; value: string };
 
+/**
+ * Which rails the reader has asked to see. Mirrors the Simple/Full rail toggle
+ * (lib/navigation/nav-mode.ts): `worker` is Simple — builder and platform tools
+ * are hidden, so an owner button must never lead there. `operator` is Full —
+ * "showing everything, including builder and platform tools" — so the real
+ * builder-rail action IS the honest primary action rather than something to hide
+ * behind a disclosure (BI-90B6D8C5).
+ */
+export type OwnerDecisionAudience = "worker" | "operator";
+
 export type OwnerDecisionCard = {
   id: string;
   source: AttentionSource;
@@ -43,6 +53,16 @@ export type OwnerDecisionCard = {
    *  has no single AI author. */
   byline?: string;
   choices: OwnerDecisionChoice[];
+  /**
+   * Plain-language "who owns this and where it lives", set ONLY when the item has
+   * no action this reader can act on. Replaces the old dead fallback button
+   * (BI-90B6D8C5): that button pointed at `/workspace/inbox?attentionId=…`, i.e.
+   * the page it was rendered on, and nothing ever read the param — so clicking it
+   * did nothing at all. An honest sentence beats a button that lies. When this is
+   * set, `choices` is empty; the real record still hangs off
+   * `technical.builderActions` below.
+   */
+  handoff?: string;
   tags: OwnerDecisionTag[];
   technical: {
     fields: OwnerTechnicalField[];
@@ -53,7 +73,9 @@ export type OwnerDecisionCard = {
 export function translateAttentionToOwnerDecision(
   item: AttentionItem,
   nowMs: number,
+  audience: OwnerDecisionAudience = "operator",
 ): OwnerDecisionCard {
+  const choices = ownerChoices(item, audience);
   return {
     id: item.id,
     source: item.source,
@@ -67,7 +89,8 @@ export function translateAttentionToOwnerDecision(
       specialistByline: specialistFor(item.source),
     },
     ...(item.author ? { byline: formatAttentionByline(item.author) } : {}),
-    choices: ownerChoices(item),
+    choices,
+    ...(choices.length === 0 ? { handoff: handoffFor(item) } : {}),
     tags: tagsFor(item, nowMs),
     technical: {
       fields: technicalFields(item),
@@ -76,23 +99,56 @@ export function translateAttentionToOwnerDecision(
   };
 }
 
-function ownerChoices(item: AttentionItem): OwnerDecisionChoice[] {
+function ownerChoices(
+  item: AttentionItem,
+  audience: OwnerDecisionAudience,
+): OwnerDecisionChoice[] {
   const linked = item.actions.filter(
     (action): action is OwnerDecisionChoice =>
-      typeof action.href === "string" && isOwnerSafeHref(action.href),
+      typeof action.href === "string" && isActionableHref(action.href, audience),
   );
-  if (linked.length > 0) return linked.slice(0, 3).map(withPlainChoiceLabel);
-  return [
-    {
-      kind: "open-in-context",
-      label: "Review this decision",
-      href: `/workspace/inbox?attentionId=${encodeURIComponent(item.id)}`,
-    },
-  ];
+  // No usable action → no button. The old fallback linked back to this very page
+  // with an `?attentionId=` param nothing reads, so it could only ever no-op;
+  // `handoff` explains the situation in words instead (BI-90B6D8C5).
+  return linked.slice(0, 3).map(withPlainChoiceLabel);
+}
+
+/**
+ * Can THIS reader act on this href?
+ *
+ * Any in-app route qualifies in Full/`operator` mode — the reader has explicitly
+ * asked to see builder and platform tools, so routing them to the surface that
+ * actually holds the record is the honest answer, not a hidden one. Simple/
+ * `worker` mode keeps the builder rails out of owner buttons (EP-NAV-COHERENCE:
+ * no cross-rail teleport for the non-technical persona).
+ */
+function isActionableHref(href: string, audience: OwnerDecisionAudience): boolean {
+  if (!href.startsWith("/")) return false;
+  // Never route the reader at the inbox itself. That is the defect this replaced:
+  // a card rendered on /workspace/inbox whose button pointed back at
+  // /workspace/inbox could not do anything, whatever query it carried. Enforced
+  // here so no future source can reintroduce it (BI-90B6D8C5).
+  if (/^\/workspace\/inbox(?:\/|\?|#|$)/i.test(href)) return false;
+  if (audience === "operator") return true;
+  return isOwnerSafeHref(href);
 }
 
 function isOwnerSafeHref(href: string): boolean {
   return href.startsWith("/") && !/^\/(?:ops|build|admin|platform)(?:\/|\?|#|$)/i.test(href);
+}
+
+/**
+ * Plain-language explanation for a card with nothing this reader can click.
+ *
+ * Names the surface that owns the record without naming a route (the owner copy
+ * contract bans raw technical strings above technical detail — owner-decision.test.ts).
+ */
+function handoffFor(item: AttentionItem): string {
+  const blast = item.triage.blastRadius;
+  if (blast && /\bFB-[A-Z0-9-]+\b/i.test(blast)) {
+    return "Your digital team holds this one — the build record is under technical detail below.";
+  }
+  return "Your digital team holds this one — the original record is under technical detail below.";
 }
 
 function withPlainChoiceLabel(action: OwnerDecisionChoice): OwnerDecisionChoice {

--- a/apps/web/lib/attention/owner-projection.ts
+++ b/apps/web/lib/attention/owner-projection.ts
@@ -1,5 +1,9 @@
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
-import { translateAttentionToOwnerDecision, type OwnerDecisionCard } from "./owner-decision";
+import {
+  translateAttentionToOwnerDecision,
+  type OwnerDecisionAudience,
+  type OwnerDecisionCard,
+} from "./owner-decision";
 import {
   classifyOwnerAttentionLane,
   type OwnerAttentionLaneDecision,
@@ -23,9 +27,19 @@ export type OwnerAttentionProjection = {
 
 export function buildOwnerAttentionProjection(
   items: AttentionItem[],
-  options: { fallbackLevel?: ProactivityLevel; nowMs: number },
+  options: {
+    fallbackLevel?: ProactivityLevel;
+    nowMs: number;
+    /**
+     * Which rails the reader asked to see (Simple/Full toggle). Decides whether a
+     * builder-rail action can be an owner button; defaults to `operator` (Full),
+     * matching resolveNavModeFromCookie's own default.
+     */
+    audience?: OwnerDecisionAudience;
+  },
 ): OwnerAttentionProjection {
   const fallbackLevel = options.fallbackLevel ?? "balanced";
+  const audience = options.audience ?? "operator";
   const needsYouNow: OwnerAttentionEntry[] = [];
   const weeklyDigest: OwnerAttentionEntry[] = [];
   const custodian: OwnerAttentionEntry[] = [];
@@ -35,7 +49,7 @@ export function buildOwnerAttentionProjection(
     const entry = {
       item,
       routing,
-      card: translateAttentionToOwnerDecision(item, options.nowMs),
+      card: translateAttentionToOwnerDecision(item, options.nowMs, audience),
     };
     if (routing.lane === "needs-you-now") needsYouNow.push(entry);
     else if (routing.lane === "weekly-digest") weeklyDigest.push(entry);

--- a/apps/web/lib/attention/owner-technical-detail.ts
+++ b/apps/web/lib/attention/owner-technical-detail.ts
@@ -8,10 +8,7 @@ export function technicalFields(item: AttentionItem): OwnerTechnicalField[] {
   const backlogItemId =
     item.technical?.backlogItemId ??
     (item.triage.blastRadius?.match(/\bBI-[A-Z0-9-]+\b/i)?.[0] ?? "Not attached");
-  const featureBuildId =
-    item.technical?.featureBuildId ??
-    readQueryId(item.deepLink, "buildId", /\bFB-[A-Z0-9-]+\b/i) ??
-    "Not attached";
+  const featureBuildId = item.technical?.featureBuildId ?? readFeatureBuildId(item) ?? "Not attached";
   return [
     { label: "Original title", value: item.title },
     { label: "Source", value: item.source },
@@ -35,9 +32,7 @@ export function technicalFields(item: AttentionItem): OwnerTechnicalField[] {
 export function builderActions(item: AttentionItem): OwnerDecisionChoice[] {
   const backlogItemId =
     item.technical?.backlogItemId ?? item.triage.blastRadius?.match(/\bBI-[A-Z0-9-]+\b/i)?.[0];
-  const featureBuildId =
-    item.technical?.featureBuildId ??
-    readQueryId(item.deepLink, "buildId", /\bFB-[A-Z0-9-]+\b/i);
+  const featureBuildId = item.technical?.featureBuildId ?? readFeatureBuildId(item);
   const actions: OwnerDecisionChoice[] = [
     { kind: "open-in-context", label: "Open in Operations", href: "/ops" },
   ];
@@ -60,6 +55,26 @@ export function builderActions(item: AttentionItem): OwnerDecisionChoice[] {
     actions.push({ ...action, href: action.href });
   }
   return actions;
+}
+
+const FEATURE_BUILD_PATTERN = /\bFB-[A-Z0-9-]+\b/i;
+
+/**
+ * The feature build this item is about, from the deep link's `buildId` query
+ * param OR from the blast radius prose.
+ *
+ * The blast-radius fallback matters (BI-90B6D8C5): an `ai-decision` item's deep
+ * link is `/platform/ai/decisions/DI-…` with no query string, so query-only
+ * parsing reported "Not attached" for cards whose own consequence line reads
+ * "build FB-1DB2A3B5 stays blocked" — and suppressed the `Resume build` action
+ * that is the one route to the surface where the gate can actually be answered.
+ */
+function readFeatureBuildId(item: AttentionItem): string | null {
+  return (
+    readQueryId(item.deepLink, "buildId", FEATURE_BUILD_PATTERN)
+    ?? item.triage.blastRadius?.match(FEATURE_BUILD_PATTERN)?.[0]
+    ?? null
+  );
 }
 
 function readQueryId(href: string, key: string, pattern: RegExp): string | null {

--- a/apps/web/lib/quality/decision-residue-staleness.test.ts
+++ b/apps/web/lib/quality/decision-residue-staleness.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWithdrawnHumanOutcome,
+  isWithdrawnHumanOutcome,
+  selectWithdrawableDecisions,
+  SYSTEM_WITHDRAWAL_RESOLVER,
+  type DecisionResidueRow,
+} from "./decision-residue-staleness";
+
+function row(overrides: Partial<DecisionResidueRow> = {}): DecisionResidueRow {
+  return {
+    interactionId: "DI-TEST000001",
+    outcomeType: "escalate",
+    buildId: "FB-TEST0001",
+    buildPhase: "ideate",
+    buildSupersededByEpicId: null,
+    backlogItemStatus: "in-progress",
+    backlogItemTriageOutcome: "build",
+    ...overrides,
+  };
+}
+
+describe("selectWithdrawableDecisions", () => {
+  it("withdraws residue whose build was abandoned — the BI-FE034C1E case", () => {
+    // The live reproduction: DI-58465A1C784B escalated on FB-1DB2A3B5, which was
+    // then abandoned. The card kept claiming the build "stays blocked".
+    const result = selectWithdrawableDecisions([
+      row({ interactionId: "DI-58465A1C784B", buildId: "FB-1DB2A3B5", buildPhase: "abandoned" }),
+    ]);
+
+    expect(result).toEqual([
+      { interactionId: "DI-58465A1C784B", reason: "originating-build-abandoned" },
+    ]);
+  });
+
+  it("keeps residue whose build is still in flight", () => {
+    for (const phase of ["ideate", "plan", "build", "review", "ship"]) {
+      expect(selectWithdrawableDecisions([row({ buildPhase: phase })])).toEqual([]);
+    }
+  });
+
+  it("keeps residue for a panicked build — a live, recoverable stall", () => {
+    expect(selectWithdrawableDecisions([row({ buildPhase: "panicked" })])).toEqual([]);
+  });
+
+  it("withdraws residue whose build shipped or died", () => {
+    expect(selectWithdrawableDecisions([row({ buildPhase: "complete" })])).toEqual([
+      { interactionId: "DI-TEST000001", reason: "originating-build-finished" },
+    ]);
+    expect(selectWithdrawableDecisions([row({ buildPhase: "failed" })])).toEqual([
+      { interactionId: "DI-TEST000001", reason: "originating-build-finished" },
+    ]);
+  });
+
+  it("withdraws residue whose build was superseded by an approved decompose", () => {
+    expect(
+      selectWithdrawableDecisions([row({ buildSupersededByEpicId: "EP-TEST0001" })]),
+    ).toEqual([{ interactionId: "DI-TEST000001", reason: "build-superseded-by-epic" }]);
+  });
+
+  it("withdraws residue on a live build whose originating item shipped", () => {
+    expect(selectWithdrawableDecisions([row({ backlogItemStatus: "done" })])).toEqual([
+      { interactionId: "DI-TEST000001", reason: "originating-item-done" },
+    ]);
+  });
+
+  it("withdraws residue whose originating item will not be done", () => {
+    for (const triageOutcome of ["discard", "duplicate"]) {
+      expect(
+        selectWithdrawableDecisions([row({ backlogItemTriageOutcome: triageOutcome })]),
+      ).toEqual([{ interactionId: "DI-TEST000001", reason: "originating-item-wont-do" }]);
+    }
+  });
+
+  it("keeps residue for an item deferred but still wanted", () => {
+    // `deferred` spans parked-and-wanted vs discarded, so staleness must key off
+    // triageOutcome — same rule as escalation-staleness.ts.
+    expect(
+      selectWithdrawableDecisions([
+        row({ backlogItemStatus: "deferred", backlogItemTriageOutcome: "build" }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("never withdraws a decision that is not build-linked", () => {
+    // Org-business and profession gate rows are answered by a human at
+    // /coworker-decisions/review; the sweep must not touch them even when the
+    // joined build fields would otherwise look terminal.
+    expect(
+      selectWithdrawableDecisions([
+        row({ buildId: null, buildPhase: "abandoned", backlogItemStatus: "done" }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("sweeps a mixed batch, withdrawing only the provably dead rows", () => {
+    const result = selectWithdrawableDecisions([
+      row({ interactionId: "DI-DEAD000001", buildPhase: "abandoned" }),
+      row({ interactionId: "DI-LIVE000001", buildPhase: "build" }),
+      row({ interactionId: "DI-ORG0000001", buildId: null }),
+      row({ interactionId: "DI-DEAD000002", buildPhase: "complete" }),
+    ]);
+
+    expect(result.map((r) => r.interactionId)).toEqual(["DI-DEAD000001", "DI-DEAD000002"]);
+  });
+
+  it("returns nothing for an empty batch", () => {
+    expect(selectWithdrawableDecisions([])).toEqual([]);
+  });
+});
+
+describe("buildWithdrawnHumanOutcome", () => {
+  const outcome = buildWithdrawnHumanOutcome({
+    reason: "originating-build-abandoned",
+    withdrawnAtIso: "2026-07-29T15:00:00.000Z",
+  });
+
+  it("never clears the gate", () => {
+    // Paired with writing no EscalationCapture, this keeps
+    // interactionWasCleared() (decision-perspective/persistence.ts) false.
+    expect(outcome.clearsGate).toBe(false);
+  });
+
+  it("never becomes candidate decision material", () => {
+    expect(outcome.candidateMaterial).toBe(false);
+  });
+
+  it("attributes the write to the sweep, not a person", () => {
+    expect(outcome.resolvedBy).toBe(SYSTEM_WITHDRAWAL_RESOLVER);
+    expect(outcome.resolverUserId).toBeNull();
+  });
+
+  it("carries no answer or rationale — nobody answered", () => {
+    expect(outcome).not.toHaveProperty("answer");
+    expect(outcome).not.toHaveProperty("rationale");
+  });
+
+  it("does not set chosenOptionId, so weight inference never reads it as a pick", () => {
+    // weight-inference-adapter.ts selects on chosenOptionId NOT NULL.
+    expect(outcome).not.toHaveProperty("chosenOptionId");
+  });
+
+  it("records the machine reason and timestamp", () => {
+    expect(outcome.reason).toBe("originating-build-abandoned");
+    expect(outcome.capturedAt).toBe("2026-07-29T15:00:00.000Z");
+  });
+});
+
+describe("isWithdrawnHumanOutcome", () => {
+  it("recognizes a withdrawal written by the sweep", () => {
+    expect(
+      isWithdrawnHumanOutcome(
+        buildWithdrawnHumanOutcome({
+          reason: "originating-build-finished",
+          withdrawnAtIso: "2026-07-29T15:00:00.000Z",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat a human capture as a withdrawal", () => {
+    expect(
+      isWithdrawnHumanOutcome({
+        type: "escalation",
+        answer: "Ship it.",
+        resolverUserId: "user_1",
+        clearsGate: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not accept a withdrawal-shaped payload from another writer", () => {
+    // The resolver marker is what makes the claim trustworthy, not the type alone.
+    expect(isWithdrawnHumanOutcome({ type: "withdrawn" })).toBe(false);
+    expect(
+      isWithdrawnHumanOutcome({ type: "withdrawn", resolvedBy: "user_1" }),
+    ).toBe(false);
+  });
+
+  it("is safe on null, primitives, and arrays", () => {
+    expect(isWithdrawnHumanOutcome(null)).toBe(false);
+    expect(isWithdrawnHumanOutcome(undefined)).toBe(false);
+    expect(isWithdrawnHumanOutcome("withdrawn")).toBe(false);
+    expect(isWithdrawnHumanOutcome([{ type: "withdrawn" }])).toBe(false);
+  });
+});

--- a/apps/web/lib/quality/decision-residue-staleness.ts
+++ b/apps/web/lib/quality/decision-residue-staleness.ts
@@ -1,0 +1,180 @@
+// Auto-withdraw stale build-linked decision residue (BI-FE034C1E, EP-ATTENTION-SURFACE).
+//
+// A Build Studio gate writes a DecisionInteraction with outcomeType
+// escalate/defer and humanOutcome null. Abandoning (or finishing) the build
+// never touches that row, so it stays unresolved forever and
+// sources/ai-decision.ts keeps projecting it into "Needs you" — where
+// owner-routing hard-routes high-risk-gate residue to needs-you-now. The card
+// then tells the owner "build FB-XXXXXXXX stays blocked" about a build that
+// died hours ago: a false consequence AND an inflated count.
+//
+// This is the same CREATE-path-without-CLEAR-path gap escalation-staleness.ts
+// closed for PlatformIssueReport rows (BI-467E8F8D), recurring on a different
+// table. The cure is deliberately the same shape, so the two sweeps read alike.
+//
+// PURE: given joined rows (the interaction + its build's phase/supersede marker
+// + the originating BacklogItem's status/triageOutcome), decide which to
+// withdraw and why. The DB read/write lives in escalation-hygiene-runner.ts so
+// this stays trivially unit-testable.
+//
+// NOT a human ruling. A withdrawal records that the QUESTION evaporated, not
+// that anyone answered it — see buildWithdrawnHumanOutcome. It must never clear
+// a gate, become candidate decision material, or count as a resolution on the
+// audit surface (decision-audit.ts reads `resolvedBy` to tell the two apart).
+
+/**
+ * Originating-item triage outcomes that mean the work will NOT be done. Mirrors
+ * escalation-staleness.ts: a `deferred` status spans both "parked, still wanted"
+ * and "discarded", so staleness keys off triageOutcome, not status alone.
+ */
+const WONT_DO_TRIAGE_OUTCOMES = new Set(["discard", "duplicate"]);
+
+/**
+ * Build phases that end the build's life. `abandoned` is the case that produced
+ * this BI; `complete`/`failed` are included because a plan-readiness gate whose
+ * build already shipped or died is equally moot — a re-attempt writes a NEW
+ * interaction rather than reviving this one. Phases still in flight
+ * (ideate/plan/build/review/ship) and `panicked` (a live, recoverable stall) are
+ * deliberately absent: those rows stay in the queue.
+ */
+const FINISHED_BUILD_PHASES = new Set(["complete", "failed"]);
+
+export interface DecisionResidueRow {
+  /** DecisionInteraction.interactionId (semantic DI-* id). */
+  interactionId: string;
+  /** escalate | defer — the unresolved residue outcomes. */
+  outcomeType: string;
+  /** FeatureBuild.buildId this decision gated, or null when not build-linked. */
+  buildId: string | null;
+  /** FeatureBuild.phase, or null when unlinked / build row missing. */
+  buildPhase: string | null;
+  /** FeatureBuild.supersededByEpicId — set when a decompose was approved. */
+  buildSupersededByEpicId: string | null;
+  /** Originating BacklogItem.status, or null if unlinked/missing. */
+  backlogItemStatus: string | null;
+  /** Originating BacklogItem.triageOutcome, or null. */
+  backlogItemTriageOutcome: string | null;
+}
+
+export type DecisionWithdrawalReason =
+  | "build-superseded-by-epic"
+  | "originating-build-abandoned"
+  | "originating-build-finished"
+  | "originating-item-done"
+  | "originating-item-wont-do";
+
+export interface WithdrawableDecision {
+  interactionId: string;
+  /** Stable machine reason for the withdrawal, surfaced in logs and on the row. */
+  reason: DecisionWithdrawalReason;
+}
+
+/**
+ * Select the decision residue that is safe to auto-withdraw, with a reason each.
+ *
+ * Conservative by construction. A row is withdrawn only when it is BUILD-LINKED
+ * and that build's life is provably over: an interaction with no `buildId` has
+ * no staleness signal to read (the org-business and profession gates write those
+ * — they are answered by a human at /coworker-decisions/review, never swept),
+ * and a build still in flight leaves its gate open.
+ */
+export function selectWithdrawableDecisions(
+  rows: DecisionResidueRow[],
+): WithdrawableDecision[] {
+  const out: WithdrawableDecision[] = [];
+  for (const row of rows) {
+    const reason = withdrawalReason(row);
+    if (reason) out.push({ interactionId: row.interactionId, reason });
+  }
+  return out;
+}
+
+function withdrawalReason(row: DecisionResidueRow): DecisionWithdrawalReason | null {
+  // Not build-linked → nothing here proves the question evaporated. Keep.
+  if (!row.buildId) return null;
+
+  // The decompose was approved → the build this gate guarded was superseded.
+  if (row.buildSupersededByEpicId) return "build-superseded-by-epic";
+
+  // The case that produced this BI: a terminal abandoned build.
+  if (row.buildPhase === "abandoned") return "originating-build-abandoned";
+
+  // Shipped or dead — either way the gate no longer guards anything.
+  if (row.buildPhase && FINISHED_BUILD_PHASES.has(row.buildPhase)) {
+    return "originating-build-finished";
+  }
+
+  // The build is still in flight, but the work it serves is settled.
+  if (row.backlogItemStatus === "done") return "originating-item-done";
+  if (
+    row.backlogItemTriageOutcome
+    && WONT_DO_TRIAGE_OUTCOMES.has(row.backlogItemTriageOutcome)
+  ) {
+    return "originating-item-wont-do";
+  }
+
+  // A live build with live work → a genuine open gate. Keep.
+  return null;
+}
+
+/** Marks a `humanOutcome` written by this sweep rather than by a person. */
+export const SYSTEM_WITHDRAWAL_RESOLVER = "system:decision-residue-hygiene";
+
+/**
+ * The withdrawal payload's shape. Kept to JSON primitives (rather than a
+ * `Record<string, unknown>`) so it is directly assignable to Prisma's
+ * `InputJsonValue` at the `humanOutcome` write.
+ */
+export type WithdrawnHumanOutcome = {
+  type: "withdrawn";
+  reason: DecisionWithdrawalReason;
+  resolvedBy: string;
+  resolverUserId: null;
+  clearsGate: false;
+  candidateMaterial: false;
+  capturedAt: string;
+};
+
+/**
+ * The `humanOutcome` payload for a withdrawal.
+ *
+ * Deliberately NOT shaped like a capture (org-decision-capture.ts /
+ * DecisionPerspectiveGatePanel). It carries no answer and no rationale, because
+ * nobody answered anything:
+ *
+ * - `clearsGate: false` + no EscalationCapture row → `interactionWasCleared`
+ *   (decision-perspective/persistence.ts) stays false, so a withdrawal can never
+ *   masquerade as a passed gate.
+ * - `candidateMaterial: false` → never promoted into the decision corpus.
+ * - `chosenOptionId` is left untouched, so the weight-inference adapter
+ *   (weight-inference-adapter.ts, which selects on chosenOptionId NOT NULL)
+ *   never reads a withdrawal as a human's option pick.
+ * - `resolvedBy` names the sweep, which is how decision-audit.ts tells a
+ *   withdrawal apart from a human resolution.
+ */
+export function buildWithdrawnHumanOutcome(input: {
+  reason: DecisionWithdrawalReason;
+  withdrawnAtIso: string;
+}): WithdrawnHumanOutcome {
+  return {
+    type: "withdrawn",
+    reason: input.reason,
+    resolvedBy: SYSTEM_WITHDRAWAL_RESOLVER,
+    resolverUserId: null,
+    clearsGate: false,
+    candidateMaterial: false,
+    capturedAt: input.withdrawnAtIso,
+  };
+}
+
+/**
+ * True when a `humanOutcome` value is a machine withdrawal rather than a human's
+ * answer. Read by any surface that reports "a human resolved this".
+ */
+export function isWithdrawnHumanOutcome(humanOutcome: unknown): boolean {
+  if (!humanOutcome || typeof humanOutcome !== "object" || Array.isArray(humanOutcome)) {
+    return false;
+  }
+  const record = humanOutcome as Record<string, unknown>;
+  return record.type === "withdrawn" && record.resolvedBy === SYSTEM_WITHDRAWAL_RESOLVER;
+}

--- a/apps/web/lib/quality/escalation-hygiene-runner.ts
+++ b/apps/web/lib/quality/escalation-hygiene-runner.ts
@@ -17,17 +17,37 @@
 // Wired into the 15-minute issue-report-triage cron AND invoked best-effort at
 // /ops render, so ghosts clear without waiting for the cron. Idempotent: zero
 // writes once converged.
+//
+// BI-FE034C1E extends the same sweep to the OTHER table with a create path and
+// no clear path: build-linked `DecisionInteraction` escalate/defer residue whose
+// build has since been abandoned/finished/superseded. Those rows kept telling the
+// owner "build FB-XXXXXXXX stays blocked" about dead builds on /workspace/inbox.
+// See sweepDecisionResidue below and decision-residue-staleness.ts for the rule.
 
-import { prisma } from "@dpf/db";
+import { Prisma, prisma } from "@dpf/db";
 import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
 import {
   selectResolvableEscalations,
   type EscalationStalenessRow,
 } from "@/lib/quality/escalation-staleness";
+import {
+  buildWithdrawnHumanOutcome,
+  selectWithdrawableDecisions,
+  type DecisionResidueRow,
+} from "@/lib/quality/decision-residue-staleness";
 
 const SWEEP_LIMIT = 200;
 
-export async function runEscalationHygiene(): Promise<{ scanned: number; resolved: number }> {
+export type EscalationHygieneResult = {
+  scanned: number;
+  resolved: number;
+  /** Build-linked DecisionInteraction residue rows examined (BI-FE034C1E). */
+  decisionsScanned: number;
+  /** Residue rows auto-withdrawn because their build's life is over. */
+  decisionsWithdrawn: number;
+};
+
+export async function runEscalationHygiene(): Promise<EscalationHygieneResult> {
   const reports = await prisma.platformIssueReport.findMany({
     where: {
       status: {
@@ -93,5 +113,94 @@ export async function runEscalationHygiene(): Promise<{ scanned: number; resolve
     }
   }
 
-  return { scanned: rows.length, resolved: resolvable.length };
+  const decisions = await sweepDecisionResidue();
+
+  return {
+    scanned: rows.length,
+    resolved: resolvable.length,
+    decisionsScanned: decisions.scanned,
+    decisionsWithdrawn: decisions.withdrawn,
+  };
+}
+
+/**
+ * Withdraw build-linked decision residue whose build's life is over
+ * (BI-FE034C1E). Runs in the same sweep as the escalation reconcile because it
+ * closes the identical create-path-without-clear-path gap on a different table,
+ * and shares its callers: /workspace/inbox render, /ops render, and the 15-min
+ * issue-report-triage cron. Idempotent — once withdrawn, `humanOutcome` is no
+ * longer null, so the row leaves this query permanently.
+ */
+async function sweepDecisionResidue(): Promise<{ scanned: number; withdrawn: number }> {
+  const rows = await prisma.decisionInteraction.findMany({
+    where: {
+      outcomeType: { in: ["escalate", "defer"] },
+      humanOutcome: { equals: Prisma.DbNull },
+      // Only build-linked rows are sweepable; the org-business and profession
+      // gates write buildId-null rows that a human answers by hand.
+      buildId: { not: null },
+    },
+    orderBy: { createdAt: "desc" },
+    take: SWEEP_LIMIT,
+    select: {
+      interactionId: true,
+      outcomeType: true,
+      buildId: true,
+      build: {
+        select: { phase: true, supersededByEpicId: true, originatingBacklogItemId: true },
+      },
+    },
+  });
+
+  // Resolve the originating BacklogItem status/outcome for the linked builds in
+  // one query (FeatureBuild.originatingBacklogItemId is the BacklogItem cuid).
+  const itemPks = Array.from(
+    new Set(
+      rows
+        .map((row) => row.build?.originatingBacklogItemId)
+        .filter((x): x is string => Boolean(x)),
+    ),
+  );
+  const items = itemPks.length
+    ? await prisma.backlogItem.findMany({
+        where: { id: { in: itemPks } },
+        select: { id: true, status: true, triageOutcome: true },
+      })
+    : [];
+  const itemByPk = new Map(items.map((i) => [i.id, i]));
+
+  const residue: DecisionResidueRow[] = rows.map((row) => {
+    const itemPk = row.build?.originatingBacklogItemId ?? null;
+    const item = itemPk ? itemByPk.get(itemPk) : null;
+    return {
+      interactionId: row.interactionId,
+      outcomeType: row.outcomeType,
+      buildId: row.buildId,
+      buildPhase: row.build?.phase ?? null,
+      buildSupersededByEpicId: row.build?.supersededByEpicId ?? null,
+      backlogItemStatus: item?.status ?? null,
+      backlogItemTriageOutcome: item?.triageOutcome ?? null,
+    };
+  });
+
+  const withdrawable = selectWithdrawableDecisions(residue);
+  const withdrawnAtIso = new Date().toISOString();
+  let withdrawn = 0;
+  for (const { interactionId, reason } of withdrawable) {
+    try {
+      await prisma.decisionInteraction.update({
+        where: { interactionId },
+        data: { humanOutcome: buildWithdrawnHumanOutcome({ reason, withdrawnAtIso }) },
+      });
+    } catch {
+      // Best-effort per row — a single failure must not stop the rest of the sweep.
+      continue;
+    }
+    withdrawn += 1;
+    if (process.env.NODE_ENV !== "test") {
+      console.log(`[escalation-hygiene] withdrew ${interactionId} (${reason})`);
+    }
+  }
+
+  return { scanned: residue.length, withdrawn };
 }

--- a/apps/web/lib/wiki/decision-audit.ts
+++ b/apps/web/lib/wiki/decision-audit.ts
@@ -4,6 +4,8 @@
 // Pure mapping/summarization lives here (unit-testable); the pages do the
 // Prisma I/O and pass rows in, mirroring decision-governance-hub.ts.
 
+import { isWithdrawnHumanOutcome } from "@/lib/quality/decision-residue-staleness";
+
 export const DECISION_AUDIT_TIERS = ["wwmd", "wwwd", "wsid"] as const;
 export type DecisionAuditTier = (typeof DECISION_AUDIT_TIERS)[number];
 
@@ -138,8 +140,19 @@ export type DecisionAuditRow = {
   optionCount: number;
   recommendedOptionId: string | null;
   outcomeType: string;
-  /** True for defer/escalate rows with no human resolution yet. */
+  /**
+   * True for defer/escalate rows with no human resolution yet. False once a
+   * human answered AND false once the question evaporated (see `withdrawn`) —
+   * a withdrawn row is no longer waiting on anyone.
+   */
   awaitingHuman: boolean;
+  /**
+   * True when the decision-residue hygiene sweep retired this row because the
+   * build it gated was abandoned/finished/superseded (BI-FE034C1E). Kept
+   * distinct from a human resolution: nobody answered the question, it stopped
+   * being asked.
+   */
+  withdrawn: boolean;
   riskTier: string;
   principleConflict: boolean;
   domainClass: string;
@@ -223,7 +236,12 @@ export function toAuditRow(row: DecisionAuditRowInput): DecisionAuditRow {
   const tier = tierForRow(row);
   const payload = asRecord(row.outcomePayload);
   const human = asRecord(row.humanOutcome);
-  const resolvedByHuman = Boolean(row.escalationCapture) || Object.keys(human).length > 0;
+  // A hygiene withdrawal writes humanOutcome without anyone answering
+  // (BI-FE034C1E), so a non-empty humanOutcome alone no longer proves a human
+  // resolved the row — check the marker before crediting one.
+  const withdrawn = isWithdrawnHumanOutcome(row.humanOutcome);
+  const resolvedByHuman =
+    !withdrawn && (Boolean(row.escalationCapture) || Object.keys(human).length > 0);
   const caller = callerForRow(payload);
   return {
     callerLabel: caller.label,
@@ -238,7 +256,8 @@ export function toAuditRow(row: DecisionAuditRowInput): DecisionAuditRow {
     recommendedOptionId:
       typeof payload.recommendedOptionId === "string" ? payload.recommendedOptionId : null,
     outcomeType: row.outcomeType,
-    awaitingHuman: UNRESOLVED_OUTCOMES.has(row.outcomeType) && !resolvedByHuman,
+    awaitingHuman: UNRESOLVED_OUTCOMES.has(row.outcomeType) && !resolvedByHuman && !withdrawn,
+    withdrawn,
     riskTier: row.riskTier,
     principleConflict: row.principleConflict,
     domainClass: row.domainClass,

--- a/apps/web/lib/wiki/decision-help.ts
+++ b/apps/web/lib/wiki/decision-help.ts
@@ -36,6 +36,12 @@ export type DecisionHelpInput = {
   hasBuild: boolean;
   /** True once a human answered (capture row or humanOutcome present). */
   resolved: boolean;
+  /**
+   * True when the hygiene sweep retired the row because the build it gated is
+   * gone (BI-FE034C1E). Distinct from `resolved`: the question stopped being
+   * asked, so telling the reader "a human already answered this" would be false.
+   */
+  withdrawn?: boolean;
 };
 
 /** The tier's playbook, named the way the rest of the surface names it. */
@@ -143,6 +149,17 @@ export function buildDecisionHelp(input: DecisionHelpInput): DecisionHelp {
     return {
       meaning: "This outcome type has no recorded guidance.",
       urgency: "Nothing is known to be waiting on you.",
+      steps: [],
+    };
+  }
+
+  // Checked BEFORE `resolved`: a withdrawal writes humanOutcome without anyone
+  // answering, so the resolved copy would credit a human who never acted.
+  if (input.withdrawn) {
+    return {
+      meaning,
+      urgency:
+        "Closed on its own — the work this question guarded is finished or dropped, so nobody needs to answer it. Kept for the record.",
       steps: [],
     };
   }

--- a/docs/superpowers/plans/2026-07-29-attention-dead-action-and-decision-residue.md
+++ b/docs/superpowers/plans/2026-07-29-attention-dead-action-and-decision-residue.md
@@ -1,0 +1,86 @@
+# "Needs you" dead action + stale decision residue — plan
+
+- Date: 2026-07-29
+- Backlog items: **BI-90B6D8C5** (the no-op `Review this decision` button), **BI-FE034C1E** (decision residue for abandoned builds never clears)
+- Epic: EP-ATTENTION-SURFACE
+- Reported by: CEO, live on `/workspace/inbox` — "when I click on review this decision, nothing happens"
+- Surfaces touched: `apps/web/lib/attention/*`, `apps/web/lib/quality/*`, `apps/web/lib/wiki/decision-{audit,help}.ts`, `apps/web/components/attention/OwnerDecisionCards.tsx`, `/workspace/inbox`, `/workspace`
+
+## Design grounding
+
+Source of truth for this surface: the [Attention Surface foundation](../specs/2026-06-23-human-attention-surface-design.md) §6, the [cognitive-load redesign](../specs/2026-07-17-needs-you-cognitive-load-redesign-design.md), and the [restaurant-owner attention reconciliation design](../specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md) §1.
+
+That last doc **asserted the defect away**: it recorded the `?attentionId=` deep link as satisfying the BI-8EA88797 exact-target requirement. It did not, because no consumer was ever built. This plan corrects that section in place rather than creating a competing design — the contract it states (plain-language copy, raw title behind progressive disclosure, no cross-rail teleport for the owner persona) is unchanged and still enforced by `owner-decision.test.ts`.
+
+For the hygiene half, the source of truth is [escalation surface honest context and auto-resolve](../specs/2026-06-23-escalation-surface-honest-context-and-auto-resolve-design.md) and its implementation `lib/quality/escalation-staleness.ts` (BI-467E8F8D). This plan extends that existing doctrine to a second table rather than inventing a new mechanism.
+
+No new spec artifact: both items are defects against contracts that already exist.
+
+## Evidence (live, 2026-07-29)
+
+Reproduced in-browser on the running portal. Clicking `Review this decision` appends `?attentionId=…` to the URL and leaves the page text byte-identical (6087 chars before and after). Of the 12 cards on the live inbox, **10 carried the dead link** — 6 `ai-decision`, 4 `business-journey`. Only `Review bill` and `Review draft` navigated anywhere.
+
+Joining the 6 decision rows against their builds:
+
+| DecisionInteraction | buildId | FeatureBuild.phase |
+|---|---|---|
+| DI-58465A1C784B | FB-1DB2A3B5 | abandoned |
+| DI-8A828E51F84E | FB-80E3FA94 | abandoned |
+| DI-5C8098BDC64D | FB-B30EDA86 | abandoned |
+| DI-D6C2C52BCF1C | FB-41D50AF1 | abandoned |
+| DI-B1D4E336A4F8 | FB-812DA73B | abandoned |
+| DI-2DB4DF4EDED6 | FB-F858D129 | abandoned |
+
+Every card claimed `build FB-XXXXXXXX stays blocked` about a dead build.
+
+## Root causes
+
+1. **Self-link fallback.** `ownerChoices` (`lib/attention/owner-decision.ts`) emitted `/workspace/inbox?attentionId=<id>` when an item had no owner-safe action. `attentionId` was written in three places and read in zero.
+2. **`isOwnerSafeHref` strips the only action.** It rejects `/ops`, `/build`, `/admin`, `/platform`. For `ai-decision` (`/platform/ai/decisions/<id>`) and `business-journey` (`/ops/journeys?…`) that is the *only* action the source carries, so the filter removed it and the placeholder replaced it.
+3. **`FB-` never parsed from `blastRadius`.** `owner-technical-detail.ts` read the build id only from the deep link's `buildId` query param. An `ai-decision` deep link has no query string, so `Feature build` read `Not attached` and no `Resume build` link was generated — suppressing the one route to the surface that *can* answer the gate.
+4. **No clear path for decision residue.** Abandoning a build never touches its `DecisionInteraction`. `runEscalationHygiene` sweeps this exact ghost shape but only for `PlatformIssueReport`.
+
+## Phase 1 — retire the residue (BI-FE034C1E)
+
+New pure selector `lib/quality/decision-residue-staleness.ts`, deliberately mirroring `escalation-staleness.ts` so the two read alike:
+
+- `selectWithdrawableDecisions(rows)` withdraws a row only when it is **build-linked** AND that build's life is provably over: `supersededByEpicId` set, phase `abandoned`, phase `complete`/`failed`, or the originating BacklogItem is `done` / triaged `discard`|`duplicate`. Phases still in flight and `panicked` (a live, recoverable stall) are kept.
+- Rows with `buildId` null are **never** swept — those come from the org-business and profession gates and are answered by a human at `/coworker-decisions/review`.
+- `buildWithdrawnHumanOutcome` writes an honest machine record: `type: "withdrawn"`, `resolvedBy: "system:decision-residue-hygiene"`, `clearsGate: false`, `candidateMaterial: false`, no answer, no rationale, no `EscalationCapture`, and `chosenOptionId` untouched.
+
+Wired as a second phase inside `runEscalationHygiene`, so all three existing callers (`/workspace/inbox` render, `/ops` render, the 15-minute `issue-report-triage` cron) get it. Idempotent: a withdrawn row's `humanOutcome` is no longer null, so it leaves the query permanently.
+
+### Keeping the withdrawal honest downstream
+
+A non-empty `humanOutcome` previously implied "a human resolved this". Three readers needed teaching:
+
+| Reader | Was | Now |
+|---|---|---|
+| `decision-perspective/persistence.ts` `interactionWasCleared` | requires `escalationCapture && clearsGate === true` | unchanged — a withdrawal satisfies neither, so it can never masquerade as a passed gate |
+| `wiki/decision-audit.ts` `toAuditRow` | `resolvedByHuman = escalationCapture \|\| humanOutcome non-empty` | excludes withdrawals; new `withdrawn` flag; `awaitingHuman` false for both |
+| `wiki/decision-help.ts` | `resolved` → *"a human already answered this"* | new `withdrawn` branch → *"Closed on its own…"*, checked first |
+| `decision-perspective/weight-inference-adapter.ts` | selects on `chosenOptionId NOT NULL` | unchanged — a withdrawal never sets it, so it is never read as an option pick |
+
+## Phase 2 — remove the dead action (BI-90B6D8C5)
+
+- `ownerChoices` no longer synthesizes a fallback. No usable action → **no button**.
+- New `OwnerDecisionAudience` (`"worker" | "operator"`), mapped from the existing Simple/Full rail cookie (`lib/navigation/nav-mode.ts`) by `/workspace/inbox` and `/workspace`:
+  - **Simple (`worker`)** — builder rails stay out of owner buttons (EP-NAV-COHERENCE, unchanged persona contract). The card renders `card.handoff`, a plain sentence naming who holds it and pointing at Technical detail.
+  - **Full (`operator`)** — the rail caption already says "showing everything, including builder and platform tools", so the item's real action *is* the card's action. `Review evidence` and `See what failed` replace the generic placeholder; both are also more specific labels than the banned generic `Review this decision` that `owner-first/ux-audit.ts` and `restaurant-cockpit/service-readiness.ts` already flag.
+- `readFeatureBuildId` now falls back to the `FB-` id in `triage.blastRadius`, restoring `Feature build` and the `Resume build` builder action.
+
+### Regression guard
+
+`owner-decision.test.ts` gains a cross-source invariant: for every `AttentionSource`, every builder-rail href, and both audiences, no choice href may match `^/workspace/inbox` or contain `attentionId=`, and a card with no choices must carry a `handoff`. A future source cannot silently reintroduce a self-link.
+
+## Non-goals
+
+- **The resolution loop itself** — answering one of these decisions from the inbox is [BI-7D99B25C](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues) (open, `build`/medium), which composes EP-WWMD-MCP BI-WWMD-MCP-08/09 (`wwmd_record_outcome`, both still open — the handler exists nowhere in code). Until it lands, the only surface that can capture human direction is `DecisionPerspectiveGatePanel` in Build Studio. This PR makes that reachable and stops the card lying; it does not build the loop.
+- No change to `isOwnerSafeHref`'s rail policy for the worker persona, the plain-language copy contract, the `owner-routing` lane rules, or the build abandon path.
+- No new Prisma model, column, or migration — the withdrawal reuses the existing `humanOutcome` Json column.
+
+## Test strategy
+
+- `lib/quality/decision-residue-staleness.test.ts` — the abandoned-build case by id; live-build and `panicked` rows kept; complete/failed/superseded/item-done/won't-do reasons; `deferred`-but-wanted kept; never sweeps a non-build-linked row; mixed batch; and the honesty properties of the withdrawal payload (no gate clear, no candidate material, no answer, no `chosenOptionId`, sweep-attributed) plus `isWithdrawnHumanOutcome` rejecting look-alikes from other writers.
+- `lib/attention/owner-decision.test.ts` — the cross-source no-self-link invariant; Simple-view suppression + handoff; Full-view promotion of the real action; `FB-` recovery from blast radius; existing plain-language and acronym contracts unchanged.
+- Functional verification on the live install: the 6 ghost cards clear and the count drops; a live build's gate card is untouched.

--- a/docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md
@@ -65,6 +65,14 @@ without violating the contract. Instead:
   the fallback action already carries an exact `?attentionId=` deep link (pre-existing) — the
   BI-8EA88797 exact-target requirement is met without changing the label.
 
+> **Correction (2026-07-29, BI-90B6D8C5).** The second half of that last bullet was wrong. The
+> `?attentionId=` deep link pointed at `/workspace/inbox` — the page the card renders on — and no
+> consumer for the param was ever built, so the exact-target requirement was **not** met and the
+> button could only ever no-op. The fallback has been removed: a card with no action this reader can
+> act on now states so in plain language, and in Full view the item's real (builder-rail) action
+> becomes the card's own action. See
+> [the 2026-07-29 plan](../plans/2026-07-29-attention-dead-action-and-decision-residue.md).
+
 ### 2. Demote generic corpus-fallback decisions behind concrete operations
 
 `classifyOwnerAttentionLane` routes an `ai-decision` item that is **unlinked corpus residue**

--- a/docs/user-guide/workspace/attention-inbox.md
+++ b/docs/user-guide/workspace/attention-inbox.md
@@ -28,6 +28,8 @@ Folding "a human must decide this now" into the backlog is a category error: the
 - **Every card explains the decision.** The top of the card gives a short question; for a blocked coworker, a plain line saying **what it was doing and why it stalled**; a concrete **impact** ("if ignored…"); the **recommendation** with the specialist it came from; and no more than three plain choices. It never invents a confidence score.
 - **Technical detail is preserved.** Open **Technical detail** to see the original title, source, work fields, linked identifiers, detection details, and builder actions. That information is moved one click down, not deleted.
 - **A projection, not another queue.** The inbox is a read-only view *over* each area's own records; it is not a second backlog or ticket tracker. Acting on an item updates the record in its home area.
+- **A card never shows a button it cannot honour.** Some items — a paused governance gate, a failed customer journey — have no action an owner can take from the inbox; their record lives on a builder or platform screen. In **Simple** view those cards show a plain sentence saying your digital team holds it, with the record one click down under **Technical detail**, rather than a button that goes nowhere. In **Full** view, where builder and platform tools are visible by choice, the real record is the card's own action.
+- **Items retire themselves when the question goes away.** If a decision was raised to unblock a build and that build is later abandoned, finished, or folded into an epic, nobody needs to answer it any more. Those cards clear automatically and stop counting toward your daily total. They are marked as closed on their own — never as though a person answered them.
 - **An empty inbox is a good day.** When nothing needs a decision, the inbox shows **"You're all caught up"** — and, when relevant, a short summary of what your digital team is handling on its own. An empty inbox is reassurance, not an unfinished list.
 
 ## What Shows Up Here
@@ -39,7 +41,7 @@ Folding "a human must decide this now" into the backlog is a category error: the
 
 ## What You Can Do
 
-- **Review the business decision** using the plain action on the card. Builder-only links never appear as the main owner action.
+- **Review the business decision** using the plain action on the card. In Simple view, builder-only links never appear as the main owner action — and neither does a placeholder button in their place.
 - **Accept, keep, or narrow a proactivity boundary** without leaving the workspace.
 - **Open Technical detail** when a builder or specialist needs the full source record.
 - **Clear or snooze the Friday review** as one batch, or review an item individually.


### PR DESCRIPTION
Reported live by the CEO: **clicking "Review this decision" on `/workspace/inbox` did nothing.**

Reproduced in-browser before changing anything — the click appends `?attentionId=` to the URL and leaves the page text byte-identical (6087 chars before and after). **10 of the 12 cards on the live inbox carried that dead link** (6 `ai-decision`, 4 `business-journey`); only `Review bill` and `Review draft` navigated anywhere.

Three stacked defects, all verified against live data rather than inferred.

## 1. The fallback linked back to the page it rendered on (BI-90B6D8C5)

`ownerChoices` in `apps/web/lib/attention/owner-decision.ts` emitted `/workspace/inbox?attentionId=<id>` when an item had no owner-safe action. `attentionId` was **written in three places and read in zero** — no consumer was ever built.

## 2. `isOwnerSafeHref` stripped the only action the source had

It rejects `/ops`, `/build`, `/admin`, `/platform`. For the two affected sources that is the *only* action they carry:

| Source | Its only action |
|---|---|
| `ai-decision` | `/platform/ai/decisions/<interactionId>` |
| `business-journey` | `/ops/journeys?journey=<id>` |

So the filter removed the real action and the placeholder took its place. Separately, `owner-technical-detail.ts` read the `FB-` id only from the deep link's `buildId` **query param**; an `ai-decision` deep link has no query string, so `Feature build` read `Not attached` on a card whose own consequence line said `build FB-1DB2A3B5 stays blocked` — suppressing the `Resume build` action that is the one route to `DecisionPerspectiveGatePanel`, the only surface that can capture human direction.

## 3. Decision residue for dead builds never cleared (BI-FE034C1E)

Every one of the six decision cards claimed a build "stays blocked". **All six builds are `phase = "abandoned"`.** Abandoning a build never touches its `DecisionInteraction`, and `runEscalationHygiene` — written for exactly this create-path-without-clear-path gap (BI-467E8F8D) — only reconciles `PlatformIssueReport` rows.

Live blast radius, measured: of 102 unresolved rows, exactly **6 are build-linked and all 6 are abandoned**. The sweep withdraws those 6 and touches none of the 96 `buildId`-null rows a human answers by hand. Inbox count 12 to 6. The originating BIs stay open where the work is still wanted (4 deferred, 1 in-progress, 1 open) — a re-attempt gets a fresh build and a fresh gate.

## Changes

- **No usable action now means no button.** A card with nothing this reader can act on renders `card.handoff`, a plain sentence naming who holds it and pointing at Technical detail.
- **New `OwnerDecisionAudience`**, mapped from the existing Simple/Full rail cookie (`apps/web/lib/navigation/nav-mode.ts`). Simple keeps builder rails out of owner buttons exactly as before (EP-NAV-COHERENCE). Full — whose own caption already reads *"showing everything, including builder and platform tools"* — promotes the item's real action to the card, so the generic placeholder becomes `Review evidence` / `See what failed`. Both are also more specific than `Review this decision`, which `owner-first/ux-audit.ts` and `restaurant-cockpit/service-readiness.ts` already flag as a banned generic.
- `isActionableHref` **hard-rejects any `/workspace/inbox` href** so no future source can reintroduce the self-link.
- `readFeatureBuildId` falls back to the `FB-` id in `triage.blastRadius`, restoring `Feature build` and `Resume build`.
- **New pure selector** `apps/web/lib/quality/decision-residue-staleness.ts`, deliberately mirroring `escalation-staleness.ts`, wired as a second phase of `runEscalationHygiene` so all three existing callers get it (inbox render, `/ops` render, the 15-min cron). Idempotent; zero writes once converged.

### Keeping the withdrawal honest

A withdrawal records that the *question evaporated*, not that anyone answered it. It writes `clearsGate: false`, `candidateMaterial: false`, no answer, no rationale, no `EscalationCapture`, leaves `chosenOptionId` untouched, and attributes itself to the sweep. Three readers needed teaching so the platform does not claim a human acted:

| Reader | Before | After |
|---|---|---|
| `persistence.ts` `interactionWasCleared` | needs `escalationCapture && clearsGate` | unchanged — a withdrawal satisfies neither |
| `wiki/decision-audit.ts` | non-empty `humanOutcome` implies resolved by human | excludes withdrawals; new `withdrawn` flag; `awaitingHuman` false for both |
| `wiki/decision-help.ts` | *"a human already answered this"* | new `withdrawn` branch, checked first: *"Closed on its own…"* |
| `weight-inference-adapter.ts` | selects on `chosenOptionId NOT NULL` | unchanged — a withdrawal never sets it |

Leaving that unfixed would have reproduced the same dishonesty class as the original bug, one table over.

## Verification

- `decision-residue-staleness.test.ts` — 21 cases: the abandoned-build case by id, live-build and `panicked` rows kept, complete/failed/superseded/item-done/won't-do reasons, `deferred`-but-wanted kept, non-build-linked rows never swept, and the payload honesty properties.
- `owner-decision.test.ts` — new cross-source invariant: for **every** `AttentionSource`, every builder-rail href, and both audiences, no choice href may match `^/workspace/inbox` or carry `attentionId`, and a card with no choices must carry a `handoff`.
- **714 tests pass** locally across the attention, wiki, quality and component suites. 27 pregate policy guards clean. Module-size, design-grounding and docs-impact gates pass locally.
- **Governed local-integration-ci gate: `gate passed`** on `f0539a2aab` (exhaustive tier, full suite, docker-build production artifact) — this is where typecheck and prod build were verified, since this worktree's `apps/web/node_modules` is hollow and the pre-commit scoped typecheck could not run (documented in the commit body).

## Out of scope

The **resolution loop itself** — actually answering one of these from the inbox — is **BI-7D99B25C** (open, `build`/medium), which composes EP-WWMD-MCP **BI-WWMD-MCP-08/09**; `wwmd_record_outcome` exists nowhere in code today, only in specs. This PR makes the existing capture surface reachable and stops the card lying; it does not build the loop. Also unchanged: `isOwnerSafeHref`'s rail policy for the worker persona, the plain-language copy contract, `owner-routing` lane rules, and the build abandon path. No new Prisma model, column, or migration.

## Design grounding

Extends existing designs; no new spec. Source of truth is `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md` section 6 and `docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md` section 1 — **that section asserted the defect away**, recording the `?attentionId=` deep link as meeting the BI-8EA88797 exact-target requirement. It never did. This PR corrects that section in place rather than creating a competing design. The hygiene half extends the BI-467E8F8D doctrine in `apps/web/lib/quality/escalation-staleness.ts` to a second table. Code substrate verified across `apps/web/lib/attention/`, `apps/web/lib/quality/` and `apps/web/lib/wiki/` before implementing. Plan: `docs/superpowers/plans/2026-07-29-attention-dead-action-and-decision-residue.md`.

Docs: `docs/user-guide/workspace/attention-inbox.md` gains two Key Concepts (a card never shows a button it cannot honour; items retire themselves when the question goes away) and a corrected What You Can Do line.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
