### PR TITLE
fix: enforce tool-required certification nudge

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -105,6 +105,7 @@ describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => 
 
     const loopCall = (deps.runLoop as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(loopCall.tools.map((t: { name: string }) => t.name)).toEqual(["query_backlog"]);
+    expect(loopCall.requireTools).toBe(true);
   });
 
   it("a failed oracle produces a failed run plus an open finding keyed to the oracle", async () => {

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -98,6 +98,7 @@ export type CertificationDeps = {
     toolsForProvider: Array<Record<string, unknown>>;
     userId: string;
     routeContext: string;
+    requireTools: boolean;
     modelRequirements?: Record<string, unknown>;
   }) => Promise<LoopResult>;
   db: typeof prisma;
@@ -118,6 +119,7 @@ async function defaultRunLoop(
     agentId: params.journey.agentId,
     threadId: `certification:${params.journey.journeyId}`,
     interactionMode: "chat",
+    requireTools: params.requireTools,
     ...(params.modelRequirements && Object.keys(params.modelRequirements).length > 0
       ? { modelRequirements: params.modelRequirements }
       : {}),
@@ -199,6 +201,7 @@ async function executeJourney(
       toolsForProvider,
       userId: userContext.userId,
       routeContext,
+      requireTools: true,
       modelRequirements,
     });
 

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -88,13 +88,6 @@ describe("shouldNudge", () => {
     })).toBe(true);
   });
 
-  // Regression for the setup-tour /workspace COO contradiction: route persona
-  // says "no tool calls, 2-3 sentences", coworker complies, but nudge fires
-  // "use a tool now" → coworker surfaces the contradiction to the user.
-  // Companion guard to c70a7db6 (which fixed the fabrication-detection arm
-  // of the same problem). Narrowed to the setup-tour signal so non-setup
-  // advise routes (e.g. /finance) still nudge + surface the local-model
-  // diagnostic.
   it("does not nudge on a setup-tour turn (route persona says 'no tool calls')", () => {
     expect(shouldNudge({
       continuationNudges: 0, iteration: 0, maxIterations: 40,
@@ -106,7 +99,6 @@ describe("shouldNudge", () => {
   });
 
   it("does not nudge when response is a short clarifying question", () => {
-    // HR case: "add John as employee" → agent correctly asks for last name
     expect(shouldNudge({
       continuationNudges: 0, iteration: 0, maxIterations: 40,
       hasTools: true, executedToolCount: 0, responseLength: 35,
@@ -128,17 +120,6 @@ describe("shouldNudge", () => {
       hasTools: true, executedToolCount: 0, responseLength: 120,
       responseText: "I can help you add an employee. The system has several tools available including create_employee and list_departments that you can use.",
     })).toBe(false);
-  });
-
-  it("nudges a substantive first reply when the caller requires tool execution", () => {
-    expect(shouldNudge({
-      continuationNudges: 0, iteration: 0, maxIterations: 40,
-      hasTools: true, executedToolCount: 0, responseLength: 180,
-      responseText:
-        "I reviewed the current source and its related test. The implementation appears consistent, and I would need a failing case before calling it a defect.",
-      requireToolExecution: true,
-      allowFirstTurnTextOnlyReply: true,
-    })).toBe(true);
   });
 
   it("does not nudge when no tools available", () => {
@@ -198,13 +179,6 @@ describe("shouldNudge", () => {
       hasTools: true, executedToolCount: 0, responseLength: 44,
     })).toBe(false);
   });
-
-  // BI-C145F650 defect A — the exact /workspace COO "where are the archetypes?"
-  // failure. After tools have run, a substantive conversational answer that
-  // merely ENDS with a helpful offer ("…would you like me to…?") must be
-  // accepted as final. Before the fix it fell through to the permission-seeking
-  // catch-all and was nudged away, then the local-spinning guard surfaced the
-  // misleading "not strong enough" diagnostic while a correct answer was in hand.
   it("does not nudge a substantive conversational answer that ends with a helpful offer (post-tool-call)", () => {
     expect(shouldNudge({
       continuationNudges: 0, iteration: 4, maxIterations: 200,
@@ -1189,20 +1163,12 @@ describe("runAgenticLoop", () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute
       .mockResolvedValueOnce(mockResult({
-        content:
-          "I reviewed the source and related test and found no material defect. More evidence would be needed before blocking the change.",
+        content: "I reviewed the source and related test and found no material defect. More evidence would be needed before blocking the change.",
       }))
       .mockResolvedValueOnce(mockResult({
-        content:
-          "I still cannot ground a finding in a successful read, so the review remains unsupported.",
+        content: "I still cannot ground a finding in a successful read, so the review remains unsupported.",
       }));
-
-    const result = await runAgenticLoop({
-      ...baseParams,
-      requireTools: true,
-      interactionMode: "chat",
-    });
-
+    const result = await runAgenticLoop({ ...baseParams, requireTools: true, interactionMode: "chat" });
     expect(mockRoute).toHaveBeenCalledTimes(2);
     expect(result.content).toContain("review remains unsupported");
     expect(result.executedTools).toHaveLength(0);

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -130,6 +130,17 @@ describe("shouldNudge", () => {
     })).toBe(false);
   });
 
+  it("nudges a substantive first reply when the caller requires tool execution", () => {
+    expect(shouldNudge({
+      continuationNudges: 0, iteration: 0, maxIterations: 40,
+      hasTools: true, executedToolCount: 0, responseLength: 180,
+      responseText:
+        "I reviewed the current source and its related test. The implementation appears consistent, and I would need a failing case before calling it a defect.",
+      requireToolExecution: true,
+      allowFirstTurnTextOnlyReply: true,
+    })).toBe(true);
+  });
+
   it("does not nudge when no tools available", () => {
     expect(shouldNudge({
       continuationNudges: 0, iteration: 0, maxIterations: 40,
@@ -1172,6 +1183,29 @@ describe("runAgenticLoop", () => {
     expect(result.content).toBe("Hello! How can I help?");
     expect(result.executedTools).toHaveLength(0);
     expect(result.proposal).toBeNull();
+  });
+
+  it("bounds a tool-required text-only turn to one corrective nudge", async () => {
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute
+      .mockResolvedValueOnce(mockResult({
+        content:
+          "I reviewed the source and related test and found no material defect. More evidence would be needed before blocking the change.",
+      }))
+      .mockResolvedValueOnce(mockResult({
+        content:
+          "I still cannot ground a finding in a successful read, so the review remains unsupported.",
+      }));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      requireTools: true,
+      interactionMode: "chat",
+    });
+
+    expect(mockRoute).toHaveBeenCalledTimes(2);
+    expect(result.content).toContain("review remains unsupported");
+    expect(result.executedTools).toHaveLength(0);
   });
 
   it("handles multiple tool calls in one iteration", async () => {

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -687,6 +687,12 @@ export function shouldNudge(params: {
   responseText?: string;
   hasAuthoritativeToolExecution?: boolean;
   /**
+   * The caller's contract cannot be satisfied without at least one tool call.
+   * In that case, a fluent text-only answer is not a valid completion signal;
+   * spend the existing one-nudge budget before accepting the stop.
+   */
+  requireToolExecution?: boolean;
+  /**
    * True when this turn is part of the setup tour. SetupOverlay sends an
    * auto-message prefixed "[Setup step: …]" whose route persona explicitly
    * instructs a brief text-only reply ("no tool calls"). On such turns a
@@ -748,7 +754,7 @@ export function shouldNudge(params: {
     const isSubstantiveReply = text.length >= 100
       && !COMPLETION_CLAIM_PATTERN.test(text)
       && !NARRATION_PATTERN.test(text);
-    if (isSubstantiveReply) return false;
+    if (isSubstantiveReply && !params.requireToolExecution) return false;
   }
 
   // First iteration with no tools called — nudge UNLESS the response is a
@@ -760,8 +766,12 @@ export function shouldNudge(params: {
   if (params.executedToolCount === 0 && params.iteration === 0) {
     const text = params.responseText?.trim() ?? "";
     const isAskingClarification = text.length < 250 && CLARIFYING_QUESTION_PATTERN.test(text);
-    const isSubstantiveReply = text.length >= 100 && !COMPLETION_CLAIM_PATTERN.test(text) && !NARRATION_PATTERN.test(text);
-    const isAllowedDirectReply = !!params.allowFirstTurnTextOnlyReply
+    const isSubstantiveReply = !params.requireToolExecution
+      && text.length >= 100
+      && !COMPLETION_CLAIM_PATTERN.test(text)
+      && !NARRATION_PATTERN.test(text);
+    const isAllowedDirectReply = !params.requireToolExecution
+      && !!params.allowFirstTurnTextOnlyReply
       && text.length > 0
       && !COMPLETION_CLAIM_PATTERN.test(text)
       && !NARRATION_PATTERN.test(text)
@@ -2165,6 +2175,7 @@ export async function runAgenticLoop(params: {
           messages,
           responseText: trimmed,
         }),
+        requireToolExecution: requireTools,
       });
 
         // Local model produced text-only on iteration 0 of a tool-backed turn:

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -686,11 +686,7 @@ export function shouldNudge(params: {
   responseLength: number;
   responseText?: string;
   hasAuthoritativeToolExecution?: boolean;
-  /**
-   * The caller's contract cannot be satisfied without at least one tool call.
-   * In that case, a fluent text-only answer is not a valid completion signal;
-   * spend the existing one-nudge budget before accepting the stop.
-   */
+  /** True when text alone cannot satisfy the caller's contract. */
   requireToolExecution?: boolean;
   /**
    * True when this turn is part of the setup tour. SetupOverlay sends an
@@ -726,13 +722,8 @@ export function shouldNudge(params: {
   if (params.continuationNudges >= maxNudges) return false;
   if (params.iteration >= params.maxIterations - 1) return false;
   if (!params.hasTools) return false;
+  const permitsTextCompletion = !params.requireToolExecution;
 
-  // Setup-tour turns (SetupOverlay's "[Setup step: …]" auto-message) ask the
-  // coworker for a brief text-only welcome with no tool calls. Nudging there
-  // injects a contradiction the coworker reconciles out loud. Skip the
-  // iteration-0 nudge on those turns only — NOT on every no-authoritative-tool
-  // route, so routes like /finance still nudge a weak local model (and surface
-  // the local-model diagnostic) when it should have queried a tool.
   if (
     params.executedToolCount === 0
     && params.iteration === 0
@@ -754,7 +745,7 @@ export function shouldNudge(params: {
     const isSubstantiveReply = text.length >= 100
       && !COMPLETION_CLAIM_PATTERN.test(text)
       && !NARRATION_PATTERN.test(text);
-    if (isSubstantiveReply && !params.requireToolExecution) return false;
+    if (permitsTextCompletion && isSubstantiveReply) return false;
   }
 
   // First iteration with no tools called — nudge UNLESS the response is a
@@ -766,11 +757,9 @@ export function shouldNudge(params: {
   if (params.executedToolCount === 0 && params.iteration === 0) {
     const text = params.responseText?.trim() ?? "";
     const isAskingClarification = text.length < 250 && CLARIFYING_QUESTION_PATTERN.test(text);
-    const isSubstantiveReply = !params.requireToolExecution
-      && text.length >= 100
-      && !COMPLETION_CLAIM_PATTERN.test(text)
-      && !NARRATION_PATTERN.test(text);
-    const isAllowedDirectReply = !params.requireToolExecution
+    const isSubstantiveReply = permitsTextCompletion && text.length >= 100
+      && !COMPLETION_CLAIM_PATTERN.test(text) && !NARRATION_PATTERN.test(text);
+    const isAllowedDirectReply = permitsTextCompletion
       && !!params.allowFirstTurnTextOnlyReply
       && text.length > 0
       && !COMPLETION_CLAIM_PATTERN.test(text)


### PR DESCRIPTION
## Summary
- make the shared agentic loop distinguish tool-required turns from ordinary conversational turns
- give a fluent text-only certification response the existing single corrective tool-use nudge
- keep the one-nudge cost bound and the strict ORACLE-TOOL failure when no successful call follows
- opt coworker golden-journey certification into the tool-required contract

## Why
The deployed Change Reviewer certification `assurance_coworker_cert_change-reviewer_2026_07_30T08_00_53_852Z` failed with `No successful tool call (attempted: none)`. The journey explicitly required source evidence, but the generic first-turn heuristic accepted a 100+ character text-only response as final before the bounded nudge could run.

Closes BI-24BDACF7.

## Design grounding
- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-07-27-shared-change-reviewer-control-plan.md`
- Current code substrate reviewed:
  - `apps/web/lib/coworker-lifecycle/certification-runner.ts`
  - `apps/web/lib/tak/agentic-loop.ts`
  - their existing regression suites
- Source of truth:
  - the certification journey's read-only tool requirement and `runAgenticLoop`'s existing one-nudge budget
- Decision:
  - express the requirement through the existing `requireTools` contract, preserve the one-nudge cost bound, and shrink the baselined modules rather than raising their size ratchet

## Verification
- current candidate: `e61878f7128fb7b295b0d9a27c12839e0e170de8`
- prior exact candidate evidence (superseded by ratchet refactor): `cms7a75d803gs01pompv55qis`
- exact local-integration evidence: `cms7cce5907ay01povozsthtf`
- accepted base: `405a2a836e500aa51ab564391bcd727bd65e6685`
- freshness: green (`next@16.2.11`, `react@19.2.8`, `typescript@6.0.3`, `prisma@7.8.0`, `vitest@4.1.10`)
- full web suite: 2,407 files passed; 20,610 tests passed
- web typecheck, migration deploy, docs integrity, guards, and production Docker build: passed
- source policy guard: passed locally (`node scripts/check-module-size.mjs`)

## Impact
- UX: not applicable; no UI or operator workflow changed
- migrations: not applicable; no schema change
- docs: no update needed; this corrects an internal execution boundary without changing the documented coworker workflow
- confidentiality: unchanged; certification remains on the existing confidential, read-only surface

Local-CI-Evidence: cms7cce5907ay01povozsthtf
