### PR TITLE
docs: plan the invoicing overhaul (EP-778F1CED)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-invoicing-overhaul.md
+++ b/docs/superpowers/plans/2026-07-31-invoicing-overhaul.md
@@ -1,0 +1,80 @@
+# Invoicing Overhaul — Implementation Plan
+
+- **Epic:** EP-778F1CED
+- **Date:** 2026-07-31
+- **Binding decision ledger:** DI-763E5529F491 (profile `mark-dpf-platform`)
+- **Origin:** Founder report — invoices cannot be edited, test invoices cannot be deleted, sent documents are not retained or revision-tracked.
+
+## Problem
+
+Three structural gaps, confirmed against `main`:
+
+1. **No edit.** `updateInvoiceStatus` ([finance.ts:144](../../../apps/web/lib/actions/finance.ts)) is status-only. The PATCH route parses four more fields and silently discards them.
+2. **No delete or void.** Neither exists in any layer — action, route, or UI — despite `void` being a declared status with a `voidedAt` column. Status transitions are entirely unvalidated.
+3. **No persisted document.** The PDF is rendered per request and discarded, so the document a customer received is unrecoverable and revisions cannot be tracked.
+
+## Binding decision
+
+`Document` has no polymorphic owner column, and the repo has **no established pattern** for binding a managed document to a business record — the only mechanism, `DocumentReference.targetExternalRef`, is free-form text whose sole production caller attaches nothing.
+
+Routed through `principle_decide`. Recommendation: **typed join table**, high confidence.
+
+| Option | Composite |
+|---|---|
+| Typed join table (`InvoiceDocument`) | **10.074** |
+| Polymorphic `ownerType`/`ownerId` on `Document` | 6.441 |
+| `DocumentReference.targetExternalRef` | 3.749 |
+
+Margin 3.633, no commandment conflict. Strongest contributors: *Ship Real Functionality*, *Research and Use Standards*, *Single Source of Truth*, *Never Assume — Verify*.
+
+This sets the precedent for quotes, purchase orders, and contracts. The trade accepted: a join table per record type, in exchange for real foreign keys and cascade semantics.
+
+## Phases
+
+Each phase is one BI, one branch, one PR.
+
+### Phase 1 — Guarded lifecycle: delete, void, transitions (BI-83574A1F)
+
+Sequenced first: it unblocks the operator immediately and establishes the status gates that Phase 2 depends on.
+
+- Declare one transition map as the single source of truth; enforce in `updateInvoiceStatus`, consult from `sendInvoice`.
+- `deleteInvoice(id)` — draft-only, and only with no `PaymentAllocation`, no `DunningLog`, no sourced `JournalEntry`. NULLs `TimesheetEntry.invoiceId`/`invoicedAt` so billable time returns to the unbilled pool.
+- `voidInvoice(id, reason)` — unwinds allocations, posts reversing journal entries where GL postings exist, records reason.
+- DELETE handler on the v1 route.
+
+**Verification:** every legal transition accepted, every illegal one rejected; `sendInvoice` on a void invoice rejected; void re-bills linked timesheet entries.
+
+### Phase 2 — Edit (BI-3FDFBFD3)
+
+Depends on Phase 1's status gates.
+
+- `updateInvoice(id, input)` accepting header fields plus a full `lineItems` array.
+- Extract the total-recomputation arithmetic out of `createInvoice` into a shared pure helper — do not duplicate it.
+- Full edit while `draft`; post-draft narrows to `notes`, `internalNotes`, `paymentTerms`, `dueDate`, so a sent invoice's economics cannot change under a customer who already holds the PDF.
+- Fix the PATCH silent-discard bug.
+- Relax the grid adapter to the same draft-only field set; keep `canAddRow`/`canDeleteRow` false.
+
+**Verification:** draft edit recomputes totals; non-draft economic edit rejected; PATCH round-trips every schema field.
+
+### Phase 3 — Document persistence (BI-C86BD108)
+
+The largest phase and the one that closes the audit gap.
+
+- New `InvoiceDocument` model: `invoiceId` (FK, cascade), `documentVersionId` (FK), `role`, `revision`, `sentToEmail?`, `@@unique([invoiceId, revision, role])`.
+- Snapshot on send: persist the rendered Buffer via `saveManagedDocument`, bind the resulting `DocumentVersion`.
+- Snapshots are immutable. A reissue creates revision N+1; it never mutates N.
+- **Open question to resolve during build:** blob storage is filesystem-backed (`documents/sha256/aa/bb/<sha>`), not object storage. Confirm the retention and backup story before a finance artifact depends on it.
+- Re-check the migration timestamp for collision after every rebase.
+
+**Verification:** the persisted `sha256` matches the emailed bytes; re-sending after an edit yields revision 2 with revision 1 byte-identical; a revision stays retrievable after the invoice is voided.
+
+### Phase 4 — UX (BI-F8A20878)
+
+- Edit / Void / Delete controls, each rendered only when its gate passes, with confirmations naming the real consequence.
+- Document revision panel — visibly distinct from the live re-render, since the two diverge after an edit.
+- Timestamps via shared `LocalTime`, viewer timezone.
+- Run `dpf-ux-fit-review` before implementation. No new tab or route family.
+
+## Precedent to retire
+
+On 2026-07-31 the five seeded test invoices (`INV-2026-0001`–`0005`) were voided by direct SQL against `dpf-postgres-1`, because no governed path existed. Phase 1 is what makes that unnecessary.


### PR DESCRIPTION
## Why

Founder report: invoices cannot be edited, test invoices cannot be deleted, and sent invoice documents are neither retained nor revision-tracked.

Three structural gaps, confirmed against `main` rather than inferred:

1. **No edit.** `updateInvoiceStatus` (`apps/web/lib/actions/finance.ts:144`) is status-only. The v1 PATCH route parses `dueDate`/`paymentTerms`/`notes`/`internalNotes` and silently discards all four — only `status` is written.
2. **No delete and no void.** Neither exists in any layer — action, route, or UI — despite `void` being a declared status with a `voidedAt` column. Status transitions are entirely unvalidated, and `sendInvoice` will re-send an already-paid or voided invoice.
3. **No persisted document.** `lib/invoice-pdf.tsx` renders the PDF per request and streams it to the download route and the send email. Nothing is retained, so the document a customer received is unrecoverable and re-downloading after an edit yields different content under the same invoice ref.

## What this adds

Documentation only — the four-phase implementation plan for **EP-778F1CED**. No code changes.

## Binding decision

`Document` has no polymorphic owner column, and the repo has no working pattern for binding a managed document to a business record: the only mechanism, `DocumentReference.targetExternalRef`, is free-form text whose sole production caller attaches nothing.

Routed through `principle_decide` (ledger `DI-763E5529F491`). Recommended a **typed `InvoiceDocument` join table** with real foreign keys — composite 10.074, against 6.441 for a polymorphic owner column on `Document` and 3.749 for `targetExternalRef`. Margin 3.633, high confidence, no commandment conflict. Strongest contributors: *Ship Real Functionality*, *Research and Use Standards*, *Single Source of Truth*.

This sets the precedent for quotes, purchase orders, and contracts.

## Phasing

| BI | Phase | Size |
|---|---|---|
| `BI-83574A1F` | Delete, void, guarded status transitions | medium |
| `BI-3FDFBFD3` | Draft-only edit including line items | medium |
| `BI-C86BD108` | Persist sent PDFs as versioned Documents | large |
| `BI-F8A20878` | UX: expose controls + revision history | medium |

Lifecycle goes first because it establishes the status gates the edit phase depends on.

## Open question carried into Phase 3

Blob storage is filesystem-backed (`documents/sha256/aa/bb/<sha>`), not object storage. That is fine for onboarding documents; the retention and backup story needs an explicit decision before a finance artifact depends on it. Flagged in the plan rather than assumed away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)