### PR TITLE
docs(ci): record non-portal UX acceptance evidence

### DIFF
--- a/docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md
+++ b/docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md
@@ -1,7 +1,7 @@
 ---
 title: Non-portal UX sweep short-circuit
 date: 2026-07-30
-status: implementation
+status: verification
 backlog_item: BI-B374EF2B
 epic: EP-0DFF753B
 spec: docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
@@ -66,6 +66,23 @@ aggregate, and workflow contract tests are unsafe to ship separately.
   from file scope alone. PR #3793 was dequeued before merge. The corrective
   contract makes every non-PR or escalated lifecycle exhaustive and keeps
   missing event identity fail-closed.
+
+## Shipped policy evidence
+
+PR #3782 merged through the governed queue at
+`a022f2d990439c29489e209aecffac4a425a5bc8`. Its exact local-CI candidate
+passed 2,416 test files / 20,721 tests, typecheck, migrations, guards, and the
+production Docker build under lease `NPEL-FD360038A1` (evidence
+`cms7wrg4u01pk01posaf3qgik`). Both the PR-head run and merge-group run executed
+the exhaustive UX sweep successfully because workflow-policy changes and
+merge-group lifecycles fail closed to full coverage.
+
+The remaining verification is deliberately carried by a substantive
+documentation-only CI evidence update after that merge. Acceptance requires
+the pull-request planner to emit `portal_ux_required=false`, the reusable
+portal runtime job to conclude `skipped` without allocating its runner or
+Postgres service, and the stable `UX Route Budget Sweep` aggregate to pass.
+The merge group for that same change must still execute the exhaustive sweep.
 
 ## Risks and rollback
 

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -252,6 +252,24 @@ The retained cross-run locator is not used by the blocking PR, merge-group, or
 push path; cross-lifecycle merge-group-to-push reuse remains owned by
 `BI-9585E580`.
 
+**Non-portal skip acceptance measurement.**
+
+Measure the optimization on a real docs-only or `apps/mobile`-only pull request
+whose base contains #3782. Record all four signals together:
+
+1. the planner output is exactly `portal_ux_required=false`;
+2. `UX Route Sweep Runtime` concludes `skipped`, so no sweep runner or Postgres
+   service is allocated;
+3. the stable `UX Route Budget Sweep` aggregate succeeds; and
+4. the merge-group run executes and passes the exhaustive route sweep.
+
+PR #3735 is the before baseline: its one-file docs-only change allocated the
+portal UX runtime for 585 seconds. The first post-policy attestation should
+therefore avoid roughly 9.75 runner-minutes on the pull-request head without
+changing merge-group route coverage. Do not infer savings from a skipped
+required context alone; retain the planner, runtime, aggregate, and
+merge-group evidence as one receipt.
+
 The CI and UX job summaries report payload bytes and packaging or
 download/validation/extraction duration. Compare those transfer measurements
 with the avoided UX build duration before retaining or tuning the artifact.


### PR DESCRIPTION
## Summary

Records the shipped #3782 non-portal UX admission policy, its governed rollout evidence, the 585-second docs-only baseline, and the four-signal acceptance method that preserves exhaustive merge-group coverage.

This is also the first real docs-only pull request based on #3782 and therefore serves as the post-policy attestation carrier. Its PR-head run must skip the reusable portal runtime before runner/Postgres allocation while keeping the stable aggregate green; its merge group must still execute the exhaustive sweep.

## Changes

- Move the implementation plan to verification and record #3782's exact merge/local-CI evidence.
- Define the inseparable planner/runtime/aggregate/merge-group receipt required to claim the optimization.
- Record PR #3735's 585-second before baseline and the expected 9.75 runner-minute saving.

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] Docs link integrity passed
  - [x] Generated doc index is fresh

- [ ] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)

- [ ] **Verification-harness limitation acknowledged** (check if any worktree-side gate was skipped because the worktree is not a full runtime; do NOT classify this as a product defect — file a platform BI instead)

### Verification evidence

- Planner dry run at rebased exact head `567899a6cc0edfae204789231ea8f99180d2ad5f` on corrected base `38afafb3054c5a96200ac231fe32c5bc99620493`: changed files are exactly two `docs/` paths; `eventName=pull_request`, `docsOnly=true`, `mobileOnly=false`, `heavy=false`, `fullSuite=false`.
- `node scripts/check-doc-links.mjs` passed for 78 user-guide pages against 581 indexed pages.
- `node scripts/gen-doc-index.mjs --check` passed.
- UX: not applicable to product behavior; this PR exists to verify the CI admission behavior attached to a real docs-only change.
- Migration: not applicable; no schema or migration files changed.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`, or an allowed `Local-CI-Override` is documented below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Override: docs-only — planner-attested `docsOnly=true`; no runtime-code gate required.

## Related issues / Epic

Backlog: BI-B374EF2B
Parent: EP-0DFF753B

## Epic / Backlog linkage (for multi-BI work)

This PR verifies BI-B374EF2B only.

## Overlap sweep

PR #3782 delivered the policy. PR #3794 corrected the event boundary after the first #3793 merge-group attempt exposed a lifecycle leak; both are merged. This documentation-only closeout records and tests the final acceptance evidence and does not overlap either implementation branch.

## Notes for the reviewer

No route assertion, baseline, tolerance, fixture, runtime code, or merge-group coverage rule changes.
