### PR TITLE
fix(ci): prove current main before local gate

### DIFF
--- a/docs/operations/local-ci-sandbox-slots.md
+++ b/docs/operations/local-ci-sandbox-slots.md
@@ -158,6 +158,15 @@ Every exact-tree result records:
 - Compose project and portal URL
 - production artifact kind, locator, identity, and integration-tree binding
 - lease, heartbeat/fence events, output path, and freshness verdict
+- accepted-base freshness as `remote-current`, `offline-accepted`, or
+  `fetch-failed`, including the admission-time resolution timestamp
+
+`origin/main` is refreshed once after admission and before the integration
+tree is synthesized. The resolved SHA remains fixed for that run. A network
+failure stops before heavy gates and is never relabeled as offline evidence.
+Operators intentionally working without network must select
+`--offline-accepted-base` (or `DPF_LOCAL_CI_OFFLINE_ACCEPTED_BASE=1`); that
+choice is preserved in the evidence.
 
 Capacity may increase only through the governed pilot after slot-isolation
 tests and the capacity-one exact-tree gate pass. A capacity-two declaration is

--- a/docs/superpowers/plans/2026-07-30-local-ci-base-freshness.md
+++ b/docs/superpowers/plans/2026-07-30-local-ci-base-freshness.md
@@ -1,0 +1,93 @@
+# Local-CI current-main base freshness
+
+Backlog item: `BI-1BDBA8AA`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+An online local-CI run refreshes `origin/main` after admission and resolves the
+integration base from that refreshed ref. Offline operation remains available
+only as an explicit accepted-base mode. Evidence distinguishes
+`remote-current`, `offline-accepted`, and `fetch-failed`; none is silently
+presented as another.
+
+## Grounding
+
+- `scripts/local-ci-runner.mjs` currently defaults `fetchBase` to false and
+  resolves `baseSha` before the optional fetch executes.
+- `scripts/lib/local-integration-ci.mjs` may fetch inside the integration plan,
+  after the caller already recorded the base SHA.
+- `scripts/lib/git-fetch-shared-safe.mjs` is the canonical safe fetch substrate
+  for linked worktrees.
+- `scripts/gate-worktree.mjs` records `fetch-base` versus `local-ref`, but that
+  label does not prove the recorded SHA was refreshed.
+
+## Phases
+
+### 1. Define freshness states test-first
+
+- Add pure state-resolution tests for online success, explicit offline
+  acceptance, and fetch failure.
+- Add a regression test where `origin/main` advances after worktree creation
+  and prove the admitted runner uses the new SHA.
+
+Verification: observe the regression fail against the current default, then
+pass after implementation.
+
+### 2. Resolve freshness once at admission
+
+- Make online refresh the default.
+- Fetch through the shared-safe helper before resolving `baseSha`.
+- Add an explicit offline accepted-base flag and environment contract.
+- A required fetch failure writes explicit failure evidence and exits before
+  integration synthesis or expensive gates.
+- Do not fetch again after the base SHA has been fixed for the admitted run.
+
+Verification: command-plan tests prove one fetch, the refreshed SHA, and no
+second fetch in the integration child.
+
+### 3. Carry truthful evidence end to end
+
+- Extend runner and integration metadata with freshness status, resolution
+  timestamp, accepted SHA, and fetch error classification.
+- Update `gate-worktree` evidence summaries to report the same status.
+- Preserve existing metadata fields for compatible readers while making the
+  new classification authoritative.
+
+Verification: metadata tests cover all three states and reject ambiguous
+  combinations.
+
+### 4. Document online and offline contracts
+
+- Update local-CI operations/testing documentation with the default online
+  behavior and explicit offline mode.
+- Explain that queued time does not cause repeated rebases: freshness is fixed
+  once, at admission, then reported.
+
+## Risks and rollback
+
+- **Network outage:** required online mode fails before consuming heavy sandbox
+  time; explicitly requested offline mode remains available.
+- **Shared clone damage:** use the existing depth-safe fetch helper.
+- **Moving base during execution:** the admitted SHA is immutable for that run;
+  later upstream movement belongs to merge-queue verification.
+- **Rollback:** revert the change to restore local accepted-base behavior. No
+  schema or stored-data rollback is involved.
+
+## Completion gate
+
+- Focused Node tests, policy guards, full exact-tree local-CI, and production
+  build pass.
+- The upstream-advance regression proves the new base SHA is used.
+- Evidence fixtures prove all three states.
+- No UI or migration changes.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-1BDBA8AA`
+- Receipt: `cms8bhbof07ut01qop006uprw`
+- Mapping: `base-freshness` -> `BI-1BDBA8AA`
+- Rationale: fetch behavior and evidence classification must ship together to
+  avoid changing execution without truthful provenance.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -301,7 +301,7 @@ abandoned entry.
 **The gate command has a checked-in default (BI-157DC9B2, BI-4BE30454):**
 [`scripts/local-ci-runner.mjs`](../../scripts/local-ci-runner.mjs) runs the
 canonical merged-code plan (`scripts/lib/local-integration-ci.mjs`: checkout
-the locally available accepted-base ref, `origin/main` by default → merge
+the admission-resolved accepted-base ref, `origin/main` by default → merge
 candidate → sandbox-freshness converge → vitest → typecheck → production build)
 in a dedicated **non-mutating scratch worktree** (`~/dpf-worktrees/.local-ci-runner`
 for slot 0 and a manifest-owned sibling for slot 1) — never in your topic
@@ -309,15 +309,28 @@ worktree. It records content-addressed
 metadata to `.git/dpf-local-ci-metadata.json` and into MCP evidence: candidate
 ref/SHA, base ref/SHA, integration commit SHA, synthesized tree SHA, command
 list, timestamps, slot key, Compose/PostgreSQL identities, the exact production
-artifact identity, whether the accepted base came from a local ref or explicit
-`--fetch-base`, toolchain fingerprint, and gate-evidence expiry. The evidence
+artifact identity, whether the accepted base was proven `remote-current`,
+explicitly `offline-accepted`, or stopped as `fetch-failed`, toolchain
+fingerprint, and gate-evidence expiry. The evidence
 also carries a `resilience` envelope: `publicationMode` (`deferred` by default
-or explicit `push-before-lease`), `acceptedBaseMode` (`local-ref` or
-`fetch-base`), and `networkTolerance` (`offline-capable` only when publication
-is deferred and the accepted base was local).
-`DPF_LOCAL_CI_BASE_REF` can point at another local accepted-base ref;
-`DPF_LOCAL_CI_FETCH_BASE=1` / `--fetch-base` is the explicit network-refresh
-mode. `DPF_LOCAL_CI_COMMAND` remains an explicit override. The
+or explicit `push-before-lease`), `acceptedBaseMode` (the same authoritative
+freshness status), and `networkTolerance` (`explicit-offline` only when the
+operator selected offline accepted-base mode).
+
+Online refresh is the default. After the lease admits the run, the runner uses
+the shared-safe fetch helper to refresh `origin/main`, resolves one immutable
+base SHA, and passes that SHA to the child plan without fetching again. A
+failed fetch records `fetch-failed` and exits before integration synthesis or
+expensive gates. This admission boundary avoids repeated rebase/rerun churn
+while queued; later movement on `main` is reconciled by the merge queue.
+
+Offline operation must be explicit:
+`--offline-accepted-base` or
+`DPF_LOCAL_CI_OFFLINE_ACCEPTED_BASE=1`. In that mode,
+`DPF_LOCAL_CI_BASE_REF` may point at another locally available accepted-base
+ref and evidence is labeled `offline-accepted`. `--fetch-base` and
+`DPF_LOCAL_CI_FETCH_BASE=1` remain compatibility aliases for the default
+required online refresh. `DPF_LOCAL_CI_COMMAND` remains an explicit override. The
 old Phase 1 stub is only reachable via `DPF_ALLOW_LOCAL_CI_STUB=1` for contract
 tests and must never be used as release evidence.
 
@@ -354,10 +367,11 @@ lock and scratch pnpm store are derived from the same manifest, so convergence
 or cleanup in one slot cannot erase the peer's duplicate-install guard or
 dependency graph.
 
-The network-disconnect proof is encoded in
+The explicit-offline network-disconnect proof is encoded in
 `tests/release/local-ci-gate-contract.test.mjs`: the contract denies network
-Git verbs during `gate-worktree.sh`, records local-only evidence with
-`networkTolerance=offline-capable`, then runs `.githooks/pre-push-gate` through
+Git verbs during `gate-worktree.sh`, selects offline accepted-base mode,
+records local-only evidence with `networkTolerance=explicit-offline`, then
+runs `.githooks/pre-push-gate` through
 the same no-network Git wrapper and proves the same unexpired SHA-bound record
 is sufficient for later publication.
 

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -36,6 +36,7 @@ import {
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
 } from "./lib/local-ci-slot-manifest.mjs";
+import { classifyBaseResilience } from "./lib/local-ci-base-freshness.mjs";
 import { writeLocalCiGateState } from "./lib/local-ci-gate-state.mjs";
 import {
   sampleLocalCiHostPressure,
@@ -1283,11 +1284,10 @@ async function main() {
   } catch {
     // no metadata written by this run — evidence.content stays null, matching the sh port.
   }
-  const resilience = {
-    publicationMode: options.pushBranch ? "push-before-lease" : "deferred",
-    acceptedBaseMode: contentMetadata?.fetchBase === true ? "fetch-base" : "local-ref",
-    networkTolerance: (!options.pushBranch && contentMetadata?.fetchBase !== true) ? "offline-capable" : "network-required",
-  };
+  const resilience = classifyBaseResilience(
+    contentMetadata,
+    options.pushBranch ? "push-before-lease" : "deferred",
+  );
 
   const commandLabel = commandSpec ? commandSpec.label : "sandbox checkout/build stub";
   let evidenceArgs = {

--- a/scripts/lib/local-ci-base-freshness.mjs
+++ b/scripts/lib/local-ci-base-freshness.mjs
@@ -1,0 +1,88 @@
+import { fetchOriginMainSharedSafe } from "./git-fetch-shared-safe.mjs";
+
+export const LOCAL_CI_BASE_FRESHNESS = Object.freeze({
+  remoteCurrent: "remote-current",
+  offlineAccepted: "offline-accepted",
+  fetchFailed: "fetch-failed",
+});
+
+export function resolveBaseFreshnessPolicy({
+  argv = [],
+  env = {},
+  baseRef = "origin/main",
+} = {}) {
+  const offline = argv.includes("--offline-accepted-base")
+    || env.DPF_LOCAL_CI_OFFLINE_ACCEPTED_BASE === "1";
+  const explicitFetch = argv.includes("--fetch-base")
+    || env.DPF_LOCAL_CI_FETCH_BASE === "1";
+  if (offline && explicitFetch) {
+    throw new Error("--offline-accepted-base conflicts with --fetch-base");
+  }
+  if (!offline && baseRef !== "origin/main") {
+    throw new Error(
+      `online base freshness only supports origin/main; pass --offline-accepted-base to accept local ref ${baseRef}`,
+    );
+  }
+  return {
+    mode: offline ? "offline-accepted" : "remote-required",
+    fetchRequired: !offline,
+  };
+}
+
+export function refreshAcceptedBase({
+  policy,
+  baseRef,
+  cwd,
+  runGit,
+  now = () => new Date(),
+}) {
+  const resolvedAt = now().toISOString();
+  if (policy.mode === "offline-accepted") {
+    const baseSha = runGit(["rev-parse", "--verify", baseRef], cwd).trim();
+    if (!baseSha) throw new Error(`accepted base ref not found locally: ${baseRef}`);
+    return {
+      status: LOCAL_CI_BASE_FRESHNESS.offlineAccepted,
+      baseSha,
+      resolvedAt,
+      fetchMode: null,
+      error: null,
+    };
+  }
+
+  try {
+    const fetch = fetchOriginMainSharedSafe((args) => runGit(args, cwd));
+    const baseSha = runGit(["rev-parse", "--verify", baseRef], cwd).trim();
+    if (!baseSha) throw new Error(`ref ${baseRef} did not resolve after fetch`);
+    return {
+      status: LOCAL_CI_BASE_FRESHNESS.remoteCurrent,
+      baseSha,
+      resolvedAt,
+      fetchMode: fetch.mode,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      status: LOCAL_CI_BASE_FRESHNESS.fetchFailed,
+      baseSha: null,
+      resolvedAt,
+      fetchMode: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function classifyBaseResilience(contentMetadata, publicationMode = "deferred") {
+  const acceptedBaseMode = contentMetadata?.baseFreshness?.status
+    ?? (contentMetadata
+      ? (contentMetadata.fetchBase === true ? "fetch-base" : "local-ref")
+      : "unknown");
+  return {
+    publicationMode,
+    acceptedBaseMode,
+    networkTolerance: acceptedBaseMode === LOCAL_CI_BASE_FRESHNESS.offlineAccepted
+      ? "explicit-offline"
+      : acceptedBaseMode === "local-ref"
+        ? "offline-capable"
+        : "network-required",
+  };
+}

--- a/scripts/lib/local-ci-base-freshness.test.mjs
+++ b/scripts/lib/local-ci-base-freshness.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  LOCAL_CI_BASE_FRESHNESS,
+  classifyBaseResilience,
+  refreshAcceptedBase,
+  resolveBaseFreshnessPolicy,
+} from "./local-ci-base-freshness.mjs";
+
+function git(cwd, args, env = {}) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "DPF Test",
+      GIT_AUTHOR_EMAIL: "dpf-test@example.invalid",
+      GIT_COMMITTER_NAME: "DPF Test",
+      GIT_COMMITTER_EMAIL: "dpf-test@example.invalid",
+      ...env,
+    },
+  }).trim();
+}
+
+test("freshness policy defaults online and makes offline acceptance explicit", () => {
+  assert.deepEqual(resolveBaseFreshnessPolicy(), {
+    mode: "remote-required",
+    fetchRequired: true,
+  });
+  assert.deepEqual(
+    resolveBaseFreshnessPolicy({ argv: ["--offline-accepted-base"] }),
+    { mode: "offline-accepted", fetchRequired: false },
+  );
+  assert.throws(
+    () => resolveBaseFreshnessPolicy({
+      argv: ["--offline-accepted-base", "--fetch-base"],
+    }),
+    /conflicts/,
+  );
+});
+
+test("online admission refresh uses origin/main that advanced after clone", () => {
+  const root = mkdtempSync(join(tmpdir(), "dpf-base-freshness-"));
+  try {
+    const remote = join(root, "remote.git");
+    const seed = join(root, "seed");
+    const work = join(root, "work");
+    git(root, ["init", "--bare", remote]);
+    git(root, ["clone", remote, seed]);
+    writeFileSync(join(seed, "value.txt"), "one\n");
+    git(seed, ["add", "value.txt"]);
+    git(seed, ["commit", "-m", "initial"]);
+    git(seed, ["branch", "-M", "main"]);
+    git(seed, ["push", "-u", "origin", "main"]);
+    git(root, ["clone", "--branch", "main", remote, work]);
+    const initial = git(work, ["rev-parse", "origin/main"]);
+
+    writeFileSync(join(seed, "value.txt"), "two\n");
+    git(seed, ["add", "value.txt"]);
+    git(seed, ["commit", "-m", "advance"]);
+    git(seed, ["push", "origin", "main"]);
+    const advanced = git(seed, ["rev-parse", "HEAD"]);
+    assert.notEqual(initial, advanced);
+
+    const result = refreshAcceptedBase({
+      policy: { mode: "remote-required", fetchRequired: true },
+      baseRef: "origin/main",
+      cwd: work,
+      runGit: (args, cwd) => git(cwd, args),
+      now: () => new Date("2026-07-31T02:00:00.000Z"),
+    });
+
+    assert.equal(result.status, LOCAL_CI_BASE_FRESHNESS.remoteCurrent);
+    assert.equal(result.baseSha, advanced);
+    assert.equal(git(work, ["rev-parse", "origin/main"]), advanced);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fetch failures are explicit evidence, not offline acceptance", () => {
+  const result = refreshAcceptedBase({
+    policy: { mode: "remote-required", fetchRequired: true },
+    baseRef: "origin/main",
+    cwd: "ignored",
+    runGit: () => {
+      throw new Error("network unavailable");
+    },
+    now: () => new Date("2026-07-31T02:00:00.000Z"),
+  });
+
+  assert.deepEqual(result, {
+    status: LOCAL_CI_BASE_FRESHNESS.fetchFailed,
+    baseSha: null,
+    resolvedAt: "2026-07-31T02:00:00.000Z",
+    fetchMode: null,
+    error: "network unavailable",
+  });
+});
+
+test("resilience evidence preserves explicit states and legacy readers", () => {
+  assert.deepEqual(
+    classifyBaseResilience({
+      schemaVersion: 2,
+      fetchBase: true,
+      baseFreshness: { status: "remote-current" },
+    }),
+    {
+      publicationMode: "deferred",
+      acceptedBaseMode: "remote-current",
+      networkTolerance: "network-required",
+    },
+  );
+  assert.deepEqual(
+    classifyBaseResilience({
+      schemaVersion: 2,
+      fetchBase: false,
+      baseFreshness: { status: "offline-accepted" },
+    }),
+    {
+      publicationMode: "deferred",
+      acceptedBaseMode: "offline-accepted",
+      networkTolerance: "explicit-offline",
+    },
+  );
+  assert.deepEqual(
+    classifyBaseResilience({ schemaVersion: 1, fetchBase: false }),
+    {
+      publicationMode: "deferred",
+      acceptedBaseMode: "local-ref",
+      networkTolerance: "offline-capable",
+    },
+  );
+  assert.deepEqual(classifyBaseResilience(null), {
+    publicationMode: "deferred",
+    acceptedBaseMode: "unknown",
+    networkTolerance: "network-required",
+  });
+});

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -150,7 +150,7 @@ describe("createLocalIntegrationPlan", () => {
     );
   });
 
-  it("uses a locally available accepted-base ref without fetching by default (BI-76551B2D)", () => {
+  it("uses the runner-resolved accepted base without fetching a second time", () => {
     const plan = createLocalIntegrationPlan({
       candidateBranch: "feat/local-ci-content-evidence",
       mode: "single-branch",

--- a/scripts/local-ci-runner.mjs
+++ b/scripts/local-ci-runner.mjs
@@ -12,7 +12,7 @@
 // here so the lease/resource contract has one implementation source.
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { connect } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +21,11 @@ import {
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
 } from "./lib/local-ci-slot-manifest.mjs";
+import {
+  LOCAL_CI_BASE_FRESHNESS,
+  refreshAcceptedBase,
+  resolveBaseFreshnessPolicy,
+} from "./lib/local-ci-base-freshness.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 
@@ -36,6 +41,14 @@ function git(args, cwd) {
 function gitOrEmpty(args, cwd) {
   const result = git(args, cwd);
   return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function gitOutput(args, cwd) {
+  const result = git(args, cwd);
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `git ${args.join(" ")} failed`).trim());
+  }
+  return result.stdout;
 }
 
 function redactUrl(url) {
@@ -177,7 +190,8 @@ async function main() {
       "Options:\n" +
       "  --candidate BRANCH   Branch to gate (default: current branch)\n" +
       "  --base-ref REF       Locally available accepted-base ref (default: origin/main)\n" +
-      "  --fetch-base         Fetch origin/main before checkout (explicit network mode)\n" +
+      "  --fetch-base         Compatibility alias for the default required online refresh\n" +
+      "  --offline-accepted-base  Explicitly use the locally available base without network proof\n" +
       "  --slot-key SLOT      Admitted physical slot (default: DPF_LOCAL_CI_SLOT_KEY or slot-0)\n" +
       "  --workspace PATH     Explicit scratch workspace override (default: admitted manifest)\n" +
       "  --dry-run            Print the resolved workspace + plan; run nothing\n" +
@@ -189,7 +203,12 @@ async function main() {
   const env = process.env;
   let candidate = valueAfter("--candidate");
   const baseRef = valueAfter("--base-ref") || env.DPF_LOCAL_CI_BASE_REF || "origin/main";
-  const fetchBase = argv.includes("--fetch-base") || env.DPF_LOCAL_CI_FETCH_BASE === "1";
+  let baseFreshnessPolicy;
+  try {
+    baseFreshnessPolicy = resolveBaseFreshnessPolicy({ argv, env, baseRef });
+  } catch (error) {
+    die(error instanceof Error ? error.message : String(error));
+  }
   const slotKey = valueAfter("--slot-key") || env.DPF_LOCAL_CI_SLOT_KEY || "slot-0";
   let workspace = valueAfter("--workspace") || env.DPF_LOCAL_CI_WORKSPACE || "";
   const dryRun = argv.includes("--dry-run");
@@ -222,29 +241,64 @@ async function main() {
   }
 
   const candidateSha = gitOrEmpty(["-C", repoTop, "rev-parse", "--verify", candidate]);
-  const baseSha = gitOrEmpty(["-C", repoTop, "rev-parse", "--verify", baseRef]);
+  const plannedFreshnessStatus = baseFreshnessPolicy.fetchRequired
+    ? "pending-admission-refresh"
+    : LOCAL_CI_BASE_FRESHNESS.offlineAccepted;
+  const localBaseSha = gitOrEmpty(["-C", repoTop, "rev-parse", "--verify", baseRef]);
+  let baseFreshness = {
+    status: plannedFreshnessStatus,
+    baseSha: localBaseSha || null,
+    resolvedAt: null,
+    fetchMode: null,
+    error: null,
+  };
+  if (!dryRun) {
+    baseFreshness = refreshAcceptedBase({
+      policy: baseFreshnessPolicy,
+      baseRef,
+      cwd: repoTop,
+      runGit: gitOutput,
+      now: () => new Date(),
+    });
+  }
+  const baseSha = baseFreshness.baseSha || "";
   const baseCommitDate = baseSha ? gitOrEmpty(["-C", repoTop, "show", "-s", "--format=%cI", baseSha]) : "";
   const metadataFile = env.DPF_LOCAL_CI_METADATA_FILE || manifest.evidence.metadata;
 
   if (dryRun) {
     process.stdout.write("local-ci-runner dry-run\n");
     process.stdout.write(
-      `candidate=${candidate}\ncandidateSha=${candidateSha || "unresolved"}\nbaseRef=${baseRef}\nbaseSha=${baseSha || "unresolved"}\nbaseCommitDate=${baseCommitDate}\nfetchBase=${fetchBase ? "1" : "0"}\nslotKey=${manifest.slotKey}\nmanifestVersion=${manifest.schemaVersion}\nroot=${root}\nworkspace=${workspace}\ncomposeProject=${manifest.compose.project}\nportalUrl=${manifest.portal.url}\npostgresContainer=${manifest.postgres.container}\npostgresDatabase=${manifest.postgres.database}\nmetadataFile=${metadataFile}\n`,
+      `candidate=${candidate}\ncandidateSha=${candidateSha || "unresolved"}\nbaseRef=${baseRef}\nbaseSha=${baseSha || "unresolved"}\nbaseCommitDate=${baseCommitDate}\nfetchBase=${baseFreshnessPolicy.fetchRequired ? "1" : "0"}\nslotKey=${manifest.slotKey}\nmanifestVersion=${manifest.schemaVersion}\nroot=${root}\nworkspace=${workspace}\ncomposeProject=${manifest.compose.project}\nportalUrl=${manifest.portal.url}\npostgresContainer=${manifest.postgres.container}\npostgresDatabase=${manifest.postgres.database}\nmetadataFile=${metadataFile}\n`,
     );
-    const fetchFlag = fetchBase ? " --fetch-base" : "";
+    process.stdout.write(`baseFreshnessPolicy=${baseFreshnessPolicy.mode}\nbaseFreshnessStatus=${baseFreshness.status}\n`);
     process.stdout.write(
-      `plan=node scripts/local-integration-ci.mjs --candidate ${candidate} --base-ref ${baseRef} --candidate-sha ${candidateSha} --base-sha ${baseSha} --slot-key ${manifest.slotKey} --metadata-out ${metadataFile}${fetchFlag} (in workspace)\n`,
+      `plan=node scripts/local-integration-ci.mjs --candidate ${candidate} --base-ref ${baseRef} --candidate-sha ${candidateSha} --base-sha ${baseSha} --slot-key ${manifest.slotKey} --metadata-out ${metadataFile} --base-freshness-status ${baseFreshness.status} (in workspace)\n`,
     );
     process.exit(0);
   }
 
   if (!candidateSha) die(`candidate ref not found locally: ${candidate}`);
+  if (baseFreshness.status === LOCAL_CI_BASE_FRESHNESS.fetchFailed) {
+    mkdirSync(dirname(metadataFile), { recursive: true });
+    writeFileSync(metadataFile, `${JSON.stringify({
+      schemaVersion: 2,
+      candidateRef: candidate,
+      candidateSha,
+      baseRef,
+      fetchBase: true,
+      baseFreshness,
+      completedAt: new Date().toISOString(),
+    }, null, 2)}\n`);
+    die(`required origin/main refresh failed: ${baseFreshness.error}`);
+  }
   if (!baseSha) die(`accepted base ref not found locally: ${baseRef} (fetch or set DPF_LOCAL_CI_BASE_REF to a local ref)`);
 
   process.stdout.write(`local-ci-runner: candidate ${candidate} @ ${candidateSha}\n`);
   process.stdout.write(`local-ci-runner: accepted base ${baseRef} @ ${baseSha}${baseCommitDate ? ` (commit date ${baseCommitDate})` : ""}\n`);
-  if (!fetchBase) {
-    process.stdout.write("local-ci-runner: using locally available base ref without fetch (BI-76551B2D)\n");
+  if (baseFreshness.status === LOCAL_CI_BASE_FRESHNESS.offlineAccepted) {
+    process.stdout.write("local-ci-runner: explicit offline mode accepted the locally available base ref\n");
+  } else {
+    process.stdout.write(`local-ci-runner: origin/main refreshed at admission (${baseFreshness.fetchMode})\n`);
   }
 
   ensureScratchWorkspace(root, workspace);
@@ -259,10 +313,12 @@ async function main() {
     "--base-ref", baseRef,
     "--candidate-sha", candidateSha,
     "--base-sha", baseSha,
+    "--base-freshness-status", baseFreshness.status,
+    "--base-resolved-at", baseFreshness.resolvedAt || "",
+    "--base-fetch-mode", baseFreshness.fetchMode || "",
     "--slot-key", manifest.slotKey,
     "--metadata-out", metadataFile,
   ];
-  if (fetchBase) args.push("--fetch-base");
   if (testDatabaseUrl) {
     args.push("--migrate-deploy");
     childEnv.DATABASE_URL = testDatabaseUrl;

--- a/scripts/local-ci-runner.test.mjs
+++ b/scripts/local-ci-runner.test.mjs
@@ -13,12 +13,12 @@ function git(args) {
   return result.stdout.trim();
 }
 
-function dryRun(slotKey) {
+function dryRun(slotKey, extraArgs = [], env = {}) {
   const candidate = git(["rev-parse", "--abbrev-ref", "HEAD"]);
   const result = spawnSync(
     process.execPath,
-    [cli, "--candidate", candidate, "--slot-key", slotKey, "--dry-run"],
-    { encoding: "utf8" },
+    [cli, "--candidate", candidate, "--slot-key", slotKey, "--dry-run", ...extraArgs],
+    { encoding: "utf8", env: { ...process.env, ...env } },
   );
   assert.equal(result.status, 0, result.stderr);
   return Object.fromEntries(
@@ -50,6 +50,24 @@ test("dry-run resolves all runner identities from the admitted slot", () => {
   }
   assert.match(slot0.plan, /--slot-key slot-0/);
   assert.match(slot1.plan, /--slot-key slot-1/);
+});
+
+test("online current-main refresh is the default and is resolved before the child plan", () => {
+  const run = dryRun("slot-0");
+
+  assert.equal(run.baseFreshnessPolicy, "remote-required");
+  assert.equal(run.baseFreshnessStatus, "pending-admission-refresh");
+  assert.equal(run.fetchBase, "1");
+  assert.doesNotMatch(run.plan, /--fetch-base/);
+});
+
+test("offline accepted-base operation requires an explicit flag", () => {
+  const run = dryRun("slot-0", ["--offline-accepted-base"]);
+
+  assert.equal(run.baseFreshnessPolicy, "offline-accepted");
+  assert.equal(run.baseFreshnessStatus, "offline-accepted");
+  assert.equal(run.fetchBase, "0");
+  assert.doesNotMatch(run.plan, /--fetch-base/);
 });
 
 test("a foreign listener never satisfies manifest Postgres ownership", () => {

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -20,6 +20,10 @@ const candidateBranch = valueAfter("--candidate");
 const baseRef = valueAfter("--base-ref") || "origin/main";
 const candidateSha = valueAfter("--candidate-sha");
 const baseSha = valueAfter("--base-sha");
+const baseFreshnessStatus = valueAfter("--base-freshness-status")
+  || (process.argv.includes("--fetch-base") ? "remote-current" : "offline-accepted");
+const baseResolvedAt = valueAfter("--base-resolved-at");
+const baseFetchMode = valueAfter("--base-fetch-mode");
 const metadataOut = valueAfter("--metadata-out");
 const evidencePlanOut = valueAfter("--evidence-plan-out")
   || (metadataOut ? join(dirname(metadataOut), "dpf-ci-evidence-plan.json") : "");
@@ -81,13 +85,18 @@ if (metadataOut) {
     nextBuildId,
   });
   const payload = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     bi: "BI-76551B2D",
     mode,
     candidateRef: candidateBranch,
     candidateSha: candidateSha || resolveGitRevision(candidateBranch),
     baseRef,
-    fetchBase,
+    fetchBase: baseFreshnessStatus === "remote-current" || fetchBase,
+    baseFreshness: {
+      status: baseFreshnessStatus,
+      resolvedAt: baseResolvedAt || null,
+      fetchMode: baseFetchMode || null,
+    },
     baseSha: baseSha || resolveGitRevision(baseRef),
     integrationBranch: plan.integrationBranch,
     slotKey: slotKey || null,

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -206,6 +206,8 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-gate-state.mjs"), join(temp, "scripts", "lib", "local-ci-gate-state.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-host-pressure.mjs"), join(temp, "scripts", "lib", "local-ci-host-pressure.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "agent-identity.mjs"), join(temp, "scripts", "lib", "agent-identity.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "local-ci-base-freshness.mjs"), join(temp, "scripts", "lib", "local-ci-base-freshness.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "git-fetch-shared-safe.mjs"), join(temp, "scripts", "lib", "git-fetch-shared-safe.mjs"));
   cpSync(
     join(repoRoot, "apps", "web", "lib", "nonprod", "local-ci-slot-resources.json"),
     join(temp, "apps", "web", "lib", "nonprod", "local-ci-slot-resources.json"),
@@ -285,8 +287,8 @@ test("gate-worktree.mjs claims, records, and releases in order, and carries evid
     );
     assert.deepEqual(evidenceCall.params.arguments.evidence.resilience, {
       publicationMode: "deferred",
-      acceptedBaseMode: "local-ref",
-      networkTolerance: "offline-capable",
+      acceptedBaseMode: "unknown",
+      networkTolerance: "network-required",
     });
 
     const state = JSON.parse(readFileSync(join(dir, ".git", "dpf-local-ci-gate.json"), "utf8"));
@@ -637,13 +639,18 @@ test("gate-worktree.mjs carries content-addressed local integration metadata int
   writeFileSync(writerScript, `
 import { writeFileSync } from "node:fs";
 writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
-  schemaVersion: 1,
+  schemaVersion: 2,
   bi: "BI-76551B2D",
   candidateRef: "feat/local-ci-sandbox",
   candidateSha: "candidate-sha",
   baseRef: "origin/main",
-  fetchBase: false,
+  fetchBase: true,
   baseSha: "base-sha",
+  baseFreshness: {
+    status: "remote-current",
+    resolvedAt: "2026-07-31T02:00:00.000Z",
+    fetchMode: "full-fetch"
+  }
 }) + "\\n");
 `);
 
@@ -661,13 +668,23 @@ writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
 
     const evidenceCall = mcp.calls.find((c) => c.params.name === "record_local_integration_result");
     assert.deepEqual(evidenceCall.params.arguments.evidence.content, {
-      schemaVersion: 1,
+      schemaVersion: 2,
       bi: "BI-76551B2D",
       candidateRef: "feat/local-ci-sandbox",
       candidateSha: "candidate-sha",
       baseRef: "origin/main",
-      fetchBase: false,
+      fetchBase: true,
       baseSha: "base-sha",
+      baseFreshness: {
+        status: "remote-current",
+        resolvedAt: "2026-07-31T02:00:00.000Z",
+        fetchMode: "full-fetch",
+      },
+    });
+    assert.deepEqual(evidenceCall.params.arguments.evidence.resilience, {
+      publicationMode: "deferred",
+      acceptedBaseMode: "remote-current",
+      networkTolerance: "network-required",
     });
   } finally {
     await mcp.close();


### PR DESCRIPTION
## Outcome

Makes the shared local-CI gate prove that its accepted `origin/main` is the current remote main before merged-code verification. This prevents stale local refs from producing false merge evidence and repetitive PR retries.

## Changes

- Adds a fail-closed base-freshness resolver with explicit `remote-current`, `local-ref`, and unavailable classifications.
- Refreshes the accepted base at admission and records the resolved base mode in durable evidence.
- Keeps offline/local-ref behavior explicit instead of silently claiming remote freshness.
- Extends the pregate contract, runner coverage, and contributor documentation.

## Verification

- Exact `pnpm pregate -- --lease-wait-seconds 7200` passed for `fix/local-ci-base-freshness@604354c5c7cab51a380f9c0c283982602e1b0f78`.
- Local-CI evidence `cms8jp7vw07yl01qojkr08jf1`, lease `NPEL-9A598180D4`.
- Freshness verdict green: Next 16.2.11, React 19.2.8, React DOM 19.2.8, TypeScript 6.0.3, Prisma 7.8.0, Vitest 4.1.10.
- Prisma deploy found 479 migrations and no pending migrations.
- Full applicable Vitest suite, production Next.js build, documentation link checks, and policy guards passed.
- No UI behavior changed; UX runtime verification is not applicable.

## Documentation impact

Updated the local-CI operations guide, pre-PR gate documentation, and implementation plan because this changes contributor and CI behavior.

Seed-Fit-Decision: global-default

Local-CI-Evidence: cms8jp7vw07yl01qojkr08jf1 (fix/local-ci-base-freshness@604354c5c7cab51a380f9c0c283982602e1b0f78)
