### PR TITLE
feat(sim): business-activity simulator P2 — cross-archetype coverage matrix (BI-78B83F58)

### DIFF
--- a/apps/web/lib/business-activity-sim/archetype-flows.test.ts
+++ b/apps/web/lib/business-activity-sim/archetype-flows.test.ts
@@ -1,0 +1,82 @@
+// apps/web/lib/business-activity-sim/archetype-flows.test.ts
+import { describe, expect, it } from "vitest";
+import { ARCHETYPE_FLOWS, type ArchetypeFlow } from "./archetype-flows";
+import { FINANCIAL_ORACLES } from "./oracles";
+import { runArchetypeMatrix, matrixViolations } from "./matrix";
+
+const flowById = (id: string): ArchetypeFlow => {
+  const f = ARCHETYPE_FLOWS.find((x) => x.archetypeId === id);
+  if (!f) throw new Error(`no flow for ${id}`);
+  return f;
+};
+
+describe("archetype flows — every archetype bills through the shared spine", () => {
+  it("field-service (trades) reuses the real dispatch lifecycle and settles clean", () => {
+    const r = flowById("trades-maintenance").run({
+      id: "t",
+      customerAccountId: "c",
+      subtotal: 300,
+      taxAmount: 30,
+    });
+    expect(r.lifecycle).toContain("complete"); // real @dpf/validators status
+    expect(r.finalStatus).toBe("paid");
+    expect(r.revenueRecognized).toBe(300); // tax is not revenue
+    expect(r.cashReceived).toBe(330);
+    expect(r.receivableBalance).toBe(0);
+    expect(FINANCIAL_ORACLES.every((o) => o(r).ok)).toBe(true);
+  });
+
+  it("SaaS recognises the subscription as delivered before it invoices", () => {
+    const r = flowById("software-platform").run({ id: "s", customerAccountId: "c", subtotal: 99 });
+    expect(r.lifecycle).toEqual(["trial", "active", "invoiced", "paid"]);
+    expect(r.workCompletedBeforeInvoice).toBe(true); // "active" precedes "invoiced"
+    expect(r.revenueRecognized).toBe(99);
+    expect(FINANCIAL_ORACLES.every((o) => o(r).ok)).toBe(true);
+  });
+
+  it("retail fulfils at the counter then bills + settles, leaving correct AR on a partial pay", () => {
+    const r = flowById("retail-goods").run({
+      id: "r",
+      customerAccountId: "c",
+      subtotal: 200,
+      taxAmount: 20,
+      paymentAmount: 150,
+    });
+    expect(r.lifecycle).toContain("fulfilled");
+    expect(r.gross).toBe(220);
+    expect(r.receivableBalance).toBe(70); // 220 − 150
+    expect(FINANCIAL_ORACLES.every((o) => o(r).ok)).toBe(true);
+  });
+});
+
+describe("runArchetypeMatrix — cross-archetype coverage", () => {
+  it("passes every oracle for every archetype in the default matrix", () => {
+    const report = runArchetypeMatrix();
+    expect(report.passed).toBe(true);
+    expect(report.passRate).toBe(1);
+    expect(matrixViolations(report)).toEqual([]);
+    // one coverage row per registered archetype
+    expect(report.archetypes.map((a) => a.archetypeId).sort()).toEqual(
+      ["retail-goods", "software-platform", "trades-maintenance"],
+    );
+  });
+
+  it("surfaces the exact archetype + scenario + invariant when a flow is broken (teeth)", () => {
+    // A deliberately broken flow: it posts a payment but never delivers the service,
+    // yet still marks itself paid — phantom billing the matrix must catch.
+    const brokenFlow: ArchetypeFlow = {
+      archetypeId: "broken-archetype",
+      label: "Broken",
+      run: (s) => {
+        const good = flowById("software-platform").run(s);
+        return { ...good, workCompletedBeforeInvoice: false };
+      },
+      defaultScenarios: [{ id: "x", customerAccountId: "c", subtotal: 100 }],
+    };
+    const report = runArchetypeMatrix([brokenFlow]);
+    expect(report.passed).toBe(false);
+    expect(report.passRate).toBe(0);
+    const violations = matrixViolations(report);
+    expect(violations.some((v) => v.includes("broken-archetype/x") && v.includes("FIN5"))).toBe(true);
+  });
+});

--- a/apps/web/lib/business-activity-sim/archetype-flows.ts
+++ b/apps/web/lib/business-activity-sim/archetype-flows.ts
@@ -1,0 +1,119 @@
+// apps/web/lib/business-activity-sim/archetype-flows.ts
+//
+// Business Activity Simulator — per-archetype operational flows (P2).
+// EP-BUSINESS-ACTIVITY-SIM · BI-78B83F58.
+//
+// One BusinessFlow per archetype: an ordered operational lifecycle plus the shared
+// runBillingCycle. Field-service (trades) reuses the REAL @dpf/validators dispatch
+// vocabulary via P1's runFieldServiceFlow. SaaS and retail use sim-local
+// lifecycles — a deliberate FINDING, not an oversight: @dpf/validators has a rich
+// lifecycle ONLY for field-dispatch, so the operational vocabulary for non-trades
+// archetypes is a real substrate gap (a candidate follow-up BI). The financial
+// half is identical for all of them, which is exactly why one oracle set scores
+// the whole matrix.
+
+import { runFieldServiceFlow } from "./field-service-flow";
+import { runBillingCycle, type BillingInput, type FinancialFlowShape } from "./billing-cycle";
+
+export type ArchetypeScenario = BillingInput & { id: string };
+
+export type ArchetypeFlowResult = FinancialFlowShape & {
+  archetypeId: string;
+  scenarioId: string;
+  /** The operational lifecycle statuses the flow passed through, in order. */
+  lifecycle: string[];
+};
+
+/**
+ * A minimal operational lifecycle: the ordered statuses a job/subscription/order
+ * passes through to the terminal "paid", and which of them count as
+ * service-delivered (the states that precede — and therefore justify — the
+ * invoice). Every lifecycle ends in "invoiced" then "paid".
+ */
+type LifecycleSpec = {
+  statuses: string[];
+  workCompleteStatuses: string[];
+};
+
+function runGenericArchetypeFlow(
+  archetypeId: string,
+  spec: LifecycleSpec,
+  scenario: ArchetypeScenario,
+): ArchetypeFlowResult {
+  const billing = runBillingCycle(scenario);
+  const lifecycle: string[] = [];
+  let workCompletedBeforeInvoice = false;
+  for (const status of spec.statuses) {
+    lifecycle.push(status);
+    if (spec.workCompleteStatuses.includes(status) && status !== "invoiced" && status !== "paid") {
+      workCompletedBeforeInvoice = true;
+    }
+  }
+  return {
+    ...billing,
+    archetypeId,
+    scenarioId: scenario.id,
+    lifecycle,
+    finalStatus: lifecycle[lifecycle.length - 1],
+    workCompletedBeforeInvoice,
+  };
+}
+
+export type ArchetypeFlow = {
+  /** The real StorefrontArchetype id (packages/storefront-templates). */
+  archetypeId: string;
+  label: string;
+  run: (scenario: ArchetypeScenario) => ArchetypeFlowResult;
+  defaultScenarios: ArchetypeScenario[];
+};
+
+// SaaS: a subscription is delivered while "active", then billed and settled.
+const SAAS_SPEC: LifecycleSpec = {
+  statuses: ["trial", "active", "invoiced", "paid"],
+  workCompleteStatuses: ["active", "invoiced", "paid"],
+};
+
+// Retail POS: goods are fulfilled at the counter, then the receipt bills + settles.
+const RETAIL_SPEC: LifecycleSpec = {
+  statuses: ["cart", "checkout", "fulfilled", "invoiced", "paid"],
+  workCompleteStatuses: ["fulfilled", "invoiced", "paid"],
+};
+
+/**
+ * The archetype coverage set. Keyed by REAL StorefrontArchetype ids so the matrix
+ * maps 1:1 onto the platform's archetypes. Field-service delegates to P1 (real
+ * dispatch lifecycle); SaaS + retail use the generic lifecycle flow.
+ */
+export const ARCHETYPE_FLOWS: ArchetypeFlow[] = [
+  {
+    archetypeId: "trades-maintenance",
+    label: "Field service (trades)",
+    run: (scenario) => {
+      const r = runFieldServiceFlow(scenario);
+      return { ...r, archetypeId: "trades-maintenance" };
+    },
+    defaultScenarios: [
+      { id: "fs-taxed-full", customerAccountId: "fs-c1", subtotal: 300, taxAmount: 30 },
+      { id: "fs-untaxed-full", customerAccountId: "fs-c2", subtotal: 450 },
+      { id: "fs-partial", customerAccountId: "fs-c3", subtotal: 200, taxAmount: 20, paymentAmount: 150 },
+    ],
+  },
+  {
+    archetypeId: "software-platform",
+    label: "SaaS subscription",
+    run: (scenario) => runGenericArchetypeFlow("software-platform", SAAS_SPEC, scenario),
+    defaultScenarios: [
+      { id: "saas-monthly", customerAccountId: "saas-c1", subtotal: 99 },
+      { id: "saas-annual-taxed", customerAccountId: "saas-c2", subtotal: 1200, taxAmount: 96 },
+    ],
+  },
+  {
+    archetypeId: "retail-goods",
+    label: "Retail POS",
+    run: (scenario) => runGenericArchetypeFlow("retail-goods", RETAIL_SPEC, scenario),
+    defaultScenarios: [
+      { id: "retail-taxed", customerAccountId: "retail-c1", subtotal: 80, taxAmount: 8 },
+      { id: "retail-partial", customerAccountId: "retail-c2", subtotal: 200, taxAmount: 20, paymentAmount: 150 },
+    ],
+  },
+];

--- a/apps/web/lib/business-activity-sim/billing-cycle.ts
+++ b/apps/web/lib/business-activity-sim/billing-cycle.ts
@@ -1,0 +1,117 @@
+// apps/web/lib/business-activity-sim/billing-cycle.ts
+//
+// Business Activity Simulator — the UNIVERSAL billing cycle (P2).
+// EP-BUSINESS-ACTIVITY-SIM · BI-78B83F58.
+//
+// The invoice → payment → GL half of a business flow is the same across every
+// archetype: a service/subscription/order is billed, the customer pays, and the
+// ledger records Dr AR / Cr Revenue / Cr Tax then Dr Bank / Cr AR. Only the
+// pre-invoice OPERATIONAL lifecycle differs by archetype (dispatch vs
+// subscription vs POS). P1 proved this for field-service; P2 extracts the shared
+// financial engine here so every archetype flow posts through the SAME real pure
+// GL functions and the SAME oracles can score them all.
+
+import {
+  buildInvoicePostingLines,
+  buildPaymentPostingLines,
+  computeTrialBalance,
+  type JournalLineInput,
+  type LedgerAccountType,
+  type TrialBalance,
+  type TrialBalanceAccount,
+} from "@/lib/finance/ledger";
+import { SIM_ACCOUNTS } from "./field-service-flow";
+
+// Reuse P1's fixed chart of accounts (single COA for the whole sim).
+const SIM_ACCOUNT_LIST: TrialBalanceAccount[] = Object.values(SIM_ACCOUNTS).map((a) => ({
+  ...a,
+  type: a.type as LedgerAccountType,
+}));
+
+export type BillingInput = {
+  customerAccountId: string;
+  /** Net-of-tax revenue for the sale (major units). */
+  subtotal: number;
+  /** Sales tax charged (0 when none). */
+  taxAmount?: number;
+  /** How much the customer actually pays. Defaults to the gross (full settlement). */
+  paymentAmount?: number;
+};
+
+export type BillingResult = {
+  journal: JournalLineInput[];
+  trialBalance: TrialBalance;
+  subtotal: number;
+  taxAmount: number;
+  gross: number;
+  paymentAmount: number;
+  /** Revenue recognised (credit balance on the revenue account), major units. */
+  revenueRecognized: number;
+  /** Outstanding receivable after settlement (gross − paid), major units. */
+  receivableBalance: number;
+  /** Cash received into the bank account, major units. */
+  cashReceived: number;
+};
+
+/**
+ * Post the invoice + customer receipt for one sale through the REAL pure GL
+ * functions and return the journal, trial balance, and the financial summary the
+ * oracles assert on. Pure and deterministic — the shared spine every archetype
+ * flow bills through. (The operational lifecycle — when a job/subscription/order
+ * reaches these states — is tracked by the archetype flow, not here.)
+ */
+export function runBillingCycle(input: BillingInput): BillingResult {
+  const subtotal = Math.max(input.subtotal, 0);
+  const taxAmount = Math.max(input.taxAmount ?? 0, 0);
+  const gross = subtotal + taxAmount;
+  const paymentAmount = input.paymentAmount ?? gross;
+
+  const journal: JournalLineInput[] = [
+    // SD → FI billing document: Dr AR (gross) / Cr Revenue (subtotal) / Cr Tax.
+    ...buildInvoicePostingLines(
+      { subtotal, taxAmount, customerAccountId: input.customerAccountId },
+      {
+        revenueAccountId: SIM_ACCOUNTS.revenue.accountId,
+        receivablesAccountId: SIM_ACCOUNTS.receivables.accountId,
+        taxPayableAccountId: SIM_ACCOUNTS.taxPayable.accountId,
+      },
+    ),
+    // Customer receipt: Dr Bank / Cr AR — the settlement half of the cash cycle.
+    ...buildPaymentPostingLines(
+      { direction: "inbound", amount: paymentAmount, customerAccountId: input.customerAccountId },
+      {
+        bankAccountId: SIM_ACCOUNTS.bank.accountId,
+        receivablesAccountId: SIM_ACCOUNTS.receivables.accountId,
+      },
+    ),
+  ];
+
+  const trialBalance = computeTrialBalance(SIM_ACCOUNT_LIST, journal);
+  const balanceOf = (accountId: string) =>
+    trialBalance.rows.find((r) => r.accountId === accountId)?.balance ?? 0;
+
+  return {
+    journal,
+    trialBalance,
+    subtotal,
+    taxAmount,
+    gross,
+    paymentAmount,
+    revenueRecognized: balanceOf(SIM_ACCOUNTS.revenue.accountId),
+    receivableBalance: balanceOf(SIM_ACCOUNTS.receivables.accountId),
+    cashReceived: balanceOf(SIM_ACCOUNTS.bank.accountId),
+  };
+}
+
+/**
+ * The minimal shape every archetype flow result must expose for the shared
+ * financial + lifecycle oracles. Both P1's FieldServiceFlowResult and P2's
+ * ArchetypeFlowResult structurally satisfy it, so one oracle set scores them all.
+ */
+export type FinancialFlowShape = BillingResult & {
+  /** True once the job/subscription/order reached a service-delivered state
+   *  before it was invoiced (the guard behind the no-phantom-billing oracle). */
+  workCompletedBeforeInvoice: boolean;
+  /** The terminal lifecycle status the flow ended in ("paid" on the happy path). */
+  finalStatus: string;
+};

--- a/apps/web/lib/business-activity-sim/matrix.ts
+++ b/apps/web/lib/business-activity-sim/matrix.ts
@@ -1,0 +1,73 @@
+// apps/web/lib/business-activity-sim/matrix.ts
+//
+// Business Activity Simulator — cross-archetype coverage matrix (P2).
+// EP-BUSINESS-ACTIVITY-SIM · BI-78B83F58.
+//
+// Runs every archetype flow's default scenarios through the SHARED financial +
+// lifecycle oracles and reports a per-archetype pass/fail matrix. This is the
+// "does the operational surface actually work across every archetype?" answer,
+// runnable in CI. P3 renders this matrix graphically; P4 drives it on the live
+// portal.
+
+import { ARCHETYPE_FLOWS, type ArchetypeFlow } from "./archetype-flows";
+import { FINANCIAL_ORACLES, type SimOracleResult } from "./oracles";
+
+export type ArchetypeScenarioResult = {
+  scenarioId: string;
+  oracles: SimOracleResult[];
+  passed: boolean;
+};
+
+export type ArchetypeCoverage = {
+  archetypeId: string;
+  label: string;
+  scenarios: ArchetypeScenarioResult[];
+  passed: boolean;
+};
+
+export type ArchetypeMatrixReport = {
+  archetypes: ArchetypeCoverage[];
+  passed: boolean;
+  /** Fraction of archetypes with every scenario × oracle green (0..1). */
+  passRate: number;
+};
+
+/**
+ * Run the coverage matrix. Never throws — a scenario that violates an oracle is
+ * reported as `passed: false` with the specific violations, so a failing matrix
+ * points straight at the archetype + scenario + invariant that broke.
+ */
+export function runArchetypeMatrix(
+  flows: ArchetypeFlow[] = ARCHETYPE_FLOWS,
+): ArchetypeMatrixReport {
+  const archetypes: ArchetypeCoverage[] = flows.map((flow) => {
+    const scenarios: ArchetypeScenarioResult[] = flow.defaultScenarios.map((scenario) => {
+      const result = flow.run(scenario);
+      const oracles = FINANCIAL_ORACLES.map((oracle) => oracle(result));
+      return { scenarioId: scenario.id, oracles, passed: oracles.every((o) => o.ok) };
+    });
+    return {
+      archetypeId: flow.archetypeId,
+      label: flow.label,
+      scenarios,
+      passed: scenarios.every((s) => s.passed),
+    };
+  });
+  const passedCount = archetypes.filter((a) => a.passed).length;
+  return {
+    archetypes,
+    passed: archetypes.every((a) => a.passed),
+    passRate: archetypes.length ? passedCount / archetypes.length : 1,
+  };
+}
+
+/** Every oracle violation across the matrix, flattened for a one-line summary. */
+export function matrixViolations(report: ArchetypeMatrixReport): string[] {
+  return report.archetypes.flatMap((a) =>
+    a.scenarios.flatMap((s) =>
+      s.oracles
+        .filter((o) => !o.ok)
+        .flatMap((o) => o.violations.map((v) => `[${a.archetypeId}/${s.scenarioId}] ${o.id}: ${v}`)),
+    ),
+  );
+}

--- a/apps/web/lib/business-activity-sim/oracles.ts
+++ b/apps/web/lib/business-activity-sim/oracles.ts
@@ -1,16 +1,18 @@
 // apps/web/lib/business-activity-sim/oracles.ts
 //
-// Financial + lifecycle oracles for the field-service flow (P1).
-// EP-BUSINESS-ACTIVITY-SIM.
+// Financial + lifecycle oracles for the business-activity flows (P1 field-service;
+// generalized to every archetype in P2). EP-BUSINESS-ACTIVITY-SIM.
 //
-// Each oracle is a pure predicate over a FieldServiceFlowResult that names exactly
-// what broke, so a failing coverage run is diagnosable. Modelled on the existing
-// dispatch harness (packages/coworker-sim-harness/src/oracles.ts): a harness whose
-// oracles cannot catch a broken flow is useless — the negative tests prove they can.
+// Each oracle is a pure predicate over a FinancialFlowShape (the shared shape both
+// P1's FieldServiceFlowResult and P2's ArchetypeFlowResult satisfy) that names
+// exactly what broke, so a failing coverage run is diagnosable. Modelled on the
+// existing dispatch harness (packages/coworker-sim-harness/src/oracles.ts): a
+// harness whose oracles cannot catch a broken flow is useless — the negative
+// tests prove they can.
 
 import { toMinorUnits } from "@/lib/finance/ledger";
-import { isTerminalStatus } from "@dpf/validators";
-import { SIM_ACCOUNTS, type FieldServiceFlowResult } from "./field-service-flow";
+import { SIM_ACCOUNTS } from "./field-service-flow";
+import { type FinancialFlowShape } from "./billing-cycle";
 
 export type SimOracleResult = {
   id: string;
@@ -19,7 +21,7 @@ export type SimOracleResult = {
   violations: string[];
 };
 
-export type SimOracle = (result: FieldServiceFlowResult) => SimOracleResult;
+export type SimOracle = (result: FinancialFlowShape) => SimOracleResult;
 
 /** Equal to the cent — compares in integer minor units so float drift never lies. */
 function moneyEq(a: number, b: number): boolean {
@@ -77,17 +79,24 @@ export const FIN5_noPhantomBilling: SimOracle = (r) => {
   return { id: "FIN5", description: "no invoice without a completed job", ok: violations.length === 0, violations };
 };
 
-/** LC1 — the job ends in a terminal, paid state (the flow ran to completion). */
+/** LC1 — the flow ends in the terminal, paid state (it ran to completion). Every
+ *  archetype lifecycle terminates in a status literally named "paid", so this
+ *  reads the same across field-service / SaaS / retail without a per-archetype
+ *  terminal predicate. */
 export const LC1_terminalPaid: SimOracle = (r) => {
   const violations: string[] = [];
-  if (r.finalStatus !== "paid" || !isTerminalStatus(r.finalStatus)) {
-    violations.push(`job ended in '${r.finalStatus}', expected terminal 'paid'`);
+  if (r.finalStatus !== "paid") {
+    violations.push(`flow ended in '${r.finalStatus}', expected terminal 'paid'`);
   }
-  return { id: "LC1", description: "the job ends terminal-paid", ok: violations.length === 0, violations };
+  return { id: "LC1", description: "the flow ends terminal-paid", ok: violations.length === 0, violations };
 };
 
-/** All oracles run on every field-service scenario. */
-export const FIELD_SERVICE_ORACLES: SimOracle[] = [
+/**
+ * Every financial + lifecycle oracle. Applies to ANY archetype flow (they all
+ * bill through the shared runBillingCycle and end terminal-paid). `FINANCIAL_ORACLES`
+ * is the P2 name; `FIELD_SERVICE_ORACLES` is kept as a back-compat alias for P1.
+ */
+export const FINANCIAL_ORACLES: SimOracle[] = [
   FIN1_ledgerBalanced,
   FIN2_revenueRecognized,
   FIN3_receivableReconciles,
@@ -95,3 +104,6 @@ export const FIELD_SERVICE_ORACLES: SimOracle[] = [
   FIN5_noPhantomBilling,
   LC1_terminalPaid,
 ];
+
+/** @deprecated P1 name — use FINANCIAL_ORACLES. Retained so P1 imports keep working. */
+export const FIELD_SERVICE_ORACLES = FINANCIAL_ORACLES;

--- a/docs/superpowers/specs/2026-07-04-business-activity-simulator-design.md
+++ b/docs/superpowers/specs/2026-07-04-business-activity-simulator-design.md
@@ -1,7 +1,7 @@
 # Business Activity Simulator — design spec
 
-**Status:** draft · 2026-07-04
-**Epic:** EP-BUSINESS-ACTIVITY-SIM (to be filed)
+**Status:** P1 shipped (PR #2720, BI-FDAD8788) · **P2 shipped** (BI-78B83F58) · P3/P4 open (BI-E51D594F / BI-041735BC) · updated 2026-07-09
+**Epic:** EP-BUSINESS-ACTIVITY-SIM
 **Author:** platform (via Claude Code, operator Mark)
 **Related:** [[living-business-workforce-activity]] concept (the read-side viz); EP-TRADES-FIELD-SERVICE; the finance spine (PRs #2546/#2548/#2559)
 
@@ -42,9 +42,9 @@ A **Business Activity Simulator**: a test/dogfood harness that drives the *real*
 ## 5. Phases
 
 - **P1 — one archetype, end-to-end, real, DB-free (this PR).** Field-service: compose the *real* `field-dispatch` lifecycle with the *real* pure `ledger.ts` posting into a single orchestrated flow, with **financial oracles** (GL balanced, AR settles to zero, revenue recognized, cash received, no phantom billing, job terminal-paid). Deterministic, runs in CI, no DB, no auth. Proves the model + gives the first re-runnable confidence run. Ships with a self-test proving the oracles have teeth (a deliberately broken flow must fail them).
-- **P2 — generalize.** Archetype factories + scenario templates (software-platform subscriptions, retail POS) → the cross-archetype coverage matrix.
-- **P3 — DB-backed fidelity.** Drive the service layer (`ledger-service`, invoice/payment services) against a test Postgres with a real seeded COA, so persistence + account-resolution are covered too. Requires the auth-context shim (§6).
-- **P4 — observability + viz.** Emit business events to `agent-event-bus`/`TaskRun`; wire the test-only archetype toggle in the living-business viz (read-side).
+- **P2 — generalize (SHIPPED, BI-78B83F58).** Extracted the universal invoice→payment→GL half into `runBillingCycle`; added SaaS (`software-platform`) + retail (`retail-goods`) archetype flows keyed to real StorefrontArchetype ids; generalized the P1 oracles to a shared `FinancialFlowShape` so one oracle set scores every archetype; `runArchetypeMatrix` produces the per-archetype pass/fail matrix. **Finding:** only field-service has a rich lifecycle in `@dpf/validators`; SaaS/retail lifecycles are sim-local — a real substrate gap (candidate follow-up: an operational-lifecycle vocabulary for non-trades archetypes). DB-backed service-layer fidelity (test Postgres + seeded COA + auth-context shim) is folded into P4.
+- **P3 — graphical living-business view (BI-E51D594F).** The read-side: archetype + its TAM (geography / market segmentation) as the visual frame, with AI-coworker / human / partner activity animated within it (network-topology / factory-automation / Porter's / IT4IT framings), drill-in to the existing portal + value-stream views. UX-fit review required.
+- **P4 — stubbed live-portal activity + DB fidelity (BI-041735BC).** Drive real dispatch/invoice/payment/AR/AP on the live portal (service layer against a real DB) behind a **test-instance-only toggle**; emit business events to `agent-event-bus`/`TaskRun` for the P3 viz.
 
 ## 6. Invocation seam (the one real design question)
 


### PR DESCRIPTION
## Why

P1 proved the operational spine works for **one** archetype (field-service). P2 answers the operator's actual concern — **"is it solid across _every_ archetype?"** — with a CI-runnable coverage matrix.

## What

The invoice→payment→GL half of a business flow is identical across archetypes; only the pre-invoice operational lifecycle differs. P2 makes that structural:

- **`billing-cycle.ts`** — extracts the universal `runBillingCycle` (all archetypes post through the same real pure `ledger.ts`) + a `FinancialFlowShape` that both P1 and P2 results satisfy.
- **`oracles.ts`** — generalized from `FieldServiceFlowResult` → `FinancialFlowShape`, so one oracle set (FIN1-5 + LC1) scores **every** archetype. `FIELD_SERVICE_ORACLES` kept as a back-compat alias — **P1 is untouched, its 9 tests still green.**
- **`archetype-flows.ts`** — a `BusinessFlow` per archetype keyed to **real `StorefrontArchetype` ids**: `trades-maintenance` reuses P1's real `@dpf/validators` dispatch lifecycle; `software-platform` (SaaS) + `retail-goods` use sim-local lifecycles.
- **`matrix.ts`** — `runArchetypeMatrix()` → per-archetype pass/fail + `matrixViolations()` pinpointing archetype/scenario/invariant.
- **test** — per-archetype positive flows, the full matrix all-green, and a **"teeth"** case where a broken archetype (marks itself paid without delivering) is caught as `FIN5`.

## Finding (recorded in the spec)

Only field-service has a rich lifecycle in `@dpf/validators`; **SaaS/retail lifecycles are sim-local** — a real substrate gap and a candidate follow-up (an operational-lifecycle vocabulary for non-trades archetypes). The financial half being universal is exactly why one oracle set covers the matrix.

## Roadmap
Spec updated: **P3** graphical living-business view (BI-E51D594F) · **P4** stubbed live-portal activity + DB fidelity behind a test-instance toggle (BI-041735BC).

## Verification
- **14/14** vitest green (P1's 9 + P2's 5) · `tsc --noEmit` clean · Module Size Guard OK · pre-push local-CI gate passed.

BI-78B83F58 · EP-BUSINESS-ACTIVITY-SIM

🤖 Generated with [Claude Code](https://claude.com/claude-code)