### PR TITLE
refactor(review): share semantic change contract (BI-1B83AA84)

### DIFF
--- a/apps/web/lib/build/verified-finding-review.test.ts
+++ b/apps/web/lib/build/verified-finding-review.test.ts
@@ -93,6 +93,18 @@ describe("buildFindingVerifierPrompt", () => {
     expect(p).toContain("REFUTE");
     expect(p).toContain('{"verified"');
   });
+
+  it("accepts a typed code-change artifact without changing legacy plan text", () => {
+    const finding = { severity: "critical" as const, description: "leaks token" };
+    const legacy = buildFindingVerifierPrompt(finding, "plan text");
+    const code = buildFindingVerifierPrompt(finding, {
+      kind: "code-change",
+      content: "const token = expose();",
+    });
+
+    expect(legacy).toContain("ARTIFACT UNDER REVIEW:\nplan text");
+    expect(code).toContain("CODE CHANGE UNDER REVIEW:\nconst token = expose();");
+  });
 });
 
 describe("verifyReviewFindings (injected dispatch)", () => {

--- a/apps/web/lib/build/verified-finding-review.ts
+++ b/apps/web/lib/build/verified-finding-review.ts
@@ -24,6 +24,19 @@ import type { ReviewResult } from "@/lib/feature-build-types";
 
 type ReviewIssue = ReviewResult["issues"][number];
 
+export type VerifiedFindingArtifact = string | {
+  kind: "plan" | "code-change";
+  content: string;
+};
+
+function normalizeArtifact(artifact: VerifiedFindingArtifact): { label: string; content: string } {
+  if (typeof artifact === "string") return { label: "ARTIFACT", content: artifact };
+  return {
+    label: artifact.kind === "code-change" ? "CODE CHANGE" : "PLAN",
+    content: artifact.content,
+  };
+}
+
 /** One verifier's judgment on one finding. `verified=false` means the verifier
  *  could not reproduce the finding against the artifact — it is downgraded to
  *  advisory rather than allowed to block. */
@@ -86,15 +99,16 @@ export function applyFindingVerdicts(
  *  plausible-but-wrong critical from triggering a wasted rework round. */
 export function buildFindingVerifierPrompt(
   finding: ReviewIssue,
-  artifact: string,
+  artifact: VerifiedFindingArtifact,
 ): string {
   const loc = finding.location ? `\nClaimed location: ${finding.location}` : "";
+  const normalized = normalizeArtifact(artifact);
   return `You are an INDEPENDENT verifier. A reviewer flagged the finding below as CRITICAL (blocking). Your job is to try to REFUTE it against the actual artifact — not to agree with it.
 
 FINDING (severity: ${finding.severity}): ${finding.description}${loc}
 
-ARTIFACT UNDER REVIEW:
-${artifact}
+${normalized.label} UNDER REVIEW:
+${normalized.content}
 
 Decide whether this finding is REAL and BLOCKING — i.e. you can concretely reproduce it in the artifact above (point to the exact place and explain the concrete failure it causes). If you cannot concretely reproduce it, or it is vague/speculative/stylistic, it is NOT verified. Default to NOT verified when uncertain — the burden of proof is on the finding.
 
@@ -136,7 +150,7 @@ export type VerifyFindingsDeps = {
  */
 export async function verifyReviewFindings(
   review: ReviewResult,
-  artifact: string,
+  artifact: VerifiedFindingArtifact,
   deps: VerifyFindingsDeps,
 ): Promise<{ review: ReviewResult; verdicts: FindingVerdict[] }> {
   const criticalIdx = review.issues

--- a/apps/web/lib/change-review/build-reviewers-compatibility.test.ts
+++ b/apps/web/lib/change-review/build-reviewers-compatibility.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCodeReviewPrompt,
+  parseReviewResponse,
+} from "@/lib/build-reviewers";
+import {
+  buildSemanticChangeReviewPrompt,
+  parseSemanticReviewResponse,
+} from "./semantic-change-review";
+
+describe("Build Studio shared-contract adapter", () => {
+  it("preserves the exact legacy code-review prompt", () => {
+    expect(buildCodeReviewPrompt("Add filter", "const x = 1;", "PASS 1 test")).toBe(
+      buildSemanticChangeReviewPrompt({
+        title: "Add filter",
+        artifact: "const x = 1;",
+        verificationEvidence: "PASS 1 test",
+        promptProfile: "build-studio-v1",
+      }),
+    );
+  });
+
+  it("preserves the shared surface-neutral parser result", () => {
+    const raw =
+      '{"decision":"fail","issues":[{"severity":"critical","description":"Auth bypass","location":"auth.ts:4"}],"summary":"blocked"}';
+    expect(parseReviewResponse(raw)).toEqual(parseSemanticReviewResponse(raw));
+  });
+});

--- a/apps/web/lib/change-review/semantic-change-review.test.ts
+++ b/apps/web/lib/change-review/semantic-change-review.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHANGE_REVIEW_POLICY_VERSION,
+  CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION,
+  assessSemanticReviewReceiptFreshness,
+  buildSemanticChangeReviewPrompt,
+  createLowRiskAutoPassReceipt,
+  createSemanticReviewReceipt,
+  parseSemanticReviewResponse,
+  projectSemanticReviewReceipt,
+  type SemanticReviewIdentity,
+} from "./semantic-change-review";
+
+const identity = (overrides: Partial<SemanticReviewIdentity> = {}): SemanticReviewIdentity => ({
+  capsuleId: "WC-12345678",
+  baseTreeHash: "tree-base",
+  headTreeHash: "tree-head",
+  diffDigest: "sha256:diff-a",
+  policyVersion: CHANGE_REVIEW_POLICY_VERSION,
+  reviewerVersion: "change-reviewer.v1",
+  specialistIds: ["security-reviewer", "architecture-reviewer"],
+  ...overrides,
+});
+
+describe("semantic review receipt freshness", () => {
+  const reviewedReceipt = () => createSemanticReviewReceipt({
+    identity: identity(),
+    disposition: "reviewed",
+    risk: "high",
+    result: { decision: "pass", issues: [], summary: "No blocking findings." },
+  });
+
+  it("is stable for the same semantic change and normalized specialist set", () => {
+    const receipt = reviewedReceipt();
+    const result = assessSemanticReviewReceiptFreshness(receipt, identity({
+      specialistIds: ["architecture-reviewer", "security-reviewer", "security-reviewer"],
+    }));
+
+    expect(result).toEqual({ fresh: true, reasons: [] });
+    expect(receipt.schemaVersion).toBe(CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION);
+  });
+
+  it.each([
+    ["code-change", { diffDigest: "sha256:diff-b", headTreeHash: "tree-head-b" }, ["head-tree-changed", "diff-changed"]],
+    ["rebase", { baseTreeHash: "tree-base-b" }, ["base-tree-changed"]],
+    ["policy", { policyVersion: "semantic-change-review.v2" }, ["policy-version-changed"]],
+    ["reviewer", { reviewerVersion: "change-reviewer.v2" }, ["reviewer-version-changed"]],
+    ["specialists", { specialistIds: ["security-reviewer"] }, ["specialist-set-changed"]],
+  ] as const)("invalidates after a %s change", (_label, overrides, expectedReasons) => {
+    const result = assessSemanticReviewReceiptFreshness(reviewedReceipt(), identity(overrides));
+    expect(result.fresh).toBe(false);
+    expect(result.reasons).toEqual(expectedReasons);
+  });
+});
+
+describe("semantic review evidence", () => {
+  it("creates auditable low-risk auto-pass evidence instead of silently skipping", () => {
+    const receipt = createLowRiskAutoPassReceipt({
+      identity: identity(),
+      rationale: "Documentation-only change is below the independent-review threshold.",
+    });
+    const projection = projectSemanticReviewReceipt(receipt);
+
+    expect(receipt.disposition).toBe("auto-pass");
+    expect(receipt.result.decision).toBe("pass");
+    expect(receipt.risk).toBe("low");
+    expect(projection.externalEvidence.operationType).toBe("semantic-change-review.receipt");
+    expect(projection.externalEvidence.details).toEqual(receipt);
+    expect(projection.activity.kind).toBe("evidence-recorded");
+    expect(projection.activity.payload).toEqual(receipt);
+  });
+});
+
+describe("surface-neutral review compatibility", () => {
+  it("builds a surface-neutral code-review prompt contract", () => {
+    const prompt = buildSemanticChangeReviewPrompt({
+      title: "Add filter",
+      artifact: "const x = 1;",
+      verificationEvidence: "PASS 1 test",
+    });
+    expect(prompt).toContain("CHANGE: Add filter");
+    expect(prompt).toContain("CODE CHANGES:\nconst x = 1;");
+    expect(prompt).toContain("VERIFICATION EVIDENCE:\nPASS 1 test");
+  });
+
+  it("parses severity-driven results and fails closed on malformed output", () => {
+    expect(parseSemanticReviewResponse('{"decision":"fail","issues":[{"severity":"important","description":"advisory"}],"summary":"ok"}').decision).toBe("pass");
+    const malformed = parseSemanticReviewResponse("not json");
+    expect(malformed.decision).toBe("fail");
+    expect(malformed.parseError).toBe(true);
+  });
+});

--- a/apps/web/lib/change-review/semantic-change-review.ts
+++ b/apps/web/lib/change-review/semantic-change-review.ts
@@ -1,0 +1,218 @@
+/**
+ * Surface-neutral semantic change-review contract.
+ *
+ * This module deliberately has no Build Studio, Prisma, GitHub, or inference
+ * dependency. Authoring surfaces create the same receipt; persistence adapters
+ * can store it in the existing ExternalEvidenceRecord and WorkCapsuleActivity
+ * streams without adding another finding or receipt table.
+ */
+
+export const CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION = "semantic-change-review-receipt.v1";
+export const CHANGE_REVIEW_POLICY_VERSION = "semantic-change-review-policy.v1";
+export const CHANGE_REVIEWER_VERSION = "change-reviewer.v1";
+
+export type SemanticReviewSeverity = "critical" | "important" | "minor";
+export type SemanticReviewDecision = "pass" | "fail";
+export type SemanticReviewRisk = "low" | "medium" | "high" | "critical";
+export type SemanticReviewDisposition = "reviewed" | "auto-pass";
+
+export interface SemanticReviewIssue {
+  severity: SemanticReviewSeverity;
+  description: string;
+  location?: string;
+  suggestion?: string;
+}
+
+export interface SemanticReviewResult {
+  decision: SemanticReviewDecision;
+  issues: SemanticReviewIssue[];
+  summary: string;
+  parseError?: true;
+}
+
+export interface SemanticReviewIdentity {
+  capsuleId: string;
+  baseTreeHash: string;
+  headTreeHash: string;
+  diffDigest: string;
+  policyVersion: string;
+  reviewerVersion: string;
+  specialistIds: readonly string[];
+}
+
+export interface SemanticReviewReceipt extends Omit<SemanticReviewIdentity, "specialistIds"> {
+  schemaVersion: typeof CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION;
+  specialistIds: string[];
+  disposition: SemanticReviewDisposition;
+  risk: SemanticReviewRisk;
+  result: SemanticReviewResult;
+  rationale?: string;
+}
+
+export type SemanticReviewStaleReason =
+  | "capsule-changed"
+  | "base-tree-changed"
+  | "head-tree-changed"
+  | "diff-changed"
+  | "policy-version-changed"
+  | "reviewer-version-changed"
+  | "specialist-set-changed";
+
+function normalizedSpecialistIds(ids: readonly string[]): string[] {
+  return [...new Set(ids.map((id) => id.trim()).filter(Boolean))].sort();
+}
+
+export function createSemanticReviewReceipt(input: {
+  identity: SemanticReviewIdentity;
+  disposition: SemanticReviewDisposition;
+  risk: SemanticReviewRisk;
+  result: SemanticReviewResult;
+  rationale?: string;
+}): SemanticReviewReceipt {
+  return {
+    schemaVersion: CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION,
+    ...input.identity,
+    specialistIds: normalizedSpecialistIds(input.identity.specialistIds),
+    disposition: input.disposition,
+    risk: input.risk,
+    result: input.result,
+    rationale: input.rationale,
+  };
+}
+
+export function createLowRiskAutoPassReceipt(input: {
+  identity: SemanticReviewIdentity;
+  rationale: string;
+}): SemanticReviewReceipt {
+  return createSemanticReviewReceipt({
+    identity: input.identity,
+    disposition: "auto-pass",
+    risk: "low",
+    rationale: input.rationale,
+    result: {
+      decision: "pass",
+      issues: [],
+      summary: `Independent semantic review auto-passed: ${input.rationale}`,
+    },
+  });
+}
+
+export function assessSemanticReviewReceiptFreshness(
+  receipt: SemanticReviewReceipt,
+  current: SemanticReviewIdentity,
+): { fresh: boolean; reasons: SemanticReviewStaleReason[] } {
+  const reasons: SemanticReviewStaleReason[] = [];
+  if (receipt.capsuleId !== current.capsuleId) reasons.push("capsule-changed");
+  if (receipt.baseTreeHash !== current.baseTreeHash) reasons.push("base-tree-changed");
+  if (receipt.headTreeHash !== current.headTreeHash) reasons.push("head-tree-changed");
+  if (receipt.diffDigest !== current.diffDigest) reasons.push("diff-changed");
+  if (receipt.policyVersion !== current.policyVersion) reasons.push("policy-version-changed");
+  if (receipt.reviewerVersion !== current.reviewerVersion) reasons.push("reviewer-version-changed");
+  if (JSON.stringify(receipt.specialistIds) !== JSON.stringify(normalizedSpecialistIds(current.specialistIds))) {
+    reasons.push("specialist-set-changed");
+  }
+  return { fresh: reasons.length === 0, reasons };
+}
+
+/** Persistence-shaped projections for the platform's existing evidence streams. */
+export function projectSemanticReviewReceipt(receipt: SemanticReviewReceipt): {
+  externalEvidence: {
+    routeContext: "change-review";
+    operationType: "semantic-change-review.receipt";
+    target: string;
+    provider: "dpf-change-review";
+    resultSummary: string;
+    details: SemanticReviewReceipt;
+  };
+  activity: {
+    kind: "evidence-recorded";
+    summary: string;
+    payload: SemanticReviewReceipt;
+  };
+} {
+  const summary = `${receipt.disposition} semantic change review ${receipt.result.decision}: ${receipt.result.summary}`;
+  return {
+    externalEvidence: {
+      routeContext: "change-review",
+      operationType: "semantic-change-review.receipt",
+      target: receipt.capsuleId,
+      provider: "dpf-change-review",
+      resultSummary: summary,
+      details: receipt,
+    },
+    activity: { kind: "evidence-recorded", summary, payload: receipt },
+  };
+}
+
+export function buildSemanticChangeReviewPrompt(input: {
+  title: string;
+  artifact: string;
+  verificationEvidence: string;
+  /** Keeps the pre-existing Build Studio prompt byte-for-byte compatible. */
+  promptProfile?: "surface-neutral" | "build-studio-v1";
+}): string {
+  const buildStudio = input.promptProfile === "build-studio-v1";
+  const introduction = buildStudio
+    ? "You are reviewing code changes for a single build task."
+    : "You are reviewing a semantic code change produced by an authoring surface.";
+  const titleLabel = buildStudio ? "TASK" : "CHANGE";
+  const evidenceLabel = buildStudio ? "TEST OUTPUT" : "VERIFICATION EVIDENCE";
+
+  return `${introduction}
+
+${titleLabel}: ${input.title}
+
+CODE CHANGES:
+${input.artifact}
+
+${evidenceLabel}:
+${input.verificationEvidence}
+
+REVIEW CHECKLIST — evaluate EVERY item before responding:
+1. Does a test exist that covers this change?
+2. Is there code duplication with existing functionality?
+3. Does the code follow project patterns (TypeScript, Next.js, Tailwind)?
+4. Are there security concerns (injection, XSS, etc.)?
+5. Is the code clean and maintainable?
+6. Does the code use CSS variables (var(--dpf-*)) for all colors — no text-white, bg-white, text-black, bg-black, or inline hex values? (Exception: text-white on accent-background buttons, semantic status colors from ThemeTokens.states)
+7. Are interactive elements keyboard-accessible with visible focus indicators? Do form inputs have associated labels? Do buttons have descriptive accessible names?
+
+DECISION DISCIPLINE: report the genuine BLOCKING issues in a single response — be comprehensive about real blockers so there are no surprises on re-review, but do NOT pad the list with nice-to-haves. Reserve "critical" for issues that would cause data loss, security holes, or broken functionality; "important"/"minor" do not block. If the change is correct and tested at a level appropriate to its scope, return "pass". A short, converging review beats an exhaustive one.
+
+RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):
+{
+  "decision": "pass" or "fail",
+  "issues": [{"severity": "critical|important|minor", "description": "..."}],
+  "summary": "one sentence summary"
+}`;
+}
+
+export function parseSemanticReviewResponse(raw: string): SemanticReviewResult {
+  try {
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new Error("No JSON found");
+    const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    const issues = Array.isArray(parsed.issues)
+      ? parsed.issues.map((issue: Record<string, unknown>) => ({
+          severity: (["critical", "important", "minor"].includes(String(issue.severity))
+            ? String(issue.severity)
+            : "minor") as SemanticReviewSeverity,
+          description: String(issue.description ?? ""),
+          location: issue.location ? String(issue.location) : undefined,
+          suggestion: issue.suggestion ? String(issue.suggestion) : undefined,
+        }))
+      : [];
+    return {
+      decision: issues.some((issue) => issue.severity === "critical") ? "fail" : "pass",
+      issues,
+      summary: String(parsed.summary ?? "Review complete"),
+    };
+  } catch {
+    return {
+      decision: "fail",
+      issues: [{ severity: "critical", description: "Review agent returned unparseable response" }],
+      summary: "Review failed — could not parse agent response",
+      parseError: true,
+    };
+  }
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -445,6 +445,7 @@
         "the-four-governance-altitudes",
         "which-plane-owns-what",
         "evidence-earned-completion",
+        "surface-neutral-semantic-change-review",
         "client-identity-and-trust",
         "operator-attention",
         "adding-another-consequential-gate"

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -4,6 +4,7 @@
 import * as crypto from "crypto";
 import type { BuildExecutionState } from "@/lib/build-exec-types";
 import type { DecisionInteractionGateView } from "@/lib/decision-perspective/types";
+import type { SemanticReviewResult } from "@/lib/change-review/semantic-change-review";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -134,19 +135,7 @@ export type TaxonomyAttributionView = {
 
 // ─── Build Disciplines Evidence Types ────────────────────────────────────────
 
-export type ReviewResult = {
-  decision: "pass" | "fail";
-  issues: Array<{
-    severity: "critical" | "important" | "minor";
-    description: string;
-    location?: string;
-    suggestion?: string;
-  }>;
-  summary: string;
-  /** True when the LLM response could not be parsed (rate-limited, empty, or
-   *  malformed output). Gates and deliberation treat parse-error branches as
-   *  absent reviewers, not dissenting votes. */
-  parseError?: true;
+export type ReviewResult = SemanticReviewResult & {
   /** Iteration tracking populated when this ReviewResult is the output of a
    *  re-review (e.g. reviewBuildPlan called against an existing planReview).
    *  Enables the operator-facing iteration progress chip and the reviewer's

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -21,6 +21,10 @@ import type {
   DeliberationActivatedRiskLevel,
 } from "@/lib/deliberation/types";
 import { ENTERPRISE_ARCHITECT_DISPLAY_NAME } from "@dpf/db/agent-identity";
+import {
+  buildSemanticChangeReviewPrompt,
+  parseSemanticReviewResponse,
+} from "@/lib/change-review/semantic-change-review";
 
 // ─── Prompt Templates ────────────────────────────────────────────────────────
 
@@ -170,33 +174,12 @@ RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):
 }
 
 export function buildCodeReviewPrompt(taskTitle: string, codeChanges: string, testOutput: string): string {
-  return `You are reviewing code changes for a single build task.
-
-TASK: ${taskTitle}
-
-CODE CHANGES:
-${codeChanges}
-
-TEST OUTPUT:
-${testOutput}
-
-REVIEW CHECKLIST — evaluate EVERY item before responding:
-1. Does a test exist that covers this change?
-2. Is there code duplication with existing functionality?
-3. Does the code follow project patterns (TypeScript, Next.js, Tailwind)?
-4. Are there security concerns (injection, XSS, etc.)?
-5. Is the code clean and maintainable?
-6. Does the code use CSS variables (var(--dpf-*)) for all colors — no text-white, bg-white, text-black, bg-black, or inline hex values? (Exception: text-white on accent-background buttons, semantic status colors from ThemeTokens.states)
-7. Are interactive elements keyboard-accessible with visible focus indicators? Do form inputs have associated labels? Do buttons have descriptive accessible names?
-
-DECISION DISCIPLINE: report the genuine BLOCKING issues in a single response — be comprehensive about real blockers so there are no surprises on re-review, but do NOT pad the list with nice-to-haves. Reserve "critical" for issues that would cause data loss, security holes, or broken functionality; "important"/"minor" do not block. If the change is correct and tested at a level appropriate to its scope, return "pass". A short, converging review beats an exhaustive one.
-
-RESPOND WITH EXACTLY THIS JSON FORMAT (no other text):
-{
-  "decision": "pass" or "fail",
-  "issues": [{"severity": "critical|important|minor", "description": "..."}],
-  "summary": "one sentence summary"
-}`;
+  return buildSemanticChangeReviewPrompt({
+    title: taskTitle,
+    artifact: codeChanges,
+    verificationEvidence: testOutput,
+    promptProfile: "build-studio-v1",
+  });
 }
 
 // ─── Architecture Alignment Review (advisory) ────────────────────────────────
@@ -525,55 +508,7 @@ export function relaxTestFirstAfterRounds(review: ReviewResult, round: number): 
 // ─── Response Parsing ────────────────────────────────────────────────────────
 
 export function parseReviewResponse(raw: string): ReviewResult {
-  try {
-    // Extract JSON from response (may have markdown code fences)
-    const jsonMatch = raw.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) throw new Error("No JSON found");
-
-    const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
-
-    const rawDecision = parsed.decision === "pass" ? "pass" : "fail";
-    const issues = Array.isArray(parsed.issues)
-      ? parsed.issues.map((issue: Record<string, unknown>) => ({
-          severity: (["critical", "important", "minor"].includes(String(issue.severity))
-            ? String(issue.severity)
-            : "minor") as "critical" | "important" | "minor",
-          description: String(issue.description ?? ""),
-          location: issue.location ? String(issue.location) : undefined,
-          suggestion: issue.suggestion ? String(issue.suggestion) : undefined,
-        }))
-      : [];
-    const summary = String(parsed.summary ?? "Review complete");
-
-    // Honor the reviewer prompt's own severity calibration:
-    //   "Use 'critical' ONLY for issues that would cause data loss,
-    //    security vulnerabilities, or broken functionality. Use
-    //    'important' for design gaps that should be addressed but
-    //    don't block implementation."
-    //
-    // In practice reviewers routinely return decision:"fail" with
-    // only "important" issues, which contradicts the prompt and
-    // trapped real builds (observed 2026-04-19 on FB-21EEA510) in an
-    // endless dual-reviewer loop that kept finding new important
-    // issues each iteration. Overriding the decision to match the
-    // declared severity of the issues — critical fails, anything else
-    // passes (issues are still surfaced for the author to address).
-    const hasCritical = issues.some((i) => i.severity === "critical");
-    const decision: "pass" | "fail" = hasCritical ? "fail" : "pass";
-    // rawDecision retained for diagnostics in logs if the LLM's own decision
-    // diverges from the severity-driven one. The severity-driven decision is
-    // authoritative — see comment above.
-    void rawDecision;
-
-    return { decision, issues, summary };
-  } catch {
-    return {
-      decision: "fail",
-      issues: [{ severity: "critical", description: "Review agent returned unparseable response" }],
-      summary: "Review failed — could not parse agent response",
-      parseError: true,
-    };
-  }
+  return parseSemanticReviewResponse(raw);
 }
 
 // ─── Deliberation Integration (Task 8) ──────────────────────────────────────

--- a/docs/architecture/agent-client-governance.md
+++ b/docs/architecture/agent-client-governance.md
@@ -72,6 +72,33 @@ assuming that a missing record means “not applicable.”
 Build Studio is not exempt. Its canonical `FeatureBuild` verification can
 satisfy dimensions through an adapter, so evidence is reused rather than copied.
 
+## Surface-neutral semantic change review
+
+Code authored in Build Studio, Codex, Claude, Grok, or another MCP client uses
+one semantic review contract. The authoring surface is attribution, not a
+different quality policy. The contract is implemented as pure functions in
+`apps/web/lib/change-review/semantic-change-review.ts`; Build Studio retains a
+compatibility adapter while external clients can construct the same receipt.
+
+A receipt is fresh only while all of its semantic identity remains unchanged:
+
+- Work Capsule;
+- base and head trees;
+- diff digest;
+- policy and reviewer versions; and
+- normalized specialist set.
+
+Changing any one of those inputs requires a new review. Reordering or repeating
+the same specialists does not. A genuinely low-risk change may auto-pass, but
+the auto-pass still emits a receipt with its rationale; review is never skipped
+silently.
+
+The receipt reuses the existing `ExternalEvidenceRecord` and
+`WorkCapsuleActivity(kind="evidence-recorded")` streams. It does not create a
+parallel finding table. This keeps the write substrate singular while allowing
+portal timelines, local hooks, CI, and promotion controls to project the same
+evidence in later rollout phases.
+
 ## Client identity and trust
 
 Client identity is useful attribution:

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -32,7 +32,7 @@ apps/web/lib/actions/tax-remittance.ts	978
 apps/web/lib/ai-operations-map/load-map-data.test.ts	928
 apps/web/lib/deliberation/orchestrator.ts	808
 apps/web/lib/explore/build-process-matrix.ts	811
-apps/web/lib/explore/feature-build-types.ts	1109
+apps/web/lib/explore/feature-build-types.ts	1098
 apps/web/lib/finance/ai-provider-finance.ts	1309
 apps/web/lib/inference/ai-provider-internals.ts	1266
 apps/web/lib/inference/routed-inference.ts	835


### PR DESCRIPTION
## Summary

Establish one surface-neutral semantic change-review contract for Build Studio, Codex, Claude, Grok, and other MCP clients. Review receipts now have deterministic freshness identity, low-risk auto-pass remains auditable, and Build Studio retains byte-compatible prompt and parser behavior through an adapter.

## Changes

- Add pure review result, prompt, parsing, version, receipt-creation, freshness, and evidence-projection contracts.
- Invalidate receipts when the capsule, base/head trees, diff, policy, reviewer, or normalized specialist set changes.
- Reuse `ExternalEvidenceRecord` and `WorkCapsuleActivity` projections; add no Prisma model.
- Generalize verified-finding review for typed plan and code-change artifacts while preserving legacy string behavior.
- Compose Build Studio's extended `ReviewResult` from the shared result type and document the cross-client architecture.

## Test plan

- [x] Runtime-bound change
  - [x] Focused source tests: 5 files, 108 tests passed.
  - [x] Governed shared local-CI: exact candidate passed exhaustive merged-code verification.
  - [x] Typecheck passed.
  - [x] Full Vitest suite passed: 2,442 files and 20,924 tests.
  - [x] Prisma generate and migration deploy passed.
  - [x] Production Docker build passed.
- [x] Finding-substrate guard passed; no eighth finding table was introduced.
- [x] Pregate preflight passed 29 guards.
- [x] UX verification not applicable: this is a pure contract/refactor with no rendered UI change.

## Pre-PR readiness

- [x] Final `gate:context` reviewed.
- [x] `pregate:preflight` passed.
- [x] Exact-tree local-CI evidence captured for the pushed candidate.
- [x] DCO sign-off present.
- [x] Overlap sweep found no PR implementing this contract.

## Related issues / Epic

Closes BI-1B83AA84.

Parent objective: BI-67E23B70.

## Notes for the reviewer

This is the shared substrate only. Later rollout slices wire local invocation and publication enforcement to the receipt contract. Build Studio remains behind a compatibility adapter, so rollback requires no data migration.
