### PR TITLE
fix(routing): stop one ambiguous English word pinning a turn to the local model (BI-CD13D818)

### DIFF
--- a/apps/web/lib/inference/data-screening/classify-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.test.ts
@@ -230,3 +230,101 @@ describe("classifyInferencePayload", () => {
     },
   );
 });
+
+// BI-CD13D818. A single ambiguous English word escalated a whole turn to
+// `restricted`, which hard-denies every external provider and left the bundled
+// local model as the only tool-capable route. Live evidence: a
+// /platform/ai/operations-map conversation classified `employee-records`,
+// "14 endpoint(s) excluded; 1 candidate(s) ranked", ~20% of recent decisions.
+// Kernel decision DI-0A58373E26D0 chose corroboration over deleting the
+// patterns, so detection stays intact and only the escalation bar moves.
+describe("ambiguous-vocabulary corroboration (BI-CD13D818)", () => {
+  const screen = (content: string) =>
+    classifyInferencePayload({
+      messages: [{ role: "user", content }],
+      systemPrompt: "",
+      taskType: "conversation",
+    });
+
+  it("does NOT escalate an AI-operations question to restricted on one ambiguous word", () => {
+    const result = screen(
+      "Which provider gives the best performance for this routing work, and what are the benefits of staying local?",
+    );
+    expect(result.overallSensitivity).not.toBe("restricted");
+  });
+
+  it("still fails closed at confidential — never silently drops to internal", () => {
+    expect(screen("What are the benefits of the local model?").overallSensitivity)
+      .toBe("confidential");
+  });
+
+  it("keeps precise employment vocabulary escalating on its own", () => {
+    for (const text of [
+      "The employee salary band needs review.",
+      "Attach the disciplinary letter.",
+      "Schedule the performance review.",
+    ]) {
+      expect(screen(text).overallSensitivity).toBe("restricted");
+    }
+  });
+
+  it("escalates when precise vocabulary accompanies an ambiguous term", () => {
+    expect(screen("Review the payroll run and the benefits elections.").overallSensitivity)
+      .toBe("restricted");
+  });
+
+  it("does not let one ambiguous word repeated across probes fake corroboration", () => {
+    const result = classifyInferencePayload({
+      messages: [
+        { role: "user", content: "What are the benefits here?" },
+        { role: "assistant", content: "The benefits are latency and cost." },
+        { role: "user", content: "Any other benefits?" },
+      ],
+      systemPrompt: "Explain the benefits of each route.",
+      taskType: "conversation",
+    });
+    expect(result.overallSensitivity).toBe("confidential");
+  });
+
+  it("treats operations vocabulary as ambiguous for security-logs too", () => {
+    expect(screen("Write an incident note about the stalled build.").overallSensitivity)
+      .not.toBe("restricted");
+    expect(
+      classifyInferencePayload({
+        messages: [{
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "c1", name: "lookup", arguments: { securityLog: "redacted" } }],
+        }],
+        systemPrompt: "",
+        taskType: "conversation",
+      }).overallSensitivity,
+    ).toBe("restricted");
+  });
+
+  it("never applies the corroboration bar to DECLARED governed data", () => {
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "Summarize this." }],
+      systemPrompt: "",
+      taskType: "conversation",
+      governedData: [{
+        assetId: "asset-1",
+        classificationKnown: true,
+        sensitivity: "restricted",
+        dataClasses: ["employee-records"],
+      }],
+    });
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("keeps the unknown-governed-data fail-closed intact", () => {
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "Summarize this." }],
+      systemPrompt: "",
+      taskType: "conversation",
+      governedData: [{ assetId: "asset-2", classificationKnown: false }],
+    });
+    expect(result.overallSensitivity).toBe("restricted");
+    expect(result.dataClasses).toContain("unknown-governed-data");
+  });
+});

--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -21,12 +21,31 @@ type ClassRule = {
   confidence: InferencePayloadMatch["confidence"];
   pathPattern?: RegExp;
   textPattern?: RegExp;
+  /**
+   * BI-CD13D818 — this rule is built from vocabulary that is ALSO ordinary
+   * English outside its protected domain ("performance", "benefits", "manager",
+   * "incident"). On its own such a match may not escalate a turn to
+   * `restricted`, because restricted hard-denies every external provider; it
+   * needs a second, distinct detector to corroborate it. A lone match still
+   * lands on `confidential`, so the control keeps failing closed.
+   *
+   * Set this ONLY where the words genuinely collide with common usage. Precise
+   * evidence — a field literally named `password` or `employeeDiscipline`, a
+   * secret-shaped token — must NOT carry this flag and escalates alone.
+   */
+  ambiguousVocabulary?: true;
 };
 
 // Text probes must contain value-shaped evidence, not merely governance or
 // instructional vocabulary that happens to name a protected data class.
+//
+// Split by precision (BI-CD13D818). The first set names employment data and
+// nothing else; the second is real HR vocabulary that is ALSO everyday English
+// on an AI-operations, capacity, or product surface, so it needs corroboration.
 const EMPLOYEE_RECORD_VALUE_PATTERN =
-  /\b(?:salary|compensation|benefits?|performance review|disciplinary|manager-only|payroll)\b/i;
+  /\b(?:salary|performance review|disciplinary|manager-only|payroll)\b/i;
+const EMPLOYEE_RECORD_AMBIGUOUS_VALUE_PATTERN =
+  /\b(?:compensation|benefits?)\b/i;
 
 const SOURCE_CODE_VALUE_PATTERN =
   /(?:\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*(?:[:=;,])|\bfunction\s+[A-Za-z_$][\w$]*\s*\(|\bclass\s+[A-Za-z_$][\w$]*(?:\s+extends\s+[A-Za-z_$][\w$]*)?\s*\{|\bimport\s+[\w*{},\s]+\s+from\s+["']|\bexport\s+(?:default\s+)?(?:const|let|var|function|class)\b|=>|```(?:ts|tsx|js|jsx|py|sql|sh|ps1)\b)/;
@@ -62,13 +81,26 @@ const CLASS_RULES: readonly ClassRule[] = [
     dataClass: "employee-records",
     reason: "employee-record-field",
     confidence: "inferred",
-    pathPattern: /\b(?:employee|worker|salary|compensation|benefit|performance|discipline|manager|payroll)\b/i,
+    pathPattern: /\b(?:employee|salary|discipline|payroll|performance[-_ ]?review)\b/i,
   },
   {
     dataClass: "employee-records",
     reason: "employee-record-text",
     confidence: "inferred",
     textPattern: EMPLOYEE_RECORD_VALUE_PATTERN,
+  },
+  {
+    // Same class, weaker evidence: these words carry employment meaning in an HR
+    // context and an entirely innocent one elsewhere (model `performance`, the
+    // `benefits` of a routing change, a capacity `manager`, a `worker` process).
+    // Corroboration-gated so one of them cannot deny all external routing on its
+    // own — the live /platform/ai/operations-map false positive.
+    dataClass: "employee-records",
+    reason: "employee-record-ambiguous-term",
+    confidence: "inferred",
+    ambiguousVocabulary: true,
+    pathPattern: /\b(?:worker|compensation|benefit|performance|manager)\b/i,
+    textPattern: EMPLOYEE_RECORD_AMBIGUOUS_VALUE_PATTERN,
   },
   {
     dataClass: "payments-finance",
@@ -112,7 +144,18 @@ const CLASS_RULES: readonly ClassRule[] = [
     dataClass: "security-logs",
     reason: "security-log-field",
     confidence: "inferred",
-    pathPattern: /\b(?:security[-_]?log|audit[-_]?log|incident|ip[-_]?address|siem|threat)\b/i,
+    pathPattern: /\b(?:security[-_]?log|audit[-_]?log|ip[-_]?address|siem)\b/i,
+  },
+  {
+    // `incident` and `threat` are security vocabulary and also ordinary
+    // operations vocabulary (an incident note about a stalled build, the threat
+    // a regression poses). Corroboration-gated for the same reason as the
+    // employee-record ambiguous terms — BI-CD13D818.
+    dataClass: "security-logs",
+    reason: "security-log-ambiguous-term",
+    confidence: "inferred",
+    ambiguousVocabulary: true,
+    pathPattern: /\b(?:incident|threat)\b/i,
   },
   {
     dataClass: "criminal-justice",
@@ -174,6 +217,15 @@ const RESTRICTED_CLASSES = new Set<InferenceDataClass>([
   "unknown-governed-data",
 ]);
 
+/**
+ * Reasons emitted by `ambiguousVocabulary` rules — derived from CLASS_RULES so a
+ * new corroboration-gated rule can never be added without this set following it
+ * (BI-CD13D818).
+ */
+const AMBIGUOUS_REASONS: ReadonlySet<string> = new Set(
+  CLASS_RULES.filter((rule) => rule.ambiguousVocabulary).map((rule) => rule.reason),
+);
+
 const CONFIDENTIAL_CLASSES = new Set<InferenceDataClass>([
   "customer-records",
   "source-code",
@@ -205,7 +257,7 @@ export function classifyInferencePayload(
 
   const dedupedMatches = dedupeMatches(matches);
   const dataClasses = uniqueSorted(dedupedMatches.map((match) => match.dataClass));
-  const overallSensitivity = inferOverallSensitivity(dataClasses, input.governedData);
+  const overallSensitivity = inferOverallSensitivity(dedupedMatches, input.governedData);
   const inputHash = hashCanonical({
     messages: input.messages,
     systemPrompt: input.systemPrompt,
@@ -372,17 +424,73 @@ function uniqueSorted<T extends string>(values: readonly T[]): T[] {
   return [...new Set(values)].sort((a, b) => a.localeCompare(b));
 }
 
+/**
+ * Escalate to `restricted` only on corroborated evidence — BI-CD13D818.
+ *
+ * WHY THIS IS NOT A SIMPLE "any restricted class => restricted" TEST.
+ *
+ * Several restricted classes are detected by regexes built from ordinary
+ * English words: `benefit(s)`, `performance`, `manager`, `worker`,
+ * `compensation`, `incident`, `threat`. On a non-HR, non-security surface those
+ * appear in their everyday sense constantly — "model performance", "the
+ * benefits of local routing", "capacity manager". A single such match escalated
+ * the whole turn to `restricted`, which the data policy then hard-denies for
+ * every external destination (`restricted-cannot-leave-boundary`), leaving only
+ * local-cleared endpoints.
+ *
+ * Observed live: a /platform/ai/operations-map conversation was classified
+ * `employee-records` and pinned to the bundled local model — 14 of 15 endpoints
+ * excluded, 1 candidate ranked. ~20% of recent routing decisions escalated this
+ * way. The same over-trigger was already fixed once for tool DECLARATIONS (see
+ * the note in collectTextProbes); this is the prose-shaped recurrence.
+ *
+ * Escalation now requires one of:
+ *   1. an explicit governed-data hint marked restricted — governance stated by
+ *      the caller, never inferred, always honoured;
+ *   2. any restricted-class match that is NOT from an `ambiguousVocabulary`
+ *      rule — a declared governed class, a secret-shaped token, or a field
+ *      literally named `password` / `employeeDiscipline`. Precise evidence
+ *      escalates alone and is never subject to the corroboration bar;
+ *   3. TWO OR MORE DISTINCT ambiguous detectors agreeing. One word echoed
+ *      across many probes is one signal, so corroboration counts distinct
+ *      `reason` values rather than match volume.
+ *
+ * A lone ambiguous signal does NOT drop to `internal` — it lands on
+ * `confidential`, which still confines routing to confidential-cleared
+ * providers. The control keeps failing closed; it just stops treating one
+ * ambiguous English word as proof of an HR or security record.
+ *
+ * Kernel decision DI-0A58373E26D0 (2026-07-31) scored this against narrowing
+ * the patterns outright, weighting paths over prose, and granting an external
+ * provider restricted clearance. This option won with high confidence (margin
+ * 2.70, no commandment conflict); granting external clearance scored worst,
+ * opposed by "Outbound and irreversible actions require explicit go" and
+ * "Least privilege, deny by default".
+ */
 function inferOverallSensitivity(
-  dataClasses: readonly InferenceDataClass[],
+  matches: readonly InferencePayloadMatch[],
   governedData: readonly GovernedPayloadHint[] | undefined,
 ): InferencePayloadSensitivity {
   if (governedData?.some((hint) => hint.sensitivity === "restricted")) {
     return "restricted";
   }
-  if (dataClasses.some((dataClass) => RESTRICTED_CLASSES.has(dataClass))) {
+
+  const restrictedMatches = matches.filter((match) => RESTRICTED_CLASSES.has(match.dataClass));
+  const hasPreciseEvidence = restrictedMatches.some(
+    (match) => !AMBIGUOUS_REASONS.has(match.reason),
+  );
+  const distinctAmbiguousReasons = new Set(
+    restrictedMatches
+      .filter((match) => AMBIGUOUS_REASONS.has(match.reason))
+      .map((match) => match.reason),
+  ).size;
+  if (hasPreciseEvidence || distinctAmbiguousReasons >= 2) {
     return "restricted";
   }
+
+  const dataClasses = matches.map((match) => match.dataClass);
   if (
+    restrictedMatches.length > 0 ||
     governedData?.some((hint) => hint.sensitivity === "confidential") ||
     dataClasses.some((dataClass) => CONFIDENTIAL_CLASSES.has(dataClass))
   ) {


### PR DESCRIPTION
Closes BI-CD13D818 (scope items 1–3). Follows [#3778](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3778), which made the *symptom* honest; this removes the *cause*.

## The finding

A coworker turn on `/platform/ai/operations-map` was classified `restricted` and routed to the bundled local model with **14 of 15 endpoints excluded and exactly 1 candidate ranked**. The persisted screen receipt named it:

```json
{ "classifiedDataClasses": ["employee-records"],
  "destinationClass": "external-service",
  "policyEffect": "deny",
  "explanationCodes": ["restricted-cannot-leave-boundary"] }
```

That page's own privacy contract guarantees the projection carries only counts, timings, route identifiers, design versions, and conformance findings. It contains no employee data. What it contains is the words **"performance"** and **"benefits"**, in their ordinary sense — both of which are in the employee-record regex.

**Scale: 85 of 420 routing decisions over four days (~20%) escalated this way.** Each one silently removed every capable external provider, because `local` and `speaches` are the only endpoints holding restricted clearance and `speaches` has no tool use.

This is a recurrence, not a new class of bug. The note in `collectTextProbes` records that tool DECLARATIONS were previously being classified, and their schemas contain field names like `password`/`employee`/`payment`, which "forces every broad agentic tool surface into restricted/local-only routing." Declarations were excluded for that reason. The same over-trigger now arrives through ordinary prose.

## The change

`ClassRule` gains an optional `ambiguousVocabulary` flag. A rule so marked **still detects and still classifies** — it simply cannot escalate a turn to `restricted` on its own. Escalation now requires one of:

1. an explicit governed-data hint marked restricted;
2. any restricted-class match from a **precise** rule — a declared governed class, a secret-shaped token, a field literally named `password` or `employeeDiscipline`;
3. **two distinct** ambiguous detectors agreeing.

Corroboration counts distinct `reason` values, not match volume, so one word echoed across many probes stays one signal.

The ambiguous words were **moved out of** the precise rules into new corroboration-gated rules rather than deleted — `employee-record-ambiguous-term` (`worker|compensation|benefit|performance|manager`) and `security-log-ambiguous-term` (`incident|threat`). Detection coverage is unchanged.

A lone ambiguous signal lands on **`confidential`, not `internal`**. The control still fails closed; it just stops treating one English word as proof of an HR or security record.

## Governance

Kernel decision **DI-0A58373E26D0**. Four options scored: corroboration, narrowing the patterns outright, weighting paths above prose, and granting an external provider restricted clearance.

- **Winner: corroboration** — composite 9.10, margin 2.70, confidence high, no commandment conflict, 0% semantic fallback.
- **Granting external clearance scored worst (2.56)**, opposed by *Outbound and irreversible actions require explicit go* and *Least privilege, deny by default*. No clearance was touched; the local-first posture is preserved.
- **Deleting the noisy words scored 4.37** — second-worst, and it was the author's pre-consultation default. The kernel's preference for keeping detection intact and moving only the escalation bar is a strictly safer change, and it flipped the approach.

## Guarantees explicitly preserved (each has a test)

- A tool argument named `password` still escalates alone. *An existing test caught an earlier, coarser version of this change that gated on `confidence` rather than vocabulary precision — that test was right, and the rule was rewritten around it.*
- Declared governed data with `sensitivity: "restricted"` is never subject to the corroboration bar.
- The `unknown-governed-data` fail-closed for data of unknown classification is intact.
- Precise employment vocabulary (`salary`, `disciplinary`, `performance review`, `payroll`) escalates alone.

## Evidence

Local-CI gate passed at `4f48565ee5ceecd8a93f9390e692d49dae971c5c` (metadata `candidateSha` matches HEAD), covering full vitest, `pnpm --filter web typecheck`, prisma migrate deploy, doc-index `--check`, doc-links, `check-guards.mjs`, and the production docker build.

- **2290/2290** across `lib/inference`, `lib/routing`, `lib/govern`.
- 8 new regression cases: the live false positive, the repeated-word non-corroboration case, precise-vocabulary escalation, security-log ambiguity, and both governed-data guarantees.
- Typecheck clean, independently confirmed locally with a canary-validated run.
- Module-size ratchet green; no baseline edit required.

Not verified on the live install — deploys are operator-gated. The owner-visible effect after deploy is that AI-operations and similar surfaces stop being pinned to the local model, while genuine HR/security payloads route exactly as before.

Seed-Fit-Decision: no-change — this alters an in-code classification predicate only. No seed data, provider catalog entry, sensitivity clearance, or bootstrap calibration is touched; `sensitivityClearance` is read nowhere in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
