### PR TITLE
feat(context): persist the arbitration trace per coworker turn (BI-3E218D80)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -718,6 +718,10 @@ export async function sendMessage(input: {
   // cap never breaks a `Use the <id> skill.` request (reused for telemetry below).
   const invokedSkillId = extractInvokedSkillId(input.content);
 
+  // BI-3E218D80. Outer scope: arbitration runs inside `useUnified`, both assistant-message
+  // writes are below it. Rationale/contract: lib/tak/arbitration-trace.ts.
+  let contextTrace: import("@/lib/tak/arbitration-trace").ArbitrationTrace | undefined;
+
   if (useUnified) {
     // ── Unified prompt path: composable blocks from route-context-map + prompt-assembler ──
     // EP-CTX-001: Context sources are submitted to the arbitrator, which enforces
@@ -816,6 +820,11 @@ export async function sendMessage(input: {
 
     // Context arbitration logging — always on for operator visibility
     console.log(formatArbitrationLog(result, budget));
+
+    // BI-3E218D80: the log above is ephemeral; persist the decision too. Labels and
+    // counts only, never content — see lib/tak/arbitration-trace.ts.
+    const { buildArbitrationTrace } = await import("@/lib/tak/arbitration-trace");
+    contextTrace = buildArbitrationTrace(result, budget);
 
     // Reconstruct domain context and route data from selected sources
     const selectedDomain = result.selected.find((s) => s.source === "domain")?.content ?? routeCtx.domainContext;
@@ -1941,6 +1950,7 @@ export async function sendMessage(input: {
           modelId: agenticResult.modelId,
           taskType: taskTypeId !== "unknown" ? taskTypeId : null,
           routedEndpointId: null, // EP-INF-009b: routing handled per-iteration by routeAndCall
+          contextTrace, // BI-3E218D80 — proposal path (see also the plain-response write)
         },
         select: { id: true, role: true, content: true, agentId: true, routeContext: true, createdAt: true },
       });
@@ -2357,6 +2367,7 @@ export async function sendMessage(input: {
       modelId: responseModelId,
       taskType: taskTypeId !== "unknown" ? taskTypeId : null,
       routedEndpointId: null, // EP-INF-009b: routing is per-iteration via routeAndCall
+      contextTrace, // BI-3E218D80 — plain-response path (see also the proposal write)
     },
     select: {
       id: true,

--- a/apps/web/lib/tak/arbitration-trace.test.ts
+++ b/apps/web/lib/tak/arbitration-trace.test.ts
@@ -1,0 +1,193 @@
+// BI-3E218D80 — arbitration trace contract.
+//
+// The load-bearing test in this file is the LEAK test: the whole reason this mapper exists
+// instead of a JSON.stringify at the call site is that ContextSource.content is recalled
+// user facts, page data, and semantic-memory excerpts. If content ever reaches the column,
+// the platform has silently created a second, ungoverned retention surface for the same
+// sensitive text — so that is asserted against the serialized JSON, not just the object.
+import { describe, expect, it } from "vitest";
+
+import { arbitrate, getBudgetForTier, type ContextSource } from "./context-arbitrator";
+import { buildArbitrationTrace, traceHasLoss } from "./arbitration-trace";
+
+const SECRET = "PATIENT_SSN_078_05_1120_DO_NOT_PERSIST";
+
+function source(over: Partial<ContextSource> & Pick<ContextSource, "tier" | "source">): ContextSource {
+  return {
+    priority: 0,
+    content: `content for ${over.source}`,
+    tokenCount: 100,
+    compressible: false,
+    ...over,
+  } as ContextSource;
+}
+
+describe("arbitration trace — records the decision, never the payload", () => {
+  it("carries no source content, even when the content is distinctive", () => {
+    const budget = getBudgetForTier("basic"); // total 800, l2Budget 0 — forces drops
+    const sources: ContextSource[] = [
+      source({ tier: "L0", source: "identity", content: SECRET, tokenCount: 50 }),
+      source({ tier: "L1", source: "user-facts", content: SECRET, tokenCount: 100 }),
+      source({ tier: "L2", source: "semantic-memory", content: SECRET, tokenCount: 400 }),
+    ];
+    const result = arbitrate(sources, budget);
+    const trace = buildArbitrationTrace(result, budget);
+
+    // Assert on the SERIALIZED form — that is what reaches the database column.
+    const serialized = JSON.stringify(trace);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain("content for");
+    // And the labels we DO want are present.
+    expect(serialized).toContain("identity");
+    expect(serialized).toContain("semantic-memory");
+  });
+
+  it("omits input-policy fields that are recoverable from code", () => {
+    const budget = getBudgetForTier("strong");
+    const result = arbitrate([source({ tier: "L1", source: "domain", priority: 3 })], budget);
+    const entry = buildArbitrationTrace(result, budget).selected[0];
+    expect(Object.keys(entry).sort()).toEqual(["source", "tier", "tokenCount"]);
+  });
+
+  it("records every selected and dropped source with its tier and cost", () => {
+    const budget = getBudgetForTier("basic"); // l1Budget 175, l2Budget 0
+    const sources: ContextSource[] = [
+      source({ tier: "L0", source: "identity", tokenCount: 60 }),
+      source({ tier: "L1", source: "domain", tokenCount: 150 }),
+      source({ tier: "L1", source: "portal-context", tokenCount: 900 }), // cannot fit
+    ];
+    const trace = buildArbitrationTrace(arbitrate(sources, budget), budget);
+
+    expect(trace.selected.map((s) => s.source)).toEqual(["identity", "domain"]);
+    expect(trace.dropped.map((s) => s.source)).toEqual(["portal-context"]);
+    expect(trace.dropped[0]).toMatchObject({ tier: "L1", tokenCount: 900 });
+  });
+});
+
+describe("compression is stated, not inferred", () => {
+  // The trace must not deduce degradation from `tokenCount === compressedTokenCount`:
+  // that inference lies whenever the two variants cost the same. arbitrate() sets an
+  // explicit flag instead, and this pins it.
+  it("flags a source whose compressed fallback was substituted", () => {
+    const budget = getBudgetForTier("basic"); // l1Budget 175
+    const sources: ContextSource[] = [
+      source({
+        tier: "L1",
+        source: "page-data",
+        tokenCount: 900,
+        compressible: true,
+        compressedContent: "short",
+        compressedTokenCount: 120,
+      }),
+    ];
+    const trace = buildArbitrationTrace(arbitrate(sources, budget), budget);
+
+    expect(trace.dropped).toHaveLength(0);
+    expect(trace.selected[0]).toMatchObject({
+      source: "page-data",
+      tokenCount: 120,
+      usedCompressed: true,
+    });
+  });
+
+  // `arbitrate` has TWO compression branches (L1 and L2) and no dedicated test file of its
+  // own, so both had to be covered here or this change would have edited an untested path.
+  // L2 also has the unused-L1-budget rollover, which this exercises incidentally.
+  it("flags a compressed L2 source, not just L1", () => {
+    const budget = getBudgetForTier("strong"); // l1Budget 800, l2Budget 1575
+    const sources: ContextSource[] = [
+      source({
+        tier: "L2",
+        source: "semantic-memory",
+        tokenCount: 5000, // exceeds the 1575 + 800 rolled-over ceiling
+        compressible: true,
+        compressedContent: "short recall",
+        compressedTokenCount: 400,
+      }),
+    ];
+    const trace = buildArbitrationTrace(arbitrate(sources, budget), budget);
+
+    expect(trace.dropped).toHaveLength(0);
+    expect(trace.selected[0]).toMatchObject({
+      source: "semantic-memory",
+      tier: "L2",
+      tokenCount: 400,
+      usedCompressed: true,
+    });
+  });
+
+  it("leaves the flag absent — not false — when nothing was degraded", () => {
+    const budget = getBudgetForTier("frontier");
+    const trace = buildArbitrationTrace(
+      arbitrate([source({ tier: "L1", source: "domain", tokenCount: 10 })], budget),
+      budget,
+    );
+    expect("usedCompressed" in trace.selected[0]).toBe(false);
+  });
+
+  it("still reports a drop when even the compressed variant cannot fit", () => {
+    const budget = getBudgetForTier("basic"); // l1Budget 175
+    const sources: ContextSource[] = [
+      source({
+        tier: "L1",
+        source: "page-data",
+        tokenCount: 900,
+        compressible: true,
+        compressedContent: "still too big",
+        compressedTokenCount: 800,
+      }),
+    ];
+    const trace = buildArbitrationTrace(arbitrate(sources, budget), budget);
+    expect(trace.selected).toHaveLength(0);
+    // The DROPPED entry reports the full cost, not the compressed one — that is the
+    // number that explains why it did not fit.
+    expect(trace.dropped[0]).toMatchObject({ source: "page-data", tokenCount: 900 });
+  });
+});
+
+describe("budget shape and loss predicate", () => {
+  it("mirrors the resolved budget so a reader needs no second lookup", () => {
+    const budget = getBudgetForTier("strong");
+    const trace = buildArbitrationTrace(arbitrate([], budget), budget);
+    expect(trace.version).toBe(1);
+    expect(trace.modelTier).toBe("strong");
+    expect(trace.budget).toEqual({ total: 3000, l0: 625, l1: 800, l2: 1575 });
+  });
+
+  it("rounds utilization instead of storing a 17-digit float", () => {
+    const budget = getBudgetForTier("strong"); // total 3000
+    const trace = buildArbitrationTrace(
+      arbitrate([source({ tier: "L0", source: "identity", tokenCount: 1000 })], budget),
+      budget,
+    );
+    // 1000/3000 = 0.3333... -> 0.333
+    expect(trace.budgetUtilization).toBe(0.333);
+  });
+
+  it("traceHasLoss is true for a drop, true for a compression, false for a clean turn", () => {
+    const clean = buildArbitrationTrace(
+      arbitrate([source({ tier: "L1", source: "domain", tokenCount: 10 })], getBudgetForTier("frontier")),
+      getBudgetForTier("frontier"),
+    );
+    expect(traceHasLoss(clean)).toBe(false);
+
+    const basic = getBudgetForTier("basic");
+    const droppedTrace = buildArbitrationTrace(
+      arbitrate([source({ tier: "L1", source: "portal-context", tokenCount: 900 })], basic),
+      basic,
+    );
+    expect(traceHasLoss(droppedTrace)).toBe(true);
+
+    const compressedTrace = buildArbitrationTrace(
+      arbitrate(
+        [source({
+          tier: "L1", source: "page-data", tokenCount: 900,
+          compressible: true, compressedContent: "s", compressedTokenCount: 120,
+        })],
+        basic,
+      ),
+      basic,
+    );
+    expect(traceHasLoss(compressedTrace)).toBe(true);
+  });
+});

--- a/apps/web/lib/tak/arbitration-trace.ts
+++ b/apps/web/lib/tak/arbitration-trace.ts
@@ -1,0 +1,107 @@
+// apps/web/lib/tak/arbitration-trace.ts
+//
+// BI-3E218D80 — the persisted arbitration trace. Extends EP-CTX-001 §9 (Observability)
+// with the one thing that section never specified: a PER-TURN record of what the coworker
+// was actually given and what was dropped for budget.
+//
+// WHY THIS EXISTS. `arbitrate()` decides what enters every coworker's system prompt.
+// Until now that decision was `console.log(formatArbitrationLog(...))` and nothing else —
+// `ArbitrationResult.dropped` had exactly one consumer, a debug-string formatter. So when
+// a coworker behaved as if it did not know something, there was no way to distinguish:
+//
+//   1. the fact was never retrieved,
+//   2. it was retrieved and DROPPED for budget,
+//   3. it was present and the model ignored it.
+//
+// Those need three different fixes and were indistinguishable from outside. This is also
+// the diagnostic the local-model cascade (BI-F4D3B9E9) needed and did not have.
+//
+// EP-CTX-001 §9.1 specified aggregate Prometheus counters (`contextSourcesDropped` et al.)
+// which were never built. Aggregates are the wrong instrument for this question anyway: a
+// counter cannot answer "why didn't THIS coworker know X on THIS turn". Hence a per-turn
+// row, not a metric.
+//
+// LABELS AND COUNTS ONLY — NEVER CONTENT. This is the load-bearing rule of the module and
+// the reason it is a separate pure function rather than a JSON.stringify at the call site.
+// Every `ContextSource` carries `content`, and that content is recalled user facts, page
+// data, and semantic-memory excerpts. It is ALREADY persisted in the message row and its
+// source tables; copying it here would balloon the column and create a second retention
+// surface for the same sensitive text, governed by nothing. The trace records that a source
+// participated and what it cost — enough to reconstruct the decision, insufficient to leak
+// the payload.
+
+import type { ArbitrationResult, ContextBudget, ContextSource, ContextTier } from "./context-arbitrator";
+
+/** One source's participation in a single arbitration. No content, by contract. */
+export type ArbitrationTraceEntry = {
+  source: string;
+  tier: ContextTier;
+  tokenCount: number;
+  /** True when `arbitrate` substituted the compressed fallback to make this fit. */
+  usedCompressed?: true;
+};
+
+export type ArbitrationTrace = {
+  /** Schema version, so a reader can tell an old row from a new one. */
+  version: 1;
+  modelTier: string;
+  budget: { total: number; l0: number; l1: number; l2: number };
+  totalTokens: number;
+  /** totalTokens / budget.total, rounded to 3dp. >1 means over budget. */
+  budgetUtilization: number;
+  selected: ArbitrationTraceEntry[];
+  dropped: ArbitrationTraceEntry[];
+};
+
+/**
+ * The one place a `ContextSource` is narrowed for persistence.
+ *
+ * `content`, `compressedContent`, `compressible`, and `priority` are deliberately absent:
+ * the first two are the payload this module exists to keep out of the database, and the
+ * latter two describe the INPUT policy rather than the outcome — they are recoverable from
+ * the code, so persisting them per turn would be noise.
+ */
+function toEntry(src: ContextSource): ArbitrationTraceEntry {
+  const entry: ArbitrationTraceEntry = {
+    source: src.source,
+    tier: src.tier,
+    tokenCount: src.tokenCount,
+  };
+  // Only present when true, so the common case stays compact in the column.
+  if (src.usedCompressed) entry.usedCompressed = true;
+  return entry;
+}
+
+/**
+ * Build the persistable trace for one arbitration. Pure — no I/O, no Date, no randomness —
+ * so it is unit-testable and safe to call on every turn.
+ */
+export function buildArbitrationTrace(
+  result: ArbitrationResult,
+  budget: ContextBudget,
+): ArbitrationTrace {
+  return {
+    version: 1,
+    modelTier: budget.modelTier,
+    budget: {
+      total: budget.totalBudget,
+      l0: budget.l0Budget,
+      l1: budget.l1Budget,
+      l2: budget.l2Budget,
+    },
+    totalTokens: result.totalTokens,
+    // Round rather than store a 17-digit float; 3dp keeps 0.1% resolution, which is far
+    // finer than the ~4-chars-per-token estimate feeding it.
+    budgetUtilization: Math.round(result.budgetUtilization * 1000) / 1000,
+    selected: result.selected.map(toEntry),
+    dropped: result.dropped.map(toEntry),
+  };
+}
+
+/**
+ * Was anything sacrificed on this turn? The cheap predicate a reader or alert wants,
+ * without re-deriving it from the arrays.
+ */
+export function traceHasLoss(trace: ArbitrationTrace): boolean {
+  return trace.dropped.length > 0 || trace.selected.some((s) => s.usedCompressed === true);
+}

--- a/apps/web/lib/tak/context-arbitrator.ts
+++ b/apps/web/lib/tak/context-arbitrator.ts
@@ -18,6 +18,17 @@ export type ContextSource = {
   compressible: boolean;      // Can this be shortened if over budget?
   compressedContent?: string; // Shorter fallback version
   compressedTokenCount?: number;
+  /**
+   * Set by `arbitrate` on a SELECTED source when it substituted the compressed
+   * fallback to make the source fit. Callers never set this.
+   *
+   * It exists so the persisted arbitration trace (BI-3E218D80) can state
+   * truthfully that a source was degraded rather than INFERRING it from
+   * `tokenCount === compressedTokenCount` — an inference that silently lies
+   * whenever the compressed and full variants happen to cost the same. An audit
+   * record whose whole purpose is trust must not be built on a guess.
+   */
+  usedCompressed?: boolean;
 };
 
 export type ContextBudget = {
@@ -105,6 +116,7 @@ export function arbitrate(
           ...src,
           content: src.compressedContent,
           tokenCount: src.compressedTokenCount,
+          usedCompressed: true,
         });
         l1Used += src.compressedTokenCount;
       } else {
@@ -129,6 +141,7 @@ export function arbitrate(
           ...src,
           content: src.compressedContent,
           tokenCount: src.compressedTokenCount,
+          usedCompressed: true,
         });
         l2Used += src.compressedTokenCount;
       } else {

--- a/docs/data-impact/2026-07-30-agent-message-context-trace.data-impact.json
+++ b/docs/data-impact/2026-07-30-agent-message-context-trace.data-impact.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "AgentMessage.contextTrace: per-turn record of which context sources entered the coworker's system prompt and which were dropped for budget. Derived operational telemetry — the ONLY copy of the arbitration decision, which was previously ephemeral container stdout."
+  ],
+  "migration": {
+    "name": "20260730040000_add_agent_message_context_trace",
+    "backfill": "none; nullable with no default, so PostgreSQL performs no table rewrite and every pre-existing AgentMessage row remains valid. NULL is meaningful rather than missing: it distinguishes 'this turn did not arbitrate' (legacy prompt path, system messages) from 'arbitrated and dropped nothing'."
+  },
+  "tests": [
+    "apps/web/lib/tak/arbitration-trace.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:agent-message",
+      "prismaModel": "AgentMessage",
+      "lifecycleDisposition": "follows the parent AgentMessage exactly; inherits the thread's cascade delete (AgentThread onDelete: Cascade), so the trace can never outlive the conversation it describes. No independent retention, no separate purge path.",
+      "fields": [
+        {
+          "fieldId": "data:agent-message#contextTrace",
+          "resolution": "governed",
+          "reason": "makes the context-arbitration decision auditable so that 'the fact was never retrieved', 'it was dropped for budget', and 'it was present and ignored' become distinguishable — three failures that need three different fixes and were previously indistinguishable from outside.",
+          "provenance": "computed deterministically by apps/web/lib/tak/arbitration-trace.ts from the ArbitrationResult of that same turn; never operator-entered, never model-generated.",
+          "flags": ["subject"],
+          "fieldPolicy": "SOURCE LABELS AND TOKEN COUNTS ONLY — never source content. Records source name, tier, token count, and whether a compressed fallback was substituted. The excluded payload (recalled user facts, page data, semantic-memory excerpts) stays in its own governed tables; copying it here would have created a second, ungoverned retention surface for the same sensitive text. Enforced by a test asserting the SERIALIZED JSON contains no content, since the serialized form is what reaches the column. Flagged subject because it is per-user conversational metadata inheriting the thread's access boundary, not because it carries personal content."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-04-03-context-budget-arbitration-design.md
+++ b/docs/superpowers/specs/2026-04-03-context-budget-arbitration-design.md
@@ -357,6 +357,53 @@ In development mode, log the arbitration decision:
   L2 dropped: attachments(420 tokens, over budget)
 ```
 
+### 9.3 Persisted per-turn trace (BI-3E218D80, shipped 2026-07-30)
+
+**Status of §9.1 and §9.2, honestly:** none of the §9.1 Prometheus metrics
+(`contextBudgetUtilization`, `contextSourceTokens`, `contextSourcesDropped`) were ever
+built. §9.2's *development-mode* log shipped as an unconditional `console.log` in
+`agent-coworker.ts`, commented "always on for operator visibility" — which container
+stdout is not, in any durable sense. So for the arbitrator's whole production life,
+`ArbitrationResult.dropped` had exactly one consumer: a debug-string formatter.
+
+That left three different failures indistinguishable from outside when a coworker behaved
+as though it lacked a fact:
+
+1. the fact was never retrieved,
+2. it was retrieved and **dropped for budget**,
+3. it was present and the model ignored it.
+
+**Aggregates are the wrong instrument for that question.** A counter cannot answer "why
+didn't *this* coworker know X on *this* turn". So this section adds a per-turn record
+rather than the metrics §9.1 proposed:
+
+- **Where:** `AgentMessage.contextTrace Json?` — one nullable column on the existing
+  per-turn row, deliberately not a new model. `TokenUsage` was rejected because it is
+  written per *provider call* (`ai-inference.ts`), and a tool loop makes several per turn.
+- **Shape:** `ArbitrationTrace` in `apps/web/lib/tak/arbitration-trace.ts`, versioned.
+- **Contract — labels and counts only, never content.** Source `content` is recalled user
+  facts, page data, and semantic-memory excerpts already persisted in their own tables;
+  copying it here would create a second, ungoverned retention surface for the same
+  sensitive text. Enforced by a test asserting the *serialized* JSON contains no content.
+- **Compression is stated, not inferred.** `arbitrate` now sets `usedCompressed` on a
+  source when it substitutes the compressed fallback, so the trace does not have to guess
+  from `tokenCount === compressedTokenCount` — an inference that lies whenever the two
+  variants cost the same. This realizes the intent already visible in §9.2's example log
+  (`page-data=680(compressed from 1200)`).
+- **Nullable on purpose:** a turn that does not arbitrate (legacy prompt path, system
+  messages) stores nothing, so "did not arbitrate" stays distinguishable from "arbitrated
+  and dropped nothing".
+
+The §9.2 log is retained — it is useful when tailing live — so this adds durability rather
+than replacing observability. §9.1's aggregate metrics remain unbuilt and are still a
+legitimate gap; they answer fleet-level questions ("how often is semantic memory trimmed
+on the basic tier?") that a per-turn row answers only by scan.
+
+Rationale of record for why this plane needed provenance at all:
+`docs/superpowers/specs/2026-07-29-progressive-disclosure-interpretable-context-enforcement-design.md`
+(finding F2 — the runtime context plane was budgeted but carried no provenance, while the
+portal-UX and static-agent-instruction planes are both ratcheted).
+
 ---
 
 ## 10. Implementation Order

--- a/packages/db/prisma/migrations/20260730040000_add_agent_message_context_trace/migration.sql
+++ b/packages/db/prisma/migrations/20260730040000_add_agent_message_context_trace/migration.sql
@@ -1,0 +1,20 @@
+-- BI-3E218D80: persist the context arbitration trace per coworker turn.
+--
+-- Extends EP-CTX-001 §9 (Observability). That section specified aggregate Prometheus
+-- counters (never built) plus a dev-mode debug log; neither can answer "why didn't THIS
+-- coworker know X on THIS turn", which is the question a single incident actually poses.
+-- Until now `ArbitrationResult.dropped` was consumed only by a console formatter, so
+-- "never retrieved" / "dropped for budget" / "present but ignored" were indistinguishable.
+--
+-- Shape is `ArbitrationTrace` from apps/web/lib/tak/arbitration-trace.ts (versioned).
+-- It holds SOURCE LABELS AND TOKEN COUNTS ONLY, never source content — that content is
+-- recalled user facts and page data already persisted in their own tables, and copying it
+-- here would create a second ungoverned retention surface for the same sensitive text.
+--
+-- @migration-safety: additive-nullable. One nullable JSONB column on an existing table.
+-- No default, so PostgreSQL does not rewrite existing rows; no constraint, index, backfill,
+-- or lock beyond the brief ACCESS EXCLUSIVE that ADD COLUMN takes to update the catalog.
+-- Every pre-existing AgentMessage row remains valid with NULL, and a turn that performs no
+-- arbitration (system messages) legitimately stores nothing.
+
+ALTER TABLE "AgentMessage" ADD COLUMN "contextTrace" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6083,6 +6083,15 @@ model AgentMessage {
   modelId          String?
   taskType         String?
   routedEndpointId String?
+  // BI-3E218D80: what the coworker was actually GIVEN on this turn, and what was dropped
+  // for budget. Extends EP-CTX-001 §9 (Observability), which specified aggregate Prometheus
+  // counters — never built — plus a dev-mode log; neither can answer "why didn't THIS
+  // coworker know X on THIS turn". Shape: lib/tak/arbitration-trace.ts (`ArbitrationTrace`,
+  // versioned). Holds SOURCE LABELS AND TOKEN COUNTS ONLY, never source content: that
+  // content is recalled user facts / page data already persisted elsewhere, and copying it
+  // here would create a second ungoverned retention surface. Nullable: every pre-existing
+  // row stays valid, and a turn that never arbitrates (system messages) simply has none.
+  contextTrace     Json?
   proposal         AgentActionProposal?
   attachments      AgentAttachment[]
   thread           AgentThread          @relation(fields: [threadId], references: [id], onDelete: Cascade)

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -15,7 +15,7 @@ apps/web/components/workbooks/Grid.tsx	1585
 apps/web/instrumentation.test.ts	945
 apps/web/instrumentation.ts	1524
 apps/web/lib/actions/agent-coworker-external.test.ts	867
-apps/web/lib/actions/agent-coworker.ts	2759
+apps/web/lib/actions/agent-coworker.ts	2770
 apps/web/lib/actions/agent-task-scheduler.test.ts	1124
 apps/web/lib/actions/ai-providers.ts	914
 apps/web/lib/actions/build-governed.test.ts	1149


### PR DESCRIPTION
Implements **BI-3E218D80**. Extends EP-CTX-001 §9 (Observability) with the one thing that section never specified: a per-turn record of what the coworker was actually **given**, and what was **dropped** for budget.

## The gap

`arbitrate()` decides what enters every coworker's system prompt. Its result was `console.log(formatArbitrationLog(...))` and nothing else — `ArbitrationResult.dropped` had exactly one consumer in the entire codebase, a debug-string formatter. So when a coworker behaved as though it lacked a fact, three different failures were indistinguishable from outside:

1. the fact was never retrieved,
2. it was retrieved and **dropped for budget**,
3. it was present and the model ignored it.

Those need three different fixes. This is also the diagnostic the local-model cascade (BI-F4D3B9E9) needed and did not have.

**Why not the metrics the spec asked for.** §9.1 specified aggregate Prometheus counters — none were ever built, but they are also the wrong instrument: a counter cannot answer *"why didn't THIS coworker know X on THIS turn"*. §9.2's *development-mode* log shipped as an unconditional `console.log` commented "always on for operator visibility", which container stdout is not. The log is retained; §9.1 remains a legitimate unbuilt gap for fleet-level questions.

## Where it lands, and what was rejected

`AgentMessage.contextTrace Json?` — one nullable column on the existing per-turn row, deliberately **not** a new model (which would trigger the eight-gate new-Prisma-model gauntlet). Substrate alternatives were checked, not assumed:

| Candidate | Why rejected |
|---|---|
| `TokenUsage` | written per **provider call** (`ai-inference.ts:740`); a tool loop makes several per turn, so the trace would duplicate and couple prompt assembly into the provider recorder |
| `Activity` | a CRM model keyed to account/contact/opportunity — category error |
| `AgentPromptContext` | per-agent config (`agentId @unique`), not per-turn |

## Labels and counts only, never content

This is the load-bearing rule, and the reason serialization is a separate pure module rather than a `JSON.stringify` at the call site. Every `ContextSource` carries `content` — recalled user facts, page data, semantic-memory excerpts — **already persisted in its own tables**. Copying it here would create a second, ungoverned retention surface for the same sensitive text.

Enforced by a test asserting the **serialized** JSON contains no content, using a distinctive sentinel, because the serialized form is what reaches the column.

## Compression is stated, not inferred

`arbitrate` now sets `usedCompressed` when it substitutes the compressed fallback. Without it the trace would deduce degradation from `tokenCount === compressedTokenCount` — an inference that silently lies whenever the two variants cost the same. Unacceptable in a record whose entire purpose is trust. This also realizes intent already visible in §9.2's own example log (`page-data=680(compressed from 1200)`).

## Two things that would have been silent bugs

- **`sendMessage` has TWO assistant-message write sites** — the tool-proposal path and the plain-response path. Wiring only one would have produced a trace that exists for some turns and not others, with nothing indicating which.
- **Arbitration runs inside `if (useUnified)`** while both writes sit at the outer scope, so a block-scoped `const` would not have been in scope. The declaration is hoisted, and stays `undefined` on the legacy path — which Prisma omits, so *"this turn did not arbitrate"* stays distinguishable from *"arbitrated and dropped nothing"* rather than being faked as an empty trace.

## Verification

Full local gate reached literal **`gate passed`**:

- `prisma migrate deploy` — **this migration applied to a real database**
- `pnpm --filter web typecheck` — clean
- **20,470 tests passed**, 19 skipped, 0 failed

Plus: 10 unit tests on the pure mapper (content-leak contract + both of `arbitrate`'s compression branches — the L2 case added specifically because `arbitrate` has no dedicated test file, so changing it would otherwise have edited an untested path); 27-guard preflight clean; module-size OK; Prisma client regenerated with `contextTrace` confirmed in the generated types.

Migration is **additive-nullable**: no default, so no table rewrite; no constraint, index, or backfill. Every pre-existing row stays valid.

### Honest note on the gate SHA

`gate passed` was reached at `fd20143a`. Main then moved 15 commits (overlapping `schema.prisma` and `module-size-baseline.txt`), so this was rebased by patch to `0f5ae50aa3`. **My nine files are byte-identical across that rebase** — only main's files differ. I re-verified on the new base (27 guards, module-size, 10 tests, client regenerated) but did not re-queue the full gate, because the local-CI queue is 8 deep on a single slot and CI re-runs `migrate deploy` + typecheck + the full suite here anyway.

## Follow-on, deliberately not in this PR

- A shrink-only ratchet on assembled L0+L1+L2 tokens per agent profile — the plane-3 analog of the instruction-plane ratchet. Now unblocked, since you cannot ratchet what you do not record. Needs a deterministic DB-free assembly fixture or it will flake in CI.
- A read surface for the trace. Cheapest honest option extends an existing observability route rather than adding one — and now needs a measured `*.ux-fit.json` manifest under the gate that landed in #3769.

Data-impact manifest: `docs/data-impact/2026-07-30-agent-message-context-trace.data-impact.json`.

Seed-Fit-Decision: global-default

No canonical seed content changed in this diff; the decision is recorded as global-default because the trace contract is platform substrate applied identically on every install, not archetype- or vertical-scoped.

Local-CI-Override: pregate reached literal "gate passed" at fd20143a (prisma migrate deploy applied this migration to a real DB, web typecheck clean, 20,470 tests passed). The subsequent rebase onto current main changed only main's files — my nine are byte-identical — and was re-verified with a clean 27-guard preflight, module-size, and unit tests. Not re-queued because the local-CI queue is 8 deep on one slot; GitHub CI re-runs migrate deploy, typecheck, and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
