### PR TITLE
fix(ci): isolate canonical harness boundaries

### DIFF
--- a/apps/web/lib/wiki/enrich-org-corpus.test.ts
+++ b/apps/web/lib/wiki/enrich-org-corpus.test.ts
@@ -192,6 +192,12 @@ function makeProposalInfer(opts: {
   });
 }
 
+/** Keep orchestration tests hermetic. Production embedding is covered by the
+ * embedding adapter tests; the fail-open case below injects its own failure. */
+async function successfulEmbed(): Promise<boolean> {
+  return true;
+}
+
 // ─── Tests ─────────────────────────────────────────────────────────────────
 
 describe("enrichOrgCorpus (BI-7C9D6198)", () => {
@@ -205,6 +211,7 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
       provenance: { sourceType: "data-entry", sourceRef: { field: "mission" } },
       trust: "first-party",
       db,
+      embed: successfulEmbed,
       infer,
     });
 
@@ -259,6 +266,7 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
       provenance: { sourceType: "research", sourceRef: { agent: "scout-coworker", urls: ["https://example.org/market"] } },
       trust: "researched",
       db,
+      embed: successfulEmbed,
       infer,
     });
 
@@ -282,6 +290,7 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
       provenance: { sourceType: "document", sourceRef: { documentId: "doc_42", page: 3 } },
       trust: "derived",
       db,
+      embed: successfulEmbed,
       infer,
     });
 
@@ -305,6 +314,7 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
       provenance: { sourceType: "data-entry", sourceRef: { field: "mission", version: 1 } },
       trust: "first-party",
       db,
+      embed: successfulEmbed,
       infer,
     });
 
@@ -317,6 +327,7 @@ describe("enrichOrgCorpus (BI-7C9D6198)", () => {
       provenance: { sourceType: "data-entry", sourceRef: { version: 1, field: "mission" } }, // key order swapped
       trust: "first-party",
       db,
+      embed: successfulEmbed,
       infer,
     });
 

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -27,6 +27,7 @@ export function dockerBuildTag(candidateBranch, slotKey = "") {
 // did (and the freshness gate correctly stays green, so nothing else catches
 // it). Verified 2026-07-05: default heap SIGABRT; 8 GiB completes cleanly.
 export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
+export const HOST_BUILD_NODE_ENV = "NODE_ENV=production";
 
 // Node 26 exposes experimental host localStorage/sessionStorage accessors even
 // when no backing file is configured. Those undefined host values shadow the
@@ -91,6 +92,7 @@ export function createToolchainFingerprint(input) {
     platform: input.platform ?? "unknown",
     arch: input.arch ?? "unknown",
     lockfileSha256: input.lockfileSha256 ?? "unknown",
+    nodeEnv: input.nodeEnv ?? "",
     nodeOptions: input.nodeOptions ?? "",
     testNodeOptions: input.testNodeOptions ?? "",
   };
@@ -143,6 +145,7 @@ export function collectToolchainFingerprint({ buildStrategy, cwd = process.cwd()
     platform: process.platform,
     arch: process.arch,
     lockfileSha256: fileSha256(`${cwd}/pnpm-lock.yaml`),
+    nodeEnv: HOST_BUILD_NODE_ENV,
     nodeOptions: HOST_BUILD_NODE_OPTIONS,
     testNodeOptions: HOST_TEST_NODE_OPTIONS,
   });
@@ -156,7 +159,10 @@ export function createLocalIntegrationPlan(input) {
     ? ["docker", "build", "--target", "build", "-t", dockerBuildTag(input.candidateBranch, input.slotKey), "."]
     // `env VAR=… cmd` keeps the plan a plain argv (no shell) — host-next is
     // POSIX-only by construction (Windows defaults to docker-build above).
-    : ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "next", "build"];
+    // The shared sandbox can inherit NODE_ENV from a prior test/dev process.
+    // Next requires a production build to run with the canonical production
+    // environment; otherwise the same source can fail in framework internals.
+    : ["env", HOST_BUILD_NODE_ENV, HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "next", "build"];
   const evidencePlanCommand = [
     "node",
     "scripts/ci-evidence-plan.mjs",

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -62,6 +62,44 @@ export function resolveCommandInvocation(command, baseEnv = process.env) {
   };
 }
 
+const SENSITIVE_COMMAND_ARG = /(?:token|secret|password|authorization|api[-_]?key|database[-_]?url)/i;
+
+function redactCommandArgs(args) {
+  let redactNext = false;
+  return args.map((arg) => {
+    if (redactNext) {
+      redactNext = false;
+      return "[REDACTED]";
+    }
+    const separator = arg.indexOf("=");
+    if (separator > 0 && SENSITIVE_COMMAND_ARG.test(arg.slice(0, separator))) {
+      return `${arg.slice(0, separator)}=[REDACTED]`;
+    }
+    if (arg.startsWith("-") && SENSITIVE_COMMAND_ARG.test(arg)) {
+      redactNext = true;
+    }
+    return arg;
+  });
+}
+
+export function createCommandFailureDiagnostics({ invocation, result, elapsedMs }) {
+  const error = result.error
+    ? {
+        name: result.error.name ?? "Error",
+        code: result.error.code ?? null,
+        message: result.error.message ?? String(result.error),
+      }
+    : null;
+  return {
+    command: invocation.command,
+    args: redactCommandArgs(invocation.args),
+    elapsedMs,
+    status: result.status ?? null,
+    signal: result.signal ?? null,
+    error,
+  };
+}
+
 export function resolveGitRevision(ref, { spawnSyncImpl = spawnSync, cwd } = {}) {
   const result = spawnSyncImpl("git", ["rev-parse", "--verify", ref], {
     cwd,

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -7,6 +7,7 @@ import {
   createLocalIntegrationPlan,
   createProductionArtifactIdentity,
   createToolchainFingerprint,
+  createCommandFailureDiagnostics,
   resolveGitRevision,
   resolveCommandInvocation,
 } from "./local-integration-ci.mjs";
@@ -310,6 +311,28 @@ describe("createLocalIntegrationPlan", () => {
       () => resolveCommandInvocation(["env", "1BAD=value", "pnpm", "test"]),
       /invalid environment assignment/,
     );
+  });
+
+  it("reports secret-safe child-process failure diagnostics", () => {
+    assert.deepEqual(createCommandFailureDiagnostics({
+      invocation: {
+        command: "pnpm",
+        args: ["--token", "sensitive", "--filter", "web", "exec", "vitest", "run"],
+      },
+      result: {
+        status: 1,
+        signal: null,
+        error: null,
+      },
+      elapsedMs: 1180,
+    }), {
+      command: "pnpm",
+      args: ["--token", "[REDACTED]", "--filter", "web", "exec", "vitest", "run"],
+      elapsedMs: 1180,
+      status: 1,
+      signal: null,
+      error: null,
+    });
   });
 });
 

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -45,6 +45,7 @@ describe("createLocalIntegrationPlan", () => {
       platform: "linux",
       arch: "arm64",
       lockfileSha256: "lock-sha",
+      nodeEnv: "NODE_ENV=production",
       nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
       testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
     });
@@ -58,6 +59,7 @@ describe("createLocalIntegrationPlan", () => {
       platform: "linux",
       arch: "arm64",
       lockfileSha256: "lock-sha",
+      nodeEnv: "NODE_ENV=production",
       nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
       testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
     });
@@ -66,6 +68,7 @@ describe("createLocalIntegrationPlan", () => {
       buildStrategy: "host-next",
       gitVersion: "git version 2.50.1",
       lockfileSha256: "lock-sha",
+      nodeEnv: "NODE_ENV=production",
       nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
       testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
       nodeVersion: "v24.0.0",
@@ -93,7 +96,7 @@ describe("createLocalIntegrationPlan", () => {
       "node scripts/check-guards.mjs",
       "env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run --maxWorkers=4",
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
-      "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",
+      "env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",
     ]);
   });
 

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   collectToolchainFingerprint,
+  createCommandFailureDiagnostics,
   createLocalIntegrationPlan,
   createProductionArtifactIdentity,
   dockerBuildTag,
@@ -51,12 +52,21 @@ const startedAt = new Date().toISOString();
 for (const command of plan.commands) {
   console.log(`[local-integration-ci] ${command.join(" ")}`);
   const invocation = resolveCommandInvocation(command);
+  const commandStartedAt = Date.now();
   const result = spawnSync(invocation.command, invocation.args, {
     stdio: "inherit",
     shell: process.platform === "win32",
     env: invocation.env,
   });
-  if (result.status !== 0) process.exit(result.status ?? 1);
+  if (result.status !== 0) {
+    const diagnostics = createCommandFailureDiagnostics({
+      invocation,
+      result,
+      elapsedMs: Date.now() - commandStartedAt,
+    });
+    console.error(`[local-integration-ci] command-failure ${JSON.stringify(diagnostics)}`);
+    process.exit(result.status ?? 1);
+  }
 }
 if (metadataOut) {
   const evidencePlan = evidencePlanOut


### PR DESCRIPTION
## Summary
- make the canonical corpus-enrichment orchestration tests deterministic by injecting the success embed dependency
- run the shared local-CI production build with the production environment contract and include it in the toolchain fingerprint
- preserve redacted child-process diagnostics when the governed runner fails, so harness faults remain distinguishable from product failures

## Verification
- exact candidate `ea95bf2dbe5b2c0f66829bdbf7073289d0facdca` merged with `origin/main` (`a2062bf08684b0eac9514545213bccba4abd79c0`) in governed `local-integration-ci`
- exhaustive evidence plan completed: migrations, docs/guards, full web Vitest suite, web typecheck, and Docker production build
- production image: `sha256:1f910e1e022939372366a93cd325eb1eeb16338b5d19a08eb38c1c3bcb48c6e6`
- gate completed at `2026-07-30T04:19:05.874Z`

## Impact
- UX verification: not applicable; internal CI/test harness only, with no portal behavior change
- migration verification: covered by the exact gate; no migration files changed
- documentation: no operator-facing or architectural contract changed

Backlog: BI-A923376E


Local-CI-Evidence: cms70l0c20bm401ogu4v4fnxp

