### PR TITLE
fix: make Marketing strategy bootstrap race-safe

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -24,10 +24,8 @@ export default async function CustomerMarketingPage() {
   // state for the same organization, so both read the canonical operating
   // snapshot. The workspace snapshot still drives the strategy/queue panels.
   //
-  // These load SEQUENTIALLY, and the workspace snapshot is handed over rather
-  // than reloaded: getMarketingWorkspaceSnapshot() upserts the MarketingStrategy
-  // row, so racing two of them concurrently collides on the organizationId
-  // unique key and renders a 500.
+  // Hand the workspace snapshot over so both projections share one point in
+  // time and avoid repeating the same organization and strategy reads.
   const snapshot = await getMarketingWorkspaceSnapshot();
   const operating = await getMarketingOperatingSnapshot({ workspace: snapshot });
 

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -3,7 +3,7 @@ import {
   deriveRevenueModelFromActivationProfile,
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
-
+import { upsertMarketingStrategyTolerant } from "@/lib/marketing/strategy-bootstrap";
 export const MARKETING_STRATEGY_STATUS = ["draft", "active", "archived"] as const;
 export type MarketingStrategyStatus = typeof MARKETING_STRATEGY_STATUS[number];
 
@@ -1119,7 +1119,7 @@ export async function getMarketingWorkspaceSnapshot(): Promise<MarketingWorkspac
       : null,
   ]).join(". ");
 
-  const strategy = await prisma.marketingStrategy.upsert({
+  const strategy = await upsertMarketingStrategyTolerant(prisma.marketingStrategy, {
     where: { organizationId: organization.id },
     update: {},
     create: {

--- a/apps/web/lib/marketing/operating-snapshot.ts
+++ b/apps/web/lib/marketing/operating-snapshot.ts
@@ -582,12 +582,8 @@ type CampaignRow = {
  */
 export async function getMarketingOperatingSnapshot(options?: {
   /**
-   * An already-loaded workspace snapshot. Pass this when the caller has one:
-   * getMarketingWorkspaceSnapshot() UPSERTS the MarketingStrategy row, so
-   * loading it twice concurrently (e.g. both halves of a Promise.all) races two
-   * inserts on the organizationId unique key and one of them fails. Callers that
-   * already hold the workspace snapshot must hand it over rather than letting
-   * this function load a second one.
+   * An already-loaded workspace snapshot. Callers should pass it when available
+   * so both projections use the same point in time and avoid duplicate reads.
    */
   workspace?: MarketingWorkspaceSnapshot | null;
   now?: Date;

--- a/apps/web/lib/marketing/strategy-bootstrap.test.ts
+++ b/apps/web/lib/marketing/strategy-bootstrap.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { upsertMarketingStrategyTolerant } from "./strategy-bootstrap";
+
+function p2002(): Error & { code: string } {
+  return Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+}
+
+describe("upsertMarketingStrategyTolerant", () => {
+  const args = {
+    where: { organizationId: "org-1" },
+    update: {},
+    create: { organizationId: "org-1" },
+  };
+
+  it("reuses the winning organization row when concurrent bootstrap loses the create race", async () => {
+    const winningStrategy = {
+      strategyId: "strategy-winner",
+      organizationId: "org-1",
+    };
+    const store = {
+      upsert: vi.fn().mockRejectedValue(p2002()),
+      findUnique: vi.fn().mockResolvedValue(winningStrategy),
+    };
+
+    await expect(upsertMarketingStrategyTolerant(store, args)).resolves.toEqual(winningStrategy);
+    expect(store.findUnique).toHaveBeenCalledWith({
+      where: { organizationId: "org-1" },
+    });
+  });
+
+  it("returns the normal upsert result without a recovery read", async () => {
+    const strategy = {
+      strategyId: "strategy-created",
+      organizationId: "org-1",
+    };
+    const store = {
+      upsert: vi.fn().mockResolvedValue(strategy),
+      findUnique: vi.fn(),
+    };
+
+    await expect(upsertMarketingStrategyTolerant(store, args)).resolves.toEqual(strategy);
+    expect(store.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("does not hide unrelated database failures", async () => {
+    const failure = Object.assign(new Error("Database unavailable"), {
+      code: "P1001",
+    });
+    const store = {
+      upsert: vi.fn().mockRejectedValue(failure),
+      findUnique: vi.fn(),
+    };
+
+    await expect(upsertMarketingStrategyTolerant(store, args)).rejects.toBe(failure);
+    expect(store.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a unique violation when no winning organization row exists", async () => {
+    const failure = p2002();
+    const store = {
+      upsert: vi.fn().mockRejectedValue(failure),
+      findUnique: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(upsertMarketingStrategyTolerant(store, args)).rejects.toBe(failure);
+  });
+});

--- a/apps/web/lib/marketing/strategy-bootstrap.ts
+++ b/apps/web/lib/marketing/strategy-bootstrap.ts
@@ -1,0 +1,42 @@
+import type { Prisma } from "@dpf/db";
+
+interface MarketingStrategyStore<TStrategy> {
+  upsert(args: Prisma.MarketingStrategyUpsertArgs): Promise<TStrategy>;
+  findUnique(args: {
+    where: { organizationId: string };
+  }): Promise<TStrategy | null>;
+}
+
+function isUniqueConstraintViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "P2002"
+  );
+}
+
+/**
+ * Bootstrap one strategy per organization even when separate route requests
+ * arrive together. Prisma can emulate an upsert as read-then-create, so the
+ * losing request reuses the row committed by the winner.
+ */
+export async function upsertMarketingStrategyTolerant<TStrategy>(
+  store: MarketingStrategyStore<TStrategy>,
+  args: Prisma.MarketingStrategyUpsertArgs & {
+    where: { organizationId: string };
+  },
+): Promise<TStrategy> {
+  try {
+    return await store.upsert(args);
+  } catch (error: unknown) {
+    if (!isUniqueConstraintViolation(error)) throw error;
+
+    const winningStrategy = await store.findUnique({
+      where: { organizationId: args.where.organizationId },
+    });
+    if (!winningStrategy) throw error;
+
+    return winningStrategy;
+  }
+}

--- a/docs/user-guide/customers/marketing.md
+++ b/docs/user-guide/customers/marketing.md
@@ -46,6 +46,12 @@ Because both the page and the coworker read the same thing, they cannot tell you
 two different stories about where marketing stands. The recommendation moves as
 the workspace moves:
 
+Opening Marketing in more than one tab, or loading page sections at the same
+time, still uses one strategy workspace for the organization. A concurrent
+first load may finish through either request, but both views resolve to that
+same saved strategy rather than presenting a setup error or creating competing
+records.
+
 | What the workspace looks like | What you are asked to do next |
 | --- | --- |
 | Drafts are waiting on you | Review them before anything reaches customers |


### PR DESCRIPTION
## Summary

Makes Marketing strategy bootstrap tolerant of the one-row-per-organization create race that occurs when independent Marketing reads initialize the same organization concurrently. The losing request now reuses the row committed by the winner while unrelated database errors remain fail-closed.

## Changes

- Adds one shared tolerant Marketing strategy bootstrap helper.
- Routes the Marketing page, operating snapshot, and shared Marketing read path through that helper.
- Covers normal creation, concurrent `P2002` recovery, unrelated database failure, and the no-winner failure case.

## Test plan

- [x] Focused `strategy-bootstrap` unit suite: 4 tests passed
- [x] Independent architecture/provenance review: FIT
- [x] Exact merged-code gate: 21,237 tests, typecheck, 485 migrations, and production Docker build passed

## Pre-PR readiness

- [x] Branch is isolated, clean, and DCO-signed
- [x] Rebased exact SHA preserves the independently reviewed source tree
- [x] `pnpm pr:ready` passed against this exact pushed branch and body

## Related issues / Epic

Parent: `EP-UX-SYSTEM`

This is the prerequisite runtime correction for the Marketing coworker live-readiness acceptance path under `BI-C1943813`.

## Documentation impact

Updates the canonical Marketing operator guide to state that concurrent first loads converge on one organization strategy workspace rather than surfacing a setup error or creating competing records.

## Design grounding

- Reviewed `docs/user-guide/customers/marketing.md` and the existing Customer → Marketing route contract.
- Reused the existing `MarketingStrategy` organization-unique source of truth and existing page/read helpers; no new visible control, route, status dialect, or navigation layer is introduced.
- Preserved the current first viewport and progressive-disclosure behavior; this change only makes concurrent reads converge on the canonical row.

## Data and migration impact

No schema or migration change. The existing unique organization ownership remains authoritative.

## Overlap sweep

No open PR title or branch currently overlaps Marketing strategy bootstrap or Marketing readiness.

Local-CI-Evidence: cmsa7b367012l01qqzzo5xatt (fix/marketing-strategy-concurrency@87f5b1c501c7b1cacc887a5cd364ea1bdce3d402)
