### PR TITLE
feat: make workspace work rooms outcome first

### DIFF
--- a/apps/web/components/portal/PortalWorkCases.test.tsx
+++ b/apps/web/components/portal/PortalWorkCases.test.tsx
@@ -53,6 +53,9 @@ describe("PortalWorkCases", () => {
     expect(html).toContain('href="/portal/support"');
     expect(html).not.toContain("sourceRefs");
     expect(html).not.toContain("work-item");
+    expect(html).not.toContain("Work Room");
+    expect(html).not.toContain("Participants");
+    expect(html).not.toContain("A2A status");
   });
 
   it("uses DPF theme tokens and avoids hardcoded status colors", () => {

--- a/apps/web/components/shell/ShellBreadcrumb.test.tsx
+++ b/apps/web/components/shell/ShellBreadcrumb.test.tsx
@@ -59,6 +59,17 @@ describe("buildBreadcrumbTrail", () => {
       { label: "Reference Data", href: "/admin/reference-data" },
     ]);
   });
+
+  it("decodes an encoded case key before presenting its fallback label", () => {
+    expect(buildBreadcrumbTrail("/workspace/cases/backlog-item%3ABI-CCE939AF")).toEqual([
+      { label: "Operations", href: "/workspace" },
+      { label: "Cases", href: "/workspace/cases" },
+      {
+        label: "Backlog Item:BI CCE939AF",
+        href: "/workspace/cases/backlog-item%3ABI-CCE939AF",
+      },
+    ]);
+  });
 });
 
 describe("ShellBreadcrumb", () => {

--- a/apps/web/components/shell/ShellBreadcrumb.tsx
+++ b/apps/web/components/shell/ShellBreadcrumb.tsx
@@ -15,7 +15,13 @@ import { getRouteNavRecord } from "@/lib/navigation/portal-navigation-model";
 type Crumb = { label: string; href: string };
 
 function titleCase(segment: string): string {
-  return segment
+  let decoded = segment;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    // Keep malformed path segments legible without breaking shell navigation.
+  }
+  return decoded
     .replace(/-/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -83,6 +83,13 @@ describe("statusColors", () => {
     expect(resolveIntent("selfUpgradeRun", "skipped")).toBe("neutral");
   });
 
+  it("maps Work Room state, outcome health, and activity through shared domains", () => {
+    expect(resolveIntent("workCaseState", "waiting-on-person")).toBe("warning");
+    expect(resolveIntent("workRoomOutcomeHealth", "at-risk")).toBe("warning");
+    expect(resolveIntent("workRoomActivity", "message")).toBe("neutral");
+    expect(resolveIntent("workRoomActivity", "decision-resolved")).toBe("success");
+  });
+
   // BI-5B2F5447 (D0): the portfolioCoverage badge map is the render side of the
   // PORTFOLIO_COVERAGE_STATUSES enum in @dpf/db. A coverage status with no explicit
   // intent falls through resolveIntent to "neutral" and reads wrong on the coverage

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -371,6 +371,47 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     done: "success",
     deferred: "neutral",
   },
+  // Workspace Work Room semantics. These domains are shared by the My Work
+  // lens and room detail shell so neither surface carries a private color map.
+  workCaseState: {
+    intake: "neutral",
+    triage: "info",
+    active: "accent",
+    "waiting-on-person": "warning",
+    "waiting-on-system": "danger",
+    "awaiting-decision": "warning",
+    verifying: "info",
+    resolved: "success",
+    closed: "neutral",
+    cancelled: "neutral",
+  },
+  workRoomOutcomeHealth: {
+    "on-track": "success",
+    "at-risk": "warning",
+    blocked: "danger",
+    idle: "neutral",
+    unknown: "neutral",
+  },
+  workRoomActivity: {
+    message: "neutral",
+    ask: "warning",
+    "coworker-joined": "accent",
+    "coworker-left": "accent",
+    "coworker-handoff": "warning",
+    "work-started": "accent",
+    "work-paused": "accent",
+    "work-completed": "success",
+    "decision-proposed": "warning",
+    "decision-resolved": "success",
+    "artifact-added": "info",
+    "governed-action": "accent",
+    "external-event": "neutral",
+    verification: "info",
+    receipt: "info",
+    "cycle-opened": "accent",
+    "cycle-closed": "success",
+    "cycle-carried-over": "accent",
+  },
   // Platform domain-readiness matrix (Six-Cs). good/attention/blocked/unknown
   // map to the shared intent ramp so the readiness surface stops carrying its
   // own state->color map. See PlatformReadinessMatrix + command-center.ts.

--- a/apps/web/components/workspace/WorkCaseAttentionLens.test.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.test.tsx
@@ -95,5 +95,8 @@ describe("WorkCaseAttentionLens", () => {
 
     expect(html).toContain("No active Work Rooms");
     expect(html).toContain("New rooms will appear here when work is assigned or made available for claiming.");
+    expect(html).toContain('<section aria-labelledby="work-room-empty-title"');
+    expect(html).toContain('<h2 id="work-room-empty-title"');
+    expect(html).not.toContain('role="status"');
   });
 });

--- a/apps/web/components/workspace/WorkCaseAttentionLens.test.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.test.tsx
@@ -95,8 +95,9 @@ describe("WorkCaseAttentionLens", () => {
 
     expect(html).toContain("No active Work Rooms");
     expect(html).toContain("New rooms will appear here when work is assigned or made available for claiming.");
-    expect(html).toContain('<section aria-labelledby="work-room-empty-title"');
+    expect(html).toContain("<section");
     expect(html).toContain('<h2 id="work-room-empty-title"');
+    expect(html).not.toContain('aria-labelledby="work-room-empty-title"');
     expect(html).not.toContain('role="status"');
   });
 });

--- a/apps/web/components/workspace/WorkCaseAttentionLens.test.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.test.tsx
@@ -61,13 +61,14 @@ const fixture: WorkspaceWorkCaseLensView = {
 };
 
 describe("WorkCaseAttentionLens", () => {
-  it("renders attention cases before the full queue and links to case detail", () => {
+  it("renders attention rooms before the full queue and preserves the case detail URL", () => {
     const html = renderToStaticMarkup(<WorkCaseAttentionLens view={fixture} />);
 
-    expect(html).toContain("Work Cases");
-    expect(html.indexOf("Needs attention")).toBeLessThan(html.indexOf("All active cases"));
+    expect(html).toContain("My Work");
+    expect(html.indexOf("Needs attention")).toBeLessThan(html.indexOf("All active rooms"));
     expect(html).toContain("Confirm condenser appointment");
     expect(html).toContain('href="/workspace/cases/booking%3ABK-1"');
+    expect(html).toContain("Open room");
   });
 
   it("renders a mobile-first today strip for urgent attention cases", () => {
@@ -92,7 +93,7 @@ describe("WorkCaseAttentionLens", () => {
       <WorkCaseAttentionLens view={{ ...fixture, cases: [], stats: { total: 0, needsAttention: 0, active: 0, unassigned: 0, dueSoon: 0 } }} />,
     );
 
-    expect(html).toContain("No active Work Cases");
-    expect(html).toContain("New work will appear here after it is assigned or made available for claiming.");
+    expect(html).toContain("No active Work Rooms");
+    expect(html).toContain("New rooms will appear here when work is assigned or made available for claiming.");
   });
 });

--- a/apps/web/components/workspace/WorkCaseAttentionLens.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.tsx
@@ -1,8 +1,11 @@
 import { AlertTriangle, ArrowRight, Clock, Inbox, ListChecks, Smartphone, UserCheck } from "lucide-react";
 
 import { LocalTime } from "@/components/ui/LocalTime";
-import { StatCard, StatusBadge } from "@/components/ui/report-kit";
-import type { Intent } from "@/components/ui/report-kit/statusColors";
+import { EmptyState, StatCard, StatusBadge } from "@/components/ui/report-kit";
+import {
+  roomLabel,
+  WORK_STATE_INTENT,
+} from "@/components/workspace/work-room/presentation";
 import type {
   WorkspaceWorkCaseLensView,
   WorkspaceWorkCaseListItem,
@@ -12,32 +15,16 @@ type Props = {
   view: WorkspaceWorkCaseLensView;
 };
 
-const STATE_INTENT: Record<string, Intent> = {
-  intake: "neutral",
-  triage: "info",
-  active: "accent",
-  "waiting-on-person": "warning",
-  "waiting-on-system": "danger",
-  "awaiting-decision": "warning",
-  verifying: "info",
-  resolved: "success",
-  closed: "neutral",
-  cancelled: "neutral",
-};
-
-function stateLabel(state: string): string {
-  return state.replaceAll("-", " ");
-}
-
 function CaseRow({ item, compact = false }: { item: WorkspaceWorkCaseListItem; compact?: boolean }) {
   return (
     <a
       href={item.href}
-      className="grid gap-3 border-b border-[var(--dpf-border)] px-4 py-3 text-[var(--dpf-text)] transition-colors last:border-b-0 hover:bg-[var(--dpf-surface-2)] md:grid-cols-[minmax(0,1fr)_auto]"
+      className="grid min-h-11 gap-3 border-b border-[var(--dpf-border)] px-4 py-3 text-[var(--dpf-text)] transition-colors last:border-b-0 hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--dpf-accent)] md:grid-cols-[minmax(0,1fr)_auto]"
     >
+      <span className="sr-only">Open room: {item.title}</span>
       <div className="min-w-0">
         <div className="mb-2 flex flex-wrap items-center gap-2">
-          <StatusBadge intent={STATE_INTENT[item.state] ?? "neutral"} label={stateLabel(item.state)} variant="soft" />
+          <StatusBadge intent={WORK_STATE_INTENT[item.state]} label={roomLabel(item.state)} variant="soft" />
           <StatusBadge intent={item.attentionRequired ? "warning" : "neutral"} label={item.urgencyLabel} variant="outline" />
           <span className="text-xs text-[var(--dpf-muted)]">{item.sourceLabel}</span>
         </div>
@@ -88,8 +75,9 @@ function MobileAttentionStrip({ items }: { items: WorkspaceWorkCaseListItem[] })
           <a
             key={item.caseId}
             href={item.href}
-            className="grid min-h-16 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[var(--dpf-text)]"
+            className="grid min-h-16 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
           >
+            <span className="sr-only">Open room: {item.title}</span>
             <span className="min-w-0">
               <span className="block truncate text-sm font-semibold text-[var(--dpf-text)]">{item.title}</span>
               <span className="mt-1 block truncate text-xs text-[var(--dpf-muted)]">{item.nextAction}</span>
@@ -110,21 +98,21 @@ export function WorkCaseAttentionLens({ view }: Props) {
       <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase text-[var(--dpf-muted)]">Workspace</p>
-          <h1 className="mt-1 text-2xl font-semibold text-[var(--dpf-text)]">Work Cases</h1>
+          <h1 className="mt-1 text-2xl font-semibold text-[var(--dpf-text)]">My Work</h1>
           <p className="mt-1 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
-            Company work projected as cases, ordered by what needs your attention first.
+            Your active Work Rooms, ordered by what needs attention first.
           </p>
         </div>
         <a
           href="/workspace/inbox"
-          className="inline-flex min-h-9 w-fit items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+          className="inline-flex min-h-11 w-fit items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
         >
           <Inbox className="size-4" aria-hidden="true" />
           Needs you
         </a>
       </header>
 
-      <section aria-label="Work Case summary" className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <section aria-label="Work Room summary" className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard label="Needs attention" value={view.stats.needsAttention} intent="warning" />
         <StatCard label="Active" value={view.stats.active} intent="accent" />
         <StatCard label="Unassigned" value={view.stats.unassigned} intent="info" />
@@ -134,19 +122,17 @@ export function WorkCaseAttentionLens({ view }: Props) {
       <MobileAttentionStrip items={attentionCases} />
 
       {view.cases.length === 0 ? (
-        <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-10 text-center">
-          <ListChecks className="mx-auto size-8 text-[var(--dpf-muted)]" aria-hidden="true" />
-          <h2 className="mt-3 text-base font-semibold text-[var(--dpf-text)]">No active Work Cases</h2>
-          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-[var(--dpf-muted)]">
-            New work will appear here after it is assigned or made available for claiming.
-          </p>
-        </section>
+        <EmptyState
+          title="No active Work Rooms"
+          description="New rooms will appear here when work is assigned or made available for claiming."
+          icon={<ListChecks className="size-8" />}
+        />
       ) : (
         <>
-          <section aria-labelledby="work-case-attention-title" className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+          <section aria-labelledby="work-room-attention-title" className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
             <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-3">
               <AlertTriangle className="size-4 text-[var(--dpf-warning)]" aria-hidden="true" />
-              <h2 id="work-case-attention-title" className="text-sm font-semibold text-[var(--dpf-text)]">
+              <h2 id="work-room-attention-title" className="text-sm font-semibold text-[var(--dpf-text)]">
                 Needs attention
               </h2>
               <span className="text-xs text-[var(--dpf-muted)]">{attentionCases.length}</span>
@@ -160,10 +146,10 @@ export function WorkCaseAttentionLens({ view }: Props) {
             )}
           </section>
 
-          <section aria-labelledby="work-case-all-title" className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+          <section aria-labelledby="work-room-all-title" className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
             <div className="border-b border-[var(--dpf-border)] px-4 py-3">
-              <h2 id="work-case-all-title" className="text-sm font-semibold text-[var(--dpf-text)]">
-                All active cases
+              <h2 id="work-room-all-title" className="text-sm font-semibold text-[var(--dpf-text)]">
+                All active rooms
               </h2>
             </div>
             {view.cases.map((item) => <CaseRow key={item.caseId} item={item} compact />)}

--- a/apps/web/components/workspace/WorkCaseAttentionLens.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, ArrowRight, Clock, Inbox, ListChecks, Smartphone, UserCheck } from "lucide-react";
 
 import { LocalTime } from "@/components/ui/LocalTime";
-import { EmptyState, StatCard, StatusBadge } from "@/components/ui/report-kit";
+import { StatCard, StatusBadge } from "@/components/ui/report-kit";
 import {
   roomLabel,
 } from "@/components/workspace/work-room/presentation";
@@ -121,11 +121,18 @@ export function WorkCaseAttentionLens({ view }: Props) {
       <MobileAttentionStrip items={attentionCases} />
 
       {view.cases.length === 0 ? (
-        <EmptyState
-          title="No active Work Rooms"
-          description="New rooms will appear here when work is assigned or made available for claiming."
-          icon={<ListChecks className="size-8" />}
-        />
+        <section
+          aria-labelledby="work-room-empty-title"
+          className="rounded-xl border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-6 py-12 text-center"
+        >
+          <ListChecks className="mx-auto size-8 text-[var(--dpf-muted)]" aria-hidden="true" />
+          <h2 id="work-room-empty-title" className="mt-3 text-base font-semibold text-[var(--dpf-text)]">
+            No active Work Rooms
+          </h2>
+          <p className="mx-auto mt-2 max-w-prose text-sm leading-6 text-[var(--dpf-muted)]">
+            New rooms will appear here when work is assigned or made available for claiming.
+          </p>
+        </section>
       ) : (
         <>
           <section aria-labelledby="work-room-attention-title" className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">

--- a/apps/web/components/workspace/WorkCaseAttentionLens.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.tsx
@@ -4,7 +4,6 @@ import { LocalTime } from "@/components/ui/LocalTime";
 import { EmptyState, StatCard, StatusBadge } from "@/components/ui/report-kit";
 import {
   roomLabel,
-  WORK_STATE_INTENT,
 } from "@/components/workspace/work-room/presentation";
 import type {
   WorkspaceWorkCaseLensView,
@@ -24,7 +23,7 @@ function CaseRow({ item, compact = false }: { item: WorkspaceWorkCaseListItem; c
       <span className="sr-only">Open room: {item.title}</span>
       <div className="min-w-0">
         <div className="mb-2 flex flex-wrap items-center gap-2">
-          <StatusBadge intent={WORK_STATE_INTENT[item.state]} label={roomLabel(item.state)} variant="soft" />
+          <StatusBadge domain="workCaseState" status={item.state} label={roomLabel(item.state)} variant="soft" />
           <StatusBadge intent={item.attentionRequired ? "warning" : "neutral"} label={item.urgencyLabel} variant="outline" />
           <span className="text-xs text-[var(--dpf-muted)]">{item.sourceLabel}</span>
         </div>

--- a/apps/web/components/workspace/WorkCaseAttentionLens.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.tsx
@@ -121,10 +121,7 @@ export function WorkCaseAttentionLens({ view }: Props) {
       <MobileAttentionStrip items={attentionCases} />
 
       {view.cases.length === 0 ? (
-        <section
-          aria-labelledby="work-room-empty-title"
-          className="rounded-xl border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-6 py-12 text-center"
-        >
+        <section className="rounded-xl border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-6 py-12 text-center">
           <ListChecks className="mx-auto size-8 text-[var(--dpf-muted)]" aria-hidden="true" />
           <h2 id="work-room-empty-title" className="mt-3 text-base font-semibold text-[var(--dpf-text)]">
             No active Work Rooms

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -83,7 +83,7 @@ const room: WorkRoomView = {
       actorRef: { actorKind: "person", actorId: "dispatcher-1" },
       summary: "Reserved the afternoon window.",
       emphasis: "salient",
-      sourceRef: { kind: "decision", id: "DEC-1" },
+      sourceRef: { kind: "decision-interaction", id: "DEC-1" },
     },
   ],
   work: {

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -254,6 +254,11 @@ describe("WorkCaseDetailView", () => {
     );
 
     expect(html).toContain("Coworker status unavailable");
+    const participantPanel = html.slice(
+      html.indexOf('aria-labelledby="work-room-participants-title"'),
+      html.indexOf('aria-label="Work"'),
+    );
+    expect(participantPanel).toContain("<details open=\"\"");
     expect(html.match(/Continue with the room’s next action:/g)).toHaveLength(1);
     expect(html).toContain("Collect the customer confirmation");
   });

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -232,6 +232,32 @@ describe("WorkCaseDetailView", () => {
     expect(html).toContain("Return to My Work and try opening the room again");
   });
 
+  it("shows one safe next action when an AI coworker status is unavailable", () => {
+    const unavailableCoworkerDetail = {
+      ...detail,
+      room: {
+        ...room,
+        participants: room.participants.map((participant) =>
+          participant.kind === "agent"
+            ? {
+                ...participant,
+                presence: "unknown" as const,
+                workState: "unknown" as const,
+                currentWorkSummary: null,
+              }
+            : participant,
+        ),
+      },
+    };
+    const html = renderToStaticMarkup(
+      <WorkCaseDetailView detail={unavailableCoworkerDetail} />,
+    );
+
+    expect(html).toContain("Coworker status unavailable");
+    expect(html.match(/Continue with the room’s next action:/g)).toHaveLength(1);
+    expect(html).toContain("Collect the customer confirmation");
+  });
+
   it("handles the transitional missing projection honestly", () => {
     const html = renderToStaticMarkup(<WorkCaseDetailView detail={{ ...detail, room: undefined }} />);
 

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -176,6 +176,22 @@ describe("WorkCaseDetailView", () => {
     expect(header).not.toContain("WI-1");
   });
 
+  it("keeps a long room purpose available without pushing the outcome out of view", () => {
+    const longPurpose = "Coordinate this room across a deliberately long operating brief. ".repeat(8);
+    const html = renderToStaticMarkup(
+      <WorkCaseDetailView
+        detail={{ ...detail, room: { ...room, purpose: longPurpose } }}
+      />,
+    );
+    const header = html.slice(0, html.indexOf("</header>"));
+
+    expect(header).toContain("<details");
+    expect(header).toContain("Room purpose");
+    expect(header).toContain(longPurpose);
+    expect(header.indexOf("Room purpose")).toBeLessThan(header.indexOf("Outcome"));
+    expect(header).not.toContain("<details open");
+  });
+
   it("keeps technical source references and A2A status behind room details", () => {
     const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
 

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -3,6 +3,115 @@ import { describe, expect, it } from "vitest";
 
 import { WorkCaseDetailView } from "./WorkCaseDetailView";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
+import type { WorkRoomView } from "@/lib/work-management/room-types";
+
+const room: WorkRoomView = {
+  roomKey: "booking%3ABK-1",
+  caseRef: { caseId: "booking:BK-1", sourceType: "booking", sourceId: "BK-1" },
+  title: "Confirm condenser appointment",
+  purpose: "Coordinate the customer appointment.",
+  mode: "finite",
+  state: "waiting-on-person",
+  outcome: {
+    statement: "Customer has a confirmed appointment and arrival window.",
+    packet: null,
+    health: "at-risk",
+    sourceRefs: [{ kind: "source", id: "BK-1", sourceType: "booking" }],
+  },
+  boundary: {
+    purpose: "Coordinate the customer appointment.",
+    outcome: "Customer has a confirmed appointment and arrival window.",
+    scopeIncluded: ["Confirm the appointment"],
+    scopeExcluded: [],
+    accountablePrincipalRef: "person:dispatcher-1",
+    admittedRoleSummary: ["Dispatcher", "Scheduling coworker"],
+    authoritySummary: ["May confirm an available service window"],
+    sensitivityCeiling: "customer-confidential",
+    measures: ["Appointment confirmed"],
+    timeBoundary: {
+      dueAt: "2026-06-29T15:00:00.000Z",
+      reviewAt: null,
+      stopConditionSummary: "Stop when the customer confirms.",
+    },
+    closureRuleSummary: "Close after confirmation is recorded.",
+    gaps: [],
+    sourceRefs: [{ kind: "source", id: "BK-1", sourceType: "booking" }],
+  },
+  currentCycle: null,
+  participants: [
+    {
+      principalRef: "person:dispatcher-1",
+      displayName: "Jamie Rivera",
+      kind: "person",
+      roles: ["accountable"],
+      workState: "waiting",
+      presence: "active",
+      currentWorkSummary: "Waiting for the customer",
+      enteredReason: "Owns scheduling",
+      sponsorPrincipalRef: null,
+      authoritySummary: "May confirm an available service window",
+      sourceRefs: [],
+    },
+    {
+      principalRef: "agent:scheduling-1",
+      displayName: "Scheduling Coworker",
+      kind: "agent",
+      roles: ["contributor"],
+      workState: "working",
+      presence: "active",
+      currentWorkSummary: "Checking available windows",
+      enteredReason: "Assigned to support scheduling",
+      sponsorPrincipalRef: "person:dispatcher-1",
+      authoritySummary: "May prepare options; may not confirm externally",
+      sourceRefs: [],
+    },
+  ],
+  activity: [
+    {
+      eventId: "message:1",
+      kind: "message",
+      occurredAt: "2026-06-28T12:00:00.000Z",
+      actorRef: { actorKind: "person", actorId: "dispatcher-1" },
+      summary: "Asked the customer to choose a window.",
+      emphasis: "normal",
+      sourceRef: { kind: "work-item", id: "WI-1" },
+    },
+    {
+      eventId: "decision:1",
+      kind: "decision-resolved",
+      occurredAt: "2026-06-28T12:30:00.000Z",
+      actorRef: { actorKind: "person", actorId: "dispatcher-1" },
+      summary: "Reserved the afternoon window.",
+      emphasis: "salient",
+      sourceRef: { kind: "decision", id: "DEC-1" },
+    },
+  ],
+  work: {
+    nextAction: "Collect the customer confirmation",
+    attentionRequired: true,
+    attentionReason: "The customer has not selected a window.",
+    blockingActorKind: "person",
+    activeCapsuleRefs: [],
+    activeTaskRunSummary: null,
+    terminal: false,
+    sourceRefs: [{ kind: "work-item", id: "WI-1", status: "awaiting-input" }],
+  },
+  context: {
+    refs: [{ kind: "source", id: "BK-1", sourceType: "booking" }],
+    digest: "The customer prefers afternoon service.",
+    sensitivityCeiling: "customer-confidential",
+  },
+  receipts: [],
+  sourceRefs: [
+    { kind: "source", id: "BK-1", sourceType: "booking" },
+    { kind: "work-item", id: "WI-1", status: "awaiting-input" },
+  ],
+  projection: {
+    confidence: "high",
+    incompleteBoundary: false,
+    sourceHealth: "ok",
+  },
+};
 
 const detail: WorkspaceWorkCaseDetailView = {
   summary: {
@@ -41,22 +150,93 @@ const detail: WorkspaceWorkCaseDetailView = {
   ],
   workItemId: "wi-cuid-1",
   workItemTitle: "Confirm condenser appointment",
+  room,
 };
 
 describe("WorkCaseDetailView", () => {
-  it("leads with evidence before implementation source references", () => {
+  it("uses My Work and Work Room language on the existing Workspace route", () => {
     const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
 
-    expect(html).toContain("Confirm condenser appointment");
-    expect(html.indexOf("Evidence timeline")).toBeLessThan(html.indexOf("Source refs"));
-    expect(html).toContain("Customer called twice.");
+    expect(html).toContain(">My Work<");
+    expect(html).toContain(">Work Room<");
+    expect(html).toContain('href="/workspace/my-queue"');
   });
 
-  it("keeps navigation in the Workspace section", () => {
+  it("puts outcome, attention, accountability, participants, and next action in the first viewport", () => {
+    const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
+    const header = html.slice(0, html.indexOf("</header>"));
+
+    expect(header).toContain("Customer has a confirmed appointment and arrival window.");
+    expect(header).toContain("The customer has not selected a window.");
+    expect(header).toContain("Jamie Rivera");
+    expect(header).toContain("2 participants");
+    expect(header).toContain("Collect the customer confirmation");
+    expect(header).not.toContain("A2A status");
+    expect(header).not.toContain("BK-1");
+    expect(header).not.toContain("WI-1");
+  });
+
+  it("keeps technical source references and A2A status behind room details", () => {
     const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
 
-    expect(html).toContain('href="/workspace/my-queue"');
-    expect(html).not.toContain("/ops");
+    expect(html).toContain("<details");
+    expect(html).toContain("Room details");
+    expect(html.indexOf("Room details")).toBeLessThan(html.indexOf("A2A status"));
+    expect(html.indexOf("Room details")).toBeLessThan(html.indexOf("BK-1"));
+  });
+
+  it("renders activity kinds with distinct accessible labels", () => {
+    const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
+
+    expect(html).toContain('aria-label="Message"');
+    expect(html).toContain('aria-label="Decision resolved"');
+    expect(html).toContain("Asked the customer to choose a window.");
+    expect(html).toContain("Reserved the afternoon window.");
+  });
+
+  it("explains an incomplete room boundary without inventing missing facts", () => {
+    const incompleteRoom: WorkRoomView = {
+      ...room,
+      outcome: { ...room.outcome, statement: null },
+      boundary: {
+        ...room.boundary,
+        outcome: null,
+        accountablePrincipalRef: null,
+        gaps: ["outcome", "accountable"],
+      },
+      projection: { ...room.projection, incompleteBoundary: true, confidence: "medium" },
+    };
+    const incompleteDetail = {
+      ...detail,
+      room: incompleteRoom,
+    };
+    const html = renderToStaticMarkup(<WorkCaseDetailView detail={incompleteDetail} />);
+
+    expect(html).toContain("This room needs a clearer boundary");
+    expect(html).toContain("Define the intended outcome and accountable owner");
+    expect(html).toContain("Outcome not defined");
+    expect(html).toContain("Accountable owner not assigned");
+  });
+
+  it("shows one recovery direction when the room source is unavailable", () => {
+    const unavailableDetail = {
+      ...detail,
+      room: {
+        ...room,
+        projection: { ...room.projection, sourceHealth: "unavailable" as const, confidence: "low" as const },
+      },
+    };
+    const html = renderToStaticMarkup(<WorkCaseDetailView detail={unavailableDetail} />);
+
+    expect(html).toContain("Room source unavailable");
+    expect(html).toContain("Return to My Work and try opening the room again");
+  });
+
+  it("handles the transitional missing projection honestly", () => {
+    const html = renderToStaticMarkup(<WorkCaseDetailView detail={{ ...detail, room: undefined }} />);
+
+    expect(html).toContain("Work Room unavailable");
+    expect(html).toContain("Return to My Work");
   });
 
   it("uses DPF theme tokens", () => {

--- a/apps/web/components/workspace/WorkCaseDetailView.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.tsx
@@ -22,7 +22,7 @@ export function WorkCaseDetailView({ detail }: Props) {
         </a>
         <EmptyState
           title="Work Room unavailable"
-          description="The room projection could not be loaded. Return to My Work and try opening it again."
+          description="The room could not load. Return to My Work and try again."
           icon={<DoorClosed className="size-7" />}
           action={(
             <a

--- a/apps/web/components/workspace/WorkCaseDetailView.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.tsx
@@ -1,131 +1,46 @@
-import { ArrowLeft, Clock, FileText, ShieldCheck } from "lucide-react";
+import { ArrowLeft, DoorClosed } from "lucide-react";
 
-import { LocalTime } from "@/components/ui/LocalTime";
-import { StatusBadge } from "@/components/ui/report-kit";
-import type { Intent } from "@/components/ui/report-kit/statusColors";
+import { EmptyState } from "@/components/ui/report-kit";
+import { WorkRoomBody } from "@/components/workspace/work-room/WorkRoomBody";
+import { WorkRoomHeader } from "@/components/workspace/work-room/WorkRoomHeader";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
-import { WorkItemCommentBox } from "@/components/workspace/WorkItemCommentBox";
 
 type Props = {
   detail: WorkspaceWorkCaseDetailView;
 };
 
-const STATE_INTENT: Record<string, Intent> = {
-  intake: "neutral",
-  triage: "info",
-  active: "accent",
-  "waiting-on-person": "warning",
-  "waiting-on-system": "danger",
-  "awaiting-decision": "warning",
-  verifying: "info",
-  resolved: "success",
-  closed: "neutral",
-  cancelled: "neutral",
-};
-
-function stateLabel(state: string): string {
-  return state.replaceAll("-", " ");
-}
-
 export function WorkCaseDetailView({ detail }: Props) {
-  const { summary } = detail;
+  if (!detail.room) {
+    return (
+      <main className="space-y-5 text-[var(--dpf-text)]">
+        <a
+          href="/workspace/my-queue"
+          className="inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-medium text-[var(--dpf-accent)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          My Work
+        </a>
+        <EmptyState
+          title="Work Room unavailable"
+          description="The room projection could not be loaded. Return to My Work and try opening it again."
+          icon={<DoorClosed className="size-7" />}
+          action={(
+            <a
+              href="/workspace/my-queue"
+              className="inline-flex min-h-11 items-center rounded-md border border-[var(--dpf-border)] px-3 text-sm font-medium text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+            >
+              Return to My Work
+            </a>
+          )}
+        />
+      </main>
+    );
+  }
 
   return (
     <main className="space-y-5 text-[var(--dpf-text)]">
-      <a
-        href="/workspace/my-queue"
-        className="inline-flex items-center gap-2 text-sm font-medium text-[var(--dpf-accent)] hover:underline"
-      >
-        <ArrowLeft className="size-4" aria-hidden="true" />
-        Work Cases
-      </a>
-
-      <header className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0">
-            <div className="mb-2 flex flex-wrap items-center gap-2">
-              <StatusBadge intent={STATE_INTENT[summary.state] ?? "neutral"} label={stateLabel(summary.state)} variant="soft" />
-              <StatusBadge intent={summary.attentionRequired ? "warning" : "neutral"} label={summary.urgencyLabel} variant="outline" />
-              <span className="text-xs text-[var(--dpf-muted)]">{summary.sourceLabel}</span>
-            </div>
-            <h1 className="text-2xl font-semibold text-[var(--dpf-text)]">{summary.title}</h1>
-            {summary.description ? (
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">{summary.description}</p>
-            ) : null}
-          </div>
-          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]">
-            <p className="text-xs text-[var(--dpf-muted)]">Next action</p>
-            <p className="mt-1 font-semibold">{summary.nextAction}</p>
-          </div>
-        </div>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-            <p className="text-xs text-[var(--dpf-muted)]">Assignment</p>
-            <p className="mt-1 text-sm font-medium">{summary.assignmentLabel}</p>
-          </div>
-          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-            <p className="text-xs text-[var(--dpf-muted)]">Effort</p>
-            <p className="mt-1 text-sm font-medium">{summary.effortLabel}</p>
-          </div>
-          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-            <p className="text-xs text-[var(--dpf-muted)]">A2A status</p>
-            <p className="mt-1 text-sm font-medium">{summary.a2aStatus}</p>
-          </div>
-          <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-            <p className="text-xs text-[var(--dpf-muted)]">Due</p>
-            <p className="mt-1 inline-flex items-center gap-1 text-sm font-medium">
-              <Clock className="size-3.5" aria-hidden="true" />
-              {summary.dueAt ? <LocalTime value={summary.dueAt} mode="date" /> : "No due date"}
-            </p>
-          </div>
-        </div>
-      </header>
-
-      <section aria-labelledby="work-case-evidence-title" className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-        <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-3">
-          <ShieldCheck className="size-4 text-[var(--dpf-success)]" aria-hidden="true" />
-          <h2 id="work-case-evidence-title" className="text-sm font-semibold text-[var(--dpf-text)]">
-            Evidence timeline
-          </h2>
-        </div>
-        {detail.evidenceTimeline.length > 0 ? (
-          <ol className="divide-y divide-[var(--dpf-border)]">
-            {detail.evidenceTimeline.map((event) => (
-              <li key={event.eventId} className="px-4 py-3">
-                <p className="text-sm font-medium text-[var(--dpf-text)]">{event.label}</p>
-                <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-                  {event.sourceRef.kind} · {event.sourceRef.status ?? event.sourceRef.id}
-                </p>
-              </li>
-            ))}
-          </ol>
-        ) : (
-          <div className="px-4 py-6 text-sm text-[var(--dpf-muted)]">
-            No evidence has been recorded for this case yet.
-          </div>
-        )}
-      </section>
-
-      <section aria-labelledby="work-case-source-title" className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-        <div className="flex items-center gap-2">
-          <FileText className="size-4 text-[var(--dpf-muted)]" aria-hidden="true" />
-          <h2 id="work-case-source-title" className="text-sm font-semibold text-[var(--dpf-text)]">Source refs</h2>
-        </div>
-        <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {detail.sourceRefs.map((ref) => (
-            <div key={`${ref.kind}:${ref.id}`} className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-              <p className="text-xs text-[var(--dpf-muted)]">{ref.kind}</p>
-              <p className="mt-1 truncate text-sm font-medium text-[var(--dpf-text)]">{ref.id}</p>
-              {ref.status ? <p className="mt-1 text-xs text-[var(--dpf-muted)]">{ref.status}</p> : null}
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section aria-labelledby="work-case-comment-title" className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-        <h2 id="work-case-comment-title" className="sr-only">Add a comment</h2>
-        <WorkItemCommentBox workItemId={detail.workItemId} workItemTitle={detail.workItemTitle} />
-      </section>
+      <WorkRoomHeader room={detail.room} summary={detail.summary} />
+      <WorkRoomBody detail={detail} room={detail.room} />
     </main>
   );
 }

--- a/apps/web/components/workspace/WorkItemCommentBox.test.tsx
+++ b/apps/web/components/workspace/WorkItemCommentBox.test.tsx
@@ -13,10 +13,10 @@ describe("WorkItemCommentBox", () => {
     );
 
     expect(html).toContain("Share an update");
-    expect(html).toContain("Add context, ask a question, or @mention a participant.");
+    expect(html).toContain("Add context or @mention a participant.");
     expect(html).toContain('aria-live="polite"');
     expect(html).toContain("min-h-11");
-    expect(html).toContain("Post update");
+    expect(html).toContain(">Post<");
     expect(html).not.toContain("window.confirm");
   });
 });

--- a/apps/web/components/workspace/WorkItemCommentBox.test.tsx
+++ b/apps/web/components/workspace/WorkItemCommentBox.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { WorkItemCommentBox } from "./WorkItemCommentBox";
+
+describe("WorkItemCommentBox", () => {
+  it("presents commenting as room activity with accessible status feedback", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemCommentBox
+        workItemId="wi-cuid-1"
+        workItemTitle="Confirm condenser appointment"
+      />,
+    );
+
+    expect(html).toContain("Share an update");
+    expect(html).toContain("Add context, ask a question, or @mention a participant.");
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("min-h-11");
+    expect(html).toContain("Post update");
+    expect(html).not.toContain("window.confirm");
+  });
+});

--- a/apps/web/components/workspace/WorkItemCommentBox.tsx
+++ b/apps/web/components/workspace/WorkItemCommentBox.tsx
@@ -43,7 +43,7 @@ export function WorkItemCommentBox({
         Share an update
       </label>
       <p id="work-item-comment-help" className="text-xs leading-5 text-[var(--dpf-muted)]">
-        Add context, ask a question, or @mention a participant.
+        Add context or @mention a participant.
       </p>
       <textarea
         id="work-item-comment"
@@ -61,7 +61,7 @@ export function WorkItemCommentBox({
           disabled={pending || body.trim().length === 0}
           className="min-h-11 rounded-md bg-[var(--dpf-accent)] px-4 text-sm font-semibold text-[var(--dpf-bg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)] disabled:opacity-50"
         >
-          {pending ? "Posting…" : "Post update"}
+          {pending ? "Posting…" : "Post"}
         </button>
         <span aria-live="polite" className="text-xs text-[var(--dpf-muted)]">{status}</span>
       </div>

--- a/apps/web/components/workspace/WorkItemCommentBox.tsx
+++ b/apps/web/components/workspace/WorkItemCommentBox.tsx
@@ -40,26 +40,30 @@ export function WorkItemCommentBox({
   return (
     <section className="space-y-2">
       <label htmlFor="work-item-comment" className="block text-sm font-semibold text-[var(--dpf-text)]">
-        Add a comment
+        Share an update
       </label>
+      <p id="work-item-comment-help" className="text-xs leading-5 text-[var(--dpf-muted)]">
+        Add context, ask a question, or @mention a participant.
+      </p>
       <textarea
         id="work-item-comment"
+        aria-describedby="work-item-comment-help"
         value={body}
         onChange={(event) => setBody(event.target.value)}
         rows={3}
-        placeholder="Comment… use @name to notify a teammate or coworker"
-        className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-2 text-sm text-[var(--dpf-text)]"
+        placeholder="Write an update…"
+        className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-3 text-sm text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
       />
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <button
           type="button"
           onClick={submit}
           disabled={pending || body.trim().length === 0}
-          className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-semibold text-white disabled:opacity-50"
+          className="min-h-11 rounded-md bg-[var(--dpf-accent)] px-4 text-sm font-semibold text-[var(--dpf-bg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)] disabled:opacity-50"
         >
-          {pending ? "Posting…" : "Post"}
+          {pending ? "Posting…" : "Post update"}
         </button>
-        {status && <span className="text-xs text-[var(--dpf-muted)]">{status}</span>}
+        <span aria-live="polite" className="text-xs text-[var(--dpf-muted)]">{status}</span>
       </div>
     </section>
   );

--- a/apps/web/components/workspace/work-room/WorkRoomBody.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomBody.tsx
@@ -1,0 +1,297 @@
+import {
+  Activity,
+  FileCheck2,
+  MessageSquareText,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { EmptyState, Notice, StatusBadge } from "@/components/ui/report-kit";
+import { WorkItemCommentBox } from "@/components/workspace/WorkItemCommentBox";
+import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
+import type {
+  WorkRoomActivityView,
+  WorkRoomBoundaryGap,
+  WorkRoomView,
+} from "@/lib/work-management/room-types";
+
+import {
+  ACTIVITY_KIND_LABEL,
+  activityIntent,
+  roomLabel,
+} from "./presentation";
+
+type Props = {
+  detail: WorkspaceWorkCaseDetailView;
+  room: WorkRoomView;
+};
+
+const BOUNDARY_GAP_LABEL: Record<WorkRoomBoundaryGap, string> = {
+  purpose: "Purpose not defined",
+  outcome: "Outcome not defined",
+  scope: "Scope not defined",
+  participants: "Participants not identified",
+  accountable: "Accountable owner not assigned",
+  authority: "Authority boundary not defined",
+  sensitivity: "Sensitivity ceiling not defined",
+  context: "Context not attached",
+  measures: "Measures not defined",
+  "time-boundary": "Time boundary not defined",
+  "closure-rule": "Closure rule not defined",
+};
+
+function ActivityEvent({ event }: { event: WorkRoomActivityView }) {
+  const label = ACTIVITY_KIND_LABEL[event.kind];
+
+  return (
+    <li className="grid grid-cols-[auto_minmax(0,1fr)] gap-3 px-4 py-3">
+      <span
+        aria-label={label}
+        className="mt-0.5 inline-flex size-8 items-center justify-center rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]"
+      >
+        <Activity className="size-4" aria-hidden="true" />
+      </span>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge intent={activityIntent(event.kind)} label={label} variant="soft" />
+          {event.occurredAt ? (
+            <LocalTime value={event.occurredAt} mode="datetime" className="text-xs text-[var(--dpf-muted)]" />
+          ) : null}
+        </div>
+        <p className={`mt-2 text-sm leading-6 ${event.emphasis === "quiet" ? "text-[var(--dpf-muted)]" : "text-[var(--dpf-text)]"}`}>
+          {event.summary}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+function BoundaryNotice({ room }: { room: WorkRoomView }) {
+  if (!room.projection.incompleteBoundary) return null;
+
+  const gaps = room.boundary.gaps.map((gap) => BOUNDARY_GAP_LABEL[gap]);
+  const repair = room.boundary.gaps.includes("outcome") && room.boundary.gaps.includes("accountable")
+    ? "Define the intended outcome and accountable owner before consequential work continues."
+    : `Complete the room boundary before consequential work continues: ${gaps.join(", ")}.`;
+
+  return (
+    <Notice variant="warn" title="This room needs a clearer boundary">
+      <p>{repair}</p>
+      <ul className="mt-2 list-disc space-y-1 pl-5">
+        {gaps.map((gap) => <li key={gap}>{gap}</li>)}
+      </ul>
+    </Notice>
+  );
+}
+
+function ParticipantPanel({ room }: { room: WorkRoomView }) {
+  return (
+    <section aria-labelledby="work-room-participants-title" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+      <details>
+        <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+          <span id="work-room-participants-title" className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+            <Users className="size-4" aria-hidden="true" />
+            Participants
+          </span>
+          <span className="text-xs text-[var(--dpf-muted)]">{room.participants.length}</span>
+        </summary>
+        <div className="border-t border-[var(--dpf-border)] px-4 py-3">
+          {room.participants.length > 0 ? (
+            <ul className="space-y-3">
+              {room.participants.map((participant) => (
+                <li key={participant.principalRef} className="text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-[var(--dpf-text)]">{participant.displayName}</span>
+                    <StatusBadge intent={participant.kind === "agent" ? "accent" : "neutral"} label={roomLabel(participant.kind)} variant="outline" />
+                  </div>
+                  <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                    {participant.roles.map(roomLabel).join(", ")}
+                    {participant.currentWorkSummary ? ` · ${participant.currentWorkSummary}` : ""}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm leading-6 text-[var(--dpf-muted)]">
+              No participants are listed yet. People and coworkers enter through assignment or governed work.
+            </p>
+          )}
+        </div>
+      </details>
+    </section>
+  );
+}
+
+function ContextPanels({ room }: { room: WorkRoomView }) {
+  const decisions = room.activity.filter((event) =>
+    event.kind === "decision-proposed" || event.kind === "decision-resolved",
+  );
+
+  return (
+    <div className="space-y-3">
+      <ParticipantPanel room={room} />
+
+      <section aria-label="Work" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <details>
+          <summary className="min-h-11 cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+            Work
+          </summary>
+          <div className="space-y-3 border-t border-[var(--dpf-border)] px-4 py-3 text-sm">
+            <div>
+              <p className="text-xs text-[var(--dpf-muted)]">Next action</p>
+              <p className="mt-1 font-medium text-[var(--dpf-text)]">{room.work.nextAction}</p>
+            </div>
+            {room.boundary.scopeIncluded.length > 0 ? (
+              <div>
+                <p className="text-xs text-[var(--dpf-muted)]">In scope</p>
+                <p className="mt-1 text-[var(--dpf-text)]">{room.boundary.scopeIncluded.join(", ")}</p>
+              </div>
+            ) : null}
+          </div>
+        </details>
+      </section>
+
+      <section aria-label="Context" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <details>
+          <summary className="min-h-11 cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+            Context
+          </summary>
+          <div className="border-t border-[var(--dpf-border)] px-4 py-3 text-sm leading-6 text-[var(--dpf-muted)]">
+            {room.context.digest ?? "No context digest has been recorded yet."}
+          </div>
+        </details>
+      </section>
+
+      <section aria-label="Decisions" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <details>
+          <summary className="min-h-11 cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+            Decisions
+          </summary>
+          <div className="border-t border-[var(--dpf-border)] px-4 py-3 text-sm">
+            {decisions.length > 0 ? (
+              <ul className="space-y-2">
+                {decisions.map((decision) => <li key={decision.eventId}>{decision.summary}</li>)}
+              </ul>
+            ) : (
+              <p className="text-[var(--dpf-muted)]">No decisions have been recorded.</p>
+            )}
+          </div>
+        </details>
+      </section>
+
+      <section aria-label="Outcome" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+        <details>
+          <summary className="min-h-11 cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+            Outcome
+          </summary>
+          <div className="border-t border-[var(--dpf-border)] px-4 py-3 text-sm leading-6 text-[var(--dpf-muted)]">
+            {room.outcome.packet?.summary
+              ?? room.outcome.statement
+              ?? "The intended outcome has not been defined."}
+          </div>
+        </details>
+      </section>
+    </div>
+  );
+}
+
+function RoomDetails({ detail, room }: Props) {
+  return (
+    <details className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+      <summary className="min-h-11 cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+        Room details
+      </summary>
+      <div className="grid gap-4 border-t border-[var(--dpf-border)] px-4 py-4 text-sm sm:grid-cols-2">
+        <div>
+          <p className="text-xs text-[var(--dpf-muted)]">A2A status</p>
+          <p className="mt-1 font-medium text-[var(--dpf-text)]">{detail.summary.a2aStatus}</p>
+        </div>
+        <div>
+          <p className="text-xs text-[var(--dpf-muted)]">Projection</p>
+          <p className="mt-1 font-medium text-[var(--dpf-text)]">
+            {roomLabel(room.projection.confidence)} confidence · {roomLabel(room.projection.sourceHealth)}
+          </p>
+        </div>
+        <div className="sm:col-span-2">
+          <p className="text-xs text-[var(--dpf-muted)]">Source references</p>
+          <ul className="mt-2 grid gap-2 sm:grid-cols-2">
+            {room.sourceRefs.map((ref) => (
+              <li key={`${ref.kind}:${ref.id}`} className="min-w-0 rounded-md bg-[var(--dpf-surface-2)] px-3 py-2">
+                <span className="text-xs text-[var(--dpf-muted)]">{roomLabel(ref.kind)}</span>
+                <span className="ml-2 break-all font-medium text-[var(--dpf-text)]">{ref.id}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </details>
+  );
+}
+
+export function WorkRoomBody({ detail, room }: Props) {
+  return (
+    <>
+      <BoundaryNotice room={room} />
+
+      <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1.65fr)_minmax(18rem,0.75fr)]">
+        <section
+          aria-labelledby="work-room-activity-title"
+          className="overflow-hidden rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+        >
+          <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-3">
+            <MessageSquareText className="size-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+            <h2 id="work-room-activity-title" className="text-sm font-semibold text-[var(--dpf-text)]">Activity</h2>
+          </div>
+          {room.activity.length > 0 ? (
+            <ol className="divide-y divide-[var(--dpf-border)]">
+              {room.activity.map((event) => <ActivityEvent key={event.eventId} event={event} />)}
+            </ol>
+          ) : (
+            <EmptyState
+              size="sm"
+              bordered={false}
+              title="No activity yet"
+              description={`This room is ready. Next: ${room.work.nextAction}.`}
+              icon={<MessageSquareText className="size-6" />}
+            />
+          )}
+
+          {detail.evidenceTimeline.length > 0 ? (
+            <details className="border-t border-[var(--dpf-border)]">
+              <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+                <ShieldCheck className="size-4 text-[var(--dpf-success)]" aria-hidden="true" />
+                Evidence
+              </summary>
+              <ol className="divide-y divide-[var(--dpf-border)] border-t border-[var(--dpf-border)]">
+                {detail.evidenceTimeline.map((event) => (
+                  <li key={event.eventId} className="px-4 py-3 text-sm text-[var(--dpf-text)]">{event.label}</li>
+                ))}
+              </ol>
+            </details>
+          ) : null}
+
+          <div className="border-t border-[var(--dpf-border)] p-4">
+            <WorkItemCommentBox workItemId={detail.workItemId} workItemTitle={detail.workItemTitle} />
+          </div>
+        </section>
+
+        <aside aria-label="Work Room context" className="space-y-3">
+          <ContextPanels room={room} />
+        </aside>
+      </div>
+
+      <RoomDetails detail={detail} room={room} />
+
+      {room.receipts.length > 0 ? (
+        <section aria-label="Receipts" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+          <h2 className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+            <FileCheck2 className="size-4" aria-hidden="true" />
+            Receipts
+          </h2>
+          <p className="mt-2 text-sm text-[var(--dpf-muted)]">{room.receipts.length} recorded</p>
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/components/workspace/work-room/WorkRoomBody.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomBody.tsx
@@ -18,7 +18,6 @@ import type {
 
 import {
   ACTIVITY_KIND_LABEL,
-  activityIntent,
   roomLabel,
 } from "./presentation";
 
@@ -54,7 +53,7 @@ function ActivityEvent({ event }: { event: WorkRoomActivityView }) {
       </span>
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
-          <StatusBadge intent={activityIntent(event.kind)} label={label} variant="soft" />
+          <StatusBadge domain="workRoomActivity" status={event.kind} label={label} variant="soft" />
           {event.occurredAt ? (
             <LocalTime value={event.occurredAt} mode="datetime" className="text-xs text-[var(--dpf-muted)]" />
           ) : null}

--- a/apps/web/components/workspace/work-room/WorkRoomBody.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomBody.tsx
@@ -85,9 +85,13 @@ function BoundaryNotice({ room }: { room: WorkRoomView }) {
 }
 
 function ParticipantPanel({ room }: { room: WorkRoomView }) {
+  const hasUnavailableCoworker = room.participants.some(
+    (participant) => participant.kind === "agent" && participant.presence === "unknown",
+  );
+
   return (
     <section aria-labelledby="work-room-participants-title" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-      <details>
+      <details open={hasUnavailableCoworker}>
         <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
           <span id="work-room-participants-title" className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
             <Users className="size-4" aria-hidden="true" />

--- a/apps/web/components/workspace/work-room/WorkRoomBody.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomBody.tsx
@@ -108,6 +108,13 @@ function ParticipantPanel({ room }: { room: WorkRoomView }) {
                     {participant.roles.map(roomLabel).join(", ")}
                     {participant.currentWorkSummary ? ` · ${participant.currentWorkSummary}` : ""}
                   </p>
+                  {participant.kind === "agent" && participant.presence === "unknown" ? (
+                    <div className="mt-2">
+                      <Notice variant="warn" title="Coworker status unavailable">
+                        Continue with the room’s next action: {room.work.nextAction}.
+                      </Notice>
+                    </div>
+                  ) : null}
                 </li>
               ))}
             </ul>

--- a/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
@@ -6,9 +6,7 @@ import type { WorkspaceWorkCaseListItem } from "@/lib/work-management/workspace-
 import type { WorkRoomView } from "@/lib/work-management/room-types";
 
 import {
-  OUTCOME_HEALTH_INTENT,
   roomLabel,
-  WORK_STATE_INTENT,
 } from "./presentation";
 
 type Props = {
@@ -63,7 +61,8 @@ export function WorkRoomHeader({ room, summary }: Props) {
             </p>
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <StatusBadge
-                intent={WORK_STATE_INTENT[room.state]}
+                domain="workCaseState"
+                status={room.state}
                 label={roomLabel(room.state)}
                 variant="soft"
               />
@@ -104,7 +103,7 @@ export function WorkRoomHeader({ room, summary }: Props) {
               Outcome
             </h2>
             {health ? (
-              <StatusBadge intent={OUTCOME_HEALTH_INTENT[health]} label={roomLabel(health)} variant="soft" />
+              <StatusBadge domain="workRoomOutcomeHealth" status={health} label={roomLabel(health)} variant="soft" />
             ) : null}
           </div>
           <p className="mt-2 text-base font-semibold leading-6 text-[var(--dpf-text)]">

--- a/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
@@ -1,0 +1,146 @@
+import { AlertTriangle, ArrowLeft, Clock, Users } from "lucide-react";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { Notice, StatusBadge } from "@/components/ui/report-kit";
+import type { WorkspaceWorkCaseListItem } from "@/lib/work-management/workspace-case-loader";
+import type { WorkRoomView } from "@/lib/work-management/room-types";
+
+import {
+  OUTCOME_HEALTH_INTENT,
+  roomLabel,
+  WORK_STATE_INTENT,
+} from "./presentation";
+
+type Props = {
+  room: WorkRoomView;
+  summary: WorkspaceWorkCaseListItem;
+};
+
+function accountableName(room: WorkRoomView): string {
+  return room.participants.find((participant) =>
+    participant.roles.includes("accountable"),
+  )?.displayName ?? "Accountable owner not assigned";
+}
+
+function participantSummary(room: WorkRoomView): string {
+  const count = room.participants.length;
+  if (count === 0) return "No participants listed";
+  const names = room.participants.slice(0, 2).map((participant) => participant.displayName);
+  const remainder = count - names.length;
+  return `${count} ${count === 1 ? "participant" : "participants"} · ${names.join(", ")}${remainder > 0 ? ` +${remainder}` : ""}`;
+}
+
+export function WorkRoomHeader({ room, summary }: Props) {
+  const health = room.outcome.health;
+  const dueAt = room.boundary.timeBoundary.reviewAt
+    ?? room.boundary.timeBoundary.dueAt
+    ?? summary.dueAt;
+
+  return (
+    <>
+      <a
+        href="/workspace/my-queue"
+        className="inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-medium text-[var(--dpf-accent)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+      >
+        <ArrowLeft className="size-4" aria-hidden="true" />
+        My Work
+      </a>
+
+      {room.projection.sourceHealth === "unavailable" ? (
+        <Notice variant="error" title="Room source unavailable">
+          This is the last available room projection. Return to My Work and try opening the room again.
+        </Notice>
+      ) : null}
+
+      <header
+        aria-labelledby="work-room-title"
+        className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 sm:p-5"
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+              Work Room
+            </p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <StatusBadge
+                intent={WORK_STATE_INTENT[room.state]}
+                label={roomLabel(room.state)}
+                variant="soft"
+              />
+              <StatusBadge intent="neutral" label={roomLabel(room.mode)} variant="outline" />
+              <StatusBadge
+                intent={summary.attentionRequired ? "warning" : "neutral"}
+                label={summary.urgencyLabel}
+                variant="outline"
+              />
+              {room.boundary.sensitivityCeiling ? (
+                <span className="text-xs text-[var(--dpf-muted)]">
+                  {roomLabel(room.boundary.sensitivityCeiling)}
+                </span>
+              ) : null}
+              <span className="text-xs text-[var(--dpf-muted)]">{summary.sourceLabel}</span>
+            </div>
+            <h1 id="work-room-title" className="mt-3 text-2xl font-semibold text-[var(--dpf-text)] sm:text-3xl">
+              {room.title}
+            </h1>
+            {room.purpose ? (
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">{room.purpose}</p>
+            ) : null}
+          </div>
+          {dueAt ? (
+            <div className="inline-flex shrink-0 items-center gap-2 text-sm text-[var(--dpf-muted)]">
+              <Clock className="size-4" aria-hidden="true" />
+              <span>
+                {room.boundary.timeBoundary.reviewAt ? "Review " : "Due "}
+                <LocalTime value={dueAt} mode="date" />
+              </span>
+            </div>
+          ) : null}
+        </div>
+
+        <section aria-labelledby="work-room-outcome-title" className="mt-5 rounded-lg bg-[var(--dpf-surface-2)] p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 id="work-room-outcome-title" className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+              Outcome
+            </h2>
+            {health ? (
+              <StatusBadge intent={OUTCOME_HEALTH_INTENT[health]} label={roomLabel(health)} variant="soft" />
+            ) : null}
+          </div>
+          <p className="mt-2 text-base font-semibold leading-6 text-[var(--dpf-text)]">
+            {room.outcome.statement ?? "Outcome not defined"}
+          </p>
+        </section>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <section aria-label="Attention" className="rounded-lg border border-[var(--dpf-border)] p-3">
+            <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+              {room.work.attentionRequired ? <AlertTriangle className="size-4 text-[var(--dpf-warning)]" aria-hidden="true" /> : null}
+              Attention
+            </p>
+            <p className="mt-2 text-sm font-medium text-[var(--dpf-text)]">
+              {room.work.attentionRequired
+                ? room.work.attentionReason ?? "Attention is required."
+                : "No immediate attention needed."}
+            </p>
+          </section>
+          <section aria-label="Next action" className="rounded-lg border border-[var(--dpf-accent)] p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">Next action</p>
+            <p className="mt-2 text-sm font-semibold text-[var(--dpf-text)]">{room.work.nextAction}</p>
+          </section>
+          <section aria-label="Accountability" className="rounded-lg border border-[var(--dpf-border)] p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">Accountable</p>
+            <p className="mt-2 text-sm font-medium text-[var(--dpf-text)]">{accountableName(room)}</p>
+          </section>
+          <section aria-label="Participant summary" className="rounded-lg border border-[var(--dpf-border)] p-3">
+            <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+              <Users className="size-4" aria-hidden="true" />
+              Participants
+            </p>
+            <p className="mt-2 text-sm font-medium text-[var(--dpf-text)]">{participantSummary(room)}</p>
+          </section>
+        </div>
+      </header>
+    </>
+  );
+}

--- a/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
@@ -30,6 +30,7 @@ function participantSummary(room: WorkRoomView): string {
 
 export function WorkRoomHeader({ room, summary }: Props) {
   const health = room.outcome.health;
+  const purposeNeedsDisclosure = (room.purpose?.length ?? 0) > 280;
   const dueAt = room.boundary.timeBoundary.reviewAt
     ?? room.boundary.timeBoundary.dueAt
     ?? summary.dueAt;
@@ -82,7 +83,14 @@ export function WorkRoomHeader({ room, summary }: Props) {
             <h1 id="work-room-title" className="mt-3 text-2xl font-semibold text-[var(--dpf-text)] sm:text-3xl">
               {room.title}
             </h1>
-            {room.purpose ? (
+            {room.purpose && purposeNeedsDisclosure ? (
+              <details className="group mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
+                <summary className="inline-flex min-h-11 cursor-pointer items-center font-medium text-[var(--dpf-accent)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+                  Room purpose
+                </summary>
+                <p className="pb-1 leading-6">{room.purpose}</p>
+              </details>
+            ) : room.purpose ? (
               <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">{room.purpose}</p>
             ) : null}
           </div>

--- a/apps/web/components/workspace/work-room/presentation.ts
+++ b/apps/web/components/workspace/work-room/presentation.ts
@@ -1,33 +1,6 @@
-import type { Intent } from "@/components/ui/report-kit/statusColors";
 import type {
   WorkRoomActivityKind,
-  WorkRoomOutcomeView,
 } from "@/lib/work-management/room-types";
-import type { WorkCaseState } from "@/lib/work-management/case-types";
-
-export const WORK_STATE_INTENT: Record<WorkCaseState, Intent> = {
-  intake: "neutral",
-  triage: "info",
-  active: "accent",
-  "waiting-on-person": "warning",
-  "waiting-on-system": "danger",
-  "awaiting-decision": "warning",
-  verifying: "info",
-  resolved: "success",
-  closed: "neutral",
-  cancelled: "neutral",
-};
-
-export const OUTCOME_HEALTH_INTENT: Record<
-  NonNullable<WorkRoomOutcomeView["health"]>,
-  Intent
-> = {
-  "on-track": "success",
-  "at-risk": "warning",
-  blocked: "danger",
-  idle: "neutral",
-  unknown: "neutral",
-};
 
 export const ACTIVITY_KIND_LABEL: Record<WorkRoomActivityKind, string> = {
   message: "Message",
@@ -54,18 +27,4 @@ export function roomLabel(value: string): string {
   return value
     .replaceAll("-", " ")
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
-
-export function activityIntent(kind: WorkRoomActivityKind): Intent {
-  if (kind === "decision-resolved" || kind === "work-completed" || kind === "cycle-closed") {
-    return "success";
-  }
-  if (kind === "ask" || kind === "decision-proposed" || kind === "coworker-handoff") {
-    return "warning";
-  }
-  if (kind === "verification" || kind === "receipt" || kind === "artifact-added") {
-    return "info";
-  }
-  if (kind === "message" || kind === "external-event") return "neutral";
-  return "accent";
 }

--- a/apps/web/components/workspace/work-room/presentation.ts
+++ b/apps/web/components/workspace/work-room/presentation.ts
@@ -1,0 +1,71 @@
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+import type {
+  WorkRoomActivityKind,
+  WorkRoomOutcomeView,
+} from "@/lib/work-management/room-types";
+import type { WorkCaseState } from "@/lib/work-management/case-types";
+
+export const WORK_STATE_INTENT: Record<WorkCaseState, Intent> = {
+  intake: "neutral",
+  triage: "info",
+  active: "accent",
+  "waiting-on-person": "warning",
+  "waiting-on-system": "danger",
+  "awaiting-decision": "warning",
+  verifying: "info",
+  resolved: "success",
+  closed: "neutral",
+  cancelled: "neutral",
+};
+
+export const OUTCOME_HEALTH_INTENT: Record<
+  NonNullable<WorkRoomOutcomeView["health"]>,
+  Intent
+> = {
+  "on-track": "success",
+  "at-risk": "warning",
+  blocked: "danger",
+  idle: "neutral",
+  unknown: "neutral",
+};
+
+export const ACTIVITY_KIND_LABEL: Record<WorkRoomActivityKind, string> = {
+  message: "Message",
+  ask: "Input needed",
+  "coworker-joined": "Coworker joined",
+  "coworker-left": "Coworker left",
+  "coworker-handoff": "Coworker handoff",
+  "work-started": "Work started",
+  "work-paused": "Work paused",
+  "work-completed": "Work completed",
+  "decision-proposed": "Decision proposed",
+  "decision-resolved": "Decision resolved",
+  "artifact-added": "Artifact added",
+  "governed-action": "Governed action",
+  "external-event": "External event",
+  verification: "Verification",
+  receipt: "Receipt",
+  "cycle-opened": "Cycle opened",
+  "cycle-closed": "Cycle closed",
+  "cycle-carried-over": "Cycle carried over",
+};
+
+export function roomLabel(value: string): string {
+  return value
+    .replaceAll("-", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function activityIntent(kind: WorkRoomActivityKind): Intent {
+  if (kind === "decision-resolved" || kind === "work-completed" || kind === "cycle-closed") {
+    return "success";
+  }
+  if (kind === "ask" || kind === "decision-proposed" || kind === "coworker-handoff") {
+    return "warning";
+  }
+  if (kind === "verification" || kind === "receipt" || kind === "artifact-added") {
+    return "info";
+  }
+  if (kind === "message" || kind === "external-event") return "neutral";
+  return "accent";
+}

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -270,6 +270,12 @@
     "apps/web/app/(shell)/platform/ai/providers/page.tsx": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
     ],
+    "apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx": [
+      "docs/user-guide/workspace/work-rooms.md"
+    ],
+    "apps/web/app/(shell)/workspace/my-queue/page.tsx": [
+      "docs/user-guide/workspace/work-rooms.md"
+    ],
     "apps/web/components/attention/AttentionInbox.tsx": [
       "docs/user-guide/workspace/attention-inbox.md"
     ],
@@ -281,6 +287,12 @@
     ],
     "apps/web/components/proactivity/ProactivityRosterList.tsx": [
       "docs/user-guide/ai-workforce/coworker-proactivity.md"
+    ],
+    "apps/web/components/workspace/WorkCaseAttentionLens.tsx": [
+      "docs/user-guide/workspace/work-rooms.md"
+    ],
+    "apps/web/components/workspace/WorkCaseDetailView.tsx": [
+      "docs/user-guide/workspace/work-rooms.md"
     ],
     "apps/web/lib/ai-inference.ts": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
@@ -520,6 +532,12 @@
       "apps/web/components/attention/AttentionInbox.tsx",
       "apps/web/components/attention/OwnerDecisionCards.tsx",
       "apps/web/lib/attention/owner-projection.ts"
+    ],
+    "docs/user-guide/workspace/work-rooms.md": [
+      "apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx",
+      "apps/web/app/(shell)/workspace/my-queue/page.tsx",
+      "apps/web/components/workspace/WorkCaseAttentionLens.tsx",
+      "apps/web/components/workspace/WorkCaseDetailView.tsx"
     ]
   }
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10361,6 +10361,19 @@
         "key-concepts",
         "what-you-can-do"
       ]
+    },
+    "docs/user-guide/workspace/work-rooms.md": {
+      "publicHref": "/user-guide/workspace/work-rooms/",
+      "portalHref": "/docs/workspace/work-rooms",
+      "publishedPublic": true,
+      "publishedPortal": true,
+      "anchors": [
+        "overview",
+        "what-you-see-first",
+        "activity-and-participants",
+        "finite-and-standing-rooms",
+        "incomplete-or-unavailable-rooms"
+      ]
     }
   }
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 594,
+  "pageCount": 595,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -137,4 +137,32 @@ describe("workspace Work Case loader", () => {
       emphasis: "quiet",
     }));
   });
+
+  it("returns no room metadata when the scoped work item is not visible to the user", async () => {
+    let query: unknown;
+    const prismaClient: WorkspaceCasePrismaClient = {
+      workItem: {
+        findMany: async () => [],
+        findFirst: async (args) => {
+          query = args;
+          return null;
+        },
+      },
+      workItemMessage: {
+        findMany: async () => {
+          throw new Error("Messages must not load for an inaccessible room.");
+        },
+      },
+    };
+
+    const detail = await loadWorkspaceWorkCaseDetail({
+      prismaClient,
+      caseKey: "booking%3ABK-PRIVATE",
+      userId: "user-without-access",
+    });
+
+    expect(detail).toBeNull();
+    expect(JSON.stringify(query)).toContain('"assignedToUserId":"user-without-access"');
+    expect(JSON.stringify(query)).toContain('"assignedToUserId":null');
+  });
 });

--- a/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
+++ b/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
@@ -240,6 +240,13 @@ Target 20-25 percent:
 
 The route continues to use the same loader. Revert the component composition to the prior `WorkCaseDetailView`; no data migration or route redirect rollback is required.
 
+### Design grounding
+
+- **Existing specs and plans reviewed:** this plan and its companion Work Rooms collaboration design, the Work Management architecture design, and the Work Case Wave 3 operator-surfaces plan.
+- **Current code substrate reviewed:** `workspace-case-loader`, `WorkCaseDetailView`, `WorkCaseAttentionLens`, `WorkItemCommentBox`, and report-kit status/empty-state primitives.
+- **Source of truth:** `WorkRoomView` remains a typed projection over the governed Work Case and its existing policy, activity, participant, action, and receipt seams.
+- **Decision:** keep `/workspace/cases/[caseKey]` as the canonical route, replace inspector composition with outcome-first room composition, reuse report-kit and theme tokens, keep diagnostics behind disclosure, and introduce neither a second work model nor a new navigation family.
+
 ### Implementation record (2026-07-28)
 
 - Preserved `/workspace/cases/[caseKey]` and composed the existing room projection into an outcome-first `WorkRoomHeader` and `WorkRoomBody`.

--- a/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
+++ b/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
@@ -240,6 +240,17 @@ Target 20-25 percent:
 
 The route continues to use the same loader. Revert the component composition to the prior `WorkCaseDetailView`; no data migration or route redirect rollback is required.
 
+### Implementation record (2026-07-28)
+
+- Preserved `/workspace/cases/[caseKey]` and composed the existing room projection into an outcome-first `WorkRoomHeader` and `WorkRoomBody`.
+- Put outcome, attention, accountability, participant summary, and next action ahead of activity; moved A2A/source diagnostics under **Room details**.
+- Integrated the existing update composer into Activity and kept informational disclosure controls prompt-free.
+- Added honest incomplete-boundary, unavailable-source, missing-projection, permission non-disclosure, customer-portal segregation, and unavailable-AI-coworker states. A coworker availability issue opens the participant disclosure and gives one safe continuation path.
+- Refactoring accounted for at least 25 percent of the slice: the monolithic detail component was split by responsibility, repeated room status intent moved into report-kit, and comment/activity presentation converged.
+- Current source evidence: 6 affected test files / 31 tests pass; scoped route generation and web typecheck pass; secret scan and DCO hooks pass.
+- Exact merged-tree production build evidence exists for the outcome-first composition before the final unavailable-coworker hardening. Re-run the merged-tree production build after the final mainline rebase.
+- Governed desktop/narrow/keyboard browser evidence remains pending behind `BI-CF4ADDAC`; do not mark this BI done or open its PR until that evidence is captured.
+
 ## 7. BI-BA868848 — Standing cycles and Outcome Packets
 
 ### Deliverable

--- a/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
+++ b/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
@@ -248,16 +248,16 @@ The route continues to use the same loader. Revert the component composition to 
 - **Source of truth:** `WorkRoomView` remains a typed projection over the governed Work Case and its existing policy, activity, participant, action, and receipt seams.
 - **Decision:** keep `/workspace/cases/[caseKey]` as the canonical route, replace inspector composition with outcome-first room composition, reuse report-kit and theme tokens, keep diagnostics behind disclosure, and introduce neither a second work model nor a new navigation family.
 
-### Implementation record (2026-07-28)
+### Implementation record (updated 2026-08-01)
 
 - Preserved `/workspace/cases/[caseKey]` and composed the existing room projection into an outcome-first `WorkRoomHeader` and `WorkRoomBody`.
 - Put outcome, attention, accountability, participant summary, and next action ahead of activity; moved A2A/source diagnostics under **Room details**.
 - Integrated the existing update composer into Activity and kept informational disclosure controls prompt-free.
 - Added honest incomplete-boundary, unavailable-source, missing-projection, permission non-disclosure, customer-portal segregation, and unavailable-AI-coworker states. A coworker availability issue opens the participant disclosure and gives one safe continuation path.
 - Refactoring accounted for at least 25 percent of the slice: the monolithic detail component was split by responsibility, repeated room status intent moved into report-kit, and comment/activity presentation converged.
-- Current source evidence: 6 affected test files / 31 tests pass; scoped route generation and web typecheck pass; secret scan and DCO hooks pass.
-- Exact merged-tree production build evidence exists for the outcome-first composition before the final unavailable-coworker hardening. Re-run the merged-tree production build after the final mainline rebase.
-- Governed desktop/narrow/keyboard browser evidence remains pending behind `BI-CF4ADDAC`; do not mark this BI done or open its PR until that evidence is captured.
+- Current source evidence: 7 affected test files / 40 tests pass; scoped route generation, web typecheck, secret scan, and DCO hooks pass.
+- Final exact merged-tree evidence `cmsa2vs0701hx01qqc4vq7ygb` covers the complete candidate at `e3cec3ef8618eb32a2f7a0fd8c024ddd02f444ed` against accepted base `af398e985a30f9a7507d3ab7802fbe7d7f97c5c8`: migrations, documentation guards, typecheck, the full Vitest suite, and the production Docker/Next build passed.
+- Governed UX evidence `cms9zqzjx0doq01r2mknr75li` and `cms9vep3v00bs01r2e0vno56z` covers authenticated desktop and 390px narrow layouts, first-viewport outcome priority, no horizontal overflow, long-purpose disclosure, and the Activity/Context/details interactions. Interactive disclosures use native `details`/`summary`; browser focusability and component semantics are verified, while the harness's synthetic Enter/Space limitation is explicitly recorded rather than presented as a product failure.
 
 ## 7. BI-BA868848 — Standing cycles and Outcome Packets
 

--- a/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
+++ b/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
@@ -204,6 +204,7 @@ The existing Work Case detail route becomes a Work Room experience that is under
 ### UX fit review
 
 - Decision: `fits-with-guardrails`.
+- Governed comparison: `DI-3D4DAE04956D` recommended `outcome-first-existing-route` with usable, high-confidence signal and a 2.920 margin over the next option.
 - Primary persona: founder, operator, or employee coordinating a bounded company outcome with people and AI coworkers.
 - Navigation layer: local page navigation and contextual actions only; the canonical detail URL remains `/workspace/cases/[caseKey]`.
 - Reuse and convergence: retain the Workspace Work Case loader and route, compose report-kit status and notice primitives, and extract focused room components from the existing monolithic detail view.

--- a/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
+++ b/docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md
@@ -201,6 +201,20 @@ The existing Work Case detail route becomes a Work Room experience that is under
 - Compose report-kit for generic status/data display.
 - Keep touch targets at least 44px where practical and preserve visible focus.
 
+### UX fit review
+
+- Decision: `fits-with-guardrails`.
+- Primary persona: founder, operator, or employee coordinating a bounded company outcome with people and AI coworkers.
+- Navigation layer: local page navigation and contextual actions only; the canonical detail URL remains `/workspace/cases/[caseKey]`.
+- Reuse and convergence: retain the Workspace Work Case loader and route, compose report-kit status and notice primitives, and extract focused room components from the existing monolithic detail view.
+- Source truth: `WorkspaceWorkCaseDetailView.room` is the visible collaboration contract. The legacy summary remains compatibility data, not a second room model.
+- First viewport: name the outcome, attention reason, accountable participant, participant group, and next action before activity or diagnostics.
+- Empty/failure behavior: distinguish an incomplete boundary from an unavailable source. Each state explains what is known and gives one safe next action; permission denial remains a non-disclosing route-level not-found response.
+- AI boundary: informational disclosure controls do not send prompts. This slice adds no coworker-starting action; any future launcher must preview context and require explicit confirmation.
+- Mental model: use **My Work**, **Work Room**, **Activity**, **Outcome**, and **Room details** in user-facing copy. Preserve **Work Case** only in implementation and technical documentation where the underlying governed record matters.
+- Evidence before merge: focused component tests, source-unavailable and incomplete-boundary fixtures, permission non-disclosure regression, theme scan, production build, and desktop/narrow keyboard-accessible browser exercise.
+- Captured in: this implementation plan, BI-32E26F62.
+
 ### Verification
 
 - focused route/component Vitest;

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -54,6 +54,7 @@ business action until the durable operations provider confirms it.
 - **Calendar** — Upcoming dates pulled from your backlog items, leave requests, deadlines, and any scheduled events in the areas you have access to.
 - **Managed Documents** — Maintained documents with lifecycle state, versions, references, and publication status.
 - **"Needs you" inbox** — The one place for business decisions that need you now. Routine technical recovery stays with your digital team, while money leaving the business and public actions always come to you.
+- **Work Rooms** — Active, access-controlled places where people and AI coworkers coordinate toward a named outcome. A Work Room is the friendly Workspace view over a governed Work Case.
 
 ## What You Can Do
 
@@ -62,5 +63,6 @@ business action until the durable operations provider confirms it.
 - Review recent activity from colleagues and digital coworkers without leaving your workspace
 - Access your calendar for today's events and upcoming deadlines
 - Open [Managed Documents](documents.md) to review document state, versions, and references
+- Open [My Work and Work Rooms](work-rooms.md) to see the outcome, accountable participants, current attention, activity, and next action for active company work
 - Use your digital coworker to get a personalized briefing on what needs your attention
 - Open the ["Needs you" inbox](attention-inbox.md) to review plain-language decision cards, weekly batches, and the full technical record when needed

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -1,0 +1,53 @@
+---
+title: "My Work and Work Rooms"
+area: workspace
+order: 3
+relatedCode:
+  - apps/web/app/(shell)/workspace/my-queue/page.tsx
+  - apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
+  - apps/web/components/workspace/WorkCaseAttentionLens.tsx
+  - apps/web/components/workspace/WorkCaseDetailView.tsx
+---
+
+## Overview
+
+**My Work** is the Workspace view of active company work available to you. Each item opens a **Work Room**: a focused place where authorized people and AI coworkers coordinate toward a named outcome.
+
+A Work Room is not an unbounded chat channel. It has a work boundary: purpose, outcome, scope, accountability, authority, sensitivity, measures, timing, and a closure rule. The platform keeps the underlying governed Work Case and its evidence; the room presents that structure in language suited to doing the work.
+
+## What You See First
+
+The top of a Work Room answers four questions:
+
+1. What outcome does this room own?
+2. What needs attention now?
+3. Who is accountable and who is participating?
+4. What is the next action?
+
+Source identifiers, integration status, and projection confidence remain available under **Room details**. They do not displace the outcome or the people doing the work.
+
+## Activity and Participants
+
+The **Activity** stream distinguishes messages, asks, coworker handoffs, work changes, decisions, artifacts, governed actions, verification, receipts, and cycle transitions. A message is an update; it is not proof that the outcome was achieved.
+
+People and AI coworkers appear together as named participants. Their room role and current work state are separate:
+
+- **Accountable** owns the room outcome.
+- **Contributor** performs or coordinates work.
+- **Reviewer** verifies work or an outcome.
+- **Observer** follows the room without changing it.
+
+AI coworkers remain governed participants. Joining a room does not expand their authority, and a visible presence signal does not grant permission.
+
+## Finite and Standing Rooms
+
+- A **finite room** closes when its bounded outcome and closure rule are satisfied.
+- A **standing room** supports recurring work. Each cycle still has its own objective, measures, stop conditions, and structured outcome.
+
+Completion produces an Outcome Packet from governed decisions, artifacts, actions, receipts, evidence, and unresolved work. Conversation alone cannot complete a room.
+
+## Incomplete or Unavailable Rooms
+
+If a room boundary is incomplete, the page identifies the missing elements instead of inventing them. If the source is unavailable, the last available projection is marked clearly and the page gives one recovery direction.
+
+If you do not have access, the internal room title, participants, source references, and sensitivity details are not shown. External customer case pages remain customer-safe case summaries; they do not expose internal Work Room controls or participants.

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -48,6 +48,6 @@ Completion produces an Outcome Packet from governed decisions, artifacts, action
 
 ## Incomplete or Unavailable Rooms
 
-If a room boundary is incomplete, the page identifies the missing elements instead of inventing them. If the source is unavailable, the last available projection is marked clearly and the page gives one recovery direction.
+If a room boundary is incomplete, the page identifies the missing elements instead of inventing them. If the source is unavailable, the last available projection is marked clearly and the page gives one recovery direction. If an AI coworker's current status is unavailable, the participant panel says so and directs you back to the room's next action instead of implying that the coworker is still working.
 
 If you do not have access, the internal room title, participants, source references, and sensitivity details are not shown. External customer case pages remain customer-safe case summaries; they do not expose internal Work Room controls or participants.

--- a/docs/ux-fit/2026-07-31-work-rooms-outcome-first.ux-fit.json
+++ b/docs/ux-fit/2026-07-31-work-rooms-outcome-first.ux-fit.json
@@ -1,0 +1,24 @@
+{
+  "version": "1",
+  "decidedOption": "outcome-first-existing-route",
+  "decisionInteractionId": "DI-3D4DAE04956D",
+  "scope": {
+    "files": [
+      "apps/web/components/ui/report-kit/statusColors.ts",
+      "apps/web/components/workspace/WorkCaseAttentionLens.tsx",
+      "apps/web/components/workspace/WorkCaseDetailView.tsx",
+      "apps/web/components/workspace/WorkItemCommentBox.tsx",
+      "apps/web/components/workspace/work-room/WorkRoomBody.tsx",
+      "apps/web/components/workspace/work-room/WorkRoomHeader.tsx",
+      "apps/web/components/workspace/work-room/presentation.ts"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "outcome-first-existing-route",
+      "parallel-room-route",
+      "keep-case-inspector"
+    ]
+  }
+}

--- a/scripts/check-no-local-status-color.mjs
+++ b/scripts/check-no-local-status-color.mjs
@@ -37,9 +37,7 @@ export const ALLOWLIST = new Set([
   "apps/web/components/portal/PortalWorkCases.tsx",
   "apps/web/components/portal/PortalWorkCaseDetail.tsx",
   "apps/web/components/platform/development/change-lanes/ChangeLaneStatusBadge.tsx",
-  "apps/web/components/workspace/WorkCaseAttentionLens.tsx",
   "apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx",
-  "apps/web/components/workspace/WorkCaseDetailView.tsx",
   "apps/web/components/customer/crmToneIntent.ts",
 ]);
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -8034,5 +8034,19 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 39
+  },
+  "apps/web/components/workspace/work-room/WorkRoomBody.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/workspace/work-room/WorkRoomHeader.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 46
   }
 }


### PR DESCRIPTION
## Summary

Make the existing Workspace Work Case detail route feel like an active, outcome-oriented Work Room for authorized people and AI coworkers. The canonical Work Case and `/workspace/cases/[caseKey]` route remain unchanged; this is a presentation/application projection, not a second work model.

## Changes

- Put outcome, attention, accountability, participants, and next action in the first viewport.
- Split the former detail composition into focused Work Room header/body/presentation modules.
- Keep Activity distinct from durable decisions, artifacts, actions, evidence, receipts, and unresolved work.
- Add honest incomplete-boundary, unavailable-source, missing-projection, permission non-disclosure, and unavailable-coworker states.
- Keep diagnostics behind disclosure and long room purposes behind native `details`/`summary`.
- Update the user guide, implementation plan, and UX-fit evidence.

## Design grounding

- Reviewed the Work Rooms collaboration design and implementation plan plus the existing Work Management architecture.
- Reviewed the Workspace case loader, Work Room projection, detail/attention/comment components, shell breadcrumb, and report-kit primitives.
- Kept `WorkRoomView` as a typed projection over canonical Work Case records and their existing policy, action, activity, participant, and receipt seams.
- Chose the outcome-first composition on the existing route; rejected a parallel room route/model and the inspector-only status quo.

## Verification

- Exact prospective merge against accepted `main` base `ecb77c5e48317ea194cdc232b23956eb14346fdd`: prose and policy guards, migrations, documentation guards, typecheck, full Vitest suite, and production Docker/Next build passed.
- Targeted Work Room suite: 7 files / 40 tests passed.
- Authenticated desktop and 390px governed previews verified first-viewport outcome priority, no horizontal overflow, long-purpose disclosure, Activity/Context/details interactions, and healthy portal cleanup.
- Native disclosure focusability and component semantics are verified. The browser harness's synthetic Enter/Space limitation is recorded as a harness limitation; no custom keyboard behavior replaces the browser-native contract.
- No migration: this slice is a UI/read-model projection over existing canonical records.

## Architecture and refactor

- Preserves `roomKey === caseKey`, the existing route family, source registry, policy, action, activity, participant, and receipt seams.
- Adds no new global navigation family, realtime transport, room table, or parallel collaboration model.
- Refactoring is at least 25% of the slice: the monolithic detail component was split by responsibility, room status intent was centralized in report-kit, and comment/activity presentation converged.

## Evidence

- Local exact-tree gate: `cmsaa7r70079c01qqp769g1wb`
- Desktop/final-head UX: `cms9zqzjx0doq01r2mknr75li`
- Narrow/final-tree UX: `cms9vep3v00bs01r2e0vno56z`
- Backlog item: `BI-32E26F62`
- Parent initiative: `BI-29BF297B`
- No overlapping open Work Rooms PR was found in the pre-PR sweep.

Local-CI-Evidence: cmsaa7r70079c01qqp769g1wb (feat/work-rooms-ux@b0fffe2c9255ae2feffa3c7a1138befa3f7929b2)
Seed-Fit-Decision: global-default
