### PR TITLE
fix(ops-map): count design conformance over the instrumented era, not the fetch window (BI-A4BC02BE)

### DIFF
--- a/apps/web/components/platform/RoutingArchitectureOverview.test.tsx
+++ b/apps/web/components/platform/RoutingArchitectureOverview.test.tsx
@@ -26,6 +26,8 @@ const EVIDENCE: RoutingEvidenceConformanceProjection = {
     unevidencedDecisions: 1,
     screenCoveredDecisions: 3,
     designBoundDecisions: 3,
+    preInstrumentationDecisions: 0,
+    instrumentedSince: null,
     unprovenDesignDecisions: 1,
     staleDesignDecisions: 0,
     attributionRate: 1,

--- a/apps/web/components/platform/RoutingArchitectureOverview.tsx
+++ b/apps/web/components/platform/RoutingArchitectureOverview.tsx
@@ -272,6 +272,7 @@ export function RoutingArchitectureOverview({
           mode={mode}
           designRevision={view.designRevision}
           evidenceWindow={view.evidenceWindow}
+          instrumentedSince={view.instrumentedSince}
           focusedStageId={selectedStageId}
           onFocusStage={focusStage}
           onClose={closeInspector}
@@ -374,6 +375,7 @@ function StationInspector({
   mode,
   designRevision,
   evidenceWindow,
+  instrumentedSince,
   focusedStageId,
   onFocusStage,
   onClose,
@@ -382,6 +384,7 @@ function StationInspector({
   mode: RoutingArchitectureMode;
   designRevision: string;
   evidenceWindow: { start: string; end: string };
+  instrumentedSince: string | null;
   focusedStageId: string | null;
   onFocusStage: (stageId: string) => void;
   onClose: () => void;
@@ -473,6 +476,11 @@ function StationInspector({
             <p className="mt-1">
               Evidence window <LocalTime value={evidenceWindow.start} /> — <LocalTime value={evidenceWindow.end} />
             </p>
+            {instrumentedSince ? (
+              <p className="mt-1">
+                Ledger begins <LocalTime value={instrumentedSince} />
+              </p>
+            ) : null}
             {focusedStage ? (
               <Link
                 href={`/ea?focus=${encodeURIComponent(focusedStage.id)}`}

--- a/apps/web/lib/ai-operations-map/routing-comparison-view-model.test.ts
+++ b/apps/web/lib/ai-operations-map/routing-comparison-view-model.test.ts
@@ -22,6 +22,8 @@ const EVIDENCE: RoutingEvidenceConformanceProjection = {
     unevidencedDecisions: 1,
     screenCoveredDecisions: 8,
     designBoundDecisions: 9,
+    preInstrumentationDecisions: 0,
+    instrumentedSince: null,
     unprovenDesignDecisions: 3,
     staleDesignDecisions: 2,
     attributionRate: 11 / 12,

--- a/apps/web/lib/ai-operations-map/routing-comparison-view-model.ts
+++ b/apps/web/lib/ai-operations-map/routing-comparison-view-model.ts
@@ -121,6 +121,13 @@ export type RoutingComparisonViewModel = {
   showObserved: boolean;
   designRevision: string;
   evidenceWindow: { start: string; end: string };
+  /**
+   * When the evidence ledger begins — the earliest design-bound decision in the
+   * window. Shown so an owner can tell "we have no record" apart from "the
+   * platform did something wrong" (BI-A4BC02BE). Null when the window holds no
+   * stamped decision, so the boundary cannot be located.
+   */
+  instrumentedSince: string | null;
   latestEvidenceAt: string | null;
   focusedStationId: OwnerRoutingStationId | null;
   summary: {
@@ -192,6 +199,7 @@ export function buildRoutingComparisonViewModel(
     showObserved: options.mode !== "designed",
     designRevision: evidence.designRevision,
     evidenceWindow: evidence.window,
+    instrumentedSince: evidence.coverage.instrumentedSince,
     latestEvidenceAt: evidence.metrics.latestEvidenceAt,
     focusedStationId: options.focusStageId
       ? stationByStageId.get(options.focusStageId) ?? null

--- a/apps/web/lib/ai-operations-map/routing-evidence-conformance.test.ts
+++ b/apps/web/lib/ai-operations-map/routing-evidence-conformance.test.ts
@@ -165,13 +165,20 @@ describe("projectRoutingEvidenceConformance", () => {
       uncorrelatedDecisions: 1,
       unevidencedDecisions: 1,
       designBoundDecisions: 0,
-      unprovenDesignDecisions: 1,
+      // BI-A4BC02BE: nothing in this window is stamped, so the instrumented era
+      // cannot be located and this legacy row counts as pre-instrumentation
+      // history rather than a conformance failure. It previously reported
+      // unprovenDesignDecisions: 1 and emitted a design-unproven finding.
+      unprovenDesignDecisions: 0,
+      preInstrumentationDecisions: 1,
+      instrumentedSince: null,
     });
+    // The other three findings are unaffected — legacy traffic is still visible
+    // as unattributed, uncorrelated, and unevidenced.
     expect(projection.findings.map((finding) => finding.issueType)).toEqual([
       "ai-routing-evidence-unattributed",
       "ai-routing-evidence-uncorrelated",
       "ai-routing-evidence-missing",
-      "ai-routing-design-unproven",
     ]);
   });
 
@@ -311,19 +318,18 @@ describe("owner-actionable findings (BI-C8BC9DD1)", () => {
     }
   });
 
-  it("classes pre-instrumentation traffic as historical, not as open work", () => {
+  // Superseded by BI-A4BC02BE. Pre-instrumentation traffic no longer produces a
+  // finding AT ALL — which is stronger than classifying it as historical, and is
+  // why this assertion changed from "is none-historical" to "does not appear".
+  it("emits no design finding at all for pre-instrumentation traffic", () => {
     const projection = projectRoutingEvidenceConformance(baseInput({
       decisions: [unstampedDecision("d-1")],
     }));
 
-    const unproven = projection.findings.find(
-      (finding) => finding.issueType === "ai-routing-design-unproven",
-    );
-    expect(unproven).toBeDefined();
-    // Declared `info`, and nothing an owner can do — both must be expressed.
-    expect(unproven?.severity).toBe("info");
-    expect(unproven?.ownerAction).toBe("none-historical");
-    expect(unproven?.nextAction).toMatch(/nothing to do/i);
+    expect(projection.findings.map((finding) => finding.issueType))
+      .not.toContain("ai-routing-design-unproven");
+    expect(projection.coverage.preInstrumentationDecisions).toBe(1);
+    expect(projection.coverage.unprovenDesignDecisions).toBe(0);
   });
 
   it("marks a boundary crossing as a platform defect the owner cannot fix", () => {
@@ -372,5 +378,105 @@ describe("owner-actionable findings (BI-C8BC9DD1)", () => {
     }));
     const remediation = projection.findings.map((finding) => finding.nextAction).join(" ");
     expect(remediation).not.toMatch(/prompt|detectedValue|rawPayload/i);
+  });
+});
+
+// BI-A4BC02BE. `unprovenDesignDecisions` was `totalDecisions - designBoundDecisions`,
+// where totalDecisions is however many rows the loader fetched. Since stamping
+// began at a fixed past point, that evaluated to `fetch_limit - total_stamped_rows`
+// and was reported to an owner as "171 issues". It measured the page size.
+describe("design conformance is bounded to the instrumented era (BI-A4BC02BE)", () => {
+  const decision = (id: string, iso: string, designRevision: string | null) => ({
+    id,
+    traceId: null,
+    designRevision,
+    agentId: "ops-coordinator",
+    actorKind: "agent",
+    actorId: "ops-coordinator",
+    selectedEndpointId: "profile-openai",
+    selectedModelId: "gpt-5",
+    taskType: "conversation",
+    sensitivity: "internal",
+    candidateTrace: [],
+    excludedTrace: [],
+    fallbackChain: [],
+    fallbacksUsed: [],
+    screenReceipt: null,
+    createdAt: new Date(iso),
+  });
+
+  const REV = AI_ROUTING_ARCHITECTURE_VERSION;
+
+  it("does not count decisions older than the first stamped one", () => {
+    const projection = projectRoutingEvidenceConformance(baseInput({
+      decisions: [
+        decision("old-1", "2026-07-27T01:00:00.000Z", null),
+        decision("old-2", "2026-07-27T02:00:00.000Z", null),
+        decision("new-1", "2026-07-27T10:00:00.000Z", REV),
+      ],
+    }));
+
+    expect(projection.coverage.preInstrumentationDecisions).toBe(2);
+    expect(projection.coverage.unprovenDesignDecisions).toBe(0);
+    expect(projection.coverage.instrumentedSince).toBe("2026-07-27T10:00:00.000Z");
+  });
+
+  it("DOES count an unstamped decision recorded after stamping began", () => {
+    const projection = projectRoutingEvidenceConformance(baseInput({
+      decisions: [
+        decision("old-1", "2026-07-27T01:00:00.000Z", null),
+        decision("new-1", "2026-07-27T10:00:00.000Z", REV),
+        decision("gap-1", "2026-07-27T11:00:00.000Z", null),
+      ],
+    }));
+
+    expect(projection.coverage.preInstrumentationDecisions).toBe(1);
+    expect(projection.coverage.unprovenDesignDecisions).toBe(1);
+    const unproven = projection.findings.find(
+      (finding) => finding.issueType === "ai-routing-design-unproven",
+    );
+    // A genuine post-instrumentation gap is a platform defect, not history.
+    expect(unproven?.ownerAction).toBe("platform-defect");
+  });
+
+  // The defining property of the old bug: the count grew purely because the
+  // caller fetched more rows. Adding pre-instrumentation history must not move it.
+  it("is invariant to how many historic rows the loader fetched", () => {
+    const stamped = decision("new-1", "2026-07-27T10:00:00.000Z", REV);
+    const historic = (n: number) =>
+      Array.from({ length: n }, (_unused, i) =>
+        decision(`old-${i}`, new Date(Date.UTC(2026, 6, 27, 1, i)).toISOString(), null));
+
+    const small = projectRoutingEvidenceConformance(baseInput({
+      decisions: [...historic(5), stamped],
+    }));
+    const large = projectRoutingEvidenceConformance(baseInput({
+      decisions: [...historic(300), stamped],
+    }));
+
+    expect(small.coverage.unprovenDesignDecisions).toBe(0);
+    expect(large.coverage.unprovenDesignDecisions).toBe(0);
+    expect(large.coverage.unprovenDesignDecisions)
+      .toBe(small.coverage.unprovenDesignDecisions);
+  });
+
+  // And it must not silently self-clear: each new stamped decision used to
+  // decrement the reported count by one with no remediation performed.
+  it("does not decrement as new stamped traffic accrues", () => {
+    const historic = [decision("old-1", "2026-07-27T01:00:00.000Z", null)];
+    const before = projectRoutingEvidenceConformance(baseInput({
+      decisions: [...historic, decision("s-1", "2026-07-27T10:00:00.000Z", REV)],
+    }));
+    const after = projectRoutingEvidenceConformance(baseInput({
+      decisions: [
+        ...historic,
+        decision("s-1", "2026-07-27T10:00:00.000Z", REV),
+        decision("s-2", "2026-07-27T12:00:00.000Z", REV),
+        decision("s-3", "2026-07-27T13:00:00.000Z", REV),
+      ],
+    }));
+
+    expect(after.coverage.unprovenDesignDecisions)
+      .toBe(before.coverage.unprovenDesignDecisions);
   });
 });

--- a/apps/web/lib/ai-operations-map/routing-evidence-conformance.ts
+++ b/apps/web/lib/ai-operations-map/routing-evidence-conformance.ts
@@ -101,7 +101,22 @@ export type RoutingEvidenceCoverage = {
   unevidencedDecisions: number;
   screenCoveredDecisions: number;
   designBoundDecisions: number;
+  /**
+   * Decisions that SHOULD name a design revision and do not — i.e. recorded
+   * after stamping began. Excludes pre-instrumentation history (BI-A4BC02BE).
+   */
   unprovenDesignDecisions: number;
+  /**
+   * Decisions recorded before design-revision stamping existed. Reported as a
+   * fact about when the ledger starts, never as a conformance failure.
+   */
+  preInstrumentationDecisions: number;
+  /**
+   * ISO timestamp of the earliest design-bound decision in the window — the
+   * point the evidence ledger begins. Null when nothing in the window is
+   * stamped, in which case the era cannot be located from this window.
+   */
+  instrumentedSince: string | null;
   staleDesignDecisions: number;
   attributionRate: number;
   traceRate: number;
@@ -217,9 +232,13 @@ const REMEDIATION: Record<
       "No action available to you. A route expected to dispatch recorded no adapter, outcome, or usage row — that is a platform gap in evidence writing, not a setting on this install.",
   },
   "ai-routing-design-unproven": {
-    ownerAction: "none-historical",
+    // Reclassified by BI-A4BC02BE. This used to count pre-instrumentation
+    // history and was therefore `none-historical`. Those rows are now excluded
+    // from the count, so anything that still reaches this finding was recorded
+    // AFTER stamping began and failed to carry a revision — a real gap.
+    ownerAction: "platform-defect",
     nextAction:
-      "Nothing to do, and this is not a fault. These decisions ran before the routing design revision was stamped onto traffic, so they cannot name the design they executed against. Every decision recorded since then is design-bound.",
+      "No action available to you. These decisions were recorded after design-revision stamping began but did not carry a revision, which is a gap in how the platform records routing evidence.",
   },
   "ai-routing-design-stale": {
     ownerAction: "none-historical",
@@ -329,8 +348,43 @@ export function projectRoutingEvidenceConformance(
   }
 
   const totalDecisions = input.decisions.length;
+
+  // BI-A4BC02BE — the design-conformance denominator must be the INSTRUMENTED
+  // ERA, not the fetch window.
+  //
+  // `unprovenDesignDecisions` was `totalDecisions - designBoundDecisions`. Since
+  // `totalDecisions` is however many rows the loader fetched (WINDOWED_SOURCE_LIMIT,
+  // 400) and design stamping began at a fixed point in the past, that expression
+  // evaluated to `fetch_limit - total_stamped_rows_in_existence`. It measured the
+  // page size, not conformance. Observed live: 400 - 229 = 171, reported to the
+  // owner as "171 issues".
+  //
+  // Two properties made it unfalsifiable. It DECREMENTED by one on every new
+  // inference (each adds a stamped row), so it silently self-cleared without any
+  // remediation; and it SCALED with the cap, so raising the limit to 1000 would
+  // have reported 771 on identical data.
+  //
+  // A decision recorded before stamping existed can never name a revision. Those
+  // are history, not failures. The earliest stamped decision in the window marks
+  // where the ledger begins; anything older is pre-instrumentation, and only
+  // unstamped decisions at or after that point are genuine conformance gaps.
+  //
+  // When the window contains no stamped decision at all the boundary cannot be
+  // located, so every unstamped row is treated as pre-instrumentation. That errs
+  // toward silence rather than toward crying wolf on an install that simply has
+  // not routed since stamping shipped.
+  const instrumentedSinceDate = earliestDate(
+    input.decisions
+      .filter((decision) => decision.designRevision)
+      .map((decision) => decision.createdAt),
+  );
+  const preInstrumentationDecisions = input.decisions.filter((decision) =>
+    !decision.designRevision &&
+    (instrumentedSinceDate === null || decision.createdAt < instrumentedSinceDate)
+  ).length;
   const uncorrelatedDecisions = totalDecisions - correlatedDecisions;
-  const unprovenDesignDecisions = totalDecisions - designBoundDecisions;
+  const unprovenDesignDecisions =
+    totalDecisions - designBoundDecisions - preInstrumentationDecisions;
   const coverage: RoutingEvidenceCoverage = {
     totalDecisions,
     attributedDecisions,
@@ -341,6 +395,8 @@ export function projectRoutingEvidenceConformance(
     screenCoveredDecisions,
     designBoundDecisions,
     unprovenDesignDecisions,
+    preInstrumentationDecisions,
+    instrumentedSince: instrumentedSinceDate?.toISOString() ?? null,
     staleDesignDecisions,
     attributionRate: rate(attributedDecisions, totalDecisions),
     traceRate: rate(tracedDecisions, totalDecisions),
@@ -407,7 +463,10 @@ export function projectRoutingEvidenceConformance(
     severity: "info",
     count: unprovenDesignDecisions,
     stage: "request",
-    message: "Historic traffic does not name the design revision it executed against.",
+    // No longer "historic": pre-instrumentation rows are excluded from this
+    // count, so anything remaining was recorded AFTER stamping began and is a
+    // genuine gap (BI-A4BC02BE).
+    message: "Traffic recorded since design-revision stamping began does not name the revision it executed against.",
   });
   addFinding(findings, {
     issueType: "ai-routing-design-stale",
@@ -631,5 +690,13 @@ function latestDate(values: Date[]): Date | null {
   if (values.length === 0) return null;
   return values.reduce((latest, value) =>
     value.getTime() > latest.getTime() ? value : latest
+  );
+}
+
+/** Earliest of the supplied dates; null when there are none (BI-A4BC02BE). */
+function earliestDate(values: Date[]): Date | null {
+  if (values.length === 0) return null;
+  return values.reduce((earliest, value) =>
+    value.getTime() < earliest.getTime() ? value : earliest
   );
 }

--- a/apps/web/lib/ea/routing-evidence-conformance-reconciler.test.ts
+++ b/apps/web/lib/ea/routing-evidence-conformance-reconciler.test.ts
@@ -19,6 +19,8 @@ function projection(findings: RoutingEvidenceConformanceProjection["findings"]):
       unevidencedDecisions: 1,
       screenCoveredDecisions: 0,
       designBoundDecisions: 0,
+      preInstrumentationDecisions: 0,
+      instrumentedSince: null,
       unprovenDesignDecisions: 1,
       staleDesignDecisions: 0,
       attributionRate: 1,

--- a/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
+++ b/docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md
@@ -539,6 +539,7 @@ not “unused” and not an unconstrained “force.”
 | `BI-52C015D8` | Cross-view drill-through and routing-decision inspector |
 | `BI-7378E34C` | Designed/Observed/Compare Operations Map UX |
 | `BI-C8BC9DD1` | Owner-actionable conformance findings — remediation contract + severity-faithful presentation |
+| `BI-A4BC02BE` | Design conformance bounded to the instrumented era, not the fetch window |
 
 Existing defect `BI-7E2A1DD0` is coordinated, not duplicated.
 
@@ -567,6 +568,39 @@ count traffic recorded before the evidence contract existed and can never reach
 zero through any action. Presenting those as open work is false. Remediation
 text is static per issue type and carries no request content, so the
 privacy-safe projection boundary in §9 is unchanged.
+
+### 15.2 Design conformance is bounded by the instrumented era (BI-A4BC02BE)
+
+`unprovenDesignDecisions` was `totalDecisions − designBoundDecisions`, where
+`totalDecisions` is however many rows the loader fetched (`WINDOWED_SOURCE_LIMIT`).
+Because design-revision stamping began at a fixed point in the past, that
+expression evaluated to `fetch_limit − total_stamped_rows_in_existence` — it
+measured the page size, not conformance. Observed live as `400 − 229 = 171`,
+presented to an owner as "171 issues".
+
+Two properties made the figure unfalsifiable, and either alone is disqualifying
+for an owner-facing number:
+
+- it **decremented on every new inference**, because each one adds a stamped
+  row, so it silently self-cleared with no remediation performed;
+- it **scaled with the cap**, so raising the limit to 1000 would have reported
+  771 on identical underlying data.
+
+A decision recorded before stamping existed can never name a revision; those are
+history, not failures. The projection now takes the earliest design-bound
+decision in the window as the point the ledger begins, counts anything older as
+`preInstrumentationDecisions`, and reserves `unprovenDesignDecisions` for
+unstamped decisions at or after that boundary — which are genuine gaps, and are
+classified `platform-defect` rather than `none-historical` accordingly.
+
+When the window contains no stamped decision the boundary cannot be located, and
+every unstamped row is treated as pre-instrumentation. That errs toward silence
+rather than toward reporting a fault on an install that has simply not routed
+since stamping shipped.
+
+`coverage.instrumentedSince` is surfaced in the station inspector so an owner can
+distinguish "we have no record of that period" from "the platform did something
+wrong".
 
 ## 16. Refactoring budget
 


### PR DESCRIPTION
Closes BI-A4BC02BE. Final item touching the number in the original founder report.

## The number was measuring the page size

The Operations Map told an owner they had **"171 issues"**. That figure was:

```
WINDOWED_SOURCE_LIMIT (400) − total_stamped_rows_in_existence (229) = 171
```

`unprovenDesignDecisions` was `totalDecisions − designBoundDecisions`, and `totalDecisions` is however many rows the loader fetched. Design-revision stamping began at a fixed point in the past, so the expression evaluated to `fetch_limit − total_stamped_rows`.

Two properties made it unfalsifiable, and **either alone disqualifies an owner-facing number**:

- it **decremented on every new inference** — each one adds a stamped row — so it silently self-cleared with no remediation ever performed;
- it **scaled with the cap** — raising the limit to 1000 would have reported 771 on identical underlying data.

## The fix: bound conformance to the instrumented era

A decision recorded before stamping existed can never name a revision. That is history, not a failure.

The projection now takes the **earliest design-bound decision in the window** as the point the ledger begins, counts anything older as `preInstrumentationDecisions`, and reserves `unprovenDesignDecisions` for unstamped decisions **at or after** that boundary — which are genuine gaps.

When the window contains no stamped decision the boundary cannot be located, so every unstamped row is treated as pre-instrumentation. That errs toward silence rather than reporting a fault on an install that simply has not routed since stamping shipped.

On the reporting install this takes the count to **0** — the finding stops firing entirely, rather than merely being labelled honestly.

## Consequence followed through

`ai-routing-design-unproven` is **reclassified from `none-historical` to `platform-defect`**. Anything that still reaches this finding was recorded after stamping began and failed to carry a revision. Leaving the [#3816](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3816) remediation text — *"nothing to do, this is not a fault"* — would have made the contract lie.

`coverage.instrumentedSince` is surfaced in the station inspector ("Ledger begins …") so an owner can tell **"we have no record of that period"** apart from **"the platform did something wrong"**.

## Two existing tests updated, not deleted

Both asserted the old semantics, and the reason is recorded inline at each site. A legacy row in a window with nothing stamped now yields **no** design finding instead of one classed historical. The unattributed / uncorrelated / unevidenced assertions in that test are untouched — legacy traffic stays visible.

## Evidence

Local-CI gate passed at `24bf2733424df85c674356b0d4886790c229a543` (metadata `candidateSha` matches HEAD) — full guard preflight, no skip.

- **701/701** across `lib/ai-operations-map`, `components/platform`, `lib/ea`
- **Typecheck 0 errors repo-wide**; prose lint OK; module ratchet green
- Four new cases pin the defect **by its two disqualifying properties directly**: invariance to how many historic rows were fetched (5 vs 300 → same result), and no decrement as stamped traffic accrues

Adding two required fields to `RoutingEvidenceCoverage` broke three coverage fixtures that **vitest could not see**, since vitest does not typecheck — third occurrence of that class in this session, caught by typechecking before commit.

Not verified on the live install — deploys are operator-gated.

## Design grounding

Extends `docs/superpowers/specs/2026-07-26-ai-routing-architecture-explainability-design.md` with delivery row `BI-A4BC02BE` and new §15.2, recording the fetch-window defect, both disqualifying properties, the instrumented-era rule, and the err-toward-silence behaviour when the boundary cannot be located. Substrate reviewed: `routing-evidence-conformance.ts`, `routing-comparison-view-model.ts`, `load-map-data.ts` (`WINDOWED_SOURCE_LIMIT`), `RoutingArchitectureOverview.tsx`, `routing-evidence-conformance-reconciler.ts`.

Seed-Fit-Decision: no-change — corrects a derived count in an in-memory projection and adds two fields to it. No seed data, provider catalog entry, clearance default, or bootstrap calibration is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
