### PR TITLE
docs(corpus): data-architect MDM + index/collation practice pages (BI-B31072B8)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 597,
+  "pageCount": 600,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -4949,6 +4949,19 @@
         "see-also"
       ]
     },
+    "docs/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong.md": {
+      "publicHref": "/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "the-rule",
+        "do-this-first",
+        "when-you-do-write-the-repair",
+        "why-not-just-add-on-conflict-do-nothing",
+        "related"
+      ]
+    },
     "docs/professions/data-architect/wiki/fix-the-seed-not-the-runtime.md": {
       "publicHref": "/professions/data-architect/wiki/fix-the-seed-not-the-runtime/",
       "portalHref": null,
@@ -4962,6 +4975,20 @@
         "decision-dimensions",
         "examples",
         "sources"
+      ]
+    },
+    "docs/professions/data-architect/wiki/index-and-collation-integrity.md": {
+      "publicHref": "/professions/data-architect/wiki/index-and-collation-integrity/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "why-a-text-index-depends-on-collation",
+        "how-it-silently-breaks",
+        "the-fingerprint",
+        "detection-find-it-before-a-ui-does",
+        "prevention-and-repair",
+        "related"
       ]
     },
     "docs/professions/data-architect/wiki/least-privilege-db-access.md": {
@@ -4990,6 +5017,21 @@
         "decision-dimensions",
         "examples",
         "sources"
+      ]
+    },
+    "docs/professions/data-architect/wiki/mdm-what-it-does-and-does-not-do.md": {
+      "publicHref": "/professions/data-architect/wiki/mdm-what-it-does-and-does-not-do/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "the-one-sentence-to-remember",
+        "what-mdm-is",
+        "what-mdm-is-not",
+        "merge-policy-tombstone-never-hard-delete",
+        "the-corollary-that-bites-prevention-shares-the-constraints-failure-mode",
+        "when-to-reach-for-mdm-and-when-not",
+        "related"
       ]
     },
     "docs/professions/data-architect/wiki/native-cohesion-over-interfacing.md": {

--- a/docs/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong.md
+++ b/docs/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong.md
@@ -1,0 +1,43 @@
+---
+title: When a Dedupe Migration Means the Constraint Is Wrong
+pageKind: entity
+status: published
+abstract: If you are about to write a migration that removes duplicate rows from behind a UNIQUE constraint, stop. A healthy unique index rejects duplicates on insert — so their presence means the index is not doing its job, usually because it has silently diverged from the heap. Fix the cause (check index/heap agreement) before deduping, or you will be back writing the same migration for the next table next week.
+sources:
+  - postgresql/amcheck
+---
+
+## The rule
+
+**A `UNIQUE` constraint that is holding duplicate rows did not fail on its own. Find out why before you dedupe.**
+
+Duplicates behind a unique index are not a data-entry accident to be swept up per table. A valid unique btree *cannot* accept a second row with the same key — the insert would be rejected. So if duplicates exist, the index was not enforcing uniqueness at the moment those rows were written. Deduping without finding the cause treats the symptom and leaves the mechanism broken: the next seed run, the next upsert, re-creates the duplicates, and you write the same repair migration again. (This is exactly how seven near-identical "repair `<table>` index integrity" migrations landed in a single day.)
+
+## Do this first
+
+1. **Check index/heap agreement.** Run amcheck's `bt_index_parent_check(index, heapallindexed => true)` on the unique index. It verifies that every heap tuple is findable through the index under the index's own comparator. A failure here — not a row count — is the real signal.
+2. **Read duplicate data with index scans disabled.** A plain `SELECT ... GROUP BY key HAVING count(*) > 1` may itself descend the corrupt index and *under-report* the duplicates. Force a heap scan first:
+   ```sql
+   SET LOCAL enable_indexscan = off;
+   SET LOCAL enable_indexonlyscan = off;
+   SET LOCAL enable_bitmapscan = off;
+   ```
+   Then count. The heap tells the truth; the index may not.
+3. **Read the runbook.** `docs/runbooks/2026-07-20-collation-drift-index-corruption.md` documents the specific incident this rule generalises, and [[professions/data-architect/index-and-collation-integrity]] explains the mechanism.
+
+## When you do write the repair
+
+Use the shared, tested pattern, not a hand-copied migration. The ratified sequence — force heap scan → rank duplicates by a declared survivor ordering → collision-checked quarantine rename into the `__dpf_quarantined__` namespace → **retire the loser in the same statement** → fail-closed assertion that no duplicate remains → drop and recreate the unique index from the repaired heap — is emitted by `buildExactKeyRepairSql` (`packages/db/src/migrations/exact-key-repair.ts`). Two traps a hand-written copy repeatedly falls into:
+
+- **Forgetting to retire the loser.** Quarantining the key alone leaves the row `active`, so it still renders as a live duplicate (a "ghost"). The retirement step must run in the *same* `UPDATE` that renames the key, or a follow-up migration is needed. The shared helper takes the retirement columns as a first-class parameter for exactly this reason.
+- **Natural-key foreign keys.** If a child table references this table's *natural key* (not its `id`) with `ON UPDATE CASCADE`, detach those constraints before renaming losers — otherwise the cascade drags a canonical child reference onto the quarantined row — and reattach after the index is rebuilt.
+
+## Why not just add `ON CONFLICT DO NOTHING`?
+
+Because that hides the corruption. If the index is diverged, `ON CONFLICT` consults the same broken index and still lets the duplicate through. The fix is index/heap integrity, not a softer insert.
+
+## Related
+
+- [[professions/data-architect/index-and-collation-integrity]] — the usual cause: a collation-comparator change under an existing index.
+- [[professions/data-architect/mdm-what-it-does-and-does-not-do]] — MDM cleans up duplicates but does not prevent them; this rule is about the prevention layer.
+- [[professions/data-architect/schema-migration-practices]] — general migration discipline.

--- a/docs/professions/data-architect/wiki/index-and-collation-integrity.md
+++ b/docs/professions/data-architect/wiki/index-and-collation-integrity.md
@@ -1,0 +1,50 @@
+---
+title: Index and Collation Integrity
+pageKind: entity
+status: published
+abstract: A text btree index is only correct relative to the collation (string-ordering) provider it was built under. Move a PostgreSQL cluster between libc implementations — for example from a musl (Alpine) base to a glibc (Debian) base — and the comparator for every text column changes underneath every existing text index. PostgreSQL still reports those indexes valid, so the damage is silent: lookups miss rows that are present, and a UNIQUE index stops rejecting duplicates. This page explains the mechanism, the fingerprint, and the detection.
+sources:
+  - postgresql/collation-support
+---
+
+## Why a text index depends on collation
+
+A btree stores keys in sorted order and finds a key by comparing at each node. For text, "sorted" is defined by a **collation** — the locale-dependent rule for how strings order (`'A' < 'a'`? `'ä'` next to `'a'` or after `'z'`?). That rule comes from a provider: the operating system's **libc**, or **ICU**. The index's physical layout *is* the output of that comparator. Search the same index with a *different* comparator and you descend into the wrong subtree.
+
+## How it silently breaks
+
+1. A cluster is `initdb`'d under **musl** (Alpine). musl ships no locale data, so every text column effectively sorts with `C` (byte-order) semantics regardless of the `en_US.utf8` label recorded in `pg_database.datcollate`.
+2. The image is later moved to a **glibc** (Debian) base — for instance to pull in an extension. glibc *does* implement `en_US.utf8`, so the comparator for every text column changes under the existing data volume.
+3. Every text btree built before the flip is now ordered by the old comparator and searched by the new one. Lookups descend the wrong subtree and **miss rows that are present in the heap**.
+
+`pg_index` still reports the index `valid`, so nothing complains. The corruption compounds:
+
+- An upsert (`where: { key }`) misses the existing row, falls through to `CREATE`, and the **`UNIQUE` index fails to reject the insert** for the same reason — so a unique constraint quietly accumulates duplicates.
+- A write-time dedup gate whose candidate lookup is a database query returns zero candidates and reports "clear" for a record that already exists.
+
+That is how one seed run produced many duplicate rows over records first created weeks earlier.
+
+## The fingerprint
+
+You can recognise a cluster that was `initdb`'d under musl and then moved to glibc:
+
+- It has only **3 libc collations** (`default`, `C`, `POSIX`) where a glibc `initdb` creates several hundred.
+- `pg_database.datcollversion` is **NULL** — which also means PostgreSQL cannot emit its normal "collation version mismatch" warning, because it has no recorded version to compare against.
+
+## Detection — find it before a UI does
+
+Do not wait to notice duplicate rows. Sweep for it:
+
+- `packages/db/scripts/index-integrity-guard.mjs` checks two things: **collation stability** (the musl fingerprint and any recorded-vs-actual collation-version mismatch) and **index/heap agreement** via `bt_index_parent_check(index, heapallindexed => true)` over every btree. The heap-agreement check is what actually catches a comparator flip.
+- The musl fingerprint and a NULL `datcollversion` are **advisory** — they describe how the cluster was built and cannot be cleared by any repair, so failing a build on them would be permanent noise. A recorded-vs-actual collation-version mismatch, or a `bt_index_parent_check` failure, is a **real** regression and must block.
+
+## Prevention and repair
+
+- **Pin the database image by digest.** A floating `:pg16` tag is what let libc move under an existing volume. Re-pin only alongside a `REINDEX` plan, and run the integrity guard against the upgraded volume *before* shipping the new digest to the fleet.
+- **Repair** is per-table: quarantine the duplicate losers, retire them, and rebuild the unique index from the repaired heap — see [[professions/data-architect/dedupe-migration-means-the-constraint-is-wrong]]. Always read duplicate data with `enable_indexscan = off` so a corrupt index does not under-report the damage.
+
+## Related
+
+- [[professions/data-architect/dedupe-migration-means-the-constraint-is-wrong]] — the rule to apply when you find duplicates behind a unique constraint.
+- [[professions/data-architect/mdm-what-it-does-and-does-not-do]] — why the write-time dedup gate shares this failure mode.
+- [[professions/data-architect/schema-migration-practices]] — migration discipline.

--- a/docs/professions/data-architect/wiki/mdm-what-it-does-and-does-not-do.md
+++ b/docs/professions/data-architect/wiki/mdm-what-it-does-and-does-not-do.md
@@ -1,0 +1,50 @@
+---
+title: Master Data Management — What It Does and Does Not Do
+pageKind: entity
+status: published
+abstract: Master Data Management (MDM) resolves duplicate and conflicting records into a single trusted version after they exist. It is a reconciliation discipline, not a prevention one — it does not stop duplicates from being created, and it is not a new database. Knowing its boundary prevents both over-reaching ("route everything through MDM") and the false comfort of assuming a write-time dedup gate cannot fail.
+sources:
+  - dama-dmbok/master-data-management
+---
+
+## The one sentence to remember
+
+**MDM resolves duplicates after the fact — it does not prevent their creation.**
+
+Master Data Management is match, merge, and survivorship over records that already exist. It is a cleanup and reconciliation discipline. Preventing a duplicate from being written in the first place is a *separate* mechanism (a write-time dedup gate, a `UNIQUE` constraint), and — critically — that prevention can fail independently of MDM. Treating MDM as if it prevents duplicates is how an install accumulates dozens of them while everyone assumes "MDM has it covered."
+
+## What MDM is
+
+- **Match** — decide, by scoring candidate records against configured rules, whether two rows describe the same real-world entity.
+- **Merge** — collapse matched records, choosing a survivor and repointing references.
+- **Survivorship** — the policy for which field values win when records are merged.
+- **Crosswalk** — the durable record that "these source keys all map to this canonical entity", so a merge can be explained and undone.
+
+## What MDM is NOT
+
+- **Not a new table.** The canonical record stays in its existing Prisma model (`CustomerAccount`, `CustomerContact`, `CustomerSite`). MDM does not introduce a parallel "golden record" store; it governs the models you already have.
+- **Not a duplicate *preventer*.** It reconciles duplicates that already exist. Prevention is the write-time dedup gate and the database `UNIQUE` constraint — different code, different failure modes.
+- **Not a generic relation-walker.** DPF's merge engine is deliberately **domain-bound** to `customer-account` / `customer-site` / `customer-contact` by a ratified kernel decision. A generic DMMF-driven merge (walk every foreign key automatically) was scored **3.17 vs 4.52 and rejected**, because soft references that carry no foreign-key relation would be silently orphaned by an automatic walker. Adding a new merge domain is a deliberate act with hand-enumerated inbound references, not a config toggle.
+
+The full contract lives in code at `apps/web/lib/mdm/domain-registry.ts` — a comment block most developers never open. This page exists so the contract is retrievable as practice rather than buried in source.
+
+## Merge policy: tombstone, never hard delete
+
+A merge **quarantines** the losing record (renames its natural key into a reserved namespace and marks it retired / superseded); it never hard-deletes. The tombstone stays for audit and for unmerge. Deletion of a regulated record is a separate, deliberately-governed action, never a side effect of a merge or a retention sweep.
+
+## The corollary that bites: prevention shares the constraint's failure mode
+
+The write-time dedup gate is supposed to be the backstop that catches a duplicate the `UNIQUE` constraint missed. But its candidate lookup is **a database query**, and the constraint is enforced **by an index**. If that index is corrupt — for example after a collation-provider change (see [[professions/data-architect/index-and-collation-integrity]]) — then an equality probe descends the wrong subtree, returns zero candidates, and the gate reports "clear" for a record that already exists. The constraint fails to reject the insert for the *same* reason. Both backstops fail together on the same input.
+
+Practical rule: a dedup gate is only as trustworthy as the index under it. Make the gate's candidate lookup read the true heap (force a heap scan) so a stale index cannot defeat it, and detect index/heap divergence on a schedule rather than by noticing duplicate rows in a UI.
+
+## When to reach for MDM, and when not
+
+- **Business master data** (customers, sites, contacts) with real-world duplicates → MDM match/merge/survivorship is the right home.
+- **Platform runtime/config data** (agents, model profiles, skills, taxonomy) → NOT MDM. These are deduped by exact-key integrity repair and prevented by correct constraints, not by a match-scoring hub. The MDM alignment spec explicitly excludes "a generic MDM product implementation" and "replacing domain-specific business rules with a generic data hub".
+
+## Related
+
+- [[professions/data-architect/index-and-collation-integrity]] — why a `UNIQUE` constraint can silently stop rejecting duplicates.
+- [[professions/data-architect/dedupe-migration-means-the-constraint-is-wrong]] — the rule to apply before writing a dedupe migration.
+- [[professions/data-architect/schema-migration-practices]] — general migration discipline.

--- a/packages/db/src/seed-profession-corpus.ts
+++ b/packages/db/src/seed-profession-corpus.ts
@@ -118,6 +118,41 @@ const PROFESSION_EXTERNAL_SOURCES: Record<string, ExternalSourceEntry> = {
     retrievedAt: "2026-06-20",
   },
 
+  // ── Data-architect: MDM + index/collation integrity (A2 / BI-B31072B8) ──
+  "dama-dmbok/master-data-management": {
+    sourceType: "framework",
+    title: "DAMA-DMBOK — Master and Reference Data Management",
+    url: "https://www.dama.org/cpages/body-of-knowledge",
+    license: "DAMA International (reference)",
+    abstract:
+      "The DAMA Data Management Body of Knowledge chapter on master and reference data: " +
+      "match, merge, survivorship, crosswalk, and the boundary that master data management " +
+      "reconciles existing records rather than preventing their creation.",
+    retrievedAt: "2026-08-01",
+  },
+  "postgresql/amcheck": {
+    sourceType: "documentation",
+    title: "PostgreSQL Documentation — amcheck",
+    url: "https://www.postgresql.org/docs/current/amcheck.html",
+    license: "PostgreSQL",
+    abstract:
+      "The amcheck extension verifies the logical consistency of B-tree indexes against the " +
+      "heap they index (bt_index_parent_check with heapallindexed => true), catching a corrupt " +
+      "index that pg_index still reports valid — the check for collation-comparator drift.",
+    retrievedAt: "2026-08-01",
+  },
+  "postgresql/collation-support": {
+    sourceType: "documentation",
+    title: "PostgreSQL Documentation — Collation Support",
+    url: "https://www.postgresql.org/docs/current/collation.html",
+    license: "PostgreSQL",
+    abstract:
+      "How PostgreSQL derives text ordering from a collation provider (libc or ICU), why a " +
+      "text B-tree is only valid relative to the provider it was built under, and how a " +
+      "provider change (e.g. musl to glibc) alters the comparator under existing indexes.",
+    retrievedAt: "2026-08-01",
+  },
+
   // ── Software-engineer family (WSID wave 2, all open-license) ──
   "owasp/asvs": {
     sourceType: "standard",


### PR DESCRIPTION
Closes **A2 (BI-B31072B8)**. Founder ask: *MDM practices should be part of the data architect's corpus, so best practice is understood and the issues now being cleaned up are avoided.*

**Verified absent before authoring:** a full-body search across every `WikiPage` returned **zero** rows for "master data" / "golden record" / "collation" / "deduplicat". The corpus skewed to SQL-injection material (4 of 8 published pages); the MDM contract lived only in a `domain-registry.ts` comment block.

## Three pages (findable rules, not essays — per the lexical slug-prefix retrieval constraint)

1. **`mdm-what-it-does-and-does-not-do`** — carries the load-bearing sentence that existed nowhere: *"MDM resolves duplicates after the fact — it does not prevent their creation."* Restates the domain-registry contract (canonical record stays in its existing model; tombstone-only merge; domain-bound by the ratified 3.17-vs-4.52 kernel decision) and the BI-FEAEB715 corollary that the write-time gate is a DB query a corrupt index defeats.
2. **`dedupe-migration-means-the-constraint-is-wrong`** — the specific rule the existing schema-migration page failed to prevent (seven copy-paste repairs in one day): a `UNIQUE` constraint holding duplicates did not fail on its own — check index/heap agreement first, read with `enable_indexscan=off`, use `buildExactKeyRepairSql`.
3. **`index-and-collation-integrity`** — the musl→glibc comparator-flip mechanism that existed nowhere; points at `index-integrity-guard.mjs` and the collation-drift runbook.

Registered the three cited sources (`dama-dmbok/master-data-management`, `postgresql/amcheck`, `postgresql/collation-support`) in `PROFESSION_EXTERNAL_SOURCES`.

## Verification (functional)

Ran `seedProfessionCorpus` against a migrated Postgres: **all three pages publish** (`status=published`), **zero** unknown-source warnings for the new sources, and **none of their wikilinks appear in the orphan-link report** (they resolve within the data-architect corpus). `packages/db` typecheck clean; **Doc Links PASS**.

## Sequencing

Corpus retrieval has one non-test caller today (interactive coworker chat), so these pages are visible in chat **now**; they reach build specialists once **A1/BI-C654F960** converges the build-specialist plane onto `requestCoworker` (plan in PR #3839). This authoring is the A2 deliverable; A1 is its distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default
