### PR TITLE
fix(auth): de-bomb mcp-api-token rotation test (repo-wide merge-queue unblock)

### DIFF
--- a/apps/web/lib/auth/mcp-api-token.test.ts
+++ b/apps/web/lib/auth/mcp-api-token.test.ts
@@ -530,7 +530,7 @@ describe("rotateMcpApiToken", () => {
       scope: "write",
       capability: "write",
       scopes: ["backlog_read", "backlog_write"],
-      expiresAt: new Date("2026-08-01T00:00:00Z"),
+      expiresAt: new Date("2999-01-01T00:00:00Z"),
       revokedAt: null,
     });
 
@@ -550,7 +550,7 @@ describe("rotateMcpApiToken", () => {
         scope: "write",
         capability: "write",
         scopes: ["backlog_read", "backlog_write"],
-        expiresAt: new Date("2026-08-01T00:00:00Z"),
+        expiresAt: new Date("2999-01-01T00:00:00Z"),
         tokenSuffix: expect.any(String),
         secretEnc: expect.stringMatching(/^enc:/),
       }),


### PR DESCRIPTION
## Repo-wide merge-queue unblock

`apps/web/lib/auth/mcp-api-token.test.ts` hardcoded `expiresAt: 2026-08-01T00:00:00Z` (lines 533, 553) for two tokens the rotation tests expect to be **active**. As of **2026-08-01** that date is now/past, so `rotateMcpApiToken` correctly refuses the expired tokens and both tests go red — **for every PR in the merge queue today**, not just one. It's a latent date-rollover time-bomb in the fixture, not a code regression.

Fix: far-future fixed expiry (`2999-01-01`) so the fixtures stay active and it never re-bombs. Test-only, 2 lines, **35/35 pass** locally.

Priority: this blocks all merges today — merging it green unblocks the queue.

Local-CI-Override: Test-only 2-line fixture date fix unblocking a repo-wide merge-queue date-bomb; targeted test 35/35 green; CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)