### PR TITLE
fix(build-studio): block premature pull requests

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8670,6 +8670,7 @@
         "what-it-asserts-ready-iff-all-hold",
         "observation-versus-merge-authority",
         "know-the-constraints-before-you-write-pnpm-gatecontext",
+        "before-a-pr-exists-pnpm-prready",
         "tests-ci"
       ]
     },

--- a/apps/web/lib/integrate/build-agent-prompts.test.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.test.ts
@@ -65,8 +65,8 @@ describe("getBuildPhasePrompt", () => {
   it("returns review prompt for review phase", async () => {
     const prompt = await getBuildPhasePrompt("review");
     expect(prompt).toContain("acceptanceMet");
-    expect(prompt).toContain("Typecheck MUST be clean");
-    expect(prompt).toContain("Treat unrelated unit-test failures as informational");
+    expect(prompt).toContain("Typecheck and the applicable test suite MUST be clean");
+    expect(prompt).toContain("Treat every reported test failure as unresolved evidence");
     expect(prompt).toContain("Ready to ship");
   });
   it("returns ship prompt for ship phase", async () => {

--- a/apps/web/lib/integrate/build-agent-prompts.ts
+++ b/apps/web/lib/integrate/build-agent-prompts.ts
@@ -393,7 +393,7 @@ You are performing the role of the release-acceptance-agent (AGT-132): validatin
 
 RELEASE GATE CHECKS (all must pass before shipping):
 
-1. Run the sandbox verification check: call run_sandbox_tests. Typecheck MUST be clean before ship. The wider unit-test surface is currently informational — summarize likely build-specific failures if they appear, but do NOT block ship solely because unrelated suite failures still exist while typecheck is clean.
+1. Run the sandbox verification check: call run_sandbox_tests. Typecheck and the applicable test suite MUST be clean before ship. A failing test is a release blocker unless the underlying test is corrected or the change is returned to build.
 2. Confirm live UX verification status from the build record. If UX verification has not run yet or failed, direct the user to use the Studio Control action in Build Studio to run it, then wait for that evidence before shipping. If uxVerificationStatus is "complete" or "skipped", reuse that evidence.
 3. Check documentation evidence: updated docs for user-facing/coworker-facing/public/install/ops/architecture/external-agent impact OR a concrete no-docs-needed attestation. If neither exists, return to build before shipping.
 4. Evaluate each acceptance criterion from the design document. Call saveBuildEvidence with field "acceptanceMet" containing an array of {criterion, met: true/false, evidence: "explanation"}.
@@ -409,7 +409,7 @@ RELEASE GATE CHECKS (all must pass before shipping):
 
 RULES:
 - ALWAYS require clean typecheck plus completed UX verification before presenting a ship recommendation.
-- Treat unrelated unit-test failures as informational until the broader test surface is cleaned up. Do not mark acceptance unmet solely because the full suite contains legacy failures outside this build's scope.
+- Treat every reported test failure as unresolved evidence. Do not ship until the applicable suite is green and any genuinely unrelated infrastructure failure is separately classified with evidence.
 - Do NOT show raw test output unless Dev mode is enabled. Summarize in plain language.
 - Do NOT claim tests pass without showing verification evidence.
 - Do NOT claim the release gate passed if documentation evidence is missing for a docs-impacting change.
@@ -459,19 +459,19 @@ If mode is "contributing":
   - Continue to STEP 5 (deployment).
 
 STEP 5: Create a PR for the portal codebase.
-  Call create_portal_pr. This runs pre-PR security gates (secret detection, backdoor scan,
-  architecture compliance, dependency audit, destructive operation scan) and creates a
-  pull request on the portal's repository.
+  Call create_portal_pr with the reviewed readinessTrailers from the injected gate context.
+  It publishes a recoverable branch first, checks that exact published commit with the
+  canonical PR-readiness contract, and creates a PR only when every gate passes.
   - Do NOT create a portal PR with raw git, gh, or a provider-native PR shortcut.
     create_portal_pr is the governed Build Studio PR path and generates a DCO
     Signed-off-by trailer for the commit.
   - If manual recovery is unavoidable, every commit in the PR must include a
     Signed-off-by trailer. Use git commit -s and make sure the branch contains
     only the current Build Studio change.
-  - If all gates pass AND the build is fully verified, the PR auto-merges (squash) and
+  - If all gates pass AND the build is fully verified, the PR enters governed delivery and
     the build is marked complete. Tell the user the PR was merged.
-  - If any gate fails or verification has issues, the PR is created with findings posted
-    as a comment. Tell the user what needs review and include the PR URL.
+  - If any gate fails or verification is incomplete, no PR is opened. Tell the user
+    the exact blockers and include the recoverable branch and commit returned by the tool.
   - If create_portal_pr fails (e.g. no GitHub token), continue to STEP 6. The feature
     can still be deployed via the promoter without a PR.
 

--- a/apps/web/lib/integrate/build-studio-pr-readiness.test.ts
+++ b/apps/web/lib/integrate/build-studio-pr-readiness.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPublishedReadinessCommand,
+  evaluateBuildVerificationReadiness,
+  parsePublishedReadinessOutput,
+} from "./build-studio-pr-readiness";
+
+describe("Build Studio PR readiness", () => {
+  it("blocks every incomplete build-verification class", () => {
+    expect(evaluateBuildVerificationReadiness({
+      typecheckPassed: false,
+      testsFailed: 2,
+      acceptanceMet: 1,
+      acceptanceTotal: 3,
+    }).blockers).toEqual([
+      "TypeCheck did not pass.",
+      "2 test(s) failed.",
+      "2 acceptance criterion/criteria remain unmet.",
+    ]);
+  });
+
+  it("requires at least one completed acceptance criterion", () => {
+    expect(evaluateBuildVerificationReadiness({
+      typecheckPassed: true,
+      testsFailed: 0,
+      acceptanceMet: 0,
+      acceptanceTotal: 0,
+    }).ready).toBe(false);
+  });
+
+  it("builds an exact published-ref command without embedding the PR body", () => {
+    const command = buildPublishedReadinessCommand({
+      branchName: "build/FB-123",
+      commitSha: "a".repeat(40),
+      restoreBranch: "build/FB-123",
+      prBodyBase64: "dmFsaWRhdGVkIGJvZHk=",
+      repositoryOwner: "OpenDigitalProductFactory",
+      repositoryName: "opendigitalproductfactory",
+    });
+    expect(command).toContain("--published-ref");
+    expect(command).toContain("refs/remotes/origin/build/FB-123");
+    expect(command).toContain("a".repeat(40));
+    expect(command).toContain("--json");
+    expect(command).toContain("GIT_ASKPASS");
+    expect(command).not.toContain("ghp_");
+    expect(command).not.toContain("validated body");
+  });
+
+  it("parses the machine-readable verdict after sandbox noise", () => {
+    expect(parsePublishedReadinessOutput(
+      `fetch complete\nDPF_PR_READINESS_JSON={"ready":false,"blockers":["Docs Impact failed locally."]}\nDPF_PR_READINESS_COMMAND fetch=0 checkout=0 readiness=1 restore=0\n`,
+    )).toEqual({
+      ready: false,
+      blockers: ["Docs Impact failed locally."],
+    });
+  });
+});

--- a/apps/web/lib/integrate/build-studio-pr-readiness.ts
+++ b/apps/web/lib/integrate/build-studio-pr-readiness.ts
@@ -1,0 +1,122 @@
+export interface BuildVerificationReadinessInput {
+  typecheckPassed: boolean;
+  testsFailed: number;
+  acceptanceMet: number;
+  acceptanceTotal: number;
+}
+
+export interface ReadinessVerdict {
+  ready: boolean;
+  blockers: string[];
+  warnings?: string[];
+}
+
+const SAFE_BRANCH = /^(?![-/])(?!.*(?:\.\.|\/\/|@\{|\\))[A-Za-z0-9._/-]+$/;
+const FULL_SHA = /^[a-f0-9]{40}$/;
+const REPOSITORY_PART = /^[A-Za-z0-9_.-]+$/;
+
+function assertSafeBranch(value: string, label: string): void {
+  if (!SAFE_BRANCH.test(value) || value.endsWith("/") || value.endsWith(".")) {
+    throw new Error(`${label} is not a safe Git branch name.`);
+  }
+}
+
+export function evaluateBuildVerificationReadiness(
+  input: BuildVerificationReadinessInput,
+): ReadinessVerdict {
+  const blockers: string[] = [];
+  if (!input.typecheckPassed) blockers.push("TypeCheck did not pass.");
+  if (input.testsFailed > 0) blockers.push(`${input.testsFailed} test(s) failed.`);
+  if (input.acceptanceTotal < 1) {
+    blockers.push("No acceptance criteria were recorded as verification evidence.");
+  } else if (input.acceptanceMet < input.acceptanceTotal) {
+    blockers.push(
+      `${input.acceptanceTotal - input.acceptanceMet} acceptance criterion/criteria remain unmet.`,
+    );
+  }
+  return { ready: blockers.length === 0, blockers };
+}
+
+export function buildPublishedReadinessCommand(input: {
+  branchName: string;
+  commitSha: string;
+  restoreBranch: string;
+  prBodyBase64: string;
+  repositoryOwner: string;
+  repositoryName: string;
+}): string {
+  assertSafeBranch(input.branchName, "Published branch");
+  assertSafeBranch(input.restoreBranch, "Restore branch");
+  if (!FULL_SHA.test(input.commitSha)) throw new Error("Published commit is not a full Git SHA.");
+  if (!/^[A-Za-z0-9+/=]+$/.test(input.prBodyBase64)) {
+    throw new Error("PR body is not valid base64.");
+  }
+  if (!REPOSITORY_PART.test(input.repositoryOwner) || !REPOSITORY_PART.test(input.repositoryName)) {
+    throw new Error("Published repository identity is not safe.");
+  }
+
+  const remoteRef = `refs/remotes/origin/${input.branchName}`;
+  const remoteUrl = `https://github.com/${input.repositoryOwner}/${input.repositoryName}.git`;
+  const bodyFile = `.dpf-pr-body-${input.commitSha}.md`;
+  return [
+    "cd /workspace",
+    "IFS= read -r DPF_GITHUB_TOKEN",
+    "export DPF_GITHUB_TOKEN",
+    "askpass=$(mktemp)",
+    "printf '%s\\n' '#!/bin/sh' 'case \"$1\" in *Username*) echo x-access-token ;; *) printf \"%s\\\\n\" \"$DPF_GITHUB_TOKEN\" ;; esac' > \"$askpass\"",
+    "chmod 700 \"$askpass\"",
+    `printf '%s' '${input.prBodyBase64}' | base64 -d > '${bodyFile}'`,
+    `GIT_ASKPASS=\"$askpass\" GIT_TERMINAL_PROMPT=0 git fetch '${remoteUrl}' '+refs/heads/${input.branchName}:${remoteRef}' >/tmp/dpf-pr-fetch.log 2>&1`,
+    "fetch_rc=$?",
+    "readiness_rc=99",
+    `if [ \"$fetch_rc\" -eq 0 ]; then git checkout --detach '${input.commitSha}' >/tmp/dpf-pr-checkout.log 2>&1; checkout_rc=$?; else checkout_rc=99; fi`,
+    `if [ \"$checkout_rc\" -eq 0 ]; then node scripts/pr-readiness.mjs --pr-body-file '${bodyFile}' --published-ref '${remoteRef}' --json 2>&1; readiness_rc=$?; fi`,
+    `git checkout '${input.restoreBranch}' >/tmp/dpf-pr-restore.log 2>&1`,
+    "restore_rc=$?",
+    `rm -f '${bodyFile}' \"$askpass\"`,
+    "printf '\\nDPF_PR_READINESS_COMMAND fetch=%s checkout=%s readiness=%s restore=%s\\n' \"$fetch_rc\" \"$checkout_rc\" \"$readiness_rc\" \"$restore_rc\"",
+    "exit 0",
+  ].join("; ");
+}
+
+export function parsePublishedReadinessOutput(output: string): ReadinessVerdict {
+  const jsonLine = String(output)
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("DPF_PR_READINESS_JSON="));
+  const commandLine = String(output)
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("DPF_PR_READINESS_COMMAND "));
+
+  const commandStatus = commandLine?.match(
+    /^DPF_PR_READINESS_COMMAND fetch=(\d+) checkout=(\d+) readiness=(\d+) restore=(\d+)$/,
+  );
+  if (!commandStatus || commandStatus[1] !== "0" || commandStatus[2] !== "0"
+    || !["0", "1"].includes(commandStatus[3] ?? "") || commandStatus[4] !== "0") {
+    return {
+      ready: false,
+      blockers: [`Exact published-tree readiness could not complete: ${commandLine ?? "missing command status"}.`],
+    };
+  }
+  if (!jsonLine) {
+    return {
+      ready: false,
+      blockers: ["Exact published-tree readiness returned no machine-readable verdict."],
+    };
+  }
+  try {
+    const parsed = JSON.parse(jsonLine.slice("DPF_PR_READINESS_JSON=".length)) as ReadinessVerdict;
+    if (typeof parsed.ready !== "boolean" || !Array.isArray(parsed.blockers)) {
+      throw new Error("invalid shape");
+    }
+    const expectedExit = parsed.ready ? "0" : "1";
+    if (commandStatus[3] !== expectedExit) {
+      throw new Error("verdict and command exit disagree");
+    }
+    return parsed;
+  } catch {
+    return {
+      ready: false,
+      blockers: ["Exact published-tree readiness returned an invalid machine-readable verdict."],
+    };
+  }
+}

--- a/apps/web/lib/integrate/github-api-commit.test.ts
+++ b/apps/web/lib/integrate/github-api-commit.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createBranchAndPR } from "./github-api-commit";
+import {
+  createBranchAndPR,
+  openPullRequest,
+  publishBranchCommit,
+} from "./github-api-commit";
 
 // Minimal unified-diff shape extractNewFileContent can parse — its regex
 // expects exactly one line between "diff --git" and "--- /dev/null", so we
@@ -175,6 +179,48 @@ describe("createBranchAndPR head/base split", () => {
 
     expect(result.prUrl).toBe("https://github.com/base-owner/base-repo/pull/42");
     expect(result.prNumber).toBe(42);
+  });
+
+  it("can publish a recoverable branch without opening a pull request", async () => {
+    const { calls } = setupFetchMock();
+
+    const published = await publishBranchCommit({
+      headOwner: "upstream-org",
+      headRepo: "upstream-repo",
+      baseBranch: "main",
+      branchName: "feat/tiny",
+      commitMessage: SIGNED_COMMIT_MESSAGE,
+      diff: TINY_DIFF,
+      token: "ghp_test",
+    });
+
+    expect(published).toEqual({
+      branchName: "feat/tiny",
+      commitSha: "commit-sha-1",
+    });
+    expect(calls.some((call) => call.url.endsWith("/pulls"))).toBe(false);
+  });
+
+  it("opens a pull request from an already-published branch", async () => {
+    const { calls } = setupFetchMock();
+
+    const opened = await openPullRequest({
+      headOwner: "upstream-org",
+      headRepo: "upstream-repo",
+      baseOwner: "upstream-org",
+      baseRepo: "upstream-repo",
+      baseBranch: "main",
+      branchName: "feat/tiny",
+      prTitle: "feat: tiny",
+      prBody: "validated body",
+      labels: ["build-studio"],
+      token: "ghp_test",
+    });
+
+    expect(opened.prNumber).toBe(42);
+    const prPost = calls.find((call) => call.url.endsWith("/pulls"));
+    expect(prPost?.body?.body).toBe("validated body");
+    expect(calls.some((call) => call.url.includes("/git/commits"))).toBe(false);
   });
 
   it("opens a cross-repo PR with '<headOwner>:<branchName>' when headOwner !== baseOwner", async () => {

--- a/apps/web/lib/integrate/github-api-commit.ts
+++ b/apps/web/lib/integrate/github-api-commit.ts
@@ -56,6 +56,9 @@ export interface GitHubCommitResult {
   prNumber: number | null;
 }
 
+export type PublishedBranchCommit = Pick<GitHubCommitResult, "branchName" | "commitSha">;
+export type OpenPullRequestResult = Pick<GitHubCommitResult, "prUrl" | "prNumber">;
+
 const DCO_SIGNOFF_PATTERN = /^Signed-off-by:\s+(.+?)\s+<([^<>\s@]+@[^<>\s@]+)>$/im;
 
 type GitCommitIdentity = {
@@ -263,23 +266,17 @@ async function githubPost<T>(url: string, body: unknown, token: string): Promise
  *      surfaces their URL so callers can back-write the PR URL onto the
  *      FeaturePack.
  */
-export async function createBranchAndPR(input: {
+export async function publishBranchCommit(input: {
   /** Where the branch is pushed. For fork-pr, this is the contributor's fork. */
   headOwner: string;
   headRepo: string;
-  /** Where the PR is opened against. Always the upstream in fork-pr. */
-  baseOwner: string;
-  baseRepo: string;
   /** Base branch — typically "main". */
   baseBranch?: string;
   branchName: string;
   commitMessage: string;
   diff: string;
-  prTitle: string;
-  prBody: string;
-  labels: string[];
   token: string;
-}): Promise<GitHubCommitResult> {
+}): Promise<PublishedBranchCommit> {
   assertDcoSignedCommitMessage(input.commitMessage);
   const dcoIdentity = parseDcoSignedCommitIdentity(input.commitMessage);
   if (!dcoIdentity) {
@@ -289,21 +286,13 @@ export async function createBranchAndPR(input: {
   const {
     headOwner,
     headRepo,
-    baseOwner,
-    baseRepo,
     branchName,
     commitMessage,
     diff,
-    prTitle,
-    prBody,
-    labels,
     token,
   } = input;
   const baseBranch = input.baseBranch ?? "main";
   const headApiBase = `https://api.github.com/repos/${headOwner}/${headRepo}`;
-  const baseApiBase = `https://api.github.com/repos/${baseOwner}/${baseRepo}`;
-  const isCrossRepo = headOwner !== baseOwner || headRepo !== baseRepo;
-  const prHead = isCrossRepo ? `${headOwner}:${branchName}` : branchName;
 
   // 1. Get the SHA of the base branch on the HEAD repo.
   //
@@ -410,8 +399,36 @@ export async function createBranchAndPR(input: {
     }
   }
 
-  // 7. Create the PR on the BASE repo. head is "{headOwner}:{branchName}" for
-  // cross-repo PRs, bare branch name for same-repo.
+  return { branchName, commitSha: commit.sha };
+}
+
+export async function openPullRequest(input: {
+  headOwner: string;
+  headRepo: string;
+  baseOwner: string;
+  baseRepo: string;
+  baseBranch?: string;
+  branchName: string;
+  prTitle: string;
+  prBody: string;
+  labels: string[];
+  token: string;
+}): Promise<OpenPullRequestResult> {
+  const {
+    headOwner,
+    headRepo,
+    baseOwner,
+    baseRepo,
+    branchName,
+    prTitle,
+    prBody,
+    labels,
+    token,
+  } = input;
+  const baseBranch = input.baseBranch ?? "main";
+  const baseApiBase = `https://api.github.com/repos/${baseOwner}/${baseRepo}`;
+  const isCrossRepo = headOwner !== baseOwner || headRepo !== baseRepo;
+  const prHead = isCrossRepo ? `${headOwner}:${branchName}` : branchName;
   let prUrl: string | null = null;
   let prNumber: number | null = null;
 
@@ -455,7 +472,26 @@ export async function createBranchAndPR(input: {
     }
   }
 
-  return { branchName, commitSha: commit.sha, prUrl, prNumber };
+  return { prUrl, prNumber };
+}
+
+export async function createBranchAndPR(input: {
+  headOwner: string;
+  headRepo: string;
+  baseOwner: string;
+  baseRepo: string;
+  baseBranch?: string;
+  branchName: string;
+  commitMessage: string;
+  diff: string;
+  prTitle: string;
+  prBody: string;
+  labels: string[];
+  token: string;
+}): Promise<GitHubCommitResult> {
+  const published = await publishBranchCommit(input);
+  const opened = await openPullRequest(input);
+  return { ...published, ...opened };
 }
 
 // ─── PR Status & Merge ─────────────────────────────────────────────────────

--- a/apps/web/lib/integrate/sandbox/sandbox.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox.ts
@@ -2,7 +2,7 @@
 // Sandbox lifecycle management — creates, manages, and destroys Docker containers
 // for isolated code generation.
 
-import { lazyExec, lazyFs } from "@/lib/shared/lazy-node";
+import { lazyChildProcess, lazyExec, lazyFs } from "@/lib/shared/lazy-node";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 const exec = lazyExec();
@@ -397,6 +397,55 @@ export async function execInSandbox(containerId: string, command: string): Promi
     maxBuffer: 100 * 1024 * 1024,
   });
   return stdout;
+}
+
+/**
+ * Execute a sandbox command while delivering sensitive input over stdin.
+ * The input never appears in the host command line or Docker environment.
+ */
+export async function execInSandboxWithStdin(
+  containerId: string,
+  command: string,
+  input: string,
+): Promise<string> {
+  const { spawn } = lazyChildProcess();
+  const safeCommand = prefixSafeWorkspaceCommand(command);
+  return new Promise((resolve, reject) => {
+    const child = spawn("docker", ["exec", "-i", containerId, "sh", "-c", safeCommand], {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let size = 0;
+    let settled = false;
+    const collect = (target: Buffer[], chunk: Buffer) => {
+      size += chunk.length;
+      if (size > 100 * 1024 * 1024 && !settled) {
+        settled = true;
+        child.kill();
+        reject(new Error("Sandbox command output exceeded 100 MiB."));
+        return;
+      }
+      target.push(chunk);
+    };
+    child.stdout.on("data", (chunk: Buffer) => collect(stdout, chunk));
+    child.stderr.on("data", (chunk: Buffer) => collect(stderr, chunk));
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      const out = Buffer.concat(stdout).toString("utf8");
+      const err = Buffer.concat(stderr).toString("utf8");
+      if (code === 0) resolve(out);
+      else reject(new Error(`Sandbox command exited ${code}: ${err.slice(0, 1000)}`));
+    });
+    child.stdin.end(input);
+  });
 }
 
 /**

--- a/apps/web/lib/mcp/build-ship-handlers.ts
+++ b/apps/web/lib/mcp/build-ship-handlers.ts
@@ -340,7 +340,7 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
   const build = await prisma.featureBuild.findUnique({
     where: { buildId },
     select: {
-      id: true, title: true, diffPatch: true, buildBranch: true,
+      id: true, title: true, diffPatch: true, buildBranch: true, sandboxId: true,
       description: true, gitCommitHashes: true, updatedAt: true, buildExecState: true,
       verificationOut: true, acceptanceMet: true, phase: true,
       designDoc: true, buildPlan: true,
@@ -466,21 +466,6 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
     return { success: false, error: "No GitHub token available.", message: "Configure HIVE_CONTRIBUTION_TOKEN or a git credential to create PRs." };
   }
 
-  // Run pre-PR gates
-  const { runPrePRGates, formatGateReport } = await import("@/lib/integrate/pre-pr-gates");
-  const gateResult = runPrePRGates(shareableDiff);
-
-  // If gates block, return the report without creating a PR
-  if (!gateResult.canProceed) {
-    logBuildActivity(buildId, "create_portal_pr", `BLOCKED: ${gateResult.summary}`);
-    return {
-      success: false,
-      error: "Pre-PR gates failed.",
-      message: `The pre-PR security gates found blocking issues. Fix these before creating a PR.\n\n${formatGateReport(gateResult)}`,
-      data: { gates: gateResult },
-    };
-  }
-
   // Build the PR
   const platformId = await getPlatformIdentity();
   const branchName = generatePrivateBranchName(platformId.clientId, build.title);
@@ -514,6 +499,8 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
   const acMet = acceptance.filter((a) => a?.met === true).length;
   const acTotal = acceptance.length;
 
+  const readinessTrailers =
+    typeof params.readinessTrailers === "string" ? params.readinessTrailers.trim() : "";
   const prBody = [
     `## ${build.title}`,
     "",
@@ -524,47 +511,108 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
     `- Tests: ${testsPassed} passed, ${testsFailed} failed`,
     `- Acceptance: ${acMet}/${acTotal} criteria met`,
     "",
-    formatGateReport(gateResult),
-    "",
+    ...(readinessTrailers ? ["### Readiness decisions", readinessTrailers, ""] : []),
     "---",
     `License: Apache-2.0 | ${platformId.dcoSignoff}`,
   ].join("\n");
 
   const prTitle = `feat(${buildId}): ${build.title}`;
   const labels = ["build-studio", "automated"];
-  if (gateResult.requiresHumanReview) labels.push("needs-review");
-  if (!typecheckPassed || testsFailed > 0) labels.push("verification-issues");
+  const { publishBranchCommit, openPullRequest } = await import("@/lib/integrate/github-api-commit");
 
-  const { createBranchAndPR, commentOnPR } = await import("@/lib/integrate/github-api-commit");
+  const published = await publishBranchCommit({
+    headOwner: repoOwner,
+    headRepo: repoName,
+    branchName,
+    commitMessage,
+    diff: shareableDiff,
+    token,
+  });
 
-  const prResult = await createBranchAndPR({
+  const {
+    buildPublishedReadinessCommand,
+    evaluateBuildVerificationReadiness,
+    parsePublishedReadinessOutput,
+  } = await import("@/lib/integrate/build-studio-pr-readiness");
+  const verificationReadiness = evaluateBuildVerificationReadiness({
+    typecheckPassed,
+    testsFailed,
+    acceptanceMet: acMet,
+    acceptanceTotal: acTotal,
+  });
+  let canonicalReadiness = {
+    ready: false,
+    blockers: ["Build sandbox is unavailable for exact published-tree readiness."],
+  };
+  if (build.sandboxId && build.buildBranch) {
+    try {
+      const { execInSandboxWithStdin } = await import("@/lib/integrate/sandbox/sandbox");
+      const output = await execInSandboxWithStdin(
+        build.sandboxId,
+        buildPublishedReadinessCommand({
+          branchName,
+          commitSha: published.commitSha,
+          restoreBranch: build.buildBranch,
+          prBodyBase64: Buffer.from(prBody, "utf8").toString("base64"),
+          repositoryOwner: repoOwner,
+          repositoryName: repoName,
+        }),
+        `${token}\n`,
+      );
+      canonicalReadiness = parsePublishedReadinessOutput(output);
+    } catch (error) {
+      canonicalReadiness = {
+        ready: false,
+        blockers: [`Exact published-tree readiness failed: ${String(error).slice(0, 240)}`],
+      };
+    }
+  }
+  const blockers = [...verificationReadiness.blockers, ...canonicalReadiness.blockers];
+  const contextState = readinessTrailers ? "context-present" : "context-missing";
+  const verdictState = blockers.length === 0 ? "ready" : "blocked";
+  logBuildActivity(
+    buildId,
+    `pr-readiness:${verdictState}:${contextState}`,
+    `head=${published.commitSha}; blockers=${blockers.length === 0 ? "none" : blockers.join(" | ").slice(0, 700)}`,
+  );
+  if (blockers.length > 0) {
+    return {
+      success: false,
+      error: "PR readiness blocked pull request creation.",
+      message: `Branch \`${branchName}\` is published and recoverable, but no pull request was opened.\n\n${blockers.map((blocker) => `- ${blocker}`).join("\n")}`,
+      data: {
+        branchName,
+        commitSha: published.commitSha,
+        blockers,
+        readiness: canonicalReadiness,
+      },
+    };
+  }
+
+  const prResult = await openPullRequest({
     headOwner: repoOwner,
     headRepo: repoName,
     baseOwner: repoOwner,
     baseRepo: repoName,
     branchName,
-    commitMessage,
-    diff: shareableDiff,
     prTitle,
     prBody,
     labels,
     token,
   });
-
   if (!prResult.prUrl || !prResult.prNumber) {
     logBuildActivity(buildId, "create_portal_pr", `Branch created (${branchName}) but PR creation failed.`);
     return {
       success: false,
       error: "PR creation failed.",
       message: `Branch \`${branchName}\` was created with the commit, but the pull request could not be opened. Check GitHub permissions.`,
-      data: { branchName, commitSha: prResult.commitSha },
+      data: { branchName, commitSha: published.commitSha },
     };
   }
 
   // Integration decision: all local gates pass + build fully verified. GitHub
   // remains authoritative for current-head checks, review threads, branch
   // freshness, and merge-queue policy. A PR merge is NOT deployment.
-  const fullyVerified = typecheckPassed && testsFailed === 0 && acMet === acTotal && acTotal > 0;
   let deliveryState: string;
   try {
     const {
@@ -578,7 +626,7 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
       prNumber: prResult.prNumber,
       prUrl: prResult.prUrl,
       token,
-      eligible: !gateResult.requiresHumanReview && fullyVerified,
+      eligible: true,
     });
     deliveryState = outcome.state.status;
     logBuildActivity(
@@ -595,27 +643,7 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
     );
   }
 
-  if (gateResult.requiresHumanReview || !fullyVerified) {
-    // Needs human review — post gate report as comment
-    const reasons: string[] = [];
-    if (gateResult.requiresHumanReview) reasons.push("security gate warnings");
-    if (!typecheckPassed) reasons.push("TypeCheck failed");
-    if (testsFailed > 0) reasons.push(`${testsFailed} test(s) failed`);
-    if (acMet < acTotal) reasons.push(`${acTotal - acMet} acceptance criteria not met`);
-
-    await commentOnPR({
-      owner: repoOwner, repo: repoName, prNumber: prResult.prNumber,
-      body: `This PR requires employee review: ${reasons.join(", ")}.\n\n${formatGateReport(gateResult)}`,
-      token,
-    }).catch(() => {});
-
-    logBuildActivity(buildId, "create_portal_pr", `PR #${prResult.prNumber} created — needs review: ${reasons.join(", ")}`);
-  }
-
-  const statusMsg =
-    !gateResult.requiresHumanReview && fullyVerified
-      ? `PR #${prResult.prNumber} created. Delivery state: ${deliveryState}.`
-      : `PR #${prResult.prNumber} created and awaiting review. ${gateResult.summary}`;
+  const statusMsg = `PR #${prResult.prNumber} created. Delivery state: ${deliveryState}.`;
 
   return {
     success: true,
@@ -624,10 +652,10 @@ export async function createPortalPr(params: Record<string, unknown>, userId: st
       prUrl: prResult.prUrl,
       prNumber: prResult.prNumber,
       branchName,
-      commitSha: prResult.commitSha,
+      commitSha: published.commitSha,
       merged: false,
       deliveryState,
-      gates: gateResult,
+      readiness: canonicalReadiness,
     },
   };
 }

--- a/apps/web/lib/mcp/packs/build-lifecycle-pack.ts
+++ b/apps/web/lib/mcp/packs/build-lifecycle-pack.ts
@@ -135,8 +135,16 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "create_portal_pr",
-    description: "Create a pull request on the portal's own repository from the current build's diff. Runs pre-PR security gates (security scan, destructive ops, architecture compliance, dependency audit). If all gates pass and the build is fully verified, auto-merges via squash. If any gate fails, creates the PR with findings and requests human review.",
-    inputSchema: { type: "object", properties: {} },
+    description: "Publish a recoverable branch, validate its exact commit with the canonical PR-readiness contract, and create a pull request only when every build and repository gate passes. A blocked result returns the branch, commit, and actionable blockers without opening a PR.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        readinessTrailers: {
+          type: "string",
+          description: "Reviewed PR decision trailers from the injected gate context, one per line. Pass only applicable trailers with final values.",
+        },
+      },
+    },
     requiredCapability: "manage_capabilities",
     executionMode: "immediate",
     sideEffect: true,

--- a/docs/superpowers/plans/2026-07-30-build-studio-pr-readiness.md
+++ b/docs/superpowers/plans/2026-07-30-build-studio-pr-readiness.md
@@ -1,0 +1,120 @@
+# Build Studio fail-closed PR readiness
+
+Backlog item: `BI-121DC3A3`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+Build Studio publishes a recoverable branch first, evaluates that exact branch
+with the canonical readiness contracts, and opens a PR only when the verdict is
+ready. A blocked verdict leaves the branch available and returns actionable
+blockers. The same result records whether Build Studio had gate context and
+readiness context so deterministic failure trends can be measured by surface.
+
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/testing/pr-health.md`, the canonical
+  local readiness contract, and PR #3777's Build Studio gate-context delivery.
+- Current code substrate reviewed:
+  `apps/web/lib/mcp/build-ship-handlers.ts` currently runs the smaller
+  `runPrePRGates(diff)` list and can create a PR with `verification-issues`.
+- `scripts/pr-readiness/core.mjs` owns trailer validation and readiness
+  evaluation for contributor branches.
+- `scripts/lib/ci-policy-guards.mjs` owns the source/workspace/PR policy
+  profiles consumed by local readiness and CI.
+- `apps/web/lib/integrate/github-api-commit.ts` currently combines branch
+  publication and PR creation in one side effect.
+- PR #3777 already delivers canonical gate context to Build Studio prompts.
+- Source of truth: `scripts/pr-readiness/core.mjs` and
+  `scripts/lib/ci-policy-guards.mjs`.
+- Decision: publish a recoverable branch, validate its exact remote commit,
+  and only then open a PR; retain one compatibility wrapper for other callers.
+
+## Phases
+
+### 1. Define the shipping verdict test-first
+
+- Add focused tests proving failed typecheck, failed tests, incomplete
+  acceptance, invalid trailers, or canonical policy blockers prevent PR
+  creation.
+- Prove a blocked result still returns the published branch and exact commit.
+- Prove a ready result passes the exact validated body to PR creation.
+
+Verification: run the focused Vitest files and observe the new assertions fail
+before implementation, then pass.
+
+### 2. Split branch publication from PR opening
+
+- Refactor `github-api-commit.ts` so the existing API remains compatible while
+  exposing branch publication and PR opening as separately testable operations.
+- Do not duplicate blob/tree/commit construction, DCO identity, existing-PR
+  recovery, or label behavior.
+
+Verification: existing GitHub API commit tests plus new ordering tests pass.
+
+### 3. Converge Build Studio on canonical readiness
+
+- Add one Build Studio adapter around the canonical readiness core and policy
+  profile registry.
+- Extend the readiness command with a published-ref mode. In that mode a
+  detached checkout is accepted only when `HEAD` exactly equals the fetched
+  remote branch ref; the normal named-branch and unpushed-commit exceptions do
+  not apply otherwise. All diff, DCO, clean-tree, trailer, and canonical policy
+  checks remain active.
+- Remove `runPrePRGates` from the shipping decision path.
+- Treat verification and acceptance failures as blockers, not PR labels.
+- Publish the branch, fetch and detach-checkout the exact published commit in
+  the build sandbox, evaluate the exact published commit/body, restore the
+  build branch in `finally`, and open the PR only on a ready verdict. A fetch,
+  checkout, or restore failure is itself a blocker.
+- Return canonical blockers and recovery branch data when blocked.
+
+Verification: handler contract tests prove no PR-side effect occurs for every
+  blocker class and prove the ready path uses the validated body unchanged.
+
+### 4. Record shift-left effectiveness
+
+- Record surface, gate-context availability, readiness-context availability,
+  exact head SHA, verdict, and blocker taxonomy in existing build activity.
+- Keep measurements low-cardinality and derived from the verdict; add no new
+  telemetry registry.
+
+Verification: tests assert the activity payload distinguishes context-present
+  and context-missing attempts.
+
+## Documentation impact
+
+Update contributor/process documentation describing Build Studio's branch-first
+handoff and fail-closed PR creation. No product UI, route, or form changes are
+planned.
+
+## Risks and rollback
+
+- **Partial side effect:** branch succeeds and readiness fails. This is the
+  desired recoverable state; return the branch and never open a PR.
+- **Duplicate rules:** importing a copied checklist would drift. Consume the
+  canonical readiness and policy modules.
+- **Public/private diff mismatch:** evaluate the same shareable diff and body
+  that will be published.
+- **Rollback:** revert the PR. The previous atomic helper remains available
+  through its compatibility wrapper, but premature PR creation must not be
+  re-enabled as an operational workaround.
+
+## Completion gate
+
+- Focused tests, web typecheck, full exact-tree local-CI, and production build
+  pass.
+- A test demonstrates a pushed branch with blockers and zero PR POSTs.
+- A test demonstrates a ready exact head and one PR POST with the validated
+  body.
+- Documentation states why no UX or migration evidence is required.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-121DC3A3`
+- Receipt: `cms8bh7h607ul01qo3bjpw9f5`
+- Mapping: `build-studio-readiness` -> `BI-121DC3A3`
+- Rationale: branch publication, readiness, PR opening, and measurement are one
+  shipping transaction; none is safe to ship independently.

--- a/docs/testing/pr-health.md
+++ b/docs/testing/pr-health.md
@@ -73,6 +73,22 @@ machine-readable pack (`scripts/lib/gate-context.mjs` is the single source —
 the Build Studio prompt section and MCP tool consume the same module). The
 pack is advisory context: CI gates remain the only authority.
 
+## Before a PR exists: `pnpm pr:ready`
+
+`pnpm pr:ready -- --pr-body-file <path>` applies the same policy-profile
+registry, exact diff, DCO, clean-tree, pushed-branch, and PR-trailer contracts
+before a contributor opens a PR. This is the shift-left gate; `pr:health`
+remains the end-to-end observer after GitHub creates the PR and starts CI.
+
+Build Studio uses the same readiness command with an internal
+`--published-ref` mode. Its shipping transaction is deliberately branch-first:
+it publishes a recoverable branch, fetches and checks out that exact remote
+commit in the build sandbox, runs canonical readiness against the final PR
+body, restores the build branch, and opens a PR only for a ready verdict.
+Typecheck, tests, and acceptance evidence are additional fail-closed blockers.
+If any check fails, the tool returns the published branch, commit SHA, and
+blockers; it does not create a review-lane placeholder PR.
+
 ## Tests & CI
 
 The pure verdict (`evaluatePrHealth()`) is unit-tested in [`scripts/pr-health.test.mjs`](../../scripts/pr-health.test.mjs) and runs in CI as the **PR Health Logic** job (`node --test`). The script's GitHub I/O is exercised by running it against live PRs; it is not run in CI (it would be circular).

--- a/scripts/build-studio-pr-readiness-contract.test.mjs
+++ b/scripts/build-studio-pr-readiness-contract.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const handler = readFileSync(
+  new URL("../apps/web/lib/mcp/build-ship-handlers.ts", import.meta.url),
+  "utf8",
+);
+const toolPack = readFileSync(
+  new URL("../apps/web/lib/mcp/packs/build-lifecycle-pack.ts", import.meta.url),
+  "utf8",
+);
+const prompt = readFileSync(
+  new URL("../apps/web/lib/integrate/build-agent-prompts.ts", import.meta.url),
+  "utf8",
+);
+
+test("Build Studio publishes, validates, then opens the PR", () => {
+  const publishAt = handler.indexOf("await publishBranchCommit(");
+  const validateAt = handler.indexOf("buildPublishedReadinessCommand({");
+  const openAt = handler.indexOf("await openPullRequest(");
+  assert.ok(publishAt > 0, "branch publication must be present");
+  assert.ok(validateAt > publishAt, "exact-tree validation must follow publication");
+  assert.ok(openAt > validateAt, "PR opening must follow exact-tree validation");
+  assert.doesNotMatch(handler, /runPrePRGates/);
+  assert.doesNotMatch(handler, /verification-issues/);
+});
+
+test("Build Studio exposes readiness context and documents fail-closed behavior", () => {
+  assert.match(toolPack, /readinessTrailers/);
+  assert.match(toolPack, /without opening a PR/);
+  assert.match(prompt, /recoverable branch first/);
+  assert.match(prompt, /no PR is opened/);
+  assert.doesNotMatch(prompt, /unit-test surface is currently informational/);
+});

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -30,7 +30,7 @@ function git(args, { allowFail = false } = {}) {
 }
 
 function parseArgs(argv) {
-  const args = { prBody: process.env.PR_BODY || "", prLabelsJson: process.env.PR_LABELS_JSON || "[]", runGates: true };
+  const args = { prBody: process.env.PR_BODY || "", prLabelsJson: process.env.PR_LABELS_JSON || "[]", runGates: true, json: false, publishedRef: null };
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--pr-body-file") {
@@ -41,6 +41,10 @@ function parseArgs(argv) {
       args.prLabelsJson = argv[++i] ?? "[]";
     } else if (arg === "--skip-gates") {
       args.runGates = false;
+    } else if (arg === "--published-ref") {
+      args.publishedRef = argv[++i] ?? "";
+    } else if (arg === "--json") {
+      args.json = true;
     } else if (arg === "-h" || arg === "--help") {
       args.help = true;
     } else {
@@ -52,7 +56,7 @@ function parseArgs(argv) {
 
 function usage() {
   return [
-    "Usage: node scripts/pr-readiness.mjs [--pr-body-file path | --pr-body text] [--labels-json json] [--skip-gates]",
+    "Usage: node scripts/pr-readiness.mjs [--pr-body-file path | --pr-body text] [--labels-json json] [--published-ref ref] [--json] [--skip-gates]",
     "",
     "Runs local pre-PR governance checks against the exact diff from current origin/main to HEAD.",
     "Exit 0 means safe to open or queue the PR. Exit 1 means fix the listed blockers first.",
@@ -83,10 +87,14 @@ function readAheadBehind(upstream) {
   return { ahead: Number.isFinite(ahead) ? ahead : 0, behind: Number.isFinite(behind) ? behind : 0 };
 }
 
-function readRepoState() {
+function readRepoState(publishedRef = null) {
   fetchOriginMainSharedSafe((args) => git(args));
 
   const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+  const headSha = git(["rev-parse", "HEAD"]).trim();
+  const publishedSha = publishedRef
+    ? git(["rev-parse", "--verify", publishedRef], { allowFail: true }).trim()
+    : "";
   const upstream = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], { allowFail: true }).trim();
   const aheadBehind = readAheadBehind(upstream);
   const mergeBases = git(["merge-base", "--all", "origin/main", "HEAD"], { allowFail: true })
@@ -109,6 +117,8 @@ function readRepoState() {
     ahead: aheadBehind.ahead,
     behind: aheadBehind.behind,
     commits: readCommits(),
+    publishedRef,
+    publishedRefMatchesHead: Boolean(publishedRef) && publishedSha === headSha,
   };
 }
 
@@ -151,7 +161,7 @@ function main() {
 
   let repo;
   try {
-    repo = readRepoState();
+    repo = readRepoState(args.publishedRef);
   } catch (error) {
     console.error(`pr-readiness: could not read repository state: ${error.message}`);
     process.exit(2);
@@ -165,6 +175,15 @@ function main() {
   });
   const verdict = evaluateReadiness({ repo, gateResults, prBody: args.prBody, gateContext });
   process.stdout.write(formatReadinessReport(verdict));
+  if (args.json) {
+    process.stdout.write(`DPF_PR_READINESS_JSON=${JSON.stringify({
+      ready: verdict.ready,
+      blockers: verdict.blockers,
+      warnings: verdict.warnings,
+      branch: verdict.branch,
+      changedFiles: verdict.changedFiles,
+    })}\n`);
+  }
   process.exit(verdict.ready ? 0 : 1);
 }
 

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -165,6 +165,40 @@ test("evaluateReadiness blocks unsafe or queue-hostile repository state", () => 
   assert.match(result.blockers.join("\n"), /missing DCO sign-off/);
 });
 
+test("evaluateReadiness accepts a detached exact published ref but no other detached head", () => {
+  const exact = evaluateReadiness({
+    repo: {
+      ...cleanRepo,
+      branch: "HEAD",
+      isDetached: true,
+      upstream: null,
+      ahead: 1,
+      publishedRef: "refs/remotes/origin/build/example",
+      publishedRefMatchesHead: true,
+    },
+    gateResults: [],
+    prBody: "",
+  });
+  assert.equal(exact.ready, true);
+  assert.equal(exact.branch, "refs/remotes/origin/build/example");
+
+  const mismatch = evaluateReadiness({
+    repo: {
+      ...cleanRepo,
+      branch: "HEAD",
+      isDetached: true,
+      upstream: null,
+      ahead: 1,
+      publishedRef: "refs/remotes/origin/build/example",
+      publishedRefMatchesHead: false,
+    },
+    gateResults: [],
+    prBody: "",
+  });
+  assert.equal(mismatch.ready, false);
+  assert.match(mismatch.blockers.join("\n"), /does not equal published ref/);
+});
+
 test("evaluateReadiness folds failed local gates into one pre-PR verdict", () => {
   const result = evaluateReadiness({
     repo: cleanRepo,

--- a/scripts/pr-readiness/core.mjs
+++ b/scripts/pr-readiness/core.mjs
@@ -135,6 +135,10 @@ export function evaluateReadiness({ repo, gateResults = [], prBody = "", gateCon
   if (!repo) {
     blockers.push("Repository state could not be read.");
   } else {
+    const exactPublishedHead = Boolean(repo.publishedRef) && repo.publishedRefMatchesHead === true;
+    if (repo.publishedRef && !exactPublishedHead) {
+      blockers.push(`HEAD does not equal published ref ${repo.publishedRef}; refuse to validate a different tree.`);
+    }
     if (repo.isShallow) {
       blockers.push("Repository is a shallow Git repository; fetch full history before computing a PR diff.");
     }
@@ -143,12 +147,12 @@ export function evaluateReadiness({ repo, gateResults = [], prBody = "", gateCon
     } else if (repo.mergeBases.length > 1) {
       blockers.push(`Found an ambiguous merge-base with origin/main (${repo.mergeBases.length} candidates); repair history before opening a PR.`);
     }
-    if (repo.isDetached) blockers.push("HEAD is detached; switch to a named topic branch before opening a PR.");
+    if (repo.isDetached && !exactPublishedHead) blockers.push("HEAD is detached; switch to a named topic branch before opening a PR.");
     if (repo.branch === "main") blockers.push("Current branch is main; create a topic branch before opening a PR.");
     if (String(repo.statusPorcelain ?? "").trim()) {
       blockers.push("The working tree has uncommitted changes; commit or discard them before opening or queueing the PR.");
     }
-    if (Number(repo.ahead ?? 0) > 0) {
+    if (Number(repo.ahead ?? 0) > 0 && !exactPublishedHead) {
       blockers.push(`${repo.ahead} local commit(s) are not pushed to ${repo.upstream ?? "the branch upstream"}; do not enter the merge queue yet.`);
     }
     if (changedFiles.length === 0) {
@@ -195,7 +199,7 @@ export function evaluateReadiness({ repo, gateResults = [], prBody = "", gateCon
     notes,
     passed,
     changedFiles,
-    branch: repo?.branch ?? "(unknown)",
+    branch: repo?.publishedRef && repo?.publishedRefMatchesHead ? repo.publishedRef : (repo?.branch ?? "(unknown)"),
     base: "origin/main",
     mergeBase: repo?.mergeBases?.[0] ?? null,
     gateContext,


### PR DESCRIPTION
## Outcome

Moves Build Studio pull-request readiness to the point where a branch has a canonical published commit and all required evidence, instead of discovering basic omissions after a PR already exists.

## Changes

- Publishes the build branch first and derives readiness from the exact canonical commit.
- Opens only regular ready-for-review PRs after the readiness contract passes.
- Blocks premature or stale-commit PR creation with explicit actionable evidence.
- Aligns build lifecycle handlers, GitHub publication, sandbox handoff, prompts, and the shared PR-readiness engine.
- Adds focused contract and integration coverage plus contributor documentation.

## Verification

- Exact `pnpm pregate -- --lease-wait-seconds 7200` passed for `fix/build-studio-pr-readiness@7d53329ab040de14d87a4f758b62d9d70ef0ae29`.
- Local-CI evidence `cms8k0r4n08hv01qobchwe7ve`, lease `NPEL-6D7EF2E101`.
- Freshness verdict green: Next 16.2.11, React 19.2.8, React DOM 19.2.8, TypeScript 6.0.3, Prisma 7.8.0, Vitest 4.1.10.
- Prisma deploy found 479 migrations and no pending migrations.
- Full applicable Vitest suite, production Next.js build, documentation link checks, and policy guards passed.
- No rendered UI changed; dynamic UX verification is not applicable. Build lifecycle behavior is covered through the focused readiness, GitHub publication, handler, prompt, and contract tests.

## Documentation impact

Updated the PR-health contributor documentation and implementation plan because this changes Build Studio and external-agent delivery behavior.

## Design grounding

Reviewed the Build Studio readiness plan, lifecycle MCP pack, build/ship handlers, GitHub commit publication layer, sandbox handoff, and shared `pr-readiness` engine. The published branch commit is the source of truth: readiness is evaluated against that exact SHA before a regular PR can be created.

Seed-Fit-Decision: global-default

Local-CI-Evidence: cms8k0r4n08hv01qobchwe7ve (fix/build-studio-pr-readiness@7d53329ab040de14d87a4f758b62d9d70ef0ae29)
