### PR TITLE
fix(ux-budget): resolve the reading tier from route audience, not shell alone (BI-1DE6F69E)

### DIFF
--- a/apps/web/lib/ux-budget/budgets.ts
+++ b/apps/web/lib/ux-budget/budgets.ts
@@ -26,6 +26,7 @@
 // CI checkers (L4/L5), and the migration league table (§7.1).
 
 import type { ReadingLevel } from "@dpf/validators";
+import type { RouteAudience } from "../navigation/route-audience";
 
 /**
  * The page shells a surface can intend to be. Deliberately NOT called "archetype" —
@@ -179,6 +180,78 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
   },
 };
 
-export function budgetFor(shell: UxShell): UxBudget {
-  return UX_BUDGETS[shell];
+// ── Audience-aware reading tier (BI-1DE6F69E) ────────────────────────────────
+//
+// The shell table above sets one reading tier per SHELL. That conflated two
+// different questions — what kind of surface this is, and who reads it — and the
+// result contradicted the platform's own readability policy
+// (`packages/validators/src/readability.ts`), which states: marketing/external and
+// business copy -> high school; reseller/partner -> college; architecture and
+// standards -> uncapped, "precision over simplicity".
+//
+// Measured consequence, from the route-budget report on 2026-07-31: EVERY /admin
+// route failed `reading-level` against the high-school cap of 9 — /admin/archetypes
+// 57.9, /admin/business-models 29.4, /admin/data-stewardship 18.6, /admin 15.4,
+// down to /admin/cockpit 12.5. They passed only because a pre-existing route gets
+// the finding as advisory, so the bar was never actually enforced anywhere. The
+// first NET-NEW admin route (/admin/graph-explorer, BI-89A149A9) measured 11.0 —
+// the lowest grade of any admin surface — and blocked, because a net-new route
+// loses the exemption. A bar that only the newest route must clear, and that the
+// plainest surface in the family cannot, is measuring the wrong thing.
+//
+// The cause is structural, not editorial: the grade is computed over the whole
+// rendered page including shared shell chrome, and operator vocabulary an admin
+// surface cannot avoid — "Infrastructure", "Architecture", "Configuration",
+// "Diagnostics" — is polysyllabic by nature, which Flesch–Kincaid punishes
+// regardless of sentence craft.
+//
+// So the tier now resolves from the route's AUDIENCE as well as its shell.
+// Deliberately `college` (grade 13) rather than `uncapped`: uncapped would remove
+// the check entirely, and nine of the twelve admin routes above still fail at 13.
+// That debt stays visible as advisory findings rather than being papered over —
+// this re-tiers the bar to the honest audience, it does not delete it.
+
+/**
+ * Reading tier by route audience, where it differs from the shell default.
+ *
+ * `admin` and `builder` are operator/architecture surfaces in the sense the
+ * readability policy means. Every other audience — `owner`, `worker`, `customer`,
+ * `public`, `auth-setup` — keeps the shell default, because the platform's
+ * hide-complexity-from-layman-users doctrine applies to them in full.
+ */
+export const AUDIENCE_READING_LEVELS: Partial<Record<RouteAudience, ReadingLevel>> = {
+  admin: "college",
+  builder: "college",
+};
+
+/** Permissiveness order. Later entries tolerate a higher grade. */
+const READING_LEVEL_ORDER: readonly ReadingLevel[] = ["high-school", "college", "uncapped"];
+
+function morePermissive(a: ReadingLevel, b: ReadingLevel): ReadingLevel {
+  return READING_LEVEL_ORDER.indexOf(a) >= READING_LEVEL_ORDER.indexOf(b) ? a : b;
+}
+
+/**
+ * The reading tier a route is judged against.
+ *
+ * The audience may only LOOSEN the shell default, never tighten it: a shell that
+ * is already permissive (`unclassified`, at college) must not be pulled back to
+ * high school just because its audience carries no override.
+ */
+export function readingLevelFor(shell: UxShell, audience?: RouteAudience | null): ReadingLevel {
+  const shellLevel = UX_BUDGETS[shell].readingLevel;
+  const audienceLevel = audience ? AUDIENCE_READING_LEVELS[audience] : undefined;
+  return audienceLevel ? morePermissive(shellLevel, audienceLevel) : shellLevel;
+}
+
+/**
+ * The budget a route is judged against.
+ *
+ * `audience` is optional so every existing caller keeps its behaviour; omitting it
+ * yields exactly the shell table above.
+ */
+export function budgetFor(shell: UxShell, audience?: RouteAudience | null): UxBudget {
+  const budget = UX_BUDGETS[shell];
+  const readingLevel = readingLevelFor(shell, audience);
+  return readingLevel === budget.readingLevel ? budget : { ...budget, readingLevel };
 }

--- a/apps/web/lib/ux-budget/evaluate.ts
+++ b/apps/web/lib/ux-budget/evaluate.ts
@@ -29,6 +29,7 @@ import type { UxBudget, UxShell } from "./budgets";
 import { budgetFor } from "./budgets";
 import { meetsReadingLevel, type UxBudgetMetrics } from "./measure";
 import type { ExemptCheck } from "./route-shells";
+import type { RouteAudience } from "../navigation/route-audience";
 
 export type BudgetSeverity = "advisory" | "blocking";
 
@@ -77,9 +78,14 @@ function within(actual: number, max: number): boolean {
 export function evaluateUxBudget(
   metrics: UxBudgetMetrics,
   shell: UxShell,
-  options: { exemptChecks?: readonly ExemptCheck[]; routeStatus?: RouteStatus } = {},
+  options: {
+    exemptChecks?: readonly ExemptCheck[];
+    routeStatus?: RouteStatus;
+    /** Route audience — loosens the reading tier for operator surfaces (BI-1DE6F69E). */
+    audience?: RouteAudience | null;
+  } = {},
 ): BudgetReport {
-  const budget: UxBudget = budgetFor(shell);
+  const budget: UxBudget = budgetFor(shell, options.audience);
   const routeStatus: RouteStatus = options.routeStatus ?? "pre-existing";
   // A net-new route cannot claim pre-migration debt it never accrued.
   const exempt = new Set<string>(routeStatus === "net-new" ? [] : (options.exemptChecks ?? []));

--- a/apps/web/lib/ux-budget/index.ts
+++ b/apps/web/lib/ux-budget/index.ts
@@ -30,9 +30,11 @@ export {
 } from "./measure";
 
 export {
+  AUDIENCE_READING_LEVELS,
   UX_BUDGETS,
   UX_SHELLS,
   budgetFor,
+  readingLevelFor,
   type UxBudget,
   type UxShell,
 } from "./budgets";
@@ -90,13 +92,18 @@ export {
 import { measureUxBudget } from "./measure";
 import { evaluateUxBudget, type BudgetReport, type RouteStatus } from "./evaluate";
 import type { UxShell } from "./budgets";
+import type { RouteAudience } from "../navigation/route-audience";
 import type { ExemptCheck } from "./route-shells";
 
 /** Convenience: measure and evaluate a served-DOM HTML string in one call. */
 export function auditUxBudget(
   html: string,
   shell: UxShell,
-  options: { exemptChecks?: readonly ExemptCheck[]; routeStatus?: RouteStatus } = {},
+  options: {
+    exemptChecks?: readonly ExemptCheck[];
+    routeStatus?: RouteStatus;
+    audience?: RouteAudience | null;
+  } = {},
 ): BudgetReport {
   return evaluateUxBudget(measureUxBudget(html), shell, options);
 }

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -33,6 +33,7 @@ import { evaluateUxBudget, type BudgetFinding, type RouteStatus } from "./evalua
 import type { UxBudgetMetrics } from "./measure";
 import type { UxShell } from "./budgets";
 import type { ExemptCheck } from "./route-shells";
+import type { RouteAudience } from "../navigation/route-audience";
 
 /** What the sweep measured for one route. */
 export type RouteMeasurement = {
@@ -44,6 +45,8 @@ export type RouteMeasurement = {
   /** Serious/critical axe violations. Necessary, never sufficient. */
   axeViolations: number;
   exemptChecks?: readonly ExemptCheck[];
+  /** Route audience — sets the reading tier for operator surfaces (BI-1DE6F69E). */
+  audience?: RouteAudience;
 };
 
 /** The frozen per-route baseline a changed route is measured against. */
@@ -144,6 +147,7 @@ export function verdictForRoute(
   const report = evaluateUxBudget(measurement.metrics, measurement.shell, {
     routeStatus,
     exemptChecks: measurement.exemptChecks,
+    audience: measurement.audience,
   });
 
   const regressions: string[] = [];

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -15,6 +15,7 @@
     {
       "routePath": "/admin",
       "shell": "list",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -26,6 +27,7 @@
     {
       "routePath": "/admin/archetypes",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -37,6 +39,7 @@
     {
       "routePath": "/admin/backups",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -49,6 +52,7 @@
     {
       "routePath": "/admin/branding",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -60,6 +64,7 @@
     {
       "routePath": "/admin/build-studio/stall-thresholds",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -71,6 +76,7 @@
     {
       "routePath": "/admin/business-models",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -82,6 +88,7 @@
     {
       "routePath": "/admin/cockpit",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -93,6 +100,7 @@
     {
       "routePath": "/admin/data-stewardship",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -104,6 +112,7 @@
     {
       "routePath": "/admin/diagnostics",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -115,6 +124,7 @@
     {
       "routePath": "/admin/hive",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -126,6 +136,7 @@
     {
       "routePath": "/admin/issue-reports",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -137,6 +148,7 @@
     {
       "routePath": "/admin/platform-development",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -148,6 +160,7 @@
     {
       "routePath": "/admin/reference-data",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -159,6 +172,7 @@
     {
       "routePath": "/admin/research",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -170,6 +184,7 @@
     {
       "routePath": "/admin/scheduled-jobs",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -182,6 +197,7 @@
     {
       "routePath": "/admin/settings",
       "shell": "settings",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -193,6 +209,7 @@
     {
       "routePath": "/admin/storefront/preset",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -204,6 +221,7 @@
     {
       "routePath": "/admin/twin-gallery",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -215,6 +233,7 @@
     {
       "routePath": "/admin/twin-gallery/[archetypeId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -227,6 +246,7 @@
     {
       "routePath": "/admin/twin-kit",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -238,6 +258,7 @@
     {
       "routePath": "/admin/wiki/lint",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -249,6 +270,7 @@
     {
       "routePath": "/build",
       "shell": "list",
+      "audience": "builder",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -260,6 +282,7 @@
     {
       "routePath": "/build/work",
       "shell": "detail",
+      "audience": "builder",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -271,6 +294,7 @@
     {
       "routePath": "/build/work/[capsuleId]",
       "shell": "detail",
+      "audience": "builder",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -283,6 +307,7 @@
     {
       "routePath": "/complaints",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -294,6 +319,7 @@
     {
       "routePath": "/compliance",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -305,6 +331,7 @@
     {
       "routePath": "/compliance/actions",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -316,6 +343,7 @@
     {
       "routePath": "/compliance/actions/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -328,6 +356,7 @@
     {
       "routePath": "/compliance/audits",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -339,6 +368,7 @@
     {
       "routePath": "/compliance/audits/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -351,6 +381,7 @@
     {
       "routePath": "/compliance/controls",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -362,6 +393,7 @@
     {
       "routePath": "/compliance/controls/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -374,6 +406,7 @@
     {
       "routePath": "/compliance/evidence",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -385,6 +418,7 @@
     {
       "routePath": "/compliance/evidence/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -397,6 +431,7 @@
     {
       "routePath": "/compliance/gaps",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -408,6 +443,7 @@
     {
       "routePath": "/compliance/incidents",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -419,6 +455,7 @@
     {
       "routePath": "/compliance/incidents/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -431,6 +468,7 @@
     {
       "routePath": "/compliance/licensing",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -442,6 +480,7 @@
     {
       "routePath": "/compliance/obligations",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -453,6 +492,7 @@
     {
       "routePath": "/compliance/obligations/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -465,6 +505,7 @@
     {
       "routePath": "/compliance/onboard",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -476,6 +517,7 @@
     {
       "routePath": "/compliance/policies",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -487,6 +529,7 @@
     {
       "routePath": "/compliance/policies/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -499,6 +542,7 @@
     {
       "routePath": "/compliance/posture",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -510,6 +554,7 @@
     {
       "routePath": "/compliance/regulations",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -521,6 +566,7 @@
     {
       "routePath": "/compliance/regulations/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -533,6 +579,7 @@
     {
       "routePath": "/compliance/risks",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -544,6 +591,7 @@
     {
       "routePath": "/compliance/risks/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -556,6 +604,7 @@
     {
       "routePath": "/compliance/submissions",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -567,6 +616,7 @@
     {
       "routePath": "/compliance/submissions/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -579,6 +629,7 @@
     {
       "routePath": "/coworker-decisions",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -590,6 +641,7 @@
     {
       "routePath": "/coworker-decisions/[...slug]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -602,6 +654,7 @@
     {
       "routePath": "/coworker-decisions/craft",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -613,6 +666,7 @@
     {
       "routePath": "/coworker-decisions/craft/[professionKey]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -625,6 +679,7 @@
     {
       "routePath": "/coworker-decisions/decisions",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -636,6 +691,7 @@
     {
       "routePath": "/coworker-decisions/decisions/[interactionId]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -648,6 +704,7 @@
     {
       "routePath": "/coworker-decisions/edit/[...slug]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -660,6 +717,7 @@
     {
       "routePath": "/coworker-decisions/matrix",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -671,6 +729,7 @@
     {
       "routePath": "/coworker-decisions/perspectives",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -682,6 +741,7 @@
     {
       "routePath": "/coworker-decisions/perspectives/[profileId]/voice",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -694,6 +754,7 @@
     {
       "routePath": "/coworker-decisions/proactivity",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -705,6 +766,7 @@
     {
       "routePath": "/coworker-decisions/review",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -716,6 +778,7 @@
     {
       "routePath": "/coworker-decisions/stance",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -727,6 +790,7 @@
     {
       "routePath": "/customer",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -738,6 +802,7 @@
     {
       "routePath": "/customer-complete-profile",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -749,6 +814,7 @@
     {
       "routePath": "/customer-link-account",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -760,6 +826,7 @@
     {
       "routePath": "/customer-login",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -772,6 +839,7 @@
     {
       "routePath": "/customer/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -784,6 +852,7 @@
     {
       "routePath": "/customer/engagements",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -795,6 +864,7 @@
     {
       "routePath": "/customer/funnel",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -806,6 +876,7 @@
     {
       "routePath": "/customer/marketing",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -817,6 +888,7 @@
     {
       "routePath": "/customer/marketing/automation",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -828,6 +900,7 @@
     {
       "routePath": "/customer/marketing/campaigns",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -839,6 +912,7 @@
     {
       "routePath": "/customer/marketing/funnel",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -850,6 +924,7 @@
     {
       "routePath": "/customer/marketing/strategy",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -861,6 +936,7 @@
     {
       "routePath": "/customer/opportunities",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -872,6 +948,7 @@
     {
       "routePath": "/customer/opportunities/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -884,6 +961,7 @@
     {
       "routePath": "/customer/quotes",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -895,6 +973,7 @@
     {
       "routePath": "/customer/quotes/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -907,6 +986,7 @@
     {
       "routePath": "/customer/sales-orders",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -918,6 +998,7 @@
     {
       "routePath": "/delivery",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -929,6 +1010,7 @@
     {
       "routePath": "/docs/[[...slug]]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -941,6 +1023,7 @@
     {
       "routePath": "/ea",
       "shell": "list",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -952,6 +1035,7 @@
     {
       "routePath": "/ea/capabilities",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -963,6 +1047,7 @@
     {
       "routePath": "/ea/data-model",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -974,6 +1059,7 @@
     {
       "routePath": "/ea/models",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -985,6 +1071,7 @@
     {
       "routePath": "/ea/models/[slug]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -997,6 +1084,7 @@
     {
       "routePath": "/ea/value-streams",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1008,6 +1096,7 @@
     {
       "routePath": "/ea/views",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1019,6 +1108,7 @@
     {
       "routePath": "/ea/views/[id]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1031,6 +1121,7 @@
     {
       "routePath": "/employee",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1042,6 +1133,7 @@
     {
       "routePath": "/finance",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1053,6 +1145,7 @@
     {
       "routePath": "/finance/assets",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1064,6 +1157,7 @@
     {
       "routePath": "/finance/assets/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1076,6 +1170,7 @@
     {
       "routePath": "/finance/assets/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1087,6 +1182,7 @@
     {
       "routePath": "/finance/banking",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1098,6 +1194,7 @@
     {
       "routePath": "/finance/banking/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1110,6 +1207,7 @@
     {
       "routePath": "/finance/banking/[id]/import",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1122,6 +1220,7 @@
     {
       "routePath": "/finance/banking/[id]/reconcile",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1134,6 +1233,7 @@
     {
       "routePath": "/finance/banking/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1145,6 +1245,7 @@
     {
       "routePath": "/finance/banking/rules",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1156,6 +1257,7 @@
     {
       "routePath": "/finance/bills",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1167,6 +1269,7 @@
     {
       "routePath": "/finance/bills/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1179,6 +1282,7 @@
     {
       "routePath": "/finance/bills/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1190,6 +1294,7 @@
     {
       "routePath": "/finance/close",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1201,6 +1306,7 @@
     {
       "routePath": "/finance/configuration",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1212,6 +1318,7 @@
     {
       "routePath": "/finance/expense-claims",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1223,6 +1330,7 @@
     {
       "routePath": "/finance/expense-claims/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1235,6 +1343,7 @@
     {
       "routePath": "/finance/funds",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1247,6 +1356,7 @@
     {
       "routePath": "/finance/invoices",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1258,6 +1368,7 @@
     {
       "routePath": "/finance/invoices/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1270,6 +1381,7 @@
     {
       "routePath": "/finance/invoices/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1281,6 +1393,7 @@
     {
       "routePath": "/finance/my-expenses",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1292,6 +1405,7 @@
     {
       "routePath": "/finance/my-expenses/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1303,6 +1417,7 @@
     {
       "routePath": "/finance/payment-runs",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1314,6 +1429,7 @@
     {
       "routePath": "/finance/payments",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1325,6 +1441,7 @@
     {
       "routePath": "/finance/purchase-orders",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1336,6 +1453,7 @@
     {
       "routePath": "/finance/purchase-orders/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1348,6 +1466,7 @@
     {
       "routePath": "/finance/purchase-orders/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1359,6 +1478,7 @@
     {
       "routePath": "/finance/recurring",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1370,6 +1490,7 @@
     {
       "routePath": "/finance/recurring/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1382,6 +1503,7 @@
     {
       "routePath": "/finance/recurring/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1393,6 +1515,7 @@
     {
       "routePath": "/finance/reports",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1404,6 +1527,7 @@
     {
       "routePath": "/finance/reports/aged-creditors",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1415,6 +1539,7 @@
     {
       "routePath": "/finance/reports/aged-debtors",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1426,6 +1551,7 @@
     {
       "routePath": "/finance/reports/cash-flow",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1437,6 +1563,7 @@
     {
       "routePath": "/finance/reports/general-ledger",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1448,6 +1575,7 @@
     {
       "routePath": "/finance/reports/outstanding",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1459,6 +1587,7 @@
     {
       "routePath": "/finance/reports/profit-loss",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1470,6 +1599,7 @@
     {
       "routePath": "/finance/reports/revenue-by-customer",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1481,6 +1611,7 @@
     {
       "routePath": "/finance/reports/vat-summary",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1492,6 +1623,7 @@
     {
       "routePath": "/finance/revenue",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1503,6 +1635,7 @@
     {
       "routePath": "/finance/settings",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1514,6 +1647,7 @@
     {
       "routePath": "/finance/settings/currency",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1525,6 +1659,7 @@
     {
       "routePath": "/finance/settings/dunning",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1536,6 +1671,7 @@
     {
       "routePath": "/finance/settings/rate-card",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1547,6 +1683,7 @@
     {
       "routePath": "/finance/settings/setup",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1558,6 +1695,7 @@
     {
       "routePath": "/finance/settings/tax",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1569,6 +1707,7 @@
     {
       "routePath": "/finance/spend",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1580,6 +1719,7 @@
     {
       "routePath": "/finance/spend/ai",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1591,6 +1731,7 @@
     {
       "routePath": "/finance/suppliers",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1602,6 +1743,7 @@
     {
       "routePath": "/finance/suppliers/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1614,6 +1756,7 @@
     {
       "routePath": "/finance/suppliers/new",
       "shell": "form",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1625,6 +1768,7 @@
     {
       "routePath": "/forgot-password",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1636,6 +1780,7 @@
     {
       "routePath": "/governance",
       "shell": "list",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1648,6 +1793,7 @@
     {
       "routePath": "/governance/records-requests",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1660,6 +1806,7 @@
     {
       "routePath": "/inventory",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1671,6 +1818,7 @@
     {
       "routePath": "/inventory/entity/[entityId]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1683,6 +1831,7 @@
     {
       "routePath": "/knowledge",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1694,6 +1843,7 @@
     {
       "routePath": "/knowledge/[articleId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1706,6 +1856,7 @@
     {
       "routePath": "/knowledge/new",
       "shell": "form",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1717,6 +1868,7 @@
     {
       "routePath": "/login",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1728,6 +1880,7 @@
     {
       "routePath": "/member-equity",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1740,6 +1893,7 @@
     {
       "routePath": "/ops",
       "shell": "list",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1751,6 +1905,7 @@
     {
       "routePath": "/ops/changes",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1762,6 +1917,7 @@
     {
       "routePath": "/ops/demand",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1773,6 +1929,7 @@
     {
       "routePath": "/ops/dev-loop",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1784,6 +1941,7 @@
     {
       "routePath": "/ops/health",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1796,6 +1954,7 @@
     {
       "routePath": "/ops/journeys",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1807,6 +1966,7 @@
     {
       "routePath": "/ops/patches",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1818,6 +1978,7 @@
     {
       "routePath": "/ops/promotions",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1829,6 +1990,7 @@
     {
       "routePath": "/ops/security",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1840,6 +2002,7 @@
     {
       "routePath": "/ops/self-upgrade",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1852,6 +2015,7 @@
     {
       "routePath": "/performance",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1863,6 +2027,7 @@
     {
       "routePath": "/platform",
       "shell": "list",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1874,6 +2039,7 @@
     {
       "routePath": "/platform/ai/agent/[agentId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1886,6 +2052,7 @@
     {
       "routePath": "/platform/ai/assignments",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1897,6 +2064,7 @@
     {
       "routePath": "/platform/ai/assignments/bindings/[bindingId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1909,6 +2077,7 @@
     {
       "routePath": "/platform/ai/browser-sessions",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1920,6 +2089,7 @@
     {
       "routePath": "/platform/ai/browser-sessions/setup",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1931,6 +2101,7 @@
     {
       "routePath": "/platform/ai/build-studio",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1942,6 +2113,7 @@
     {
       "routePath": "/platform/ai/capacity-continuity",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1953,6 +2125,7 @@
     {
       "routePath": "/platform/ai/catalog",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1964,6 +2137,7 @@
     {
       "routePath": "/platform/ai/decisions/[interactionId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1976,6 +2150,7 @@
     {
       "routePath": "/platform/ai/founder-review",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1987,6 +2162,7 @@
     {
       "routePath": "/platform/ai/memory",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -1998,6 +2174,7 @@
     {
       "routePath": "/platform/ai/operations-map",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2009,6 +2186,7 @@
     {
       "routePath": "/platform/ai/overview",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2020,6 +2198,7 @@
     {
       "routePath": "/platform/ai/priority/outcomes",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2031,6 +2210,7 @@
     {
       "routePath": "/platform/ai/prompts",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2042,6 +2222,7 @@
     {
       "routePath": "/platform/ai/providers",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2053,6 +2234,7 @@
     {
       "routePath": "/platform/ai/providers/[providerId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2065,6 +2247,7 @@
     {
       "routePath": "/platform/ai/readiness",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2076,6 +2259,7 @@
     {
       "routePath": "/platform/ai/runtime-health",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2087,6 +2271,7 @@
     {
       "routePath": "/platform/ai/skills",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2098,6 +2283,7 @@
     {
       "routePath": "/platform/audit",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2109,6 +2295,7 @@
     {
       "routePath": "/platform/audit/authority",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2120,6 +2307,7 @@
     {
       "routePath": "/platform/audit/journal",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2131,6 +2319,7 @@
     {
       "routePath": "/platform/audit/ledger",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2142,6 +2331,7 @@
     {
       "routePath": "/platform/audit/metrics",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2153,6 +2343,7 @@
     {
       "routePath": "/platform/audit/operations",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2164,6 +2355,7 @@
     {
       "routePath": "/platform/audit/routes",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2175,6 +2367,7 @@
     {
       "routePath": "/platform/development/change-lanes",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2187,6 +2380,7 @@
     {
       "routePath": "/platform/device-catalog",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2198,6 +2392,7 @@
     {
       "routePath": "/platform/edge-nodes",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2209,6 +2404,7 @@
     {
       "routePath": "/platform/federation-links",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2220,6 +2416,7 @@
     {
       "routePath": "/platform/federation-proposals",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2231,6 +2428,7 @@
     {
       "routePath": "/platform/identity",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2242,6 +2440,7 @@
     {
       "routePath": "/platform/identity/agents",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2253,6 +2452,7 @@
     {
       "routePath": "/platform/identity/applications",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2264,6 +2464,7 @@
     {
       "routePath": "/platform/identity/authorization",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2275,6 +2476,7 @@
     {
       "routePath": "/platform/identity/authorization/bindings/[bindingId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2287,6 +2489,7 @@
     {
       "routePath": "/platform/identity/directory",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2298,6 +2501,7 @@
     {
       "routePath": "/platform/identity/federation",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2309,6 +2513,7 @@
     {
       "routePath": "/platform/identity/groups",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2320,6 +2525,7 @@
     {
       "routePath": "/platform/identity/principals",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2331,6 +2537,7 @@
     {
       "routePath": "/platform/schedule",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2343,6 +2550,7 @@
     {
       "routePath": "/platform/service-desk",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2354,6 +2562,7 @@
     {
       "routePath": "/platform/services/[serverId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2366,6 +2575,7 @@
     {
       "routePath": "/platform/tools",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2377,6 +2587,7 @@
     {
       "routePath": "/platform/tools/built-ins",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2388,6 +2599,7 @@
     {
       "routePath": "/platform/tools/catalog",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2399,6 +2611,7 @@
     {
       "routePath": "/platform/tools/catalog/sync",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2410,6 +2623,7 @@
     {
       "routePath": "/platform/tools/discovery",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2421,6 +2635,7 @@
     {
       "routePath": "/platform/tools/discovery/promotion-audit",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2432,6 +2647,7 @@
     {
       "routePath": "/platform/tools/integrations",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2443,6 +2659,7 @@
     {
       "routePath": "/platform/tools/integrations/adp",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2454,6 +2671,7 @@
     {
       "routePath": "/platform/tools/integrations/communications",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2465,6 +2683,7 @@
     {
       "routePath": "/platform/tools/integrations/email-postmark",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2476,6 +2695,7 @@
     {
       "routePath": "/platform/tools/integrations/facebook-lead-ads",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2487,6 +2707,7 @@
     {
       "routePath": "/platform/tools/integrations/facebook-pages",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2498,6 +2719,7 @@
     {
       "routePath": "/platform/tools/integrations/google-business-profile",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2509,6 +2731,7 @@
     {
       "routePath": "/platform/tools/integrations/google-marketing-intelligence",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2520,6 +2743,7 @@
     {
       "routePath": "/platform/tools/integrations/hubspot",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2531,6 +2755,7 @@
     {
       "routePath": "/platform/tools/integrations/instagram-business",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2542,6 +2767,7 @@
     {
       "routePath": "/platform/tools/integrations/linkedin-personal-social",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2553,6 +2779,7 @@
     {
       "routePath": "/platform/tools/integrations/mailchimp",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2564,6 +2791,7 @@
     {
       "routePath": "/platform/tools/integrations/microsoft365-communications",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2575,6 +2803,7 @@
     {
       "routePath": "/platform/tools/integrations/quickbooks",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2586,6 +2815,7 @@
     {
       "routePath": "/platform/tools/integrations/stripe",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2597,6 +2827,7 @@
     {
       "routePath": "/platform/tools/integrations/whatsapp-business",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2608,6 +2839,7 @@
     {
       "routePath": "/platform/tools/inventory",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2619,6 +2851,7 @@
     {
       "routePath": "/platform/tools/services",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2630,6 +2863,7 @@
     {
       "routePath": "/platform/tools/services/[serverId]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2642,6 +2876,7 @@
     {
       "routePath": "/platform/tools/services/activate",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2653,6 +2888,7 @@
     {
       "routePath": "/portal",
       "shell": "cockpit",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2665,6 +2901,7 @@
     {
       "routePath": "/portal/account",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2677,6 +2914,7 @@
     {
       "routePath": "/portal/cases",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2689,6 +2927,7 @@
     {
       "routePath": "/portal/cases/[caseKey]",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2701,6 +2940,7 @@
     {
       "routePath": "/portal/health",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2713,6 +2953,7 @@
     {
       "routePath": "/portal/health/intake/[packetId]",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2725,6 +2966,7 @@
     {
       "routePath": "/portal/orders",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2737,6 +2979,7 @@
     {
       "routePath": "/portal/services",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2749,6 +2992,7 @@
     {
       "routePath": "/portal/sign-in",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2760,6 +3004,7 @@
     {
       "routePath": "/portal/sign-up",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2772,6 +3017,7 @@
     {
       "routePath": "/portal/support",
       "shell": "detail",
+      "audience": "customer",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2784,6 +3030,7 @@
     {
       "routePath": "/portfolio/[[...slug]]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2796,6 +3043,7 @@
     {
       "routePath": "/portfolio/product-line/[id]/direction",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2808,6 +3056,7 @@
     {
       "routePath": "/portfolio/product/[id]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2820,6 +3069,7 @@
     {
       "routePath": "/portfolio/product/[id]/architecture",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2832,6 +3082,7 @@
     {
       "routePath": "/portfolio/product/[id]/backlog",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2844,6 +3095,7 @@
     {
       "routePath": "/portfolio/product/[id]/changes",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2856,6 +3108,7 @@
     {
       "routePath": "/portfolio/product/[id]/direction",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2868,6 +3121,7 @@
     {
       "routePath": "/portfolio/product/[id]/direction/intelligence",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2880,6 +3134,7 @@
     {
       "routePath": "/portfolio/product/[id]/direction/outcomes",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2892,6 +3147,7 @@
     {
       "routePath": "/portfolio/product/[id]/direction/roadmap",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2904,6 +3160,7 @@
     {
       "routePath": "/portfolio/product/[id]/health",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2916,6 +3173,7 @@
     {
       "routePath": "/portfolio/product/[id]/inventory",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2928,6 +3186,7 @@
     {
       "routePath": "/portfolio/product/[id]/knowledge",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2940,6 +3199,7 @@
     {
       "routePath": "/portfolio/product/[id]/offerings",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2952,6 +3212,7 @@
     {
       "routePath": "/portfolio/product/[id]/supply-chain",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2964,6 +3225,7 @@
     {
       "routePath": "/portfolio/product/[id]/team",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2976,6 +3238,7 @@
     {
       "routePath": "/portfolio/product/[id]/versions",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -2988,6 +3251,7 @@
     {
       "routePath": "/portfolio/products/[productId]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3000,6 +3264,7 @@
     {
       "routePath": "/rental",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3012,6 +3277,7 @@
     {
       "routePath": "/reset-password",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3023,6 +3289,7 @@
     {
       "routePath": "/s/[slug]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3035,6 +3302,7 @@
     {
       "routePath": "/s/[slug]/book/[itemId]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3047,6 +3315,7 @@
     {
       "routePath": "/s/[slug]/booking/confirmed",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3059,6 +3328,7 @@
     {
       "routePath": "/s/[slug]/checkout",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3071,6 +3341,7 @@
     {
       "routePath": "/s/[slug]/donate",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3083,6 +3354,7 @@
     {
       "routePath": "/s/[slug]/donation/received",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3095,6 +3367,7 @@
     {
       "routePath": "/s/[slug]/inquire",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3107,6 +3380,7 @@
     {
       "routePath": "/s/[slug]/inquire/[itemId]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3119,6 +3393,7 @@
     {
       "routePath": "/s/[slug]/inquiry/received",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3131,6 +3406,7 @@
     {
       "routePath": "/s/[slug]/item/[itemId]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3143,6 +3419,7 @@
     {
       "routePath": "/s/[slug]/order/[itemId]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3155,6 +3432,7 @@
     {
       "routePath": "/s/[slug]/order/received",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3167,6 +3445,7 @@
     {
       "routePath": "/s/[slug]/policies",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3179,6 +3458,7 @@
     {
       "routePath": "/s/[slug]/sign-in",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3191,6 +3471,7 @@
     {
       "routePath": "/s/[slug]/sign-up",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3203,6 +3484,7 @@
     {
       "routePath": "/s/approve/[token]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3215,6 +3497,7 @@
     {
       "routePath": "/s/expense-approve/[token]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3227,6 +3510,7 @@
     {
       "routePath": "/s/pay/[token]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3239,6 +3523,7 @@
     {
       "routePath": "/s/quote/[token]",
       "shell": "public",
+      "audience": "public",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3251,6 +3536,7 @@
     {
       "routePath": "/sandbox-restricted",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3262,6 +3548,7 @@
     {
       "routePath": "/service-requests",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3274,6 +3561,7 @@
     {
       "routePath": "/setup",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3286,6 +3574,7 @@
     {
       "routePath": "/storefront",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3297,6 +3586,7 @@
     {
       "routePath": "/storefront/animals",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3309,6 +3599,7 @@
     {
       "routePath": "/storefront/dispatch",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3320,6 +3611,7 @@
     {
       "routePath": "/storefront/inbox",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3332,6 +3624,7 @@
     {
       "routePath": "/storefront/intake",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3343,6 +3636,7 @@
     {
       "routePath": "/storefront/items",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3355,6 +3649,7 @@
     {
       "routePath": "/storefront/items/[id]/catalog",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3367,6 +3662,7 @@
     {
       "routePath": "/storefront/items/[id]/purchases",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3379,6 +3675,7 @@
     {
       "routePath": "/storefront/sections",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3391,6 +3688,7 @@
     {
       "routePath": "/storefront/settings",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3403,6 +3701,7 @@
     {
       "routePath": "/storefront/settings/business",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3414,6 +3713,7 @@
     {
       "routePath": "/storefront/settings/capabilities",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3425,6 +3725,7 @@
     {
       "routePath": "/storefront/settings/operations",
       "shell": "settings",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3436,6 +3737,7 @@
     {
       "routePath": "/storefront/setup",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3447,6 +3749,7 @@
     {
       "routePath": "/storefront/tables",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3459,6 +3762,7 @@
     {
       "routePath": "/storefront/team",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3470,6 +3774,7 @@
     {
       "routePath": "/storefront/units",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3482,6 +3787,7 @@
     {
       "routePath": "/welcome",
       "shell": "form",
+      "audience": "auth-setup",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3494,6 +3800,7 @@
     {
       "routePath": "/wiki/[...slug]",
       "shell": "detail",
+      "audience": "admin",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3506,6 +3813,7 @@
     {
       "routePath": "/workbooks",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3517,6 +3825,7 @@
     {
       "routePath": "/workbooks/[workbookId]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3529,6 +3838,7 @@
     {
       "routePath": "/workbooks/system/[entityType]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3541,6 +3851,7 @@
     {
       "routePath": "/workspace",
       "shell": "cockpit",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3553,6 +3864,7 @@
     {
       "routePath": "/workspace/calendar",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3565,6 +3877,7 @@
     {
       "routePath": "/workspace/cases/[caseKey]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3577,6 +3890,7 @@
     {
       "routePath": "/workspace/documents",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3588,6 +3902,7 @@
     {
       "routePath": "/workspace/documents/[documentId]",
       "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3600,6 +3915,7 @@
     {
       "routePath": "/workspace/inbox",
       "shell": "detail",
+      "audience": "worker",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",
@@ -3611,6 +3927,7 @@
     {
       "routePath": "/workspace/my-queue",
       "shell": "detail",
+      "audience": "worker",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",

--- a/apps/web/lib/ux-budget/route-shells.ts
+++ b/apps/web/lib/ux-budget/route-shells.ts
@@ -163,6 +163,12 @@ export const ROUTE_SWEEP_EXCLUSIONS = {
 export type RouteShellPolicy = {
   routePath: string;
   shell: UxShell;
+  /**
+   * Who the route is for. Carried here so the sweep can resolve the reading tier
+   * without a second registry lookup (BI-1DE6F69E) — the shell alone cannot say
+   * whether a surface is operator-facing.
+   */
+  audience: RouteAudience;
   /** True once the route has adopted its L1 shell. */
   migrated: boolean;
   /** Checks waived while the route is pre-migration — recorded baseline debt. */
@@ -181,6 +187,7 @@ export function shellPolicyFor(routePath: string, c: ShellClassifiable): RouteSh
   return {
     routePath,
     shell: shellForRoute(c),
+    audience: c.audience,
     migrated,
     exemptChecks: migrated ? [] : PRE_MIGRATION_EXEMPT_CHECKS,
     sweepEligible: sweepExclusionReason === undefined,

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   auditUxBudget,
+  budgetFor,
   countDisclosureRegions,
   countPrimaryActions,
   countVisibleFields,
@@ -17,8 +18,11 @@ import {
   leadBandHtml,
   maxChoicesPerControl,
   measureUxBudget,
+  meetsReadingLevel,
+  readingLevelFor,
   removeSubtrees,
   shellForRoute,
+  UX_BUDGETS,
   UX_SHELLS,
 } from "./index";
 import { countWords } from "../owner-first/ux-audit";
@@ -147,6 +151,59 @@ describe("budget axes", () => {
 
   it("does not fabricate a reading grade for an empty surface", () => {
     expect(measureUxBudget("<div></div>").readingGradeLevel).toBe(0);
+  });
+});
+
+describe("reading tier resolves from audience, not shell alone (BI-1DE6F69E)", () => {
+  it("keeps the shell default for every audience without an override", () => {
+    for (const audience of ["owner", "worker", "customer", "public", "auth-setup"] as const) {
+      expect(readingLevelFor("detail", audience)).toBe("high-school");
+      expect(readingLevelFor("cockpit", audience)).toBe("high-school");
+    }
+  });
+
+  it("gives operator surfaces the college tier the readability policy specifies", () => {
+    expect(readingLevelFor("detail", "admin")).toBe("college");
+    expect(readingLevelFor("list", "admin")).toBe("college");
+    expect(readingLevelFor("detail", "builder")).toBe("college");
+  });
+
+  it("falls back to the shell default when no audience is supplied", () => {
+    expect(readingLevelFor("detail")).toBe("high-school");
+    expect(readingLevelFor("detail", null)).toBe("high-school");
+  });
+
+  it("only ever loosens — an already-permissive shell is never tightened", () => {
+    // `unclassified` sits at college; an audience with no override must not pull it
+    // back to high school.
+    expect(UX_BUDGETS.unclassified.readingLevel).toBe("college");
+    expect(readingLevelFor("unclassified", "customer")).toBe("college");
+    expect(readingLevelFor("unclassified", "admin")).toBe("college");
+  });
+
+  it("re-tiers the bar without deleting it — an operator surface still has a cap", () => {
+    // The whole point: 11.0 (the plainest admin surface measured) passes, but the
+    // family's real debt — 15.4, 18.6, 29.4, 57.9 — still fails.
+    const budget = budgetFor("detail", "admin");
+    expect(budget.readingLevel).toBe("college");
+    expect(meetsReadingLevel({ readingGradeLevel: 11 } as never, budget.readingLevel)).toBe(true);
+    expect(meetsReadingLevel({ readingGradeLevel: 13 } as never, budget.readingLevel)).toBe(true);
+    expect(meetsReadingLevel({ readingGradeLevel: 15.4 } as never, budget.readingLevel)).toBe(false);
+    expect(meetsReadingLevel({ readingGradeLevel: 57.9 } as never, budget.readingLevel)).toBe(false);
+  });
+
+  it("does not loosen a customer-facing surface", () => {
+    const budget = budgetFor("detail", "customer");
+    expect(budget.readingLevel).toBe("high-school");
+    expect(meetsReadingLevel({ readingGradeLevel: 11 } as never, budget.readingLevel)).toBe(false);
+  });
+
+  it("carries the audience on every generated shell row so the sweep can resolve it", () => {
+    const registry = JSON.parse(
+      readFileSync(resolve(__dirname, "route-shells.generated.json"), "utf8"),
+    ) as { routes: { routePath: string; audience?: string }[] };
+    expect(registry.routes.length).toBeGreaterThan(0);
+    expect(registry.routes.filter((r) => !r.audience)).toEqual([]);
   });
 });
 

--- a/apps/web/scripts/build-route-shells.ts
+++ b/apps/web/scripts/build-route-shells.ts
@@ -41,8 +41,10 @@ type Registry = {
 
 function build(): Registry {
   const routes = buildRoutePolicies(readRouteManifestRows(ROOT)).map((policy) => {
+    // `audience` is retained (BI-1DE6F69E): the reading tier resolves from the
+    // route's audience as well as its shell, so the sweep needs it here rather
+    // than joining against the audience registry a second time.
     const {
-      audience: _audience,
       destinationKind: _destinationKind,
       classificationSource: _classificationSource,
       ...shellPolicy

--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -39,6 +39,7 @@ import {
   type RouteMeasurement,
 } from "../lib/ux-budget/ratchet";
 import type { UxShell } from "../lib/ux-budget/budgets";
+import type { RouteAudience } from "../lib/navigation/route-audience";
 import type {
   ExemptCheck,
   RouteSweepExclusionReason,
@@ -84,6 +85,7 @@ export function uxSweepAxeOptions() {
 type ShellRow = {
   routePath: string;
   shell: UxShell;
+  audience: RouteAudience;
   migrated: boolean;
   exemptChecks: ExemptCheck[];
   sweepEligible: boolean;
@@ -450,6 +452,7 @@ async function measureRoute(
   const measurement = {
     routePath: row.routePath,
     shell: row.shell,
+    audience: row.audience,
     // Collapse wall-clock text first: seeded records render "updated <now>", so a
     // raw measurement moves with the clock (BI-EA221325).
     metrics: measureUxBudget(normaliseVolatileText(html)),

--- a/docs/superpowers/specs/2026-07-31-audience-aware-reading-tier-design.md
+++ b/docs/superpowers/specs/2026-07-31-audience-aware-reading-tier-design.md
@@ -1,0 +1,130 @@
+---
+title: Audience-aware reading tier for the UX budget
+date: 2026-07-31
+backlog: BI-1DE6F69E
+epic: EP-UX-SYSTEM
+status: implemented
+---
+
+# Audience-aware reading tier
+
+## Problem
+
+`apps/web/lib/ux-budget/budgets.ts` set one reading tier per **shell**. Every
+classified shell (`cockpit`, `list`, `detail`, `settings`, `form`, `public`) was
+`high-school` — a Flesch–Kincaid cap of grade 9 — and only `unclassified` was
+`college`.
+
+That conflated two different questions: *what kind of surface is this* and *who
+reads it*. The result contradicted the platform's own readability policy in
+[`packages/validators/src/readability.ts`](../../../packages/validators/src/readability.ts),
+which states: marketing/external and business copy → high school; reseller/partner
+→ college; **architecture and standards → uncapped, "precision over simplicity"**.
+
+An operator/admin surface was therefore graded against the marketing bar.
+
+## Evidence
+
+From the CI route-budget report on 2026-07-31 (run 30639446475, artifact
+`ux-route-budget-report`), **every** `/admin` route failed `reading-level`:
+
+| Route | Grade | Route | Grade |
+| --- | --- | --- | --- |
+| /admin/archetypes | 57.9 | /admin/hive | 14.0 |
+| /admin/business-models | 29.4 | /admin/build-studio/stall-thresholds | 13.8 |
+| /admin/data-stewardship | 18.6 | /admin/issue-reports | 13.8 |
+| /admin | 15.4 | /admin/cockpit | 12.5 |
+| /admin/diagnostics | 15.2 | /admin/platform-development | 12.5 |
+| /admin/branding | 14.5 | /admin/graph-explorer (net-new) | 11.0 |
+
+They passed only because a pre-existing route receives the finding as
+**advisory** — `evaluate.ts` drops `exemptChecks` when `routeStatus === "net-new"`,
+so the identical finding is **blocking** for a new route.
+
+The first net-new admin route measured **11.0**, the *lowest* grade of any admin
+surface, and blocked. A bar that only the newest route must clear, and that the
+plainest surface in the family cannot, is measuring the wrong thing.
+
+The cause is structural rather than editorial. The grade is computed over the whole
+rendered page including shared shell chrome, and the operator vocabulary an admin
+surface cannot avoid — "Infrastructure", "Architecture", "Configuration",
+"Diagnostics" — is polysyllabic by nature, which Flesch–Kincaid penalises whatever
+the sentence craft.
+
+## Design
+
+The reading tier now resolves from **shell + audience**:
+
+```ts
+readingLevelFor(shell, audience) // budgets.ts
+```
+
+`AUDIENCE_READING_LEVELS` maps `admin` and `builder` → `college`. Every other
+audience (`owner`, `worker`, `customer`, `public`, `auth-setup`) keeps the shell
+default, because the hide-complexity-from-layman-users doctrine applies to them in
+full.
+
+`audience` is threaded through `budgetFor` → `evaluateUxBudget` → `verdictForRoute`
+→ the sweep, and is now carried on each generated `route-shells` row so the sweep
+resolves it without a second registry lookup. Every parameter is optional, so
+callers that omit it get exactly the previous shell table.
+
+## Decisions
+
+**D1 — `college`, not `uncapped`.** The readability policy would permit uncapped
+for an architecture audience, but uncapped removes the check entirely. At `college`
+(grade 13) **nine of the twelve** admin routes above still fail. That debt stays
+visible as advisory findings. This re-tiers the bar to the honest audience; it does
+not delete it.
+
+**D2 — Audience may only loosen, never tighten.** `unclassified` already sits at
+`college`; an audience with no override must not pull it back to high school.
+`readingLevelFor` takes the more permissive of the two.
+
+**D3 — Carry `audience` on the shell row rather than joining registries.** The
+shell alone cannot say whether a surface is operator-facing, and the sweep already
+reads the shell registry per route. `build-route-shells.ts` previously discarded
+`audience` from the policy; it now retains it.
+
+**D4 — No route is exempted and no baseline is edited.** The alternative fixes
+considered for the triggering route were to park it in the pre-migration exemption
+baseline (the anti-pattern the ratchet exists to prevent) or to add filler prose to
+dilute the page average (gaming the metric). Both were rejected.
+
+## Research & Benchmarking
+
+- **GOV.UK content standards** — targets reading age 9 for *public* guidance and
+  explicitly exempts specialist and internal-facing content, on the grounds that
+  forcing domain terms out of technical copy reduces precision without helping the
+  reader. Adopted: audience, not surface type, selects the tier.
+- **Microsoft Writing Style Guide / IBM Design Language** — both maintain separate
+  registers for end-user versus administrator documentation, with the admin
+  register permitting unavoidable domain vocabulary. Adopted as the two-tier split.
+- **WCAG 3.0 draft (Clear Language)** — scopes readability outcomes to content
+  where comprehension is the barrier, and warns that automated grade formulas
+  penalise necessary terminology. Pattern rejected: a single global grade cap.
+- **Flesch–Kincaid itself** — the formula weights syllables-per-word heavily, so a
+  surface whose nouns are "Infrastructure" and "Configuration" scores high with no
+  possible sentence remedy. Anti-pattern identified: treating a syllable-count
+  proxy as a comprehension measure for specialist surfaces.
+
+**Gap filled:** DPF already *had* the right policy in `readability.ts`; the UX
+budget simply did not consult it. This connects the two rather than inventing a
+third rule.
+
+## Minimum Architectural Alignment Checklist
+
+1. **Deployment contracts** — none affected; no API shape, install path, service
+   boundary, or self-upgrade step changes.
+2. **Canonical identity** — not identity-bearing.
+3. **No parallel utilities** — extends `budgetFor`/`evaluateUxBudget` and reuses
+   the existing `RouteAudience` taxonomy and `ReadingLevel` enum. No second policy
+   table is introduced; `AUDIENCE_READING_LEVELS` is the one override map.
+4. **This rulebook** — no rule is re-homed. The readability policy remains
+   single-source in `packages/validators/src/readability.ts`.
+
+## Consequence
+
+`/admin/graph-explorer` (BI-89A149A9, PR #3813) was blocked solely by this check
+and is unblocked by this change. Nine admin routes continue to report the finding
+as advisory debt, which is the honest outcome.


### PR DESCRIPTION
The UX budget set one reading tier per **shell** — every classified shell at `high-school` (Flesch–Kincaid grade 9), only `unclassified` at `college`. That conflated *what kind of surface this is* with *who reads it*, and contradicted the platform's own readability policy in `packages/validators/src/readability.ts`:

> marketing/external & business copy → high school; reseller/partner → college; **architecture and standards → uncapped (precision over simplicity)**

So operator surfaces were being graded against the marketing bar.

## The measurement that exposed it

From the CI route-budget report on run 30639446475 (`ux-route-budget-report` artifact), **every** `/admin` route fails `reading-level`:

| Route | Grade | | Route | Grade |
| --- | --- | --- | --- | --- |
| /admin/archetypes | 57.9 | | /admin/hive | 14.0 |
| /admin/business-models | 29.4 | | /admin/build-studio/stall-thresholds | 13.8 |
| /admin/data-stewardship | 18.6 | | /admin/issue-reports | 13.8 |
| /admin | 15.4 | | /admin/cockpit | 12.5 |
| /admin/diagnostics | 15.2 | | /admin/platform-development | 12.5 |
| /admin/branding | 14.5 | | /admin/graph-explorer (net-new) | **11.0** |

They pass only because a pre-existing route receives the finding as **advisory** — `evaluate.ts` drops `exemptChecks` when `routeStatus === "net-new"`, so the identical finding is **blocking** on a new route.

The first net-new admin route measured **11.0**, the *lowest* grade of any admin surface, and blocked. A bar that only the newest route must clear, and that the plainest surface in the family cannot, is measuring the wrong thing.

The cause is structural rather than editorial: the grade covers the whole rendered page including shared shell chrome, and operator vocabulary an admin surface cannot avoid — "Infrastructure", "Configuration", "Diagnostics" — is polysyllabic by nature, which the formula penalises whatever the sentence craft.

## Change

`readingLevelFor(shell, audience)` resolves the tier. `AUDIENCE_READING_LEVELS` maps `admin` and `builder` → `college`; `owner`, `worker`, `customer`, `public`, `auth-setup` keep the shell default, because hide-complexity-from-layman-users applies to them in full.

The audience threads through `budgetFor` → `evaluateUxBudget` → `verdictForRoute` → the sweep, and is now retained on each generated `route-shells` row (`build-route-shells.ts` previously discarded it). Every parameter is optional, so callers that omit it get exactly the previous table.

## Decisions

**`college`, not `uncapped`.** The policy would permit uncapped for an architecture audience, but that deletes the check. At grade 13, **nine of the twelve** admin routes above still fail. That debt stays visible as advisory findings. This re-tiers the bar to the honest audience; it does not remove it.

**Audience may only loosen, never tighten.** `unclassified` already sits at `college`; an audience with no override must not pull it back to high school.

**Rejected:** parking the triggering route in the pre-migration exemption baseline (the anti-pattern the ratchet exists to prevent), and adding filler prose to dilute the page average (gaming the metric).

## Blast radius

118 routes (`admin` 115 + `builder` 3) are now judged at grade 13 instead of 9. That is the intended effect and the only behavioural change: the tier can never tighten, and no other audience moves.

## Design grounding

Source of truth: new artifact `docs/superpowers/specs/2026-07-31-audience-aware-reading-tier-design.md`, including Research & Benchmarking (GOV.UK explicitly exempts specialist and internal-facing content from its reading-age target; Microsoft and IBM both maintain a separate administrator register; the WCAG 3.0 Clear Language draft warns that automated grade formulas penalise necessary terminology).

Substrate reviewed: `apps/web/lib/ux-budget/{budgets,evaluate,ratchet,measure,route-shells,index}.ts`, `apps/web/lib/navigation/route-audience.ts`, `apps/web/scripts/{build-route-shells,ux-route-sweep}.ts`, `packages/validators/src/readability.ts`.

DPF already had the right policy; the UX budget simply never consulted it. This connects the two rather than inventing a third rule.

## Verification

Substrate: `D:/DPF-worktrees/ux-reading-tier` for source-local gates; shared local-CI convergence sandbox for the gate.

- **local-CI gate — `gate passed`** (SHA `b44f3bd580`, admitted on slot-0 with a real image build)
- `vitest` — 9 files / 160 tests across `lib/ux-budget`, `lib/navigation`, `lib/owner-first`, including seven new cases covering tier resolution, the loosen-only rule, and every generated row carrying an audience
- `tsc --noEmit` over `apps/web` — 0 errors
- Route manifest / audience / shells / page-purpose registries all current
- Style drift, token drift, module size, prose lint, doc-link integrity, UX-Fit gate — clean
- pregate preflight — 29 guards clean

Closes BI-1DE6F69E. Unblocks BI-89A149A9 (#3813) as a consequence, not as a bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Local-CI-Override: The shared local-CI sandbox could not admit a run for this head SHA. Root cause is host memory, not this change: available memory measured 5.8 GB against the lease pool's own `minAvailableMemoryBytes` floor of 8 GB, which is why the pool reports `hostSafeCapacity: 1` / `rollbackReason: "slot-fence-unhealthy"`, and why every gate attempt was killed during `tsc --noEmit` or the Next build — both run with `NODE_OPTIONS=--max-old-space-size=8192`, asking for 8 GB that is not there. A separate thread is working the host-memory issue; deliberately not remediated from here.

Local-CI-Evidence: The identical tree passed the full gate at SHA `b44f3bd5800fc01c73c48579fd0f76ae25dc4cb4` — `gate passed`, admitted on slot-0, 12m elapsed (20:45:26Z to 20:57:52Z), including `pnpm --filter web typecheck`, full `vitest run --maxWorkers=4`, and a real production build via `local-ci-bounded-build.mjs` producing image `sha256:3237c5138b25dd8fba608fcb06a439864d8c1fc371e97c0d8912c4d68180a7cd`, merged against `origin/main` at `0b29e31bd7`. The current head `175c60c0ad` is that same commit rebased onto current main with **zero content change** — `git diff` between the two trees is empty.

Post-rebase re-verification in the worktree: all four route registries current, `tsc --noEmit` 0 errors, 6 test files / 139 tests pass.

