### PR TITLE
fix(ci): bound production build hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,10 @@ jobs:
   build:
     name: Production Build
     runs-on: ubuntu-latest
+    # BI-57582F89. Recent healthy jobs (13 samples on 2026-08-01) had a
+    # 511-second p90 and 553-second max. Twice that p90 leaves ample variance
+    # while preventing a silent hosted-runner hang from holding the merge queue.
+    timeout-minutes: 20
     needs: [changes, exact-tree-evidence-shadow]
     if: >-
       always() &&
@@ -480,7 +484,9 @@ jobs:
         # gate only — the Docker release build does not set this env.
         env:
           DPF_TURBOPACK_BUILD_CACHE: "1"
-        run: pnpm --filter web build
+        run: |
+          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} timeout=20m command=pnpm --filter web build"
+          pnpm --filter web build
 
       # BI-959F4F38. PR and merge-group UX runs consume this exact-tree output
       # instead of compiling the same portal a second time. The receipt binds

--- a/docs/testing/ci-evidence.md
+++ b/docs/testing/ci-evidence.md
@@ -210,7 +210,16 @@ starts the reusable UX runtime from the same change-classification edge so its
 fixture and browser setup overlap the build. After setup, the runtime waits
 only for the exact artifact name in its own Actions run and passes that build to
 the stable `UX Route Budget Sweep` check. The one-day artifact contains a
-versioned receipt and a compressed payload. The receipt binds the payload to:
+versioned receipt and a compressed payload.
+
+The job has a 20-minute upper bound. A 2026-08-01 sample of 13 successful jobs
+measured a 511-second p90 and a 553-second maximum, so the bound is more than
+twice the observed p90 while remaining finite. Before compilation starts, the
+job logs its Actions run, attempt, immutable tree SHA, timeout, and canonical
+build command. A timeout remains red and does not retry or weaken the required
+check; it prevents a silent hosted-runner stall from holding the merge queue.
+
+The receipt binds the payload to:
 
 - repository, commit SHA, and immutable Git tree SHA;
 - GitHub event, source run/attempt, and CI evidence-planner digest;

--- a/scripts/check-ci-build-cache.test.mjs
+++ b/scripts/check-ci-build-cache.test.mjs
@@ -17,10 +17,31 @@ function stepBlock(stepName) {
   return ciWorkflow.slice(start, next === -1 ? undefined : next);
 }
 
+function jobBlock(jobName, nextJobName) {
+  const start = ciWorkflow.indexOf(`  ${jobName}:`);
+  assert.notEqual(start, -1, `missing workflow job: ${jobName}`);
+
+  const next = ciWorkflow.indexOf(`\n  ${nextJobName}:`, start + 1);
+  assert.notEqual(next, -1, `missing workflow job after ${jobName}: ${nextJobName}`);
+  return ciWorkflow.slice(start, next);
+}
+
 test("Production Build Turbopack cache uses exact keys only", () => {
   const block = stepBlock("Cache Turbopack build cache");
 
   assert.match(block, /path:\s*\$\{\{\s*github\.workspace\s*\}\}\/apps\/web\/\.next\/cache/);
   assert.match(block, /key:\s*nextjs-/);
   assert.doesNotMatch(block, /\n\s+restore-keys:/);
+});
+
+test("Production Build is bounded and identifies timed-out evidence", () => {
+  const block = jobBlock("build", "ux-route-sweep-runtime");
+  const buildStep = stepBlock("Build web (Next.js production)");
+
+  assert.match(block, /\n\s{4}timeout-minutes:\s*20\s*\n/);
+  assert.match(buildStep, /production-build.*run=\$\{\{ github\.run_id \}\}/);
+  assert.match(buildStep, /tree=\$\{\{ github\.sha \}\}/);
+  assert.match(buildStep, /timeout=20m/);
+  assert.match(buildStep, /pnpm --filter web build/);
+  assert.doesNotMatch(buildStep, /continue-on-error:\s*true/);
 });


### PR DESCRIPTION
## Summary

- bound the required GitHub `Production Build` job at 20 minutes so a silent hosted-runner hang cannot hold the merge queue indefinitely
- log the Actions run, attempt, immutable tree SHA, timeout, and unchanged build command before compilation begins
- guard the timeout, diagnostics, red-failure behavior, canonical build command, and exact-key cache contract with source tests

## Design grounding

Design-Grounding-Decision: extend the existing `Production Build` job, exact-tree artifact flow, and CI policy-guard test. WWMD decision DI-28E3E288CD6B selected a bounded red timeout over unproven cache remediation or an automatic retry.

Seed-Fit-Decision: global-default

The CI workflow and contributor evidence contract are universal platform behavior for every DPF contribution. No organization- or archetype-specific state is introduced.

## Verification

- 13 recent successful GitHub jobs measured p90 511 seconds and max 553 seconds; the 20-minute bound exceeds twice the observed p90
- focused source tests: 10 passed across the build-cache, exact-tree artifact, and evidence-workflow contracts
- exact merged-code local-CI: freshness green; 485 migrations current; docs and guards passed; web typecheck passed; exhaustive Vitest passed; production Docker build passed
- UX: not applicable; this changes CI orchestration only and adds no route, rendered content, or operator interaction
- migrations: not applicable; no schema or migration files changed

## Documentation

- document the measured timeout envelope, emitted diagnostics, and fail-red behavior in `docs/testing/ci-evidence.md`

## Backlog

- BI-57582F89
