### PR TITLE
feat(ops): default-on observe-mode for worktree/sandbox GC backstops

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,17 @@ services:
       # jobs are registered only when this flag is on. Library defaults stay
       # off for tests and ad-hoc imports; compose is the deployment contract.
       DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED: ${DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED:-1}
+      # Multi-client governance soak (BI-42FA7DD8): observe-only fleet
+      # backstops for leftover worktrees and Build Studio sandbox builds.
+      # Primary reaping stays session-lifecycle (worktree-session-hygiene on
+      # SessionEnd) and transactional (sandbox GC on promote/abandon/
+      # complete) — these are dry-run-only backstops for whatever slips
+      # through. Default ON for every compose install so operators get the
+      # visibility without asking. Do NOT default AUTO_REAP or
+      # DELETE_BRANCHES to 1 here: those are live/destructive and require an
+      # explicit per-install operator opt-in after a clean observe soak.
+      DPF_WORKTREE_JANITOR_ENABLED: ${DPF_WORKTREE_JANITOR_ENABLED:-1}
+      DPF_SANDBOX_BUILD_GC_ENABLED: ${DPF_SANDBOX_BUILD_GC_ENABLED:-1}
       # Register ScheduledJob heartbeat rows and other low-risk boot hygiene
       # for installed runtimes. Without this, first-run installs have no
       # code-graph job row and status surfaces report missing background work.


### PR DESCRIPTION
## Summary
- `DPF_WORKTREE_JANITOR_ENABLED` and `DPF_SANDBOX_BUILD_GC_ENABLED` had no default anywhere in the shipped `docker-compose.yml`. Both were previously only set on one dev machine's gitignored `.env` / `docker-compose.override.yml` (untracked, local-only) -- every other install, including customer installs, would silently have these fleet-backstop jobs registered on their daily Inngest schedule but no-op every run, with no dry-run visibility unless an operator knew to hand-set the flags.
- Defaults both to `"1"` (observe-only dry-run reporting) in the portal service's environment block, matching the existing pattern immediately above for `DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED` / `DPF_OPTIONAL_STARTUP_TASKS_ENABLED`.
- Deliberately does **not** default `DPF_WORKTREE_JANITOR_AUTO_REAP` or `DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES` -- those remain live/destructive opt-in only, per the `dpf-worktree-hygiene` skill's explicit guardrail (dry-run soak first, explicit operator go before any live reap).

## Test plan
- [x] `docker compose config` validates cleanly with the new flags resolving to `"1"` by default (verified with dummy required secrets to get past unrelated `AUTH_SECRET`/`CREDENTIAL_ENCRYPTION_KEY` interpolation guards).
- [x] `node scripts/check-compose-env-contract.mjs` passes (unaffected -- that guard covers volume host-path vars, not this environment block).
- [x] Checked for existing unit tests referencing these flag names (`sandbox-build-gc.test.ts`, `worktree-janitor.test.ts`) -- both pass explicit env objects directly to the function under test and don't read the real compose file, so no conflict with the new default.
- [x] Manually applied the equivalent config to the dev machine's live portal (`docker compose up -d portal`), confirmed via `docker exec dpf-portal-1 printenv` that both flags are live and `AUTO_REAP`/`DELETE_BRANCHES` are correctly absent, and confirmed postgres data integrity was unaffected by the container recreate.
- [x] gitleaks secret scan passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)