### PR TITLE
feat(hr): make team, role, and location editable from the org chart (BI-HCM-004)

### DIFF
--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -252,7 +252,24 @@ export default async function EmployeePage({ searchParams }: Props) {
             )}
           </div>
         ) : view === "orgchart" ? (
-          <OrgChartView employees={employees} canReassign={canManageWorkforce} />
+          <OrgChartView
+            employees={employees}
+            canReassign={canManageWorkforce}
+            referenceData={{
+              departments: workforceReferenceData.departments.map((d) => ({
+                id: d.id,
+                name: d.name,
+              })),
+              positions: workforceReferenceData.positions.map((p) => ({
+                id: p.id,
+                title: p.title,
+              })),
+              workLocations: workforceReferenceData.workLocations.map((wl) => ({
+                id: wl.id,
+                name: wl.name,
+              })),
+            }}
+          />
         ) : view === "mypolicies" ? (
           <MyPoliciesView />
         ) : (

--- a/apps/web/components/employee/OrgChartView.tsx
+++ b/apps/web/components/employee/OrgChartView.tsx
@@ -25,7 +25,7 @@ import "@xyflow/react/dist/style.css";
 
 import { confirmDialog } from "@/components/ui/Dialog";
 import { Notice, StatCard, StatusBadge } from "@/components/ui/report-kit";
-import { reassignEmployeeManager } from "@/lib/actions/workforce";
+import { assignEmployeeOrg, reassignEmployeeManager } from "@/lib/actions/workforce";
 import { computeOrgChartLayout, ORG_NODE_H, ORG_NODE_W } from "@/lib/graph/layout-org-chart";
 import {
   buildOrgGraph,
@@ -35,10 +35,19 @@ import {
 import type { EmployeeDirectoryRow } from "@/lib/workforce/workforce-types";
 import { OrgChartNode, type OrgChartNodeData } from "./OrgChartNode";
 
+/** Reference sets for the placement pickers. Values are row ids — what EmployeeProfile stores. */
+export type OrgReferenceData = {
+  departments: Array<{ id: string; name: string }>;
+  positions: Array<{ id: string; title: string }>;
+  workLocations: Array<{ id: string; name: string }>;
+};
+
 type Props = {
   employees: EmployeeDirectoryRow[];
   /** When false the chart is read-only (no drag, no pickers). */
   canReassign?: boolean;
+  /** Omitted when the caller has no reference sets to offer; placement pickers then hide. */
+  referenceData?: OrgReferenceData;
   onSelect?: (employee: EmployeeDirectoryRow) => void;
 };
 
@@ -86,7 +95,7 @@ export function OrgChartView(props: Props) {
   );
 }
 
-function OrgChartViewInner({ employees, canReassign = true, onSelect }: Props) {
+function OrgChartViewInner({ employees, canReassign = true, referenceData, onSelect }: Props) {
   const [density, setDensity] = useState<Density>("chart");
   const [search, setSearch] = useState("");
   const [departmentFilter, setDepartmentFilter] = useState("");
@@ -221,6 +230,32 @@ function OrgChartViewInner({ employees, canReassign = true, onSelect }: Props) {
             ? { managerEmployeeId: managerId }
             : { dottedLineManagerId: managerId }),
           line,
+        });
+        setPendingId(null);
+        setFeedback(
+          result.ok
+            ? { tone: "success", message: result.message }
+            : { tone: "error", message: result.message },
+        );
+      });
+    },
+    [],
+  );
+
+  /**
+   * Change one placement field — team, role, or location.
+   *
+   * Exactly one key is sent. `assignEmployeeOrg` now has PATCH semantics, so the fields this
+   * call omits are left alone; before that it rewrote every field from its input and a
+   * single-field call silently cleared the other four.
+   */
+  const runPlacement = useCallback(
+    (employeeId: string, field: "departmentId" | "positionId" | "workLocationId", value: string | null) => {
+      setPendingId(employeeId);
+      startTransition(async () => {
+        const result = await assignEmployeeOrg({
+          employeeProfileId: employeeId,
+          [field]: value,
         });
         setPendingId(null);
         setFeedback(
@@ -469,8 +504,10 @@ function OrgChartViewInner({ employees, canReassign = true, onSelect }: Props) {
           employee={selected}
           employees={employees}
           canReassign={canReassign}
+          referenceData={referenceData}
           busy={isPending}
           onReassign={runReassign}
+          onPlacement={runPlacement}
         />
       </div>
 
@@ -542,19 +579,71 @@ function OrgList({
   );
 }
 
-/** Selected person's reporting lines, editable through the governed action. */
+/** One placement field. Kept local — it is this panel's layout, not a reusable primitive. */
+function PlacementPicker({
+  label,
+  emptyLabel,
+  disabled,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  emptyLabel: string;
+  disabled: boolean;
+  value: string | null;
+  options: Array<{ id: string; label: string }>;
+  onChange: (value: string | null) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-dpf-caption uppercase tracking-widest text-[var(--dpf-muted)]">
+        {label}
+      </span>
+      <select
+        disabled={disabled}
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+        className="w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-text)] disabled:opacity-50"
+      >
+        <option value="" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
+          {emptyLabel}
+        </option>
+        {options.map((opt) => (
+          <option
+            key={opt.id}
+            value={opt.id}
+            className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+          >
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/** Selected person's reporting lines and placement, editable through the governed actions. */
 function OrgDetailPanel({
   employee,
   employees,
   canReassign,
+  referenceData,
   busy,
   onReassign,
+  onPlacement,
 }: {
   employee: EmployeeDirectoryRow | null;
   employees: EmployeeDirectoryRow[];
   canReassign: boolean;
+  referenceData?: OrgReferenceData;
   busy: boolean;
   onReassign: (employeeId: string, managerId: string | null, line: "solid" | "dotted") => void;
+  onPlacement: (
+    employeeId: string,
+    field: "departmentId" | "positionId" | "workLocationId",
+    value: string | null,
+  ) => void;
 }) {
   const options = useMemo(
     () => (employee ? eligibleManagers(employees, employee.id) : []),
@@ -631,6 +720,36 @@ function OrgDetailPanel({
             ))}
           </select>
         </label>
+
+        {/* Placement. Each picker sends ONE field; the rest are left untouched. */}
+        {referenceData && (
+          <>
+            <PlacementPicker
+              label="Team"
+              emptyLabel="Unassigned"
+              disabled={!canReassign || busy}
+              value={employee.departmentId}
+              options={referenceData.departments.map((d) => ({ id: d.id, label: d.name }))}
+              onChange={(v) => onPlacement(employee.id, "departmentId", v)}
+            />
+            <PlacementPicker
+              label="Role"
+              emptyLabel="No role"
+              disabled={!canReassign || busy}
+              value={employee.positionId}
+              options={referenceData.positions.map((p) => ({ id: p.id, label: p.title }))}
+              onChange={(v) => onPlacement(employee.id, "positionId", v)}
+            />
+            <PlacementPicker
+              label="Location"
+              emptyLabel="No location"
+              disabled={!canReassign || busy}
+              value={employee.workLocationId}
+              options={referenceData.workLocations.map((w) => ({ id: w.id, label: w.name }))}
+              onChange={(v) => onPlacement(employee.id, "workLocationId", v)}
+            />
+          </>
+        )}
       </div>
 
       {!canReassign && (

--- a/apps/web/lib/actions/workforce.ts
+++ b/apps/web/lib/actions/workforce.ts
@@ -11,6 +11,7 @@ import { resolveGovernedAction } from "@/lib/governance-resolver";
 import { syncEmployeePrincipal } from "@/lib/identity/principal-linking";
 import { validateLifecycleTransition, validateEmployeeProfileInput, type EmployeeProfileInput, type EmploymentEventType, type WorkforceStatus } from "@/lib/workforce-types";
 import { wouldCreateManagerCycle } from "@/lib/workforce/org-chart-model";
+import { patchOptional } from "@/lib/workforce/patch-optional";
 
 export type WorkforceActionResult = {
   ok: boolean;
@@ -349,9 +350,18 @@ export async function assignEmployeeOrg(input: AssignEmployeeOrgInput): Promise<
       });
       if (!existing) return workforceDenied("Employee profile not found.");
 
-      const nextDepartmentId = trimOptional(input.departmentId);
-      const nextPositionId = trimOptional(input.positionId);
-      const nextManagerEmployeeId = trimOptional(input.managerEmployeeId);
+      // PATCH semantics: an ABSENT key means "leave this field alone"; an explicit null or
+      // empty string means "clear it". Previously every field was rewritten from the input,
+      // and `trimOptional(undefined)` is null, so any partial caller silently wiped the four
+      // fields it did not mention. That hazard is why the org chart had to route around this
+      // action instead of using it (BI-HCM-004).
+      const nextDepartmentId = patchOptional(input, "departmentId", existing.departmentId);
+      const nextPositionId = patchOptional(input, "positionId", existing.positionId);
+      const nextManagerEmployeeId = patchOptional(
+        input,
+        "managerEmployeeId",
+        existing.managerEmployeeId,
+      );
 
       // Self-management is rejected above, but that alone still allows a cycle: moving a
       // manager underneath one of their own reports detaches that entire branch from every
@@ -367,9 +377,13 @@ export async function assignEmployeeOrg(input: AssignEmployeeOrgInput): Promise<
           );
         }
       }
-      const nextDottedLineManagerId = trimOptional(input.dottedLineManagerId);
-      const nextWorkLocationId = trimOptional(input.workLocationId);
-      const nextTimezone = trimOptional(input.timezone);
+      const nextDottedLineManagerId = patchOptional(
+        input,
+        "dottedLineManagerId",
+        existing.dottedLineManagerId,
+      );
+      const nextWorkLocationId = patchOptional(input, "workLocationId", existing.workLocationId);
+      const nextTimezone = patchOptional(input, "timezone", existing.timezone);
       const effectiveAt = input.effectiveAt ?? new Date();
 
       await prisma.$transaction(async (tx) => {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9782,6 +9782,7 @@
         "check-organization-placement",
         "work-with-the-org-chart",
         "change-who-someone-reports-to",
+        "change-someones-team-role-or-location",
         "find-people-and-spot-problems",
         "set-compensation-inputs",
         "record-and-approve-time",

--- a/apps/web/lib/workforce/patch-optional.test.ts
+++ b/apps/web/lib/workforce/patch-optional.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { patchOptional, trimToNull } from "./patch-optional";
+
+// Regression guard for the hazard that kept `assignEmployeeOrg` unusable: it rewrote every
+// field from its input, and the old helper collapsed `undefined` to null, so a caller that
+// mentioned only the manager silently cleared department, position, work location, and
+// timezone. The org chart shipped a second narrow action to avoid it (BI-HCM-004).
+describe("patchOptional", () => {
+  const current = "current-value";
+
+  it("keeps the current value when the key is absent", () => {
+    expect(patchOptional({}, "departmentId", current)).toBe(current);
+  });
+
+  it("keeps the current value when the key is present but undefined", () => {
+    expect(patchOptional({ departmentId: undefined }, "departmentId", current)).toBe(current);
+  });
+
+  it("clears on an explicit null", () => {
+    expect(patchOptional({ departmentId: null }, "departmentId", current)).toBeNull();
+  });
+
+  it("clears on an explicit empty string", () => {
+    expect(patchOptional({ departmentId: "" }, "departmentId", current)).toBeNull();
+  });
+
+  it("clears on a whitespace-only string", () => {
+    expect(patchOptional({ departmentId: "   " }, "departmentId", current)).toBeNull();
+  });
+
+  it("sets and trims a supplied value", () => {
+    expect(patchOptional({ departmentId: "  dept-2  " }, "departmentId", current)).toBe("dept-2");
+  });
+
+  it("leaves unmentioned siblings untouched — the actual defect", () => {
+    const input = { managerEmployeeId: "mgr-9" };
+    expect(patchOptional(input, "managerEmployeeId", null)).toBe("mgr-9");
+    expect(patchOptional(input, "departmentId" as never, "dept-1")).toBe("dept-1");
+    expect(patchOptional(input, "positionId" as never, "pos-1")).toBe("pos-1");
+    expect(patchOptional(input, "workLocationId" as never, "loc-1")).toBe("loc-1");
+    expect(patchOptional(input, "timezone" as never, "Europe/London")).toBe("Europe/London");
+  });
+
+  it("treats a null current value as a valid starting point", () => {
+    expect(patchOptional({}, "departmentId", null)).toBeNull();
+  });
+});
+
+describe("trimToNull", () => {
+  it("nulls blank, whitespace, undefined, and null", () => {
+    expect(trimToNull("")).toBeNull();
+    expect(trimToNull("   ")).toBeNull();
+    expect(trimToNull(undefined)).toBeNull();
+    expect(trimToNull(null)).toBeNull();
+  });
+
+  it("trims a real value", () => {
+    expect(trimToNull("  x  ")).toBe("x");
+  });
+});

--- a/apps/web/lib/workforce/patch-optional.ts
+++ b/apps/web/lib/workforce/patch-optional.ts
@@ -1,0 +1,31 @@
+// PATCH-semantics helper for partial workforce updates (BI-HCM-004).
+//
+// Lives outside `lib/actions/workforce.ts` because that module is `"use server"` and may only
+// export async functions — a sync helper cannot be exported from it for testing.
+
+/** Trim to a value, or null when blank/absent. */
+export function trimToNull(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Resolve one optional field under PATCH semantics.
+ *
+ *   absent key   -> keep `current` (the caller is not talking about this field)
+ *   null or ""   -> clear it (an explicit, deliberate unset)
+ *   value        -> set it
+ *
+ * Distinguishing "absent" from "empty" is the entire point. Collapsing both to null — which
+ * is what a plain `trimToNull(input.field)` does — turns every partial update into a silent
+ * wipe of the fields it never mentioned. `assignEmployeeOrg` had exactly that shape, which is
+ * why the org chart had to route around it rather than reuse it.
+ */
+export function patchOptional<K extends string>(
+  input: Partial<Record<K, string | null>>,
+  key: K,
+  current: string | null,
+): string | null {
+  if (!(key in input) || input[key] === undefined) return current;
+  return trimToNull(input[key]);
+}

--- a/docs/superpowers/specs/2026-07-30-interactive-org-chart-design.md
+++ b/docs/superpowers/specs/2026-07-30-interactive-org-chart-design.md
@@ -127,6 +127,29 @@ Role *definitions* remain read-only: no action in the codebase mutates `Platform
 one is new substrate warranting its own risk-band decision and admin-scope check. That gap is
 recorded as follow-up rather than smuggled into this change.
 
+## Addendum — 2026-07-31: placement editing, and the hazard fixed at source
+
+The first slice routed *around* `assignEmployeeOrg` rather than repairing it, which left
+department, position, and work location uneditable anywhere in the portal — the same defect
+this spec was written to fix, one field over. `assignEmployeeOrg` still had zero callers.
+
+`assignEmployeeOrg` now has **PATCH semantics**: an absent key means "leave this field alone",
+an explicit `null` or `""` means "clear it". The distinguishing logic lives in
+`apps/web/lib/workforce/patch-optional.ts` — outside the `"use server"` action module, which
+may only export async functions, so a sync helper could not be exported from it for testing.
+
+That removes the hazard at its source instead of asking every caller to defend against it. The
+org chart's detail panel now carries Team, Role, and Location pickers, each sending exactly one
+field.
+
+Scored at `DI-85C62D7D17CE` against a modal alternative and against keeping the
+rewrite-everything action and passing all current values from the client. The kernel ranked
+that last option last, for the same reason it ranked the equivalent option last in the original
+decision: a client that must remember to resend four unrelated fields will eventually forget.
+
+`reassignEmployeeManager` stays. It is still the right shape for drag-to-reassign — one field,
+one employment event, one cycle check — and it is what the drag handler calls.
+
 ## Not in this slice
 
 BI-HCM-004 also covers approval routing and delegated approval driven by the org service. This slice

--- a/docs/user-guide/hr/index.md
+++ b/docs/user-guide/hr/index.md
@@ -101,6 +101,16 @@ The platform refuses a move that would create a reporting loop — you cannot pl
 underneath one of their own reports, directly or indirectly. Managers who would create a loop are
 not offered in the picker at all, and a drag that would cause one is rejected with an explanation.
 
+### Change Someone's Team, Role, or Location
+
+The side panel also holds **Team**, **Role**, and **Location** pickers. Each one saves on its
+own — changing someone's team leaves their role, location, and reporting lines exactly as they
+were. Set a picker back to its blank option ("Unassigned", "No role", "No location") to clear
+that field.
+
+These are the same placements shown on the Directory view; editing them here updates the
+employee record everywhere.
+
 ### Find People and Spot Problems
 
 Use the search box and the team and status filters to narrow the chart. Filtered-out people are

--- a/docs/ux-fit/2026-07-31-org-assignment-editable.ux-fit.json
+++ b/docs/ux-fit/2026-07-31-org-assignment-editable.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "inline-pickers-patch-action",
+  "decisionInteractionId": "DI-85C62D7D17CE",
+  "scope": {
+    "files": [
+      "apps/web/components/employee/OrgChartView.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "inline-pickers-patch-action",
+      "separate-placement-modal",
+      "pass-all-fields-no-patch"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -4904,7 +4904,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 129
+    "textMass": 135
   },
   "apps/web/components/employee/ReviewPanel.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Follow-up to #3801 and #3822. Part of **BI-HCM-004**.

## The gap

`assignEmployeeOrg` **still had zero callers.** #3801 found it orphaned and then routed
*around* it with a narrow manager-only action rather than repairing it — so department,
position, and work location remained uneditable anywhere in the portal. That is the same
"governed action exists but is unreachable" defect the org chart was built to fix, one field
over. `OrgAssignmentPanel` is still a read-only display with no form.

## Why it could not simply be called

`assignEmployeeOrg` rewrote all six fields from its input, and `trimOptional(undefined)` is
`null`. A caller that mentioned only the manager therefore **silently cleared department,
position, work location, and timezone**. Any UI wired to it had to remember to resend four
unrelated fields on every edit, forever.

## Fix the hazard at source, then use the action

- **`assignEmployeeOrg` now has PATCH semantics.** An absent key means "leave this field
  alone"; an explicit `null` or `""` means "clear it". Changing an established action's
  semantics is normally risky — it is safe here precisely because a sweep across `apps/web`
  and `packages`, including tests and MCP packs, confirmed **no callers to regress**.
- The distinguishing logic lives in a new `apps/web/lib/workforce/patch-optional.ts` rather
  than inside the action, because `lib/actions/workforce.ts` is a `"use server"` module and
  may only export async functions — a sync helper cannot be exported from it for testing.
- The org chart's detail panel gains **Team**, **Role**, and **Location** pickers, each
  sending exactly one field. The blank option clears. Gated on the same
  `manage_user_lifecycle` capability as reassignment.

`reassignEmployeeManager` stays. It remains the right shape for drag-to-reassign — one field,
one employment event, one cycle check — and is what the drag handler calls.

## Correctness detail

`EmployeeProfile.departmentId` / `positionId` / `workLocationId` reference the **row `id`**,
not the semantic `departmentId` / `positionId` / `locationId` string (confirmed in
`packages/db/prisma/schema.prisma`). The pickers send `.id` accordingly.

## Design grounding

- **Existing specs/plans reviewed:**
  `docs/superpowers/specs/2026-07-30-interactive-org-chart-design.md` — extended with a dated
  addendum recording the source-level fix and why the narrow action remains;
  `docs/ux-fit/2026-07-30-employee-org-chart-interactive.ux-fit.json` — prior decision,
  unchanged by this work.
- **Current code substrate reviewed:** `lib/actions/workforce.ts` (`assignEmployeeOrg`,
  `reassignEmployeeManager`, `withGovernedWorkforceAction`, `trimOptional`),
  `components/employee/OrgAssignmentPanel.tsx` (the read-only display this supersedes for
  editing), `components/employee/OrgChartView.tsx`, `packages/db/prisma/schema.prisma`.
- **Source of truth:** `EmployeeProfile.departmentId` / `positionId` / `workLocationId`, with
  `Department` / `Position` / `WorkLocation` as reference sets already loaded by
  `getWorkforceReferenceData`.
- **Decision:** repair the existing governed action rather than add a third one. No new route
  and no new component family — `PlacementPicker` is local panel layout, not a new primitive.

## UX fit

`docs/ux-fit/2026-07-31-org-assignment-editable.ux-fit.json` — `propose-n-pick`,
`DI-85C62D7D17CE`, high confidence, margin 2.52. Scored against a separate placement modal and
against keeping the rewrite-everything action while resending all current values from the
client. **The kernel ranked that last option last** — the same verdict it reached on the
equivalent option in the original org-chart decision.

## Verification

- Local-CI sandbox gate: `gate passed` for head `2186cda078`, including the production build.
- 30/30 pregate preflight guards clean.
- 180 unit tests green — 10 new, covering absent vs `undefined` vs `null` vs `""` vs
  whitespace vs value, and explicitly that unmentioned sibling fields survive.
- Typecheck clean for every file in this change.

Functional verification of the new pickers on the canonical install is **not** claimed here;
it needs the change deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
