### PR TITLE
fix(ci): make calibration cache identity source-complete

### DIFF
--- a/.github/workflows/ci-calibration.yml
+++ b/.github/workflows/ci-calibration.yml
@@ -246,7 +246,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: apps/web/.next/cache
-          key: turbopack-build-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'apps/web/**/*.{ts,tsx,js,jsx}') }}
+          # hashFiles does not expand brace globs. Keep every supported web
+          # source extension explicit so a source edit always rolls the key.
+          key: turbopack-build-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.ts', 'apps/web/**/*.tsx', 'apps/web/**/*.js', 'apps/web/**/*.jsx') }}
 
       - name: Measure Turbopack restore
         id: turbopack-restore-measure
@@ -287,7 +289,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: apps/web/.next/cache
-          key: turbopack-build-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'apps/web/**/*.{ts,tsx,js,jsx}') }}
+          key: turbopack-build-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.ts', 'apps/web/**/*.tsx', 'apps/web/**/*.js', 'apps/web/**/*.jsx') }}
 
       - name: Measure Turbopack save
         id: turbopack-save-measure

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -93,7 +93,11 @@ Workflow: `.github/workflows/ci-calibration.yml` (`CI Calibration`)
 - Runs on a schedule (Mon/Thu 06:00 UTC) and `workflow_dispatch`
 - Never runs on `pull_request` and is never a required merge check
 - Executes observation unit tests, web + database coverage, shadow related-test comparison
-- Measures exact-key cache economics for `pnpm-store` and `turbopack-build` (`actions/cache/restore@v5` + `actions/cache/save@v5`, no prefix `restore-keys` on Turbopack)
+- Measures exact-key cache economics for `pnpm-store` and `turbopack-build`
+  (`actions/cache/restore@v5` + `actions/cache/save@v5`, no prefix
+  `restore-keys` on Turbopack). The Turbopack key hashes the lockfile plus
+  explicit `ts`, `tsx`, `js`, and `jsx` source globs; GitHub `hashFiles` does
+  not expand brace globs.
 - Publishes a versioned observation artifact bound to the immutable tree SHA (`ci-observation`, 30-day retention)
 
 ## Activation gate (later waves)

--- a/scripts/ci-coverage-config.test.mjs
+++ b/scripts/ci-coverage-config.test.mjs
@@ -82,3 +82,20 @@ test("calibration measures both pnpm and exact-key Turbopack cache economics", (
     /key:\s*nextjs-[\s\S]{0,300}restore-keys:/,
   );
 });
+
+test("calibration Turbopack keys cover every supported web source extension", () => {
+  const supportedSourceHash =
+    /hashFiles\('apps\/web\/\*\*\/\*\.ts', 'apps\/web\/\*\*\/\*\.tsx', 'apps\/web\/\*\*\/\*\.js', 'apps\/web\/\*\*\/\*\.jsx'\)/g;
+  const matches = calibrationWorkflow.match(supportedSourceHash) ?? [];
+
+  assert.equal(
+    matches.length,
+    2,
+    "restore and save must use the same complete source hash",
+  );
+  assert.doesNotMatch(
+    calibrationWorkflow,
+    /hashFiles\([^)]*\{ts,tsx,js,jsx\}[^)]*\)/,
+    "GitHub hashFiles does not expand brace globs",
+  );
+});


### PR DESCRIPTION
## Summary

Correct the scheduled CI calibration's Turbopack cache identity so web source edits reliably roll the exact cache key. GitHub `hashFiles` supports multiple explicit patterns, while `@actions/glob` documents only `*`, `?`, character classes, and `**` as supported pattern forms; the previous brace expression could therefore leave calibration results attached to the wrong source identity.

## Changes

- replace the unsupported `apps/web/**/*.{ts,tsx,js,jsx}` pattern with explicit `ts`, `tsx`, `js`, and `jsx` arguments in both restore and save keys
- preserve independent lockfile and source hashes in the key for readable cache provenance
- add a workflow contract test that requires identical source-complete restore/save keys and rejects brace globs
- document the calibration identity contract

Primary references:

- https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#hashfiles
- https://github.com/actions/toolkit/blob/main/packages/glob/README.md#patterns

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] TypeScript passed in the exact governed local-CI gate
  - [x] `node --test scripts/ci-coverage-config.test.mjs` — 6/6 passed

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks passed
  - [x] Functional verification ran against the governed shared nonprod environment (lease id: `NPEL-FBF74B11CC`)
  - [x] Evidence captured below

- [ ] **Verification-harness limitation acknowledged**

### Verification evidence

- exact candidate `90aebdd772de283039f116e05b0fa784dc859de7`
- accepted base `405a2a836e500aa51ab564391bcd727bd65e6685`
- integration tree `12e6942d2db05fb65870de70e473dd793c6fd520`
- evidence `cms7cu85f08xx01pol9h7s3ie`
- sandbox freshness green; 24 guards passed
- exhaustive Vitest: 2,407 files / 20,609 tests passed
- TypeScript and migrations passed
- production Docker image `sha256:4e885fc3981f6ed7ab6748a9a694f7bcb80b50b29753563ce1dabcb17ab3c3d1`
- `node scripts/check-doc-links.mjs` passed (78 pages / 581 indexed)
- no UX/product behavior changed, so no interactive UX verification is applicable

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and against the final diff
- [x] `pnpm run pregate:preflight` passed through the supervised exact-SHA gate
- [x] Exact-tree local-CI evidence captured
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cms7cu85f08xx01pol9h7s3ie (fix/ci-calibration-cache-key@90aebdd772de283039f116e05b0fa784dc859de7)

## Related issues / Epic

Related backlog item: `BI-2F60FDCE` — CI observation baselines.

## Epic / Backlog linkage (for multi-BI work)

Single-BI correction under the existing CI observation/calibration stream.

## Overlap sweep

PR #3782 also edits `docs/testing/ci-evidence.md`, but its workflow/test
concern is separate and it remains intentionally held for the independent
Marketing fixture correction. This narrow calibration repair can land first;
#3782 will be rebased afterward so the documentation edits are reconciled
without mixing the concerns.

## Notes for the reviewer

This does not activate Turbopack caching. It repairs measurement identity only. The latest calibration still shows a 0% hit on a 2.82 GB cache and remains quarantined until representative observations prove positive economics.
