### PR TITLE
fix(ci): honor exhaustive lifecycle for heavy gates

### DIFF
--- a/docs/superpowers/plans/2026-07-30-exhaustive-ci-heavy-output.md
+++ b/docs/superpowers/plans/2026-07-30-exhaustive-ci-heavy-output.md
@@ -1,0 +1,74 @@
+---
+title: Exhaustive CI heavy-output boundary
+date: 2026-07-30
+status: implementation
+backlog_item: BI-486DB0D7
+epic: EP-0DFF753B
+spec: docs/superpowers/specs/2026-07-26-ci-evidence-efficiency-design.md
+---
+
+# Exhaustive CI heavy-output boundary
+
+## Outcome
+
+Make the evidence planner's `fullSuite` decision authoritative for the GitHub
+`heavy` output. A lifecycle or fail-safe escalation that requires exhaustive
+evidence must execute Typecheck, Vitest, and Production Build even when the
+changed files are intrinsically docs-only or app-mobile-only.
+
+This also lets exhaustive UX consume the same-run exact-tree production artifact
+instead of compiling the portal serially after fixture setup.
+
+## Prior-design reconciliation
+
+- The CI evidence-efficiency design makes `merge_group` the exhaustive pre-main
+  safety net. File-scope selection may accelerate pull-request feedback, but it
+  must not override an exhaustive lifecycle.
+- The non-portal UX short-circuit remains pull-request-only. Its dedicated
+  `portal_ux_required` output stays independent from the heavy gate switch.
+- The exact-tree build-artifact design already moves one production bundle from
+  Production Build to UX. This repair supplies that artifact on every exhaustive
+  lifecycle; it does not add another build.
+
+## Root-cause evidence
+
+Merge-group run `30588354166` correctly required exhaustive UX for a docs-only
+combined tree, but emitted `heavy=false`. Production Build, Typecheck, and
+Vitest therefore skipped their real work. UX could not rendezvous with a
+same-run artifact and spent 247 seconds in a fallback portal build before the
+182-second route sweep.
+
+`githubOutputsForPlan` currently serializes `heavy` from `plan.scope.heavy`
+alone even though the semantic plan independently records `fullSuite=true`.
+
+## Implementation
+
+1. Add a failing planner-output contract for docs-only exhaustive lifecycles.
+2. Emit `heavy=true` whenever `plan.fullSuite` or intrinsic file scope is heavy.
+3. Keep ordinary docs-only and app-mobile-only pull requests light.
+4. Retain the existing fail-closed portal UX lifecycle rules.
+5. Verify focused planner/workflow contracts, then run the governed exact-SHA
+   local-CI gate before publication.
+
+## Acceptance
+
+- Docs-only `merge_group`, `push`, `workflow_dispatch`, `schedule`, and
+  `local-ci` plans emit `heavy=true` and `portal_ux_required=true`.
+- An escalated docs-only pull request emits both values as `true`.
+- A non-escalated docs-only pull request emits both values as `false`.
+- Runtime-code pull requests remain heavy and require portal UX.
+- Merge-group GitHub evidence shows full Typecheck, Vitest, Production Build,
+  and UX; UX materializes the exact-tree build artifact without fallback.
+
+## Documentation impact
+
+Update contributor CI evidence documentation. No operator-facing or product UI
+documentation changes are required because this changes CI execution only.
+
+## Backlog coverage
+
+Receipt: `cms84henv0aik01podqr9wy5m`.
+
+This plan is atomic: the planner output, regression contract, and contributor
+documentation form one fail-closed lifecycle boundary. Shipping any part alone
+would leave either the defect or its operating guidance incorrect.

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -186,6 +186,12 @@ remains unchanged because it does not narrow runtime evidence.
 
 Affected-test and affected-route selection remain observation only. The planner
 continues to emit the existing `heavy` and `mobile` compatibility outputs.
+`heavy` is true when either the file scope intrinsically requires the full
+workspace gates or the semantic plan has expanded to `fullSuite`. Therefore an
+ordinary docs-only or `apps/mobile`-only pull request can remain light, while
+`merge_group`, push, workflow dispatch, schedule, local-CI, and fail-safe
+escalations execute Typecheck, Vitest, and Production Build regardless of file
+scope.
 The planner also emits a dedicated `portal_ux_required` workflow output. It is
 `false` only for docs-only and `apps/mobile`-only pull requests, the two audited
 scopes that cannot alter the rendered web portal. Those changes short-circuit
@@ -241,7 +247,9 @@ non-portal pull request (`portal_ux_required=false`), CI skips the reusable
 sweep job before runner and Postgres allocation; the stable `UX Route Budget
 Sweep` aggregate accepts that skip only for the exact planner signal.
 `merge_group`, push, workflow dispatch, missing/malformed scope, and all portal
-changes remain exhaustive. When packaging/upload does not produce a usable
+changes remain exhaustive. Their full-suite `heavy=true` output also ensures
+the same-run Production Build artifact exists for UX, avoiding a serial
+fallback build after fixture setup. When packaging/upload does not produce a usable
 artifact, the reusable runtime starts the normal local production build
 immediately. Missing, expired, incomplete, corrupt, or identity-mismatched
 evidence removes any partial `.next` output and runs the normal local production

--- a/scripts/ci-evidence-plan.mjs
+++ b/scripts/ci-evidence-plan.mjs
@@ -137,6 +137,11 @@ function writeText(path, contents) {
 }
 
 export function githubOutputsForPlan(plan) {
+  // `fullSuite` is the planner's authoritative fail-safe/lifecycle decision.
+  // File scope may keep a clean docs/mobile pull request light, but it must not
+  // suppress Typecheck, Vitest, or Production Build after the planner expands
+  // a merge group, push, or unsafe input to exhaustive evidence.
+  const heavy = plan.fullSuite === true || plan.scope.heavy === true;
   // Keep the portal UX decision independent from the broader heavy-CI switch.
   // A clean pull_request is the only lifecycle allowed to omit runtime proof:
   // merge_group, push, dispatch, schedule, local-CI, missing event identity,
@@ -148,7 +153,7 @@ export function githubOutputsForPlan(plan) {
     && (plan.scope.docsOnly || plan.scope.mobileOnly);
   const portalUxRequired = !nonPortalPullRequest;
   return [
-    `heavy=${plan.scope.heavy}`,
+    `heavy=${heavy}`,
     `portal_ux_required=${portalUxRequired}`,
     `mobile=${plan.scope.mobile}`,
     `evidence_tier=${plan.evidenceTier}`,

--- a/scripts/ci-evidence-plan.test.mjs
+++ b/scripts/ci-evidence-plan.test.mjs
@@ -134,6 +134,9 @@ describe("ci-evidence-plan CLI", () => {
       selection: { selectedPercentage: 0 },
     });
 
+    assert.match(runtime, /^heavy=true$/m);
+    assert.match(docs, /^heavy=false$/m);
+    assert.match(mobile, /^heavy=false$/m);
     assert.match(runtime, /^portal_ux_required=true$/m);
     assert.match(docs, /^portal_ux_required=false$/m);
     assert.match(mobile, /^portal_ux_required=false$/m);
@@ -150,7 +153,13 @@ describe("ci-evidence-plan CLI", () => {
     };
 
     for (const eventName of ["merge_group", "push", "workflow_dispatch", "schedule", "local-ci"]) {
-      const output = githubOutputsForPlan({ ...docsOnlyPlan, eventName });
+      const output = githubOutputsForPlan({
+        ...docsOnlyPlan,
+        eventName,
+        fullSuite: true,
+        evidenceTier: "exhaustive",
+      });
+      assert.match(output, /^heavy=true$/m, `${eventName} must run the heavy gates`);
       assert.match(output, /^portal_ux_required=true$/m, `${eventName} must stay exhaustive`);
     }
 
@@ -159,6 +168,7 @@ describe("ci-evidence-plan CLI", () => {
       fullSuite: true,
       evidenceTier: "exhaustive",
     });
+    assert.match(escalatedPullRequest, /^heavy=true$/m);
     assert.match(escalatedPullRequest, /^portal_ux_required=true$/m);
 
     const missingLifecycle = githubOutputsForPlan({


### PR DESCRIPTION
## Summary
- make the planner's `fullSuite` decision authoritative for the GitHub `heavy` output
- preserve the pull-request-only docs/mobile UX short-circuit
- ensure exhaustive merge groups run Typecheck, Vitest, and Production Build so UX can reuse the same-run exact-tree artifact

## Root cause
Merge-group run 30588354166 correctly required exhaustive UX for a docs-only combined tree, but `githubOutputsForPlan` emitted `heavy=false` from file scope alone. Production Build, Typecheck, and Vitest skipped; UX then spent 247 seconds on a serial fallback build before its 182-second sweep.

## Verification
- focused planner/artifact/readiness contracts: 14 passed
- exact governed local-CI candidate: `b3ddbad1fd5c9265c101704f21c681af3f8dbfd4`
- base: `1449b1970122e78edd0a296a3924f2709d77a441`
- lease: `NPEL-162BD1ABAF`
- evidence: `cms84q78l0b2o01po97fvbsq8`
- 24 guards, typecheck, migrations/docs, 2,416 test files / 20,721 tests, production Docker build passed
- image: `sha256:d5d5b9646116647796fc3ed70c13fa742ec2c0bc581a5544538844cd81be62b4`

## Documentation impact
Contributor CI evidence and the implementation plan are updated. No operator UI or migration impact.

Backlog: BI-486DB0D7


Local-CI-Evidence: cms84q78l0b2o01po97fvbsq8

