### PR TITLE
fix(ci): prevent local build control-plane starvation (BI-CE6E2882)

### DIFF
--- a/apps/web/lib/build/autonomous-build-custody.ts
+++ b/apps/web/lib/build/autonomous-build-custody.ts
@@ -29,6 +29,7 @@ const STALE_HEARTBEAT_MS = 10 * 60 * 1000;
 
 const REPAIR_COPY: Record<string, string> = {
   blocked_sandbox_drift: "The shared verification environment is being refreshed.",
+  blocked_control_plane_starvation: "The shared verification control plane is awaiting governed recovery.",
   sandbox_unavailable: "Build Studio is waiting for a governed verification environment.",
   provider_unavailable: "Build Studio is switching to an eligible AI provider.",
   oracles_red: "Build Studio is repairing evidence that did not pass verification.",

--- a/apps/web/lib/build/autonomous-recovery-policy.test.ts
+++ b/apps/web/lib/build/autonomous-recovery-policy.test.ts
@@ -13,6 +13,7 @@ describe("classifyAutonomousBuildFailure", () => {
     ["tool protocol mismatch", "code_generated", "tool-protocol-mismatch"],
     ["maximum context length exceeded", "code_generated", "context-overflow"],
     ["blocked_sandbox_drift", "sandbox_created", "sandbox-drift"],
+    ["blocked_control_plane_starvation", "tests_run", "control-plane-starvation"],
     ["error TS2322 typecheck failed", "code_generated", "scoped-verification-failure"],
   ] as const)("classifies %s", (message, step, expected) => {
     expect(classifyAutonomousBuildFailure({ message, step })).toBe(expected);
@@ -79,6 +80,19 @@ describe("decideAutonomousRecovery", () => {
 
     expect(decision).toMatchObject({
       action: "converge-governed-sandbox",
+      consumedBudget: false,
+      terminal: false,
+      state,
+    });
+  });
+
+  it("waits for governed recovery after control-plane starvation", () => {
+    const state = initialAutonomousRecoveryState();
+    expect(decideAutonomousRecovery({
+      failureClass: "control-plane-starvation",
+      state,
+    })).toMatchObject({
+      action: "await-governed-runner",
       consumedBudget: false,
       terminal: false,
       state,

--- a/apps/web/lib/build/autonomous-recovery-policy.ts
+++ b/apps/web/lib/build/autonomous-recovery-policy.ts
@@ -9,6 +9,7 @@ export const AUTONOMOUS_FAILURE_CLASSES = [
   "reproduced-review-finding",
   "plan-oscillation",
   "sandbox-drift",
+  "control-plane-starvation",
   "post-push-ci-failure",
   "queue-stale-base",
   "unresolved-review-thread",
@@ -74,6 +75,9 @@ export function classifyAutonomousBuildFailure(input: {
   }
   if (/blocked_sandbox_drift|sandbox.*(?:drift|freshness)/.test(text)) {
     return "sandbox-drift";
+  }
+  if (/blocked_control_plane_starvation|control-plane.*starv/.test(text)) {
+    return "control-plane-starvation";
   }
   if (
     /typecheck|error ts\d{4}|tests? failed|build failed/.test(text)
@@ -212,7 +216,10 @@ export function decideAutonomousRecovery(input: {
       state,
     };
   }
-  if (failureClass === "self-upgrade-failure") {
+  if (
+    failureClass === "self-upgrade-failure"
+    || failureClass === "control-plane-starvation"
+  ) {
     return {
       action: "await-governed-runner",
       consumedBudget: false,

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8673,6 +8673,7 @@
         "observation-versus-merge-authority",
         "know-the-constraints-before-you-write-pnpm-gatecontext",
         "before-a-pr-exists-pnpm-prready",
+        "local-ci-infrastructure-outcomes",
         "tests-ci"
       ]
     },

--- a/apps/web/lib/mcp/packs/build-evidence-pack.test.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.test.ts
@@ -153,6 +153,7 @@ describe("build-evidence pack — handler behavior (delegation preserved)", () =
       "antigravity",
       "coworker",
     ]);
+    expect(properties?.status.enum).toContain("blocked_control_plane_starvation");
   });
 
   it("record_execution_evidence surfaces not_found for an unknown item", async () => {

--- a/apps/web/lib/mcp/packs/build-evidence-pack.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.ts
@@ -66,7 +66,7 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "record_local_integration_result",
-    description: "Record the result of a local merged-code integration gate before push or PR. Captures candidate branch, mode, status (passed | failed | conflict | blocked_sandbox_drift — the latter means the shared sandbox was stale/not-ready and the run is NOT product evidence), and evidence including dependency-freshness verdict.",
+    description: "Record the result of a local merged-code integration gate before push or PR. Captures candidate branch, mode, status (passed | failed | conflict | blocked_sandbox_drift | blocked_control_plane_starvation), and evidence including dependency freshness and concurrent control-plane health. Blocked statuses are infrastructure evidence, not product failures.",
     inputSchema: {
       type: "object",
       properties: {
@@ -77,7 +77,7 @@ const definitions: ToolDefinition[] = [
         taskRunId: { type: "string" },
         candidateBranch: { type: "string" },
         mode: { type: "string", enum: ["single-branch", "sibling-set", "post-merge-main"] },
-        status: { type: "string", enum: ["passed", "failed", "conflict", "blocked_sandbox_drift"] },
+        status: { type: "string", enum: ["passed", "failed", "conflict", "blocked_sandbox_drift", "blocked_control_plane_starvation"] },
         summary: { type: "string" },
         evidence: { type: "object" },
       },
@@ -233,7 +233,7 @@ async function recordLocalIntegrationResultHandler(
   if (!["single-branch", "sibling-set", "post-merge-main"].includes(mode)) {
     return { success: false, error: "invalid_mode", message: `Unsupported local integration mode: ${mode}` };
   }
-  if (!["passed", "failed", "conflict", "blocked_sandbox_drift"].includes(status)) {
+  if (!["passed", "failed", "conflict", "blocked_sandbox_drift", "blocked_control_plane_starvation"].includes(status)) {
     return { success: false, error: "invalid_status", message: `Unsupported local integration status: ${status}` };
   }
 
@@ -246,7 +246,7 @@ async function recordLocalIntegrationResultHandler(
     taskRunId: stringValue("taskRunId") || undefined,
     candidateBranch,
     mode: mode as "single-branch" | "sibling-set" | "post-merge-main",
-    status: status as "passed" | "failed" | "conflict" | "blocked_sandbox_drift",
+    status: status as "passed" | "failed" | "conflict" | "blocked_sandbox_drift" | "blocked_control_plane_starvation",
     summary,
     evidence: evidence as import("@dpf/db").Prisma.InputJsonValue,
   });

--- a/apps/web/lib/nonprod/local-ci-pool-circuit-breaker.test.mjs
+++ b/apps/web/lib/nonprod/local-ci-pool-circuit-breaker.test.mjs
@@ -78,6 +78,24 @@ it("passed, slot-0, and non-slot evidence cannot trip the breaker", async () => 
   expect(reads).toBe(0);
 });
 
+it("control-plane starvation contracts capacity even when observed from slot-0", async () => {
+  const writes = [];
+  const platformConfig = {
+    findUnique: async () => ({ value: CONFIG, updatedAt: new Date("2026-07-31T00:00:00.000Z") }),
+    updateMany: async (args) => {
+      writes.push(args);
+      return { count: 1 };
+    },
+  };
+  const result = await contractLocalCiPoolAfterGateResult({
+    platformConfig,
+    status: "blocked_control_plane_starvation",
+    evidence: slotEvidence("slot-0"),
+  });
+  expect(result.status).toBe("contracted");
+  expect(writes[0].data.value.requestedCapacity).toBe(1);
+});
+
 it("an optimistic-concurrency miss retries against the latest policy", async () => {
   const newer = {
     ...CONFIG,

--- a/apps/web/lib/nonprod/local-ci-pool-circuit-breaker.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-circuit-breaker.ts
@@ -9,7 +9,8 @@ type LocalCiGateStatus =
   | "passed"
   | "failed"
   | "conflict"
-  | "blocked_sandbox_drift";
+  | "blocked_sandbox_drift"
+  | "blocked_control_plane_starvation";
 
 export type PlatformConfigCircuitBreakerStore = {
   findUnique: (args: {
@@ -48,6 +49,7 @@ function shouldContract(
   status: LocalCiGateStatus,
   evidence: unknown,
 ): boolean {
+  if (status === "blocked_control_plane_starvation") return true;
   return status !== "passed" && evidenceSlotKey(evidence) === "slot-1";
 }
 

--- a/apps/web/lib/nonprod/local-ci-slot-resources.json
+++ b/apps/web/lib/nonprod/local-ci-slot-resources.json
@@ -1,5 +1,12 @@
 {
   "schemaVersion": 1,
+  "builderPolicy": {
+    "version": 2,
+    "memoryBytes": 17179869184,
+    "cpuQuota": 800000,
+    "cpuPeriod": 100000,
+    "maxParallelism": 4
+  },
   "slots": {
     "slot-0": {
       "ordinal": 0,

--- a/apps/web/lib/nonprod/local-integration.test.ts
+++ b/apps/web/lib/nonprod/local-integration.test.ts
@@ -80,6 +80,28 @@ describe("recordLocalIntegrationResult", () => {
     );
   });
 
+  it("records control-plane starvation as infrastructure evidence", async () => {
+    await recordLocalIntegrationResult({
+      actorUserId: "user-1",
+      provider: "codex",
+      externalSessionId: "gate-starved",
+      routeContext: "/build",
+      candidateBranch: "fix/control-plane",
+      mode: "single-branch",
+      status: "blocked_control_plane_starvation",
+      summary: "The shared control-plane degraded during the production build.",
+      evidence: { controlPlane: { samples: 2, healthyThroughout: false } },
+    }, { platformConfig });
+
+    expect(mockRecordExternalEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          status: "blocked_control_plane_starvation",
+        }),
+      }),
+    );
+  });
+
   it("contracts the pool before recording a failed slot-1 result", async () => {
     const updatedAt = new Date("2026-07-30T12:00:00.000Z");
     platformConfig.findUnique.mockResolvedValueOnce({

--- a/apps/web/lib/nonprod/local-integration.ts
+++ b/apps/web/lib/nonprod/local-integration.ts
@@ -18,7 +18,12 @@ export type LocalIntegrationResultInput = {
   // "blocked_sandbox_drift": the shared sandbox's installed dependency graph
   // did not match the lockfile (or was mid-install), so the gate refused to
   // produce product evidence. A sandbox defect, not a product failure (BI-ECDF9520).
-  status: "passed" | "failed" | "conflict" | "blocked_sandbox_drift";
+  status:
+    | "passed"
+    | "failed"
+    | "conflict"
+    | "blocked_sandbox_drift"
+    | "blocked_control_plane_starvation";
   summary: string;
   evidence: Prisma.InputJsonValue;
 };

--- a/docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md
+++ b/docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md
@@ -946,6 +946,7 @@ type AutonomousBuildEligibility = {
 | Reproduced blocking review finding | repair and fresh re-review | 2 converging rounds |
 | Plan oscillation | decompose or return to design with retained findings | 1 decomposition |
 | Sandbox drift | classify `blocked_sandbox_drift`; converge governed sandbox | no product-failure charge |
+| Control-plane starvation | classify `blocked_control_plane_starvation`; stop the admitted build and await governed recovery | no product-failure charge; capacity remains one |
 | Post-push CI failure | inspect, classify, repair, locally verify, push new SHA | 2 rounds |
 | Queue rejection/stale base | exit queue, safe owned-commit replay, verify, re-enroll | 1 safe replay |
 | Unresolved review thread | reproduce/address/request re-review | 2 converging rounds |

--- a/docs/superpowers/plans/2026-07-31-local-ci-control-plane-starvation.md
+++ b/docs/superpowers/plans/2026-07-31-local-ci-control-plane-starvation.md
@@ -1,0 +1,147 @@
+# Local-CI Control-Plane Starvation Implementation Plan
+
+- **Status:** ready for implementation
+- **Date:** 2026-07-31
+- **Backlog item:** `BI-CE6E2882`
+- **Epic:** `EP-0DFF753B`
+- **Architecture:** `docs/superpowers/specs/2026-07-31-local-ci-control-plane-starvation-design.md`
+- **WWMD decision:** `DI-EBA2C9239C5C`
+- **Work Capsule:** `WC-BD87F076`
+- **Backlog coverage receipt:** `cms9082c00he801mznrw3jxfr` (`atomic`)
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-CE6E2882`
+- Receipt: `cms9082c00he801mznrw3jxfr`
+- Dependencies: none
+- Rationale: The bounded builder, independent watchdog, infrastructure status,
+  evidence propagation, pilot rollback rule, and recovery policy form one safety
+  boundary. Shipping any part independently would either leave starvation possible,
+  detect it without containment, or lose the evidence needed to prevent unsafe
+  capacity expansion.
+- Bounded local-CI build and end-to-end control-plane starvation prevention ->
+  `BI-CE6E2882`
+
+## Outcome
+
+Prevent a canonical local-CI production build from consuming the shared control
+plane, prove portal/MCP/Docker/PostgreSQL responsiveness throughout each build, and
+classify a sustained breach as infrastructure evidence that binds the capacity pilot.
+The implementation preserves exact Docker artifact identity and keeps requested
+capacity at one.
+
+## Atomic delivery decision
+
+This plan is one safety boundary under `BI-CE6E2882`. Resource bounding without the
+watchdog would be unproven; a watchdog without bounding would detect harm after it
+began; a new status without pilot consumption would allow unsafe expansion. None of
+the four implementation sections is independently shippable or claimable as the
+outcome.
+
+## 1. Define the bounded builder contract with tests
+
+### Files
+
+- modify `apps/web/lib/nonprod/local-ci-slot-resources.json`
+- modify `scripts/lib/local-ci-slot-manifest.mjs`
+- modify `scripts/lib/local-ci-slot-manifest.test.mjs`
+- create `scripts/config/local-ci-buildkitd.toml`
+- create `scripts/lib/local-ci-bounded-builder.mjs`
+- create `scripts/lib/local-ci-bounded-builder.test.mjs`
+
+### Red-green sequence
+
+1. Add failing tests for deterministic slot builder identity, resource policy
+   projection, Buildx create arguments, and effective-container limit validation.
+2. Add the checked-in BuildKit parallelism configuration and slot resource policy.
+3. Implement idempotent inspect-or-create provisioning. Fail closed on driver or
+   resource drift; never fall back to plain `docker build`.
+4. Prove command arguments are argv-safe and no secret-bearing environment value is
+   written to evidence.
+
+## 2. Add the concurrent control-plane watchdog
+
+### Files
+
+- create `scripts/lib/local-ci-control-plane-watchdog.mjs`
+- create `scripts/lib/local-ci-control-plane-watchdog.test.mjs`
+- create `scripts/local-ci-bounded-build.mjs`
+- modify `scripts/lib/local-integration-ci.mjs`
+- modify `scripts/lib/local-integration-ci.test.mjs`
+- modify `scripts/local-integration-ci.mjs`
+
+### Red-green sequence
+
+1. Add failing tests for valid portal payloads, MCP protocol responses, Docker and
+   PostgreSQL timeouts, recovery after one unhealthy round, and sustained two-round
+   breach.
+2. Add failing tests proving the child process tree is terminated and reserved exit
+   code 5 is emitted only for a sustained control-plane breach.
+3. Implement the asynchronous Buildx wrapper with injected probes and timers.
+4. Persist versioned samples and resource policy to the slot evidence path, tied to
+   branch, SHA, integration tree, and slot.
+5. Replace only the `docker-build` production command; leave host-next behavior
+   unchanged.
+
+## 3. Carry the distinct infrastructure status end to end
+
+### Files
+
+- modify `scripts/lib/sandbox-freshness.mjs`
+- modify `scripts/lib/sandbox-freshness.test.mjs`
+- modify `scripts/gate-worktree.mjs`
+- modify `apps/web/lib/nonprod/local-integration.ts`
+- modify `apps/web/lib/nonprod/local-integration.test.ts`
+- modify `apps/web/lib/mcp/packs/build-evidence-pack.ts`
+- modify relevant MCP pack tests
+- modify `apps/web/lib/nonprod/local-ci-pool-circuit-breaker.ts`
+- modify `apps/web/lib/nonprod/local-ci-pool-circuit-breaker.test.mjs`
+
+### Red-green sequence
+
+1. Add failing status-mapping and evidence-validation tests for
+   `blocked_control_plane_starvation`.
+2. Implement reserved exit-code classification and MCP schema/handler support.
+3. Attach the watchdog evidence to the gate record and pending evidence.
+4. Make any starvation result contract requested capacity to one without charging a
+   product failure.
+
+## 4. Bind the pilot and contributor documentation
+
+### Files
+
+- modify `scripts/lib/local-ci-pilot-report.mjs`
+- modify `scripts/lib/local-ci-pilot-report.test.mjs`
+- modify `docs/testing/pr-health.md`
+- modify `docs/superpowers/plans/2026-07-25-governed-playbook-experimentation-autonomous-build-studio-plan.md` only if its sandbox failure table lacks the new status
+
+### Red-green sequence
+
+1. Add a failing pilot test proving one control-plane breach forces `ROLLBACK`.
+2. Include per-surface health-throughout counts and starvation failures in the pilot
+   report.
+3. Document the status, evidence location, non-product semantics, and explicit
+   recovery boundary.
+
+## Verification
+
+1. Run all affected Node tests from the source-only worktree using the repository
+   runtime.
+2. Run affected web Vitest tests and typecheck in the governed sandbox.
+3. Run module-size and documentation guards.
+4. Claim the `local-integration-ci` lease and run the exact merged-tree pregate. Capture
+   branch/SHA/slot, builder policy, freshness, production artifact, and all four
+   control-plane signals.
+5. Run a representative injected-breach harness and prove exit 5, process-tree
+   termination, infrastructure classification, and pilot rollback.
+6. Push a DCO-signed commit, open a ready PR, run `pnpm pr:health`, enqueue with squash
+   auto-merge, then use governed self-upgrade before live verification.
+
+## Rollback
+
+Revert the bounded-builder integration and status addition through a PR. Do not
+restore unbounded execution as an operational workaround; leave capacity at one and
+classify gates blocked until a safe replacement is deployed. Builder containers are
+slot-scoped cache infrastructure and may be removed only through the governed local-CI
+cleanup/recovery path.

--- a/docs/superpowers/specs/2026-07-31-local-ci-control-plane-starvation-design.md
+++ b/docs/superpowers/specs/2026-07-31-local-ci-control-plane-starvation-design.md
@@ -1,0 +1,129 @@
+# Local-CI Control-Plane Starvation Prevention
+
+- **Status:** accepted for implementation
+- **Date:** 2026-07-31
+- **Backlog item:** `BI-CE6E2882`
+- **Epic:** `EP-0DFF753B`
+- **Work Capsule:** `WC-BD87F076`
+- **WWMD decision:** `DI-EBA2C9239C5C`
+
+## Decision
+
+Keep the canonical Docker production artifact, but run its build in a slot-scoped
+`docker-container` BuildKit builder with explicit CPU, memory, and BuildKit
+parallelism ceilings. While the build runs, independently probe the installed
+portal, MCP endpoint, Docker Engine, and PostgreSQL over its host port. A sustained
+control-plane breach terminates the build, records a distinct
+`blocked_control_plane_starvation` infrastructure outcome tied to branch, SHA, and
+slot, and prevents capacity expansion.
+
+The gate does not restart Docker Desktop, the portal, or PostgreSQL. A shared-service
+restart remains an intentional governed recovery action. A TCP listener without a
+valid application response is unhealthy.
+
+## Incident boundary
+
+The evidence establishes two separate events:
+
+1. Lease `NPEL-E5F0F81B36` ran an unconstrained daemon-side `docker build`. The
+   production build compiled, reached TypeScript, then stopped progressing while
+   portal HTTP/MCP, Docker Engine API, and independent PostgreSQL access became
+   unavailable.
+2. Later, a separate process explicitly called Docker Desktop `/app/quit`. That was
+   not the initiating build pressure and must not be represented as natural or
+   automatic recovery; the restart extended the outage while the engine bridge
+   failed to return.
+
+Prevention and evidence address the first event. Governed recovery semantics address
+the second. The implementation must not conflate them.
+
+## Existing substrate to extend
+
+| Concern | Source of truth | Extension |
+| --- | --- | --- |
+| Slot identity | `local-ci-slot-resources.json`, `local-ci-slot-manifest.mjs` | Add deterministic builder identity and resource policy |
+| Build orchestration | `local-integration-ci.mjs` | Replace plain Windows `docker build` with the bounded wrapper |
+| Gate evidence | `gate-worktree.mjs`, `local-integration.ts` | Add control-plane samples and reserved status |
+| Infrastructure classification | `sandbox-freshness.mjs`, MCP evidence pack | Map a reserved exit code without charging product failure |
+| Capacity rollback | `local-ci-pool-circuit-breaker.ts`, pilot report | Treat any starvation signal as binding rollback evidence |
+
+No new table, scheduler, lease type, or runtime is justified.
+
+## Resource boundary
+
+Each slot owns one named Buildx builder. The builder uses Docker's
+`docker-container` driver so its BuildKit daemon has enforceable container resource
+limits. The checked-in slot policy supplies:
+
+- a 16 GiB memory ceiling, empirically raised from 12 GiB after the bounded
+  representative build reached page-data collection but BuildKit correctly
+  terminated it with `ResourceExhausted`; this leaves substantial host headroom
+  while accommodating the proven 8 GiB Node heap plus Next worker memory;
+- an eight-CPU quota with a 100 ms period;
+- BuildKit `max-parallelism = 4`;
+- `default-load=true`, preserving the image-inspection and artifact identity path.
+
+Provisioning is idempotent and fail closed. An absent builder may be created. An
+existing builder whose driver or effective HostConfig does not match the declared
+policy is drift, not permission to run unbounded. The gate reports the mismatch and
+stops; it does not silently recreate or resize shared infrastructure.
+
+## Control-plane watchdog
+
+The bounded build wrapper starts the Buildx build and samples every five seconds:
+
+- `GET http://127.0.0.1:3000/api/health`, requiring HTTP 200 and an identifiable
+  healthy payload;
+- a read-only MCP request, requiring a valid protocol response;
+- `docker info`, with a short process timeout;
+- `SELECT 1` over `127.0.0.1:5432`, independently of `docker exec`.
+
+The wrapper resolves the installed PostgreSQL container's live credentials once
+before the build, retains the connection URL only in process memory, and never
+serializes it. Subsequent database samples use the host port directly, so they
+remain independent if Docker Engine becomes unresponsive.
+
+Every probe has an individual timeout. Two consecutive unhealthy sample rounds form
+a sustained breach. This avoids one transient packet becoming a false rollback while
+bounding detection to approximately ten seconds. The wrapper then terminates the
+complete build client process tree, emits a versioned JSON evidence record, and exits
+with reserved code 5.
+
+The record contains branch, candidate SHA, integration tree SHA when available, slot,
+builder policy, timestamps, every probe result, breach reason, and termination result.
+Secrets and connection strings are never serialized.
+
+## Outcome semantics
+
+Exit code 5 maps to `blocked_control_plane_starvation`. It is:
+
+- an infrastructure/control-plane failure, not a product build failure;
+- a binding circuit-breaker input for any slot and especially slot 1;
+- a binding rollback blocker in the capacity pilot report;
+- never convertible to `failed` merely because an older portal does not yet know the
+  enum—the pending evidence remains explicit and is finalized after deployment.
+
+Normal Docker build errors remain `failed`. Dependency drift remains
+`blocked_sandbox_drift`. The statuses are intentionally disjoint.
+
+## Recovery and rollout
+
+The watchdog may stop only its admitted build process tree. It may not restart or
+stop shared DPF services. If the control plane remains unavailable after termination,
+the gate records `recovery_required` with the failed probes and the operator-visible
+next action. A Docker Desktop or shared-service restart requires explicit authority
+and must be auditable.
+
+Requested capacity remains one. A future pilot can request two only after repeated
+bounded-build evidence proves the control plane healthy throughout representative
+builds. The prior rollback remains binding until that new evidence exists.
+
+## Verification contract
+
+- unit tests prove builder command/limit validation, timeout handling, sustained
+  breach classification, process-tree termination, status mapping, and pilot rollback;
+- a representative harness runs a controlled long build with all four probes healthy;
+- a fault-injection harness makes each probe fail and proves exit 5 plus evidence;
+- the exact local-CI pregate proves the Docker artifact still builds and records the
+  bounded policy;
+- portal/MCP/PostgreSQL/Docker health is sampled before, during, and after the gate.

--- a/docs/testing/pr-health.md
+++ b/docs/testing/pr-health.md
@@ -89,6 +89,25 @@ Typecheck, tests, and acceptance evidence are additional fail-closed blockers.
 If any check fails, the tool returns the published branch, commit SHA, and
 blockers; it does not create a review-lane placeholder PR.
 
+## Local-CI infrastructure outcomes
+
+The governed local pregate distinguishes a product failure from two shared
+verification failures:
+
+- `blocked_sandbox_drift` means the installed dependency graph was stale or not
+  ready. Converge the governed sandbox and rerun; do not charge the candidate.
+- `blocked_control_plane_starvation` means portal HTTP, MCP, Docker Engine, or
+  direct PostgreSQL health failed in two consecutive rounds during the bounded
+  production build. The gate stops only its admitted build tree, preserves the
+  samples in the slot's `dpf-local-ci-control-plane*.json` evidence, contracts
+  requested capacity to one, and blocks capacity-pilot retention.
+
+A TCP listener alone is not health: the portal probe requires HTTP 200 and a
+valid healthy payload, MCP requires a valid read response, and PostgreSQL is
+queried over the host port independently of Docker exec. The gate never restarts
+Docker Desktop or shared DPF services. If health does not return after the build
+is terminated, recovery is a separately authorized, auditable operation.
+
 ## Tests & CI
 
 The pure verdict (`evaluatePrHealth()`) is unit-tested in [`scripts/pr-health.test.mjs`](../../scripts/pr-health.test.mjs) and runs in CI as the **PR Health Logic** job (`node --test`). The script's GitHub I/O is exercised by running it against live PRs; it is not run in CI (it would be circular).

--- a/scripts/config/local-ci-buildkitd.toml
+++ b/scripts/config/local-ci-buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 4

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -1213,6 +1213,7 @@ async function main() {
   }
   try {
     rmSync(freshnessReportFile, { force: true });
+    rmSync(slotManifest.evidence.controlPlane, { force: true });
   } catch (error) {
     releaseLocalSandboxFence({ path: localFencePath, token: localFenceToken });
     await releaseLeaseOnce();
@@ -1350,6 +1351,14 @@ async function main() {
   } catch {
     // no metadata written by this run — evidence.content stays null, matching the sh port.
   }
+  let controlPlaneEvidence = null;
+  try {
+    controlPlaneEvidence = JSON.parse(
+      readFileSync(slotManifest.evidence.controlPlane, "utf8"),
+    );
+  } catch {
+    // A non-build failure may occur before the bounded wrapper writes samples.
+  }
   const resilience = classifyBaseResilience(
     contentMetadata,
     options.pushBranch ? "push-before-lease" : "deferred",
@@ -1393,6 +1402,7 @@ async function main() {
         postgresVolume: slotManifest.postgres.volume,
         dependencyStore: slotManifest.dependencies.freshStore,
         artifactPath: slotManifest.evidence.artifact,
+        controlPlaneEvidencePath: slotManifest.evidence.controlPlane,
       },
       leaseId,
       leaseEvents,
@@ -1405,6 +1415,7 @@ async function main() {
       pushBeforeLease: options.pushBranch,
       resilience,
       content: contentMetadata,
+      controlPlane: controlPlaneEvidence,
       gatePassed: outcome.gatePassed,
       freshness,
       commands: [commandLabel],
@@ -1423,7 +1434,16 @@ async function main() {
     failureSummary,
   };
 
-  let evidenceResponse = await mcpCall("record_local_integration_result", evidenceArgs, { mcpUrl: options.mcpUrl, bearerToken });
+  let evidenceResponse;
+  try {
+    evidenceResponse = await mcpCall("record_local_integration_result", evidenceArgs, { mcpUrl: options.mcpUrl, bearerToken });
+  } catch (error) {
+    evidenceResponse = {
+      success: false,
+      error: "transport_unavailable",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
   if (evidenceResponse?.success !== true && outcome.status === "blocked_sandbox_drift" && evidenceResponse?.error === "invalid_status") {
     process.stdout.write("gate-worktree: portal does not know blocked_sandbox_drift yet; recording as failed with sandbox-drift evidence\n");
     evidenceArgs = { ...evidenceArgs, status: "failed", summary: `[SANDBOX_DRIFT — not product evidence] ${evidenceArgs.summary}` };
@@ -1435,6 +1455,31 @@ async function main() {
     evidenceId = evidenceResponse.entityId || "";
   } else {
     const evidenceError = evidenceResponse?.error ?? evidenceResponse?.data?.error ?? "";
+    if (outcome.status === "blocked_control_plane_starvation") {
+      writePendingEvidence(pendingEvidenceFile, {
+        branch,
+        sha,
+        expiresAt,
+        reason: evidenceError || "control_plane_unavailable",
+        retryAfterSeconds: 30,
+        recordArgs: evidenceArgs,
+      });
+      writeState(stateFile, {
+        branch,
+        sha,
+        gatePassed: false,
+        leaseId,
+        evidenceId: "",
+        status: outcome.status,
+        expiresAt,
+        resilience,
+        leaseEvents,
+        evidencePending: true,
+        evidencePendingReason: evidenceError || "control_plane_unavailable",
+      });
+      process.stderr.write("gate-worktree: control-plane starvation evidence is preserved locally and pending portal recovery.\n");
+      process.exit(5);
+    }
     if (outcome.gatePassed && evidenceError === "portal_quiescing") {
       const retryAfterSeconds = Number(
         evidenceResponse?.data?.retryAfterSeconds
@@ -1502,6 +1547,10 @@ async function main() {
     process.stderr.write(`gate-worktree: BLOCKED (sandbox drift): ${outcome.summary}\n`);
     process.stderr.write("gate-worktree: this is a sandbox defect, not product build evidence; converge the sandbox and re-run the gate\n");
     process.exit(3);
+  }
+  if (outcome.status === "blocked_control_plane_starvation") {
+    process.stderr.write(`gate-worktree: BLOCKED (control-plane starvation): ${outcome.summary}\n`);
+    process.exit(5);
   }
   die("gate failed");
 }

--- a/scripts/lib/local-ci-bounded-builder.mjs
+++ b/scripts/lib/local-ci-bounded-builder.mjs
@@ -1,0 +1,80 @@
+function gibibytes(bytes) {
+  const gib = bytes / (1024 ** 3);
+  if (!Number.isInteger(gib) || gib <= 0) {
+    throw new Error("builder memory must be a positive whole number of GiB");
+  }
+  return `${gib}g`;
+}
+
+export function buildxCreateArgs(builder, configPath) {
+  return [
+    "buildx", "create",
+    "--name", builder.name,
+    "--driver", "docker-container",
+    "--driver-opt", `memory=${gibibytes(builder.memoryBytes)}`,
+    "--driver-opt", `cpu-quota=${builder.cpuQuota}`,
+    "--driver-opt", `cpu-period=${builder.cpuPeriod}`,
+    "--driver-opt", "default-load=true",
+    "--buildkitd-config", configPath,
+    "--bootstrap",
+  ];
+}
+
+export function buildxBuildArgs({ builder, tag, context = "." }) {
+  return [
+    "buildx", "build", "--builder", builder.name,
+    "--target", "build", "--tag", tag, "--load", context,
+  ];
+}
+
+export function validateBuilderInspection(builder, inspection) {
+  const failures = [];
+  if (inspection?.driver !== "docker-container") failures.push("driver");
+  if (inspection?.container !== builder.container) failures.push("container");
+  if (inspection?.memoryBytes !== builder.memoryBytes) failures.push("memory");
+  if (inspection?.cpuQuota !== builder.cpuQuota) failures.push("cpu-quota");
+  if (inspection?.cpuPeriod !== builder.cpuPeriod) failures.push("cpu-period");
+  return { ok: failures.length === 0, failures };
+}
+
+export function databaseUrlFromContainerEnvironment(lines, {
+  host = "127.0.0.1",
+  port = 5432,
+} = {}) {
+  const values = Object.fromEntries(
+    String(lines || "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return separator > 0
+          ? [line.slice(0, separator), line.slice(separator + 1)]
+          : [line, ""];
+      }),
+  );
+  const user = values.POSTGRES_USER || "dpf";
+  const password = values.POSTGRES_PASSWORD;
+  const database = values.POSTGRES_DB || "dpf";
+  if (!password) throw new Error("live PostgreSQL password is unavailable");
+  return `postgresql://${encodeURIComponent(user)}:${encodeURIComponent(password)}`
+    + `@${host}:${port}/${encodeURIComponent(database)}`;
+}
+
+export function classifyBoundedBuildExit({ exitCode, output }) {
+  if (
+    exitCode !== 0
+    && /ResourceExhausted|cannot allocate memory|SIGKILL.*next build/i.test(output || "")
+  ) {
+    return {
+      status: "blocked_control_plane_starvation",
+      exitCode: 5,
+      failures: ["builder:resource-exhausted"],
+    };
+  }
+  return {
+    status: exitCode === 0 ? "healthy" : "failed",
+    exitCode,
+    failures: [],
+  };
+}

--- a/scripts/lib/local-ci-bounded-builder.test.mjs
+++ b/scripts/lib/local-ci-bounded-builder.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildxBuildArgs,
+  buildxCreateArgs,
+  classifyBoundedBuildExit,
+  databaseUrlFromContainerEnvironment,
+  validateBuilderInspection,
+} from "./local-ci-bounded-builder.mjs";
+
+const builder = {
+  name: "dpf-local-ci-buildkit-v2-0",
+  container: "buildx_buildkit_dpf-local-ci-buildkit-v2-00",
+  memoryBytes: 16 * 1024 ** 3,
+  cpuQuota: 800_000,
+  cpuPeriod: 100_000,
+  maxParallelism: 4,
+};
+
+test("Buildx create uses the slot-scoped mechanical resource boundary", () => {
+  assert.deepEqual(buildxCreateArgs(builder, "scripts/config/local-ci-buildkitd.toml"), [
+    "buildx", "create",
+    "--name", builder.name,
+    "--driver", "docker-container",
+    "--driver-opt", "memory=16g",
+    "--driver-opt", "cpu-quota=800000",
+    "--driver-opt", "cpu-period=100000",
+    "--driver-opt", "default-load=true",
+    "--buildkitd-config", "scripts/config/local-ci-buildkitd.toml",
+    "--bootstrap",
+  ]);
+});
+
+test("resource-limit termination is infrastructure evidence, not a product red", () => {
+  assert.deepEqual(classifyBoundedBuildExit({
+    exitCode: 1,
+    output: "ResourceExhausted: next build cannot allocate memory",
+  }), {
+    status: "blocked_control_plane_starvation",
+    exitCode: 5,
+    failures: ["builder:resource-exhausted"],
+  });
+  assert.deepEqual(classifyBoundedBuildExit({
+    exitCode: 1,
+    output: "TypeScript error TS2322",
+  }), {
+    status: "failed",
+    exitCode: 1,
+    failures: [],
+  });
+});
+
+test("live PostgreSQL credentials are encoded without assuming the install password", () => {
+  assert.equal(databaseUrlFromContainerEnvironment(
+    "POSTGRES_USER=dpf\r\nPOSTGRES_PASSWORD=secret with:/?\r\nPOSTGRES_DB=dpf\r\n",
+  ), "postgresql://dpf:secret%20with%3A%2F%3F@127.0.0.1:5432/dpf");
+  assert.throws(
+    () => databaseUrlFromContainerEnvironment("POSTGRES_USER=dpf"),
+    /password is unavailable/,
+  );
+});
+
+test("Buildx build preserves the canonical loaded image artifact", () => {
+  assert.deepEqual(buildxBuildArgs({ builder, tag: "dpf-test-build", context: "." }), [
+    "buildx", "build", "--builder", builder.name,
+    "--target", "build", "--tag", "dpf-test-build", "--load", ".",
+  ]);
+});
+
+test("effective builder inspection must match every declared ceiling", () => {
+  assert.deepEqual(validateBuilderInspection(builder, {
+    driver: "docker-container",
+    container: builder.container,
+    memoryBytes: builder.memoryBytes,
+    cpuQuota: builder.cpuQuota,
+    cpuPeriod: builder.cpuPeriod,
+  }), { ok: true, failures: [] });
+
+  const drift = validateBuilderInspection(builder, {
+    driver: "docker",
+    container: builder.container,
+    memoryBytes: 0,
+    cpuQuota: 0,
+    cpuPeriod: builder.cpuPeriod,
+  });
+  assert.equal(drift.ok, false);
+  assert.deepEqual(drift.failures.sort(), ["cpu-quota", "driver", "memory"]);
+});

--- a/scripts/lib/local-ci-control-plane-watchdog.mjs
+++ b/scripts/lib/local-ci-control-plane-watchdog.mjs
@@ -1,0 +1,83 @@
+const SURFACES = ["portal", "mcp", "docker", "postgres"];
+
+export const EXIT_CONTROL_PLANE_STARVATION = 5;
+
+export function classifyControlPlaneSample(probes) {
+  const failures = SURFACES.flatMap((surface) => {
+    const probe = probes?.[surface];
+    return probe?.healthy === true
+      ? []
+      : [`${surface}:${probe?.reason || "unhealthy"}`];
+  });
+  return { healthy: failures.length === 0, failures };
+}
+
+export async function monitorControlPlane({
+  sample,
+  isComplete,
+  wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  intervalMs = 5_000,
+  consecutiveFailureLimit = 2,
+}) {
+  const samples = [];
+  let consecutiveFailures = 0;
+  while (true) {
+    const probes = await sample();
+    const classification = classifyControlPlaneSample(probes);
+    samples.push({
+      observedAt: new Date().toISOString(),
+      probes,
+      ...classification,
+    });
+    consecutiveFailures = classification.healthy
+      ? 0
+      : consecutiveFailures + 1;
+    if (consecutiveFailures >= consecutiveFailureLimit) {
+      return {
+        status: "blocked_control_plane_starvation",
+        samples,
+        failures: classification.failures,
+      };
+    }
+    if (isComplete()) {
+      return { status: "healthy", samples, failures: [] };
+    }
+    await wait(intervalMs);
+  }
+}
+
+export async function establishHealthyControlPlane({
+  sample,
+  wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  intervalMs = 5_000,
+  attempts = 2,
+}) {
+  const samples = [];
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const probes = await sample();
+    const classification = classifyControlPlaneSample(probes);
+    samples.push({
+      observedAt: new Date().toISOString(),
+      probes,
+      ...classification,
+    });
+    if (classification.healthy) {
+      return { status: "healthy", samples, failures: [] };
+    }
+    if (attempt + 1 < attempts) await wait(intervalMs);
+  }
+  return {
+    status: "blocked_control_plane_starvation",
+    samples,
+    failures: samples.at(-1)?.failures || ["control-plane:unhealthy"],
+  };
+}
+
+export function terminateProcessTreeCommand(pid, platform = process.platform) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error("process tree root must be a positive integer PID");
+  }
+  return platform === "win32"
+    ? { command: "taskkill.exe", args: ["/PID", String(pid), "/T", "/F"] }
+    : { command: "kill", args: ["-TERM", `-${pid}`] };
+}

--- a/scripts/lib/local-ci-control-plane-watchdog.test.mjs
+++ b/scripts/lib/local-ci-control-plane-watchdog.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyControlPlaneSample,
+  establishHealthyControlPlane,
+  monitorControlPlane,
+  terminateProcessTreeCommand,
+} from "./local-ci-control-plane-watchdog.mjs";
+
+const healthy = {
+  portal: { healthy: true, elapsedMs: 4 },
+  mcp: { healthy: true, elapsedMs: 5 },
+  docker: { healthy: true, elapsedMs: 7 },
+  postgres: { healthy: true, elapsedMs: 3 },
+};
+
+test("all four independent surfaces must be healthy", () => {
+  assert.deepEqual(classifyControlPlaneSample(healthy), {
+    healthy: true,
+    failures: [],
+  });
+  assert.deepEqual(classifyControlPlaneSample({
+    ...healthy,
+    portal: { healthy: false, reason: "http-200-invalid-payload" },
+    docker: { healthy: false, reason: "timeout" },
+  }), {
+    healthy: false,
+    failures: ["portal:http-200-invalid-payload", "docker:timeout"],
+  });
+});
+
+test("one transient round recovers without tripping the boundary", async () => {
+  const rounds = [
+    { ...healthy, mcp: { healthy: false, reason: "timeout" } },
+    healthy,
+    healthy,
+  ];
+  let complete = false;
+  const result = await monitorControlPlane({
+    sample: async () => {
+      const value = rounds.shift();
+      if (rounds.length === 0) complete = true;
+      return value;
+    },
+    isComplete: () => complete,
+    wait: async () => {},
+    consecutiveFailureLimit: 2,
+  });
+  assert.equal(result.status, "healthy");
+  assert.equal(result.samples.length, 3);
+});
+
+test("two consecutive unhealthy rounds form a sustained starvation breach", async () => {
+  const result = await monitorControlPlane({
+    sample: async () => ({
+      ...healthy,
+      postgres: { healthy: false, reason: "timeout" },
+    }),
+    isComplete: () => false,
+    wait: async () => {},
+    consecutiveFailureLimit: 2,
+  });
+  assert.equal(result.status, "blocked_control_plane_starvation");
+  assert.equal(result.samples.length, 2);
+  assert.deepEqual(result.failures, ["postgres:timeout"]);
+});
+
+test("an unhealthy control plane blocks the build before it starts", async () => {
+  const result = await establishHealthyControlPlane({
+    sample: async () => ({
+      ...healthy,
+      portal: { healthy: false, reason: "timeout" },
+    }),
+    wait: async () => {},
+  });
+  assert.equal(result.status, "blocked_control_plane_starvation");
+  assert.equal(result.samples.length, 2);
+  assert.deepEqual(result.failures, ["portal:timeout"]);
+});
+
+test("process-tree termination stays local to the admitted build", () => {
+  assert.deepEqual(terminateProcessTreeCommand(4321, "win32"), {
+    command: "taskkill.exe",
+    args: ["/PID", "4321", "/T", "/F"],
+  });
+  assert.deepEqual(terminateProcessTreeCommand(4321, "linux"), {
+    command: "kill",
+    args: ["-TERM", "-4321"],
+  });
+});

--- a/scripts/lib/local-ci-pilot-report.mjs
+++ b/scripts/lib/local-ci-pilot-report.mjs
@@ -23,6 +23,7 @@ const defectCountFields = [
   "unattributedFailureCount",
   "pressureCeilingBreachCount",
   "dockerHealthFailureCount",
+  "controlPlaneStarvationCount",
 ];
 
 function validWindow(value, { pilot = false } = {}) {
@@ -140,6 +141,9 @@ export function evaluateLocalCiPilot({
     blockers.push("host-pressure-ceiling-breached");
   }
   if (pilot.dockerHealthFailureCount > 0) blockers.push("docker-health-degraded");
+  if (pilot.controlPlaneStarvationCount > 0) {
+    blockers.push("control-plane-starvation-observed");
+  }
   if (
     comparison.medianServiceDurationRegressionPercent
     > thresholds.maximumMedianServiceDurationRegressionPercent

--- a/scripts/lib/local-ci-pilot-report.test.mjs
+++ b/scripts/lib/local-ci-pilot-report.test.mjs
@@ -33,6 +33,7 @@ const safePilot = {
   unattributedFailureCount: 0,
   pressureCeilingBreachCount: 0,
   dockerHealthFailureCount: 0,
+  controlPlaneStarvationCount: 0,
 };
 
 test("retains capacity two only when representative evidence clears every threshold", () => {
@@ -64,6 +65,7 @@ test("unsafe host health or threshold regressions recommend rollback", () => {
   const scenarios = [
     [{ pressureCeilingBreachCount: 1 }, "host-pressure-ceiling-breached"],
     [{ dockerHealthFailureCount: 1 }, "docker-health-degraded"],
+    [{ controlPlaneStarvationCount: 1 }, "control-plane-starvation-observed"],
     [{ medianServiceDurationMs: 700 }, "service-duration-regressed"],
     [{ infrastructureFailureRatePercent: 6 }, "infrastructure-failure-rate-high"],
   ];

--- a/scripts/lib/local-ci-slot-manifest.mjs
+++ b/scripts/lib/local-ci-slot-manifest.mjs
@@ -12,6 +12,7 @@ export const LOCAL_CI_SLOT_KEYS = Object.freeze(
   Object.keys(SLOT_RESOURCE_MANIFEST.slots),
 );
 export const LOCAL_CI_DECLARED_CAPACITY = LOCAL_CI_SLOT_KEYS.length;
+const BUILDER_POLICY = Object.freeze(SLOT_RESOURCE_MANIFEST.builderPolicy);
 
 const SLOT_RESOURCES = Object.freeze(
   Object.fromEntries(
@@ -39,6 +40,7 @@ function requireAbsolutePath(name, value) {
  * @property {{convergenceLock: string, freshStore: string}} dependencies
  * @property {{build: string, log: string}} output
  * @property {{metadata: string, freshness: string, pending: string, state: string, artifact: string}} evidence
+ * @property {{policyVersion: number, name: string, container: string, memoryBytes: number, cpuQuota: number, cpuPeriod: number, maxParallelism: number}} builder
  * @property {{scratchBoundary: string, composeProject: string, postgresContainer: string, postgresVolume: string}} cleanup
  */
 
@@ -83,6 +85,7 @@ export function createLocalCiSlotManifest(input) {
   const postgresContainer = `dpf-local-ci-postgres-${resources.ordinal}`;
   const postgresVolume = `dpf-local-ci-postgres-${resources.ordinal}`;
   const evidenceSuffix = resources.ordinal === 0 ? "" : `-${slotKey}`;
+  const builderName = `dpf-local-ci-buildkit-v${BUILDER_POLICY.version}-${resources.ordinal}`;
 
   return Object.freeze({
     schemaVersion: LOCAL_CI_SLOT_MANIFEST_SCHEMA_VERSION,
@@ -113,6 +116,15 @@ export function createLocalCiSlotManifest(input) {
       convergenceLock: join(workspace, ".dpf-freshness-converge.lock"),
       freshStore: join(workspace, ".pnpm-fresh-store"),
     }),
+    builder: Object.freeze({
+      policyVersion: BUILDER_POLICY.version,
+      name: builderName,
+      container: `buildx_buildkit_${builderName}0`,
+      memoryBytes: BUILDER_POLICY.memoryBytes,
+      cpuQuota: BUILDER_POLICY.cpuQuota,
+      cpuPeriod: BUILDER_POLICY.cpuPeriod,
+      maxParallelism: BUILDER_POLICY.maxParallelism,
+    }),
     output: Object.freeze({
       build: join(workspace, "apps", "web", ".next"),
       log: join(candidateGitDir, `dpf-local-ci-output${evidenceSuffix}.log`),
@@ -123,6 +135,7 @@ export function createLocalCiSlotManifest(input) {
       pending: join(candidateGitDir, `dpf-local-ci-pending-evidence${evidenceSuffix}.json`),
       state: join(candidateGitDir, `dpf-local-ci-gate${evidenceSuffix}.json`),
       artifact: join(candidateGitDir, `dpf-local-ci-artifact${evidenceSuffix}.json`),
+      controlPlane: join(candidateGitDir, `dpf-local-ci-control-plane${evidenceSuffix}.json`),
     }),
     cleanup: Object.freeze({
       scratchBoundary: workspace,
@@ -161,6 +174,14 @@ export function localCiSlotEnvironment(manifest) {
     DPF_LOCAL_CI_ARTIFACT_FILE: manifest.evidence.artifact,
     DPF_LOCAL_CI_OUTPUT_FILE: manifest.output.log,
     DPF_LOCAL_CI_BUILD_OUTPUT: manifest.output.build,
+    DPF_LOCAL_CI_BUILDER_NAME: manifest.builder.name,
+    DPF_LOCAL_CI_BUILDER_CONTAINER: manifest.builder.container,
+    DPF_LOCAL_CI_BUILDER_POLICY_VERSION: String(manifest.builder.policyVersion),
+    DPF_LOCAL_CI_BUILDER_MEMORY_BYTES: String(manifest.builder.memoryBytes),
+    DPF_LOCAL_CI_BUILDER_CPU_QUOTA: String(manifest.builder.cpuQuota),
+    DPF_LOCAL_CI_BUILDER_CPU_PERIOD: String(manifest.builder.cpuPeriod),
+    DPF_LOCAL_CI_BUILDER_MAX_PARALLELISM: String(manifest.builder.maxParallelism),
+    DPF_LOCAL_CI_CONTROL_PLANE_EVIDENCE_FILE: manifest.evidence.controlPlane,
   };
 }
 

--- a/scripts/lib/local-ci-slot-manifest.test.mjs
+++ b/scripts/lib/local-ci-slot-manifest.test.mjs
@@ -59,6 +59,9 @@ test("slot manifests are versioned and every mutable identity is isolated", () =
     (slot) => slot.evidence.pending,
     (slot) => slot.evidence.state,
     (slot) => slot.evidence.artifact,
+    (slot) => slot.builder.name,
+    (slot) => slot.builder.container,
+    (slot) => slot.evidence.controlPlane,
   ];
 
   for (const identity of identities) {
@@ -126,6 +129,28 @@ test("slot environment is derived from the manifest without hidden arithmetic", 
     DPF_LOCAL_CI_ARTIFACT_FILE: manifest.evidence.artifact,
     DPF_LOCAL_CI_OUTPUT_FILE: manifest.output.log,
     DPF_LOCAL_CI_BUILD_OUTPUT: manifest.output.build,
+    DPF_LOCAL_CI_BUILDER_NAME: manifest.builder.name,
+    DPF_LOCAL_CI_BUILDER_CONTAINER: manifest.builder.container,
+    DPF_LOCAL_CI_BUILDER_POLICY_VERSION: "2",
+    DPF_LOCAL_CI_BUILDER_MEMORY_BYTES: String(manifest.builder.memoryBytes),
+    DPF_LOCAL_CI_BUILDER_CPU_QUOTA: String(manifest.builder.cpuQuota),
+    DPF_LOCAL_CI_BUILDER_CPU_PERIOD: String(manifest.builder.cpuPeriod),
+    DPF_LOCAL_CI_BUILDER_MAX_PARALLELISM: String(manifest.builder.maxParallelism),
+    DPF_LOCAL_CI_CONTROL_PLANE_EVIDENCE_FILE: manifest.evidence.controlPlane,
+  });
+});
+
+test("builder resources reserve capacity for the shared control plane", () => {
+  const manifest = createLocalCiSlotManifest({ ...fixture(), slotKey: "slot-0" });
+
+  assert.deepEqual(manifest.builder, {
+    policyVersion: 2,
+    name: "dpf-local-ci-buildkit-v2-0",
+    container: "buildx_buildkit_dpf-local-ci-buildkit-v2-00",
+    memoryBytes: 16 * 1024 ** 3,
+    cpuQuota: 800_000,
+    cpuPeriod: 100_000,
+    maxParallelism: 4,
   });
 });
 

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -236,7 +236,16 @@ export function createLocalIntegrationPlan(input) {
   const baseRef = input.baseRef ?? "origin/main";
   const buildStrategy = input.buildStrategy ?? defaultBuildStrategy(input.hostPlatform);
   const productionBuildCommand = buildStrategy === "docker-build"
-    ? ["docker", "build", "--target", "build", "-t", dockerBuildTag(input.candidateBranch, input.slotKey), "."]
+    ? [
+        "node",
+        "scripts/local-ci-bounded-build.mjs",
+        "--tag",
+        dockerBuildTag(input.candidateBranch, input.slotKey),
+        "--slot-key",
+        input.slotKey || "slot-0",
+        "--candidate",
+        input.candidateBranch,
+      ]
     // `env VAR=… cmd` keeps the plan a plain argv (no shell) — host-next is
     // POSIX-only by construction (Windows defaults to docker-build above).
     // The shared sandbox can inherit NODE_ENV from a prior test/dev process.

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -102,6 +102,18 @@ describe("createLocalIntegrationPlan", () => {
     ]);
   });
 
+  it("routes Windows production builds through the bounded watchdog wrapper", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "fix/control-plane",
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "win32",
+      slotKey: "slot-0",
+    });
+    assert.equal(plan.commands.at(-1).join(" "),
+      "node scripts/local-ci-bounded-build.mjs --tag dpf-local-integration-slot-0-fix-control-plane-build --slot-key slot-0 --candidate fix/control-plane");
+  });
+
   it("scopes integration refs and freshness to the admitted slot", () => {
     const plan = createLocalIntegrationPlan({
       candidateBranch: "feat/slot-safe-gate",
@@ -268,7 +280,7 @@ describe("createLocalIntegrationPlan", () => {
     ));
   });
 
-  it("uses a Docker production build on Windows hosts", () => {
+  it("uses a bounded Docker production build on Windows hosts", () => {
     const plan = createLocalIntegrationPlan({
       candidateBranch: "feat/build-studio-decision-skills-slice-1",
       mode: "single-branch",
@@ -277,7 +289,7 @@ describe("createLocalIntegrationPlan", () => {
     });
 
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
-      "docker build --target build -t dpf-local-integration-feat-build-studio-decision-skills-slice-1-build .",
+      "node scripts/local-ci-bounded-build.mjs --tag dpf-local-integration-feat-build-studio-decision-skills-slice-1-build --slot-key slot-0 --candidate feat/build-studio-decision-skills-slice-1",
     ));
     assert.ok(!plan.commands.map((command) => command.join(" ")).join("\n").includes(
       "exec next build",

--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -299,6 +299,7 @@ export const EXIT_GREEN = 0;
 export const EXIT_USAGE = 2;
 export const EXIT_SANDBOX_DRIFT = 3;
 export const EXIT_SANDBOX_NOT_READY = 4;
+export const EXIT_CONTROL_PLANE_STARVATION = 5;
 
 export function exitCodeForVerdict(verdict) {
   if (verdict === "green") return EXIT_GREEN;
@@ -326,6 +327,14 @@ export function classifyGateOutcome({ freshnessVerdict, gateExitCode }) {
       gatePassed: false,
       productEvidence: false,
       summary: "local-CI gate blocked: freshness preflight reported sandbox drift. This is a sandbox defect, NOT product build evidence.",
+    };
+  }
+  if (gateExitCode === EXIT_CONTROL_PLANE_STARVATION) {
+    return {
+      status: "blocked_control_plane_starvation",
+      gatePassed: false,
+      productEvidence: false,
+      summary: "local-CI gate blocked: the shared portal/MCP/Docker/PostgreSQL control-plane degraded during the build. This is infrastructure evidence, NOT a product build failure.",
     };
   }
   if (gateExitCode === 0) {

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -319,3 +319,11 @@ test("classifyGateOutcome treats pnpm lifecycle exit 3 as product evidence when 
   assert.equal(failed.status, "failed");
   assert.equal(failed.productEvidence, true);
 });
+
+test("classifyGateOutcome reserves exit 5 for control-plane starvation", () => {
+  const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: 5 });
+  assert.equal(outcome.status, "blocked_control_plane_starvation");
+  assert.equal(outcome.gatePassed, false);
+  assert.equal(outcome.productEvidence, false);
+  assert.match(outcome.summary, /control-plane/i);
+});

--- a/scripts/local-ci-bounded-build.mjs
+++ b/scripts/local-ci-bounded-build.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { mcpCall } from "./lib/mcp-client.mjs";
+import {
+  buildxBuildArgs,
+  buildxCreateArgs,
+  classifyBoundedBuildExit,
+  databaseUrlFromContainerEnvironment,
+  validateBuilderInspection,
+} from "./lib/local-ci-bounded-builder.mjs";
+import {
+  EXIT_CONTROL_PLANE_STARVATION,
+  establishHealthyControlPlane,
+  monitorControlPlane,
+  terminateProcessTreeCommand,
+} from "./lib/local-ci-control-plane-watchdog.mjs";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const BUILDKIT_CONFIG = join(SCRIPT_DIR, "config", "local-ci-buildkitd.toml");
+
+function valueAfter(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] || "" : "";
+}
+
+function usage() {
+  return "Usage: node scripts/local-ci-bounded-build.mjs --tag IMAGE --slot-key SLOT --candidate BRANCH\n";
+}
+
+function numberFromEnv(name) {
+  const value = Number(process.env[name]);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function builderFromEnvironment() {
+  const name = process.env.DPF_LOCAL_CI_BUILDER_NAME || "";
+  const container = process.env.DPF_LOCAL_CI_BUILDER_CONTAINER || "";
+  if (!name || !container) throw new Error("slot builder identity is missing");
+  return {
+    policyVersion: numberFromEnv("DPF_LOCAL_CI_BUILDER_POLICY_VERSION"),
+    name,
+    container,
+    memoryBytes: numberFromEnv("DPF_LOCAL_CI_BUILDER_MEMORY_BYTES"),
+    cpuQuota: numberFromEnv("DPF_LOCAL_CI_BUILDER_CPU_QUOTA"),
+    cpuPeriod: numberFromEnv("DPF_LOCAL_CI_BUILDER_CPU_PERIOD"),
+    maxParallelism: numberFromEnv("DPF_LOCAL_CI_BUILDER_MAX_PARALLELISM"),
+  };
+}
+
+function runDocker(args, timeout = 20_000) {
+  return spawnSync("docker", args, {
+    encoding: "utf8",
+    shell: false,
+    windowsHide: true,
+    timeout,
+  });
+}
+
+function inspectBuilder(builder) {
+  const buildx = runDocker(["buildx", "inspect", builder.name], 15_000);
+  if (buildx.status !== 0) return { status: "absent", detail: buildx.stderr || buildx.stdout };
+  const host = runDocker([
+    "inspect", builder.container, "--format", "{{json .HostConfig}}",
+  ], 15_000);
+  if (host.status !== 0) return { status: "invalid", detail: host.stderr || host.stdout };
+  let hostConfig;
+  try {
+    hostConfig = JSON.parse(host.stdout);
+  } catch {
+    return { status: "invalid", detail: "builder HostConfig was not JSON" };
+  }
+  const inspection = {
+    driver: /^Driver:\s+docker-container\s*$/m.test(buildx.stdout)
+      ? "docker-container"
+      : "unknown",
+    container: builder.container,
+    memoryBytes: Number(hostConfig.Memory),
+    cpuQuota: Number(hostConfig.CpuQuota),
+    cpuPeriod: Number(hostConfig.CpuPeriod),
+  };
+  return { status: "present", inspection };
+}
+
+function ensureBoundedBuilder(builder) {
+  let observed = inspectBuilder(builder);
+  if (observed.status === "absent") {
+    const created = runDocker(buildxCreateArgs(builder, BUILDKIT_CONFIG), 120_000);
+    if (created.status !== 0) {
+      throw new Error(`bounded builder creation failed: ${(created.stderr || created.stdout).trim()}`);
+    }
+    observed = inspectBuilder(builder);
+  }
+  if (observed.status !== "present") {
+    throw new Error(`bounded builder inspection failed: ${observed.detail || observed.status}`);
+  }
+  const validation = validateBuilderInspection(builder, observed.inspection);
+  if (!validation.ok) {
+    throw new Error(`bounded builder resource drift: ${validation.failures.join(",")}`);
+  }
+  return observed.inspection;
+}
+
+async function timedProbe(run, timeoutMs = 3_000) {
+  const started = Date.now();
+  let timer;
+  try {
+    const value = await Promise.race([
+      run(),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+      }),
+    ]);
+    return {
+      healthy: value === true,
+      elapsedMs: Date.now() - started,
+      ...(value === true ? {} : { reason: "invalid-response" }),
+    };
+  } catch (error) {
+    return {
+      healthy: false,
+      elapsedMs: Date.now() - started,
+      reason: error instanceof Error && error.message === "timeout" ? "timeout" : "request-failed",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function commandHealthy(command, args, timeoutMs) {
+  return await new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: "ignore", windowsHide: true, shell: false });
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve(false);
+    }, timeoutMs);
+    child.once("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      resolve(code === 0);
+    });
+  });
+}
+
+async function probePostgres(databaseUrl) {
+  const { Client } = await import("pg");
+  const client = new Client({ connectionString: databaseUrl, connectionTimeoutMillis: 2_500 });
+  try {
+    await client.connect();
+    const result = await client.query("SELECT 1 AS healthy");
+    return result.rows[0]?.healthy === 1;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+function resolveControlPlaneDatabaseUrl() {
+  if (process.env.DPF_CONTROL_PLANE_DATABASE_URL) {
+    return process.env.DPF_CONTROL_PLANE_DATABASE_URL;
+  }
+  const container = process.env.DPF_CONTROL_PLANE_POSTGRES_CONTAINER
+    || "dpf-postgres-1";
+  const inspected = runDocker([
+    "inspect",
+    container,
+    "--format",
+    "{{range .Config.Env}}{{println .}}{{end}}",
+  ], 5_000);
+  if (inspected.status !== 0) {
+    throw new Error("live PostgreSQL container environment is unavailable");
+  }
+  return databaseUrlFromContainerEnvironment(inspected.stdout);
+}
+
+async function probeControlPlane(databaseUrl) {
+  const portalUrl = process.env.DPF_CONTROL_PLANE_PORTAL_URL || "http://127.0.0.1:3000";
+  const mcpUrl = process.env.DPF_MCP_URL || `${portalUrl}/api/mcp/v1`;
+  const bearerToken = process.env.DPF_MCP_BEARER_TOKEN || "";
+  const [portal, mcp, docker, postgres] = await Promise.all([
+    timedProbe(async () => {
+      const response = await fetch(`${portalUrl}/api/health`, { signal: AbortSignal.timeout(2_500) });
+      if (response.status !== 200) return false;
+      const payload = await response.json();
+      return ["ok", "healthy"].includes(String(payload?.status).toLowerCase());
+    }),
+    timedProbe(async () => {
+      if (!bearerToken) return false;
+      const response = await mcpCall("get_quiescence_status", {}, {
+        mcpUrl,
+        bearerToken,
+        timeoutMs: 2_500,
+      });
+      return response?.success === true;
+    }),
+    timedProbe(() => commandHealthy("docker", ["info"], 2_500)),
+    timedProbe(() => probePostgres(databaseUrl)),
+  ]);
+  return { portal, mcp, docker, postgres };
+}
+
+function resolveGit(args) {
+  const result = spawnSync("git", args, { encoding: "utf8", shell: false });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function writeEvidence(path, payload) {
+  if (!path) return;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    process.stdout.write(usage());
+    return 0;
+  }
+  const tag = valueAfter("--tag");
+  const slotKey = valueAfter("--slot-key") || process.env.DPF_LOCAL_CI_SLOT_KEY || "slot-0";
+  const candidate = valueAfter("--candidate");
+  if (!tag || !candidate) {
+    process.stderr.write(usage());
+    return 2;
+  }
+
+  const builder = builderFromEnvironment();
+  const evidencePath = process.env.DPF_LOCAL_CI_CONTROL_PLANE_EVIDENCE_FILE || "";
+  const startedAt = new Date().toISOString();
+  const identity = {
+    candidate,
+    candidateSha: resolveGit(["rev-parse", "--verify", candidate]),
+    integrationCommitSha: resolveGit(["rev-parse", "--verify", "HEAD"]),
+    integrationTreeSha: resolveGit(["rev-parse", "--verify", "HEAD^{tree}"]),
+    slotKey,
+    imageTag: tag,
+  };
+  const policy = {
+    version: builder.policyVersion,
+    builderName: builder.name,
+    memoryBytes: builder.memoryBytes,
+    cpuQuota: builder.cpuQuota,
+    cpuPeriod: builder.cpuPeriod,
+    maxParallelism: builder.maxParallelism,
+  };
+
+  let controlPlaneDatabaseUrl;
+  try {
+    controlPlaneDatabaseUrl = resolveControlPlaneDatabaseUrl();
+  } catch (error) {
+    const payload = {
+      schemaVersion: 1,
+      status: "blocked_control_plane_starvation",
+      phase: "control-plane-credential-resolution",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      identity,
+      policy,
+      failures: [error instanceof Error ? error.message : String(error)],
+      samples: [],
+    };
+    writeEvidence(evidencePath, payload);
+    process.stderr.write(`[local-ci-bounded-build] ${payload.status} ${payload.failures[0]}\n`);
+    return EXIT_CONTROL_PLANE_STARVATION;
+  }
+
+  const preflight = await establishHealthyControlPlane({
+    sample: () => probeControlPlane(controlPlaneDatabaseUrl),
+  });
+  if (preflight.status !== "healthy") {
+    const payload = {
+      schemaVersion: 1,
+      status: preflight.status,
+      phase: "control-plane-preflight",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      identity,
+      policy,
+      failures: preflight.failures,
+      samples: preflight.samples,
+    };
+    writeEvidence(evidencePath, payload);
+    process.stderr.write(`[local-ci-bounded-build] ${payload.status} ${payload.failures.join(",")}\n`);
+    return EXIT_CONTROL_PLANE_STARVATION;
+  }
+
+  try {
+    ensureBoundedBuilder(builder);
+  } catch (error) {
+    const payload = {
+      schemaVersion: 1,
+      status: "blocked_control_plane_starvation",
+      phase: "builder-preflight",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      identity,
+      policy,
+      failures: [error instanceof Error ? error.message : String(error)],
+      samples: preflight.samples,
+    };
+    writeEvidence(evidencePath, payload);
+    process.stderr.write(`[local-ci-bounded-build] ${payload.status} ${payload.failures[0]}\n`);
+    return EXIT_CONTROL_PLANE_STARVATION;
+  }
+
+  const args = buildxBuildArgs({ builder, tag, context: "." });
+  const child = spawn("docker", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+    shell: false,
+    detached: process.platform !== "win32",
+  });
+  let childComplete = false;
+  let childExit = null;
+  let buildOutput = "";
+  const capture = (stream, destination) => {
+    stream.on("data", (chunk) => {
+      destination.write(chunk);
+      buildOutput = `${buildOutput}${chunk}`.slice(-32_000);
+    });
+  };
+  capture(child.stdout, process.stdout);
+  capture(child.stderr, process.stderr);
+  const closed = new Promise((resolve) => {
+    child.once("error", () => {
+      childComplete = true;
+      childExit = 1;
+      resolve();
+    });
+    child.once("close", (code) => {
+      childComplete = true;
+      childExit = code ?? 1;
+      resolve();
+    });
+  });
+  const watchdog = await monitorControlPlane({
+    sample: () => probeControlPlane(controlPlaneDatabaseUrl),
+    isComplete: () => childComplete,
+  });
+  let termination = null;
+  if (watchdog.status === "blocked_control_plane_starvation" && !childComplete) {
+    const command = terminateProcessTreeCommand(child.pid);
+    const stopped = spawnSync(command.command, command.args, {
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 15_000,
+    });
+    termination = { status: stopped.status, signal: stopped.signal || null };
+  }
+  await closed;
+  const buildOutcome = classifyBoundedBuildExit({
+    exitCode: childExit,
+    output: buildOutput,
+  });
+  const finalStatus = watchdog.status === "blocked_control_plane_starvation"
+    ? watchdog.status
+    : buildOutcome.status;
+  const failures = watchdog.status === "blocked_control_plane_starvation"
+    ? watchdog.failures
+    : buildOutcome.failures;
+  const payload = {
+    schemaVersion: 1,
+    status: finalStatus,
+    phase: "production-build",
+    startedAt,
+    completedAt: new Date().toISOString(),
+    identity,
+    policy,
+    failures,
+    samples: [...preflight.samples, ...watchdog.samples],
+    buildExitCode: childExit,
+    termination,
+  };
+  writeEvidence(evidencePath, payload);
+  if (finalStatus === "blocked_control_plane_starvation") {
+    process.stderr.write(`[local-ci-bounded-build] ${finalStatus} ${failures.join(",")}\n`);
+    return EXIT_CONTROL_PLANE_STARVATION;
+  }
+  return buildOutcome.exitCode;
+}
+
+process.exitCode = await main();


### PR DESCRIPTION
Closes BI-CE6E2882.

## Outcome

Prevents a local-CI production build from starving the shared DPF control plane. Each slot now builds through a Docker Buildx container with an enforced 16 GiB memory boundary, an 8-CPU quota, and BuildKit parallelism capped at four. The existing one-slot capacity remains unchanged.

The runner probes four independent surfaces throughout the build: portal health, read-only MCP, Docker Engine, and direct PostgreSQL. Two consecutive unhealthy rounds terminate the scoped build process tree and classify the gate as `blocked_control_plane_starvation`, preserving an infrastructure diagnosis instead of charging a product failure.

The same evidence now participates in gate records, pilot rollback decisions, capacity contraction, and governed autonomous recovery. Resource-limit kills are likewise classified as infrastructure evidence.

## Verification

- Exact merged-code local-CI gate passed for `fix/local-ci-control-plane-starvation@549b8755602329878a760a50557dc82669651e66`.
- Repository preflight: 29 guards clean.
- Typecheck: passed.
- Vitest: 2,437 files and 20,882 tests passed; declared skips/todos only.
- Production Docker build: passed, including page-data collection and image export/import.
- Builder enforcement observed from Docker: 17,179,869,184 bytes memory, CPU quota 800000/period 100000, max parallelism 4.
- Watchdog: 15 consecutive final-SHA samples, zero failures across portal, MCP, Docker, and PostgreSQL. The preceding uncached pressure run recorded 77 consecutive healthy samples through the full compilation and image export.
- UX/migration: not applicable; this changes CI/control-plane infrastructure and adds no UI or schema migration.

Local-CI-Evidence: cms94282d0onz01mz8c64qute (fix/local-ci-control-plane-starvation@549b8755602329878a760a50557dc82669651e66)

## Design grounding

Implements `docs/superpowers/specs/2026-07-31-local-ci-control-plane-starvation-design.md` and its execution plan. The design extends the existing slot manifest, exact-tree gate, evidence pack, pilot circuit breaker, and autonomous recovery contracts rather than introducing a second sandbox or changing admission capacity.

WWMD selected the bounded-build-and-watchdog option in decision `DI-EBA2C9239C5C` with high confidence. The first empirical boundary at 12 GiB protected the control plane but exhausted during page-data collection; the final 16 GiB boundary passed while preserving roughly 27 GiB of host reserve.

Seed-Fit-Decision: reject-as-seed

This is runtime CI infrastructure; no seed, provider catalog, bootstrap calibration, or migration is changed.

## Operational constraint

This closes starvation prevention for the existing single-slot sandbox. It does not overturn the governed two-slot pilot's binding rollback and does not claim overlapping builds, third-party FIFO, or owner-loss isolation are proven.
