### PR TITLE
fix(ai): converge system-owned model defaults

### DIFF
--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -38,6 +38,8 @@ An availability label is not a runtime guess. It is projected from the current s
 
 Missing declarations or unevaluated readiness appear as **Coverage not defined**. Missing backing appears as **Setup needed**, and lifecycle, safety, or routing blockers appear as **Needs attention**. These states fail closed and do not show the Ask action. A recovery action appears only when DPF has an owner-capable destination that the signed-in operator can access, such as business type, capabilities, capability needs, the runnable certification job, or AI readiness. Platform-managed catalog defects remain visible in Availability evidence without a misleading operator action. Coworker-specific actions preserve the current roster filters. Opening a named Ask action never sends work automatically; the operator must submit a message explicitly.
 
+Model assignments explicitly saved by an operator remain unchanged during upgrades. Platform-supplied defaults are system-owned and converge to the current release declaration, so an obsolete default from an earlier release cannot silently leave a coworker unavailable after the platform has corrected that default.
+
 ## Key Concepts
 
 - **Provider Registry** — The list of AI providers connected to the platform (e.g., Anthropic/Claude, OpenAI/Codex, xAI/Grok, Docker Model Runner for local models). Each provider has its own credential path, status, sensitivity clearance, and set of available models.

--- a/packages/db/src/agent-model-defaults.test.ts
+++ b/packages/db/src/agent-model-defaults.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults";
+import {
+  AGENT_MODEL_CONFIG_DEFAULTS,
+  resolveAgentModelDefaultUpdate,
+} from "./agent-model-defaults";
 
 describe("agent model config defaults", () => {
   it("covers route specialists that require tool-backed coworker work", () => {
@@ -9,5 +12,78 @@ describe("agent model config defaults", () => {
     expect(byId.get("finance-agent")?.minimumTier).toBe("strong");
     expect(byId.get("licensing-specialist")?.minimumCapabilities?.toolUse).toBe(true);
     expect(byId.get("licensing-specialist")?.minimumTier).toBe("strong");
+  });
+
+  it("converges a stale system-owned row to the current declaration", () => {
+    const declaration = AGENT_MODEL_CONFIG_DEFAULTS.find(
+      (entry) => entry.agentId === "marketing-specialist",
+    )!;
+
+    expect(
+      resolveAgentModelDefaultUpdate(
+        {
+          minimumTier: "frontier",
+          budgetClass: "quality_first",
+          pinnedProviderId: "legacy-provider",
+          pinnedModelId: "legacy-model",
+          minimumCapabilities: { toolUse: false },
+          minimumContextTokens: 16_000,
+          configuredById: null,
+        },
+        declaration,
+      ),
+    ).toEqual({
+      minimumTier: "adequate",
+      budgetClass: "balanced",
+      pinnedProviderId: null,
+      pinnedModelId: null,
+      minimumCapabilities: { toolUse: true },
+      minimumContextTokens: 0,
+    });
+  });
+
+  it("preserves operator-owned routing choices", () => {
+    const declaration = AGENT_MODEL_CONFIG_DEFAULTS.find(
+      (entry) => entry.agentId === "marketing-specialist",
+    )!;
+
+    expect(
+      resolveAgentModelDefaultUpdate(
+        {
+          minimumTier: "frontier",
+          budgetClass: "quality_first",
+          pinnedProviderId: "chosen-provider",
+          pinnedModelId: "chosen-model",
+          minimumCapabilities: { toolUse: false },
+          minimumContextTokens: 64_000,
+          configuredById: "user-1",
+        },
+        declaration,
+      ),
+    ).toBeNull();
+  });
+
+  it("backfills missing safety floors without replacing operator choices", () => {
+    const declaration = AGENT_MODEL_CONFIG_DEFAULTS.find(
+      (entry) => entry.agentId === "marketing-specialist",
+    )!;
+
+    expect(
+      resolveAgentModelDefaultUpdate(
+        {
+          minimumTier: "frontier",
+          budgetClass: "quality_first",
+          pinnedProviderId: "chosen-provider",
+          pinnedModelId: "chosen-model",
+          minimumCapabilities: null,
+          minimumContextTokens: null,
+          configuredById: "user-1",
+        },
+        declaration,
+      ),
+    ).toEqual({
+      minimumCapabilities: { toolUse: true },
+      minimumContextTokens: 0,
+    });
   });
 });

--- a/packages/db/src/agent-model-defaults.ts
+++ b/packages/db/src/agent-model-defaults.ts
@@ -6,6 +6,25 @@ export type AgentModelConfigDefault = {
   minimumContextTokens?: number;
 };
 
+export type ExistingAgentModelConfig = {
+  minimumTier: string;
+  budgetClass: string;
+  pinnedProviderId: string | null;
+  pinnedModelId: string | null;
+  minimumCapabilities: unknown;
+  minimumContextTokens: number | null;
+  configuredById: string | null;
+};
+
+export type AgentModelDefaultUpdate = {
+  minimumTier?: string;
+  budgetClass?: string;
+  pinnedProviderId?: null;
+  pinnedModelId?: null;
+  minimumCapabilities?: Record<string, boolean>;
+  minimumContextTokens?: number;
+};
+
 export const AGENT_MODEL_CONFIG_DEFAULTS: AgentModelConfigDefault[] = [
   { agentId: "build-specialist", minimumTier: "strong", budgetClass: "quality_first", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
   { agentId: "change-reviewer", minimumTier: "strong", budgetClass: "quality_first", minimumCapabilities: { toolUse: true }, minimumContextTokens: 32000 },
@@ -46,3 +65,40 @@ export const AGENT_MODEL_CONFIG_DEFAULTS: AgentModelConfigDefault[] = [
   // expensive founder time that a weak model would waste.
   { agentId: "ux-design-critic", minimumTier: "strong", budgetClass: "balanced", minimumCapabilities: { toolUse: true, imageInput: true }, minimumContextTokens: 32000 },
 ];
+
+export function resolveAgentModelDefaultUpdate(
+  existing: ExistingAgentModelConfig,
+  declaration: AgentModelConfigDefault,
+): AgentModelDefaultUpdate | null {
+  if (existing.configuredById === null) {
+    const desired: AgentModelDefaultUpdate = {
+      minimumTier: declaration.minimumTier,
+      budgetClass: declaration.budgetClass,
+      pinnedProviderId: null,
+      pinnedModelId: null,
+      ...(declaration.minimumCapabilities !== undefined
+        ? { minimumCapabilities: declaration.minimumCapabilities }
+        : {}),
+      ...(declaration.minimumContextTokens !== undefined
+        ? { minimumContextTokens: declaration.minimumContextTokens }
+        : {}),
+    };
+    const changed = Object.entries(desired).some(([key, value]) => {
+      const current = existing[key as keyof ExistingAgentModelConfig];
+      return JSON.stringify(current) !== JSON.stringify(value);
+    });
+    return changed ? desired : null;
+  }
+
+  const backfill: AgentModelDefaultUpdate = {
+    ...(declaration.minimumCapabilities !== undefined &&
+    existing.minimumCapabilities === null
+      ? { minimumCapabilities: declaration.minimumCapabilities }
+      : {}),
+    ...(declaration.minimumContextTokens !== undefined &&
+    existing.minimumContextTokens === null
+      ? { minimumContextTokens: declaration.minimumContextTokens }
+      : {}),
+  };
+  return Object.keys(backfill).length > 0 ? backfill : null;
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -80,7 +80,10 @@ import { seedCoworkerServiceCatalog } from "./coworker-service-catalog-seed.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
 import { buildTaxonomyNodeEntries, type TaxonomySeedRow } from "./taxonomy-seed-entries.js";
-import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
+import {
+  AGENT_MODEL_CONFIG_DEFAULTS,
+  resolveAgentModelDefaultUpdate,
+} from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
 import { deriveLocalModelCapabilityPrior, localInputModalities } from "./local-model-capabilities.js";
 import { ensureDefaultProviderConnection } from "./provider-connection.js";
@@ -2352,26 +2355,15 @@ async function seedAgentModelDefaults(): Promise<void> {
       where: { agentId: d.agentId },
     });
     if (existing) {
-      // Admin-configured rows are preserved for tier/budget.
-      // Only capability floor and context minimum are backfilled if null —
-      // these are system defaults, not admin choices.
-      const needsCapUpdate =
-        (d.minimumCapabilities !== undefined && existing.minimumCapabilities === null) ||
-        (d.minimumContextTokens !== undefined && existing.minimumContextTokens === null);
-
-      if (needsCapUpdate) {
+      const update = resolveAgentModelDefaultUpdate(existing, d);
+      if (update) {
         await prisma.agentModelConfig.update({
           where: { agentId: d.agentId },
-          data: {
-            ...(d.minimumCapabilities !== undefined && existing.minimumCapabilities === null
-              ? { minimumCapabilities: d.minimumCapabilities }
-              : {}),
-            ...(d.minimumContextTokens !== undefined && existing.minimumContextTokens === null
-              ? { minimumContextTokens: d.minimumContextTokens }
-              : {}),
-          },
+          data: update,
         });
-        console.log(`  Updated config for ${d.agentId}`);
+        console.log(
+          `  Updated ${existing.configuredById === null ? "system" : "operator"} config for ${d.agentId}`,
+        );
       }
       existed++;
       continue;


### PR DESCRIPTION
## Summary
- converge system-owned AI coworker model defaults to their current declarations during seed
- preserve every operator-owned tier, budget, pin, capability, and context choice
- add focused ownership/convergence tests and document the rule in the AI Workforce guide

## Why
The Marketing coworker declaration now requires the `adequate` tier, but this install retained an obsolete system-owned `frontier` default. The seed treated every existing row as operator-owned even when `configuredById` was null, leaving Marketing unroutable despite healthy model supply.

## Verification
- exact candidate: `d5699bcffeae0a68a32b4c97caa95c848f0e1092`
- accepted base: `f05c81154ebae1cd79337936481cad39c616cd09`
- local merged-code evidence: `cms8looia011n01okrzr40qt8`
- 479 migrations applied
- 2,437 test files passed; 20,869 tests passed
- web typecheck passed
- production Docker build passed

## UX Fit
This repairs the declared availability state without weakening fail-closed routing. Operator overrides remain authoritative; only system-owned defaults converge.

## Documentation
Updated `docs/user-guide/ai-workforce/index.md` with the system-owned versus operator-owned model-policy behavior.


Seed-Fit-Decision: global-default

Local-CI-Evidence: cms8looia011n01okrzr40qt8

