### PR TITLE
feat(stock): stock coverage starter — supplies, recipes, and derived coverage (BI-1323E39E)

### DIFF
--- a/apps/web/app/api/storefront/admin/stock-items/route.ts
+++ b/apps/web/app/api/storefront/admin/stock-items/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+import { apiErrorResponse } from "@/lib/api/error";
+import { newId } from "@/lib/shared/new-id";
+
+// Operator door for the stock coverage starter: define the supplies you count
+// and, optionally, how much of each a menu item uses. One route rather than two
+// because "an ingredient and where it is used" is a single operator thought.
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
+  }
+
+  const items = await prisma.stockItem.findMany({
+    orderBy: { name: "asc" },
+    select: {
+      stockItemId: true,
+      name: true,
+      unit: true,
+      onHandQuantity: true,
+      reorderPoint: true,
+      reorderQuantity: true,
+      isActive: true,
+      supplier: { select: { name: true } },
+      components: {
+        select: {
+          quantityPerUnit: true,
+          storefrontItem: { select: { itemId: true, name: true } },
+        },
+      },
+    },
+  });
+
+  return NextResponse.json(
+    items.map((item) => ({
+      ...item,
+      onHandQuantity: item.onHandQuantity.toString(),
+      reorderPoint: item.reorderPoint.toString(),
+      reorderQuantity: item.reorderQuantity.toString(),
+      supplierName: item.supplier?.name ?? null,
+      components: item.components.map((c) => ({
+        storefrontItemId: c.storefrontItem.itemId,
+        storefrontItemName: c.storefrontItem.name,
+        quantityPerUnit: c.quantityPerUnit.toString(),
+      })),
+    })),
+  );
+}
+
+type UsedByLine = { storefrontItemId?: unknown; quantityPerUnit?: unknown };
+
+type CreateStockItemBody = {
+  name?: unknown;
+  unit?: unknown;
+  onHandQuantity?: unknown;
+  reorderPoint?: unknown;
+  reorderQuantity?: unknown;
+  supplierName?: unknown;
+  /** Optional recipe lines: which sellable items consume this supply. */
+  usedBy?: unknown;
+};
+
+function num(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
+  }
+
+  const body = (await req.json().catch(() => ({}))) as CreateStockItemBody;
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const unit = typeof body.unit === "string" ? body.unit.trim() : "";
+  if (!name || !unit) {
+    return apiErrorResponse("INVALID_INPUT", "name and unit are required", 400);
+  }
+
+  const organization = await prisma.organization.findFirst({ select: { id: true } });
+  if (!organization) {
+    return apiErrorResponse("NOT_FOUND", "Organization not found", 400);
+  }
+
+  const supplierName = typeof body.supplierName === "string" ? body.supplierName.trim() : "";
+  const supplier = supplierName
+    ? await prisma.supplier.findFirst({ where: { name: supplierName }, select: { id: true } })
+    : null;
+
+  const data = {
+    organizationId: organization.id,
+    name,
+    unit,
+    onHandQuantity: num(body.onHandQuantity),
+    reorderPoint: num(body.reorderPoint),
+    reorderQuantity: num(body.reorderQuantity),
+    supplierId: supplier?.id ?? null,
+    isActive: true,
+  };
+
+  // Idempotent on (organization, name) so a harness or a re-submitted form
+  // updates the level instead of failing on the unique index.
+  const stockItem = await prisma.stockItem.upsert({
+    where: { organizationId_name: { organizationId: organization.id, name } },
+    update: data,
+    create: { ...data, stockItemId: `stk-${newId(8)}` },
+    select: { id: true, stockItemId: true, name: true },
+  });
+
+  const usedBy = Array.isArray(body.usedBy) ? (body.usedBy as UsedByLine[]) : [];
+  let componentsLinked = 0;
+  for (const line of usedBy) {
+    const itemRef = typeof line.storefrontItemId === "string" ? line.storefrontItemId.trim() : "";
+    const quantityPerUnit = num(line.quantityPerUnit);
+    if (!itemRef || quantityPerUnit <= 0) continue;
+    const storefrontItem = await prisma.storefrontItem.findFirst({
+      where: { itemId: itemRef },
+      select: { id: true },
+    });
+    if (!storefrontItem) continue;
+    await prisma.storefrontItemComponent.upsert({
+      where: {
+        storefrontItemId_stockItemId: {
+          storefrontItemId: storefrontItem.id,
+          stockItemId: stockItem.id,
+        },
+      },
+      update: { quantityPerUnit },
+      create: { storefrontItemId: storefrontItem.id, stockItemId: stockItem.id, quantityPerUnit },
+    });
+    componentsLinked++;
+  }
+
+  return NextResponse.json(
+    { stockItemId: stockItem.stockItemId, name: stockItem.name, componentsLinked },
+    { status: 201 },
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1612,6 +1612,18 @@
       "file": "apps/web/app/api/storefront/admin/setup/route.ts"
     },
     {
+      "routePath": "/api/storefront/admin/stock-items",
+      "kind": "route",
+      "segments": [
+        "api",
+        "storefront",
+        "admin",
+        "stock-items"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/storefront/admin/stock-items/route.ts"
+    },
+    {
       "routePath": "/api/storefront/admin/units",
       "kind": "route",
       "segments": [

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 598,
+  "routeCount": 599,
   "routes": [
     {
       "routePath": "/",

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -29,6 +29,7 @@ import { BUSINESS_PRODUCT_PORTFOLIO_ASSETS } from "./business-product-portfolio-
 import { HOSPITALITY_CAPACITY_ASSETS } from "./hospitality-capacity-assets";
 import { BEAUTY_CAPACITY_ASSETS } from "./beauty-capacity-assets";
 import { LIFECYCLE_GOVERNANCE_ASSETS } from "./lifecycle-governance-assets";
+import { STOCK_COVERAGE_ASSETS } from "./stock-coverage-assets";
 
 // ─── Definitions (spec §6.1) ─────────────────────────────────────────────────
 
@@ -656,6 +657,7 @@ const SEED_ASSETS: readonly DataAssetDefinition[] = [
   ...HOSPITALITY_CAPACITY_ASSETS,
   ...BEAUTY_CAPACITY_ASSETS,
   ...LIFECYCLE_GOVERNANCE_ASSETS,
+  ...STOCK_COVERAGE_ASSETS,
   ...PROCESSING_GOVERNANCE_ASSETS,
    {
     id: "data:agent-conversation",

--- a/apps/web/lib/govern/data/stock-coverage-assets.ts
+++ b/apps/web/lib/govern/data/stock-coverage-assets.ts
@@ -4,34 +4,37 @@
 // subject locator is the organization and the projection stays local.
 
 import type { DataAssetDefinition } from "./assets";
+import type { ClassificationProvenance } from "./taxonomy";
 
-const PROVENANCE = {
+const PROVENANCE: ClassificationProvenance = {
   source: "manual",
   state: "confirmed",
   assertedBy: "data-steward",
   effectiveFrom: "2026-07-31",
-} as const;
+};
 
-const SHARED = {
-  domain: "spend-procurement-assets",
-  ownerRole: "business-operator",
-  stewardRole: "data-steward",
-  sensitivity: "internal",
-  criticality: "medium",
-  subjectLocators: [{ role: "organization", fieldPath: "organization" }],
-  lifecycleClass: "operational",
-  purposeCapabilities: ["service-delivery", "platform-operations"],
-  residencyClass: "local-only",
-  classification: PROVENANCE,
+const CLASSIFICATION = {
+  state: "confirmed",
+  source: "manual",
+  effectiveFrom: "2026-07-31",
 } as const;
 
 export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
   {
-    ...SHARED,
     id: "data:stock-item",
     physical: { prismaModel: "StockItem" },
+    domain: "spend-procurement-assets",
+    ownerRole: "business-operator",
+    stewardRole: "data-steward",
     categories: ["configuration", "operational"],
+    sensitivity: "internal",
+    criticality: "standard",
+    subjectLocators: [{ role: "organization", fieldPath: "organization" }],
+    lifecycleClass: "operational",
+    purposeCapabilities: ["service-delivery", "platform-operations"],
+    residencyClass: "local-only",
     projectionClass: "structure",
+    classification: CLASSIFICATION,
     // Two fields carry more consequence than their type suggests: a wrong
     // number here produces a confidently wrong reorder proposal, so both are
     // governed rather than inherited.
@@ -55,11 +58,20 @@ export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
     ],
   },
   {
-    ...SHARED,
     id: "data:storefront-item-component",
     physical: { prismaModel: "StorefrontItemComponent" },
+    domain: "spend-procurement-assets",
+    ownerRole: "business-operator",
+    stewardRole: "data-steward",
     categories: ["configuration"],
+    sensitivity: "internal",
+    criticality: "standard",
+    subjectLocators: [{ role: "organization", fieldPath: "stockItem.organization" }],
+    lifecycleClass: "operational",
+    purposeCapabilities: ["service-delivery", "platform-operations"],
+    residencyClass: "local-only",
     projectionClass: "structure",
+    classification: CLASSIFICATION,
     fields: [
       {
         id: "data:storefront-item-component#quantityPerUnit",

--- a/apps/web/lib/govern/data/stock-coverage-assets.ts
+++ b/apps/web/lib/govern/data/stock-coverage-assets.ts
@@ -1,0 +1,71 @@
+// Data-governance registration for the stock coverage starter (BI-1323E39E,
+// first slice of BI-SPEND-003). Supplies and recipe lines are the organization's
+// own operating data: no data subject beyond the organization itself, so the
+// subject locator is the organization and the projection stays local.
+
+import type { DataAssetDefinition } from "./assets";
+
+const SHARED = {
+  domain: "spend-procurement-assets",
+  ownerRole: "business-operator",
+  stewardRole: "data-steward",
+  sensitivity: "internal",
+  criticality: "medium",
+  subjectLocators: [{ role: "organization", fieldPath: "organization" }],
+  lifecycleClass: "operational",
+  purposeCapabilities: ["service-delivery", "platform-operations"],
+  residencyClass: "local-only",
+  classification: {
+    state: "confirmed",
+    source: "manual",
+    effectiveFrom: "2026-07-31",
+  },
+} as const;
+
+export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    ...SHARED,
+    id: "data:stock-item",
+    physical: { prismaModel: "StockItem" },
+    categories: ["configuration", "operational"],
+    projectionClass: "structure",
+    // Two fields carry more consequence than their type suggests: a wrong
+    // number here produces a confidently wrong reorder proposal, so both are
+    // governed rather than inherited.
+    fields: [
+      {
+        id: "data:stock-item#onHandQuantity",
+        physicalName: "onHandQuantity",
+        resolution: "governed",
+        resolutionReason:
+          "Operator-maintained stocktake count, not a measured ledger; coverage projections are only as good as this number and must never be presented as measured.",
+        provenance: "manual",
+      },
+      {
+        id: "data:stock-item#reorderPoint",
+        physicalName: "reorderPoint",
+        resolution: "governed",
+        resolutionReason:
+          "The threshold that turns a stock level into a restocking proposal — an operator decision, never a platform default.",
+        provenance: "manual",
+      },
+    ],
+  },
+  {
+    ...SHARED,
+    id: "data:storefront-item-component",
+    physical: { prismaModel: "StorefrontItemComponent" },
+    categories: ["configuration"],
+    projectionClass: "structure",
+    fields: [
+      {
+        id: "data:storefront-item-component#quantityPerUnit",
+        physicalName: "quantityPerUnit",
+        resolution: "governed",
+        resolutionReason:
+          "The multiplier turning units sold into derived consumption; an incorrect value silently scales every coverage projection built on it.",
+        provenance: "manual",
+      },
+    ],
+  },
+];

--- a/apps/web/lib/govern/data/stock-coverage-assets.ts
+++ b/apps/web/lib/govern/data/stock-coverage-assets.ts
@@ -5,6 +5,13 @@
 
 import type { DataAssetDefinition } from "./assets";
 
+const PROVENANCE = {
+  source: "manual",
+  state: "confirmed",
+  assertedBy: "data-steward",
+  effectiveFrom: "2026-07-31",
+} as const;
+
 const SHARED = {
   domain: "spend-procurement-assets",
   ownerRole: "business-operator",
@@ -15,11 +22,7 @@ const SHARED = {
   lifecycleClass: "operational",
   purposeCapabilities: ["service-delivery", "platform-operations"],
   residencyClass: "local-only",
-  classification: {
-    state: "confirmed",
-    source: "manual",
-    effectiveFrom: "2026-07-31",
-  },
+  classification: PROVENANCE,
 } as const;
 
 export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
@@ -39,7 +42,7 @@ export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
         resolution: "governed",
         resolutionReason:
           "Operator-maintained stocktake count, not a measured ledger; coverage projections are only as good as this number and must never be presented as measured.",
-        provenance: "manual",
+        provenance: PROVENANCE,
       },
       {
         id: "data:stock-item#reorderPoint",
@@ -47,7 +50,7 @@ export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
         resolution: "governed",
         resolutionReason:
           "The threshold that turns a stock level into a restocking proposal — an operator decision, never a platform default.",
-        provenance: "manual",
+        provenance: PROVENANCE,
       },
     ],
   },
@@ -64,7 +67,7 @@ export const STOCK_COVERAGE_ASSETS: readonly DataAssetDefinition[] = [
         resolution: "governed",
         resolutionReason:
           "The multiplier turning units sold into derived consumption; an incorrect value silently scales every coverage projection built on it.",
-        provenance: "manual",
+        provenance: PROVENANCE,
       },
     ],
   },

--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -40,6 +40,7 @@ import { subagentFanoutPack } from "./packs/subagent-fanout-pack";
 import { mdmStewardshipPack } from "./packs/mdm-stewardship-pack";
 import { crmContactsPack } from "./packs/crm-contacts-pack";
 import { storefrontActivityPack } from "./packs/storefront-activity-pack";
+import { stockCoveragePack } from "./packs/stock-coverage-pack";
 import { queueAwarenessPack } from "./packs/queue-awareness-pack";
 import { documentPack } from "./packs/document-pack";
 import { screenPack } from "./packs/screen-pack";
@@ -116,6 +117,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   mdmStewardshipPack,
   crmContactsPack,
   storefrontActivityPack,
+  stockCoveragePack,
   queueAwarenessPack,
   documentPack,
   screenPack,

--- a/apps/web/lib/mcp/packs/stock-coverage-pack.test.ts
+++ b/apps/web/lib/mcp/packs/stock-coverage-pack.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { stockCoveragePack, tallySoldUnits } from "./stock-coverage-pack";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+
+describe("stock-coverage pack", () => {
+  it("registers list_stock_coverage as a read-only view_storefront tool", () => {
+    const def = stockCoveragePack.definitions.find((d) => d.name === "list_stock_coverage");
+    expect(def).toBeDefined();
+    expect(def!.requiredCapability).toBe("view_storefront");
+    expect(def!.sideEffect).toBe(false);
+    expect(stockCoveragePack.handlers.list_stock_coverage).toBeTypeOf("function");
+  });
+
+  it("gates the tool behind stock_read and mirrors the shared grant map", () => {
+    expect(stockCoveragePack.grants.list_stock_coverage).toEqual(["stock_read"]);
+    expect(isToolAllowedByGrants("list_stock_coverage", ["stock_read"])).toBe(true);
+    expect(isToolAllowedByGrants("list_stock_coverage", ["storefront_read"])).toBe(false);
+    expect(isToolAllowedByGrants("list_stock_coverage", ["backlog_read"])).toBe(false);
+  });
+
+  it("keeps the tool description provenance-free and steers away from a one-day window", () => {
+    const def = stockCoveragePack.definitions[0]!;
+    expect(def.description).not.toMatch(/BI-|Phase \d|apps\/web|EP-/);
+    // BI-D1E5E722 follow-through: a same-day window silently reads as "no demand".
+    expect(def.description).toMatch(/multi-day/i);
+  });
+});
+
+describe("tallySoldUnits", () => {
+  it("sums units per storefront item across orders", () => {
+    expect(
+      tallySoldUnits([
+        [{ qty: 2, itemId: "ITEM-PIZZA" }],
+        [{ qty: 3, itemId: "ITEM-PIZZA" }, { qty: 1, itemId: "ITEM-SALAD" }],
+      ]),
+    ).toEqual([
+      { storefrontItemId: "ITEM-PIZZA", units: 5 },
+      { storefrontItemId: "ITEM-SALAD", units: 1 },
+    ]);
+  });
+
+  it("defaults a missing quantity to one and skips lines with no item id", () => {
+    expect(tallySoldUnits([[{ itemId: "ITEM-PIZZA" }, { qty: 4 }]])).toEqual([
+      { storefrontItemId: "ITEM-PIZZA", units: 1 },
+    ]);
+  });
+
+  it("tolerates malformed payloads", () => {
+    expect(tallySoldUnits(["not-an-array", null, undefined, [{}]])).toEqual([]);
+  });
+});

--- a/apps/web/lib/mcp/packs/stock-coverage-pack.ts
+++ b/apps/web/lib/mcp/packs/stock-coverage-pack.ts
@@ -1,0 +1,176 @@
+// Stock coverage pack. Turns "what sold" into "what is about to run out", so an
+// operations coworker can propose a restock with a quantity and a supplier
+// instead of guessing or reporting a capability gap.
+//
+// Read-only and consolidated: one tool answers the whole question (levels,
+// derived consumption, days of cover, suggested order) rather than making the
+// model stitch three calls together.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+import {
+  computeStockCoverage,
+  describeCoverageRow,
+  type ComponentLine,
+  type SoldUnits,
+  type StockLevel,
+} from "@/lib/stock/stock-coverage";
+
+const DEFAULT_WINDOW_DAYS = 7;
+const MAX_WINDOW_DAYS = 90;
+const MAX_ROWS = 30;
+/** Orders scanned to derive consumption — bounded so one call stays cheap. */
+const ORDER_SCAN_CAP = 500;
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "list_stock_coverage",
+    description:
+      "Show which supplies are running low: on-hand level, how much each is being consumed " +
+      "based on what actually sold, days of cover left, and a suggested order quantity with " +
+      "the supplier. Use for restocking, purchasing, and 'can we get through the week' " +
+      "questions. Covers a multi-day window (default 7 days) because a single day is rarely " +
+      "a reliable trend. Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        windowDays: {
+          type: "number",
+          description: `Days of sales to derive consumption from (default ${DEFAULT_WINDOW_DAYS}, max ${MAX_WINDOW_DAYS}).`,
+        },
+        belowReorderPointOnly: {
+          type: "boolean",
+          description: "Only return supplies at or below their reorder point.",
+        },
+        limit: {
+          type: "number",
+          description: `Rows to return (default ${MAX_ROWS}, max ${MAX_ROWS}).`,
+        },
+      },
+    },
+    requiredCapability: "view_storefront",
+    sideEffect: false,
+  },
+];
+
+type OrderItemLine = { qty?: unknown; itemId?: unknown };
+
+/** Units sold per storefront item id, from the free-JSON order items column. */
+export function tallySoldUnits(orderItemPayloads: unknown[]): SoldUnits[] {
+  const byItem = new Map<string, number>();
+  for (const payload of orderItemPayloads) {
+    if (!Array.isArray(payload)) continue;
+    for (const line of payload as OrderItemLine[]) {
+      if (typeof line !== "object" || line === null) continue;
+      const itemId = typeof line.itemId === "string" && line.itemId.trim() ? line.itemId.trim() : null;
+      if (!itemId) continue;
+      const qty = typeof line.qty === "number" && line.qty > 0 ? line.qty : 1;
+      byItem.set(itemId, (byItem.get(itemId) ?? 0) + qty);
+    }
+  }
+  return [...byItem.entries()].map(([storefrontItemId, units]) => ({ storefrontItemId, units }));
+}
+
+function clampInt(value: unknown, fallback: number, max: number): number {
+  const n = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : fallback;
+  return Math.max(1, Math.min(max, n));
+}
+
+async function listStockCoverageTool(params: Record<string, unknown>): Promise<ToolResult> {
+  const windowDays = clampInt(params["windowDays"], DEFAULT_WINDOW_DAYS, MAX_WINDOW_DAYS);
+  const limit = clampInt(params["limit"], MAX_ROWS, MAX_ROWS);
+  const belowOnly = params["belowReorderPointOnly"] === true;
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+  const { prisma } = await import("@dpf/db");
+
+  const [stockRows, componentRows, orders] = await Promise.all([
+    prisma.stockItem.findMany({
+      where: { isActive: true },
+      select: {
+        stockItemId: true,
+        name: true,
+        unit: true,
+        onHandQuantity: true,
+        reorderPoint: true,
+        reorderQuantity: true,
+        supplier: { select: { name: true } },
+      },
+    }),
+    prisma.storefrontItemComponent.findMany({
+      select: {
+        quantityPerUnit: true,
+        stockItem: { select: { stockItemId: true } },
+        storefrontItem: { select: { itemId: true } },
+      },
+    }),
+    prisma.storefrontOrder.findMany({
+      where: { createdAt: { gte: since }, status: { not: "cancelled" } },
+      orderBy: { createdAt: "desc" },
+      take: ORDER_SCAN_CAP,
+      select: { items: true },
+    }),
+  ]);
+
+  if (stockRows.length === 0) {
+    return {
+      success: true,
+      message:
+        "No supplies are being tracked yet, so there is nothing to project. Add the supplies you " +
+        "count and the amount each menu item uses, then this will show what is running low.",
+      data: { rows: [], windowDays, trackedStockItems: 0 },
+    };
+  }
+
+  const stock: StockLevel[] = stockRows.map((s) => ({
+    stockItemId: s.stockItemId,
+    name: s.name,
+    unit: s.unit,
+    onHandQuantity: Number(s.onHandQuantity),
+    reorderPoint: Number(s.reorderPoint),
+    reorderQuantity: Number(s.reorderQuantity),
+    supplierName: s.supplier?.name ?? null,
+  }));
+  const components: ComponentLine[] = componentRows.map((c) => ({
+    storefrontItemId: c.storefrontItem.itemId,
+    stockItemId: c.stockItem.stockItemId,
+    quantityPerUnit: Number(c.quantityPerUnit),
+  }));
+
+  const coverage = computeStockCoverage({
+    stock,
+    components,
+    sold: tallySoldUnits(orders.map((o) => o.items)),
+    windowDays,
+  });
+  const filtered = (belowOnly ? coverage.filter((r) => r.belowReorderPoint) : coverage).slice(0, limit);
+  const lowCount = coverage.filter((r) => r.belowReorderPoint).length;
+  const headline = filtered.length
+    ? filtered.slice(0, 3).map(describeCoverageRow).join(" | ")
+    : "Nothing is at or below its reorder point.";
+
+  return {
+    success: true,
+    message:
+      `${lowCount} of ${coverage.length} tracked supplies are at or below their reorder point ` +
+      `(consumption derived from the last ${windowDays} day(s) of sales). ${headline}`,
+    data: {
+      windowDays,
+      trackedStockItems: coverage.length,
+      belowReorderPointCount: lowCount,
+      ordersScanned: orders.length,
+      rows: filtered,
+    },
+  };
+}
+
+export const stockCoveragePack: ToolPack = {
+  packId: "stock-coverage",
+  definitions,
+  handlers: {
+    list_stock_coverage: listStockCoverageTool,
+  },
+  grants: {
+    list_stock_coverage: ["stock_read"],
+  },
+};

--- a/apps/web/lib/stock/stock-coverage.test.ts
+++ b/apps/web/lib/stock/stock-coverage.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeStockCoverage,
+  describeCoverageRow,
+  type ComponentLine,
+  type StockLevel,
+} from "./stock-coverage";
+
+// The live restaurant exercise shape: 11 Margherita Pizzas sold in the window,
+// each consuming 0.2 kg mozzarella and 0.15 kg tomato.
+const PIZZA = "item-pizza";
+const SALAD = "item-salad";
+
+const stock: StockLevel[] = [
+  {
+    stockItemId: "stock-mozzarella",
+    name: "Mozzarella",
+    unit: "kg",
+    onHandQuantity: 2,
+    reorderPoint: 3,
+    reorderQuantity: 10,
+    supplierName: "Greenfield Logistics",
+  },
+  {
+    stockItemId: "stock-tomato",
+    name: "San Marzano Tomatoes",
+    unit: "kg",
+    onHandQuantity: 20,
+    reorderPoint: 5,
+    reorderQuantity: 12,
+    supplierName: null,
+  },
+  {
+    stockItemId: "stock-napkins",
+    name: "Napkins",
+    unit: "case",
+    onHandQuantity: 4,
+    reorderPoint: 2,
+    reorderQuantity: 0,
+    supplierName: null,
+  },
+];
+
+const components: ComponentLine[] = [
+  { storefrontItemId: PIZZA, stockItemId: "stock-mozzarella", quantityPerUnit: 0.2 },
+  { storefrontItemId: PIZZA, stockItemId: "stock-tomato", quantityPerUnit: 0.15 },
+  { storefrontItemId: SALAD, stockItemId: "stock-tomato", quantityPerUnit: 0.1 },
+];
+
+describe("computeStockCoverage", () => {
+  it("derives consumption from sales x recipe and projects days of cover", () => {
+    const rows = computeStockCoverage({
+      stock,
+      components,
+      sold: [{ storefrontItemId: PIZZA, units: 11 }],
+      windowDays: 2,
+    });
+    const mozzarella = rows.find((r) => r.stockItemId === "stock-mozzarella")!;
+    expect(mozzarella.consumedInWindow).toBe(2.2); // 11 x 0.2
+    expect(mozzarella.dailyConsumption).toBe(1.1); // over 2 days
+    expect(mozzarella.daysOfCover).toBe(1.8); // 2 kg on hand / 1.1
+    expect(mozzarella.belowReorderPoint).toBe(true);
+    expect(mozzarella.suggestedOrderQuantity).toBe(10); // configured reorder quantity
+  });
+
+  it("sums a stock item consumed by more than one sellable item", () => {
+    const rows = computeStockCoverage({
+      stock,
+      components,
+      sold: [
+        { storefrontItemId: PIZZA, units: 10 },
+        { storefrontItemId: SALAD, units: 4 },
+      ],
+      windowDays: 1,
+    });
+    const tomato = rows.find((r) => r.stockItemId === "stock-tomato")!;
+    expect(tomato.consumedInWindow).toBe(1.9); // 10x0.15 + 4x0.1
+  });
+
+  it("reports no cover estimate rather than infinite cover when nothing was consumed", () => {
+    const rows = computeStockCoverage({
+      stock,
+      components,
+      sold: [],
+      windowDays: 7,
+    });
+    for (const row of rows) {
+      expect(row.consumedInWindow).toBe(0);
+      expect(row.daysOfCover).toBeNull();
+    }
+  });
+
+  it("falls back to clearing the reorder point when no reorder quantity is configured", () => {
+    const rows = computeStockCoverage({
+      stock: [
+        {
+          stockItemId: "stock-x",
+          name: "Olive Oil",
+          unit: "litre",
+          onHandQuantity: 1,
+          reorderPoint: 4,
+          reorderQuantity: 0,
+          supplierName: null,
+        },
+      ],
+      components: [],
+      sold: [],
+      windowDays: 7,
+    });
+    expect(rows[0]!.belowReorderPoint).toBe(true);
+    expect(rows[0]!.suggestedOrderQuantity).toBe(3); // 4 - 1
+  });
+
+  it("orders the most urgent first: below-reorder items, then shortest cover", () => {
+    const rows = computeStockCoverage({
+      stock,
+      components,
+      sold: [{ storefrontItemId: PIZZA, units: 11 }],
+      windowDays: 2,
+    });
+    expect(rows[0]!.name).toBe("Mozzarella"); // only one below its reorder point
+    // Tomato is consumed (finite cover) so it must rank ahead of untouched napkins.
+    expect(rows[1]!.name).toBe("San Marzano Tomatoes");
+    expect(rows[2]!.name).toBe("Napkins");
+  });
+
+  it("ignores malformed sales and recipe lines instead of poisoning the arithmetic", () => {
+    const rows = computeStockCoverage({
+      stock,
+      components: [
+        ...components,
+        { storefrontItemId: PIZZA, stockItemId: "stock-mozzarella", quantityPerUnit: 0 },
+      ],
+      sold: [
+        { storefrontItemId: PIZZA, units: 11 },
+        { storefrontItemId: PIZZA, units: -5 },
+        { storefrontItemId: SALAD, units: Number.NaN },
+      ],
+      windowDays: 2,
+    });
+    expect(rows.find((r) => r.stockItemId === "stock-mozzarella")!.consumedInWindow).toBe(2.2);
+  });
+
+  it("treats a non-positive window as one day rather than dividing by zero", () => {
+    const rows = computeStockCoverage({
+      stock,
+      components,
+      sold: [{ storefrontItemId: PIZZA, units: 5 }],
+      windowDays: 0,
+    });
+    const mozzarella = rows.find((r) => r.stockItemId === "stock-mozzarella")!;
+    expect(Number.isFinite(mozzarella.dailyConsumption)).toBe(true);
+    expect(mozzarella.dailyConsumption).toBe(1); // 5 x 0.2 over 1 day
+  });
+});
+
+describe("describeCoverageRow", () => {
+  it("names the shortfall, the quantity, and the supplier when below the reorder point", () => {
+    const [row] = computeStockCoverage({
+      stock: [stock[0]!],
+      components,
+      sold: [{ storefrontItemId: PIZZA, units: 11 }],
+      windowDays: 2,
+    });
+    expect(describeCoverageRow(row!)).toBe(
+      "Mozzarella: 2 kg on hand, 1.1 kg/day, 1.8 days of cover — at or below reorder point, order 10 kg from Greenfield Logistics",
+    );
+  });
+
+  it("says plainly when there is no usage to project from", () => {
+    const [row] = computeStockCoverage({
+      stock: [stock[2]!],
+      components,
+      sold: [],
+      windowDays: 7,
+    });
+    expect(describeCoverageRow(row!)).toContain("no usage in this window");
+  });
+});

--- a/apps/web/lib/stock/stock-coverage.ts
+++ b/apps/web/lib/stock/stock-coverage.ts
@@ -1,0 +1,139 @@
+// Stock coverage — how close a stocked supply is to running out, given what
+// actually sold (BI-SPEND-003 first slice).
+//
+// Pure and dependency-free so the arithmetic is testable without a database and
+// reusable by a tool, a page, or a scheduled review. Consumption is DERIVED from
+// sales rather than read from a decrement ledger: multiply each sold item by its
+// recipe line. That keeps a starter free of partial-fulfilment and reversal
+// semantics while still answering the operator's real question.
+
+/** One recipe line: selling one unit of `storefrontItemId` consumes this much. */
+export type ComponentLine = {
+  storefrontItemId: string;
+  stockItemId: string;
+  quantityPerUnit: number;
+};
+
+/** A stocked supply as the operator maintains it. */
+export type StockLevel = {
+  stockItemId: string;
+  name: string;
+  unit: string;
+  onHandQuantity: number;
+  reorderPoint: number;
+  reorderQuantity: number;
+  supplierName?: string | null;
+};
+
+/** Units of a sellable item sold within the observed window. */
+export type SoldUnits = {
+  storefrontItemId: string;
+  units: number;
+};
+
+export type StockCoverageRow = {
+  stockItemId: string;
+  name: string;
+  unit: string;
+  onHandQuantity: number;
+  reorderPoint: number;
+  /** Total consumed across the window, derived from sales × recipe. */
+  consumedInWindow: number;
+  /** Average consumption per day across the window. */
+  dailyConsumption: number;
+  /**
+   * Days of stock remaining at the observed rate. `null` when nothing consumed
+   * in the window — no rate means no honest projection, which is different from
+   * "infinite cover" and must not be rendered as a comfortable number.
+   */
+  daysOfCover: number | null;
+  /** True when on-hand has reached or fallen below the reorder point. */
+  belowReorderPoint: boolean;
+  /** What to order now: the configured reorder quantity, or enough to clear the
+   *  reorder point when no reorder quantity was configured. */
+  suggestedOrderQuantity: number;
+  supplierName: string | null;
+};
+
+function round(value: number, dp = 2): number {
+  const factor = 10 ** dp;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Compute coverage per stock item. `windowDays` must be > 0; sales outside the
+ * window are the caller's to exclude. Items with no recipe line simply show zero
+ * consumption and a null projection.
+ */
+export function computeStockCoverage(input: {
+  stock: StockLevel[];
+  components: ComponentLine[];
+  sold: SoldUnits[];
+  windowDays: number;
+}): StockCoverageRow[] {
+  const windowDays = input.windowDays > 0 ? input.windowDays : 1;
+  const unitsByItem = new Map<string, number>();
+  for (const s of input.sold) {
+    if (!Number.isFinite(s.units) || s.units <= 0) continue;
+    unitsByItem.set(s.storefrontItemId, (unitsByItem.get(s.storefrontItemId) ?? 0) + s.units);
+  }
+
+  const consumedByStock = new Map<string, number>();
+  for (const line of input.components) {
+    const units = unitsByItem.get(line.storefrontItemId);
+    if (!units || !Number.isFinite(line.quantityPerUnit) || line.quantityPerUnit <= 0) continue;
+    consumedByStock.set(
+      line.stockItemId,
+      (consumedByStock.get(line.stockItemId) ?? 0) + units * line.quantityPerUnit,
+    );
+  }
+
+  return input.stock
+    .map((item) => {
+      const consumed = consumedByStock.get(item.stockItemId) ?? 0;
+      const daily = consumed / windowDays;
+      const daysOfCover = daily > 0 ? round(item.onHandQuantity / daily, 1) : null;
+      const belowReorderPoint = item.onHandQuantity <= item.reorderPoint;
+      const shortfall = Math.max(0, item.reorderPoint - item.onHandQuantity);
+      const suggested = belowReorderPoint
+        ? item.reorderQuantity > 0
+          ? item.reorderQuantity
+          : round(shortfall)
+        : 0;
+      return {
+        stockItemId: item.stockItemId,
+        name: item.name,
+        unit: item.unit,
+        onHandQuantity: round(item.onHandQuantity),
+        reorderPoint: round(item.reorderPoint),
+        consumedInWindow: round(consumed),
+        dailyConsumption: round(daily),
+        daysOfCover,
+        belowReorderPoint,
+        suggestedOrderQuantity: round(suggested),
+        supplierName: item.supplierName ?? null,
+      };
+    })
+    .sort((a, b) => {
+      // Most urgent first: below-reorder items, then the shortest honest cover.
+      if (a.belowReorderPoint !== b.belowReorderPoint) return a.belowReorderPoint ? -1 : 1;
+      const aCover = a.daysOfCover ?? Number.POSITIVE_INFINITY;
+      const bCover = b.daysOfCover ?? Number.POSITIVE_INFINITY;
+      if (aCover !== bCover) return aCover - bCover;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+/** One-line operator summary of a coverage row, e.g.
+ *  "Mozzarella: 8 kg on hand, 2.2 kg/day, 3.6 days of cover — below reorder
+ *   point, order 10 kg from Greenfield Logistics". Pure. */
+export function describeCoverageRow(row: StockCoverageRow): string {
+  const cover =
+    row.daysOfCover === null
+      ? "no usage in this window, so no cover estimate"
+      : `${row.daysOfCover} days of cover`;
+  const head = `${row.name}: ${row.onHandQuantity} ${row.unit} on hand, ${row.dailyConsumption} ${row.unit}/day, ${cover}`;
+  if (!row.belowReorderPoint) return head;
+  const supplier = row.supplierName ? ` from ${row.supplierName}` : "";
+  return `${head} — at or below reorder point, order ${row.suggestedOrderQuantity} ${row.unit}${supplier}`;
+}

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -565,6 +565,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // Guest activity (orders / reservations / inquiries) is the storefront's
   // demand signal; one consolidated read tool carries it.
   list_storefront_activity:     ["storefront_read"],
+  list_stock_coverage:          ["stock_read"],
   get_marketing_summary:        ["marketing_read"],
   suggest_campaign_ideas:       ["marketing_read"],
   build_tracked_links:          ["marketing_read"],

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1543,7 +1543,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 15931,
+      "defaultVisibleWords": 15977,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1543,7 +1543,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 15977,
+      "defaultVisibleWords": 15993,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,

--- a/docs/data-impact/2026-07-31-stock-coverage-starter.data-impact.json
+++ b/docs/data-impact/2026-07-31-stock-coverage-starter.data-impact.json
@@ -1,0 +1,85 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "StockItem: operator-maintained supply master (name, counting unit, on-hand, reorder thresholds); no PII",
+    "StorefrontItemComponent: per-unit consumption link from a sellable item to a supply; no PII"
+  ],
+  "migration": {
+    "name": "20260731210000_add_stock_coverage_starter",
+    "backfill": "none — purely additive; two new tables, no existing row read, written, or newly constrained"
+  },
+  "tests": [
+    "apps/web/lib/stock/stock-coverage.test.ts",
+    "apps/web/lib/mcp/packs/stock-coverage-pack.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:stock-item",
+      "prismaModel": "StockItem",
+      "lifecycleDisposition": "domain-lifecycle-managed — retired through isActive and organization cascade, never aged out",
+      "fields": [
+        {
+          "fieldId": "data:stock-item#stockItemId",
+          "resolution": "governed",
+          "reason": "stable supply identity so coverage history and recipe links survive renames",
+          "provenance": "generated at operator creation"
+        },
+        {
+          "fieldId": "data:stock-item#organizationId",
+          "resolution": "governed",
+          "reason": "supply levels are the organization's own operating data and must not leak across tenants",
+          "provenance": "install organization",
+          "flags": ["subject"],
+          "fieldPolicy": "organization-scoped; cascade delete with the organization"
+        },
+        {
+          "fieldId": "data:stock-item#onHandQuantity",
+          "resolution": "governed",
+          "reason": "operator-maintained stocktake number; the coverage projection is only as good as this count and must never be presented as a measured ledger",
+          "provenance": "operator stocktake entry"
+        },
+        {
+          "fieldId": "data:stock-item#reorderPoint",
+          "resolution": "governed",
+          "reason": "the threshold that turns a level into a proposal — an operator decision, not a platform default",
+          "provenance": "operator configuration"
+        },
+        {
+          "fieldId": "data:stock-item#supplierId",
+          "resolution": "governed",
+          "reason": "points at a confidential Supplier row; the supplier's own contact and bank detail stay in that row and are never copied here",
+          "provenance": "operator selection",
+          "fieldPolicy": "nullable reference; SET NULL on supplier delete so coverage survives supplier churn"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:storefront-item-component",
+      "prismaModel": "StorefrontItemComponent",
+      "lifecycleDisposition": "domain-lifecycle-managed — cascades with its sellable item and its supply",
+      "fields": [
+        {
+          "fieldId": "data:storefront-item-component#storefrontItemId",
+          "resolution": "governed",
+          "reason": "identifies the sellable item whose sales drive derived consumption",
+          "provenance": "operator recipe entry"
+        },
+        {
+          "fieldId": "data:storefront-item-component#stockItemId",
+          "resolution": "governed",
+          "reason": "identifies the consumed supply; the pair is unique so a recipe line cannot be silently duplicated",
+          "provenance": "operator recipe entry"
+        },
+        {
+          "fieldId": "data:storefront-item-component#quantityPerUnit",
+          "resolution": "governed",
+          "reason": "the multiplier turning units sold into consumption; a wrong value produces a confidently wrong reorder proposal",
+          "provenance": "operator recipe entry"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-31-stock-coverage-starter.md
+++ b/docs/superpowers/plans/2026-07-31-stock-coverage-starter.md
@@ -1,0 +1,79 @@
+# Stock Coverage Starter — first slice of BI-SPEND-003
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-31 |
+| Parent backlog item | BI-SPEND-003 (xlarge — "Inventory, stock, and cost-of-goods starter capability") |
+| Epic | EP-SPEND-PROCUREMENT-ASSETS |
+| Driving evidence | Restaurant archetype exercise, 2026-07-29 → 07-31 |
+
+## Why this slice exists
+
+The restaurant exercise set every AI coworker to assertive proactivity and asked
+one question nightly: *what sold, and what should we reorder?* Five platform
+defects were fixed getting the coworker to the point where it could ask that
+question honestly (#3725, #3733, #3740, #3763, #3805). The last run
+(TR-SCHED-1F1147E8) called its sales-read tool successfully and then reported
+the truth: **the platform cannot link a dish to its ingredients or hold a stock
+level**, so no restocking proposal is possible.
+
+BI-SPEND-003 is the parent capability (receipts, adjustments, valuation, COGS
+posting) and is sized xlarge. This plan carves the smallest slice that closes
+the operator's loop — *"we are about to run out of the thing our best seller
+needs"* — without pulling in accounting.
+
+## Decomposition decision
+
+BI-SPEND-003 stays open as the parent. This slice ships:
+
+1. **Two persistent models.**
+   - `StockItem` — a supply the operator counts: unit, on-hand quantity,
+     reorder point, reorder quantity, optional supplier.
+   - `StorefrontItemComponent` — one recipe line: selling one unit of a
+     `StorefrontItem` consumes `quantityPerUnit` of a `StockItem`.
+2. **A pure coverage engine** (`apps/web/lib/stock/stock-coverage.ts`):
+   consumption derived from actual sales × recipe, days of cover, below-reorder
+   flag, suggested order quantity, urgency ordering.
+3. **One read tool** (`list_stock_coverage`, grant `stock_read`) so a coworker
+   can propose a restock with a quantity and a supplier.
+4. **One operator door** (`POST/GET /api/storefront/admin/stock-items`) so a
+   human can enter and see what they stock — a coworker-only capability the
+   owner cannot inspect would be a governance defect, not a feature.
+
+Explicitly **out** of this slice, remaining in BI-SPEND-003: goods receipts,
+stock adjustments/wastage, valuation, COGS posting to the ledger, purchase-order
+generation, and multi-location stock.
+
+## The load-bearing design decision
+
+**Consumption is derived from sales, not from a decrement ledger.**
+
+`onHandQuantity` is a stocktake number the operator maintains; the engine
+multiplies units actually sold (from `StorefrontOrder.items`) by the recipe
+lines to derive a consumption rate. Consequences, accepted deliberately:
+
+- No partial-fulfilment, cancellation-reversal, or double-decrement semantics —
+  the class of bug that makes naive inventory features untrustworthy.
+- The number degrades honestly: with no sales in the window the engine returns
+  `daysOfCover: null` ("no usage to project from"), never a comfortable
+  infinity.
+- It matches how a small operator actually works: count on Monday, sell all
+  week, reorder before it runs out.
+
+A decrement ledger becomes correct once goods receipts and wastage exist —
+i.e. inside the parent BI, not before it.
+
+## Verification
+
+- Unit tests for the pure engine (derivation, multi-item stock, null-projection,
+  reorder fallback, urgency ordering, malformed input, zero window) and for the
+  pack contract (capability, grant gating, provenance-free description).
+- Live acceptance on the restaurant install: seed the eight-dish menu's
+  ingredients, then let the daily restocking task run and produce a proposal
+  naming the supply, the quantity, and the supplier.
+
+## Follow-ups this slice deliberately leaves open
+
+- Operator UI for stock levels (the API is the door; a page is not in scope).
+- Purchase-order generation from a proposal (`PurchaseOrder` already exists).
+- The parent BI-SPEND-003 accounting surface.

--- a/docs/testing/archetype-exercise-harness.md
+++ b/docs/testing/archetype-exercise-harness.md
@@ -46,6 +46,11 @@ A pack at `scripts/harness/scenarios/<name>.mjs` default-exports:
 - `catalog` — items for the admin items API (name/description/category/ctaType/price)
 - `personas` — named customers with emails and addresses
 - `demand` — ordered `{ kind: "order" | "booking", item, persona, qty }` wave
+- `stock` — supplies the operator counts (`unit`, `onHandQuantity`,
+  `reorderPoint`, `reorderQuantity`, optional `supplierName`) and `usedBy`
+  recipe lines naming the catalog items that consume them; seeded through
+  `POST /api/storefront/admin/stock-items` so `list_stock_coverage` has
+  something to project from
 - `stubs` — where real-world rails are stubbed or deferred (e.g. card payment is
   order-then-settle today, so no card stub is needed at order time; supplier
   ordering awaits an ingredient-stock substrate)
@@ -70,6 +75,7 @@ automation tracked as BI-0AA828E3).
   reads) are manual follow-ups today; candidates for a `--observe` pass.
 - Coworkers read the demand signal the harness generates through the
   `list_storefront_activity` tool (orders with an item-quantity rollup,
-  reservations, inquiries; `storefront_read` grant) — the read side of the
-  proactive restocking loop. Acting on it (draft purchase orders) still awaits
-  the ingredient-stock substrate (BI-SPEND-003).
+  reservations, inquiries; `storefront_read` grant), and turn it into coverage
+  through `list_stock_coverage` (`stock_read` grant): days of cover and a
+  suggested order quantity per supply, derived from sales × recipe. Generating
+  the purchase order itself remains BI-SPEND-003 scope.

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -956,6 +956,16 @@
       "implies": []
     },
     {
+      "key": "stock_read",
+      "description": "Read stocked-supply levels and derived coverage: on-hand quantity, consumption from sales, days of cover, and suggested reorder quantity.",
+      "category": "consume",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "list_stock_coverage"
+      ],
+      "implies": []
+    },
+    {
       "key": "order_create",
       "description": "Create order.",
       "category": "consume",

--- a/packages/db/prisma/migrations/20260731210000_add_stock_coverage_starter/migration.sql
+++ b/packages/db/prisma/migrations/20260731210000_add_stock_coverage_starter/migration.sql
@@ -1,0 +1,59 @@
+-- BI-SPEND-003 (first slice): stock coverage starter.
+--
+-- Adds the smallest honest model of "are we about to run out of what we sell":
+--   StockItem                — a stocked supply the operator counts (unit, on-hand,
+--                              reorder point/quantity, optional supplier).
+--   StorefrontItemComponent  — one recipe line: selling one unit of a StorefrontItem
+--                              consumes quantityPerUnit of a StockItem.
+--
+-- Consumption is DERIVED from actual sales (StorefrontOrder.items) rather than from a
+-- decrement ledger, so this slice carries no partial-fulfilment or reversal semantics.
+-- Receipts, adjustments, valuation, and COGS posting stay in BI-SPEND-003 scope.
+--
+-- @migration-safety: data-safe: purely additive. Two NEW tables — no existing row can
+-- violate a constraint that did not previously apply to it, and no existing table is
+-- altered except by the FK constraints these new tables own (which reference existing
+-- primary keys and take only brief catalog locks). No backfill, no data movement, no
+-- column added to an existing table, no tightening of an existing constraint.
+
+CREATE TABLE "StockItem" (
+    "id" TEXT NOT NULL,
+    "stockItemId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "unit" TEXT NOT NULL,
+    "onHandQuantity" DECIMAL(65,30) NOT NULL DEFAULT 0,
+    "reorderPoint" DECIMAL(65,30) NOT NULL DEFAULT 0,
+    "reorderQuantity" DECIMAL(65,30) NOT NULL DEFAULT 0,
+    "supplierId" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StockItem_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "StorefrontItemComponent" (
+    "id" TEXT NOT NULL,
+    "storefrontItemId" TEXT NOT NULL,
+    "stockItemId" TEXT NOT NULL,
+    "quantityPerUnit" DECIMAL(65,30) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StorefrontItemComponent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "StockItem_stockItemId_key" ON "StockItem"("stockItemId");
+CREATE UNIQUE INDEX "StockItem_organizationId_name_key" ON "StockItem"("organizationId", "name");
+CREATE INDEX "StockItem_organizationId_isActive_idx" ON "StockItem"("organizationId", "isActive");
+CREATE INDEX "StockItem_supplierId_idx" ON "StockItem"("supplierId");
+
+CREATE UNIQUE INDEX "StorefrontItemComponent_storefrontItemId_stockItemId_key" ON "StorefrontItemComponent"("storefrontItemId", "stockItemId");
+CREATE INDEX "StorefrontItemComponent_stockItemId_idx" ON "StorefrontItemComponent"("stockItemId");
+
+ALTER TABLE "StockItem" ADD CONSTRAINT "StockItem_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "StockItem" ADD CONSTRAINT "StockItem_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "Supplier"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "StorefrontItemComponent" ADD CONSTRAINT "StorefrontItemComponent_storefrontItemId_fkey" FOREIGN KEY ("storefrontItemId") REFERENCES "StorefrontItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "StorefrontItemComponent" ADD CONSTRAINT "StorefrontItemComponent_stockItemId_fkey" FOREIGN KEY ("stockItemId") REFERENCES "StockItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4662,6 +4662,7 @@ model Organization {
   updatedAt                         DateTime                           @updatedAt
   brandingConfig                    BrandingConfig?
   storefrontConfig                  StorefrontConfig?
+  stockItems                        StockItem[]
   operationalSceneLayouts           OperationalSceneLayout[]
   hospitalityResources              HospitalityResource[]              @relation("HospitalityResourceOrganization")
   hospitalityCapacityPools          HospitalityCapacityPool[]          @relation("HospitalityCapacityPoolOrganization")
@@ -10554,6 +10555,7 @@ model StorefrontItem {
   bookingHolds           BookingHold[]
   rentableUnits          RentableUnit[]
   rentalAgreements       RentalAgreement[]
+  stockComponents        StorefrontItemComponent[]
 
   @@unique([id, storefrontId])
   @@index([storefrontId, isActive, sortOrder])
@@ -12047,6 +12049,66 @@ model PaymentAllocation {
 
 // ─── Finance: Accounts Payable ─────────────────────────────────────
 
+// ── Stock coverage starter (EP-SPEND-PROCUREMENT-ASSETS, BI-SPEND-003 slice) ──
+// The smallest honest model of "are we about to run out of what we sell":
+// a stocked supply the operator counts, and the per-unit link from a sellable
+// StorefrontItem to the supplies it consumes.
+//
+// Deliberately NOT a warehouse system. onHandQuantity is operator-maintained
+// (a stocktake number), and CONSUMPTION IS DERIVED FROM ACTUAL SALES rather
+// than from a decrement ledger — which is how a small operator actually works,
+// and which keeps this slice free of partial-fulfilment/reversal semantics.
+// Receipts, adjustments, valuation, and COGS posting remain BI-SPEND-003 scope.
+//
+// Naming note: `InventoryEntity` is the IT-estate discovery model and `Bom*` is
+// the software bill of materials; neither describes physical supplies, so this
+// is genuinely new substrate rather than a fork of either.
+
+model StockItem {
+  id             String   @id @default(cuid())
+  stockItemId    String   @unique
+  organizationId String
+  name           String
+  /// Counting unit the operator thinks in (kg, litre, each, case).
+  unit           String
+  /// Latest counted quantity. Operator-maintained; not a running ledger.
+  onHandQuantity Decimal  @default(0)
+  /// Reorder when coverage falls to/below this quantity.
+  reorderPoint   Decimal  @default(0)
+  /// Suggested quantity to order when below the reorder point.
+  reorderQuantity Decimal @default(0)
+  supplierId     String?
+  isActive       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  supplier     Supplier?                @relation(fields: [supplierId], references: [id], onDelete: SetNull)
+  components   StorefrontItemComponent[]
+
+  @@unique([organizationId, name])
+  @@index([organizationId, isActive])
+  @@index([supplierId])
+}
+
+/// One line of a sellable item's recipe: selling one unit of `storefrontItem`
+/// consumes `quantityPerUnit` of `stockItem`. Archetype-neutral — a dish
+/// consumes mozzarella, a salon service consumes colourant.
+model StorefrontItemComponent {
+  id               String   @id @default(cuid())
+  storefrontItemId String
+  stockItemId      String
+  quantityPerUnit  Decimal
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  storefrontItem StorefrontItem @relation(fields: [storefrontItemId], references: [id], onDelete: Cascade)
+  stockItem      StockItem      @relation(fields: [stockItemId], references: [id], onDelete: Cascade)
+
+  @@unique([storefrontItemId, stockItemId])
+  @@index([stockItemId])
+}
+
 model Supplier {
   id              String   @id @default(cuid())
   supplierId      String   @unique
@@ -12070,6 +12132,7 @@ model Supplier {
   supplierContracts    SupplierContract[]
   financeWorkItems     FinanceWorkItem[]
   masterDataSourceRefs MasterDataSourceRef[]      @relation("SupplierMdmSourceRef")
+  stockItems           StockItem[]
 
   @@index([status])
 }

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -127,6 +127,12 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   StorefrontConfig: "internal",
   StorefrontSection: "internal",
   StorefrontItem: "internal",
+  // Stock coverage starter (BI-SPEND-003 slice). Supply names, counting units,
+  // and quantities carry no PII — the customer-identifying data stays in the
+  // order/booking tables, and the supplier's own contact/bank detail stays in
+  // the confidential Supplier row this only points at by id.
+  StockItem: "internal",
+  StorefrontItemComponent: "internal",
   HospitalityResource: "internal",
   HospitalityCapacityPool: "internal",
   HospitalityResourceAvailability: "internal",

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -314,6 +314,7 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "marketing_read",
     "marketing_write",
     "storefront_read",
+    "stock_read",
     "web_search",
   ],
   "ops-coordinator": ["backlog_read", "backlog_write", "backlog_triage", "registry_read", "portfolio_read"],

--- a/scripts/harness/archetype-exercise.mjs
+++ b/scripts/harness/archetype-exercise.mjs
@@ -154,12 +154,46 @@ async function generateDemand(scenario, itemsByName, orgSlug) {
   step("generate-demand", `${orders} orders submitted`);
 }
 
+async function seedStock(scenario, itemsByName) {
+  const stock = scenario.stock ?? [];
+  if (stock.length === 0) return;
+  let created = 0;
+  let gaps = 0;
+  for (const entry of stock) {
+    const usedBy = (entry.usedBy ?? [])
+      .map((line) => {
+        const item = itemsByName.get(line.item);
+        if (!item) return null;
+        return { storefrontItemId: item.itemId, quantityPerUnit: line.quantityPerUnit };
+      })
+      .filter(Boolean);
+    const res = await http("/api/storefront/admin/stock-items", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...entry, usedBy }),
+    });
+    if (res.status === 404 || res.status === 405) {
+      report.observations.push({
+        kind: "capability-gap",
+        detail: "No stock-items admin API on this install; stock coverage cannot be seeded.",
+      });
+      return;
+    }
+    if (!res.ok) throw new Error(`stock seed failed (${entry.name}): ${res.status}`);
+    const body = await res.json().catch(() => ({}));
+    if ((body.componentsLinked ?? 0) < usedBy.length) gaps++;
+    created++;
+  }
+  step("seed-stock", `${created} supplies seeded${gaps ? `, ${gaps} with unresolved recipe lines` : ""}`);
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 const { default: scenario } = await import(`./scenarios/${args.scenario}.mjs`);
 await login();
 if (args.reset) await resetArchetype(scenario);
 await seedCatalog(scenario);
 const itemsByName = await resolveSlugAndItems();
+await seedStock(scenario, itemsByName);
 await generateDemand(scenario, itemsByName, scenario.orgSlug);
 report.finishedAt = new Date().toISOString();
 if (args.report) {

--- a/scripts/harness/scenarios/restaurant.mjs
+++ b/scripts/harness/scenarios/restaurant.mjs
@@ -38,6 +38,27 @@ export default {
       { kind: "order", item: "Tiramisu", persona: p.vik, qty: 2 },
     ];
   },
+  // Stock coverage starter (BI-SPEND-003 slice): the supplies the kitchen counts
+  // and how much of each a dish uses. Seeded through
+  // POST /api/storefront/admin/stock-items so the coverage tool has something to
+  // project from; quantities are illustrative, not a real recipe book.
+  stock: [
+    { name: "Mozzarella", unit: "kg", onHandQuantity: 2, reorderPoint: 3, reorderQuantity: 10, supplierName: "Greenfield Logistics",
+      usedBy: [{ item: "Margherita Pizza", quantityPerUnit: 0.2 }] },
+    { name: "San Marzano Tomatoes", unit: "kg", onHandQuantity: 12, reorderPoint: 4, reorderQuantity: 12,
+      usedBy: [{ item: "Margherita Pizza", quantityPerUnit: 0.15 }, { item: "Bruschetta", quantityPerUnit: 0.1 }] },
+    { name: "Fresh Basil", unit: "bunch", onHandQuantity: 3, reorderPoint: 4, reorderQuantity: 12,
+      usedBy: [{ item: "Margherita Pizza", quantityPerUnit: 0.1 }, { item: "Bruschetta", quantityPerUnit: 0.1 }] },
+    { name: "Pizza Flour", unit: "kg", onHandQuantity: 25, reorderPoint: 10, reorderQuantity: 25,
+      usedBy: [{ item: "Margherita Pizza", quantityPerUnit: 0.25 }] },
+    { name: "Atlantic Salmon", unit: "kg", onHandQuantity: 4, reorderPoint: 2, reorderQuantity: 6,
+      usedBy: [{ item: "Grilled Salmon", quantityPerUnit: 0.22 }] },
+    { name: "Guanciale", unit: "kg", onHandQuantity: 1.5, reorderPoint: 1, reorderQuantity: 4,
+      usedBy: [{ item: "Spaghetti Carbonara", quantityPerUnit: 0.08 }] },
+    { name: "Mascarpone", unit: "kg", onHandQuantity: 2, reorderPoint: 2, reorderQuantity: 6,
+      usedBy: [{ item: "Tiramisu", quantityPerUnit: 0.12 }] },
+  ],
+
   stubs: {
     // Card payment: storefront orders are order-then-settle today, so no card
     // rail is needed at order time. When checkout gains a payment step, stub it

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -17,7 +17,7 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 567
+      "value": 569
     },
     "prismaSchemaLines": {
       "direction": "informational",

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -97,3 +97,5 @@ ProductSoldEntitlement  domain-lifecycle-managed  # Rights end through their exp
 ProductFulfillmentInstance  domain-lifecycle-managed  # Fulfillment records close through booking, rental, or supported-instance lifecycle transitions and ProductSold cascade.
 ProductSoldComponentAllocation  domain-lifecycle-managed  # Non-additive package attribution follows its immutable ProductSold fact and is never independently aged out.
 StorefrontOrderLineItem  domain-lifecycle-managed  # Normalized commercial lines follow the owning StorefrontOrder lifecycle; independent purging would corrupt order and sale evidence.
+StockItem  domain-lifecycle-managed  # Operator-maintained supply master: retired through isActive and organization cascade, never aged out — a stocked item is current until the operator stops stocking it.
+StorefrontItemComponent  domain-lifecycle-managed  # Recipe lines follow their sellable item and stock item via cascade; an age sweep would silently delete a live product's composition.

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,14 +3,14 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 348,
-      "reason": "Adds one surface-neutral semantic change-review operation because the existing review tools are task- or plan-scoped and cannot issue a fresh stable-commit Work Capsule receipt shared by external delivery and Build Studio.",
-      "recordedAt": "2026-08-01T03:57:17.246Z"
+      "value": 349,
+      "reason": "Adds one consolidated read that turns sales into supply coverage — days of cover and a suggested order quantity per stocked supply. Nothing in the registry could answer 'what are we about to run out of': the sales reads stop at what was ordered, and the finance/procurement tools start at a purchase order that already exists. Without it a proactive operations coworker can only report a capability gap, which is what the live restaurant run did.",
+      "recordedAt": "2026-08-01"
     },
     "registry.packFiles": {
-      "value": 80,
-      "reason": "Keeps the shared semantic change-review contract in its own bounded pack so both delivery surfaces can load the capability without coupling it to an unrelated domain pack.",
-      "recordedAt": "2026-08-01T03:57:17.246Z"
+      "value": 81,
+      "reason": "Keeps supply coverage in its own bounded pack rather than widening the storefront pack, so the capability travels with its own grant (stock_read) and an archetype that stocks nothing never pays for it in its selection space.",
+      "recordedAt": "2026-08-01"
     },
     "tier.coreToolNames": {
       "value": 22


### PR DESCRIPTION
Closes BI-1323E39E — the first slice carved out of the xlarge **BI-SPEND-003**, driven by the restaurant archetype exercise. Work Capsule WC-1BC4B54C. Plan: `docs/superpowers/plans/2026-07-31-stock-coverage-starter.md`.

## Why

Nine merged PRs took an assertive coworker to the point where it could ask *"what should we reorder?"* honestly. The last run (TR-SCHED-1F1147E8) called its sales-read tool successfully and then reported the truth: **the platform cannot link a dish to its ingredients or hold a stock level**, so no restocking proposal was possible. This is the smallest slice that closes that loop.

## What changed

- **`StockItem` + `StorefrontItemComponent`** — a counted supply (unit, on-hand, reorder point/quantity, optional supplier) and one recipe line (selling one unit consumes `quantityPerUnit` of a supply). Purely additive migration with a `@migration-safety: data-safe` attestation.
- **Pure coverage engine** (`apps/web/lib/stock/stock-coverage.ts`) — consumption **derived from actual sales × recipe**, not a decrement ledger. This is the load-bearing design decision: it carries no partial-fulfilment or reversal semantics, and it degrades honestly (nothing sold in the window ⇒ `daysOfCover: null`, never a comfortable infinity).
- **`list_stock_coverage` tool** behind a new `stock_read` grant, so the coworker proposes a **quantity and a supplier** instead of reporting a capability gap. Its description steers to a multi-day window — closing the same-day-window trap the live run exposed (BI-7DD10687).
- **`POST/GET /api/storefront/admin/stock-items`** so an operator can enter and inspect what they stock; a coworker-only capability the owner cannot see would be a governance defect.
- **Harness** scenario pack + runner seed the restaurant's seven supplies and their recipes.

## Governance

Every gate a new persistent model owes, satisfied rather than deferred: table classification (internal — no PII), stewardship disposition (`domain-lifecycle-managed`, both models), a committed data-impact manifest, the substrate model-count ratchet (**hand-edited only my metric** — an `--update` snapshot would also have swept another session's unclaimed `productionModuleHotspotCount` improvement into a tighter baseline), and **registration in `DATA_ASSET_REGISTRY`** (the legacy coverage baseline is sealed shrink-only, so a new model must be governed on arrival — correct contract). The three fields that produce a *confidently wrong* proposal if mis-entered — `onHandQuantity`, `reorderPoint`, `quantityPerUnit` — are marked **governed** with explicit reasons rather than inheriting.

## Design grounding

Substrate verified before adding anything new: `InventoryEntity` is IT-estate discovery, `Bom*` is the **software** bill of materials, `Product` is the commercial catalog — none model physical supplies. Specs/plans reviewed: the authored plan above, `docs/architecture/context-engineering-standards.md` (consolidated, capped, provenance-free tool), `docs/architecture/enforced-ci-gates.md` (stewardship contract). Code substrate: `tool-pack.ts`/`pack-registry.ts`, `storefront-activity-pack.ts` (precedent), `agent-grants.ts` default-deny map, `table-classification.ts`, `workforce-seed.ts`.

Seed-Fit-Decision: global-default — the two models and the `stock_read` grant are platform substrate for every install; the restaurant recipes live in the harness scenario pack, never the platform seed.

## Deliberately out of scope (stays in parent BI-SPEND-003)

Goods receipts, stock adjustments/wastage, valuation, COGS posting, purchase-order generation, multi-location stock. Operator UI for stock levels is a named follow-up — the API is its door.

## Verification

Local-CI pregate **`gate passed`** at head SHA (24 guards, typecheck, 20,900+ tests). Live acceptance after deploy + seed: the daily restocking task should name the supply, the quantity, and the supplier — mozzarella is seeded below its reorder point so the first run has something true to say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)