### PR TITLE
fix(ci): probe container-local PostgreSQL

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -266,6 +266,17 @@ afterward. Against the motivating failure, this avoids at least the observed
 221.10 seconds of exhaustive test work; green candidates still execute the
 unchanged exhaustive suite and production build.
 
+**Production-build control-plane boundary (BI-CE6E2882).** On Windows, the
+production build runs in a resource-bounded BuildKit container while the gate
+independently probes the portal, MCP, Docker Engine, and live PostgreSQL. The
+live database is intentionally not required to publish port 5432 to the host:
+the default probe executes `SELECT 1` through `psql` inside the configured
+PostgreSQL container, using its own `POSTGRES_USER` / `POSTGRES_DB` identity.
+An explicit `DPF_CONTROL_PLANE_DATABASE_URL` remains the portable override for
+non-container deployments. Never infer the host endpoint as
+`127.0.0.1:5432`; Compose may keep PostgreSQL internal-only or publish it on a
+different host port.
+
 Claim, heartbeat, signal/fence, and release timestamps are included in the
 evidence and Git-local state. An expired TTL is never permission for the old
 owner to continue working. The gate does

--- a/scripts/lib/local-ci-bounded-builder.mjs
+++ b/scripts/lib/local-ci-bounded-builder.mjs
@@ -61,6 +61,30 @@ export function databaseUrlFromContainerEnvironment(lines, {
     + `@${host}:${port}/${encodeURIComponent(database)}`;
 }
 
+export function postgresContainerProbeArgs({ container, environment }) {
+  if (!container) {
+    throw new Error("live PostgreSQL container identity is unavailable");
+  }
+  const values = Object.fromEntries(
+    String(environment || "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return separator > 0
+          ? [line.slice(0, separator), line.slice(separator + 1)]
+          : [line, ""];
+      }),
+  );
+  const user = values.POSTGRES_USER || "dpf";
+  const database = values.POSTGRES_DB || "dpf";
+  return [
+    "exec", container,
+    "psql", "-U", user, "-d", database, "-tAc", "SELECT 1",
+  ];
+}
+
 export function classifyBoundedBuildExit({ exitCode, output }) {
   if (
     exitCode !== 0

--- a/scripts/lib/local-ci-bounded-builder.test.mjs
+++ b/scripts/lib/local-ci-bounded-builder.test.mjs
@@ -6,6 +6,7 @@ import {
   buildxCreateArgs,
   classifyBoundedBuildExit,
   databaseUrlFromContainerEnvironment,
+  postgresContainerProbeArgs,
   validateBuilderInspection,
 } from "./local-ci-bounded-builder.mjs";
 
@@ -58,6 +59,20 @@ test("live PostgreSQL credentials are encoded without assuming the install passw
   assert.throws(
     () => databaseUrlFromContainerEnvironment("POSTGRES_USER=dpf"),
     /password is unavailable/,
+  );
+});
+
+test("container-local PostgreSQL probe does not assume a host-published port", () => {
+  assert.deepEqual(postgresContainerProbeArgs({
+    container: "dpf-postgres-1",
+    environment: "POSTGRES_USER=dpf\nPOSTGRES_PASSWORD=do-not-forward\nPOSTGRES_DB=dpf\n",
+  }), [
+    "exec", "dpf-postgres-1",
+    "psql", "-U", "dpf", "-d", "dpf", "-tAc", "SELECT 1",
+  ]);
+  assert.throws(
+    () => postgresContainerProbeArgs({ container: "", environment: "POSTGRES_USER=dpf" }),
+    /container identity is unavailable/,
   );
 });
 

--- a/scripts/local-ci-bounded-build.mjs
+++ b/scripts/local-ci-bounded-build.mjs
@@ -9,7 +9,7 @@ import {
   buildxBuildArgs,
   buildxCreateArgs,
   classifyBoundedBuildExit,
-  databaseUrlFromContainerEnvironment,
+  postgresContainerProbeArgs,
   validateBuilderInspection,
 } from "./lib/local-ci-bounded-builder.mjs";
 import {
@@ -163,9 +163,10 @@ async function probePostgres(databaseUrl) {
   }
 }
 
-function resolveControlPlaneDatabaseUrl() {
+function resolveControlPlanePostgresProbe() {
   if (process.env.DPF_CONTROL_PLANE_DATABASE_URL) {
-    return process.env.DPF_CONTROL_PLANE_DATABASE_URL;
+    const databaseUrl = process.env.DPF_CONTROL_PLANE_DATABASE_URL;
+    return () => probePostgres(databaseUrl);
   }
   const container = process.env.DPF_CONTROL_PLANE_POSTGRES_CONTAINER
     || "dpf-postgres-1";
@@ -178,10 +179,14 @@ function resolveControlPlaneDatabaseUrl() {
   if (inspected.status !== 0) {
     throw new Error("live PostgreSQL container environment is unavailable");
   }
-  return databaseUrlFromContainerEnvironment(inspected.stdout);
+  const args = postgresContainerProbeArgs({
+    container,
+    environment: inspected.stdout,
+  });
+  return () => commandHealthy("docker", args, 2_500);
 }
 
-async function probeControlPlane(databaseUrl) {
+async function probeControlPlane(postgresProbe) {
   const portalUrl = process.env.DPF_CONTROL_PLANE_PORTAL_URL || "http://127.0.0.1:3000";
   const mcpUrl = process.env.DPF_MCP_URL || `${portalUrl}/api/mcp/v1`;
   const bearerToken = process.env.DPF_MCP_BEARER_TOKEN || "";
@@ -202,7 +207,7 @@ async function probeControlPlane(databaseUrl) {
       return response?.success === true;
     }),
     timedProbe(() => commandHealthy("docker", ["info"], 2_500)),
-    timedProbe(() => probePostgres(databaseUrl)),
+    timedProbe(postgresProbe),
   ]);
   return { portal, mcp, docker, postgres };
 }
@@ -251,9 +256,9 @@ async function main() {
     maxParallelism: builder.maxParallelism,
   };
 
-  let controlPlaneDatabaseUrl;
+  let controlPlanePostgresProbe;
   try {
-    controlPlaneDatabaseUrl = resolveControlPlaneDatabaseUrl();
+    controlPlanePostgresProbe = resolveControlPlanePostgresProbe();
   } catch (error) {
     const payload = {
       schemaVersion: 1,
@@ -272,7 +277,7 @@ async function main() {
   }
 
   const preflight = await establishHealthyControlPlane({
-    sample: () => probeControlPlane(controlPlaneDatabaseUrl),
+    sample: () => probeControlPlane(controlPlanePostgresProbe),
   });
   if (preflight.status !== "healthy") {
     const payload = {
@@ -341,7 +346,7 @@ async function main() {
     });
   });
   const watchdog = await monitorControlPlane({
-    sample: () => probeControlPlane(controlPlaneDatabaseUrl),
+    sample: () => probeControlPlane(controlPlanePostgresProbe),
     isComplete: () => childComplete,
   });
   let termination = null;


### PR DESCRIPTION
## Summary

- probe the canonical PostgreSQL control plane from inside its Docker container when no explicit host database URL is configured
- preserve `DPF_CONTROL_PLANE_DATABASE_URL` as the portable explicit override
- cover the container-local command contract and document why the default must not assume a published host port

## Why

The bounded production-build watchdog treated `dpf-postgres-1` as a host-reachable database at `127.0.0.1:5432`, although the canonical container publishes no host port. Multiple exact candidates passed the exhaustive suite and then false-failed with `postgres:request-failed`. The default probe now executes `psql SELECT 1` inside the named PostgreSQL container while keeping explicit URL probing available for other deployments.

## Verification

- focused tests: 11 passed
- governed merged-code gate: freshness green against `origin/main@b23363d44cc`
- migrations: 482 applied/current
- policy guards: 24 passed; deterministic preflight: 31 clean
- TypeScript: passed
- exhaustive Vitest: 2,465 files / 21,102 tests passed; 4 files and 19 tests skipped; 18 todo
- production Docker/Next build: passed; image `sha256:b66fbe05ebf963460fa8f54554016e31960997d4fab59f0e81a3bee2c5dc41c6`
- exact candidate: `b597b8b6ab4c9930995ae66e7f6ed5df21319be5`

Local-CI-Evidence: cms9ycfit0b3501r24f0azsph (fix/local-ci-postgres-port-probe@b597b8b6ab4c9930995ae66e7f6ed5df21319be5)

## UX and migration

- UX: not applicable; this changes only the CI control-plane watchdog and its documentation
- Migration: not applicable; no database schema or migration changed

Backlog: BI-CE6E2882

