### PR TITLE
Gate rule preservation across the instruction-plane split (BI-0020D511 §12f)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,6 +52,7 @@ scripts/hand-rolled-loading-baseline.txt merge=union
 # Instruction-plane size ratchet baseline (BI-0020D511) — always-on agent
 # doctrine plane; union-merge so concurrent re-baselines never conflict.
 scripts/instruction-plane-baseline.txt merge=union
+scripts/instruction-plane-rule-baseline.txt merge=union
 
 # Archetype completeness ratchet baseline — concurrent PRs that each re-run
 # --update must not conflict; union-merge and let --update re-dedupe/sort.

--- a/docs/superpowers/specs/2026-07-24-agent-instruction-plane-split-and-ratchet-design.md
+++ b/docs/superpowers/specs/2026-07-24-agent-instruction-plane-split-and-ratchet-design.md
@@ -332,6 +332,18 @@ Phase 1 moves `AGENTS.md` §4/§6/§8/§16 procedure *into* these files. Loading
 
 **Recommended Phase 1 acceptance addition:** a small compliance set — one task per commandment-tier rule (DCO sign-off, branch guard, no-hardcoded-colors, worktree-not-runtime, consult-scopes-before-asking) run against pre- and post-split doctrine on at least Claude Code **and** one non-Claude surface. Without it the 58% cut is unfalsifiable, and per §12d it is exactly the non-Claude surfaces that would absorb the regression.
 
+#### 12f-i. Status (2026-07-31) — the gap splits in two; the deterministic half is BUILT
+
+Framing this as one gap conflated two separable questions:
+
+- **(a) Preservation — did the cut *drop* a rule?** Deterministic, and now gated. `scripts/check-instruction-plane-rule-coverage.mjs` (guard `instruction-plane-rule-coverage`) keys each load-bearing rule on its **kernel-principle anchor** — the `→ [kernel principle](docs/.../x.md)` target — rather than on prose, because Phase 1 is *supposed* to reword and relocate the prose. **46 anchors are baselined from the pre-split plane** (35 kernel + 11 flat profession-wiki). The invariant: every baselined anchor must remain referenced from an always-on file *or* from a registered `manifest.ruleDestinations` target. Relocation passes; deletion fails. This makes Phase 1's *"no rule statement lost (diff-reviewed against the commandment set)"* machine-checked instead of a hand diff-review across a 58% rewrite of a 90kB file — the review step most likely to decay into a rubber stamp precisely when it matters most.
+
+  **Timing was the binding constraint:** the baseline is only trustworthy while the pre-cut plane still exists to be measured. Captured now, before Phase 1 moves anything.
+
+  Two by-products worth carrying into Phase 1: the guard reports **7 duplicated anchors** in today's always-on prose (`worktree-is-source-control-not-runtime` is linked **3×**; `single-source-of-truth`, `all-changes-land-via-pr`, `mcp-is-the-coordination-plane`, `one-common-process-three-surfaces`, `organization-canonical-identity`, `schema-audit-before-features` twice each) — the same SSOT drift shape as Problem 2, advisory for now because fixing them is Phase 1's job. And the anchor pattern must admit *both* wiki shapes; an earlier draft required a directory under `wiki/` and silently dropped all 11 profession anchors — a false-green the guard's own test now pins.
+
+- **(b) Efficacy — does a *shortened* rule still steer the agent?** **Still open, and not addressable deterministically.** This is the compliance set described above and it needs real model runs across surfaces. Nothing in (a) speaks to it: a rule can be perfectly reachable and still stop working once its rationale and worked example are gone, which is exactly what §12d predicts for the weaker surfaces. **A green rule-coverage run must not be read as "the cut was safe" — only as "the cut lost nothing outright."**
+
 ### 12g. Other optimizations worth considering (beyond the article)
 
 1. **Directory-scoped `AGENTS.md`.** §3 of the root file notes subdirectory files "MAY extend this… none exist today." Both Claude Code and Codex load nested `AGENTS.md` by path proximity — a genuine, zero-cost progressive-disclosure channel that Phase 1 should use as a *destination tier* alongside skills: `apps/web/AGENTS.md` (§12 UI styling), `packages/db/AGENTS.md` (§3 enums, §11 stewardship, migration safety), `scripts/AGENTS.md`. Rules land closer to the code they govern and cost nothing to sessions working elsewhere.

--- a/scripts/check-instruction-plane-rule-coverage.mjs
+++ b/scripts/check-instruction-plane-rule-coverage.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+// Instruction-plane RULE-COVERAGE guard — BI-0020D511 §12f (design doc
+// docs/superpowers/specs/2026-07-24-agent-instruction-plane-split-and-ratchet-design.md).
+//
+// WHY THIS EXISTS
+// check-instruction-plane-size.mjs counts BYTES. Bytes are the whole point of the
+// Phase 1 split, but a byte gate cannot tell a good cut from a lossy one: deleting a
+// commandment scores exactly like relocating it. §12f names this gap outright — "the
+// ratchet is a byte gate with no behavioural counterpart, so a 58% cut is currently
+// unfalsifiable". Phase 1's own acceptance criterion says "no rule *statement* lost
+// (diff-reviewed against the commandment set)", and a hand diff-review across a 58%
+// rewrite of a 90kB file is exactly the check that silently degrades into a rubber stamp.
+//
+// This guard makes that criterion machine-checked.
+//
+// WHAT IS A "RULE", MECHANICALLY
+// Rule identity is the KERNEL-PRINCIPLE ANCHOR, not the prose. AGENTS.md states each
+// load-bearing rule as a bullet ending in `→ [kernel principle](docs/.../foo.md)`. That
+// target path is a durable identifier: Phase 1 is *supposed* to reword, shorten, and
+// relocate the prose, so keying on sentences would fire on every intended edit and teach
+// everyone to run --update reflexively. Keying on the anchor fires only when a rule stops
+// being reachable at all — which is the actual defect.
+//
+// THE INVARIANT
+// Every anchor baselined from the pre-split plane must remain reachable from either:
+//   (a) an always-on file (the rule stayed in doctrine), or
+//   (b) a registered destination — manifest.ruleDestinations (the rule moved to its skill
+//       or reference doc, which is what Phase 1 is FOR).
+// A rule that appears in neither has been dropped, and that fails.
+//
+// WHAT THIS IS NOT
+// This is the DETERMINISTIC half of §12f. It proves a rule still EXISTS somewhere an agent
+// can reach; it does NOT prove a shortened rule still STEERS an agent the same way. That
+// second half needs behavioural evals against real surfaces and is deliberately out of
+// scope here — see §12f. Do not let a green run here be read as "the cut was safe",
+// only as "the cut lost nothing outright".
+//
+// Prior art deliberately mirrored: scripts/check-golden-decisions.mjs, which gates the
+// kernel-principle CORPUS on canonical decision outcomes with no vitest dependency. Same
+// spirit (doctrine regression, pure node, fast), different plane — golden-decisions cannot
+// see AGENTS.md, so relocating a rule out of the always-on plane is invisible to it.
+//
+//   node scripts/check-instruction-plane-rule-coverage.mjs            # check (CI)
+//   node scripts/check-instruction-plane-rule-coverage.mjs --update   # re-baseline
+//   node scripts/check-instruction-plane-rule-coverage.mjs --strict   # duplicates become errors
+
+import { existsSync, globSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST_PATH = join(REPO_ROOT, "scripts", "instruction-plane-manifest.json");
+// Line-oriented `<anchor>\t<label>`, merge=union like the size baseline so concurrent
+// re-baselines never conflict. Duplicate anchors after a union merge collapse to one.
+const BASELINE_PATH = join(REPO_ROOT, "scripts", "instruction-plane-rule-baseline.txt");
+
+/**
+ * Default: anything under a kernel/profession `wiki/` tree is a rule anchor. BOTH shapes
+ * occur and both are load-bearing — `founder-kernel/wiki/principles/<rule>.md` (35 today)
+ * and the flat profession shape `professions/<prof>/wiki/<rule>.md` (11 today, e.g.
+ * strongly-typed-string-enums, backlog-lives-in-postgresql). An earlier pattern that
+ * required a directory under `wiki/` silently dropped all 11, which is precisely the
+ * false-green this guard exists to prevent — hence the optional group, and hence
+ * `check-instruction-plane-rule-coverage.test.mjs` asserts a profession anchor is caught.
+ */
+const DEFAULT_ANCHOR_RE = "wiki/(?:[a-z0-9-]+/)?[a-z0-9-]+\\.md$";
+
+/** Parse `<anchor>\t<label>` lines; later duplicates keep the first label. */
+export function parseRuleBaseline(text) {
+  const out = new Map();
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^(\S+)(?:\s+(.*))?$/);
+    if (!m) continue;
+    if (!out.has(m[1])) out.set(m[1], (m[2] ?? "").trim());
+  }
+  return out;
+}
+
+export function serializeRuleBaseline(anchors) {
+  return (
+    [...anchors.entries()]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([anchor, label]) => (label ? `${anchor}\t${label}` : anchor))
+      .join("\n") + "\n"
+  );
+}
+
+/**
+ * The bolded lead-in of a rule bullet — `- **Never fabricate.** Ground claims…` yields
+ * "Never fabricate.". Human-readable only; never part of anchor identity, because Phase 1
+ * rewording it is intended behaviour, not a regression.
+ */
+export function ruleLabel(line) {
+  const m = line.match(/^\s*[-*]\s+\*\*(.+?)\*\*/);
+  if (m) return m[1].replace(/\s+/g, " ").trim().slice(0, 80);
+  const h = line.match(/^#{2,4}\s+(.+?)\s*$/);
+  if (h) return h[1].replace(/\s+/g, " ").trim().slice(0, 80);
+  return "";
+}
+
+/**
+ * Every rule anchor referenced by a doc, with the label of the line that carries it.
+ * Returns `Array<{ anchor, label, line }>` — one entry per OCCURRENCE, so a rule linked
+ * twice yields two entries (the duplicate signal below depends on that).
+ */
+export function ruleAnchors(text, anchorRe = DEFAULT_ANCHOR_RE) {
+  const re = new RegExp(anchorRe);
+  const found = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const linkRe = /\]\(([^)\s]+?\.md)(?:#[^)]*)?\)/g;
+    let m;
+    while ((m = linkRe.exec(lines[i])) !== null) {
+      if (/:\/\//.test(m[1])) continue;
+      const anchor = m[1].replace(/^\.\//, "").replace(/^\//, "");
+      if (!re.test(anchor)) continue;
+      found.push({ anchor, label: ruleLabel(lines[i]), line: i + 1 });
+    }
+  }
+  return found;
+}
+
+/** Union of anchors referenced anywhere in a set of `path -> text` entries. */
+export function anchorsIn(fileTexts, anchorRe) {
+  const set = new Set();
+  for (const text of Object.values(fileTexts)) {
+    if (text == null) continue;
+    for (const { anchor } of ruleAnchors(text, anchorRe)) set.add(anchor);
+  }
+  return set;
+}
+
+/**
+ * Pure evaluation, exported for tests.
+ *
+ * @param {object} a
+ * @param {Map<string,string>} a.baseline      anchor -> label, from the pre-split plane
+ * @param {Record<string,string|null>} a.alwaysOnTexts
+ * @param {Record<string,string|null>} a.destinationTexts  registered relocation targets
+ * @param {(p: string) => boolean} a.targetExists
+ */
+export function evaluateRuleCoverage({
+  baseline,
+  alwaysOnTexts,
+  destinationTexts = {},
+  targetExists = () => true,
+  anchorRe = DEFAULT_ANCHOR_RE,
+  strict = false,
+}) {
+  const errors = [];
+  const warnings = [];
+
+  const inPlane = anchorsIn(alwaysOnTexts, anchorRe);
+  const inDestinations = anchorsIn(destinationTexts, anchorRe);
+
+  // 1. Preservation (HARD) — the whole point of the guard.
+  const lost = [];
+  for (const [anchor, label] of baseline) {
+    if (inPlane.has(anchor) || inDestinations.has(anchor)) continue;
+    lost.push(
+      `rule anchor "${anchor}"${label ? ` (${label})` : ""} is no longer referenced from ` +
+        `the always-on plane OR any registered destination — the rule statement was DROPPED, ` +
+        `not relocated`,
+    );
+  }
+  errors.push(...lost.sort());
+
+  // 2. Dangling target (HARD) — a rule pointing at a deleted principle page is a rule an
+  //    agent cannot actually read, which is the same defect one hop later.
+  for (const anchor of [...inPlane].sort()) {
+    if (!targetExists(anchor)) {
+      errors.push(`rule anchor "${anchor}" is referenced from the always-on plane but the target file does not exist`);
+    }
+  }
+
+  // 3. Duplicate anchor (ADVISORY) — the same rule linked from two places in always-on
+  //    prose is the SSOT drift shape this BI's Problem 2 describes. Advisory because the
+  //    pre-split file already has instances and fixing them is Phase 1 work.
+  for (const [file, text] of Object.entries(alwaysOnTexts)) {
+    if (text == null) continue;
+    const seen = new Map();
+    for (const { anchor, line } of ruleAnchors(text, anchorRe)) {
+      if (!seen.has(anchor)) seen.set(anchor, []);
+      seen.get(anchor).push(line);
+    }
+    for (const [anchor, lines] of [...seen.entries()].sort()) {
+      if (lines.length < 2) continue;
+      const msg = `${file} links rule anchor "${anchor}" ${lines.length}× (lines ${lines.join(", ")}) — state a rule once, per single-source-of-truth`;
+      (strict ? errors : warnings).push(msg);
+    }
+  }
+
+  // 4. Net-new anchors are NOT an error — adding a rule is always allowed. Reported so an
+  //    intentional addition shows up in the run and lands in the baseline on --update.
+  const added = [...inPlane].filter((a) => !baseline.has(a)).sort();
+
+  return { errors, warnings, added, planCount: inPlane.size, baselineCount: baseline.size };
+}
+
+function loadManifest() {
+  return JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+}
+
+function readTexts(paths) {
+  const texts = {};
+  for (const p of paths) {
+    try {
+      texts[p] = readFileSync(join(REPO_ROOT, p), "utf8");
+    } catch {
+      texts[p] = null;
+    }
+  }
+  return texts;
+}
+
+function destinationPaths(manifest) {
+  const globs = Array.isArray(manifest.ruleDestinations) ? manifest.ruleDestinations : [];
+  const out = new Set();
+  for (const g of globs) {
+    for (const f of globSync(g, { cwd: REPO_ROOT })) out.add(f.replace(/\\/g, "/"));
+  }
+  return [...out].sort();
+}
+
+function main() {
+  const manifest = loadManifest();
+  const anchorRe = manifest.ruleAnchorPattern || DEFAULT_ANCHOR_RE;
+  const alwaysOnTexts = readTexts(manifest.alwaysOn);
+
+  if (process.argv.includes("--update")) {
+    const anchors = new Map();
+    for (const text of Object.values(alwaysOnTexts)) {
+      if (text == null) continue;
+      for (const { anchor, label } of ruleAnchors(text, anchorRe)) {
+        if (!anchors.has(anchor) || (!anchors.get(anchor) && label)) anchors.set(anchor, label);
+      }
+    }
+    writeFileSync(BASELINE_PATH, serializeRuleBaseline(anchors));
+    console.log(
+      `Wrote instruction-plane rule baseline: ${anchors.size} rule anchors from ${manifest.alwaysOn.length} always-on files.`,
+    );
+    process.exit(0);
+  }
+
+  let baseline;
+  try {
+    baseline = parseRuleBaseline(readFileSync(BASELINE_PATH, "utf8"));
+  } catch {
+    console.error(
+      `Missing baseline ${relative(REPO_ROOT, BASELINE_PATH)} — run: node scripts/check-instruction-plane-rule-coverage.mjs --update`,
+    );
+    process.exit(1);
+  }
+
+  const destinationTexts = readTexts(destinationPaths(manifest));
+  const { errors, warnings, added, planCount, baselineCount } = evaluateRuleCoverage({
+    baseline,
+    alwaysOnTexts,
+    destinationTexts,
+    targetExists: (p) => existsSync(join(REPO_ROOT, p)),
+    anchorRe,
+    strict: process.argv.includes("--strict"),
+  });
+
+  for (const w of warnings) console.warn(`  [advisory] ${w}`);
+  for (const a of added) console.log(`  [new rule] ${a} — will be baselined on --update`);
+
+  if (errors.length > 0) {
+    console.error("Instruction-plane rule coverage FAILED (BI-0020D511 §12f).\n");
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error("");
+    console.error(
+      "The split may relocate a rule; it may not delete one. Move the rule to a skill or",
+    );
+    console.error(
+      "reference doc listed in manifest.ruleDestinations, or — if the rule is genuinely",
+    );
+    console.error("retired — say so in the commit body and run --update.");
+    process.exit(1);
+  }
+
+  console.log(
+    `Instruction-plane rule coverage OK — ${planCount} rule anchors reachable ` +
+      `(baseline ${baselineCount})` +
+      (warnings.length ? `. ${warnings.length} advisory duplicate(s).` : "."),
+  );
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("check-instruction-plane-rule-coverage.mjs")) {
+  main();
+}

--- a/scripts/check-instruction-plane-rule-coverage.test.mjs
+++ b/scripts/check-instruction-plane-rule-coverage.test.mjs
@@ -1,0 +1,167 @@
+// Tests for the instruction-plane rule-coverage guard (BI-0020D511 §12f).
+// node:test runner, matching the other guard tests — no vitest dependency in the
+// guard CI job.
+//
+// The bar here is the same one the size ratchet's tests set: prove the guard BLOCKS the
+// failure it exists for, not merely that the happy path prints OK. The failure it exists
+// for is a Phase 1 cut that deletes a rule instead of relocating it, so the load-bearing
+// case is "anchor vanishes from every plane → error", and its twin "anchor moved to a
+// registered destination → no error". A guard that passed the first but failed the second
+// would be worse than none: it would block the split it is supposed to make safe.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateRuleCoverage,
+  parseRuleBaseline,
+  serializeRuleBaseline,
+  ruleAnchors,
+  ruleLabel,
+  anchorsIn,
+} from "./check-instruction-plane-rule-coverage.mjs";
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const KERNEL = "docs/founder-kernel/wiki/principles/never-fabricate.md";
+const PROFESSION = "docs/professions/data-architect/wiki/strongly-typed-string-enums.md";
+
+const bullet = (label, anchor) => `- **${label}** Some prose. → [kernel principle](${anchor})`;
+
+test("ruleAnchors picks up the kernel-principle shape", () => {
+  const found = ruleAnchors(bullet("Never fabricate.", KERNEL));
+  assert.equal(found.length, 1);
+  assert.equal(found[0].anchor, KERNEL);
+  assert.equal(found[0].label, "Never fabricate.");
+});
+
+test("ruleAnchors picks up the FLAT profession shape (regression: an earlier pattern dropped all 11)", () => {
+  const found = ruleAnchors(bullet("Typed enums.", PROFESSION));
+  assert.equal(found.length, 1, "profession wiki pages have no directory under wiki/");
+  assert.equal(found[0].anchor, PROFESSION);
+});
+
+test("ruleAnchors ignores non-rule links and external URLs", () => {
+  const text = [
+    "See [the spec](docs/superpowers/specs/2026-07-24-thing-design.md) for detail.",
+    "See [upstream](https://example.com/wiki/principles/foo.md) too.",
+  ].join("\n");
+  assert.deepEqual(ruleAnchors(text), []);
+});
+
+test("ruleLabel falls back to a heading, then to empty", () => {
+  assert.equal(ruleLabel("### 4. Branching, Commits & PRs"), "4. Branching, Commits & PRs");
+  assert.equal(ruleLabel("plain prose with a [link](docs/x/wiki/principles/y.md)"), "");
+});
+
+test("a rule that vanishes from every plane FAILS — the whole point of the guard", () => {
+  const baseline = new Map([[KERNEL, "Never fabricate."]]);
+  const { errors } = evaluateRuleCoverage({
+    baseline,
+    alwaysOnTexts: { "AGENTS.md": "- **Some other rule.** No anchors here." },
+    destinationTexts: {},
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /DROPPED, not relocated/);
+  assert.match(errors[0], /never-fabricate/);
+});
+
+test("a rule RELOCATED to a registered destination passes — the split must stay possible", () => {
+  const baseline = new Map([[KERNEL, "Never fabricate."]]);
+  const { errors } = evaluateRuleCoverage({
+    baseline,
+    alwaysOnTexts: { "AGENTS.md": "Doctrine shrank; the rule moved to its skill." },
+    destinationTexts: {
+      "packages/dpf-skill-pack/skills/dpf-x/SKILL.md": bullet("Never fabricate.", KERNEL),
+    },
+  });
+  assert.deepEqual(errors, []);
+});
+
+test("relocation to an UNREGISTERED file still fails — destinations are an allow-list", () => {
+  const baseline = new Map([[KERNEL, "Never fabricate."]]);
+  const { errors } = evaluateRuleCoverage({
+    baseline,
+    alwaysOnTexts: { "AGENTS.md": "moved away" },
+    // Not passed as a destination: the manifest never registered it.
+    destinationTexts: {},
+  });
+  assert.equal(errors.length, 1);
+});
+
+test("a dangling anchor target FAILS — an unreadable rule is a lost rule one hop later", () => {
+  const baseline = new Map([[KERNEL, "Never fabricate."]]);
+  const { errors } = evaluateRuleCoverage({
+    baseline,
+    alwaysOnTexts: { "AGENTS.md": bullet("Never fabricate.", KERNEL) },
+    targetExists: () => false,
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /target file does not exist/);
+});
+
+test("adding a NEW rule is never an error, and is reported for the next --update", () => {
+  const { errors, added } = evaluateRuleCoverage({
+    baseline: new Map(),
+    alwaysOnTexts: { "AGENTS.md": bullet("Brand new rule.", KERNEL) },
+  });
+  assert.deepEqual(errors, []);
+  assert.deepEqual(added, [KERNEL]);
+});
+
+test("a duplicated anchor is advisory by default and an error under --strict", () => {
+  const text = [bullet("Rule.", KERNEL), bullet("Same rule restated.", KERNEL)].join("\n");
+  const loose = evaluateRuleCoverage({
+    baseline: new Map([[KERNEL, "Rule."]]),
+    alwaysOnTexts: { "AGENTS.md": text },
+  });
+  assert.deepEqual(loose.errors, []);
+  assert.equal(loose.warnings.length, 1);
+  assert.match(loose.warnings[0], /2×/);
+
+  const strict = evaluateRuleCoverage({
+    baseline: new Map([[KERNEL, "Rule."]]),
+    alwaysOnTexts: { "AGENTS.md": text },
+    strict: true,
+  });
+  assert.equal(strict.errors.length, 1);
+});
+
+test("baseline round-trips, and a union-merge duplicate collapses to one entry", () => {
+  const anchors = new Map([
+    [PROFESSION, "Typed enums."],
+    [KERNEL, "Never fabricate."],
+  ]);
+  const round = parseRuleBaseline(serializeRuleBaseline(anchors));
+  assert.equal(round.size, 2);
+  assert.equal(round.get(KERNEL), "Never fabricate.");
+  // merge=union can leave the same anchor twice; the first label wins, size stays 1.
+  const merged = parseRuleBaseline(`${KERNEL}\tNever fabricate.\n${KERNEL}\tNever fabricate.\n`);
+  assert.equal(merged.size, 1);
+});
+
+test("anchorsIn tolerates a missing file (null text) without throwing", () => {
+  assert.deepEqual([...anchorsIn({ "gone.md": null })], []);
+});
+
+test("the committed baseline matches the live always-on plane", () => {
+  const manifest = JSON.parse(
+    readFileSync(join(REPO_ROOT, "scripts", "instruction-plane-manifest.json"), "utf8"),
+  );
+  const baseline = parseRuleBaseline(
+    readFileSync(join(REPO_ROOT, "scripts", "instruction-plane-rule-baseline.txt"), "utf8"),
+  );
+  const texts = {};
+  for (const f of manifest.alwaysOn) texts[f] = readFileSync(join(REPO_ROOT, f), "utf8");
+  const live = anchorsIn(texts, manifest.ruleAnchorPattern);
+
+  // Every live anchor is baselined. (The reverse is the guard's job, not the test's:
+  // a baselined anchor may legitimately live in a destination after Phase 1.)
+  for (const anchor of live) {
+    assert.ok(baseline.has(anchor), `live rule anchor ${anchor} is missing from the baseline — run --update`);
+  }
+  assert.ok(live.size >= 40, `expected the pre-split plane to carry 40+ rule anchors, saw ${live.size}`);
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -26,6 +26,7 @@ const EXPECTED_LEGACY_JOBS = [
   "docs-staleness-detector",
   "finding-substrate-guard",
   "instruction-plane-guard",
+  "instruction-plane-rule-coverage",
   "janitor-tests",
   "mcp-tool-pack-guard",
   "mobile-jest-pin-guard",

--- a/scripts/instruction-plane-manifest.json
+++ b/scripts/instruction-plane-manifest.json
@@ -14,6 +14,14 @@
       "fields": ["name", "description"]
     }
   ],
+  "_ruleDestinationsComment": "Where a rule is allowed to LIVE after Phase 1 relocates it out of always-on prose. scripts/check-instruction-plane-rule-coverage.mjs treats a baselined rule anchor as preserved if it is referenced from an always-on file OR from any file matched here; a rule referenced from neither was dropped, not moved, and fails. Widen this list when the split opens a new destination — that is a deliberate, reviewable act, which is the point.",
+  "ruleDestinations": [
+    "packages/dpf-skill-pack/skills/*/SKILL.md",
+    "docs/architecture/*.md",
+    "docs/operations/*.md",
+    "*/AGENTS.md",
+    "*/*/AGENTS.md"
+  ],
   "perSectionCharBudget": 6000,
   "maxLineChars": 800,
   "maxExtractedItemChars": 700,

--- a/scripts/instruction-plane-rule-baseline.txt
+++ b/scripts/instruction-plane-rule-baseline.txt
@@ -1,0 +1,46 @@
+docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md	All changes land via PR against `main`
+docs/founder-kernel/wiki/principles/always-push-after-committing.md	Always push
+docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md	Architecture over shortcuts.
+docs/founder-kernel/wiki/principles/branch-guard-before-implementation.md	Branch guard before implementation and commit:
+docs/founder-kernel/wiki/principles/build-gate-mandatory.md
+docs/founder-kernel/wiki/principles/classify-ambiguous-requests-before-acting.md	Classify ambiguous requests before acting.
+docs/founder-kernel/wiki/principles/consult-specs-first.md	Ground new work in existing platform work.
+docs/founder-kernel/wiki/principles/db-fallback-explicit.md	DB fallback must be explicit.
+docs/founder-kernel/wiki/principles/dco-sign-off-required.md	DCO sign-off required on every commit.
+docs/founder-kernel/wiki/principles/decisions-belong-to-their-scope.md	WWMD vs WWWD — which decision surface governs.
+docs/founder-kernel/wiki/principles/design-research-required.md
+docs/founder-kernel/wiki/principles/governance-approves-evidence-not-provenance.md	Governance approves evidence, not provenance — the keystone.
+docs/founder-kernel/wiki/principles/image-identity-equals-bytes.md	The live install advances only via the self-upgrade pipeline, and a built image 
+docs/founder-kernel/wiki/principles/keep-root-clone-as-merge-worktree.md	Keep the root clone as the merge/release worktree
+docs/founder-kernel/wiki/principles/learnings-belong-in-the-shared-commons.md	Learnings belong in the shared commons.
+docs/founder-kernel/wiki/principles/mcp-is-the-coordination-plane.md	MCP is the coordination plane.
+docs/founder-kernel/wiki/principles/mention-uncommitted-changes.md
+docs/founder-kernel/wiki/principles/never-ask-user-to-run-commands.md	Never ask the user to run commands.
+docs/founder-kernel/wiki/principles/never-fabricate.md	Never fabricate.
+docs/founder-kernel/wiki/principles/no-assumptions.md	Never assume — verify.
+docs/founder-kernel/wiki/principles/no-hardcoded-colors.md
+docs/founder-kernel/wiki/principles/no-native-browser-dialogs.md
+docs/founder-kernel/wiki/principles/one-common-process-three-surfaces.md	Four peer surfaces, one process.
+docs/founder-kernel/wiki/principles/one-concern-per-pr.md	One concern per branch, one concern per PR.
+docs/founder-kernel/wiki/principles/plan-before-install-paths.md	Plan before acting on install/seed/template paths.
+docs/founder-kernel/wiki/principles/reap-sidecars-to-upgrade-tools.md	Tooling-upgrade = operator-triggered quiesce-reap-upgrade.
+docs/founder-kernel/wiki/principles/research-and-use-standards.md	Research and use standards.
+docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md	Use paid AI capacity responsibly.
+docs/founder-kernel/wiki/principles/runtime-gates-via-shared-lease.md	`:3001` and every shared singleton are lease-gated.
+docs/founder-kernel/wiki/principles/single-source-of-truth.md	Single source of truth.
+docs/founder-kernel/wiki/principles/state-results-directly.md
+docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md
+docs/founder-kernel/wiki/principles/worktree-is-source-control-not-runtime.md	Worktrees are source-control isolation, not runtime isolation.
+docs/founder-kernel/wiki/principles/worktree-per-session.md	Concurrent sessions:
+docs/founder-kernel/wiki/principles/worktree-selection-and-reaping.md	Worktree canonical location = dedicated sibling `D:/DPF-worktrees/<topic>`
+docs/professions/data-architect/wiki/fix-the-seed-not-the-runtime.md	Fix the seed, not the runtime.
+docs/professions/data-architect/wiki/live-state-over-seed-data.md	Live state over seed data.
+docs/professions/data-architect/wiki/organization-canonical-identity.md
+docs/professions/data-architect/wiki/principal-convergence.md
+docs/professions/data-architect/wiki/schema-audit-before-features.md
+docs/professions/data-architect/wiki/strongly-typed-string-enums.md
+docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md
+docs/professions/portfolio-management/wiki/backlog-lives-in-postgresql.md	Backlog lives in PostgreSQL
+docs/professions/portfolio-management/wiki/check-epic-overlap-before-creating.md	Before creating a new epic:
+docs/professions/release-service-management/wiki/release-qa-plan.md
+docs/professions/software-engineer/wiki/tool-evaluation-pipeline.md

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -130,6 +130,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-instruction-plane-size.test.mjs"),
       node("scripts/check-instruction-plane-size.mjs"),
     ]),
+    // The size ratchet's twin: bytes measure the cut, this measures what the cut LOST.
+    // A byte gate scores deleting a commandment identically to relocating it, so Phase 1
+    // needs both or "58% smaller" is unfalsifiable (BI-0020D511 §12f).
+    guard("instruction-plane-rule-coverage", "Instruction Plane Rule Coverage", [
+      node("--test", "scripts/check-instruction-plane-rule-coverage.test.mjs"),
+      node("scripts/check-instruction-plane-rule-coverage.mjs"),
+    ]),
     // Plane-3 sibling of the instruction-plane guard, deliberately a SOFTER shape: it
     // never forbids growth in standing context cost, only growth recorded in silence.
     guard("context-economy-guard", "Context Economy Guard", [


### PR DESCRIPTION
## Summary

The instruction-plane ratchet counts **bytes**, and bytes cannot distinguish a good cut from a lossy one — deleting a commandment scores exactly like relocating it. §12f named this as an open gap: *"the ratchet is a byte gate with no behavioural counterpart, so a 58% cut is currently unfalsifiable."*

Phase 1's acceptance criterion says *"no rule **statement** lost (diff-reviewed against the commandment set)"*. A hand diff-review across a 58% rewrite of a 90kB file is the kind of check that quietly decays into a rubber stamp exactly when it matters most. This PR makes it machine-checked.

**Timing was the binding constraint.** The baseline is only trustworthy while the pre-cut plane still exists to be measured. Captured now, before Phase 1 moves anything.

## Changes

- **`scripts/check-instruction-plane-rule-coverage.mjs`** — new guard. Rules are keyed on their **kernel-principle anchor** (the `→ [kernel principle](docs/.../x.md)` target), not their prose. **46 anchors baselined** from the pre-split plane (35 kernel + 11 flat profession-wiki). Invariant: every baselined anchor must stay referenced from an always-on file **or** a registered `manifest.ruleDestinations` target. Relocation passes; deletion fails.
- **`scripts/instruction-plane-manifest.json`** — new `ruleDestinations` allow-list: where a rule is permitted to live after Phase 1 relocates it.
- **`scripts/instruction-plane-rule-baseline.txt`** — the 46 anchors, `merge=union` per `.gitattributes` so concurrent re-baselines don't conflict.
- **`scripts/check-instruction-plane-rule-coverage.test.mjs`** — 13 tests.
- **`scripts/lib/ci-policy-guards.mjs`** + registry test — wired as `instruction-plane-rule-coverage` under Policy Guards (source).
- **Spec §12f-i** — records that the gap splits in two and which half is now closed.

### Why anchors, not prose

Phase 1 is *supposed* to reword, shorten, and relocate rule prose. A guard keyed on sentences would fire on every intended edit and train everyone to run `--update` reflexively — the classic ratchet-that-cries-wolf. The anchor is a durable identifier that survives exactly the edits Phase 1 wants to make, and fires only when a rule stops being reachable at all.

## Test plan

- [x] **Source-only change** (guard script, tests, manifest/baseline, spec prose — no server route, MCP tool, runtime wiring, migration, or UX surface)
  - [x] Targeted unit tests — named below
  - [x] Guard self-run, doc index, doc links, doc-reference integrity, module size

### Verification evidence

```
$ node scripts/check-instruction-plane-rule-coverage.mjs
Instruction-plane rule coverage OK — 46 rule anchors reachable (baseline 46).
  7 advisory duplicate(s).

$ node --test scripts/check-instruction-plane-rule-coverage.test.mjs  # tests 13 / pass 13 / fail 0
$ node --test scripts/check-instruction-plane-size.test.mjs           # tests 18 / pass 18 / fail 0
$ node --test scripts/ci-policy-guards.test.mjs                       # tests  5 / pass  5 / fail 0

$ node scripts/check-instruction-plane-size.mjs   → OK, 108033 bytes (baseline 108033), unchanged
$ node scripts/gen-doc-index.mjs --check          → doc index fresh (581 pages).
$ node scripts/check-doc-links.mjs                → PASS — no error-level findings.
$ node scripts/check-doc-reference-integrity.mjs  → OK — no net-new broken references.
$ node scripts/check-module-size.mjs              → Module-size OK.
```

**Proven negatively, not just green.** Deleting the `never-fabricate` bullet from `AGENTS.md` — a lossy cut — fails the guard:

```
Instruction-plane rule coverage FAILED (BI-0020D511 §12f).
  - rule anchor "docs/founder-kernel/wiki/principles/never-fabricate.md" (Never fabricate.)
    is no longer referenced from the always-on plane OR any registered destination —
    the rule statement was DROPPED, not relocated
```

The test suite pins the twin case too: a rule **relocated** into a registered destination passes. A guard that blocked deletion but also blocked relocation would be worse than none — it would block the split it exists to make safe.

**Pre-existing, unrelated:** `scripts/check-guards.mjs` reports 1/24 failing (`check-no-provider-local-connector-lifecycle.test.mjs` self-test). Present on `main`; that loop only discovers the `check-no-*` family, which this guard is not part of.

- [x] **Verification-harness limitation acknowledged** — no runtime-bound gate applies to this diff; nothing was skipped for harness reasons.

## Pre-PR readiness

Docs/source-only path; no shared-sandbox lease taken. Full CI is the backstop.

Local-CI-Override: source-only change (guard script + tests + manifest/baseline + spec prose); no runtime code in the diff, all applicable gates runnable source-locally and captured above.

## Related issues / Epic

Refs **BI-0020D511** §12f. Extends the spec in place rather than opening a competing one. Does not reopen the §3 kernel decision (`DI-F844365B0DCC`, Option B), and does not touch the §11 open questions.

## Overlap sweep

Adds two new files and touches `instruction-plane-manifest.json`, `ci-policy-guards.mjs` + its registry test, `.gitattributes`, and §12f of the spec. No overlap with BI-ACC7A2B5 (merged) or BI-C5A31A24 (§8/§8a of `AGENTS.md`, untouched here). `AGENTS.md` itself is **unmodified** — the size ratchet total is unchanged at 108,033.

## Notes for the reviewer

- **Scope is deliberately half the gap, and the PR says so in the code.** This proves a rule still *exists* somewhere reachable. It does **not** prove a shortened rule still *steers* an agent — that needs behavioural evals across surfaces and remains open, which matters because §12d predicts the weaker surfaces absorb exactly that regression. A green run means "the cut lost nothing outright", not "the cut was safe". §12f-i states this explicitly so a future reader doesn't over-read the gate.
- **The guard found 7 duplicated anchors in today's always-on prose** — `worktree-is-source-control-not-runtime` is linked **3×**; `single-source-of-truth`, `all-changes-land-via-pr`, `mcp-is-the-coordination-plane`, `one-common-process-three-surfaces`, `organization-canonical-identity` and `schema-audit-before-features` twice each. Same SSOT drift shape as this BI's Problem 2. Shipped **advisory**, consistent with Phase 0's stance — fixing them is Phase 1 work, not this PR's.
- **A near-miss worth flagging.** My first anchor pattern required a directory under `wiki/`, which silently dropped all 11 flat profession anchors (`strongly-typed-string-enums`, `backlog-lives-in-postgresql`, …) — the guard would have reported a confident, wrong 35. That is precisely the false-green this guard exists to prevent, so the corrected pattern carries a comment explaining the shape and a test that pins a profession anchor specifically.
- **`ruleDestinations` is an allow-list on purpose.** Widening it is a deliberate, reviewable act. A rule "relocated" somewhere unregistered still fails — otherwise the split could launder a rule into an unreachable corner and score green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX2tk9whhQLGawaEYKRF13)_