### PR TITLE
docs(agents): route pre-push gate and worktree verification mechanics into the shared skill pack (BI-33980CB6)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8651,6 +8651,7 @@
         "where-ci-runs-it",
         "run-locally-before-pushing",
         "the-pre-push-gate-pregate-default-on",
+        "reading-the-result-a-queued-run-can-exit-0",
         "the-pre-commit-typecheck-gate",
         "test-runner-pins-must-hold",
         "appsmobile-jest-must-stay-on-29x",

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -231,6 +231,29 @@ is available only as an explicit `scripts/gate-worktree.sh --push` (or
 `scripts/gate-worktree.mjs --push`) operation for recovery/transition cases
 that intentionally need it.
 
+### Reading the result — a queued run can exit 0
+
+Admission is queued (one slot until BI-A4427AB8). While waiting, the run prints
+`local-CI admission queued at position N`. **A run that never reaches admission
+can still terminate with exit code 0**, so exit status alone does not
+distinguish "gate passed" from "gate never ran". Confirm by artifact:
+
+1. The run ends with the literal line `gate passed`.
+2. It wrote the metadata record (the path is echoed as
+   `[local-integration-ci] metadata …`), and in that record **`candidateSha` is
+   the commit you are about to push**, with `baseSha` the base it merged
+   against. Check `evidencePlan.evidenceTier` / `fullSuite` describe the
+   coverage you expected.
+3. `grep -v "admission queued"` over the log. If only queue polling remains,
+   nothing ran.
+
+**Never wrap `pregate` in `timeout`.** Killing it mid-queue is what produces the
+false green above; run it unbounded. Queue contention is not a reason to reach
+for `DPF_SKIP_PREPUSH_GATE` — with a valid record for the head SHA the push is
+admitted normally. Cancelling a run can also leave a stale queued lease pinned
+to the **old** SHA; release it, or the next run queues behind your own
+abandoned entry.
+
 **The gate command has a checked-in default (BI-157DC9B2, BI-4BE30454):**
 [`scripts/local-ci-runner.mjs`](../../scripts/local-ci-runner.mjs) runs the
 canonical merged-code plan (`scripts/lib/local-integration-ci.mjs`: checkout
@@ -420,6 +443,9 @@ Name them so you catch yourself.
 | Reaching for `DPF_SKIP_*` to get past a hook | Bypasses are for verified false positives only | Fix the underlying error; CI gates it anyway |
 | Verifying UX against worktree `next dev` | Not the production-bundled runtime | Use the canonical install or sandbox lease (AGENTS.md §13) |
 | Treating a local green as the merge gate | The binding gate is the CI **Unit Tests** check | Local pass = evidence; CI pass = the gate |
+| Reading a `pregate` exit code as the verdict | A run killed while queued exits 0 without running | Require `gate passed` + a metadata record whose `candidateSha` is yours |
+| Wrapping `pregate` in `timeout` | Cuts it off mid-queue and manufactures a false green | Run it unbounded; background it and wait |
+| Trusting a green test run without naming the tree | Sibling worktrees hold identical paths; shell cwd persists between calls | Check the runner's root banner; reconcile the test count against your file |
 
 ## What this gate is NOT
 

--- a/packages/dpf-skill-pack/skills/dpf-local-merge-ci-before-push/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-local-merge-ci-before-push/SKILL.md
@@ -57,9 +57,26 @@ If a gate cannot run in the worktree because pnpm/corepack is missing, workspace
 6. Record the local integration result through MCP — `passed`, `failed`, `conflict`, or `blocked_sandbox_drift` (stale sandbox; carries the freshness verdict and resolved `next`/`react`/`react-dom` versions in evidence).
 7. Push only when the merged-code gate is green. If it is red, report the failure and next fix; if it is blocked on sandbox drift, converge and re-run — do not report a product failure.
 
+## Reading a pregate result — a queued run can exit 0
+
+`pregate` first waits for admission to the shared `local-integration-ci` lease. While it waits it prints `local-CI admission queued at position N`. **A run that never gets admitted can still terminate with exit code 0**, so the exit status alone does not distinguish "gate passed" from "gate never ran".
+
+Confirm a real pass by the artifacts, not the exit code:
+
+1. The run ends with the literal line `gate passed`.
+2. It wrote `.git/worktrees/<name>/dpf-local-ci-metadata.json` (path is echoed as `[local-integration-ci] metadata …`), and in that record **`candidateSha` is the commit you are about to push** and `baseSha` is the `origin/main` it merged against. Also check `evidencePlan.evidenceTier` / `fullSuite` describe the coverage you expected.
+3. Sanity-check the log actually contains gate work. `grep -v "admission queued"` — if nothing but queue polling remains, nothing ran.
+
+Then push normally: with a valid record for the head SHA the pre-push hook admits the push, and `DPF_SKIP_PREPUSH_GATE` is **not** needed.
+
+- **Never wrap `pregate` in `timeout`.** Killing it mid-queue is what produces the false green above. Run it unbounded (background it and wait for completion).
+- Queue contention is not a reason to override the gate. Waiting is correct; `DPF_SKIP_PREPUSH_GATE` is for a verified-clean push the gate structurally cannot cover, and it is recorded either way.
+- Cancelling a pregate can leave a stale queued lease pinned to the **old** SHA — release it before re-running, or the next run queues behind your own abandoned entry.
+
 ## Guardrails
 
 - Do not treat "passed in my worktree" as merge readiness.
+- Do not treat a pregate exit code as the verdict. The verdict is `gate passed` plus a metadata record whose `candidateSha` matches your commit.
 - A stale sandbox is not a product failure. Never record a red build as product evidence while the freshness preflight is red or unrun — classify it `blocked_sandbox_drift` and converge first.
 - Never start a second dependency install while one is running, and never "fix" a stale sandbox by installing dependencies inside a topic worktree.
 - Do not run destructive Compose cleanup against the root `dpf` project.

--- a/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
@@ -116,6 +116,31 @@ Prefer flag-enabled scheduled GC. Manual one-shot only with go:
 - Keep currently checked-out / non-terminal (`review`, `building`, …) branches.
 - `git worktree prune` inside sandbox if a dir was deleted out from under git.
 
+## Per-worktree caches and links that make a fresh worktree look broken
+
+A new worktree does not inherit the root clone's tool caches or generated artifacts. Each of these presents as a hang or a scary failure and is really just an unseeded worktree.
+
+**gitleaks re-downloads per worktree.** The pre-commit scan caches under the *worktree's* git dir, not the root clone's. A cancelled download leaves a half-written zip that makes the next commit appear to hang. Seed it from the root clone:
+
+```bash
+V=<version>; T="$(git rev-parse --git-path dpf-tools/gitleaks/$V)"
+mkdir -p "$T" && cp "<root-clone>/.git/dpf-tools/gitleaks/$V/gitleaks.exe" "$T/"
+```
+
+**`packages/db` tests need the generated Prisma client.** Junction it rather than regenerating per worktree — on Windows the link name must be *relative* (an absolute target path errors with "Parameter format not correct"):
+
+```bash
+cd packages/db && MSYS_NO_PATHCONV=1 cmd /c "mklink /J generated <root-clone>\packages\db\generated"
+```
+
+Remove that junction with `cmd /c rmdir generated` — **never `rm -rf`**, which follows the link and eats the target's contents.
+
+**The junction then trips the pre-commit Prisma staleness guard**, which compares mtimes (`schema.prisma` newer than `generated/client/client.ts`) and tries to regenerate. In a fresh worktree the schema is simply newer than the borrowed artifact. Confirm the schemas are identical (`md5sum` both), then remove the junction, commit, and recreate it — do **not** regenerate through the junction, which writes into the root clone.
+
+**A stale `index.lock` after a killed commit.** Check the holder before removing anything: `wmic process where processid=<pid> get commandline`. With many concurrent sessions, a live `git.exe` usually belongs to **another** worktree and does not hold your lock. Only then remove `.git/worktrees/<name>/index.lock`.
+
+**Commit messages: use `git commit -F <file>`.** PowerShell here-strings (`@'…'@`) are not parsed by the Bash tool and leak a literal `@` into the subject line. Verify with `git log -1 --format=%s`.
+
 ## Guardrails
 
 - **Dry-run default.** Live reap is never the default agent action.

--- a/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
@@ -123,6 +123,17 @@ Before editing or reviewing from an existing worktree:
 4. If `source-only`, you may edit and commit, but final answers and PR/evidence notes must say local worktree gates were not run and must point to canonical-runtime/local-CI evidence for any verification claim.
 5. Commit or capture dirty work frequently. A dirty active worker worktree blocks upgrade apply because uncommitted output cannot be safely rebased, promoted, or abandoned by automation.
 
+## Confirm which worktree your command actually ran in
+
+With many sibling worktrees holding the same file paths, a command can succeed against the **wrong** copy and look entirely normal. The shell's working directory **persists between tool calls**: one `cd` into a sibling worktree silently retargets every later command that relies on a relative path.
+
+- **Use absolute paths** in shell commands that read, test, or build. Do not rely on the cwd left by an earlier call.
+- **Read the runner's own root banner.** Vitest prints `RUN v<version> <root>` — if that root is not your worktree, the results are another branch's. Pin it explicitly: `node <abs>/node_modules/vitest/vitest.mjs run --root <ABSOLUTE pkg dir> <files>`.
+- **Cross-check the count.** Compare `grep -c '  it(' <file>` against the reported test total. A passing run whose count doesn't match your file did not execute your file. The same logic applies to any "N passed" summary — reconcile N against something you can count in your own tree.
+- After `git reset --hard origin/main`, re-confirm `git log --oneline -1`; never assume the base you started from.
+
+This is a *false green*, not a flake: nothing errors, and the pass is real — for someone else's code.
+
 ## Output template
 
 ```
@@ -145,6 +156,7 @@ Before editing or reviewing from an existing worktree:
 - **Never modify or move the root clone for active feature work.** The root clone is the merge/release/install worktree per `keep-root-clone-as-merge-worktree`; raw `git switch`, `git checkout`, `git reset`, `git pull`, `git merge`, and `git rebase` in that clone are root mutations, not setup.
 - Don't treat the worktree as a runtime by default. Commit from the worktree, verify against the canonical install. 'Make the worktree runnable' is a dedicated platform task, not a side-effect of every feature thread.
 - **Never claim unrun gates passed.** A `source-only` worktree can hold correct code, but its local typecheck/build/test status is unknown until proven in that worktree or in canonical runtime/local-CI.
+- **Never accept a green test run without confirming it targeted your worktree.** A sibling worktree holds the same paths; the runner's root banner and the test count are the proof.
 
 ## Worked example (this session, 2026-05-24)
 


### PR DESCRIPTION
## Problem

Four verification traps were being rediscovered per session because they lived only in client-local memory, which reaches exactly one client on one machine. `dpf-route-learning-to-commons` already states the rule — local client memory is *"a staging record at most"* — and these were never routed.

Each one produced a **plausible-looking pass that was not real**:

1. **`pregate` false green.** Admission to the single shared local-CI slot is queued, printing `local-CI admission queued at position N`. A run killed while still queued **terminates with exit code 0**, so exit status alone does not distinguish "gate passed" from "gate never ran". (This PR's own gate demonstrated the correct signal: `gate passed` plus a metadata record whose `candidateSha` matches HEAD.)
2. **Shell cwd persists between tool calls.** One `cd` into a sibling worktree silently retargets later relative-path commands. Vitest reported a green 49-test run against *another worktree's* copy of the file under edit; the working copy had 54.
3. **PowerShell here-strings in the Bash tool.** `@'…'@` is not parsed by bash and leaks a literal `@` into the commit subject.
4. **Per-worktree tool caches.** gitleaks caches under the *worktree's* git dir (so it re-downloads, and a cancelled download looks like a hang), `packages/db` tests need a `generated` junction, and that junction's older mtime then trips the pre-commit Prisma staleness guard.

## Why the skill pack

`packages/dpf-skill-pack/skills/<slug>/SKILL.md` is the single artifact that reaches both external clients and in-platform coworkers — `seed-skills.ts` discovers these files *"so the same files can be loaded by Claude/Codex plugins and seeded into coworkers"*, which is the Build Studio path. One file, every surface.

## Why AGENTS.md is deliberately untouched

The instruction-plane ratchet (`scripts/check-instruction-plane-size.mjs`) sums bytes across the always-on files and forbids growth past `scripts/instruction-plane-baseline.txt` — currently 91,044 of 91,227, i.e. **183 bytes of headroom**. Its own failure message says "move procedure/history out".

So the operational detail goes to [`docs/testing/pre-pr-gate.md`](docs/testing/pre-pr-gate.md), which AGENTS.md §5 **already links**: a new "Reading the result — a queued run can exit 0" subsection under the pregate section, plus three rows in the existing "Common drift" table. Loading this on demand rather than always-on is the progressive-disclosure principle applied to the agent plane, enforced mechanically against the very plane it would otherwise have bloated.

## Changes

| File | What |
| --- | --- |
| `dpf-local-merge-ci-before-push/SKILL.md` | How to read a pregate result (require `gate passed` + metadata `candidateSha` == your commit); never wrap it in `timeout`; queue contention is not grounds for `DPF_SKIP_PREPUSH_GATE`; release a stale queued lease pinned to the old SHA |
| `dpf-worktree-per-session/SKILL.md` | Confirm which worktree a command ran in — absolute paths, read vitest's `RUN <root>` banner, reconcile the reported test count against `grep -c '  it('` in your own file |
| `dpf-worktree-hygiene/SKILL.md` | gitleaks cache seeding, the `generated` junction (relative link name, `cmd /c rmdir` never `rm -rf`), the Prisma mtime guard, `git commit -F`, and checking a lock holder's commandline before removing `index.lock` |
| `docs/testing/pre-pr-gate.md` | "Reading the result" subsection + 3 "Common drift" rows |
| `doc-index.generated.json` | Regenerated by the pre-commit derived-artifact hook (new doc anchor) |

Documentation only — no TypeScript, schema, or route changes.

## Verification

- `packages/db` `seed-skills.test.ts` — 18/18 (runner root confirmed as this worktree, per trap 2 above).
- `scripts/check-instruction-plane-size.mjs` — OK, 91,044 bytes across 3 always-on files against a 91,227 baseline.
- `scripts/check-doc-reference-integrity.mjs` — OK, no net-new broken references.
- `pnpm run pregate` — `gate passed`, `candidateSha d714f1a13b`, `baseSha 95b98a554d`, `evidenceTier: exhaustive`, `fullSuite: true`.

Seed-Fit-Decision: global-default

These are platform agent-instruction skills under a canonical seed path (`packages/dpf-skill-pack/skills/`). The verification mechanics are properties of the DPF toolchain itself and apply identically to every install — nothing here is archetype- or vertical-specific, and nothing is install-local.

Backlog: BI-33980CB6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
