### PR TITLE
refactor(db): shared exact-key integrity repair helper with inline retirement (BI-8EEEF8CB)

### DIFF
--- a/docs/runbooks/2026-07-20-collation-drift-index-corruption.md
+++ b/docs/runbooks/2026-07-20-collation-drift-index-corruption.md
@@ -133,8 +133,19 @@ So dedupe is **two** steps, not one:
    `retiredAt`/`retiredReason`; `TaxonomyNode` → `status='retired'`; `SkillDefinition` →
    `status='quarantined'`. Retire, do not delete — the tombstone stays for audit and unmerge.
 
-The durable fix is to fold step 2 into the helper (let each table declare its tombstone marker) so a
-future dedupe retires losers in one pass — tracked in BI-8EEEF8CB.
+The durable fix shipped (BI-8EEEF8CB): the shared authoring helper at
+[`packages/db/src/migrations/exact-key-repair.ts`](../../packages/db/src/migrations/exact-key-repair.ts)
+(`buildExactKeyRepairSql`) folds step 2 into step 1. Each table declares its tombstone marker in the
+`retirement` config field, so the same UPDATE that renames the loser also retires it — a future
+dedupe never needs the `20260721190000_retire_quarantined_duplicate_rows`-style follow-up. Authoring
+a new repair is now a config (table, key columns, survivor order, retirement markers, natural-key FKs
+to detach) rather than a hand-copied 70-line migration; the ratified sequence lives in one
+unit-and-DB-tested place. **Do not hand-copy a prior repair migration** — call the helper.
+
+The recurring *detection* half — a platform scheduled sweep that runs
+`index-integrity-guard.mjs` against the live install DB and raises an advisory/BI on corruption — is
+tracked as a follow-up to BI-8EEEF8CB (a CI cron cannot catch this class: CI's cluster is freshly
+initdb'd under glibc every run, so the musl→glibc flip never reproduces there).
 
 ## Preventing recurrence
 

--- a/packages/db/scripts/index-integrity-guard.mjs
+++ b/packages/db/scripts/index-integrity-guard.mjs
@@ -52,9 +52,18 @@
 //
 // Exit: 0 clean · 1 corruption or collation drift found · 2 invocation error
 //
-// Wired into:
-//   - .github/workflows/migration-safety-guard.yml (CI, against the CI cluster)
+// Invoked by:
 //   - packages/db/scripts/index-integrity-guard.test.ts (vitest)
+//   - `pnpm --filter @dpf/db run index-integrity` (manual, against DATABASE_URL)
+//
+// NOT yet wired as a recurring platform sweep. A CI cron would be theatre: CI's
+// cluster is freshly initdb'd under glibc every run, so the musl->glibc
+// collation flip this guard exists to catch (an EXISTING volume carried across
+// an image change) can never reproduce there. The real home is a platform-side
+// scheduled sweep against the live install DB that raises an advisory/BI on
+// corruption — tracked as the recurring-detector follow-up to BI-8EEEF8CB. The
+// repair half of that BI (the shared authoring helper) lives at
+// packages/db/src/migrations/exact-key-repair.ts.
 
 import pg from "pg";
 import {

--- a/packages/db/src/migrations/exact-key-repair.db.test.ts
+++ b/packages/db/src/migrations/exact-key-repair.db.test.ts
@@ -1,0 +1,152 @@
+// Functional proof for buildExactKeyRepairSql (BI-8EEEF8CB): the emitted SQL is
+// executed against a real Postgres, against real seeded duplicates, and the
+// repaired state is asserted. A structural test proves the SQL is SHAPED right;
+// this proves it WORKS — dedupes, retires losers, and rebuilds the index.
+//
+// Uses an isolated scratch schema so it touches no platform table. Skips
+// cleanly when DATABASE_URL is unset (e.g. a source-only checkout).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import { buildExactKeyRepairSql } from "./exact-key-repair";
+
+const DATABASE_URL = process.env.DATABASE_URL ?? "postgresql://dpf:dpf_dev@localhost:54329/dpf";
+const SCHEMA = "exact_key_repair_test";
+
+let client: pg.Client | undefined;
+let reachable = false;
+
+beforeAll(async () => {
+  client = new pg.Client({ connectionString: DATABASE_URL });
+  try {
+    await client.connect();
+    reachable = true;
+  } catch {
+    reachable = false;
+    return;
+  }
+  await client.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+  await client.query(`CREATE SCHEMA ${SCHEMA}`);
+  await client.query(`SET search_path TO ${SCHEMA}`);
+});
+
+afterAll(async () => {
+  if (client && reachable) {
+    await client.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`).catch(() => {});
+  }
+  await client?.end().catch(() => {});
+});
+
+describe("buildExactKeyRepairSql executed against Postgres", () => {
+  it("dedupes a corrupted unique key, retires losers, and rebuilds the index", async (ctx) => {
+    if (!reachable) ctx.skip();
+    const c = client!;
+    await c.query(`SET search_path TO ${SCHEMA}`);
+
+    // A table standing in for a real one: a natural key, a status column (the
+    // retirement target), and timestamps for survivor ranking.
+    await c.query(`
+      CREATE TABLE "Widget" (
+        id text PRIMARY KEY,
+        "widgetKey" text NOT NULL,
+        status text NOT NULL DEFAULT 'active',
+        "createdAt" timestamptz NOT NULL DEFAULT now()
+      )`);
+
+    // Two logical keys, each with duplicates. The SURVIVOR is the oldest row.
+    await c.query(`
+      INSERT INTO "Widget" (id, "widgetKey", status, "createdAt") VALUES
+        ('w-alpha-old',   'alpha', 'active', '2026-01-01'),
+        ('w-alpha-mid',   'alpha', 'active', '2026-02-01'),
+        ('w-alpha-new',   'alpha', 'active', '2026-03-01'),
+        ('w-beta-old',    'beta',  'active', '2026-01-15'),
+        ('w-beta-new',    'beta',  'active', '2026-02-15'),
+        ('w-gamma-only',  'gamma', 'active', '2026-01-20')`);
+
+    // Build the index the "corrupted" way: it exists, but the heap holds dupes.
+    // (We create it non-unique to allow the duplicate seed; the repair drops and
+    // recreates it UNIQUE from the repaired heap — exactly the real scenario
+    // where a collation flip let a UNIQUE index accumulate duplicates.)
+    await c.query(`CREATE INDEX "Widget_widgetKey_key" ON "Widget" ("widgetKey")`);
+
+    const sql = buildExactKeyRepairSql({
+      table: "Widget",
+      keyColumns: ["widgetKey"],
+      survivorOrder: '"createdAt" ASC, id ASC',
+      uniqueIndexName: "Widget_widgetKey_key",
+      retirement: [{ column: "status", value: "'retired'" }],
+      reason: "BI-TEST — functional repair of Widget.",
+    });
+
+    // The generated migration is schema-agnostic; run it on the search_path.
+    await c.query(`SET search_path TO ${SCHEMA}`);
+    await c.query(sql);
+
+    // 1. No duplicate logical keys remain among LIVE rows.
+    const live = await c.query(
+      `SELECT "widgetKey", count(*) c FROM "Widget" WHERE status = 'active' GROUP BY "widgetKey" ORDER BY "widgetKey"`,
+    );
+    expect(live.rows).toEqual([
+      { widgetKey: "alpha", c: "1" },
+      { widgetKey: "beta", c: "1" },
+      { widgetKey: "gamma", c: "1" },
+    ]);
+
+    // 2. The SURVIVOR is the oldest row, key intact, still active.
+    const survivors = await c.query(
+      `SELECT id FROM "Widget" WHERE status = 'active' ORDER BY id`,
+    );
+    expect(survivors.rows.map((r) => r.id)).toEqual([
+      "w-alpha-old",
+      "w-beta-old",
+      "w-gamma-only",
+    ]);
+
+    // 3. Losers are RETIRED (the #3374 gap) and renamed into the reserved
+    //    namespace — retained, never deleted.
+    const losers = await c.query(
+      `SELECT id, "widgetKey", status FROM "Widget" WHERE status = 'retired' ORDER BY id`,
+    );
+    expect(losers.rows.map((r) => r.id).sort()).toEqual(["w-alpha-mid", "w-alpha-new", "w-beta-new"]);
+    for (const row of losers.rows) {
+      expect(row.status).toBe("retired");
+      expect(row.widgetKey).toMatch(/^__dpf_quarantined__/);
+    }
+
+    // 4. The rebuilt index is genuinely UNIQUE — a duplicate insert now fails.
+    await expect(
+      c.query(`INSERT INTO "Widget" (id, "widgetKey") VALUES ('w-dup', 'alpha')`),
+    ).rejects.toThrow();
+
+    // 5. Nothing was lost: all six original rows still exist.
+    const total = await c.query(`SELECT count(*)::int AS n FROM "Widget"`);
+    expect(total.rows[0].n).toBe(6);
+  });
+
+  it("is idempotent — a second run on a clean heap changes nothing and still asserts", async (ctx) => {
+    if (!reachable) ctx.skip();
+    const c = client!;
+    await c.query(`SET search_path TO ${SCHEMA}`);
+    await c.query(`DROP TABLE IF EXISTS "Clean"`);
+    await c.query(`
+      CREATE TABLE "Clean" (id text PRIMARY KEY, k text NOT NULL, status text NOT NULL DEFAULT 'active')`);
+    await c.query(`INSERT INTO "Clean" (id, k) VALUES ('a','1'),('b','2')`);
+    await c.query(`CREATE UNIQUE INDEX "Clean_k_key" ON "Clean" (k)`);
+
+    const sql = buildExactKeyRepairSql({
+      table: "Clean",
+      keyColumns: ["k"],
+      survivorOrder: "id",
+      uniqueIndexName: "Clean_k_key",
+      retirement: [{ column: "status", value: "'retired'" }],
+      reason: "BI-TEST — idempotent no-op.",
+    });
+    await c.query(`SET search_path TO ${SCHEMA}`);
+    await c.query(sql);
+
+    const rows = await c.query(`SELECT status FROM "Clean" ORDER BY id`);
+    // No duplicates existed, so nothing was retired.
+    expect(rows.rows.every((r) => r.status === "active")).toBe(true);
+  });
+});

--- a/packages/db/src/migrations/exact-key-repair.test.ts
+++ b/packages/db/src/migrations/exact-key-repair.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildExactKeyRepairSql,
+  type ExactKeyRepairConfig,
+} from "./exact-key-repair";
+
+// A minimal single-column config mirroring the ScheduledJob template.
+function scheduledJobConfig(overrides: Partial<ExactKeyRepairConfig> = {}): ExactKeyRepairConfig {
+  return {
+    table: "ScheduledJob",
+    keyColumns: ["jobId"],
+    survivorOrder: '"updatedAt" DESC, "lastRunAt" DESC NULLS LAST, "createdAt" DESC, id DESC',
+    uniqueIndexName: "ScheduledJob_jobId_key",
+    reason: "BI-TEST — restore ScheduledJob heap/index agreement.",
+    ...overrides,
+  };
+}
+
+describe("buildExactKeyRepairSql — the ratified sequence", () => {
+  const sql = buildExactKeyRepairSql(scheduledJobConfig());
+
+  it("emits every step of the ratified sequence, in order", () => {
+    const order = [
+      "BEGIN;",
+      "SET LOCAL enable_indexscan = off;",
+      "SET LOCAL enable_indexonlyscan = off;",
+      "SET LOCAL enable_bitmapscan = off;",
+      "row_number() OVER (",
+      "__dpf_quarantined__",
+      "RAISE EXCEPTION",
+      'DROP INDEX IF EXISTS "ScheduledJob_jobId_key";',
+      'CREATE UNIQUE INDEX "ScheduledJob_jobId_key"',
+      "COMMIT;",
+    ];
+    let cursor = 0;
+    for (const token of order) {
+      const at = sql.indexOf(token, cursor);
+      expect(at, `"${token}" must appear after the previous step`).toBeGreaterThan(-1);
+      cursor = at;
+    }
+  });
+
+  it("disables all three index scan classes so ranking and assertion read the heap", () => {
+    expect(sql).toContain("SET LOCAL enable_indexscan = off;");
+    expect(sql).toContain("SET LOCAL enable_indexonlyscan = off;");
+    expect(sql).toContain("SET LOCAL enable_bitmapscan = off;");
+  });
+
+  it("ranks by the declared survivor ordering, keeping row 1", () => {
+    expect(sql).toContain(
+      'ORDER BY "updatedAt" DESC, "lastRunAt" DESC NULLS LAST, "createdAt" DESC, id DESC',
+    );
+    expect(sql).toContain("WHERE duplicate_rank > 1");
+  });
+
+  it("uses the collision-checked reserved-namespace rename", () => {
+    expect(sql).toContain(
+      "quarantine_key := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row.original_key;",
+    );
+    expect(sql).toMatch(/WHILE EXISTS \([\s\S]*?quarantine_key := quarantine_key \|\| '_';/);
+  });
+
+  it("carries a heap-grounded fail-closed assertion before the index rebuild", () => {
+    const assertAt = sql.indexOf("RAISE EXCEPTION");
+    const rebuildAt = sql.indexOf("CREATE UNIQUE INDEX");
+    expect(assertAt).toBeGreaterThan(-1);
+    expect(assertAt).toBeLessThan(rebuildAt);
+    expect(sql).toContain("HAVING count(*) > 1");
+  });
+
+  it("drops then recreates the unique index from the repaired heap", () => {
+    const drop = sql.indexOf('DROP INDEX IF EXISTS "ScheduledJob_jobId_key";');
+    const create = sql.indexOf('CREATE UNIQUE INDEX "ScheduledJob_jobId_key" ON "ScheduledJob" ("jobId");');
+    expect(drop).toBeGreaterThan(-1);
+    expect(create).toBeGreaterThan(drop);
+  });
+
+  it("adds no FK detach/reattach when none are declared", () => {
+    expect(sql).not.toContain("DROP CONSTRAINT");
+    expect(sql).not.toContain("ADD CONSTRAINT");
+  });
+
+  it("adds no retirement clause when none is declared", () => {
+    // The rename UPDATE sets only the quarantine column.
+    expect(sql).toMatch(/SET "jobId" = quarantine_key\s*\n\s*WHERE id = duplicate_row\.id;/);
+  });
+});
+
+describe("retirement — the #3374 gap this helper closes", () => {
+  it("applies retirement assignments in the SAME update that renames the loser", () => {
+    const sql = buildExactKeyRepairSql(
+      scheduledJobConfig({
+        table: "DigitalProduct",
+        keyColumns: ["productId"],
+        survivorOrder: '"createdAt", id',
+        uniqueIndexName: "DigitalProduct_productId_key",
+        retirement: [
+          { column: "lifecycleStatus", value: "'retired'" },
+          { column: "coverageStatus", value: "'quarantined'" },
+          { column: "updatedAt", value: "now()" },
+        ],
+        reason: "BI-TEST — DigitalProduct with retirement.",
+      }),
+    );
+    // A single UPDATE assigns the key AND the retirement columns.
+    expect(sql).toMatch(
+      /UPDATE "DigitalProduct"\s*\n\s*SET "productId" = quarantine_key,\s*\n\s*"lifecycleStatus" = 'retired',\s*\n\s*"coverageStatus" = 'quarantined',\s*\n\s*"updatedAt" = now\(\)\s*\n\s*WHERE id = duplicate_row\.id;/,
+    );
+    // The fleet-safety header advertises that no follow-up is needed.
+    expect(sql).toContain("no follow-up migration is needed");
+  });
+});
+
+describe("natural-key foreign keys — detach before, reattach after", () => {
+  const sql = buildExactKeyRepairSql(
+    scheduledJobConfig({
+      table: "DigitalProduct",
+      keyColumns: ["productId"],
+      survivorOrder: '"createdAt", id',
+      uniqueIndexName: "DigitalProduct_productId_key",
+      naturalKeyForeignKeys: [
+        {
+          childTable: "CoworkerService",
+          constraint: "CoworkerService_digitalProductId_fkey",
+          childColumns: ["digitalProductId"],
+          parentColumns: ["productId"],
+          onDelete: "SET NULL",
+          onUpdate: "CASCADE",
+        },
+      ],
+      reason: "BI-TEST — DigitalProduct with FK detach.",
+    }),
+  );
+
+  it("detaches the FK before the quarantine loop and reattaches after the index rebuild", () => {
+    const detach = sql.indexOf(
+      'DROP CONSTRAINT IF EXISTS "CoworkerService_digitalProductId_fkey"',
+    );
+    const loop = sql.indexOf("FOR duplicate_row IN");
+    const rebuild = sql.indexOf("CREATE UNIQUE INDEX");
+    const reattach = sql.indexOf(
+      'ADD CONSTRAINT "CoworkerService_digitalProductId_fkey"',
+    );
+    expect(detach).toBeGreaterThan(-1);
+    expect(detach).toBeLessThan(loop); // detach precedes the rename
+    expect(reattach).toBeGreaterThan(rebuild); // reattach follows the rebuild
+  });
+
+  it("restores the exact FK definition, referencing the natural key not id", () => {
+    expect(sql).toContain(
+      'FOREIGN KEY ("digitalProductId") REFERENCES "DigitalProduct"("productId")\n' +
+        "  ON DELETE SET NULL ON UPDATE CASCADE;",
+    );
+  });
+});
+
+describe("multi-column keys", () => {
+  const sql = buildExactKeyRepairSql({
+    table: "ModelProfile",
+    keyColumns: ["providerId", "modelId"],
+    quarantineColumn: "modelId",
+    survivorOrder: '"lastEvalAt" DESC NULLS LAST, "evalCount" DESC, id DESC',
+    uniqueIndexName: "ModelProfile_providerId_modelId_key",
+    reason: "BI-TEST — ModelProfile composite key.",
+  });
+
+  it("partitions and asserts on the full composite key", () => {
+    expect(sql).toContain('PARTITION BY "providerId", "modelId"');
+    expect(sql).toContain('GROUP BY "providerId", "modelId"');
+  });
+
+  it("quarantines only the designated column and rebuilds the composite index", () => {
+    expect(sql).toContain('SET "modelId" = quarantine_key');
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "ModelProfile_providerId_modelId_key" ON "ModelProfile" ("providerId", "modelId");',
+    );
+  });
+
+  it("defaults the quarantine column to the LAST key column when unspecified", () => {
+    const s = buildExactKeyRepairSql({
+      table: "DiscoveredModel",
+      keyColumns: ["providerId", "modelId"],
+      survivorOrder: "id",
+      uniqueIndexName: "DiscoveredModel_providerId_modelId_key",
+      reason: "BI-TEST — default quarantine column.",
+    });
+    expect(s).toContain('AS original_key'); // present
+    expect(s).toContain('SET "modelId" = quarantine_key'); // last column
+  });
+});
+
+describe("validation — malformed input fails loud, not silently", () => {
+  it("rejects an empty key", () => {
+    expect(() =>
+      buildExactKeyRepairSql(scheduledJobConfig({ keyColumns: [] })),
+    ).toThrow(/keyColumns must be non-empty/);
+  });
+
+  it("rejects a quarantine column that is not part of the key", () => {
+    expect(() =>
+      buildExactKeyRepairSql(scheduledJobConfig({ quarantineColumn: "notAKeyColumn" })),
+    ).toThrow(/must be one of keyColumns/);
+  });
+
+  it("rejects an identifier carrying a quote or semicolon (SQL-shape guard)", () => {
+    expect(() =>
+      buildExactKeyRepairSql(scheduledJobConfig({ table: 'Sched"; DROP' })),
+    ).toThrow(/invalid table identifier/);
+  });
+
+  it("rejects an empty survivor order", () => {
+    expect(() =>
+      buildExactKeyRepairSql(scheduledJobConfig({ survivorOrder: "   " })),
+    ).toThrow(/survivorOrder is required/);
+  });
+});
+
+describe("golden equivalence with the ratified hand-written templates", () => {
+  // The generator must reproduce the semantics of the templates it replaces.
+  // We assert on the load-bearing lines rather than byte-identity, since the
+  // hand-written files carry bespoke prose comments.
+  it("reproduces the ScheduledJob (simple) template's operative SQL", () => {
+    const sql = buildExactKeyRepairSql(scheduledJobConfig());
+    for (const line of [
+      "SET LOCAL enable_indexscan = off;",
+      'PARTITION BY "jobId"',
+      "quarantine_key := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row.original_key;",
+      "RAISE EXCEPTION 'ScheduledJob integrity repair left duplicate keys';",
+      'DROP INDEX IF EXISTS "ScheduledJob_jobId_key";',
+      'CREATE UNIQUE INDEX "ScheduledJob_jobId_key" ON "ScheduledJob" ("jobId");',
+    ]) {
+      expect(sql).toContain(line);
+    }
+  });
+
+  it("reproduces the DigitalProduct (FK detach + retirement) template's operative SQL", () => {
+    const sql = buildExactKeyRepairSql({
+      table: "DigitalProduct",
+      keyColumns: ["productId"],
+      survivorOrder: '"createdAt", id',
+      uniqueIndexName: "DigitalProduct_productId_key",
+      retirement: [
+        { column: "lifecycleStatus", value: "'retired'" },
+        { column: "coverageStatus", value: "'quarantined'" },
+        { column: "updatedAt", value: "now()" },
+      ],
+      naturalKeyForeignKeys: [
+        {
+          childTable: "CoworkerService",
+          constraint: "CoworkerService_digitalProductId_fkey",
+          childColumns: ["digitalProductId"],
+          parentColumns: ["productId"],
+          onDelete: "SET NULL",
+          onUpdate: "CASCADE",
+        },
+        {
+          childTable: "CoworkerOffer",
+          constraint: "CoworkerOffer_digitalProductId_fkey",
+          childColumns: ["digitalProductId"],
+          parentColumns: ["productId"],
+          onDelete: "SET NULL",
+          onUpdate: "CASCADE",
+        },
+      ],
+      reason: "BI-TEST — DigitalProduct full template.",
+    });
+    for (const line of [
+      'DROP CONSTRAINT IF EXISTS "CoworkerService_digitalProductId_fkey";',
+      'DROP CONSTRAINT IF EXISTS "CoworkerOffer_digitalProductId_fkey";',
+      '"lifecycleStatus" = \'retired\'',
+      "RAISE EXCEPTION 'DigitalProduct integrity repair left duplicate keys';",
+      'ADD CONSTRAINT "CoworkerService_digitalProductId_fkey"',
+      'ADD CONSTRAINT "CoworkerOffer_digitalProductId_fkey"',
+    ]) {
+      expect(sql).toContain(line);
+    }
+  });
+});

--- a/packages/db/src/migrations/exact-key-repair.ts
+++ b/packages/db/src/migrations/exact-key-repair.ts
@@ -1,0 +1,264 @@
+// Shared exact-key integrity repair authoring helper (BI-8EEEF8CB).
+//
+// THE PROBLEM
+// Between 2026-07-20 and 2026-07-29, eleven near-identical "repair <table>
+// index integrity" migrations landed, each a hand-written copy of the same
+// sequence (force heap scan -> rank duplicates -> collision-checked quarantine
+// rename -> assert no duplicate remains -> drop/recreate the unique index, with
+// an optional natural-key FK detach/reattach around it). The founder's framing:
+// duplicate data of this sort should be handled by a reliable PATTERN, not a
+// bespoke migration per table.
+//
+// A partial SQL-level helper already existed — the pg_temp
+// dpf_quarantine_duplicate_keys function inside
+// 20260720193000_repair_remaining_unique_index_integrity — but it is redeclared
+// inside every migration (pg_temp, never shared across files) and, critically,
+// it renames ONLY the key column. It has no RETIREMENT step, which is why
+// PR #3374 ("retire quarantined duplicate rows left active by the generic
+// dedupe", BI-8CCF7F13) had to follow up: the renamed losers were still active
+// and rendered as live ghost coworkers. The one hand-written migration that got
+// it right — 20260720133000_repair_digital_product_index_integrity — inlined
+// `lifecycleStatus = 'retired', coverageStatus = 'quarantined'` in the loser
+// UPDATE, but that variation could not be expressed by the generic function.
+//
+// THIS HELPER
+// A single, tested place that emits the COMPLETE ratified sequence from a
+// declarative config, with retirement SET clauses as a first-class field so a
+// future dedupe marks its losers non-live IN THE SAME statement and never needs
+// a #3374-style follow-up. The emitted output is plain, reviewable SQL written
+// to a Prisma migration file — DDL stays explicit in the migration for review,
+// while the SEQUENCE stops being copy-pasted.
+//
+// Ratified sequence: docs/superpowers/specs/2026-05-31-master-data-management-
+// alignment-design.md §5.5 (BI-7C2B91EF / DI-AED2CD86A2B0). Templates:
+// 20260720180000_repair_scheduled_job_index_integrity (simple) and
+// 20260720133000_repair_digital_product_index_integrity (natural-key FK detach).
+//
+// This is platform data-integrity capability ADJACENT to MDM, not a domain
+// registration inside it — the MDM merge substrate is domain-bound by a ratified
+// kernel decision and is the wrong home (see BI-8EEEF8CB investigation notes).
+
+/** A column set on every quarantined loser in the same UPDATE that renames the
+ *  key — the RETIREMENT step. `value` is raw SQL (e.g. `'retired'`, `now()`),
+ *  emitted verbatim, so the caller controls quoting. This is the field whose
+ *  absence forced the #3374 follow-up. */
+export interface RetirementAssignment {
+  /** Column name (unquoted; the emitter quotes it as an identifier). */
+  column: string;
+  /** Raw SQL value expression, emitted verbatim (e.g. "'retired'", "now()"). */
+  value: string;
+}
+
+/** A natural-key-targeting foreign key that must be detached before loser keys
+ *  move, so ON UPDATE CASCADE cannot drag a canonical child reference onto a
+ *  quarantined row, then reattached after the index is rebuilt. */
+export interface NaturalKeyForeignKey {
+  /** Child table holding the FK. */
+  childTable: string;
+  /** Constraint name (exact, as in the schema). */
+  constraint: string;
+  /** Child column(s) participating in the FK. */
+  childColumns: string[];
+  /** Parent column(s) referenced — the natural key, not `id`. */
+  parentColumns: string[];
+  /** ON DELETE action to restore (e.g. "CASCADE", "SET NULL", "RESTRICT"). */
+  onDelete: string;
+  /** ON UPDATE action to restore (typically "CASCADE"). */
+  onUpdate: string;
+}
+
+export interface ExactKeyRepairConfig {
+  /** Table whose unique key holds duplicates. */
+  table: string;
+  /** The unique key column(s). The PARTITION BY of the survivor ranking. */
+  keyColumns: string[];
+  /**
+   * Which single key column receives the reserved-namespace quarantine rename.
+   * Must be a text column. Defaults to the last of `keyColumns` (matching the
+   * multi-column precedent in the "remaining" migration, which renamed the
+   * second member of a two-column key).
+   */
+  quarantineColumn?: string;
+  /**
+   * ORDER BY inside the partition. Row 1 is the SURVIVOR; every other row is a
+   * quarantined loser. Raw SQL (e.g. `"createdAt", id` keeps the oldest;
+   * `"updatedAt" DESC, id DESC` keeps the freshest).
+   */
+  survivorOrder: string;
+  /** Exact name of the unique index to drop and recreate. */
+  uniqueIndexName: string;
+  /**
+   * Columns the rebuilt unique index covers. Defaults to `keyColumns` — set it
+   * only when the physical index column order differs from the key order.
+   */
+  indexColumns?: string[];
+  /**
+   * RETIREMENT: extra assignments applied to every loser in the rename UPDATE,
+   * marking it non-live so it does not render as a ghost. OMITTING THIS IS A
+   * DECISION, not a default — a table whose losers have a lifecycle/active
+   * status MUST retire them here or repeat the #3374 follow-up.
+   */
+  retirement?: RetirementAssignment[];
+  /** Natural-key FKs to detach before and reattach after the repair. */
+  naturalKeyForeignKeys?: NaturalKeyForeignKey[];
+  /** Header attestation line, e.g. "BI-XXXXXXXX — restore <Table> heap/index agreement." */
+  reason: string;
+}
+
+/** Quote a Postgres identifier: wrap in double quotes, escape embedded quotes. */
+function ident(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function assertValidIdentifier(name: string, role: string): void {
+  // Identifiers are authored by a migration developer, not user input, but a
+  // stray quote or newline would silently produce malformed SQL. Fail loud.
+  if (!name || /["\n\r;]/.test(name)) {
+    throw new Error(`exact-key-repair: invalid ${role} identifier ${JSON.stringify(name)}`);
+  }
+}
+
+/**
+ * Emit the complete ratified exact-key integrity repair as a single reviewable
+ * SQL migration body. Deterministic and pure — no DB access.
+ */
+export function buildExactKeyRepairSql(config: ExactKeyRepairConfig): string {
+  const {
+    table,
+    keyColumns,
+    survivorOrder,
+    uniqueIndexName,
+    retirement = [],
+    naturalKeyForeignKeys = [],
+    reason,
+  } = config;
+
+  if (keyColumns.length === 0) {
+    throw new Error("exact-key-repair: keyColumns must be non-empty");
+  }
+  if (!survivorOrder.trim()) {
+    throw new Error("exact-key-repair: survivorOrder is required (row 1 is the survivor)");
+  }
+  assertValidIdentifier(table, "table");
+  assertValidIdentifier(uniqueIndexName, "uniqueIndexName");
+  keyColumns.forEach((c) => assertValidIdentifier(c, "key column"));
+
+  const quarantineColumn = config.quarantineColumn ?? keyColumns[keyColumns.length - 1];
+  assertValidIdentifier(quarantineColumn, "quarantineColumn");
+  if (!keyColumns.includes(quarantineColumn)) {
+    throw new Error(
+      `exact-key-repair: quarantineColumn "${quarantineColumn}" must be one of keyColumns`,
+    );
+  }
+  const indexColumns = config.indexColumns ?? keyColumns;
+  indexColumns.forEach((c) => assertValidIdentifier(c, "index column"));
+  retirement.forEach((r) => assertValidIdentifier(r.column, "retirement column"));
+
+  const partitionBy = keyColumns.map(ident).join(", ");
+  const groupBy = keyColumns.map(ident).join(", ");
+  const retirementSets = retirement
+    .map((r) => `,\n      ${ident(r.column)} = ${r.value}`)
+    .join("");
+
+  const detachFks = naturalKeyForeignKeys
+    .map(
+      (fk) =>
+        `ALTER TABLE ${ident(fk.childTable)}\n  DROP CONSTRAINT IF EXISTS ${ident(fk.constraint)};`,
+    )
+    .join("\n");
+
+  const reattachFks = naturalKeyForeignKeys
+    .map((fk) => {
+      const childCols = fk.childColumns.map(ident).join(", ");
+      const parentCols = fk.parentColumns.map(ident).join(", ");
+      return (
+        `ALTER TABLE ${ident(fk.childTable)}\n` +
+        `  ADD CONSTRAINT ${ident(fk.constraint)}\n` +
+        `  FOREIGN KEY (${childCols}) REFERENCES ${ident(table)}(${parentCols})\n` +
+        `  ON DELETE ${fk.onDelete} ON UPDATE ${fk.onUpdate};`
+      );
+    })
+    .join("\n");
+
+  const fleetSafetyFk = naturalKeyForeignKeys.length
+    ? " The natural-key foreign keys are detached before loser keys move so ON" +
+      " UPDATE CASCADE cannot steal references from the canonical survivor, then" +
+      " restored to their exact prior definitions."
+    : "";
+  const fleetSafetyRetire = retirement.length
+    ? " Losers are marked non-live in the same statement that quarantines them," +
+      " so no follow-up migration is needed to hide them."
+    : "";
+
+  return `-- ${reason}
+--
+-- Generated by packages/db/src/migrations/exact-key-repair.ts
+-- (buildExactKeyRepairSql). Do not hand-edit the sequence; change the config
+-- and regenerate. Fleet safety: every conflicting row is RETAINED under a
+-- collision-checked reserved key, never deleted.${fleetSafetyFk}${fleetSafetyRetire}
+-- Clean installs change no data; the migration is idempotent and fails closed
+-- if any duplicate remains.
+
+BEGIN;
+
+-- Force heap scans so ranking, collision checks, and the final assertion read
+-- the true heap, never a btree that may itself be the corrupted structure.
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+${detachFks ? `\n${detachFks}\n` : ""}
+DO $$
+DECLARE
+  duplicate_row RECORD;
+  quarantine_key TEXT;
+BEGIN
+  FOR duplicate_row IN
+    WITH ranked AS MATERIALIZED (
+      SELECT
+        id,
+        ${ident(quarantineColumn)} AS original_key,
+        row_number() OVER (
+          PARTITION BY ${partitionBy}
+          ORDER BY ${survivorOrder}
+        ) AS duplicate_rank
+      FROM ${ident(table)}
+    )
+    SELECT id, original_key
+    FROM ranked
+    WHERE duplicate_rank > 1
+    ORDER BY original_key, id
+  LOOP
+    quarantine_key := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row.original_key;
+    WHILE EXISTS (
+      SELECT 1
+      FROM ${ident(table)}
+      WHERE ${ident(quarantineColumn)} = quarantine_key AND id <> duplicate_row.id
+    ) LOOP
+      quarantine_key := quarantine_key || '_';
+    END LOOP;
+
+    UPDATE ${ident(table)}
+    SET ${ident(quarantineColumn)} = quarantine_key${retirementSets}
+    WHERE id = duplicate_row.id;
+  END LOOP;
+END $$;
+
+-- Heap-grounded assertion: every index scan class is disabled above.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM ${ident(table)}
+    GROUP BY ${groupBy}
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION '${table} integrity repair left duplicate keys';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS ${ident(uniqueIndexName)};
+CREATE UNIQUE INDEX ${ident(uniqueIndexName)} ON ${ident(table)} (${indexColumns.map(ident).join(", ")});
+${reattachFks ? `\n${reattachFks}\n` : ""}
+COMMIT;
+`;
+}


### PR DESCRIPTION
Closes BI-8EEEF8CB.

## The problem

Between 2026-07-20 and 2026-07-29, **eleven** near-identical `repair <table> index integrity` migrations landed — each a hand-written copy of the same sequence. Founder framing: *duplicate data of this sort should be handled by a reliable **pattern**, not a bespoke migration per table.*

A partial SQL helper already existed — the `pg_temp` `dpf_quarantine_duplicate_keys` function inside `20260720193000_repair_remaining_unique_index_integrity` — but it has two gaps:

1. It's redeclared inside every migration (`pg_temp`), never shared across files.
2. **It renames only the key column — no retirement step.** That is exactly why [#3374](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3374) ("retire quarantined duplicate rows left active by the generic dedupe", BI-8CCF7F13) had to follow up: renamed losers stayed `active` and rendered as **live ghost coworkers**. The one migration that got it right (`20260720133000_repair_digital_product`) inlined the retirement SETs — but the generic function couldn't express that variation.

## What ships

- **`packages/db/src/migrations/exact-key-repair.ts`** — `buildExactKeyRepairSql(config)`, a pure, deterministic emitter of the complete ratified sequence (spec §5.5, BI-7C2B91EF): force heap scan → rank by declared survivor order → collision-checked `__dpf_quarantined__` rename → fail-closed heap-grounded assertion → drop/recreate the unique index, with optional natural-key FK detach-before / reattach-after. **Retirement is a first-class config field** — extra SET clauses applied to every loser in the *same* UPDATE that renames it, so a future dedupe marks losers non-live in one pass and never needs a #3374-style follow-up. Authoring a repair is now a config, not a 70-line copy.
- **20 structural tests** — sequence order, all three heap-scan disables, collision loop, assertion-before-rebuild, retirement in the rename UPDATE, FK detach/reattach ordering, composite keys, SQL-shape input validation, and golden equivalence with the two hand-written templates it replaces.
- **2 functional DB-backed tests** — the *emitted* SQL is executed against a real Postgres over seeded duplicates in an isolated scratch schema. Asserts: survivor kept (oldest), losers retired **and** renamed (never deleted), the rebuilt index genuinely rejects a duplicate insert, nothing lost, idempotent on a clean heap. Skips cleanly with no `DATABASE_URL`.
- **`index-integrity-guard.mjs` header corrected** — it claimed to be "Wired into migration-safety-guard.yml", but **no workflow invokes it**. The comment now states the truth and records why a CI cron would be theatre: CI's cluster is freshly `initdb`'d under glibc every run, so the musl→glibc collation flip this guard catches can never reproduce there.
- **Runbook updated** — the "durable fix … tracked in BI-8EEEF8CB" note now points at the shipped helper, with *"do not hand-copy a prior repair migration."*

## Scope

The BI's title — extract the shared repair helper with the retirement step — is delivered and functionally proven. The recurring **detection** half (a platform scheduled sweep against the live install DB that raises an advisory/BI on corruption) is a genuinely separable surface — a new Inngest function, the scheduling-map catalog + parity test, and an alert sink — filed as a tightly-scoped follow-up rather than bloating this PR. **Not silently dropped:** the guard header and runbook both record it.

MDM was assessed and ruled out as the home (domain-bound by a ratified kernel decision; zero rows on this install; no natural-key-FK concept) — the reasoning is in the BI, not re-litigated here.

**No live data migration:** this install currently holds 0 duplicates on the repaired tables, so the helper changes no data. It is migration-authoring tooling — hence no data-impact manifest applies.

## Verification

- **22/22 tests pass** (20 structural + 2 functional DB-backed).
- `packages/db` typecheck clean (exit 0).
- Pre-push gate overridden with reason: the isolated `packages/db` change is green; 3 unrelated DB-test files (`adapter-run-telemetry`, `discovery-sync.postgres`) fail on **pre-existing schema drift in the shared local CI postgres** (missing `AdapterRunTelemetry.traceId` migration) — this branch adds no migration and touches none of those tables. `apps/web` untouched (only a hook-regenerated `doc-index.generated.json`); its local scoped typecheck OOM/timeout is the known apps/web condition. CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)