### PR TITLE
feat(tools): soft guard for the standing tool surface (plane 4)

### DIFF
--- a/scripts/check-tool-surface.mjs
+++ b/scripts/check-tool-surface.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+// scripts/check-tool-surface.mjs
+//
+// Plane-4 (tool surface) sibling of the plane-3 context-economy guard. Same doctrine,
+// same soft shape, and it REUSES that guard's review machinery rather than restating it:
+// one rule about how claims come due, applied to two planes.
+//
+// WHAT IS ALREADY GOVERNED — and therefore what this does NOT do. The DISPATCH path is
+// in good shape and this guard deliberately leaves it alone:
+//   • the per-turn attachment cap is bounded by LOCAL_TOOL_SELECTION_CLIFF for the
+//     cliff-prone small-local class, not merely by window-fit
+//     (apps/web/lib/actions/coworker-tool-budget.ts);
+//   • MAX_COWORKER_ATTACHED_TOOLS is a hard ceiling above that;
+//   • the long tail loads on demand, so the cap costs cost, not capability;
+//   • tool DESCRIPTIONS are already enforced (tool-description-hygiene.test.ts, P5).
+//
+// WHAT IS NOT GOVERNED, and is the whole point of this file: the STANDING REGISTRY. Tool
+// definitions accumulate in apps/web/lib/mcp/packs/* with nothing asking why. Every added
+// tool is permanent: it enlarges the selection space every surface that lists tools must
+// discriminate within, and the definition-token tax paid by any client that lists them
+// all. `estimateToolDefinitionTokens` exists (lib/tak/context-economy-metrics.ts) but its
+// own header says it changes nothing that is sent — a thermometer, exactly as the runtime
+// context plane was before BI-3E218D80.
+//
+// A BIGGER REGISTRY IS NOT AUTOMATICALLY WORSE. Tools are capability, and capability is
+// the point. So this guard does not cap the registry and never says no. It says: growth is
+// permitted, growth in SILENCE is not — and the claim you record comes due, because
+// "this tool earns its place" is a prediction like any other.
+//
+//   node scripts/check-tool-surface.mjs            # check (CI)
+//   node scripts/check-tool-surface.mjs --update   # re-baseline, then write the reasons
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  DEFAULT_REVIEW_BY_DAYS,
+  enforceClaimReview,
+  reviewClaims,
+} from "./check-context-economy.mjs";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BASELINE_PATH = join(REPO_ROOT, "scripts", "tool-surface-baseline.json");
+const PACKS_DIR = join(REPO_ROOT, "apps", "web", "lib", "mcp", "packs");
+const TIER_REL = join("apps", "web", "lib", "mcp", "tool-tier.ts");
+const BUDGET_REL = join("apps", "web", "lib", "actions", "coworker-tool-budget.ts");
+const METRICS_REL = join("apps", "web", "lib", "tak", "context-economy-metrics.ts");
+
+// ── Measurement (pure) ──────────────────────────────────────────────────────────
+
+const TOOL_NAME_RE = /^\s+name: "[a-z_][a-z0-9_]*",/gm;
+const INPUT_SCHEMA_RE = /^\s+inputSchema:/gm;
+
+function countMatches(source, re) {
+  return (source.match(re) ?? []).length;
+}
+
+/**
+ * Count model-facing tool definitions in one pack source.
+ *
+ * `inputSchema` IS THE AUTHORITATIVE MARKER, not `name`. This was learned the hard way:
+ * counting `name:` reported 350 repo-wide, but public-web-design-pack.ts carries three
+ * extra `name:` fields inside JSON-RPC `params` payloads where its handlers CALL another
+ * MCP server (`params: { name: "browse_open" }`). Those are outbound calls, not
+ * definitions — the real total is 347. Every ToolDefinition has exactly one
+ * `inputSchema`, and handler code has none, so the schema count is the honest one.
+ *
+ * `name` is retained purely as a tripwire in the one direction that cannot happen
+ * legitimately: MORE schemas than names would mean the ToolDefinition shape itself
+ * changed, and the count could no longer be trusted. More names than schemas is normal
+ * and expected. A guard built on a quietly wrong measurement is worse than no guard, so
+ * this reports the broken direction rather than guessing.
+ */
+export function countPackTools(source) {
+  const byName = countMatches(source, TOOL_NAME_RE);
+  const bySchema = countMatches(source, INPUT_SCHEMA_RE);
+  return { byName, bySchema, tools: bySchema, agrees: bySchema <= byName };
+}
+
+/** Number of entries in the `CORE_MCP_TOOL_NAMES` set — the opt-in lean tier. */
+export function countCoreTierTools(tierSource) {
+  const block = /CORE_MCP_TOOL_NAMES[\s\S]*?\]\)/.exec(tierSource);
+  if (!block) return null;
+  return countMatches(block[0], /^\s+"[a-z_][a-z0-9_]*",?$/gm);
+}
+
+/** Read a named numeric constant, e.g. `export const MAX_COWORKER_ATTACHED_TOOLS = 48;`. */
+export function readNumericConstant(source, name) {
+  const m = new RegExp(`${name}\\s*=\\s*(\\d[\\d_]*)`).exec(source);
+  return m ? Number(m[1].replaceAll("_", "")) : null;
+}
+
+/**
+ * The measured standing surface, as flat `key -> number` entries the baseline holds.
+ * `packSources` is a map of filename -> source so disagreements can be named per file.
+ */
+export function measureToolSurface({ packSources, tierSource, budgetSource, metricsSource }) {
+  const measured = {};
+  const disagreements = [];
+  let tools = 0;
+  let packs = 0;
+
+  for (const [file, source] of Object.entries(packSources)) {
+    const { byName, bySchema, tools: packTools, agrees } = countPackTools(source);
+    if (!agrees) {
+      disagreements.push(`${file}: ${bySchema} inputSchema fields exceed ${byName} name fields`);
+    }
+    tools += packTools;
+    packs += 1;
+  }
+
+  measured["registry.toolDefinitions"] = tools;
+  measured["registry.packFiles"] = packs;
+
+  const core = countCoreTierTools(tierSource);
+  if (core !== null) measured["tier.coreToolNames"] = core;
+
+  const maxAttached = readNumericConstant(budgetSource, "MAX_COWORKER_ATTACHED_TOOLS");
+  if (maxAttached !== null) measured["dispatch.maxAttachedTools"] = maxAttached;
+
+  const cliff = readNumericConstant(metricsSource, "LOCAL_TOOL_SELECTION_CLIFF");
+
+  return { measured, disagreements, cliff };
+}
+
+// ── Evaluation (pure) ───────────────────────────────────────────────────────────
+
+/**
+ * Same three rules as the plane-3 guard: no silent drift past the baseline, a raised
+ * baseline needs a substantive reason, shrink is welcome. Growth is never forbidden.
+ */
+export function evaluateToolSurface({ measured, baseline, baseBaseline, disagreements = [] }) {
+  const errors = [];
+  const notes = [];
+  const justified = [];
+
+  for (const d of disagreements) {
+    errors.push(
+      `tool-definition shape disagreement in ${d} — the count cannot be trusted, so this ` +
+        `guard refuses to report a number rather than quietly measuring the wrong thing.`,
+    );
+  }
+
+  for (const [key, now] of Object.entries(measured)) {
+    const entry = baseline?.[key];
+    if (!entry || typeof entry.value !== "number") {
+      errors.push(`${key} is measured at ${now} but missing from the baseline — run --update.`);
+      continue;
+    }
+
+    if (now > entry.value) {
+      errors.push(
+        `${key} grew ${entry.value} -> ${now} without re-baselining. Growth is allowed — ` +
+          `raise the baseline and record WHY this tool earns a permanent place in the ` +
+          `selection space every surface must discriminate within.`,
+      );
+      continue;
+    }
+
+    const was = baseBaseline?.[key]?.value;
+    if (typeof was === "number" && entry.value > was) {
+      const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
+      if (reason.length < 20) {
+        errors.push(
+          `${key} baseline was raised ${was} -> ${entry.value} with no substantive reason. ` +
+            `Say what capability it buys and why an existing tool could not carry it — a bare ` +
+            `"added a tool" is the attestation theater these guards exist to prevent.`,
+        );
+      } else {
+        justified.push(`${key} ${was} -> ${entry.value}: ${reason}`);
+      }
+    }
+
+    if (now < entry.value) {
+      notes.push(`${key} is ${now}, below its ${entry.value} baseline — run --update to keep the gain.`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors, notes, justified };
+}
+
+// ── I/O ─────────────────────────────────────────────────────────────────────────
+
+function readPackSources() {
+  const sources = {};
+  for (const file of readdirSync(PACKS_DIR)) {
+    if (!file.endsWith(".ts") || file.includes(".test.")) continue;
+    sources[file] = readFileSync(join(PACKS_DIR, file), "utf8");
+  }
+  return sources;
+}
+
+function readBaseline(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")).entries ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readBaselineAtBase() {
+  try {
+    const out = execFileSync("git", ["show", "origin/main:scripts/tool-surface-baseline.json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return JSON.parse(out).entries ?? null;
+  } catch {
+    // Same fail-open contract as the plane-3 guard: a missing comparison must never
+    // invent a violation.
+    return null;
+  }
+}
+
+function main() {
+  const { measured, disagreements, cliff } = measureToolSurface({
+    packSources: readPackSources(),
+    tierSource: readFileSync(join(REPO_ROOT, TIER_REL), "utf8"),
+    budgetSource: readFileSync(join(REPO_ROOT, BUDGET_REL), "utf8"),
+    metricsSource: readFileSync(join(REPO_ROOT, METRICS_REL), "utf8"),
+  });
+
+  if (process.argv.includes("--update")) {
+    const existing = readBaseline(BASELINE_PATH) ?? {};
+    const entries = {};
+    for (const [key, value] of Object.entries(measured)) {
+      const prior = existing[key];
+      entries[key] = {
+        value,
+        ...(prior && prior.value === value && prior.reason
+          ? {
+              reason: prior.reason,
+              ...(prior.recordedAt ? { recordedAt: prior.recordedAt } : {}),
+              ...(prior.reviewByDays ? { reviewByDays: prior.reviewByDays } : {}),
+            }
+          : {}),
+      };
+    }
+    writeFileSync(
+      BASELINE_PATH,
+      JSON.stringify(
+        {
+          _comment:
+            "Plane-4 standing tool-surface baseline (scripts/check-tool-surface.mjs). Growth is " +
+            "ALLOWED but never silent: raise a value and record `reason` + `recordedAt` saying " +
+            "what capability it buys. Dispatch-time caps are governed elsewhere and are not " +
+            "the subject of this baseline.",
+          selectionCliff: cliff,
+          entries,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    console.log(`Wrote tool-surface baseline: ${Object.keys(entries).length} entries.`);
+    process.exit(0);
+  }
+
+  const baseline = readBaseline(BASELINE_PATH);
+  if (!baseline) {
+    console.error("Missing scripts/tool-surface-baseline.json — run --update to create it.");
+    process.exit(1);
+  }
+
+  const { errors, notes, justified } = evaluateToolSurface({
+    measured,
+    baseline,
+    baseBaseline: readBaselineAtBase(),
+    disagreements,
+  });
+
+  const review = reviewClaims({ baseline, now: Date.now(), defaultReviewByDays: DEFAULT_REVIEW_BY_DAYS });
+  const claimVerdict = enforceClaimReview({ review, raisedNewClaim: justified.length > 0 });
+
+  for (const j of justified) console.log(`  [recorded] ${j}`);
+  for (const n of notes) console.log(`  [note] ${n}`);
+  for (const w of claimVerdict.warnings) console.log(`  [review] ${w}`);
+  errors.push(...claimVerdict.errors);
+
+  if (errors.length > 0) {
+    console.error("\nTool-surface guard failed.\n");
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error("");
+    console.error("This guard does not cap the registry and cannot say no. Tools are capability.");
+    console.error("What it refuses is a permanent addition to the selection space recorded in");
+    console.error("silence — because the claim has to survive long enough to be checked.");
+    console.error("");
+    console.error("  node scripts/check-tool-surface.mjs --update   # then write the reasons");
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log(
+    `Tool-surface OK — ${measured["registry.toolDefinitions"]} tool definitions across ` +
+      `${measured["registry.packFiles"]} packs; core tier ${measured["tier.coreToolNames"]}, ` +
+      `per-turn ceiling ${measured["dispatch.maxAttachedTools"]}, selection cliff ${cliff}.` +
+      (justified.length ? ` ${justified.length} recorded increase(s).` : ""),
+  );
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("check-tool-surface.mjs")) {
+  main();
+}

--- a/scripts/check-tool-surface.test.mjs
+++ b/scripts/check-tool-surface.test.mjs
@@ -1,0 +1,184 @@
+// scripts/check-tool-surface.test.mjs
+//
+// Plane-4 guard contract. Two things matter most here:
+//   1. the count is SELF-VALIDATING — it refuses to report a number it cannot trust,
+//      because a guard built on a quietly wrong measurement is worse than no guard;
+//   2. it never forbids growth — tools are capability. It forbids SILENT growth.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+
+import {
+  countCoreTierTools,
+  countPackTools,
+  evaluateToolSurface,
+  measureToolSurface,
+  readNumericConstant,
+} from "./check-tool-surface.mjs";
+
+const PACK = `
+export const examplePack = {
+  definitions: [
+    {
+      name: "record_effort_context",
+      description: "…",
+      inputSchema: { type: "object" },
+    },
+    {
+      name: "read_effort_context",
+      description: "…",
+      inputSchema: { type: "object" },
+    },
+  ],
+};`;
+
+// ── measurement ──
+
+test("counts one tool per definition", () => {
+  const c = countPackTools(PACK);
+  assert.equal(c.byName, 2);
+  assert.equal(c.bySchema, 2);
+  assert.equal(c.agrees, true);
+});
+
+// Why inputSchema is authoritative, learned the hard way: public-web-design-pack.ts
+// carries three extra `name:` fields inside JSON-RPC params where its handlers CALL
+// another MCP server. Counting names reported 350 repo-wide; the true total is 347.
+test("a name field in handler code is seen but does not inflate the count", () => {
+  const withOutboundCall =
+    PACK +
+    '\nasync function handler() {\n' +
+    '  return fetch(url, { body: JSON.stringify({ method: "tools/call", params: {\n' +
+    '          name: "browse_open",\n' +
+    "  } }) });\n}";
+  const c = countPackTools(withOutboundCall);
+  assert.equal(c.tools, 2, "still two real definitions");
+  assert.ok(c.byName > c.bySchema, "the stray name is seen");
+  assert.equal(c.agrees, true, "more names than schemas is normal, not a broken shape");
+});
+
+test("MORE schemas than names is the one impossible direction, and is flagged", () => {
+  const broken = PACK.replace('      name: "read_effort_context",\n', "");
+  const c = countPackTools(broken);
+  assert.equal(c.agrees, false, "shape changed — the count can no longer be trusted");
+});
+
+test("a disagreement is reported as a refusal to report a number", () => {
+  const r = evaluateToolSurface({
+    measured: {},
+    baseline: {},
+    baseBaseline: {},
+    disagreements: ["sneaky-pack.ts: 3 inputSchema fields exceed 2 name fields"],
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => /refuses to report a number/.test(e)));
+});
+
+test("reads the core tier size and named numeric constants", () => {
+  const tier = `export const CORE_MCP_TOOL_NAMES: ReadonlySet<string> = new Set([\n  "a",\n  "b",\n  "c",\n]);`;
+  assert.equal(countCoreTierTools(tier), 3);
+  assert.equal(readNumericConstant("export const MAX_COWORKER_ATTACHED_TOOLS = 48;", "MAX_COWORKER_ATTACHED_TOOLS"), 48);
+  assert.equal(readNumericConstant("export const ACCURACY_CLIFF_PRONE_MAX_CONTEXT = 32_768;", "ACCURACY_CLIFF_PRONE_MAX_CONTEXT"), 32768);
+  assert.equal(readNumericConstant("nothing here", "MISSING"), null);
+});
+
+test("aggregates packs into flat baseline keys", () => {
+  const { measured } = measureToolSurface({
+    packSources: { "a.ts": PACK, "b.ts": PACK },
+    tierSource: `CORE_MCP_TOOL_NAMES = new Set([\n  "a",\n])`,
+    budgetSource: "export const MAX_COWORKER_ATTACHED_TOOLS = 48;",
+    metricsSource: "export const LOCAL_TOOL_SELECTION_CLIFF = 15;",
+  });
+  assert.equal(measured["registry.toolDefinitions"], 4);
+  assert.equal(measured["registry.packFiles"], 2);
+  assert.equal(measured["dispatch.maxAttachedTools"], 48);
+});
+
+// ── growth is allowed; silence is not ──
+
+test("silent growth past the baseline fails, and says growth is allowed", () => {
+  const r = evaluateToolSurface({
+    measured: { "registry.toolDefinitions": 360 },
+    baseline: { "registry.toolDefinitions": { value: 350 } },
+    baseBaseline: { "registry.toolDefinitions": { value: 350 } },
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => /grew 350 -> 360 without re-baselining/.test(e)));
+  assert.ok(r.errors.some((e) => /Growth is allowed/.test(e)), "must not read as a prohibition");
+});
+
+test("a raised baseline with a substantive reason passes and is surfaced", () => {
+  const r = evaluateToolSurface({
+    measured: { "registry.toolDefinitions": 360 },
+    baseline: {
+      "registry.toolDefinitions": {
+        value: 360,
+        reason: "Ten warehousing tools; the existing inventory pack cannot express dock scheduling.",
+      },
+    },
+    baseBaseline: { "registry.toolDefinitions": { value: 350 } },
+  });
+  assert.equal(r.ok, true, r.errors.join("; "));
+  assert.ok(r.justified.some((j) => /350 -> 360/.test(j)));
+});
+
+test("a token reason is rejected as theater", () => {
+  const r = evaluateToolSurface({
+    measured: { "registry.toolDefinitions": 360 },
+    baseline: { "registry.toolDefinitions": { value: 360, reason: "added a tool" } },
+    baseBaseline: { "registry.toolDefinitions": { value: 350 } },
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => /attestation theater/.test(e)));
+});
+
+test("shrink passes and is nudged to be locked in", () => {
+  const r = evaluateToolSurface({
+    measured: { "registry.toolDefinitions": 340 },
+    baseline: { "registry.toolDefinitions": { value: 350 } },
+    baseBaseline: { "registry.toolDefinitions": { value: 350 } },
+  });
+  assert.equal(r.ok, true);
+  assert.ok(r.notes.some((n) => /keep the gain/.test(n)));
+});
+
+test("a missing base comparison never fails closed", () => {
+  const r = evaluateToolSurface({
+    measured: { "registry.toolDefinitions": 360 },
+    baseline: { "registry.toolDefinitions": { value: 360 } },
+    baseBaseline: null,
+  });
+  assert.equal(r.ok, true);
+});
+
+// ── the committed baseline matches the real tree ──
+
+test("the shipped baseline is in sync with the live registry, and is non-trivial", () => {
+  const root = new URL("../", import.meta.url);
+  const packsDir = new URL("apps/web/lib/mcp/packs/", root);
+  const packSources = {};
+  for (const f of readdirSync(packsDir)) {
+    if (!f.endsWith(".ts") || f.includes(".test.")) continue;
+    packSources[f] = readFileSync(new URL(f, packsDir), "utf8");
+  }
+
+  const { measured, disagreements } = measureToolSurface({
+    packSources,
+    tierSource: readFileSync(new URL("apps/web/lib/mcp/tool-tier.ts", root), "utf8"),
+    budgetSource: readFileSync(new URL("apps/web/lib/actions/coworker-tool-budget.ts", root), "utf8"),
+    metricsSource: readFileSync(new URL("apps/web/lib/tak/context-economy-metrics.ts", root), "utf8"),
+  });
+
+  assert.deepEqual(disagreements, [], "every pack must match the ToolDefinition shape");
+
+  const baseline = JSON.parse(
+    readFileSync(new URL("scripts/tool-surface-baseline.json", root), "utf8"),
+  ).entries;
+  const r = evaluateToolSurface({ measured, baseline, baseBaseline: baseline });
+  assert.equal(r.ok, true, r.errors.join("; "));
+
+  // Guards against a vacuous pass: this repo has hundreds of tools across dozens of
+  // packs, so a measurement in the single digits means the parse silently broke.
+  assert.ok(measured["registry.toolDefinitions"] > 100, "expected a real registry count");
+  assert.ok(measured["registry.packFiles"] > 20, "expected many packs");
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -45,6 +45,7 @@ const EXPECTED_LEGACY_JOBS = [
   "spec-plan-doc-gate",
   "stewardship-scope-guard",
   "style-drift-guard",
+  "tool-surface-guard",
   "ux-fit-gate",
 ];
 

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -143,6 +143,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-context-economy.test.mjs"),
       node("scripts/check-context-economy.mjs"),
     ]),
+    // Plane 4 — the standing TOOL registry, same soft shape and reusing plane 3's claim
+    // review. Dispatch-time caps are governed elsewhere; this is the part that accretes.
+    guard("tool-surface-guard", "Tool Surface Guard", [
+      node("--test", "scripts/check-tool-surface.test.mjs"),
+      node("scripts/check-tool-surface.mjs"),
+    ]),
     guard("archetype-completeness-guard", "Archetype Completeness Guard", [
       node("--test", "scripts/check-archetype-completeness.test.mjs"),
       node("scripts/check-archetype-completeness.mjs"),

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Plane-4 standing tool-surface baseline (scripts/check-tool-surface.mjs). Growth is ALLOWED but never silent: raise a value and record `reason` + `recordedAt` saying what capability it buys. Dispatch-time caps are governed elsewhere and are not the subject of this baseline.",
+  "selectionCliff": 15,
+  "entries": {
+    "registry.toolDefinitions": {
+      "value": 347
+    },
+    "registry.packFiles": {
+      "value": 79
+    },
+    "tier.coreToolNames": {
+      "value": 22
+    },
+    "dispatch.maxAttachedTools": {
+      "value": 48
+    }
+  }
+}


### PR DESCRIPTION
The last of the four consumer planes to get a controlling mechanism. Same doctrine and same soft shape as the plane-3 context-economy guard (#3804/#3818), and it **reuses that guard's claim-review machinery** rather than restating it — one rule about how claims come due, applied to two planes.

## What is already governed — and what this deliberately does not touch

I checked the dispatch path before building, rather than assuming it was the gap:

- the per-turn attachment cap is **bounded by `LOCAL_TOOL_SELECTION_CLIFF`** for the cliff-prone small-local class, not merely by window-fit;
- `MAX_COWORKER_ATTACHED_TOOLS` (48) is a hard ceiling above that, and a local model only exceeds the cliff on a **measured** fidelity ceiling;
- the long tail loads on demand, so the cap costs cost, not capability;
- tool **descriptions** are already enforced (`tool-description-hygiene.test.ts`, P5).

So **"48 > 15" is not a defect**, and this guard does not claim it is.

## What is not governed

The **standing registry**. **347 tool definitions across 79 packs**, accumulated with nothing asking why. Every added tool is permanent: it enlarges the selection space every listing surface must discriminate within, and the definition-token tax any client listing them all pays.

`estimateToolDefinitionTokens` exists — but its own header says it changes nothing that is sent. A thermometer, exactly as the runtime context plane was before #3790.

**A bigger registry is not automatically worse.** Tools are capability, and capability is the point. So this never caps the registry and cannot say *no*. Growth is permitted; growth **in silence** is not, and the recorded claim comes due — because *"this tool earns its place"* is a prediction like any other.

## The measurement caught itself being wrong

This is why it is built with a cross-check rather than a single regex.

Counting `name:` reported **350** repo-wide. The cross-check against `inputSchema:` disagreed on `public-web-design-pack.ts` (11 vs 8) — and the three extras turned out to be JSON-RPC `params: { name: "browse_open" }` payloads where that pack's handlers **call another MCP server**. Outbound calls, not definitions. **The true total is 347.**

`inputSchema` is now authoritative, because only real definitions carry one. `name` is retained purely as a tripwire in the one direction that cannot happen legitimately: *more schemas than names* would mean the `ToolDefinition` shape itself changed and the count could no longer be trusted. A guard built on a quietly wrong measurement is worse than no guard, so it reports the broken direction rather than guessing.

## Verification

- **12 unit tests**: both count-validation directions, all three growth rules, and a **non-vacuity assertion** (>100 tools, >20 packs) so a silently broken parse cannot pass as "clean".
- **End-to-end against real source**: added a genuine tool definition to `effort-context-pack.ts` → **exit 1** naming `347 -> 348` *while stating growth is allowed*; reverted → green.
- A test asserts the committed baseline is in sync with the live registry **and** that no pack disagrees on shape.
- **38 tests green** across this guard, the plane-3 guard, and the policy-guard registry; **31-guard preflight clean**.

Registered in `EXPECTED_LEGACY_JOBS` up front — `pregate-preflight` **filters self-tests**, so a clean preflight structurally cannot see a broken registry conformance test. That cost a CI round-trip on #3804; not repeating it.

## The four planes, complete

| Plane | Before this thread | Now |
|---|---|---|
| Portal UX | ratcheted, but scored the prescribed constructs at zero | #3764, #3769 |
| Static agent instruction plane | ratcheted | unchanged |
| Runtime assembled context | thermometer | #3790 → #3804 → #3818 |
| **Tool surface** | **thermometer** | **this** |

Seed-Fit-Decision: global-default

No canonical seed content changed. Global-default because the guard is platform CI substrate applied identically on every install.

Local-CI-Override: Scripts-only — five files under scripts/, no apps/web runtime, no TypeScript in the Next build, no schema or migration, so local-CI's unique coverage adds nothing. Verified with a clean 31-guard preflight, 38 tests including the registry conformance self-test, and an end-to-end probe against a real pack. Branch is level with origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
