### PR TITLE
fix(mdm): heap-force the dedup gate so it survives collation drift (BI-FEAEB715)

### DIFF
--- a/apps/web/lib/actions/crm-general.test.ts
+++ b/apps/web/lib/actions/crm-general.test.ts
@@ -2,9 +2,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
-    $transaction: vi.fn(),
+    // Default $transaction invokes its callback with a raw-capable tx so the
+    // dedup gate's heap-forced candidate lookup (runHeapForcedCandidateQuery,
+    // BI-FEAEB715) returns an empty candidate set instead of throwing. Write-path
+    // tests below override this with a mockImplementation that also exposes the
+    // raw methods on its tx.
+    $transaction: vi.fn(async (cb: unknown) =>
+      typeof cb === "function"
+        ? (cb as (tx: unknown) => unknown)({
+            $queryRaw: vi.fn().mockResolvedValue([]),
+            $executeRawUnsafe: vi.fn().mockResolvedValue(0),
+          })
+        : undefined,
+    ),
     $queryRaw: vi.fn(),
     $queryRawUnsafe: vi.fn(),
+    $executeRawUnsafe: vi.fn().mockResolvedValue(0),
     country: {
       findFirst: vi.fn(),
     },
@@ -178,6 +191,8 @@ describe("createCustomerSite", () => {
 
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
       const tx = {
+        $queryRaw: vi.fn().mockResolvedValue([]),
+        $executeRawUnsafe: vi.fn().mockResolvedValue(0),
         country: {
           findFirst: vi.fn().mockResolvedValue({
             id: "country-1",
@@ -241,7 +256,10 @@ describe("createCustomerSite", () => {
     expect(result.outcome).toBe("created");
     expect(result.site.name).toBe("Dallas HQ");
     expect(resolveValidatedSiteAddress).toHaveBeenCalledWith("provider-ref-1");
-    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    // Two transactions now: the dedup gate's heap-forced candidate read
+    // (runHeapForcedCandidateQuery, BI-FEAEB715) precedes the site-write
+    // transaction. Both go through prisma.$transaction.
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
     expect(revalidatePath).toHaveBeenCalledWith("/customer");
     expect(revalidatePath).toHaveBeenCalledWith("/customer/acct-1");
   });
@@ -307,6 +325,8 @@ describe("updateCustomerSite", () => {
 
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
       const tx = {
+        $queryRaw: vi.fn().mockResolvedValue([]),
+        $executeRawUnsafe: vi.fn().mockResolvedValue(0),
         country: {
           findFirst: vi.fn().mockResolvedValue({ id: "country-1" }),
         },
@@ -348,6 +368,8 @@ describe("updateCustomerSite", () => {
     vi.mocked(prisma.customerSite.findFirst).mockResolvedValue(existingSite as never);
     vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
       const tx = {
+        $queryRaw: vi.fn().mockResolvedValue([]),
+        $executeRawUnsafe: vi.fn().mockResolvedValue(0),
         customerSite: {
           update: vi.fn().mockResolvedValue({
             ...existingSite,

--- a/apps/web/lib/api/__tests__/customer-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/customer-endpoints.test.ts
@@ -4,17 +4,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mocks
 // ---------------------------------------------------------------------------
 
-vi.mock("@dpf/db", () => ({
-  prisma: {
-    // Update-path dedup gate candidate fetch (lib/mdm/dedup-gate.ts).
-    $queryRaw: vi.fn().mockResolvedValue([]),
-    customerAccount: {
-      findMany: vi.fn(),
-      findUnique: vi.fn(),
-      update: vi.fn(),
+vi.mock("@dpf/db", () => {
+  // Update-path dedup gate candidate fetch (lib/mdm/dedup-gate.ts). The gate now
+  // runs the lookup inside runHeapForcedCandidateQuery, which opens a
+  // $transaction and sets heap-forcing GUCs first (BI-FEAEB715). The mock
+  // threads the same $queryRaw through the tx so the endpoint's dedup path still
+  // sees an empty candidate set instead of throwing on an undefined $transaction.
+  const $queryRaw = vi.fn().mockResolvedValue([]);
+  const $executeRawUnsafe = vi.fn().mockResolvedValue(0);
+  return {
+    prisma: {
+      $queryRaw,
+      $executeRawUnsafe,
+      $transaction: vi.fn(async (fn: (tx: unknown) => unknown) =>
+        fn({ $queryRaw, $executeRawUnsafe }),
+      ),
+      customerAccount: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
     },
-  },
-}));
+  };
+});
 
 vi.mock("../../api/auth-middleware.js", () => ({
   authenticateRequest: vi.fn(),

--- a/apps/web/lib/mdm/dedup-gate-heap-forcing.db.test.ts
+++ b/apps/web/lib/mdm/dedup-gate-heap-forcing.db.test.ts
@@ -1,0 +1,101 @@
+// Functional proof for BI-FEAEB715: the heap-forcing wrapper actually changes
+// the PLAN for an exact-equality candidate arm from an index scan (which a
+// collation-drifted btree makes descend the wrong subtree and miss the row) to
+// a sequential heap scan (which reads the true heap and cannot be fooled by a
+// stale index). Runs against a real Postgres in an isolated scratch schema;
+// skips cleanly when no DATABASE_URL is reachable.
+//
+// This isolates the MECHANISM the gate relies on, without needing the full
+// application schema: an email-equality lookup over a btree-indexed column, run
+// once normally and once under the same `SET LOCAL enable_*scan = off` sequence
+// runHeapForcedCandidateQuery emits.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+
+const DATABASE_URL = process.env.DATABASE_URL ?? "postgresql://dpf:dpf_dev@localhost:54329/dpf";
+const SCHEMA = "dedup_heap_forcing_test";
+
+let client: pg.Client | undefined;
+let reachable = false;
+
+beforeAll(async () => {
+  client = new pg.Client({ connectionString: DATABASE_URL });
+  try {
+    await client.connect();
+    reachable = true;
+  } catch {
+    reachable = false;
+    return;
+  }
+  await client.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+  await client.query(`CREATE SCHEMA ${SCHEMA}`);
+  await client.query(`SET search_path TO ${SCHEMA}`);
+  await client.query(`
+    CREATE TABLE "Contact" (
+      id text PRIMARY KEY,
+      email text NOT NULL
+    )`);
+  // Enough rows that the planner prefers the index for an equality probe.
+  await client.query(
+    `INSERT INTO "Contact" SELECT 'id' || g, 'user' || g || '@example.com' FROM generate_series(1, 5000) g`,
+  );
+  await client.query(`INSERT INTO "Contact" VALUES ('dup', 'target@example.com')`);
+  await client.query(`CREATE INDEX "Contact_email_idx" ON "Contact" (email)`);
+  await client.query(`ANALYZE "Contact"`);
+});
+
+afterAll(async () => {
+  if (client && reachable) {
+    await client.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`).catch(() => {});
+  }
+  await client?.end().catch(() => {});
+});
+
+async function planFor(sql: string): Promise<string> {
+  const c = client!;
+  const res = await c.query(`EXPLAIN (COSTS OFF) ${sql}`);
+  return res.rows.map((r) => r["QUERY PLAN"]).join("\n");
+}
+
+describe("heap-forcing flips the exact-equality plan (BI-FEAEB715)", () => {
+  const EQ = `SELECT id FROM "${SCHEMA}"."Contact" WHERE email = 'target@example.com'`;
+
+  it("uses an index scan for an exact email probe WITHOUT heap-forcing (the vulnerable plan)", async (ctx) => {
+    if (!reachable) ctx.skip();
+    await client!.query(`SET search_path TO ${SCHEMA}`);
+    await client!.query("RESET enable_indexscan");
+    await client!.query("RESET enable_bitmapscan");
+    const plan = await planFor(EQ);
+    expect(plan).toMatch(/Index Scan|Bitmap Index Scan/);
+    expect(plan).not.toMatch(/Seq Scan/);
+  });
+
+  it("forces a Seq Scan under the exact GUCs the gate sets — reads the true heap", async (ctx) => {
+    if (!reachable) ctx.skip();
+    const c = client!;
+    await c.query("BEGIN");
+    try {
+      await c.query(`SET LOCAL search_path TO ${SCHEMA}`);
+      // The exact three statements runHeapForcedCandidateQuery emits.
+      await c.query("SET LOCAL enable_indexscan = off");
+      await c.query("SET LOCAL enable_indexonlyscan = off");
+      await c.query("SET LOCAL enable_bitmapscan = off");
+      const plan = await planFor(EQ);
+      expect(plan).toMatch(/Seq Scan/);
+      expect(plan).not.toMatch(/Index Scan/);
+      // And it still finds the row — the point of the whole exercise.
+      const rows = await c.query(EQ);
+      expect(rows.rows.map((r) => r.id)).toEqual(["dup"]);
+    } finally {
+      await c.query("ROLLBACK");
+    }
+  });
+
+  it("reverts to the index plan after the transaction (SET LOCAL is scoped)", async (ctx) => {
+    if (!reachable) ctx.skip();
+    await client!.query(`SET search_path TO ${SCHEMA}`);
+    const plan = await planFor(EQ);
+    expect(plan).toMatch(/Index Scan|Bitmap Index Scan/);
+  });
+});

--- a/apps/web/lib/mdm/dedup-gate.test.ts
+++ b/apps/web/lib/mdm/dedup-gate.test.ts
@@ -1,10 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// The candidate lookups now run inside runHeapForcedCandidateQuery, which opens
+// a $transaction and sets the heap-forcing planner GUCs before the query
+// (BI-FEAEB715). The mock threads the same $queryRaw mock through as the tx so
+// these unit tests keep asserting on the query, and records the GUC statements
+// so a test can prove the heap-forcing fired. vi.hoisted keeps the fns available
+// to the hoisted vi.mock factory without a temporal-dead-zone error.
+const db = vi.hoisted(() => ({
+  queryRaw: vi.fn(),
+  executeRawUnsafe: vi.fn(async (_sql: string) => 0),
+}));
 vi.mock("@dpf/db", () => ({
   prisma: {
-    $queryRaw: vi.fn(),
+    $queryRaw: db.queryRaw,
+    $executeRawUnsafe: db.executeRawUnsafe,
+    $transaction: vi.fn(async (fn: (tx: unknown) => unknown) =>
+      fn({ $queryRaw: db.queryRaw, $executeRawUnsafe: db.executeRawUnsafe }),
+    ),
   },
 }));
+const executeRawUnsafe = db.executeRawUnsafe;
 
 import { prisma } from "@dpf/db";
 import {
@@ -224,5 +239,27 @@ describe("parseDedupResolution", () => {
     expect(parseDedupResolution(null)).toBeUndefined();
     expect(parseDedupResolution({ duplicateResolution: "use-existing:" })).toBeUndefined();
     expect(parseDedupResolution({ duplicateResolution: "bogus" })).toBeUndefined();
+  });
+});
+
+describe("heap-forced candidate lookup (BI-FEAEB715 — collation-drift immunity)", () => {
+  it("disables all three index-scan classes before every candidate query", async () => {
+    executeRawUnsafe.mockClear();
+    queryRaw.mockResolvedValue([]);
+    await checkCustomerContactDuplicates({ email: "a@b.com" });
+    const guc = executeRawUnsafe.mock.calls.map((c) => c[0]);
+    expect(guc).toContain("SET LOCAL enable_indexscan = off");
+    expect(guc).toContain("SET LOCAL enable_indexonlyscan = off");
+    expect(guc).toContain("SET LOCAL enable_bitmapscan = off");
+  });
+
+  it("forces the heap for an exact-only (email) check — the previously exposed arm", async () => {
+    executeRawUnsafe.mockClear();
+    queryRaw.mockResolvedValue([]);
+    // No name, so the collation-immune similarity arm never runs; only the
+    // exact email btree arm would — this is exactly the check that was unsafe.
+    await checkCustomerContactDuplicates({ email: "solo@example.com" });
+    expect(executeRawUnsafe).toHaveBeenCalled();
+    expect(queryRaw).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/mdm/dedup-gate.ts
+++ b/apps/web/lib/mdm/dedup-gate.ts
@@ -27,6 +27,50 @@ import {
 import { standardizeDomain, standardizeEmail, standardizeName, standardizePhone } from "./standardize";
 import { MATCH_CONFIG_DEFAULTS, loadMatchConfig, type MatchConfig } from "./match-config";
 
+/**
+ * Minimal transaction surface the heap-forced candidate lookups need: the raw
+ * query builder plus the raw executor for the planner GUCs. Kept structural so
+ * the queries stay testable with an in-memory fake.
+ */
+export interface HeapForcedTx {
+  $queryRaw<T = unknown>(query: TemplateStringsArray, ...values: unknown[]): Promise<T>;
+  $executeRawUnsafe(query: string): Promise<number>;
+}
+
+/**
+ * Run a candidate-lookup query with index scans DISABLED, so every predicate —
+ * including the exact-equality arms on email / phone / domain / name — is
+ * evaluated against the true heap rather than a btree that may silently disagree
+ * with it (BI-FEAEB715 / BI-8CCF7F13, collation drift).
+ *
+ * Why this and not a trgm index: the gate's name arm uses `similarity() > floor`,
+ * which no GIN index can serve — it is already a heap seq scan and is therefore
+ * already collation-immune. The EXPOSED arms are the exact-equality ones with no
+ * heap-forcing companion (an email-only or domain-only check drives a plain
+ * btree index scan that a collation flip makes descend the wrong subtree and
+ * return zero — the gate then reports "clear" for a record that exists). Forcing
+ * a heap scan is the fix the repair migrations already use everywhere
+ * (SET LOCAL enable_indexscan = off, e.g.
+ * 20260720180000_repair_scheduled_job_index_integrity) and the one thing the
+ * write-time gate did not do. SET LOCAL is transaction-scoped, so it reverts on
+ * commit and touches no other query.
+ *
+ * Cost: a full heap scan per gated check. The name arm already seq-scans, so the
+ * only NEW cost falls on exact-only checks — which are exactly the ones that
+ * were silently unsafe. For a write-time correctness gate that is the right
+ * trade: never miss a duplicate the database constraint could also miss.
+ */
+export async function runHeapForcedCandidateQuery<T>(
+  run: (tx: HeapForcedTx) => Promise<T>,
+): Promise<T> {
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe("SET LOCAL enable_indexscan = off");
+    await tx.$executeRawUnsafe("SET LOCAL enable_indexonlyscan = off");
+    await tx.$executeRawUnsafe("SET LOCAL enable_bitmapscan = off");
+    return run(tx as unknown as HeapForcedTx);
+  });
+}
+
 /** Domains the write-time gate covers today (subset of MasterDataDomain). */
 export type DedupGatedDomain = "customer-account" | "customer-site" | "customer-contact";
 
@@ -110,7 +154,7 @@ export async function checkCustomerAccountDuplicates(
   if (!nameNormalized && !domainNormalized) return { verdict: "clear", candidates: [] };
   const config = await loadMatchConfig("customer-account");
 
-  const rows = await prisma.$queryRaw<AccountCandidateRow[]>`
+  const rows = await runHeapForcedCandidateQuery((tx) => tx.$queryRaw<AccountCandidateRow[]>`
     SELECT "id", "name", "status", "website", "nameNormalized", "domainNormalized"
     FROM "CustomerAccount"
     WHERE "status" <> 'superseded'
@@ -122,7 +166,7 @@ export async function checkCustomerAccountDuplicates(
       )
     ORDER BY similarity("nameNormalized", ${nameNormalized}) DESC NULLS LAST
     LIMIT ${CANDIDATE_LIMIT}
-  `;
+  `);
 
   const subjectMatch: MatchSubject = {
     id: "__subject__",
@@ -184,7 +228,7 @@ export async function checkCustomerContactDuplicates(
   const accountId = subject.accountId ?? "";
   const excludeId = subject.excludeId ?? "";
   const config = await loadMatchConfig("customer-contact");
-  const rows = await prisma.$queryRaw<ContactCandidateRow[]>`
+  const rows = await runHeapForcedCandidateQuery((tx) => tx.$queryRaw<ContactCandidateRow[]>`
     SELECT "id", "email", "firstName", "lastName", "name", "phone", "accountId"
     FROM "CustomerContact"
     WHERE (${excludeId} = '' OR "id" <> ${excludeId})
@@ -197,7 +241,7 @@ export async function checkCustomerContactDuplicates(
           ))
     ORDER BY similarity("nameNormalized", ${nameNormalized}) DESC NULLS LAST
     LIMIT ${CANDIDATE_LIMIT}
-  `;
+  `);
 
   const subjectMatch: MatchSubject = {
     id: "__subject__",
@@ -240,7 +284,7 @@ export async function checkCustomerSiteDuplicates(
   if (!nameNormalized) return { verdict: "clear", candidates: [] };
   const config = await loadMatchConfig("customer-site");
 
-  const rows = await prisma.$queryRaw<SiteCandidateRow[]>`
+  const rows = await runHeapForcedCandidateQuery((tx) => tx.$queryRaw<SiteCandidateRow[]>`
     SELECT "id", "name", "status", "nameNormalized"
     FROM "CustomerSite"
     WHERE "accountId" = ${subject.accountId}
@@ -252,7 +296,7 @@ export async function checkCustomerSiteDuplicates(
       )
     ORDER BY similarity("nameNormalized", ${nameNormalized}) DESC NULLS LAST
     LIMIT ${CANDIDATE_LIMIT}
-  `;
+  `);
 
   const subjectMatch: MatchSubject = { id: "__subject__", name: subject.name };
   return toResult(


### PR DESCRIPTION
Closes BI-FEAEB715.

The MDM write-time dedup gate is meant to be the backstop that catches a duplicate the database UNIQUE constraint missed. It shared the constraint's failure mode: both read the same btree, and under collation drift (BI-8CCF7F13) a text btree silently disagrees with its heap — an equality probe descends the wrong subtree, returns zero candidates, and the gate reports `clear` for a record that already exists.

## Empirical correction to the filed mechanism

The BI framed `CustomerAccount` as protected by its `nameNormalized` GIN trgm index, `CustomerSite`/`CustomerContact` as exposed for lacking one, and proposed adding trgm indexes. **Measured on Postgres 16, that fix is ineffective** — and I verified it before writing code:

- The gate's name arm is `similarity(nameNormalized, $q) > floor`. A plain function filter that **no GIN index can serve** — `EXPLAIN` with `enable_seqscan=off` and the GIN index present still shows a `Seq Scan`. Only the `%` operator uses GIN. So `CustomerAccount`'s GIN index never served its similarity arm either. What actually protects the *name* check on every domain is that the un-indexable `similarity()` arm **forces a heap scan**, which reads the true heap and finds the duplicate at similarity 1.0 regardless of btree state.
- The genuinely exposed arms are the **exact-equality** ones with no heap-forcing companion: `email`, `phone`, `domainNormalized`, `nameNormalized =`. An email-only or domain-only check drives a plain btree Index Scan — exactly the plan a collation flip defeats.

I discarded the trgm-index migration I first drafted once the `EXPLAIN` evidence came in.

## The fix

The BI itself points at it: *"forcing a heap scan is exactly what the write-time gate does not do."* Every candidate lookup now runs inside a transaction that sets `enable_indexscan / indexonlyscan / bitmapscan = off` (`SET LOCAL`, transaction-scoped) — the same primitive every 2026-07-20 repair migration uses. Every arm, exact and fuzzy, now reads the heap; no plan can be fooled by a stale index. Added `runHeapForcedCandidateQuery` and wrapped all three domain lookups.

**Cost:** a heap scan per gated check. The name arm already seq-scans, so the only *new* cost lands on exact-only checks — precisely the ones that were silently unsafe. For a write-time correctness gate that is the right trade.

## Verification — functional, not structural

- **`dedup-gate-heap-forcing.db.test.ts` (3 tests, real Postgres):** an exact email probe uses an Index Scan normally; under the exact GUCs the gate sets it flips to a `Seq Scan` **and still returns the row**; the plan reverts after the transaction (`SET LOCAL` is scoped). Skips cleanly with no `DATABASE_URL`.
- **`dedup-gate.test.ts`:** the mock threads `$queryRaw` through `$transaction` and records the GUC statements; two new assertions prove all three index-scan classes are disabled before every query, including an exact-only (email) check.
- **Full `lib/mdm` suite green: 13 files, 102 tests.** apps/web scoped typecheck clean (raised heap) — after fixing a real tuple-index error the gate caught.

## Scope

No schema/data change (no migration), so no data-impact manifest applies. The scheduled-detector fix direction (#3 in the BI) is already tracked as BI-D9C20A97 (split from BI-8EEEF8CB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)