### PR TITLE
fix(marketing): stop fabricating a placeholder campaign brief (BI-71D945CD)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -461,9 +461,17 @@ describe("executeScheduledAgentTask — coworker self-task model + required-tool
     });
   });
 
-  it("force-creates a brief when the loop narrated without calling the tool and no recent brief exists", async () => {
+  // BI-71D945CD. These two cases previously asserted the opposite: that a
+  // narrating loop got a placeholder "Acquisition campaign brief (needs refresh)"
+  // force-created for it, recency-guarded so it was not duplicated tick-over-tick.
+  // That trade made sense only while an empty Campaigns page was a wall of zeros.
+  // The canonical marketing operating snapshot now renders an honest, actionable
+  // empty state instead — "establish one bounded campaign", plus a blocker with
+  // one recovery action — so fabricating a brief is strictly worse than the truth.
+  it("does NOT fabricate a brief when the loop narrated without calling the tool", async () => {
     arrangeMarketingSelfTask();
-    // No successful tool call recorded this run, and no recent brief anywhere.
+    // No successful tool call recorded this run, and no recent brief anywhere —
+    // formerly the exact trigger for the forced placeholder.
     mocks.prisma.toolExecution.findFirst.mockResolvedValue(null);
     mocks.prisma.marketingCampaignBrief.findFirst.mockResolvedValue(null);
     mocks.runAgenticLoop.mockResolvedValue({
@@ -473,31 +481,23 @@ describe("executeScheduledAgentTask — coworker self-task model + required-tool
 
     await executeScheduledAgentTask("self-marketing-specialist-user-1");
 
-    expect(mocks.governedExecuteTool).toHaveBeenCalledWith(
-      expect.objectContaining({
-        toolName: "create_marketing_campaign_brief",
-        context: expect.objectContaining({
-          routeContext: "/customer/marketing",
-          agentId: "marketing-specialist",
-          taskRunId: "TR-SCHED-MKTG1",
-        }),
-      }),
-    );
+    expect(mocks.governedExecuteTool).not.toHaveBeenCalled();
   });
 
-  it("does NOT force-create a brief when a recent brief already exists (recency guard)", async () => {
+  it("still runs the marketing self-task — the loop is unchanged, only the forced artifact is gone", async () => {
     arrangeMarketingSelfTask();
-    // The loop didn't record a tool call this run, but a recent brief exists —
-    // forcing would duplicate a placeholder, so the fallback must stand down.
     mocks.prisma.toolExecution.findFirst.mockResolvedValue(null);
-    mocks.prisma.marketingCampaignBrief.findFirst.mockResolvedValue({ briefId: "brief-existing" });
+    mocks.prisma.marketingCampaignBrief.findFirst.mockResolvedValue(null);
     mocks.runAgenticLoop.mockResolvedValue({
-      content: "Campaign brief recorded. Done.",
+      content: "Nothing new to add this cycle.",
       executedTools: [],
     });
 
     await executeScheduledAgentTask("self-marketing-specialist-user-1");
 
+    // The coworker still gets its turn; it simply is not compelled to invent an
+    // artifact when it has nothing real to say.
+    expect(mocks.runAgenticLoop).toHaveBeenCalledOnce();
     expect(mocks.governedExecuteTool).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.test.ts
@@ -222,6 +222,28 @@ describe("coworkerSelfTaskRequiredTool (anti-fabrication floor)", () => {
   it("returns null for a coworker with no self-task", () => {
     expect(coworkerSelfTaskRequiredTool("some-advisor")).toBeNull();
   });
+
+  // BI-71D945CD. The Marketing Strategist USED to be forced to create a
+  // placeholder "Acquisition campaign brief (needs refresh)" whenever its loop
+  // produced nothing, on the reasoning that a provisional brief beat an empty
+  // Campaigns page. The canonical marketing operating snapshot (BI-CEA797A1) now
+  // renders an honest, actionable empty state for exactly that case — next step
+  // "establish-campaign" plus a no-campaign blocker carrying one recovery action
+  // — so the fabricated brief is strictly worse than the truth. Observed live on
+  // 2026-07-31 creating real placeholder rows because model dispatch was failing.
+  it("does NOT force a placeholder brief for the Marketing Strategist", () => {
+    expect(coworkerSelfTaskRequiredTool(MKT)).toBeNull();
+  });
+
+  // The removal is deliberately marketing-only: the other three surfaces have no
+  // equivalent honest empty state, so dropping their fallbacks would trade a
+  // placeholder for a genuine wall of zeros. This pins the scope so a future
+  // edit cannot silently widen or narrow it.
+  it("leaves the other coworkers' procedural guarantees intact", () => {
+    expect(coworkerSelfTaskRequiredTool(INV)?.name).toBe("create_knowledge_article");
+    expect(coworkerSelfTaskRequiredTool(PLT)?.name).toBe("create_knowledge_article");
+    expect(coworkerSelfTaskRequiredTool(DOC)?.name).toBe("doc_save");
+  });
 });
 
 describe("inferLevelFromSelfTaskSchedule", () => {

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -266,12 +266,6 @@ export type CoworkerSelfTaskProceduralTool = {
   hasRecentArtifact: () => Promise<boolean>;
 };
 
-// A brief created within this window counts as "recent", so the forced fallback
-// stands down. Wider than the daily assertive cadence so a single placeholder is
-// never re-created tick-over-tick; the coworker's own (capable-model) briefs land
-// well inside it and suppress the fallback entirely.
-const RECENT_CAMPAIGN_BRIEF_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
-
 // Recency windows for the sub-daily self-tasks. Each is wider than that
 // coworker's Assertive cadence gap (twice-weekly) so a single placeholder is
 // never re-created between two consecutive runs.
@@ -298,34 +292,24 @@ async function hasRecentKnowledgeArticle(titlePrefix: string): Promise<boolean> 
  * the coworker's self-task has no procedural guarantee (the loop's own output is
  * sufficient). Mirrors getRequiredProceduralToolForScheduledTask for the curated
  * self-task registry above.
+ *
+ * The Marketing Strategist deliberately has NO guarantee (BI-71D945CD). It used
+ * to be forced to create a placeholder campaign brief, on the reasoning that a
+ * provisional brief beat an empty Campaigns page. The canonical marketing
+ * operating snapshot removed that premise: an empty marketing workspace now
+ * renders an honest, actionable next step ("establish one bounded campaign")
+ * plus a blocker carrying one recovery action, so a fabricated brief is strictly
+ * worse than the truth. Observed creating real placeholder rows on a live
+ * install while model dispatch was failing, which is exactly when the loop
+ * produces nothing and the fallback fires every tick.
+ *
+ * Before adding a guarantee for another coworker, check whether that surface has
+ * an honest empty state first — a placeholder is only ever better than a wall of
+ * zeros, never better than the truth.
  */
 export function coworkerSelfTaskRequiredTool(
   agentId: string,
 ): CoworkerSelfTaskProceduralTool | null {
-  if (agentId === "marketing-specialist") {
-    return {
-      name: "create_marketing_campaign_brief",
-      // Honest, generic placeholder. Only reached when the marketing page has no
-      // recent brief AND the coworker's loop failed to produce one — so a clearly
-      // provisional brief beats an empty Campaigns page. required: title, objective.
-      args: {
-        title: "Acquisition campaign brief (needs refresh)",
-        objective:
-          "Provisional acquisition brief created automatically because the Campaigns page had no recent brief. Refresh with a segment-specific objective, audience, and channel mix.",
-        notes:
-          "Auto-generated fallback so the Campaigns page is not empty. The Marketing Strategist should replace this with a grounded, ICP-specific brief on its next run.",
-      },
-      hasRecentArtifact: async () => {
-        const since = new Date(Date.now() - RECENT_CAMPAIGN_BRIEF_WINDOW_MS);
-        const recent = await prisma.marketingCampaignBrief.findFirst({
-          where: { createdAt: { gte: since } },
-          select: { briefId: true },
-        });
-        return recent !== null;
-      },
-    };
-  }
-
   if (agentId === "inventory-specialist") {
     return {
       name: "create_knowledge_article",

--- a/docs/user-guide/customers/marketing.md
+++ b/docs/user-guide/customers/marketing.md
@@ -100,6 +100,13 @@ Campaign briefs precede individual assets. This order prevents a polished post
 or email from becoming the de facto strategy. Asset tasks are the concrete work
 items that can become approval-gated drafts.
 
+The Marketing Strategist will not invent a placeholder brief to make the page
+look busy. If it has nothing grounded to propose this cycle, Campaigns stays
+empty and the overview tells you so plainly, with the next step being to
+establish one bounded campaign. An empty Campaigns page is a truthful state, not
+a broken one — and it is more useful than a provisional brief you would have to
+recognise and discard.
+
 When no campaign exists, return to the strategist workspace rather than creating
 unrelated assets. When an asset is incomplete, revise the task or proof before
 moving it into review.


### PR DESCRIPTION
Tracked by **BI-71D945CD** under **EP-MARKETING**.

## What was happening

On 2026-07-31 the Marketing Strategist created this on the live install:

> **title:** "Acquisition campaign brief (needs refresh)"
> **notes:** "Auto-generated fallback so the Campaigns page is not empty."

It came from the `marketing-specialist` branch of `coworkerSelfTaskRequiredTool`, which forces an artifact whenever the coworker's loop produces nothing. An identical attempt the day before failed outright, so it fires regardless of outcome.

## Why remove it now

The mechanism was **deliberate, not sloppy**. It carries a 3-day recency guard so placeholders aren't duplicated tick-over-tick, and its in-code rationale was that *a clearly provisional brief beats an empty Campaigns page*. That trade was sound while an empty marketing surface meant a wall of zeros.

`BI-CEA797A1` removed the premise. The canonical operating snapshot now renders an honest, actionable empty state for exactly this case — next step *"establish one bounded campaign"* plus a `no-campaign` blocker carrying one recovery action. A fabricated brief is now **strictly worse than the truth**: the owner has to recognise it as fake and discard it, and it counts against the archetype-fit quarantine banner while it sits there.

Two things made this urgent rather than theoretical:

- The code comment assumes *"the coworker (on a capable model) produces the real artifact itself"*. That is currently false — model dispatch is failing (`BI-8058697C`: local returns a context/logits 500, codex is pool-exhausted), so the loop reliably produces nothing and the fallback is the **normal path**, not a rare backstop.
- It is quietly accreting placeholder artifacts on the dogfood install.

## Scope: marketing only, deliberately

The same mechanism serves `inventory-specialist`, `platform-engineer` and `doc-specialist`. **None of those surfaces has an equivalent honest empty state**, so removing their fallbacks would trade a placeholder for a genuine wall of zeros.

Scored through the kernel rather than decided by hand — `principle_decide` ledger `DI-CB2CEAA5BFFD`, composite 9.62, margin 4.54, high confidence, no commandment conflict. Strongest contributors: *Ship Real Functionality* and *Never Fabricate*. The function's doc now records that reasoning, so the next person adding a guarantee checks for an honest empty state first.

**The marketing self-task is unchanged and still runs.** It is simply no longer compelled to invent an artifact when it has nothing real to say.

## Tests

Written red-first. Two existing tests had **codified the old behaviour** (`BI-3F09BDD4`'s "force-creates a brief when the loop narrated without calling the tool" and its recency-guard sibling). They are **reframed to assert the new contract, not deleted**, so the case stays covered. Added a scope pin asserting the other three coworkers keep their guarantees, so a future edit cannot silently widen or narrow this.

- **382 tests pass across 42 files** (`lib/operate/scheduled-jobs`, `lib/actions/agent-task-scheduler`, `lib/marketing`).
- `pregate-preflight`: **30 guards clean in 49.6s** — includes UX-Fit Gate, Design Grounding Gate, Doc Reference Integrity, Prose Lint. `Repo Guard Loop` was environment-skipped for a missing local runtime (pre-existing; CI still enforces it).
- Module-size ratchet OK; substrate-regression guard OK.

### Runtime-bound gates

Not run locally. The shared `local-integration-ci` slot pool was saturated by six concurrent sessions across two windows; my lease queued (position 4, then 3 → 2) without being admitted. The pool queues correctly — this is contention, not the fence-spin failure mode seen previously — but I did not serially re-queue against it. CI on this PR is the authoritative gate for typecheck, production build and the full suite.

Local-CI-Override: shared local-integration-ci slot pool saturated by six concurrent sessions across two windows without admission; 30 pregate-preflight guards clean and 382 unit tests green locally; typecheck, production build and full suite deferred to CI.
Docs-Impact-Decision: docs/user-guide/customers/marketing.md updated — an empty Campaigns page is a truthful state and the strategist will not invent a placeholder to look busy.
Process-Spine-Decision: narrow independently shippable slice of the Deliverable B anti-filler intent under BI-71D945CD; the full operating-cycle reducer stays with BI-A6D5DF95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)