### PR TITLE
fix(identity): clear the installation owner for confidential business data (BI-B709EBDC)

### DIFF
--- a/apps/web/lib/identity/principal-linking.test.ts
+++ b/apps/web/lib/identity/principal-linking.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 });
 
 describe("syncUserPrincipal", () => {
-  it("creates the installation owner principal with public and internal clearance", async () => {
+  it("creates the installation owner principal cleared through confidential", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "owner-user",
       email: "owner@example.com",
@@ -65,7 +65,7 @@ describe("syncUserPrincipal", () => {
     expect(prisma.principal.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         kind: "human",
-        sensitivityClearance: ["public", "internal"],
+        sensitivityClearance: ["public", "internal", "confidential"],
       }),
     });
   });

--- a/packages/db/src/principal-sensitivity.test.ts
+++ b/packages/db/src/principal-sensitivity.test.ts
@@ -36,14 +36,27 @@ describe("principal sensitivity clearance", () => {
     );
   });
 
-  it("gives the installation owner only the public and internal floor", () => {
-    expect(INSTALLATION_OWNER_SENSITIVITY_FLOOR).toEqual(["public", "internal"]);
+  it("clears the installation owner for the business's own data up to confidential — never restricted", () => {
+    // The seed creates tier-2 coworkers at sensitivity "confidential"; the
+    // authority gate requires the owner's clearance to include that level, so
+    // the floor must carry it or every such coworker is unauthorizable.
+    expect(INSTALLATION_OWNER_SENSITIVITY_FLOOR).toEqual([
+      "public",
+      "internal",
+      "confidential",
+    ]);
     expect(
       resolvePrincipalSensitivityClearance({
         existing: ["public"],
         isSuperuser: true,
       }),
-    ).toEqual(["public", "internal"]);
+    ).toEqual(["public", "internal", "confidential"]);
+    expect(
+      resolvePrincipalSensitivityClearance({
+        existing: ["public"],
+        isSuperuser: true,
+      }),
+    ).not.toContain("restricted");
   });
 
   it("preserves governed clearance without widening ordinary principals", () => {

--- a/packages/db/src/principal-sensitivity.ts
+++ b/packages/db/src/principal-sensitivity.ts
@@ -7,9 +7,17 @@ export const PRINCIPAL_SENSITIVITIES = [
 
 export type PrincipalSensitivity = (typeof PRINCIPAL_SENSITIVITIES)[number];
 
+// The installation owner is the accountable human for the business's own
+// data: the same seed that grants this floor also creates tier-2 coworkers at
+// sensitivity "confidential" (workforce-seed), and the coworker authority gate
+// requires the acting human's clearance to include the coworker's sensitivity —
+// a floor without "confidential" makes every such coworker permanently
+// unauthorizable on a fresh install. "restricted" stays above the floor and
+// must be granted explicitly.
 export const INSTALLATION_OWNER_SENSITIVITY_FLOOR = [
   "public",
   "internal",
+  "confidential",
 ] as const satisfies readonly PrincipalSensitivity[];
 
 const PRINCIPAL_SENSITIVITY_SET = new Set<string>(PRINCIPAL_SENSITIVITIES);


### PR DESCRIPTION
Closes BI-B709EBDC.

Live repro TR-SCHED-AB47AA71 (restaurant exercise, after #3763 deployed): the storefront coworker chose `list_storefront_activity` with valid args and was denied **sensitivity-clearance-denied** — then, correctly, proposed a capability-need rather than guessing. Root cause: the seed creates tier-2 coworkers at sensitivity `confidential` (`workforce-seed.ts`) while the same seed's `INSTALLATION_OWNER_SENSITIVITY_FLOOR` stopped at `internal`, so the seeded install owner could never authorize the coworkers the platform ships. Live evidence: the admin principal's clearance was `{public, internal}`.

## What changed
- `INSTALLATION_OWNER_SENSITIVITY_FLOOR` now carries `confidential` — the owner/superuser is the accountable human for the business's own guest orders, bookings, and CRM. **`restricted` stays above the floor** and must be granted explicitly.
- Regression tests: floor content + superuser resolution include confidential and exclude restricted; the owner-principal creation test mirrors the new floor.
- Live installs self-heal on the next seed run (`resolvePrincipalSensitivityClearance` merges existing clearance with the floor).

Composes with #3778 (clearance pins routing — confidential turns route local-only) and #3733/#3740 (which made the local tool surface servable): together they complete the fully-local confidential-coworker path.

## Design grounding
Code substrate reviewed: `apps/web/lib/govern/authority/coworker-authority-decision.ts` (sensitivity-clearance check), `apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts` (dataPolicy.sensitivity = agent sensitivity), `packages/db/src/workforce-seed.ts` (confidential tier-2 coworkers), `packages/db/src/principal-sensitivity.ts` + `seed.ts` clearance merge, `apps/web/lib/identity/principal-linking.ts`. Decision: one-constant correction reconciling two halves of the same seed; authority model unchanged.

Seed-Fit-Decision: global-default — the owner clearance floor is bootstrap identity doctrine for every install; no install-specific values.

## Verification
Local-CI pregate passed on this exact tree after the test-mirror commit (`gate passed`), but the evidence record did not persist to this head SHA and the shared sandbox is currently 12-deep queued, so a re-run is hours out; pushed with a recorded override. PR CI runs the full suite as the arbiter.

Local-CI-Override: pregate passed on this tree but its record did not persist; sandbox saturated (12 queued leases). Change is one seed constant + two mirroring tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)