### PR TITLE
test(ci): prove typecheck short-circuits heavy gates

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -246,7 +246,12 @@ gate, freshness, Prisma generation, migrations, and the cheap doc/repository
 guards run first. Web typecheck then runs before exhaustive Vitest, followed by
 the production build. This preserves every successful-candidate proof while
 returning a definitive compile/type-generation failure before the shared slot
-spends several minutes on tests that cannot make that candidate buildable.
+spends several minutes on tests that cannot make that candidate buildable. The
+executor contract uses the real Windows plan with an injected typecheck exit 2
+and proves that neither Vitest nor the Docker production build is launched
+afterward. Against the motivating failure, this avoids at least the observed
+221.10 seconds of exhaustive test work; green candidates still execute the
+unchanged exhaustive suite and production build.
 
 Claim, heartbeat, signal/fence, and release timestamps are included in the
 evidence and Git-local state. An expired TTL is never permission for the old

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -100,6 +100,48 @@ export function createCommandFailureDiagnostics({ invocation, result, elapsedMs 
   };
 }
 
+export function executeLocalIntegrationPlan(plan, {
+  spawnSyncImpl = spawnSync,
+  baseEnv = process.env,
+  platform = process.platform,
+  now = Date.now,
+  log = console.log,
+  error = console.error,
+} = {}) {
+  let completedCommandCount = 0;
+  for (const command of plan.commands) {
+    log(`[local-integration-ci] ${command.join(" ")}`);
+    const invocation = resolveCommandInvocation(command, baseEnv);
+    const commandStartedAt = now();
+    const result = spawnSyncImpl(invocation.command, invocation.args, {
+      stdio: "inherit",
+      shell: platform === "win32",
+      env: invocation.env,
+    });
+    if (result.status !== 0) {
+      const diagnostics = createCommandFailureDiagnostics({
+        invocation,
+        result,
+        elapsedMs: now() - commandStartedAt,
+      });
+      error(`[local-integration-ci] command-failure ${JSON.stringify(diagnostics)}`);
+      return {
+        status: result.status ?? 1,
+        completedCommandCount,
+        failedCommand: [...command],
+        diagnostics,
+      };
+    }
+    completedCommandCount += 1;
+  }
+  return {
+    status: 0,
+    completedCommandCount,
+    failedCommand: null,
+    diagnostics: null,
+  };
+}
+
 export function resolveGitRevision(ref, { spawnSyncImpl = spawnSync, cwd } = {}) {
   const result = spawnSyncImpl("git", ["rev-parse", "--verify", ref], {
     cwd,

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -8,6 +8,7 @@ import {
   createProductionArtifactIdentity,
   createToolchainFingerprint,
   createCommandFailureDiagnostics,
+  executeLocalIntegrationPlan,
   resolveGitRevision,
   resolveCommandInvocation,
 } from "./local-integration-ci.mjs";
@@ -354,6 +355,52 @@ describe("createLocalIntegrationPlan", () => {
       signal: null,
       error: null,
     });
+  });
+});
+
+describe("executeLocalIntegrationPlan", () => {
+  it("does not launch exhaustive tests or a production build after typecheck fails", () => {
+    const launched = [];
+    const errors = [];
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "fix/controlled-typecheck-red",
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "win32",
+    });
+
+    const result = executeLocalIntegrationPlan(plan, {
+      baseEnv: {},
+      platform: "win32",
+      now: () => 100,
+      log: () => {},
+      error: (message) => errors.push(message),
+      spawnSyncImpl(command, args) {
+        launched.push([command, ...args]);
+        return {
+          status: command === "pnpm" && args.includes("typecheck") ? 2 : 0,
+          signal: null,
+        };
+      },
+    });
+
+    assert.equal(result.status, 2);
+    assert.deepEqual(
+      launched.at(-1),
+      ["pnpm", "--filter", "web", "typecheck"],
+      "typecheck must be the terminal launched command",
+    );
+    assert.equal(
+      launched.some((command) => command.includes("vitest")),
+      false,
+      "Vitest must not launch after a red typecheck",
+    );
+    assert.equal(
+      launched.some((command) => command[0] === "docker" || command.includes("next")),
+      false,
+      "the production build must not launch after a red typecheck",
+    );
+    assert.match(errors.join("\n"), /command-failure/);
   });
 });
 

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -4,11 +4,10 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   collectToolchainFingerprint,
-  createCommandFailureDiagnostics,
   createLocalIntegrationPlan,
   createProductionArtifactIdentity,
   dockerBuildTag,
-  resolveCommandInvocation,
+  executeLocalIntegrationPlan,
   resolveGitRevision,
 } from "./lib/local-integration-ci.mjs";
 
@@ -49,24 +48,9 @@ const plan = createLocalIntegrationPlan({
   slotKey: slotKey || undefined,
 });
 const startedAt = new Date().toISOString();
-for (const command of plan.commands) {
-  console.log(`[local-integration-ci] ${command.join(" ")}`);
-  const invocation = resolveCommandInvocation(command);
-  const commandStartedAt = Date.now();
-  const result = spawnSync(invocation.command, invocation.args, {
-    stdio: "inherit",
-    shell: process.platform === "win32",
-    env: invocation.env,
-  });
-  if (result.status !== 0) {
-    const diagnostics = createCommandFailureDiagnostics({
-      invocation,
-      result,
-      elapsedMs: Date.now() - commandStartedAt,
-    });
-    console.error(`[local-integration-ci] command-failure ${JSON.stringify(diagnostics)}`);
-    process.exit(result.status ?? 1);
-  }
+const execution = executeLocalIntegrationPlan(plan);
+if (execution.status !== 0) {
+  process.exit(execution.status);
 }
 if (metadataOut) {
   const evidencePlan = evidencePlanOut


### PR DESCRIPTION
## Summary

Closes the remaining BI-7BCCDE3D evidence gap by testing the local-CI command executor, not only the planned command order. A controlled typecheck exit 2 now proves that exhaustive Vitest and the production build are never launched after the definitive compile failure.

## Changes

- Extract the existing sequential command loop into an injectable `executeLocalIntegrationPlan` seam without changing command planning, arguments, diagnostics, metadata, or exit semantics.
- Exercise the real Windows local-CI plan with all preceding commands simulated green and typecheck simulated red.
- Assert that typecheck is the terminal launched command and that neither Vitest nor Docker/Next build starts.
- Document the measured 221.10-second avoided test window and the unchanged green-candidate coverage contract.

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [ ] `pnpm typecheck` (worktree OK)
  - [ ] Targeted unit tests (worktree OK; name the file(s) run)

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime** — pick one:
        - [ ] root local install (`http://localhost:3000`)
        - [x] governed shared nonprod env (lease id: NPEL-33FD2B7ED8)
        - [ ] CI workflow run (link: ____)
  - [x] Evidence captured below (command + observed output, screenshot, MCP record id, etc.)

- [x] **Verification-harness limitation acknowledged** (check if any worktree-side gate was skipped because the worktree is not a full runtime; do NOT classify this as a product defect — file a platform BI instead)

### Verification evidence

- TDD red: focused test initially failed because `executeLocalIntegrationPlan` did not exist.
- Controlled red: the real Windows plan simulated all preceding steps green, returned exit 2 at `pnpm --filter web typecheck`, and proved `vitest`, `docker build`, and `next build` were not launched.
- Focused contracts: `node --test scripts/lib/local-integration-ci.test.mjs scripts/local-ci-runner.test.mjs tests/release/local-ci-gate-contract.test.mjs tests/release/pregate-node-gate-contract.test.mjs` — 44 passed, 0 failed, 32 expected native-shell skips on Windows.
- Docs: link integrity and generated doc index checks passed.
- Exact governed local-CI: evidence `cms7xwd1j02yc01potblb19qh`, candidate `d30a1066cc9bff80f81520f6e003e3b600733868`, base `a022f2d990439c29489e209aecffac4a425a5bc8`, integration `375d13887fb4dfe3981f134854ea99192dbb45a3`, lease `NPEL-33FD2B7ED8`.
- Green-candidate coverage retained: 2,416 test files / 20,721 tests passed in 208.64 seconds, typecheck/migrations/guards passed, and the production Docker build completed.
- Production image: `sha256:aa8c021cadaca83c7d289a1de88d6a22f0168cdbcc2230e0830fd9e7312d1f47`.
- UX: not applicable; this refactors CI command execution and adds a harness contract, with no portal UI or operator workflow change.
- Migration: not applicable; no schema or migration files changed.
- Source-local guard limitation: one pinned guard self-test runtime was absent in the source-only worktree and was classified unrun; the canonical sandbox ran the full guard suite successfully.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`, or an allowed `Local-CI-Override` is documented below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cms7xwd1j02yc01potblb19qh (fix/local-ci-typecheck-short-circuit-proof@d30a1066cc9bff80f81520f6e003e3b600733868)

## Related issues / Epic

Backlog: BI-7BCCDE3D
Parent: EP-0DFF753B

## Epic / Backlog linkage (for multi-BI work)

This PR covers BI-7BCCDE3D only.

## Overlap sweep

PR #3788 delivered the command reordering and is already merged. This follow-on adds the separately accepted executor-level failure proof; no active PR owns the same narrow contract.

## Notes for the reviewer

No test, guard, migration, or build command is removed, skipped, or weakened. Successful candidates still execute the complete plan. The refactor only makes the existing sequential loop directly testable.
