### PR TITLE
feat(capacity): add shared scarce-resource mirror

### DIFF
--- a/apps/web/lib/capacity/adapter-registry.test.ts
+++ b/apps/web/lib/capacity/adapter-registry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ResourceCapacityProfile } from "@dpf/storefront-templates";
+import type { CapacityAdapter } from "./adapter-registry";
+import {
+  CAPACITY_ADAPTER_DESCRIPTORS,
+  CapacityAdapterRegistry,
+  projectCapacitySnapshot,
+} from "./adapter-registry";
+
+const profile: ResourceCapacityProfile = {
+  archetypeId: "hair-salon",
+  category: "beauty-personal-care",
+  enabled: true,
+  patterns: ["appointment"],
+  authorities: ["provider-calendar", "staffing"],
+  resourceNoun: { singular: "chair", plural: "chairs" },
+  physical: true,
+  forwardHorizon: false,
+  supportsBuffers: true,
+  supportsTravel: false,
+};
+
+function adapter(authority: CapacityAdapter["authority"]): CapacityAdapter {
+  return {
+    authority,
+    load: vi.fn(async () => ({
+      authority,
+      state: "ok" as const,
+      resources: [{
+        ref: { authority, resourceType: "chair", resourceId: `${authority}-1` },
+        organizationId: "org-1",
+        label: `${authority} chair`,
+        capacity: 1,
+        capacityUnit: "appointments",
+        status: "available" as const,
+        capabilityKeys: [],
+      }],
+      allocations: [],
+      availability: [],
+      watermark: { source: authority, observedAt: "2026-08-01T14:00:00.000Z" },
+    })),
+  };
+}
+
+describe("CapacityAdapterRegistry", () => {
+  it("describes a canonical source path for every required capacity pattern", () => {
+    const patterns = new Set(CAPACITY_ADAPTER_DESCRIPTORS.flatMap((item) => item.patterns));
+    for (const pattern of ["appointment", "dispatch", "rental", "class", "venue", "project-resource"] as const) {
+      expect(patterns.has(pattern), `${pattern} needs an adapter descriptor`).toBe(true);
+    }
+    expect(CAPACITY_ADAPTER_DESCRIPTORS.every((item) => item.canonicalSources.length > 0)).toBe(true);
+  });
+
+  it("refuses duplicate authority registrations", () => {
+    const registry = new CapacityAdapterRegistry([adapter("provider-calendar")]);
+    expect(() => registry.register(adapter("provider-calendar"))).toThrow(/already registered/i);
+  });
+
+  it("loads only authorities declared by the archetype profile", async () => {
+    const provider = adapter("provider-calendar");
+    const rental = adapter("rental");
+    const snapshot = await projectCapacitySnapshot({
+      profile,
+      organizationId: "org-1",
+      window: { startAt: "2026-08-01T13:00:00.000Z", endAt: "2026-08-01T17:00:00.000Z" },
+      registry: new CapacityAdapterRegistry([provider, rental]),
+    });
+
+    expect(provider.load).toHaveBeenCalledOnce();
+    expect(rental.load).not.toHaveBeenCalled();
+    expect(snapshot.resources).toHaveLength(1);
+  });
+
+  it("retains missing and degraded authorities instead of treating them as free capacity", async () => {
+    const provider = adapter("provider-calendar");
+    provider.load = vi.fn<CapacityAdapter["load"]>(async () => ({
+      authority: "provider-calendar",
+      state: "degraded" as const,
+      resources: [],
+      allocations: [],
+      availability: [],
+      diagnostic: "provider calendar unavailable",
+    }));
+
+    const snapshot = await projectCapacitySnapshot({
+      profile,
+      organizationId: "org-1",
+      window: { startAt: "2026-08-01T13:00:00.000Z", endAt: "2026-08-01T17:00:00.000Z" },
+      registry: new CapacityAdapterRegistry([provider]),
+    });
+
+    expect(snapshot.sourceStates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ authority: "provider-calendar", state: "degraded" }),
+      expect.objectContaining({ authority: "staffing", state: "degraded" }),
+    ]));
+    expect(snapshot.attentionSignals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "source-degraded" }),
+    ]));
+  });
+
+  it("rejects cross-organization resources returned by a broken adapter", async () => {
+    const broken = adapter("provider-calendar");
+    broken.load = vi.fn<CapacityAdapter["load"]>(async () => ({
+      authority: "provider-calendar",
+      state: "ok" as const,
+      resources: [{
+        ref: { authority: "provider-calendar", resourceType: "chair", resourceId: "chair-foreign" },
+        organizationId: "org-2",
+        label: "Foreign chair",
+        capacity: 1,
+        capacityUnit: "appointments",
+        status: "available" as const,
+        capabilityKeys: [],
+      }],
+      allocations: [],
+      availability: [],
+    }));
+
+    await expect(projectCapacitySnapshot({
+      profile,
+      organizationId: "org-1",
+      window: { startAt: "2026-08-01T13:00:00.000Z", endAt: "2026-08-01T17:00:00.000Z" },
+      registry: new CapacityAdapterRegistry([broken]),
+    })).rejects.toThrow(/organization scope/i);
+  });
+});

--- a/apps/web/lib/capacity/adapter-registry.ts
+++ b/apps/web/lib/capacity/adapter-registry.ts
@@ -1,0 +1,174 @@
+import type {
+  ResourceCapacityPattern,
+  ResourceCapacityAuthority,
+  ResourceCapacityProfile,
+} from "@dpf/storefront-templates";
+import type {
+  CapacityAdapterLoadResult,
+  CapacityAdapterLoadInput,
+} from "./adapter-types";
+import {
+  capacityResourceRefKey,
+  type CapacityAttentionSignal,
+  type CapacitySnapshot,
+  type CapacityWindow,
+} from "./contracts";
+
+export interface CapacityAdapterDescriptor {
+  authority: ResourceCapacityAuthority;
+  patterns: ResourceCapacityPattern[];
+  canonicalSources: string[];
+}
+
+/**
+ * The bounded-context ownership map. Descriptors are not registrations: a
+ * vertical still supplies a loader and the registry reports it degraded until
+ * that loader exists.
+ */
+export const CAPACITY_ADAPTER_DESCRIPTORS: CapacityAdapterDescriptor[] = [
+  {
+    authority: "provider-calendar",
+    patterns: ["appointment", "class"],
+    canonicalSources: ["ServiceProvider", "ProviderService", "ProviderAvailability", "StorefrontBooking", "BookingHold"],
+  },
+  {
+    authority: "staffing",
+    patterns: ["appointment", "dispatch", "class", "venue", "project-resource", "service-floor", "occupancy"],
+    canonicalSources: ["StaffingShift", "StaffingAssignment", "StaffingResourceLink"],
+  },
+  {
+    authority: "hospitality",
+    patterns: ["service-floor", "venue"],
+    canonicalSources: ["HospitalityResource", "HospitalityResourceAvailability", "HospitalityCapacityAllocation"],
+  },
+  {
+    authority: "care",
+    patterns: ["appointment", "occupancy"],
+    canonicalSources: ["CareResource", "CareAppointmentResource", "CareAppointment"],
+  },
+  {
+    authority: "rental",
+    patterns: ["rental"],
+    canonicalSources: ["RentableUnit", "RentalAgreement", "BookingHold"],
+  },
+  {
+    authority: "field-operations",
+    patterns: ["dispatch", "project-resource"],
+    canonicalSources: ["CustomerSite", "StaffingShift", "StaffingResourceLink"],
+  },
+  {
+    authority: "venue-operations",
+    patterns: ["venue"],
+    canonicalSources: ["StorefrontBooking", "StaffingShift", "StaffingResourceLink"],
+  },
+];
+
+export interface CapacityAdapter {
+  authority: ResourceCapacityAuthority;
+  load(input: CapacityAdapterLoadInput): Promise<CapacityAdapterLoadResult>;
+}
+
+export class CapacityAdapterRegistry {
+  private readonly adapters = new Map<ResourceCapacityAuthority, CapacityAdapter>();
+
+  constructor(adapters: readonly CapacityAdapter[] = []) {
+    for (const adapter of adapters) this.register(adapter);
+  }
+
+  register(adapter: CapacityAdapter): void {
+    if (this.adapters.has(adapter.authority)) {
+      throw new Error(`Capacity adapter ${adapter.authority} is already registered`);
+    }
+    this.adapters.set(adapter.authority, adapter);
+  }
+
+  get(authority: ResourceCapacityAuthority): CapacityAdapter | undefined {
+    return this.adapters.get(authority);
+  }
+}
+
+function degradedSignal(
+  authority: ResourceCapacityAuthority,
+  diagnostic: string,
+): CapacityAttentionSignal {
+  return {
+    signalId: `source-degraded:${authority}`,
+    kind: "source-degraded",
+    authority,
+    detail: diagnostic,
+  };
+}
+
+export async function projectCapacitySnapshot(input: {
+  profile: ResourceCapacityProfile;
+  organizationId: string;
+  window: CapacityWindow;
+  registry: CapacityAdapterRegistry;
+}): Promise<CapacitySnapshot> {
+  if (!input.profile.enabled) {
+    return {
+      profile: input.profile,
+      organizationId: input.organizationId,
+      window: input.window,
+      resources: [],
+      allocations: [],
+      availability: [],
+      sourceStates: [],
+      attentionSignals: [],
+    };
+  }
+
+  const results = await Promise.all(
+    input.profile.authorities.map(
+      async (authority): Promise<CapacityAdapterLoadResult> => {
+        const adapter = input.registry.get(authority);
+        if (!adapter) {
+          return {
+            authority,
+            state: "degraded",
+            resources: [],
+            allocations: [],
+            availability: [],
+            diagnostic: `No ${authority} capacity adapter is registered`,
+          };
+        }
+        return adapter.load({
+          profile: input.profile,
+          organizationId: input.organizationId,
+          window: input.window,
+        });
+      },
+    ),
+  );
+
+  for (const result of results) {
+    const crossOrganization = result.resources.find(
+      (resource) => resource.organizationId !== input.organizationId,
+    );
+    if (crossOrganization) {
+      throw new Error(
+        `Capacity adapter ${result.authority} violated organization scope for ${capacityResourceRefKey(crossOrganization.ref)}`,
+      );
+    }
+  }
+
+  return {
+    profile: input.profile,
+    organizationId: input.organizationId,
+    window: input.window,
+    resources: results.flatMap((result) => result.resources),
+    allocations: results.flatMap((result) => result.allocations),
+    availability: results.flatMap((result) => result.availability),
+    sourceStates: results.map((result) => ({
+      authority: result.authority,
+      state: result.state,
+      ...(result.diagnostic ? { diagnostic: result.diagnostic } : {}),
+      ...(result.watermark ? { watermark: result.watermark } : {}),
+    })),
+    attentionSignals: results.flatMap((result) =>
+      result.state === "degraded"
+        ? [degradedSignal(result.authority, result.diagnostic ?? `${result.authority} source is degraded`)]
+        : []
+    ),
+  };
+}

--- a/apps/web/lib/capacity/adapter-types.ts
+++ b/apps/web/lib/capacity/adapter-types.ts
@@ -1,0 +1,27 @@
+import type {
+  ResourceCapacityAuthority,
+  ResourceCapacityProfile,
+} from "@dpf/storefront-templates";
+import type {
+  CapacityAllocation,
+  CapacityAvailability,
+  CapacityResource,
+  CapacitySourceWatermark,
+  CapacityWindow,
+} from "./contracts";
+
+export interface CapacityAdapterLoadInput {
+  profile: ResourceCapacityProfile;
+  organizationId: string;
+  window: CapacityWindow;
+}
+
+export interface CapacityAdapterLoadResult {
+  authority: ResourceCapacityAuthority;
+  state: "ok" | "unsupported" | "degraded";
+  resources: CapacityResource[];
+  allocations: CapacityAllocation[];
+  availability: CapacityAvailability[];
+  diagnostic?: string;
+  watermark?: CapacitySourceWatermark;
+}

--- a/apps/web/lib/capacity/contracts.ts
+++ b/apps/web/lib/capacity/contracts.ts
@@ -1,0 +1,138 @@
+import type {
+  ResourceCapacityAuthority,
+  ResourceCapacityProfile,
+} from "@dpf/storefront-templates";
+import type { OperationalSourceWatermark } from "@/lib/operations/source-health";
+
+export const CAPACITY_RESOURCE_STATUSES = [
+  "available",
+  "busy",
+  "blocked",
+  "offline",
+  "unknown",
+] as const;
+
+export type CapacityResourceStatus = (typeof CAPACITY_RESOURCE_STATUSES)[number];
+
+export const CAPACITY_ALLOCATION_LIFECYCLES = [
+  "held",
+  "confirmed",
+  "active",
+  "released",
+  "cancelled",
+] as const;
+
+export type CapacityAllocationLifecycle = (typeof CAPACITY_ALLOCATION_LIFECYCLES)[number];
+
+export const CAPACITY_CONFLICT_KINDS = [
+  "time-overlap",
+  "capacity-exceeded",
+  "unavailable",
+  "capability-mismatch",
+  "travel-window",
+  "source-degraded",
+] as const;
+
+export type CapacityConflictKind = (typeof CAPACITY_CONFLICT_KINDS)[number];
+
+export interface CapacityResourceRef {
+  authority: ResourceCapacityAuthority;
+  resourceType: string;
+  resourceId: string;
+}
+
+export interface CapacityResource {
+  ref: CapacityResourceRef;
+  organizationId: string;
+  label: string;
+  capacity: number;
+  capacityUnit: string;
+  status: CapacityResourceStatus;
+  locationRef?: string;
+  capabilityKeys: string[];
+  sourceVersion?: string;
+}
+
+export interface CapacityWindow {
+  startAt: string;
+  endAt: string;
+}
+
+export interface CapacityInterval extends CapacityWindow {
+  preparationMinutes: number;
+  cleanupMinutes: number;
+  travelBeforeMinutes: number;
+  travelAfterMinutes: number;
+}
+
+export interface CapacityAllocation {
+  allocationId: string;
+  resourceRef: CapacityResourceRef;
+  demandRef: string;
+  interval: CapacityInterval;
+  quantity: number;
+  lifecycle: CapacityAllocationLifecycle;
+}
+
+export interface CapacityAvailability extends CapacityWindow {
+  resourceRef: CapacityResourceRef;
+  kind: "available" | "unavailable";
+  reason?: string;
+}
+
+export interface CapacityDemand {
+  demandRef: string;
+  resourceRef: CapacityResourceRef;
+  interval: CapacityInterval;
+  quantity: number;
+  requiredCapabilityKeys: string[];
+  availableTravelMinutes?: number;
+}
+
+export interface CapacityConflict {
+  kind: CapacityConflictKind;
+  resourceRef: CapacityResourceRef;
+  demandRef: string;
+  conflictingAllocationIds: string[];
+  detail: string;
+}
+
+export type CapacityAttentionKind =
+  | CapacityConflictKind
+  | "idle-capacity"
+  | "blocked-resource";
+
+export interface CapacityAttentionSignal {
+  signalId: string;
+  kind: CapacityAttentionKind;
+  authority: ResourceCapacityAuthority;
+  resourceRef?: CapacityResourceRef;
+  demandRef?: string;
+  detail: string;
+}
+
+export interface CapacitySourceWatermark extends OperationalSourceWatermark {
+  source: ResourceCapacityAuthority;
+}
+
+export interface CapacitySourceState {
+  authority: ResourceCapacityAuthority;
+  state: "ok" | "unsupported" | "degraded";
+  diagnostic?: string;
+  watermark?: CapacitySourceWatermark;
+}
+
+export interface CapacitySnapshot {
+  profile: ResourceCapacityProfile;
+  organizationId: string;
+  window: CapacityWindow;
+  resources: CapacityResource[];
+  allocations: CapacityAllocation[];
+  availability: CapacityAvailability[];
+  sourceStates: CapacitySourceState[];
+  attentionSignals: CapacityAttentionSignal[];
+}
+
+export function capacityResourceRefKey(ref: CapacityResourceRef): string {
+  return `${ref.authority}:${ref.resourceType}:${ref.resourceId}`;
+}

--- a/apps/web/lib/capacity/index.ts
+++ b/apps/web/lib/capacity/index.ts
@@ -1,0 +1,4 @@
+export * from "./contracts";
+export * from "./intervals";
+export * from "./adapter-types";
+export * from "./adapter-registry";

--- a/apps/web/lib/capacity/intervals.test.ts
+++ b/apps/web/lib/capacity/intervals.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { CapacityAllocation, CapacityInterval, CapacityResource } from "./contracts";
+import {
+  capacityConflictsToAttentionSignals,
+  capacityFootprint,
+  evaluateCapacityDemand,
+  intervalsOverlap,
+  utilizationPercent,
+} from "./intervals";
+
+const resource: CapacityResource = {
+  ref: { authority: "provider-calendar", resourceType: "chair", resourceId: "chair-1" },
+  organizationId: "org-1",
+  label: "Chair 1",
+  capacity: 1,
+  capacityUnit: "appointments",
+  status: "available",
+  capabilityKeys: ["hair-colour"],
+};
+
+const interval = (startAt: string, endAt: string, extra: Partial<CapacityInterval> = {}): CapacityInterval => ({
+  startAt,
+  endAt,
+  preparationMinutes: 0,
+  cleanupMinutes: 0,
+  travelBeforeMinutes: 0,
+  travelAfterMinutes: 0,
+  ...extra,
+});
+
+const allocation = (overrides: Partial<CapacityAllocation> = {}): CapacityAllocation => ({
+  allocationId: "allocation-1",
+  resourceRef: resource.ref,
+  demandRef: "booking-1",
+  interval: interval("2026-08-01T14:00:00.000Z", "2026-08-01T15:00:00.000Z"),
+  quantity: 1,
+  lifecycle: "confirmed",
+  ...overrides,
+});
+
+describe("capacity interval semantics", () => {
+  it("expands the effective footprint by travel, preparation, and cleanup", () => {
+    const footprint = capacityFootprint(interval(
+      "2026-08-01T14:00:00.000Z",
+      "2026-08-01T15:00:00.000Z",
+      { travelBeforeMinutes: 20, preparationMinutes: 10, cleanupMinutes: 15, travelAfterMinutes: 25 },
+    ));
+
+    expect(new Date(footprint.startMs).toISOString()).toBe("2026-08-01T13:30:00.000Z");
+    expect(new Date(footprint.endMs).toISOString()).toBe("2026-08-01T15:40:00.000Z");
+  });
+
+  it("uses half-open intervals so adjacent work does not conflict", () => {
+    expect(intervalsOverlap(
+      interval("2026-08-01T14:00:00.000Z", "2026-08-01T15:00:00.000Z"),
+      interval("2026-08-01T15:00:00.000Z", "2026-08-01T16:00:00.000Z"),
+    )).toBe(false);
+  });
+
+  it("detects capacity, capability, availability, and travel-window conflicts", () => {
+    const conflicts = evaluateCapacityDemand({
+      resource: { ...resource, status: "blocked" },
+      allocations: [allocation()],
+      demand: {
+        demandRef: "booking-2",
+        resourceRef: resource.ref,
+        interval: interval("2026-08-01T14:30:00.000Z", "2026-08-01T15:30:00.000Z", { travelBeforeMinutes: 20 }),
+        quantity: 1,
+        requiredCapabilityKeys: ["balayage"],
+        availableTravelMinutes: 10,
+      },
+    });
+
+    expect(conflicts.map((item) => item.kind)).toEqual(expect.arrayContaining([
+      "unavailable",
+      "capability-mismatch",
+      "travel-window",
+      "time-overlap",
+      "capacity-exceeded",
+    ]));
+    expect(capacityConflictsToAttentionSignals(conflicts)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "capacity-exceeded",
+          authority: "provider-calendar",
+          demandRef: "booking-2",
+        }),
+      ]),
+    );
+  });
+
+  it("does not consume released or cancelled allocations", () => {
+    const conflicts = evaluateCapacityDemand({
+      resource,
+      allocations: [allocation({ lifecycle: "released" }), allocation({ lifecycle: "cancelled", allocationId: "allocation-2" })],
+      demand: {
+        demandRef: "booking-2",
+        resourceRef: resource.ref,
+        interval: interval("2026-08-01T14:30:00.000Z", "2026-08-01T15:30:00.000Z"),
+        quantity: 1,
+        requiredCapabilityKeys: [],
+      },
+    });
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it("calculates bounded utilization over the requested window", () => {
+    expect(utilizationPercent({
+      resource,
+      allocations: [allocation()],
+      window: interval("2026-08-01T13:00:00.000Z", "2026-08-01T17:00:00.000Z"),
+    })).toBe(25);
+  });
+});

--- a/apps/web/lib/capacity/intervals.ts
+++ b/apps/web/lib/capacity/intervals.ts
@@ -1,0 +1,148 @@
+import {
+  capacityResourceRefKey,
+  type CapacityAllocation,
+  type CapacityAttentionSignal,
+  type CapacityConflict,
+  type CapacityDemand,
+  type CapacityInterval,
+  type CapacityResource,
+  type CapacityWindow,
+} from "./contracts";
+
+const MINUTE_MS = 60_000;
+const CONSUMING_LIFECYCLES = new Set<CapacityAllocation["lifecycle"]>([
+  "held",
+  "confirmed",
+  "active",
+]);
+
+function epoch(value: string): number {
+  const result = Date.parse(value);
+  if (!Number.isFinite(result)) throw new Error(`Invalid capacity timestamp: ${value}`);
+  return result;
+}
+
+function windowBounds(window: CapacityWindow): { startMs: number; endMs: number } {
+  const startMs = epoch(window.startAt);
+  const endMs = epoch(window.endAt);
+  if (endMs <= startMs) throw new Error("Capacity interval end must be after start");
+  return { startMs, endMs };
+}
+
+export function capacityFootprint(interval: CapacityInterval): {
+  startMs: number;
+  endMs: number;
+} {
+  const { startMs, endMs } = windowBounds(interval);
+  const before = Math.max(0, interval.travelBeforeMinutes) + Math.max(0, interval.preparationMinutes);
+  const after = Math.max(0, interval.cleanupMinutes) + Math.max(0, interval.travelAfterMinutes);
+  return {
+    startMs: startMs - before * MINUTE_MS,
+    endMs: endMs + after * MINUTE_MS,
+  };
+}
+
+export function intervalsOverlap(left: CapacityInterval, right: CapacityInterval): boolean {
+  const a = capacityFootprint(left);
+  const b = capacityFootprint(right);
+  return a.startMs < b.endMs && b.startMs < a.endMs;
+}
+
+function sameResource(resource: CapacityResource, allocation: CapacityAllocation): boolean {
+  return capacityResourceRefKey(resource.ref) === capacityResourceRefKey(allocation.resourceRef);
+}
+
+export function evaluateCapacityDemand(input: {
+  resource: CapacityResource;
+  allocations: readonly CapacityAllocation[];
+  demand: CapacityDemand;
+}): CapacityConflict[] {
+  const conflicts: CapacityConflict[] = [];
+  const base = {
+    resourceRef: input.resource.ref,
+    demandRef: input.demand.demandRef,
+    conflictingAllocationIds: [] as string[],
+  };
+
+  if (input.resource.status === "blocked" || input.resource.status === "offline" || input.resource.status === "unknown") {
+    conflicts.push({ ...base, kind: "unavailable", detail: `${input.resource.label} is ${input.resource.status}` });
+  }
+
+  const missingCapabilities = input.demand.requiredCapabilityKeys.filter(
+    (capability) => !input.resource.capabilityKeys.includes(capability),
+  );
+  if (missingCapabilities.length > 0) {
+    conflicts.push({
+      ...base,
+      kind: "capability-mismatch",
+      detail: `Missing capabilities: ${missingCapabilities.join(", ")}`,
+    });
+  }
+
+  const requiredTravel = Math.max(0, input.demand.interval.travelBeforeMinutes) +
+    Math.max(0, input.demand.interval.travelAfterMinutes);
+  if (input.demand.availableTravelMinutes !== undefined && requiredTravel > input.demand.availableTravelMinutes) {
+    conflicts.push({
+      ...base,
+      kind: "travel-window",
+      detail: `${requiredTravel} travel minutes required; ${input.demand.availableTravelMinutes} available`,
+    });
+  }
+
+  const overlapping = input.allocations.filter(
+    (allocation) =>
+      CONSUMING_LIFECYCLES.has(allocation.lifecycle) &&
+      sameResource(input.resource, allocation) &&
+      intervalsOverlap(allocation.interval, input.demand.interval),
+  );
+  if (overlapping.length > 0) {
+    conflicts.push({
+      ...base,
+      kind: "time-overlap",
+      conflictingAllocationIds: overlapping.map((allocation) => allocation.allocationId),
+      detail: `${overlapping.length} consuming allocation(s) overlap the requested footprint`,
+    });
+  }
+
+  const consumed = overlapping.reduce((total, allocation) => total + Math.max(0, allocation.quantity), 0);
+  if (consumed + Math.max(0, input.demand.quantity) > Math.max(0, input.resource.capacity)) {
+    conflicts.push({
+      ...base,
+      kind: "capacity-exceeded",
+      conflictingAllocationIds: overlapping.map((allocation) => allocation.allocationId),
+      detail: `${consumed + input.demand.quantity} ${input.resource.capacityUnit} requested; ${input.resource.capacity} available`,
+    });
+  }
+
+  return conflicts;
+}
+
+/** Translate source-neutral conflicts into the shared owner-attention carrier. */
+export function capacityConflictsToAttentionSignals(
+  conflicts: readonly CapacityConflict[],
+): CapacityAttentionSignal[] {
+  return conflicts.map((conflict, index) => ({
+    signalId: `${conflict.kind}:${capacityResourceRefKey(conflict.resourceRef)}:${conflict.demandRef}:${index}`,
+    kind: conflict.kind,
+    authority: conflict.resourceRef.authority,
+    resourceRef: conflict.resourceRef,
+    demandRef: conflict.demandRef,
+    detail: conflict.detail,
+  }));
+}
+
+export function utilizationPercent(input: {
+  resource: CapacityResource;
+  allocations: readonly CapacityAllocation[];
+  window: CapacityWindow;
+}): number {
+  const window = windowBounds(input.window);
+  const availableMs = (window.endMs - window.startMs) * Math.max(1, input.resource.capacity);
+  const consumedMs = input.allocations.reduce((total, allocation) => {
+    if (!CONSUMING_LIFECYCLES.has(allocation.lifecycle) || !sameResource(input.resource, allocation)) return total;
+    const footprint = capacityFootprint(allocation.interval);
+    const overlapMs = Math.max(0, Math.min(window.endMs, footprint.endMs) - Math.max(window.startMs, footprint.startMs));
+    return total + overlapMs * Math.max(0, allocation.quantity);
+  }, 0);
+  return Math.round((Math.min(consumedMs, availableMs) / availableMs) * 1_000) / 10;
+}

--- a/apps/web/lib/operations/source-health.ts
+++ b/apps/web/lib/operations/source-health.ts
@@ -1,0 +1,12 @@
+/** Shared source-observation contract for bounded operational read models. */
+export interface OperationalSourceWatermark {
+  source: string;
+  observedAt: string;
+  sourceVersion?: string;
+}
+
+/** A source that could not contribute facts to an otherwise usable snapshot. */
+export interface OperationalDegradedSource {
+  source: string;
+  reason: string;
+}

--- a/apps/web/lib/twin/operations-snapshot.ts
+++ b/apps/web/lib/twin/operations-snapshot.ts
@@ -16,6 +16,10 @@ import type {
   UtilityMeterData,
   WorkItemData,
 } from "@/components/twin/types";
+import type {
+  OperationalDegradedSource,
+  OperationalSourceWatermark,
+} from "@/lib/operations/source-health";
 
 export const OPERATIONS_SNAPSHOT_SCHEMA_VERSION = "operations.v1" as const;
 
@@ -25,15 +29,8 @@ export interface OperationsIdentity {
   template: TwinTemplate;
 }
 
-export interface OperationsSourceWatermark {
-  source: string;
-  observedAt: string;
-}
-
-export interface OperationsDegradedSource {
-  source: string;
-  reason: string;
-}
+export type OperationsSourceWatermark = OperationalSourceWatermark;
+export type OperationsDegradedSource = OperationalDegradedSource;
 
 export interface OperationsSnapshotTelemetry {
   durationMs: number;

--- a/docs/superpowers/plans/2026-08-01-shared-scarce-resource-capacity.md
+++ b/docs/superpowers/plans/2026-08-01-shared-scarce-resource-capacity.md
@@ -1,0 +1,116 @@
+# Shared Scarce-Resource Capacity Implementation Plan
+
+> **DPF-native execution:** Follow `AGENTS.md`, use the isolated
+> `feat/scarce-resource-substrate` worktree, define behavior with TDD, and run
+> runtime-bound gates through the governed `local-integration-ci` environment.
+> This source-only worktree must not install a parallel dependency graph or run
+> a worktree Compose runtime.
+
+- **Backlog:** `BI-D1D54D93`
+- **Work Capsule:** `WC-2C4CCA14`
+- **Design:**
+  `docs/superpowers/specs/2026-08-01-shared-scarce-resource-capacity-design.md`
+- **Base:** `origin/main@4c47253e646`
+- **Decision:** `DI-23BD40A7AA2E` — typed runtime mirror, high confidence
+- **Coverage receipt:** `cmsa0ddd60eki01r20z2pfpf1`
+- **Coverage decision:** atomic
+
+## Backlog coverage
+
+The work is one medium, independently shippable platform contract. Splitting
+profile derivation from the normalized projection would leave either an unused
+taxonomy or an ungoverned universal adapter. Concrete vertical loaders remain
+separate backlog items and PRs.
+
+| Key | Deliverable | Independently shippable | Depends on |
+| --- | --- | --- | --- |
+| `capacity-profile` | Archetype-gated pattern/authority derivation | No | — |
+| `runtime-contract` | Normalized resource, interval, allocation, conflict, attention, and source-health types | No | profile |
+| `registry-projection` | Adapter registry and pure bounded projection | No | runtime contract |
+| `fixtures-guards` | Six-pattern matrix, adapter contract fixtures, docs, and exports | No | registry/projection |
+
+## Phase 1 — Contract tests first
+
+1. Add profile tests for representative appointment, dispatch, rental, class,
+   venue, and project-resource archetypes.
+2. Assert nonphysical board archetypes do not receive physical resource
+   authorities merely because a noun exists.
+3. Add interval/conflict tests for half-open adjacency, preparation/cleanup,
+   travel windows, quantity capacity, released allocations, capability
+   mismatch, and utilization.
+4. Add registry tests for duplicate authorities, profile gating, unsupported
+   adapters, degraded sources, source watermarks, and organization isolation.
+5. Add a six-pattern adapter-contract fixture that retains canonical source
+   references for drill-through.
+
+## Phase 2 — Archetype capacity profile
+
+1. Add `resource-capacity-profile.ts` to `@dpf/storefront-templates`.
+2. Define closed pattern and authority constants plus their union types.
+3. Derive the profile from axes, scheduling defaults, field-dispatch profile,
+   and `TwinProfile`; add no second hand-authored taxonomy.
+4. Export the profile through the package index.
+5. Keep the existing `ArchetypeDefinition` public shape stable unless a genuine
+   leaf exception is proven by tests; prefer derivation over an override field.
+
+## Phase 3 — Shared runtime contract and projection
+
+1. Add `apps/web/lib/capacity/contracts.ts` for normalized resources,
+   allocations, availability, source state, conflicts, and attention signals.
+2. Add `intervals.ts` for effective footprints, half-open overlap, capacity
+   consumption, utilization, and conflict explanation.
+3. Add `adapter-registry.ts` with duplicate-authority rejection and
+   archetype-profile gating.
+4. Add `project-capacity-snapshot.ts` to load applicable adapters in parallel,
+   retain degraded sources, and produce one source-watermarked snapshot.
+5. Keep the projection read-only. Its result is advisory until a canonical
+   domain command rechecks and commits.
+
+## Phase 4 — Representative adapter descriptors
+
+1. Register typed descriptors for provider calendar, staffing, hospitality,
+   care, rental, and field operations.
+2. Bind descriptor applicability to the derived profile.
+3. Provide fixture-backed adapters for all six required patterns; do not add
+   production SQL loaders for verticals whose backlog item has not yet claimed
+   source ownership.
+4. Document the adapter implementation checklist used by beauty, rental, hotel,
+   HOA, HVAC, classes, and venue work.
+
+## Phase 5 — Documentation and handoff
+
+1. Update the operational-twin architecture to point at this mirror as the
+   shared resource read contract.
+2. Update the salon BOOK plan so `BI-D1D54D93` is an explicit prerequisite of
+   the beauty capacity deliverable.
+3. Record the decision and verification evidence on `BI-D1D54D93`.
+4. Unblock the beauty capacity capsule only after the shared PR merges.
+
+## Refactor allocation
+
+At least 20% of implementation effort is reserved for consolidation:
+
+- one interval/footprint implementation instead of vertical overlap helpers;
+- one adapter registry rather than switch statements in every workspace;
+- one source-health and watermark shape shared with the operations hot path;
+- derived archetype applicability instead of copied category lists;
+- explicit canonical source references instead of label/name inference.
+
+## Verification gates
+
+1. Targeted template-profile, interval, registry, and projection tests.
+2. Affected-package typecheck and architecture/module-size guards.
+3. No migration gate required: Prisma schema and migration directory are
+   unchanged.
+4. No direct UX gate required: this concern adds no route or controls.
+5. Governed exact merged-code local-CI gate after the PostgreSQL watchdog fix
+   lands, including exhaustive Vitest and production Docker/Next build.
+6. Ready-for-review PR only after exact evidence is recorded; merge through the
+   governed squash queue and run `pnpm pr:health` before claiming readiness.
+
+## Rollback
+
+The change is additive and read-only. Rollback removes the new exports and
+capacity modules; canonical domain tables and commands are untouched. A
+vertical consumer must keep its existing source-specific read path until its
+adapter PR has independently passed functional and UX verification.

--- a/docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md
+++ b/docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md
@@ -65,6 +65,15 @@ Templates arrange the grammar for a class of operation. Physical templates rende
 
 ## 5. `TwinProfile` — derive, never author
 
+> **2026-08-01 capacity-contract note:** `TwinProfile` remains the visual and
+> vocabulary grammar. The source-neutral resource read contract is the typed
+> runtime mirror defined in
+> [`2026-08-01-shared-scarce-resource-capacity-design.md`](2026-08-01-shared-scarce-resource-capacity-design.md).
+> It derives applicability from this profile, preserves each bounded context as
+> authority, and normalizes availability, allocations, conflicts, utilization,
+> source health, and attention signals for twin consumers. It does not turn
+> `TwinProfile` or `OperationalSceneLayout` into a resource database.
+
 ```ts
 // packages/storefront-templates/src/twin-profile.ts (proposed; pure, DB-free)
 export interface TwinProfile {

--- a/docs/superpowers/specs/2026-08-01-shared-scarce-resource-capacity-design.md
+++ b/docs/superpowers/specs/2026-08-01-shared-scarce-resource-capacity-design.md
@@ -1,0 +1,304 @@
+# Shared Scarce-Resource Capacity Design
+
+- **Backlog:** `BI-D1D54D93`
+- **Work Capsule:** `WC-2C4CCA14`
+- **Unblocks:** `BI-CD2A412D`, `BI-B1C4A514`, `BI-094A0A1D`,
+  `BI-DD6C4354`, `BI-495B1461`, `BI-4939EE33`, `BI-F8143960`, and the
+  physical-archetype operational workspaces
+- **Plan:**
+  `docs/superpowers/plans/2026-08-01-shared-scarce-resource-capacity.md`
+- **Umbrella:**
+  `docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md`
+
+## Decision
+
+DPF will establish a **typed runtime mirror**, not a new universal resource
+database authority.
+
+Existing bounded contexts keep their canonical records:
+
+- people and bookable-provider time remain in `ServiceProvider`,
+  `ProviderService`, and `ProviderAvailability`;
+- restaurant and hospitality capacity remains in `HospitalityResource` and its
+  availability/allocation models;
+- clinical rooms and equipment remain in `CareResource` and care allocations;
+- rental inventory remains in `RentableUnit`, agreements, and holds;
+- workforce shifts and co-scheduled resources remain in `StaffingShift`,
+  `StaffingAssignment`, and `StaffingResourceLink`;
+- field assets, locations, work, and travel remain in their field-operation
+  owners;
+- `OperationalSceneLayout` continues to own placement only.
+
+The shared layer derives an archetype-gated resource profile and adapts these
+sources into one read contract for capacity, availability, utilization,
+conflicts, and source health. Domain commands continue to enforce conflicts at
+their authoritative transaction boundary.
+
+### Governed options
+
+Decision `DI-23BD40A7AA2E` compared three options:
+
+| Option | Composite | Result |
+| --- | ---: | --- |
+| New canonical resource tables | 3.182 | Rejected: premature authority migration and fleet-wide blast radius |
+| Typed runtime mirror | **4.657** | **Selected: high confidence** |
+| Persisted identity bridge | 4.195 | Deferred until adapter evidence proves a durable cross-domain identity need |
+
+The selected option won by 0.462 with strong structured coverage, 5.9%
+semantic fallback, and no commandment conflict. The strongest positive
+contributors were Research and Use Standards and Never Assume—Verify. The
+decision also follows the kernel's “Mirror, don't migrate” and “Audit Existing
+Schema Before Adding Large Features” principles.
+
+## Design grounding
+
+- **Existing specifications reviewed:**
+  - `docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md`
+  - `docs/superpowers/specs/2026-07-17-organization-workforce-staffing-scheduling-design.md`
+  - `docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md`
+  - `docs/superpowers/specs/2026-07-30-food-hospitality-resource-capacity-design.md`
+  - `docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md`
+- **Current substrate reviewed:** `ArchetypeDefinition`, `TwinProfile`,
+  `FieldDispatchProfile`, `SchedulingDefaults`, `ServiceProvider`,
+  `ProviderAvailability`, `BookingHold`, `HospitalityResource`, `CareResource`,
+  `RentableUnit`, `StaffingResourceLink`, `FixedAsset`, and
+  `OperationalSceneLayout`.
+- **Live backlog reviewed:** the shared dependency and 21 category resource
+  items, including beauty, rental, HOA/property, trades/HVAC, healthcare,
+  fitness/classes, venue, and warehousing.
+- **Code graph result:** the committed code graph returned no curated result for
+  the compound resource queries, so direct source/schema inspection is the
+  grounding authority for this design.
+
+## Problem
+
+DPF already models scarce resources, but each bounded context exposes a
+different shape. Operational-twin and owner-attention consumers would otherwise
+repeat source-specific joins and interval logic, or create another central table
+that competes with valid domain owners.
+
+The shared problem is not “where should every resource row live?” It is:
+
+1. which resource/capacity patterns apply to this archetype;
+2. which existing source owns each resource and allocation;
+3. how those sources become a bounded, typed operational view;
+4. how intervals, buffers, travel, capacity, and conflicts are interpreted
+   consistently; and
+5. how missing/degraded sources remain visible rather than becoming fabricated
+   availability.
+
+## Archetype capacity profile
+
+Add a pure `deriveResourceCapacityProfile(archetype)` function beside the
+existing `deriveTwinProfile` and `deriveFieldDispatchProfile` family in
+`@dpf/storefront-templates`.
+
+The profile is derived from canonical archetype axes, scheduling defaults,
+field-dispatch profile, and twin profile. It is not a second hand-authored
+taxonomy.
+
+```ts
+type ResourceCapacityPattern =
+  | "appointment"
+  | "dispatch"
+  | "rental"
+  | "class"
+  | "venue"
+  | "project-resource";
+
+type ResourceAuthority =
+  | "provider-calendar"
+  | "staffing"
+  | "hospitality"
+  | "care"
+  | "rental"
+  | "field-operations";
+
+interface ResourceCapacityProfile {
+  archetypeId: string;
+  category: ArchetypeCategory;
+  enabled: boolean;
+  patterns: ResourceCapacityPattern[];
+  authorities: ResourceAuthority[];
+  resourceNoun: TwinNoun;
+  physical: boolean;
+  forwardHorizon: boolean;
+  supportsBuffers: boolean;
+  supportsTravel: boolean;
+}
+```
+
+The initial rule matrix must represent at least:
+
+| Pattern | Derivation signal | Representative archetypes | Primary authority |
+| --- | --- | --- | --- |
+| appointment | `schedulingPattern=slot` / BOOK | hair salon, healthcare | provider calendar plus vertical physical owner |
+| dispatch | field-dispatch enabled / TERRITORY | HVAC, moving | field operations plus staffing |
+| rental | reservation-and-return / YARD | equipment rental | rental |
+| class | `schedulingPattern=class` / BOOK class-grid | fitness, education | provider calendar plus staffing |
+| venue | VENUE | event venue | hospitality or venue-domain adapter when present |
+| project-resource | project/job-site axes / TERRITORY | construction, HOA work | field operations plus staffing |
+
+Derivation is archetype-gated: a source adapter cannot make a resource visible
+for an archetype whose profile does not declare the matching pattern and
+authority.
+
+## Normalized runtime contract
+
+The web runtime owns a source-neutral contract under
+`apps/web/lib/capacity/`. It is a read model, never an alternate write model.
+
+```ts
+interface CapacityResourceRef {
+  authority: ResourceAuthority;
+  resourceType: string;
+  resourceId: string;
+}
+
+interface CapacityResource {
+  ref: CapacityResourceRef;
+  organizationId: string;
+  label: string;
+  capacity: number;
+  capacityUnit: string;
+  status: "available" | "busy" | "blocked" | "offline" | "unknown";
+  locationRef?: string;
+  capabilityKeys: string[];
+  sourceVersion?: string;
+}
+
+interface CapacityInterval {
+  startAt: Date;
+  endAt: Date;
+  preparationMinutes: number;
+  cleanupMinutes: number;
+  travelBeforeMinutes: number;
+  travelAfterMinutes: number;
+}
+
+interface CapacityAllocation {
+  allocationId: string;
+  resourceRef: CapacityResourceRef;
+  demandRef: string;
+  interval: CapacityInterval;
+  quantity: number;
+  lifecycle: "held" | "confirmed" | "active" | "released" | "cancelled";
+}
+```
+
+The normalized snapshot includes resources, allocations, availability windows,
+attention signals, source watermarks, and degraded-source diagnostics. Every
+record retains its authority and source identifier so a later operator command
+can route back to the correct domain.
+
+## Adapter registry
+
+Each adapter:
+
+- declares one `ResourceAuthority`;
+- states which profile patterns it supports;
+- loads only organization-scoped records from its canonical source;
+- normalizes resource, availability, allocation, and watermark facts;
+- returns a typed unsupported/degraded result when the source is absent;
+- never writes through the mirror.
+
+The registry refuses duplicate authority registrations and skips adapters that
+the derived archetype profile does not authorize. Initial contract tests cover
+provider calendar, staffing, hospitality, care, rental, and field-operation
+adapter descriptors. Vertical PRs add concrete loaders as their authoritative
+sources are exercised.
+
+Descriptor presence is not readiness. `venue-operations`, pet occupancy, and
+other patterns without a complete physical-resource owner remain explicitly
+degraded until their vertical PR establishes one. In particular, the
+Food & Hospitality-owned `HospitalityResource` must not be reused as the
+physical-space authority for the separate Live Events & Venues category.
+Likewise, finance-owned `FixedAsset` is not an operational field-asset source:
+it lacks the organization and scheduling contracts required by this mirror.
+Adding an authority requires its descriptor, profile-gating tests, and a named
+canonical source in the same PR; registering a loader requires organization
+scope and watermark contract tests.
+
+## Shared interval and conflict semantics
+
+One pure interval module defines:
+
+- effective footprint = travel-before + preparation + service + cleanup +
+  travel-after;
+- half-open interval overlap (`[start, end)`) so adjacent work does not
+  conflict;
+- quantity consumption against resource capacity;
+- lifecycle filtering so released/cancelled allocations do not consume;
+- utilization for a bounded window;
+- conflict kinds: `time-overlap`, `capacity-exceeded`, `unavailable`,
+  `capability-mismatch`, `travel-window`, and `source-degraded`.
+
+This computation predicts and explains conflicts. Atomic enforcement remains
+inside the canonical domain transaction and existing database constraints. The
+shared mirror must never label an assignment “safe to commit” merely because a
+read snapshot showed no conflict.
+
+## Attention contract
+
+The shared projection emits structured signals, not English tied to one
+vertical:
+
+- conflicting demand;
+- idle/open capacity opportunity;
+- blocked/offline resource;
+- capability mismatch;
+- travel-window infeasibility;
+- degraded or stale authority.
+
+Vertical presentations supply owner language (“open chair for 45 minutes,”
+“truck cannot reach the next job,” “room unavailable for massage”). The common
+signal retains resource and demand references for drill-through and action.
+
+## Performance and failure behavior
+
+- Profile derivation is pure and deterministic.
+- Adapter loads run in parallel under the existing bounded operations-load
+  runtime.
+- The projection is linearithmic at worst in allocations per resource; it must
+  not scan unrelated organizations or archetypes.
+- Missing adapters return `source-degraded`; they never imply zero demand or
+  free capacity.
+- The hot path carries source watermarks and can be cached with bounded
+  staleness; commands always re-check at the authoritative write boundary.
+
+## UX fit
+
+This concern adds no route or user-facing control, so direct UX verification is
+not applicable. Its output contract is specifically designed for the existing
+Business Operations workspace, Cartesian scene/list parity, first-viewport
+attention, and owner-language vertical presentations. Each consuming vertical
+must perform its own measured UX review and latency verification.
+
+## Migration and rollout
+
+No Prisma migration is required. The mirror reads existing canonical models and
+adds TypeScript contracts, derivation, registry, projection, tests, and
+architecture documentation.
+
+Rollout is additive:
+
+1. ship profile, registry, and pure projection;
+2. bind beauty to provider/staffing adapters;
+3. add rental, hotel, HOA, HVAC, and other adapters through their vertical PRs;
+4. evaluate a persisted identity bridge only after at least three independently
+   implemented verticals reveal a repeated identity or availability write need.
+
+## Verification
+
+- profile matrix covers appointment, dispatch, rental, class, venue, and
+  project-resource patterns and rejects non-applicable adapters;
+- interval tests cover buffers, travel, adjacency, lifecycle release, capacity,
+  and utilization;
+- registry tests cover duplicate authority, unsupported, degraded, and
+  organization-scoped aggregation;
+- adapter contract fixtures prove source references and watermarks survive the
+  mirror;
+- source-local typecheck and targeted tests pass;
+- governed merged-code exhaustive tests and production build pass before PR;
+- UX and migration are recorded as not applicable with the concrete reasons
+  above.

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -9,6 +9,7 @@ export * from "./archetypes/index";
 export * from "./media-profile";
 export * from "./operational-value-stream";
 export * from "./twin-profile";
+export * from "./resource-capacity-profile";
 export * from "./scene-layout";
 export * from "./business-view-profile";
 export * from "./performance-metric-catalog";

--- a/packages/storefront-templates/src/resource-capacity-profile.test.ts
+++ b/packages/storefront-templates/src/resource-capacity-profile.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+import {
+  RESOURCE_CAPACITY_AUTHORITIES,
+  RESOURCE_CAPACITY_PATTERNS,
+  deriveResourceCapacityProfile,
+} from "./resource-capacity-profile";
+
+function archetype(archetypeId: string) {
+  const match = ALL_ARCHETYPES.find((item) => item.archetypeId === archetypeId);
+  if (!match) throw new Error(`Missing archetype fixture ${archetypeId}`);
+  return match;
+}
+
+describe("deriveResourceCapacityProfile", () => {
+  it.each([
+    ["hair-salon", "appointment", "provider-calendar"],
+    ["hvac-contractor", "dispatch", "field-operations"],
+    ["equipment-rental", "rental", "rental"],
+    ["gym", "class", "provider-calendar"],
+    ["event-venue", "venue", "venue-operations"],
+    ["new-home-builder", "project-resource", "field-operations"],
+  ] as const)("maps %s to the %s capacity pattern", (archetypeId, pattern, authority) => {
+    const profile = deriveResourceCapacityProfile(archetype(archetypeId));
+
+    expect(profile.enabled).toBe(true);
+    expect(profile.patterns).toContain(pattern);
+    expect(profile.authorities).toContain(authority);
+  });
+
+  it("keeps mobile beauty on the dispatch/travel path", () => {
+    const profile = deriveResourceCapacityProfile(archetype("mobile-beauty"));
+
+    expect(profile.patterns).toContain("dispatch");
+    expect(profile.supportsTravel).toBe(true);
+  });
+
+  it("represents existing restaurant and room occupancy authorities", () => {
+    expect(deriveResourceCapacityProfile(archetype("restaurant"))).toMatchObject({
+      patterns: ["service-floor"],
+      authorities: expect.arrayContaining(["hospitality"]),
+    });
+    expect(deriveResourceCapacityProfile(archetype("pet-boarding"))).toMatchObject({
+      patterns: ["occupancy"],
+    });
+  });
+
+  it("does not manufacture physical capacity for board-only archetypes", () => {
+    const profile = deriveResourceCapacityProfile(archetype("software-platform"));
+
+    expect(profile.enabled).toBe(false);
+    expect(profile.patterns).toEqual([]);
+    expect(profile.authorities).toEqual([]);
+  });
+
+  it("returns only closed pattern and authority values for every archetype", () => {
+    for (const definition of ALL_ARCHETYPES) {
+      const profile = deriveResourceCapacityProfile(definition);
+      for (const pattern of profile.patterns) {
+        expect(RESOURCE_CAPACITY_PATTERNS).toContain(pattern);
+      }
+      for (const authority of profile.authorities) {
+        expect(RESOURCE_CAPACITY_AUTHORITIES).toContain(authority);
+      }
+    }
+  });
+});

--- a/packages/storefront-templates/src/resource-capacity-profile.ts
+++ b/packages/storefront-templates/src/resource-capacity-profile.ts
@@ -1,0 +1,145 @@
+import type { ArchetypeCategory, ArchetypeDefinition } from "./types";
+import { deriveTwinProfile, type TwinNoun } from "./twin-profile";
+
+export const RESOURCE_CAPACITY_PATTERNS = [
+  "appointment",
+  "dispatch",
+  "rental",
+  "class",
+  "venue",
+  "project-resource",
+  "service-floor",
+  "occupancy",
+] as const;
+
+export type ResourceCapacityPattern = (typeof RESOURCE_CAPACITY_PATTERNS)[number];
+
+export const RESOURCE_CAPACITY_AUTHORITIES = [
+  "provider-calendar",
+  "staffing",
+  "hospitality",
+  "care",
+  "rental",
+  "field-operations",
+  "venue-operations",
+] as const;
+
+export type ResourceCapacityAuthority = (typeof RESOURCE_CAPACITY_AUTHORITIES)[number];
+
+export interface ResourceCapacityProfile {
+  archetypeId: string;
+  category: ArchetypeCategory;
+  enabled: boolean;
+  patterns: ResourceCapacityPattern[];
+  authorities: ResourceCapacityAuthority[];
+  resourceNoun: TwinNoun;
+  physical: boolean;
+  forwardHorizon: boolean;
+  supportsBuffers: boolean;
+  supportsTravel: boolean;
+}
+
+function patternsFor(archetype: ArchetypeDefinition): ResourceCapacityPattern[] {
+  const twin = deriveTwinProfile(archetype);
+  if (!twin.physical) return [];
+
+  switch (twin.template) {
+    case "BOOK":
+      return [twin.variant === "class-grid" ? "class" : "appointment"];
+    case "TERRITORY":
+      return [
+        archetype.category === "hoa-property-management" ||
+        archetype.category === "real-estate-construction"
+          ? "project-resource"
+          : "dispatch",
+      ];
+    case "YARD":
+      return ["rental"];
+    case "VENUE":
+      return ["venue"];
+    case "ROOMS":
+      return ["occupancy"];
+    case "FLOOR":
+    case "BAYS":
+    case "DOCK":
+      return ["service-floor"];
+    default:
+      return [];
+  }
+}
+
+function authoritiesFor(
+  archetype: ArchetypeDefinition,
+  patterns: readonly ResourceCapacityPattern[],
+): ResourceCapacityAuthority[] {
+  const authorities = new Set<ResourceCapacityAuthority>();
+
+  for (const pattern of patterns) {
+    switch (pattern) {
+      case "appointment":
+        authorities.add("provider-calendar");
+        authorities.add("staffing");
+        if (archetype.category === "healthcare-wellness") authorities.add("care");
+        break;
+      case "class":
+        authorities.add("provider-calendar");
+        authorities.add("staffing");
+        break;
+      case "dispatch":
+      case "project-resource":
+        authorities.add("field-operations");
+        authorities.add("staffing");
+        break;
+      case "rental":
+        authorities.add("rental");
+        break;
+      case "venue":
+        authorities.add("venue-operations");
+        authorities.add("staffing");
+        break;
+      case "occupancy":
+        if (archetype.category === "healthcare-wellness") authorities.add("care");
+        authorities.add("staffing");
+        break;
+      case "service-floor":
+        if (archetype.category === "food-hospitality") authorities.add("hospitality");
+        authorities.add("staffing");
+        break;
+    }
+  }
+
+  return [...authorities];
+}
+
+/**
+ * Derive the scarce-resource read profile from the same archetype facts that
+ * already select the operational twin. This is applicability and routing only;
+ * canonical resource records remain in their bounded-context owners.
+ */
+export function deriveResourceCapacityProfile(
+  archetype: ArchetypeDefinition,
+): ResourceCapacityProfile {
+  const twin = deriveTwinProfile(archetype);
+  const patterns = patternsFor(archetype);
+  const authorities = authoritiesFor(archetype, patterns);
+
+  return {
+    archetypeId: archetype.archetypeId,
+    category: archetype.category,
+    enabled: patterns.length > 0 && authorities.length > 0,
+    patterns,
+    authorities,
+    resourceNoun: { ...twin.resourceNoun },
+    physical: twin.physical,
+    forwardHorizon: twin.forwardHorizon === true,
+    supportsBuffers: patterns.some((pattern) =>
+      pattern === "appointment" ||
+      pattern === "class" ||
+      pattern === "venue" ||
+      pattern === "service-floor"
+    ),
+    supportsTravel: patterns.some((pattern) =>
+      pattern === "dispatch" || pattern === "project-resource"
+    ),
+  };
+}


### PR DESCRIPTION
## Summary

- derive a shared scarce-resource capacity profile from the existing operational-twin archetype facts
- add source-neutral capacity contracts, half-open interval/buffer/travel conflict semantics, and bounded-context adapter registration
- preserve canonical vertical ownership while making missing or degraded capacity sources explicit
- refactor Operations source health/watermark contracts into a reusable shared home
- document the architecture decision and implementation plan for the vertical capacity dependency

## Verification

- exact merged-code gate passed against current `origin/main`: migration deploy, documentation and policy guards, web typecheck, 2,469 Vitest files / 21,144 tests, and production Docker/Next.js build
- UX: not applicable; this PR adds no user-facing route or control
- migration: not applicable; this PR changes no database schema
