### PR TITLE
fix(ci): preserve exhaustive UX lifecycle boundary

### DIFF
--- a/docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md
+++ b/docs/superpowers/plans/2026-07-30-non-portal-ux-sweep-short-circuit.md
@@ -42,8 +42,9 @@ aggregate, and workflow contract tests are unsafe to ship separately.
 2. Guard the reusable `sweep` job with `inputs.run_sweep == true`, before runner and
    service allocation.
 3. Emit `portal_ux_required` from the planner's existing scope fields without
-   changing the semantic plan or its calibrated digest, then pass that output
-   to `run_sweep`.
+   changing the semantic plan or its calibrated digest. Permit `false` only
+   when `eventName=pull_request`, `fullSuite=false`, and the audited scope is
+   docs-only or app-mobile-only; then pass that output to `run_sweep`.
 4. Make the stable aggregate depend on both `changes` and the runtime call. Accept
    `runtime=skipped` only when the authoritative signal is exactly
    `portal_ux_required=false`; require `runtime=success` otherwise.
@@ -60,6 +61,11 @@ aggregate, and workflow contract tests are unsafe to ship separately.
   allocation and compare wall time against PR #3735's 585-second UX runtime
   baseline.
 - Merge-group for the same PR: verify the full route sweep still runs and passes.
+- Acceptance run 30579201050 proved the PR-head skip, but merge-group run
+  30579822976 also skipped because the first implementation derived the output
+  from file scope alone. PR #3793 was dequeued before merge. The corrective
+  contract makes every non-PR or escalated lifecycle exhaustive and keeps
+  missing event identity fail-closed.
 
 ## Risks and rollback
 

--- a/scripts/ci-evidence-plan.mjs
+++ b/scripts/ci-evidence-plan.mjs
@@ -138,10 +138,15 @@ function writeText(path, contents) {
 
 export function githubOutputsForPlan(plan) {
   // Keep the portal UX decision independent from the broader heavy-CI switch.
-  // Today docs-only and app-mobile-only changes are the two scopes that cannot
-  // alter the rendered web portal. Deriving the dedicated output from those
-  // existing audited scope fields preserves the calibrated plan digest.
-  const portalUxRequired = !plan.scope.docsOnly && !plan.scope.mobileOnly;
+  // A clean pull_request is the only lifecycle allowed to omit runtime proof:
+  // merge_group, push, dispatch, schedule, local-CI, missing event identity,
+  // and any escalated/full-suite plan remain exhaustive. This is intentionally
+  // stricter than file scope alone because merge-group coverage is the safety
+  // net that permits the PR-head optimization.
+  const nonPortalPullRequest = plan.eventName === "pull_request"
+    && plan.fullSuite === false
+    && (plan.scope.docsOnly || plan.scope.mobileOnly);
+  const portalUxRequired = !nonPortalPullRequest;
   return [
     `heavy=${plan.scope.heavy}`,
     `portal_ux_required=${portalUxRequired}`,

--- a/scripts/ci-evidence-plan.test.mjs
+++ b/scripts/ci-evidence-plan.test.mjs
@@ -110,18 +110,24 @@ describe("ci-evidence-plan CLI", () => {
 
   it("keeps portal UX scope independent from the broad heavy-CI switch", () => {
     const runtime = githubOutputsForPlan({
+      eventName: "pull_request",
+      fullSuite: false,
       scope: { docsOnly: false, mobileOnly: false, heavy: true, mobile: false },
       evidenceTier: "exhaustive",
       digest: "a".repeat(64),
       selection: { selectedPercentage: 100 },
     });
     const docs = githubOutputsForPlan({
+      eventName: "pull_request",
+      fullSuite: false,
       scope: { docsOnly: true, mobileOnly: false, heavy: false, mobile: false },
       evidenceTier: "affected",
       digest: "b".repeat(64),
       selection: { selectedPercentage: 0 },
     });
     const mobile = githubOutputsForPlan({
+      eventName: "pull_request",
+      fullSuite: false,
       scope: { docsOnly: false, mobileOnly: true, heavy: false, mobile: true },
       evidenceTier: "affected",
       digest: "c".repeat(64),
@@ -131,6 +137,35 @@ describe("ci-evidence-plan CLI", () => {
     assert.match(runtime, /^portal_ux_required=true$/m);
     assert.match(docs, /^portal_ux_required=false$/m);
     assert.match(mobile, /^portal_ux_required=false$/m);
+  });
+
+  it("requires portal UX for exhaustive and non-PR lifecycles even when the diff is docs-only", () => {
+    const docsOnlyPlan = {
+      eventName: "pull_request",
+      fullSuite: false,
+      scope: { docsOnly: true, mobileOnly: false, heavy: false, mobile: false },
+      evidenceTier: "affected",
+      digest: "d".repeat(64),
+      selection: { selectedPercentage: 0 },
+    };
+
+    for (const eventName of ["merge_group", "push", "workflow_dispatch", "schedule", "local-ci"]) {
+      const output = githubOutputsForPlan({ ...docsOnlyPlan, eventName });
+      assert.match(output, /^portal_ux_required=true$/m, `${eventName} must stay exhaustive`);
+    }
+
+    const escalatedPullRequest = githubOutputsForPlan({
+      ...docsOnlyPlan,
+      fullSuite: true,
+      evidenceTier: "exhaustive",
+    });
+    assert.match(escalatedPullRequest, /^portal_ux_required=true$/m);
+
+    const missingLifecycle = githubOutputsForPlan({
+      ...docsOnlyPlan,
+      eventName: undefined,
+    });
+    assert.match(missingLifecycle, /^portal_ux_required=true$/m);
   });
 
   it("turns malformed optional advice into exhaustive evidence instead of aborting", () => {


### PR DESCRIPTION
## Summary

Fixes the lifecycle hole exposed by the first real non-portal attestation. PR #3793 correctly skipped the portal UX runtime on its docs-only PR head, but its merge-group run also skipped because `portal_ux_required` used file scope alone and discarded the planner's exhaustive event/full-suite decision.

Only a clean `pull_request` plan may now skip. `merge_group`, push, workflow dispatch, schedule, local-CI, missing event identity, and any escalated/full-suite plan require exhaustive portal UX.

## Changes

- Bind `portal_ux_required=false` to all three conditions: `eventName=pull_request`, `fullSuite=false`, and audited docs/mobile-only scope.
- Add regression coverage for merge-group, push, dispatch, schedule, local-CI, missing lifecycle identity, and escalated pull requests.
- Record failed acceptance run 30579822976 and the governed dequeue of #3793 in the implementation plan.

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [ ] `pnpm typecheck` (worktree OK)
  - [ ] Targeted unit tests (worktree OK; name the file(s) run)

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime** — pick one:
        - [ ] root local install (`http://localhost:3000`)
        - [x] governed shared nonprod env (lease id: NPEL-E5809AFB62)
        - [ ] CI workflow run (link: ____)
  - [x] Evidence captured below (command + observed output, screenshot, MCP record id, etc.)

- [x] **Verification-harness limitation acknowledged** (check if any worktree-side gate was skipped because the worktree is not a full runtime; do NOT classify this as a product defect — file a platform BI instead)

### Verification evidence

- TDD red reproduced the defect: docs-only `merge_group` emitted `portal_ux_required=false`.
- Focused green: `node --test scripts/ci-evidence-plan.test.mjs scripts/ci-build-artifact-workflow.test.mjs scripts/merge-readiness-policy.test.mjs` — 14 passed, 0 failed.
- Failed acceptance: #3793 PR-head run 30579201050 skipped correctly; merge-group run 30579822976 also skipped unexpectedly. #3793 was dequeued and verified open/unmerged.
- Exact governed local-CI: evidence `cms7znz1v057z01po4ecq5mox`, candidate `a8eaba383b512a8d3affbedc5bee4464f69418cc`, base `5257c404d62aab8abb230fb8a17c758285af6cae`, integration `a7065842c94c0d437bcd76b18600be1b71e1fd24`, lease `NPEL-E5809AFB62`.
- Green-candidate coverage retained: 2,416 test files / 20,721 tests passed, typecheck/migrations/guards passed, and the production Docker build completed.
- Production image: `sha256:e815d2009d7ba54cbe073c1ce1fe6af41dd5e7e4bb25c3b8039f136ced221951`.
- UX: not applicable to product UI; this is CI lifecycle admission logic. The decisive UX workflow evidence will be the corrected merge-group sweep.
- Migration: not applicable; no schema or migration files changed.
- Source-local guard limitation: one pinned guard self-test runtime was absent in the source-only worktree and was classified unrun; the canonical sandbox ran the full guard suite successfully.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`, or an allowed `Local-CI-Override` is documented below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cms7znz1v057z01po4ecq5mox (fix/ci-ux-event-boundary@a8eaba383b512a8d3affbedc5bee4464f69418cc)

## Related issues / Epic

Backlog: BI-B374EF2B
Parent: EP-0DFF753B

## Epic / Backlog linkage (for multi-BI work)

This PR covers the BI-B374EF2B lifecycle-boundary correction only.

## Overlap sweep

PR #3782 delivered the initial short-circuit and is merged. PR #3793 is the dequeued docs-only attestation and contains no implementation overlap. No other open PR owns this corrective event boundary.

## Notes for the reviewer

No route assertion, baseline, tolerance, fixture, or product behavior changes. The correction increases coverage by restoring exhaustive non-PR lifecycles.
