### PR TITLE
feat: shift PR readiness checks before CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,20 @@
 
 <!-- Paste the exact canonical-runtime evidence: command, output snippet, screenshot link, MCP evidence record, or CI job URL. -->
 
+## Pre-PR readiness
+
+<!-- Complete these before creating the PR. A pushed branch is the handoff artifact while any item remains open. -->
+
+- [ ] `pnpm gate:context` reviewed before implementation and again against the final diff
+- [ ] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
+- [ ] Exact-tree local-CI evidence captured with `pnpm run pregate`, or an allowed `Local-CI-Override` is documented below
+- [ ] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push
+
+<!-- Add exactly one when applicable:
+Local-CI-Evidence: <evidence-record-id> (<branch>@<sha>)
+Local-CI-Override: <allowed reason>
+-->
+
 ## Related issues / Epic
 
 <!-- Link issues this PR closes or relates to. Use "Closes #123" to auto-close on merge. -->

--- a/docs/superpowers/plans/2026-07-29-gate-context-pack-plan.md
+++ b/docs/superpowers/plans/2026-07-29-gate-context-pack-plan.md
@@ -54,7 +54,26 @@ found by this slice's first drift-guard run and fixed in the same change.
    generator module verbatim.
 3. **pr-readiness-convergence** → BI-9652021C: `buildGatePlan()` derived from
    `POLICY_GUARD_PROFILES`; readiness report leads with the gate-context
-   section; one trailer inventory.
+   section; one trailer inventory; the shared `dpf-pr-with-dco` skill and
+   GitHub PR template both require the mechanical readiness verdict after the
+   final push and before PR creation.
+
+## Acceptance (pr-readiness-convergence slice)
+
+- Deleting or adding an executable policy command in
+  `POLICY_GUARD_PROFILES` changes the pre-PR plan without editing a second
+  registry; policy self-tests are not redundantly replayed and CI setup that
+  mutates Git state is excluded from author worktrees. A missing source-only
+  host runtime is reported honestly as CI-enforced rather than mislabeled as a
+  product failure, matching the pregate-preflight degradation contract.
+- The readiness report renders the prospective gate-context checklist before
+  its pass/fail verdict for the exact `origin/main...HEAD` diff.
+- Trailer parsing and prospective trailer guidance consume one canonical
+  trailer-name contract.
+- The shared external-agent PR skill and GitHub template instruct authors to
+  run `pnpm gate:context`, the cheap no-lease preflight, exact-tree pregate
+  when applicable, and `pnpm pr:ready -- --pr-body-file ...` before creating
+  a regular PR.
 
 ## Acceptance (this slice)
 

--- a/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
@@ -88,6 +88,13 @@ DPF's PR contract is strict and non-negotiable: **every change lands via PR**, *
    ```
    For UX changes: drive the change against the running app (`/run` or `/verify` skill) and capture dynamic-analysis evidence.
 
+   Before requesting the shared sandbox, run the cheap deterministic checks:
+   ```
+   pnpm gate:context
+   pnpm run pregate:preflight
+   ```
+   Resolve the prospective constraints and host-side guard failures first. Do not spend a scarce sandbox lease discovering a missing PR trailer, plan receipt, derived artifact, or source-policy violation.
+
 3b. **Local-CI sandbox gate (default-on pre-push, BI-C74F4DE9).** For runtime-code branches, run `pnpm run pregate` before the push — the chained pre-push hook refuses an ungated push otherwise. Carry the evidence into the PR body as a trailer so `pnpm pr:health` reads the branch as merge-ready even when checked from another machine:
    ```
    Local-CI-Evidence: <evidence-record-id> (<branch>@<sha>)
@@ -112,24 +119,15 @@ DPF's PR contract is strict and non-negotiable: **every change lands via PR**, *
    ```
    `-u origin <branch>` only on the first push.
 
-7. **Open the regular PR.** Do not use `--draft`; a DPF PR is the ready-for-review / ready-to-merge signal.
+7. **Prepare and mechanically validate the PR body.** Write the final Markdown body to a temporary file using the client's native filesystem tool, including exact verification evidence and any required trailers. After the final push, run:
    ```
-   gh pr create --title "<convention>: <imperative summary>" --body "$(cat <<'EOF'
-   ## Summary
-   - <1-3 bullet points naming what the PR does and why>
-   - <reference parent BI / epic if applicable, e.g. "BI-XXXX">
+   pnpm pr:ready -- --pr-body-file <path-to-pr-body.md>
+   ```
+   This command derives its local checks from the same policy profiles as CI, validates Git/DCO/push state and PR trailers, and leads with the gate-context checklist for the exact diff. If it reports `PR readiness: NOT READY`, fix every blocker and rerun it. Do not create the PR yet.
 
-   ## Test plan
-   - [x] vitest <target file or suite>: <N passing>
-   - [x] typecheck: clean
-   - [x] next build: <pass or n/a if no UI surface>
-   - [x] UX verification: <dynamic-analysis report or n/a>
-
-   <Any operator-context notes — overlap sweep result, dependencies, etc.>
-
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   EOF
-   )"
+8. **Open the regular PR only after `pr:ready` reports READY.** Do not use `--draft`; a DPF PR is the ready-for-review / ready-to-merge signal. Reuse the exact body file that passed readiness:
+   ```
+   gh pr create --title "<convention>: <imperative summary>" --body-file <path-to-pr-body.md>
    ```
 
    - Title: imperative form, prefixed by repo convention (`docs:`, `fix:`, `feat:`, `chore:`, `spec:`). Under ~72 chars.
@@ -140,7 +138,7 @@ DPF's PR contract is strict and non-negotiable: **every change lands via PR**, *
      ```
      Expected: `isDraft` is `false`. If it is `true` and the branch gates are green, run `gh pr ready <number>` immediately; if the gates are not green, close the PR and keep the branch.
 
-8. **Report the PR URL.** With the BI id (if applicable) and the build-gate evidence summary so the operator can ratify without re-running checks.
+9. **Report the PR URL.** With the BI id (if applicable) and the build-gate evidence summary so the operator can ratify without re-running checks.
 
 ## Output template
 

--- a/scripts/lib/gate-context.mjs
+++ b/scripts/lib/gate-context.mjs
@@ -45,6 +45,7 @@ import {
   UX_ROUTE_FILE_RE,
 } from "./gate-sensitivity.mjs";
 import { findCanonicalSeedContentPaths } from "./seed-fit-gate.mjs";
+import { PR_TRAILER_NAMES } from "./pr-trailer-contract.mjs";
 import {
   MODULE_SIZE_HARD_CAP,
   MODULE_SIZE_SOFT_CEILING,
@@ -99,7 +100,7 @@ function trailerConstraints(files, addedLinesByFile) {
   if ((newSubstantial.length > 0 || addedSourceLines > ADDED_SOURCE_LINE_THRESHOLD) && !docsTouched) {
     trailers.push({
       gate: "Spec/Plan/Doc",
-      trailer: "Process-Spine-Decision:",
+      trailer: `${PR_TRAILER_NAMES.processSpine}:`,
       level: "required",
       because: newSubstantial.length > 0
         ? `new source module(s)/route(s): ${newSubstantial.slice(0, 5).map((f) => f.path).join(", ")}`
@@ -112,7 +113,7 @@ function trailerConstraints(files, addedLinesByFile) {
   if (designSensitive.length > 0) {
     trailers.push({
       gate: "Design Grounding",
-      trailer: "Design-Grounding-Decision:",
+      trailer: `${PR_TRAILER_NAMES.designGrounding}:`,
       level: "required",
       because: `design-sensitive file(s): ${designSensitive.slice(0, 5).join(", ")}`,
       alternative: "a '## Design grounding' section in the PR body (specs/plans reviewed + code substrate reviewed + source of truth + decision)",
@@ -156,7 +157,7 @@ function trailerConstraints(files, addedLinesByFile) {
   if (seedPaths.length > 0) {
     trailers.push({
       gate: "Seed Contribution Fit",
-      trailer: "Seed-Fit-Decision:",
+      trailer: `${PR_TRAILER_NAMES.seedFit}:`,
       level: "required",
       because: `canonical seed content changed: ${seedPaths.slice(0, 5).join(", ")}`,
       note: "this one goes in the PR BODY (the gate reads the push-event body, not commit trailers)",

--- a/scripts/lib/gate-sensitivity.mjs
+++ b/scripts/lib/gate-sensitivity.mjs
@@ -11,9 +11,11 @@
 // skill-pack hooks' local mirrors to it (the hooks keep dependency-free copies
 // because the pack is distributed outside this repo).
 
+import { PR_TRAILER_NAMES } from "./pr-trailer-contract.mjs";
+
 // ── Spec/Plan/Doc gate (scripts/check-spec-plan-doc.mjs) ─────────────────────
 
-export const PROCESS_SPINE_ATTESTATION_RE = /Process-Spine-Decision:/i;
+export const PROCESS_SPINE_ATTESTATION_RE = new RegExp(`${PR_TRAILER_NAMES.processSpine}:`, "i");
 
 // What COUNTS as a substantial implementation surface (triggers the gate):
 // NEW source modules and routes are a high-signal, low-false-positive marker
@@ -38,7 +40,7 @@ export const DOC_ARTIFACT_RE =
  * so tooling can still RECOGNISE the dead trailer in order to warn about it (see
  * RETIRED_TRAILERS in scripts/pr-readiness/core.mjs). Do not gate on it.
  */
-export const UX_FIT_ATTESTATION_RE = /UX-Fit-Decision:/i;
+export const UX_FIT_ATTESTATION_RE = new RegExp(`${PR_TRAILER_NAMES.uxFitRetired}:`, "i");
 
 // Added lines that introduce a user-facing control the operator must understand.
 export const UI_CONTROL_RE = /<input\b|<select\b|<textarea\b|type=["'](?:number|range)["']|<form\b/i;

--- a/scripts/lib/pr-trailer-contract.mjs
+++ b/scripts/lib/pr-trailer-contract.mjs
@@ -1,0 +1,17 @@
+// Canonical PR-body trailer names shared by prospective gate context,
+// pre-PR readiness, and CI-facing sensitivity checks.
+//
+// Keep values colon-free. Consumers add punctuation appropriate to their
+// output or matcher so parsing and author guidance cannot drift independently.
+
+export const PR_TRAILER_NAMES = Object.freeze({
+  processSpine: "Process-Spine-Decision",
+  uxFitRetired: "UX-Fit-Decision",
+  seedFit: "Seed-Fit-Decision",
+  designGrounding: "Design-Grounding-Decision",
+  docsImpact: "Docs-Impact-Decision",
+  localCiEvidence: "Local-CI-Evidence",
+  localCiOverride: "Local-CI-Override",
+});
+
+export const SUPPORTED_PR_TRAILERS = Object.freeze(Object.values(PR_TRAILER_NAMES));

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -10,7 +10,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { buildGatePlan, evaluateReadiness, formatReadinessReport } from "./pr-readiness/core.mjs";
+import { collectWorktreeDiff } from "./gate-context.mjs";
+import { buildGateContext } from "./lib/gate-context.mjs";
 import { fetchOriginMainSharedSafe, isShallowRepository } from "./lib/git-fetch-shared-safe.mjs";
+import { isEnvironmentFailureOutput } from "./lib/pregate-preflight.mjs";
 
 function git(args, { allowFail = false } = {}) {
   try {
@@ -89,10 +92,8 @@ function readRepoState() {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  const changedFiles = git(["diff", "--name-only", "origin/main...HEAD"], { allowFail: true })
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const worktreeDiff = collectWorktreeDiff({ base: "origin/main" });
+  const changedFiles = worktreeDiff.changedFiles.map((entry) => entry.path);
 
   return {
     branch,
@@ -100,6 +101,8 @@ function readRepoState() {
     isShallow: isShallowRepository((args) => git(args)),
     mergeBases,
     changedFiles,
+    changedFileEntries: worktreeDiff.changedFiles,
+    addedLinesByFile: worktreeDiff.addedLinesByFile,
     statusPorcelain: git(["status", "--porcelain"], { allowFail: true }),
     upstream: upstream || null,
     ahead: aheadBehind.ahead,
@@ -116,11 +119,13 @@ function runGate(gate) {
     encoding: "utf8",
     maxBuffer: 32 * 1024 * 1024,
   });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
   return {
     name: gate.name,
     ok: result.status === 0,
+    skippedEnvironment: result.status !== 0 && isEnvironmentFailureOutput(output),
     exitCode: result.status ?? 1,
-    output: [result.stdout, result.stderr].filter(Boolean).join("\n").trim(),
+    output,
   };
 }
 
@@ -148,7 +153,11 @@ function main() {
 
   const gatePlan = buildGatePlan({ prBody: args.prBody, prLabelsJson: args.prLabelsJson });
   const gateResults = args.runGates ? gatePlan.map(runGate) : [];
-  const verdict = evaluateReadiness({ repo, gateResults, prBody: args.prBody });
+  const gateContext = buildGateContext({
+    changedFiles: repo.changedFileEntries,
+    addedLinesByFile: repo.addedLinesByFile,
+  });
+  const verdict = evaluateReadiness({ repo, gateResults, prBody: args.prBody, gateContext });
   process.stdout.write(formatReadinessReport(verdict));
   process.exit(verdict.ready ? 0 : 1);
 }

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import {
@@ -6,8 +7,10 @@ import {
   evaluateReadiness,
   formatReadinessReport,
   parsePrBodyTrailers,
+  SUPPORTED_TRAILERS,
   validatePrBodyTrailers,
 } from "./pr-readiness/core.mjs";
+import { PR_TRAILER_NAMES } from "./lib/pr-trailer-contract.mjs";
 
 const cleanRepo = {
   branch: "feat/example",
@@ -28,26 +31,65 @@ const cleanRepo = {
   ],
 };
 
-test("buildGatePlan mirrors pre-PR governance gates that CI owns", () => {
-  const plan = buildGatePlan({ prBody: "UX-Fit-Decision: no-ui-change", prLabelsJson: "[]" });
+test("buildGatePlan derives runnable checks from the canonical policy profiles", () => {
+  const profiles = {
+    source: [
+      {
+        id: "source-a",
+        name: "Source A",
+        commands: [
+          ["node", ["--test", "source-a.test.mjs"]],
+          ["node", ["scripts/source-a.mjs"]],
+        ],
+      },
+    ],
+    "pull-request": [
+      {
+        id: "pr-a",
+        name: "PR A",
+        commands: [["node", ["scripts/pr-a.mjs"]]],
+      },
+      {
+        id: "mutating",
+        name: "Mutating",
+        commands: [
+          ["git", ["merge", "origin/main"]],
+          ["node", ["scripts/after-merge.mjs"]],
+        ],
+      },
+    ],
+  };
+  const plan = buildGatePlan({
+    prBody: "Seed-Fit-Decision: global-default",
+    prLabelsJson: "[]",
+    profiles,
+  });
   assert.deepEqual(
-    plan.map((gate) => gate.name),
+    plan.map((gate) => [gate.name, gate.command]),
     [
-      "Spec/Plan/Doc Gate",
-      "Plan Backlog Coverage Gate",
-      "Seed Contribution Fit Gate",
-      "UX-Fit Gate",
-      "Design Grounding Gate",
-      "Data-Impact Gate",
-      "Docs Impact Gate",
-      "Doc Link Integrity",
-      "Doc Reference Integrity",
-      "Retired Superpowers Skill Guard",
+      ["Source A", ["node", ["scripts/source-a.mjs"]]],
+      ["PR A", ["node", ["scripts/pr-a.mjs"]]],
     ],
   );
   assert.equal(plan[0].env.BASE_SHA, "origin/main");
-  assert.equal(plan[2].env.GITHUB_EVENT_NAME, "pull_request");
-  assert.equal(plan[2].env.PR_LABELS_JSON, "[]");
+  assert.equal(plan[1].env.GITHUB_EVENT_NAME, "pull_request");
+  assert.equal(plan[1].env.PR_LABELS_JSON, "[]");
+});
+
+test("buildGatePlan changes when the canonical profile changes", () => {
+  const guard = {
+    id: "only-guard",
+    name: "Only Guard",
+    commands: [["node", ["scripts/only-guard.mjs"]]],
+  };
+  const populated = buildGatePlan({
+    profiles: { source: [guard], "pull-request": [] },
+  });
+  const deleted = buildGatePlan({
+    profiles: { source: [], "pull-request": [] },
+  });
+  assert.deepEqual(populated.map((entry) => entry.name), ["Only Guard"]);
+  assert.deepEqual(deleted, []);
 });
 
 test("parsePrBodyTrailers extracts supported trailers with line numbers", () => {
@@ -110,17 +152,81 @@ test("evaluateReadiness folds failed local gates into one pre-PR verdict", () =>
   assert.match(result.warnings.join("\n"), /editing the PR body after a workflow run has started/);
 });
 
+test("evaluateReadiness reports a missing host runtime honestly without treating it as a product failure", () => {
+  const result = evaluateReadiness({
+    repo: cleanRepo,
+    gateResults: [
+      {
+        name: "Repo Guard Loop",
+        ok: false,
+        skippedEnvironment: true,
+        exitCode: 1,
+        output: "GuardRuntimeEnvironmentError: pinned TypeScript missing",
+      },
+    ],
+    prBody: "",
+  });
+  assert.equal(result.ready, true);
+  assert.equal(result.blockers.length, 0);
+  assert.match(result.warnings.join("\n"), /source-only host/);
+  assert.match(result.warnings.join("\n"), /CI still enforces it/);
+});
+
 test("formatReadinessReport uses plain-language headings and changed-file summary", () => {
   const result = evaluateReadiness({
     repo: { ...cleanRepo, changedFiles: ["a.ts", "b.ts"] },
     gateResults: [],
     prBody: "",
+    gateContext: {
+      trailers: [
+        {
+          gate: "Design Grounding",
+          trailer: `${PR_TRAILER_NAMES.designGrounding}:`,
+          level: "required",
+          because: "design-sensitive file changed",
+        },
+      ],
+      moduleSize: [],
+      ratchets: [],
+      derivedArtifacts: [],
+      routes: [],
+      migrations: [],
+      verification: ["run the readiness command"],
+    },
   });
   const report = formatReadinessReport(result);
+  assert.ok(
+    report.indexOf("# Gate context") < report.indexOf("PR readiness: READY"),
+    "the prospective checklist must lead the pass/fail verdict",
+  );
+  assert.match(report, /Design-Grounding-Decision:/);
   assert.match(report, /PR readiness: READY/);
   assert.match(report, /Changed files: 2/);
   assert.match(report, /What passed/);
   assert.match(report, /Safe to open or queue the PR/);
+});
+
+test("one trailer contract feeds readiness parsing and gate-context names", () => {
+  assert.ok(SUPPORTED_TRAILERS.has(PR_TRAILER_NAMES.processSpine));
+  assert.ok(SUPPORTED_TRAILERS.has(PR_TRAILER_NAMES.designGrounding));
+  assert.ok(SUPPORTED_TRAILERS.has(PR_TRAILER_NAMES.seedFit));
+  assert.ok(SUPPORTED_TRAILERS.has(PR_TRAILER_NAMES.docsImpact));
+  assert.ok(SUPPORTED_TRAILERS.has(PR_TRAILER_NAMES.localCiEvidence));
+  assert.ok(SUPPORTED_TRAILERS.has(PR_TRAILER_NAMES.localCiOverride));
+});
+
+test("shared PR skill and GitHub template require the mechanical readiness checklist", () => {
+  const skill = readFileSync(
+    new URL("../packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md", import.meta.url),
+    "utf8",
+  );
+  const template = readFileSync(
+    new URL("../.github/PULL_REQUEST_TEMPLATE.md", import.meta.url),
+    "utf8",
+  );
+  assert.match(skill, /pnpm pr:ready -- --pr-body-file/);
+  assert.match(template, /## Pre-PR readiness/);
+  assert.match(template, /pnpm pr:ready -- --pr-body-file/);
 });
 
 // BI-D967DEE0: the UX-Fit trailer is retired. pr-readiness still PARSES it so the author

--- a/scripts/pr-readiness/core.mjs
+++ b/scripts/pr-readiness/core.mjs
@@ -1,16 +1,23 @@
 import { SEED_FIT_DECISIONS } from "../lib/seed-fit-gate.mjs";
+import { POLICY_GUARD_PROFILES } from "../lib/ci-policy-guards.mjs";
+import { formatGateContextMarkdown } from "../lib/gate-context.mjs";
+import {
+  PR_TRAILER_NAMES,
+  SUPPORTED_PR_TRAILERS,
+} from "../lib/pr-trailer-contract.mjs";
 
 const VALID_SEED_FIT_DECISIONS = new Set(SEED_FIT_DECISIONS);
-
-const SUPPORTED_TRAILERS = new Set([
-  "Process-Spine-Decision",
-  "UX-Fit-Decision",
-  "Seed-Fit-Decision",
-  "Design-Grounding-Decision",
-  "Docs-Impact-Decision",
-  "Local-CI-Evidence",
-  "Local-CI-Override",
+const MUTATING_GIT_COMMANDS = new Set([
+  "checkout",
+  "clean",
+  "commit",
+  "merge",
+  "rebase",
+  "reset",
+  "switch",
 ]);
+
+export const SUPPORTED_TRAILERS = new Set(SUPPORTED_PR_TRAILERS);
 
 /**
  * Trailers that are still PARSED so the author gets told they are inert, rather than
@@ -19,35 +26,46 @@ const SUPPORTED_TRAILERS = new Set([
  */
 const RETIRED_TRAILERS = new Map([
   [
-    "UX-Fit-Decision",
+    PR_TRAILER_NAMES.uxFitRetired,
     'retired by BI-D967DEE0 — the UX-Fit Gate now requires a measured manifest at docs/ux-fit/<date>-<slug>.ux-fit.json (evidence.kind "sweep-measurement" or "propose-n-pick"). This trailer no longer satisfies any gate.',
   ],
 ]);
 
-const REQUIRED_GATE_SCRIPTS = [
-  ["Spec/Plan/Doc Gate", "scripts/check-spec-plan-doc.mjs"],
-  ["Plan Backlog Coverage Gate", "scripts/check-plan-backlog-coverage.mjs"],
-  ["Seed Contribution Fit Gate", "scripts/check-seed-fit-decision.mjs"],
-  ["UX-Fit Gate", "scripts/check-ux-fit-decision.mjs"],
-  ["Design Grounding Gate", "scripts/check-design-grounding-decision.mjs"],
-  ["Data-Impact Gate", "scripts/check-data-impact.mjs"],
-  ["Docs Impact Gate", "scripts/check-docs-impact.mjs"],
-  ["Doc Link Integrity", "scripts/check-doc-links.mjs"],
-  ["Doc Reference Integrity", "scripts/check-doc-reference-integrity.mjs"],
-  ["Retired Superpowers Skill Guard", "scripts/check-no-retired-superpowers-skills.mjs"],
-];
+function isSelfTest([command, args]) {
+  return command === "node" && args[0] === "--test";
+}
 
-export function buildGatePlan({ prBody = "", prLabelsJson = "[]" } = {}) {
-  return REQUIRED_GATE_SCRIPTS.map(([name, script]) => ({
-    name,
-    command: [process.execPath, [script]],
-    env: {
-      BASE_SHA: "origin/main",
-      PR_BODY: prBody,
-      PR_LABELS_JSON: prLabelsJson,
-      GITHUB_EVENT_NAME: "pull_request",
-    },
-  }));
+function mutatesGitState([command, args]) {
+  return command === "git" && MUTATING_GIT_COMMANDS.has(args[0]);
+}
+
+export function buildGatePlan({
+  prBody = "",
+  prLabelsJson = "[]",
+  profiles = POLICY_GUARD_PROFILES,
+} = {}) {
+  const env = {
+    BASE_SHA: "origin/main",
+    PR_BODY: prBody,
+    PR_LABELS_JSON: prLabelsJson,
+    GITHUB_EVENT_NAME: "pull_request",
+  };
+
+  return ["source", "pull-request"].flatMap((profileName) =>
+    (profiles[profileName] ?? []).flatMap((entry) => {
+      // The readiness command runs in the author's topic worktree. Never replay
+      // CI setup that rewrites Git state there. Its checks remain covered by CI
+      // and by the exact-tree local-CI gate.
+      if (entry.commands.some(mutatesGitState)) return [];
+
+      const commands = entry.commands.filter((command) => !isSelfTest(command));
+      return commands.map((command, index) => ({
+        name: commands.length === 1 ? entry.name : `${entry.name} (${index + 1}/${commands.length})`,
+        command,
+        env,
+      }));
+    }),
+  );
 }
 
 export function parsePrBodyTrailers(prBody = "") {
@@ -83,14 +101,14 @@ export function validatePrBodyTrailers(prBody = "") {
     }
   }
 
-  const seedFit = byName.get("Seed-Fit-Decision")?.[0]?.value;
+  const seedFit = byName.get(PR_TRAILER_NAMES.seedFit)?.[0]?.value;
   if (seedFit && !VALID_SEED_FIT_DECISIONS.has(seedFit)) {
     blockers.push(
       `Invalid Seed-Fit-Decision "${seedFit}". Valid values: ${[...VALID_SEED_FIT_DECISIONS].join(", ")}.`,
     );
   }
 
-  if (byName.has("Local-CI-Evidence") && byName.has("Local-CI-Override")) {
+  if (byName.has(PR_TRAILER_NAMES.localCiEvidence) && byName.has(PR_TRAILER_NAMES.localCiOverride)) {
     blockers.push("Use either Local-CI-Evidence or Local-CI-Override, not both.");
   }
 
@@ -103,7 +121,7 @@ export function validatePrBodyTrailers(prBody = "") {
   return { ok: blockers.length === 0, blockers, warnings, trailers };
 }
 
-export function evaluateReadiness({ repo, gateResults = [], prBody = "" } = {}) {
+export function evaluateReadiness({ repo, gateResults = [], prBody = "", gateContext = null } = {}) {
   const blockers = [];
   const warnings = [];
   const notes = [];
@@ -144,6 +162,12 @@ export function evaluateReadiness({ repo, gateResults = [], prBody = "" } = {}) 
   warnings.push(...trailerVerdict.warnings);
 
   for (const gate of gateResults) {
+    if (gate.skippedEnvironment) {
+      warnings.push(
+        `${gate.name} could not run on this source-only host; CI still enforces it. ${summarizeGateOutput(gate.output)}`,
+      );
+      continue;
+    }
     if (gate.ok) {
       passed.push(gate.name);
       continue;
@@ -170,11 +194,15 @@ export function evaluateReadiness({ repo, gateResults = [], prBody = "" } = {}) 
     branch: repo?.branch ?? "(unknown)",
     base: "origin/main",
     mergeBase: repo?.mergeBases?.[0] ?? null,
+    gateContext,
   };
 }
 
 export function formatReadinessReport(result) {
   const lines = [];
+  if (result.gateContext) {
+    lines.push(formatGateContextMarkdown(result.gateContext).trimEnd(), "");
+  }
   lines.push(`PR readiness: ${result.ready ? "READY" : "NOT READY"}`);
   lines.push(`Branch: ${result.branch}`);
   lines.push(`Base: ${result.base}${result.mergeBase ? ` (merge-base ${result.mergeBase.slice(0, 12)})` : ""}`);


### PR DESCRIPTION
## Summary

- Shift deterministic policy, trailer, and derived-artifact checks before PR creation instead of discovering them in GitHub Actions.
- Derive the pre-PR gate plan from the same `POLICY_GUARD_PROFILES` registry CI uses and lead readiness output with exact-diff gate context.
- Require the mechanical readiness sequence in the shared external-agent PR skill and GitHub PR template.

Backlog: BI-9652021C
Work Capsule: WC-B2914DD9
Parent: BI-2677A465

## Changes

- Added one canonical PR trailer-name contract used by readiness and prospective gate context.
- Removed the hand-maintained readiness gate list in favor of the CI policy profiles, excluding policy self-tests and Git-mutating CI setup.
- Preserved honest source-only degradation: missing host runtimes remain CI-enforced warnings, not product failures.
- Added final-diff gate context to `pr:ready`.
- Added a pre-PR checklist to the shared skill and PR template.

## Test plan

- [x] `node --test scripts/pr-readiness.test.mjs scripts/gate-context.test.mjs scripts/check-spec-plan-doc.test.mjs scripts/check-ux-fit-decision.test.mjs` — 46 passing
- [x] `pnpm run pregate:preflight` — 27 guards clean; one source-only environment skip with CI enforcement retained
- [x] `git diff --check`
- [x] No product UI, route, schema, migration, or runtime behavior changed; UX verification and production portal build are not applicable

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Shared sandbox admission was attempted; the governed lane had one active run and eleven queued requests, so this source-only developer-tooling change uses the explicit override below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

## Overlap sweep

- PR #3774 was inspected. It updates different verification skills and is complementary; it does not touch `dpf-pr-with-dco` or the readiness implementation.
- The active two-slot sandbox pilot remains separately owned by BI-A4427AB8; this PR does not modify sandbox capacity or admission.

## Documentation impact

The shared PR skill, GitHub PR template, and the existing gate-context implementation plan are updated in this change. No operator workflow or product UI documentation changes are needed because this is contributor/agent delivery mechanics only.

Seed-Fit-Decision: global-default
Docs-Impact-Decision: shared PR skill, PR template, and implementation plan updated; no operator-facing product behavior changed
Local-CI-Override: source-only developer workflow tooling; shared sandbox lane saturated at one active plus eleven queued, with 46 targeted tests and 27 host-side policy guards passing
