### PR TITLE
fix(ci): run prose lint before PR creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,30 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # Workspace-dependent deterministic guards share the canonical policy
+  # inventory without forcing a full install into the lightweight source job.
+  # The heavy scope gate preserves the former Prose Lint Guard behavior.
+  policy-guards-workspace:
+    name: Policy Guards (workspace)
+    runs-on: ubuntu-latest
+    needs: changes
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup pnpm with cache
+        if: needs.changes.outputs.heavy == 'true'
+        uses: ./.github/actions/setup-pnpm
+      - name: Run named workspace policy guards
+        if: needs.changes.outputs.heavy == 'true'
+        run: node scripts/ci-policy-guards.mjs --profile workspace --results "$RUNNER_TEMP/policy-guards-workspace.json"
+      - name: Upload workspace policy results
+        if: always() && needs.changes.outputs.heavy == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-guards-workspace-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/policy-guards-workspace.json
+          if-no-files-found: error
+          retention-days: 30
+
   policy-guards-pr:
     name: Policy Guards (PR)
     runs-on: ubuntu-latest
@@ -152,34 +176,6 @@ jobs:
           path: ${{ runner.temp }}/policy-guards-pr.json
           if-no-files-found: error
           retention-days: 30
-
-  prose-lint-guard:
-    name: Prose Lint Guard
-    runs-on: ubuntu-latest
-    needs: changes
-    # BI-88D8C725 (EP-UX-SYSTEM §6 L4 / §8.1 D6). Fast in-loop signal for UI
-    # copy — archetype vocabulary conformance, banned generic decision labels
-    # (owner-first/ux-audit.ts, applied at source), the readability tier
-    # (lib/readability/'s Flesch-Kincaid policy, now wired in), and sentence
-    # length / text-mass heuristics. Same ratchet contract as the Style Drift
-    # Guard below: scripts/prose-lint-baseline.json may shrink but never grow.
-    # This complements, and does not replace, the rendered UX sweep (still the
-    # binding measurement) — Vale-shaped, answers in seconds inside the build
-    # loop. Needs the full workspace install (imports @dpf/validators + the
-    # apps/web vocabulary/ux-audit modules directly — the whole point is to
-    # reuse those signals, not reimplement them), unlike the zero-dependency
-    # guards below, so it is gated on `heavy` like Typecheck.
-    steps:
-      - uses: actions/checkout@v7
-      - name: Setup pnpm with cache
-        if: needs.changes.outputs.heavy == 'true'
-        uses: ./.github/actions/setup-pnpm
-      - name: Prose lint guard unit tests
-        if: needs.changes.outputs.heavy == 'true'
-        run: pnpm run check:prose-lint:test
-      - name: Run guard
-        if: needs.changes.outputs.heavy == 'true'
-        run: pnpm run check:prose-lint
 
   routing-contract:
     name: Routing Tier Contract
@@ -549,8 +545,8 @@ jobs:
       - changes
       - typecheck
       - policy-guards-source
+      - policy-guards-workspace
       - policy-guards-pr
-      - prose-lint-guard
       - routing-contract
       - test-web
       - test-packages

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -87,12 +87,24 @@ on the latest `main` run — don't hard-code a number here, it goes stale.
 
 ### Policy guard profiles
 
-Fast source and PR-policy checks are registered in
+Fast deterministic checks are registered in
 [`scripts/lib/ci-policy-guards.mjs`](../../scripts/lib/ci-policy-guards.mjs).
 The registry preserves the former job name, display name, command sequence, and
 profile for every migrated guard. The runner executes every named entry even
 when an earlier entry fails, then writes a per-guard pass/fail/duration table to
 the GitHub job summary and a machine-readable artifact.
+
+The profiles reflect execution substrate, not separate policy inventories:
+
+- `source` uses Node plus the isolated guard-AST runtime;
+- `workspace` uses the pinned full workspace graph for checks such as prose
+  lint; and
+- `pull-request` uses PR event context and trailers.
+
+`pregate:preflight` and `pr:ready` consume all locally honest checks from these
+same profiles. In a source-only worktree, a missing workspace runtime is
+reported as environment-skipped and remains CI-enforced; in a compile-ready
+worktree, prose drift is therefore found before the sandbox lease or PR.
 
 Consolidation follows a fail-safe promotion sequence:
 
@@ -169,11 +181,12 @@ pnpm run pregate            # → node scripts/pregate.mjs
 `local-integration-ci` lease, `pregate.mjs` runs the deterministic CI policy
 guards host-natively — the same check commands CI's Policy Guards jobs run
 (module size, style drift, derived-artifact staleness, doc links, SBOM, plus
-the commit-range-driven UX-Fit and Design Grounding trailer gates), with guard
-self-tests stripped and PR-body-dependent gates (Seed-Fit, Decision Baseline)
-left to CI. A violation aborts in well under a minute **before any lease is
-claimed**, so a doomed run never occupies the contended sandbox slot. A guard
-this host cannot execute (missing isolated runtime) is reported as
+the workspace-dependent prose ratchet, and the commit-range-driven UX-Fit and
+Design Grounding trailer gates), with guard self-tests stripped and
+PR-body-dependent gates (Seed-Fit, Decision Baseline) left to CI. A violation
+aborts in well under a minute **before any lease is claimed**, so a doomed run
+never occupies the contended sandbox slot. A guard this host cannot execute
+(missing isolated or workspace runtime) is reported as
 `environment-skipped` with its remedy — a warning, never a false red; CI
 remains the enforcer. Run it standalone with `pnpm run pregate:preflight`
 (`--plan` prints the guard plan without running it). Emergency skip:

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 
 import {
   POLICY_GUARD_PROFILES,
+  resolvePolicyGuardInvocation,
   runPolicyProfile,
 } from "./lib/ci-policy-guards.mjs";
 
@@ -33,6 +34,7 @@ const EXPECTED_LEGACY_JOBS = [
   "override-provenance-guard",
   "package-boundary-guard",
   "pr-health-test",
+  "prose-lint-guard",
   "repo-guard-loop",
   "reporting-composition-guard",
   "sbom-divergence-guard",
@@ -52,6 +54,25 @@ function workflowJobBlock(workflow, jobId) {
 }
 
 describe("CI policy guard registry", () => {
+  it("launches pnpm through cmd on Windows without enabling shell mode globally", () => {
+    assert.deepEqual(
+      resolvePolicyGuardInvocation("pnpm", ["run", "check:prose-lint"], {
+        platform: "win32",
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      }),
+      {
+        command: "C:\\Windows\\System32\\cmd.exe",
+        args: ["/d", "/s", "/c", "pnpm run check:prose-lint"],
+      },
+    );
+    assert.deepEqual(
+      resolvePolicyGuardInvocation("pnpm", ["run", "check:prose-lint"], {
+        platform: "linux",
+      }),
+      { command: "pnpm", args: ["run", "check:prose-lint"] },
+    );
+  });
+
   it("accounts for every migrated legacy job exactly once", () => {
     const entries = Object.values(POLICY_GUARD_PROFILES).flat();
     const legacyJobs = entries.map((entry) => entry.legacyJobId).sort();
@@ -106,14 +127,17 @@ describe("CI policy guard registry", () => {
     );
   });
 
-  it("wires blocking source and pull-request profiles in CI", () => {
+  it("wires blocking source, workspace, and pull-request profiles in CI", () => {
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
     assert.match(workflow, /^  policy-guards-source:$/m);
     assert.match(workflow, /node scripts\/ci-policy-guards\.mjs --profile source/);
+    assert.match(workflow, /^  policy-guards-workspace:$/m);
+    assert.match(workflow, /node scripts\/ci-policy-guards\.mjs --profile workspace/);
     assert.match(workflow, /^  policy-guards-pr:$/m);
     assert.match(workflow, /node scripts\/ci-policy-guards\.mjs --profile pull-request/);
     const policyJobs = [
       workflowJobBlock(workflow, "policy-guards-source"),
+      workflowJobBlock(workflow, "policy-guards-workspace"),
       workflowJobBlock(workflow, "policy-guards-pr"),
     ].join("\n");
     assert.equal(

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -11,6 +11,43 @@ function guard(legacyJobId, name, commands) {
 
 const node = (...args) => ["node", args];
 const git = (...args) => ["git", args];
+const pnpm = (...args) => ["pnpm", args];
+
+export const LOCAL_READINESS_PROFILE_NAMES = Object.freeze([
+  "source",
+  "workspace",
+  "pull-request",
+]);
+
+export function isPolicyGuardSelfTest([command, args]) {
+  return command === "node" && args[0] === "--test"
+    || command === "pnpm" && args[0] === "run" && args[1]?.endsWith(":test");
+}
+
+function quoteWindowsCommandToken(token) {
+  const value = String(token);
+  if (!/[\s"&|<>^()%]/.test(value)) return value;
+  return `"${value.replaceAll("%", "%%").replaceAll('"', '""')}"`;
+}
+
+export function resolvePolicyGuardInvocation(
+  command,
+  args,
+  { platform = process.platform, env = process.env } = {},
+) {
+  if (platform !== "win32" || command !== "pnpm") {
+    return { command, args };
+  }
+  return {
+    command: env.ComSpec || env.COMSPEC || "cmd.exe",
+    args: [
+      "/d",
+      "/s",
+      "/c",
+      [command, ...args].map(quoteWindowsCommandToken).join(" "),
+    ],
+  };
+}
 
 export const POLICY_GUARD_PROFILES = Object.freeze({
   source: Object.freeze([
@@ -152,6 +189,16 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("scripts/runtime-artifact-janitor.mjs", "--help"),
     ]),
   ]),
+  // Guards in this profile are still cheap and deterministic, but they import
+  // workspace packages or use the workspace's pinned TypeScript executor.
+  // Keeping them separate preserves the source profile's minimal install while
+  // letting CI, pregate preflight, and pr:ready consume one canonical inventory.
+  workspace: Object.freeze([
+    guard("prose-lint-guard", "Prose Lint Guard", [
+      pnpm("run", "check:prose-lint:test"),
+      pnpm("run", "check:prose-lint"),
+    ]),
+  ]),
   "pull-request": Object.freeze([
     guard("ux-fit-gate", "UX-Fit Gate", [
       node("--test", "packages/dpf-skill-pack/hooks/ux-fit-precheck.test.mjs"),
@@ -238,13 +285,15 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
 
 export async function runPolicyProfile({
   entries,
-  execute = (command, args) =>
-    spawnSync(command, args, {
+  execute = (command, args) => {
+    const invocation = resolvePolicyGuardInvocation(command, args);
+    return spawnSync(invocation.command, invocation.args, {
       cwd: process.cwd(),
       env: process.env,
       stdio: "inherit",
       shell: false,
-    }).status ?? 1,
+    }).status ?? 1;
+  },
   logger = () => {},
   now = () => Date.now(),
 }) {

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -32,7 +32,12 @@
 
 import { spawnSync } from "node:child_process";
 
-import { POLICY_GUARD_PROFILES, runPolicyProfile } from "./ci-policy-guards.mjs";
+import {
+  POLICY_GUARD_PROFILES,
+  isPolicyGuardSelfTest,
+  resolvePolicyGuardInvocation,
+  runPolicyProfile,
+} from "./ci-policy-guards.mjs";
 import { GUARD_RUNTIME_ENVIRONMENT_ERROR_NAME } from "./load-pinned-guard-typescript.mjs";
 
 export const PREFLIGHT_SKIP_ENV = "DPF_SKIP_PREGATE_PREFLIGHT_REASON";
@@ -55,7 +60,7 @@ export const LOCAL_SAFE_PR_GUARD_IDS = Object.freeze([
 // "the tree violates the guard". Kept narrow: each entry is a message Node or
 // the guard runtime itself emits for a missing execution substrate.
 export const ENVIRONMENT_FAILURE_RE =
-  /ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module/;
+  /ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module|node_modules missing|tsx(?::|\W+is) (?:command )?not (?:recognized|found)/i;
 
 export function isEnvironmentFailureOutput(output) {
   const text = String(output ?? "");
@@ -67,15 +72,16 @@ function stripSelfTests(entries) {
   return entries
     .map((entry) => ({
       ...entry,
-      commands: entry.commands.filter(
-        ([command, args]) => !(command === "node" && args[0] === "--test"),
-      ),
+      commands: entry.commands.filter((command) => !isPolicyGuardSelfTest(command)),
     }))
     .filter((entry) => entry.commands.length > 0);
 }
 
 export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES } = {}) {
-  const source = stripSelfTests(profiles.source);
+  const source = stripSelfTests([
+    ...(profiles.source ?? []),
+    ...(profiles.workspace ?? []),
+  ]);
   const trailer = stripSelfTests(
     profiles["pull-request"].filter((entry) =>
       LOCAL_SAFE_PR_GUARD_IDS.includes(entry.id),
@@ -85,13 +91,14 @@ export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES } = {}) {
 }
 
 function defaultExecute(command, args) {
-  const result = spawnSync(command, args, {
+  const invocation = resolvePolicyGuardInvocation(command, args);
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: process.cwd(),
     env: process.env,
     encoding: "utf8",
     shell: false,
   });
-  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`;
   if (result.status !== 0) process.stderr.write(output);
   return { exitCode: result.status ?? 1, output };
 }

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 
 import { buildGatePlan, evaluateReadiness, formatReadinessReport } from "./pr-readiness/core.mjs";
 import { collectWorktreeDiff } from "./gate-context.mjs";
+import { resolvePolicyGuardInvocation } from "./lib/ci-policy-guards.mjs";
 import { buildGateContext } from "./lib/gate-context.mjs";
 import { fetchOriginMainSharedSafe, isShallowRepository } from "./lib/git-fetch-shared-safe.mjs";
 import { isEnvironmentFailureOutput } from "./lib/pregate-preflight.mjs";
@@ -113,13 +114,18 @@ function readRepoState() {
 
 function runGate(gate) {
   const [command, args] = gate.command;
-  const result = spawnSync(command, args, {
+  const invocation = resolvePolicyGuardInvocation(command, args);
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: process.cwd(),
     env: { ...process.env, ...gate.env },
     encoding: "utf8",
     maxBuffer: 32 * 1024 * 1024,
+    shell: false,
   });
-  const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+  const output = [result.stdout, result.stderr, result.error?.message]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
   return {
     name: gate.name,
     ok: result.status === 0,

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -111,6 +111,22 @@ test("parsePrBodyTrailers extracts supported trailers with line numbers", () => 
   ]);
 });
 
+test("parsePrBodyTrailers ignores commented template examples", () => {
+  const trailers = parsePrBodyTrailers(
+    [
+      "Intro",
+      "<!-- Add exactly one:",
+      "Local-CI-Evidence: <record>",
+      "Local-CI-Override: <reason>",
+      "-->",
+      "UX-Fit-Decision: no-ui-impact",
+    ].join("\n"),
+  );
+  assert.deepEqual(trailers, [
+    { name: "UX-Fit-Decision", value: "no-ui-impact", line: 6 },
+  ]);
+});
+
 test("validatePrBodyTrailers catches duplicate trailers and invalid seed-fit decisions", () => {
   const result = validatePrBodyTrailers(
     [

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -43,6 +43,16 @@ test("buildGatePlan derives runnable checks from the canonical policy profiles",
         ],
       },
     ],
+    workspace: [
+      {
+        id: "workspace-a",
+        name: "Workspace A",
+        commands: [
+          ["pnpm", ["run", "workspace-a:test"]],
+          ["pnpm", ["run", "workspace-a"]],
+        ],
+      },
+    ],
     "pull-request": [
       {
         id: "pr-a",
@@ -68,12 +78,13 @@ test("buildGatePlan derives runnable checks from the canonical policy profiles",
     plan.map((gate) => [gate.name, gate.command]),
     [
       ["Source A", ["node", ["scripts/source-a.mjs"]]],
+      ["Workspace A", ["pnpm", ["run", "workspace-a"]]],
       ["PR A", ["node", ["scripts/pr-a.mjs"]]],
     ],
   );
   assert.equal(plan[0].env.BASE_SHA, "origin/main");
-  assert.equal(plan[1].env.GITHUB_EVENT_NAME, "pull_request");
-  assert.equal(plan[1].env.PR_LABELS_JSON, "[]");
+  assert.equal(plan[2].env.GITHUB_EVENT_NAME, "pull_request");
+  assert.equal(plan[2].env.PR_LABELS_JSON, "[]");
 });
 
 test("buildGatePlan changes when the canonical profile changes", () => {

--- a/scripts/pr-readiness/core.mjs
+++ b/scripts/pr-readiness/core.mjs
@@ -69,7 +69,11 @@ export function buildGatePlan({
 }
 
 export function parsePrBodyTrailers(prBody = "") {
-  return String(prBody)
+  const visibleBody = String(prBody).replace(
+    /<!--[\s\S]*?-->/g,
+    (comment) => comment.replace(/[^\r\n]/g, ""),
+  );
+  return visibleBody
     .split(/\r?\n/)
     .flatMap((line, index) => {
       const match = line.match(/^\s*([A-Za-z][A-Za-z-]*):\s*(\S.*)?$/);

--- a/scripts/pr-readiness/core.mjs
+++ b/scripts/pr-readiness/core.mjs
@@ -1,5 +1,9 @@
 import { SEED_FIT_DECISIONS } from "../lib/seed-fit-gate.mjs";
-import { POLICY_GUARD_PROFILES } from "../lib/ci-policy-guards.mjs";
+import {
+  LOCAL_READINESS_PROFILE_NAMES,
+  POLICY_GUARD_PROFILES,
+  isPolicyGuardSelfTest,
+} from "../lib/ci-policy-guards.mjs";
 import { formatGateContextMarkdown } from "../lib/gate-context.mjs";
 import {
   PR_TRAILER_NAMES,
@@ -31,10 +35,6 @@ const RETIRED_TRAILERS = new Map([
   ],
 ]);
 
-function isSelfTest([command, args]) {
-  return command === "node" && args[0] === "--test";
-}
-
 function mutatesGitState([command, args]) {
   return command === "git" && MUTATING_GIT_COMMANDS.has(args[0]);
 }
@@ -51,14 +51,14 @@ export function buildGatePlan({
     GITHUB_EVENT_NAME: "pull_request",
   };
 
-  return ["source", "pull-request"].flatMap((profileName) =>
+  return LOCAL_READINESS_PROFILE_NAMES.flatMap((profileName) =>
     (profiles[profileName] ?? []).flatMap((entry) => {
       // The readiness command runs in the author's topic worktree. Never replay
       // CI setup that rewrites Git state there. Its checks remain covered by CI
       // and by the exact-tree local-CI gate.
       if (entry.commands.some(mutatesGitState)) return [];
 
-      const commands = entry.commands.filter((command) => !isSelfTest(command));
+      const commands = entry.commands.filter((command) => !isPolicyGuardSelfTest(command));
       return commands.map((command, index) => ({
         name: commands.length === 1 ? entry.name : `${entry.name} (${index + 1}/${commands.length})`,
         command,

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -47,11 +47,23 @@ test("buildPreflightPlan strips guard self-tests but keeps every check command",
         commands: [["node", ["--test", "scripts/only.test.mjs"]]],
       },
     ],
+    workspace: [
+      {
+        id: "workspace-check",
+        legacyJobId: "workspace-check",
+        name: "Workspace Check",
+        commands: [
+          ["pnpm", ["run", "workspace-check:test"]],
+          ["pnpm", ["run", "workspace-check"]],
+        ],
+      },
+    ],
     "pull-request": [],
   };
   const plan = buildPreflightPlan({ profiles });
-  assert.deepEqual(plan.map((entry) => entry.id), ["g1"]);
+  assert.deepEqual(plan.map((entry) => entry.id), ["g1", "workspace-check"]);
   assert.deepEqual(plan[0].commands, [["node", ["scripts/g1.mjs"]]]);
+  assert.deepEqual(plan[1].commands, [["pnpm", ["run", "workspace-check"]]]);
 });
 
 test("buildPreflightPlan includes only commit-range-safe pull-request gates", () => {
@@ -74,6 +86,12 @@ test("buildPreflightPlan contains no --test invocations at all", () => {
       );
     }
   }
+});
+
+test("buildPreflightPlan includes the workspace-dependent prose guard", () => {
+  const prose = buildPreflightPlan().find((entry) => entry.id === "prose-lint-guard");
+  assert.ok(prose, "prose lint must run before a sandbox lease or PR");
+  assert.deepEqual(prose.commands, [["pnpm", ["run", "check:prose-lint"]]]);
 });
 
 // ── run + classification ────────────────────────────────────────────────────
@@ -198,6 +216,8 @@ test("runPreflight honors the recorded emergency skip", async () => {
 test("environment failure classification uses stable runtime signals, not guard verdicts", () => {
   assert.ok(ENVIRONMENT_FAILURE_RE.test("Error [ERR_MODULE_NOT_FOUND]: Cannot find package"));
   assert.ok(isEnvironmentFailureOutput("GuardRuntimeEnvironmentError: localized wording"));
+  assert.ok(isEnvironmentFailureOutput("Local package.json exists, but node_modules missing"));
+  assert.ok(isEnvironmentFailureOutput("'tsx' is not recognized as an internal or external command"));
   assert.ok(!isEnvironmentFailureOutput("module exceeds ratchet baseline: 1050 > 1047 lines"));
   assert.ok(!isEnvironmentFailureOutput("Missing UX-Fit-Decision trailer"));
 });


### PR DESCRIPTION
## Summary

Move prose lint into the canonical pre-PR policy inventory so copy-ratchet failures are found before a shared-sandbox lease or pull request, while keeping workspace-dependent checks separate from lightweight source guards.

## Changes

- add a workspace policy profile consumed by CI, `pregate:preflight`, and `pr:ready`
- retire the bespoke Prose Lint Guard workflow job without weakening Merge Readiness
- normalize Windows `pnpm` shim execution and source-only environment classification
- ignore commented PR-template trailer examples during readiness validation
- document the substrate-based profile contract

## Test plan

- [x] 36 focused Node tests passed for policy registry, preflight, readiness, and CI coverage
- [x] merge-readiness policy drift check passed
- [x] `pnpm pr:ready -- --pr-body-file ...` returned `PR readiness: READY` on the final pushed branch
- [x] exact-tree local-CI gate passed: 24/24 guard-loop checks, web typecheck, 2,416 test files / 20,721 tests, and production Docker build
- [x] UX verification not applicable: contributor/CI tooling only; no product UI changed
- [x] migration verification not applicable: no schema or data changes

## Pre-PR readiness

- [x] gate context reviewed against the final diff
- [x] host preflight passed in 50.8 seconds with two honest source-only environment skips
- [x] exact-tree local-CI evidence captured after an 8m53s queue wait and 13m59s service run
- [x] final branch is pushed, clean, DCO-signed, and mechanically ready

## Backlog

- BI-5E4BFDB5
- Work Capsule WC-4E557ACE

## Overlap sweep

- PR #3791 adds one unrelated agent-identity self-test to the source profile; this change is additive and compatible.
- PR #3797 owns exact-tree receipt enforcement; this change does not duplicate that substrate.

## Documentation impact

Updated `docs/testing/pre-pr-gate.md`. No operator guide, public positioning, route map, migration, prompt, or product-UX documentation changes are needed.
