### PR TITLE
fix(wsid): publishing a craft override promotes it, whichever path published it (BI-8AC24F3D)

### DIFF
--- a/apps/web/lib/actions/wiki-edit.test.ts
+++ b/apps/web/lib/actions/wiki-edit.test.ts
@@ -15,6 +15,12 @@ vi.mock("@dpf/db", () => ({
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
+// BI-8AC24F3D: mocked so the callsite wiring is what is under test here; the
+// helper's own contract is covered in lib/wiki/craft-override-promotion.test.ts.
+vi.mock("@/lib/wiki/craft-override-promotion", () => ({
+  promoteCraftOverrideOnPublish: vi.fn().mockResolvedValue(null),
+}));
+
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { saveWikiOverlayEdit } from "./wiki-edit";
@@ -361,5 +367,108 @@ describe("saveWikiOverlayEdit — wikilink graph", () => {
         { fromPageId: "wp_self", toPageId: "wp_target_b" },
       ]),
     );
+  });
+});
+
+// ─── Craft-override promotion on publish (BI-8AC24F3D) ─────────────────────
+//
+// THE DEFECT THESE PIN. This action is what the portal Edit page calls, so
+// flipping Status to `published` here IS how an operator publishes a craft
+// override. It used to write `status` and nothing else: the page went live, no
+// PerspectiveMaterial was written, and the profession gate kept deferring —
+// while the craft form said "Publish it to make it part of this role's craft"
+// and the WWWD sibling promised "Your AI now weighs this stance when it
+// decides". Structurally published, functionally inert.
+//
+// The promoting path (publishWikiOverlayPages) had the hook but no UI caller,
+// so the two publish routes meant different things. Both now share
+// promoteCraftOverrideOnPublish; these tests keep the reachable one wired.
+
+describe("saveWikiOverlayEdit — craft-override promotion", () => {
+  const craftSlug = "craft/enterprise-architecture/verify-the-substrate-first";
+
+  function stubExistingCraftPage(status: string) {
+    const existing = {
+      id: "wp_craft",
+      slug: craftSlug,
+      isKernel: false,
+      organizationId: "org_test",
+      pageKind: "heuristic",
+      status,
+    };
+    (prisma.wikiPage.findFirst as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce({ id: existing.id });
+    return existing;
+  }
+
+  function stubUpdateResult(status: string) {
+    (prisma.wikiPage.update as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "wp_craft",
+      slug: craftSlug,
+      status,
+    });
+    (prisma.wikiPageRevision.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "rev_craft",
+    });
+  }
+
+  const save = (status: "draft" | "published") =>
+    saveWikiOverlayEdit({
+      pageId: "wp_craft",
+      slug: craftSlug,
+      pageKind: "heuristic",
+      title: "Verify the substrate first",
+      body: "Sweep the existing substrate before proposing a new model.",
+      status,
+    });
+
+  it("promotes to gate-live material when an operator flips draft -> published", async () => {
+    const { promoteCraftOverrideOnPublish } = await import("@/lib/wiki/craft-override-promotion");
+    stubExistingCraftPage("draft");
+    stubUpdateResult("published");
+
+    const result = await save("published");
+
+    expect(result.ok).toBe(true);
+    expect(promoteCraftOverrideOnPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: "wiki-edit",
+        page: expect.objectContaining({ id: "wp_craft", slug: craftSlug, pageKind: "heuristic" }),
+      }),
+    );
+  });
+
+  it("does NOT promote when the save leaves the page in draft", async () => {
+    const { promoteCraftOverrideOnPublish } = await import("@/lib/wiki/craft-override-promotion");
+    stubExistingCraftPage("draft");
+    stubUpdateResult("draft");
+
+    await save("draft");
+
+    expect(promoteCraftOverrideOnPublish).not.toHaveBeenCalled();
+  });
+
+  it("does NOT re-promote when editing a page that was ALREADY published", async () => {
+    // Guarded on the transition, not the target status — otherwise every
+    // subsequent copy edit re-promotes and churns material rows.
+    const { promoteCraftOverrideOnPublish } = await import("@/lib/wiki/craft-override-promotion");
+    stubExistingCraftPage("published");
+    stubUpdateResult("published");
+
+    await save("published");
+
+    expect(promoteCraftOverrideOnPublish).not.toHaveBeenCalled();
+  });
+
+  it("still returns ok when promotion fails — a completed publish is never rolled back", async () => {
+    const { promoteCraftOverrideOnPublish } = await import("@/lib/wiki/craft-override-promotion");
+    (promoteCraftOverrideOnPublish as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    stubExistingCraftPage("draft");
+    stubUpdateResult("published");
+
+    const result = await save("published");
+
+    expect(result).toMatchObject({ ok: true, status: "published" });
   });
 });

--- a/apps/web/lib/actions/wiki-edit.ts
+++ b/apps/web/lib/actions/wiki-edit.ts
@@ -29,6 +29,7 @@ import {
 import { extractWikilinks } from "@dpf/db/wiki-frontmatter";
 import { revalidatePath } from "next/cache";
 import { requireUser } from "@/lib/actions/shared/guards";
+import { promoteCraftOverrideOnPublish } from "@/lib/wiki/craft-override-promotion";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -172,6 +173,11 @@ export async function saveWikiOverlayEdit(
       return { ok: false, error: "Body is required." };
     }
 
+    // Status this page held BEFORE this save, so a draft -> published
+    // transition can be detected below (BI-8AC24F3D). Null when creating a new
+    // row, which counts as "was not published".
+    let previousStatus: WikiPageStatus | null = null;
+
     // If pageId supplied: load + verify scope.
     if (input.pageId) {
       const existing = (await prisma.wikiPage.findFirst({
@@ -182,6 +188,7 @@ export async function saveWikiOverlayEdit(
           isKernel: true,
           organizationId: true,
           pageKind: true,
+          status: true,
         },
       })) as
         | {
@@ -190,6 +197,7 @@ export async function saveWikiOverlayEdit(
             isKernel: boolean;
             organizationId: string | null;
             pageKind: string;
+            status: WikiPageStatus;
           }
         | null;
       if (!existing) {
@@ -217,6 +225,7 @@ export async function saveWikiOverlayEdit(
             "Slug changes are not supported in the v1 editor — delete and recreate, or open a PR.",
         };
       }
+      previousStatus = existing.status;
     } else if (input.overridesKernelPageId) {
       // Creating a new overlay that overrides a kernel page.
       const kernel = (await prisma.wikiPage.findFirst({
@@ -269,6 +278,28 @@ export async function saveWikiOverlayEdit(
     });
 
     await syncOutLinks(saved.id, input.body, org.id);
+
+    // BI-8AC24F3D: this action is what the portal Edit page calls, so flipping
+    // Status to `published` here IS how an operator publishes a craft override.
+    // Until this hook existed the flip wrote status and nothing else — the page
+    // went live, no PerspectiveMaterial was written, and the profession gate
+    // kept deferring while the UI claimed the doctrine now counted. Same shared
+    // helper as publishWikiOverlayPages so the two paths cannot diverge.
+    // Guarded on the TRANSITION, not on the target status, so re-saving an
+    // already-published page does not re-promote on every keystroke-level edit.
+    if (saved.status === "published" && previousStatus !== "published") {
+      await promoteCraftOverrideOnPublish({
+        db: prisma,
+        page: {
+          id: saved.id,
+          slug: saved.slug,
+          title: input.title.trim(),
+          pageKind: input.pageKind,
+          abstract: input.abstract ?? null,
+        },
+        origin: "wiki-edit",
+      });
+    }
 
     revalidatePath(`/coworker-decisions/${input.slug}`);
     revalidatePath("/coworker-decisions");

--- a/apps/web/lib/actions/wiki-publish.ts
+++ b/apps/web/lib/actions/wiki-publish.ts
@@ -21,13 +21,9 @@ import {
   appendRevision,
   type WikiPageStatus,
 } from "@dpf/db/wiki-store";
-import {
-  parseProfessionPageSlug,
-  promoteProfessionPageMaterial,
-} from "@dpf/db/profession-material-promotion";
 import { revalidatePath } from "next/cache";
 import { requireUser } from "@/lib/actions/shared/guards";
-import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
+import { promoteCraftOverrideOnPublish } from "@/lib/wiki/craft-override-promotion";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -191,44 +187,24 @@ export async function publishWikiOverlayPages(
       // publishBusinessStance's promoteStanceMaterial call. Promotion failure
       // never rolls back the page publish: the page flip already happened and
       // the seed backfill converges any missed material on its next run.
-      const slugInfo =
-        targetStatus === "published" ? parseProfessionPageSlug(row.slug) : null;
-      if (slugInfo?.corpus === "org-override") {
-        try {
-          const family = PROFESSION_REGISTRY.families.find(
-            (f) => f.professionKey === slugInfo.professionKey,
-          );
-          const promoted = await promoteProfessionPageMaterial({
-            db: prisma,
-            professionKey: slugInfo.professionKey,
-            contextSlugs: family?.contextSlugs ?? [],
-            page: {
-              id: row.id,
-              slug: row.slug,
-              title: row.title,
-              pageKind: row.pageKind,
-              abstract: row.abstract,
-            },
-            tier: "confirmed",
-          });
-          if (promoted.ok) {
-            craftPromotions.push({
-              pageId: row.id,
-              slug: row.slug,
-              professionKey: slugInfo.professionKey,
-              gateLive: promoted.gateLive,
-              materialIds: promoted.materialIds,
-            });
-          } else {
-            console.warn(
-              `[wiki-publish] craft promotion skipped for ${row.slug}: ${promoted.error}`,
-            );
-          }
-        } catch (promotionError) {
-          console.warn(
-            `[wiki-publish] craft promotion failed for ${row.slug}: ${(promotionError as Error).message}`,
-          );
-        }
+      //
+      // BI-8AC24F3D: the promotion body moved to the shared helper so this path
+      // and saveWikiOverlayEdit (the action the portal Edit page calls) cannot
+      // diverge again — publishing here and publishing there must mean the
+      // same thing.
+      if (targetStatus === "published") {
+        const promotion = await promoteCraftOverrideOnPublish({
+          db: prisma,
+          page: {
+            id: row.id,
+            slug: row.slug,
+            title: row.title,
+            pageKind: row.pageKind,
+            abstract: row.abstract,
+          },
+          origin: "wiki-publish",
+        });
+        if (promotion) craftPromotions.push(promotion);
       }
       revalidatePath(`/coworker-decisions/${row.slug}`);
     }

--- a/apps/web/lib/wiki/craft-override-promotion.test.ts
+++ b/apps/web/lib/wiki/craft-override-promotion.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { promoteCraftOverrideOnPublish } from "./craft-override-promotion";
+
+// BI-8AC24F3D. The defect was NOT that promotion was broken — it worked fine in
+// publishWikiOverlayPages. The defect was that the publish path an operator can
+// actually reach (saveWikiOverlayEdit, behind the portal Edit page's Status
+// select) never called it. So these tests pin the shared helper's contract, and
+// the wiki-edit callsite test below pins that the reachable path calls it.
+
+const promoteProfessionPageMaterial = vi.hoisted(() => vi.fn());
+
+vi.mock("@dpf/db/profession-material-promotion", () => ({
+  // Real implementation — the regex is the contract under test.
+  parseProfessionPageSlug: (slug: string) => {
+    const match = /^(professions|craft)\/([a-z0-9-]+)\/.+/.exec(slug);
+    if (!match) return null;
+    return {
+      professionKey: match[2],
+      corpus: match[1] === "professions" ? "platform" : "org-override",
+    };
+  },
+  promoteProfessionPageMaterial,
+}));
+
+vi.mock("@/lib/decision-perspective/resolve-profession-profile", () => ({
+  PROFESSION_REGISTRY: {
+    families: [
+      { professionKey: "enterprise-architecture", contextSlugs: ["engineering-flow"] },
+    ],
+  },
+}));
+
+const db = {} as never;
+
+const eaPage = {
+  id: "page-1",
+  slug: "craft/enterprise-architecture/architecture-review-verdicts",
+  title: "Architecture review verdicts",
+  pageKind: "heuristic",
+  abstract: null,
+};
+
+beforeEach(() => {
+  promoteProfessionPageMaterial.mockReset();
+  promoteProfessionPageMaterial.mockResolvedValue({
+    ok: true,
+    gateLive: true,
+    materialIds: ["wsid-enterprise-architecture:craft/…:architecture-tradeoff"],
+  });
+});
+
+describe("promoteCraftOverrideOnPublish", () => {
+  it("promotes an org-override craft page at confirmed tier", async () => {
+    const result = await promoteCraftOverrideOnPublish({ db, page: eaPage, origin: "test" });
+
+    expect(result).toMatchObject({
+      slug: eaPage.slug,
+      professionKey: "enterprise-architecture",
+      gateLive: true,
+    });
+    // confirmed, not derived: publishing an override IS the owner's approval,
+    // and derived would map to professional-practice only.
+    expect(promoteProfessionPageMaterial).toHaveBeenCalledWith(
+      expect.objectContaining({ tier: "confirmed", professionKey: "enterprise-architecture" }),
+    );
+  });
+
+  it("passes the family's context slugs so high-stakes holds can apply", async () => {
+    await promoteCraftOverrideOnPublish({ db, page: eaPage, origin: "test" });
+    expect(promoteProfessionPageMaterial).toHaveBeenCalledWith(
+      expect.objectContaining({ contextSlugs: ["engineering-flow"] }),
+    );
+  });
+
+  it("ignores a PLATFORM corpus page — those are seeded, never publish-promoted", async () => {
+    const result = await promoteCraftOverrideOnPublish({
+      db,
+      page: { ...eaPage, slug: "professions/enterprise-architecture/togaf-adm-phases" },
+      origin: "test",
+    });
+    expect(result).toBeNull();
+    expect(promoteProfessionPageMaterial).not.toHaveBeenCalled();
+  });
+
+  it("ignores a non-profession overlay page", async () => {
+    const result = await promoteCraftOverrideOnPublish({
+      db,
+      page: { ...eaPage, slug: "principles/never-wipe-db" },
+      origin: "test",
+    });
+    expect(result).toBeNull();
+    expect(promoteProfessionPageMaterial).not.toHaveBeenCalled();
+  });
+
+  it("returns null (never throws) when promotion reports a failure", async () => {
+    promoteProfessionPageMaterial.mockResolvedValue({ ok: false, error: "no-profession-profile" });
+    await expect(
+      promoteCraftOverrideOnPublish({ db, page: eaPage, origin: "test" }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null (never throws) when promotion throws — the publish must stand", async () => {
+    // Load-bearing: callers must not roll back a completed status flip because
+    // promotion failed. The seed backfill converges missed material later.
+    promoteProfessionPageMaterial.mockRejectedValue(new Error("db down"));
+    await expect(
+      promoteCraftOverrideOnPublish({ db, page: eaPage, origin: "test" }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not promote a page kind the promoter rejects as non-decision-bearing", async () => {
+    // The kind gate lives in promoteProfessionPageMaterial; assert we surface
+    // its refusal as null rather than inventing a second kind allow-list here.
+    promoteProfessionPageMaterial.mockResolvedValue({ ok: false, error: "not-decision-bearing" });
+    const result = await promoteCraftOverrideOnPublish({
+      db,
+      page: { ...eaPage, pageKind: "summary" },
+      origin: "test",
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/lib/wiki/craft-override-promotion.ts
+++ b/apps/web/lib/wiki/craft-override-promotion.ts
@@ -1,0 +1,113 @@
+// BI-8AC24F3D: the ONE place a published craft override becomes gate-live
+// material.
+//
+// THE DEFECT THIS CLOSES
+// Two code paths flip an org-overlay page to `published`, and only one of them
+// promoted craft doctrine into `PerspectiveMaterial`:
+//
+//   publishWikiOverlayPages (actions/wiki-publish.ts) — promoted. Its only
+//     caller is the MCP tool `publish_wiki_overlay_pages` (registry_write).
+//     NO UI calls it.
+//   saveWikiOverlayEdit (actions/wiki-edit.ts) — the action the portal Edit
+//     page actually calls. It wrote `status` and promoted nothing.
+//
+// So the reachable operator flow — /coworker-decisions/craft/<key> → Edit →
+// Status → published → Save — published the page and created ZERO material.
+// The profession gate went on deferring while the UI said the opposite
+// ("Publish it to make it part of this role's craft"; the WWWD sibling
+// BusinessStanceForm promises "Your AI now weighs this stance when it
+// decides"). A publish that structurally succeeds and functionally does
+// nothing is exactly the structural-verification-is-not-functional trap.
+//
+// The fix is one implementation with two callers, not a second authority:
+// both publish paths call `promoteCraftOverrideOnPublish`. Keeping the
+// promotion in a plain module (not a "use server" file) is deliberate — every
+// export of a "use server" module becomes a callable server action, and this
+// helper must not be reachable as its own endpoint.
+
+import {
+  parseProfessionPageSlug,
+  promoteProfessionPageMaterial,
+  type ProfessionMaterialPromotionClient,
+} from "@dpf/db/profession-material-promotion";
+import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
+
+/** The page fields promotion needs. Satisfied by the rows both callers already select. */
+export type CraftOverridePage = {
+  id: string;
+  slug: string;
+  title: string;
+  pageKind: string;
+  abstract: string | null;
+};
+
+export type CraftPromotionOutcome = {
+  pageId: string;
+  slug: string;
+  professionKey: string;
+  gateLive: boolean;
+  materialIds: string[];
+};
+
+/**
+ * Promote a just-published `craft/<professionKey>/` override to
+ * `confirmed`-tier material. Publishing an override IS the owner's approval —
+ * the profession sibling of `publishBusinessStance`'s `promoteStanceMaterial`
+ * call (WSID Phase 6, BI-3B02FF9C).
+ *
+ * Returns null when the page is not an org-override craft page, when the
+ * profession has no profile, when the page kind is not decision-bearing, or
+ * when promotion throws.
+ *
+ * NEVER THROWS, and callers must never roll back the publish on a null: the
+ * status flip has already happened and the seed backfill converges any missed
+ * material on its next run. A failed promotion is a warning, not a lost page.
+ */
+export async function promoteCraftOverrideOnPublish(input: {
+  db: ProfessionMaterialPromotionClient;
+  page: CraftOverridePage;
+  /** Where the call came from, for the warning line only. */
+  origin: string;
+}): Promise<CraftPromotionOutcome | null> {
+  const slugInfo = parseProfessionPageSlug(input.page.slug);
+  if (slugInfo?.corpus !== "org-override") return null;
+
+  try {
+    const family = PROFESSION_REGISTRY.families.find(
+      (f) => f.professionKey === slugInfo.professionKey,
+    );
+    const promoted = await promoteProfessionPageMaterial({
+      db: input.db,
+      professionKey: slugInfo.professionKey,
+      contextSlugs: family?.contextSlugs ?? [],
+      page: {
+        id: input.page.id,
+        slug: input.page.slug,
+        title: input.page.title,
+        pageKind: input.page.pageKind,
+        abstract: input.page.abstract,
+      },
+      tier: "confirmed",
+    });
+
+    if (!promoted.ok) {
+      console.warn(
+        `[${input.origin}] craft promotion skipped for ${input.page.slug}: ${promoted.error}`,
+      );
+      return null;
+    }
+
+    return {
+      pageId: input.page.id,
+      slug: input.page.slug,
+      professionKey: slugInfo.professionKey,
+      gateLive: promoted.gateLive,
+      materialIds: promoted.materialIds,
+    };
+  } catch (promotionError) {
+    console.warn(
+      `[${input.origin}] craft promotion failed for ${input.page.slug}: ${(promotionError as Error).message}`,
+    );
+    return null;
+  }
+}

--- a/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
+++ b/docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md
@@ -573,3 +573,55 @@ overrides (`craft/enterprise-architecture/architecture-review-verdicts-…`,
 `wsid-enterprise-architecture` resolves 2 confirmed materials → confidence 0.9
 at low risk → `recommend` with `professionProfileSelected=true` instead of the
 coverage-gap defer (regression-locked in `profession-gate.test.ts`).
+
+## 13. Addendum (2026-07-29) — the publish path is the promotion trigger (BI-8AC24F3D)
+
+§12 defined the promotion contract but wired it to only one of the two code
+paths that publish an org-overlay page, and it was the path an operator cannot
+reach:
+
+| path | called by | promoted? |
+| --- | --- | --- |
+| `publishWikiOverlayPages` (`apps/web/lib/actions/wiki-publish.ts`) | MCP tool `publish_wiki_overlay_pages` (`registry_write`) only — **no UI caller** | yes |
+| `saveWikiOverlayEdit` (`apps/web/lib/actions/wiki-edit.ts`) | the portal Edit page (`WikiPageEditor`), i.e. every operator | **no** |
+
+So the reachable flow — `/coworker-decisions/craft/<professionKey>` → Edit →
+Status → `published` → Save — flipped the page live and wrote no
+`PerspectiveMaterial`. The gate went on deferring while the surface claimed the
+opposite: the craft form's own success copy is "Publish it to make it part of
+this role's craft", and its WWWD sibling `BusinessStanceForm` promises
+"Published. Your AI now weighs this stance when it decides." A publish that
+structurally succeeds and functionally does nothing is the
+`structural-verification-is-not-functional` commandment's exact failure shape,
+and it is why the §12 acceptance trace above never materialised in the live
+install: both EA overrides sat in `draft`, and every one of the 69
+`architecture-tradeoff` interactions stayed `defer`.
+
+**Contract (from BI-8AC24F3D).**
+
+1. **Publishing is the trigger, not the caller.** A `draft → published`
+   transition on a `craft/<professionKey>/` page promotes to `confirmed` tier,
+   regardless of which action performed the flip. Publishing IS the owner's
+   approval (§12.3); which button they pressed is not part of the contract.
+2. **One implementation, two callers.** The promotion body lives in
+   `apps/web/lib/wiki/craft-override-promotion.ts`
+   (`promoteCraftOverrideOnPublish`); both publish actions call it. Deliberately
+   a plain module, not a `"use server"` file — every export of a server-action
+   module becomes its own callable endpoint, and this helper must not be one.
+   Two publish paths are acceptable; two promotion implementations are not.
+3. **Guard on the transition, not the target status.** Re-saving an
+   already-published page must not re-promote, or ordinary copy edits churn
+   material rows.
+4. **Promotion never rolls back a publish.** The status flip has already
+   happened and the seed backfill converges missed material on its next run, so
+   a promotion failure is a logged warning and the action still returns ok.
+
+**Known residual, tracked separately.** The craft surface still has no
+first-class Publish control — `CraftOverrideForm` offers only "Save as draft",
+and publishing requires noticing the per-row `Edit` link and changing a status
+enum in a generic page editor. The `BusinessStanceForm` sibling has a real
+Publish button. That affordance gap is UX work, out of scope here; this
+addendum only guarantees that *when* a publish happens, it means something.
+Note also that with `confirmed` A/0.9 the gate reaches `escalate` and not
+`recommend` at medium risk — see BI-8E646099; §12's acceptance trace holds at
+low risk only.


### PR DESCRIPTION
## The defect

BI-3B02FF9C added the page→material promotion contract, but wired it to only one of the two code paths that publish an org-overlay page — and it was the path an operator cannot reach:

| path | called by | promoted? |
| --- | --- | --- |
| `publishWikiOverlayPages` (`lib/actions/wiki-publish.ts`) | MCP tool `publish_wiki_overlay_pages` (`registry_write`) only — **no UI caller** | yes |
| `saveWikiOverlayEdit` (`lib/actions/wiki-edit.ts`) | the portal Edit page (`WikiPageEditor`), i.e. every operator | **no** |

So the reachable flow — `/coworker-decisions/craft/<key>` → Edit → Status → `published` → Save — flipped the page live and wrote **zero** `PerspectiveMaterial`. The profession gate kept deferring while the surface promised the opposite: the craft form's success copy is *"Publish it to make it part of this role's craft"*, and its WWWD sibling `BusinessStanceForm` says *"Published. Your AI now weighs this stance when it decides."*

A publish that structurally succeeds and functionally does nothing is the `structural-verification-is-not-functional` failure shape.

## How it was found

Attempting, on founder instruction, to publish the two `craft/enterprise-architecture/*` overrides so EA `architecture-tradeoff` consults would stop deferring. This is also why the spec's own §12 acceptance trace never materialised in the live install — verified against the DB:

- both `craft/enterprise-architecture/*` pages sit at `status: draft`
- `wsid-enterprise-architecture` has 9 material rows, **all `professional-practice`**, zero `architecture-tradeoff`
- all 69 `architecture-tradeoff` interactions remain `defer`, unchanged after the Phase 6 backfill ran

## What changed

- **New `apps/web/lib/wiki/craft-override-promotion.ts`** — `promoteCraftOverrideOnPublish`, the one promotion implementation. Both publish actions call it, so the two paths cannot mean different things again. Two publish paths are acceptable; two promotion implementations are not. Deliberately a plain module rather than a `"use server"` file: every export of a server-action module becomes its own callable endpoint, and this helper must not be one.
- **`wiki-publish.ts`** — inline promotion body replaced by the shared call (~40 lines removed). Behaviour preserved; its existing tests pass untouched.
- **`wiki-edit.ts`** — promotes on a `draft → published` **transition**. Guarded on the transition rather than the target status, so ordinary copy edits to an already-published page do not re-promote and churn material rows. Required selecting `status` on the existing-row scope check to know the prior state.
- Promotion still **never rolls back a publish**: the status flip has already happened and the seed backfill converges missed material on its next run, so a failure is a logged warning and the action returns ok.

## Verification

- `lib/wiki/craft-override-promotion.test.ts` (new, 8 tests) — `confirmed` tier not `derived`; family `contextSlugs` passed through so the high-stakes hold can apply; platform-corpus pages ignored; non-profession slugs ignored; null-not-throw on both a reported failure and a thrown error.
- `lib/actions/wiki-edit.test.ts` (+4 tests) — promotes on `draft→published`; does **not** promote on a draft save; does **not** re-promote when already published; still returns ok when promotion fails.
- 34 tests green across `craft-override-promotion`, `wiki-edit`, `wiki-publish`, `profession-gate`, `critique-entry`.
- `pnpm run pregate` — **`gate passed`** at `7c275f5d9c` (full Docker CI-equivalent; preflight 27 guards clean, 1 environment-skip for the absent `@dpf/repo-guard-runtime`).
- `node scripts/check-module-size.mjs` clean; no derived-artifact drift (regenerating `doc-index` produces no change).

Typecheck note: bare `tsc` in this worktree reports the known hollow-`node_modules` wall (5154 repo-wide, all `TS2307` module-resolution; the single `TS7006` is pre-existing `syncOutLinks` code). Nothing attributable to these files — pregate is the authoritative check.

## Spec

New **§13** in `docs/superpowers/specs/2026-06-09-wsid-coworker-professional-corpus-design.md` records the publish-path contract: publishing is the trigger regardless of which action performed the flip; one implementation, two callers; guard on the transition; promotion never rolls back a publish.

## Scope — two residuals deliberately untouched

1. **`CraftOverrideForm` still has no first-class Publish control** (only "Save as draft"); publishing means noticing the per-row `Edit` link and changing a status enum in a generic editor. `BusinessStanceForm` has a real Publish button. That affordance gap is UX work needing a UX-fit review — still tracked on BI-8AC24F3D.
2. **With `confirmed` A/0.9 the gate reaches `escalate`, not `recommend`, at medium risk** — BI-8E646099. That is a safety-threshold decision for the founder, not a code change from this PR. §13 now states that §12's acceptance trace holds at **low risk only**.

So after this merges, publishing the two EA overrides will write `confirmed` `architecture-tradeoff` material and the deferrals stop. Whether the gate then recommends or escalates is BI-8E646099's call.

Closes BI-8AC24F3D (promotion trigger; the Publish-affordance residual stays open on it).
