### PR TITLE
docs(marketing): mark Deliverable A shipped in the evidence-to-outcome plan

### DIFF
--- a/docs/superpowers/plans/2026-07-28-marketing-evidence-to-outcome-loop.md
+++ b/docs/superpowers/plans/2026-07-28-marketing-evidence-to-outcome-loop.md
@@ -1,6 +1,6 @@
 # Marketing Strategist Evidence-to-Outcome Loop Implementation Plan
 
-**Status:** planned
+**Status:** in progress — Deliverable A shipped 2026-07-28 (PR #3701, `ef16e317ce`); B, C and D remain
 
 **Backlog item:** `BI-IMP-14F9E938`
 
@@ -161,7 +161,9 @@ The coworker prompt must stop forcing plan-only replies and one-step waits for s
 
 ### Deliverable A — canonical operating snapshot and tool-contract repair
 
-**Backlog item:** `BI-CEA797A1`
+**Status:** SHIPPED 2026-07-28 — PR #3701, squash-merged as `ef16e317ce`. Do not re-implement; extend it.
+
+**Backlog item:** `BI-CEA797A1` (done)
 
 **Independently shippable:** yes
 **Depends on:** none
@@ -192,6 +194,18 @@ Verification:
 - tool-registry/grant contract tests;
 - source-local typecheck;
 - functional MCP probe against seeded campaigns showing the same state on the owner page and in tool output.
+
+#### What actually landed (read before building B, C or D)
+
+- `apps/web/lib/marketing/operating-snapshot.ts` is the canonical projection. It **composes** `getMarketingWorkspaceSnapshot()` rather than replacing it, and adds campaign identities (execution + measurement rollups), channel-adapter readiness incl. contractual operations an adapter does *not* implement, evidence freshness, blockers each carrying one recovery action, and one next executable step. Pure builders are separate from the single DB assembler.
+- `projectOperatingSnapshotForTools()` is the MCP-facing view; `buildMarketingOwnerDecision()` re-voices the *same* canonical next step for the owner. A parity test walks every next-step id, so the tool surface and the page cannot disagree.
+- Campaign drill-ins are organization-scoped via `requireCampaignInScope`, and a missing/unknown `campaignId` returns candidate ids plus one recovery instruction.
+- Supporting modules to reuse, not re-create: `org-scope.ts`, `archetype-context.ts`, `acquisition-signals.ts`, and `loadPublicationMetricsForTasks()` in `campaign-performance.ts`.
+
+Two constraints B and C inherit:
+
+- **Do not pass `getMarketingOperatingSnapshot()` a workspace it must reload.** `getMarketingWorkspaceSnapshot()` upserts `MarketingStrategy`; loading it twice concurrently races the `organizationId` unique key and 500s the render. Hand the loaded snapshot over via `{ workspace }`. The underlying upsert is still racy on a cold workspace — tracked as `BI-48025D6B`.
+- **Evidence *sufficiency* is still C's job.** The snapshot reports `attributionConfidence` and `stale` — what the data can honestly support — not whether a winner may be declared.
 
 ### Deliverable B — governed recurring acquisition operating cycle
 


### PR DESCRIPTION
Docs-only. The plan at `docs/superpowers/plans/2026-07-28-marketing-evidence-to-outcome-loop.md` still read **`Status: planned`** after Deliverable A landed on 2026-07-28 (PR #3701, `ef16e317ce`, `BI-CEA797A1` closed done).

That matters because the plan is the first artifact an agent reads when told "implement this plan" — and it explicitly instructs starting at Deliverable A. Duplicate rebuilding is a recurring and expensive failure mode in this repo, and the live backlog saying `done` only helps an agent that thinks to check it.

## What changed

- Plan status → in progress, naming what shipped and what remains (B, C, D).
- Deliverable A marked **SHIPPED** with its merge sha and a "do not re-implement; extend it" note.
- New **"What actually landed"** section before Deliverable B, naming the modules to extend rather than re-create (`operating-snapshot.ts`, `org-scope.ts`, `archetype-context.ts`, `acquisition-signals.ts`, `loadPublicationMetricsForTasks`).
- Carries forward the two constraints B and C inherit:
  - hand `getMarketingOperatingSnapshot()` an already-loaded workspace snapshot — loading it twice concurrently races the `MarketingStrategy` upsert and 500s the render (residual race tracked as `BI-48025D6B`);
  - evidence *sufficiency* stays Deliverable C's job; the snapshot only reports what the data can honestly support.

## Verification

`check-doc-links` PASS, `check-doc-reference-integrity` OK. No code, no contract change, no route change.

Docs-Impact-Decision: this IS the docs change — corrects stale implementation-history status on the plan.
Process-Spine-Decision: updates the governed plan artifact to match delivered state under coverage receipt cms4zgdfk004b01mxv2iq8rr7; no scope or backlog-coverage change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)