### PR TITLE
fix(hr): draw the org chart's reporting lines (BI-HCM-004)

### DIFF
--- a/apps/web/components/employee/OrgChartView.test.ts
+++ b/apps/web/components/employee/OrgChartView.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { ORG_NODE_H, ORG_NODE_W } from "@/lib/graph/layout-org-chart";
+import { orgFlowNodeShell } from "./OrgChartView";
+
+// Regression guard for the defect that shipped in PR #3801: the org chart rendered every
+// person as an island with NO reporting lines, because the node footprint was passed as
+// top-level `width`/`height`. React Flow v12 treats those as the internal MEASURED
+// dimensions, so `measured` stayed unpopulated, edge paths never computed, and nothing
+// warned — not a console message, not a failing test. Model and layout unit tests all
+// passed while the chart's single most important visual element was missing.
+describe("orgFlowNodeShell", () => {
+  const shell = orgFlowNodeShell({ id: "emp-1", position: { x: 10, y: 20 }, draggable: true });
+
+  it("carries the footprint in style, which is what React Flow v12 reads", () => {
+    expect(shell.style).toEqual({ width: ORG_NODE_W, height: ORG_NODE_H });
+  });
+
+  it("does NOT set top-level width/height — that silently kills every edge path", () => {
+    expect(shell).not.toHaveProperty("width");
+    expect(shell).not.toHaveProperty("height");
+  });
+
+  it("keeps the registered node type so the custom card renders", () => {
+    expect(shell.type).toBe("orgPerson");
+  });
+
+  it("passes through id, position, and draggability", () => {
+    expect(shell.id).toBe("emp-1");
+    expect(shell.position).toEqual({ x: 10, y: 20 });
+    expect(shell.draggable).toBe(true);
+  });
+
+  it("marks the node undraggable when the operator cannot reassign", () => {
+    expect(
+      orgFlowNodeShell({ id: "e", position: { x: 0, y: 0 }, draggable: false }).draggable,
+    ).toBe(false);
+  });
+});

--- a/apps/web/components/employee/OrgChartView.tsx
+++ b/apps/web/components/employee/OrgChartView.tsx
@@ -46,6 +46,29 @@ const NODE_TYPES = { orgPerson: OrgChartNode };
 
 type Density = "chart" | "list";
 
+/**
+ * The React Flow node envelope for one person.
+ *
+ * Exported and pure so the size contract is testable: the footprint MUST travel in `style`.
+ * React Flow v12 treats top-level `width`/`height` as the internal MEASURED dimensions, so
+ * setting them there leaves `measured` unpopulated and edge paths never compute — the chart
+ * renders every person with no reporting lines, silently and with no console warning. That
+ * shipped once (PR #3801) because unit tests covered the model and layout but never a render.
+ */
+export function orgFlowNodeShell(input: {
+  id: string;
+  position: { x: number; y: number };
+  draggable: boolean;
+}): Pick<Node, "id" | "type" | "position" | "draggable" | "style"> {
+  return {
+    id: input.id,
+    type: "orgPerson",
+    position: input.position,
+    draggable: input.draggable,
+    style: { width: ORG_NODE_W, height: ORG_NODE_H },
+  };
+}
+
 function matchesSearch(emp: EmployeeDirectoryRow, needle: string): boolean {
   if (!needle) return true;
   const hay = [emp.displayName, emp.positionTitle, emp.departmentName, emp.workEmail]
@@ -136,13 +159,12 @@ function OrgChartViewInner({ employees, canReassign = true, onSelect }: Props) {
           pending: emp.id === pendingId,
         };
         return {
-          id: emp.id,
-          type: "orgPerson",
-          position: positions[emp.id] ?? { x: 0, y: 0 },
+          ...orgFlowNodeShell({
+            id: emp.id,
+            position: positions[emp.id] ?? { x: 0, y: 0 },
+            draggable: canReassign,
+          }),
           data: data as unknown as Record<string, unknown>,
-          draggable: canReassign,
-          width: ORG_NODE_W,
-          height: ORG_NODE_H,
         } satisfies Node;
       }),
     );


### PR DESCRIPTION
Follow-up to #3801. Part of **BI-HCM-004**.

## The defect

The org chart shipped in #3801 **rendered every person as an island — no reporting lines at
all.** That is the single most important visual element of a chart, and it was missing on
`main`.

## Cause

The node footprint was passed as top-level `width`/`height`. React Flow v12 treats those as
the internal **measured** dimensions, so `measured` stayed unpopulated and edge paths never
computed.

The failure is almost perfectly silent. Nodes render. Handles render (6 source, 6 target).
The arrowhead `<marker>` is even created from `markerEnd` — so the edges *do* reach React
Flow. Only `.react-flow__edge-path` is absent, with no console warning and no failing test.

[`EaCanvas.tsx:376`](apps/web/components/ea/EaCanvas.tsx) already sets
`node.style = { width, height }` for exactly this reason. The working idiom was in the repo;
this change adopts it.

## How it was found

By driving the live install, which is the only thing that would have caught it.

With a real manager relationship in the database (`Elif Ueno` → `Kofi Wolfe`):

- the stat band was correct — `Managers 1`, `Avg span 1.0`, `No manager 5`
- the manager's card correctly read `1 direct`
- dagre had correctly placed the report at `translate(780px, 182px)`, directly beneath the
  manager at `translate(780px, 0px)`
- and `document.querySelectorAll('.react-flow__edge-path').length` was **0**

Data right, layout right, line missing.

## Also verified on the live install (all working, unchanged by this PR)

- Selecting a person opens the detail panel, and that person is correctly **absent from their
  own "Reports to" list** — `eligibleManagers` excluding self, i.e. the cycle guard.
- A reassignment through the picker persists to `EmployeeProfile.managerEmployeeId` and writes
  a `manager_changed` `EmploymentEvent` with `reason: org_chart_reassignment`, attributed to
  the acting user.
- The success notice renders and the stat band updates live without a manual reload.

## Regression guard

The original suite — 26 tests over the org-chart model and the dagre layout — passed
throughout the defect. It never rendered a component, which is exactly how this reached main.

This adds a pure, exported `orgFlowNodeShell` and five tests asserting the footprint travels
in `style` and that top-level `width`/`height` are **absent**. A revert of the fix fails the
suite.

## Verification

- Local-CI sandbox gate: `gate passed` for head `5bf0e28163`, including the production build.
- 29/29 pregate preflight guards clean.
- 163 unit tests green across the affected suites (5 new).

Still requires a self-upgrade before the drawn lines can be confirmed on the canonical
install; that confirmation is not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
