### PR TITLE
feat(build): A1 Phase 2a — governed profession-corpus injection for build specialists (BI-C654F960)

### DIFF
--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -14,6 +14,7 @@ import { runAgenticLoop, type AgenticResult } from "@/lib/agentic-loop";
 import { agentEventBus, type AgentEvent } from "@/lib/agent-event-bus";
 import { getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
 import { getBuildContextSection } from "@/lib/integrate/build-agent-prompts";
+import { appendGovernedSpecialistCorpus } from "@/lib/integrate/build-specialist-corpus";
 import {
   buildDependencyGraph,
   type AssignedTask,
@@ -941,12 +942,15 @@ async function dispatchSpecialist(params: {
   const scopedTools = allTools.filter(t => allowedToolNames.has(t.name));
   const toolsForProvider = toolsToOpenAIFormat(scopedTools);
 
-  const systemPrompt = await buildSpecialistPrompt({
+  const baseSystemPrompt = await buildSpecialistPrompt({
     role,
     taskDescription: `Task: ${task.title}\n\nFiles to work on:\n${(task.files ?? []).map(f => `- ${f.path} (${f.action}): ${f.purpose}`).join("\n") || "See task description for details."}`,
     buildContext,
     priorResults,
   });
+  // A1 (BI-C654F960) Phase 2a: govern the inline path — append the real
+  // specialist Agent's corpus (BI-B31072B8). Flag-gated default-off (no-op).
+  const { prompt: systemPrompt } = await appendGovernedSpecialistCorpus(baseSystemPrompt, { role, agentId, query: task.title });
 
   let lastResult: AgenticResult | null = null;
   let retries = 0;

--- a/apps/web/lib/integrate/build-specialist-corpus.test.ts
+++ b/apps/web/lib/integrate/build-specialist-corpus.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  appendGovernedSpecialistCorpus,
+  governedSpecialistCorpusEnabled,
+  BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG,
+} from "./build-specialist-corpus";
+import type { ProfessionCorpusClient } from "@/lib/decision-perspective/profession-corpus";
+
+const BASE = "You are the Data Architect.\n\n--- Your Assigned Task ---\nDo the thing";
+
+/** A fake corpus client returning one data-architect page for the DA family. */
+function fakeDb(rows: Array<{ slug: string; title: string; abstract: string; body: string }>): ProfessionCorpusClient {
+  return {
+    wikiPage: {
+      findMany: vi.fn(async () =>
+        rows.map((r) => ({ ...r, metadata: null })) as never,
+      ),
+    },
+  };
+}
+
+describe("governedSpecialistCorpusEnabled — default off", () => {
+  it("is off when the flag is unset", () => {
+    expect(governedSpecialistCorpusEnabled({})).toBe(false);
+  });
+  it("is off for any value other than exactly 'true'", () => {
+    expect(governedSpecialistCorpusEnabled({ [BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG]: "1" })).toBe(false);
+    expect(governedSpecialistCorpusEnabled({ [BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG]: "TRUE" })).toBe(false);
+  });
+  it("is on only for 'true'", () => {
+    expect(governedSpecialistCorpusEnabled({ [BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG]: "true" })).toBe(true);
+  });
+});
+
+describe("appendGovernedSpecialistCorpus (A1 Phase 2a, BI-C654F960)", () => {
+  const on = { [BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG]: "true" };
+  const off = {};
+
+  it("is a STRICT no-op when the flag is off (the default) — prompt byte-identical", async () => {
+    const db = fakeDb([{ slug: "professions/data-architect/x", title: "X", abstract: "a", body: "b" }]);
+    const res = await appendGovernedSpecialistCorpus(BASE, {
+      agentId: "data-architect",
+      query: "task",
+      db,
+      env: off,
+    });
+    expect(res.prompt).toBe(BASE);
+    expect(res.injected).toBe(false);
+    // The corpus is not even queried when disabled.
+    expect(db.wikiPage.findMany).not.toHaveBeenCalled();
+  });
+
+  it("injects the real Agent's corpus when enabled and the family resolves", async () => {
+    const db = fakeDb([
+      {
+        slug: "professions/data-architect/mdm-what-it-does-and-does-not-do",
+        title: "MDM — What It Does and Does Not Do",
+        abstract: "MDM resolves duplicates after the fact.",
+        body: "MDM resolves duplicates after the fact — it does not prevent their creation.",
+      },
+    ]);
+    const res = await appendGovernedSpecialistCorpus(BASE, {
+      agentId: "data-architect",
+      query: "master data dedupe",
+      db,
+      env: on,
+    });
+    expect(res.injected).toBe(true);
+    expect(res.pages).toBeGreaterThan(0);
+    expect(res.prompt.startsWith(BASE)).toBe(true);
+    expect(res.prompt.length).toBeGreaterThan(BASE.length);
+    // The corpus content actually landed in the prompt.
+    expect(res.prompt).toContain("MDM");
+  });
+
+  it("returns the base unchanged when the agent maps to no profession family", async () => {
+    const db = fakeDb([{ slug: "professions/data-architect/x", title: "X", abstract: "a", body: "b" }]);
+    const res = await appendGovernedSpecialistCorpus(BASE, {
+      agentId: "not-a-profession-agent-zzz",
+      query: "task",
+      db,
+      env: on,
+    });
+    expect(res.prompt).toBe(BASE);
+    expect(res.injected).toBe(false);
+  });
+
+  it("fail-open: a resolve error returns the base prompt unchanged", async () => {
+    const db: ProfessionCorpusClient = {
+      wikiPage: { findMany: vi.fn(async () => { throw new Error("db down"); }) },
+    };
+    const res = await appendGovernedSpecialistCorpus(BASE, {
+      agentId: "data-architect",
+      query: "task",
+      db,
+      env: on,
+    });
+    expect(res.prompt).toBe(BASE);
+    expect(res.injected).toBe(false);
+  });
+});

--- a/apps/web/lib/integrate/build-specialist-corpus.ts
+++ b/apps/web/lib/integrate/build-specialist-corpus.ts
@@ -1,0 +1,90 @@
+// A1 (BI-C654F960) Phase 2a — governed profession-corpus injection for build
+// specialists, flag-gated default-off.
+//
+// THE CONVERGENCE STEP THIS IS. The build orchestrator runs each specialist on a
+// hardcoded persona string (SPECIALIST_PROMPTS) and never injects the
+// profession corpus — so the data-architecture practice corpus (BI-B31072B8),
+// though published and retrievable, reaches only interactive chat, never a
+// build. The correct fix (see the A1 investigation notes on BI-C654F960) is to
+// GOVERN THE INLINE PATH: resolve the REAL specialist Agent's corpus and thread
+// it into the same inline runAgenticLoop the build already runs — NOT to hand
+// off via requestCoworker (an async CollaborationResult that cannot return the
+// synchronous AgenticResult the build needs), and NOT to bake corpus into
+// buildSpecialistPrompt as an end state (which would entrench the legacy plane).
+//
+// This is the FIRST governed increment: corpus injection keyed on the real Agent
+// identity. Grant-based tool scoping, the DelegationChain hop, authority
+// enforcement, and retiring SPECIALIST_PROMPTS are later phases.
+//
+// SAFETY: flag-gated default-off. With the flag off (the default) this returns
+// the base prompt UNCHANGED, so the build path behaves EXACTLY as today and the
+// legacy persona-string plane stays the active path. Fail-open: any resolve
+// error returns the base unchanged — corpus is additive context, never a gate.
+
+import { prisma } from "@dpf/db";
+import {
+  resolveProfessionCorpusContext,
+  type ProfessionCorpusClient,
+} from "@/lib/decision-perspective/profession-corpus";
+
+/** Env flag that enables governed corpus injection into build specialists. */
+export const BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG = "BUILD_GOVERNED_SPECIALIST_CORPUS";
+
+/** Default-off: only the exact string "true" enables it. */
+export function governedSpecialistCorpusEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[BUILD_GOVERNED_SPECIALIST_CORPUS_FLAG] === "true";
+}
+
+export interface AppendGovernedCorpusResult {
+  /** The system prompt to use — the base unchanged when disabled or on a miss. */
+  prompt: string;
+  /** Whether a corpus block was actually appended. */
+  injected: boolean;
+  /** Number of corpus pages injected (0 when not injected). */
+  pages: number;
+}
+
+/**
+ * Append the real specialist Agent's profession corpus to its inline system
+ * prompt. Returns the base prompt unchanged when the flag is off, the agent maps
+ * to no profession family, the corpus is empty, or resolution errors.
+ */
+export async function appendGovernedSpecialistCorpus(
+  basePrompt: string,
+  opts: {
+    /** The specialist's real Agent id (SPECIALIST_AGENT_IDS[role]). */
+    agentId: string;
+    /** The retrieval query — the task at hand ranks the corpus pages. */
+    query: string;
+    /** Specialist role, for the injection log line. */
+    role?: string;
+    db?: ProfessionCorpusClient;
+    env?: Record<string, string | undefined>;
+  },
+): Promise<AppendGovernedCorpusResult> {
+  if (!governedSpecialistCorpusEnabled(opts.env)) {
+    return { prompt: basePrompt, injected: false, pages: 0 };
+  }
+  const corpus = await resolveProfessionCorpusContext({
+    db: opts.db ?? (prisma as unknown as ProfessionCorpusClient),
+    identity: { agentId: opts.agentId },
+    query: opts.query,
+  }).catch((e) => {
+    console.warn("[build-specialist-corpus] resolve failed (fail-open):", e);
+    return null;
+  });
+
+  if (!corpus?.promptBlock) {
+    return { prompt: basePrompt, injected: false, pages: 0 };
+  }
+  console.info(
+    `[build-specialist] governed corpus injected for ${opts.role ?? "specialist"} (${opts.agentId}): ${corpus.pages.length} page(s)`,
+  );
+  return {
+    prompt: `${basePrompt}\n\n${corpus.promptBlock}`,
+    injected: true,
+    pages: corpus.pages.length,
+  };
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -36,7 +36,7 @@ apps/web/lib/explore/feature-build-types.ts	1098
 apps/web/lib/finance/ai-provider-finance.ts	1309
 apps/web/lib/inference/ai-provider-internals.ts	1266
 apps/web/lib/integrate/build-agent-prompts.ts	1075
-apps/web/lib/integrate/build-orchestrator.ts	1796
+apps/web/lib/integrate/build-orchestrator.ts	1800
 apps/web/lib/integrate/sandbox/build-branch.ts	949
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874


### PR DESCRIPTION
The **first governed increment** of A1's convergence (specialist plane → A2A), shipped **behind a default-off flag** so it changes nothing on the build path until deliberately enabled. Advances BI-C654F960 (stays open for the remaining phases).

## Why this, and why it's safe

The build orchestrator runs each specialist on a hardcoded persona string and **never injects the profession corpus** — so the data-architecture practice corpus (BI-B31072B8, PR #3843) reaches only interactive chat, never a build. My A1 investigation (recorded on the BI) established the correct fix: **govern the inline path** — resolve the *real* specialist Agent's corpus into the same inline `runAgenticLoop` the build already runs — *not* hand off via `requestCoworker` (an async `CollaborationResult` that can't return the synchronous `AgenticResult` the build needs), and *not* bake corpus into `buildSpecialistPrompt` as an end state.

**The only change to the active build path** is passing the specialist system prompt through a helper that returns it **unchanged when the flag is off** (the default). No execution-model change, no schema change, reversible by a flag.

## What ships

- **`build-specialist-corpus.ts`** — `appendGovernedSpecialistCorpus`: resolves the specialist Agent's profession corpus (via the existing `resolveProfessionCorpusContext`, keyed on the real `agentId`) and appends its `promptBlock`. Flag-gated `BUILD_GOVERNED_SPECIALIST_CORPUS` (default off → strict no-op). Fail-open on any error or family miss.
- **`build-orchestrator.ts`** — the specialist prompt is threaded through the helper.

## Verification — functional, incl. real data

- **7 unit tests**: default-off is a strict no-op (corpus not even queried); flag-on injects; unmapped family → base unchanged; resolve error → fail-open.
- **End-to-end against the real seeded data-architect corpus** (flag on): `injected=true`, **3 pages**, prompt grows and contains the **MDM practice content authored in A2**. Flag off: prompt byte-identical.
- apps/web typecheck clean. No migration.

## Scope

Phase 2a (corpus injection) — **not** the full convergence. Grant-based tool scoping, the DelegationChain hop, authority enforcement, and retiring `SPECIALIST_PROMPTS` are later phases (plan: PR #3839). But this delivers the highest-value convergence outcome — the A2 corpus reaching build specialists — safely and now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: flag-gated default-off build change; 7 unit tests + end-to-end real-corpus proof, apps/web typecheck clean, module-size re-baselined. Local full suite parity with main (pre-existing shard flakiness unrelated).
