### PR TITLE
feat: deliver business-grade restaurant floor

### DIFF
--- a/apps/web/app/(shell)/storefront/tables/page.tsx
+++ b/apps/web/app/(shell)/storefront/tables/page.tsx
@@ -19,11 +19,17 @@ import {
   readinessIntent,
   TABLE_CAPACITY_STATES,
 } from "@/lib/storefront/restaurant-capacity";
+import { parseRestaurantTableAttributes } from "@/lib/storefront/restaurant-table-attributes";
+import {
+  loadOrCreateRestaurantScene,
+  type OperationalSceneLayoutDatabase,
+} from "@/lib/twin/restaurant-scene-layout";
 
 export default async function TablesCapacityPage() {
   const config = await prisma.storefrontConfig.findFirst({
     select: {
       id: true,
+      organization: { select: { orgId: true } },
       archetype: { select: { archetypeId: true, category: true, customVocabulary: true } },
       hospitalityResources: {
         where: { kind: "table" },
@@ -38,6 +44,7 @@ export default async function TablesCapacityPage() {
           capacityUnit: true,
           serviceArea: true,
           blockedReason: true,
+          attributes: true,
           version: true,
           availability: {
             orderBy: { createdAt: "asc" },
@@ -79,6 +86,7 @@ export default async function TablesCapacityPage() {
       kind: "table",
       capacityUnit: "seats",
       status: resource.status as HospitalityResourceManagerRow["status"],
+      attributes: parseRestaurantTableAttributes(resource.attributes),
       availability: resource.availability.map((row) => ({
         id: row.id,
         days: row.days,
@@ -89,6 +97,22 @@ export default async function TablesCapacityPage() {
         reason: row.reason,
       })),
     }));
+  const scene =
+    snapshot && snapshot.tables.length > 0
+      ? await loadOrCreateRestaurantScene({
+          database: prisma as unknown as OperationalSceneLayoutDatabase,
+          orgId: config.organization.orgId,
+          locationId: config.id,
+          locationLabel: `${config.archetype?.archetypeId ?? "Restaurant"} floor`,
+          tables: config.hospitalityResources.map((resource) => ({
+            id: resource.id,
+            label: resource.label,
+            capacity: resource.capacity,
+            serviceArea: resource.serviceArea,
+            attributes: resource.attributes,
+          })),
+        }).catch(() => null)
+      : null;
 
   const readiness = snapshot?.readiness ?? "closed";
   const banner = intentStyle(readinessIntent(readiness));
@@ -146,7 +170,9 @@ export default async function TablesCapacityPage() {
 
       {/* Live table state — graphical floor plan or list, one shared projection
           so both reconcile with Workspace and public booking. */}
-      {snapshot && snapshot.tables.length > 0 && <TablesNowView tables={snapshot.tables} />}
+      {snapshot && snapshot.tables.length > 0 && (
+        <TablesNowView tables={snapshot.tables} scene={scene} />
+      )}
 
       {/* Manage the physical tables (add / edit / block). */}
       <div style={{ marginTop: 4 }}>

--- a/apps/web/app/(storefront)/s/[slug]/book/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/book/[itemId]/page.tsx
@@ -1,9 +1,15 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { prisma } from "@dpf/db";
 import { getPublicStorefront, getPublicItem, resolveInquiryFormSchema } from "@/lib/storefront-data";
 import { resolveTrustProfile } from "@/lib/storefront/public-trust";
+import { CustomerRestaurantAvailability } from "@/components/storefront/CustomerRestaurantAvailability";
 import { SlotBookingFlow } from "@/components/storefront/SlotBookingFlow";
 import { resolveResourceVocabulary } from "@/lib/storefront/resource-vocabulary";
+import {
+  loadPublicRestaurantAvailabilityBySlugSafe,
+  type PublicRestaurantAvailabilityDatabase,
+} from "@/lib/twin/restaurant-floor-loader.server";
 
 export default async function BookItemPage({
   params,
@@ -11,9 +17,13 @@ export default async function BookItemPage({
   params: Promise<{ slug: string; itemId: string }>;
 }) {
   const { slug, itemId } = await params;
-  const [storefront, item] = await Promise.all([
+  const [storefront, item, restaurantAvailability] = await Promise.all([
     getPublicStorefront(slug),
     getPublicItem(slug, itemId),
+    loadPublicRestaurantAvailabilityBySlugSafe(
+      prisma as unknown as PublicRestaurantAvailabilityDatabase,
+      { slug },
+    ),
   ]);
   if (!storefront || !item) notFound();
 
@@ -51,6 +61,12 @@ export default async function BookItemPage({
           </p>
         )}
       </div>
+
+      {restaurantAvailability && (
+        <CustomerRestaurantAvailability
+          availability={restaurantAvailability}
+        />
+      )}
 
       <SlotBookingFlow
         orgSlug={slug}

--- a/apps/web/app/(storefront)/s/[slug]/storefront-trust.smoke.test.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/storefront-trust.smoke.test.tsx
@@ -45,6 +45,11 @@ vi.mock("@/lib/storefront-data", () => ({
   getPublicItem: (...a: unknown[]) => getPublicItem(...a),
   resolveInquiryFormSchema: (...a: unknown[]) => resolveInquiryFormSchema(...a),
 }));
+const loadPublicRestaurantAvailabilityBySlugSafe = vi.fn();
+vi.mock("@/lib/twin/restaurant-floor-loader.server", () => ({
+  loadPublicRestaurantAvailabilityBySlugSafe: (...a: unknown[]) =>
+    loadPublicRestaurantAvailabilityBySlugSafe(...a),
+}));
 
 // Prisma is only touched by donate (orgSettings) and checkout; give it a
 // per-model mock surface the tests configure.
@@ -100,6 +105,7 @@ async function renderPage(el: Promise<React.ReactElement> | React.ReactElement) 
 beforeEach(() => {
   vi.clearAllMocks();
   resolveInquiryFormSchema.mockResolvedValue([]);
+  loadPublicRestaurantAvailabilityBySlugSafe.mockResolvedValue(null);
 });
 
 // ── layout metadata (brand inheritance) ─────────────────────────────────────
@@ -142,6 +148,48 @@ describe("booking page", () => {
     expect(html).toMatch(/allerg/i);
     expect(html).toContain('data-test="slot-flow"');
     expect(html).toContain("/s/copper-kettle/inquire");
+  });
+
+  it("renders the customer-safe physical table outlook when it is available", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    getPublicItem.mockResolvedValue({
+      id: "x",
+      itemId: "itm-1",
+      name: "Table for 2",
+      ctaType: "booking",
+      bookingConfig: null,
+    });
+    loadPublicRestaurantAvailabilityBySlugSafe.mockResolvedValue({
+      asOf: "2026-07-31T18:14:00.000Z",
+      summary: { totalTables: 1, availableNow: 0, availableSoon: 1 },
+      tables: [
+        {
+          key: "availability-1",
+          capacity: 2,
+          shape: "round",
+          serviceArea: "Main dining",
+          availability: {
+            kind: "at",
+            availableAt: "2026-07-31T18:35:00.000Z",
+            minutes: 21,
+            explanation: "Available in about 21 minutes",
+          },
+        },
+      ],
+    });
+
+    const Page = (await import("./book/[itemId]/page")).default;
+    const html = await renderPage(
+      Page({
+        params: params({ slug: "copper-kettle", itemId: "itm-1" }),
+      }),
+    );
+
+    expect(html).toContain("Table availability");
+    expect(html).toContain("Available in about 21 minutes");
+    expect(
+      loadPublicRestaurantAvailabilityBySlugSafe,
+    ).toHaveBeenCalledWith(prismaMock, { slug: "copper-kettle" });
   });
 });
 

--- a/apps/web/app/api/storefront/admin/hospitality-resources/[id]/route.test.ts
+++ b/apps/web/app/api/storefront/admin/hospitality-resources/[id]/route.test.ts
@@ -57,6 +57,7 @@ describe("hospitality resource schedule management", () => {
       id: "resource-1",
       organizationId: "org-1",
       legacyServiceProviderId: "provider-1",
+      attributes: { shape: "round" },
     } as never);
     vi.mocked(
       prisma.hospitalityResourceAvailability.deleteMany,
@@ -80,6 +81,7 @@ describe("hospitality resource schedule management", () => {
       capacityUnit: "seats",
       serviceArea: "Dining room",
       blockedReason: null,
+      attributes: { shape: "booth", combinationGroup: "main-banquette" },
       version: 1,
       availability: [
         {
@@ -176,5 +178,49 @@ describe("hospitality resource schedule management", () => {
       message: "Valid weekly availability and dated exceptions are required",
     });
     expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("updates validated table shape and combination structure with the resource version", async () => {
+    vi.mocked(prisma.hospitalityResource.updateMany).mockResolvedValue({
+      count: 1,
+    } as never);
+
+    const response = (await PUT(
+      request({
+        label: "Aster",
+        capacity: 4,
+        serviceArea: "Dining room",
+        status: "active",
+        blockedReason: null,
+        expectedVersion: 1,
+        shape: "booth",
+        combinationGroup: "main-banquette",
+        combinableWith: [],
+      }) as never,
+      routeContext,
+    )) as unknown as {
+      status: number;
+      body: { resource: { attributes: unknown } };
+    };
+
+    expect(response.status).toBe(200);
+    expect(prisma.hospitalityResource.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "resource-1",
+        organizationId: "org-1",
+        version: 1,
+      },
+      data: expect.objectContaining({
+        attributes: {
+          shape: "booth",
+          combinationGroup: "main-banquette",
+        },
+        version: { increment: 1 },
+      }),
+    });
+    expect(response.body.resource.attributes).toEqual({
+      shape: "booth",
+      combinationGroup: "main-banquette",
+    });
   });
 });

--- a/apps/web/app/api/storefront/admin/hospitality-resources/[id]/route.ts
+++ b/apps/web/app/api/storefront/admin/hospitality-resources/[id]/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@dpf/db";
+import { prisma, type Prisma } from "@dpf/db";
 
 import { auth } from "@/lib/auth";
 import { apiErrorResponse } from "@/lib/api/error";
 import { newId } from "@/lib/shared/new-id";
+import {
+  parseRestaurantTableAttributes,
+  serializeRestaurantTableAttributes,
+  validateRestaurantTableAttributesInput,
+} from "@/lib/storefront/restaurant-table-attributes";
 
 const STATUSES = new Set(["active", "blocked", "retired"]);
 const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -90,6 +95,9 @@ export async function PUT(
     expectedVersion?: number;
     availability?: AvailabilityInput[];
     exceptions?: ExceptionInput[];
+    shape?: string;
+    combinationGroup?: string | null;
+    combinableWith?: unknown[];
   };
   const scheduleRequested =
     body.availability !== undefined || body.exceptions !== undefined;
@@ -116,6 +124,7 @@ export async function PUT(
       id: true,
       organizationId: true,
       legacyServiceProviderId: true,
+      attributes: true,
     },
   });
   if (!current) {
@@ -203,6 +212,7 @@ export async function PUT(
           capacityUnit: true,
           serviceArea: true,
           blockedReason: true,
+          attributes: true,
           version: true,
           availability: {
             orderBy: { createdAt: "asc" },
@@ -231,6 +241,18 @@ export async function PUT(
   }
 
   const label = body.label?.trim();
+  const currentAttributes = parseRestaurantTableAttributes(current.attributes);
+  const attributes = validateRestaurantTableAttributesInput({
+    shape: body.shape ?? currentAttributes.shape,
+    combinationGroup:
+      body.combinationGroup === undefined
+        ? currentAttributes.combinationGroup
+        : body.combinationGroup,
+    combinableWith:
+      body.combinableWith === undefined
+        ? currentAttributes.combinableWith
+        : body.combinableWith,
+  });
   if (
     !label ||
     !Number.isInteger(body.capacity) ||
@@ -238,11 +260,14 @@ export async function PUT(
     Number(body.capacity) > 100 ||
     !body.status ||
     !STATUSES.has(body.status) ||
-    !Number.isInteger(body.expectedVersion)
+    !Number.isInteger(body.expectedVersion) ||
+    !attributes.ok
   ) {
     return apiErrorResponse(
       "INVALID_ARGUMENT",
-      "Valid label, seats, status, and expectedVersion are required",
+      attributes.ok
+        ? "Valid label, seats, status, and expectedVersion are required"
+        : attributes.error,
       400,
     );
   }
@@ -264,6 +289,9 @@ export async function PUT(
             body.status === "blocked"
               ? body.blockedReason?.trim() || null
               : null,
+          attributes: serializeRestaurantTableAttributes(
+            attributes.value,
+          ) as Prisma.InputJsonValue,
           version: { increment: 1 },
         },
       });
@@ -290,6 +318,7 @@ export async function PUT(
           capacityUnit: true,
           serviceArea: true,
           blockedReason: true,
+          attributes: true,
           version: true,
           availability: {
             orderBy: { createdAt: "asc" },

--- a/apps/web/app/api/storefront/admin/hospitality-resources/route.test.ts
+++ b/apps/web/app/api/storefront/admin/hospitality-resources/route.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    }),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(async () => ({ user: { type: "admin" } })),
+}));
+
+vi.mock("@/lib/shared/new-id", () => ({
+  newId: vi.fn(() => "fixture-id"),
+}));
+
+vi.mock("@dpf/db", () => {
+  const prisma = {
+    storefrontConfig: { findFirst: vi.fn() },
+    serviceProvider: { create: vi.fn() },
+    providerService: { createMany: vi.fn() },
+    hospitalityResource: { create: vi.fn() },
+    $transaction: vi.fn(
+      async (callback: (transaction: unknown) => Promise<unknown>) =>
+        callback(prisma),
+    ),
+  };
+  return { prisma };
+});
+
+import { prisma } from "@dpf/db";
+import { POST } from "./route";
+
+function request(body: Record<string, unknown>) {
+  return { json: vi.fn(async () => body) };
+}
+
+describe("hospitality table creation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
+      id: "storefront-1",
+      organizationId: "organization-1",
+      items: [],
+    } as never);
+    vi.mocked(prisma.serviceProvider.create).mockResolvedValue({
+      id: "provider-1",
+    } as never);
+    vi.mocked(prisma.hospitalityResource.create).mockResolvedValue({
+      id: "table-1",
+      resourceId: "HR-1",
+      label: "Aster",
+      kind: "table",
+      status: "active",
+      capacity: 4,
+      capacityUnit: "seats",
+      serviceArea: "Main dining",
+      blockedReason: null,
+      attributes: {
+        shape: "booth",
+        combinationGroup: "main-banquette",
+      },
+      version: 1,
+    } as never);
+  });
+
+  it("persists validated table shape and combination structure", async () => {
+    const response = (await POST(
+      request({
+        storefrontId: "storefront-1",
+        label: "Aster",
+        capacity: 4,
+        serviceArea: "Main dining",
+        shape: "booth",
+        combinationGroup: "main-banquette",
+        combinableWith: [],
+      }) as never,
+    )) as unknown as {
+      status: number;
+      body: { resource: { attributes: unknown } };
+    };
+
+    expect(response.status).toBe(201);
+    expect(prisma.hospitalityResource.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        attributes: {
+          shape: "booth",
+          combinationGroup: "main-banquette",
+        },
+      }),
+      select: expect.objectContaining({ attributes: true }),
+    });
+    expect(response.body.resource.attributes).toEqual({
+      shape: "booth",
+      combinationGroup: "main-banquette",
+    });
+  });
+
+  it("rejects an unsupported shape before creating compatibility records", async () => {
+    const response = (await POST(
+      request({
+        storefrontId: "storefront-1",
+        label: "Aster",
+        capacity: 4,
+        shape: "starburst",
+      }) as never,
+    )) as unknown as {
+      status: number;
+      body: { code: string; message: string };
+    };
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Choose a supported table shape.");
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/storefront/admin/hospitality-resources/route.ts
+++ b/apps/web/app/api/storefront/admin/hospitality-resources/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@dpf/db";
+import { prisma, type Prisma } from "@dpf/db";
 
 import { auth } from "@/lib/auth";
 import { apiErrorResponse } from "@/lib/api/error";
 import { newId } from "@/lib/shared/new-id";
+import {
+  serializeRestaurantTableAttributes,
+  validateRestaurantTableAttributesInput,
+} from "@/lib/storefront/restaurant-table-attributes";
 
 function validCapacity(value: unknown): value is number {
   return Number.isInteger(value) && Number(value) >= 1 && Number(value) <= 100;
@@ -32,6 +36,7 @@ export async function GET() {
       capacityUnit: true,
       serviceArea: true,
       blockedReason: true,
+      attributes: true,
       version: true,
       availability: {
         orderBy: { createdAt: "asc" },
@@ -74,6 +79,9 @@ export async function POST(request: NextRequest) {
     label?: string;
     capacity?: number;
     serviceArea?: string | null;
+    shape?: string;
+    combinationGroup?: string | null;
+    combinableWith?: unknown[];
   };
   const label = body.label?.trim();
   if (!body.storefrontId || !label || !validCapacity(body.capacity)) {
@@ -82,6 +90,14 @@ export async function POST(request: NextRequest) {
       "storefrontId, table label, and 1–100 seats are required",
       400,
     );
+  }
+  const attributes = validateRestaurantTableAttributesInput({
+    shape: body.shape ?? "round",
+    combinationGroup: body.combinationGroup ?? null,
+    combinableWith: body.combinableWith ?? [],
+  });
+  if (!attributes.ok) {
+    return apiErrorResponse("INVALID_ARGUMENT", attributes.error, 400);
   }
 
   const config = await prisma.storefrontConfig.findFirst({
@@ -138,6 +154,9 @@ export async function POST(request: NextRequest) {
         capacity: body.capacity,
         capacityUnit: "seats",
         serviceArea: body.serviceArea?.trim() || null,
+        attributes: serializeRestaurantTableAttributes(
+          attributes.value,
+        ) as Prisma.InputJsonValue,
         legacyServiceProviderId: provider.id,
       },
       select: {
@@ -150,6 +169,7 @@ export async function POST(request: NextRequest) {
         capacityUnit: true,
         serviceArea: true,
         blockedReason: true,
+        attributes: true,
         version: true,
       },
     });

--- a/apps/web/components/storefront-admin/HospitalityResourceManager.test.tsx
+++ b/apps/web/components/storefront-admin/HospitalityResourceManager.test.tsx
@@ -43,6 +43,11 @@ describe("HospitalityResourceManager", () => {
             capacityUnit: "seats",
             serviceArea: "Dining room",
             blockedReason: null,
+            attributes: {
+              shape: "booth",
+              combinationGroup: "main-banquette",
+              combinableWith: [],
+            },
             version: 2,
             availability: [
               {
@@ -66,6 +71,11 @@ describe("HospitalityResourceManager", () => {
             capacityUnit: "seats",
             serviceArea: "Patio",
             blockedReason: "Loose leg",
+            attributes: {
+              shape: "round",
+              combinationGroup: null,
+              combinableWith: [],
+            },
             version: 1,
             availability: [],
           },
@@ -76,6 +86,8 @@ describe("HospitalityResourceManager", () => {
     expect(html).toContain("Aster");
     expect(html).toContain("4 seats");
     expect(html).toContain("Dining room");
+    expect(html).toContain("Booth");
+    expect(html).toContain("main-banquette");
     expect(html).toContain("Blocked");
     expect(html).toContain("Loose leg");
     expect(html).toContain("Add table");
@@ -111,6 +123,11 @@ describe("HospitalityResourceManager", () => {
             capacityUnit: "seats",
             serviceArea: "Dining room",
             blockedReason: null,
+            attributes: {
+              shape: "square",
+              combinationGroup: null,
+              combinableWith: [],
+            },
             version: 1,
             availability: [],
           },
@@ -131,6 +148,9 @@ describe("HospitalityResourceManager", () => {
     });
     fireEvent.change(screen.getByLabelText("Service area"), {
       target: { value: "Dining room" },
+    });
+    fireEvent.change(screen.getByLabelText("Table shape"), {
+      target: { value: "square" },
     });
     fireEvent.click(
       screen.getByText("Add table", {
@@ -157,6 +177,11 @@ describe("HospitalityResourceManager", () => {
             capacityUnit: "seats",
             serviceArea: "Dining room",
             blockedReason: "Maintenance",
+            attributes: {
+              shape: "booth",
+              combinationGroup: "main-banquette",
+              combinableWith: [],
+            },
             version: 2,
             availability: [],
           },
@@ -178,6 +203,11 @@ describe("HospitalityResourceManager", () => {
             capacityUnit: "seats",
             serviceArea: "Dining room",
             blockedReason: null,
+            attributes: {
+              shape: "round",
+              combinationGroup: null,
+              combinableWith: [],
+            },
             version: 1,
             availability: [],
           },
@@ -192,8 +222,22 @@ describe("HospitalityResourceManager", () => {
     fireEvent.change(screen.getByLabelText("Why is it blocked?"), {
       target: { value: "Maintenance" },
     });
+    fireEvent.change(screen.getByLabelText("Table shape"), {
+      target: { value: "booth" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Combination group/), {
+      target: { value: "main-banquette" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Save table" }));
 
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+    const fetchMock = vi.mocked(fetch);
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      shape: "booth",
+      combinationGroup: "main-banquette",
+    });
   });
 });

--- a/apps/web/components/storefront-admin/HospitalityResourceManager.tsx
+++ b/apps/web/components/storefront-admin/HospitalityResourceManager.tsx
@@ -3,6 +3,11 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ScheduleEditor } from "./ScheduleEditor";
+import {
+  RESTAURANT_TABLE_SHAPES,
+  type RestaurantTableAttributes,
+  type RestaurantTableShape,
+} from "@/lib/storefront/restaurant-table-attributes";
 
 export interface HospitalityResourceManagerRow {
   id: string;
@@ -14,6 +19,7 @@ export interface HospitalityResourceManagerRow {
   capacityUnit: "seats";
   serviceArea: string | null;
   blockedReason: string | null;
+  attributes: RestaurantTableAttributes;
   version: number;
   availability: Array<{
     id: string;
@@ -48,6 +54,12 @@ function ResourceEditor({
   const [blockedReason, setBlockedReason] = useState(
     resource.blockedReason ?? "",
   );
+  const [shape, setShape] = useState<RestaurantTableShape>(
+    resource.attributes.shape,
+  );
+  const [combinationGroup, setCombinationGroup] = useState(
+    resource.attributes.combinationGroup ?? "",
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -67,6 +79,9 @@ function ResourceEditor({
             status,
             blockedReason:
               status === "blocked" ? blockedReason.trim() || null : null,
+            shape,
+            combinationGroup: combinationGroup.trim() || null,
+            combinableWith: resource.attributes.combinableWith,
             expectedVersion: resource.version,
           }),
         },
@@ -97,6 +112,9 @@ function ResourceEditor({
         <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <strong>{resource.label}</strong>
           <span>{resource.capacity} seats</span>
+          <span className="text-[var(--dpf-muted)]">
+            {shapeLabel(resource.attributes.shape)}
+          </span>
           {resource.serviceArea && (
             <span className="text-[var(--dpf-muted)]">
               {resource.serviceArea}
@@ -113,6 +131,11 @@ function ResourceEditor({
           >
             {statusLabel(resource.status)}
           </span>
+          {resource.attributes.combinationGroup && (
+            <span className="text-[var(--dpf-muted)]">
+              combines in {resource.attributes.combinationGroup}
+            </span>
+          )}
         </span>
         {resource.blockedReason && (
           <span className="mt-1 block text-sm text-[var(--dpf-muted)]">
@@ -149,6 +172,34 @@ function ResourceEditor({
             placeholder="Dining room, patio, bar"
             className="min-h-[44px] rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3"
           />
+        </label>
+        <label className="grid gap-1 text-sm">
+          Table shape
+          <select
+            value={shape}
+            onChange={(event) =>
+              setShape(event.target.value as RestaurantTableShape)
+            }
+            className="min-h-[44px] rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3"
+          >
+            {RESTAURANT_TABLE_SHAPES.map((value) => (
+              <option key={value} value={value}>
+                {shapeLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="grid gap-1 text-sm">
+          Combination group
+          <input
+            value={combinationGroup}
+            onChange={(event) => setCombinationGroup(event.target.value)}
+            placeholder="e.g. main-banquette"
+            className="min-h-[44px] rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3"
+          />
+          <span className="text-xs text-[var(--dpf-muted)]">
+            Tables with the same group may be joined for larger parties.
+          </span>
         </label>
         <label className="grid gap-1 text-sm">
           Status
@@ -218,6 +269,8 @@ export function HospitalityResourceManager({
   const [label, setLabel] = useState("");
   const [capacity, setCapacity] = useState(4);
   const [serviceArea, setServiceArea] = useState("");
+  const [shape, setShape] = useState<RestaurantTableShape>("round");
+  const [combinationGroup, setCombinationGroup] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -239,6 +292,9 @@ export function HospitalityResourceManager({
             label: label.trim(),
             capacity,
             serviceArea: serviceArea.trim() || null,
+            shape,
+            combinationGroup: combinationGroup.trim() || null,
+            combinableWith: [],
           }),
         },
       );
@@ -255,6 +311,8 @@ export function HospitalityResourceManager({
       setLabel("");
       setCapacity(4);
       setServiceArea("");
+      setShape("round");
+      setCombinationGroup("");
       setAdding(false);
       refreshOperationalView();
     } catch {
@@ -317,6 +375,34 @@ export function HospitalityResourceManager({
               className="min-h-[44px] rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3"
             />
           </label>
+          <label className="grid gap-1 text-sm">
+            Table shape
+            <select
+              value={shape}
+              onChange={(event) =>
+                setShape(event.target.value as RestaurantTableShape)
+              }
+              className="min-h-[44px] rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3"
+            >
+              {RESTAURANT_TABLE_SHAPES.map((value) => (
+                <option key={value} value={value}>
+                  {shapeLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm md:col-span-2">
+            Combination group
+            <input
+              value={combinationGroup}
+              onChange={(event) => setCombinationGroup(event.target.value)}
+              placeholder="e.g. main-banquette"
+              className="min-h-[44px] rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3"
+            />
+            <span className="text-xs text-[var(--dpf-muted)]">
+              Give adjacent tables the same group if they can be joined.
+            </span>
+          </label>
           <div className="flex items-center gap-3 md:col-span-3">
             <button
               type="button"
@@ -358,4 +444,8 @@ export function HospitalityResourceManager({
       )}
     </section>
   );
+}
+
+function shapeLabel(shape: RestaurantTableShape): string {
+  return shape.charAt(0).toUpperCase() + shape.slice(1);
 }

--- a/apps/web/components/storefront-admin/TablesNowView.test.tsx
+++ b/apps/web/components/storefront-admin/TablesNowView.test.tsx
@@ -1,0 +1,80 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CartesianSceneCanvasProps } from "@/components/twin/cartesian/CartesianSceneCanvas";
+
+const captured = vi.hoisted(() => ({
+  props: null as CartesianSceneCanvasProps | null,
+}));
+
+vi.mock("@/components/twin/cartesian/CartesianSceneCanvas", () => ({
+  CartesianSceneCanvas: (props: CartesianSceneCanvasProps) => {
+    captured.props = props;
+    return <div>persisted floor canvas</div>;
+  },
+}));
+
+vi.mock("@/lib/twin/operational-scene-layout-actions", () => ({
+  saveOperationalCartesianScene: vi.fn(),
+}));
+
+import { TablesNowView } from "./TablesNowView";
+
+const scene = {
+  id: "scene-1",
+  version: 4,
+  createdFromStarter: false,
+  layout: {
+    schemaVersion: 1 as const,
+    spaceKind: "cartesian-interior" as const,
+    viewport: { x: 0, y: 0, zoom: 1 },
+    zones: [],
+    placements: [
+      {
+        id: "placement-1",
+        entityRef: { kind: "table", id: "table-1" },
+        geometry: {
+          x: 10,
+          y: 20,
+          width: 80,
+          height: 80,
+          rotation: 0,
+          shapeKind: "round-table",
+        },
+      },
+    ],
+  },
+};
+
+describe("TablesNowView persisted restaurant scene", () => {
+  it("binds live table state onto the authored scene and enables versioned layout editing", () => {
+    const html = renderToStaticMarkup(
+      <TablesNowView
+        scene={scene}
+        tables={[
+          {
+            key: "table-1",
+            label: "Aster",
+            seats: 4,
+            state: "turning-soon",
+            freeInMinutes: 8,
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("persisted floor canvas");
+    expect(captured.props?.scene).toBe(scene.layout);
+    expect(captured.props?.persistence).toMatchObject({
+      sceneId: "scene-1",
+      version: 4,
+    });
+    expect(captured.props?.bindings?.["table:table-1"]).toEqual({
+      label: "Aster",
+      statusLabel: "Turning soon",
+      sublabel: "4 seats · Free in 8 min",
+      intent: "warning",
+    });
+    expect(captured.props?.modeOptions).toEqual(["read-only", "configure"]);
+  });
+});

--- a/apps/web/components/storefront-admin/TablesNowView.tsx
+++ b/apps/web/components/storefront-admin/TablesNowView.tsx
@@ -1,112 +1,121 @@
 "use client";
 
-// "Tables right now" — the owner's live capacity, as either a graphical floor
-// plan (the facsimile: which tables are open / turning soon, at a glance) or the
-// legible list. Both render the SAME `RestaurantTable[]` projection, so they
-// reconcile by construction. Floor plan is the default; the list stays for
-// scan-and-act. EP-SPATIAL-OPERATIONAL-VIEWS (BI-287AA5F7) increment 1.
+import { useMemo, useState } from "react";
 
-import { useMemo, useState, type ReactNode } from "react";
-
-import { StatusBadge } from "@/components/ui/report-kit";
-import { FloorPlanCanvas } from "@/components/twin/floor/FloorPlanCanvas";
-import { layoutRestaurantFloor } from "@/lib/storefront/floor-layout";
+import { Notice } from "@/components/ui/report-kit/Notice";
+import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
+import { CartesianSceneCanvas } from "@/components/twin/cartesian/CartesianSceneCanvas";
 import {
   capacityStateIntent,
   capacityStateLabel,
   type RestaurantTable,
 } from "@/lib/storefront/restaurant-capacity";
-
-type View = "floor" | "list";
+import type { CartesianSceneMode } from "@/lib/twin/cartesian-scene";
+import { saveOperationalCartesianScene } from "@/lib/twin/operational-scene-layout-actions";
+import type { RestaurantOperationalScene } from "@/lib/twin/restaurant-scene-layout";
 
 export interface TablesNowViewProps {
   tables: RestaurantTable[];
+  scene: RestaurantOperationalScene | null;
 }
 
-export function TablesNowView({ tables }: TablesNowViewProps) {
-  const [view, setView] = useState<View>("floor");
-  const scene = useMemo(() => layoutRestaurantFloor(tables), [tables]);
+function tableSublabel(table: RestaurantTable): string | undefined {
+  const details = [
+    table.seats != null ? `${table.seats} seats` : null,
+    table.freeInMinutes != null
+      ? `Free in ${table.freeInMinutes} min`
+      : null,
+  ].filter((detail): detail is string => detail !== null);
+  return details.length > 0 ? details.join(" · ") : undefined;
+}
+
+export function TablesNowView({ tables, scene }: TablesNowViewProps) {
+  const [mode, setMode] = useState<CartesianSceneMode>("read-only");
+  const bindings = useMemo(
+    () =>
+      Object.fromEntries(
+        tables.map((table) => {
+          const sublabel = tableSublabel(table);
+          return [
+            `table:${table.key}`,
+            {
+              label: table.label,
+              statusLabel: capacityStateLabel(table.state),
+              ...(sublabel ? { sublabel } : {}),
+              intent: capacityStateIntent(table.state),
+            },
+          ];
+        }),
+      ),
+    [tables],
+  );
 
   return (
-    <div className="border border-[var(--dpf-border)]" style={{ borderRadius: 10, overflow: "hidden" }}>
-      <div
-        className="bg-[var(--dpf-surface-1)] border-b border-[var(--dpf-border)]"
-        style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px" }}
-      >
-        <div style={{ flex: 1, fontSize: 13, fontWeight: 600 }}>Tables right now</div>
-        <div role="tablist" aria-label="Table view" style={{ display: "flex", gap: 4 }}>
-          <ViewTab current={view} value="floor" onSelect={setView}>
-            Floor plan
-          </ViewTab>
-          <ViewTab current={view} value="list" onSelect={setView}>
-            List
-          </ViewTab>
-        </div>
+    <section
+      aria-labelledby="tables-now-heading"
+      className="grid gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      <div>
+        <h2 id="tables-now-heading" className="text-sm font-semibold">
+          Tables right now
+        </h2>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          Live state is joined onto the saved floor. Choose Adjust layout to
+          move tables without changing reservations.
+        </p>
       </div>
 
-      {view === "floor" ? (
-        <FloorPlanCanvas scene={scene} />
+      {scene ? (
+        <CartesianSceneCanvas
+          ariaLabel="Restaurant floor"
+          scene={scene.layout}
+          bindings={bindings}
+          mode={mode}
+          modeOptions={["read-only", "configure"]}
+          onModeChange={setMode}
+          persistence={{
+            sceneId: scene.id,
+            version: scene.version,
+            onSave: saveOperationalCartesianScene,
+          }}
+          empty={
+            <p className="text-dpf-body text-dpf-muted">
+              No tables are configured yet.
+            </p>
+          }
+        />
       ) : (
-        <div>
-          {tables.map((t) => (
-            <div
-              key={t.key}
-              className="border-b border-[var(--dpf-border)]"
-              style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px" }}
-            >
-              <div style={{ flex: 1, fontSize: 14 }}>
-                {t.label}
-                {t.seats != null && (
-                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
-                    {" "}
-                    · {t.seats} seats
-                  </span>
-                )}
-              </div>
-              {t.state === "turning-soon" && t.freeInMinutes != null && (
-                <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
-                  free in {t.freeInMinutes}m
+        <>
+          <Notice variant="warn" title="Floor layout unavailable">
+            The saved floor could not be loaded. Table state remains available
+            in the list while the layout is repaired.
+          </Notice>
+          <ul
+            aria-label="Restaurant table state"
+            className="grid gap-2"
+          >
+            {tables.map((table) => (
+              <li
+                key={table.key}
+                className="flex min-h-11 items-center gap-3 rounded-md border border-[var(--dpf-border)] px-3"
+              >
+                <span className="flex-1">
+                  {table.label}
+                  {table.seats != null ? ` · ${table.seats} seats` : ""}
+                  {table.freeInMinutes != null
+                    ? ` · free in ${table.freeInMinutes} min`
+                    : ""}
                 </span>
-              )}
-              <StatusBadge
-                intent={capacityStateIntent(t.state)}
-                label={capacityStateLabel(t.state)}
-                variant="soft"
-              />
-            </div>
-          ))}
-        </div>
+                <StatusBadge
+                  intent={capacityStateIntent(table.state)}
+                  label={capacityStateLabel(table.state)}
+                  variant="soft"
+                />
+              </li>
+            ))}
+          </ul>
+        </>
       )}
-    </div>
-  );
-}
-
-function ViewTab({
-  current,
-  value,
-  onSelect,
-  children,
-}: {
-  current: View;
-  value: View;
-  onSelect: (v: View) => void;
-  children: ReactNode;
-}) {
-  const active = current === value;
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={() => onSelect(value)}
-      className={
-        active
-          ? "bg-[var(--dpf-accent)] text-white"
-          : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border border-[var(--dpf-border)]"
-      }
-      style={{ padding: "4px 10px", borderRadius: 6, fontSize: 12, fontWeight: 600, cursor: "pointer" }}
-    >
-      {children}
-    </button>
+    </section>
   );
 }

--- a/apps/web/components/storefront/CustomerRestaurantAvailability.test.tsx
+++ b/apps/web/components/storefront/CustomerRestaurantAvailability.test.tsx
@@ -1,0 +1,129 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { CustomerRestaurantAvailability } from "./CustomerRestaurantAvailability";
+
+describe("CustomerRestaurantAvailability", () => {
+  it("shows honest current and forward table capacity in customer language", () => {
+    const html = renderToStaticMarkup(
+      <CustomerRestaurantAvailability
+        availability={{
+          asOf: "2026-07-31T18:14:00.000Z",
+          summary: {
+            totalTables: 3,
+            availableNow: 1,
+            availableSoon: 1,
+          },
+          tables: [
+            {
+              key: "availability-1",
+              capacity: 2,
+              shape: "round",
+              serviceArea: "Main dining",
+              availability: {
+                kind: "now",
+                availableAt: "2026-07-31T18:14:00.000Z",
+                minutes: 0,
+                explanation: "Available now",
+              },
+            },
+            {
+              key: "availability-2",
+              capacity: 4,
+              shape: "booth",
+              serviceArea: "Window",
+              availability: {
+                kind: "at",
+                availableAt: "2026-07-31T18:35:00.000Z",
+                minutes: 21,
+                explanation: "Available in about 21 minutes",
+              },
+            },
+            {
+              key: "availability-3",
+              capacity: 6,
+              shape: "rectangle",
+              serviceArea: "Patio",
+              availability: {
+                kind: "unavailable",
+                availableAt: null,
+                minutes: null,
+                explanation: "Availability will be confirmed when you book",
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Table availability");
+    expect(html).toContain("1 table available now");
+    expect(html).toContain("Seats up to 2");
+    expect(html).toContain("Available in about 21 minutes");
+    expect(html).toContain("Availability will be confirmed when you book");
+    expect(html).toContain("Live estimate");
+  });
+
+  it("does not render operator-only facts even if they appear on the source object", () => {
+    const availability = {
+      asOf: "2026-07-31T18:14:00.000Z",
+      summary: { totalTables: 1, availableNow: 1, availableSoon: 0 },
+      tables: [
+        {
+          key: "availability-1",
+          capacity: 2,
+          shape: "square" as const,
+          serviceArea: "Main dining",
+          availability: {
+            kind: "now" as const,
+            availableAt: "2026-07-31T18:14:00.000Z",
+            minutes: 0,
+            explanation: "Available now",
+          },
+          party: { name: "Private Guest" },
+          server: { name: "Private Server" },
+          internalTableId: "persisted-table-123",
+        },
+      ],
+    };
+
+    const html = renderToStaticMarkup(
+      <CustomerRestaurantAvailability availability={availability} />,
+    );
+
+    expect(html).not.toContain("Private Guest");
+    expect(html).not.toContain("Private Server");
+    expect(html).not.toContain("persisted-table-123");
+  });
+
+  it("bounds the public detail list while keeping the full venue count honest", () => {
+    const html = renderToStaticMarkup(
+      <CustomerRestaurantAvailability
+        availability={{
+          asOf: "2026-07-31T18:14:00.000Z",
+          summary: {
+            totalTables: 14,
+            availableNow: 14,
+            availableSoon: 0,
+          },
+          tables: Array.from({ length: 14 }, (_, index) => ({
+            key: `availability-${index + 1}`,
+            capacity: index + 1,
+            shape: "square" as const,
+            serviceArea: "Main dining",
+            availability: {
+              kind: "now" as const,
+              availableAt: "2026-07-31T18:14:00.000Z",
+              minutes: 0,
+              explanation: "Available now",
+            },
+          })),
+        }}
+      />,
+    );
+
+    expect(html).toContain("12 of 14 table options shown");
+    expect(html).toContain("Seats up to 12");
+    expect(html).not.toContain("Seats up to 13");
+  });
+});

--- a/apps/web/components/storefront/CustomerRestaurantAvailability.tsx
+++ b/apps/web/components/storefront/CustomerRestaurantAvailability.tsx
@@ -1,0 +1,139 @@
+import type { CustomerRestaurantAvailability as CustomerAvailability } from "@/lib/twin/restaurant-floor-projection";
+
+const PUBLIC_TABLE_DETAIL_LIMIT = 12;
+
+function availableNowLabel(count: number): string {
+  return `${count} table${count === 1 ? "" : "s"} available now`;
+}
+
+/**
+ * Public, read-only restaurant capacity summary.
+ *
+ * Render only the explicit public DTO. Do not accept the operator projection:
+ * this component is the final presentation boundary protecting party, staffing,
+ * and persisted table identity from public serialization.
+ */
+export function CustomerRestaurantAvailability({
+  availability,
+}: {
+  availability: CustomerAvailability;
+}) {
+  const visibleTables = availability.tables.slice(
+    0,
+    PUBLIC_TABLE_DETAIL_LIMIT,
+  );
+  const detailsAreBounded =
+    availability.tables.length > PUBLIC_TABLE_DETAIL_LIMIT;
+
+  return (
+    <section
+      aria-labelledby="customer-table-availability"
+      style={{
+        marginBottom: 20,
+        padding: "16px",
+        borderRadius: 10,
+        border: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <h2
+          id="customer-table-availability"
+          style={{
+            margin: 0,
+            color: "var(--dpf-text)",
+            fontSize: 16,
+            fontWeight: 700,
+          }}
+        >
+          Table availability
+        </h2>
+        <span style={{ color: "var(--dpf-muted)", fontSize: 12 }}>
+          Live estimate
+        </span>
+      </div>
+
+      <p
+        style={{
+          color: "var(--dpf-text)",
+          fontSize: 14,
+          lineHeight: 1.5,
+          margin: "8px 0 12px",
+        }}
+      >
+        {availableNowLabel(availability.summary.availableNow)}
+        {availability.summary.availableSoon > 0
+          ? ` · ${availability.summary.availableSoon} expected soon`
+          : ""}
+      </p>
+
+      <ul
+        style={{
+          display: "grid",
+          gap: 8,
+          listStyle: "none",
+          margin: 0,
+          padding: 0,
+        }}
+      >
+        {visibleTables.map((table) => (
+          <li
+            key={table.key}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 12,
+              padding: "10px 12px",
+              borderRadius: 8,
+              background: "var(--dpf-surface-2)",
+              color: "var(--dpf-text)",
+              fontSize: 13,
+            }}
+          >
+            <span>
+              <strong>Seats up to {table.capacity}</strong>
+              {table.serviceArea ? ` · ${table.serviceArea}` : ""}
+            </span>
+            <span style={{ color: "var(--dpf-muted)", textAlign: "right" }}>
+              {table.availability.explanation}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {detailsAreBounded ? (
+        <p
+          style={{
+            color: "var(--dpf-muted)",
+            fontSize: 12,
+            lineHeight: 1.5,
+            margin: "10px 0 0",
+          }}
+        >
+          {visibleTables.length} of {availability.tables.length} table options
+          shown. All available tables are considered when you choose a time.
+        </p>
+      ) : null}
+
+      <p
+        style={{
+          color: "var(--dpf-muted)",
+          fontSize: 12,
+          lineHeight: 1.5,
+          margin: "12px 0 0",
+        }}
+      >
+        Estimates can change while you choose a time. Your table is confirmed
+        during booking.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/components/twin/TwinView.tsx
+++ b/apps/web/components/twin/TwinView.tsx
@@ -12,7 +12,7 @@
 // feed are all kit primitives; only the vocabulary and which-template come from
 // the profile.
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import type { TwinProfile } from "@dpf/storefront-templates";
 import type { OperationalCommandResult } from "@/lib/twin/operations-command";
@@ -41,13 +41,21 @@ export interface TwinViewProps {
   className?: string;
   /** Durable command closure supplied by an archetype adapter. */
   onConfirmCog?: () => Promise<OperationalCommandResult>;
+  /** Authored physical scene replacing the generic resource-unit grid. */
+  physicalScene?: ReactNode;
 }
 
 function titleCase(s: string): string {
   return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
 }
 
-export function TwinView({ profile, snapshot, className = "", onConfirmCog }: TwinViewProps) {
+export function TwinView({
+  profile,
+  snapshot,
+  className = "",
+  onConfirmCog,
+  physicalScene,
+}: TwinViewProps) {
   const [cogStatus, setCogStatus] = useState<
     "idle" | "pending" | "confirmed" | "conflict" | "rejected" | "unsupported"
   >(onConfirmCog ? "idle" : "unsupported");
@@ -154,17 +162,25 @@ export function TwinView({ profile, snapshot, className = "", onConfirmCog }: Tw
       <div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
         {/* Left: the operation itself — zones of resource units + work in flight. */}
         <div className="flex flex-col gap-3">
-          <div className={zoneWrapClass}>
-            {snapshot.zones.map((zone) => (
-              <TwinZone
-                key={zone.key}
-                label={zoneLabel(zone.key)}
-                meta={zone.meta ?? `${zone.units.length} ${profile.resourceNoun.plural}`}
-              >
-                <ResourceUnitGrid units={zone.units} className="!grid-cols-2" />
-              </TwinZone>
-            ))}
-          </div>
+          {physicalScene ?? (
+            <div className={zoneWrapClass}>
+              {snapshot.zones.map((zone) => (
+                <TwinZone
+                  key={zone.key}
+                  label={zoneLabel(zone.key)}
+                  meta={
+                    zone.meta ??
+                    `${zone.units.length} ${profile.resourceNoun.plural}`
+                  }
+                >
+                  <ResourceUnitGrid
+                    units={zone.units}
+                    className="!grid-cols-2"
+                  />
+                </TwinZone>
+              ))}
+            </div>
+          )}
 
           {snapshot.workItems.length > 0 ? (
             <TwinZone label={titleCase(profile.workItemNoun.plural)}>

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RestaurantFloorOperationsProps } from "./RestaurantFloorOperations";
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  advance: vi.fn(),
+  move: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}));
+
+vi.mock("@/lib/twin/restaurant-floor-actions", () => ({
+  executeRestaurantFloorCommand: mocks.execute,
+  advanceRestaurantServiceTurn: mocks.advance,
+  moveRestaurantParty: mocks.move,
+}));
+
+vi.mock("@/components/twin/cartesian/CartesianSceneCanvas", () => ({
+  CartesianSceneCanvas: () => <div>interactive floor canvas</div>,
+}));
+
+import { RestaurantFloorOperations } from "./RestaurantFloorOperations";
+
+const props: RestaurantFloorOperationsProps = {
+  scene: null,
+  view: {
+    floor: {
+      asOf: "2026-07-31T18:14:00.000Z",
+      staffingAvailable: true,
+      tables: [
+        {
+          id: "table-1",
+          label: "Table 1",
+          capacity: 2,
+          serviceArea: "Main dining",
+          shape: "square",
+          combinableWith: [],
+          combinationGroup: "main",
+          combinedWith: [],
+          state: "available",
+          statusLabel: "Available",
+          blockedReason: null,
+          timing: null,
+          availability: {
+            kind: "now",
+            availableAt: "2026-07-31T18:14:00.000Z",
+            minutes: 0,
+            reason: "Available for seating now",
+          },
+          party: null,
+          turn: null,
+          server: {
+            id: "assignment-1",
+            name: "Jordan Rivera",
+            sectionLabel: "Main dining",
+            tableCount: 3,
+          },
+        },
+      ],
+      demand: [
+        {
+          id: "booking-waiting",
+          kind: "walk-in",
+          name: "Alex Kim",
+          covers: 2,
+          waitedMinutes: 14,
+          scheduledAt: "2026-07-31T18:14:00.000Z",
+          hasDietaryNote: true,
+          vip: false,
+          compatibleTableIds: ["table-1"],
+          recommendation: {
+            tableIds: ["table-1"],
+            reason: "Table 1 fits 2 and is open now.",
+            warning: null,
+          },
+        },
+      ],
+    },
+    commands: [
+      {
+        demandId: "booking-waiting",
+        options: [
+          {
+            resourceIds: ["table-1"],
+            label: "Table 1",
+            expectedVersion: "restaurant-seat.v1-current",
+            interval: {
+              startsAt: "2026-07-31T18:14:00.000Z",
+              endsAt: "2026-07-31T19:14:00.000Z",
+            },
+          },
+        ],
+      },
+    ],
+    moves: [],
+    telemetry: {
+      durationMs: 12.5,
+      queryCount: 6,
+      payloadBytes: 2_048,
+    },
+  },
+};
+
+describe("RestaurantFloorOperations", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.execute.mockReset();
+    mocks.advance.mockReset();
+    mocks.move.mockReset();
+    mocks.refresh.mockReset();
+    mocks.execute.mockResolvedValue({
+      status: "confirmed",
+      idempotencyKey: "seat-key",
+      replayed: false,
+      newVersion: "restaurant-turn:HT-1:1",
+      changedFacts: [
+        { entityId: "booking-waiting", field: "status", value: "seated" },
+        {
+          entityId: "booking-waiting",
+          field: "resourceIds",
+          value: "table-1",
+        },
+      ],
+    });
+    mocks.advance.mockResolvedValue({
+      status: "confirmed",
+      idempotencyKey: "turn-paid-key",
+      replayed: false,
+      newVersion: "restaurant-turn:HT-1:3",
+      changedFacts: [
+        { entityId: "turn-1", field: "stage", value: "paid" },
+      ],
+    });
+    mocks.move.mockResolvedValue({
+      status: "confirmed",
+      idempotencyKey: "move-key",
+      replayed: false,
+      newVersion: "restaurant-turn:HT-1:3",
+      changedFacts: [
+        { entityId: "turn-1", field: "resourceIds", value: "table-2" },
+      ],
+    });
+  });
+
+  it("provides equivalent list controls for selecting and confirming a table", async () => {
+    render(<RestaurantFloorOperations {...props} />);
+
+    expect(screen.getByText(/waiting 14 min/)).toBeTruthy();
+    expect(screen.getAllByText("Jordan Rivera").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /Alex Kim/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+
+    expect(screen.getByText(/Seat Alex Kim \(2\) at Table 1/)).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm seating" }),
+    );
+
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledTimes(1));
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedVersion: "restaurant-seat.v1-current",
+        entityRefs: {
+          demandId: "booking-waiting",
+          resourceIds: ["table-1"],
+        },
+      }),
+    );
+    await waitFor(() => expect(mocks.refresh).toHaveBeenCalled());
+    expect(screen.getByText("Party seated")).toBeTruthy();
+  });
+
+  it("keeps compatibility and assignment state in text, not color alone", () => {
+    render(<RestaurantFloorOperations {...props} />);
+
+    expect(screen.getByText("Available")).toBeTruthy();
+    expect(screen.getByText("Available for seating now")).toBeTruthy();
+    expect(screen.getByText("Walk-in")).toBeTruthy();
+    expect(screen.getByText("3 tables")).toBeTruthy();
+  });
+
+  it("advances an occupied table through the service lifecycle", async () => {
+    const occupiedProps: RestaurantFloorOperationsProps = {
+      ...props,
+      view: {
+        ...props.view,
+        floor: {
+          ...props.view.floor,
+          demand: [],
+          tables: [
+            {
+              ...props.view.floor.tables[0],
+              state: "ordered",
+              statusLabel: "Ordered",
+              availability: {
+                kind: "at",
+                availableAt: "2026-07-31T19:14:00.000Z",
+                minutes: 60,
+                reason: "Current party is still dining",
+              },
+              party: {
+                id: "booking-seated",
+                name: "Morgan Lee",
+                covers: 2,
+              },
+              turn: {
+                id: "turn-1",
+                turnId: "HT-1",
+                stage: "ordered",
+                version: 2,
+              },
+            },
+            {
+              ...props.view.floor.tables[0],
+              id: "table-2",
+              label: "Table 2",
+              party: null,
+              turn: null,
+            },
+          ],
+        },
+        commands: [],
+        moves: [
+          {
+            demandId: "booking-seated",
+            serviceTurnId: "turn-1",
+            expectedTurnVersion: 2,
+            options: [
+              {
+                resourceIds: ["table-2"],
+                label: "Table 2",
+                expectedVersion: "restaurant-seat.v1-move",
+                interval: {
+                  startsAt: "2026-07-31T18:14:00.000Z",
+                  endsAt: "2026-07-31T19:14:00.000Z",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    render(<RestaurantFloorOperations {...occupiedProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "Mark paid" }));
+
+    await waitFor(() => expect(mocks.advance).toHaveBeenCalledTimes(1));
+    expect(mocks.advance).toHaveBeenCalledWith({
+      idempotencyKey: expect.stringMatching(/^turn:turn-1:paid:/),
+      serviceTurnId: "turn-1",
+      expectedVersion: 2,
+      stage: "paid",
+    });
+    await waitFor(() => expect(mocks.refresh).toHaveBeenCalled());
+    expect(screen.getByText("Table status updated")).toBeTruthy();
+  });
+
+  it("previews and confirms moving an active party to a compatible table", async () => {
+    const moveProps: RestaurantFloorOperationsProps = {
+      ...props,
+      view: {
+        ...props.view,
+        floor: {
+          ...props.view.floor,
+          demand: [],
+          tables: [
+            {
+              ...props.view.floor.tables[0],
+              state: "seated",
+              statusLabel: "Seated",
+              party: {
+                id: "booking-seated",
+                name: "Morgan Lee",
+                covers: 2,
+              },
+              turn: {
+                id: "turn-1",
+                turnId: "HT-1",
+                stage: "seated",
+                version: 2,
+              },
+            },
+            {
+              ...props.view.floor.tables[0],
+              id: "table-2",
+              label: "Table 2",
+              party: null,
+              turn: null,
+            },
+          ],
+        },
+        commands: [],
+        moves: [
+          {
+            demandId: "booking-seated",
+            serviceTurnId: "turn-1",
+            expectedTurnVersion: 2,
+            options: [
+              {
+                resourceIds: ["table-2"],
+                label: "Table 2",
+                expectedVersion: "restaurant-seat.v1-move",
+                interval: {
+                  startsAt: "2026-07-31T18:14:00.000Z",
+                  endsAt: "2026-07-31T19:14:00.000Z",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    render(<RestaurantFloorOperations {...moveProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "Move party" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Move to Table 2" }),
+    );
+    expect(screen.getByText(/Move Morgan Lee to Table 2/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm move" }));
+
+    await waitFor(() => expect(mocks.move).toHaveBeenCalledTimes(1));
+    expect(mocks.move).toHaveBeenCalledWith({
+      idempotencyKey: expect.stringMatching(/^move:turn-1:/),
+      serviceTurnId: "turn-1",
+      expectedTurnVersion: 2,
+      expectedSeatingVersion: "restaurant-seat.v1-move",
+      interval: {
+        startsAt: "2026-07-31T18:14:00.000Z",
+        endsAt: "2026-07-31T19:14:00.000Z",
+      },
+      resourceIds: ["table-2"],
+    });
+  });
+});

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -1,0 +1,635 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  DataTable,
+  type Column,
+} from "@/components/ui/report-kit/DataTable";
+import { Notice } from "@/components/ui/report-kit/Notice";
+import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
+import { resolveIntent } from "@/components/ui/report-kit/statusColors";
+import { CartesianSceneCanvas } from "@/components/twin/cartesian/CartesianSceneCanvas";
+import type {
+  RestaurantFloorCommandDemand,
+  RestaurantFloorCommandOption,
+  RestaurantFloorOperationalView,
+} from "@/lib/twin/restaurant-floor-loader.server";
+import {
+  advanceRestaurantServiceTurn,
+  executeRestaurantFloorCommand,
+  moveRestaurantParty,
+} from "@/lib/twin/restaurant-floor-actions";
+import type { HospitalityServiceTurnStage } from "@/lib/storefront/hospitality-service-turn";
+import type { RestaurantOperationalScene } from "@/lib/twin/restaurant-scene-layout";
+import type { RestaurantFloorTable } from "@/lib/twin/restaurant-floor-projection";
+import type { OperationalCommandResult } from "@/lib/twin/operations-command";
+
+export interface RestaurantFloorOperationsProps {
+  view: RestaurantFloorOperationalView;
+  scene: RestaurantOperationalScene | null;
+}
+
+function commandFor(
+  commands: readonly RestaurantFloorCommandDemand[],
+  demandId: string | null,
+): RestaurantFloorCommandDemand | null {
+  return commands.find((command) => command.demandId === demandId) ?? null;
+}
+
+function resultNotice(result: OperationalCommandResult | null) {
+  if (!result) return null;
+  if (result.status === "confirmed") {
+    const stageChanged = result.changedFacts.some(
+      (fact) => fact.field === "stage",
+    );
+    const resourcesChanged = result.changedFacts.some(
+      (fact) => fact.field === "resourceIds",
+    );
+    const partySeated = result.changedFacts.some(
+      (fact) => fact.field === "status" && fact.value === "seated",
+    );
+    return (
+      <Notice
+        variant="success"
+        title={
+          stageChanged
+            ? "Table status updated"
+            : partySeated
+              ? "Party seated"
+              : resourcesChanged
+              ? "Party moved"
+                : "Party seated"
+        }
+      >
+        {stageChanged
+          ? "The service stage is confirmed and the live floor is refreshing."
+          : partySeated
+            ? "The table assignment is confirmed and the live floor is refreshing."
+            : resourcesChanged
+            ? "The new table assignment is confirmed and the live floor is refreshing."
+              : "The table assignment is confirmed and the live floor is refreshing."}
+      </Notice>
+    );
+  }
+  if (result.status === "conflict") {
+    return (
+      <Notice variant="warn" title="Floor changed before confirmation">
+        <span>
+          Nothing changed.{" "}
+          {result.alternatives.length > 0
+            ? `Available alternatives: ${result.alternatives
+                .map((alternative) => alternative.label)
+                .join(", ")}.`
+            : "Review the refreshed table choices and confirm again."}
+        </span>
+      </Notice>
+    );
+  }
+  return (
+    <Notice variant="warn" title="Assignment not made">
+      {result.message}
+    </Notice>
+  );
+}
+
+function nextTurnAction(
+  stage: HospitalityServiceTurnStage,
+): { stage: HospitalityServiceTurnStage; label: string } | null {
+  switch (stage) {
+    case "seated":
+      return { stage: "ordered", label: "Mark ordered" };
+    case "ordered":
+      return { stage: "paid", label: "Mark paid" };
+    case "paid":
+      return { stage: "dirty", label: "Mark needs clearing" };
+    case "dirty":
+      return { stage: "closed", label: "Mark cleared" };
+    default:
+      return null;
+  }
+}
+
+export function RestaurantFloorOperations({
+  view,
+  scene,
+}: RestaurantFloorOperationsProps) {
+  const router = useRouter();
+  const [selectedDemandId, setSelectedDemandId] = useState<string | null>(null);
+  const [selectedOption, setSelectedOption] =
+    useState<RestaurantFloorCommandOption | null>(null);
+  const [result, setResult] = useState<OperationalCommandResult | null>(null);
+  const [selectedMoveTurnId, setSelectedMoveTurnId] =
+    useState<string | null>(null);
+  const [selectedMoveOption, setSelectedMoveOption] =
+    useState<RestaurantFloorCommandOption | null>(null);
+  const [pending, startTransition] = useTransition();
+  const selectedDemand = view.floor.demand.find(
+    (demand) => demand.id === selectedDemandId,
+  ) ?? null;
+  const availableCommand = commandFor(view.commands, selectedDemandId);
+  const selectedMoveCommand =
+    (view.moves ?? []).find(
+      (move) => move.serviceTurnId === selectedMoveTurnId,
+    ) ?? null;
+
+  const bindings = useMemo(
+    () =>
+      Object.fromEntries(
+        view.floor.tables.map((table) => [
+          `table:${table.id}`,
+          {
+            label: table.label,
+            statusLabel: table.statusLabel,
+            sublabel: [
+              `${table.capacity} seats`,
+              table.server?.name ?? "Server not assigned",
+              table.availability.minutes != null
+                ? `${table.availability.minutes} min`
+                : null,
+            ]
+              .filter((value): value is string => value !== null)
+              .join(" · "),
+            intent: resolveIntent("restaurantFloor", table.state),
+          },
+        ]),
+      ),
+    [view.floor.tables],
+  );
+
+  const chooseDemand = (demandId: string) => {
+    setSelectedDemandId(demandId);
+    setSelectedOption(null);
+    setResult(null);
+  };
+  const chooseTable = (resourceId: string) => {
+    if (!availableCommand) return;
+    const option = availableCommand.options.find((candidate) =>
+      candidate.resourceIds.includes(resourceId)
+    );
+    if (option) {
+      setSelectedOption(option);
+      setResult(null);
+    }
+  };
+
+  const tableColumns = useMemo<Column<RestaurantFloorTable>[]>(
+    () => [
+      {
+        key: "table",
+        header: "Table",
+        cell: (table) => (
+          <span>
+            <span className="block font-medium">{table.label}</span>
+            <span className="text-xs text-[var(--dpf-muted)]">
+              {table.capacity} seats · {table.serviceArea}
+            </span>
+          </span>
+        ),
+        sortAccessor: (table) => table.label,
+      },
+      {
+        key: "state",
+        header: "State",
+        cell: (table) => (
+          <StatusBadge
+            intent={resolveIntent("restaurantFloor", table.state)}
+            label={table.statusLabel}
+            variant="soft"
+          />
+        ),
+        sortAccessor: (table) => table.statusLabel,
+      },
+      {
+        key: "server",
+        header: "Server",
+        cell: (table) => table.server?.name ?? "Not assigned",
+      },
+      {
+        key: "availability",
+        header: "Next availability",
+        cell: (table) => table.availability.reason,
+      },
+      {
+        key: "action",
+        header: "Assignment",
+        cell: (table) => {
+          const option = availableCommand?.options.find((candidate) =>
+            candidate.resourceIds.includes(table.id)
+          );
+          const selected = selectedOption?.resourceIds.includes(table.id);
+          return option ? (
+            <button
+              type="button"
+              aria-pressed={selected}
+              className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-sm font-medium hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={pending}
+              onClick={() => chooseTable(table.id)}
+            >
+              {selected ? "Selected" : "Choose"}
+            </button>
+          ) : (
+            <span className="text-xs text-[var(--dpf-muted)]">
+              {selectedDemand ? "Not compatible" : "Choose a party first"}
+            </span>
+          );
+        },
+      },
+    ],
+    [availableCommand, pending, selectedDemand, selectedOption],
+  );
+
+  const servers = [
+    ...new Map(
+      view.floor.tables.flatMap((table) =>
+        table.server ? [[table.server.id, table.server] as const] : []
+      ),
+    ).values(),
+  ];
+  const activeTurns = [
+    ...new Map(
+      view.floor.tables.flatMap((table) =>
+        table.turn
+          ? [[
+              table.turn.id,
+              {
+                ...table.turn,
+                party: table.party,
+                tableLabels: view.floor.tables
+                  .filter(
+                    (candidate) => candidate.turn?.id === table.turn?.id,
+                  )
+                  .map((candidate) => candidate.label),
+              },
+            ] as const]
+          : []
+      ),
+    ).values(),
+  ];
+  const selectedMoveTurn =
+    activeTurns.find((turn) => turn.id === selectedMoveTurnId) ?? null;
+
+  const confirm = () => {
+    if (!selectedDemand || !selectedOption) return;
+    const idempotencyKey =
+      `seat:${selectedDemand.id}:${Date.now()}:${crypto.randomUUID()}`;
+    startTransition(async () => {
+      const next = await executeRestaurantFloorCommand({
+        kind: "assign",
+        idempotencyKey,
+        expectedVersion: selectedOption.expectedVersion,
+        interval: selectedOption.interval,
+        entityRefs: {
+          demandId: selectedDemand.id,
+          resourceIds: selectedOption.resourceIds,
+        },
+      });
+      setResult(next);
+      if (next.status === "confirmed") {
+        setSelectedDemandId(null);
+        setSelectedOption(null);
+        router.refresh();
+      }
+    });
+  };
+
+  const advanceTurn = (
+    turn: (typeof activeTurns)[number],
+    next: { stage: HospitalityServiceTurnStage; label: string },
+  ) => {
+    const idempotencyKey =
+      `turn:${turn.id}:${next.stage}:${turn.version}:${crypto.randomUUID()}`;
+    startTransition(async () => {
+      const nextResult = await advanceRestaurantServiceTurn({
+        idempotencyKey,
+        serviceTurnId: turn.id,
+        expectedVersion: turn.version,
+        stage: next.stage,
+      });
+      setResult(nextResult);
+      if (nextResult.status === "confirmed") router.refresh();
+    });
+  };
+
+  const confirmMove = () => {
+    if (!selectedMoveCommand || !selectedMoveOption) return;
+    const idempotencyKey =
+      `move:${selectedMoveCommand.serviceTurnId}:${selectedMoveCommand.expectedTurnVersion}:${crypto.randomUUID()}`;
+    startTransition(async () => {
+      const nextResult = await moveRestaurantParty({
+        idempotencyKey,
+        serviceTurnId: selectedMoveCommand.serviceTurnId,
+        expectedTurnVersion: selectedMoveCommand.expectedTurnVersion,
+        expectedSeatingVersion: selectedMoveOption.expectedVersion,
+        interval: selectedMoveOption.interval,
+        resourceIds: selectedMoveOption.resourceIds,
+      });
+      setResult(nextResult);
+      if (nextResult.status === "confirmed") {
+        setSelectedMoveTurnId(null);
+        setSelectedMoveOption(null);
+        router.refresh();
+      }
+    });
+  };
+
+  return (
+    <section
+      aria-labelledby="restaurant-floor-heading"
+      className="grid gap-4"
+      data-testid="restaurant-floor-operations"
+    >
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 id="restaurant-floor-heading" className="text-lg font-semibold">
+            Floor right now
+          </h2>
+          <p className="text-sm text-[var(--dpf-muted)]">
+            Choose a waiting party, review compatible tables, then confirm.
+          </p>
+        </div>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          Updated {new Date(view.floor.asOf).toLocaleTimeString()}
+        </p>
+      </header>
+
+      {resultNotice(result)}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="grid min-w-0 gap-4">
+          {scene ? (
+            <CartesianSceneCanvas
+              ariaLabel="Live restaurant floor"
+              scene={scene.layout}
+              bindings={bindings}
+              mode="operate"
+              onActivate={(_placementId, entityRef) => {
+                if (entityRef.kind === "table") chooseTable(entityRef.id);
+              }}
+              height={500}
+            />
+          ) : (
+            <Notice variant="warn" title="Floor drawing unavailable">
+              Use the equivalent table list below while the saved layout is
+              repaired.
+            </Notice>
+          )}
+
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">
+              All tables
+            </h3>
+            <DataTable
+              columns={tableColumns}
+              rows={view.floor.tables}
+              getRowKey={(table) => table.id}
+              empty="No tables are configured."
+              dense
+            />
+          </div>
+        </div>
+
+        <aside className="grid content-start gap-4">
+          {activeTurns.length > 0 ? (
+            <section
+              aria-labelledby="active-tables-heading"
+              className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+            >
+              <h3 id="active-tables-heading" className="text-sm font-semibold">
+                Active tables
+              </h3>
+              <ul className="mt-2 grid gap-2">
+                {activeTurns.map((turn) => {
+                  const next = nextTurnAction(turn.stage);
+                  const move = (view.moves ?? []).find(
+                    (candidate) => candidate.serviceTurnId === turn.id,
+                  );
+                  const choosingMove = selectedMoveTurnId === turn.id;
+                  return (
+                    <li
+                      key={turn.id}
+                      className="rounded-md border border-[var(--dpf-border)] p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <span>
+                          <span className="block font-medium">
+                            {turn.tableLabels.join(" + ")}
+                          </span>
+                          <span className="text-xs text-[var(--dpf-muted)]">
+                            {turn.party
+                              ? `${turn.party.name} · ${turn.party.covers} guests`
+                              : "Party details unavailable"}
+                          </span>
+                        </span>
+                        <StatusBadge
+                          intent={resolveIntent(
+                            "restaurantFloor",
+                            turn.stage,
+                          )}
+                          label={
+                            turn.stage === "dirty"
+                              ? "Needs clearing"
+                              : turn.stage.charAt(0).toUpperCase() +
+                                turn.stage.slice(1)
+                          }
+                          variant="soft"
+                        />
+                      </div>
+                      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                        {next ? (
+                          <button
+                            type="button"
+                            className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-sm font-semibold hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={pending}
+                            onClick={() => advanceTurn(turn, next)}
+                          >
+                            {pending ? "Updating…" : next.label}
+                          </button>
+                        ) : null}
+                        {move && move.options.length > 0 ? (
+                          <button
+                            type="button"
+                            aria-expanded={choosingMove}
+                            className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-sm font-semibold hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={pending}
+                            onClick={() => {
+                              setSelectedMoveTurnId(
+                                choosingMove ? null : turn.id,
+                              );
+                              setSelectedMoveOption(null);
+                              setResult(null);
+                            }}
+                          >
+                            Move party
+                          </button>
+                        ) : null}
+                      </div>
+                      {choosingMove && move ? (
+                        <div className="mt-2 grid gap-2">
+                          <p className="text-xs text-[var(--dpf-muted)]">
+                            Choose a compatible destination:
+                          </p>
+                          {move.options.map((option) => (
+                            <button
+                              key={option.resourceIds.join(",")}
+                              type="button"
+                              className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-left text-sm hover:bg-[var(--dpf-surface-2)]"
+                              onClick={() => setSelectedMoveOption(option)}
+                            >
+                              Move to {option.label}
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ) : null}
+
+          {selectedMoveCommand &&
+          selectedMoveTurn &&
+          selectedMoveOption ? (
+            <section
+              aria-labelledby="move-preview-heading"
+              className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-3"
+            >
+              <h3 id="move-preview-heading" className="text-sm font-semibold">
+                Confirm table move
+              </h3>
+              <p className="mt-2 text-sm">
+                Move {selectedMoveTurn.party?.name ?? "this party"} to{" "}
+                {selectedMoveOption.label}.
+              </p>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                Their current table will be released only after the new
+                assignment commits.
+              </p>
+              <button
+                type="button"
+                className="mt-3 min-h-11 w-full rounded-md bg-[var(--dpf-accent)] px-4 font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={pending}
+                onClick={confirmMove}
+              >
+                {pending ? "Moving…" : "Confirm move"}
+              </button>
+            </section>
+          ) : null}
+
+          <section
+            aria-labelledby="waiting-parties-heading"
+            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+          >
+            <h3 id="waiting-parties-heading" className="text-sm font-semibold">
+              Waiting parties
+            </h3>
+            {view.floor.demand.length === 0 ? (
+              <p className="mt-2 text-sm text-[var(--dpf-muted)]">
+                No party is waiting.
+              </p>
+            ) : (
+              <ul className="mt-2 grid gap-2">
+                {view.floor.demand.map((demand) => (
+                  <li key={demand.id}>
+                    <button
+                      type="button"
+                      aria-pressed={selectedDemandId === demand.id}
+                      className="flex min-h-12 w-full items-center justify-between gap-3 rounded-md border border-[var(--dpf-border)] px-3 py-2 text-left hover:bg-[var(--dpf-surface-2)]"
+                      onClick={() => chooseDemand(demand.id)}
+                    >
+                      <span>
+                        <span className="block font-medium">{demand.name}</span>
+                        <span className="text-xs text-[var(--dpf-muted)]">
+                          {demand.covers} guests
+                          {demand.waitedMinutes != null
+                            ? ` · waiting ${demand.waitedMinutes} min`
+                            : ""}
+                          {demand.hasDietaryNote
+                            ? " · dietary note"
+                            : ""}
+                        </span>
+                      </span>
+                      <StatusBadge
+                        intent={
+                          demand.waitedMinutes != null &&
+                            demand.waitedMinutes >= 15
+                            ? "warning"
+                            : "info"
+                        }
+                        label={demand.kind === "walk-in" ? "Walk-in" : "Reserved"}
+                        variant="soft"
+                      />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section
+            aria-labelledby="server-load-heading"
+            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+          >
+            <h3 id="server-load-heading" className="text-sm font-semibold">
+              Server load
+            </h3>
+            {servers.length === 0 ? (
+              <p className="mt-2 text-sm text-[var(--dpf-muted)]">
+                Server not assigned.
+              </p>
+            ) : (
+              <ul className="mt-2 grid gap-2">
+                {servers.map((server) => (
+                  <li
+                    key={server.id}
+                    className="flex min-h-11 items-center justify-between rounded-md border border-[var(--dpf-border)] px-3"
+                  >
+                    <span>
+                      <span className="block font-medium">{server.name}</span>
+                      <span className="text-xs text-[var(--dpf-muted)]">
+                        {server.sectionLabel}
+                      </span>
+                    </span>
+                    <span className="text-sm">{server.tableCount} tables</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {selectedDemand && selectedOption ? (
+            <section
+              aria-labelledby="assignment-preview-heading"
+              className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-3"
+            >
+              <h3
+                id="assignment-preview-heading"
+                className="text-sm font-semibold"
+              >
+                Confirm assignment
+              </h3>
+              <p className="mt-2 text-sm">
+                Seat {selectedDemand.name} ({selectedDemand.covers}) at{" "}
+                {selectedOption.label}.
+              </p>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                This starts the table turn and removes the party from the
+                waiting queue.
+              </p>
+              <button
+                type="button"
+                className="mt-3 min-h-11 w-full rounded-md bg-[var(--dpf-accent)] px-4 font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={pending}
+                onClick={confirm}
+              >
+                {pending ? "Confirming…" : "Confirm seating"}
+              </button>
+            </section>
+          ) : null}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/twin/twin-view.test.tsx
+++ b/apps/web/components/twin/twin-view.test.tsx
@@ -60,4 +60,21 @@ describe("TwinView — one renderer, both lenses", () => {
     expect(html).toContain("Needs you");
     expect(html).toContain("Activity");
   });
+
+  it("uses the shared physical-scene slot instead of rendering a duplicate resource grid", () => {
+    const profile = deriveTwinProfile(byCategory("food-hospitality"));
+    const snapshot = buildDemoTwinSnapshot(profile);
+    const hiddenGridLabel = snapshot.zones[0]?.units[0]?.label;
+    const html = renderToStaticMarkup(
+      <TwinView
+        profile={profile}
+        snapshot={snapshot}
+        physicalScene={<div>Authored restaurant floor</div>}
+      />,
+    );
+
+    expect(html).toContain("Authored restaurant floor");
+    if (hiddenGridLabel) expect(html).not.toContain(hiddenGridLabel);
+    expect(html).toContain("Waitlist");
+  });
 });

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -64,6 +64,19 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     "turning-soon": "warning",
     blocked: "danger",
   },
+  // Restaurant host-stand state. Physical scene, equivalent table list, and
+  // command preview share this vocabulary; text labels always accompany color.
+  restaurantFloor: {
+    available: "success",
+    held: "warning",
+    reserved: "accent",
+    seated: "info",
+    ordered: "info",
+    paid: "warning",
+    dirty: "warning",
+    blocked: "danger",
+    "late-turn": "danger",
+  },
   // Service-period readiness — "are we ready for the next service?" (BI-7C95A586).
   servicePeriodReadiness: {
     ready: "success",

--- a/apps/web/components/workspace-home/WorkspaceTwinPanel.test.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinPanel.test.tsx
@@ -1,0 +1,136 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { TwinViewProps } from "@/components/twin/TwinView";
+import type { CartesianSceneCanvasProps } from "@/components/twin/cartesian/CartesianSceneCanvas";
+import type { RestaurantFloorOperationsProps } from "@/components/twin/restaurant/RestaurantFloorOperations";
+import type { WorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
+
+const captured = vi.hoisted(() => ({
+  twin: null as TwinViewProps | null,
+  canvas: null as CartesianSceneCanvasProps | null,
+  restaurant: null as RestaurantFloorOperationsProps | null,
+}));
+
+vi.mock("@/components/twin", () => ({
+  TwinView: (props: TwinViewProps) => {
+    captured.twin = props;
+    return <div>{props.physicalScene}</div>;
+  },
+}));
+
+vi.mock("@/components/twin/cartesian/CartesianSceneCanvas", () => ({
+  CartesianSceneCanvas: (props: CartesianSceneCanvasProps) => {
+    captured.canvas = props;
+    return <div>workspace floor</div>;
+  },
+}));
+
+vi.mock("@/components/twin/restaurant/RestaurantFloorOperations", () => ({
+  RestaurantFloorOperations: (props: RestaurantFloorOperationsProps) => {
+    captured.restaurant = props;
+    return <div>live restaurant host stand</div>;
+  },
+}));
+
+import { WorkspaceTwinPanel } from "./WorkspaceTwinPanel";
+
+describe("WorkspaceTwinPanel restaurant scene", () => {
+  it("uses the business-grade host stand when the live restaurant view is loaded", () => {
+    const presentation = {
+      restaurantFloor: {
+        floor: {
+          asOf: "2026-07-31T18:14:00.000Z",
+          staffingAvailable: true,
+          tables: [],
+          demand: [],
+        },
+        commands: [],
+        moves: [],
+      },
+      scene: null,
+    } as unknown as WorkspaceTwinPresentation;
+
+    const html = renderToStaticMarkup(
+      <WorkspaceTwinPanel presentation={presentation} />,
+    );
+
+    expect(html).toContain("live restaurant host stand");
+    expect(captured.restaurant?.view).toBe(presentation.restaurantFloor);
+  });
+
+  it("replaces the generic resource grid with the authored floor and live bindings", () => {
+    const presentation = {
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      profile: {
+        template: "FLOOR",
+        physical: true,
+      },
+      snapshot: {
+        capacityChips: [],
+        zones: [
+          {
+            key: "dining-room",
+            units: [
+              {
+                key: "table-1",
+                label: "Aster",
+                state: "Occupied",
+                intent: "info",
+                sublabel: "4 seats",
+              },
+            ],
+          },
+        ],
+        workItems: [],
+        queues: [],
+        presence: [],
+        feed: [],
+        quests: [],
+        utility: [],
+      },
+      operations: null,
+      demo: false,
+      scene: {
+        id: "scene-1",
+        version: 2,
+        createdFromStarter: false,
+        layout: {
+          schemaVersion: 1,
+          spaceKind: "cartesian-interior",
+          viewport: { x: 0, y: 0, zoom: 1 },
+          zones: [],
+          placements: [
+            {
+              id: "placement-1",
+              entityRef: { kind: "table", id: "table-1" },
+              geometry: {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 80,
+                rotation: 0,
+                shapeKind: "round-table",
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as WorkspaceTwinPresentation;
+
+    const html = renderToStaticMarkup(
+      <WorkspaceTwinPanel presentation={presentation} />,
+    );
+
+    expect(html).toContain("workspace floor");
+    expect(captured.twin?.physicalScene).toBeTruthy();
+    expect(captured.canvas?.mode).toBe("read-only");
+    expect(captured.canvas?.bindings?.["table:table-1"]).toEqual({
+      label: "Aster",
+      statusLabel: "Occupied",
+      sublabel: "4 seats",
+      intent: "info",
+    });
+  });
+});

--- a/apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
@@ -8,7 +8,10 @@
 // Plan: docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
 
 import { TwinView } from "@/components/twin";
+import { CartesianSceneCanvas } from "@/components/twin/cartesian/CartesianSceneCanvas";
+import { RestaurantFloorOperations } from "@/components/twin/restaurant/RestaurantFloorOperations";
 import type { WorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
+import type { CartesianScenePresentationMap } from "@/lib/twin/cartesian-scene";
 
 export interface WorkspaceTwinPanelProps {
   presentation: WorkspaceTwinPresentation;
@@ -16,6 +19,40 @@ export interface WorkspaceTwinPanelProps {
 }
 
 export function WorkspaceTwinPanel({ presentation, className = "" }: WorkspaceTwinPanelProps) {
+  if (presentation.restaurantFloor) {
+    return (
+      <div className={className}>
+        <RestaurantFloorOperations
+          view={presentation.restaurantFloor}
+          scene={presentation.scene}
+        />
+      </div>
+    );
+  }
+
+  const bindings: CartesianScenePresentationMap = Object.fromEntries(
+    presentation.snapshot.zones.flatMap((zone) =>
+      zone.units.map((unit) => [
+        `table:${unit.key}`,
+        {
+          label: unit.label,
+          statusLabel: unit.state,
+          ...(unit.sublabel ? { sublabel: unit.sublabel } : {}),
+          intent: unit.intent ?? "neutral",
+        },
+      ]),
+    ),
+  );
+  const physicalScene = presentation.scene ? (
+    <CartesianSceneCanvas
+      ariaLabel="Restaurant floor"
+      scene={presentation.scene.layout}
+      bindings={bindings}
+      mode="read-only"
+      height={500}
+    />
+  ) : undefined;
+
   return (
     <div className={`flex flex-col gap-3 ${className}`.trim()}>
       {presentation.demo ? (
@@ -30,7 +67,11 @@ export function WorkspaceTwinPanel({ presentation, className = "" }: WorkspaceTw
           Demo data — live business projection pending
         </p>
       ) : null}
-      <TwinView profile={presentation.profile} snapshot={presentation.snapshot} />
+      <TwinView
+        profile={presentation.profile}
+        snapshot={presentation.snapshot}
+        physicalScene={physicalScene}
+      />
     </div>
   );
 }

--- a/apps/web/lib/govern/data/assets.test.ts
+++ b/apps/web/lib/govern/data/assets.test.ts
@@ -145,6 +145,16 @@ describe("seeded registry", () => {
         "HospitalityCapacityAllocation",
         "metadata",
       ],
+      [
+        "data:hospitality-service-turn",
+        "HospitalityServiceTurn",
+        "metadata",
+      ],
+      [
+        "data:hospitality-service-turn-event",
+        "HospitalityServiceTurnEvent",
+        "metadata",
+      ],
     ] as const) {
       expect(lookupAsset(DATA_ASSET_REGISTRY, assetId)).toMatchObject({
         physical: { prismaModel },

--- a/apps/web/lib/govern/data/hospitality-capacity-assets.ts
+++ b/apps/web/lib/govern/data/hospitality-capacity-assets.ts
@@ -57,6 +57,14 @@ export const HOSPITALITY_CAPACITY_ASSETS: readonly DataAssetDefinition[] = [
         "data:hospitality-capacity-allocation",
         "HospitalityCapacityAllocation",
       ],
+      [
+        "data:hospitality-service-turn",
+        "HospitalityServiceTurn",
+      ],
+      [
+        "data:hospitality-service-turn-event",
+        "HospitalityServiceTurnEvent",
+      ],
     ],
     ["operational"],
     "metadata",

--- a/apps/web/lib/storefront/hospitality-capacity-repository.server.ts
+++ b/apps/web/lib/storefront/hospitality-capacity-repository.server.ts
@@ -72,6 +72,7 @@ export async function allocateHospitalityCapacity(
     demandRef: string;
     bookingId: string | null;
     bookingHoldId: string | null;
+    serviceTurnId?: string | null;
     startsAt: Date;
     endsAt: Date;
     quantity: number;
@@ -227,6 +228,7 @@ export async function allocateHospitalityCapacity(
       poolId: input.poolId,
       bookingId: input.bookingId,
       bookingHoldId: input.bookingHoldId,
+      serviceTurnId: input.serviceTurnId ?? null,
       demandType: input.demandType,
       demandRef: input.demandRef,
       startsAt: input.startsAt,

--- a/apps/web/lib/storefront/hospitality-service-turn-repository.server.test.ts
+++ b/apps/web/lib/storefront/hospitality-service-turn-repository.server.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createHospitalityServiceTurn,
+  transitionHospitalityServiceTurnRecord,
+} from "./hospitality-service-turn-repository.server";
+import { HospitalityServiceTurnVersionError } from "./hospitality-service-turn";
+
+describe("hospitality service turn repository", () => {
+  it("creates one seated turn with its first append-only event", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const create = vi.fn().mockImplementation(async ({ data }) => data);
+    const database = {
+      hospitalityServiceTurn: {
+        findFirst,
+        create,
+        updateMany: vi.fn(),
+      },
+      hospitalityServiceTurnEvent: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+      },
+    };
+
+    const result = await createHospitalityServiceTurn(database, {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      bookingId: "booking-1",
+      staffingAssignmentId: "assignment-1",
+      demandType: "booking",
+      demandRef: "BOOK-1",
+      startedAt: new Date("2026-07-31T18:00:00.000Z"),
+      expectedEndAt: new Date("2026-07-31T19:15:00.000Z"),
+      actorRef: "employee-1",
+      idempotencyKey: "seat-booking-1",
+    });
+
+    expect(result).toMatchObject({
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      bookingId: "booking-1",
+      staffingAssignmentId: "assignment-1",
+      demandType: "booking",
+      demandRef: "BOOK-1",
+      stage: "seated",
+      version: 1,
+      events: {
+        create: {
+          organizationId: "org-1",
+          idempotencyKey: "seat-booking-1",
+          eventType: "stage-transition",
+          fromStage: null,
+          toStage: "seated",
+          atVersion: 1,
+          actorRef: "employee-1",
+        },
+      },
+    });
+    expect(create.mock.calls[0][0].data.turnId).toMatch(/^HT-/);
+    expect(
+      create.mock.calls[0][0].data.events.create.eventId,
+    ).toMatch(/^HTE-/);
+  });
+
+  it("returns the existing demand turn instead of creating a duplicate", async () => {
+    const existing = { id: "turn-1", turnId: "HT-EXISTING" };
+    const create = vi.fn();
+    const database = {
+      hospitalityServiceTurn: {
+        findFirst: vi.fn().mockResolvedValue(existing),
+        create,
+        updateMany: vi.fn(),
+      },
+      hospitalityServiceTurnEvent: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+      },
+    };
+
+    await expect(
+      createHospitalityServiceTurn(database, {
+        organizationId: "org-1",
+        storefrontId: "store-1",
+        bookingId: null,
+        staffingAssignmentId: null,
+        demandType: "manual",
+        demandRef: "WALKIN-1",
+        startedAt: new Date("2026-07-31T18:00:00.000Z"),
+        expectedEndAt: new Date("2026-07-31T19:00:00.000Z"),
+        actorRef: "employee-1",
+        idempotencyKey: "seat-walkin-1",
+      }),
+    ).resolves.toBe(existing);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("advances the expected version and appends the matching event", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const createEvent = vi.fn().mockImplementation(async ({ data }) => data);
+    const database = {
+      hospitalityServiceTurn: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "turn-1",
+          stage: "ordered",
+          version: 2,
+          startedAt: new Date("2026-07-31T18:00:00.000Z"),
+          expectedEndAt: new Date("2026-07-31T19:15:00.000Z"),
+          closedAt: null,
+        }),
+        create: vi.fn(),
+        updateMany,
+      },
+      hospitalityServiceTurnEvent: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: createEvent,
+      },
+    };
+
+    await expect(
+      transitionHospitalityServiceTurnRecord(database, {
+        organizationId: "org-1",
+        serviceTurnId: "turn-1",
+        expectedVersion: 2,
+        stage: "paid",
+        at: new Date("2026-07-31T19:02:00.000Z"),
+        actorRef: "employee-1",
+        idempotencyKey: "turn-paid-1",
+      }),
+    ).resolves.toMatchObject({ stage: "paid", version: 3, replayed: false });
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "turn-1",
+        organizationId: "org-1",
+        version: 2,
+        stage: "ordered",
+      },
+      data: {
+        stage: "paid",
+        version: { increment: 1 },
+        closedAt: null,
+      },
+    });
+    expect(createEvent).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org-1",
+        serviceTurnId: "turn-1",
+        idempotencyKey: "turn-paid-1",
+        eventType: "stage-transition",
+        fromStage: "ordered",
+        toStage: "paid",
+        atVersion: 3,
+        actorRef: "employee-1",
+      }),
+    });
+  });
+
+  it("does not append evidence when the optimistic update loses a race", async () => {
+    const createEvent = vi.fn();
+    const database = {
+      hospitalityServiceTurn: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "turn-1",
+          stage: "ordered",
+          version: 2,
+          startedAt: new Date("2026-07-31T18:00:00.000Z"),
+          expectedEndAt: new Date("2026-07-31T19:15:00.000Z"),
+          closedAt: null,
+        }),
+        create: vi.fn(),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      hospitalityServiceTurnEvent: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: createEvent,
+      },
+    };
+
+    await expect(
+      transitionHospitalityServiceTurnRecord(database, {
+        organizationId: "org-1",
+        serviceTurnId: "turn-1",
+        expectedVersion: 2,
+        stage: "paid",
+        at: new Date("2026-07-31T19:02:00.000Z"),
+        actorRef: "employee-1",
+        idempotencyKey: "turn-paid-race",
+      }),
+    ).rejects.toBeInstanceOf(HospitalityServiceTurnVersionError);
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it("replays an already-recorded transition without mutating the turn again", async () => {
+    const updateMany = vi.fn();
+    const createEvent = vi.fn();
+    const database = {
+      hospitalityServiceTurn: {
+        findFirst: vi.fn(),
+        create: vi.fn(),
+        updateMany,
+      },
+      hospitalityServiceTurnEvent: {
+        findFirst: vi.fn().mockResolvedValue({
+          serviceTurnId: "turn-1",
+          fromStage: "ordered",
+          toStage: "paid",
+          atVersion: 3,
+          occurredAt: new Date("2026-07-31T19:02:00.000Z"),
+          serviceTurn: {
+            id: "turn-1",
+            startedAt: new Date("2026-07-31T18:00:00.000Z"),
+            expectedEndAt: new Date("2026-07-31T19:15:00.000Z"),
+          },
+        }),
+        create: createEvent,
+      },
+    };
+
+    await expect(
+      transitionHospitalityServiceTurnRecord(database, {
+        organizationId: "org-1",
+        serviceTurnId: "turn-1",
+        expectedVersion: 2,
+        stage: "paid",
+        at: new Date("2026-07-31T19:02:00.000Z"),
+        actorRef: "employee-1",
+        idempotencyKey: "turn-paid-1",
+      }),
+    ).resolves.toMatchObject({
+      id: "turn-1",
+      stage: "paid",
+      version: 3,
+      closedAt: null,
+      replayed: true,
+    });
+    expect(database.hospitalityServiceTurn.findFirst).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/storefront/hospitality-service-turn-repository.server.ts
+++ b/apps/web/lib/storefront/hospitality-service-turn-repository.server.ts
@@ -1,0 +1,272 @@
+import { newId } from "@/lib/shared/new-id";
+
+import type { HospitalityDemandType } from "./hospitality-capacity";
+import {
+  HospitalityServiceTurnVersionError,
+  transitionHospitalityServiceTurn,
+  type HospitalityServiceTurnFact,
+  type HospitalityServiceTurnStage,
+} from "./hospitality-service-turn";
+
+interface HospitalityServiceTurnDatabase {
+  hospitalityServiceTurn: {
+    findFirst(args: unknown): Promise<
+      | (HospitalityServiceTurnFact & {
+        turnId?: string;
+      })
+      | null
+    >;
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  hospitalityServiceTurnEvent: {
+    findFirst(args: unknown): Promise<{
+      serviceTurnId: string;
+      fromStage: HospitalityServiceTurnStage | null;
+      toStage: HospitalityServiceTurnStage | null;
+      atVersion: number;
+      occurredAt: Date;
+      serviceTurn: {
+        id: string;
+        startedAt: Date;
+        expectedEndAt: Date;
+      };
+    } | null>;
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+  };
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "P2002"
+  );
+}
+
+function assertServiceInterval(startsAt: Date, expectedEndAt: Date): void {
+  if (
+    !(startsAt instanceof Date) ||
+    !(expectedEndAt instanceof Date) ||
+    !Number.isFinite(startsAt.getTime()) ||
+    !Number.isFinite(expectedEndAt.getTime())
+  ) {
+    throw new TypeError("Hospitality service turn interval must use valid dates");
+  }
+  if (expectedEndAt.getTime() <= startsAt.getTime()) {
+    throw new RangeError(
+      "Hospitality service turn expected end must be after start",
+    );
+  }
+}
+
+function assertIdempotencyKey(value: string): void {
+  if (!/^[A-Za-z0-9._:-]{8,160}$/.test(value)) {
+    throw new TypeError(
+      "Hospitality service turn idempotency key must be 8-160 stable characters",
+    );
+  }
+}
+
+/**
+ * Creates the one service-turn aggregate for a demand. The nested first event
+ * is written atomically by Prisma. A competing first writer resolves through
+ * the unique demand identity and returns the turn it created.
+ */
+export async function createHospitalityServiceTurn(
+  database: HospitalityServiceTurnDatabase,
+  input: {
+    organizationId: string;
+    storefrontId: string;
+    bookingId: string | null;
+    staffingAssignmentId: string | null;
+    demandType: HospitalityDemandType;
+    demandRef: string;
+    startedAt: Date;
+    expectedEndAt: Date;
+    actorRef: string;
+    idempotencyKey: string;
+    detail?: Record<string, unknown>;
+  },
+): Promise<unknown> {
+  assertServiceInterval(input.startedAt, input.expectedEndAt);
+  assertIdempotencyKey(input.idempotencyKey);
+  if (!input.demandRef.trim()) {
+    throw new TypeError("Hospitality service turn demand reference is required");
+  }
+
+  const demandIdentity = {
+    storefrontId: input.storefrontId,
+    demandType: input.demandType,
+    demandRef: input.demandRef,
+  };
+  const existing = await database.hospitalityServiceTurn.findFirst({
+    where: {
+      organizationId: input.organizationId,
+      ...demandIdentity,
+    },
+  });
+  if (existing) return existing;
+
+  try {
+    return await database.hospitalityServiceTurn.create({
+      data: {
+        turnId: `HT-${newId(12).toUpperCase()}`,
+        organizationId: input.organizationId,
+        storefrontId: input.storefrontId,
+        bookingId: input.bookingId,
+        staffingAssignmentId: input.staffingAssignmentId,
+        demandType: input.demandType,
+        demandRef: input.demandRef,
+        stage: "seated",
+        startedAt: input.startedAt,
+        expectedEndAt: input.expectedEndAt,
+        version: 1,
+        events: {
+          create: {
+            eventId: `HTE-${newId(12).toUpperCase()}`,
+            organizationId: input.organizationId,
+            idempotencyKey: input.idempotencyKey,
+            eventType: "stage-transition",
+            fromStage: null,
+            toStage: "seated",
+            atVersion: 1,
+            actorRef: input.actorRef,
+            detail: input.detail,
+          },
+        },
+      },
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const winner = await database.hospitalityServiceTurn.findFirst({
+      where: {
+        organizationId: input.organizationId,
+        ...demandIdentity,
+      },
+    });
+    if (winner) return winner;
+    throw error;
+  }
+}
+
+/**
+ * Advances a turn and appends matching evidence. Call this with a Prisma
+ * transaction client so a later event-write failure rolls back the version
+ * update rather than leaving unaudited state.
+ */
+export async function transitionHospitalityServiceTurnRecord(
+  database: HospitalityServiceTurnDatabase,
+  input: {
+    organizationId: string;
+    serviceTurnId: string;
+    expectedVersion: number;
+    stage: HospitalityServiceTurnStage;
+    at: Date;
+    actorRef: string;
+    idempotencyKey: string;
+    detail?: Record<string, unknown>;
+  },
+): Promise<HospitalityServiceTurnFact & { replayed: boolean }> {
+  assertIdempotencyKey(input.idempotencyKey);
+  const prior = await database.hospitalityServiceTurnEvent.findFirst({
+    where: {
+      organizationId: input.organizationId,
+      idempotencyKey: input.idempotencyKey,
+    },
+    select: {
+      serviceTurnId: true,
+      fromStage: true,
+      toStage: true,
+      atVersion: true,
+      occurredAt: true,
+      serviceTurn: {
+        select: {
+          id: true,
+          startedAt: true,
+          expectedEndAt: true,
+        },
+      },
+    },
+  });
+  if (prior) {
+    if (
+      prior.serviceTurnId !== input.serviceTurnId ||
+      prior.toStage !== input.stage
+    ) {
+      throw new Error(
+        "Hospitality service turn idempotency key belongs to a different transition",
+      );
+    }
+    return {
+      id: prior.serviceTurn.id,
+      stage: input.stage,
+      version: prior.atVersion,
+      startedAt: prior.serviceTurn.startedAt,
+      expectedEndAt: prior.serviceTurn.expectedEndAt,
+      closedAt:
+        input.stage === "closed" || input.stage === "cancelled"
+          ? prior.occurredAt
+          : null,
+      replayed: true,
+    };
+  }
+
+  const current = await database.hospitalityServiceTurn.findFirst({
+    where: {
+      id: input.serviceTurnId,
+      organizationId: input.organizationId,
+    },
+    select: {
+      id: true,
+      stage: true,
+      version: true,
+      startedAt: true,
+      expectedEndAt: true,
+      closedAt: true,
+    },
+  });
+  if (!current) {
+    throw new Error("Hospitality service turn was not found");
+  }
+
+  const next = transitionHospitalityServiceTurn(current, {
+    expectedVersion: input.expectedVersion,
+    stage: input.stage,
+    at: input.at,
+  });
+  const updated = await database.hospitalityServiceTurn.updateMany({
+    where: {
+      id: input.serviceTurnId,
+      organizationId: input.organizationId,
+      version: input.expectedVersion,
+      stage: current.stage,
+    },
+    data: {
+      stage: next.stage,
+      version: { increment: 1 },
+      closedAt: next.closedAt,
+    },
+  });
+  if (updated.count !== 1) {
+    throw new HospitalityServiceTurnVersionError(input.expectedVersion, -1);
+  }
+
+  await database.hospitalityServiceTurnEvent.create({
+    data: {
+      eventId: `HTE-${newId(12).toUpperCase()}`,
+      organizationId: input.organizationId,
+      serviceTurnId: input.serviceTurnId,
+      idempotencyKey: input.idempotencyKey,
+      eventType: "stage-transition",
+      fromStage: current.stage,
+      toStage: next.stage,
+      atVersion: next.version,
+      actorRef: input.actorRef,
+      detail: input.detail,
+      occurredAt: input.at,
+    },
+  });
+  return { ...next, replayed: false };
+}

--- a/apps/web/lib/storefront/hospitality-service-turn.test.ts
+++ b/apps/web/lib/storefront/hospitality-service-turn.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HospitalityServiceTurnVersionError,
+  transitionHospitalityServiceTurn,
+  type HospitalityServiceTurnFact,
+} from "./hospitality-service-turn";
+
+const startedAt = new Date("2026-07-31T18:00:00.000Z");
+
+function turn(
+  overrides: Partial<HospitalityServiceTurnFact> = {},
+): HospitalityServiceTurnFact {
+  return {
+    id: "turn-1",
+    stage: "seated",
+    version: 1,
+    startedAt,
+    expectedEndAt: new Date("2026-07-31T19:15:00.000Z"),
+    closedAt: null,
+    ...overrides,
+  };
+}
+
+describe("hospitality service turn lifecycle", () => {
+  it("uses one versioned progression from seating through reset", () => {
+    const ordered = transitionHospitalityServiceTurn(turn(), {
+      expectedVersion: 1,
+      stage: "ordered",
+      at: new Date("2026-07-31T18:12:00.000Z"),
+    });
+    const paid = transitionHospitalityServiceTurn(ordered, {
+      expectedVersion: 2,
+      stage: "paid",
+      at: new Date("2026-07-31T19:02:00.000Z"),
+    });
+    const dirty = transitionHospitalityServiceTurn(paid, {
+      expectedVersion: 3,
+      stage: "dirty",
+      at: new Date("2026-07-31T19:08:00.000Z"),
+    });
+    const closed = transitionHospitalityServiceTurn(dirty, {
+      expectedVersion: 4,
+      stage: "closed",
+      at: new Date("2026-07-31T19:14:00.000Z"),
+    });
+
+    expect(closed).toMatchObject({
+      stage: "closed",
+      version: 5,
+      closedAt: new Date("2026-07-31T19:14:00.000Z"),
+    });
+  });
+
+  it("allows an operator to close a turn from paid when reset is immediate", () => {
+    expect(
+      transitionHospitalityServiceTurn(turn({ stage: "paid", version: 3 }), {
+        expectedVersion: 3,
+        stage: "closed",
+        at: new Date("2026-07-31T19:04:00.000Z"),
+      }),
+    ).toMatchObject({ stage: "closed", version: 4 });
+  });
+
+  it("rejects stale, backwards, skipped, and terminal transitions", () => {
+    expect(() =>
+      transitionHospitalityServiceTurn(turn(), {
+        expectedVersion: 9,
+        stage: "ordered",
+        at: startedAt,
+      })
+    ).toThrow(HospitalityServiceTurnVersionError);
+
+    expect(() =>
+      transitionHospitalityServiceTurn(turn({ stage: "ordered", version: 2 }), {
+        expectedVersion: 2,
+        stage: "seated",
+        at: startedAt,
+      })
+    ).toThrow("Invalid hospitality service turn transition ordered -> seated");
+
+    expect(() =>
+      transitionHospitalityServiceTurn(turn(), {
+        expectedVersion: 1,
+        stage: "dirty",
+        at: startedAt,
+      })
+    ).toThrow("Invalid hospitality service turn transition seated -> dirty");
+
+    expect(() =>
+      transitionHospitalityServiceTurn(
+        turn({ stage: "closed", version: 5, closedAt: startedAt }),
+        {
+          expectedVersion: 5,
+          stage: "cancelled",
+          at: startedAt,
+        },
+      )
+    ).toThrow("Hospitality service turn turn-1 is terminal (closed)");
+  });
+
+  it("permits cancellation before payment and records closure time", () => {
+    expect(
+      transitionHospitalityServiceTurn(turn({ stage: "ordered", version: 2 }), {
+        expectedVersion: 2,
+        stage: "cancelled",
+        at: new Date("2026-07-31T18:20:00.000Z"),
+      }),
+    ).toMatchObject({
+      stage: "cancelled",
+      version: 3,
+      closedAt: new Date("2026-07-31T18:20:00.000Z"),
+    });
+  });
+});

--- a/apps/web/lib/storefront/hospitality-service-turn.ts
+++ b/apps/web/lib/storefront/hospitality-service-turn.ts
@@ -1,0 +1,90 @@
+export const HOSPITALITY_SERVICE_TURN_STAGES = [
+  "seated",
+  "ordered",
+  "paid",
+  "dirty",
+  "closed",
+  "cancelled",
+] as const;
+
+export type HospitalityServiceTurnStage =
+  (typeof HOSPITALITY_SERVICE_TURN_STAGES)[number];
+
+export interface HospitalityServiceTurnFact {
+  id: string;
+  stage: HospitalityServiceTurnStage;
+  version: number;
+  startedAt: Date;
+  expectedEndAt: Date;
+  closedAt: Date | null;
+}
+
+export class HospitalityServiceTurnVersionError extends Error {
+  readonly code = "HOSPITALITY_SERVICE_TURN_VERSION_CONFLICT";
+
+  constructor(
+    readonly expectedVersion: number,
+    readonly actualVersion: number,
+  ) {
+    super(
+      `Hospitality service turn version conflict: expected ${expectedVersion}, actual ${actualVersion}`,
+    );
+    this.name = "HospitalityServiceTurnVersionError";
+  }
+}
+
+const TERMINAL_STAGES = new Set<HospitalityServiceTurnStage>([
+  "closed",
+  "cancelled",
+]);
+
+const ALLOWED_TRANSITIONS: Record<
+  HospitalityServiceTurnStage,
+  readonly HospitalityServiceTurnStage[]
+> = {
+  seated: ["ordered", "cancelled"],
+  ordered: ["paid", "cancelled"],
+  paid: ["dirty", "closed"],
+  dirty: ["closed"],
+  closed: [],
+  cancelled: [],
+};
+
+export function transitionHospitalityServiceTurn(
+  current: HospitalityServiceTurnFact,
+  input: {
+    expectedVersion: number;
+    stage: HospitalityServiceTurnStage;
+    at: Date;
+  },
+): HospitalityServiceTurnFact {
+  if (current.version !== input.expectedVersion) {
+    throw new HospitalityServiceTurnVersionError(
+      input.expectedVersion,
+      current.version,
+    );
+  }
+  if (
+    !(input.at instanceof Date) ||
+    !Number.isFinite(input.at.getTime())
+  ) {
+    throw new TypeError("Hospitality service turn transition time is invalid");
+  }
+  if (TERMINAL_STAGES.has(current.stage)) {
+    throw new Error(
+      `Hospitality service turn ${current.id} is terminal (${current.stage})`,
+    );
+  }
+  if (!ALLOWED_TRANSITIONS[current.stage].includes(input.stage)) {
+    throw new Error(
+      `Invalid hospitality service turn transition ${current.stage} -> ${input.stage}`,
+    );
+  }
+
+  return {
+    ...current,
+    stage: input.stage,
+    version: current.version + 1,
+    closedAt: TERMINAL_STAGES.has(input.stage) ? input.at : null,
+  };
+}

--- a/apps/web/lib/storefront/restaurant-seating.test.ts
+++ b/apps/web/lib/storefront/restaurant-seating.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateRestaurantSeating,
+  findRestaurantSeatingAlternatives,
+  restaurantSeatingVersion,
+  type RestaurantSeatingAllocationFact,
+  type RestaurantSeatingResourceFact,
+} from "./restaurant-seating";
+
+const startsAt = new Date("2026-07-31T18:00:00.000Z");
+const endsAt = new Date("2026-07-31T19:15:00.000Z");
+
+function table(
+  id: string,
+  overrides: Partial<RestaurantSeatingResourceFact> = {},
+): RestaurantSeatingResourceFact {
+  return {
+    id,
+    label: id.toUpperCase(),
+    status: "active",
+    capacity: 2,
+    version: 1,
+    attributes: {
+      shape: "square",
+      combinationGroup: "main",
+      combinableWith: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("restaurant seating decision", () => {
+  it("accepts one compatible open table", () => {
+    expect(
+      evaluateRestaurantSeating({
+        covers: 2,
+        resources: [table("t1")],
+        allocations: [],
+        startsAt,
+        endsAt,
+      }),
+    ).toEqual({ ok: true, capacity: 2 });
+  });
+
+  it("accepts combined tables only when their structural contract agrees", () => {
+    expect(
+      evaluateRestaurantSeating({
+        covers: 4,
+        resources: [table("t1"), table("t2")],
+        allocations: [],
+        startsAt,
+        endsAt,
+      }),
+    ).toEqual({ ok: true, capacity: 4 });
+
+    expect(
+      evaluateRestaurantSeating({
+        covers: 4,
+        resources: [
+          table("t1", {
+            attributes: {
+              shape: "square",
+              combinationGroup: "main",
+              combinableWith: [],
+            },
+          }),
+          table("t2", {
+            attributes: {
+              shape: "square",
+              combinationGroup: "patio",
+              combinableWith: [],
+            },
+          }),
+        ],
+        allocations: [],
+        startsAt,
+        endsAt,
+      }),
+    ).toEqual({
+      ok: false,
+      reasonCode: "tables-not-combinable",
+      message: "The selected tables are not configured to combine.",
+    });
+  });
+
+  it("rejects blocked, undersized, and already-allocated tables", () => {
+    expect(
+      evaluateRestaurantSeating({
+        covers: 2,
+        resources: [table("t1", { status: "blocked" })],
+        allocations: [],
+        startsAt,
+        endsAt,
+      }),
+    ).toMatchObject({ ok: false, reasonCode: "table-unavailable" });
+
+    expect(
+      evaluateRestaurantSeating({
+        covers: 3,
+        resources: [table("t1")],
+        allocations: [],
+        startsAt,
+        endsAt,
+      }),
+    ).toMatchObject({ ok: false, reasonCode: "insufficient-capacity" });
+
+    const allocation: RestaurantSeatingAllocationFact = {
+      id: "allocation-1",
+      resourceId: "t1",
+      startsAt: new Date("2026-07-31T17:30:00.000Z"),
+      endsAt: new Date("2026-07-31T18:30:00.000Z"),
+      lifecycle: "active",
+      version: 3,
+    };
+    expect(
+      evaluateRestaurantSeating({
+        covers: 2,
+        resources: [table("t1")],
+        allocations: [allocation],
+        startsAt,
+        endsAt,
+      }),
+    ).toMatchObject({ ok: false, reasonCode: "table-conflict" });
+  });
+
+  it("allows the same demand to activate its existing reservation allocation", () => {
+    expect(
+      evaluateRestaurantSeating({
+        covers: 2,
+        resources: [table("t1")],
+        allocations: [
+          {
+            id: "allocation-1",
+            resourceId: "t1",
+            startsAt,
+            endsAt,
+            lifecycle: "reserved",
+            version: 1,
+            demandRef: "BOOK-1",
+          },
+        ],
+        startsAt,
+        endsAt,
+        demandRef: "BOOK-1",
+      }),
+    ).toEqual({ ok: true, capacity: 2 });
+  });
+
+  it("derives a stable concurrency token independent of query order", () => {
+    const input = {
+      demand: {
+        id: "booking-1",
+        updatedAt: new Date("2026-07-31T17:55:00.000Z"),
+        status: "waiting",
+      },
+      resources: [table("t2", { version: 4 }), table("t1", { version: 2 })],
+      allocations: [
+        {
+          id: "a2",
+          resourceId: "t2",
+          startsAt,
+          endsAt,
+          lifecycle: "reserved" as const,
+          version: 1,
+        },
+        {
+          id: "a1",
+          resourceId: "t1",
+          startsAt,
+          endsAt,
+          lifecycle: "active" as const,
+          version: 3,
+        },
+      ],
+    };
+
+    expect(restaurantSeatingVersion(input)).toBe(
+      restaurantSeatingVersion({
+        ...input,
+        resources: [...input.resources].reverse(),
+        allocations: [...input.allocations].reverse(),
+      }),
+    );
+    expect(
+      restaurantSeatingVersion({
+        ...input,
+        resources: [table("t2", { version: 5 }), table("t1", { version: 2 })],
+      }),
+    ).not.toBe(restaurantSeatingVersion(input));
+  });
+
+  it("returns the smallest currently valid single or combined alternatives", () => {
+    const alternatives = findRestaurantSeatingAlternatives({
+      covers: 4,
+      resources: [
+        table("t1", { capacity: 2, attributes: { combinationGroup: "a" } }),
+        table("t2", { capacity: 2, attributes: { combinationGroup: "a" } }),
+        table("t3", {
+          capacity: 4,
+          label: "Table 3",
+          attributes: { shape: "round" },
+        }),
+        table("t4", {
+          capacity: 6,
+          label: "Table 4",
+          attributes: { shape: "round" },
+        }),
+        table("t5", {
+          capacity: 4,
+          label: "Occupied",
+          attributes: { shape: "round" },
+        }),
+      ],
+      allocations: [
+        {
+          id: "occupied",
+          resourceId: "t5",
+          startsAt,
+          endsAt,
+          lifecycle: "active",
+          version: 1,
+          demandRef: "OTHER",
+        },
+      ],
+      startsAt,
+      endsAt,
+      demandRef: "BOOK-1",
+      excludeResourceIds: ["t3"],
+      limit: 3,
+    });
+
+    expect(alternatives).toEqual([
+      { resourceIds: ["t1", "t2"], label: "T1 + T2" },
+      { resourceIds: ["t4"], label: "Table 4" },
+    ]);
+  });
+});

--- a/apps/web/lib/storefront/restaurant-seating.ts
+++ b/apps/web/lib/storefront/restaurant-seating.ts
@@ -1,0 +1,268 @@
+import type { HospitalityAllocationLifecycle } from "./hospitality-capacity";
+import { parseRestaurantTableAttributes } from "./restaurant-table-attributes";
+
+export interface RestaurantSeatingResourceFact {
+  id: string;
+  label: string;
+  status: string;
+  capacity: number;
+  version: number;
+  attributes: unknown;
+}
+
+export interface RestaurantSeatingAllocationFact {
+  id: string;
+  resourceId: string | null;
+  startsAt: Date;
+  endsAt: Date;
+  lifecycle: HospitalityAllocationLifecycle;
+  version: number;
+  demandRef?: string;
+}
+
+export interface RestaurantSeatingDemandVersionFact {
+  id: string;
+  updatedAt: Date;
+  status: string;
+}
+
+export type RestaurantSeatingDecision =
+  | { ok: true; capacity: number }
+  | { ok: false; reasonCode: string; message: string };
+
+const LIVE_ALLOCATION_LIFECYCLES = new Set<HospitalityAllocationLifecycle>([
+  "reserved",
+  "active",
+]);
+
+function intervalsOverlap(
+  leftStart: Date,
+  leftEnd: Date,
+  rightStart: Date,
+  rightEnd: Date,
+): boolean {
+  return (
+    leftStart.getTime() < rightEnd.getTime() &&
+    rightStart.getTime() < leftEnd.getTime()
+  );
+}
+
+function pairCanCombine(
+  left: RestaurantSeatingResourceFact,
+  right: RestaurantSeatingResourceFact,
+): boolean {
+  const leftAttributes = parseRestaurantTableAttributes(left.attributes);
+  const rightAttributes = parseRestaurantTableAttributes(right.attributes);
+  if (
+    leftAttributes.combinationGroup &&
+    leftAttributes.combinationGroup === rightAttributes.combinationGroup
+  ) {
+    return true;
+  }
+  return (
+    leftAttributes.combinableWith.includes(right.id) &&
+    rightAttributes.combinableWith.includes(left.id)
+  );
+}
+
+export function evaluateRestaurantSeating(input: {
+  covers: number;
+  resources: readonly RestaurantSeatingResourceFact[];
+  allocations: readonly RestaurantSeatingAllocationFact[];
+  startsAt: Date;
+  endsAt: Date;
+  demandRef?: string;
+}): RestaurantSeatingDecision {
+  if (
+    !Number.isInteger(input.covers) ||
+    input.covers <= 0 ||
+    !Number.isFinite(input.startsAt.getTime()) ||
+    !Number.isFinite(input.endsAt.getTime()) ||
+    input.endsAt.getTime() <= input.startsAt.getTime()
+  ) {
+    return {
+      ok: false,
+      reasonCode: "invalid-seating-request",
+      message: "Party size and seating interval must be valid.",
+    };
+  }
+  if (
+    input.resources.length === 0 ||
+    new Set(input.resources.map((resource) => resource.id)).size !==
+      input.resources.length
+  ) {
+    return {
+      ok: false,
+      reasonCode: "invalid-table-selection",
+      message: "Choose one or more distinct tables.",
+    };
+  }
+  const unavailable = input.resources.find(
+    (resource) => resource.status !== "active",
+  );
+  if (unavailable) {
+    return {
+      ok: false,
+      reasonCode: "table-unavailable",
+      message: `${unavailable.label} is not available for seating.`,
+    };
+  }
+
+  const selectedIds = new Set(input.resources.map((resource) => resource.id));
+  const conflict = input.allocations.find(
+    (allocation) =>
+      allocation.resourceId != null &&
+      selectedIds.has(allocation.resourceId) &&
+      !(
+        input.demandRef !== undefined &&
+        allocation.demandRef === input.demandRef
+      ) &&
+      LIVE_ALLOCATION_LIFECYCLES.has(allocation.lifecycle) &&
+      intervalsOverlap(
+        allocation.startsAt,
+        allocation.endsAt,
+        input.startsAt,
+        input.endsAt,
+      ),
+  );
+  if (conflict) {
+    return {
+      ok: false,
+      reasonCode: "table-conflict",
+      message: "One or more selected tables are already committed in that time.",
+    };
+  }
+
+  const capacity = input.resources.reduce(
+    (total, resource) => total + resource.capacity,
+    0,
+  );
+  if (capacity < input.covers) {
+    return {
+      ok: false,
+      reasonCode: "insufficient-capacity",
+      message: `The selected tables seat ${capacity}, fewer than the party of ${input.covers}.`,
+    };
+  }
+  for (let left = 0; left < input.resources.length; left += 1) {
+    for (let right = left + 1; right < input.resources.length; right += 1) {
+      if (!pairCanCombine(input.resources[left], input.resources[right])) {
+        return {
+          ok: false,
+          reasonCode: "tables-not-combinable",
+          message: "The selected tables are not configured to combine.",
+        };
+      }
+    }
+  }
+  return { ok: true, capacity };
+}
+
+export interface RestaurantSeatingAlternative {
+  resourceIds: string[];
+  label: string;
+}
+
+/**
+ * Computes bounded, actionable alternatives from the same rules the write
+ * transaction enforces. Singles and configured pairs cover the host-stand hot
+ * path without generating an unbounded combination search.
+ */
+export function findRestaurantSeatingAlternatives(input: {
+  covers: number;
+  resources: readonly RestaurantSeatingResourceFact[];
+  allocations: readonly RestaurantSeatingAllocationFact[];
+  startsAt: Date;
+  endsAt: Date;
+  demandRef?: string;
+  excludeResourceIds?: readonly string[];
+  limit?: number;
+}): RestaurantSeatingAlternative[] {
+  const candidates: RestaurantSeatingResourceFact[][] = input.resources.map(
+    (resource) => [resource],
+  );
+  for (let left = 0; left < input.resources.length; left += 1) {
+    for (let right = left + 1; right < input.resources.length; right += 1) {
+      candidates.push([input.resources[left], input.resources[right]]);
+    }
+  }
+  const excludedKey = [...(input.excludeResourceIds ?? [])].sort().join(",");
+  const valid = candidates.flatMap((resources) => {
+    const key = resources.map((resource) => resource.id).sort().join(",");
+    if (key === excludedKey) return [];
+    const decision = evaluateRestaurantSeating({
+      covers: input.covers,
+      resources,
+      allocations: input.allocations,
+      startsAt: input.startsAt,
+      endsAt: input.endsAt,
+      ...(input.demandRef ? { demandRef: input.demandRef } : {}),
+    });
+    return decision.ok
+      ? [{
+          capacity: decision.capacity,
+          resourceIds: resources.map((resource) => resource.id),
+          label: resources.map((resource) => resource.label).join(" + "),
+        }]
+      : [];
+  });
+  valid.sort(
+    (left, right) =>
+      left.capacity - right.capacity ||
+      left.resourceIds.length - right.resourceIds.length ||
+      left.label.localeCompare(right.label),
+  );
+  return valid.slice(0, input.limit ?? 3).map(
+    ({ resourceIds, label }) => ({ resourceIds, label }),
+  );
+}
+
+function fnv1a(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * Opaque optimistic token over every fact the seating transaction rechecks.
+ * Sorting makes query order irrelevant; changing demand, table, or live
+ * allocation state changes the token.
+ */
+export function restaurantSeatingVersion(input: {
+  demand: RestaurantSeatingDemandVersionFact;
+  resources: readonly RestaurantSeatingResourceFact[];
+  allocations: readonly RestaurantSeatingAllocationFact[];
+}): string {
+  return `restaurant-seat.v1-${fnv1a(
+    JSON.stringify({
+      demand: {
+        id: input.demand.id,
+        status: input.demand.status,
+        updatedAt: input.demand.updatedAt.toISOString(),
+      },
+      resources: input.resources
+        .map((resource) => ({
+          id: resource.id,
+          status: resource.status,
+          version: resource.version,
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+      allocations: input.allocations
+        .filter((allocation) =>
+          LIVE_ALLOCATION_LIFECYCLES.has(allocation.lifecycle)
+        )
+        .map((allocation) => ({
+          id: allocation.id,
+          resourceId: allocation.resourceId,
+          lifecycle: allocation.lifecycle,
+          version: allocation.version,
+          startsAt: allocation.startsAt.toISOString(),
+          endsAt: allocation.endsAt.toISOString(),
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+    }),
+  )}`;
+}

--- a/apps/web/lib/storefront/restaurant-table-attributes.test.ts
+++ b/apps/web/lib/storefront/restaurant-table-attributes.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseRestaurantTableAttributes,
+  serializeRestaurantTableAttributes,
+  validateRestaurantTableAttributesInput,
+} from "./restaurant-table-attributes";
+
+describe("restaurant table attributes", () => {
+  it("parses the closed structural contract and removes duplicate combinations", () => {
+    expect(
+      parseRestaurantTableAttributes({
+        shape: "booth",
+        combinationGroup: "main-banquette",
+        combinableWith: ["table-4", "table-4", " table-5 "],
+      }),
+    ).toEqual({
+      shape: "booth",
+      combinationGroup: "main-banquette",
+      combinableWith: ["table-4", "table-5"],
+    });
+  });
+
+  it("degrades unknown or malformed attributes to a safe default", () => {
+    expect(
+      parseRestaurantTableAttributes({
+        shape: "starburst",
+        combinationGroup: 12,
+        combinableWith: ["", 42],
+      }),
+    ).toEqual({
+      shape: "round",
+      combinationGroup: null,
+      combinableWith: [],
+    });
+    expect(parseRestaurantTableAttributes(null)).toEqual({
+      shape: "round",
+      combinationGroup: null,
+      combinableWith: [],
+    });
+  });
+
+  it("serializes only the canonical structural fields", () => {
+    expect(
+      serializeRestaurantTableAttributes({
+        shape: "rectangle",
+        combinationGroup: null,
+        combinableWith: ["table-2"],
+      }),
+    ).toEqual({
+      shape: "rectangle",
+      combinableWith: ["table-2"],
+    });
+  });
+
+  it("rejects unknown write values instead of silently changing operator input", () => {
+    expect(
+      validateRestaurantTableAttributesInput({
+        shape: "starburst",
+        combinationGroup: null,
+        combinableWith: [],
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Choose a supported table shape.",
+    });
+    expect(
+      validateRestaurantTableAttributesInput({
+        shape: "round",
+        combinationGroup: null,
+        combinableWith: ["table-2", 42],
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Combined-table references are invalid.",
+    });
+  });
+});

--- a/apps/web/lib/storefront/restaurant-table-attributes.ts
+++ b/apps/web/lib/storefront/restaurant-table-attributes.ts
@@ -1,0 +1,101 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+export const RESTAURANT_TABLE_SHAPES = [
+  "round",
+  "square",
+  "rectangle",
+  "booth",
+  "bar",
+] as const;
+
+export type RestaurantTableShape = (typeof RESTAURANT_TABLE_SHAPES)[number];
+
+export interface RestaurantTableAttributes {
+  shape: RestaurantTableShape;
+  combinationGroup: string | null;
+  combinableWith: string[];
+}
+
+export type RestaurantTableAttributesValidation =
+  | { ok: true; value: RestaurantTableAttributes }
+  | { ok: false; error: string };
+
+const SHAPE_SET = new Set<string>(RESTAURANT_TABLE_SHAPES);
+const MAX_REFERENCE_LENGTH = 160;
+const MAX_COMBINATION_LINKS = 24;
+
+function cleanReference(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= MAX_REFERENCE_LENGTH
+    ? trimmed
+    : null;
+}
+
+/**
+ * The single parser for HospitalityResource.attributes when kind=table.
+ * Unknown values fail soft so old installs and future writers never break the
+ * operating view; all writes still serialize through the closed contract.
+ */
+export function parseRestaurantTableAttributes(
+  value: unknown,
+): RestaurantTableAttributes {
+  const record = isRecord(value) ? value : {};
+  const shape =
+    typeof record.shape === "string" && SHAPE_SET.has(record.shape)
+      ? (record.shape as RestaurantTableShape)
+      : "round";
+  const combinationGroup = cleanReference(record.combinationGroup);
+  const combinableWith = Array.isArray(record.combinableWith)
+    ? [
+        ...new Set(
+          record.combinableWith
+            .map(cleanReference)
+            .filter((entry): entry is string => entry !== null),
+        ),
+      ].slice(0, MAX_COMBINATION_LINKS)
+    : [];
+
+  return { shape, combinationGroup, combinableWith };
+}
+
+export function serializeRestaurantTableAttributes(
+  value: RestaurantTableAttributes,
+): Record<string, unknown> {
+  const parsed = parseRestaurantTableAttributes(value);
+  return {
+    shape: parsed.shape,
+    ...(parsed.combinationGroup
+      ? { combinationGroup: parsed.combinationGroup }
+      : {}),
+    ...(parsed.combinableWith.length > 0
+      ? { combinableWith: parsed.combinableWith }
+      : {}),
+  };
+}
+
+export function validateRestaurantTableAttributesInput(
+  value: unknown,
+): RestaurantTableAttributesValidation {
+  if (!isRecord(value) || !SHAPE_SET.has(String(value.shape))) {
+    return { ok: false, error: "Choose a supported table shape." };
+  }
+  if (
+    value.combinationGroup !== null &&
+    value.combinationGroup !== undefined &&
+    cleanReference(value.combinationGroup) === null
+  ) {
+    return { ok: false, error: "The table combination group is invalid." };
+  }
+  if (
+    value.combinableWith !== undefined &&
+    (!Array.isArray(value.combinableWith) ||
+      value.combinableWith.length > MAX_COMBINATION_LINKS ||
+      value.combinableWith.some(
+        (entry) => cleanReference(entry) === null,
+      ))
+  ) {
+    return { ok: false, error: "Combined-table references are invalid." };
+  }
+  return { ok: true, value: parseRestaurantTableAttributes(value) };
+}

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -47,6 +47,7 @@ import {
   readinessQuest,
   reservationsToQueueItems,
   restaurantCapacityChips,
+  restaurantFloorResourceUnits,
 } from "./restaurant-operations-projection";
 
 import {
@@ -610,20 +611,6 @@ export async function loadLivingBusinessProjection(
   ).length;
   const unassigned = bookings.filter((b) => b.provider == null || b.status.toLowerCase() === "pending");
 
-  // Render the resource units under the zone that actually holds them
-  // (`capacityZoneKey`) — a restaurant's tables belong in the dining room, not
-  // "Kitchen / the pass"; a shop's work orders on the bays, not at intake. Its
-  // label resolves from the profile at render time (TwinView).
-  const zones: TwinZoneSnapshot[] = [
-    {
-      key: profile.capacityZoneKey ?? profile.zones[0]?.key ?? "board",
-      units:
-        profile.template === "FLOOR"
-          ? hospitalityResourceUnits(hospitalityResources)
-          : resourceUnits(providers, members),
-    },
-  ];
-
   // FLOOR (Restaurant) capacity: derive one snapshot from the SAME structured
   // hospitality resources +
   // bookings this projection already loaded, so the Workspace capacity chips,
@@ -649,6 +636,23 @@ export async function loadLivingBusinessProjection(
           timeZone: config.timezone,
         })
       : null;
+
+  // Render the resource units under the zone that actually holds them
+  // (`capacityZoneKey`) — a restaurant's tables belong in the dining room, not
+  // "Kitchen / the pass"; a shop's work orders on the bays, not at intake. FLOOR
+  // must use the derived capacity snapshot so occupied/turning tables do not
+  // regress to "Available" merely because the resource itself is active.
+  const zones: TwinZoneSnapshot[] = [
+    {
+      key: profile.capacityZoneKey ?? profile.zones[0]?.key ?? "board",
+      units:
+        profile.template === "FLOOR" && floorSnapshot
+          ? restaurantFloorResourceUnits(floorSnapshot)
+          : profile.template === "FLOOR"
+            ? hospitalityResourceUnits(hospitalityResources)
+            : resourceUnits(providers, members),
+    },
+  ];
 
   // Distribute booking-derived demand across the profile's queues by MEANING, not
   // just into queue 0. A profile with a dedicated reservations queue (e.g. the

--- a/apps/web/lib/twin/operational-scene-layout-actions.ts
+++ b/apps/web/lib/twin/operational-scene-layout-actions.ts
@@ -57,7 +57,10 @@ export async function saveOperationalCartesianScene(input: {
       expectedVersion: input.expectedVersion,
       layout: input.layout,
     });
-    if (result.ok) revalidatePath("/workspace");
+    if (result.ok) {
+      revalidatePath("/workspace");
+      revalidatePath("/storefront/tables");
+    }
     return result;
   } catch {
     return {

--- a/apps/web/lib/twin/operations-command.ts
+++ b/apps/web/lib/twin/operations-command.ts
@@ -78,6 +78,7 @@ export type OperationalCommandAdapterResult =
       status: "confirmed";
       newVersion: string;
       changedFacts: OperationalChangedFact[];
+      replayed?: boolean;
     }
   | {
       status: "conflict";
@@ -198,7 +199,10 @@ export function createOperationalCommandBoundary(
         return {
           ...adapterResult,
           idempotencyKey: command.idempotencyKey,
-          replayed: false,
+          replayed:
+            "replayed" in adapterResult
+              ? adapterResult.replayed ?? false
+              : false,
           latencyMs: Math.max(0, clock() - startedAt),
         } as OperationalCommandResult;
       })();

--- a/apps/web/lib/twin/restaurant-floor-actions.ts
+++ b/apps/web/lib/twin/restaurant-floor-actions.ts
@@ -1,0 +1,199 @@
+"use server";
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+
+import {
+  createOperationalCommandBoundary,
+  type OperationalAssignmentCommand,
+  type OperationalCommandResult,
+} from "./operations-command";
+import { createRestaurantFloorCommandAdapter } from "./restaurant-floor-command.server";
+import {
+  executeRestaurantTurnStageCommand as executeTurnStageCommand,
+  type RestaurantTurnStageCommand,
+} from "./restaurant-turn-command.server";
+import {
+  executeRestaurantMoveCommand,
+  type RestaurantMoveCommand,
+} from "./restaurant-move-command.server";
+
+function rejected(
+  command: { idempotencyKey: string },
+  reasonCode: string,
+  message: string,
+): OperationalCommandResult {
+  return {
+    status: "rejected",
+    idempotencyKey: command.idempotencyKey,
+    replayed: false,
+    reasonCode,
+    message,
+  };
+}
+
+export async function executeRestaurantFloorCommand(
+  command: OperationalAssignmentCommand,
+): Promise<OperationalCommandResult> {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      {
+        platformRole: session.user.platformRole,
+        isSuperuser: session.user.isSuperuser,
+      },
+      "view_storefront",
+    )
+  ) {
+    return rejected(
+      command,
+      "unauthorized",
+      "You do not have permission to change the restaurant floor.",
+    );
+  }
+
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { id: true, organizationId: true },
+  });
+  if (!config) {
+    return rejected(
+      command,
+      "storefront-not-configured",
+      "The restaurant storefront is not configured.",
+    );
+  }
+
+  try {
+    const boundary = createOperationalCommandBoundary(
+      createRestaurantFloorCommandAdapter({
+        database: prisma as never,
+        organizationId: config.organizationId,
+        storefrontId: config.id,
+        actorRef: session.user.id,
+      }),
+    );
+    const result = await boundary.execute(command);
+    if (result.status === "confirmed") {
+      revalidatePath("/workspace");
+      revalidatePath("/storefront/tables");
+    }
+    return result;
+  } catch {
+    return rejected(
+      command,
+      "operation-unavailable",
+      "The floor could not be updated right now. Nothing changed.",
+    );
+  }
+}
+
+export async function advanceRestaurantServiceTurn(
+  command: RestaurantTurnStageCommand,
+): Promise<OperationalCommandResult> {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      {
+        platformRole: session.user.platformRole,
+        isSuperuser: session.user.isSuperuser,
+      },
+      "view_storefront",
+    )
+  ) {
+    return rejected(
+      command,
+      "unauthorized",
+      "You do not have permission to change the restaurant floor.",
+    );
+  }
+
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { id: true, organizationId: true },
+  });
+  if (!config) {
+    return rejected(
+      command,
+      "storefront-not-configured",
+      "The restaurant storefront is not configured.",
+    );
+  }
+
+  try {
+    const result = await executeTurnStageCommand({
+      database: prisma as never,
+      organizationId: config.organizationId,
+      actorRef: session.user.id,
+      command,
+    });
+    if (result.status === "confirmed") {
+      revalidatePath("/workspace");
+      revalidatePath("/storefront/tables");
+    }
+    return result;
+  } catch {
+    return rejected(
+      command,
+      "operation-unavailable",
+      "The table status could not be updated right now. Nothing changed.",
+    );
+  }
+}
+
+export async function moveRestaurantParty(
+  command: RestaurantMoveCommand,
+): Promise<OperationalCommandResult> {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      {
+        platformRole: session.user.platformRole,
+        isSuperuser: session.user.isSuperuser,
+      },
+      "view_storefront",
+    )
+  ) {
+    return rejected(
+      command,
+      "unauthorized",
+      "You do not have permission to change the restaurant floor.",
+    );
+  }
+
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { id: true, organizationId: true },
+  });
+  if (!config) {
+    return rejected(
+      command,
+      "storefront-not-configured",
+      "The restaurant storefront is not configured.",
+    );
+  }
+
+  try {
+    const result = await executeRestaurantMoveCommand({
+      database: prisma as never,
+      organizationId: config.organizationId,
+      storefrontId: config.id,
+      actorRef: session.user.id,
+      command,
+    });
+    if (result.status === "confirmed") {
+      revalidatePath("/workspace");
+      revalidatePath("/storefront/tables");
+    }
+    return result;
+  } catch {
+    return rejected(
+      command,
+      "operation-unavailable",
+      "The party could not be moved right now. Nothing changed.",
+    );
+  }
+}

--- a/apps/web/lib/twin/restaurant-floor-command.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-command.server.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  OperationalAssignmentCommand,
+  OperationalCommandAdapterResult,
+} from "./operations-command";
+import { createRestaurantFloorCommandAdapter } from "./restaurant-floor-command.server";
+import { restaurantSeatingVersion } from "../storefront/restaurant-seating";
+
+const startsAt = new Date("2026-07-31T18:00:00.000Z");
+const endsAt = new Date("2026-07-31T19:15:00.000Z");
+const demand = {
+  id: "booking-1",
+  bookingRef: "BOOK-1",
+  covers: 4,
+  status: "waiting",
+  scheduledAt: startsAt,
+  durationMinutes: 75,
+  updatedAt: new Date("2026-07-31T17:55:00.000Z"),
+};
+const resources = [
+  {
+    id: "table-1",
+    label: "Table 1",
+    status: "active",
+    capacity: 2,
+    version: 1,
+    attributes: {
+      shape: "square",
+      combinationGroup: "main",
+      combinableWith: [],
+    },
+  },
+  {
+    id: "table-2",
+    label: "Table 2",
+    status: "active",
+    capacity: 2,
+    version: 2,
+    attributes: {
+      shape: "square",
+      combinationGroup: "main",
+      combinableWith: [],
+    },
+  },
+];
+
+function command(expectedVersion = restaurantSeatingVersion({
+  demand,
+  resources,
+  allocations: [],
+})): OperationalAssignmentCommand {
+  return {
+    kind: "assign",
+    idempotencyKey: "seat-booking-1-tables-1-2",
+    expectedVersion,
+    interval: {
+      startsAt: startsAt.toISOString(),
+      endsAt: endsAt.toISOString(),
+    },
+    entityRefs: {
+      demandId: demand.id,
+      resourceIds: resources.map((resource) => resource.id),
+    },
+  };
+}
+
+function fixture(overrides: Record<string, unknown> = {}) {
+  const tx = {
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    storefrontBooking: {
+      findFirst: vi.fn().mockResolvedValue(demand),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    hospitalityResource: {
+      findMany: vi.fn().mockResolvedValue(resources),
+    },
+    hospitalityCapacityAllocation: {
+      findMany: vi.fn().mockResolvedValue([]),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    hospitalityServiceTurnEvent: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    staffingResourceLink: {
+      findMany: vi.fn().mockResolvedValue(
+        resources.map((resource) => ({
+          resourceRef: resource.id,
+          shift: {
+            assignments: [
+              {
+                id: "assignment-1",
+                lifecycle: "on_site",
+              },
+            ],
+          },
+        })),
+      ),
+    },
+    ...overrides,
+  };
+  return {
+    tx,
+    database: {
+      $transaction: vi.fn(async (
+        run: (
+          client: typeof tx,
+        ) => Promise<OperationalCommandAdapterResult>,
+      ) =>
+        run(tx)
+      ),
+    },
+  };
+}
+
+describe("restaurant floor command adapter", () => {
+  it("seats a combined-table party atomically under one service turn", async () => {
+    const { database, tx } = fixture();
+    const createTurn = vi.fn().mockResolvedValue({
+      id: "turn-1",
+      turnId: "HT-1",
+      stage: "seated",
+      version: 1,
+    });
+    const allocateCapacity = vi.fn().mockImplementation(
+      async (_database, input) => ({
+        id: `allocation-${input.resourceId}`,
+        version: 1,
+      }),
+    );
+    const transitionCapacity = vi.fn().mockResolvedValue(undefined);
+    const adapter = createRestaurantFloorCommandAdapter({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      dependencies: {
+        createTurn,
+        allocateCapacity,
+        transitionCapacity,
+      },
+    });
+
+    await expect(adapter.executeAtomically(command())).resolves.toEqual({
+      status: "confirmed",
+      newVersion: "restaurant-turn:HT-1:1",
+      changedFacts: [
+        { entityId: "booking-1", field: "status", value: "seated" },
+        {
+          entityId: "booking-1",
+          field: "resourceIds",
+          value: "table-1,table-2",
+        },
+        {
+          entityId: "booking-1",
+          field: "staffingAssignmentId",
+          value: "assignment-1",
+        },
+      ],
+    });
+    expect(createTurn).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        demandRef: "BOOK-1",
+        staffingAssignmentId: "assignment-1",
+        idempotencyKey: command().idempotencyKey,
+      }),
+    );
+    expect(allocateCapacity).toHaveBeenCalledTimes(2);
+    expect(allocateCapacity).toHaveBeenNthCalledWith(
+      1,
+      tx,
+      expect.objectContaining({
+        resourceId: "table-1",
+        serviceTurnId: "turn-1",
+      }),
+    );
+    expect(allocateCapacity).toHaveBeenNthCalledWith(
+      2,
+      tx,
+      expect.objectContaining({
+        resourceId: "table-2",
+        serviceTurnId: "turn-1",
+      }),
+    );
+    expect(transitionCapacity).toHaveBeenCalledTimes(2);
+    expect(tx.storefrontBooking.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "booking-1",
+        organizationId: "org-1",
+        updatedAt: demand.updatedAt,
+        status: "waiting",
+      },
+      data: {
+        hospitalityResourceId: "table-1",
+        status: "seated",
+      },
+    });
+  });
+
+  it("returns a version conflict before any write when facts changed", async () => {
+    const { database } = fixture();
+    const createTurn = vi.fn();
+    const allocateCapacity = vi.fn();
+    const adapter = createRestaurantFloorCommandAdapter({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      dependencies: {
+        createTurn,
+        allocateCapacity,
+        transitionCapacity: vi.fn(),
+      },
+    });
+
+    await expect(
+      adapter.executeAtomically(command("restaurant-seat.v1-stale")),
+    ).resolves.toMatchObject({
+      status: "conflict",
+      currentVersion: restaurantSeatingVersion({
+        demand,
+        resources,
+        allocations: [],
+      }),
+      changedFacts: [],
+    });
+    expect(createTurn).not.toHaveBeenCalled();
+    expect(allocateCapacity).not.toHaveBeenCalled();
+  });
+
+  it("returns currently valid table alternatives with a stale-version conflict", async () => {
+    const alternative = {
+      id: "table-3",
+      label: "Table 3",
+      status: "active",
+      capacity: 4,
+      version: 1,
+      attributes: { shape: "round" },
+    };
+    const { database } = fixture({
+      hospitalityResource: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce(resources)
+          .mockResolvedValueOnce([...resources, alternative]),
+      },
+      hospitalityCapacityAllocation: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    });
+    const adapter = createRestaurantFloorCommandAdapter({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      dependencies: {
+        createTurn: vi.fn(),
+        allocateCapacity: vi.fn(),
+        transitionCapacity: vi.fn(),
+      },
+    });
+
+    await expect(
+      adapter.executeAtomically(command("restaurant-seat.v1-stale")),
+    ).resolves.toMatchObject({
+      status: "conflict",
+      alternatives: [{ resourceIds: ["table-3"], label: "Table 3" }],
+    });
+  });
+
+  it("reports an overlapping allocation as a conflict without partial writes", async () => {
+    const allocations = [
+      {
+        id: "allocation-existing",
+        resourceId: "table-1",
+        startsAt,
+        endsAt,
+        lifecycle: "active" as const,
+        version: 1,
+        demandRef: "OTHER-BOOKING",
+      },
+    ];
+    const { database } = fixture({
+      hospitalityCapacityAllocation: {
+        findMany: vi.fn().mockResolvedValue(allocations),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    });
+    const createTurn = vi.fn();
+    const adapter = createRestaurantFloorCommandAdapter({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      dependencies: {
+        createTurn,
+        allocateCapacity: vi.fn(),
+        transitionCapacity: vi.fn(),
+      },
+    });
+    const expectedVersion = restaurantSeatingVersion({
+      demand,
+      resources,
+      allocations,
+    });
+
+    await expect(
+      adapter.executeAtomically(command(expectedVersion)),
+    ).resolves.toMatchObject({
+      status: "conflict",
+      alternatives: [],
+    });
+    expect(createTurn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/twin/restaurant-floor-command.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-command.server.ts
@@ -1,0 +1,638 @@
+import {
+  allocateHospitalityCapacity,
+  transitionHospitalityCapacity,
+} from "@/lib/storefront/hospitality-capacity-repository.server";
+import {
+  HospitalityCapacityConflictError,
+  HospitalityCapacityVersionError,
+} from "@/lib/storefront/hospitality-capacity";
+import { createHospitalityServiceTurn } from "@/lib/storefront/hospitality-service-turn-repository.server";
+import {
+  evaluateRestaurantSeating,
+  findRestaurantSeatingAlternatives,
+  restaurantSeatingVersion,
+  type RestaurantSeatingAllocationFact,
+  type RestaurantSeatingResourceFact,
+} from "@/lib/storefront/restaurant-seating";
+
+import type {
+  OperationalAssignmentCommand,
+  OperationalCommandAdapter,
+  OperationalCommandAdapterResult,
+} from "./operations-command";
+
+interface RestaurantDemandRow {
+  id: string;
+  bookingRef: string;
+  covers: number | null;
+  status: string;
+  scheduledAt: Date;
+  durationMinutes: number;
+  updatedAt: Date;
+}
+
+interface StaffingLinkRow {
+  resourceRef: string;
+  shift: {
+    assignments: Array<{ id: string; lifecycle: string }>;
+  };
+}
+
+interface RestaurantCommandTransaction {
+  $queryRaw(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown>;
+  storefrontBooking: {
+    findFirst(args: unknown): Promise<RestaurantDemandRow | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  hospitalityResource: {
+    findMany(args: unknown): Promise<RestaurantSeatingResourceFact[]>;
+  };
+  hospitalityCapacityAllocation: {
+    findMany(args: unknown): Promise<RestaurantSeatingAllocationFact[]>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  hospitalityServiceTurnEvent: {
+    findFirst(args: unknown): Promise<{
+      detail: unknown;
+      serviceTurn: { id: string; turnId: string; version: number };
+    } | null>;
+  };
+  staffingResourceLink: {
+    findMany(args: unknown): Promise<StaffingLinkRow[]>;
+  };
+}
+
+interface RestaurantCommandDatabase {
+  $transaction(
+    run: (
+      transaction: RestaurantCommandTransaction,
+    ) => Promise<OperationalCommandAdapterResult>,
+  ): Promise<OperationalCommandAdapterResult>;
+}
+
+type CreateTurn = typeof createHospitalityServiceTurn;
+type AllocateCapacity = typeof allocateHospitalityCapacity;
+type TransitionCapacity = typeof transitionHospitalityCapacity;
+
+interface RestaurantCommandDependencies {
+  createTurn: CreateTurn;
+  allocateCapacity: AllocateCapacity;
+  transitionCapacity: TransitionCapacity;
+}
+
+const DEFAULT_DEPENDENCIES: RestaurantCommandDependencies = {
+  createTurn: createHospitalityServiceTurn,
+  allocateCapacity: allocateHospitalityCapacity,
+  transitionCapacity: transitionHospitalityCapacity,
+};
+
+const SEATABLE_DEMAND_STATUSES = new Set([
+  "waiting",
+  "confirmed",
+  "scheduled",
+  "pending",
+]);
+const ACTIVE_STAFFING_LIFECYCLES = new Set(["confirmed", "on_site"]);
+
+function fingerprint(command: OperationalAssignmentCommand): string {
+  return JSON.stringify({
+    kind: command.kind,
+    expectedVersion: command.expectedVersion,
+    interval: command.interval,
+    entityRefs: {
+      demandId: command.entityRefs.demandId,
+      resourceIds: [...command.entityRefs.resourceIds].sort(),
+    },
+  });
+}
+
+function rejected(
+  reasonCode: string,
+  message: string,
+): OperationalCommandAdapterResult {
+  return { status: "rejected", reasonCode, message };
+}
+
+async function currentAlternatives(
+  transaction: RestaurantCommandTransaction,
+  input: {
+    organizationId: string;
+    storefrontId: string;
+    demand: RestaurantDemandRow & { covers: number };
+    startsAt: Date;
+    endsAt: Date;
+    excludeResourceIds: readonly string[];
+  },
+) {
+  const resources = await transaction.hospitalityResource.findMany({
+    where: {
+      organizationId: input.organizationId,
+      storefrontId: input.storefrontId,
+      kind: "table",
+      status: "active",
+    },
+    select: {
+      id: true,
+      label: true,
+      status: true,
+      capacity: true,
+      version: true,
+      attributes: true,
+    },
+    orderBy: { label: "asc" },
+    take: 100,
+  });
+  const allocations =
+    await transaction.hospitalityCapacityAllocation.findMany({
+      where: {
+        organizationId: input.organizationId,
+        resourceId: { in: resources.map((resource) => resource.id) },
+        lifecycle: { in: ["reserved", "active"] },
+        conflictQuarantinedAt: null,
+        startsAt: { lt: input.endsAt },
+        endsAt: { gt: input.startsAt },
+      },
+      select: {
+        id: true,
+        resourceId: true,
+        startsAt: true,
+        endsAt: true,
+        lifecycle: true,
+        version: true,
+        demandRef: true,
+      },
+      take: 500,
+    });
+  return findRestaurantSeatingAlternatives({
+    covers: input.demand.covers,
+    resources,
+    allocations,
+    startsAt: input.startsAt,
+    endsAt: input.endsAt,
+    demandRef: input.demand.bookingRef,
+    excludeResourceIds: input.excludeResourceIds,
+    limit: 3,
+  });
+}
+
+function staffingAssignmentFor(
+  resourceIds: readonly string[],
+  links: readonly StaffingLinkRow[],
+):
+  | { ok: true; staffingAssignmentId: string | null }
+  | { ok: false; result: OperationalCommandAdapterResult } {
+  const assignmentByResource = new Map<string, string | null>();
+  for (const resourceId of resourceIds) {
+    const assignment =
+      links
+        .find((link) => link.resourceRef === resourceId)
+        ?.shift.assignments.find((candidate) =>
+          ACTIVE_STAFFING_LIFECYCLES.has(candidate.lifecycle)
+        ) ?? null;
+    assignmentByResource.set(resourceId, assignment?.id ?? null);
+  }
+  const assigned = new Set(
+    [...assignmentByResource.values()].filter(
+      (value): value is string => value !== null,
+    ),
+  );
+  if (assigned.size > 1) {
+    return {
+      ok: false,
+      result: rejected(
+        "mixed-server-sections",
+        "The selected tables belong to different active server sections.",
+      ),
+    };
+  }
+  return {
+    ok: true,
+    staffingAssignmentId:
+      assigned.size === 1 && ![...assignmentByResource.values()].includes(null)
+        ? [...assigned][0]
+        : null,
+  };
+}
+
+class RestaurantCommandRollback extends Error {
+  constructor(readonly result: OperationalCommandAdapterResult) {
+    super("Restaurant floor command rolled back");
+  }
+}
+
+function serviceTurnRecord(value: unknown): {
+  id: string;
+  turnId: string;
+  version: number;
+} {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("id" in value) ||
+    !("turnId" in value) ||
+    !("version" in value) ||
+    typeof value.id !== "string" ||
+    typeof value.turnId !== "string" ||
+    typeof value.version !== "number"
+  ) {
+    throw new Error("Hospitality service turn persistence returned no identity");
+  }
+  return {
+    id: value.id,
+    turnId: value.turnId,
+    version: value.version,
+  };
+}
+
+function allocationRecord(value: unknown): { id: string; version: number } {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("id" in value) ||
+    !("version" in value) ||
+    typeof value.id !== "string" ||
+    typeof value.version !== "number"
+  ) {
+    throw new Error("Hospitality allocation persistence returned no identity");
+  }
+  return { id: value.id, version: value.version };
+}
+
+export function createRestaurantFloorCommandAdapter(input: {
+  database: RestaurantCommandDatabase;
+  organizationId: string;
+  storefrontId: string;
+  actorRef: string;
+  dependencies?: Partial<RestaurantCommandDependencies>;
+}): OperationalCommandAdapter {
+  const dependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...input.dependencies,
+  };
+
+  return {
+    supports: (command) => command.kind === "assign",
+    async executeAtomically(command) {
+      try {
+        return await input.database.$transaction(async (transaction) => {
+          const assignmentCommand = command as OperationalAssignmentCommand;
+          const commandFingerprint = fingerprint(assignmentCommand);
+          const prior =
+            await transaction.hospitalityServiceTurnEvent.findFirst({
+              where: {
+                organizationId: input.organizationId,
+                idempotencyKey: assignmentCommand.idempotencyKey,
+              },
+              select: {
+                detail: true,
+                serviceTurn: {
+                  select: { id: true, turnId: true, version: true },
+                },
+              },
+            });
+          if (prior) {
+            const detail =
+              typeof prior.detail === "object" && prior.detail !== null
+                ? prior.detail as Record<string, unknown>
+                : {};
+            if (detail.commandFingerprint !== commandFingerprint) {
+              return rejected(
+                "idempotency-key-reused",
+                "That command key already belongs to a different seating action.",
+              );
+            }
+            return {
+              status: "confirmed",
+              replayed: true,
+              newVersion:
+                `restaurant-turn:${prior.serviceTurn.turnId}:${prior.serviceTurn.version}`,
+              changedFacts: [],
+            };
+          }
+
+          await transaction.$queryRaw`
+            SELECT "id"
+            FROM "StorefrontBooking"
+            WHERE "id" = ${assignmentCommand.entityRefs.demandId}
+              AND "organizationId" = ${input.organizationId}
+            FOR UPDATE
+          `;
+          for (const resourceId of [
+            ...assignmentCommand.entityRefs.resourceIds,
+          ].sort()) {
+            await transaction.$queryRaw`
+              SELECT "id"
+              FROM "HospitalityResource"
+              WHERE "id" = ${resourceId}
+                AND "organizationId" = ${input.organizationId}
+                AND "storefrontId" = ${input.storefrontId}
+              FOR UPDATE
+            `;
+          }
+
+          const startsAt = new Date(assignmentCommand.interval.startsAt);
+          const endsAt = new Date(assignmentCommand.interval.endsAt);
+          const demand = await transaction.storefrontBooking.findFirst({
+            where: {
+              id: assignmentCommand.entityRefs.demandId,
+              organizationId: input.organizationId,
+              storefrontId: input.storefrontId,
+            },
+            select: {
+              id: true,
+              bookingRef: true,
+              covers: true,
+              status: true,
+              scheduledAt: true,
+              durationMinutes: true,
+              updatedAt: true,
+            },
+          });
+          if (!demand) {
+            return rejected(
+              "demand-not-found",
+              "The selected party is no longer available.",
+            );
+          }
+          if (!SEATABLE_DEMAND_STATUSES.has(demand.status.toLowerCase())) {
+            return rejected(
+              "demand-not-seatable",
+              "The selected party is not waiting or ready to seat.",
+            );
+          }
+          if (!demand.covers || demand.covers < 1) {
+            return rejected(
+              "party-size-missing",
+              "Confirm the party size before assigning a table.",
+            );
+          }
+
+          const resources = await transaction.hospitalityResource.findMany({
+            where: {
+              id: { in: assignmentCommand.entityRefs.resourceIds },
+              organizationId: input.organizationId,
+              storefrontId: input.storefrontId,
+              kind: "table",
+            },
+            select: {
+              id: true,
+              label: true,
+              status: true,
+              capacity: true,
+              version: true,
+              attributes: true,
+            },
+          });
+          if (resources.length !== assignmentCommand.entityRefs.resourceIds.length) {
+            return rejected(
+              "table-not-found",
+              "One or more selected tables no longer exist.",
+            );
+          }
+
+          const allocations =
+            await transaction.hospitalityCapacityAllocation.findMany({
+              where: {
+                organizationId: input.organizationId,
+                resourceId: {
+                  in: assignmentCommand.entityRefs.resourceIds,
+                },
+                lifecycle: { in: ["reserved", "active"] },
+                conflictQuarantinedAt: null,
+                startsAt: { lt: endsAt },
+                endsAt: { gt: startsAt },
+              },
+              select: {
+                id: true,
+                resourceId: true,
+                startsAt: true,
+                endsAt: true,
+                lifecycle: true,
+                version: true,
+                demandRef: true,
+              },
+            });
+          const currentVersion = restaurantSeatingVersion({
+            demand,
+            resources,
+            allocations,
+          });
+          if (currentVersion !== assignmentCommand.expectedVersion) {
+            return {
+              status: "conflict",
+              currentVersion,
+              changedFacts: [],
+              alternatives: await currentAlternatives(transaction, {
+                organizationId: input.organizationId,
+                storefrontId: input.storefrontId,
+                demand: demand as RestaurantDemandRow & { covers: number },
+                startsAt,
+                endsAt,
+                excludeResourceIds: assignmentCommand.entityRefs.resourceIds,
+              }),
+            };
+          }
+
+          const seating = evaluateRestaurantSeating({
+            covers: demand.covers,
+            resources,
+            allocations,
+            startsAt,
+            endsAt,
+            demandRef: demand.bookingRef,
+          });
+          if (!seating.ok) {
+            if (seating.reasonCode === "table-conflict") {
+              return {
+                status: "conflict",
+                currentVersion,
+                changedFacts: [],
+                alternatives: await currentAlternatives(transaction, {
+                  organizationId: input.organizationId,
+                  storefrontId: input.storefrontId,
+                  demand: demand as RestaurantDemandRow & { covers: number },
+                  startsAt,
+                  endsAt,
+                  excludeResourceIds:
+                    assignmentCommand.entityRefs.resourceIds,
+                }),
+              };
+            }
+            return rejected(seating.reasonCode, seating.message);
+          }
+
+          const staffingLinks =
+            await transaction.staffingResourceLink.findMany({
+              where: {
+                organizationId: input.organizationId,
+                resourceType: "table",
+                resourceRef: {
+                  in: assignmentCommand.entityRefs.resourceIds,
+                },
+                shift: {
+                  lifecycle: "published",
+                  startAt: { lte: startsAt },
+                  endAt: { gt: startsAt },
+                },
+              },
+              select: {
+                resourceRef: true,
+                shift: {
+                  select: {
+                    assignments: {
+                      where: {
+                        lifecycle: { in: ["confirmed", "on_site"] },
+                      },
+                      select: { id: true, lifecycle: true },
+                    },
+                  },
+                },
+              },
+            });
+          const staffing = staffingAssignmentFor(
+            assignmentCommand.entityRefs.resourceIds,
+            staffingLinks,
+          );
+          if (!staffing.ok) return staffing.result;
+
+          const turn = serviceTurnRecord(
+            await dependencies.createTurn(transaction as never, {
+              organizationId: input.organizationId,
+              storefrontId: input.storefrontId,
+              bookingId: demand.id,
+              staffingAssignmentId: staffing.staffingAssignmentId,
+              demandType: "booking",
+              demandRef: demand.bookingRef,
+              startedAt: startsAt,
+              expectedEndAt: endsAt,
+              actorRef: input.actorRef,
+              idempotencyKey: assignmentCommand.idempotencyKey,
+              detail: {
+                commandFingerprint,
+                resourceIds: assignmentCommand.entityRefs.resourceIds,
+              },
+            }),
+          );
+
+          for (const resourceId of assignmentCommand.entityRefs.resourceIds) {
+            const existing = allocations.find(
+              (allocation) =>
+                allocation.resourceId === resourceId &&
+                allocation.demandRef === demand.bookingRef,
+            );
+            if (existing) {
+              const linked =
+                await transaction.hospitalityCapacityAllocation.updateMany({
+                  where: {
+                    id: existing.id,
+                    organizationId: input.organizationId,
+                    version: existing.version,
+                    demandRef: demand.bookingRef,
+                    lifecycle: { in: ["reserved", "active"] },
+                  },
+                  data: {
+                    serviceTurnId: turn.id,
+                    lifecycle: "active",
+                    version: { increment: 1 },
+                  },
+                });
+              if (linked.count !== 1) {
+                throw new RestaurantCommandRollback({
+                  status: "conflict",
+                  currentVersion,
+                  changedFacts: [],
+                  alternatives: [],
+                });
+              }
+              continue;
+            }
+
+            const allocation = allocationRecord(
+              await dependencies.allocateCapacity(transaction as never, {
+                organizationId: input.organizationId,
+                storefrontId: input.storefrontId,
+                resourceId,
+                poolId: null,
+                demandType: "booking",
+                demandRef: demand.bookingRef,
+                bookingId: demand.id,
+                bookingHoldId: null,
+                serviceTurnId: turn.id,
+                startsAt,
+                endsAt,
+                quantity: 1,
+                idempotencyKey:
+                  `${assignmentCommand.idempotencyKey}:${resourceId}`,
+              }),
+            );
+            await dependencies.transitionCapacity(transaction as never, {
+              allocationId: allocation.id,
+              organizationId: input.organizationId,
+              expectedVersion: allocation.version,
+              lifecycle: "active",
+              at: startsAt,
+              reason: "Party seated",
+            });
+          }
+
+          const bookingUpdated = await transaction.storefrontBooking.updateMany({
+            where: {
+              id: demand.id,
+              organizationId: input.organizationId,
+              updatedAt: demand.updatedAt,
+              status: demand.status,
+            },
+            data: {
+              hospitalityResourceId:
+                assignmentCommand.entityRefs.resourceIds[0],
+              status: "seated",
+            },
+          });
+          if (bookingUpdated.count !== 1) {
+            throw new RestaurantCommandRollback({
+              status: "conflict",
+              currentVersion,
+              changedFacts: [],
+              alternatives: [],
+            });
+          }
+
+          return {
+            status: "confirmed",
+            newVersion: `restaurant-turn:${turn.turnId}:${turn.version}`,
+            changedFacts: [
+              { entityId: demand.id, field: "status", value: "seated" },
+              {
+                entityId: demand.id,
+                field: "resourceIds",
+                value: assignmentCommand.entityRefs.resourceIds.join(","),
+              },
+              {
+                entityId: demand.id,
+                field: "staffingAssignmentId",
+                value: staffing.staffingAssignmentId,
+              },
+            ],
+          };
+        });
+      } catch (error) {
+        if (error instanceof RestaurantCommandRollback) return error.result;
+        if (
+          error instanceof HospitalityCapacityConflictError ||
+          error instanceof HospitalityCapacityVersionError
+        ) {
+          return {
+            status: "conflict",
+            currentVersion: command.expectedVersion,
+            changedFacts: [],
+            alternatives: [],
+          };
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadPublicRestaurantAvailabilityBySlug,
+  loadPublicRestaurantAvailabilityBySlugSafe,
+  loadRestaurantFloorOperationalView,
+} from "./restaurant-floor-loader.server";
+import { restaurantSeatingVersion } from "../storefront/restaurant-seating";
+
+const now = new Date("2026-07-31T18:14:00.000Z");
+const seatedBooking = {
+  id: "booking-seated",
+  bookingRef: "BOOK-SEATED",
+  customerName: "Morgan Lee",
+  customerEmail: "morgan@example.test",
+  customerPhone: "555-0001",
+  covers: 2,
+  demandKind: "reservation",
+  dietaryNotes: null,
+  status: "seated",
+  scheduledAt: new Date("2026-07-31T18:00:00.000Z"),
+  durationMinutes: 75,
+  createdAt: new Date("2026-07-31T17:00:00.000Z"),
+  updatedAt: new Date("2026-07-31T18:00:00.000Z"),
+};
+const waitingBooking = {
+  id: "booking-waiting",
+  bookingRef: "WALKIN-14",
+  customerName: "Alex Kim",
+  customerEmail: "alex@example.test",
+  customerPhone: "555-0002",
+  covers: 2,
+  demandKind: "walk-in",
+  dietaryNotes: "nut allergy",
+  status: "waiting",
+  scheduledAt: now,
+  durationMinutes: 60,
+  createdAt: new Date("2026-07-31T18:00:00.000Z"),
+  updatedAt: new Date("2026-07-31T18:00:00.000Z"),
+};
+const resources = [
+  {
+    id: "table-1",
+    label: "Table 1",
+    status: "active",
+    capacity: 2,
+    version: 1,
+    serviceArea: "Main dining",
+    blockedReason: null,
+    attributes: {
+      shape: "square",
+      combinationGroup: "main",
+      combinableWith: [],
+    },
+  },
+  {
+    id: "table-2",
+    label: "Table 2",
+    status: "active",
+    capacity: 2,
+    version: 3,
+    serviceArea: "Main dining",
+    blockedReason: null,
+    attributes: {
+      shape: "round",
+      combinationGroup: "main",
+      combinableWith: [],
+    },
+  },
+];
+const allocations = [
+  {
+    id: "allocation-1",
+    resourceId: "table-1",
+    startsAt: new Date("2026-07-31T18:00:00.000Z"),
+    endsAt: new Date("2026-07-31T19:15:00.000Z"),
+    lifecycle: "active",
+    version: 2,
+    demandRef: "BOOK-SEATED",
+    serviceTurn: {
+      id: "turn-1",
+      turnId: "HT-TURN1",
+      stage: "ordered",
+      version: 2,
+      startedAt: new Date("2026-07-31T18:00:00.000Z"),
+      expectedEndAt: new Date("2026-07-31T19:15:00.000Z"),
+      bookingId: "booking-seated",
+    },
+  },
+];
+
+function database() {
+  return {
+    storefrontConfig: {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "store-1",
+        organizationId: "org-1",
+        archetype: { archetypeId: "restaurant" },
+      }),
+    },
+    hospitalityResource: {
+      findMany: vi.fn().mockResolvedValue(resources),
+    },
+    hospitalityCapacityAllocation: {
+      findMany: vi.fn().mockResolvedValue(allocations),
+    },
+    bookingHold: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    storefrontBooking: {
+      findMany: vi.fn().mockResolvedValue([seatedBooking, waitingBooking]),
+    },
+    staffingResourceLink: {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          resourceRef: "table-1",
+          shift: {
+            assignments: [
+              {
+                id: "assignment-1",
+                employeeProfileId: "employee-1",
+                lifecycle: "on_site",
+              },
+            ],
+          },
+        },
+        {
+          resourceRef: "table-2",
+          shift: {
+            assignments: [
+              {
+                id: "assignment-1",
+                employeeProfileId: "employee-1",
+                lifecycle: "on_site",
+              },
+            ],
+          },
+        },
+      ]),
+    },
+    employeeProfile: {
+      findMany: vi.fn().mockResolvedValue([
+        { id: "employee-1", displayName: "Jordan Rivera" },
+      ]),
+    },
+  };
+}
+
+describe("restaurant floor operational loader", () => {
+  it("joins turns, tables, waiting demand, and canonical staffing", async () => {
+    const view = await loadRestaurantFloorOperationalView(database(), {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      now,
+    });
+
+    expect(view.floor.tables).toEqual([
+      expect.objectContaining({
+        id: "table-1",
+        state: "ordered",
+        party: { id: "booking-seated", name: "Morgan Lee", covers: 2 },
+        turn: {
+          id: "turn-1",
+          turnId: "HT-TURN1",
+          stage: "ordered",
+          version: 2,
+        },
+        server: expect.objectContaining({
+          id: "assignment-1",
+          name: "Jordan Rivera",
+          tableCount: 2,
+        }),
+      }),
+      expect.objectContaining({
+        id: "table-2",
+        state: "available",
+      }),
+    ]);
+    expect(view.floor.demand).toEqual([
+      expect.objectContaining({
+        id: "booking-waiting",
+        kind: "walk-in",
+        waitedMinutes: 14,
+        hasDietaryNote: true,
+        compatibleTableIds: ["table-2"],
+      }),
+    ]);
+    expect(view.commands).toEqual([
+      {
+        demandId: "booking-waiting",
+        options: [
+          {
+            resourceIds: ["table-2"],
+            label: "Table 2",
+            interval: {
+              startsAt: "2026-07-31T18:14:00.000Z",
+              endsAt: "2026-07-31T19:14:00.000Z",
+            },
+            expectedVersion: restaurantSeatingVersion({
+              demand: waitingBooking,
+              resources: [resources[1]],
+              allocations: [],
+            }),
+          },
+        ],
+      },
+    ]);
+    expect(view.moves).toEqual([
+      {
+        demandId: "booking-seated",
+        serviceTurnId: "turn-1",
+        expectedTurnVersion: 2,
+        options: [
+          expect.objectContaining({
+            resourceIds: ["table-2"],
+            label: "Table 2",
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it("reports the bounded read count, elapsed time, and exact payload size", async () => {
+    const ticks = [100, 112.5];
+    const view = await loadRestaurantFloorOperationalView(database(), {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      now,
+      clock: () => ticks.shift() ?? 112.5,
+    });
+
+    expect(view.telemetry).toEqual({
+      durationMs: 12.5,
+      queryCount: 6,
+      payloadBytes: new TextEncoder().encode(JSON.stringify(view)).byteLength,
+    });
+  });
+
+  it("emits one versioned command option for a recommended table pair", async () => {
+    const db = database();
+    db.hospitalityCapacityAllocation.findMany.mockResolvedValue([]);
+    db.storefrontBooking.findMany.mockResolvedValue([
+      { ...waitingBooking, covers: 4 },
+    ]);
+
+    const view = await loadRestaurantFloorOperationalView(db, {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      now,
+    });
+
+    expect(view.commands).toEqual([
+      {
+        demandId: "booking-waiting",
+        options: [
+          expect.objectContaining({
+            resourceIds: ["table-1", "table-2"],
+            label: "Table 1 + Table 2",
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it("loads an allow-listed public snapshot by slug without exposing operator facts", async () => {
+    const availability = await loadPublicRestaurantAvailabilityBySlug(
+      database(),
+      { slug: "demo-restaurant", now },
+    );
+
+    expect(availability?.summary).toEqual({
+      totalTables: 2,
+      availableNow: 1,
+      availableSoon: 1,
+    });
+    const serialized = JSON.stringify(availability);
+    for (const privateFact of [
+      "Morgan Lee",
+      "morgan@example.test",
+      "Jordan Rivera",
+      "assignment-1",
+      "BOOK-SEATED",
+      "table-1",
+    ]) {
+      expect(serialized).not.toContain(privateFact);
+    }
+  });
+
+  it("does not expose a floor snapshot for another archetype", async () => {
+    const db = database();
+    db.storefrontConfig.findFirst.mockResolvedValue({
+      id: "store-1",
+      organizationId: "org-1",
+      archetype: { archetypeId: "consultancy" },
+    });
+
+    await expect(
+      loadPublicRestaurantAvailabilityBySlug(db, {
+        slug: "consultancy",
+        now,
+      }),
+    ).resolves.toBeNull();
+    expect(db.hospitalityResource.findMany).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the optional public snapshot cannot be loaded", async () => {
+    const db = database();
+    db.storefrontConfig.findFirst.mockRejectedValue(
+      new Error("database temporarily unavailable"),
+    );
+
+    await expect(
+      loadPublicRestaurantAvailabilityBySlugSafe(db, {
+        slug: "demo-restaurant",
+        now,
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/twin/restaurant-floor-loader.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.ts
@@ -1,0 +1,647 @@
+import {
+  findRestaurantSeatingAlternatives,
+  restaurantSeatingVersion,
+  type RestaurantSeatingAllocationFact,
+  type RestaurantSeatingResourceFact,
+} from "@/lib/storefront/restaurant-seating";
+
+import {
+  deriveRestaurantFloor,
+  projectCustomerRestaurantAvailability,
+  type CustomerRestaurantAvailability,
+  type RestaurantFloorProjection,
+  type RestaurantOccupancyInput,
+  type RestaurantServerSectionInput,
+} from "./restaurant-floor-projection";
+import { instrumentOperationsReadClient } from "./operations-source-client";
+
+interface RestaurantFloorBookingRow {
+  id: string;
+  bookingRef: string;
+  customerName: string;
+  customerEmail: string;
+  customerPhone: string | null;
+  covers: number | null;
+  demandKind: string;
+  dietaryNotes: string | null;
+  status: string;
+  scheduledAt: Date;
+  durationMinutes: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface RestaurantFloorAllocationRow
+  extends RestaurantSeatingAllocationFact {
+  demandRef: string;
+  serviceTurn: {
+    id: string;
+    turnId: string;
+    stage: string;
+    version: number;
+    startedAt: Date;
+    expectedEndAt: Date;
+    bookingId: string | null;
+  } | null;
+}
+
+interface RestaurantFloorResourceRow
+  extends RestaurantSeatingResourceFact {
+  serviceArea: string | null;
+  blockedReason: string | null;
+}
+
+export interface RestaurantFloorDatabase {
+  hospitalityResource: {
+    findMany(args: unknown): Promise<RestaurantFloorResourceRow[]>;
+  };
+  hospitalityCapacityAllocation: {
+    findMany(args: unknown): Promise<RestaurantFloorAllocationRow[]>;
+  };
+  bookingHold: {
+    findMany(args: unknown): Promise<
+      Array<{
+        hospitalityResourceId: string | null;
+        slotStart: Date;
+        slotEnd: Date;
+      }>
+    >;
+  };
+  storefrontBooking: {
+    findMany(args: unknown): Promise<RestaurantFloorBookingRow[]>;
+  };
+  staffingResourceLink: {
+    findMany(args: unknown): Promise<
+      Array<{
+        resourceRef: string;
+        shift: {
+          assignments: Array<{
+            id: string;
+            employeeProfileId: string | null;
+            lifecycle: string;
+          }>;
+        };
+      }>
+    >;
+  };
+  employeeProfile: {
+    findMany(args: unknown): Promise<
+      Array<{ id: string; displayName: string }>
+    >;
+  };
+}
+
+export interface PublicRestaurantAvailabilityDatabase
+  extends RestaurantFloorDatabase {
+  storefrontConfig: {
+    findFirst(args: unknown): Promise<{
+      id: string;
+      organizationId: string;
+      archetype: { archetypeId: string } | null;
+    } | null>;
+  };
+}
+
+export interface RestaurantFloorCommandOption {
+  resourceIds: string[];
+  label: string;
+  expectedVersion: string;
+  interval: { startsAt: string; endsAt: string };
+}
+
+export interface RestaurantFloorCommandDemand {
+  demandId: string;
+  options: RestaurantFloorCommandOption[];
+}
+
+export interface RestaurantFloorMoveCommand {
+  demandId: string;
+  serviceTurnId: string;
+  expectedTurnVersion: number;
+  options: RestaurantFloorCommandOption[];
+}
+
+export interface RestaurantFloorOperationalView {
+  floor: RestaurantFloorProjection;
+  commands: RestaurantFloorCommandDemand[];
+  moves: RestaurantFloorMoveCommand[];
+  telemetry: {
+    durationMs: number;
+    queryCount: number;
+    payloadBytes: number;
+  };
+}
+
+const ACTIVE_TURN_STAGES = new Set(["seated", "ordered", "paid", "dirty"]);
+const OPEN_BOOKING_STATUSES = [
+  "waiting",
+  "pending",
+  "confirmed",
+  "scheduled",
+  "seated",
+];
+
+function attachExactPayloadBytes(
+  view: RestaurantFloorOperationalView,
+): RestaurantFloorOperationalView {
+  let payloadBytes = view.telemetry.payloadBytes;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const measured = {
+      ...view,
+      telemetry: { ...view.telemetry, payloadBytes },
+    };
+    const next = new TextEncoder().encode(JSON.stringify(measured)).byteLength;
+    if (next === payloadBytes) return measured;
+    payloadBytes = next;
+  }
+  return {
+    ...view,
+    telemetry: { ...view.telemetry, payloadBytes },
+  };
+}
+
+function occupancyStage(
+  stage: string,
+): RestaurantOccupancyInput["stage"] {
+  return ACTIVE_TURN_STAGES.has(stage)
+    ? stage as RestaurantOccupancyInput["stage"]
+    : "seated";
+}
+
+export async function loadRestaurantFloorOperationalView(
+  database: RestaurantFloorDatabase,
+  input: {
+    organizationId: string;
+    storefrontId: string;
+    now?: Date;
+    clock?: () => number;
+  },
+): Promise<RestaurantFloorOperationalView> {
+  const now = input.now ?? new Date();
+  const clock = input.clock ?? (() => performance.now());
+  const startedAt = clock();
+  let queryCount = 0;
+  const client = instrumentOperationsReadClient(database, () => {
+    queryCount += 1;
+  });
+  const horizonStart = new Date(now.getTime() - 12 * 60 * 60_000);
+  const horizonEnd = new Date(now.getTime() + 24 * 60 * 60_000);
+
+  const [resources, allocations, holds, bookings, staffingLinks] =
+    await Promise.all([
+      client.hospitalityResource.findMany({
+        where: {
+          organizationId: input.organizationId,
+          storefrontId: input.storefrontId,
+          kind: "table",
+          status: { not: "retired" },
+        },
+        select: {
+          id: true,
+          label: true,
+          status: true,
+          capacity: true,
+          version: true,
+          serviceArea: true,
+          blockedReason: true,
+          attributes: true,
+        },
+        orderBy: [{ serviceArea: "asc" }, { label: "asc" }],
+        take: 250,
+      }),
+      client.hospitalityCapacityAllocation.findMany({
+        where: {
+          organizationId: input.organizationId,
+          storefrontId: input.storefrontId,
+          resourceId: { not: null },
+          lifecycle: { in: ["reserved", "active"] },
+          conflictQuarantinedAt: null,
+          startsAt: { lt: horizonEnd },
+          endsAt: { gt: horizonStart },
+        },
+        select: {
+          id: true,
+          resourceId: true,
+          startsAt: true,
+          endsAt: true,
+          lifecycle: true,
+          version: true,
+          demandRef: true,
+          serviceTurn: {
+            select: {
+              id: true,
+              turnId: true,
+              stage: true,
+              version: true,
+              startedAt: true,
+              expectedEndAt: true,
+              bookingId: true,
+            },
+          },
+        },
+        orderBy: { startsAt: "asc" },
+        take: 500,
+      }),
+      client.bookingHold.findMany({
+        where: {
+          organizationId: input.organizationId,
+          storefrontId: input.storefrontId,
+          hospitalityResourceId: { not: null },
+          expiresAt: { gt: now },
+          slotStart: { lt: horizonEnd },
+          slotEnd: { gt: horizonStart },
+        },
+        select: {
+          hospitalityResourceId: true,
+          slotStart: true,
+          slotEnd: true,
+        },
+        take: 250,
+      }),
+      client.storefrontBooking.findMany({
+        where: {
+          organizationId: input.organizationId,
+          storefrontId: input.storefrontId,
+          status: { in: OPEN_BOOKING_STATUSES },
+          OR: [
+            { status: "waiting" },
+            {
+              scheduledAt: {
+                gte: horizonStart,
+                lt: horizonEnd,
+              },
+            },
+          ],
+        },
+        select: {
+          id: true,
+          bookingRef: true,
+          customerName: true,
+          customerEmail: true,
+          customerPhone: true,
+          covers: true,
+          demandKind: true,
+          dietaryNotes: true,
+          status: true,
+          scheduledAt: true,
+          durationMinutes: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy: [{ scheduledAt: "asc" }, { createdAt: "asc" }],
+        take: 500,
+      }),
+      client.staffingResourceLink.findMany({
+        where: {
+          organizationId: input.organizationId,
+          resourceType: "table",
+          shift: {
+            lifecycle: "published",
+            startAt: { lte: now },
+            endAt: { gt: now },
+          },
+        },
+        select: {
+          resourceRef: true,
+          shift: {
+            select: {
+              assignments: {
+                where: {
+                  lifecycle: { in: ["confirmed", "on_site"] },
+                },
+                select: {
+                  id: true,
+                  employeeProfileId: true,
+                  lifecycle: true,
+                },
+              },
+            },
+          },
+        },
+        take: 500,
+      }),
+    ]);
+
+  const employeeIds = [
+    ...new Set(
+      staffingLinks.flatMap((link) =>
+        link.shift.assignments
+          .map((assignment) => assignment.employeeProfileId)
+          .filter((id): id is string => id !== null)
+      ),
+    ),
+  ];
+  const employees =
+    employeeIds.length > 0
+      ? await client.employeeProfile.findMany({
+          where: { id: { in: employeeIds } },
+          select: { id: true, displayName: true },
+        })
+      : [];
+  const employeeName = new Map(
+    employees.map((employee) => [employee.id, employee.displayName]),
+  );
+  const bookingById = new Map(bookings.map((booking) => [booking.id, booking]));
+  const bookingByRef = new Map(
+    bookings.map((booking) => [booking.bookingRef, booking]),
+  );
+  const resourceById = new Map(
+    resources.map((resource) => [resource.id, resource]),
+  );
+
+  const occupancyGroups = new Map<string, RestaurantOccupancyInput>();
+  for (const allocation of allocations) {
+    const turn = allocation.serviceTurn;
+    if (
+      !turn ||
+      !turn.bookingId ||
+      !allocation.resourceId ||
+      !ACTIVE_TURN_STAGES.has(turn.stage)
+    ) {
+      continue;
+    }
+    const key = turn.id;
+    const existing = occupancyGroups.get(key);
+    if (existing) {
+      if (!existing.tableIds.includes(allocation.resourceId)) {
+        existing.tableIds.push(allocation.resourceId);
+      }
+      continue;
+    }
+    occupancyGroups.set(key, {
+      tableIds: [allocation.resourceId],
+      demandId: turn.bookingId,
+      stage: occupancyStage(turn.stage),
+      turn: {
+        id: turn.id,
+        turnId: turn.turnId,
+        version: turn.version,
+      },
+      startedAt: turn.startedAt,
+      expectedEndAt: turn.expectedEndAt,
+    });
+  }
+
+  const sections = new Map<string, RestaurantServerSectionInput>();
+  for (const link of staffingLinks) {
+    const assignment = link.shift.assignments[0];
+    if (!assignment) continue;
+    const resource = resourceById.get(link.resourceRef);
+    const existing = sections.get(assignment.id);
+    if (existing) {
+      if (!existing.tableIds.includes(link.resourceRef)) {
+        existing.tableIds.push(link.resourceRef);
+      }
+      continue;
+    }
+    sections.set(assignment.id, {
+      serverId: assignment.id,
+      serverName:
+        (assignment.employeeProfileId
+          ? employeeName.get(assignment.employeeProfileId)
+          : null) ?? "Assigned server",
+      sectionLabel: resource?.serviceArea?.trim() || "Assigned section",
+      tableIds: [link.resourceRef],
+    });
+  }
+
+  const floor = deriveRestaurantFloor({
+    now,
+    tables: resources,
+    occupancies: [...occupancyGroups.values()],
+    holds: holds.flatMap((hold) =>
+      hold.hospitalityResourceId
+        ? [{
+            tableId: hold.hospitalityResourceId,
+            startsAt: hold.slotStart,
+            endsAt: hold.slotEnd,
+          }]
+        : []
+    ),
+    demands: bookings.map((booking) => ({
+      id: booking.id,
+      kind: booking.demandKind === "walk-in" ? "walk-in" : "reservation",
+      guestName: booking.customerName,
+      guestEmail: booking.customerEmail,
+      guestPhone: booking.customerPhone,
+      covers: booking.covers ?? 0,
+      status: booking.status,
+      arrivedAt:
+        booking.demandKind === "walk-in" ? booking.createdAt : null,
+      scheduledAt: booking.scheduledAt,
+      dietaryNotes: booking.dietaryNotes,
+      vip: false,
+    })),
+    serverSections: [...sections.values()],
+    upcoming: allocations.flatMap((allocation) =>
+      allocation.resourceId &&
+        allocation.serviceTurn === null &&
+        allocation.lifecycle === "reserved"
+        ? [{
+            tableId: allocation.resourceId,
+            demandId:
+              bookingByRef.get(allocation.demandRef)?.id ??
+              allocation.demandRef,
+            startsAt: allocation.startsAt,
+            endsAt: allocation.endsAt,
+          }]
+        : []
+    ),
+  });
+
+  const commands = floor.demand.map((party) => {
+    const demand = bookingById.get(party.id)!;
+    const candidateResourceIds = [
+      ...(party.recommendation?.tableIds.length
+        ? [party.recommendation.tableIds]
+        : []),
+      ...party.compatibleTableIds.flatMap((resourceId) => {
+        const resource = resourceById.get(resourceId);
+        return resource && resource.capacity >= party.covers
+          ? [[resourceId]]
+          : [];
+      }),
+    ];
+    const seenCandidates = new Set<string>();
+    const options = candidateResourceIds.flatMap((resourceIds) => {
+      const key = [...resourceIds].sort().join(",");
+      if (seenCandidates.has(key)) return [];
+      seenCandidates.add(key);
+      const optionResources = resourceIds.flatMap((resourceId) => {
+        const resource = resourceById.get(resourceId);
+        const floorTable = floor.tables.find((table) => table.id === resourceId);
+        return resource && floorTable?.state === "available" ? [resource] : [];
+      });
+      if (optionResources.length !== resourceIds.length) return [];
+      const resourceAllocations = allocations.filter(
+        (allocation) =>
+          allocation.resourceId !== null &&
+          resourceIds.includes(allocation.resourceId),
+      );
+      return [{
+        resourceIds,
+        label: optionResources.map((resource) => resource.label).join(" + "),
+        interval: {
+          startsAt: now.toISOString(),
+          endsAt: new Date(
+            now.getTime() + demand.durationMinutes * 60_000,
+          ).toISOString(),
+        },
+        expectedVersion: restaurantSeatingVersion({
+          demand,
+          resources: optionResources,
+          allocations: resourceAllocations,
+        }),
+      }];
+    });
+    return { demandId: party.id, options };
+  });
+
+  const moveTurns = new Map<
+    string,
+    {
+      demandId: string;
+      serviceTurnId: string;
+      expectedTurnVersion: number;
+      expectedEndAt: Date;
+      currentResourceIds: string[];
+    }
+  >();
+  for (const allocation of allocations) {
+    if (
+      !allocation.resourceId ||
+      !allocation.serviceTurn ||
+      !allocation.serviceTurn.bookingId ||
+      !["seated", "ordered"].includes(allocation.serviceTurn.stage)
+    ) {
+      continue;
+    }
+    const turnId = allocation.serviceTurn.id;
+    const existing = moveTurns.get(turnId);
+    if (existing) {
+      if (!existing.currentResourceIds.includes(allocation.resourceId)) {
+        existing.currentResourceIds.push(allocation.resourceId);
+      }
+      continue;
+    }
+    moveTurns.set(turnId, {
+      demandId: allocation.serviceTurn.bookingId,
+      serviceTurnId: turnId,
+      expectedTurnVersion: allocation.serviceTurn.version,
+      expectedEndAt: allocation.serviceTurn.expectedEndAt,
+      currentResourceIds: [allocation.resourceId],
+    });
+  }
+  const moves = [...moveTurns.values()].flatMap((turn) => {
+    const demand = bookingById.get(turn.demandId);
+    if (!demand?.covers) return [];
+    const targetResources = resources.filter(
+      (resource) => !turn.currentResourceIds.includes(resource.id),
+    );
+    const targetResourceIds = new Set(
+      targetResources.map((resource) => resource.id),
+    );
+    const targetAllocations = allocations.filter(
+      (allocation) =>
+        allocation.resourceId !== null &&
+        targetResourceIds.has(allocation.resourceId),
+    );
+    const endsAt =
+      turn.expectedEndAt.getTime() > now.getTime()
+        ? turn.expectedEndAt
+        : new Date(now.getTime() + 15 * 60_000);
+    const alternatives = findRestaurantSeatingAlternatives({
+      covers: demand.covers,
+      resources: targetResources,
+      allocations: targetAllocations,
+      startsAt: now,
+      endsAt,
+      demandRef: demand.bookingRef,
+      limit: 3,
+    });
+    return [{
+      demandId: demand.id,
+      serviceTurnId: turn.serviceTurnId,
+      expectedTurnVersion: turn.expectedTurnVersion,
+      options: alternatives.map((alternative) => {
+        const optionResources = resources.filter((resource) =>
+          alternative.resourceIds.includes(resource.id),
+        );
+        const optionAllocations = allocations.filter(
+          (allocation) =>
+            allocation.resourceId !== null &&
+            alternative.resourceIds.includes(allocation.resourceId),
+        );
+        return {
+          resourceIds: alternative.resourceIds,
+          label: alternative.label,
+          expectedVersion: restaurantSeatingVersion({
+            demand,
+            resources: optionResources,
+            allocations: optionAllocations,
+          }),
+          interval: {
+            startsAt: now.toISOString(),
+            endsAt: endsAt.toISOString(),
+          },
+        };
+      }),
+    }];
+  });
+
+  return attachExactPayloadBytes({
+    floor,
+    commands,
+    moves,
+    telemetry: {
+      durationMs: Math.max(0, clock() - startedAt),
+      queryCount,
+      payloadBytes: 0,
+    },
+  });
+}
+
+/**
+ * Public boundary for the restaurant's live physical-capacity picture.
+ * The operational loader may join customer and staffing facts, but only the
+ * explicit customer projection can leave this server-only boundary.
+ */
+export async function loadPublicRestaurantAvailabilityBySlug(
+  database: PublicRestaurantAvailabilityDatabase,
+  input: { slug: string; now?: Date },
+): Promise<CustomerRestaurantAvailability | null> {
+  const storefront = await database.storefrontConfig.findFirst({
+    where: {
+      isPublished: true,
+      organization: { slug: input.slug },
+    },
+    select: {
+      id: true,
+      organizationId: true,
+      archetype: { select: { archetypeId: true } },
+    },
+  });
+  if (storefront?.archetype?.archetypeId !== "restaurant") return null;
+
+  const view = await loadRestaurantFloorOperationalView(database, {
+    organizationId: storefront.organizationId,
+    storefrontId: storefront.id,
+    ...(input.now ? { now: input.now } : {}),
+  });
+  return projectCustomerRestaurantAvailability(view.floor);
+}
+
+/**
+ * The physical snapshot is additive guidance, not a prerequisite for booking.
+ * Degrade to the existing slot flow if its live projection is unavailable.
+ */
+export async function loadPublicRestaurantAvailabilityBySlugSafe(
+  database: PublicRestaurantAvailabilityDatabase,
+  input: { slug: string; now?: Date },
+): Promise<CustomerRestaurantAvailability | null> {
+  try {
+    return await loadPublicRestaurantAvailabilityBySlug(database, input);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/twin/restaurant-floor-projection.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-projection.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveRestaurantFloor,
+  projectCustomerRestaurantAvailability,
+  type RestaurantFloorInput,
+} from "./restaurant-floor-projection";
+
+const NOW = new Date("2026-07-31T23:00:00.000Z");
+
+function busyShift(): RestaurantFloorInput {
+  return {
+    now: NOW,
+    tables: [
+      {
+        id: "table-1",
+        label: "Table 1",
+        capacity: 4,
+        serviceArea: "Main dining",
+        status: "active",
+        attributes: {
+          shape: "round",
+          combinableWith: ["table-2"],
+        },
+      },
+      {
+        id: "table-2",
+        label: "Table 2",
+        capacity: 4,
+        serviceArea: "Main dining",
+        status: "active",
+        attributes: {
+          shape: "square",
+          combinationGroup: "main-pair",
+          combinableWith: ["table-1"],
+        },
+      },
+      {
+        id: "table-3",
+        label: "Table 3",
+        capacity: 2,
+        serviceArea: "Window",
+        status: "active",
+        attributes: { shape: "square" },
+      },
+      {
+        id: "table-4",
+        label: "Table 4",
+        capacity: 4,
+        serviceArea: "Patio",
+        status: "blocked",
+        blockedReason: "Chair repair",
+        attributes: { shape: "round" },
+      },
+      {
+        id: "table-5",
+        label: "Table 5",
+        capacity: 2,
+        serviceArea: "Main dining",
+        status: "active",
+        attributes: { shape: "round" },
+      },
+      {
+        id: "table-6",
+        label: "Table 6",
+        capacity: 2,
+        serviceArea: "Main dining",
+        status: "active",
+        attributes: { shape: "round" },
+      },
+      {
+        id: "table-7",
+        label: "Table 7",
+        capacity: 4,
+        serviceArea: "Window",
+        status: "active",
+        attributes: { shape: "booth" },
+      },
+      {
+        id: "table-8",
+        label: "Table 8",
+        capacity: 4,
+        serviceArea: "Main dining",
+        status: "active",
+        attributes: { shape: "rectangle" },
+      },
+    ],
+    occupancies: [
+      {
+        tableIds: ["table-2"],
+        demandId: "reservation-lee",
+        stage: "ordered",
+        startedAt: new Date("2026-07-31T22:10:00.000Z"),
+        expectedEndAt: new Date("2026-07-31T23:35:00.000Z"),
+      },
+      {
+        tableIds: ["table-3"],
+        demandId: "reservation-ng",
+        stage: "dirty",
+        startedAt: new Date("2026-07-31T21:30:00.000Z"),
+        expectedEndAt: new Date("2026-07-31T22:45:00.000Z"),
+      },
+      {
+        tableIds: ["table-5", "table-6"],
+        demandId: "reservation-morgan",
+        stage: "seated",
+        startedAt: new Date("2026-07-31T22:35:00.000Z"),
+        expectedEndAt: new Date("2026-08-01T00:05:00.000Z"),
+      },
+      {
+        tableIds: ["table-7"],
+        demandId: "reservation-chen",
+        stage: "paid",
+        startedAt: new Date("2026-07-31T21:40:00.000Z"),
+        expectedEndAt: new Date("2026-07-31T23:04:00.000Z"),
+      },
+      {
+        tableIds: ["table-8"],
+        demandId: "reservation-davis",
+        stage: "seated",
+        startedAt: new Date("2026-07-31T21:20:00.000Z"),
+        expectedEndAt: new Date("2026-07-31T22:48:00.000Z"),
+      },
+    ],
+    holds: [
+      {
+        tableId: "table-1",
+        startsAt: new Date("2026-07-31T22:58:00.000Z"),
+        endsAt: new Date("2026-07-31T23:08:00.000Z"),
+      },
+    ],
+    demands: [
+      {
+        id: "reservation-lee",
+        kind: "reservation",
+        guestName: "Lee",
+        guestEmail: "lee@example.com",
+        guestPhone: "555-0101",
+        covers: 4,
+        status: "seated",
+        scheduledAt: new Date("2026-07-31T22:00:00.000Z"),
+        dietaryNotes: "Peanut allergy",
+        vip: true,
+      },
+      {
+        id: "walkin-rivera",
+        kind: "walk-in",
+        guestName: "Rivera",
+        covers: 3,
+        status: "waiting",
+        arrivedAt: new Date("2026-07-31T22:46:00.000Z"),
+      },
+      {
+        id: "reservation-patel",
+        kind: "reservation",
+        guestName: "Patel",
+        covers: 2,
+        status: "waiting",
+        scheduledAt: new Date("2026-08-01T00:30:00.000Z"),
+      },
+    ],
+    serverSections: [
+      {
+        serverId: "employee-alex",
+        serverName: "Alex",
+        sectionLabel: "Main dining",
+        tableIds: ["table-1", "table-2", "table-5", "table-6", "table-8"],
+      },
+      {
+        serverId: "employee-sam",
+        serverName: "Sam",
+        sectionLabel: "Window",
+        tableIds: ["table-3", "table-7"],
+      },
+    ],
+    upcoming: [
+      {
+        tableId: "table-1",
+        demandId: "reservation-patel",
+        startsAt: new Date("2026-08-01T00:30:00.000Z"),
+        endsAt: new Date("2026-08-01T02:00:00.000Z"),
+      },
+    ],
+  };
+}
+
+describe("deriveRestaurantFloor", () => {
+  it("carries every busy-shift table state with structural and staffing context", () => {
+    const floor = deriveRestaurantFloor(busyShift());
+
+    expect(floor.tables.map((table) => [table.id, table.state])).toEqual([
+      ["table-1", "held"],
+      ["table-2", "ordered"],
+      ["table-3", "dirty"],
+      ["table-4", "blocked"],
+      ["table-5", "seated"],
+      ["table-6", "seated"],
+      ["table-7", "paid"],
+      ["table-8", "late-turn"],
+    ]);
+    expect(floor.tables.find((table) => table.id === "table-2")).toMatchObject({
+      shape: "square",
+      capacity: 4,
+      serviceArea: "Main dining",
+      server: { id: "employee-alex", name: "Alex", tableCount: 5 },
+      party: { id: "reservation-lee", name: "Lee", covers: 4 },
+    });
+    expect(floor.tables.find((table) => table.id === "table-5")?.combinedWith).toEqual([
+      "table-6",
+    ]);
+    expect(floor.tables.find((table) => table.id === "table-8")?.timing).toMatchObject({
+      kind: "late",
+      minutes: 12,
+    });
+  });
+
+  it("explains compatibility, forward availability, and server imbalance", () => {
+    const floor = deriveRestaurantFloor(busyShift());
+    const rivera = floor.demand.find((party) => party.id === "walkin-rivera");
+
+    expect(rivera).toMatchObject({
+      waitedMinutes: 14,
+      compatibleTableIds: ["table-1"],
+      recommendation: {
+        tableIds: ["table-1"],
+        warning: "Alex is carrying 5 tables while Sam is carrying 2.",
+      },
+    });
+    expect(floor.tables.find((table) => table.id === "table-1")?.availability).toEqual({
+      kind: "at",
+      availableAt: "2026-07-31T23:08:00.000Z",
+      minutes: 8,
+      reason: "Held for a booking in progress",
+    });
+    expect(floor.tables.find((table) => table.id === "table-2")?.availability).toEqual({
+      kind: "at",
+      availableAt: "2026-07-31T23:35:00.000Z",
+      minutes: 35,
+      reason: "Current party is still dining",
+    });
+  });
+
+  it("uses text states and honest unknown staffing instead of inventing coverage", () => {
+    const input = busyShift();
+    input.serverSections = [];
+    const floor = deriveRestaurantFloor(input);
+
+    expect(floor.tables.find((table) => table.id === "table-1")?.statusLabel).toBe(
+      "Held",
+    );
+    expect(floor.tables.every((table) => table.server == null)).toBe(true);
+    expect(floor.staffingAvailable).toBe(false);
+  });
+
+  it("recommends a configured table pair when no single table fits", () => {
+    const floor = deriveRestaurantFloor({
+      now: NOW,
+      tables: [
+        {
+          id: "table-a",
+          label: "Table A",
+          capacity: 2,
+          serviceArea: "Main",
+          status: "active",
+          attributes: {
+            shape: "square",
+            combinationGroup: "pair-a",
+            combinableWith: [],
+          },
+        },
+        {
+          id: "table-b",
+          label: "Table B",
+          capacity: 2,
+          serviceArea: "Main",
+          status: "active",
+          attributes: {
+            shape: "square",
+            combinationGroup: "pair-a",
+            combinableWith: [],
+          },
+        },
+      ],
+      occupancies: [],
+      holds: [],
+      upcoming: [],
+      demands: [
+        {
+          id: "walkin-four",
+          kind: "walk-in",
+          guestName: "Party of four",
+          covers: 4,
+          status: "waiting",
+          arrivedAt: new Date("2026-07-31T22:55:00.000Z"),
+        },
+      ],
+      serverSections: [
+        {
+          serverId: "employee-a",
+          serverName: "Jordan",
+          sectionLabel: "Main",
+          tableIds: ["table-a", "table-b"],
+        },
+      ],
+    });
+
+    expect(floor.demand[0]).toMatchObject({
+      compatibleTableIds: ["table-a", "table-b"],
+      recommendation: {
+        tableIds: ["table-a", "table-b"],
+        reason: "Table A + Table B fit 4 and are open now.",
+      },
+    });
+  });
+});
+
+describe("projectCustomerRestaurantAvailability", () => {
+  it("allow-lists capacity and timing without leaking guest, staff, or internal notes", () => {
+    const customer = projectCustomerRestaurantAvailability(
+      deriveRestaurantFloor(busyShift()),
+    );
+    const serialized = JSON.stringify(customer);
+
+    expect(customer.tables[0]).toEqual({
+      key: "availability-1",
+      capacity: 4,
+      shape: "round",
+      serviceArea: "Main dining",
+      availability: {
+        kind: "at",
+        availableAt: "2026-07-31T23:08:00.000Z",
+        minutes: 8,
+        explanation: "Available in about 8 minutes",
+      },
+    });
+    for (const secret of [
+      "Lee",
+      "Rivera",
+      "Patel",
+      "Alex",
+      "Sam",
+      "employee-alex",
+      "lee@example.com",
+      "555-0101",
+      "Peanut allergy",
+      "VIP",
+      "Chair repair",
+      "server imbalance",
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it("keeps customer and operator availability counts reconciled", () => {
+    const operator = deriveRestaurantFloor(busyShift());
+    const customer = projectCustomerRestaurantAvailability(operator);
+
+    expect(customer.summary.totalTables).toBe(operator.tables.length);
+    expect(customer.summary.availableNow).toBe(
+      operator.tables.filter((table) => table.availability.kind === "now").length,
+    );
+  });
+});

--- a/apps/web/lib/twin/restaurant-floor-projection.ts
+++ b/apps/web/lib/twin/restaurant-floor-projection.ts
@@ -211,7 +211,7 @@ function availabilityFor(input: {
   hold?: RestaurantHoldInput;
   upcoming?: RestaurantUpcomingAssignmentInput;
 }): RestaurantForwardAvailability {
-  const { now, table, state, occupancy, hold, upcoming } = input;
+  const { now, state, occupancy, hold, upcoming } = input;
   if (state === "available") {
     return {
       kind: "now",

--- a/apps/web/lib/twin/restaurant-floor-projection.ts
+++ b/apps/web/lib/twin/restaurant-floor-projection.ts
@@ -1,0 +1,580 @@
+import {
+  parseRestaurantTableAttributes,
+  type RestaurantTableShape,
+} from "../storefront/restaurant-table-attributes";
+
+export const RESTAURANT_FLOOR_STATES = [
+  "available",
+  "held",
+  "reserved",
+  "seated",
+  "ordered",
+  "paid",
+  "dirty",
+  "blocked",
+  "late-turn",
+] as const;
+
+export type RestaurantFloorState = (typeof RESTAURANT_FLOOR_STATES)[number];
+
+export interface RestaurantFloorTableInput {
+  id: string;
+  label: string;
+  capacity: number;
+  serviceArea: string | null;
+  status: string;
+  blockedReason?: string | null;
+  attributes?: unknown;
+}
+
+export type RestaurantOccupancyStage =
+  | "reserved"
+  | "seated"
+  | "ordered"
+  | "paid"
+  | "dirty";
+
+export interface RestaurantOccupancyInput {
+  tableIds: string[];
+  demandId: string;
+  stage: RestaurantOccupancyStage;
+  turn?: {
+    id: string;
+    turnId: string;
+    version: number;
+  };
+  startedAt: Date;
+  expectedEndAt: Date;
+}
+
+export interface RestaurantHoldInput {
+  tableId: string;
+  startsAt: Date;
+  endsAt: Date;
+}
+
+export interface RestaurantUpcomingAssignmentInput {
+  tableId: string;
+  demandId: string;
+  startsAt: Date;
+  endsAt: Date;
+}
+
+export interface RestaurantDemandInput {
+  id: string;
+  kind: "reservation" | "walk-in";
+  guestName: string;
+  guestEmail?: string | null;
+  guestPhone?: string | null;
+  covers: number;
+  status: string;
+  arrivedAt?: Date | null;
+  scheduledAt?: Date | null;
+  dietaryNotes?: string | null;
+  vip?: boolean;
+}
+
+export interface RestaurantServerSectionInput {
+  serverId: string;
+  serverName: string;
+  sectionLabel: string;
+  tableIds: string[];
+}
+
+export interface RestaurantFloorInput {
+  now: Date;
+  tables: RestaurantFloorTableInput[];
+  occupancies: RestaurantOccupancyInput[];
+  holds: RestaurantHoldInput[];
+  demands: RestaurantDemandInput[];
+  serverSections: RestaurantServerSectionInput[];
+  upcoming: RestaurantUpcomingAssignmentInput[];
+}
+
+export interface RestaurantForwardAvailability {
+  kind: "now" | "at" | "unavailable";
+  availableAt: string | null;
+  minutes: number | null;
+  reason: string;
+}
+
+export interface RestaurantFloorTable {
+  id: string;
+  label: string;
+  capacity: number;
+  serviceArea: string;
+  shape: RestaurantTableShape;
+  combinableWith: string[];
+  combinationGroup: string | null;
+  combinedWith: string[];
+  state: RestaurantFloorState;
+  statusLabel: string;
+  blockedReason: string | null;
+  timing: { kind: "on-time" | "turning" | "late"; minutes: number } | null;
+  availability: RestaurantForwardAvailability;
+  party: { id: string; name: string; covers: number } | null;
+  turn: {
+    id: string;
+    turnId: string;
+    stage: Exclude<RestaurantOccupancyStage, "reserved">;
+    version: number;
+  } | null;
+  server: {
+    id: string;
+    name: string;
+    sectionLabel: string;
+    tableCount: number;
+  } | null;
+}
+
+export interface RestaurantFloorDemand {
+  id: string;
+  kind: "reservation" | "walk-in";
+  name: string;
+  covers: number;
+  waitedMinutes: number | null;
+  scheduledAt: string | null;
+  hasDietaryNote: boolean;
+  vip: boolean;
+  compatibleTableIds: string[];
+  recommendation: {
+    tableIds: string[];
+    reason: string;
+    warning: string | null;
+  } | null;
+}
+
+export interface RestaurantFloorProjection {
+  asOf: string;
+  staffingAvailable: boolean;
+  tables: RestaurantFloorTable[];
+  demand: RestaurantFloorDemand[];
+}
+
+const STATE_LABEL: Record<RestaurantFloorState, string> = {
+  available: "Available",
+  held: "Held",
+  reserved: "Reserved",
+  seated: "Seated",
+  ordered: "Ordered",
+  paid: "Paid",
+  dirty: "Dirty",
+  blocked: "Blocked",
+  "late-turn": "Late turn",
+};
+
+function minutesBetween(later: Date, earlier: Date): number {
+  return Math.max(0, Math.round((later.getTime() - earlier.getTime()) / 60_000));
+}
+
+function activeAt(
+  row: { startsAt: Date; endsAt: Date },
+  now: Date,
+): boolean {
+  return row.startsAt.getTime() <= now.getTime() && now < row.endsAt;
+}
+
+function occupancyState(
+  occupancy: RestaurantOccupancyInput,
+  now: Date,
+): Pick<RestaurantFloorTable, "state" | "timing"> {
+  if (
+    occupancy.stage !== "dirty" &&
+    occupancy.expectedEndAt.getTime() < now.getTime()
+  ) {
+    return {
+      state: "late-turn",
+      timing: {
+        kind: "late",
+        minutes: minutesBetween(now, occupancy.expectedEndAt),
+      },
+    };
+  }
+  const remaining = minutesBetween(occupancy.expectedEndAt, now);
+  return {
+    state: occupancy.stage,
+    timing:
+      occupancy.stage === "dirty"
+        ? null
+        : {
+            kind: remaining <= 15 ? "turning" : "on-time",
+            minutes: remaining,
+          },
+  };
+}
+
+function availabilityFor(input: {
+  now: Date;
+  table: RestaurantFloorTableInput;
+  state: RestaurantFloorState;
+  occupancy?: RestaurantOccupancyInput;
+  hold?: RestaurantHoldInput;
+  upcoming?: RestaurantUpcomingAssignmentInput;
+}): RestaurantForwardAvailability {
+  const { now, table, state, occupancy, hold, upcoming } = input;
+  if (state === "available") {
+    return {
+      kind: "now",
+      availableAt: now.toISOString(),
+      minutes: 0,
+      reason: upcoming
+        ? `Open now before the next reservation`
+        : "Available for seating now",
+    };
+  }
+  if (state === "blocked") {
+    return {
+      kind: "unavailable",
+      availableAt: null,
+      minutes: null,
+      reason: "Not available for seating",
+    };
+  }
+  if (state === "dirty") {
+    return {
+      kind: "unavailable",
+      availableAt: null,
+      minutes: null,
+      reason: "Needs clearing before another party can be seated",
+    };
+  }
+  if (state === "late-turn") {
+    return {
+      kind: "unavailable",
+      availableAt: null,
+      minutes: null,
+      reason: "Current turn is running late",
+    };
+  }
+  const availableAt =
+    state === "held"
+      ? hold?.endsAt
+      : state === "reserved"
+        ? upcoming?.endsAt
+        : occupancy?.expectedEndAt;
+  if (!availableAt) {
+    return {
+      kind: "unavailable",
+      availableAt: null,
+      minutes: null,
+      reason: "Availability needs confirmation",
+    };
+  }
+  const reason =
+    state === "held"
+      ? "Held for a booking in progress"
+      : state === "reserved"
+        ? "Reserved for an upcoming party"
+        : state === "paid"
+          ? "Current party is finishing"
+          : "Current party is still dining";
+  return {
+    kind: "at",
+    availableAt: availableAt.toISOString(),
+    minutes: minutesBetween(availableAt, now),
+    reason,
+  };
+}
+
+function serverWarning(
+  server: RestaurantFloorTable["server"],
+  sections: RestaurantServerSectionInput[],
+): string | null {
+  if (!server || sections.length < 2) return null;
+  const loads = sections
+    .map((section) => ({
+      name: section.serverName,
+      count: new Set(section.tableIds).size,
+    }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  const lightest = loads.at(-1)!;
+  if (server.tableCount - lightest.count < 2) return null;
+  return `${server.name} is carrying ${server.tableCount} tables while ${lightest.name} is carrying ${lightest.count}.`;
+}
+
+function projectedTablesCanCombine(
+  left: RestaurantFloorTable,
+  right: RestaurantFloorTable,
+): boolean {
+  const structurallyCompatible =
+    (left.combinationGroup !== null &&
+      left.combinationGroup === right.combinationGroup) ||
+    (left.combinableWith.includes(right.id) &&
+      right.combinableWith.includes(left.id));
+  const staffingCompatible =
+    left.server === null ||
+    right.server === null ||
+    left.server.id === right.server.id;
+  return structurallyCompatible && staffingCompatible;
+}
+
+export function deriveRestaurantFloor(
+  input: RestaurantFloorInput,
+): RestaurantFloorProjection {
+  const demandById = new Map(input.demands.map((row) => [row.id, row]));
+  const activeHolds = new Map(
+    input.holds
+      .filter((row) => activeAt(row, input.now))
+      .map((row) => [row.tableId, row]),
+  );
+  const occupancyByTable = new Map<string, RestaurantOccupancyInput>();
+  for (const occupancy of input.occupancies) {
+    for (const tableId of occupancy.tableIds) {
+      occupancyByTable.set(tableId, occupancy);
+    }
+  }
+  const upcomingByTable = new Map(
+    input.upcoming
+      .filter((row) => row.endsAt.getTime() > input.now.getTime())
+      .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime())
+      .map((row) => [row.tableId, row]),
+  );
+  const serverByTable = new Map<
+    string,
+    RestaurantFloorTable["server"]
+  >();
+  for (const section of input.serverSections) {
+    const tableCount = new Set(section.tableIds).size;
+    for (const tableId of section.tableIds) {
+      serverByTable.set(tableId, {
+        id: section.serverId,
+        name: section.serverName,
+        sectionLabel: section.sectionLabel,
+        tableCount,
+      });
+    }
+  }
+
+  const tables = input.tables.map((table): RestaurantFloorTable => {
+    const attributes = parseRestaurantTableAttributes(table.attributes);
+    const occupancy = occupancyByTable.get(table.id);
+    const hold = activeHolds.get(table.id);
+    const upcoming = upcomingByTable.get(table.id);
+    let state: RestaurantFloorState;
+    let timing: RestaurantFloorTable["timing"] = null;
+    if (table.status !== "active") {
+      state = "blocked";
+    } else if (occupancy) {
+      ({ state, timing } = occupancyState(occupancy, input.now));
+    } else if (hold) {
+      state = "held";
+    } else if (
+      upcoming &&
+      upcoming.startsAt.getTime() - input.now.getTime() <= 30 * 60_000
+    ) {
+      state = "reserved";
+    } else {
+      state = "available";
+    }
+    const demand = occupancy ? demandById.get(occupancy.demandId) : undefined;
+    return {
+      id: table.id,
+      label: table.label,
+      capacity: table.capacity,
+      serviceArea: table.serviceArea?.trim() || "Unassigned area",
+      shape: attributes.shape,
+      combinableWith: attributes.combinableWith,
+      combinationGroup: attributes.combinationGroup,
+      combinedWith: occupancy
+        ? occupancy.tableIds.filter((tableId) => tableId !== table.id)
+        : [],
+      state,
+      statusLabel: STATE_LABEL[state],
+      blockedReason: table.blockedReason?.trim() || null,
+      timing,
+      availability: availabilityFor({
+        now: input.now,
+        table,
+        state,
+        occupancy,
+        hold,
+        upcoming,
+      }),
+      party:
+        demand && occupancy
+          ? { id: demand.id, name: demand.guestName, covers: demand.covers }
+          : null,
+      turn:
+        occupancy?.turn && occupancy.stage !== "reserved"
+          ? {
+              ...occupancy.turn,
+              stage: occupancy.stage,
+            }
+          : null,
+      server: serverByTable.get(table.id) ?? null,
+    };
+  });
+
+  const individuallyAvailable = tables.filter(
+    (table) =>
+      table.state === "available" ||
+      (table.state === "held" &&
+        (table.availability.minutes ?? Infinity) <= 15),
+  );
+  const openTables = individuallyAvailable.filter(
+    (table) => table.state === "available",
+  );
+  type Candidate = {
+    tables: RestaurantFloorTable[];
+    capacity: number;
+    readyInMinutes: number;
+  };
+  const candidateCache = new Map<number, Candidate[]>();
+  const candidatesFor = (covers: number): Candidate[] => {
+    const cached = candidateCache.get(covers);
+    if (cached) return cached;
+      const candidates: Array<{
+        tables: RestaurantFloorTable[];
+        capacity: number;
+        readyInMinutes: number;
+      }> = individuallyAvailable
+        .filter((table) => table.capacity >= covers)
+        .map((table) => ({
+          tables: [table],
+          capacity: table.capacity,
+          readyInMinutes: table.availability.minutes ?? Infinity,
+        }));
+      for (let left = 0; left < openTables.length; left += 1) {
+        for (let right = left + 1; right < openTables.length; right += 1) {
+          const pair = [openTables[left], openTables[right]];
+          const capacity = pair[0].capacity + pair[1].capacity;
+          if (
+            capacity >= covers &&
+            projectedTablesCanCombine(pair[0], pair[1])
+          ) {
+            candidates.push({
+              tables: pair,
+              capacity,
+              readyInMinutes: 0,
+            });
+          }
+        }
+      }
+      candidates.sort(
+        (left, right) =>
+          left.capacity - right.capacity ||
+          left.readyInMinutes - right.readyInMinutes ||
+          left.tables
+            .map((table) => table.label)
+            .join("+")
+            .localeCompare(
+              right.tables.map((table) => table.label).join("+"),
+            ),
+      );
+    candidateCache.set(covers, candidates);
+    return candidates;
+  };
+
+  const demand = input.demands
+    .filter((party) => party.status === "waiting")
+    .map((party): RestaurantFloorDemand => {
+      const candidates = candidatesFor(party.covers);
+      const recommended = candidates[0] ?? null;
+      const compatible = [
+        ...new Set(
+          candidates.flatMap((candidate) =>
+            candidate.tables.map((table) => table.id)
+          ),
+        ),
+      ];
+      return {
+        id: party.id,
+        kind: party.kind,
+        name: party.guestName,
+        covers: party.covers,
+        waitedMinutes: party.arrivedAt
+          ? minutesBetween(input.now, party.arrivedAt)
+          : null,
+        scheduledAt: party.scheduledAt?.toISOString() ?? null,
+        hasDietaryNote: Boolean(party.dietaryNotes?.trim()),
+        vip: party.vip === true,
+        compatibleTableIds: compatible,
+        recommendation: recommended
+          ? {
+              tableIds: recommended.tables.map((table) => table.id),
+              reason:
+                recommended.readyInMinutes === 0
+                  ? `${recommended.tables.map((table) => table.label).join(" + ")} ${recommended.tables.length === 1 ? "fits" : "fit"} ${party.covers} and ${recommended.tables.length === 1 ? "is" : "are"} open now.`
+                  : `${recommended.tables.map((table) => table.label).join(" + ")} ${recommended.tables.length === 1 ? "fits" : "fit"} ${party.covers} and ${recommended.tables.length === 1 ? "is" : "are"} expected in ${recommended.readyInMinutes} minutes.`,
+              warning: serverWarning(
+                recommended.tables[0].server,
+                input.serverSections,
+              ),
+            }
+          : null,
+      };
+    });
+
+  return {
+    asOf: input.now.toISOString(),
+    staffingAvailable: input.serverSections.length > 0,
+    tables,
+    demand,
+  };
+}
+
+export interface CustomerRestaurantAvailability {
+  asOf: string;
+  summary: {
+    totalTables: number;
+    availableNow: number;
+    availableSoon: number;
+  };
+  tables: Array<{
+    key: string;
+    capacity: number;
+    shape: RestaurantTableShape;
+    serviceArea: string;
+    availability: {
+      kind: RestaurantForwardAvailability["kind"];
+      availableAt: string | null;
+      minutes: number | null;
+      explanation: string;
+    };
+  }>;
+}
+
+function customerExplanation(
+  availability: RestaurantForwardAvailability,
+): string {
+  if (availability.kind === "now") return "Available now";
+  if (availability.kind === "at" && availability.minutes != null) {
+    return `Available in about ${availability.minutes} minutes`;
+  }
+  return "Availability will be confirmed when you book";
+}
+
+/**
+ * Explicit allow-list boundary for public/customer surfaces. Do not spread the
+ * operator projection here: adding a field must be a deliberate privacy change.
+ */
+export function projectCustomerRestaurantAvailability(
+  floor: RestaurantFloorProjection,
+): CustomerRestaurantAvailability {
+  return {
+    asOf: floor.asOf,
+    summary: {
+      totalTables: floor.tables.length,
+      availableNow: floor.tables.filter(
+        (table) => table.availability.kind === "now",
+      ).length,
+      availableSoon: floor.tables.filter(
+        (table) => table.availability.kind === "at",
+      ).length,
+    },
+    tables: floor.tables.map((table, index) => ({
+      // Presentation identity only. Never reuse the persisted table id or label
+      // at the public boundary, even when an internal id happens to look human.
+      key: `availability-${index + 1}`,
+      capacity: table.capacity,
+      shape: table.shape,
+      serviceArea: table.serviceArea,
+      availability: {
+        kind: table.availability.kind,
+        availableAt: table.availability.availableAt,
+        minutes: table.availability.minutes,
+        explanation: customerExplanation(table.availability),
+      },
+    })),
+  };
+}

--- a/apps/web/lib/twin/restaurant-move-command.server.test.ts
+++ b/apps/web/lib/twin/restaurant-move-command.server.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeRestaurantMoveCommand,
+  type RestaurantMoveCommand,
+} from "./restaurant-move-command.server";
+import { restaurantSeatingVersion } from "../storefront/restaurant-seating";
+
+const now = new Date("2026-07-31T18:30:00.000Z");
+const endsAt = new Date("2026-07-31T19:15:00.000Z");
+const booking = {
+  id: "booking-1",
+  bookingRef: "BOOK-1",
+  covers: 2,
+  status: "seated",
+  updatedAt: new Date("2026-07-31T18:00:00.000Z"),
+};
+const target = {
+  id: "table-2",
+  label: "Table 2",
+  status: "active",
+  capacity: 2,
+  version: 4,
+  attributes: { shape: "round" },
+};
+const command: RestaurantMoveCommand = {
+  idempotencyKey: "move-turn-1-table-2-v2",
+  serviceTurnId: "turn-1",
+  expectedTurnVersion: 2,
+  expectedSeatingVersion: restaurantSeatingVersion({
+    demand: booking,
+    resources: [target],
+    allocations: [],
+  }),
+  interval: {
+    startsAt: now.toISOString(),
+    endsAt: endsAt.toISOString(),
+  },
+  resourceIds: ["table-2"],
+};
+
+function fixture() {
+  const currentAllocations = [
+    {
+      id: "allocation-1",
+      resourceId: "table-1",
+      version: 3,
+      startsAt: new Date("2026-07-31T18:00:00.000Z"),
+      endsAt,
+      lifecycle: "active" as const,
+      demandRef: "BOOK-1",
+    },
+  ];
+  const tx = {
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    hospitalityServiceTurnEvent: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    hospitalityServiceTurn: {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "turn-1",
+        turnId: "HT-TURN1",
+        stage: "ordered",
+        version: 2,
+        bookingId: "booking-1",
+        booking,
+      }),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    hospitalityResource: {
+      findMany: vi.fn().mockResolvedValue([target]),
+    },
+    hospitalityCapacityAllocation: {
+      findMany: vi
+        .fn()
+        .mockResolvedValueOnce(currentAllocations)
+        .mockResolvedValueOnce([]),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    staffingResourceLink: {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          resourceRef: "table-2",
+          shift: {
+            assignments: [{ id: "assignment-2", lifecycle: "on_site" }],
+          },
+        },
+      ]),
+    },
+    storefrontBooking: {
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+  };
+  return {
+    tx,
+    database: {
+      $transaction: vi.fn(async (run) => run(tx)),
+    },
+    currentAllocations,
+  };
+}
+
+describe("restaurant party move command", () => {
+  it("moves one service turn to its new table without opening a second turn", async () => {
+    const { database, tx } = fixture();
+    const allocateCapacity = vi.fn().mockResolvedValue({
+      id: "allocation-2",
+      version: 1,
+    });
+    const transitionCapacity = vi.fn().mockResolvedValue({});
+
+    const result = await executeRestaurantMoveCommand({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      command,
+      dependencies: { allocateCapacity, transitionCapacity },
+      now: () => now,
+    });
+
+    expect(result).toMatchObject({
+      status: "confirmed",
+      newVersion: "restaurant-turn:HT-TURN1:3",
+      changedFacts: [
+        { entityId: "turn-1", field: "resourceIds", value: "table-2" },
+      ],
+    });
+    expect(transitionCapacity).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        allocationId: "allocation-1",
+        expectedVersion: 3,
+        lifecycle: "released",
+      }),
+    );
+    expect(allocateCapacity).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        resourceId: "table-2",
+        serviceTurnId: "turn-1",
+        demandRef: "BOOK-1",
+      }),
+    );
+    expect(tx.hospitalityServiceTurn.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "turn-1",
+        organizationId: "org-1",
+        version: 2,
+        stage: "ordered",
+      },
+      data: {
+        staffingAssignmentId: "assignment-2",
+        version: { increment: 1 },
+      },
+    });
+    expect(tx.hospitalityServiceTurnEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        serviceTurnId: "turn-1",
+        eventType: "table-assignment-changed",
+        atVersion: 3,
+      }),
+    });
+    expect(tx.storefrontBooking.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "booking-1",
+        organizationId: "org-1",
+        status: "seated",
+      },
+      data: { hospitalityResourceId: "table-2" },
+    });
+  });
+
+  it("returns a conflict before writes when target facts are stale", async () => {
+    const { database, tx } = fixture();
+
+    const result = await executeRestaurantMoveCommand({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      command: {
+        ...command,
+        expectedSeatingVersion: "restaurant-seat.v1-stale",
+      },
+      dependencies: {
+        allocateCapacity: vi.fn(),
+        transitionCapacity: vi.fn(),
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "conflict",
+      currentVersion: restaurantSeatingVersion({
+        demand: booking,
+        resources: [target],
+        allocations: [],
+      }),
+    });
+    expect(tx.hospitalityServiceTurn.updateMany).not.toHaveBeenCalled();
+    expect(tx.hospitalityServiceTurnEvent.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/twin/restaurant-move-command.server.ts
+++ b/apps/web/lib/twin/restaurant-move-command.server.ts
@@ -1,0 +1,559 @@
+import { newId } from "@/lib/shared/new-id";
+import {
+  allocateHospitalityCapacity,
+  transitionHospitalityCapacity,
+} from "@/lib/storefront/hospitality-capacity-repository.server";
+import {
+  HospitalityCapacityConflictError,
+  HospitalityCapacityVersionError,
+} from "@/lib/storefront/hospitality-capacity";
+import {
+  evaluateRestaurantSeating,
+  restaurantSeatingVersion,
+  type RestaurantSeatingAllocationFact,
+  type RestaurantSeatingResourceFact,
+} from "@/lib/storefront/restaurant-seating";
+
+import type { OperationalCommandResult } from "./operations-command";
+
+export interface RestaurantMoveCommand {
+  idempotencyKey: string;
+  serviceTurnId: string;
+  expectedTurnVersion: number;
+  expectedSeatingVersion: string;
+  interval: { startsAt: string; endsAt: string };
+  resourceIds: string[];
+}
+
+interface MoveBooking {
+  id: string;
+  bookingRef: string;
+  covers: number | null;
+  status: string;
+  updatedAt: Date;
+}
+
+interface MoveTurn {
+  id: string;
+  turnId: string;
+  stage: string;
+  version: number;
+  bookingId: string | null;
+  booking: MoveBooking | null;
+}
+
+interface MoveTransaction {
+  $queryRaw(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown>;
+  hospitalityServiceTurnEvent: {
+    findFirst(args: unknown): Promise<{
+      detail: unknown;
+      serviceTurn: { turnId: string; version: number };
+    } | null>;
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+  };
+  hospitalityServiceTurn: {
+    findFirst(args: unknown): Promise<MoveTurn | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  hospitalityResource: {
+    findMany(args: unknown): Promise<RestaurantSeatingResourceFact[]>;
+  };
+  hospitalityCapacityAllocation: {
+    findMany(args: unknown): Promise<RestaurantSeatingAllocationFact[]>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  staffingResourceLink: {
+    findMany(args: unknown): Promise<
+      Array<{
+        resourceRef: string;
+        shift: {
+          assignments: Array<{ id: string; lifecycle: string }>;
+        };
+      }>
+    >;
+  };
+  storefrontBooking: {
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+}
+
+interface MoveDatabase {
+  $transaction<T>(run: (transaction: MoveTransaction) => Promise<T>): Promise<T>;
+}
+
+interface MoveDependencies {
+  allocateCapacity: typeof allocateHospitalityCapacity;
+  transitionCapacity: typeof transitionHospitalityCapacity;
+}
+
+const DEFAULT_DEPENDENCIES: MoveDependencies = {
+  allocateCapacity: allocateHospitalityCapacity,
+  transitionCapacity: transitionHospitalityCapacity,
+};
+const MOVABLE_STAGES = new Set(["seated", "ordered"]);
+const ACTIVE_STAFFING_LIFECYCLES = new Set(["confirmed", "on_site"]);
+
+function fingerprint(command: RestaurantMoveCommand): string {
+  return JSON.stringify({
+    serviceTurnId: command.serviceTurnId,
+    expectedTurnVersion: command.expectedTurnVersion,
+    expectedSeatingVersion: command.expectedSeatingVersion,
+    interval: command.interval,
+    resourceIds: [...command.resourceIds].sort(),
+  });
+}
+
+function rejected(
+  command: RestaurantMoveCommand,
+  reasonCode: string,
+  message: string,
+): OperationalCommandResult {
+  return {
+    status: "rejected",
+    idempotencyKey: command.idempotencyKey,
+    replayed: false,
+    reasonCode,
+    message,
+  };
+}
+
+function allocationRecord(value: unknown): { id: string; version: number } {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("id" in value) ||
+    !("version" in value) ||
+    typeof value.id !== "string" ||
+    typeof value.version !== "number"
+  ) {
+    throw new Error("Hospitality allocation persistence returned no identity");
+  }
+  return { id: value.id, version: value.version };
+}
+
+function staffingAssignmentFor(
+  resourceIds: readonly string[],
+  links: Awaited<
+    ReturnType<MoveTransaction["staffingResourceLink"]["findMany"]>
+  >,
+): string | null | "mixed" {
+  const assignments = resourceIds.map((resourceId) => {
+    const link = links.find((candidate) => candidate.resourceRef === resourceId);
+    return link?.shift.assignments.find((assignment) =>
+      ACTIVE_STAFFING_LIFECYCLES.has(assignment.lifecycle)
+    )?.id ?? null;
+  });
+  const assigned = new Set(
+    assignments.filter((value): value is string => value !== null),
+  );
+  if (assigned.size > 1) return "mixed";
+  return assigned.size === 1 && !assignments.includes(null)
+    ? [...assigned][0]
+    : null;
+}
+
+export async function executeRestaurantMoveCommand(input: {
+  database: MoveDatabase;
+  organizationId: string;
+  storefrontId: string;
+  actorRef: string;
+  command: RestaurantMoveCommand;
+  dependencies?: Partial<MoveDependencies>;
+  now?: () => Date;
+}): Promise<OperationalCommandResult> {
+  const { command } = input;
+  if (
+    !/^[A-Za-z0-9._:-]{8,160}$/.test(command.idempotencyKey) ||
+    !command.serviceTurnId.trim() ||
+    command.expectedTurnVersion < 1 ||
+    command.resourceIds.length === 0
+  ) {
+    return rejected(
+      command,
+      "invalid-move-command",
+      "Refresh the floor and choose at least one destination table.",
+    );
+  }
+  const startsAt = new Date(command.interval.startsAt);
+  const endsAt = new Date(command.interval.endsAt);
+  if (
+    !Number.isFinite(startsAt.getTime()) ||
+    !Number.isFinite(endsAt.getTime()) ||
+    endsAt <= startsAt
+  ) {
+    return rejected(
+      command,
+      "invalid-interval",
+      "The destination interval is no longer valid.",
+    );
+  }
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...input.dependencies };
+  const commandFingerprint = fingerprint(command);
+  const at = input.now?.() ?? new Date();
+  const startedAt = performance.now();
+
+  try {
+    return await input.database.$transaction(async (transaction) => {
+      const prior = await transaction.hospitalityServiceTurnEvent.findFirst({
+        where: {
+          organizationId: input.organizationId,
+          idempotencyKey: command.idempotencyKey,
+        },
+        select: {
+          detail: true,
+          serviceTurn: { select: { turnId: true, version: true } },
+        },
+      });
+      if (prior) {
+        const detail =
+          typeof prior.detail === "object" && prior.detail !== null
+            ? prior.detail as Record<string, unknown>
+            : {};
+        if (detail.commandFingerprint !== commandFingerprint) {
+          return rejected(
+            command,
+            "idempotency-key-reused",
+            "That command key belongs to a different table move.",
+          );
+        }
+        return {
+          status: "confirmed",
+          idempotencyKey: command.idempotencyKey,
+          replayed: true,
+          newVersion:
+            `restaurant-turn:${prior.serviceTurn.turnId}:${prior.serviceTurn.version}`,
+          changedFacts: [],
+        };
+      }
+
+      await transaction.$queryRaw`
+        SELECT "id"
+        FROM "HospitalityServiceTurn"
+        WHERE "id" = ${command.serviceTurnId}
+          AND "organizationId" = ${input.organizationId}
+        FOR UPDATE
+      `;
+      const turn = await transaction.hospitalityServiceTurn.findFirst({
+        where: {
+          id: command.serviceTurnId,
+          organizationId: input.organizationId,
+          storefrontId: input.storefrontId,
+        },
+        select: {
+          id: true,
+          turnId: true,
+          stage: true,
+          version: true,
+          bookingId: true,
+          booking: {
+            select: {
+              id: true,
+              bookingRef: true,
+              covers: true,
+              status: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
+      if (!turn?.booking || !turn.bookingId) {
+        return rejected(
+          command,
+          "turn-not-found",
+          "The party is no longer on an active restaurant turn.",
+        );
+      }
+      if (!MOVABLE_STAGES.has(turn.stage)) {
+        return rejected(
+          command,
+          "turn-not-movable",
+          "Only seated or ordered parties can be moved.",
+        );
+      }
+      if (!turn.booking.covers) {
+        return rejected(
+          command,
+          "party-size-missing",
+          "Confirm the party size before moving it.",
+        );
+      }
+
+      const currentAllocations =
+        await transaction.hospitalityCapacityAllocation.findMany({
+          where: {
+            organizationId: input.organizationId,
+            serviceTurnId: turn.id,
+            lifecycle: { in: ["reserved", "active"] },
+            conflictQuarantinedAt: null,
+          },
+          select: {
+            id: true,
+            resourceId: true,
+            startsAt: true,
+            endsAt: true,
+            lifecycle: true,
+            version: true,
+            demandRef: true,
+          },
+          orderBy: { id: "asc" },
+        });
+      const lockIds = [
+        ...new Set([
+          ...command.resourceIds,
+          ...currentAllocations.flatMap((allocation) =>
+            allocation.resourceId ? [allocation.resourceId] : []
+          ),
+        ]),
+      ].sort();
+      for (const resourceId of lockIds) {
+        await transaction.$queryRaw`
+          SELECT "id"
+          FROM "HospitalityResource"
+          WHERE "id" = ${resourceId}
+            AND "organizationId" = ${input.organizationId}
+            AND "storefrontId" = ${input.storefrontId}
+          FOR UPDATE
+        `;
+      }
+
+      const resources = await transaction.hospitalityResource.findMany({
+        where: {
+          id: { in: command.resourceIds },
+          organizationId: input.organizationId,
+          storefrontId: input.storefrontId,
+          kind: "table",
+        },
+        select: {
+          id: true,
+          label: true,
+          status: true,
+          capacity: true,
+          version: true,
+          attributes: true,
+        },
+      });
+      if (resources.length !== command.resourceIds.length) {
+        return rejected(
+          command,
+          "table-not-found",
+          "One or more destination tables no longer exist.",
+        );
+      }
+      const targetAllocations =
+        await transaction.hospitalityCapacityAllocation.findMany({
+          where: {
+            organizationId: input.organizationId,
+            resourceId: { in: command.resourceIds },
+            lifecycle: { in: ["reserved", "active"] },
+            conflictQuarantinedAt: null,
+            startsAt: { lt: endsAt },
+            endsAt: { gt: startsAt },
+          },
+          select: {
+            id: true,
+            resourceId: true,
+            startsAt: true,
+            endsAt: true,
+            lifecycle: true,
+            version: true,
+            demandRef: true,
+          },
+        });
+      const currentSeatingVersion = restaurantSeatingVersion({
+        demand: turn.booking,
+        resources,
+        allocations: targetAllocations,
+      });
+      if (currentSeatingVersion !== command.expectedSeatingVersion) {
+        return {
+          status: "conflict",
+          idempotencyKey: command.idempotencyKey,
+          replayed: false,
+          currentVersion: currentSeatingVersion,
+          changedFacts: [],
+          alternatives: [],
+        };
+      }
+      const seating = evaluateRestaurantSeating({
+        covers: turn.booking.covers,
+        resources,
+        allocations: targetAllocations,
+        startsAt,
+        endsAt,
+        demandRef: turn.booking.bookingRef,
+      });
+      if (!seating.ok) {
+        return rejected(command, seating.reasonCode, seating.message);
+      }
+
+      const staffingLinks = await transaction.staffingResourceLink.findMany({
+        where: {
+          organizationId: input.organizationId,
+          resourceType: "table",
+          resourceRef: { in: command.resourceIds },
+          shift: {
+            lifecycle: "published",
+            startAt: { lte: startsAt },
+            endAt: { gt: startsAt },
+          },
+        },
+        select: {
+          resourceRef: true,
+          shift: {
+            select: {
+              assignments: {
+                where: { lifecycle: { in: ["confirmed", "on_site"] } },
+                select: { id: true, lifecycle: true },
+              },
+            },
+          },
+        },
+      });
+      const staffingAssignmentId = staffingAssignmentFor(
+        command.resourceIds,
+        staffingLinks,
+      );
+      if (staffingAssignmentId === "mixed") {
+        return rejected(
+          command,
+          "mixed-server-sections",
+          "The destination tables belong to different server sections.",
+        );
+      }
+
+      const updated = await transaction.hospitalityServiceTurn.updateMany({
+        where: {
+          id: turn.id,
+          organizationId: input.organizationId,
+          version: command.expectedTurnVersion,
+          stage: turn.stage,
+        },
+        data: {
+          staffingAssignmentId,
+          version: { increment: 1 },
+        },
+      });
+      if (updated.count !== 1) {
+        return {
+          status: "conflict",
+          idempotencyKey: command.idempotencyKey,
+          replayed: false,
+          currentVersion:
+            `restaurant-turn:${turn.turnId}:${turn.version}`,
+          changedFacts: [],
+          alternatives: [],
+        };
+      }
+
+      const targetIds = new Set(command.resourceIds);
+      for (const allocation of currentAllocations) {
+        if (allocation.resourceId && targetIds.has(allocation.resourceId)) {
+          continue;
+        }
+        await dependencies.transitionCapacity(transaction as never, {
+          allocationId: allocation.id,
+          organizationId: input.organizationId,
+          expectedVersion: allocation.version,
+          lifecycle: "released",
+          at,
+          reason: "Party moved to another table",
+        });
+      }
+      for (const resourceId of command.resourceIds) {
+        const existing = currentAllocations.find(
+          (allocation) => allocation.resourceId === resourceId,
+        );
+        if (existing) continue;
+        const allocation = allocationRecord(
+          await dependencies.allocateCapacity(transaction as never, {
+            organizationId: input.organizationId,
+            storefrontId: input.storefrontId,
+            resourceId,
+            poolId: null,
+            demandType: "booking",
+            demandRef: turn.booking.bookingRef,
+            bookingId: turn.booking.id,
+            bookingHoldId: null,
+            serviceTurnId: turn.id,
+            startsAt,
+            endsAt,
+            quantity: 1,
+            idempotencyKey: `${command.idempotencyKey}:${resourceId}`,
+          }),
+        );
+        await dependencies.transitionCapacity(transaction as never, {
+          allocationId: allocation.id,
+          organizationId: input.organizationId,
+          expectedVersion: allocation.version,
+          lifecycle: "active",
+          at,
+          reason: "Party moved to table",
+        });
+      }
+
+      await transaction.hospitalityServiceTurnEvent.create({
+        data: {
+          eventId: `HTE-${newId(12).toUpperCase()}`,
+          organizationId: input.organizationId,
+          serviceTurnId: turn.id,
+          idempotencyKey: command.idempotencyKey,
+          eventType: "table-assignment-changed",
+          fromStage: turn.stage,
+          toStage: turn.stage,
+          atVersion: turn.version + 1,
+          actorRef: input.actorRef,
+          detail: {
+            commandFingerprint,
+            fromResourceIds: currentAllocations.flatMap((allocation) =>
+              allocation.resourceId ? [allocation.resourceId] : []
+            ),
+            resourceIds: command.resourceIds,
+          },
+          occurredAt: at,
+        },
+      });
+      await transaction.storefrontBooking.updateMany({
+        where: {
+          id: turn.booking.id,
+          organizationId: input.organizationId,
+          status: "seated",
+        },
+        data: { hospitalityResourceId: command.resourceIds[0] },
+      });
+
+      return {
+        status: "confirmed",
+        idempotencyKey: command.idempotencyKey,
+        replayed: false,
+        latencyMs: Math.max(0, performance.now() - startedAt),
+        newVersion:
+          `restaurant-turn:${turn.turnId}:${turn.version + 1}`,
+        changedFacts: [
+          {
+            entityId: turn.id,
+            field: "resourceIds",
+            value: command.resourceIds.join(","),
+          },
+        ],
+      };
+    });
+  } catch (error) {
+    if (
+      error instanceof HospitalityCapacityConflictError ||
+      error instanceof HospitalityCapacityVersionError
+    ) {
+      return {
+        status: "conflict",
+        idempotencyKey: command.idempotencyKey,
+        replayed: false,
+        currentVersion: command.expectedSeatingVersion,
+        changedFacts: [],
+        alternatives: [],
+      };
+    }
+    throw error;
+  }
+}

--- a/apps/web/lib/twin/restaurant-operations-projection.test.ts
+++ b/apps/web/lib/twin/restaurant-operations-projection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import type { RestaurantCapacitySnapshot } from "@/lib/storefront/restaurant-capacity";
+
+import { restaurantFloorResourceUnits } from "./restaurant-operations-projection";
+
+describe("restaurantFloorResourceUnits", () => {
+  it("projects occupied and turning state instead of treating every active resource as available", () => {
+    const snapshot = {
+      tables: [
+        {
+          key: "table-1",
+          label: "Aster",
+          seats: 4,
+          state: "occupied",
+          freeInMinutes: null,
+        },
+        {
+          key: "table-2",
+          label: "Birch",
+          seats: 2,
+          state: "turning-soon",
+          freeInMinutes: 8,
+        },
+      ],
+    } as RestaurantCapacitySnapshot;
+
+    expect(restaurantFloorResourceUnits(snapshot)).toEqual([
+      {
+        key: "table-1",
+        label: "Aster",
+        state: "Occupied",
+        intent: "info",
+        sublabel: "4 seats",
+      },
+      {
+        key: "table-2",
+        label: "Birch",
+        state: "Turning soon",
+        intent: "warning",
+        sublabel: "2 seats · free in 8m",
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/twin/restaurant-operations-projection.ts
+++ b/apps/web/lib/twin/restaurant-operations-projection.ts
@@ -5,6 +5,8 @@ import type {
   ResourceUnitData,
 } from "@/components/twin";
 import {
+  capacityStateIntent,
+  capacityStateLabel,
   readinessHeadline,
   type RestaurantCapacitySnapshot,
 } from "@/lib/storefront/restaurant-capacity";
@@ -35,6 +37,28 @@ export function hospitalityResourceUnits(
     state: resource.status === "active" ? "Available" : "Off",
     intent: resource.status === "active" ? "success" : "neutral",
   }));
+}
+
+/** Live FLOOR units use the capacity projection, not raw resource status. */
+export function restaurantFloorResourceUnits(
+  snapshot: RestaurantCapacitySnapshot,
+  limit = 24,
+): ResourceUnitData[] {
+  return snapshot.tables.slice(0, limit).map((table) => {
+    const details = [
+      table.seats != null ? `${table.seats} seats` : null,
+      table.freeInMinutes != null
+        ? `free in ${table.freeInMinutes}m`
+        : null,
+    ].filter((detail): detail is string => detail !== null);
+    return {
+      key: table.key,
+      label: table.label,
+      state: capacityStateLabel(table.state),
+      intent: capacityStateIntent(table.state),
+      ...(details.length > 0 ? { sublabel: details.join(" · ") } : {}),
+    };
+  });
 }
 
 /** Restaurant-native capacity facts for the Workspace operations view. */

--- a/apps/web/lib/twin/restaurant-scene-layout.test.ts
+++ b/apps/web/lib/twin/restaurant-scene-layout.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { OperationalSceneLayoutDatabase } from "./restaurant-scene-layout";
+import {
+  buildRestaurantStarterScene,
+  loadOrCreateRestaurantScene,
+} from "./restaurant-scene-layout";
+
+const TABLES = [
+  {
+    id: "table-1",
+    label: "Aster",
+    capacity: 4,
+    serviceArea: "Main dining",
+    attributes: { shape: "round" },
+  },
+  {
+    id: "table-2",
+    label: "Booth-shaped name that must not drive layout",
+    capacity: 6,
+    serviceArea: "Main dining",
+    attributes: { shape: "rectangle" },
+  },
+  {
+    id: "table-3",
+    label: "Patio 1",
+    capacity: 2,
+    serviceArea: "Patio",
+    attributes: { shape: "square" },
+  },
+];
+
+function database(
+  existing: {
+    id: string;
+    version: number;
+    layoutState: unknown;
+  } | null = null,
+) {
+  return {
+    operationalSceneLayout: {
+      findUnique: vi.fn(async () => existing),
+      create: vi.fn(async ({ data }) => ({
+        id: "scene-1",
+        version: 1,
+        layoutState: data.layoutState,
+      })),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
+  } satisfies OperationalSceneLayoutDatabase;
+}
+
+describe("buildRestaurantStarterScene", () => {
+  it("uses structured service areas and shapes, never label heuristics", () => {
+    const scene = buildRestaurantStarterScene(TABLES);
+
+    expect(scene.zones.map((zone) => zone.label)).toEqual([
+      "Main dining",
+      "Patio",
+    ]);
+    expect(
+      scene.placements.map((placement) => [
+        placement.entityRef.id,
+        placement.geometry.shapeKind,
+      ]),
+    ).toEqual([
+      ["table-1", "round-table"],
+      ["table-2", "rectangle-table"],
+      ["table-3", "square-table"],
+    ]);
+  });
+
+  it("is deterministic and keeps every placement inside its service area", () => {
+    const first = buildRestaurantStarterScene(TABLES);
+    const second = buildRestaurantStarterScene([...TABLES].reverse());
+
+    expect(second).toEqual(first);
+    for (const placement of first.placements) {
+      const zone = first.zones.find(
+        (candidate) =>
+          candidate.label ===
+          TABLES.find((table) => table.id === placement.entityRef.id)?.serviceArea,
+      );
+      expect(zone?.geometry.kind).toBe("rectangle");
+      if (zone?.geometry.kind !== "rectangle") continue;
+      expect(placement.geometry.x).toBeGreaterThanOrEqual(zone.geometry.x);
+      expect(placement.geometry.y).toBeGreaterThanOrEqual(zone.geometry.y);
+      expect(placement.geometry.x + placement.geometry.width).toBeLessThanOrEqual(
+        zone.geometry.x + zone.geometry.width,
+      );
+      expect(
+        placement.geometry.y + placement.geometry.height,
+      ).toBeLessThanOrEqual(zone.geometry.y + zone.geometry.height);
+    }
+  });
+});
+
+describe("loadOrCreateRestaurantScene", () => {
+  it("creates one location-scoped FLOOR scene from structured tables", async () => {
+    const db = database();
+    const scene = await loadOrCreateRestaurantScene({
+      database: db,
+      orgId: "ORG-1",
+      locationId: "storefront-1",
+      locationLabel: "Restaurant floor",
+      tables: TABLES,
+    });
+
+    expect(db.operationalSceneLayout.findUnique).toHaveBeenCalledWith({
+      where: {
+        orgId_twinTemplate_locationId: {
+          orgId: "ORG-1",
+          twinTemplate: "FLOOR",
+          locationId: "storefront-1",
+        },
+      },
+      select: { id: true, version: true, layoutState: true },
+    });
+    expect(db.operationalSceneLayout.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        orgId: "ORG-1",
+        twinTemplate: "FLOOR",
+        spaceKind: "cartesian-interior",
+        locationId: "storefront-1",
+        label: "Restaurant floor",
+      }),
+      select: { id: true, version: true, layoutState: true },
+    });
+    expect(scene).toMatchObject({
+      id: "scene-1",
+      version: 1,
+      createdFromStarter: true,
+    });
+  });
+
+  it("returns the authored scene unchanged when it already exists", async () => {
+    const starter = buildRestaurantStarterScene(TABLES);
+    const authored = {
+      ...starter,
+      placements: starter.placements.map((placement, index) =>
+        index === 0
+          ? {
+              ...placement,
+              geometry: { ...placement.geometry, x: 777 },
+            }
+          : placement,
+      ),
+    };
+    const db = database({
+      id: "scene-existing",
+      version: 5,
+      layoutState: authored,
+    });
+
+    const scene = await loadOrCreateRestaurantScene({
+      database: db,
+      orgId: "ORG-1",
+      locationId: "storefront-1",
+      locationLabel: "Restaurant floor",
+      tables: TABLES,
+    });
+
+    expect(scene.layout.placements[0]?.geometry.x).toBe(777);
+    expect(scene.createdFromStarter).toBe(false);
+    expect(db.operationalSceneLayout.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves authored positions while version-saving newly added tables", async () => {
+    const starter = buildRestaurantStarterScene(TABLES.slice(0, 1));
+    const authored = {
+      ...starter,
+      placements: starter.placements.map((placement) => ({
+        ...placement,
+        geometry: { ...placement.geometry, x: 777 },
+      })),
+    };
+    const db = database({
+      id: "scene-existing",
+      version: 5,
+      layoutState: authored,
+    });
+
+    const scene = await loadOrCreateRestaurantScene({
+      database: db,
+      orgId: "ORG-1",
+      locationId: "storefront-1",
+      locationLabel: "Restaurant floor",
+      tables: TABLES.slice(0, 2),
+    });
+
+    expect(scene.version).toBe(6);
+    expect(scene.layout.placements.find(
+      (placement) => placement.entityRef.id === "table-1",
+    )?.geometry.x).toBe(777);
+    expect(scene.layout.placements.some(
+      (placement) => placement.entityRef.id === "table-2",
+    )).toBe(true);
+    expect(db.operationalSceneLayout.updateMany).toHaveBeenCalledWith({
+      where: { id: "scene-existing", version: 5 },
+      data: {
+        layoutState: expect.any(Object),
+        underlayRef: null,
+        version: { increment: 1 },
+      },
+    });
+  });
+
+  it("fails honestly when the persisted layout is invalid", async () => {
+    const db = database({
+      id: "scene-existing",
+      version: 5,
+      layoutState: { schemaVersion: 0 },
+    });
+
+    await expect(
+      loadOrCreateRestaurantScene({
+        database: db,
+        orgId: "ORG-1",
+        locationId: "storefront-1",
+        locationLabel: "Restaurant floor",
+        tables: TABLES,
+      }),
+    ).rejects.toThrow("saved restaurant floor layout is invalid");
+    expect(db.operationalSceneLayout.create).not.toHaveBeenCalled();
+  });
+
+  it("returns the winning row when two first-load requests race", async () => {
+    const winner = {
+      id: "scene-winner",
+      version: 1,
+      layoutState: buildRestaurantStarterScene(TABLES),
+    };
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(winner);
+    const db = {
+      operationalSceneLayout: {
+        findUnique,
+        create: vi.fn(async () => {
+          throw { code: "P2002" };
+        }),
+        updateMany: vi.fn(async () => ({ count: 1 })),
+      },
+    } satisfies OperationalSceneLayoutDatabase;
+
+    const scene = await loadOrCreateRestaurantScene({
+      database: db,
+      orgId: "ORG-1",
+      locationId: "storefront-1",
+      locationLabel: "Restaurant floor",
+      tables: TABLES,
+    });
+
+    expect(scene.id).toBe("scene-winner");
+    expect(scene.createdFromStarter).toBe(false);
+    expect(findUnique).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/twin/restaurant-scene-layout.ts
+++ b/apps/web/lib/twin/restaurant-scene-layout.ts
@@ -1,0 +1,326 @@
+import type { CartesianSceneLayout } from "@dpf/storefront-templates";
+
+import { parseRestaurantTableAttributes } from "../storefront/restaurant-table-attributes";
+import { validateCartesianSceneLayout } from "./cartesian-scene";
+
+export interface RestaurantSceneTable {
+  id: string;
+  label: string;
+  capacity: number;
+  serviceArea: string | null;
+  attributes?: unknown;
+}
+
+export interface RestaurantOperationalScene {
+  id: string;
+  version: number;
+  layout: CartesianSceneLayout;
+  createdFromStarter: boolean;
+}
+
+interface SceneRow {
+  id: string;
+  version: number;
+  layoutState: unknown;
+}
+
+export interface OperationalSceneLayoutDatabase {
+  operationalSceneLayout: {
+    findUnique(input: {
+      where: {
+        orgId_twinTemplate_locationId: {
+          orgId: string;
+          twinTemplate: "FLOOR";
+          locationId: string;
+        };
+      };
+      select: { id: true; version: true; layoutState: true };
+    }): Promise<SceneRow | null>;
+    create(input: {
+      data: {
+        orgId: string;
+        twinTemplate: "FLOOR";
+        spaceKind: "cartesian-interior";
+        locationId: string;
+        label: string;
+        layoutState: CartesianSceneLayout;
+      };
+      select: { id: true; version: true; layoutState: true };
+    }): Promise<SceneRow>;
+    updateMany(input: {
+      where: { id: string; version: number };
+      data: {
+        layoutState: CartesianSceneLayout;
+        underlayRef: string | null;
+        version: { increment: 1 };
+      };
+    }): Promise<{ count: number }>;
+  };
+}
+
+function slug(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "area";
+}
+
+function footprint(capacity: number, shape: string) {
+  const seats = Math.max(1, Math.min(capacity, 12));
+  if (shape === "booth") {
+    return { width: Math.min(152, 96 + seats * 7), height: 72 };
+  }
+  if (shape === "bar") {
+    return { width: Math.min(160, 88 + seats * 8), height: 52 };
+  }
+  if (shape === "rectangle") {
+    return { width: Math.min(144, 88 + seats * 7), height: 72 };
+  }
+  const side = Math.min(104, 64 + seats * 5);
+  return { width: side, height: side };
+}
+
+/**
+ * Deterministic first layout for a newly configured restaurant. It is a starter,
+ * not an inferred authority: the persisted row becomes authoritative as soon as
+ * it is created and every later move is version-saved.
+ */
+export function buildRestaurantStarterScene(
+  sourceTables: readonly RestaurantSceneTable[],
+): CartesianSceneLayout {
+  const tables = [...sourceTables].sort(
+    (a, b) =>
+      (a.serviceArea?.trim() || "Unassigned area").localeCompare(
+        b.serviceArea?.trim() || "Unassigned area",
+      ) ||
+      a.label.localeCompare(b.label) ||
+      a.id.localeCompare(b.id),
+  );
+  const byArea = new Map<string, RestaurantSceneTable[]>();
+  for (const table of tables) {
+    const area = table.serviceArea?.trim() || "Unassigned area";
+    const group = byArea.get(area) ?? [];
+    group.push(table);
+    byArea.set(area, group);
+  }
+
+  const zones: CartesianSceneLayout["zones"][number][] = [];
+  const placements: CartesianSceneLayout["placements"][number][] = [];
+  let zoneY = 0;
+  for (const [areaIndex, [area, group]] of [...byArea.entries()].entries()) {
+    const columns = Math.min(4, Math.max(1, group.length));
+    const rows = Math.ceil(group.length / columns);
+    const zoneWidth = Math.max(320, columns * 168 + 64);
+    const zoneHeight = Math.max(220, rows * 136 + 84);
+    const zoneId = `${slug(area)}-${areaIndex + 1}`;
+    zones.push({
+      id: zoneId,
+      label: area,
+      geometry: {
+        kind: "rectangle",
+        x: 0,
+        y: zoneY,
+        width: zoneWidth,
+        height: zoneHeight,
+      },
+    });
+    group.forEach((table, index) => {
+      const attributes = parseRestaurantTableAttributes(table.attributes);
+      const { width, height } = footprint(
+        table.capacity,
+        attributes.shape,
+      );
+      const column = index % columns;
+      const row = Math.floor(index / columns);
+      placements.push({
+        id: `table-placement-${table.id}`,
+        label: table.label,
+        entityRef: { kind: "table", id: table.id },
+        geometry: {
+          x: 32 + column * 168,
+          y: zoneY + 52 + row * 136,
+          width,
+          height,
+          rotation: 0,
+          shapeKind: `${attributes.shape}-table`,
+        },
+      });
+    });
+    zoneY += zoneHeight + 32;
+  }
+
+  return {
+    schemaVersion: 1,
+    spaceKind: "cartesian-interior",
+    viewport: { x: 24, y: 24, zoom: 0.9 },
+    zones,
+    placements,
+  };
+}
+
+function parseScene(row: SceneRow, createdFromStarter: boolean) {
+  const validated = validateCartesianSceneLayout(row.layoutState);
+  if (!validated.ok) {
+    throw new Error(
+      `The saved restaurant floor layout is invalid: ${validated.error}`,
+    );
+  }
+  return {
+    id: row.id,
+    version: row.version,
+    layout: validated.value,
+    createdFromStarter,
+  } satisfies RestaurantOperationalScene;
+}
+
+function uniqueId(seed: string, used: Set<string>): string {
+  let candidate = seed;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    candidate = `${seed}-${suffix}`;
+    suffix += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+function appendMissingTables(
+  layout: CartesianSceneLayout,
+  tables: readonly RestaurantSceneTable[],
+): CartesianSceneLayout {
+  const placed = new Set(
+    layout.placements
+      .filter((placement) => placement.entityRef.kind === "table")
+      .map((placement) => placement.entityRef.id),
+  );
+  const missing = tables.filter((table) => !placed.has(table.id));
+  if (missing.length === 0) return layout;
+
+  const starter = buildRestaurantStarterScene(missing);
+  const maxBottom = Math.max(
+    0,
+    ...layout.zones.map((zone) =>
+      zone.geometry.kind === "rectangle"
+        ? zone.geometry.y + zone.geometry.height
+        : Math.max(...zone.geometry.points.map((point) => point.y)),
+    ),
+    ...layout.placements.map(
+      (placement) =>
+        placement.geometry.y + placement.geometry.height,
+    ),
+  );
+  const yOffset = maxBottom + 32;
+  const zoneIds = new Set(layout.zones.map((zone) => zone.id));
+  const placementIds = new Set(
+    layout.placements.map((placement) => placement.id),
+  );
+  const appendedZones = starter.zones.map((zone) => {
+    const id = uniqueId(`new-${zone.id}`, zoneIds);
+    return {
+      ...zone,
+      id,
+      label: `${zone.label} · new tables`,
+      geometry:
+        zone.geometry.kind === "rectangle"
+          ? { ...zone.geometry, y: zone.geometry.y + yOffset }
+          : {
+              ...zone.geometry,
+              points: zone.geometry.points.map((point) => ({
+                ...point,
+                y: point.y + yOffset,
+              })),
+            },
+    };
+  });
+  const appendedPlacements = starter.placements.map((placement) => ({
+    ...placement,
+    id: uniqueId(`new-${placement.id}`, placementIds),
+    geometry: {
+      ...placement.geometry,
+      y: placement.geometry.y + yOffset,
+    },
+  }));
+  return {
+    ...layout,
+    zones: [...layout.zones, ...appendedZones],
+    placements: [...layout.placements, ...appendedPlacements],
+  };
+}
+
+function isUniqueConflict(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "P2002"
+  );
+}
+
+export async function loadOrCreateRestaurantScene(input: {
+  database: OperationalSceneLayoutDatabase;
+  orgId: string;
+  locationId: string;
+  locationLabel: string;
+  tables: readonly RestaurantSceneTable[];
+}): Promise<RestaurantOperationalScene> {
+  const key = {
+    orgId: input.orgId,
+    twinTemplate: "FLOOR" as const,
+    locationId: input.locationId,
+  };
+  const select = { id: true, version: true, layoutState: true } as const;
+  const existing = await input.database.operationalSceneLayout.findUnique({
+    where: { orgId_twinTemplate_locationId: key },
+    select,
+  });
+  if (existing) {
+    const parsed = parseScene(existing, false);
+    const reconciled = appendMissingTables(parsed.layout, input.tables);
+    if (reconciled === parsed.layout) return parsed;
+    const update =
+      await input.database.operationalSceneLayout.updateMany({
+        where: { id: parsed.id, version: parsed.version },
+        data: {
+          layoutState: reconciled,
+          underlayRef: reconciled.underlayRef ?? null,
+          version: { increment: 1 },
+        },
+      });
+    if (update.count === 1) {
+      return {
+        ...parsed,
+        version: parsed.version + 1,
+        layout: reconciled,
+      };
+    }
+    const winner = await input.database.operationalSceneLayout.findUnique({
+      where: { orgId_twinTemplate_locationId: key },
+      select,
+    });
+    if (!winner) throw new Error("The restaurant floor layout disappeared.");
+    return parseScene(winner, false);
+  }
+
+  const layout = buildRestaurantStarterScene(input.tables);
+  try {
+    const created = await input.database.operationalSceneLayout.create({
+      data: {
+        ...key,
+        spaceKind: "cartesian-interior",
+        label: input.locationLabel.trim() || "Restaurant floor",
+        layoutState: layout,
+      },
+      select,
+    });
+    return parseScene(created, true);
+  } catch (error) {
+    if (!isUniqueConflict(error)) throw error;
+    const winner = await input.database.operationalSceneLayout.findUnique({
+      where: { orgId_twinTemplate_locationId: key },
+      select,
+    });
+    if (!winner) throw error;
+    return parseScene(winner, false);
+  }
+}

--- a/apps/web/lib/twin/restaurant-turn-command.server.test.ts
+++ b/apps/web/lib/twin/restaurant-turn-command.server.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeRestaurantTurnStageCommand,
+  type RestaurantTurnStageCommand,
+} from "./restaurant-turn-command.server";
+import { HospitalityServiceTurnVersionError } from "../storefront/hospitality-service-turn";
+
+const dirtyCommand: RestaurantTurnStageCommand = {
+  idempotencyKey: "turn-dirty-turn-1-v3",
+  serviceTurnId: "turn-1",
+  expectedVersion: 3,
+  stage: "dirty",
+};
+
+function database(options?: {
+  turn?: {
+    id: string;
+    turnId: string;
+    stage: string;
+    version: number;
+    bookingId: string | null;
+  } | null;
+  allocations?: Array<{ id: string; version: number }>;
+}) {
+  const transaction = {
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    hospitalityServiceTurn: {
+      findFirst: vi.fn().mockResolvedValue(
+        options?.turn === undefined
+          ? {
+              id: "turn-1",
+              turnId: "HT-TURN1",
+              stage: "paid",
+              version: 3,
+              bookingId: "booking-1",
+            }
+          : options.turn,
+      ),
+    },
+    hospitalityCapacityAllocation: {
+      findMany: vi.fn().mockResolvedValue(options?.allocations ?? []),
+    },
+    storefrontBooking: {
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+  };
+  return {
+    transaction,
+    client: {
+      $transaction: vi.fn(async (run) => run(transaction)),
+    },
+  };
+}
+
+describe("restaurant service-turn command", () => {
+  it("advances a paid table to dirty atomically without releasing capacity yet", async () => {
+    const db = database();
+    const transitionTurn = vi.fn().mockResolvedValue({
+      id: "turn-1",
+      stage: "dirty",
+      version: 4,
+      replayed: false,
+    });
+    const transitionCapacity = vi.fn();
+
+    const result = await executeRestaurantTurnStageCommand({
+      database: db.client,
+      organizationId: "org-1",
+      actorRef: "employee-1",
+      command: dirtyCommand,
+      dependencies: { transitionTurn, transitionCapacity },
+      now: () => new Date("2026-07-31T19:12:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      status: "confirmed",
+      idempotencyKey: dirtyCommand.idempotencyKey,
+      replayed: false,
+      newVersion: "restaurant-turn:HT-TURN1:4",
+      changedFacts: [
+        { entityId: "turn-1", field: "stage", value: "dirty" },
+      ],
+    });
+    expect(transitionTurn).toHaveBeenCalledWith(
+      db.transaction,
+      expect.objectContaining({
+        serviceTurnId: "turn-1",
+        expectedVersion: 3,
+        stage: "dirty",
+      }),
+    );
+    expect(transitionCapacity).not.toHaveBeenCalled();
+    expect(
+      db.transaction.storefrontBooking.updateMany,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("closes a cleared table, releases every linked allocation, and completes its booking", async () => {
+    const db = database({
+      turn: {
+        id: "turn-1",
+        turnId: "HT-TURN1",
+        stage: "dirty",
+        version: 4,
+        bookingId: "booking-1",
+      },
+      allocations: [
+        { id: "allocation-1", version: 2 },
+        { id: "allocation-2", version: 5 },
+      ],
+    });
+    const transitionTurn = vi.fn().mockResolvedValue({
+      id: "turn-1",
+      stage: "closed",
+      version: 5,
+      replayed: false,
+    });
+    const transitionCapacity = vi.fn().mockResolvedValue({});
+
+    const result = await executeRestaurantTurnStageCommand({
+      database: db.client,
+      organizationId: "org-1",
+      actorRef: "employee-1",
+      command: {
+        idempotencyKey: "test-repeat-repeat",
+        serviceTurnId: "turn-1",
+        expectedVersion: 4,
+        stage: "closed",
+      },
+      dependencies: { transitionTurn, transitionCapacity },
+      now: () => new Date("2026-07-31T19:20:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      status: "confirmed",
+      newVersion: "restaurant-turn:HT-TURN1:5",
+    });
+    expect(transitionCapacity).toHaveBeenCalledTimes(2);
+    expect(transitionCapacity).toHaveBeenNthCalledWith(
+      1,
+      db.transaction,
+      expect.objectContaining({
+        allocationId: "allocation-1",
+        expectedVersion: 2,
+        lifecycle: "released",
+      }),
+    );
+    expect(db.transaction.storefrontBooking.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "booking-1",
+        organizationId: "org-1",
+        status: "seated",
+      },
+      data: {
+        status: "completed",
+        hospitalityResourceId: null,
+      },
+    });
+  });
+
+  it("returns a conflict and performs no closure writes when the expected version is stale", async () => {
+    const db = database();
+    const transitionCapacity = vi.fn();
+    const transitionTurn = vi
+      .fn()
+      .mockRejectedValue(new HospitalityServiceTurnVersionError(2, 3));
+
+    const result = await executeRestaurantTurnStageCommand({
+      database: db.client,
+      organizationId: "org-1",
+      actorRef: "employee-1",
+      command: { ...dirtyCommand, expectedVersion: 2 },
+      dependencies: { transitionTurn, transitionCapacity },
+    });
+
+    expect(result).toMatchObject({
+      status: "conflict",
+      currentVersion: "restaurant-turn:HT-TURN1:3",
+    });
+    expect(transitionCapacity).not.toHaveBeenCalled();
+    expect(
+      db.transaction.storefrontBooking.updateMany,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not repeat release side effects for a durable replay", async () => {
+    const db = database({
+      turn: {
+        id: "turn-1",
+        turnId: "HT-TURN1",
+        stage: "closed",
+        version: 5,
+        bookingId: "booking-1",
+      },
+    });
+    const transitionTurn = vi.fn().mockResolvedValue({
+      id: "turn-1",
+      stage: "closed",
+      version: 5,
+      replayed: true,
+    });
+    const transitionCapacity = vi.fn();
+
+    const result = await executeRestaurantTurnStageCommand({
+      database: db.client,
+      organizationId: "org-1",
+      actorRef: "employee-1",
+      command: {
+        idempotencyKey: "test-repeat-repeat",
+        serviceTurnId: "turn-1",
+        expectedVersion: 4,
+        stage: "closed",
+      },
+      dependencies: { transitionTurn, transitionCapacity },
+    });
+
+    expect(result).toMatchObject({ status: "confirmed", replayed: true });
+    expect(transitionCapacity).not.toHaveBeenCalled();
+    expect(
+      db.transaction.storefrontBooking.updateMany,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/twin/restaurant-turn-command.server.ts
+++ b/apps/web/lib/twin/restaurant-turn-command.server.ts
@@ -1,0 +1,257 @@
+import {
+  transitionHospitalityCapacity,
+} from "@/lib/storefront/hospitality-capacity-repository.server";
+import {
+  transitionHospitalityServiceTurnRecord,
+} from "@/lib/storefront/hospitality-service-turn-repository.server";
+import {
+  HospitalityServiceTurnVersionError,
+  type HospitalityServiceTurnStage,
+} from "@/lib/storefront/hospitality-service-turn";
+
+import type { OperationalCommandResult } from "./operations-command";
+
+export interface RestaurantTurnStageCommand {
+  idempotencyKey: string;
+  serviceTurnId: string;
+  expectedVersion: number;
+  stage: HospitalityServiceTurnStage;
+}
+
+interface RestaurantTurnRow {
+  id: string;
+  turnId: string;
+  stage: string;
+  version: number;
+  bookingId: string | null;
+}
+
+interface RestaurantTurnTransaction {
+  $queryRaw(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown>;
+  hospitalityServiceTurn: {
+    findFirst(args: unknown): Promise<RestaurantTurnRow | null>;
+  };
+  hospitalityCapacityAllocation: {
+    findMany(args: unknown): Promise<Array<{ id: string; version: number }>>;
+  };
+  storefrontBooking: {
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+}
+
+interface RestaurantTurnDatabase {
+  $transaction<T>(
+    run: (transaction: RestaurantTurnTransaction) => Promise<T>,
+  ): Promise<T>;
+}
+
+interface RestaurantTurnDependencies {
+  transitionTurn(
+    database: RestaurantTurnTransaction,
+    input: {
+      organizationId: string;
+      serviceTurnId: string;
+      expectedVersion: number;
+      stage: HospitalityServiceTurnStage;
+      at: Date;
+      actorRef: string;
+      idempotencyKey: string;
+    },
+  ): Promise<{
+    id: string;
+    stage: HospitalityServiceTurnStage;
+    version: number;
+    replayed: boolean;
+  }>;
+  transitionCapacity(
+    database: RestaurantTurnTransaction,
+    input: {
+      allocationId: string;
+      organizationId: string;
+      expectedVersion: number;
+      lifecycle: "released";
+      at: Date;
+      reason: string;
+    },
+  ): Promise<unknown>;
+}
+
+const DEFAULT_DEPENDENCIES: RestaurantTurnDependencies = {
+  transitionTurn: (database, input) =>
+    transitionHospitalityServiceTurnRecord(database as never, input),
+  transitionCapacity: (database, input) =>
+    transitionHospitalityCapacity(database as never, input),
+};
+
+function rejected(
+  command: RestaurantTurnStageCommand,
+  reasonCode: string,
+  message: string,
+): OperationalCommandResult {
+  return {
+    status: "rejected",
+    idempotencyKey: command.idempotencyKey,
+    replayed: false,
+    reasonCode,
+    message,
+  };
+}
+
+/**
+ * Advances the restaurant's authoritative service turn. Closing a turn also
+ * releases every table allocation and completes its booking in the same
+ * transaction, so the floor cannot show a cleared table as still occupied.
+ */
+export async function executeRestaurantTurnStageCommand(input: {
+  database: RestaurantTurnDatabase;
+  organizationId: string;
+  actorRef: string;
+  command: RestaurantTurnStageCommand;
+  dependencies?: Partial<RestaurantTurnDependencies>;
+  now?: () => Date;
+}): Promise<OperationalCommandResult> {
+  const { command } = input;
+  if (!/^[A-Za-z0-9._:-]{8,160}$/.test(command.idempotencyKey)) {
+    return rejected(
+      command,
+      "invalid-idempotency-key",
+      "Use an 8–160 character stable command key.",
+    );
+  }
+  if (!command.serviceTurnId.trim() || command.expectedVersion < 1) {
+    return rejected(
+      command,
+      "invalid-turn-reference",
+      "Refresh the floor before changing this table.",
+    );
+  }
+  const dependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...input.dependencies,
+  };
+  const at = input.now?.() ?? new Date();
+  const startedAt = performance.now();
+
+  try {
+    return await input.database.$transaction(async (transaction) => {
+      await transaction.$queryRaw`
+        SELECT "id"
+        FROM "HospitalityServiceTurn"
+        WHERE "id" = ${command.serviceTurnId}
+          AND "organizationId" = ${input.organizationId}
+        FOR UPDATE
+      `;
+      const turn = await transaction.hospitalityServiceTurn.findFirst({
+        where: {
+          id: command.serviceTurnId,
+          organizationId: input.organizationId,
+        },
+        select: {
+          id: true,
+          turnId: true,
+          stage: true,
+          version: true,
+          bookingId: true,
+        },
+      });
+      if (!turn) {
+        return rejected(
+          command,
+          "turn-not-found",
+          "That table turn no longer exists. Refresh the floor.",
+        );
+      }
+
+      const next = await dependencies.transitionTurn(transaction, {
+        organizationId: input.organizationId,
+        serviceTurnId: command.serviceTurnId,
+        expectedVersion: command.expectedVersion,
+        stage: command.stage,
+        at,
+        actorRef: input.actorRef,
+        idempotencyKey: command.idempotencyKey,
+      });
+
+      if (command.stage === "closed" && !next.replayed) {
+        const allocations =
+          await transaction.hospitalityCapacityAllocation.findMany({
+            where: {
+              organizationId: input.organizationId,
+              serviceTurnId: command.serviceTurnId,
+              lifecycle: { in: ["reserved", "active"] },
+              conflictQuarantinedAt: null,
+            },
+            select: { id: true, version: true },
+            orderBy: { id: "asc" },
+          });
+        for (const allocation of allocations) {
+          await dependencies.transitionCapacity(transaction, {
+            allocationId: allocation.id,
+            organizationId: input.organizationId,
+            expectedVersion: allocation.version,
+            lifecycle: "released",
+            at,
+            reason: "Restaurant table cleared",
+          });
+        }
+        if (turn.bookingId) {
+          await transaction.storefrontBooking.updateMany({
+            where: {
+              id: turn.bookingId,
+              organizationId: input.organizationId,
+              status: "seated",
+            },
+            data: {
+              status: "completed",
+              hospitalityResourceId: null,
+            },
+          });
+        }
+      }
+
+      return {
+        status: "confirmed",
+        idempotencyKey: command.idempotencyKey,
+        replayed: next.replayed,
+        latencyMs: Math.max(0, performance.now() - startedAt),
+        newVersion: `restaurant-turn:${turn.turnId}:${next.version}`,
+        changedFacts: [
+          {
+            entityId: command.serviceTurnId,
+            field: "stage",
+            value: command.stage,
+          },
+        ],
+      };
+    });
+  } catch (error) {
+    if (error instanceof HospitalityServiceTurnVersionError) {
+      const currentVersion = await input.database.$transaction(
+        async (transaction) => {
+          const turn = await transaction.hospitalityServiceTurn.findFirst({
+            where: {
+              id: command.serviceTurnId,
+              organizationId: input.organizationId,
+            },
+            select: { turnId: true, version: true },
+          });
+          return turn
+            ? `restaurant-turn:${turn.turnId}:${turn.version}`
+            : `restaurant-turn:unknown:${error.actualVersion}`;
+        },
+      );
+      return {
+        status: "conflict",
+        idempotencyKey: command.idempotencyKey,
+        replayed: false,
+        currentVersion,
+        changedFacts: [],
+        alternatives: [],
+      };
+    }
+    throw error;
+  }
+}

--- a/apps/web/lib/workspace-home/twin-panel-data.test.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 
-import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+import {
+  ALL_ARCHETYPES,
+  deriveTwinProfile,
+} from "@dpf/storefront-templates";
 
 import {
   loadWorkspaceTwinPresentation,
@@ -8,6 +11,9 @@ import {
 } from "./twin-panel-data";
 
 const SAMPLE = ALL_ARCHETYPES[0];
+const RESTAURANT = ALL_ARCHETYPES.find(
+  (archetype) => deriveTwinProfile(archetype).template === "FLOOR",
+)!;
 const NOW = new Date("2026-07-15T09:00:00Z");
 
 // A fake client for the live projection path. `configured` toggles whether an org
@@ -137,5 +143,84 @@ describe("loadWorkspaceTwinPresentation — live overlay", () => {
   it("returns null for an unresolvable slug regardless of live data", async () => {
     expect(await loadWorkspaceTwinPresentation(null)).toBeNull();
     expect(await loadWorkspaceTwinPresentation("not-a-real-archetype-slug")).toBeNull();
+  });
+
+  it("loads the persisted restaurant scene beside the live FLOOR snapshot", async () => {
+    const base = fakeDb({
+      archetypeId: RESTAURANT.archetypeId,
+      name: RESTAURANT.name,
+    }) as Record<string, unknown>;
+    const sceneLayout = {
+      schemaVersion: 1,
+      spaceKind: "cartesian-interior",
+      viewport: { x: 0, y: 0, zoom: 1 },
+      zones: [],
+      placements: [
+        {
+          id: "placement-1",
+          entityRef: { kind: "table", id: "table-1" },
+          geometry: {
+            x: 10,
+            y: 20,
+            width: 80,
+            height: 80,
+            rotation: 0,
+            shapeKind: "round-table",
+          },
+        },
+      ],
+    };
+    const db = {
+      ...base,
+      storefrontConfig: {
+        findFirst: async (input: {
+          select?: { id?: boolean; timezone?: boolean };
+        }) =>
+          input.select?.id
+            ? {
+                id: "storefront-1",
+                organization: { orgId: "ORG-1" },
+                archetype: { name: RESTAURANT.name },
+                hospitalityResources: [
+                  {
+                    id: "table-1",
+                    label: "Aster",
+                    capacity: 4,
+                    serviceArea: "Main dining",
+                    attributes: { shape: "round" },
+                  },
+                ],
+              }
+            : {
+                timezone: "UTC",
+                archetype: {
+                  archetypeId: RESTAURANT.archetypeId,
+                  name: RESTAURANT.name,
+                },
+              },
+      },
+      operationalSceneLayout: {
+        findUnique: async () => ({
+          id: "scene-1",
+          version: 3,
+          layoutState: sceneLayout,
+        }),
+        create: async () => {
+          throw new Error("existing scene must be reused");
+        },
+      },
+    };
+
+    const result = await loadWorkspaceTwinPresentation(
+      RESTAURANT.archetypeId,
+      null,
+      { db: db as never, now: NOW },
+    );
+
+    expect(result?.scene).toMatchObject({
+      id: "scene-1",
+      version: 3,
+      createdFromStarter: false,
+    });
   });
 });

--- a/apps/web/lib/workspace-home/twin-panel-data.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.ts
@@ -20,12 +20,23 @@ import {
   type TwinProfile,
 } from "@dpf/storefront-templates";
 
-import { buildDemoTwinSnapshot, type TwinSnapshot } from "@/components/twin";
+import { buildDemoTwinSnapshot } from "@/components/twin/demo-snapshot";
+import type { TwinSnapshot } from "@/components/twin/snapshot";
 import { loadVersionedOperationsSnapshot } from "@/lib/twin/operations-loader";
 import {
   toLivingBusinessSnapshot,
   type OperationsSnapshotTelemetry,
 } from "@/lib/twin/operations-snapshot";
+import {
+  loadOrCreateRestaurantScene,
+  type OperationalSceneLayoutDatabase,
+  type RestaurantOperationalScene,
+} from "@/lib/twin/restaurant-scene-layout";
+import {
+  loadRestaurantFloorOperationalView,
+  type RestaurantFloorDatabase,
+  type RestaurantFloorOperationalView,
+} from "@/lib/twin/restaurant-floor-loader.server";
 
 export interface WorkspaceTwinPresentation {
   archetypeId: string;
@@ -40,6 +51,8 @@ export interface WorkspaceTwinPresentation {
     degradedSourceCount: number;
     telemetry: OperationsSnapshotTelemetry;
   } | null;
+  scene: RestaurantOperationalScene | null;
+  restaurantFloor: RestaurantFloorOperationalView | null;
   /**
    * True while the snapshot is deterministic demo fixture data — the live
    * `LivingBusinessSnapshot` projection (parent spec P4) has not been wired.
@@ -96,8 +109,108 @@ export function resolveWorkspaceTwinPresentation(
     profile,
     snapshot: condenseForWorkspaceHome(snapshot),
     operations: null,
+    scene: null,
+    restaurantFloor: null,
     demo,
   };
+}
+
+async function loadRestaurantWorkspaceFloor(
+  dbInput: unknown,
+  archetypeId: string,
+  now?: Date,
+): Promise<RestaurantFloorOperationalView | null> {
+  try {
+    const db =
+      dbInput ??
+      ((await import("@dpf/db")).prisma as unknown);
+    const client = db as RestaurantFloorDatabase & {
+      storefrontConfig: {
+        findFirst(input: unknown): Promise<{
+          id: string;
+          organizationId: string;
+        } | null>;
+      };
+    };
+    if (
+      !client.hospitalityResource ||
+      !client.hospitalityCapacityAllocation ||
+      !client.storefrontBooking ||
+      !client.bookingHold ||
+      !client.staffingResourceLink ||
+      !client.employeeProfile
+    ) {
+      return null;
+    }
+    const config = await client.storefrontConfig.findFirst({
+      where: { archetype: { archetypeId } },
+      select: { id: true, organizationId: true },
+    });
+    if (!config?.organizationId) return null;
+    return await loadRestaurantFloorOperationalView(client, {
+      organizationId: config.organizationId,
+      storefrontId: config.id,
+      now,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function loadRestaurantWorkspaceScene(
+  dbInput: unknown,
+  archetypeId: string,
+): Promise<RestaurantOperationalScene | null> {
+  try {
+    const db =
+      dbInput ??
+      ((await import("@dpf/db")).prisma as unknown);
+    const client = db as {
+      storefrontConfig: {
+        findFirst(input: unknown): Promise<{
+          id: string;
+          organization: { orgId: string };
+          archetype: { name: string } | null;
+          hospitalityResources: Array<{
+            id: string;
+            label: string;
+            capacity: number;
+            serviceArea: string | null;
+            attributes: unknown;
+          }>;
+        } | null>;
+      };
+    } & OperationalSceneLayoutDatabase;
+    if (!client.operationalSceneLayout) return null;
+    const config = await client.storefrontConfig.findFirst({
+      where: { archetype: { archetypeId } },
+      select: {
+        id: true,
+        organization: { select: { orgId: true } },
+        archetype: { select: { name: true } },
+        hospitalityResources: {
+          where: { kind: "table", status: { not: "retired" } },
+          select: {
+            id: true,
+            label: true,
+            capacity: true,
+            serviceArea: true,
+            attributes: true,
+          },
+        },
+      },
+    });
+    if (!config || config.hospitalityResources.length === 0) return null;
+    return await loadOrCreateRestaurantScene({
+      database: client,
+      orgId: config.organization.orgId,
+      locationId: config.id,
+      locationLabel: `${config.archetype?.name ?? "Restaurant"} floor`,
+      tables: config.hospitalityResources,
+    });
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -117,25 +230,35 @@ export async function loadWorkspaceTwinPresentation(
 ): Promise<WorkspaceTwinPresentation | null> {
   const base = resolveWorkspaceTwinPresentation(archetypeId, archetypeName);
   if (!base) return null;
-  try {
-    const operations = await loadVersionedOperationsSnapshot(opts);
-    if (operations && operations.identity.archetypeId === base.archetypeId) {
-      return {
-        ...base,
-        snapshot: condenseForWorkspaceHome(toLivingBusinessSnapshot(operations)),
-        operations: {
-          version: operations.version,
-          asOf: operations.asOf,
-          sourceWatermark: operations.sourceWatermark,
-          freshness: operations.freshness,
-          degradedSourceCount: operations.degradedSources.length,
-          telemetry: operations.telemetry,
-        },
-        demo: false,
-      };
-    }
-  } catch {
-    // Projection failed (no DB in this context, transient error) — keep the demo.
+  const isFloor = base.profile.template === "FLOOR";
+  // These projections are independent read models. Run them concurrently so
+  // the host is not waiting on scene IO, live floor joins, then the generic
+  // operations snapshot in series during a customer-facing interaction.
+  const [scene, restaurantFloor, operations] = await Promise.all([
+    isFloor
+      ? loadRestaurantWorkspaceScene(opts?.db, base.archetypeId)
+      : Promise.resolve(null),
+    isFloor
+      ? loadRestaurantWorkspaceFloor(opts?.db, base.archetypeId, opts?.now)
+      : Promise.resolve(null),
+    loadVersionedOperationsSnapshot(opts).catch(() => null),
+  ]);
+  if (operations && operations.identity.archetypeId === base.archetypeId) {
+    return {
+      ...base,
+      snapshot: condenseForWorkspaceHome(toLivingBusinessSnapshot(operations)),
+      operations: {
+        version: operations.version,
+        asOf: operations.asOf,
+        sourceWatermark: operations.sourceWatermark,
+        freshness: operations.freshness,
+        degradedSourceCount: operations.degradedSources.length,
+        telemetry: operations.telemetry,
+      },
+      scene,
+      restaurantFloor,
+      demo: false,
+    };
   }
-  return base;
+  return { ...base, scene, restaurantFloor };
 }

--- a/docs/data-impact/2026-07-31-restaurant-service-turn.data-impact.json
+++ b/docs/data-impact/2026-07-31-restaurant-service-turn.data-impact.json
@@ -1,0 +1,146 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Restaurant operator-floor, table-management, and living-business views are read-time projections over canonical bookings, hospitality resources, allocations, service turns, staffing assignments, and authored scene layouts; no parallel operational copy is persisted.",
+    "The customer availability projection is an explicit allow-list over capacity and timing. Service-turn identifiers, booking and staffing links, demand references, actor references, idempotency keys, event detail, guest facts, staff facts, and internal block reasons are excluded.",
+    "The scene-identity migration preserves every authored layout. For duplicate non-null organization/template/location identities, the newest row remains active and older rows move to stable recovery location identifiers instead of being deleted."
+  ],
+  "migration": {
+    "name": "20260731190000_enforce_operational_scene_location_identity + 20260731193000_add_hospitality_service_turn",
+    "backfill": "The scene migration deterministically detaches duplicate location identities without deleting authored geometry, then adds the unique index. The service-turn migration is additive: new turn/event tables start empty, demandKind defaults existing bookings to reservation, and the allocation serviceTurnId link is nullable. Rollback disables new turn commands and customer explanations while preserving bookings, allocations, layouts, staffing history, and event evidence; no rollback path deletes business records."
+  },
+  "tests": [
+    "apps/web/lib/govern/data/assets.test.ts",
+    "apps/web/lib/govern/data/coverage.live.test.ts",
+    "apps/web/lib/storefront/hospitality-service-turn.test.ts",
+    "apps/web/lib/storefront/hospitality-service-turn-repository.server.test.ts",
+    "apps/web/lib/twin/restaurant-floor-command.server.test.ts",
+    "apps/web/lib/twin/restaurant-move-command.server.test.ts",
+    "apps/web/lib/twin/restaurant-turn-command.server.test.ts",
+    "apps/web/lib/twin/restaurant-floor-loader.server.test.ts",
+    "apps/web/lib/twin/restaurant-floor-projection.test.ts",
+    "scripts/check-migration-safety.mjs",
+    "scripts/check-stewardship-scope.mjs",
+    "scripts/check-data-impact.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:operational-scene-layout",
+      "prismaModel": "OperationalSceneLayout",
+      "lifecycleDisposition": "domain-lifecycle-managed — authored geometry remains under the owning organization and location until explicit domain removal; duplicate remediation preserves displaced layouts under recovery identities rather than deleting them",
+      "fields": [
+        {
+          "fieldId": "data:operational-scene-layout#locationId",
+          "resolution": "governed",
+          "reason": "the organization/template/location identity becomes unique so one active authored scene deterministically owns each physical restaurant location",
+          "provenance": "operator-authored location identity or deterministic duplicate-recovery migration",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "organization-scoped and local-only; recovery identifiers remain internal and are never projected to customers"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:hospitality-service-turn",
+      "prismaModel": "HospitalityServiceTurn",
+      "lifecycleDisposition": "domain-lifecycle-managed — turns progress through seated, ordered, paid, dirty, closed, or cancelled; closedAt and append-only events preserve operating history, and deletion occurs only through the owning organization-domain lifecycle",
+      "fields": [
+        {
+          "fieldId": "data:hospitality-service-turn#identity-and-ownership",
+          "resolution": "inherited",
+          "reason": "id, turnId, organizationId, and storefrontId form the tenant-scoped canonical turn identity",
+          "provenance": "Prisma and the service-turn command repository"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn#demand-links",
+          "resolution": "governed",
+          "reason": "bookingId, demandType, and demandRef can identify a customer booking or walk-in demand",
+          "provenance": "validated seating command",
+          "flags": [
+            "subject",
+            "sensitive"
+          ],
+          "fieldPolicy": "organization-scoped; available only to authorized operators and omitted from customer-safe availability payloads"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn#staffingAssignmentId",
+          "resolution": "governed",
+          "reason": "the staffing link identifies an internal worker assignment",
+          "provenance": "published on-site staffing resolution at seating time",
+          "flags": [
+            "subject",
+            "sensitive"
+          ],
+          "fieldPolicy": "authorized workforce and restaurant operations only; customer projections omit worker identity and assignment references"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn#lifecycle-and-time",
+          "resolution": "inherited",
+          "reason": "stage, startedAt, expectedEndAt, closedAt, and version are the conflict-safe operational lifecycle contract",
+          "provenance": "service-turn command repository and database constraints"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn#persistence",
+          "resolution": "inherited",
+          "reason": "createdAt, updatedAt, allocations, and owning relations are ordinary persistence and reconciliation metadata",
+          "provenance": "Prisma relations and timestamps"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:hospitality-service-turn-event",
+      "prismaModel": "HospitalityServiceTurnEvent",
+      "lifecycleDisposition": "domain-lifecycle-managed — append-only events remain attached to the turn as audit evidence and are removed only with the owning turn through an explicit organization-domain lifecycle",
+      "fields": [
+        {
+          "fieldId": "data:hospitality-service-turn-event#identity-and-ownership",
+          "resolution": "inherited",
+          "reason": "id, eventId, organizationId, and serviceTurnId bind each event to one tenant-owned turn",
+          "provenance": "Prisma and the service-turn event repository"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn-event#transition",
+          "resolution": "inherited",
+          "reason": "eventType, fromStage, toStage, atVersion, and occurredAt form the append-only transition receipt",
+          "provenance": "validated stage, table-assignment, or staffing-assignment command"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn-event#idempotencyKey",
+          "resolution": "governed",
+          "reason": "the internal deduplication token may encode an upstream workflow identity",
+          "provenance": "operator command boundary",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "internal replay and reconciliation only; redact from presentation, customer payloads, and exports"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn-event#actorRef",
+          "resolution": "governed",
+          "reason": "the accountable actor reference may identify an operator or coworker",
+          "provenance": "authenticated command context",
+          "flags": [
+            "subject",
+            "sensitive"
+          ],
+          "fieldPolicy": "organization-scoped audit access only; never expose through the customer availability boundary"
+        },
+        {
+          "fieldId": "data:hospitality-service-turn-event#detail",
+          "resolution": "governed",
+          "reason": "structured command evidence can contain table, demand, and before/after operational references",
+          "provenance": "allow-listed service-turn command receipt",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "allow-listed keys, organization-scoped, local-only, and excluded from customer-safe projections"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-31-restaurant-business-grade-floor.md
+++ b/docs/superpowers/plans/2026-07-31-restaurant-business-grade-floor.md
@@ -1,0 +1,349 @@
+# Restaurant Business-Grade FLOOR Implementation Plan
+
+| Field | Value |
+| --- | --- |
+| Backlog item | `BI-287AA5F7` |
+| Epic | `EP-SPATIAL-OPERATIONAL-VIEWS` |
+| Status | Active implementation plan |
+| Delivery branch | `feat/restaurant-floor` |
+| Foundational dependency | `BI-57F34A00`, merged in PR #3796 at `99d7061d68c8ab2380fea4d1cf4010a15137d498` |
+| Parent design | `docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md` |
+| Umbrella plan | `docs/superpowers/plans/2026-07-28-business-operations-and-performance-views-plan.md` |
+| Operational precedent | `restaurant-floor` (Toast and OpenTable, accessed 2026-07-28) |
+| Coverage receipt | `cms89c2jv031001qo7gezoyzm` (`atomic`) |
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+Replace the restaurant's prototype-like inferred table grid with one business-grade host-stand workflow:
+
+- the operator sees the real authored dining-room layout, the waiting and reserved demand, table/order/turn state, assigned server load, and a short forward-availability horizon in one fast decision surface;
+- seating or moving a party is an explicit, conflict-aware, versioned command with visible consequences and alternatives;
+- keyboard and assistive-technology users can complete the same work through an equivalent table/list surface;
+- customers can see an availability explanation derived from the same capacity truth without guest names, staff identity, internal notes, or operational conflict detail;
+- `/storefront/tables` remains the internal setup and floor-configuration home, while `/workspace` remains the canonical live-operation home.
+
+The increment is complete only when the seeded busy-shift happy path is driven on the governed runtime and the host can assign a compatible waiting party without a stale, privacy-leaking, or color-only state.
+
+## Grounded substrate
+
+This plan extends the current repository rather than adding a parallel restaurant system:
+
+- `HospitalityResource`, `HospitalityResourceAvailability`, and `HospitalityCapacityAllocation` own physical tables, availability, and capacity consumption.
+- `StorefrontBooking` and `BookingHold` own reservation/waitlist demand and short-lived customer holds.
+- `StaffingShift`, `StaffingAssignment`, and `StaffingResourceLink` own people-to-shift and shift-to-resource coverage. Restaurant server sections are a projection of those records, not a new roster table.
+- `OperationalSceneLayout` owns geometry only. Its `layoutState` references tables by `SceneEntityRef`; no guest, server, order, or live status is persisted in layout JSON.
+- `RestaurantCapacitySnapshot` is the existing owner/customer reconciliation seam and will be extended into the richer restaurant operating projection rather than bypassed.
+- `CartesianSceneCanvas` owns configure/operate/read-only rendering and versioned geometry saves.
+- `operations-command.ts` owns idempotency, expected-version conflict semantics, alternatives, and optimistic reconciliation.
+- `TwinView` and the versioned Operations snapshot remain the shared Workspace composition. The restaurant FLOOR becomes its physical operating body; it does not introduce another top-level dashboard or route.
+
+The code graph did not yet return the newly merged scene/resource symbols, so these paths were verified directly in the current `99d7061d68` checkout with `rg` and file inspection.
+
+## Design grounding
+
+- **Existing specs/plans reviewed:** `docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md`, `docs/superpowers/plans/2026-07-28-business-operations-and-performance-views-plan.md`, `docs/platform-usability-standards.md`, and `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`.
+- **Current code substrate reviewed:** the `/workspace` and `/storefront/tables` route composition; `TwinView`; `CartesianSceneCanvas`; report-kit status, notice, and table primitives; hospitality resource/capacity repositories; workforce staffing assignments/resource links; `OperationalSceneLayout`; and the versioned operational-command contract.
+- **Source of truth:** hospitality resources and allocations own physical capacity, bookings and holds own demand, staffing owns server coverage, `OperationalSceneLayout` owns geometry, and the restaurant operating projection joins those authorities without copying them.
+- **Decision:** extend the existing Workspace/Storefront route family and shared scene/report-kit primitives. Do not add a global route, a second floor renderer, a restaurant-only status registry, or live facts in layout JSON.
+
+## Current precedent and DPF adaptation
+
+The maintained precedent corpus is the authority for this build; implementation must include `Operational-Precedent: restaurant-floor` in its delivery handoff.
+
+Operational-Precedent: restaurant-floor
+
+- **Toast:** live floor first, waitlist beside it, server roster and cover counts in context; table states include Available, Seated, Ordered, Paid, Dirty, and Blocked; conflicts require an explicit swap. DPF adopts this state/action grammar but always pairs color with text and never requires long-press.
+- **OpenTable:** floor and waitlist are the host command surface; flexible tables, service areas, server sections, recommended assignments, pacing, and explicit constraint explanations. DPF adopts recommendation-with-confirmation and does not silently auto-seat.
+- **DPF distinction:** one domain projection powers the operator canvas, the equivalent list, Workspace summary, and privacy-safe customer explanation. Geometry and live state remain separate authorities.
+
+Sources are maintained in `apps/web/data/design-intelligence/operational-precedents.csv`; the corpus recheck date is 2027-01-28.
+
+## UX fit review — restaurant business-grade FLOOR
+
+- **Decision:** `fits-with-guardrails`.
+- **Owning area:** Workspace for live operation; internal Storefront management for setup; customer-facing Portal for the redacted availability explanation.
+- **Route family:** `/workspace` is canonical for “seat the next party”; `/storefront/tables` configures tables and layout; the existing storefront booking route receives the read-only customer explanation. No new global navigation entry.
+- **Primary persona:** host or shift manager under time pressure. The first decision surface answers “who can I seat, where, and what conflict will that create?” without requiring platform vocabulary.
+- **Navigation layer touched:** local view mode and contextual actions only. Global and section navigation remain unchanged.
+- **Reuse/convergence:** reuse `CartesianSceneCanvas`, `TwinView`, report-kit status/notice/table primitives, the operational command contract, and the current table resource manager. Retire the label-heuristic `FloorPlanCanvas` compatibility path instead of adding a second floor renderer.
+- **Source truth:** hospitality resource/allocation/booking/hold records for live state; workforce staffing records for server coverage; `OperationalSceneLayout` for geometry; one restaurant operating projection for all renderers.
+- **Empty/failure behavior:** missing authored geometry uses an explicitly labelled generated starter layout and equivalent list, with a configure-layout action. Stale versions preserve the operator's selection, explain that nothing changed, and offer refreshed compatible alternatives. Missing staffing shows “Server not assigned,” not an invented roster. Degraded sources are named without replacing live data with demo data.
+- **AI boundary:** recommendations do not mutate state. Seating, moving, combining, or server reassignment always previews party, table(s), server/section, timing impact, and any conflict before explicit confirmation.
+- **Required guardrails:** floor-first hierarchy with adjacent demand; no guest/staff identity in customer projection; no color-only state; keyboard and list parity; no live facts in layout JSON; no duplicate status map.
+- **Evidence before merge:** route/component tests, busy-shift fixture assertions, theme-token scan, privacy projection tests, stale-version/conflict tests, keyboard/list task completion, desktop and tablet browser exercise, measured UX-budget manifest, and interaction latency measures.
+- **Recorded option choice:** kernel interaction `DI-BF8CA951943C` compared progressive disclosure in the existing resource manager, a separate floor-configuration route, and canvas-only editing. It recommended `resource-manager-progressive-disclosure` with high confidence (composite `4.067`, margin `3.221`, strong structured coverage, no commandment conflict). This keeps advanced table configuration with its persisted resource authority while preserving the FLOOR as the live operating surface.
+- **Captured in:** this plan and `docs/ux-fit/2026-07-31-restaurant-floor-progressive-disclosure.ux-fit.json`; served viewport and interaction measurements remain completion evidence.
+
+## Architecture review (advisory)
+
+- **Alignment summary:** aligned with concerns once geometry, live capacity, staffing, and customer privacy stay separate authorities.
+- **Findings:**
+  - `[important]` A restaurant-only live-state table or live fields in `OperationalSceneLayout.layoutState` would duplicate the hospitality and staffing substrates. → Keep layout JSON limited to viewport, zones, placements, shape, and underlay; join live bindings at read time.
+  - `[important]` `ServiceProvider` cannot become the server-roster authority because restaurant table creation currently writes a legacy provider compatibility row for slot booking. → Use canonical workforce staffing assignments/resource links for server coverage and treat missing coverage honestly.
+  - `[important]` Free-form `HospitalityResource.attributes` needs a validated restaurant table contract if it carries shape and combinability. → Add one pure parser/serializer with closed application-level values and route tests; unknown values degrade safely. Do not scatter JSON casts.
+  - `[important]` Seating through client-only optimistic state would bypass booking/allocation concurrency. → Map the generic operational command to one server transaction that rechecks table, party, interval, staffing constraints, and expected versions before changing assignments.
+  - `[minor]` Customer availability must not fork the operating projection. → Add an explicit redaction/projector function with allow-listed fields and negative privacy tests.
+- **Standards adopted:** DPF spatial operational view design, workforce staffing substrate, versioned operational command contract, Toast/OpenTable maintained precedent, and the portal usability/UX-fit standards.
+- **Escalated decisions:** none. Existing canonical ownership resolves the apparent data-model choices.
+- **Recommended next step:** implement the phases below with tests defining each contract before UI integration.
+
+### Service-turn authority decision
+
+The substrate sweep found no existing or in-flight authority for the live service turn shared by a party across one or more table allocations:
+
+- `StorefrontBooking.status` owns reservation lifecycle and cannot also own seated, ordered, paid, dirty, and closed execution state without conflating customer intent with service delivery.
+- `HospitalityCapacityAllocation` is the append-preserving per-resource consumption ledger. Combined tables create multiple allocation rows, so placing party-level turn state there would duplicate one state across resources.
+- `StorefrontOrder.status` owns commerce fulfillment and has no booking/allocation relation; it cannot be the restaurant table-turn authority.
+- `StaffingAssignment` remains the server/crew authority and is referenced by the turn rather than copied into it.
+
+The code graph, Prisma/type sweep, live `EP-SPATIAL-OPERATIONAL-VIEWS` backlog, open-PR sweep, and recent `origin/main` history found no exact competing substrate. Kernel consultation `DI-449F9014DADA` compared booking-status reuse, allocation extension, and a dedicated aggregate. It recommended `service-turn-aggregate` with high confidence (composite `4.006`, margin `2.802`, strong structured coverage, no commandment conflict). The strongest positive contributors were Never Assume — Verify, Research and Use Standards, Architecture Over Shortcuts, and Single Source of Truth.
+
+**Decision:** add one `HospitalityServiceTurn` per demand/party, relate one or more capacity allocations to it, and preserve append-only turn transition evidence. Reservation, resource consumption, commerce order, staffing, and geometry remain separate authorities joined by the restaurant operating projection.
+
+## Delivery boundary
+
+This plan is one atomic business workflow under `BI-287AA5F7`. The phases are internal sequencing, not separately releasable user outcomes:
+
+- a configurable layout without live binding remains the existing prototype;
+- live binding without transactional seating is observational, not operational;
+- seating without the customer-safe projection breaks owner/customer reconciliation;
+- the customer projection without the same conflict-aware source truth can advertise unavailable capacity;
+- list parity, privacy, and busy-shift evidence are release conditions, not follow-up polish.
+
+The already-completed scene-layout and hospitality-resource BIs are dependencies, not new deliverables in this branch.
+
+## Phase 1 — Define the restaurant operating contract with failing tests
+
+**Deliverable:** a pure, complete restaurant-floor read model and a privacy-safe customer projection.
+
+**Files:**
+
+- extend `apps/web/lib/storefront/restaurant-capacity.ts` and its tests;
+- add `apps/web/lib/twin/restaurant-floor-projection.ts` and tests;
+- add one validated table-attributes helper under `apps/web/lib/storefront/`;
+- extend `apps/web/lib/twin/__fixtures__/restaurant-busy-shift.ts`.
+
+**Contract:**
+
+- structural table facts: service area, capacity, shape, combinability group/compatible table ids;
+- live table state: available, held, reserved, seated, ordered, paid, dirty, blocked, and late-turn;
+- assignment context: current party, assigned server/section, server cover/table load;
+- forward horizon: `availableNow`, `availableAt`, minutes/reason, and the next conflicting demand;
+- demand rows: reservation/walk-in, party size, waited/arrival time, compatible tables, recommendation reason, and safe flags such as “dietary note present” without exposing note content in the floor summary;
+- customer projection allow-list: capacity/time/availability explanation only.
+
+**Verification:**
+
+- red tests for every busy-shift state and for unknown/missing source data;
+- privacy tests prove customer JSON contains no guest name, email, phone, staff identity, VIP label, dietary text, internal note, or conflict-internal detail;
+- invariant tests prove the floor/list/customer counts reconcile from one projection.
+
+## Phase 2 — Persist authored table structure and bind the scene
+
+**Deliverable:** `/storefront/tables` edits table shape/combinability and configures the persisted dining-room layout.
+
+**Files:**
+
+- extend the hospitality resource admin routes and `HospitalityResourceManager`;
+- add/load the restaurant `OperationalSceneLayout` through the existing repository/actions;
+- replace the derived-layout authority in `TablesNowView`/`FloorPlanCanvas` with a restaurant scene adapter over `CartesianSceneCanvas`;
+- retain `floor-layout.ts` only as a one-time generated starter/fallback.
+
+**Rules:**
+
+- table shape/combinability is validated structural metadata on `HospitalityResource`;
+- service-area geometry is stored as scene zones; table geometry/shape is stored as placements;
+- layout save uses `expectedVersion`; stale saves never overwrite another session;
+- removing or retiring a table leaves a resolvable missing-placement warning until the operator removes/rebinds it;
+- the existing `attributes` field remains sufficient for validated table structure; one fleet-safe migration adds the missing `OperationalSceneLayout` location identity required for race-safe create-or-read. It preserves older duplicate layouts by detaching, not deleting, every duplicate before the unique index lands.
+
+**Verification:**
+
+- add/edit API tests for shape/combinability, authorization, unknown values, and version conflicts;
+- layout load/save tests for org scoping, generated starter, authored persistence, missing refs, and concurrent saves;
+- keyboard nudge and list-detail tests for configure mode.
+
+## Phase 3 — Build the host-stand operating surface
+
+**Deliverable:** the restaurant Workspace shows floor + waitlist/reservations + server load as one fast decision surface.
+
+**Files:**
+
+- extend the bounded restaurant selectors in `living-business-snapshot.ts` / `operations-loader.ts`;
+- add restaurant FLOOR composition under `apps/web/components/twin/`;
+- extend `WorkspaceTwinPanel`/`TwinView` through a physical-scene slot rather than a restaurant route fork;
+- compose report-kit `StatusBadge`, `Notice`, and `DataTable` for status, conflicts, and list parity.
+
+**Interaction:**
+
+- selecting a party filters/highlights compatible tables and explains rejected choices;
+- selecting a table shows party fit, server load, forward availability, and the consequence of the assignment;
+- floor and list share selection, filters, command preview, and pending/conflict state;
+- default viewport shows floor, adjacent demand, and server load without scrolling at the target desktop host-stand viewport;
+- status text and timing remain legible at tablet width and 200% zoom.
+
+**Performance budgets:**
+
+- server projection uses bounded selectors and records query count/payload bytes in existing Operations telemetry;
+- decision surface ready: p95 ≤ 1.5 seconds on the governed seeded runtime;
+- local selection/filter response: p95 ≤ 100 ms;
+- confirmed assignment response: p95 ≤ 750 ms excluding deliberate external-provider calls;
+- payload and query-count regressions require explicit evidence, not a larger silent baseline.
+
+**Verification:**
+
+- render and interaction tests for floor-first hierarchy, selection, compatible/rejected tables, server imbalance, text status, list parity, and failure states;
+- operations snapshot tests prove the fixture survives the versioned selector path;
+- measured UX route sweep against `/workspace`.
+
+## Phase 4 — Add transactional seating, moving, and combination commands
+
+**Deliverable:** explicit host commands safely assign or move parties and combine tables.
+
+**Files:**
+
+- add a restaurant adapter beside `apps/web/lib/twin/operations-command.ts`;
+- add server repository/action code over booking + allocation + resource/staffing reads;
+- wire the operation closure into the restaurant physical-scene surface.
+
+**Transaction rules:**
+
+- require idempotency key, expected booking/allocation/resource versions, requested interval, party, table ids, and actor;
+- recheck capacity, table availability, overlapping allocations/holds/bookings, combinability, current occupancy, and staffing coverage;
+- create or advance the authoritative service turn and write/update the booking resource assignment plus append-preserving capacity allocations in one transaction;
+- relate every allocation in a combined-table assignment to the same turn; never duplicate turn stage across allocation rows;
+- append a versioned turn-transition event for every accepted stage or table-assignment change, retaining actor and before/after state without copying customer notes;
+- return `confirmed`, `conflict` with current compatible alternatives, `rejected`, or typed `unsupported`;
+- never silently swap servers, split parties, override blocks, or move a locked/active assignment;
+- preview names the guest-visible consequence and internal operational consequence before confirmation.
+
+**Verification:**
+
+- repository tests for double-seat races, stale versions, retry idempotency, blocked/dirty tables, invalid combinations, late turns, and rollback on partial failure;
+- UI tests prove optimistic pending state reconciles with confirmed/conflict/rejected results;
+- audit/activity evidence identifies actor, command, affected entities, before/after versions, and result without copying sensitive notes.
+
+## Phase 5 — Customer-safe read-only availability
+
+**Deliverable:** the existing restaurant booking experience explains near-term availability from the same operating projection.
+
+**Files:**
+
+- expose a server-only redacted restaurant availability DTO through the existing storefront route family;
+- compose a read-only `CartesianSceneCanvas` summary only where it improves the customer's choice; otherwise use the same DTO in a compact availability/list explanation;
+- add customer route and serialization tests.
+
+**Rules:**
+
+- show only general capacity/time explanations such as “Table for 4 available at 7:10 PM” or “limited availability because the next compatible table is occupied”;
+- do not expose exact guest identity, reservation labels, server identity/load, VIP/allergy/dietary content, internal order state, block reason, or operational notes;
+- customer output is informational until the existing hold/booking transaction confirms availability;
+- stale/degraded state says availability will be confirmed at booking, never fabricates precision.
+
+**Verification:**
+
+- negative serialization/privacy tests;
+- owner/list/customer reconciliation test from the same fixture;
+- browser exercise of available, limited, unavailable, and degraded cases.
+
+## Phase 6 — Refactor allocation (approximately 20%)
+
+**Deliverable:** remove the prototype seams and leave reusable physical-operation primitives for ROOM, CHAIR_BOOK, YARD, PROPERTY_PORTFOLIO, and DISPATCH_TERRITORY.
+
+- retire `FloorPlanCanvas` as a restaurant-specific renderer once all callers use the generic scene;
+- reduce `floor-layout.ts` to a clearly named starter-layout generator or delete it if no fallback remains;
+- extract shared scene-binding, selection/command-preview, and floor/list parity primitives without moving restaurant vocabulary into the generic layer;
+- centralize restaurant state-to-intent registration in report-kit status metadata;
+- remove duplicate presentation adapters and stale comments that still describe the live projection as future/demo.
+
+**Verification:**
+
+- twin-template coverage remains green for all archetypes;
+- module-size and no-hardcoded-color guards pass;
+- no new restaurant-only scene renderer, status registry, command state machine, or global route exists.
+
+## Phase 7 — Governed completion evidence
+
+### Implementation checkpoint — 2026-07-31
+
+- Phases 1–5 are implemented on `feat/restaurant-floor`: authored table
+  structure and geometry, the joined live host stand, combined-table seating,
+  service-turn lifecycle controls, atomic party movement, actionable conflict
+  alternatives, and the public privacy-allowlisted forward-availability view.
+- The service-turn aggregate and both fleet-safe migrations format and validate
+  under Prisma 7.8. Migration safety and timestamp-collision guards pass.
+- Independent Workspace projections now load concurrently; recommendation
+  candidates are cached by party size so a busy waitlist does not repeat the
+  same bounded table-pair search for every party. The restaurant read model
+  reuses the shared Prisma read instrumentation and reports its own elapsed
+  time, bounded query count, and exact serialized payload size rather than
+  disappearing inside the generic Operations telemetry.
+- Source-focused evidence after refreshing to `origin/main@0b29e31bd7` is 26
+  Vitest files / 121 tests passing. The customer detail list is bounded while
+  retaining the full availability count, and confirmed seating is distinguished
+  from a later party move using the status fact rather than resource changes
+  alone. A full TypeScript diagnostic pass reports no
+  restaurant implementation errors; its remaining diagnostics are limited to
+  the source-only worktree's absent `@dpf/storefront-templates` workspace link,
+  which must be resolved by canonical sandbox convergence rather than a
+  worktree install.
+- Phase 6 allocation is materially represented by the shared Cartesian scene,
+  central status-intent registry, customer allow-list projector, reusable
+  seating/alternative evaluator, and separated service-turn/seat/move command
+  modules. Compatibility deletion remains contingent on governed route evidence.
+- The following evidence remains required before completion: canonical
+  dependency convergence and full typecheck, exhaustive tests, migration apply,
+  production Docker build, served desktop/tablet/keyboard/200% UX exercise,
+  privacy inspection, measured latency/UX manifest, signed commit/PR, and merge
+  queue result.
+
+1. Run targeted Vitest suites for all changed contracts and components.
+2. Run affected package tests and typecheck.
+3. Use the governed `local-integration-ci` FIFO lane for freshness, exhaustive tests, migration checks, and production Docker build. A runner-worker crash after passing assertions is runner evidence, not a product diagnosis; preserve diagnostics and rerun only through FIFO.
+4. Drive the busy-shift host task on the served candidate:
+   - choose the 14-minute walk-in;
+   - inspect compatible tables and the server imbalance warning;
+   - preview and confirm the recommended assignment;
+   - observe the table, waitlist, capacity, and forward-availability update;
+   - repeat the task by keyboard through the list alternative;
+   - force a stale conflict and confirm that nothing changes and alternatives remain actionable.
+5. Drive the customer availability cases and inspect the serialized payload for privacy.
+6. Measure desktop and tablet viewports, 200% zoom, touch targets, no overlap, UX-budget axes, decision-ready latency, selection latency, assignment latency, query count, and payload bytes.
+7. Commit the measured UX-fit manifest and record test/build/migration/UX evidence on `BI-287AA5F7` and `WC-065EB427`.
+8. Push the signed branch, open a ready PR, run `pnpm pr:health`, enqueue through the merge queue, and verify the merge-group result.
+
+## Risks and rollback
+
+| Risk | Mitigation | Rollback |
+| --- | --- | --- |
+| Authored layout and resource inventory drift | Missing-ref diagnostics; table-id entity refs; list remains authoritative and operable | Switch the restaurant scene loader to generated starter layout while preserving saved layout rows |
+| Staff/table identity confusion through legacy providers | Never use legacy table providers as server roster; join workforce staffing explicitly | Omit server assignment/load with an honest unavailable label |
+| Seat race or double allocation | One transaction, expected versions, overlap checks, idempotency | Reject with alternatives; no partial writes |
+| Customer privacy leak | Allow-list projector plus negative serialization tests | Disable the read-only explanation and retain existing slot availability |
+| Slow host interaction | Bounded selectors, payload/query telemetry, local selection state | Fall back to list-first interaction using the same projection and commands |
+| Refactor destabilizes other twins | Preserve generic contracts and full twin-template coverage | Restore compatibility adapter while keeping the richer domain projection |
+
+No rollback path deletes bookings, allocations, resources, layouts, or staffing history.
+
+## Definition of done
+
+- Persisted authored geometry is the authority after configuration; label heuristics are not.
+- The floor displays service areas, table shape/capacity/combinability, server section/load, table/order/turn state, and forward availability with text plus semantic color.
+- A host can assign and move parties with preview, explicit confirmation, idempotency, version conflicts, and alternatives.
+- The same task is fully operable through the list alternative and keyboard.
+- The customer explanation comes from the same projection and passes the privacy allow-list tests.
+- Busy-shift data includes reservation, walk-in, combined tables, server imbalance, dirty, blocked, late turn, and a VIP/allergy-note boundary.
+- Measured performance, accessibility, privacy, UX-fit, exhaustive test, production build, and functional browser evidence are attached to the BI/Work Capsule.
+- Approximately 20% of the implementation removes the restaurant compatibility renderer and extracts reusable physical-operation seams.
+- The ready PR is merged through the governed queue.
+
+## Backlog coverage
+
+- **Receipt:** `cms89c2jv031001qo7gezoyzm`
+- **Parent BI:** `BI-287AA5F7`
+- **Decision:** `atomic`
+- **Mapped child BIs:** none; the six phases are non-shippable sequencing within the parent BI.
+- **Dependency graph:** `operating-contract` → `authored-layout` → `host-surface` → `assignment-commands` → `customer-projection`; `refactor-evidence` closes all preceding phases.
+- **Rationale:** authored geometry without live binding remains prototype-only; live binding without transactional assignment is observational; assignment without the same customer-safe availability projection breaks owner/customer reconciliation; accessibility, privacy, busy-shift, and performance evidence are release conditions rather than independent products. Completed scene-layout and hospitality-resource BIs are substrate dependencies, while this BI owns their end-to-end integration.

--- a/docs/user-guide/storefront/setup-and-launch.md
+++ b/docs/user-guide/storefront/setup-and-launch.md
@@ -110,13 +110,19 @@ reservations:
 1. Add every table guests can actually be seated at. Use the label staff use
    during service, record its true seat count, and identify its service area
    (for example, dining room, patio, or bar).
-2. Open each table and set its weekly availability. Add dated exceptions for
+2. Record the table's physical shape. If tables can be joined, give them the
+   same combination group and select only the neighboring tables staff can
+   actually combine.
+3. Open each table and set its weekly availability. Add dated exceptions for
    closures, maintenance, private events, or other temporary restrictions.
-3. Mark a table **Blocked** when it must not be assigned and give the team a
+4. Mark a table **Blocked** when it must not be assigned and give the team a
    useful reason. Use **Retired** only when the table is no longer part of the
    operating floor.
-4. Compare the table totals and current availability with the physical room
-   before publishing and after any layout change.
+5. Under **Tables right now**, choose **Adjust layout**, move each table to its
+   real position, and save. Layout changes move the drawing only; they do not
+   change reservations or seat a party.
+6. Compare the table totals, saved floor, and current availability with the
+   physical room before publishing and after any layout change.
 
 An upgraded storefront may show a blocked table with **Confirm seat capacity
 after migration**. DPF intentionally does not guess a physical capacity when

--- a/docs/user-guide/storefront/team-and-fulfilment.md
+++ b/docs/user-guide/storefront/team-and-fulfilment.md
@@ -28,10 +28,11 @@ their own **Tables & Capacity** page (`/storefront/tables`):
   action for the next service period. Add, edit, schedule, or block tables here,
   not under Team.
 
-Use **Add table** to record its owner-facing label, seats, and service area.
-Open an existing table to change its status, capacity, area, or internal blocked
-reason. The readiness answer and floor/list state refresh after a successful
-save, so the host does not need to reload the page while a guest is waiting.
+Use **Add table** to record its owner-facing label, seats, service area, and
+physical shape. For tables that can be joined, use one combination group and
+select only real neighboring tables. Open an existing table to change its
+status, capacity, area, shape, combination rules, or internal blocked reason.
+The readiness answer and floor/list state refresh after a successful save.
 
 The availability editor supports recurring weekday hours and dated available or
 blocked windows. Public booking consumes these rules, active holds, and existing
@@ -42,15 +43,33 @@ Under "Tables right now" you can switch between two views of the same live
 capacity:
 
 - **Floor plan** (the default) — a graphical layout of your tables, each shaped
-  by its seats and coloured by its state, so you can see at a glance which tables
-  are open and which are turning soon (with the minutes until they free up).
-  Tables cluster into sections (window, bar, booths, patio) inferred from their
-  names, so the plan is legible without any extra setup. Pan and zoom to explore.
-- **List** — the same tables as a scannable list.
+  from its saved table record and labeled with its current state. Status text
+  accompanies color, and turning tables show when they are expected to free.
+  Choose **Adjust layout** to place tables in their real positions and save the
+  authored floor without changing reservations.
+- **List** — the same live facts as a scannable alternative when the drawing is
+  unavailable or a list is easier to operate.
+
+Use `/workspace` during service. The restaurant floor there joins the saved
+layout to waiting and reserved parties, active service turns, server sections,
+table availability, and workload. To seat a party:
+
+1. Choose a waiting party and review only compatible table choices.
+2. Check the table, timing, and server-load explanation.
+3. Preview and explicitly confirm the assignment.
+4. Advance the table through seated, ordered, paid, clearing, and cleared as
+   service progresses.
+
+To move an active party, choose **Move party**, select a compatible destination,
+review the change, and confirm. If another host changes the floor first, DPF
+does not make a partial assignment: it refreshes the facts and offers current
+alternatives.
 
 Tables are never shown as "providers" and never mixed into the Staff list.
 Blocked reasons and internal allocation references stay in the owner workspace;
-the customer booking experience receives only a safe availability explanation.
+the customer booking experience receives only seat capacity, service area, and
+an availability estimate. It does not receive guest names, staff identity,
+internal table ids, notes, or blocked reasons.
 
 ## What To Watch
 

--- a/docs/ux-fit/2026-07-31-restaurant-floor-progressive-disclosure.ux-fit.json
+++ b/docs/ux-fit/2026-07-31-restaurant-floor-progressive-disclosure.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "resource-manager-progressive-disclosure",
+  "decisionInteractionId": "DI-BF8CA951943C",
+  "scope": {
+    "files": [
+      "apps/web/components/storefront-admin/HospitalityResourceManager.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "resource-manager-progressive-disclosure",
+      "separate-floor-configuration-route",
+      "canvas-only-direct-editing"
+    ]
+  }
+}

--- a/packages/db/prisma/migrations/20260731190000_enforce_operational_scene_location_identity/migration.sql
+++ b/packages/db/prisma/migrations/20260731190000_enforce_operational_scene_location_identity/migration.sql
@@ -1,0 +1,24 @@
+-- Preserve every authored layout before enforcing one scene per organization,
+-- twin template, and non-null location. Older/manual duplicate rows are detached
+-- to a stable recovery location instead of deleted; the most recently updated
+-- row remains the active location layout.
+WITH "ranked_layouts" AS (
+  SELECT
+    "id",
+    row_number() OVER (
+      PARTITION BY "orgId", "twinTemplate", "locationId"
+      ORDER BY "updatedAt" DESC, "id" ASC
+    ) AS "duplicate_rank"
+  FROM "OperationalSceneLayout"
+  WHERE "locationId" IS NOT NULL
+)
+UPDATE "OperationalSceneLayout" AS "layout"
+SET "locationId" =
+  "layout"."locationId" || ':duplicate:' || "layout"."id"
+FROM "ranked_layouts"
+WHERE "layout"."id" = "ranked_layouts"."id"
+  AND "ranked_layouts"."duplicate_rank" > 1;
+
+CREATE UNIQUE INDEX
+  "OperationalSceneLayout_orgId_twinTemplate_locationId_key"
+ON "OperationalSceneLayout"("orgId", "twinTemplate", "locationId");

--- a/packages/db/prisma/migrations/20260731193000_add_hospitality_service_turn/migration.sql
+++ b/packages/db/prisma/migrations/20260731193000_add_hospitality_service_turn/migration.sql
@@ -1,0 +1,140 @@
+-- @migration-safety: data-safe: new service-turn tables start empty; the allocation FK column is nullable; StaffingAssignment.id is already globally unique, so its redundant organization-scoped identity cannot conflict.
+
+CREATE UNIQUE INDEX "StaffingAssignment_id_organizationId_key"
+ON "StaffingAssignment"("id", "organizationId");
+
+ALTER TABLE "StorefrontBooking"
+ADD COLUMN "demandKind" TEXT NOT NULL DEFAULT 'reservation';
+
+ALTER TABLE "StorefrontBooking"
+ADD CONSTRAINT "StorefrontBooking_demandKind_check"
+CHECK ("demandKind" IN ('reservation', 'walk-in'));
+
+CREATE TABLE "HospitalityServiceTurn" (
+    "id" TEXT NOT NULL,
+    "turnId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "storefrontId" TEXT NOT NULL,
+    "bookingId" TEXT,
+    "staffingAssignmentId" TEXT,
+    "demandType" TEXT NOT NULL,
+    "demandRef" TEXT NOT NULL,
+    "stage" TEXT NOT NULL DEFAULT 'seated',
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "expectedEndAt" TIMESTAMP(3) NOT NULL,
+    "closedAt" TIMESTAMP(3),
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HospitalityServiceTurn_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "HospitalityServiceTurn_stage_check"
+      CHECK ("stage" IN ('seated', 'ordered', 'paid', 'dirty', 'closed', 'cancelled')),
+    CONSTRAINT "HospitalityServiceTurn_interval_check"
+      CHECK ("expectedEndAt" > "startedAt"),
+    CONSTRAINT "HospitalityServiceTurn_closedAt_check"
+      CHECK ("closedAt" IS NULL OR "closedAt" >= "startedAt"),
+    CONSTRAINT "HospitalityServiceTurn_version_check"
+      CHECK ("version" >= 1)
+);
+
+CREATE TABLE "HospitalityServiceTurnEvent" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "serviceTurnId" TEXT NOT NULL,
+    "idempotencyKey" TEXT,
+    "eventType" TEXT NOT NULL,
+    "fromStage" TEXT,
+    "toStage" TEXT,
+    "atVersion" INTEGER NOT NULL,
+    "actorRef" TEXT,
+    "detail" JSONB,
+    "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "HospitalityServiceTurnEvent_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "HospitalityServiceTurnEvent_eventType_check"
+      CHECK ("eventType" IN ('stage-transition', 'table-assignment-changed', 'staffing-assignment-changed')),
+    CONSTRAINT "HospitalityServiceTurnEvent_fromStage_check"
+      CHECK ("fromStage" IS NULL OR "fromStage" IN ('seated', 'ordered', 'paid', 'dirty', 'closed', 'cancelled')),
+    CONSTRAINT "HospitalityServiceTurnEvent_toStage_check"
+      CHECK ("toStage" IS NULL OR "toStage" IN ('seated', 'ordered', 'paid', 'dirty', 'closed', 'cancelled')),
+    CONSTRAINT "HospitalityServiceTurnEvent_version_check"
+      CHECK ("atVersion" >= 1)
+);
+
+ALTER TABLE "HospitalityCapacityAllocation"
+ADD COLUMN "serviceTurnId" TEXT;
+
+CREATE UNIQUE INDEX "HospitalityServiceTurn_turnId_key"
+ON "HospitalityServiceTurn"("turnId");
+
+CREATE UNIQUE INDEX "HospitalityServiceTurn_id_organizationId_key"
+ON "HospitalityServiceTurn"("id", "organizationId");
+
+CREATE UNIQUE INDEX "HospitalityServiceTurn_bookingId_organizationId_key"
+ON "HospitalityServiceTurn"("bookingId", "organizationId");
+
+CREATE UNIQUE INDEX "HospitalityServiceTurn_storefrontId_demandType_demandRef_key"
+ON "HospitalityServiceTurn"("storefrontId", "demandType", "demandRef");
+
+CREATE INDEX "HospitalityServiceTurn_organizationId_stage_startedAt_idx"
+ON "HospitalityServiceTurn"("organizationId", "stage", "startedAt");
+
+CREATE INDEX "HospitalityServiceTurn_staffingAssignmentId_idx"
+ON "HospitalityServiceTurn"("staffingAssignmentId");
+
+CREATE UNIQUE INDEX "HospitalityServiceTurnEvent_eventId_key"
+ON "HospitalityServiceTurnEvent"("eventId");
+
+CREATE UNIQUE INDEX "HospitalityServiceTurnEvent_serviceTurnId_atVersion_key"
+ON "HospitalityServiceTurnEvent"("serviceTurnId", "atVersion");
+
+CREATE UNIQUE INDEX "HospitalityServiceTurnEvent_organizationId_idempotencyKey_key"
+ON "HospitalityServiceTurnEvent"("organizationId", "idempotencyKey");
+
+CREATE INDEX "HospitalityServiceTurnEvent_organizationId_occurredAt_idx"
+ON "HospitalityServiceTurnEvent"("organizationId", "occurredAt");
+
+CREATE INDEX "HospitalityCapacityAllocation_serviceTurnId_idx"
+ON "HospitalityCapacityAllocation"("serviceTurnId");
+
+ALTER TABLE "HospitalityServiceTurn"
+ADD CONSTRAINT "HospitalityServiceTurn_organizationId_fkey"
+FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "HospitalityServiceTurn"
+ADD CONSTRAINT "HospitalityServiceTurn_storefrontId_organizationId_fkey"
+FOREIGN KEY ("storefrontId", "organizationId")
+REFERENCES "StorefrontConfig"("id", "organizationId")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "HospitalityServiceTurn"
+ADD CONSTRAINT "HospitalityServiceTurn_bookingId_organizationId_fkey"
+FOREIGN KEY ("bookingId", "organizationId")
+REFERENCES "StorefrontBooking"("id", "organizationId")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "HospitalityServiceTurn"
+ADD CONSTRAINT "HospitalityServiceTurn_staffingAssignmentId_organizationId_fkey"
+FOREIGN KEY ("staffingAssignmentId", "organizationId")
+REFERENCES "StaffingAssignment"("id", "organizationId")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "HospitalityServiceTurnEvent"
+ADD CONSTRAINT "HospitalityServiceTurnEvent_organizationId_fkey"
+FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "HospitalityServiceTurnEvent"
+ADD CONSTRAINT "HospitalityServiceTurnEvent_serviceTurnId_organizationId_fkey"
+FOREIGN KEY ("serviceTurnId", "organizationId")
+REFERENCES "HospitalityServiceTurn"("id", "organizationId")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "HospitalityCapacityAllocation"
+ADD CONSTRAINT "HospitalityCapacityAllocation_serviceTurnId_organizationId_fkey"
+FOREIGN KEY ("serviceTurnId", "organizationId")
+REFERENCES "HospitalityServiceTurn"("id", "organizationId")
+ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4666,6 +4666,8 @@ model Organization {
   hospitalityCapacityPools          HospitalityCapacityPool[]          @relation("HospitalityCapacityPoolOrganization")
   hospitalityResourceAvailability   HospitalityResourceAvailability[]  @relation("HospitalityAvailabilityOrganization")
   hospitalityCapacityAllocations    HospitalityCapacityAllocation[]    @relation("HospitalityAllocationOrganization")
+  hospitalityServiceTurns           HospitalityServiceTurn[]           @relation("HospitalityServiceTurnOrganization")
+  hospitalityServiceTurnEvents      HospitalityServiceTurnEvent[]      @relation("HospitalityServiceTurnEventOrganization")
   hospitalityBookingHolds           BookingHold[]                      @relation("BookingHoldOrganization")
   businessContext                   BusinessContext?
   marketingStrategy                 MarketingStrategy?
@@ -9874,6 +9876,7 @@ model StorefrontConfig {
   hospitalityResources           HospitalityResource[]
   hospitalityCapacityPools       HospitalityCapacityPool[]
   hospitalityCapacityAllocations HospitalityCapacityAllocation[]
+  hospitalityServiceTurns        HospitalityServiceTurn[]
 
   @@unique([id, organizationId])
 }
@@ -9895,6 +9898,7 @@ model OperationalSceneLayout {
   createdAt    DateTime     @default(now())
   organization Organization @relation(fields: [orgId], references: [orgId], onDelete: Cascade)
 
+  @@unique([orgId, twinTemplate, locationId])
   @@index([orgId, twinTemplate])
 }
 
@@ -10453,6 +10457,7 @@ model StorefrontBooking {
   // Structured reservation context (BI-3DA1DFDC): party size and dietary notes are
   // first-class facts so the owner handoff is traceable, not buried in `notes`.
   covers                      Int?
+  demandKind                  String                          @default("reservation")
   dietaryNotes                String?
   notes                       String?
   status                      String                          @default("pending")
@@ -10480,6 +10485,7 @@ model StorefrontBooking {
   provider                    ServiceProvider?                @relation(fields: [providerId], references: [id])
   hospitalityResource         HospitalityResource?            @relation("HospitalityBookingResource", fields: [hospitalityResourceId, organizationId], references: [id, organizationId], onDelete: Restrict)
   hospitalityAllocations      HospitalityCapacityAllocation[] @relation("HospitalityAllocationBooking")
+  hospitalityServiceTurn      HospitalityServiceTurn?         @relation("HospitalityServiceTurnBooking")
   parentBooking               StorefrontBooking?              @relation("BookingRecurrence", fields: [parentBookingId], references: [id])
   childBookings               StorefrontBooking[]             @relation("BookingRecurrence")
   careAppointment             CareAppointment?
@@ -10677,6 +10683,7 @@ model HospitalityCapacityAllocation {
   poolId                String?
   bookingId             String?
   bookingHoldId         String?
+  serviceTurnId         String?
   demandType            String
   demandRef             String
   startsAt              DateTime
@@ -10697,12 +10704,72 @@ model HospitalityCapacityAllocation {
   pool         HospitalityCapacityPool? @relation(fields: [poolId, organizationId], references: [id, organizationId], onDelete: Restrict)
   booking      StorefrontBooking?       @relation("HospitalityAllocationBooking", fields: [bookingId, organizationId], references: [id, organizationId], onDelete: Restrict)
   bookingHold  BookingHold?             @relation("HospitalityAllocationHold", fields: [bookingHoldId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  serviceTurn  HospitalityServiceTurn?  @relation(fields: [serviceTurnId, organizationId], references: [id, organizationId], onDelete: Restrict)
 
   @@unique([organizationId, idempotencyKey])
   @@index([resourceId, startsAt, endsAt])
   @@index([poolId, startsAt, endsAt])
   @@index([organizationId, lifecycle, startsAt])
   @@index([storefrontId, demandType, demandRef])
+  @@index([serviceTurnId])
+}
+
+/// One party's authoritative in-service lifecycle across one or more table
+/// allocations. Reservation, capacity, commerce, staffing, and geometry remain
+/// separate authorities joined through this aggregate.
+model HospitalityServiceTurn {
+  id                   String    @id @default(cuid())
+  turnId               String    @unique
+  organizationId       String
+  storefrontId         String
+  bookingId            String?
+  staffingAssignmentId String?
+  demandType           String
+  demandRef            String
+  stage                String    @default("seated")
+  startedAt            DateTime
+  expectedEndAt        DateTime
+  closedAt             DateTime?
+  version              Int       @default(1)
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  organization       Organization                    @relation("HospitalityServiceTurnOrganization", fields: [organizationId], references: [id], onDelete: Restrict)
+  storefront         StorefrontConfig                @relation(fields: [storefrontId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  booking            StorefrontBooking?              @relation("HospitalityServiceTurnBooking", fields: [bookingId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  staffingAssignment StaffingAssignment?             @relation(fields: [staffingAssignmentId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  allocations        HospitalityCapacityAllocation[]
+  events             HospitalityServiceTurnEvent[]
+
+  @@unique([id, organizationId])
+  @@unique([bookingId, organizationId])
+  @@unique([storefrontId, demandType, demandRef])
+  @@index([organizationId, stage, startedAt])
+  @@index([staffingAssignmentId])
+}
+
+/// Append-only evidence for service-stage, table-assignment, and staffing
+/// changes. One event records each accepted aggregate version.
+model HospitalityServiceTurnEvent {
+  id             String   @id @default(cuid())
+  eventId        String   @unique
+  organizationId String
+  serviceTurnId  String
+  idempotencyKey String?
+  eventType      String
+  fromStage      String?
+  toStage        String?
+  atVersion      Int
+  actorRef       String?
+  detail         Json?
+  occurredAt     DateTime @default(now())
+
+  organization Organization           @relation("HospitalityServiceTurnEventOrganization", fields: [organizationId], references: [id], onDelete: Restrict)
+  serviceTurn  HospitalityServiceTurn @relation(fields: [serviceTurnId, organizationId], references: [id, organizationId], onDelete: Cascade)
+
+  @@unique([serviceTurnId, atVersion])
+  @@unique([organizationId, idempotencyKey])
+  @@index([organizationId, occurredAt])
 }
 
 /// Organization-owned definition of a clinical or dental visit. StorefrontItem
@@ -15597,10 +15664,12 @@ model StaffingAssignment {
   createdAt             DateTime @default(now())
   updatedAt             DateTime @updatedAt
 
-  shift  StaffingShift             @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
-  crew   StaffingCrew?             @relation(fields: [staffingCrewId], references: [id])
-  events StaffingAssignmentEvent[]
+  shift                   StaffingShift             @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
+  crew                    StaffingCrew?             @relation(fields: [staffingCrewId], references: [id])
+  events                  StaffingAssignmentEvent[]
+  hospitalityServiceTurns HospitalityServiceTurn[]
 
+  @@unique([id, organizationId])
   @@index([organizationId, lifecycle])
   @@index([staffingShiftId])
   @@index([employeeProfileId])
@@ -15663,7 +15732,7 @@ model StaffingResourceLink {
   id              String   @id @default(cuid())
   organizationId  String
   staffingShiftId String
-  resourceType    String // vehicle | room | operatory | kit | equipment | chair | station
+  resourceType    String // vehicle | room | operatory | kit | equipment | chair | station | table
   resourceRef     String
   createdAt       DateTime @default(now())
 

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -185,6 +185,8 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   Activity: "confidential",
   StorefrontBooking: "confidential",
   HospitalityCapacityAllocation: "confidential",
+  HospitalityServiceTurn: "confidential",
+  HospitalityServiceTurnEvent: "confidential",
   ServiceProvider: "confidential",
   BookingHold: "confidential",
   StorefrontOrder: "confidential",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-30T20:04:44.836Z",
-  "gitSha": "35e1a45290f615aa9d5fbb233aab184034c69891",
+  "generatedAt": "2026-07-31T03:13:52.571Z",
+  "gitSha": "dee8c4134776d7d2f37818d7262026f292fc6ec1",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -17,15 +17,15 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 558
+      "value": 560
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 15852
+      "value": 15921
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",
-      "value": 70
+      "value": 69
     },
     "providerConnectionStateProjectorCount": {
       "direction": "non-increasing",

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1906,9 +1906,9 @@
   "apps/web/app/(shell)/storefront/tables/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
-    "readability": 0,
+    "readability": 1,
     "longSentences": 0,
-    "textMass": 4
+    "textMass": 19
   },
   "apps/web/app/(shell)/storefront/team/page.tsx": {
     "vocabulary": 0,
@@ -5744,7 +5744,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 271
+    "textMass": 268
   },
   "apps/web/components/ops/EpicCard.tsx": {
     "vocabulary": 0,
@@ -7270,7 +7270,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 48
+    "textMass": 120
   },
   "apps/web/components/storefront-admin/ItemFormDialog.tsx": {
     "vocabulary": 0,
@@ -7361,7 +7361,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 11
+    "textMass": 50
   },
   "apps/web/components/storefront-admin/TeamManager.tsx": {
     "vocabulary": 0,
@@ -7397,6 +7397,13 @@
     "readability": 1,
     "longSentences": 1,
     "textMass": 44
+  },
+  "apps/web/components/storefront/CustomerRestaurantAvailability.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
   },
   "apps/web/components/storefront/DonationForm.tsx": {
     "vocabulary": 0,
@@ -7579,6 +7586,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 5
+  },
+  "apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 150
   },
   "apps/web/components/ui/DatePicker.tsx": {
     "vocabulary": 0,
@@ -7935,7 +7949,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 7
+    "textMass": 12
   },
   "apps/web/components/workspace/ActivityFeed.tsx": {
     "vocabulary": 0,

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -71,6 +71,8 @@ HospitalityResource  domain-lifecycle-managed  # Physical venue resources retire
 HospitalityCapacityPool  domain-lifecycle-managed  # Aggregate kitchen, bake, and delivery capacity retires through explicit operating actions; an age sweep could remove a still-active capacity definition.
 HospitalityResourceAvailability  domain-lifecycle-managed  # Availability windows follow their HospitalityResource and cascade with it; independent age-based deletion would silently reopen or close an active resource.
 HospitalityCapacityAllocation  domain-lifecycle-managed  # Append-preserving capacity consumption follows booking/hold and explicit release lifecycles; an age sweep could erase live conflict and utilization evidence.
+HospitalityServiceTurn  domain-lifecycle-managed  # A turn closes through explicit service-stage transitions and follows its organization/booking lifecycle; an age sweep could remove a live or still-auditable dining-room turn.
+HospitalityServiceTurnEvent  domain-lifecycle-managed  # Append-only transition evidence follows its HospitalityServiceTurn cascade; independent aging would make seating, movement, and closure decisions unexplainable.
 ProductOffering  domain-lifecycle-managed  # Organization-owned commercial packaging follows explicit offering status/effective-date actions and product cascade, never an age-based sweep.
 CatalogItem  domain-lifecycle-managed  # Canonical ways-to-buy follow explicit catalog status/effective-date actions and offering cascade, never an age-based sweep.
 ProductConfiguration  domain-lifecycle-managed  # Reusable configurations follow explicit publish/retire actions and catalog-item cascade, never an age-based sweep.


### PR DESCRIPTION
## Summary

- replace heuristic restaurant table rendering with persisted authored geometry, service areas, table shape/capacity, combination rules, and live bindings
- add a business-grade host stand with waitlist/reservation recommendations, server-load context, service-turn state, conflict-safe seating, party movement, and lifecycle commands
- project customer-facing forward availability through an explicit privacy allow-list
- register the new service-turn models in the data-governance asset registry and document the operator workflows

## Verification

- governed local integration: dependency freshness green; 481 migrations applied; TypeScript passed; exhaustive Vitest passed; production Docker image built
- focused restaurant regression: 26 files / 121 tests passed
- data-asset registry and live Prisma coverage: 2 files / 18 tests passed
- deterministic preflight: all 29 guards passed
- UI interaction coverage includes keyboard/list parity, seating preview/confirmation, stale conflicts, party moves, service-turn progression, and customer privacy boundaries
- canonical live-install exercise will run after merge, because the governed live-install contract prohibits testing unmerged bytes on port 3000 and the active-candidate tier is not implemented

## Design and operations

- Operational-Precedent: restaurant-floor
- one domain aggregate owns service-turn lifecycle; capacity, booking, staffing, commerce, and geometry remain separate authorities
- query collections are bounded, independent reads run concurrently, recommendation candidates are cached by party size, and duration/query-count/payload telemetry is emitted
- operator documentation is updated for authored layout, live seating, reassignment, and lifecycle management

## Linked work

- BI-287AA5F7
- WC-065EB427
