### PR TITLE
docs(ux): close the user-guide and prompt-source vocabulary gaps (BI-F2EC4699)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9630,7 +9630,7 @@
         "platform-governance-role-access",
         "superuser-status",
         "capabilities",
-        "hitl-human-in-the-loop-tiers",
+        "oversight-levels",
         "customer-accounts"
       ]
     },
@@ -9907,7 +9907,7 @@
         "built-in-business-model-templates",
         "assigning-a-business-model-to-a-product",
         "assigning-users-to-roles",
-        "hitl-tier",
+        "oversight-level",
         "escalation",
         "creating-custom-business-models"
       ]

--- a/docs/user-guide/getting-started/roles-and-access.md
+++ b/docs/user-guide/getting-started/roles-and-access.md
@@ -55,18 +55,20 @@ Access is controlled by capabilities — specific permissions like `view_portfol
 
 The `manage_business_models` capability is granted to HR-000, HR-200, and HR-300, allowing them to create, clone, and manage business model templates.
 
-## HITL (Human-in-the-Loop) Tiers
+## Oversight levels
 
-Both platform governance roles and business model roles carry a HITL tier that controls how much autonomy the AI agents have when acting within that role's authority domain:
+Both platform governance roles and business model roles carry an oversight level that controls how much autonomy your AI coworkers have when acting within that role's authority domain. The portal shows the plain label; the level is stored internally as the HITL tier (0-3), which is the technical name for the same setting.
 
-| Tier | Label | Behaviour |
-| ---- | ----- | --------- |
-| 0 | Blocked | Agent cannot act — human must always decide |
-| 1 | Approve before | Human must approve the proposal before execution |
-| 2 | Review after | Agent acts immediately; human reviews asynchronously |
-| 3 | Autonomous | Agent acts and logs; no human review required |
+| Level | Shown as | What happens |
+| ----- | -------- | ------------ |
+| 0 | Employee only | The coworker cannot act — an employee always decides |
+| 1 | Needs approval | An employee must approve the proposal before it runs |
+| 2 | Employee review | The coworker acts immediately; an employee reviews it afterwards |
+| 3 | Runs on its own | The coworker acts and logs it; no employee review needed |
 
-Business model roles default to HITL tier 2 (spot-check). Platform governance roles vary by risk profile.
+In dense tables the same four levels are abbreviated to **Manual**, **Approve**, **Review**, and **Auto**.
+
+Business model roles default to **Employee review**. Platform governance roles vary by risk profile.
 
 ## Customer Accounts
 

--- a/docs/user-guide/hr/index.md
+++ b/docs/user-guide/hr/index.md
@@ -147,7 +147,7 @@ After a workforce change, confirm the relevant evidence:
 - timesheet state, approver, approval date, or rejection reason
 - customer/service context for billable hours
 - policy acknowledgement or requirement completion
-- platform role, HITL tier, and active/inactive account state
+- platform role, oversight level, and active/inactive account state
 - append-only lifecycle event and effective date where one was produced
 
 If a change is wrong, prefer the supported corrective action: edit a draft or rejected timesheet, reject a submitted period with a reason, restore an account’s active state, or make a new governed lifecycle correction. Preserve the prior audit evidence.

--- a/docs/user-guide/products/business-model-roles.md
+++ b/docs/user-guide/products/business-model-roles.md
@@ -51,11 +51,11 @@ Once a business model is assigned to a product, its roles are available in the *
 
 Each role can only have one active assignment at a time. The assignment is effective immediately.
 
-## HITL Tier
+## Oversight level
 
-Each role carries a default HITL (Human-in-the-Loop) tier that controls AI agent autonomy for actions within that authority domain. All built-in roles default to **HITL tier 2** (spot-check):
+Each role carries a default oversight level that controls AI coworker autonomy for actions within that authority domain. The level is stored internally as the HITL tier; the portal shows the plain label. All built-in roles default to **Employee review**:
 
-- The agent acts immediately on proposals within the authority domain
+- The coworker acts immediately on proposals within the authority domain
 - The assigned role holder receives an async notification to review
 - No pre-approval is needed unless the action escalates to a platform governance role
 

--- a/prompts/route-persona/evaluate-orchestrator.prompt.md
+++ b/prompts/route-persona/evaluate-orchestrator.prompt.md
@@ -70,7 +70,7 @@ The runtime grants come from [`packages/db/data/agent_registry.json`](../../../p
 - `backlog_read` — read backlog items in your VS
 - `decision_record_create` — record stage-gate decisions
 - `agent_control_read` — read agent status when delegating
-- `role_registry_read` — read the human role registry to identify HR escalation targets
+- `role_registry_read` — read the employee role registry to identify HR escalation targets
 - `investment_proposal_create` — author investment proposals (currently aspirational; no tool implementation yet — see #322 self-assessment)
 - `gap_analysis_read` — read gap analyses (currently aspirational)
 - `spec_plan_read` — read specs and plans

--- a/prompts/route-persona/governance-orchestrator.prompt.md
+++ b/prompts/route-persona/governance-orchestrator.prompt.md
@@ -31,7 +31,7 @@ interpretiveModel: "Healthy Governance: every promotion has a recorded constrain
 
 You are the Governance Orchestrator (AGT-ORCH-800). You own the **Governance value stream** — the platform's enforcement substrate. Your scope is the Enterprise Architecture Functional Component (§6.1.3): constraint validation, value-stream data-object enforcement, promotion workflow, and the evidence chain that makes audit possible.
 
-MUST-0047 through MUST-0053 (architectural guardrails) are your floor. HITL tier 0 — every decision in your scope can require a qualified human in the loop, not because of formality but because governance failures cascade.
+MUST-0047 through MUST-0053 (architectural guardrails) are your floor. Oversight tier 0 (employee only) — every decision in your scope can require a qualified employee in the loop, not because of formality but because governance failures cascade.
 
 Per PR #322's self-assessment, this orchestrator is **blocked across the board** — every governance-specific verb is unhonored at the catalog level. Track D Wave 6 resolves this. Until it does, you operate paper-only on your enforcement scope and surface the gap continuously.
 
@@ -85,7 +85,7 @@ Enforcement, not authoring. You enforce active constraints and guardrails; you d
 
 Evidence chain integrity is non-negotiable. Tampering attempts (decisions without rationale, evidence references that don't resolve, audit records altered after creation) are flagged as critical, not surfaced as warnings.
 
-HITL tier 0 means a qualified human is required for decisions in your scope. When you reach a decision the active constraint or guardrail set classifies as tier-0, you do not act — you escalate to HR-300 or the appropriate role-mapped human.
+Oversight tier 0 (employee only) means a qualified employee is required for decisions in your scope. When you reach a decision the active constraint or guardrail set classifies as tier-0, you do not act — you escalate to HR-300 or the appropriate role-mapped employee.
 
 Cross-VS implications. A governance-gate failure usually means another VS needs to fix something before promotion succeeds. Name the VS, name the gap, hand the cross-cutting coordination to the COO. You do not author the fix in another VS.
 

--- a/prompts/route-persona/hr-specialist.prompt.md
+++ b/prompts/route-persona/hr-specialist.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: hr-specialist
 displayName: HR Director
-description: People, roles, accountability chains, governance compliance. HITL coverage and delegation oversight.
+description: People, roles, accountability chains, governance compliance. Oversight coverage and delegation.
 category: route-persona
 version: 2
 
@@ -19,22 +19,22 @@ variables: []
 stage: ""
 sensitivity: confidential
 
-perspective: "Network of human roles, capabilities, and accountability chains — HR-000 through HR-500"
+perspective: "Network of employee roles, capabilities, and accountability chains — HR-000 through HR-500"
 heuristics: "Capability matching, delegation analysis, compliance checking, succession planning"
-interpretiveModel: "Accountability and capability coverage — every critical decision has a qualified human in the loop"
+interpretiveModel: "Accountability and capability coverage — every critical decision has a qualified employee in the loop"
 ---
 
 # Role
 
-You are the HR Director for the `/employee` route. You see the platform as a network of human roles, capabilities, and accountability chains. You encode the world as role assignments (HR-000 through HR-500), HITL tier commitments, delegation grants, team memberships, and SLA compliance.
+You are the HR Director for the `/employee` route. You see the platform as a network of employee roles, capabilities, and accountability chains. You encode the world as role assignments (HR-000 through HR-500), oversight commitments, delegation grants, team memberships, and SLA compliance.
 
-The platform is governed by the principle that every critical decision has a qualified human in the loop. Your job is to surface where that principle is upheld and where it is at risk.
+The platform is governed by the principle that every critical decision has a qualified employee in the loop. Your job is to surface where that principle is upheld and where it is at risk.
 
 # Accountable For
 
-- **Capability coverage**: every role has the capabilities it needs; no role has so many it cannot meet HITL commitments.
+- **Capability coverage**: every role has the capabilities it needs; no role has so many it cannot meet oversight commitments.
 - **Delegation hygiene**: grants are appropriate to the risk level; expired delegations are surfaced; over-broad grants are flagged.
-- **HITL compliance**: HITL tier commitments are met. When a tier-0 decision is on the verge of being made without a qualified human, you surface it.
+- **Oversight compliance**: oversight commitments are met. When a tier-0 decision is on the verge of being made without a qualified employee, you surface it.
 - **Succession readiness**: every critical role has a backup. Single-points-of-failure in the approval chain are visible.
 - **SLA compliance**: human-response SLAs are met. When they are not, you say so cleanly, with the specific role and the specific gap.
 
@@ -43,7 +43,7 @@ The platform is governed by the principle that every critical decision has a qua
 - **AGT-ORCH-000 (the COO)** — your superior in the chain between you and HR-000. Cross-cutting workforce decisions that affect multiple routes are the COO's to coordinate.
 - **HR-000 (CEO)** — your ultimate human supervisor. Strategic HR decisions (hires, role splits, capability gaps that need investment) escalate here.
 - **All HR-XX roles** — the human supervisors of every other agent in the registry. You see the full role network and surface gaps in coverage.
-- **AGT-ORCH-800 (governance-orchestrator)** — governance enforcement; you coordinate when HITL compliance crosses into constraint validation territory.
+- **AGT-ORCH-800 (governance-orchestrator)** — governance enforcement; you coordinate when oversight compliance crosses into constraint validation territory.
 
 # Out Of Scope
 
@@ -63,11 +63,11 @@ The runtime grants for this agent come from the registry's `tool_grants` array a
 
 # Operating Rules
 
-The user is on the `/employee` route. They see role assignments, team structures, HITL tiers, delegation grants, and workforce profiles. Reference specific roles by HR-id, specific tiers by number, specific grants by name — never generic.
+The user is on the `/employee` route. They see role assignments, team structures, oversight levels, delegation grants, and workforce profiles. Reference specific roles by HR-id, specific tiers by number, specific grants by name — never generic.
 
 Capability matching is your default check. When asked about a role, the first questions are: does this role have what it needs; is it overcommitted; who is the backup.
 
-Compliance checking is honest. When you observe a tier-0 decision happening without a qualified human, name it — even when the user didn't ask. (Calmly, once, with the specific decision and the specific gap.)
+Compliance checking is honest. When you observe a tier-0 decision happening without a qualified employee, name it — even when the user didn't ask. (Calmly, once, with the specific decision and the specific gap.)
 
 Succession planning is structural. Single-points-of-failure are bugs in the role network; surface them when you see them.
 

--- a/prompts/specialist/scope-agreement-agent.prompt.md
+++ b/prompts/specialist/scope-agreement-agent.prompt.md
@@ -28,7 +28,7 @@ interpretiveModel: "Healthy scope agreements: every agreement traces to an appro
 
 You are the Scope Agreement Agent (AGT-113). You assemble **Scope Agreement artifacts** from approved investment proposals (AGT-111's output) during §5.1.1 Evaluate Scenarios. The Scope Agreement is the canonical Evaluate-VS exit artifact — Explore VS (AGT-ORCH-200) executes against it.
 
-You operate at HITL tier 0: every Scope Agreement requires CEO (HR-000) sign-off. Your job is to make those agreements signable in one pass.
+You operate at oversight tier 0 (employee only): every Scope Agreement requires CEO (HR-000) sign-off. Your job is to make those agreements signable in one pass.
 
 # Accountable For
 
@@ -46,7 +46,7 @@ You operate at HITL tier 0: every Scope Agreement requires CEO (HR-000) sign-off
 - **AGT-ORCH-200 (Explore Orchestrator)** — downstream; signed agreements hand to Explore for §5.2 execution.
 - **AGT-WS-PORTFOLIO (Portfolio Analyst)** — peer route-persona; portfolio-mix implications of a Scope Agreement come back from AGT-WS-PORTFOLIO before signoff.
 - **AGT-ORCH-000 (the COO)** — cross-cutting peer; cross-VS Scope-Agreement implications are the COO's.
-- **HR-000 (CEO)** — your direct human supervisor. Every Scope Agreement requires HR-000 signoff (HITL tier 0).
+- **HR-000 (CEO)** — your direct supervising employee. Every Scope Agreement requires HR-000 signoff (oversight tier 0).
 
 # Out Of Scope
 
@@ -76,6 +76,6 @@ Funding allocation is honest. Every funding line carries source, amount, time ho
 
 Signable artifacts. HR-000 should be able to sign / defer / reject without re-investigation. Re-investigation is a defect. The agreement structure: rationale → evidence → alternatives → action → expected outcome → funding → handoff target.
 
-HITL tier 0 is non-negotiable. Every Scope Agreement requires CEO signoff. You don't approve agreements within your own authority; the platform's HITL-0 design is structural.
+Oversight tier 0 is non-negotiable. Every Scope Agreement requires CEO signoff. You don't approve agreements within your own authority; the platform's employee-only design is structural.
 
 Aspirational-grant honesty. `scope_agreement_create` being unhonored means today you produce decision-record drafts that are *informally* scope agreements. Surface the gap when it bites.


### PR DESCRIPTION
Follow-up to #3749 (BI-F2EC4699), which shipped the vocabulary change but left three gaps. A completeness audit of that PR against the original ask found them; all three sit inside its agreed copy-only scope, and no CI gate caught them because no gate asks "did the sweep actually finish".

## The gaps

**1. Two customer-facing user-guide pages were never touched.** Both still carried whole HITL sections, including a table row reading *"Agent cannot act — human must always decide"*:

- `docs/user-guide/getting-started/roles-and-access.md` — `## HITL (Human-in-the-Loop) Tiers`
- `docs/user-guide/products/business-model-roles.md` — `## HITL Tier`

A getting-started page is about the worst place to leave the acronym. Both now lead with the labels the portal actually renders — **Employee only / Needs approval / Employee review / Runs on its own** — name the dense-table abbreviations (**Manual / Approve / Review / Auto**) that #3749 introduced, and keep one bridge clause recording HITL as the internal name.

**2. A straight miss in a page #3749 did edit.** `hr/index.md` still read "platform role, HITL tier, and active/inactive account state".

**3. The `prompts/*.prompt.md` files had diverged from the runtime strings #3749 changed** in `lib/tak/agent-routing.ts`. This one matters beyond tidiness:

- `loadPrompt()` resolves a DB `PromptTemplate` first, with the `agent-routing.ts` string as fallback.
- The `.prompt.md` file is what `prompt-admin.ts` reads for **"reset to original"**.

So left alone, an operator clicking reset would have silently restored the old "human roles" / "HITL tier commitments" vocabulary and undone the change at runtime.

`hr-specialist.prompt.md` was also **factually wrong** after #3749: it told the coworker *"They see role assignments, team structures, HITL tiers"* when the portal now renders **Oversight**. A coworker reading that would describe the screen using a label the user cannot see.

Aligned: `route-persona/{hr-specialist,governance-orchestrator,evaluate-orchestrator}` and `specialist/scope-agreement-agent`. Precise tier mechanics are preserved — a "tier-0 decision" still reads as tier 0, now named "employee only".

## Verification

- Zero `HITL` left in `prompts/`.
- The four remaining mentions in `docs/user-guide` are all intentional bridge clauses ("stored internally as the HITL tier").
- Zero `HITL` rendered in any `.tsx` (confirmed on current main, post-#3749).
- `doc-index` regenerated (579 pages); prose lint, docs-impact, doc-reference-integrity, plan coverage, and all five derived artifacts green.

## Note on the branch

#3749 was squash-merged and its branch deleted, so my push recreated the branch on stale history. I caught that a PR from it would have **clobbered #3764** (report-kit `CollapsibleList`/`ExpandableCard` changes and a 276-line spec file). The branch was reset onto current `origin/main` and only these 8 files re-applied — the tree diff against main is exactly this change and nothing else.

Docs-Impact-Decision: documentation-only vocabulary alignment plus agent-prompt reset sources. No route changed in this commit, and the user-guide page for every route #3749 touched was already updated there.

Seed-Fit-Decision: global-default

Local-CI-Override: Docs and prompt-file copy only — no application code, no schema, no dependency. Prose lint, docs-impact, doc-reference-integrity, plan-backlog-coverage and all five derived-artifact checks verified green locally; the shared local-integration-ci slot remains contended by other sessions. CI is the enforcing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
