### PR TITLE
fix(ci): skip portal UX runtime for non-portal PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       heavy: ${{ steps.decide.outputs.heavy }}
+      portal_ux_required: ${{ steps.decide.outputs.portal_ux_required }}
       evidence_plan_digest: ${{ steps.decide.outputs.evidence_plan_digest }}
       evidence_tier: ${{ steps.decide.outputs.evidence_tier }}
     steps:
@@ -413,22 +414,36 @@ jobs:
       actions: read
       contents: read
     with:
+      # The evidence planner is authoritative. Only its exact non-portal value
+      # (docs-only or app-mobile-only) suppresses the runtime; missing,
+      # malformed, or unknown values fail safe to the exhaustive sweep.
+      run_sweep: ${{ needs.changes.outputs.portal_ux_required != 'false' }}
       reuse_current_run_build: ${{ needs.changes.outputs.heavy == 'true' }}
       workers: "2"
 
   # Preserve the stable branch-protection context even though the runtime now
-  # lives in a reusable workflow. `always()` converts dependency skip/failure
-  # into an explicit red check instead of leaving merge queue status ambiguous.
+  # lives in a reusable workflow. An explicit non-portal classification may skip
+  # the runtime before runner allocation; every other skip/failure is red.
   ux-route-sweep:
     name: UX Route Budget Sweep
     runs-on: ubuntu-latest
     if: always()
-    needs: ux-route-sweep-runtime
+    needs: [changes, ux-route-sweep-runtime]
     steps:
-      - name: Assert the route runtime passed
+      - name: Assert the planned route evidence completed
         env:
+          PORTAL_UX_REQUIRED: ${{ needs.changes.outputs.portal_ux_required }}
           RUNTIME_RESULT: ${{ needs.ux-route-sweep-runtime.result }}
         run: |
+          if [ "$PORTAL_UX_REQUIRED" = "false" ]; then
+            if [ "$RUNTIME_RESULT" != "skipped" ]; then
+              echo "::error::Non-portal UX runtime concluded $RUNTIME_RESULT instead of skipped"
+              exit 1
+            fi
+            echo "Non-portal PR: UX runtime allocation was correctly skipped"
+            exit 0
+          fi
+
           if [ "$RUNTIME_RESULT" != "success" ]; then
             echo "::error::UX Route Sweep Runtime concluded $RUNTIME_RESULT"
             exit 1

--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_sweep:
+        description: "Allocate the UX runtime and execute the exhaustive route sweep"
+        required: false
+        type: boolean
+        default: true
       workers:
         description: "Bounded route workers"
         required: false
@@ -72,6 +77,10 @@ concurrency:
 jobs:
   sweep:
     name: UX Route Sweep Runtime
+    # Skip before GitHub allocates a runner or starts Postgres. The reusable
+    # workflow defaults to exhaustive execution; only an explicit caller input
+    # may suppress it. Manual calibration is always exhaustive.
+    if: ${{ github.event_name == 'workflow_dispatch' || inputs.run_sweep == true }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md
+++ b/docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md
@@ -1,0 +1,90 @@
+---
+title: Non-portal UX sweep short-circuit
+date: 2026-07-30
+status: implementation
+backlog_item: BI-B374EF2B
+epic: EP-0DFF753B
+spec: docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
+---
+
+# Non-portal UX sweep short-circuit
+
+## Outcome
+
+Make the existing authoritative docs-only and `apps/mobile`-only pull-request
+classifications prevent allocation of the reusable web-portal UX sweep runner
+and Postgres service. Publish that decision through a dedicated
+`portal_ux_required` output rather than coupling UX evidence to the broad
+`heavy` build/test switch. Preserve the stable `UX Route Budget Sweep` required
+context and retain exhaustive evidence for `merge_group`, `push`,
+`workflow_dispatch`, and every unknown or malformed scope.
+
+This is one atomic delivery: the reusable workflow input, caller wiring, fail-closed
+aggregate, and workflow contract tests are unsafe to ship separately.
+
+## Prior-design reconciliation
+
+- The CI evidence-efficiency design keeps pull-request selection behind stable required
+  contexts and retains exhaustive merge-group proof. This slice implements that lifecycle
+  distinction; it does not activate affected-test or changed-route selection.
+- The merge-readiness design requires always-triggered aggregate contexts. GitHub's
+  documented job-level skip semantics preserve a successful dependency result without the
+  pending-check failure mode caused by workflow-level path filters.
+- The current evidence planner already owns docs-only and app-mobile-only
+  classification. Workflow YAML consumes its dedicated `portal_ux_required`
+  output; it does not introduce a second path classifier.
+- Route assertions, baselines, tolerances, fixtures, route inventory, and production
+  behavior are unchanged. Only the PR lifecycle admission boundary changes.
+
+## Implementation
+
+1. Add a boolean `run_sweep` `workflow_call` input whose safe default is `true`.
+2. Guard the reusable `sweep` job with `inputs.run_sweep == true`, before runner and
+   service allocation.
+3. Emit `portal_ux_required` from the planner's existing scope fields without
+   changing the semantic plan or its calibrated digest, then pass that output
+   to `run_sweep`.
+4. Make the stable aggregate depend on both `changes` and the runtime call. Accept
+   `runtime=skipped` only when the authoritative signal is exactly
+   `portal_ux_required=false`; require `runtime=success` otherwise.
+5. Test-drive the YAML contract: explicit docs/mobile-only no-op, exhaustive
+   defaults, stable check names, and fail-closed aggregate states.
+
+## Verification
+
+- Red/green source contract test for workflow wiring.
+- Existing workflow-policy and merge-readiness contract suites.
+- YAML/action validation and documentation guards.
+- Governed exact-SHA local-CI before publication.
+- Representative non-portal PR: verify no reusable sweep runner/service
+  allocation and compare wall time against PR #3735's 585-second UX runtime
+  baseline.
+- Merge-group for the same PR: verify the full route sweep still runs and passes.
+
+## Risks and rollback
+
+- **False skip:** constrained to the planner's dedicated exact string
+  `portal_ux_required=false`; missing, malformed, and non-PR values resolve to
+  full execution.
+- **Required-check ambiguity:** the stable aggregate runs with `always()` and explicitly
+  evaluates both scope and runtime result.
+- **Reusable workflow misuse:** `run_sweep` defaults to `true`, so direct/manual and future
+  callers remain exhaustive unless they deliberately provide `false`.
+- **Rollback:** revert this single workflow-contract commit; no data or baseline migration
+  is involved.
+
+## Documentation impact
+
+Update contributor CI evidence guidance to state that non-portal PRs skip web
+UX runtime allocation while merge groups remain exhaustive. No operator-facing
+portal documentation changes are needed because product behavior is unchanged.
+
+## Backlog coverage
+
+Receipt: `cms75u2v60pfd01ogozeqbzw3`.
+
+- Parent BI: `BI-B374EF2B`
+- Deliverable: `non-portal-ux-sweep-short-circuit` → `BI-B374EF2B`
+- Dependencies: none
+- Decision: atomic; all five steps form one required-check contract and are not
+  independently shippable.

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -184,11 +184,16 @@ above the policy threshold; and every `merge_group`, `push`,
 `workflow_dispatch`, or scheduled event. The docs-only compatibility exemption
 remains unchanged because it does not narrow runtime evidence.
 
-This is observation only. The planner continues to emit the existing `heavy`
-and `mobile` compatibility outputs, but it does not skip any test, typecheck,
-build, migration, guard, or merge-queue proof. Activation is owned by
-`BI-4527C1DA` and still requires the calibration and 100% observed-failure
-recall conditions above.
+Affected-test and affected-route selection remain observation only. The planner
+continues to emit the existing `heavy` and `mobile` compatibility outputs.
+The planner also emits a dedicated `portal_ux_required` workflow output. It is
+`false` only for docs-only and `apps/mobile`-only pull requests, the two audited
+scopes that cannot alter the rendered web portal. Those changes short-circuit
+the reusable UX sweep before runner and Postgres allocation. This output is
+deliberately separate from `heavy` so future build/test scope changes cannot
+silently weaken portal evidence. Activation of broader source selection is
+owned by `BI-4527C1DA` and still requires the calibration and 100% observed-
+failure recall conditions above.
 
 ## Exact-tree production-build reuse
 
@@ -231,10 +236,14 @@ about one minute to PR feedback by serializing setup behind the build. The
 workflow retains only `actions: read` plus `contents: read`. See
 [Store and share data with workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data).
 
-Reuse is an optimization, never an exemption. On `heavy=false` changes, or
-when packaging/upload does not produce a usable artifact, the reusable runtime
-starts the normal local production build immediately. Missing, expired,
-incomplete, corrupt, or identity-mismatched
+Reuse is an optimization, never an exemption. On an explicitly classified
+non-portal pull request (`portal_ux_required=false`), CI skips the reusable
+sweep job before runner and Postgres allocation; the stable `UX Route Budget
+Sweep` aggregate accepts that skip only for the exact planner signal.
+`merge_group`, push, workflow dispatch, missing/malformed scope, and all portal
+changes remain exhaustive. When packaging/upload does not produce a usable
+artifact, the reusable runtime starts the normal local production build
+immediately. Missing, expired, incomplete, corrupt, or identity-mismatched
 evidence removes any partial `.next` output and runs the normal local production
 build. Packaging or upload failure is also non-authoritative: `Production Build`
 retains its successful result and UX rebuilds locally. Manual baseline

--- a/docs/testing/pr-health.md
+++ b/docs/testing/pr-health.md
@@ -36,7 +36,11 @@ Branch protection uses the smaller, versioned contract in
 
 - **Merge Readiness** aggregates every job in `.github/workflows/ci.yml`;
 - **UX Route Budget Sweep** is the stable aggregate for the reusable
-  browser/Postgres runtime called by CI; and
+  browser/Postgres runtime called by CI. It accepts a skipped runtime only when
+  the authoritative planner says the change is non-portal
+  (`portal_ux_required=false`, limited to docs-only and `apps/mobile`-only);
+  all unknown, portal, and merge-group scopes require a successful exhaustive
+  run; and
 - **DCO** proves commit sign-off.
 
 CI runs for `pull_request` and `merge_group`, while the UX implementation is a

--- a/scripts/ci-build-artifact-workflow.test.mjs
+++ b/scripts/ci-build-artifact-workflow.test.mjs
@@ -57,7 +57,7 @@ describe("production-build artifact workflow wiring", () => {
   it("preserves the stable required check and manual calibration path", () => {
     assert.match(
       ci,
-      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep\s*\n\s+runs-on: ubuntu-latest\s*\n\s+if: always\(\)\s*\n\s+needs: ux-route-sweep-runtime/,
+      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep\s*\n\s+runs-on: ubuntu-latest\s*\n\s+if: always\(\)\s*\n\s+needs: \[changes, ux-route-sweep-runtime\]/,
     );
     assert.match(ci, /needs\.ux-route-sweep-runtime\.result/);
     assert.match(ci, /merge_group:/);
@@ -65,6 +65,40 @@ describe("production-build artifact workflow wiring", () => {
     assert.doesNotMatch(ux, /^\s{2}push:/m);
     assert.match(ux, /update_baseline:/);
     assert.match(ux, /--update-baseline/);
+  });
+
+  it("skips runner allocation only for an explicit non-portal PR scope", () => {
+    assert.match(
+      ux,
+      /run_sweep:\s*\n\s+description:[^\n]*\n\s+required: false\s*\n\s+type: boolean\s*\n\s+default: true/,
+    );
+    assert.match(
+      ux,
+      /sweep:\s*\n\s+name: UX Route Sweep Runtime[\s\S]*?if: \$\{\{ github\.event_name == 'workflow_dispatch' \|\| inputs\.run_sweep == true \}\}\s*\n\s+runs-on:/,
+    );
+    assert.match(
+      ci,
+      /run_sweep: \$\{\{ needs\.changes\.outputs\.portal_ux_required != 'false' \}\}/,
+      "only the planner's exact non-portal signal may suppress exhaustive UX evidence",
+    );
+    assert.match(
+      ci,
+      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep[\s\S]*?needs: \[changes, ux-route-sweep-runtime\]/,
+    );
+    assert.match(
+      ci,
+      /PORTAL_UX_REQUIRED: \$\{\{ needs\.changes\.outputs\.portal_ux_required \}\}/,
+    );
+    assert.match(
+      ci,
+      /if \[ "\$PORTAL_UX_REQUIRED" = "false" \]; then[\s\S]*?\[ "\$RUNTIME_RESULT" != "skipped" \][\s\S]*?exit 1[\s\S]*?exit 0/,
+      "the stable aggregate must accept a skip only for the authoritative non-portal scope",
+    );
+    assert.match(
+      ci,
+      /if \[ "\$RUNTIME_RESULT" != "success" \]; then[\s\S]*?exit 1/,
+      "all non-docs and unknown scopes must fail closed unless the sweep succeeds",
+    );
   });
 
   it("grants only read access to workflow artifacts", () => {

--- a/scripts/ci-evidence-plan.mjs
+++ b/scripts/ci-evidence-plan.mjs
@@ -136,16 +136,26 @@ function writeText(path, contents) {
   writeFileSync(path, contents);
 }
 
-function writeGitHubOutputs(path, plan) {
-  if (!path) return;
-  appendFileSync(path, [
+export function githubOutputsForPlan(plan) {
+  // Keep the portal UX decision independent from the broader heavy-CI switch.
+  // Today docs-only and app-mobile-only changes are the two scopes that cannot
+  // alter the rendered web portal. Deriving the dedicated output from those
+  // existing audited scope fields preserves the calibrated plan digest.
+  const portalUxRequired = !plan.scope.docsOnly && !plan.scope.mobileOnly;
+  return [
     `heavy=${plan.scope.heavy}`,
+    `portal_ux_required=${portalUxRequired}`,
     `mobile=${plan.scope.mobile}`,
     `evidence_tier=${plan.evidenceTier}`,
     `evidence_plan_digest=${plan.digest}`,
     `evidence_selected_percentage=${plan.selection.selectedPercentage}`,
     "",
-  ].join("\n"));
+  ].join("\n");
+}
+
+function writeGitHubOutputs(path, plan) {
+  if (!path) return;
+  appendFileSync(path, githubOutputsForPlan(plan));
 }
 
 export function runEvidencePlannerCli(args = process.argv.slice(2)) {

--- a/scripts/ci-evidence-plan.test.mjs
+++ b/scripts/ci-evidence-plan.test.mjs
@@ -12,6 +12,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { after, before, describe, it } from "node:test";
 
+import { githubOutputsForPlan } from "./ci-evidence-plan.mjs";
+
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const cliPath = join(repoRoot, "scripts", "ci-evidence-plan.mjs");
 let fixture;
@@ -100,9 +102,35 @@ describe("ci-evidence-plan CLI", () => {
     assert.equal(result.status, 0, result.stderr);
     const output = readFileSync(githubOutput, "utf8");
     assert.match(output, /^heavy=true$/m);
+    assert.match(output, /^portal_ux_required=true$/m);
     assert.match(output, /^mobile=false$/m);
     assert.match(output, /^evidence_tier=exhaustive$/m);
     assert.match(output, /^evidence_plan_digest=[a-f0-9]{64}$/m);
+  });
+
+  it("keeps portal UX scope independent from the broad heavy-CI switch", () => {
+    const runtime = githubOutputsForPlan({
+      scope: { docsOnly: false, mobileOnly: false, heavy: true, mobile: false },
+      evidenceTier: "exhaustive",
+      digest: "a".repeat(64),
+      selection: { selectedPercentage: 100 },
+    });
+    const docs = githubOutputsForPlan({
+      scope: { docsOnly: true, mobileOnly: false, heavy: false, mobile: false },
+      evidenceTier: "affected",
+      digest: "b".repeat(64),
+      selection: { selectedPercentage: 0 },
+    });
+    const mobile = githubOutputsForPlan({
+      scope: { docsOnly: false, mobileOnly: true, heavy: false, mobile: true },
+      evidenceTier: "affected",
+      digest: "c".repeat(64),
+      selection: { selectedPercentage: 0 },
+    });
+
+    assert.match(runtime, /^portal_ux_required=true$/m);
+    assert.match(docs, /^portal_ux_required=false$/m);
+    assert.match(mobile, /^portal_ux_required=false$/m);
   });
 
   it("turns malformed optional advice into exhaustive evidence instead of aborting", () => {

--- a/scripts/merge-readiness-policy.test.mjs
+++ b/scripts/merge-readiness-policy.test.mjs
@@ -14,8 +14,10 @@ const manifest = {
   workflows: { ci: "ci.yml", ux: "ux.yml" },
   aggregateJobId: "merge-readiness",
   aggregateJobName: "Merge Readiness",
-  uxJobId: "sweep",
+  uxJobId: "ux-route-sweep",
   uxJobName: "UX Route Budget Sweep",
+  uxRuntimeJobId: "sweep",
+  uxRuntimeJobName: "UX Route Sweep Runtime",
 };
 
 test("dependency evaluator accepts only success and intentional skips", () => {
@@ -36,9 +38,15 @@ test("dependency evaluator accepts only success and intentional skips", () => {
 });
 
 test("workflow conformance requires complete aggregate coverage and merge-group triggers", () => {
-  const ci = `on:\n  merge_group:\njobs:\n  build:\n    name: Build\n  lint:\n    name: Lint\n  merge-readiness:\n    name: Merge Readiness\n    needs:\n      - build\n`;
-  const ux = `on:\n  merge_group:\njobs:\n  sweep:\n    name: UX Route Budget Sweep\n`;
-  assert.deepEqual(parseWorkflowJobIds(ci), ["build", "lint", "merge-readiness"]);
+  const ci = `on:\n  merge_group:\njobs:\n  build:\n    name: Build\n  lint:\n    name: Lint\n  ux-route-sweep-runtime:\n    name: UX Route Sweep Runtime\n  ux-route-sweep:\n    name: UX Route Budget Sweep\n  merge-readiness:\n    name: Merge Readiness\n    needs:\n      - build\n      - ux-route-sweep-runtime\n      - ux-route-sweep\n`;
+  const ux = `on:\n  workflow_call:\njobs:\n  sweep:\n    name: UX Route Sweep Runtime\n`;
+  assert.deepEqual(parseWorkflowJobIds(ci), [
+    "build",
+    "lint",
+    "ux-route-sweep-runtime",
+    "ux-route-sweep",
+    "merge-readiness",
+  ]);
   assert.deepEqual(validateWorkflowConformance({ manifest, ciSource: ci, uxSource: ux }), [
     "aggregate is missing CI jobs: lint",
   ]);


### PR DESCRIPTION
## Summary

- skip the reusable web-portal UX sweep before runner/service allocation only when the evidence planner explicitly classifies the PR as non-portal
- use a dedicated `portal_ux_required` output instead of coupling UX evidence to the broad `heavy` build/test switch
- limit the skip to docs-only and `apps/mobile`-only changes; all portal, unknown, merge-group, push, and manual scopes remain exhaustive
- preserve the stable `UX Route Budget Sweep` and `Merge Readiness` checks with a fail-closed aggregate

## Why

A successful one-file docs-only PR spent 585 seconds in the UX runtime even though all other heavy jobs short-circuited. Across the ten most recent successful CI runs, the UX job took a 610-second median (574–798), versus 461 seconds for Production Build and roughly 205–210 seconds for each web test shard.

The evidence planner already owns docs/mobile scope. This PR exposes that decision through one purpose-specific workflow output without changing the calibrated semantic plan or digest.

## Verification

- exact governed local-CI: `cms7wrg4u01pk01posaf3qgik`
- candidate: `a40e79e3aec357d8c2833944bcce4015405d8ce9`
- base: `b74d3f41157756bc2d68222e71aede2ef2f913f5`
- integration: `eeade3d553d16ac1744434faa63f0d47f7addc46`
- 2,416 test files / 20,721 tests passed
- all 24 guards, TypeScript, migrations, docs, and production Docker build passed
- production image: `sha256:41da34020fbda066e9aad33f9f512987d3d35e9b78c179acb31abf04ed7e60c4`
- planner/workflow contract suite: 43 tests passed, including runtime/docs/mobile scope separation

## Coverage and impact

No route assertion, baseline, tolerance, fixture, route inventory, or production behavior changes. This PR is CI-policy-bearing, so its PR and merge-group runs remain exhaustive. After merge, a representative docs-only PR will provide the required before/after wall-time attestation.

UX: not applicable to product UI; portal-changing PRs and every merge group retain exhaustive UX evidence.
Migration: not applicable; no schema or migration change.
Docs: CI evidence, PR-health guidance, and the implementation plan are updated here.

Local-CI-Evidence: cms7wrg4u01pk01posaf3qgik (fix/docs-only-ux-sweep-skip@a40e79e3aec357d8c2833944bcce4015405d8ce9)

Backlog: BI-B374EF2B
Plan: `docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md`
