### PR TITLE
fix(ci): reuse exact-tree evidence on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,15 +71,16 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  # BI-9585E580 foundation. Observe whether a completed merge-group receipt
-  # would authorize exact-tree reuse, but do not feed this verdict into any
-  # job-level condition yet. A missing/malformed/mismatched receipt therefore
-  # leaves the existing exhaustive push lifecycle completely unchanged.
+  # BI-9585E580. Reuse a completed merge-group receipt only when its immutable
+  # Git tree and every policy/toolchain/evidence invariant match this main
+  # push. Any unavailable or non-true verdict fails closed to exhaustive work.
   exact-tree-evidence-shadow:
-    name: Exact-tree Evidence Shadow
+    name: Exact-tree Evidence Reuse
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'push'
+    outputs:
+      reusable: ${{ steps.validate-ci-evidence.outputs.reusable }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -117,7 +118,7 @@ jobs:
           --input-dir "$RUNNER_TEMP/ci-evidence"
           --source-run-id "${{ steps.locate-ci-evidence.outputs.source_run_id }}"
 
-      - name: Report shadow fallback
+      - name: Report exhaustive fallback
         if: >-
           always() &&
           steps.validate-ci-evidence.outputs.reusable != 'true'
@@ -126,17 +127,22 @@ jobs:
           VALIDATE_REASON: ${{ steps.validate-ci-evidence.outputs.reason }}
         run: |
           {
-            echo "### Exact-tree evidence shadow verdict"
+            echo "### Exact-tree evidence reuse verdict"
             echo
-            echo "- Would reuse: **no**"
+            echo "- Reused: **no**"
             echo "- Reason: ${VALIDATE_REASON:-${LOCATE_REASON:-evidence unavailable}}"
-            echo "- Enforcement: disabled; this push still runs exhaustive evidence"
+            echo "- Enforcement: fail-closed; this push runs exhaustive evidence"
           } >> "$GITHUB_STEP_SUMMARY"
 
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     steps:
       - uses: actions/checkout@v7
 
@@ -194,7 +200,12 @@ jobs:
   policy-guards-workspace:
     name: Policy Guards (workspace)
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     steps:
       - uses: actions/checkout@v7
       - name: Setup pnpm with cache
@@ -243,6 +254,12 @@ jobs:
   routing-contract:
     name: Routing Tier Contract
     runs-on: ubuntu-latest
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     # Merge-blocking. Locks the "right LLM for the right job" principle
     # into CI — asserts that for every task type in BUILT_IN_TASK_REQUIREMENTS,
     # routing picks a model that meets the tier floor, required capabilities,
@@ -285,7 +302,12 @@ jobs:
   test-web:
     name: Unit Tests (web shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     strategy:
       # Surface every shard's failures, don't cancel siblings on first red.
       fail-fast: false
@@ -330,7 +352,12 @@ jobs:
   test-packages:
     name: Unit Tests (packages)
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -382,14 +409,26 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: [test-web, test-packages]
+    needs: [changes, exact-tree-evidence-shadow, test-web, test-packages]
     if: always()
     steps:
       - name: Assert all unit-test jobs passed
+        env:
+          REUSE_EXACT_TREE: ${{ needs.exact-tree-evidence-shadow.outputs.reusable }}
+          WEB_RESULT: ${{ needs.test-web.result }}
+          PACKAGES_RESULT: ${{ needs.test-packages.result }}
         run: |
-          echo "web shards: ${{ needs.test-web.result }}"
-          echo "packages:   ${{ needs.test-packages.result }}"
-          if [ "${{ needs.test-web.result }}" != "success" ] || [ "${{ needs.test-packages.result }}" != "success" ]; then
+          echo "web shards: $WEB_RESULT"
+          echo "packages:   $PACKAGES_RESULT"
+          if [ "$REUSE_EXACT_TREE" = "true" ]; then
+            if [ "$WEB_RESULT" != "skipped" ] || [ "$PACKAGES_RESULT" != "skipped" ]; then
+              echo "::error::Exact-tree reuse expected unit-test jobs to be skipped"
+              exit 1
+            fi
+            echo "Exact-tree merge-group unit-test evidence reused"
+            exit 0
+          fi
+          if [ "$WEB_RESULT" != "success" ] || [ "$PACKAGES_RESULT" != "success" ]; then
             echo "::error::One or more unit-test jobs failed"
             exit 1
           fi
@@ -398,7 +437,12 @@ jobs:
   build:
     name: Production Build
     runs-on: ubuntu-latest
-    needs: changes
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     env:
       ADMIN_PASSWORD: ci_admin_changeme
       DATABASE_URL: postgresql://dpf:ci_test_password@localhost:5432/dpf
@@ -464,10 +508,16 @@ jobs:
   # BI-D9E8B8CB. Start fixture provisioning alongside Production Build, then
   # rendezvous with that exact current-run artifact after setup. A job-level
   # `needs: build` serialized the setup and measured slower than the prior
-  # topology, so `changes` is the only scheduling dependency.
+  # topology. `changes` remains the only producer dependency; the receipt job
+  # is a push-only allocation gate and never serializes PR/merge-group setup.
   ux-route-sweep-runtime:
     name: UX Route Sweep Runtime
-    needs: changes
+    needs: [changes, exact-tree-evidence-shadow]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     uses: ./.github/workflows/ux-route-sweep.yml
     permissions:
       actions: read
@@ -487,13 +537,23 @@ jobs:
     name: UX Route Budget Sweep
     runs-on: ubuntu-latest
     if: always()
-    needs: [changes, ux-route-sweep-runtime]
+    needs: [changes, exact-tree-evidence-shadow, ux-route-sweep-runtime]
     steps:
       - name: Assert the planned route evidence completed
         env:
           PORTAL_UX_REQUIRED: ${{ needs.changes.outputs.portal_ux_required }}
+          REUSE_EXACT_TREE: ${{ needs.exact-tree-evidence-shadow.outputs.reusable }}
           RUNTIME_RESULT: ${{ needs.ux-route-sweep-runtime.result }}
         run: |
+          if [ "$REUSE_EXACT_TREE" = "true" ]; then
+            if [ "$RUNTIME_RESULT" != "skipped" ]; then
+              echo "::error::Exact-tree reuse expected UX runtime to be skipped"
+              exit 1
+            fi
+            echo "Exact-tree merge-group UX evidence reused"
+            exit 0
+          fi
+
           if [ "$PORTAL_UX_REQUIRED" = "false" ]; then
             if [ "$RUNTIME_RESULT" != "skipped" ]; then
               echo "::error::Non-portal UX runtime concluded $RUNTIME_RESULT instead of skipped"
@@ -561,8 +621,13 @@ jobs:
     # Not a required context, so it can be skipped at job level on docs-only PRs
     # (the integration harness only exercises code paths). needs typecheck for
     # ordering; needs changes for the heavy gate.
-    needs: [changes, typecheck]
-    if: needs.changes.outputs.heavy == 'true'
+    needs: [changes, exact-tree-evidence-shadow, typecheck]
+    if: >-
+      always() &&
+      needs.changes.outputs.heavy == 'true' &&
+      needs.typecheck.result == 'success' &&
+      (github.event_name != 'push' ||
+      needs.exact-tree-evidence-shadow.outputs.reusable != 'true')
     env:
       AUTH_SECRET: ci-placeholder
       CREDENTIAL_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -7436,7 +7436,7 @@
         "local-ci-admission-and-fairness",
         "impact-planner-shadow-mode",
         "exact-tree-production-build-reuse",
-        "exact-tree-cross-lifecycle-receipt-foundation-shadow",
+        "exact-tree-cross-lifecycle-receipt-reuse",
         "ux-route-sweep-stability",
         "baseline-snapshot"
       ]

--- a/docs/superpowers/plans/2026-07-31-exact-tree-reuse-activation.md
+++ b/docs/superpowers/plans/2026-07-31-exact-tree-reuse-activation.md
@@ -1,0 +1,50 @@
+# Exact-tree main-push reuse activation
+
+**Backlog:** BI-9585E580  
+**Work Capsule:** WC-BFB3F681
+**Plan coverage receipt:** cms8zpzk20gtp01mz2hwg417d (`atomic`)
+
+## Outcome
+
+Reuse a successful merge-group CI receipt when the subsequent `main` push has
+the identical Git tree. Pull-request and merge-group verification remain
+exhaustive. Missing, expired, malformed, incomplete, or mismatched evidence
+falls back to the existing exhaustive push workflow.
+
+## Atomic scope
+
+This is one independently releasable policy change: receipt validation and
+workflow allocation must change together. Activating only the workflow would
+trust receipts that can contain skipped heavy gates; hardening receipts without
+using their verdict would deliver no cycle-time reduction.
+
+## Implementation
+
+1. Define the heavy gate set that a reusable receipt must record as
+   `success`; `skipped` is not reusable evidence for those gates.
+2. Expose the validated receipt verdict from the push-only exact-tree job.
+3. On `push` only, skip duplicate heavy job allocations when and only when the
+   verdict is exactly `true`. Any other value runs exhaustive verification.
+4. Keep the stable `Unit Tests`, `UX Route Sweep`, and `Merge Readiness`
+   aggregate checks. Their summaries explicitly attest exact-tree reuse.
+5. Update CI evidence documentation and architecture tests.
+
+## Verification
+
+- Receipt unit tests reject a skipped required heavy gate at creation and
+  validation.
+- Workflow architecture tests prove PR and merge-group runs stay exhaustive,
+  only duplicated heavy push jobs consume the verdict, and unknown verdicts
+  fall back to exhaustive execution.
+- Repository policy and injection guards pass.
+- Exact-SHA governed local CI passes before publication.
+- The merge-group run creates a complete receipt; the resulting `main` push
+  validates that receipt, skips only duplicated heavy jobs, and keeps all
+  stable aggregate checks green.
+
+## Non-goals
+
+- No affected-test selection activation; BI-2F60FDCE remains shadow-only until
+  its two-week recall threshold is satisfied.
+- No reduction in pull-request or merge-group coverage.
+- No queue-capacity, runner-slot, or local-CI lease changes.

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -282,19 +282,24 @@ The CI and UX job summaries report payload bytes and packaging or
 download/validation/extraction duration. Compare those transfer measurements
 with the avoided UX build duration before retaining or tuning the artifact.
 
-## Exact-tree cross-lifecycle receipt (foundation shadow)
+## Exact-tree cross-lifecycle receipt reuse
 
 `BI-9585E580` adds the GitHub-native evidence contract needed to avoid a second
-exhaustive run after an identical merge-group tree reaches `main`. The initial
-slice is deliberately **shadow-only**:
+exhaustive run after an identical merge-group tree reaches `main`:
 
 - a successful merge-group `Merge Readiness` job writes
   `ci-evidence.json` plus `ci-evidence.sha256` after it has accepted every
   dependency;
 - the artifact name includes the immutable Git tree, not only the commit SHA;
 - a push job discovers, downloads, and validates the candidate receipt; and
-- Typecheck, unit/integration tests, Production Build, and UX still run
-  exhaustively regardless of the shadow verdict.
+- only an exact `reusable=true` verdict suppresses duplicate Typecheck,
+  workspace policy, routing-contract, unit/integration-test, Production Build,
+  and UX runner allocations on that `main` push.
+
+Pull-request and merge-group runs remain exhaustive. The stable `Unit Tests`,
+`UX Route Budget Sweep`, and `Merge Readiness` checks remain present on a
+reused push and explicitly attest that their heavy dependencies were skipped
+because exact-tree evidence was accepted.
 
 The receipt binds repository, commit and tree identity, source event/run,
 workflow fingerprint, producer plan digest, planner implementation fingerprint,
@@ -305,17 +310,17 @@ manifest. The companion checksum detects receipt tampering. Validation re-reads
 the source run, its artifact inventory, and the latest CheckRuns for every
 required context—including the independently executed DCO check—from GitHub.
 
-Only a completed, successful `merge_group` producer is eligible. A different
-tree, changed workflow/planner/policy/toolchain, missing or failed gate,
+Only a completed, successful `merge_group` producer is eligible. Every heavy
+gate reused by the push must be recorded as `success`; a merely `skipped` heavy
+gate is not reusable evidence. A different tree, changed
+workflow/planner/policy/toolchain, missing, skipped, or failed required gate,
 different artifact digest, malformed receipt, expiry, API failure, or missing
-evidence produces the explicit shadow verdict `exhaustive`. Unknown never means
-reuse.
+evidence produces the explicit verdict `exhaustive`. Unknown never means reuse.
 
-This foundation does not change branch protection or mint a DPF
+This policy does not change branch protection or mint a DPF
 `ToolExecutionReceipt`; GitHub CheckRun/CheckSuite state and workflow artifacts
-remain the evidence authority. Activation stays separate and must prove the
-real shadow path before any job-level condition consumes the verdict. The
-affected-test calibration window is also unchanged.
+remain the evidence authority. The affected-test calibration window is
+unchanged and remains shadow-only.
 
 GitHub documents that merge-queue checks run against the merge-group head SHA
 and that artifacts from another workflow run require an explicit run identifier

--- a/scripts/ci-build-artifact-workflow.test.mjs
+++ b/scripts/ci-build-artifact-workflow.test.mjs
@@ -18,7 +18,10 @@ describe("production-build artifact workflow wiring", () => {
   });
 
   it("rendezvous with the same-run build without serializing fixture setup", () => {
-    assert.match(ci, /ux-route-sweep-runtime:[\s\S]*?needs: changes/);
+    assert.match(
+      ci,
+      /ux-route-sweep-runtime:[\s\S]*?needs: \[changes, exact-tree-evidence-shadow\]/,
+    );
     assert.doesNotMatch(ci, /ux-route-sweep-runtime:[\s\S]*?needs: \[changes, build\]/);
     assert.match(ci, /uses: \.\/\.github\/workflows\/ux-route-sweep\.yml/);
     assert.match(
@@ -57,7 +60,7 @@ describe("production-build artifact workflow wiring", () => {
   it("preserves the stable required check and manual calibration path", () => {
     assert.match(
       ci,
-      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep\s*\n\s+runs-on: ubuntu-latest\s*\n\s+if: always\(\)\s*\n\s+needs: \[changes, ux-route-sweep-runtime\]/,
+      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep\s*\n\s+runs-on: ubuntu-latest\s*\n\s+if: always\(\)\s*\n\s+needs: \[changes, exact-tree-evidence-shadow, ux-route-sweep-runtime\]/,
     );
     assert.match(ci, /needs\.ux-route-sweep-runtime\.result/);
     assert.match(ci, /merge_group:/);
@@ -67,7 +70,7 @@ describe("production-build artifact workflow wiring", () => {
     assert.match(ux, /--update-baseline/);
   });
 
-  it("skips runner allocation only for an explicit non-portal PR scope", () => {
+  it("skips runner allocation only for non-portal scope or accepted exact-tree reuse", () => {
     assert.match(
       ux,
       /run_sweep:\s*\n\s+description:[^\n]*\n\s+required: false\s*\n\s+type: boolean\s*\n\s+default: true/,
@@ -83,7 +86,16 @@ describe("production-build artifact workflow wiring", () => {
     );
     assert.match(
       ci,
-      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep[\s\S]*?needs: \[changes, ux-route-sweep-runtime\]/,
+      /ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep[\s\S]*?needs: \[changes, exact-tree-evidence-shadow, ux-route-sweep-runtime\]/,
+    );
+    assert.match(
+      ci,
+      /REUSE_EXACT_TREE: \$\{\{ needs\.exact-tree-evidence-shadow\.outputs\.reusable \}\}/,
+    );
+    assert.match(
+      ci,
+      /if \[ "\$REUSE_EXACT_TREE" = "true" \]; then[\s\S]*?\[ "\$RUNTIME_RESULT" != "skipped" \][\s\S]*?exit 1[\s\S]*?exit 0/,
+      "the aggregate must accept a runtime skip only after an exact reusable verdict",
     );
     assert.match(
       ci,

--- a/scripts/ci-evidence-receipt-workflow.test.mjs
+++ b/scripts/ci-evidence-receipt-workflow.test.mjs
@@ -4,7 +4,14 @@ import { describe, it } from "node:test";
 
 const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
 
-describe("exact-tree CI receipt foundation workflow", () => {
+function jobBlock(job) {
+  const start = workflow.indexOf(`  ${job}:`);
+  assert.ok(start >= 0, `missing ${job}`);
+  const next = workflow.slice(start + 2).search(/\n  [a-z0-9-]+:\s*\n/);
+  return workflow.slice(start, next < 0 ? workflow.length : start + 2 + next);
+}
+
+describe("exact-tree CI receipt reuse workflow", () => {
   it("publishes a merge-group receipt only after aggregate policy acceptance", () => {
     const aggregate = workflow.slice(workflow.indexOf("  merge-readiness:"));
     const evaluateAt = aggregate.indexOf("node scripts/merge-readiness-policy.mjs evaluate-needs");
@@ -24,37 +31,72 @@ describe("exact-tree CI receipt foundation workflow", () => {
     assert.match(aggregate, /name: \$\{\{ steps\.create-ci-evidence\.outputs\.artifact_name \}\}/);
   });
 
-  it("observes exact-tree evidence on push without suppressing any gate", () => {
-    const start = workflow.indexOf("  exact-tree-evidence-shadow:");
-    const end = workflow.indexOf("\n  typecheck:", start);
-    const shadow = workflow.slice(start, end);
+  it("exports a push-only, fail-closed reuse verdict", () => {
+    const reuse = jobBlock("exact-tree-evidence-shadow");
 
-    assert.ok(start >= 0, "shadow job must exist");
-    assert.match(shadow, /if: github\.event_name == 'push'/);
-    assert.match(shadow, /node scripts\/ci-evidence-receipt\.mjs locate/);
-    assert.match(shadow, /uses: actions\/download-artifact@v8/);
-    assert.match(shadow, /github-token: \$\{\{ github\.token \}\}/);
-    assert.match(shadow, /run-id: \$\{\{ steps\.locate-ci-evidence\.outputs\.source_run_id \}\}/);
-    assert.match(shadow, /node scripts\/ci-evidence-receipt\.mjs validate/);
+    assert.match(reuse, /if: github\.event_name == 'push'/);
+    assert.match(reuse, /outputs:\s*\n\s+reusable: \$\{\{ steps\.validate-ci-evidence\.outputs\.reusable \}\}/);
+    assert.match(reuse, /node scripts\/ci-evidence-receipt\.mjs locate/);
+    assert.match(reuse, /uses: actions\/download-artifact@v8/);
+    assert.match(reuse, /github-token: \$\{\{ github\.token \}\}/);
+    assert.match(reuse, /run-id: \$\{\{ steps\.locate-ci-evidence\.outputs\.source_run_id \}\}/);
+    assert.match(reuse, /node scripts\/ci-evidence-receipt\.mjs validate/);
+    assert.match(reuse, /steps\.validate-ci-evidence\.outputs\.reusable != 'true'/);
+  });
 
-    assert.doesNotMatch(
-      workflow,
-      /needs\.exact-tree-evidence-shadow\.outputs\.(?:reusable|reuse)/,
-      "foundation shadow verdict must not control job allocation",
-    );
-    for (const job of ["typecheck", "test-web", "test-packages", "build", "ux-route-sweep-runtime"]) {
-      const blockStart = workflow.indexOf(`  ${job}:`);
-      assert.ok(blockStart >= 0, `missing ${job}`);
-      const nextJob = workflow.slice(blockStart + 2).search(/\n  [a-z0-9-]+:\s*\n/);
-      const block = workflow.slice(
-        blockStart,
-        nextJob < 0 ? workflow.length : blockStart + 2 + nextJob,
+  it("suppresses only duplicated heavy push jobs after exact-tree acceptance", () => {
+    const heavyJobs = [
+      "typecheck",
+      "policy-guards-workspace",
+      "routing-contract",
+      "test-web",
+      "test-packages",
+      "build",
+      "ux-route-sweep-runtime",
+      "adp-integration-tests",
+    ];
+    for (const job of heavyJobs) {
+      const block = jobBlock(job);
+      assert.match(block, /exact-tree-evidence-shadow/, `${job} must depend on the reuse verdict`);
+      assert.match(
+        block,
+        /if: >-\s+always\(\) &&/,
+        `${job} must run its condition even when the push-only reuse job is skipped`,
       );
-      assert.doesNotMatch(block, /exact-tree-evidence-shadow/, `${job} must remain exhaustive`);
+      assert.match(
+        block,
+        /github\.event_name != 'push' \|\|\s+needs\.exact-tree-evidence-shadow\.outputs\.reusable != 'true'/,
+        `${job} must fail closed to exhaustive execution`,
+      );
+    }
+
+    for (const job of [
+      "policy-guards-source",
+      "policy-guards-pr",
+      "dockerfile-node-version",
+      "compose-image-pins",
+    ]) {
+      assert.doesNotMatch(
+        jobBlock(job),
+        /needs\.exact-tree-evidence-shadow\.outputs\.reusable/,
+        `${job} must remain independently executable`,
+      );
     }
   });
 
-  it("keeps the shadow job inside the stable merge-readiness aggregate", () => {
+  it("keeps stable aggregate checks authoritative during reuse", () => {
+    const unitTests = jobBlock("unit-tests");
+    assert.match(unitTests, /needs: \[changes, exact-tree-evidence-shadow, test-web, test-packages\]/);
+    assert.match(unitTests, /REUSE_EXACT_TREE: \$\{\{ needs\.exact-tree-evidence-shadow\.outputs\.reusable \}\}/);
+    assert.match(unitTests, /Exact-tree merge-group unit-test evidence reused/);
+
+    const uxSweep = jobBlock("ux-route-sweep");
+    assert.match(uxSweep, /needs: \[changes, exact-tree-evidence-shadow, ux-route-sweep-runtime\]/);
+    assert.match(uxSweep, /REUSE_EXACT_TREE: \$\{\{ needs\.exact-tree-evidence-shadow\.outputs\.reusable \}\}/);
+    assert.match(uxSweep, /Exact-tree merge-group UX evidence reused/);
+  });
+
+  it("keeps the reuse job inside the stable merge-readiness aggregate", () => {
     assert.match(
       workflow,
       /merge-readiness:\s*\n\s+name: Merge Readiness[\s\S]*?needs:[\s\S]*?- exact-tree-evidence-shadow/,

--- a/scripts/ci-evidence-receipt.mjs
+++ b/scripts/ci-evidence-receipt.mjs
@@ -30,6 +30,18 @@ const PLANNER_PATHS = [
   "config/ci-evidence-policy.json",
 ];
 const SETUP_PATH = ".github/actions/setup-pnpm/action.yml";
+const REUSABLE_HEAVY_GATE_IDS = [
+  "typecheck",
+  "policy-guards-workspace",
+  "routing-contract",
+  "test-web",
+  "test-packages",
+  "unit-tests",
+  "build",
+  "ux-route-sweep-runtime",
+  "ux-route-sweep",
+  "adp-integration-tests",
+];
 
 function parseArgs(argv) {
   const [mode, ...rest] = argv;
@@ -171,6 +183,7 @@ async function create(options) {
     },
     toolchain: identity.toolchain,
     gates: needs,
+    requiredSuccessfulGateIds: REUSABLE_HEAVY_GATE_IDS,
     artifacts,
     createdAt: new Date(now).toISOString(),
     expiresAt: new Date(now + CI_EVIDENCE_LIFETIME_MS).toISOString(),
@@ -187,12 +200,12 @@ async function create(options) {
   appendSummary([
     "### Exact-tree CI evidence receipt",
     "",
-    "- Mode: foundation shadow; no post-merge work is skipped",
+    "- Mode: exact-tree main-push reuse",
     "- Receipt: created with a companion SHA-256 checksum",
-    "- Scope: immutable tree, policy, toolchain, gates, checks, and artifacts",
+    "- Scope: immutable tree, policy, toolchain, successful heavy gates, checks, and artifacts",
   ]);
   console.log(
-    `[ci-evidence-receipt] created shadow receipt for tree ${receipt.source.treeSha} `
+    `[ci-evidence-receipt] created reusable receipt for tree ${receipt.source.treeSha} `
     + `with ${receipt.gates.length} gates`,
   );
 }
@@ -222,7 +235,7 @@ async function locate() {
       reason: verdict.reason,
       tree_sha: treeSha,
     });
-    console.log(`[ci-evidence-receipt] shadow discovery: ${verdict.reason}`);
+    console.log(`[ci-evidence-receipt] reuse discovery: ${verdict.reason}`);
   } catch (error) {
     const reason = "discovery unavailable; exhaustive evidence remains required";
     appendOutput({
@@ -270,6 +283,7 @@ async function validate(options) {
         mergePolicyRequiredContexts: identity.mergePolicyRequiredContexts,
         toolchain: identity.toolchain,
         gateIds: expectedGateIds(),
+        requiredSuccessfulGateIds: REUSABLE_HEAVY_GATE_IDS,
         artifacts: normalizeArtifactInventory(await runArtifacts(sourceRunId)),
         sourceChecks: checks.check_runs ?? [],
       },
@@ -283,28 +297,28 @@ async function validate(options) {
       reason,
     });
     appendSummary([
-      "### Exact-tree evidence shadow verdict",
+      "### Exact-tree evidence reuse verdict",
       "",
-      `- Would reuse: **${result.ok ? "yes" : "no"}**`,
+      `- Reusable: **${result.ok ? "yes" : "no"}**`,
       `- Reason: ${reason}`,
-      "- Enforcement: disabled; this push still runs exhaustive evidence",
+      `- Enforcement: ${result.ok ? "duplicate heavy push jobs are skipped" : "exhaustive fallback"}`,
     ]);
     if (!result.ok) {
       console.warn(
-        `[ci-evidence-receipt] shadow validation rejected evidence: ${result.reasons.join("; ")}`,
+        `[ci-evidence-receipt] reuse validation rejected evidence: ${result.reasons.join("; ")}`,
       );
     } else {
-      console.log("[ci-evidence-receipt] shadow validation accepted exact-tree evidence");
+      console.log("[ci-evidence-receipt] reuse validation accepted exact-tree evidence");
     }
   } catch (error) {
     const reason = "validation unavailable; exhaustive evidence remains required";
     appendOutput({ reusable: "false", reason });
     appendSummary([
-      "### Exact-tree evidence shadow verdict",
+      "### Exact-tree evidence reuse verdict",
       "",
-      "- Would reuse: **no**",
+      "- Reusable: **no**",
       `- Reason: ${reason}`,
-      "- Enforcement: disabled; this push still runs exhaustive evidence",
+      "- Enforcement: exhaustive fallback",
     ]);
     console.warn(`[ci-evidence-receipt] ${reason}: ${error.message}`);
   }

--- a/scripts/lib/ci-evidence-receipt.mjs
+++ b/scripts/lib/ci-evidence-receipt.mjs
@@ -35,6 +35,21 @@ function normalizedGates(gates) {
     .sort((left, right) => left.jobId.localeCompare(right.jobId));
 }
 
+function normalizedRequiredGateIds(gateIds) {
+  if (!Array.isArray(gateIds)) return null;
+  const normalized = gateIds.filter((gateId) => typeof gateId === "string" && gateId.length > 0);
+  if (normalized.length === 0 || normalized.length !== gateIds.length) return null;
+  if (new Set(normalized).size !== normalized.length) return null;
+  return [...normalized].sort();
+}
+
+function incompleteRequiredGates(gates, requiredGateIds) {
+  const results = new Map(gates.map((gate) => [gate.jobId, gate.result]));
+  return requiredGateIds
+    .map((jobId) => ({ jobId, result: results.get(jobId) }))
+    .filter((gate) => gate.result !== "success");
+}
+
 export function normalizeArtifactInventory(artifacts) {
   return (artifacts ?? [])
     .filter((artifact) =>
@@ -74,6 +89,16 @@ export function createEvidenceReceipt(input) {
     );
   }
   if (gates.length === 0) throw new Error("cannot attest an empty CI gate set");
+  const requiredGateIds = normalizedRequiredGateIds(input.requiredSuccessfulGateIds);
+  if (!requiredGateIds) throw new Error("cannot attest an invalid required successful gate set");
+  const incompleteRequired = incompleteRequiredGates(gates, requiredGateIds);
+  if (incompleteRequired.length > 0) {
+    throw new Error(
+      `required successful CI gates are incomplete: ${
+        incompleteRequired.map((gate) => `${gate.jobId}=${gate.result ?? "missing"}`).join(", ")
+      }`,
+    );
+  }
 
   const artifacts = normalizeArtifactInventory(input.artifacts);
   if (artifacts.length === 0) throw new Error("cannot attest an empty artifact inventory");
@@ -174,6 +199,14 @@ export function validateEvidenceReceipt({ receipt, expected, checksum, now = Dat
   const actualGateIds = gates.map((gate) => gate.jobId).sort();
   const expectedGateIds = [...expected.gateIds].sort();
   if (!same(actualGateIds, expectedGateIds)) reasons.push("gate set mismatch");
+  const requiredGateIds = normalizedRequiredGateIds(expected.requiredSuccessfulGateIds);
+  if (!requiredGateIds) {
+    reasons.push("invalid required successful gate set");
+  } else {
+    for (const gate of incompleteRequiredGates(gates, requiredGateIds)) {
+      reasons.push(`required successful gate ${gate.jobId}=${gate.result ?? "missing"}`);
+    }
+  }
 
   const artifacts = normalizeArtifactInventory(receipt.artifacts);
   if (invalidArtifacts(artifacts).length > 0 || artifacts.length === 0) {

--- a/scripts/lib/ci-evidence-receipt.test.mjs
+++ b/scripts/lib/ci-evidence-receipt.test.mjs
@@ -50,6 +50,15 @@ function fixtureInput() {
       "ux-route-sweep": "success",
       "exact-tree-evidence-shadow": "skipped",
     },
+    requiredSuccessfulGateIds: [
+      "typecheck",
+      "test-web",
+      "test-packages",
+      "unit-tests",
+      "build",
+      "ux-route-sweep-runtime",
+      "ux-route-sweep",
+    ],
     artifacts: [
       {
         name: "ci-evidence-plan-30590378765-1",
@@ -80,6 +89,7 @@ function expectedFrom(input) {
     mergePolicyRequiredContexts: input.mergePolicy.requiredContexts,
     toolchain: input.toolchain,
     gateIds: Object.keys(input.gates),
+    requiredSuccessfulGateIds: input.requiredSuccessfulGateIds,
     artifacts: input.artifacts,
     sourceChecks: input.mergePolicy.requiredContexts.map((name) => ({
       name,
@@ -115,6 +125,37 @@ describe("exact-tree CI evidence receipt", () => {
         /cannot attest incomplete CI gates: typecheck=/,
       );
     }
+  });
+
+  it("refuses to create reusable evidence when a required heavy gate was skipped or omitted", () => {
+    const skipped = fixtureInput();
+    skipped.gates.typecheck = "skipped";
+    assert.throws(
+      () => createEvidenceReceipt(skipped),
+      /required successful CI gates are incomplete: typecheck=skipped/,
+    );
+
+    const omitted = fixtureInput();
+    delete omitted.gates.typecheck;
+    assert.throws(
+      () => createEvidenceReceipt(omitted),
+      /required successful CI gates are incomplete: typecheck=missing/,
+    );
+  });
+
+  it("rejects a tampered receipt that marks a required heavy gate skipped", () => {
+    const input = fixtureInput();
+    const receipt = createEvidenceReceipt(input);
+    receipt.gates.find((gate) => gate.jobId === "typecheck").result = "skipped";
+    const result = validateEvidenceReceipt({
+      receipt,
+      expected: expectedFrom(input),
+      checksum: receiptChecksum(receipt),
+      now: NOW + 60_000,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.reasons.join("\n"), /required successful gate typecheck=skipped/);
   });
 
   it("fails closed for every receipt identity and completeness mismatch", () => {


### PR DESCRIPTION
## Summary

- reuse complete merge-group evidence when the subsequent `main` push has the same immutable tree
- skip only the duplicated heavy jobs after a fail-closed receipt validation; keep lightweight policy checks and aggregate checks independently executable
- require every reusable heavy gate to be present and successful when a receipt is created and when it is consumed

## Architecture and safety

- backlog: BI-9585E580
- work capsule: WC-BFB3F681
- absent, expired, malformed, mismatched, incomplete, skipped, or red evidence falls back to the exhaustive path
- affected-test selection remains shadow-only and local-CI capacity remains one

## Verification

- governed exact-SHA local CI passed for `7148aa3561e74ca372334e7079142b9aec0c686e` on accepted base `5a93ad2630d4e3fe7ab887d86f3be79c801a939b`
- exhaustive tests, typecheck, 479 migrations, docs/guards, freshness, and production Docker build passed
- focused workflow/receipt/policy suite: 34 tests passed; Actions injection audit, doc links, derived index, policy drift, and diff checks passed
- UX verification not applicable: CI workflow, validation scripts, tests, and documentation only

Local-CI-Evidence: cms90tbau0j1301mzizk5f1ug (fix/ci-exact-tree-reuse-activation@7148aa3561e74ca372334e7079142b9aec0c686e)
