### PR TITLE
fix(release): keep publishing the Release even if the Edge binary build fails

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,9 +6,10 @@ name: Publish GitHub Release
 # (git describe is the canonical platform version - see version.json and
 # apps/web/lib/platform/version.ts). This workflow turns those tags into
 # official, dated Release entries. Every Release automatically carries the
-# source archives GitHub generates (.zip / .tar.gz), which are downloadable
-# and counted per-asset - so the project finally accrues a real
-# downloads-over-time series instead of relying on uncounted git clones.
+# source archives GitHub generates (.zip / .tar.gz) - but GitHub does NOT
+# expose per-download counts for those auto-generated archives. The real
+# downloads-over-time series comes from the *uploaded* native Edge binaries
+# this workflow attaches (below); only uploaded assets carry a download_count.
 #
 # Docker image publishing is handled separately by publish-image.yml. This
 # workflow also attaches the integrity-bound native Edge binaries required for
@@ -86,22 +87,38 @@ jobs:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
-          git checkout --detach "refs/tags/${TAG}"
-          make -C services/edge-node-go build-darwin-arm64 VERSION="${TAG}"
-          make -C services/edge-node-go build-windows-amd64 VERSION="${TAG}"
-          cd services/edge-node-go/bin
-          sha256sum dpf-edge-node-darwin-arm64 dpf-edge-node-windows-amd64.exe > dpf-edge-node-checksums.sha256
-          cd ../../..
-          if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+
+          # 1. Ensure the Release exists FIRST. Creating it up front means a
+          #    later binary-build failure degrades to a source-only Release
+          #    rather than blocking the Release (and its notes) entirely.
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists - reusing it (idempotent)."
+          else
             gh release create "${TAG}" \
               --repo "${GITHUB_REPOSITORY}" \
               --title "${TAG}" \
               --generate-notes \
               --verify-tag
+            echo "Created GitHub Release ${TAG}."
           fi
-          gh release upload "${TAG}" \
-            services/edge-node-go/bin/dpf-edge-node-darwin-arm64 \
-            services/edge-node-go/bin/dpf-edge-node-windows-amd64.exe \
-            services/edge-node-go/bin/dpf-edge-node-checksums.sha256 \
-            --repo "${GITHUB_REPOSITORY}" --clobber
-          echo "Published GitHub Release ${TAG} with native Edge assets."
+
+          # 2. Build + attach the native Edge binaries from the tag's tree.
+          #    These uploaded assets are what carry per-download counters.
+          #    A build failure here must NOT delete the Release, so the make
+          #    steps run in an `if` (which suspends `set -e`); on failure we
+          #    warn and leave the source-only Release in place.
+          git checkout --detach "refs/tags/${TAG}"
+          if make -C services/edge-node-go build-darwin-arm64 VERSION="${TAG}" \
+             && make -C services/edge-node-go build-windows-amd64 VERSION="${TAG}"; then
+            ( cd services/edge-node-go/bin \
+              && sha256sum dpf-edge-node-darwin-arm64 dpf-edge-node-windows-amd64.exe \
+                 > dpf-edge-node-checksums.sha256 )
+            gh release upload "${TAG}" \
+              services/edge-node-go/bin/dpf-edge-node-darwin-arm64 \
+              services/edge-node-go/bin/dpf-edge-node-windows-amd64.exe \
+              services/edge-node-go/bin/dpf-edge-node-checksums.sha256 \
+              --repo "${GITHUB_REPOSITORY}" --clobber
+            echo "Attached native Edge assets to Release ${TAG}."
+          else
+            echo "::warning::Edge binary build failed for ${TAG}; published a source-only Release. Re-run this workflow after fixing the build to attach the counted binary assets."
+          fi


### PR DESCRIPTION
## What

Two hardening fixes to `.github/workflows/publish-release.yml`, both aimed at making releases reliably accrue **download counts**.

## Why

Investigating why the existing releases show `assets=0` / no download numbers turned up two things:

1. **A resilience gap.** The workflow ran the Go cross-compile of the native Edge binaries *before* creating the Release, under `set -euo pipefail`. So if that `make` ever fails, the step aborts and **no Release (or release notes) is published at all** for that tag — a build hiccup takes down the whole release, not just the binaries.
2. **A misleading comment.** The header claimed the auto-generated source archives are *"downloadable and counted per-asset."* They're downloadable but **not** counted — GitHub only exposes a `download_count` for *uploaded* assets. That misconception is exactly why the existing source-only releases show no download numbers.

## Changes

1. **Reorder:** create the Release first, then build + attach the Edge binaries. The build/upload is isolated in an `if` (which suspends `set -e`), so a build failure now **degrades to a source-only Release** with a `::warning::` telling you to re-run once the build is fixed — instead of blocking the Release entirely. Idempotent and re-runnable (`gh release upload --clobber`).
2. **Fix the comment** to state accurately that only the uploaded Edge binaries carry per-download counters.

## Behaviour after merge
- A healthy tag → Release **with** the 3 counted binary assets (darwin-arm64, windows-amd64, checksums) — download counts start accruing.
- A tag where the Edge build breaks → source-only Release still published + a warning, rather than a missing release.

## Not changed
The intentional native-Edge-binary attachment itself is preserved — this only reorders it and corrects the comment. Source-distribution behaviour and triggers are unchanged.

## Context
Follow-up to the release/traffic work in #2038 and #2039 (both merged). The `assets=0` on the current `v6.4.0`/`v6.5.0`/`v6.5.1` releases is historical — those were cut by the earlier source-only workflow version; this change makes future releases carry counted assets.

https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2

---
_Generated by [Claude Code](https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2)_