### PR TITLE
fix(workforce): stop the HR roster deep-linking to 404 coworker records (BI-005DDC70)

### DIFF
--- a/apps/web/lib/coworker-record/roster.ts
+++ b/apps/web/lib/coworker-record/roster.ts
@@ -10,7 +10,6 @@
 
 import { prisma } from "@dpf/db";
 import {
-  COWORKER_SLUG_TO_CANONICAL_AGENT_ID,
   resolveAgentIdentity,
   resolveCanonicalAgentId,
 } from "@dpf/db/agent-identity";
@@ -36,7 +35,15 @@ import {
   type CoworkerInteractionProjection,
   type RosterServiceEvidence,
 } from "./roster-presentation";
-import { SELECTABLE_COWORKER_STATE } from "./selectable-coworker";
+import {
+  SELECTABLE_COWORKER_STATE,
+  dropDualSeedAliasAgents,
+} from "./selectable-coworker";
+
+// Re-exported from its original home so existing importers keep one name for
+// the dual-seed collapse; the implementation now sits beside the selection
+// state it is half of (see ./selectable-coworker).
+export { dropDualSeedAliasAgents };
 
 // BI-74FD6420: roster collapses dual-seed slug + AGT-* pairs for display only.
 // Seed still creates slug agentId rows for FK consumers (service catalog, etc.).
@@ -92,32 +99,6 @@ type FamilyCoverage = {
 };
 
 const DECISION_WINDOW_DAYS = 30;
-
-/**
- * Keep one display row only when the full canonical + executable identity pair
- * is selectable (BI-74FD6420). Known slug rows never render independently:
- * their detail route canonicalizes to AGT-* and execution still uses the slug,
- * so an orphan on either side cannot complete the roster's primary job.
- */
-export function dropDualSeedAliasAgents<T extends { agentId: string }>(
-  agents: T[],
-  slugToCanonical: Readonly<Record<string, string>> = COWORKER_SLUG_TO_CANONICAL_AGENT_ID,
-): T[] {
-  const present = new Set(agents.map((a) => a.agentId));
-  const canonicalToSlug = new Map(
-    Object.entries(slugToCanonical).map(([slug, canonical]) => [
-      canonical,
-      slug,
-    ]),
-  );
-  return agents.filter((a) => {
-    const canonical = slugToCanonical[a.agentId];
-    if (canonical && canonical !== a.agentId) return false;
-    const runtimeSlug = canonicalToSlug.get(a.agentId);
-    if (runtimeSlug && !present.has(runtimeSlug)) return false;
-    return true;
-  });
-}
 
 /** One query over all profession corpus pages, bucketed by family key. */
 async function loadAllCoverage(): Promise<Map<string, FamilyCoverage>> {

--- a/apps/web/lib/coworker-record/selectable-coworker.ts
+++ b/apps/web/lib/coworker-record/selectable-coworker.ts
@@ -1,5 +1,6 @@
 import {
   CANONICAL_AGENT_ID_TO_COWORKER_SLUG,
+  COWORKER_SLUG_TO_CANONICAL_AGENT_ID,
   resolveCanonicalAgentId,
 } from "@dpf/db/agent-identity";
 
@@ -20,4 +21,35 @@ export function selectableCoworkerIdentityRefs(requestedRef: string): {
       CANONICAL_AGENT_ID_TO_COWORKER_SLUG[canonicalAgentId] ??
       canonicalAgentId,
   };
+}
+
+/**
+ * Keep one display row only when the full canonical + executable identity pair
+ * is selectable (BI-74FD6420). Known slug rows never render independently:
+ * their detail route canonicalizes to AGT-* and execution still uses the slug,
+ * so an orphan on either side cannot complete the roster's primary job.
+ *
+ * Lives here, beside SELECTABLE_COWORKER_STATE, because the two together ARE
+ * the selection contract the coworker detail route enforces: any roster that
+ * deep-links to /platform/ai/agent/[agentId] must apply BOTH or it renders
+ * rows whose links 404.
+ */
+export function dropDualSeedAliasAgents<T extends { agentId: string }>(
+  agents: T[],
+  slugToCanonical: Readonly<Record<string, string>> = COWORKER_SLUG_TO_CANONICAL_AGENT_ID,
+): T[] {
+  const present = new Set(agents.map((a) => a.agentId));
+  const canonicalToSlug = new Map(
+    Object.entries(slugToCanonical).map(([slug, canonical]) => [
+      canonical,
+      slug,
+    ]),
+  );
+  return agents.filter((a) => {
+    const canonical = slugToCanonical[a.agentId];
+    if (canonical && canonical !== a.agentId) return false;
+    const runtimeSlug = canonicalToSlug.get(a.agentId);
+    if (runtimeSlug && !present.has(runtimeSlug)) return false;
+    return true;
+  });
 }

--- a/apps/web/lib/workforce/workforce-roster.test.ts
+++ b/apps/web/lib/workforce/workforce-roster.test.ts
@@ -212,6 +212,55 @@ describe("loadWorkforceRoster (BI-554E1A14, BI-9A5F0EA3)", () => {
     expect(members[0].agentNeeds?.perTaskTokenLimit).toBeNull();
   });
 
+  // BI-005DDC70: every agent row on this roster deep-links to
+  // /platform/ai/agent/[agentId], which serves ONLY coworkers passing the
+  // selection contract. Loading unfiltered put 20 dead links on the page.
+  describe("selection contract (links must resolve)", () => {
+    it("queries only selectable coworkers (active, not archived, production)", async () => {
+      const db = makeDb({ employees: [], agents: [AGENT] });
+
+      await loadWorkforceRoster({ db: db as never });
+
+      expect(db.agent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: "active", archived: false, lifecycleStage: "production" },
+        }),
+      );
+    });
+
+    it("drops a canonical AGT-* row whose executable slug twin is not selectable", async () => {
+      // AGT-WS-ADMIN's runtime identity is the `admin-assistant` slug row. When
+      // that twin is filtered out by the state predicate, the detail route
+      // returns notFound — so the canonical row must not render either.
+      const canonicalOnly = { ...AGENT, agentId: "AGT-WS-ADMIN" };
+      const db = makeDb({ employees: [], agents: [canonicalOnly] });
+
+      const { members, summary } = await loadWorkforceRoster({ db: db as never });
+
+      expect(members).toEqual([]);
+      expect(summary.agents).toBe(0);
+    });
+
+    it("shows one row per dual-seed pair, keeping the canonical AGT-* id", async () => {
+      const canonical = { ...AGENT, agentId: "AGT-WS-ADMIN" };
+      const slugTwin = { ...AGENT, agentId: "admin-assistant" };
+      const db = makeDb({ employees: [], agents: [canonical, slugTwin] });
+
+      const { members } = await loadWorkforceRoster({ db: db as never });
+
+      expect(members.map((m) => m.id)).toEqual(["AGT-WS-ADMIN"]);
+    });
+  });
+
+  it("labels a coworker with its curated displayName, not the raw seed handle", async () => {
+    const seeded = { ...AGENT, name: "admin-assistant", displayName: "Platform Admin" };
+    const db = makeDb({ employees: [], agents: [seeded] });
+
+    const { members } = await loadWorkforceRoster({ db: db as never });
+
+    expect(members[0].displayName).toBe("Platform Admin");
+  });
+
   it("returns an empty roster when there is no workforce", async () => {
     const db = makeDb({ employees: [], agents: [] });
 

--- a/apps/web/lib/workforce/workforce-roster.ts
+++ b/apps/web/lib/workforce/workforce-roster.ts
@@ -25,6 +25,10 @@ import {
   loadCertificationStates,
   type CoworkerCertificationState,
 } from "@/lib/coworker-lifecycle/certification-status";
+import {
+  SELECTABLE_COWORKER_STATE,
+  dropDualSeedAliasAgents,
+} from "@/lib/coworker-record/selectable-coworker";
 
 export type WorkforceMemberKind = "human" | "agent";
 
@@ -140,6 +144,8 @@ type EmployeeRow = {
 type AgentRow = {
   agentId: string;
   name: string;
+  /** Curated role label (AGENT_IDENTITY_OVERRIDES); falls back to the seed name. */
+  displayName?: string | null;
   status: string;
   valueStream: string | null;
   humanSupervisorId: string | null;
@@ -236,7 +242,10 @@ function agentToMember(
   return {
     kind: "agent",
     id: row.agentId,
-    displayName: row.name,
+    // The curated role label, never the raw seed handle: the roster showed
+    // "admin-assistant" / "build-specialist" where every other surface says
+    // "Platform Admin" / "Build Lead" (BI-005DDC70).
+    displayName: row.displayName || row.name,
     status: row.status,
     role: row.valueStream,
     group: row.portfolioId,
@@ -310,7 +319,7 @@ export async function loadWorkforceRoster(input?: {
 }): Promise<WorkforceRoster> {
   const db = input?.db ?? (prisma as unknown as WorkforceRosterClient);
 
-  const [employees, agents] = await Promise.all([
+  const [employees, agentsRaw] = await Promise.all([
     db.employeeProfile.findMany({
       orderBy: { displayName: "asc" },
       select: {
@@ -322,10 +331,17 @@ export async function loadWorkforceRoster(input?: {
       },
     }) as Promise<EmployeeRow[]>,
     db.agent.findMany({
+      // BI-005DDC70: this roster deep-links every coworker to
+      // /platform/ai/agent/[agentId], and that route serves ONLY coworkers that
+      // pass the selection contract. Loading unfiltered rendered retired /
+      // quarantined / draft agents (and dual-seed slug twins) as live rows whose
+      // links 404. Same predicate as the AI Workforce roster — one contract.
+      where: SELECTABLE_COWORKER_STATE,
       orderBy: { name: "asc" },
       select: {
         agentId: true,
         name: true,
+        displayName: true,
         status: true,
         valueStream: true,
         humanSupervisorId: true,
@@ -344,6 +360,11 @@ export async function loadWorkforceRoster(input?: {
       },
     }) as Promise<AgentRow[]>,
   ]);
+
+  // The second half of the selection contract: a canonical AGT-* row whose
+  // executable slug twin is not selectable (and a slug twin shown beside its
+  // canonical) cannot open its detail record either.
+  const agents = dropDualSeedAliasAgents(agentsRaw);
 
   const supervisorIds = [
     ...new Set(


### PR DESCRIPTION
Founder report: clicking many AI coworkers on `/employee?view=workforce` returns a 404 — "admin-assistant", "build specialists", and others.

## What was wrong

The HR Workforce roster deep-links every coworker to `/platform/ai/agent/[agentId]`. That route serves **only** coworkers that satisfy the selection contract:

1. `SELECTABLE_COWORKER_STATE` — `status: active`, `archived: false`, `lifecycleStage: production`
2. the executable identity pair rule — a canonical `AGT-*` row and its runtime slug twin must **both** be selectable, or `loadCoworkerRecord` returns null

The AI Workforce roster (`lib/coworker-record/roster.ts`) applies both. `loadWorkforceRoster` applied **neither** — `agent.findMany` had no `where` clause and no dual-seed collapse.

## Evidence (live install, authenticated)

Before: the roster rendered **110** coworker links, **20** of which 404'd —
- 18 quarantined/retired rows (`__dpf_quarantined__*`), including the ones named `admin-assistant` and `build-specialist` the founder clicked
- `change-reviewer` (`lifecycleStage: draft`)
- `AGT-WS-REVIEW`, whose executable slug twin `change-reviewer` is not selectable

After: the roster's population is **77** agents, and **all 77** detail routes return 200.

## Changes

- `loadWorkforceRoster` applies `SELECTABLE_COWORKER_STATE` and `dropDualSeedAliasAgents` — the same contract the coworker record enforces.
- `dropDualSeedAliasAgents` moves from `lib/coworker-record/roster.ts` to `lib/coworker-record/selectable-coworker.ts`, beside the state predicate it is the other half of; `roster.ts` re-exports it so existing importers and `roster-dedupe.test.ts` are untouched.
- Agent rows are labelled with the curated `displayName` ("Platform Admin", "Build Lead") rather than the raw seed `name` ("admin-assistant", "build-specialist") — which is why the dual-seed twins were indistinguishable on this roster.
- Four regression tests: the query's `where`, the orphaned-pair drop, the dual-seed collapse, and the display label.

## Not covered here

Other surfaces deep-link the coworker record from *historical activity* rows, which can name retired agents: `AiOperationsMap`, `AgentModelAssignmentTable`, `a2a-interaction-graph`, and the `coworker-decisions` pages. Same class of defect, different data path — not addressed by this PR. Related: BI-F24C004D (duplicate coworkers on the proactivity roster).

## Verification

- `apps/web` typecheck clean (canary-verified, not a silent OOM pass).
- 172 tests pass across `lib/workforce` + `lib/coworker-record`.
- Local pregate: `gate passed`.
- Live install sweep as above.

Backlog item: BI-005DDC70

Seed-Fit-Decision: not-applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
