### PR TITLE
feat(context): make recorded context-economy claims come due for review

### DIFF
--- a/scripts/check-context-economy.mjs
+++ b/scripts/check-context-economy.mjs
@@ -33,6 +33,18 @@
 // Per-turn ACTUALS are now recorded by BI-3E218D80 (AgentMessage.contextTrace); this
 // guard governs the declared budget, which is the part a PR can change.
 //
+// CLAIM REVIEW — the half that makes "soft" mean something. Letting cost grow on a
+// recorded promise is only honest if the promise is revisited: "this complexity removes
+// load later" is a PREDICTION, and a prediction nobody returns to is just a comment.
+// So a recorded `reason` carries a `recordedAt`, and after `reviewByDays` (default 90)
+// it comes due. Enforcement is scoped so it cannot become collateral damage: an overdue
+// claim is always REPORTED, but it only BLOCKS a change that is itself raising a NEW
+// claim — you do not get to add context debt while your existing claims are unreviewed.
+// A naive "overdue fails the build" rule would red every PR in the repo the morning a
+// claim expired, and a guard that punishes bystanders is one people learn to route
+// around. Re-affirm by moving `recordedAt` and saying what actually happened; the
+// evidence for that answer is in the contextTrace data, not in this script.
+//
 //   node scripts/check-context-economy.mjs          # check (CI)
 //   node scripts/check-context-economy.mjs --update # re-baseline (then write the reasons)
 
@@ -148,6 +160,87 @@ export function evaluateContextEconomy({ measured, baseline, baseBaseline }) {
   return { ok: errors.length === 0, errors, notes, justified };
 }
 
+// ── Claim review: the half that makes "soft" mean something ─────────────────────
+
+/** How long a recorded justification stands before it must be revisited. */
+export const DEFAULT_REVIEW_BY_DAYS = 90;
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Which recorded claims are now due for review.
+ *
+ * WHY THIS EXISTS. The guard above lets standing context cost grow as long as the
+ * author records what long-term cognitive load it buys. That is the right trade — but
+ * a claim nobody ever revisits is just a comment. "This complexity removes load later"
+ * is a PREDICTION, and the only honest way to hold a prediction accountable is to come
+ * back to it. Without this, a soft guard decays into a warning nobody reads, which is
+ * the exact failure this whole line of work started from.
+ *
+ * `now` is injected so the result is deterministic under test.
+ */
+export function reviewClaims({ baseline, now, defaultReviewByDays = DEFAULT_REVIEW_BY_DAYS }) {
+  const due = [];
+  const undated = [];
+
+  for (const [key, entry] of Object.entries(baseline ?? {})) {
+    const reason = typeof entry?.reason === "string" ? entry.reason.trim() : "";
+    if (!reason) continue; // no claim recorded — nothing to revisit
+
+    const recordedAt = entry.recordedAt ? Date.parse(entry.recordedAt) : NaN;
+    if (Number.isNaN(recordedAt)) {
+      // A claim with no date can never come due, so it would be an immortal excuse.
+      undated.push(key);
+      continue;
+    }
+
+    const windowDays = Number(entry.reviewByDays) > 0 ? Number(entry.reviewByDays) : defaultReviewByDays;
+    const ageDays = Math.floor((now - recordedAt) / MS_PER_DAY);
+    if (ageDays >= windowDays) {
+      due.push({ key, ageDays, windowDays, reason, value: entry.value });
+    }
+  }
+
+  return { due, undated };
+}
+
+/**
+ * Turn the review into enforcement, WITHOUT reddening unrelated work.
+ *
+ * A naive "overdue claims fail the build" rule would red every PR in the repo the
+ * morning a claim expired — the same collateral pain as a policy guard failing on files
+ * the author never touched. So overdue claims are always REPORTED, and they only BLOCK
+ * a change that is itself raising a NEW claim: you do not get to add context debt while
+ * your existing claims are unreviewed. Same shape as the UX budget's "legacy debt earns
+ * a ratchet; new code has no legacy excuse".
+ */
+export function enforceClaimReview({ review, raisedNewClaim }) {
+  const errors = [];
+  const warnings = [];
+
+  for (const key of review.undated) {
+    warnings.push(
+      `${key} carries a reason with no recordedAt, so it can never come due for review — ` +
+        `add recordedAt (YYYY-MM-DD) when you re-baseline.`,
+    );
+  }
+
+  for (const claim of review.due) {
+    const line =
+      `${claim.key} claim is ${claim.ageDays}d old (review window ${claim.windowDays}d): ` +
+      `"${claim.reason}"`;
+    if (raisedNewClaim) {
+      errors.push(
+        `${line} — this change raises a NEW claim while that one is unreviewed. Re-affirm it ` +
+          `(update recordedAt and say what actually happened) or shrink the value back.`,
+      );
+    } else {
+      warnings.push(`${line} — due for review: did the promised reduction actually arrive?`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
 // ── I/O ─────────────────────────────────────────────────────────────────────────
 
 function readBaseline(path) {
@@ -185,8 +278,16 @@ function main() {
       entries[key] = {
         value,
         // Carry a prior reason forward only while the number is unchanged; a raised
-        // number needs a fresh justification, not an inherited one.
-        ...(prior && prior.value === value && prior.reason ? { reason: prior.reason } : {}),
+        // number needs a fresh justification, not an inherited one. `recordedAt` travels
+        // WITH the reason so the review clock is not silently reset by an unrelated
+        // re-baseline — re-affirming a claim has to be a deliberate edit.
+        ...(prior && prior.value === value && prior.reason
+          ? {
+              reason: prior.reason,
+              ...(prior.recordedAt ? { recordedAt: prior.recordedAt } : {}),
+              ...(prior.reviewByDays ? { reviewByDays: prior.reviewByDays } : {}),
+            }
+          : {}),
       };
     }
     writeFileSync(
@@ -215,16 +316,26 @@ function main() {
     process.exit(1);
   }
 
-  const { ok, errors, notes, justified } = evaluateContextEconomy({
+  const { errors, notes, justified } = evaluateContextEconomy({
     measured,
     baseline,
     baseBaseline: readBaselineAtBase(),
   });
 
+  // A claim raised in THIS change is what turns an overdue claim from a warning into a
+  // blocker — see enforceClaimReview for why it is scoped that way.
+  const review = reviewClaims({ baseline, now: Date.now() });
+  const claimVerdict = enforceClaimReview({ review, raisedNewClaim: justified.length > 0 });
+
   for (const j of justified) console.log(`  [recorded] ${j}`);
   for (const n of notes) console.log(`  [note] ${n}`);
+  for (const w of claimVerdict.warnings) console.log(`  [review] ${w}`);
+  errors.push(...claimVerdict.errors);
 
-  if (!ok) {
+  // Recomputed AFTER the review errors are folded in — reading a stale `ok` here would
+  // print the review failures and then exit 0, which is the false green this guard exists
+  // to prevent.
+  if (errors.length > 0) {
     console.error("\nContext-economy guard failed (BI-3E218D80 follow-on).\n");
     for (const e of errors) console.error(`  - ${e}`);
     console.error("");

--- a/scripts/check-context-economy.test.mjs
+++ b/scripts/check-context-economy.test.mjs
@@ -176,7 +176,6 @@ test("the committed baseline is in sync with the live source", () => {
 // more importantly, pin the SCOPE of enforcement: overdue claims must not red unrelated
 // work, or the guard becomes the collateral-damage kind everyone learns to ignore.
 
-const DAY = 86_400_000;
 const NOW = Date.parse("2026-07-31T00:00:00Z");
 const claim = (over) => ({ value: 4000, reason: "Funds the profession corpus inline, removing a manual lookup.", ...over });
 

--- a/scripts/check-context-economy.test.mjs
+++ b/scripts/check-context-economy.test.mjs
@@ -10,10 +10,12 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import {
+  enforceClaimReview,
   evaluateContextEconomy,
   measureContextEconomy,
   parseStandingSources,
   parseTierBudgets,
+  reviewClaims,
 } from "./check-context-economy.mjs";
 
 const ARBITRATOR = `
@@ -166,4 +168,93 @@ test("the committed baseline is in sync with the live source", () => {
   assert.equal(result.ok, true, result.errors.join("; "));
   // And the guard is actually measuring something, not vacuously passing on an empty set.
   assert.ok(Object.keys(measured).length >= 5);
+});
+
+// ── claim review: the half that makes "soft" mean something ──
+//
+// A recorded claim nobody revisits is just a comment. These pin the review clock and,
+// more importantly, pin the SCOPE of enforcement: overdue claims must not red unrelated
+// work, or the guard becomes the collateral-damage kind everyone learns to ignore.
+
+const DAY = 86_400_000;
+const NOW = Date.parse("2026-07-31T00:00:00Z");
+const claim = (over) => ({ value: 4000, reason: "Funds the profession corpus inline, removing a manual lookup.", ...over });
+
+test("a claim inside its review window is not due", () => {
+  const r = reviewClaims({
+    baseline: { "budget.strong.totalBudget": claim({ recordedAt: "2026-07-01" }) },
+    now: NOW,
+  });
+  assert.deepEqual(r.due, []);
+});
+
+test("a claim past its window comes due, with its age and the original reason", () => {
+  const r = reviewClaims({
+    baseline: { "budget.strong.totalBudget": claim({ recordedAt: "2026-01-01" }) },
+    now: NOW,
+  });
+  assert.equal(r.due.length, 1);
+  assert.equal(r.due[0].key, "budget.strong.totalBudget");
+  assert.ok(r.due[0].ageDays > 90);
+  assert.match(r.due[0].reason, /profession corpus/);
+});
+
+test("a per-entry reviewByDays overrides the default", () => {
+  const base = { "budget.strong.totalBudget": claim({ recordedAt: "2026-07-01", reviewByDays: 7 }) };
+  assert.equal(reviewClaims({ baseline: base, now: NOW }).due.length, 1);
+});
+
+test("an entry with no reason is not a claim and never comes due", () => {
+  const r = reviewClaims({
+    baseline: { "budget.strong.totalBudget": { value: 3000, recordedAt: "2020-01-01" } },
+    now: NOW,
+  });
+  assert.deepEqual(r.due, []);
+  assert.deepEqual(r.undated, []);
+});
+
+test("a reason with no recordedAt is flagged — an undated claim is an immortal excuse", () => {
+  const r = reviewClaims({ baseline: { "budget.strong.totalBudget": claim({}) }, now: NOW });
+  assert.deepEqual(r.undated, ["budget.strong.totalBudget"]);
+  const v = enforceClaimReview({ review: r, raisedNewClaim: false });
+  assert.equal(v.ok, true, "undated is a warning, not a blocker");
+  assert.ok(v.warnings.some((w) => /never come due/.test(w)));
+});
+
+// The scoping rule — this is the design decision worth protecting.
+test("an overdue claim WARNS on an unrelated change instead of reddening it", () => {
+  const review = reviewClaims({
+    baseline: { "budget.strong.totalBudget": claim({ recordedAt: "2026-01-01" }) },
+    now: NOW,
+  });
+  const v = enforceClaimReview({ review, raisedNewClaim: false });
+  assert.equal(v.ok, true, "must not red a PR that touched nothing related");
+  assert.ok(v.warnings.some((w) => /due for review/.test(w)));
+});
+
+test("but BLOCKS a change that raises a NEW claim while one is unreviewed", () => {
+  const review = reviewClaims({
+    baseline: { "budget.strong.totalBudget": claim({ recordedAt: "2026-01-01" }) },
+    now: NOW,
+  });
+  const v = enforceClaimReview({ review, raisedNewClaim: true });
+  assert.equal(v.ok, false);
+  assert.ok(v.errors.some((e) => /raises a NEW claim while that one is unreviewed/.test(e)));
+  assert.ok(v.errors.some((e) => /shrink the value back/.test(e)));
+});
+
+test("re-affirming by moving recordedAt forward clears the block", () => {
+  const review = reviewClaims({
+    baseline: { "budget.strong.totalBudget": claim({ recordedAt: "2026-07-20" }) },
+    now: NOW,
+  });
+  assert.deepEqual(review.due, []);
+  assert.equal(enforceClaimReview({ review, raisedNewClaim: true }).ok, true);
+});
+
+test("the shipped baseline has no undated claims", () => {
+  const baseline = JSON.parse(
+    readFileSync(new URL("../scripts/context-economy-baseline.json", import.meta.url), "utf8"),
+  ).entries;
+  assert.deepEqual(reviewClaims({ baseline, now: NOW }).undated, []);
 });


### PR DESCRIPTION
Completes the soft guard from #3804.

That guard let standing context cost grow provided the author recorded what long-term cognitive load it buys — the right trade under the doctrine that complexity is fine when it removes load over time. But it could only **detect** the addition and **preserve** the claim. It could not hold the claim to account, and **a claim nobody revisits is just a comment.**

"This complexity removes load later" is a **prediction**. The only honest way to hold a prediction accountable is to come back to it. So a recorded `reason` now carries a `recordedAt`, and after `reviewByDays` (default 90) it comes due.

## The scoping rule is the design, not the expiry

A naive *"overdue claims fail the build"* would red every PR in the repo the morning a claim expired — the same collateral pain as a policy guard failing on files the author never touched, which is exactly how guards teach people to route around them.

So:

| Situation | Result |
|---|---|
| Overdue claim exists, your change raises none | **Reported every run**, exit 0 — bystanders are never reddened |
| Overdue claim exists, your change raises a **new** one | **Blocks** — re-affirm it or shrink the value back |

Same shape as the UX budget's *"legacy debt earns a ratchet; new code has no legacy excuse."* Pressure lands on the person adding debt, not on whoever happens to push that morning.

## Two smaller holes closed

- A `reason` with **no `recordedAt`** can never come due — an immortal excuse. Now surfaced as a warning.
- `--update` carries `recordedAt`/`reviewByDays` forward **with** the reason, so an unrelated re-baseline can't silently reset the review clock. Re-affirming has to be a deliberate edit.

## A bug I introduced and caught

`main()` destructured `ok` from `evaluateContextEconomy` **before** folding in the review errors — so it would have printed the review failures and then **exited 0**. Precisely the false green this guard exists to prevent. Now recomputed from `errors.length` after the fold, with a comment saying why.

## What this deliberately does not do

It does **not** try to score whether the promised reduction arrived. It cannot — CI has no database. It forces the question and names the claim; the evidence for the answer lives in `AgentMessage.contextTrace` (#3790). **Guard asks, data answers.**

## Verification

- **21 unit tests** on the guard, 9 on the review loop: window arithmetic, per-entry `reviewByDays` override, "no reason is not a claim", the undated-claim warning, and both halves of the scoping rule.
- **End-to-end against the real script** with a genuinely overdue claim: overdue alone → `[review] … 211d old … due for review` and **exit 0**; overdue + a newly raised claim → **exit 1** naming the stale claim and offering re-affirm or shrink. Baseline restored afterwards.
- A test asserts the shipped baseline carries no undated claims.
- **29-guard pregate-preflight clean**; 26 tests green across the guard and the policy-guard registry.

Seed-Fit-Decision: global-default

No canonical seed content changed. Global-default because the review contract is platform CI substrate applied identically on every install.

Local-CI-Override: Scripts-only — two files under scripts/, no apps/web runtime, no TypeScript in the Next build, no schema or migration, so local-CI's unique coverage (typecheck, full suite, migrate deploy) adds nothing here. Verified with a clean 29-guard preflight, 26 tests, and an end-to-end probe proving both halves of the scoping rule. Local-CI queue remains deeply contended; GitHub CI still runs everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
