### PR TITLE
fix: keep no-dispatch certification inconclusive

### DIFF
--- a/apps/web/lib/build/inference-failure.test.ts
+++ b/apps/web/lib/build/inference-failure.test.ts
@@ -50,6 +50,11 @@ describe("classifyInferenceFailure", () => {
         "No AI provider credentials are configured for this feature. Open Platform › AI Operations › Providers & Routing, connect a cloud provider (Claude, OpenAI, Google, or similar), then try again.",
       ),
     ).toBe("config");
+    expect(
+      classifyInferenceFailure(
+        "No AI model can handle this request right now. This usually means your cloud AI providers are disconnected or their sign-in has expired, and the built-in local model can't fit this assistant's larger requests on its own. Open Platform > AI Operations > Providers & Routing to reconnect a provider — waiting won't clear this on its own.",
+      ),
+    ).toBe("config");
   });
 
   it("classifies empty-response fallbacks", () => {

--- a/apps/web/lib/build/inference-failure.ts
+++ b/apps/web/lib/build/inference-failure.ts
@@ -73,6 +73,10 @@ const MATCHERS: Matcher[] = [
   // agent-coworker NoProvidersAvailableError system copy / generic config gap.
   { kind: "config", test: /No AI providers are configured/i },
   { kind: "config", test: /No eligible AI endpoints/i },
+  // describeToolRouteFailure generic no-endpoint copy. This is emitted after
+  // routing rejects every candidate for a mixed set of reasons (for example
+  // sensitivity clearance + model tier), so no model response occurred.
+  { kind: "config", test: /^No AI model can handle this request right now\./i },
   // "The AI provider is temporarily unavailable. Please try again…" (fallback)
   { kind: "provider-unavailable", test: /AI provider is temporarily unavailable/i },
   { kind: "provider-unavailable", test: /AI (?:co-?workers?|providers?) are temporarily offline/i },

--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -162,6 +162,27 @@ describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => 
     expect(created.findings).toHaveLength(0);
   });
 
+  it("a no-dispatch routing response yields an INCONCLUSIVE run instead of scoring operator-safe copy", async () => {
+    const { deps, created } = makeDeps({
+      loopContent:
+        "No AI model can handle this request right now. This usually means your cloud " +
+        "AI providers are disconnected or their sign-in has expired, and the built-in " +
+        "local model can't fit this assistant's larger requests on its own. Open " +
+        "Platform > AI Operations > Providers & Routing to reconnect a provider — " +
+        "waiting won't clear this on its own.",
+      executedTools: [],
+    });
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.results[0].status).toBe("inconclusive");
+    expect(sweep.inconclusive).toBe(1);
+    expect(sweep.failed).toBe(0);
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("inconclusive");
+    expect(sweep.results[0].journeys.every((journey) => journey.capacityInconclusive)).toBe(true);
+    expect(created.findings).toHaveLength(0);
+  });
+
   it("a recovered oracle is absent-cleaned via updateMany scoped to the agent", async () => {
     const { deps, updateManyCalls } = makeDeps();
     await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -45,9 +45,10 @@ export type JourneyResult = {
   journeyId: string;
   mode: GoldenJourney["mode"];
   passed: boolean;
-  /** The journey could not be assessed because inference was at capacity and the
-   *  admission wait was exhausted — capacity backpressure, NOT a substantive
-   *  failure of the coworker. Such a run is requeued, never scored as a failure. */
+  /** The journey could not be assessed because inference never exercised the
+   *  coworker — capacity backpressure, provider unavailability, or no eligible
+   *  routed endpoint. Retained under its original serialized name for receipt
+   *  compatibility. Such a run is never scored as a coworker failure. */
   capacityInconclusive: boolean;
   verdicts: OracleVerdict[];
   executedToolNames: string[];
@@ -141,7 +142,7 @@ function defaultDeps(): CertificationDeps {
   };
 }
 
-function capacityInconclusiveJourney(
+function inferenceInconclusiveJourney(
   journey: GoldenJourney,
   startedAt: number,
   deps: CertificationDeps,
@@ -201,12 +202,14 @@ async function executeJourney(
       modelRequirements,
     });
 
-    // runAgenticLoop intentionally converts routing failures into operator-safe
-    // content instead of throwing. Preserve that UX contract while recognizing
-    // its canonical capacity signal here: a pool/rate-limit exhaustion means the
-    // coworker was not actually exercised and must be requeued, not failed.
-    if (classifyInferenceFailure(loop.content) === "rate-limit") {
-      return capacityInconclusiveJourney(journey, startedAt, deps);
+    // runAgenticLoop intentionally converts routing/dispatch failures into
+    // operator-safe content instead of throwing. Any canonical inference-failure
+    // reply means the model never produced a behavioral answer, so certification
+    // has no coworker behavior to score. This includes non-transient configuration
+    // gaps: bounded scheduling decides whether to retry, while the AssuranceRun
+    // remains honestly inconclusive rather than falsely failing the coworker.
+    if (classifyInferenceFailure(loop.content) !== null) {
+      return inferenceInconclusiveJourney(journey, startedAt, deps);
     }
 
     const verdicts = evaluateJourneyOracles({
@@ -235,7 +238,7 @@ async function executeJourney(
     // the journey inconclusive with NO failure verdicts, so the run is requeued
     // and the coworker is never wrongly failed for a busy box.
     if (isAdmissionTimeout(error)) {
-      return capacityInconclusiveJourney(journey, startedAt, deps);
+      return inferenceInconclusiveJourney(journey, startedAt, deps);
     }
     const message = getErrorMessage(error);
     const verdicts = evaluateJourneyOracles({


### PR DESCRIPTION
## Summary
- classify a downgraded inference with no successful tool dispatch as inconclusive instead of a genuine certification failure
- preserve attempted-tool diagnostics while preventing false failed AssuranceRuns
- add regression coverage at the inference-failure and certification-runner boundaries

## Verification
- exact candidate `82c4f107d4ca4466edc680f9f31ba3c4a31f96fd` merged with `origin/main` (`ff1f4d95d5aedb7d231a0f345f947e5a3ad5207d`) in governed `local-integration-ci`
- 2,380 test files passed; 20,461 tests passed
- migrations, documentation/policy guards, web typecheck, and Docker production build passed
- production image: `sha256:a2484b25f8e9d1ddc6194e62de96d9f1668f920537f21c021e4514dc04a71fbc`

## Impact
- UX verification: not applicable; this changes certification classification logic only and no portal UI
- migration verification: no migration files changed; migrate deploy passed in the exact gate
- documentation: no operator-facing workflow or architecture contract changed

Backlog: BI-1F3A4C88

Local-CI-Evidence: cms75w1gy0pg601og0mhapowm