### PR TITLE
fix(ux): sweep the rendered "human" strings the first two PRs missed (BI-F2EC4699)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
@@ -183,7 +183,7 @@ export default async function DecisionRecordPage({ params }: { params: Params })
             No option was actually scored: every principle contribution was
             zero, so no recommendation stands. This usually means the consult
             was submitted without per-option feature values. The decision
-            needs human judgment — or a re-run with scoreable options.
+            needs an owner decision — or a re-run with scoreable options.
           </p>
         ) : null}
         {contributors.length > 0 ? (
@@ -219,7 +219,7 @@ export default async function DecisionRecordPage({ params }: { params: Params })
       {/* Human resolution */}
       <section className="mb-6">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
-          Human review
+          Employee review
         </h2>
         {row.escalationCapture ? (
           <div className="rounded-lg border border-[var(--dpf-border)] p-3 text-sm">

--- a/apps/web/app/(shell)/platform/ai/capacity-continuity/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/capacity-continuity/page.tsx
@@ -48,7 +48,7 @@ export default function CapacityContinuityPage() {
             Capacity Continuity
           </h1>
           <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
-            Operating policy for using paid AI capacity while human attention is available,
+            Operating policy for using paid AI capacity while employee attention is available,
             reduced, away, or redirected to business events.
           </p>
         </div>

--- a/apps/web/app/(shell)/platform/identity/authorization/page.tsx
+++ b/apps/web/app/(shell)/platform/identity/authorization/page.tsx
@@ -164,7 +164,7 @@ export default async function PlatformIdentityAuthorizationPage({ searchParams }
           <div>
             <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Editing binding {activeBinding.bindingId}</h2>
             <p className="text-xs text-[var(--dpf-muted)]">
-              Human-first edit surface for the shared authority binding record.
+              Employee-first edit surface for the shared authority binding record.
             </p>
           </div>
           <BindingDetailDrawer binding={activeBinding} evidence={activeBindingEvidence} />
@@ -175,7 +175,7 @@ export default async function PlatformIdentityAuthorizationPage({ searchParams }
         <div>
           <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Authorization Bindings</h2>
           <p className="text-xs text-[var(--dpf-muted)]">
-            Human-first view of route and coworker authority bindings. This is the shared source of truth for who can
+            Employee-first view of route and coworker authority bindings. This is the shared source of truth for who can
             access which governed surface.
           </p>
         </div>

--- a/apps/web/app/(shell)/platform/identity/page.tsx
+++ b/apps/web/app/(shell)/platform/identity/page.tsx
@@ -27,7 +27,7 @@ export default async function PlatformIdentityPage() {
       <div>
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Identity &amp; Access</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Operate human, contractor, AI coworker, and service identity from one platform authority plane.
+          Operate employee, contractor, AI coworker, and service identity from one platform authority plane.
         </p>
       </div>
 

--- a/apps/web/app/(shell)/platform/page.tsx
+++ b/apps/web/app/(shell)/platform/page.tsx
@@ -42,7 +42,7 @@ export default async function PlatformPage() {
       <div>
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Platform</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Keep AI operations, connection lifecycle management, governance evidence, and controlled admin surfaces understandable for a small human team.
+          Keep AI operations, connection lifecycle management, governance evidence, and controlled admin surfaces understandable for a small employee team.
         </p>
       </div>
 

--- a/apps/web/components/ea/ReferenceProposalQueue.tsx
+++ b/apps/web/components/ea/ReferenceProposalQueue.tsx
@@ -20,7 +20,7 @@ export function ReferenceProposalQueue({ proposals }: Props) {
       <div className="mb-3">
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Proposal Queue</h3>
         <p className="text-xs text-[var(--dpf-muted)]">
-          AI and human-proposed reference-model changes awaiting review.
+          AI and employee-proposed reference-model changes awaiting review.
         </p>
       </div>
       <div className="space-y-2">

--- a/apps/web/components/employee/WorkforceActivityPanel.tsx
+++ b/apps/web/components/employee/WorkforceActivityPanel.tsx
@@ -57,7 +57,7 @@ function ConcernRow({ concern }: { concern: WorkforceConcern }) {
 
 function ownerChip(item: WorkforceActiveWorkItem): string {
   if (item.ownerKind === "agent") return "AI agent";
-  if (item.ownerKind === "human") return "human";
+  if (item.ownerKind === "human") return "employee";
   return "unassigned";
 }
 

--- a/apps/web/components/employee/WorkforceRosterPanel.test.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.test.tsx
@@ -44,16 +44,16 @@ const roster: WorkforceRoster = {
 };
 
 describe("WorkforceRosterPanel", () => {
-  it("renders both humans and AI agents with the agent-needs lens", () => {
+  it("renders both employees and AI agents with the agent-needs lens", () => {
     const html = renderToStaticMarkup(<WorkforceRosterPanel roster={roster} />);
 
     // both populations present
     expect(html).toContain("Ada Lovelace");
-    expect(html).toContain("human");
+    expect(html).toContain("employee");
     expect(html).toContain("Chief of Staff");
     expect(html).toContain("AI coworker");
 
-    // agent-needs lens surfaced — incl. human-role parity + approval/interface owner
+    // agent-needs lens surfaced — incl. employee-role parity + approval/interface owner
     expect(html).toContain("role parity");
     expect(html).toContain("approval owner");
     expect(html).toContain("Chief Executive Officer"); // resolved parity/owner role

--- a/apps/web/components/employee/WorkforceRosterPanel.tsx
+++ b/apps/web/components/employee/WorkforceRosterPanel.tsx
@@ -99,7 +99,7 @@ function MemberRow({ member }: { member: WorkforceMember }) {
           </p>
         </div>
         <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-muted)] shrink-0">
-          {isAgent ? "AI coworker" : "human"}
+          {isAgent ? "AI coworker" : "employee"}
         </span>
       </div>
       {isAgent && <AgentNeeds member={member} />}
@@ -122,7 +122,7 @@ export function WorkforceRosterPanel({ roster }: { roster: WorkforceRoster }) {
 
       {members.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)] py-8 text-center">
-          No workforce members yet. Humans and AI coworkers will appear here as they are onboarded.
+          No workforce members yet. Employees and AI coworkers will appear here as they are onboarded.
         </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/apps/web/components/finance/AiSpendWorkspace.test.tsx
+++ b/apps/web/components/finance/AiSpendWorkspace.test.tsx
@@ -77,7 +77,7 @@ describe("AiSpendWorkspace", () => {
     expect(html).toContain("Unpriced active providers");
     expect(html).toContain("2 need finance setup");
     expect(html).toContain("Employee asks queued");
-    expect(html).toContain("Finance Specialist needs human input");
+    expect(html).toContain("Finance Specialist needs employee input");
     expect(html).toContain("Provision Anthropic billing browser profile for Finance Specialist");
     expect(html).toContain("Can you sign in once to the Anthropic billing portal");
     expect(html).toContain("Service account browser profile");

--- a/apps/web/components/finance/AiSpendWorkspace.tsx
+++ b/apps/web/components/finance/AiSpendWorkspace.tsx
@@ -175,11 +175,11 @@ export function AiSpendWorkspace({
                 <StatusBadge intent="warning" label={`${overview.openWorkItems} queued`} />
               </div>
               <h2 className="mt-3 text-base font-semibold text-[var(--dpf-text)]">
-                Finance Specialist needs human input
+                Finance Specialist needs employee input
               </h2>
               <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
                 Missing AI provider costs are treated as finance traceability gaps until the coworker can
-                retrieve billing details or a human supplies the exact subscription, renewal, and payment evidence.
+                retrieve billing details or an employee supplies the exact subscription, renewal, and payment evidence.
               </p>
             </div>
             <AiFinanceCoworkerAskButton

--- a/apps/web/components/integrations/EntraConnectPanel.tsx
+++ b/apps/web/components/integrations/EntraConnectPanel.tsx
@@ -29,7 +29,7 @@ export function EntraConnectPanel({ state }: { state: EntraConnectionState }) {
           Setup guidance
         </p>
         <p className="mt-2 text-sm text-[var(--dpf-text)]">
-          Start by connecting Entra as an upstream authority for human sign-in and group bootstrap.
+          Start by connecting Entra as an upstream authority for employee sign-in and group bootstrap.
           DPF then maps imported workforce context into local groups, route bundles, and coworker
           approvals instead of delegating authorization decisions upstream.
         </p>

--- a/apps/web/components/ops/DemandBoard.tsx
+++ b/apps/web/components/ops/DemandBoard.tsx
@@ -38,7 +38,7 @@ const QUADRANT_TOKEN: Record<ValueEffortQuadrant, string> = {
   time_sink: "var(--dpf-warning)",
 };
 
-const ESTIMATE_SOURCE_LABEL: Record<string, string> = { ai: "AI", human: "human", agreed: "agreed" };
+const ESTIMATE_SOURCE_LABEL: Record<string, string> = { ai: "AI", human: "employee", agreed: "agreed" };
 
 /** Tiny inline text button used across the estimate controls. */
 function MiniButton({

--- a/apps/web/components/platform/DelegationChainPanel.tsx
+++ b/apps/web/components/platform/DelegationChainPanel.tsx
@@ -295,7 +295,7 @@ export function DelegationChainPanel({ agents, bmrNodes }: DelegationChainProps)
             Delegation Chain
           </h2>
           <p style={{ fontSize: 10, color: "var(--dpf-muted)", margin: "4px 0 0 0" }}>
-            Human role to agent hierarchy. Click rows to expand/collapse.
+            Employee role to agent hierarchy. Click rows to expand/collapse.
           </p>
         </div>
         <div style={{ display: "flex", gap: 6 }}>

--- a/apps/web/components/platform/DelegationGrantPanel.tsx
+++ b/apps/web/components/platform/DelegationGrantPanel.tsx
@@ -24,7 +24,7 @@ export function DelegationGrantPanel({ grants }: Props) {
         <div>
           <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Recent delegation grants</h2>
           <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-            Human-issued temporary authority for governed agent workflows.
+            Employee-issued temporary authority for governed agent workflows.
           </p>
         </div>
         <span className="rounded-full bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] font-medium uppercase tracking-widest text-[var(--dpf-muted)]">

--- a/apps/web/components/platform/GovernanceOverviewPanel.tsx
+++ b/apps/web/components/platform/GovernanceOverviewPanel.tsx
@@ -34,7 +34,7 @@ export function GovernanceOverviewPanel({ summary, recentGrants }: Props) {
       <div>
         <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Identity governance</h2>
         <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-          Human accountability, governed agents, and temporary delegation state.
+          Employee accountability, governed agents, and temporary delegation state.
         </p>
       </div>
 

--- a/apps/web/components/platform/authority/BindingBootstrapPanel.tsx
+++ b/apps/web/components/platform/authority/BindingBootstrapPanel.tsx
@@ -30,7 +30,7 @@ export function BindingBootstrapPanel({
         <div className="space-y-1">
           <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Bootstrap coverage</h3>
           <p className="text-xs text-[var(--dpf-muted)]">
-            Authority bindings are inferred from current route-to-coworker mappings and human access layers. Review
+            Authority bindings are inferred from current route-to-coworker mappings and employee access layers. Review
             anything we could not infer confidently before assuming the control plane is complete.
           </p>
         </div>

--- a/apps/web/components/platform/identity/AuthorizationBundlePanel.tsx
+++ b/apps/web/components/platform/identity/AuthorizationBundlePanel.tsx
@@ -67,7 +67,7 @@ export function AuthorizationBundlePanel({
             <div>
               <h2 className="text-base font-semibold text-[var(--dpf-text)]">Role bundles</h2>
               <p className="mt-1 text-sm text-[var(--dpf-muted)]">
-                Platform roles remain the top-level human authorization bundle, then fan out into route access and capability grants.
+                Platform roles remain the top-level employee authorization bundle, then fan out into route access and capability grants.
               </p>
             </div>
             <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
@@ -153,7 +153,7 @@ export function AuthorizationBundlePanel({
             <div className="mt-4 space-y-3">
               {roleAssignments.length === 0 ? (
                 <div className="rounded-2xl border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4 text-sm text-[var(--dpf-muted)]">
-                  No human role assignments have been made yet.
+                  No employee role assignments have been made yet.
                 </div>
               ) : null}
               {roleAssignments.map((assignment) => (

--- a/apps/web/components/platform/identity/PrincipalDirectoryPanel.tsx
+++ b/apps/web/components/platform/identity/PrincipalDirectoryPanel.tsx
@@ -17,7 +17,7 @@ export function PrincipalDirectoryPanel({ principals }: { principals: PrincipalR
       <div>
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Principals</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Review the shared identity inventory for humans, AI coworkers, and future service identities.
+          Review the shared identity inventory for employees, AI coworkers, and future service identities.
         </p>
       </div>
 

--- a/apps/web/components/shell/Header.tsx
+++ b/apps/web/components/shell/Header.tsx
@@ -105,7 +105,7 @@ export function Header({ platformRole, brandName, brandLogoUrl, brandLogoUrlLigh
             </div>
             {!simpleMode && (
               <p className="mt-0.5 hidden truncate text-xs text-[var(--dpf-muted)] lg:block">
-                Small human team, AI coworkers filling in specialist expertise
+                Small employee team, AI coworkers filling in specialist expertise
               </p>
             )}
           </div>

--- a/apps/web/components/workspace/WorkCaseAttentionLens.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.tsx
@@ -112,7 +112,7 @@ export function WorkCaseAttentionLens({ view }: Props) {
           <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Workspace</p>
           <h1 className="mt-1 text-2xl font-semibold text-[var(--dpf-text)]">Work Cases</h1>
           <p className="mt-1 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
-            Company work projected as cases, ordered by what needs human attention first.
+            Company work projected as cases, ordered by what needs your attention first.
           </p>
         </div>
         <a
@@ -155,7 +155,7 @@ export function WorkCaseAttentionLens({ view }: Props) {
               attentionCases.map((item) => <CaseRow key={item.caseId} item={item} />)
             ) : (
               <div className="px-4 py-6 text-sm text-[var(--dpf-muted)]">
-                Nothing requires human attention right now.
+                Nothing requires your attention right now.
               </div>
             )}
           </section>

--- a/apps/web/lib/actions/demand-estimate.ts
+++ b/apps/web/lib/actions/demand-estimate.ts
@@ -46,7 +46,7 @@ export async function recordEstimate(input: {
   const itemId = typeof input.itemId === "string" ? input.itemId.trim() : "";
   if (!itemId) return { ok: false, error: "No item to estimate." };
   if (input.by !== "ai" && input.by !== "human") {
-    return { ok: false, error: "Estimate source must be AI or human." };
+    return { ok: false, error: "Estimate source must be AI or employee." };
   }
 
   const args: Record<string, unknown> = { itemId, by: input.by };

--- a/apps/web/lib/docs-quick-help.ts
+++ b/apps/web/lib/docs-quick-help.ts
@@ -320,7 +320,7 @@ const QUICK_HELP_MAP: QuickHelpEntry[] = [
     routePrefix: "/coworker-decisions",
     help: {
       whatThisPageIs:
-        "How your AI decides — the questions it consulted your governance on, what it recommended, and the calls it put in front of a human (escalated or deferred).",
+        "How your AI decides — the questions it consulted your governance on, what it recommended, and the calls it put in front of you (escalated or deferred).",
       actionNow:
         "Use Review & adjust: it rolls the waiting decisions into a few themes. Answer a theme once, or add a stance covering it, and your AI stops needing to ask.",
       ifNothingDone:

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -597,7 +597,7 @@ export const PHASE_LABELS: Record<BuildPhase, string> = {
   ship:     "Ready to Ship",
   complete: "Complete",
   failed:   "Failed",
-  abandoned: "Escalated to human",
+  abandoned: "Escalated to owner",
 };
 
 export const PHASE_COLOURS: Record<BuildPhase, string> = {


### PR DESCRIPTION
Third and final follow-up for BI-F2EC4699, after #3749 (the change) and #3767 (docs/prompt gaps).

## How these were found

The founder spotted two on a live screenshot — which is exactly the functional verification I had flagged as this work's weakest point. It found real misses within seconds:

- **"Small human team, AI coworkers filling in specialist expertise"** — the shell header, on every page.
- **"Escalated to human"** ×2 — build status badges.

## Why my sweep missed them

Two different failure modes, both worth recording:

1. **A tooling blind spot.** My candidate-extraction regex required the JSX tags on the *same line* as the text, so a bare text line like `Header.tsx:108` never matched. Re-running without that constraint surfaced **24** rendered strings.
2. **A review miss.** `feature-build-types.ts:600` (`abandoned: "Escalated to human"`) *was* in my original candidate list. I simply did not act on it. No tooling excuse.

## What changed

Same role resolution as the merged work — **employee** for workforce, **owner** for the accountable decision-maker, and second person where the reader *is* the owner:

| | sites |
|---|---|
| **employee** | header + `/platform` "small human team"; capacity-continuity "human attention"; identity "Operate human, contractor…"; authorization "Human-first" ×2; `ReferenceProposalQueue` "human-proposed"; roster empty-state "Humans and AI coworkers"; the roster and activity **chips that rendered the bare word "human"**; `AiSpendWorkspace` "needs human input" / "a human supplies"; Entra "human sign-in"; `DemandBoard` estimate label; `DelegationChainPanel` "Human role to agent hierarchy"; `DelegationGrantPanel` "Human-issued"; `GovernanceOverviewPanel` "Human accountability"; `BindingBootstrapPanel` "human access layers"; `AuthorizationBundlePanel` "human authorization bundle" / "No human role assignments"; `PrincipalDirectoryPanel` "for humans"; demand-estimate validation message |
| **owner** | "Escalated to human" → **"Escalated to owner"**; coworker-decisions "needs human judgment" → "needs an owner decision" |
| **you** | `WorkCaseAttentionLens` "needs human attention" / "Nothing requires human attention", and `docs-quick-help` "in front of a human" — the owner is the reader of those surfaces |

## Deliberately retained

Consistent with the depth decision merged in #3749: the `human` **principal-kind axis** in the identity domain ("human principals", "Non-human service identities", the principal-spine description), the `escalated-to-human` and `ownerKind: "human"` **enum discriminants**, the `humanize*` / `humanReason` helpers, and code comments. There, "human" is the accurate opposite of "agent".

## Verification

- **450 tests pass** across the touched areas, zero assertion failures.
- Updated the two assertions that read changed labels (`AiSpendWorkspace` "needs employee input", `WorkforceRosterPanel` chip). Both live in files that cannot execute locally — `next/link` is absent from both clones' `node_modules` — so they are CI-verified, not locally verified. Flagging that explicitly.
- Style drift, token drift, prose lint, docs-impact and all five derived artifacts green.

Branch was reset onto current `origin/main` after #3767 merged, so the tree diff against main is exactly these 24 files.

Docs-Impact-Decision: label-level copy inside already-documented routes; each route's user-guide page was aligned in #3749/#3767 and this vocabulary matches what those pages already describe.

Seed-Fit-Decision: global-default

Local-CI-Override: Rendered-label copy only — no logic, schema, or dependency change. 450 tests green in the touched areas plus style/token drift, prose lint, docs-impact and all derived-artifact checks; the shared local-integration-ci slot remains contended by other sessions. CI is the enforcing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-07-29-employee-oversight-vocabulary.md` — the plan governing this vocabulary change, including the founder's three scope decisions (copy-only depth, role-resolved owner-vs-employee, acronym dropped from the UI).
  - `docs/platform-usability-standards.md` — the "Name the role, not the species" rule added in #3749, which is the standard these strings are being brought into line with.
  - BI-08393602 / PR #3527 — the precedent for splitting a technical term from its user-facing counterpart ("Agent" vs "AI coworker").
- Current code substrate reviewed:
  - `apps/web/lib/workforce/oversight-copy.ts` — the canonical copy module from #3749; no new vocabulary was invented here, these strings adopt it.
  - `apps/web/lib/owner-first/vocabulary.ts` — the existing owner-first lens, which is why owner-facing surfaces resolve to "owner"/second person rather than "employee".
  - The identity domain (`Principal.kind`, `platform/identity/*`) to confirm which "human" references are the principal-kind axis and must NOT change.
  - Each of the 24 call sites, to classify its referent as workforce, owner, or reader before choosing a word.
- Source of truth:
  - `apps/web/lib/workforce/oversight-copy.ts` for oversight language; `docs/platform-usability-standards.md` for the role-naming rule.
- Decision:
  - Localized copy-only fix. No contract, routing, schema, queue, or component-API change — 24 rendered string literals plus two test assertions that read them. Enum discriminants, principal kinds, and helper names are deliberately untouched.

Design-Grounding-Decision: reviewed docs/superpowers/plans/2026-07-29-employee-oversight-vocabulary.md, docs/platform-usability-standards.md, apps/web/lib/workforce/oversight-copy.ts and apps/web/lib/owner-first/; localized copy-only fix, no contract or routing change.
