### PR TITLE
fix(discovery): make autoResolveWhen executable so satisfied issues close themselves

### DIFF
--- a/docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md
+++ b/docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md
@@ -132,6 +132,48 @@ concurrency 1) delegating to the pure `runQualityIssueDriftSweep(db)`
    its owner. This is the runtime analogue of the compile-time gate: a NEW
    detector that starts accumulating is surfaced automatically.
 
+## Making `autoResolveWhen` executable (BI-A3D12F85)
+
+The two mechanisms above close rows by SUBJECT STATE. Neither evaluated a type's
+own declared close condition, because `autoResolveWhen` was **prose no code path
+read** — 18 types declared a machine-checkable condition in a string field with
+zero consumers.
+
+Measured on the live install after the direction-dual shipped: **134 of 196 open
+rows (68%) had their stated condition already satisfied** — 67
+`lifecycle_unverified` on entities already reporting `supported`, 67
+`catalog_match_ambiguous` on entities that already had a manufacturer. Discovery
+enriched them; nothing closed the tickets.
+
+**Where the condition is evaluated, and why.** `evaluateInventoryQuality` now
+returns `resolvedIssueKeys` alongside `issues`: each resolve is literally the
+`else` branch of its emit branch. Deriving both in one pass from one set of facts
+makes drift between raise and resolve structurally impossible — which is the
+failure this whole arc keeps re-encountering.
+
+It deliberately does NOT live in the drift sweep. Some warranting facts
+(evidence-derived `normalizationStatus`) never reach the `InventoryEntity` row,
+so a sweep-side predicate would be blind to them and would close real signal.
+
+**Bounded by construction.** Only entities present in the current sweep are
+reconciled; an entity nobody observed cannot have its facts re-evaluated, and
+each source clears its own entities on its own cadence. Docker-origin rows are
+skipped before any branch, so they emit no resolve keys either — emitting them
+would close issues raised by a source that DID evaluate them.
+
+**Ratchet.** A conformance test drives every emit branch and asserts each emitted
+type is either reconciled or `raisedBySubjectAbsence`, so a new detector cannot
+ship an emit branch without a resolve branch.
+
+**Ordering vs the router.** This precedes the phase-2 auto-processing loop
+deliberately. Routing first would have funded a coworker to hand-work 435 rows,
+~68% of which needed a boolean evaluated. Mechanical work mechanically; route
+only the residue.
+
+The write path (upsert warranted, reconcile-on-condition, reconcile-on-recovery)
+now lives in `packages/db/src/discovery-quality-persistence.ts`, extracted as a
+coherent seam when `discovery-sync.ts` passed the 800-LOC module ceiling.
+
 **Why not an open-count CI ratchet.** The `module-size-baseline.txt` pattern
 cannot apply — the open count lives in the operator's database, which CI has no
 access to. Drift monitoring must run at runtime, which is what this sweep is.

--- a/packages/db/src/discovery-attribution.reconcile.test.ts
+++ b/packages/db/src/discovery-attribution.reconcile.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateInventoryQuality,
+  RECONCILED_ENTITY_ISSUE_TYPES,
+  type InventoryQualityEntityInput,
+} from "./discovery-attribution";
+import { QUALITY_ISSUE_REGISTRY } from "./quality-issue-registry";
+
+// The executable half of `autoResolveWhen`.
+//
+// The registry declared every type's close condition in PROSE that no code path
+// read — only stale_entity / stale_relationship ever had an implementation. On
+// the live install that left 134 of 196 open rows (68%) whose stated condition
+// was ALREADY TRUE: 67 lifecycle_unverified on entities reporting `supported`,
+// 67 catalog_match_ambiguous on entities that already had a manufacturer.
+//
+// These tests pin the negation: when a condition stops holding, the sweep that
+// notices must report the key as resolved.
+
+/** A fully-identified, fully-attributed entity — nothing should be warranted. */
+function cleanEntity(
+  overrides: Partial<InventoryQualityEntityInput> = {},
+): InventoryQualityEntityInput {
+  return {
+    entityKey: "organization:internal:host:srv:app-01",
+    entityType: "host",
+    attributionStatus: "attributed",
+    attributionConfidence: 0.99,
+    candidateTaxonomy: [],
+    taxonomyNodeId: "foundational/compute/servers",
+    manufacturer: "Dell Inc.",
+    observedVersion: "1.2.3",
+    normalizedVersion: "1.2.3",
+    normalizationStatus: "normalized",
+    supportStatus: "supported",
+    hasSoftwareEvidence: true,
+    ...overrides,
+  };
+}
+
+const keyFor = (entity: InventoryQualityEntityInput, suffix: string) =>
+  `inventory_entity:${entity.entityKey}:${suffix}`;
+
+describe("evaluateInventoryQuality — reconcile-on-condition", () => {
+  it("reports lifecycle_unverified resolved once supportStatus is known", () => {
+    const entity = cleanEntity({ supportStatus: "supported" });
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality([entity]);
+
+    expect(resolvedIssueKeys).toContain(keyFor(entity, "lifecycle_unverified"));
+    expect(issues.map((i) => i.issueType)).not.toContain("lifecycle_unverified");
+  });
+
+  it("still raises lifecycle_unverified while supportStatus is unknown", () => {
+    const entity = cleanEntity({ supportStatus: "unknown" });
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality([entity]);
+
+    expect(issues.map((i) => i.issueType)).toContain("lifecycle_unverified");
+    // Critically NOT resolved — closing a warranted row would destroy real signal.
+    expect(resolvedIssueKeys).not.toContain(keyFor(entity, "lifecycle_unverified"));
+  });
+
+  it("reports catalog_match_ambiguous resolved once identity evidence lands", () => {
+    const entity = cleanEntity();
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality([entity]);
+
+    expect(resolvedIssueKeys).toContain(keyFor(entity, "catalog_match_ambiguous"));
+    expect(issues.map((i) => i.issueType)).not.toContain("catalog_match_ambiguous");
+  });
+
+  it("keeps catalog_match_ambiguous open while any identity clause still holds", () => {
+    // Manufacturer present, but an observed version that never normalized — the
+    // middle clause of the emit condition. A resolver that only checked
+    // manufacturer would wrongly close this.
+    const entity = cleanEntity({ normalizedVersion: null });
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality([entity]);
+
+    expect(issues.map((i) => i.issueType)).toContain("catalog_match_ambiguous");
+    expect(resolvedIssueKeys).not.toContain(keyFor(entity, "catalog_match_ambiguous"));
+  });
+
+  it("reports attribution issues resolved once the entity is attributed", () => {
+    const entity = cleanEntity({ attributionStatus: "attributed" });
+    const { resolvedIssueKeys } = evaluateInventoryQuality([entity]);
+
+    expect(resolvedIssueKeys).toContain(keyFor(entity, "attribution_missing"));
+    expect(resolvedIssueKeys).toContain(keyFor(entity, "taxonomy_low_confidence"));
+  });
+
+  it("never reports the same key as both raised and resolved", () => {
+    // The emit/resolve branches are an if/else on one condition, so this holds by
+    // construction — pinned because a future edit could split them apart and the
+    // caller upserts `issues` while closing `resolvedIssueKeys`, so an overlap
+    // would make the outcome depend on statement order.
+    const entities = [
+      cleanEntity({ entityKey: "k1", supportStatus: "unknown" }),
+      cleanEntity({ entityKey: "k2", manufacturer: null }),
+      cleanEntity({ entityKey: "k3", attributionStatus: "needs_review" }),
+      cleanEntity({ entityKey: "k4" }),
+    ];
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality(entities);
+
+    const raised = new Set(issues.map((i) => i.issueKey));
+    const overlap = resolvedIssueKeys.filter((key) => raised.has(key));
+    expect(overlap).toEqual([]);
+  });
+
+  it("does not reconcile Docker-origin entities it refuses to evaluate", () => {
+    // Docker rows are skipped before any issue branch. Emitting resolve keys for
+    // them would silently close issues raised by a source that DID evaluate them.
+    // A key the guard genuinely matches (docker-host: prefix), AND one that would
+    // otherwise be warranted — so this proves the `continue` fires rather than
+    // just that a clean entity raises nothing.
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality([
+      cleanEntity({
+        entityKey: "docker-host:abc123",
+        supportStatus: "unknown",
+        manufacturer: null,
+        attributionStatus: "needs_review",
+      }),
+    ]);
+
+    expect(issues).toEqual([]);
+    expect(resolvedIssueKeys).toEqual([]);
+  });
+});
+
+describe("reconcile conformance — a new detector cannot skip its resolve branch", () => {
+  it("every entity-subject type the evaluator can emit is reconciled or absence-raised", () => {
+    // Drive every emit branch at once, then assert each emitted type either has a
+    // resolve branch (listed in RECONCILED_ENTITY_ISSUE_TYPES) or is raised BY its
+    // subject's absence (stale_entity, whose dual is reconcile-on-recovery).
+    // Adding an emit branch without a resolve branch fails here, which is exactly
+    // how `autoResolveWhen` became prose nothing executed.
+    const { issues } = evaluateInventoryQuality([
+      {
+        entityKey: "organization:internal:host:srv:needs-everything",
+        entityType: "host",
+        attributionStatus: "needs_review",
+        attributionConfidence: 0.1,
+        candidateTaxonomy: [{ nodeId: "foundational/compute/servers", score: 0.1 }],
+        manufacturer: null,
+        observedVersion: "9",
+        normalizedVersion: null,
+        normalizationStatus: "needs_review",
+        supportStatus: "unknown",
+        hasSoftwareEvidence: false,
+      },
+    ]);
+
+    const emitted = [...new Set(issues.map((issue) => issue.issueType))];
+    expect(emitted.length).toBeGreaterThan(0);
+
+    const uncovered = emitted.filter(
+      (type) =>
+        !(RECONCILED_ENTITY_ISSUE_TYPES as readonly string[]).includes(type)
+        && !QUALITY_ISSUE_REGISTRY[type].raisedBySubjectAbsence,
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  it("every reconciled type is an entity-subject type that is not absence-raised", () => {
+    for (const type of RECONCILED_ENTITY_ISSUE_TYPES) {
+      const contract = QUALITY_ISSUE_REGISTRY[type];
+      expect(contract.subject).toBe("entity");
+      expect(contract.raisedBySubjectAbsence).toBe(false);
+    }
+  });
+});

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -97,7 +97,44 @@ export type InventoryQualityIssue = {
 
 export type InventoryQualityEvaluation = {
   issues: InventoryQualityIssue[];
+  /**
+   * Issue keys this pass proved are NO LONGER WARRANTED — the exact negation of
+   * the emission conditions above, for entities this sweep actually examined.
+   *
+   * Why this exists: `QualityIssueContract.autoResolveWhen` declared each type's
+   * close condition in PROSE that no code path read. Only stale_entity /
+   * stale_relationship ever had a real implementation. So `lifecycle_unverified`
+   * kept saying "resolves when supportStatus becomes known" while 67 rows sat
+   * open on entities that already reported `supported`, and
+   * `catalog_match_ambiguous` kept 67 open on entities that already had a
+   * manufacturer — 134 of 196 open rows (68%) whose stated condition was
+   * already true.
+   *
+   * Why it is computed HERE and not in the drift sweep: the resolve condition is
+   * the negation of the emit condition, so deriving both in one pass from one set
+   * of facts makes drift between them structurally impossible. The sweep could
+   * not do it correctly anyway — some warranting facts (evidence-derived
+   * normalizationStatus) never reach the InventoryEntity row, and a predicate
+   * blind to a warranting condition would close real signal.
+   *
+   * Bounded by construction: only entities in THIS sweep are reconciled. An
+   * entity nobody observed cannot have its facts re-evaluated, and each source
+   * clears its own entities on its own cadence.
+   */
+  resolvedIssueKeys: string[];
 };
+
+/**
+ * Entity-subject issue types whose warrant is recomputed on every sweep. Each
+ * must have BOTH an emit branch and a matching not-warranted branch in
+ * `evaluateInventoryQuality`; the registry conformance test asserts the set.
+ */
+export const RECONCILED_ENTITY_ISSUE_TYPES = [
+  "attribution_missing",
+  "taxonomy_attribution_low_confidence",
+  "lifecycle_unverified",
+  "catalog_match_ambiguous",
+] as const satisfies readonly QualityIssueType[];
 
 const IDENTITY_OPTIONAL_ENTITY_TYPES = new Set([
   "network_interface",
@@ -341,6 +378,7 @@ export function evaluateInventoryQuality(
   relationships: InventoryQualityRelationshipInput[] = [],
 ): InventoryQualityEvaluation {
   const issues: InventoryQualityIssue[] = [];
+  const resolvedIssueKeys: string[] = [];
 
   for (const entity of entities) {
     // Docker-origin entities (containers, bridge-IP hosts, vpnkit
@@ -352,7 +390,12 @@ export function evaluateInventoryQuality(
       continue;
     }
 
-    if (entity.attributionStatus === "needs_review" || entity.attributionStatus === "unmapped") {
+    // Each entity-subject type below emits when warranted and records its key as
+    // RESOLVED when not. The else-branch is the executable form of the contract's
+    // `autoResolveWhen` prose — same facts, same pass, so the two cannot drift.
+    const attributionUnresolved =
+      entity.attributionStatus === "needs_review" || entity.attributionStatus === "unmapped";
+    if (attributionUnresolved) {
       issues.push({
         issueKey: `inventory_entity:${entity.entityKey}:attribution_missing`,
         issueType: "attribution_missing",
@@ -361,10 +404,13 @@ export function evaluateInventoryQuality(
         summary: `${entity.entityType} ${entity.entityKey} requires taxonomy or product attribution review`,
         inventoryEntityKey: entity.entityKey,
       });
+    } else {
+      // "the entity gains a taxonomy or product attribution"
+      resolvedIssueKeys.push(`inventory_entity:${entity.entityKey}:attribution_missing`);
     }
 
     if (
-      (entity.attributionStatus === "needs_review" || entity.attributionStatus === "unmapped")
+      attributionUnresolved
       && (entity.attributionConfidence ?? 0) < LOW_CONFIDENCE_THRESHOLD
       && (entity.candidateTaxonomy?.length ?? 0) > 0
     ) {
@@ -376,6 +422,10 @@ export function evaluateInventoryQuality(
         summary: `${entity.entityType} ${entity.entityKey} has low-confidence taxonomy attribution candidates`,
         inventoryEntityKey: entity.entityKey,
       });
+    } else {
+      // "attribution confidence rises above the low-confidence threshold" — or the
+      // attribution resolved outright, or the candidate list emptied.
+      resolvedIssueKeys.push(`inventory_entity:${entity.entityKey}:taxonomy_low_confidence`);
     }
 
     // Only the MANAGED estate raises an issue when it vanishes. An ARP
@@ -397,6 +447,10 @@ export function evaluateInventoryQuality(
     }
 
     const normalizedSupportStatus = entity.supportStatus?.trim().toLowerCase() ?? "unknown";
+    if (normalizedSupportStatus !== "unknown") {
+      // "support lifecycle (supportStatus) becomes known for the entity"
+      resolvedIssueKeys.push(`inventory_entity:${entity.entityKey}:lifecycle_unverified`);
+    }
     if (normalizedSupportStatus === "unknown") {
       issues.push({
         issueKey: `inventory_entity:${entity.entityKey}:lifecycle_unverified`,
@@ -430,6 +484,10 @@ export function evaluateInventoryQuality(
         summary: `${entity.entityType} ${entity.entityKey} still needs identity review for ${detailParts.join(", ")}`,
         inventoryEntityKey: entity.entityKey,
       });
+    } else {
+      // "identity evidence resolves (manufacturer + normalized version + catalog
+      // match)" — also covers an entity whose type became identity-optional.
+      resolvedIssueKeys.push(`inventory_entity:${entity.entityKey}:catalog_match_ambiguous`);
     }
   }
 
@@ -461,6 +519,9 @@ export function evaluateInventoryQuality(
     }
   }
 
-  return { issues };
+  // An issue key can only appear on one side: each branch above is an if/else on
+  // the same condition, so a key emitted this pass is never also reported
+  // resolved. The caller closes `resolvedIssueKeys` and upserts `issues`.
+  return { issues, resolvedIssueKeys };
 }
 

--- a/packages/db/src/discovery-quality-persistence.ts
+++ b/packages/db/src/discovery-quality-persistence.ts
@@ -1,0 +1,146 @@
+// discovery-quality-persistence.ts
+//
+// Persisting one discovery run's quality-issue outcome: raise what is warranted,
+// close what is not. Extracted from discovery-sync.ts, which had grown past the
+// 800-LOC module ceiling — this is a coherent seam (the whole
+// PortfolioQualityIssue write path for a sweep) rather than an arbitrary split.
+//
+// Three passes, in order:
+//
+//   1. Upsert the issues this sweep decided are warranted.
+//   2. Reconcile-on-CONDITION — close issues whose emission condition this pass
+//      proved is no longer true. This is the executable form of the registry's
+//      `autoResolveWhen`, which was prose no code path read.
+//   3. Reconcile-on-RECOVERY — close stale_entity / stale_relationship rows for
+//      subjects observed active again.
+//
+// 2 and 3 are duals: (3) fires when a missing subject comes back, (2) when a
+// present subject stops warranting its issue.
+
+import type { InventoryQualityEvaluation } from "./discovery-attribution";
+
+/** Narrow write surface — the real Prisma transaction client is a superset. */
+export interface QualityIssuePersistenceTx {
+  portfolioQualityIssue: {
+    upsert(args: {
+      where: { issueKey: string };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }): Promise<unknown>;
+    updateMany(args: {
+      where: Record<string, unknown>;
+      data: { status: string; resolvedAt: Date };
+    }): Promise<{ count: number }>;
+  };
+}
+
+export interface PersistQualityIssuesInput {
+  evaluation: InventoryQualityEvaluation;
+  /** entityKey -> persisted InventoryEntity id, for FK linkage. */
+  entityIdsByEntityKey: Map<string, string>;
+  /** entityKey -> taxonomyNodeId for entities in this run. */
+  taxonomyNodeIdByEntityKey: Map<string, string | null>;
+  /** issueKeys already present before this run — anything else counts as created. */
+  existingIssueKeys: ReadonlySet<string>;
+  /** Entity keys this sweep confirmed active. */
+  currentEntityKeys: Iterable<string>;
+  /** Relationship keys this sweep observed. */
+  currentRelationshipKeys: readonly string[];
+  now: Date;
+}
+
+export interface PersistQualityIssuesResult {
+  createdIssues: number;
+}
+
+export async function persistQualityIssues(
+  tx: QualityIssuePersistenceTx,
+  input: PersistQualityIssuesInput,
+): Promise<PersistQualityIssuesResult> {
+  const {
+    evaluation,
+    entityIdsByEntityKey,
+    taxonomyNodeIdByEntityKey,
+    existingIssueKeys,
+    currentEntityKeys,
+    currentRelationshipKeys,
+    now,
+  } = input;
+
+  let createdIssues = 0;
+
+  for (const issue of evaluation.issues) {
+    const inventoryEntityId = issue.inventoryEntityKey
+      ? entityIdsByEntityKey.get(issue.inventoryEntityKey)
+      : undefined;
+    const resolvedTaxonomyNodeId = issue.inventoryEntityKey
+      ? taxonomyNodeIdByEntityKey.get(issue.inventoryEntityKey) ?? undefined
+      : undefined;
+
+    const fields = {
+      issueType: issue.issueType,
+      status: issue.status,
+      severity: issue.severity,
+      summary: issue.summary,
+      ...(resolvedTaxonomyNodeId
+        ? { taxonomyNode: { connect: { nodeId: resolvedTaxonomyNodeId } } }
+        : {}),
+      ...(inventoryEntityId ? { inventoryEntity: { connect: { id: inventoryEntityId } } } : {}),
+    };
+
+    await tx.portfolioQualityIssue.upsert({
+      where: { issueKey: issue.issueKey },
+      create: { issueKey: issue.issueKey, ...fields },
+      update: fields,
+    });
+
+    if (!existingIssueKeys.has(issue.issueKey)) createdIssues += 1;
+  }
+
+  // (2) Reconcile-on-condition. `evaluateInventoryQuality` derived these in the
+  // same pass, from the same facts, as the negation of its emit branches — so the
+  // resolve rule cannot drift from the raise rule. See the `resolvedIssueKeys`
+  // docblock in discovery-attribution.ts for why it is computed there.
+  if (evaluation.resolvedIssueKeys.length > 0) {
+    await tx.portfolioQualityIssue.updateMany({
+      where: { status: "open", issueKey: { in: evaluation.resolvedIssueKeys } },
+      data: { status: "resolved", resolvedAt: now },
+    });
+  }
+
+  // (3) Reconcile-on-recovery: a subject observed active in THIS sweep is no
+  // longer stale. The stale writer only ever opened rows and never closed
+  // recovered ones, so a row that went stale for one sweep and came back stayed
+  // open forever (the churn behind 1.5k+ accumulated rows). Keyed by issueKey
+  // with the subject key embedded, so it is source-bounded by construction:
+  // another source's stale issue has a different key and is never matched.
+  const recoveredEntityIssueKeys = [...currentEntityKeys].map(
+    (entityKey) => `inventory_entity:${entityKey}:stale`,
+  );
+  if (recoveredEntityIssueKeys.length > 0) {
+    await tx.portfolioQualityIssue.updateMany({
+      where: {
+        issueType: "stale_entity",
+        status: "open",
+        issueKey: { in: recoveredEntityIssueKeys },
+      },
+      data: { status: "resolved", resolvedAt: now },
+    });
+  }
+
+  const recoveredRelationshipIssueKeys = currentRelationshipKeys.map(
+    (relationshipKey) => `inventory_relationship:${relationshipKey}:stale`,
+  );
+  if (recoveredRelationshipIssueKeys.length > 0) {
+    await tx.portfolioQualityIssue.updateMany({
+      where: {
+        issueType: "stale_relationship",
+        status: "open",
+        issueKey: { in: recoveredRelationshipIssueKeys },
+      },
+      data: { status: "resolved", resolvedAt: now },
+    });
+  }
+
+  return { createdIssues };
+}

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -1,4 +1,5 @@
 import { evaluateInventoryQuality } from "./discovery-attribution";
+import { persistQualityIssues } from "./discovery-quality-persistence";
 import type { NormalizedDiscoveryOutput } from "./discovery-normalize";
 import { deriveInventoryEvidenceSnapshot } from "./discovery-evidence";
 import { deriveInventoryEnrichment } from "./inventory-enrichment";
@@ -667,84 +668,17 @@ export async function persistBootstrapDiscoveryRun(
       })),
     );
 
-    let createdIssues = 0;
-    for (const issue of qualityEvaluation.issues) {
-      const inventoryEntityId = issue.inventoryEntityKey
-        ? entityIdsByEntityKey.get(issue.inventoryEntityKey)
-        : undefined;
-
-      const resolvedTaxonomyNodeId = issue.inventoryEntityKey
-        ? normalized.inventoryEntities.find(
-            (entity) => entity.entityKey === issue.inventoryEntityKey,
-          )?.taxonomyNodeId ?? undefined
-        : undefined;
-
-      await tx.portfolioQualityIssue.upsert({
-        where: { issueKey: issue.issueKey },
-        create: {
-          issueKey: issue.issueKey,
-          issueType: issue.issueType,
-          status: issue.status,
-          severity: issue.severity,
-          summary: issue.summary,
-          ...(resolvedTaxonomyNodeId
-            ? { taxonomyNode: { connect: { nodeId: resolvedTaxonomyNodeId } } }
-            : {}),
-          ...(inventoryEntityId ? { inventoryEntity: { connect: { id: inventoryEntityId } } } : {}),
-        },
-        update: {
-          issueType: issue.issueType,
-          status: issue.status,
-          severity: issue.severity,
-          summary: issue.summary,
-          ...(resolvedTaxonomyNodeId
-            ? { taxonomyNode: { connect: { nodeId: resolvedTaxonomyNodeId } } }
-            : {}),
-          ...(inventoryEntityId ? { inventoryEntity: { connect: { id: inventoryEntityId } } } : {}),
-        },
-      });
-
-      if (!existingIssueKeys.has(issue.issueKey)) {
-        createdIssues += 1;
-      }
-    }
-
-    // Reconcile-on-recovery: an entity or relationship observed active in THIS
-    // sweep is no longer stale, so any open stale_entity / stale_relationship
-    // issue for it must resolve. The stale-issue writer only ever opened rows and
-    // never resolved recovered ones, so a row that went stale for one sweep and
-    // came back stayed open forever (the churn that accumulated 1.5k+ open rows).
-    // Keyed by issueKey — the entity/relationship key is embedded — so this is
-    // source-bounded by construction: a key this sweep confirmed active belongs to
-    // this source, and another source's stale issue has a different key and is
-    // never matched. Docker-origin churn is handled by suppression at emission (it
-    // never recovers under the same key); this closes the loop for real estate.
-    const recoveredEntityIssueKeys = [...currentEntityKeys].map(
-      (entityKey) => `inventory_entity:${entityKey}:stale`,
-    );
-    if (recoveredEntityIssueKeys.length > 0) {
-      await tx.portfolioQualityIssue.updateMany({
-        where: {
-          issueType: "stale_entity",
-          status: "open",
-          issueKey: { in: recoveredEntityIssueKeys },
-        },
-        data: { status: "resolved", resolvedAt: now },
-      });
-    }
-    const recoveredRelationshipIssueKeys = normalized.inventoryRelationships.map(
-      (relationship) => `inventory_relationship:${relationship.relationshipKey}:stale`,
-    );
-    if (recoveredRelationshipIssueKeys.length > 0) {
-      await tx.portfolioQualityIssue.updateMany({
-        where: {
-          issueType: "stale_relationship",
-          status: "open",
-          issueKey: { in: recoveredRelationshipIssueKeys },
-        },
-        data: { status: "resolved", resolvedAt: now },
-      });
-    }
+    const { createdIssues } = await persistQualityIssues(tx, {
+      evaluation: qualityEvaluation,
+      entityIdsByEntityKey,
+      taxonomyNodeIdByEntityKey: new Map(
+        normalized.inventoryEntities.map((entity) => [entity.entityKey, entity.taxonomyNodeId ?? null]),
+      ),
+      existingIssueKeys,
+      currentEntityKeys,
+      currentRelationshipKeys: normalized.inventoryRelationships.map((r) => r.relationshipKey),
+      now,
+    });
 
     return {
       summary: summarizeDiscoveryPersistence({

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -68,5 +68,4 @@ apps/web/lib/work-capsules/work-capsule-store.ts	1056
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118
-packages/db/src/discovery-sync.ts	810
 packages/db/src/wiki-store.test.ts	824


### PR DESCRIPTION
## Why

`QualityIssueContract.autoResolveWhen` declared every issue type's close condition in **prose that no code path read** — grep for it outside its own declarations and tests returns zero consumers. Only `stale_entity` / `stale_relationship` ever had a real implementation, plus the subject-loss dual added in #3807.

Measured on the live install after #3807 deployed:

| issue type | open on ACTIVE entities | close-condition **already true** |
|---|---|---|
| `lifecycle_unverified` | 103 | **67** |
| `catalog_match_ambiguous` | 93 | **67** |
| | 196 | **134 (68%)** |

`lifecycle_unverified` promised "resolves when supportStatus becomes known" while 67 rows sat open on entities already reporting `supported`. `catalog_match_ambiguous` promised "resolves when identity evidence resolves" while 67 sat open on entities that already had a manufacturer. Discovery enriched them; nothing closed the tickets.

Both types also fire on identical entity counts (host 71/71, monitoring_service 6/6, service 5/5, application 2/2) — blanket per-entity emission, not selective findings.

## What changed

`evaluateInventoryQuality` now returns `resolvedIssueKeys` alongside `issues`, and the sweep closes them in the same transaction — generalising the hardcoded `stale_entity` recovery block that already proved the pattern.

**Each resolve is literally the `else` of its emit branch.** Deriving both in one pass from one set of facts makes drift between raise and resolve structurally impossible — which is the failure this whole arc keeps re-encountering.

**Why not in the drift sweep.** Some warranting facts (evidence-derived `normalizationStatus`) never reach the `InventoryEntity` row. A sweep-side predicate would be blind to them and would close real signal.

**Bounded by construction.** Only entities in the current sweep are reconciled — an entity nobody observed cannot have its facts re-evaluated, and each source clears its own on its own cadence. Docker-origin rows are skipped before any branch, so they emit no resolve keys either; emitting them would close issues raised by a source that DID evaluate them.

## Why this precedes routing work to a coworker

BI-0B420A1D phase 2 (drift → BI → fund → route) would have funded a coworker to hand-work 435 rows, ~68% of which needed a boolean evaluated. Mechanical work mechanically; route only the residue. **Ordering matters more than either piece.**

## Module-size: ratchet TIGHTENED, not eroded

The guard rejected the first version — `discovery-sync.ts` grew 810 → 830. That file was baselined at 810 in #3807 under "no fix of any size could land"; bumping it again would have been erosion two PRs running.

Instead I took the guard's own advice and extracted the coherent seam: the whole quality-issue write path (upsert warranted → reconcile-on-condition → reconcile-on-recovery) now lives in `packages/db/src/discovery-quality-persistence.ts`. `discovery-sync.ts` is **743 lines, down from 810** — under the ceiling, so its baseline entry is **removed entirely**. Baseline count **70 → 69**.

## Verification

- 9 new tests; **the 2 load-bearing ones canaried** (each fails with its resolve branch disabled).
- `packages/db` suite: 1785 pass. The 1 failure (`inventory-entity-canonical-read-completeness`) is **pre-existing and load-dependent** — it passes in isolation at 5.8s against a 5s limit, and a full-suite run on a stashed tree fails identically (1 failed / 1785 passed).
- Both typecheck configs clean.
- 30/30 preflight guards clean across three runs.
- Conformance ratchet: drives every emit branch and asserts each emitted type is either reconciled or `raisedBySubjectAbsence`, so a new detector cannot ship an emit branch without a resolve branch.

**NOT YET OBSERVED ON THE LIVE INSTALL.** The reconcile runs on the next discovery sweep per source, so rows clear on that cadence rather than at merge. Expected: 474 → ~340.

## Local-CI attestation

Two sandbox-gate attempts failed **without reaching a verdict on this code**: one crashed post-admission (exit `4294967295`; the gate self-released its lease), one never got admitted. Neither was a guard or test failure.

Both a crash and a cancel leave the claimKey (`local-ci:<session>:<sha>`) terminal, so each retry needs a fresh commit amend — and retrying adds a fifth competitor to a queue with `effectiveCapacity: 1` already contended by four live sessions.

Local-CI-Override: Shared local-CI queue saturated (capacity 1, three other live sessions queued ahead); two attempts failed without reaching a verdict on this code — one crashed post-admission, one never admitted. Local evidence complete: 30/30 guards, 1785 tests, both typechecks clean, 2 canaried tests, module-size ratchet tightened 70->69. Operator-approved; CI is authoritative.

Refs: BI-A3D12F85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
