### PR TITLE
feat(context): soft context-economy guard — growth allowed, silence is not

### DIFF
--- a/scripts/check-context-economy.mjs
+++ b/scripts/check-context-economy.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+// scripts/check-context-economy.mjs
+//
+// Plane-3 context-economy guard. The runtime-context analog of the instruction-plane
+// ratchet (check-instruction-plane-size.mjs) — but DELIBERATELY A DIFFERENT SHAPE.
+//
+// WHY NOT SHRINK-ONLY. The instruction plane may only shrink, full stop. Copying that
+// here would be wrong, and would block exactly the work worth doing: founder doctrine is
+// that complexity is acceptable when it removes cognitive load over time ("in time,
+// complexity is OK, as this will remove cognitive load long term, so be it"). A monotonic
+// shrink-only guard reds the change that spends context now to remove operator load later
+// — a false negative on the investment, not a defect caught.
+//
+// So this guard CANNOT SAY NO. It can only say "say why, on the record". Growth is always
+// permitted; growth in silence is not. The teeth are in the recorded justification, which
+// persists next to the number it justifies and can be revisited when the promised
+// reduction was supposed to arrive.
+//
+// This mirrors how plane 1 already works: the UX budget runs mostly advisory with blocking
+// reserved for surfaces that have no legacy excuse ("Legacy debt earns a ratchet; new code
+// has no legacy excuse" — lib/ux-budget/budgets.ts). Hard rules on this platform are
+// commandment-tier only (laws, lives); everything else is defeasible by design.
+//
+// WHAT IT MEASURES — deterministic, from source, no database. CI can never read an
+// install's DB, and the assembled prompt is per-turn runtime state, so the honest
+// measurable is the STANDING cost the code commits every turn to:
+//
+//   1. `budgets.<tier>` — the per-model-tier token allowance from context-arbitrator's
+//      BUDGETS table. This is the ceiling every turn on that tier is allowed to spend.
+//   2. `standingSources` — how many context sources compete for it in the coworker
+//      assembly. Each one is a permanent tax on every dispatch, not a per-turn choice.
+//
+// Per-turn ACTUALS are now recorded by BI-3E218D80 (AgentMessage.contextTrace); this
+// guard governs the declared budget, which is the part a PR can change.
+//
+//   node scripts/check-context-economy.mjs          # check (CI)
+//   node scripts/check-context-economy.mjs --update # re-baseline (then write the reasons)
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BASELINE_PATH = join(REPO_ROOT, "scripts", "context-economy-baseline.json");
+const ARBITRATOR_REL = "apps/web/lib/tak/context-arbitrator.ts";
+const ASSEMBLY_REL = "apps/web/lib/actions/agent-coworker.ts";
+
+// ── Measurement (pure) ──────────────────────────────────────────────────────────
+
+/**
+ * Per-tier total token budgets from the BUDGETS table. Parsed rather than imported
+ * because this is a .mjs guard and the source is TypeScript — the same approach the
+ * other repo guards take.
+ */
+export function parseTierBudgets(arbitratorSource) {
+  const budgets = {};
+  const re = /(\w+):\s*\{\s*modelTier:\s*"(\w+)"\s*,\s*totalBudget:\s*(\d+)/g;
+  let m;
+  while ((m = re.exec(arbitratorSource)) !== null) {
+    budgets[m[2]] = Number(m[3]);
+  }
+  return budgets;
+}
+
+/**
+ * Distinct standing context-source labels in the coworker assembly. Deduplicated: the
+ * question is "how many things claim a share of every turn", not how many times a label
+ * is mentioned.
+ */
+export function parseStandingSources(assemblySource) {
+  const labels = new Set();
+  const re = /source:\s*"([a-z0-9-]+)"/g;
+  let m;
+  while ((m = re.exec(assemblySource)) !== null) labels.add(m[1]);
+  return [...labels].sort();
+}
+
+/** The full measured picture, as flat `key -> number` entries the baseline can hold. */
+export function measureContextEconomy({ arbitratorSource, assemblySource }) {
+  const budgets = parseTierBudgets(arbitratorSource);
+  const sources = parseStandingSources(assemblySource);
+  const measured = {};
+  for (const [tier, total] of Object.entries(budgets)) {
+    measured[`budget.${tier}.totalBudget`] = total;
+  }
+  measured["assembly.standingSources"] = sources.length;
+  return { measured, sources };
+}
+
+// ── Evaluation (pure) ───────────────────────────────────────────────────────────
+
+/**
+ * @param {object} input
+ * @param {Record<string, number>} input.measured        what the tree says now
+ * @param {Record<string, {value:number, reason?:string}>} input.baseline  committed baseline (this PR)
+ * @param {Record<string, {value:number, reason?:string}>|null} input.baseBaseline  baseline at origin/main
+ * @returns {{ok:boolean, errors:string[], notes:string[], justified:string[]}}
+ */
+export function evaluateContextEconomy({ measured, baseline, baseBaseline }) {
+  const errors = [];
+  const notes = [];
+  const justified = [];
+
+  for (const [key, now] of Object.entries(measured)) {
+    const entry = baseline?.[key];
+    if (!entry || typeof entry.value !== "number") {
+      errors.push(
+        `${key} is measured at ${now} but missing from the baseline — run --update, then ` +
+          `record a reason for it.`,
+      );
+      continue;
+    }
+
+    // 1. The tree may not exceed what the committed baseline declares.
+    if (now > entry.value) {
+      errors.push(
+        `${key} grew ${entry.value} -> ${now} without re-baselining. Growth is allowed — ` +
+          `raise the baseline and record WHY, including what cognitive load it removes ` +
+          `and when.`,
+      );
+      continue;
+    }
+
+    // 2. If the baseline itself was RAISED in this change, it must carry a reason.
+    //    This is the whole point of the guard: growth in silence is what is forbidden,
+    //    not growth.
+    const was = baseBaseline?.[key]?.value;
+    if (typeof was === "number" && entry.value > was) {
+      const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
+      if (reason.length < 20) {
+        errors.push(
+          `${key} baseline was raised ${was} -> ${entry.value} with no substantive reason. ` +
+            `Record what long-term cognitive load this buys — a bare "increased" is the ` +
+            `attestation theater this guard exists to prevent.`,
+        );
+      } else {
+        justified.push(`${key} ${was} -> ${entry.value}: ${reason}`);
+      }
+    }
+
+    // 3. Shrink is always welcome, and worth retightening so the gain is kept.
+    if (now < entry.value) {
+      notes.push(`${key} is ${now}, below its ${entry.value} baseline — run --update to keep the gain.`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors, notes, justified };
+}
+
+// ── I/O ─────────────────────────────────────────────────────────────────────────
+
+function readBaseline(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")).entries ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readBaselineAtBase() {
+  try {
+    const out = execFileSync("git", ["show", "origin/main:scripts/context-economy-baseline.json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return JSON.parse(out).entries ?? null;
+  } catch {
+    // No base to compare against (new file, shallow clone, detached CI). Rule 2 is then
+    // skipped and rule 1 still holds — never fail closed on a missing comparison.
+    return null;
+  }
+}
+
+function main() {
+  const arbitratorSource = readFileSync(join(REPO_ROOT, ARBITRATOR_REL), "utf8");
+  const assemblySource = readFileSync(join(REPO_ROOT, ASSEMBLY_REL), "utf8");
+  const { measured, sources } = measureContextEconomy({ arbitratorSource, assemblySource });
+
+  if (process.argv.includes("--update")) {
+    const existing = readBaseline(BASELINE_PATH) ?? {};
+    const entries = {};
+    for (const [key, value] of Object.entries(measured)) {
+      const prior = existing[key];
+      entries[key] = {
+        value,
+        // Carry a prior reason forward only while the number is unchanged; a raised
+        // number needs a fresh justification, not an inherited one.
+        ...(prior && prior.value === value && prior.reason ? { reason: prior.reason } : {}),
+      };
+    }
+    writeFileSync(
+      BASELINE_PATH,
+      JSON.stringify(
+        {
+          _comment:
+            "Plane-3 context-economy baseline (scripts/check-context-economy.mjs). Growth is " +
+            "ALLOWED but never silent: raise a value and record `reason` saying what long-term " +
+            "cognitive load it removes. Shrink freely and re-run --update to keep the gain.",
+          standingSources: sources,
+          entries,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    console.log(`Wrote context-economy baseline: ${Object.keys(entries).length} entries.`);
+    console.log("Now add a `reason` to every entry you RAISED — the guard requires it.");
+    process.exit(0);
+  }
+
+  const baseline = readBaseline(BASELINE_PATH);
+  if (!baseline) {
+    console.error("Missing scripts/context-economy-baseline.json — run --update to create it.");
+    process.exit(1);
+  }
+
+  const { ok, errors, notes, justified } = evaluateContextEconomy({
+    measured,
+    baseline,
+    baseBaseline: readBaselineAtBase(),
+  });
+
+  for (const j of justified) console.log(`  [recorded] ${j}`);
+  for (const n of notes) console.log(`  [note] ${n}`);
+
+  if (!ok) {
+    console.error("\nContext-economy guard failed (BI-3E218D80 follow-on).\n");
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error("");
+    console.error("This guard does not forbid growth. Standing context cost may rise when it");
+    console.error("buys a durable reduction in cognitive load — that trade is legitimate and");
+    console.error("expected. What it forbids is raising the cost SILENTLY, because the claim");
+    console.error("has to survive long enough to be checked against what actually happened.");
+    console.error("");
+    console.error("  node scripts/check-context-economy.mjs --update   # then write the reasons");
+    console.error("");
+    process.exit(1);
+  }
+
+  const budgetSummary = Object.entries(measured)
+    .filter(([k]) => k.startsWith("budget."))
+    .map(([k, v]) => `${k.split(".")[1]}=${v}`)
+    .join(" ");
+  console.log(
+    `Context-economy OK — ${sources.length} standing sources; budgets ${budgetSummary}.` +
+      (justified.length ? ` ${justified.length} recorded increase(s).` : ""),
+  );
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("check-context-economy.mjs")) {
+  main();
+}

--- a/scripts/check-context-economy.test.mjs
+++ b/scripts/check-context-economy.test.mjs
@@ -1,0 +1,169 @@
+// scripts/check-context-economy.test.mjs
+//
+// The load-bearing assertions here are the two halves of the founder doctrine this guard
+// encodes: growth WITH a recorded reason must PASS (complexity that buys long-term
+// cognitive-load reduction is legitimate), and growth WITHOUT one must FAIL. A guard that
+// only did the second half would be the shrink-only ratchet that blocks the investment;
+// a guard that only did the first would be a warning nobody reads.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  evaluateContextEconomy,
+  measureContextEconomy,
+  parseStandingSources,
+  parseTierBudgets,
+} from "./check-context-economy.mjs";
+
+const ARBITRATOR = `
+const BUDGETS: Record<ModelTier, ContextBudget> = {
+  frontier: { modelTier: "frontier", totalBudget: 6000, l0Budget: 625, l1Budget: 1500, l2Budget: 3875 },
+  basic:    { modelTier: "basic",    totalBudget: 800,  l0Budget: 625, l1Budget: 175,  l2Budget: 0 },
+};`;
+
+const ASSEMBLY = `
+  { tier: "L1", source: "domain", compressible: false },
+  { tier: "L1", source: "page-data", compressible: true },
+  { tier: "L2", source: "semantic-memory", compressible: true },
+  const selectedDomain = result.selected.find((s) => s.source === "domain");
+`;
+
+// ── measurement ──
+
+test("parses each model tier's standing token allowance", () => {
+  assert.deepEqual(parseTierBudgets(ARBITRATOR), { frontier: 6000, basic: 800 });
+});
+
+test("counts DISTINCT standing sources — a label mentioned twice is still one claimant", () => {
+  assert.deepEqual(parseStandingSources(ASSEMBLY), ["domain", "page-data", "semantic-memory"]);
+});
+
+test("measures budgets and source count into flat baseline keys", () => {
+  const { measured, sources } = measureContextEconomy({
+    arbitratorSource: ARBITRATOR,
+    assemblySource: ASSEMBLY,
+  });
+  assert.equal(measured["budget.frontier.totalBudget"], 6000);
+  assert.equal(measured["assembly.standingSources"], 3);
+  assert.deepEqual(sources, ["domain", "page-data", "semantic-memory"]);
+});
+
+// ── the doctrine: growth is allowed, silence is not ──
+
+test("growth WITH a substantive recorded reason passes, and the reason is surfaced", () => {
+  const result = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 4000 },
+    baseline: {
+      "budget.strong.totalBudget": {
+        value: 4000,
+        reason:
+          "Raised to fund the profession corpus inline, which removes the operator's manual " +
+          "lookup step on every advisory turn.",
+      },
+    },
+    baseBaseline: { "budget.strong.totalBudget": { value: 3000 } },
+  });
+  assert.equal(result.ok, true, result.errors.join("; "));
+  assert.ok(result.justified.some((j) => /3000 -> 4000/.test(j)));
+});
+
+test("growth WITHOUT a reason fails and asks what load it removes", () => {
+  const result = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 4000 },
+    baseline: { "budget.strong.totalBudget": { value: 4000 } },
+    baseBaseline: { "budget.strong.totalBudget": { value: 3000 } },
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /no substantive reason/.test(e)), result.errors.join("; "));
+  assert.ok(result.errors.some((e) => /long-term cognitive load/.test(e)));
+});
+
+test("a token reason is rejected as the attestation theater it is", () => {
+  const result = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 4000 },
+    baseline: { "budget.strong.totalBudget": { value: 4000, reason: "increased" } },
+    baseBaseline: { "budget.strong.totalBudget": { value: 3000 } },
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /attestation theater/.test(e)));
+});
+
+test("the tree may not quietly exceed the committed baseline", () => {
+  const result = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 9000 },
+    baseline: { "budget.strong.totalBudget": { value: 3000 } },
+    baseBaseline: { "budget.strong.totalBudget": { value: 3000 } },
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /without re-baselining/.test(e)));
+  assert.ok(result.errors.some((e) => /Growth is allowed/.test(e)), "must not read as a prohibition");
+});
+
+test("a new standing source is caught — it is a permanent tax on every dispatch", () => {
+  const result = evaluateContextEconomy({
+    measured: { "assembly.standingSources": 8 },
+    baseline: { "assembly.standingSources": { value: 7 } },
+    baseBaseline: { "assembly.standingSources": { value: 7 } },
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /assembly\.standingSources grew 7 -> 8/.test(e)));
+});
+
+// ── shrink, and fail-open cases ──
+
+test("shrink always passes and is nudged to be locked in", () => {
+  const result = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 2000 },
+    baseline: { "budget.strong.totalBudget": { value: 3000 } },
+    baseBaseline: { "budget.strong.totalBudget": { value: 3000 } },
+  });
+  assert.equal(result.ok, true);
+  assert.ok(result.notes.some((n) => /keep the gain/.test(n)));
+});
+
+test("an unmeasured key is reported rather than silently ignored", () => {
+  const result = evaluateContextEconomy({
+    measured: { "budget.new-tier.totalBudget": 500 },
+    baseline: {},
+    baseBaseline: {},
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /missing from the baseline/.test(e)));
+});
+
+test("a missing base comparison never fails closed — rule 1 still holds, rule 2 is skipped", () => {
+  // Shallow clone / new file / detached CI: we cannot tell whether the baseline was
+  // raised, so we must not invent a violation.
+  const raisedNoReason = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 4000 },
+    baseline: { "budget.strong.totalBudget": { value: 4000 } },
+    baseBaseline: null,
+  });
+  assert.equal(raisedNoReason.ok, true);
+
+  const overBaseline = evaluateContextEconomy({
+    measured: { "budget.strong.totalBudget": 5000 },
+    baseline: { "budget.strong.totalBudget": { value: 4000 } },
+    baseBaseline: null,
+  });
+  assert.equal(overBaseline.ok, false);
+});
+
+// ── the committed baseline matches the real tree ──
+
+test("the committed baseline is in sync with the live source", () => {
+  const root = new URL("../", import.meta.url);
+  const { measured } = measureContextEconomy({
+    arbitratorSource: readFileSync(new URL("apps/web/lib/tak/context-arbitrator.ts", root), "utf8"),
+    assemblySource: readFileSync(new URL("apps/web/lib/actions/agent-coworker.ts", root), "utf8"),
+  });
+  const baseline = JSON.parse(
+    readFileSync(new URL("scripts/context-economy-baseline.json", root), "utf8"),
+  ).entries;
+
+  const result = evaluateContextEconomy({ measured, baseline, baseBaseline: baseline });
+  assert.equal(result.ok, true, result.errors.join("; "));
+  // And the guard is actually measuring something, not vacuously passing on an empty set.
+  assert.ok(Object.keys(measured).length >= 5);
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -14,6 +14,7 @@ const EXPECTED_LEGACY_JOBS = [
   "bundle-boundary-guard",
   "capability-consumer-guard",
   "compose-env-contract-guard",
+  "context-economy-guard",
   "data-impact-gate",
   "decision-baseline",
   "derived-artifact-registry",

--- a/scripts/context-economy-baseline.json
+++ b/scripts/context-economy-baseline.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Plane-3 context-economy baseline (scripts/check-context-economy.mjs). Growth is ALLOWED but never silent: raise a value and record `reason` saying what long-term cognitive load it removes. Shrink freely and re-run --update to keep the gain.",
+  "standingSources": [
+    "domain",
+    "knowledge",
+    "page-data",
+    "portal-context",
+    "profession-corpus",
+    "semantic-memory",
+    "user-facts"
+  ],
+  "entries": {
+    "budget.frontier.totalBudget": {
+      "value": 6000
+    },
+    "budget.strong.totalBudget": {
+      "value": 3000
+    },
+    "budget.adequate.totalBudget": {
+      "value": 1500
+    },
+    "budget.basic.totalBudget": {
+      "value": 800
+    },
+    "assembly.standingSources": {
+      "value": 7
+    }
+  }
+}

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -130,6 +130,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-instruction-plane-size.test.mjs"),
       node("scripts/check-instruction-plane-size.mjs"),
     ]),
+    // Plane-3 sibling of the instruction-plane guard, deliberately a SOFTER shape: it
+    // never forbids growth in standing context cost, only growth recorded in silence.
+    guard("context-economy-guard", "Context Economy Guard", [
+      node("--test", "scripts/check-context-economy.test.mjs"),
+      node("scripts/check-context-economy.mjs"),
+    ]),
     guard("archetype-completeness-guard", "Archetype Completeness Guard", [
       node("--test", "scripts/check-archetype-completeness.test.mjs"),
       node("scripts/check-archetype-completeness.mjs"),


### PR DESCRIPTION
The plane-3 sibling of the instruction-plane ratchet — and **deliberately a different shape**.

## Why not shrink-only

The instruction plane may only shrink. Copying that here would have blocked exactly the work worth doing.

Founder doctrine, stated 2026-07-30: cognitive load is the terminal value — removal positive, addition negative — **but complexity is acceptable when it removes load over time.** *"In time, complexity is OK, as this will remove cognitive load long term, so be it."* A monotonic shrink-only guard reds the change that spends context now to remove operator load later: a false negative on the investment, not a defect caught. Hard rules here are commandment-tier only (laws, lives); everything else is defeasible by design.

So **this guard cannot say no.** It can only say *"say why, on the record."* Growth is always permitted; growth in silence is not.

This mirrors **plane 1**, not plane 2. The UX budget already runs 8 advisory to 4 blocking and splits by route age — *"Legacy debt earns a ratchet; new code has no legacy excuse."* That was the right template; I initially recommended the wrong one.

## What it measures

Deterministic, from source, no database. CI can never read an install's DB, and the assembled prompt is per-turn runtime state — so the honest measurable is the **standing** cost the code commits every turn to:

| Key | Meaning |
|---|---|
| `budget.<tier>.totalBudget` | the per-model-tier allowance from the arbitrator's `BUDGETS` table — the ceiling every turn on that tier may spend |
| `assembly.standingSources` | how many context sources compete for it; each is a permanent tax on every dispatch, not a per-turn choice |

Per-turn **actuals** are already recorded by BI-3E218D80 (`AgentMessage.contextTrace`). This governs the *declared budget*, which is the part a PR can actually change.

## Three rules

1. The tree may not exceed the committed baseline — catches silent drift.
2. A baseline **raised** since `origin/main` must carry a substantive reason. A token `"increased"` is rejected **by name** as the attestation theater the UX-Fit gate was just rewritten to eliminate (#3769) — making the same mistake twice would be careless.
3. Shrink always passes, and is nudged to be re-baselined so the gain is kept.

**Fails open, not closed.** When the base baseline can't be read (new file, shallow clone, detached CI), rule 2 is skipped and rule 1 still holds. A guard that invented violations from a missing comparison would train people to ignore it.

## Two honest limits

**Rule 2 isn't live until this lands.** It compares against `origin/main:scripts/context-economy-baseline.json`, which doesn't exist yet. So rule 2 is unit-proven here and becomes enforceable from the *next* PR onward; rule 1 is proven end-to-end. Stated rather than papered over.

**The deeper one:** *"this complexity removes load long term"* is a **prediction**, not a measurement. The UX-fit gate works because a committed baseline adjudicates a word count — checkable now. A long-term-payoff claim isn't checkable at decision time by anything. So this guard **detects the addition and preserves the claim; it cannot score it.** Revisiting recorded reasons against what actually happened is the missing half, and is deliberately not faked here.

## Verification

- **12 unit tests**, covering both halves of the doctrine: growth *with* a substantive reason passes and surfaces it; growth *without* fails and asks what load it removes; a token reason is rejected as theater.
- **End-to-end against real source**: raised the strong tier 3000 → 9000 in `context-arbitrator.ts`; guard exited 1 naming the exact delta *and* stating that growth is allowed. Reverted via `git checkout`; guard green again.
- A test asserts the committed baseline is in sync with the live tree **and** that it measures ≥5 keys, so it cannot pass vacuously on an empty measurement.
- `pregate-preflight`: **29 guards clean**, no environment skips, with the new guard wired in.

### Local-CI override

Scripts-only change — 3 new files under `scripts/` plus one line in `ci-policy-guards.mjs`. No `apps/web` runtime, no TypeScript in the Next build, no schema, no migration, so the local-CI gate's unique coverage (typecheck, full suite, `migrate deploy`) adds essentially nothing. The part that *does* exercise this change is the 29-guard preflight, which passed clean. The local-CI queue was 12 deep on a single slot with the active lease ~30 minutes in; I chose not to occupy it for this.

## Follow-on

The review loop — revisiting recorded reasons against whether the promised reduction materialised — is the missing half named above. Without it a soft guard decays toward a warning nobody reads, which is the failure mode this whole line of work started from.

Seed-Fit-Decision: global-default

No canonical seed content changed. Recorded as global-default because the guard is platform CI substrate applied identically on every install, not archetype- or vertical-scoped.

Local-CI-Override: Scripts-only change with no runtime, TypeScript-build, schema, or migration surface; 29-guard pregate-preflight clean with no environment skips, 12 unit tests, and an end-to-end probe against real source. Local-CI queue was 12 deep on one slot; GitHub CI still runs the full suite here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
