### PR TITLE
fix(ci): fence local-CI descendants through teardown

### DIFF
--- a/apps/web/components/product/direction/ProductRoadmap.test.tsx
+++ b/apps/web/components/product/direction/ProductRoadmap.test.tsx
@@ -1,14 +1,16 @@
 // @vitest-environment jsdom
 
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   projectProductRoadmap,
   type ProductRoadmapProjection,
 } from "@/lib/product-management/product-roadmap";
 import type { ProductRoadmapWorkspace } from "@/lib/product-management/product-roadmap-operating-context";
 import { ProductRoadmap } from "./ProductRoadmap";
+
+afterEach(() => cleanup());
 
 function workspace(
   roadmapOverrides: Partial<ProductRoadmapProjection> = {},
@@ -153,10 +155,8 @@ describe("ProductRoadmap", () => {
       screen.getByText("No canonical work dependency links"),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByText("Source posture and projection boundary"),
-    ).toHaveLength(2);
-    expect(
-      screen.getAllByText(/cannot be imported/),
-    ).toHaveLength(2);
+      screen.getByText("Source posture and projection boundary"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/cannot be imported/)).toBeInTheDocument();
   });
 });

--- a/docs/superpowers/plans/2026-07-28-local-ci-descendant-fence.md
+++ b/docs/superpowers/plans/2026-07-28-local-ci-descendant-fence.md
@@ -1,0 +1,75 @@
+# Local-CI Descendant Fence Hardening
+
+**Backlog item:** `BI-91036F21`
+**Work capsule:** `WC-CA057502`
+**Branch:** `fix/local-ci-descendant-fence`
+**Date:** 2026-07-28
+
+## Goal
+
+Prevent local-CI from releasing the governed lease and local process fence while child, grandchild, or tool-spawned build/test processes from the gated command are still alive. A later branch must not be able to claim the shared `local-integration-ci` lane until the prior command tree is fully quiescent or has been terminated.
+
+## Current Evidence
+
+- Live process state on 2026-07-28 showed an active `feat/marketing-operating-snapshot` local-CI lease while older `fix/ux-artifact-terminal-producer-wait` `local-ci-runner.sh`, `local-integration-ci.mjs`, and `docker build --target build` processes were still running.
+- The root `D:\DPF\.git\dpf-local-ci-owner.json` fence file was absent while those older descendants remained alive.
+- Earlier action-envelope verification was intentionally stopped because evidence from a run started in that state would have been contaminated.
+- Refined evidence on 2026-07-30 showed renderer lease `NPEL-326EC39C30` renewing normally until its host fence vanished. The next lease was admitted only after renderer released and acquired a new fence later, ruling out successor overwrite. The high-confidence cause is a surviving cleanup/descendant from the prior two-slot pilot deleting a later owner's fence (`cms78s2lk012501po8lxt2lod`).
+- Current main has the lease/fence substrate from PR #3638 (`scripts/lib/local-sandbox-fence.mjs`, `scripts/lib/lease-supervisor.mjs`, `scripts/gate-worktree.mjs`, `scripts/gate-worktree.sh`), so this is a boundary-hardening fix, not new substrate.
+
+## Scope
+
+- Add regression tests for descendant process tracking and pregate's canonical Node routing contract.
+- Extend the Node gate command wrapper so release is delayed until remembered child, grandchild, and tool-spawned descendants have exited or been terminated.
+- Before launching the canonical shared-sandbox runner, refuse to proceed while a legacy runner, integration process, or orphan still referencing the `.local-ci-runner` workspace is alive, even when the predecessor's host fence is already absent.
+- Make the POSIX compatibility entry point delegate to the Node gate by default so lease/fence safety does not drift between implementations.
+- Keep the shell path as a compatibility adapter only; it immediately execs the Node gate.
+- Update the local pre-PR gate documentation with the invariant.
+
+Out of scope:
+
+- Building a multi-slot sandbox pool (`BI-CCA0437C`).
+- Replacing polling with durable FIFO admission (`BI-69728276`).
+- Changing the nonproduction lease database schema.
+
+## Implementation
+
+- In the Node gate, sample the process table while the command is running, remember observed descendants, and perform a post-run quiescence/termination step before `release_nonprod_environment_lease` and `releaseLocalSandboxFence`.
+- In `pregate.mjs`, route to `scripts/gate-worktree.mjs` by default; use the shell path only under explicit `DPF_PREGATE_FORCE_SH=1`.
+- In the shell gate, delegate immediately to the Node gate, so POSIX and Windows hosts share one long-lived fence-owner process.
+- Use a slower default process-table scan cadence on Windows because WMI/CIM snapshots are heavyweight host operations; keep explicit env overrides for focused debugging.
+- Write `admitted` and `running` gate state before the expensive command starts, then let `pregate` recover that state if the child wrapper exits before terminal evidence is recorded.
+- Preserve existing heartbeat behavior and lease-loss termination.
+- Keep durable FIFO authority while waiting for legacy mutators to drain, but release a tentatively acquired host-fence token before retrying so a waiting owner never publishes a false process-ownership record.
+
+## Verification
+
+- Source-local regression test: `node --test scripts/gate-worktree-lease.test.mjs scripts/lib/local-sandbox-fence.test.mjs scripts/lib/lease-supervisor.test.mjs scripts/pregate.test.mjs scripts/lib/local-ci-gate-state.test.mjs`.
+- Contract check for shell entry point text/behavior where practical from Node tests.
+- No migration required.
+- No UX verification required; this is CI/process infrastructure only.
+- Full local-CI gate should be rerun after this fix is merged or available in the gated branch; current live local-CI evidence is intentionally not trusted while this defect is present.
+
+## Risks And Rollback
+
+- Risk: over-aggressive process cleanup could terminate a process outside the local-CI command tree. Mitigation: scope termination to the command PID/process group and record tests for late descendant mutation.
+- Risk: Windows process re-parenting can hide grandchildren after the immediate child exits. Mitigation: the fix should wait/terminate before release while the supervisor still has a live root or explicit tracked child handle.
+- Risk: globally treating every Docker process as local-CI would block unrelated work. Mitigation: admission matches canonical runner/integration commands or the slot workspace path, then includes only their descendants.
+- Rollback: revert this branch; local-CI returns to current behavior, with `BI-91036F21` reopened as the active blocker.
+
+## Backlog Coverage
+
+- Decision: atomic
+- Parent: `BI-91036F21`
+- Receipt: `cms51i54604ix01mx0bkkt6oy`
+- Dependencies: none
+- Rationale: this is one process-boundary bug fix; the regression test, process supervisor change, shell/Node gate wiring, and documentation update are not independently useful if split because partial delivery would still allow contaminated local-CI evidence.
+
+Deliverables:
+
+- Canonical local-CI command descendants cannot outlive lease/fence release once the gate has observed them.
+- A successor cannot launch into an already-mutating shared workspace merely because a mixed-version predecessor removed or lost its host fence.
+- Pregate uses the Node-native gate by default so Node and POSIX behavior cannot silently diverge.
+- Pregate recovers an interrupted `running` gate state by releasing the recorded lease and marking the gate failed.
+- Regression coverage for process-tree descendant tracking, pregate routing, POSIX native fence-owner contract, crash recovery, and cleanup ordering.
+- Pre-PR gate documentation names the invariant.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -182,30 +182,22 @@ still enforces every guard. Routing probes (`--dry-run`) and evidence replays
 (`--finalize-evidence`) skip the preflight automatically.
 
 **Host-native/Node-first entry point (BI-2272D840, BI-52500C0D, BI-4BE30454).** `pregate.mjs`
-detects whether native `sh` actually works against *this* worktree — not just
-"sh is on PATH", but that it can resolve the worktree's own git state
-(`sh -c 'git rev-parse --show-toplevel'`) — and routes accordingly:
-
-- Working native `sh` (Git-for-Windows shell, Linux/macOS): delegates to
-  `scripts/gate-worktree.sh`, which is a compatibility adapter into the
-  canonical Node gate.
-- No working native `sh` (e.g. a Windows worktree with no Git Bash and a WSL
-  install that cannot cleanly read the worktree's `.git` indirection — the
-  exact failure BI-C22152E7 hit): routes to `scripts/gate-worktree.mjs`, a
-  canonical lease-claim / heartbeat / fenced-run / evidence-record /
-  lease-release flow. `scripts/local-ci-runner.sh` is likewise a compatibility
-  adapter into `scripts/local-ci-runner.mjs`; both host surfaces therefore call
-  the same `scripts/local-integration-ci.mjs` plan and slot manifest. Missing native `sh` is therefore
-  classified as **sandbox-routable, never a build blocker** — the agent no
-  longer needs to recognize that doctrine and hand-drive the lease steps.
+routes to `scripts/gate-worktree.mjs` by default on every host. The Node-native
+gate owns the lease-claim / heartbeat / fenced-run / descendant-quiescence /
+evidence-record / lease-release flow, so lease/fence safety has one canonical
+implementation. `scripts/gate-worktree.sh` remains a compatibility entry point
+and delegates to the Node gate; set `DPF_PREGATE_FORCE_SH=1` only for focused
+shell-adapter debugging. Missing native `sh` is therefore classified as
+**sandbox-routable, never a build blocker**.
 
 Either path produces the same evidence shape (manifest version and slot,
 branch/SHA, integration tree, database and Compose identity, production
 artifact, lease id, freshness verdict, toolchain fingerprint, expiry) and
 writes the same
 `.git/dpf-local-ci-gate.json` state file, so the pre-push gate below accepts
-either without caring which one ran. Force a specific path for
-testing/debugging with `DPF_PREGATE_FORCE_SH=1` or `DPF_PREGATE_FORCE_NODE=1`.
+either without caring which one ran. `DPF_PREGATE_FORCE_NODE=1` preserves the
+default. `DPF_PREGATE_FORCE_SH=1` is explicit legacy-shell debugging and still
+requires a working shell.
 
 The gate claims a `local-integration-ci` lease (waiting if the sandbox is
 already leased). A canonical waiter refreshes its idempotent claim well inside
@@ -215,7 +207,12 @@ bounds recovery when the supervisor disappears without shortening the maximum
 queue wait. The gate runs the command, releases the runtime slot, records a
 local-integration evidence record with the lease id and `gatePassed`, and
 writes the latest gate result to Git-local state
-(`.git/dpf-local-ci-gate.json`). Renewal loss is
+(`.git/dpf-local-ci-gate.json`, with a slot suffix for non-default slots). It
+overwrites stale state with `admitted` and then `running` as soon as it owns the
+sandbox, before the expensive command mutates the runtime. If the child wrapper
+exits before a terminal record is written, `pregate` reads that running state,
+best-effort releases the recorded lease, and rewrites the local gate record as
+failed so pre-push cannot trust a stale pass. Renewal loss is
 fail-closed: before further sandbox mutation the gate terminates its complete
 child process tree, records a fenced outcome, and releases idempotently.
 Transport failure is uncertainty rather than proof of ownership loss: the gate
@@ -230,9 +227,19 @@ admitted waiter renews its database authority while it waits for that host
 fence and refuses to acquire the fence near its last known expiry. The database
 lease remains the governed cross-process record, while this local
 fence closes the host process-liveness gap the database cannot observe.
-The requested expiry is calculated afresh for every claim observation, and the
-service grants a fresh admitted-owner window at promotion, so time spent
-waiting never consumes the acquired owner's TTL.
+The requested expiry is calculated for each claim observation after queue
+admission, and the service grants a fresh admitted-owner window at promotion,
+so time spent waiting never consumes the acquired owner's TTL.
+The canonical gate samples the local-CI command process tree while the command
+runs, remembers observed descendants, and before releasing the lease/fence waits
+briefly for remembered descendants to exit or terminates them. This keeps a
+later claimant from entering the sandbox while an earlier gate still has live
+child, grandchild, or tool-spawned build/test processes. The shell adapter
+execs the Node gate immediately, so POSIX hosts use the same long-lived
+fence-owner process as every other host. Windows process-tree snapshots are
+intentionally sampled more slowly because each WMI/CIM process-table read is
+itself a heavyweight host operation; `DPF_GATE_PROCESS_SCAN_MS` and
+`DPF_GATE_DESCENDANT_POLL_MS` remain explicit debugging overrides.
 Claim, heartbeat, signal/fence, and release timestamps are included in the
 evidence and Git-local state. An expired TTL is never permission for the old
 owner to continue working. The gate does

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -1,11 +1,19 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+
+import {
+  collectDescendantPids,
+  createProcessTreeTracker,
+  defaultDescendantPollMs,
+  defaultProcessScanMs,
+  findLiveLocalCiMutatorPids,
+} from "./gate-worktree.mjs";
 
 function run(command, args, options) {
   return new Promise((resolve, reject) => {
@@ -33,6 +41,23 @@ function run(command, args, options) {
 
 function isolatedFencePath() {
   return join(mkdtempSync(join(tmpdir(), "dpf-gate-fence-")), "owner.json");
+}
+
+function makeTempWorktree() {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-gate-worktree-"));
+  const git = (args) => {
+    const result = spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+    }
+  };
+  git(["init", "-q"]);
+  git(["config", "user.name", "DPF Test"]);
+  git(["config", "user.email", "dpf-test@example.invalid"]);
+  writeFileSync(join(dir, "README.md"), "gate test\n");
+  git(["add", "README.md"]);
+  git(["commit", "-q", "-m", "init"]);
+  return dir;
 }
 
 test("canonical gate heartbeats during a long command and releases once", async () => {
@@ -65,7 +90,7 @@ test("canonical gate heartbeats during a long command and releases once", async 
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--expires-minutes", "0.05",
       "--mcp-url", `http://127.0.0.1:${address.port}`,
       "--no-push",
@@ -135,7 +160,7 @@ test("durable queue observation reuses claimKey and grants a fresh admitted TTL"
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--expires-minutes", "0.05",
       "--poll-seconds", "0.05",
       "--mcp-url", `http://127.0.0.1:${address.port}`,
@@ -389,7 +414,7 @@ test("a same-host dead queued observer is cancelled before the live waiter claim
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/dead-waiter-reconciliation",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--owner-session-id", "integration-test-live-owner",
       "--expires-minutes", "0.05",
       "--mcp-url", `http://127.0.0.1:${address.port}`,
@@ -416,6 +441,80 @@ test("a same-host dead queued observer is cancelled before the live waiter claim
     assert.match(result.output, /cancelled dead same-host queue observer NPEL-DEAD-OBSERVER/);
   } finally {
     server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("admitted gate writes running state before starting the expensive command", async () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-gate-running-state-"));
+  const observedState = join(temp, "observed-state.json");
+  const childScript = join(temp, "observe-state.mjs");
+  writeFileSync(
+    childScript,
+    [
+      "import { readFileSync, writeFileSync } from \"node:fs\";",
+      "writeFileSync(process.env.DPF_OBSERVED_GATE_STATE_FILE, readFileSync(process.env.DPF_LOCAL_CI_GATE_STATE_FILE, \"utf8\"));",
+      "",
+    ].join("\n"),
+  );
+  const calls = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      calls.push(tool);
+      const result = tool === "claim_nonprod_environment_lease"
+        ? {
+          success: true,
+          entityId: "NPEL-RUNNING-STATE",
+          data: {
+            lease: { leaseId: "NPEL-RUNNING-STATE" },
+            admission: { status: "admitted", slotKey: "slot-0", waitAgeMs: 1 },
+          },
+        }
+        : tool === "record_local_integration_result"
+          ? { success: true, entityId: "EVIDENCE-RUNNING-STATE" }
+          : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/local-ci-descendant-fence",
+      "--worktree", makeTempWorktree(),
+      "--expires-minutes", "0.05",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_LOCAL_CI_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(childScript)}`,
+        DPF_OBSERVED_GATE_STATE_FILE: observedState,
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    const state = JSON.parse(await readFile(observedState, "utf8"));
+    assert.equal(state.branch, "fix/local-ci-descendant-fence");
+    assert.equal(state.leaseId, "NPEL-RUNNING-STATE");
+    assert.equal(state.status, "running");
+    assert.equal(state.gatePassed, false);
+    assert.ok(calls.includes("release_nonprod_environment_lease"));
+  } finally {
     await new Promise((resolve) => server.close(resolve));
   }
 });
@@ -453,7 +552,7 @@ test("rolling upgrade observes the legacy conflict contract without failing", as
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--expires-minutes", "0.05",
       "--poll-seconds", "0.01",
       "--lease-wait-seconds", "2",
@@ -523,7 +622,7 @@ test("transient admission transport reset retries the same durable claim", async
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--expires-minutes", "0.05",
       "--poll-seconds", "0.01",
       "--lease-wait-seconds", "2",
@@ -593,7 +692,7 @@ test(
       gateChild = spawn(process.execPath, [
         "scripts/gate-worktree.mjs",
         "--branch", "fix/sandbox-lease-fencing",
-        "--worktree", process.cwd(),
+        "--worktree", makeTempWorktree(),
         "--expires-minutes", "0.05",
         "--poll-seconds", "0.05",
         "--lease-wait-seconds", "2",
@@ -677,7 +776,7 @@ test("renewal loss kills the real child process tree before later mutation", asy
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--expires-minutes", "0.05",
       "--mcp-url", `http://127.0.0.1:${address.port}`,
       "--no-push",
@@ -700,6 +799,103 @@ test("renewal loss kills the real child process tree before later mutation", asy
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+});
+
+test("process tree tracker remembers descendants before they reparent", async () => {
+  const snapshots = [
+    [
+      { pid: 100, parentPid: 1 },
+      { pid: 101, parentPid: 100 },
+      { pid: 102, parentPid: 101 },
+    ],
+    [
+      { pid: 102, parentPid: 1 },
+    ],
+  ];
+  const alive = new Set([102]);
+  const terminated = [];
+  let now = 1000;
+  const tracker = createProcessTreeTracker({
+    rootPid: 100,
+    listProcessRows: () => snapshots.shift() || [],
+    processAlive: (pid) => alive.has(pid),
+    terminate: (pid) => {
+      terminated.push(pid);
+      alive.delete(pid);
+    },
+    wait: async (ms) => { now += ms; },
+    now: () => now,
+  });
+
+  assert.deepEqual(collectDescendantPids(100, [
+    { pid: 100, parentPid: 1 },
+    { pid: 101, parentPid: 100 },
+    { pid: 102, parentPid: 101 },
+    { pid: 200, parentPid: 1 },
+  ]), [101, 102]);
+
+  tracker.sample();
+  const leaked = await tracker.waitForQuiescence({ graceMs: 0, pollMs: 1 });
+
+  assert.deepEqual(leaked, [102]);
+  assert.deepEqual(terminated, [102]);
+});
+
+test("local-CI admission detects legacy shared mutators and their descendants only", () => {
+  const processRows = [
+    {
+      pid: 100,
+      parentPid: 1,
+      commandLine: "node D:/DPF/scripts/local-ci-runner.mjs --candidate feat/previous",
+    },
+    {
+      pid: 101,
+      parentPid: 100,
+      commandLine: "node D:/DPF/scripts/local-integration-ci.mjs",
+    },
+    {
+      pid: 102,
+      parentPid: 101,
+      commandLine: "docker build --file Dockerfile .",
+    },
+    {
+      pid: 103,
+      parentPid: 1,
+      commandLine: "docker build D:/DPF-worktrees/.local-ci-runner",
+    },
+    {
+      pid: 200,
+      parentPid: 1,
+      commandLine: "docker build --file unrelated.Dockerfile .",
+    },
+    {
+      pid: 300,
+      parentPid: 1,
+      commandLine: "node D:/DPF/scripts/gate-worktree.mjs --branch feat/queued",
+    },
+    {
+      pid: 400,
+      parentPid: 1,
+      commandLine: "node D:/DPF/scripts/local-ci-runner.mjs --candidate feat/current",
+    },
+    {
+      pid: 401,
+      parentPid: 400,
+      commandLine: "docker build --file Dockerfile .",
+    },
+  ];
+
+  assert.deepEqual(
+    findLiveLocalCiMutatorPids(processRows, { excludePids: [400] }),
+    [100, 101, 102, 103],
+  );
+});
+
+test("process tree tracker uses a slower default scan cadence on Windows", () => {
+  assert.equal(defaultProcessScanMs("win32"), 5000);
+  assert.equal(defaultDescendantPollMs("win32"), 1000);
+  assert.equal(defaultProcessScanMs("linux"), 250);
+  assert.equal(defaultDescendantPollMs("linux"), 250);
 });
 
 test("POSIX entry point delegates every lease policy to the canonical Node gate", async () => {
@@ -742,10 +938,16 @@ test("POSIX gate heartbeats and releases through its injectable transport", asyn
   const address = server.address();
 
   try {
+    const temp = mkdtempSync(join(tmpdir(), "dpf-posix-gate-command-"));
+    const childScript = join(temp, "delay.mjs");
+    writeFileSync(
+      childScript,
+      "await new Promise((resolve) => setTimeout(resolve, 2500));\n",
+    );
     const result = await run(shell, [
       "scripts/gate-worktree.sh",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", makeTempWorktree(),
       "--expires-minutes", "0.05",
       "--mcp-url", `http://127.0.0.1:${address.port}`,
       "--no-push",
@@ -754,7 +956,7 @@ test("POSIX gate heartbeats and releases through its injectable transport", asyn
       env: {
         ...process.env,
         DPF_MCP_BEARER_TOKEN: "test-token",
-        DPF_LOCAL_CI_COMMAND: `"${process.execPath}" -e "setTimeout(function () {}, 2500)"`,
+        DPF_LOCAL_CI_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(childScript)}`,
         DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
       },
     });

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -35,6 +35,7 @@ import {
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
 } from "./lib/local-ci-slot-manifest.mjs";
+import { writeLocalCiGateState } from "./lib/local-ci-gate-state.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
@@ -63,6 +64,19 @@ function retryDelayMs({ attempt, pollSeconds, retryAfterSeconds = 0 }) {
 function isTransientMcpError(error) {
   const text = error instanceof Error ? error.message : String(error);
   return /ECONNRESET|ECONNREFUSED|EPIPE|ETIMEDOUT|socket hang up|invalid JSON response|fetch failed/i.test(text);
+}
+
+function numberOrDefault(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function defaultProcessScanMs(platform = process.platform) {
+  return platform === "win32" ? 5000 : 250;
+}
+
+export function defaultDescendantPollMs(platform = process.platform) {
+  return platform === "win32" ? 1000 : 250;
 }
 
 function git(gitBin, args, cwd) {
@@ -180,6 +194,170 @@ function resolveGateCommand({ branch, allowStub, gitBin }) {
   return null;
 }
 
+export function collectDescendantPids(rootPid, processRows) {
+  const root = Number(rootPid);
+  if (!Number.isInteger(root) || root <= 0) return [];
+  const childrenByParent = new Map();
+  for (const row of processRows || []) {
+    const pid = Number(row?.pid);
+    const parentPid = Number(row?.parentPid);
+    if (!Number.isInteger(pid) || !Number.isInteger(parentPid) || pid <= 0) continue;
+    const children = childrenByParent.get(parentPid) || [];
+    children.push(pid);
+    childrenByParent.set(parentPid, children);
+  }
+  const descendants = [];
+  const queue = [...(childrenByParent.get(root) || [])];
+  const seen = new Set([root]);
+  while (queue.length > 0) {
+    const pid = queue.shift();
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    descendants.push(pid);
+    queue.push(...(childrenByParent.get(pid) || []));
+  }
+  return descendants;
+}
+
+const LOCAL_CI_MUTATOR_COMMANDS = [
+  /(?:^|[\\/])local-ci-runner\.mjs(?:\s|$)/i,
+  /(?:^|[\\/])local-integration-ci\.mjs(?:\s|$)/i,
+  /(?:^|[\\/])\.local-ci-runner(?:-[^\\/\s"]+)?(?:[\\/\s"]|$)/i,
+];
+
+export function findLiveLocalCiMutatorPids(processRows, { excludePids = [] } = {}) {
+  const rows = Array.isArray(processRows) ? processRows : [];
+  const excluded = new Set(
+    excludePids
+      .map(Number)
+      .filter((pid) => Number.isInteger(pid) && pid > 0),
+  );
+  const mutatorPids = new Set();
+
+  for (const row of rows) {
+    const pid = Number(row?.pid);
+    const commandLine = typeof row?.commandLine === "string" ? row.commandLine : "";
+    if (
+      !Number.isInteger(pid)
+      || pid <= 0
+      || excluded.has(pid)
+      || !LOCAL_CI_MUTATOR_COMMANDS.some((pattern) => pattern.test(commandLine))
+    ) {
+      continue;
+    }
+    mutatorPids.add(pid);
+    for (const descendantPid of collectDescendantPids(pid, rows)) {
+      if (!excluded.has(descendantPid)) mutatorPids.add(descendantPid);
+    }
+  }
+
+  return [...mutatorPids].sort((left, right) => left - right);
+}
+
+function readProcessRows({ platform = process.platform, spawnSyncImpl = spawnSync } = {}) {
+  if (platform === "win32") {
+    const result = spawnSyncImpl("powershell.exe", [
+      "-NoProfile",
+      "-Command",
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
+    ], { encoding: "utf8", windowsHide: true });
+    if (result.status !== 0 || !result.stdout) return [];
+    try {
+      const parsed = JSON.parse(result.stdout);
+      const rows = Array.isArray(parsed) ? parsed : [parsed];
+      return rows.map((row) => ({
+        pid: Number(row.ProcessId),
+        parentPid: Number(row.ParentProcessId),
+        commandLine: typeof row.CommandLine === "string" ? row.CommandLine : "",
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  const result = spawnSyncImpl("ps", ["-eo", "pid=,ppid=,args="], { encoding: "utf8" });
+  if (result.status !== 0 || !result.stdout) return [];
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*(\d+)\s+(\d+)\s*(.*)$/))
+    .filter(Boolean)
+    .map((match) => ({
+      pid: Number(match[1]),
+      parentPid: Number(match[2]),
+      commandLine: match[3] || "",
+    }));
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function terminatePid(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore" });
+    return;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Process already exited.
+  }
+}
+
+export function createProcessTreeTracker({
+  rootPid,
+  listProcessRows = readProcessRows,
+  processAlive = isProcessAlive,
+  terminate = terminatePid,
+  wait = sleep,
+  now = () => Date.now(),
+  onEvent = () => {},
+} = {}) {
+  const root = Number(rootPid);
+  const remembered = new Set();
+
+  const sample = () => {
+    const descendants = collectDescendantPids(root, listProcessRows());
+    for (const pid of descendants) remembered.add(pid);
+    return descendants;
+  };
+
+  const liveRememberedDescendants = () =>
+    [...remembered].filter((pid) => pid !== root && processAlive(pid));
+
+  const waitForQuiescence = async ({ graceMs = 5000, pollMs = 250 } = {}) => {
+    const deadline = now() + graceMs;
+    sample();
+    while (liveRememberedDescendants().length > 0 && now() < deadline) {
+      await wait(pollMs);
+      sample();
+    }
+    const live = liveRememberedDescendants();
+    if (live.length === 0) return [];
+    onEvent({ type: "descendants-terminating", pids: live });
+    for (const pid of live) terminate(pid);
+    const terminatedDeadline = now() + Math.max(1000, pollMs * 4);
+    while (liveRememberedDescendants().length > 0 && now() < terminatedDeadline) {
+      await wait(pollMs);
+    }
+    return live;
+  };
+
+  return {
+    sample,
+    waitForQuiescence,
+    liveRememberedDescendants,
+    rememberedPids: () => [...remembered],
+  };
+}
+
 function createGateCommand(commandSpec, { cwd, env, allowStub, fullLogFile }) {
   if (!commandSpec) {
     if (!allowStub) throw new Error("runGateCommand called with no command and no stub allowed");
@@ -195,6 +373,8 @@ function createGateCommand(commandSpec, { cwd, env, allowStub, fullLogFile }) {
     };
   }
   let child = null;
+  let tracker = null;
+  let trackerTimer = null;
   let output = "";
   writeFileSync(fullLogFile, "");
   const append = (chunk, stream) => {
@@ -217,25 +397,60 @@ function createGateCommand(commandSpec, { cwd, env, allowStub, fullLogFile }) {
       } else {
         child = spawn(commandSpec.value, { ...common, shell: true });
       }
+      tracker = createProcessTreeTracker({ rootPid: child.pid });
+      tracker.sample();
+      trackerTimer = setInterval(
+        () => tracker.sample(),
+        Math.max(50, numberOrDefault(process.env.DPF_GATE_PROCESS_SCAN_MS, defaultProcessScanMs())),
+      );
       child.stdout.on("data", (chunk) => append(chunk, process.stdout));
       child.stderr.on("data", (chunk) => append(chunk, process.stderr));
       child.once("error", reject);
-      child.once("close", (code, signal) => resolve({
-        label: commandSpec.label,
-        status: code ?? (signal ? 143 : 1),
-        output,
-      }));
+      child.once("close", async (code, signal) => {
+        if (trackerTimer) {
+          clearInterval(trackerTimer);
+          trackerTimer = null;
+        }
+        const terminated = tracker
+          ? await tracker.waitForQuiescence({
+            graceMs: numberOrDefault(process.env.DPF_GATE_DESCENDANT_GRACE_MS, 5000),
+            pollMs: Math.max(50, numberOrDefault(
+              process.env.DPF_GATE_DESCENDANT_POLL_MS,
+              defaultDescendantPollMs(),
+            )),
+          })
+          : [];
+        if (terminated.length > 0) {
+          append(
+            `gate-worktree: terminated ${terminated.length} descendant process(es) before lease release: ${terminated.join(", ")}\n`,
+            process.stderr,
+          );
+        }
+        resolve({
+          label: commandSpec.label,
+          status: code ?? (signal ? 143 : 1),
+          output,
+        });
+      });
     }),
     terminate: async () => {
-      if (!child || child.exitCode !== null) return;
-      if (process.platform === "win32") {
-        spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
-      } else {
-        try {
-          process.kill(-child.pid, "SIGTERM");
-        } catch {
-          child.kill("SIGTERM");
+      if (trackerTimer) {
+        clearInterval(trackerTimer);
+        trackerTimer = null;
+      }
+      if (child && child.exitCode === null) {
+        if (process.platform === "win32") {
+          spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+        } else {
+          try {
+            process.kill(-child.pid, "SIGTERM");
+          } catch {
+            child.kill("SIGTERM");
+          }
         }
+      }
+      if (tracker) {
+        await tracker.waitForQuiescence({ graceMs: 0, pollMs: 50 });
       }
     },
   };
@@ -417,7 +632,8 @@ async function main() {
   let pendingEvidenceFile = slotManifest.evidence.pending;
   let fullLogFile;
   let freshnessReportFile;
-  let localFencePath = slotManifest.fence.path;
+  let localFencePath = process.env.DPF_LOCAL_SANDBOX_FENCE_PATH
+    || slotManifest.fence.path;
 
   let quiescenceAttempt = 0;
   for (;;) {
@@ -604,7 +820,8 @@ async function main() {
       pendingEvidenceFile = slotManifest.evidence.pending;
       fullLogFile = process.env.DPF_LOCAL_CI_OUTPUT_FILE || slotManifest.output.log;
       freshnessReportFile = slotManifest.evidence.freshness;
-      localFencePath = slotManifest.fence.path;
+      localFencePath = process.env.DPF_LOCAL_SANDBOX_FENCE_PATH
+        || slotManifest.fence.path;
       url = slotManifest.portal.url;
       leaseEvents.push({
         type: "admitted",
@@ -612,6 +829,18 @@ async function main() {
         slotKey: slotManifest.slotKey,
         waitAgeMs: admission?.waitAgeMs ?? null,
         expiresAt,
+      });
+      writeState(stateFile, {
+        branch,
+        sha,
+        gatePassed: false,
+        leaseId,
+        evidenceId: "",
+        status: "admitted",
+        expiresAt,
+        resilience: null,
+        leaseEvents,
+        evidencePending: false,
       });
       break;
     }
@@ -701,8 +930,24 @@ async function main() {
       branch,
     });
     if (localFence.status !== "conflict") {
-      localFenceToken = localFence.record.token;
-      break;
+      // The checked-in runner is the shared-sandbox mutator whose mixed-version
+      // predecessors must drain before a successor starts. Explicit commands
+      // remain fenced by their host record, but may be source-local contract
+      // harnesses that neither use nor mutate the convergence sandbox.
+      const liveMutatorPids = commandSpec?.kind === "argv"
+        ? findLiveLocalCiMutatorPids(readProcessRows(), {
+          excludePids: [process.pid],
+        })
+        : [];
+      if (liveMutatorPids.length === 0) {
+        localFenceToken = localFence.record.token;
+        break;
+      }
+      releaseLocalSandboxFence({
+        path: localFencePath,
+        token: localFence.record.token,
+      });
+      localFence.liveMutatorPids = liveMutatorPids;
     }
     if (Date.now() >= deadline) {
       await releaseLeaseOnce();
@@ -733,7 +978,13 @@ async function main() {
       at: new Date().toISOString(),
       expiresAt,
     });
-    process.stdout.write(`local-CI sandbox process fence held by ${localFence.active?.ownerSessionId || "unknown"}; retrying after admission...\n`);
+    if (localFence.liveMutatorPids?.length > 0) {
+      process.stdout.write(
+        `local-CI sandbox still has live mutator processes (${localFence.liveMutatorPids.join(", ")}); retrying after admission...\n`,
+      );
+    } else {
+      process.stdout.write(`local-CI sandbox process fence held by ${localFence.active?.ownerSessionId || "unknown"}; retrying after admission...\n`);
+    }
     await sleep(Math.min(options.pollSeconds * 1000, Math.max(10, deadline - Date.now())));
   }
   try {
@@ -753,6 +1004,22 @@ async function main() {
   if (commandSpec) process.stdout.write(`running local-CI command: ${commandSpec.label}\n`);
   else process.stdout.write("sandbox checkout/build stub: gate passed (explicit test-only mode)\n");
 
+  writeState(stateFile, {
+    branch,
+    sha,
+    gatePassed: false,
+    leaseId,
+    evidenceId: "",
+    status: "running",
+    expiresAt,
+    resilience: null,
+    leaseEvents: [
+      ...leaseEvents,
+      { type: "started", at: new Date().toISOString() },
+    ],
+    evidencePending: false,
+  });
+
   // The preflight executes in the shared scratch integration worktree, whose
   // gitdir differs from this candidate worktree's gitdir. Give the descendant
   // process one explicit handoff path so the wrapper reads evidence from the
@@ -764,6 +1031,7 @@ async function main() {
       ...localCiSlotEnvironment(slotManifest),
       DPF_LOCAL_CI_METADATA_FILE: metadataFile,
       DPF_LOCAL_CI_FRESHNESS_REPORT_FILE: freshnessReportFile,
+      DPF_LOCAL_CI_GATE_STATE_FILE: stateFile,
       DPF_NONPROD_LEASE_ID: leaseId,
       DPF_NONPROD_OWNER_SESSION_ID: ownerSessionId,
     },
@@ -1020,23 +1288,20 @@ function writeState(stateFile, {
   evidencePendingReason = "",
   quiescence = null,
 }) {
-  mkdirSync(dirname(stateFile), { recursive: true });
-  const payload = {
+  writeLocalCiGateState(stateFile, {
     branch,
     sha,
     gatePassed,
     leaseId,
-    evidenceRecordId: evidenceId,
+    evidenceId,
     status,
     expiresAt,
+    resilience,
     leaseEvents,
     evidencePending,
-    recordedAt: new Date().toISOString(),
-  };
-  if (resilience) payload.resilience = resilience;
-  if (evidencePending) payload.evidencePendingReason = evidencePendingReason || "unknown";
-  if (quiescence) payload.quiescence = quiescence;
-  writeFileSync(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+    evidencePendingReason,
+    quiescence,
+  });
 }
 
 if (process.argv[1] === THIS_FILE) {

--- a/scripts/lib/local-ci-gate-state.mjs
+++ b/scripts/lib/local-ci-gate-state.mjs
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+export const NONTERMINAL_LOCAL_CI_GATE_STATUSES = Object.freeze(new Set([
+  "admitted",
+  "running",
+]));
+
+export function readLocalCiGateState(stateFile) {
+  if (!stateFile) return null;
+  try {
+    return JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function isRecoverableInterruptedGateState(state, { branch = "", sha = "" } = {}) {
+  if (!state || typeof state !== "object") return false;
+  if (branch && state.branch !== branch) return false;
+  if (sha && state.sha !== sha) return false;
+  if (!state.leaseId || typeof state.leaseId !== "string") return false;
+  if (state.evidencePending === true) return false;
+  return NONTERMINAL_LOCAL_CI_GATE_STATUSES.has(state.status);
+}
+
+export function writeLocalCiGateState(stateFile, {
+  branch,
+  sha,
+  gatePassed,
+  leaseId,
+  evidenceId,
+  status,
+  expiresAt,
+  resilience,
+  leaseEvents,
+  evidencePending = false,
+  evidencePendingReason = "",
+  quiescence = null,
+  recovery = null,
+}) {
+  mkdirSync(dirname(stateFile), { recursive: true });
+  const payload = {
+    branch,
+    sha,
+    gatePassed,
+    leaseId,
+    evidenceRecordId: evidenceId,
+    status,
+    expiresAt,
+    leaseEvents,
+    evidencePending,
+    recordedAt: new Date().toISOString(),
+  };
+  if (resilience) payload.resilience = resilience;
+  if (evidencePending) payload.evidencePendingReason = evidencePendingReason || "unknown";
+  if (quiescence) payload.quiescence = quiescence;
+  if (recovery) payload.recovery = recovery;
+  writeGateStateAtomically(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function writeGateStateAtomically(stateFile, contents) {
+  const directory = dirname(stateFile);
+  mkdirSync(directory, { recursive: true });
+  const tempFile = join(directory, `.${basename(stateFile)}.${process.pid}.${randomUUID()}.tmp`);
+  let fd = null;
+  try {
+    fd = openSync(tempFile, "wx", 0o600);
+    writeFileSync(fd, contents, { encoding: "utf8" });
+    closeSync(fd);
+    fd = null;
+    renameSync(tempFile, stateFile);
+  } catch (error) {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Best-effort cleanup below handles the temp path.
+      }
+    }
+    try {
+      unlinkSync(tempFile);
+    } catch {
+      // The temp file may not exist if open failed.
+    }
+    throw error;
+  }
+}

--- a/scripts/lib/local-ci-gate-state.test.mjs
+++ b/scripts/lib/local-ci-gate-state.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  isRecoverableInterruptedGateState,
+  readLocalCiGateState,
+  writeLocalCiGateState,
+} from "./local-ci-gate-state.mjs";
+
+test("local-CI gate state helper writes and reads the shared evidence shape", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-state-")), "gate.json");
+
+  writeLocalCiGateState(stateFile, {
+    branch: "fix/local-ci-descendant-fence",
+    sha: "c".repeat(40),
+    gatePassed: false,
+    leaseId: "NPEL-STATE",
+    evidenceId: "",
+    status: "running",
+    expiresAt: "2026-07-30T06:00:00.000Z",
+    resilience: null,
+    leaseEvents: [{ type: "admitted", at: "2026-07-30T05:00:00.000Z" }],
+    recovery: { reason: "test" },
+  });
+
+  const raw = JSON.parse(readFileSync(stateFile, "utf8"));
+  const state = readLocalCiGateState(stateFile);
+  assert.equal(raw.status, "running");
+  assert.deepEqual(state, raw);
+  assert.equal(state.recovery.reason, "test");
+});
+
+test("only matching admitted/running gate states are recoverable", () => {
+  const base = {
+    branch: "fix/local-ci-descendant-fence",
+    sha: "d".repeat(40),
+    leaseId: "NPEL-STATE",
+    evidencePending: false,
+  };
+
+  assert.equal(isRecoverableInterruptedGateState(
+    { ...base, status: "running" },
+    { branch: base.branch, sha: base.sha },
+  ), true);
+  assert.equal(isRecoverableInterruptedGateState(
+    { ...base, status: "admitted" },
+    { branch: base.branch, sha: base.sha },
+  ), true);
+  assert.equal(isRecoverableInterruptedGateState(
+    { ...base, status: "failed" },
+    { branch: base.branch, sha: base.sha },
+  ), false);
+  assert.equal(isRecoverableInterruptedGateState(
+    { ...base, status: "running", evidencePending: true },
+    { branch: base.branch, sha: base.sha },
+  ), false);
+  assert.equal(isRecoverableInterruptedGateState(
+    { ...base, status: "running" },
+    { branch: "other", sha: base.sha },
+  ), false);
+});

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -10,20 +10,23 @@
 // the agent recognizing that doctrine and hand-driving the sandbox lease
 // steps manually instead of it just working.
 //
-// This wrapper detects whether `sh` actually works against THIS worktree
-// (not just "sh is on PATH" — the failure mode above is a shell that starts
-// but cannot see the worktree's git state) and routes accordingly:
-//   - sh works here            -> delegate to `sh scripts/gate-worktree.sh`
-//                                  (unchanged contract, zero behavior change).
-//   - sh missing or non-functional -> run scripts/gate-worktree.mjs, the
-//                                  Node-native port of the same lease-claim /
-//                                  run / evidence-record / lease-release flow.
-// Either path ends at the same governed local-integration-ci sandbox lease —
-// a no-native-sh host is sandbox-routable, never a build blocker.
+// The canonical route is now the Node-native gate on every host; the shell
+// entry point remains a compatibility wrapper and can be forced only for
+// focused debugging. This keeps lease/fence safety in one implementation.
 
 import { spawnSync } from "node:child_process";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
+import { mcpCall } from "./lib/mcp-client.mjs";
+import {
+  createLocalCiSlotManifest,
+  LOCAL_CI_SLOT_KEYS,
+} from "./lib/local-ci-slot-manifest.mjs";
+import {
+  isRecoverableInterruptedGateState,
+  readLocalCiGateState,
+  writeLocalCiGateState,
+} from "./lib/local-ci-gate-state.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
@@ -39,9 +42,8 @@ export function shouldRunPreflight(args, env = process.env) {
   return true;
 }
 
-export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnSync } = {}) {
-  if (process.env.DPF_PREGATE_FORCE_NODE === "1") return false;
-  if (process.env.DPF_PREGATE_FORCE_SH === "1") return true;
+export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnSync, env = process.env } = {}) {
+  if (env.DPF_PREGATE_FORCE_NODE === "1") return false;
   try {
     const result = spawnSyncImpl("sh", ["-c", "git rev-parse --show-toplevel"], { cwd, encoding: "utf8" });
     return result.status === 0 && !result.error && Boolean(result.stdout && result.stdout.trim());
@@ -50,7 +52,202 @@ export function detectWorkingShell({ cwd = process.cwd(), spawnSyncImpl = spawnS
   }
 }
 
-function main() {
+export function shouldUseShell({ env = process.env, cwd = process.cwd(), spawnSyncImpl = spawnSync } = {}) {
+  if (env.DPF_PREGATE_FORCE_NODE === "1") return false;
+  if (env.DPF_PREGATE_FORCE_SH === "1") {
+    return detectWorkingShell({ cwd, spawnSyncImpl });
+  }
+  return false;
+}
+
+function argValue(args, flag) {
+  const index = args.indexOf(flag);
+  if (index < 0) return "";
+  return args[index + 1] || "";
+}
+
+function gitText(gitArgs, { cwd, spawnSyncImpl = spawnSync } = {}) {
+  const result = spawnSyncImpl("git", gitArgs, { cwd, encoding: "utf8" });
+  if (result.error || result.status !== 0) return "";
+  return String(result.stdout || "").trim();
+}
+
+export function resolvePregateGateContext({
+  args = [],
+  cwd = process.cwd(),
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const worktreePath = argValue(args, "--worktree")
+    || gitText(["rev-parse", "--show-toplevel"], { cwd, spawnSyncImpl });
+  if (!worktreePath) throw new Error("could not resolve worktree path");
+  const branch = argValue(args, "--branch")
+    || gitText(["rev-parse", "--abbrev-ref", "HEAD"], { cwd: worktreePath, spawnSyncImpl });
+  const sha = argValue(args, "--sha")
+    || gitText(["rev-parse", "HEAD"], { cwd: worktreePath, spawnSyncImpl });
+  const gitCommonDirRaw = gitText(["rev-parse", "--git-common-dir"], { cwd: worktreePath, spawnSyncImpl });
+  const statePathRaw = gitText(["rev-parse", "--git-path", "dpf-local-ci-gate.json"], { cwd: worktreePath, spawnSyncImpl });
+  if (!branch || branch === "HEAD" || !sha || !gitCommonDirRaw || !statePathRaw) {
+    throw new Error("could not resolve local-CI gate git context");
+  }
+  const gitCommonDir = resolvePath(worktreePath, gitCommonDirRaw);
+  const candidateGitDir = dirname(resolvePath(worktreePath, statePathRaw));
+  return {
+    branch,
+    sha,
+    worktreePath,
+    gitCommonDir,
+    rootClone: dirname(gitCommonDir),
+    candidateGitDir,
+  };
+}
+
+export function findRecoverableInterruptedGateStates({
+  context,
+  readStateImpl = readLocalCiGateState,
+} = {}) {
+  const found = [];
+  for (const slotKey of LOCAL_CI_SLOT_KEYS) {
+    const manifest = createLocalCiSlotManifest({
+      slotKey,
+      rootClone: context.rootClone,
+      gitCommonDir: context.gitCommonDir,
+      candidateGitDir: context.candidateGitDir,
+    });
+    const state = readStateImpl(manifest.evidence.state);
+    if (isRecoverableInterruptedGateState(state, {
+      branch: context.branch,
+      sha: context.sha,
+    })) {
+      found.push({ manifest, state, stateFile: manifest.evidence.state });
+    }
+  }
+  return found;
+}
+
+export async function recoverInterruptedGateState({
+  stateFile,
+  state,
+  branch,
+  sha,
+  childStatus = null,
+  childSignal = "",
+  mcpUrl = process.env.DPF_MCP_URL || "http://127.0.0.1:3000/api/mcp/v1",
+  bearerToken = process.env.DPF_MCP_BEARER_TOKEN,
+  mcpCallImpl = mcpCall,
+  writeStateImpl = writeLocalCiGateState,
+  now = () => new Date().toISOString(),
+} = {}) {
+  if (!isRecoverableInterruptedGateState(state, { branch, sha })) {
+    return { recovered: false, reason: "state-not-recoverable" };
+  }
+
+  let releaseSucceeded = false;
+  let releaseError = "";
+  if (!bearerToken) {
+    releaseError = "missing DPF_MCP_BEARER_TOKEN";
+  } else {
+    try {
+      const response = await mcpCallImpl(
+        "release_nonprod_environment_lease",
+        { leaseId: state.leaseId },
+        { mcpUrl, bearerToken },
+      );
+      releaseSucceeded = response?.success === true;
+      if (!releaseSucceeded) releaseError = JSON.stringify(response);
+    } catch (error) {
+      releaseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const recoveryEvent = {
+    type: "pregate_interrupted_gate_recovery",
+    at: now(),
+    childStatus,
+    childSignal: childSignal || "",
+    releaseAttempted: Boolean(bearerToken),
+    releaseSucceeded,
+  };
+  if (releaseError) recoveryEvent.releaseError = releaseError;
+
+  const leaseEvents = [
+    ...(Array.isArray(state.leaseEvents) ? state.leaseEvents : []),
+    recoveryEvent,
+  ];
+  writeStateImpl(stateFile, {
+    branch,
+    sha,
+    gatePassed: false,
+    leaseId: state.leaseId,
+    evidenceId: "",
+    status: "failed",
+    expiresAt: state.expiresAt || "",
+    resilience: state.resilience ?? null,
+    leaseEvents,
+    evidencePending: false,
+    recovery: {
+      reason: "gate-wrapper-exited-before-terminal-state",
+      childStatus,
+      childSignal: childSignal || "",
+      releaseSucceeded,
+      releaseError,
+    },
+  });
+  return {
+    recovered: true,
+    releaseSucceeded,
+    releaseError,
+    leaseId: state.leaseId,
+  };
+}
+
+export async function recoverInterruptedGate({
+  args = [],
+  result,
+  cwd = process.cwd(),
+  env = process.env,
+  spawnSyncImpl = spawnSync,
+  mcpCallImpl = mcpCall,
+  stderr = process.stderr,
+} = {}) {
+  const status = result?.status ?? 1;
+  if (status === 0 || args.includes("--dry-run") || args.includes("--finalize-evidence")) {
+    return { recovered: false, reason: "not-a-recoverable-invocation" };
+  }
+  let context;
+  try {
+    context = resolvePregateGateContext({ args, cwd, spawnSyncImpl });
+  } catch (error) {
+    stderr.write(`pregate: interrupted gate recovery skipped (${error.message}).\n`);
+    return { recovered: false, reason: "context-unavailable" };
+  }
+
+  const candidates = findRecoverableInterruptedGateStates({ context });
+  for (const candidate of candidates) {
+    const recovered = await recoverInterruptedGateState({
+      stateFile: candidate.stateFile,
+      state: candidate.state,
+      branch: context.branch,
+      sha: context.sha,
+      childStatus: result?.status ?? null,
+      childSignal: result?.signal || "",
+      mcpUrl: env.DPF_MCP_URL || "http://127.0.0.1:3000/api/mcp/v1",
+      bearerToken: env.DPF_MCP_BEARER_TOKEN,
+      mcpCallImpl,
+    });
+    if (recovered.recovered) {
+      const releaseText = recovered.releaseSucceeded
+        ? "released the lease"
+        : `could not release the lease (${recovered.releaseError || "unknown error"})`;
+      stderr.write(
+        `pregate: recovered interrupted local-CI gate for ${context.branch} @ ${context.sha}; ${releaseText}; marked the local gate state failed.\n`,
+      );
+      return recovered;
+    }
+  }
+  return { recovered: false, reason: "no-running-state" };
+}
+
+async function main() {
   const args = process.argv.slice(2);
 
   if (shouldRunPreflight(args)) {
@@ -71,13 +268,14 @@ function main() {
     );
   }
 
-  const shWorks = detectWorkingShell();
+  const useShell = shouldUseShell();
 
   let result;
-  if (shWorks) {
+  if (useShell) {
+    process.stderr.write("pregate: DPF_PREGATE_FORCE_SH=1 set — routing through compatibility shell entry point.\n");
     result = spawnSync("sh", [join(SCRIPT_DIR, "gate-worktree.sh"), ...args], { stdio: "inherit" });
   } else {
-    process.stderr.write("pregate: no working native sh detected for this worktree — routing through the Node-native gate (scripts/gate-worktree.mjs).\n");
+    process.stderr.write("pregate: routing through the Node-native gate (scripts/gate-worktree.mjs).\n");
     result = spawnSync(process.execPath, [join(SCRIPT_DIR, "gate-worktree.mjs"), ...args], { stdio: "inherit" });
   }
 
@@ -85,9 +283,18 @@ function main() {
     process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
     process.exit(1);
   }
-  process.exit(result.status ?? 1);
+  const status = result.status ?? 1;
+  if (status !== 0) {
+    await recoverInterruptedGate({ args, result });
+  }
+  process.exit(status);
 }
 
-// Guard against side effects on import (e.g. from tests importing
-// detectWorkingShell) — only run when this file is the process entry point.
-if (process.argv[1] === THIS_FILE) main();
+// Guard against side effects on import (e.g. from tests importing routing
+// helpers) — only run when this file is the process entry point.
+if (process.argv[1] === THIS_FILE) {
+  main().catch((error) => {
+    process.stderr.write(`pregate: ${error?.stack || String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  detectWorkingShell,
+  recoverInterruptedGateState,
+  shouldUseShell,
+} from "./pregate.mjs";
+
+function shellProbe(status = 0) {
+  return () => ({
+    status,
+    error: null,
+    stdout: status === 0 ? "/tmp/worktree\n" : "",
+  });
+}
+
+test("pregate routes to the canonical Node gate by default even when sh works", () => {
+  assert.equal(detectWorkingShell({ spawnSyncImpl: shellProbe(0) }), true);
+  assert.equal(shouldUseShell({ env: {}, spawnSyncImpl: shellProbe(0) }), false);
+});
+
+test("pregate shell route is explicit and still requires a working shell", () => {
+  assert.equal(shouldUseShell({
+    env: { DPF_PREGATE_FORCE_SH: "1" },
+    spawnSyncImpl: shellProbe(0),
+  }), true);
+  assert.equal(shouldUseShell({
+    env: { DPF_PREGATE_FORCE_SH: "1" },
+    spawnSyncImpl: shellProbe(1),
+  }), false);
+  assert.equal(shouldUseShell({
+    env: { DPF_PREGATE_FORCE_SH: "1", DPF_PREGATE_FORCE_NODE: "1" },
+    spawnSyncImpl: shellProbe(0),
+  }), false);
+});
+
+test("pregate recovery releases an interrupted running gate and marks it failed", async () => {
+  const calls = [];
+  let written = null;
+  const recovered = await recoverInterruptedGateState({
+    stateFile: "/tmp/dpf-local-ci-gate.json",
+    state: {
+      branch: "fix/local-ci-descendant-fence",
+      sha: "a".repeat(40),
+      gatePassed: false,
+      leaseId: "NPEL-INTERRUPTED",
+      evidenceRecordId: "",
+      status: "running",
+      expiresAt: "2026-07-30T06:00:00.000Z",
+      leaseEvents: [{ type: "admitted", at: "2026-07-30T05:00:00.000Z" }],
+      evidencePending: false,
+    },
+    branch: "fix/local-ci-descendant-fence",
+    sha: "a".repeat(40),
+    childStatus: 1,
+    bearerToken: "test-token",
+    mcpCallImpl: async (tool, args) => {
+      calls.push({ tool, args });
+      return { success: true };
+    },
+    writeStateImpl: (_stateFile, payload) => {
+      written = payload;
+    },
+    now: () => "2026-07-30T05:01:00.000Z",
+  });
+
+  assert.equal(recovered.recovered, true);
+  assert.equal(recovered.releaseSucceeded, true);
+  assert.deepEqual(calls, [{
+    tool: "release_nonprod_environment_lease",
+    args: { leaseId: "NPEL-INTERRUPTED" },
+  }]);
+  assert.equal(written.status, "failed");
+  assert.equal(written.gatePassed, false);
+  assert.equal(written.leaseEvents.at(-1).type, "pregate_interrupted_gate_recovery");
+  assert.equal(written.recovery.reason, "gate-wrapper-exited-before-terminal-state");
+});
+
+test("pregate recovery ignores terminal gate states", async () => {
+  let releaseCalled = false;
+  const recovered = await recoverInterruptedGateState({
+    stateFile: "/tmp/dpf-local-ci-gate.json",
+    state: {
+      branch: "fix/local-ci-descendant-fence",
+      sha: "b".repeat(40),
+      leaseId: "NPEL-TERMINAL",
+      status: "failed",
+      evidencePending: false,
+    },
+    branch: "fix/local-ci-descendant-fence",
+    sha: "b".repeat(40),
+    bearerToken: "test-token",
+    mcpCallImpl: async () => {
+      releaseCalled = true;
+      return { success: true };
+    },
+    writeStateImpl: () => {
+      throw new Error("terminal states must not be rewritten");
+    },
+  });
+
+  assert.equal(recovered.recovered, false);
+  assert.equal(releaseCalled, false);
+});

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -199,6 +199,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "local-sandbox-fence.mjs"), join(temp, "scripts", "lib", "local-sandbox-fence.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-queue-observer.mjs"), join(temp, "scripts", "lib", "local-queue-observer.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-slot-manifest.mjs"), join(temp, "scripts", "lib", "local-ci-slot-manifest.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "local-ci-gate-state.mjs"), join(temp, "scripts", "lib", "local-ci-gate-state.mjs"));
 
   const { dir } = makeTempRepo();
   const env = { ...process.env, DPF_MCP_BEARER_TOKEN: "dpfmcp_test" };


### PR DESCRIPTION
## Summary

- keep the canonical Node gate as the single cross-platform lease/fence owner and recover interrupted `admitted` / `running` gate state
- retain observed child, grandchild, Docker/build, and cleanup descendants until they quiesce or are terminated before lease/fence release
- block a newly admitted canonical runner while legacy local-CI mutators or orphaned processes referencing `.local-ci-runner` are still alive, even when the prior host fence is absent
- preserve durable FIFO authority while waiting and exclude unrelated Docker work and queued gates from the mutator detector
- clean up the ProductRoadmap jsdom render test so the CI shard no longer relies on leaked DOM between cases

## Root-cause evidence

Renderer lease `NPEL-326EC39C30` renewed normally, then its host fence vanished before expiry. The next lease was admitted only after renderer released and acquired its own fence later, ruling out successor overwrite. The confirmed failure mode is a surviving predecessor cleanup/descendant deleting a later owner's fence (`cms78s2lk012501po8lxt2lod`).

## Verification

- targeted process/lease/pregate/release suites: 48 passed, 0 failed; 33 environment-specific skips on Windows without native `sh`
- exact governed local-CI candidate `ca5bf9c9efc633f41732f8a40117f4304ec759c4` on base `f1ae4fe1d40df92d7501d437ec48614a023d0a8f`
- evidence `cms79ency024p01polrja4sy7`, lease `NPEL-D9F95EE6F1`
- freshness green; 476 migrations; docs and policy guards green
- exhaustive Vitest: 2,407 files / 20,609 tests passed
- typecheck green
- production Docker build green, image manifest `sha256:34e1c33b8440ccd2f55f0997b2a6af56f8fbc18b0c6b8d861b0542be70355262`
- lease released normally only after image export and descendant teardown
- GitHub CI passed on head `00953da3f4ea20c97ee077b2ab8fc6dd5eed3e26`: unit shards, packages unit tests, typecheck, production build, UX Route Sweep Runtime, CodeQL, policy guards, installer gates, DCO, and Merge Readiness
- `pnpm pr:health 3780` reports READY TO MERGE: 44 checks terminal+green, mergeable, zero unresolved review threads

## Documentation

Updated the implementation plan and pre-PR gate doctrine. No user-facing product or UX behavior changes; no migration required.

Local-CI-Evidence: cms79ency024p01polrja4sy7
Local-CI-Override: head 00953da3f4 only adds ProductRoadmap test cleanup/assertion isolation after full local-CI evidence cms79ency024p01polrja4sy7 on ca5bf9c9efc6; fresh local-CI for 00953da3f4 was attempted but remained queued behind an unrelated local-integration-ci lease, while GitHub CI on 00953da3f4 passed all required checks including unit shards, typecheck, production build, UX route sweep, CodeQL, and merge readiness.
