### PR TITLE
fix(attention): hide memory internals from owner cards

### DIFF
--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -55,12 +55,22 @@ const SELF_EXPLANATORY_SOURCES = new Set<AttentionSource>([
   "compliance-submission",
 ]);
 
+/** Source context that is valuable to builders but is not safe owner copy.
+ * Keep the raw `item.context` unchanged for `technicalFields()` and replace only
+ * the collapsed situation line. This is the progressive-disclosure boundary:
+ * translation here, complete source record one click down. */
+const OWNER_SAFE_SITUATION: Partial<Record<AttentionSource, string>> = {
+  "coworker-memory": "A coworker saved a new note from completed work.",
+};
+
 /** The plain "what the coworker was doing and why it stalled" line. Surfaced from
  *  the item's own context one-liner for sources whose headline is generic
  *  (blocked/paused/proposal); undefined for self-explanatory approvals. This is
  *  the rationale the owner needs to decide — it was previously discarded. */
 export function situationFor(item: AttentionItem): string | undefined {
   if (SELF_EXPLANATORY_SOURCES.has(item.source)) return undefined;
+  const translated = OWNER_SAFE_SITUATION[item.source];
+  if (translated) return translated;
   const context = (item.context ?? "").trim();
   return context.length > 0 ? context : undefined;
 }

--- a/apps/web/lib/attention/owner-decision.test.ts
+++ b/apps/web/lib/attention/owner-decision.test.ts
@@ -166,6 +166,46 @@ describe("translateAttentionToOwnerDecision", () => {
     expect(card.technical.fields).toContainEqual({ label: "Original title", value: raw });
   });
 
+  it("keeps raw coworker-memory content below technical detail", () => {
+    const rawContext =
+      "Integrate Orchestrator remembered a caution: OpenCode task failed with UnknownError. " +
+      "Check server logs and apps/web/app/api/route.ts before retrying codex-gpt.";
+    const card = translateAttentionToOwnerDecision(
+      item({
+        source: "coworker-memory",
+        context: rawContext,
+        deepLink: "/platform/ai/memory",
+        actions: [
+          { kind: "open-in-context", label: "Review memory", href: "/platform/ai/memory" },
+        ],
+        triage: {
+          timeToAct: "none",
+          residueReason: "new-memory-note",
+          decideEffort: "review",
+          irreversible: false,
+        },
+      }),
+      Date.parse("2026-07-30T12:00:00Z"),
+    );
+    const collapsedOwnerCopy = [
+      card.headline,
+      card.situation,
+      card.whyItMatters,
+      card.ifYouDoNothing,
+      card.recommendation.text,
+      card.recommendation.specialistByline,
+    ].filter(Boolean).join(" ");
+    const details = Object.fromEntries(
+      card.technical.fields.map((field) => [field.label, field.value]),
+    );
+
+    expect(card.situation).toBe("A coworker saved a new note from completed work.");
+    expect(collapsedOwnerCopy).not.toMatch(
+      /OpenCode|UnknownError|server logs|route\.ts|codex-gpt/i,
+    );
+    expect(details["Original context"]).toBe(rawContext);
+  });
+
   it("keeps builder, platform, and admin routes below technical detail in Simple view", () => {
     const card = translateAttentionToOwnerDecision(
       item({

--- a/docs/ux-fit/2026-07-30-owner-safe-memory-digest.ux-fit.json
+++ b/docs/ux-fit/2026-07-30-owner-safe-memory-digest.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "fixed-owner-summary",
+  "decisionInteractionId": "DI-2525558BD68A",
+  "scope": {
+    "files": [
+      "apps/web/lib/attention/owner-decision-copy.ts"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "fixed-owner-summary",
+      "omit-situation",
+      "heuristic-rewrite"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- translate coworker-memory context into a calm owner-facing situation line
- retain the complete stored context in the Technical detail drawer
- lock the progressive-disclosure boundary with a regression test

## Problem

Friday review cards on `/workspace/inbox` could expose raw coworker-memory internals in their collapsed owner copy, including provider names, exception names, source paths, and log instructions. That violated the owner-facing attention contract even though Technical detail already existed for that information.

## Fix

`situationFor()` now applies a source-specific owner translation for `coworker-memory`: “A coworker saved a new note from completed work.” The source record is not rewritten or discarded. `technicalFields()` continues to expose the original context one click down.

## Verification

- targeted owner-decision suite: 31/31 tests passed
- merged-code sandbox freshness: green against `origin/main`
- exhaustive suite: 2,437 test files passed; 20,870 tests passed
- TypeScript: passed
- production Next.js Docker build: passed
- migrations: 479 checked; none pending
- live `/workspace/inbox` verification follows merge and governed deployment

## UX fit

- considered fixed owner summary, omitting the situation, and heuristic rewriting
- selected the fixed owner summary through decision interaction `DI-2525558BD68A`
- no controls, routes, or navigation hierarchy changed

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md` and `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`
- Current code substrate reviewed: `apps/web/lib/attention/sources/coworker-memory.ts`, `apps/web/lib/attention/owner-decision-copy.ts`, and `apps/web/lib/attention/owner-technical-detail.ts`
- Source of truth remains `CoworkerMemoryNote`, projected through `AttentionItem`
- Decision: localize translation at the owner-copy boundary; do not change routing, schema, or stored records

## Documentation and migration impact

No user-guide change is needed: this fixes the existing documented progressive-disclosure contract and adds no workflow. No schema or migration change.

Backlog: BI-1535A5F0

Local-CI-Evidence: cms906jup0hda01mzq3hyh04x (fix/owner-safe-memory-digest@0f35b9a547d870123ba8e1a82f2183754e658870)
