### PR TITLE
fix(observability): stop the disk-full outage recurring — image retention + alert push

### DIFF
--- a/apps/web/lib/queue/functions/alert-delivery-bridge.test.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.test.ts
@@ -6,6 +6,13 @@ const mocks = vi.hoisted(() => ({
   resolve: vi.fn(),
   findMany: vi.fn(),
   isVoiceNarrationEnabled: vi.fn(),
+  notify: vi.fn(),
+  resolveRecipient: vi.fn(),
+}));
+
+vi.mock("@/lib/attention/notify-live", () => ({
+  notifyAttentionLive: mocks.notify,
+  resolveOperatorRecipient: mocks.resolveRecipient,
 }));
 
 vi.mock("@/lib/observability/alert-sources", () => ({
@@ -50,6 +57,94 @@ describe("runAlertDeliveryScan", () => {
       keyOf(a.labels.alertname, a.labels.service),
     );
     mocks.findMany.mockResolvedValue([]);
+    mocks.resolveRecipient.mockResolvedValue("owner-1");
+    mocks.notify.mockResolvedValue(undefined);
+  });
+
+  // The last mile that was missing when WindowsHostDiskCritical sat open for
+  // twelve days (2026-07-19 → the 2026-07-31 disk-full outage) with no
+  // human-facing signal: the row existed and projected into the inbox, but
+  // nothing ever pushed it.
+  describe("operator notification", () => {
+    it("pushes a newly-opened alert to the operator", async () => {
+      mocks.fetchAlertSources.mockResolvedValue({
+        alerts: [alert("WindowsHostDiskCritical", "prometheus", "firing")],
+        reached: BOTH_UP,
+      });
+
+      const res = await runAlertDeliveryScan();
+
+      expect(res.notified).toBe(1);
+      expect(mocks.notify).toHaveBeenCalledTimes(1);
+      const pushed = mocks.notify.mock.calls[0][0];
+      expect(pushed.source).toBe("platform-health");
+      expect(pushed.userId).toBe("owner-1");
+      expect(pushed.itemKey).toBe(keyOf("WindowsHostDiskCritical"));
+      expect(pushed.deepLink).toBe("/ops/health");
+    });
+
+    it("does NOT re-notify an alert that is already open", async () => {
+      // The row is already open from an earlier cycle — it is being re-confirmed,
+      // not newly detected. Re-notifying here is exactly what would turn a
+      // 5-minute cron into inbox noise once the first notification is read.
+      mocks.findMany.mockResolvedValue([
+        { issueKey: keyOf("WindowsHostDiskCritical"), details: { source: "prometheus" } },
+      ]);
+      mocks.fetchAlertSources.mockResolvedValue({
+        alerts: [alert("WindowsHostDiskCritical", "prometheus", "firing")],
+        reached: BOTH_UP,
+      });
+
+      const res = await runAlertDeliveryScan();
+
+      expect(res.delivered).toBe(1); // still refreshed
+      expect(res.notified).toBe(0);  // but not re-pushed
+      expect(mocks.notify).not.toHaveBeenCalled();
+    });
+
+    it("marks critical alerts high-risk and warnings bounded-write", async () => {
+      const critical = {
+        ...alert("WindowsHostDiskCritical", "prometheus", "firing"),
+        labels: { alertname: "WindowsHostDiskCritical", severity: "critical" },
+      };
+      const warning = {
+        ...alert("WindowsHostDiskPressure", "prometheus", "firing"),
+        labels: { alertname: "WindowsHostDiskPressure", severity: "warning" },
+      };
+      mocks.fetchAlertSources.mockResolvedValue({ alerts: [critical, warning], reached: BOTH_UP });
+
+      await runAlertDeliveryScan();
+
+      expect(mocks.notify.mock.calls[0][0].riskClass).toBe("high-risk");
+      expect(mocks.notify.mock.calls[1][0].riskClass).toBe("bounded-write");
+    });
+
+    it("skips notification when no operator resolves, without failing delivery", async () => {
+      mocks.resolveRecipient.mockResolvedValue(null);
+      mocks.fetchAlertSources.mockResolvedValue({
+        alerts: [alert("PostgresDown", "prometheus", "firing")],
+        reached: BOTH_UP,
+      });
+
+      const res = await runAlertDeliveryScan();
+
+      expect(res.delivered).toBe(1); // delivery still succeeded
+      expect(res.notified).toBe(0);
+      expect(mocks.notify).not.toHaveBeenCalled();
+    });
+
+    it("does not notify when both sources are unreachable", async () => {
+      mocks.fetchAlertSources.mockResolvedValue({
+        alerts: [],
+        reached: { prometheus: false, "loki-ruler": false },
+      });
+
+      const res = await runAlertDeliveryScan();
+
+      expect(res.sourcesUnreachable).toBe(true);
+      expect(res.notified).toBe(0);
+      expect(mocks.notify).not.toHaveBeenCalled();
+    });
   });
 
   it("delivers one issue per FIRING alert and ignores pending ones", async () => {

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.ts
@@ -30,7 +30,12 @@ import {
   upsertHealthAlertIssue,
   resolveHealthAlertIssue,
 } from "@/lib/observability/health-alert-issue";
-import { notifyAttentionLive, resolveOperatorRecipient } from "@/lib/attention/notify-live";
+// NOT a static import. notify-live statically pulls in `prisma` and the agent
+// event bus, and this module deliberately keeps @dpf/db out of module scope
+// (see the dynamic `await import("@dpf/db")` in runAlertDeliveryScan). A static
+// import here instantiates Prisma for every importer of this module — including
+// lib/queue/functions/index.ts and anything that touches it — which killed the
+// vitest run outright. Loaded lazily inside the scan instead.
 
 // Defensive bound on issues touched per cycle. Real alert counts are tiny
 // (rules x services); this only matters under a pathological fan-out. No hard
@@ -134,6 +139,9 @@ export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
   // a human was missing. This is that last mile.
   let notified = 0;
   if (newlyOpened.length > 0) {
+    const { notifyAttentionLive, resolveOperatorRecipient } = await import(
+      "@/lib/attention/notify-live"
+    );
     const recipient = await resolveOperatorRecipient();
     // No resolvable owner → skip silently; notification is best-effort by
     // contract and must never fail the delivery path.

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.ts
@@ -30,6 +30,7 @@ import {
   upsertHealthAlertIssue,
   resolveHealthAlertIssue,
 } from "@/lib/observability/health-alert-issue";
+import { notifyAttentionLive, resolveOperatorRecipient } from "@/lib/attention/notify-live";
 
 // Defensive bound on issues touched per cycle. Real alert counts are tiny
 // (rules x services); this only matters under a pathological fan-out. No hard
@@ -44,6 +45,8 @@ export interface AlertDeliveryResult {
   sourcesReached: Record<AlertSourceSystem, boolean>;
   /** True iff BOTH sources were unreachable — nothing delivered or resolved. */
   sourcesUnreachable?: boolean;
+  /** Newly-opened alerts pushed to the operator's inbox bell this cycle. */
+  notified: number;
 }
 
 const ZERO = (reached: Record<AlertSourceSystem, boolean>): AlertDeliveryResult => ({
@@ -52,6 +55,7 @@ const ZERO = (reached: Record<AlertSourceSystem, boolean>): AlertDeliveryResult 
   resolved: 0,
   capped: false,
   sourcesReached: reached,
+  notified: 0,
 });
 
 /**
@@ -87,7 +91,24 @@ export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
   // we just saw firing so reconciliation can resolve the rest.
   // `prisma as never` at the db-handle boundary matches the established pattern
   // for passing the full client to a narrow injectable handle (discovery-runner.ts).
+  // Snapshot which health-alert issues are ALREADY open, BEFORE any upsert, so a
+  // genuinely new alert can be told apart from one merely re-confirmed this
+  // cycle. This transition gate is what keeps the push below from re-nagging:
+  // notifyAttention only suppresses duplicates while the notification is UNREAD,
+  // so without it, every 5-minute cycle would mint a fresh row the moment the
+  // operator reads one — the failure mode that left 5199 unread taskrun.stalled
+  // rows and trained the inbox to be ignored.
+  const previouslyOpen = new Set(
+    (
+      await prisma.portfolioQualityIssue.findMany({
+        where: { issueType: "health_alert", status: "open" },
+        select: { issueKey: true },
+      })
+    ).map((r) => r.issueKey),
+  );
+
   const firingKeys = new Set<string>();
+  const newlyOpened: { key: string; alert: (typeof firing)[number] }[] = [];
   let delivered = 0;
   for (const a of firing) {
     const key = await upsertHealthAlertIssue(prisma as never, {
@@ -98,6 +119,38 @@ export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
     });
     firingKeys.add(key);
     delivered++;
+    if (!previouslyOpen.has(key)) newlyOpened.push({ key, alert: a });
+  }
+
+  // Push NEW alerts to the operator's inbox bell.
+  //
+  // The read-only projection into the attention inbox
+  // (lib/attention/sources/platform-health.ts) already existed, but nothing ever
+  // pushed — the row only surfaced if a human happened to open that view. So
+  // WindowsHostDiskCritical ("disk G: above 90%") sat open and re-confirmed every
+  // 5 minutes for TWELVE DAYS, from 2026-07-19 until the disk hit 0 bytes free on
+  // 2026-07-31, took the VM's ext4 filesystem read-only, and killed Postgres with
+  // SIGBUS. Detection, delivery and persistence all worked; only the last mile to
+  // a human was missing. This is that last mile.
+  let notified = 0;
+  if (newlyOpened.length > 0) {
+    const recipient = await resolveOperatorRecipient();
+    // No resolvable owner → skip silently; notification is best-effort by
+    // contract and must never fail the delivery path.
+    if (recipient) {
+      for (const { key, alert } of newlyOpened) {
+        await notifyAttentionLive({
+          source: "platform-health",
+          itemKey: key,
+          userId: recipient,
+          title: alert.annotations?.summary ?? alert.labels.alertname ?? "Platform health alert",
+          body: alert.annotations?.description,
+          deepLink: "/ops/health",
+          riskClass: alert.labels.severity === "critical" ? "high-risk" : "bounded-write",
+        });
+        notified++;
+      }
+    }
   }
 
   // Reconcile-resolve. Only resolve open issues that (a) we OWN via a source we
@@ -121,7 +174,7 @@ export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
     resolved++;
   }
 
-  return { firing: firingAll.length, delivered, resolved, capped, sourcesReached: reached };
+  return { firing: firingAll.length, delivered, resolved, capped, sourcesReached: reached, notified };
 }
 
 // BI-915C40C6: every-minute crons multiply orphan accumulation (1440 runs/day).

--- a/scripts/lib/local-integration-image-retention.mjs
+++ b/scripts/lib/local-integration-image-retention.mjs
@@ -1,0 +1,82 @@
+// Retention for per-branch local-integration build images.
+//
+// scripts/local-ci-bounded-build.mjs tags one full portal image per candidate
+// branch (dockerBuildTag() in ./local-integration-ci.mjs). Nothing ever removed
+// them, so a slot accumulated one ~5GB image per branch it had ever verified.
+// On 2026-07-31 that reached 72 images / ~212GB of unique layers and helped fill
+// the Docker data disk to 0 bytes free, which took the ext4 filesystem
+// read-only and killed Postgres with SIGBUS.
+//
+// Retention rule: a slot needs exactly one image — the newest one that built
+// successfully. Once a working replacement exists, every older image for that
+// same slot is superseded and reapable.
+
+// Tag shape is `dpf-` + integrationBranchName().replace(/\//g, "-") + `-build`,
+// i.e. `dpf-local-integration-slot-0-<branch>-build` when a slot key is given
+// and `dpf-local-integration-<branch>-build` when it is not.
+const SLOT_SCOPED = /^dpf-local-integration-slot-\d+-/;
+
+export function slotImagePrefix(slotKey = "") {
+  return slotKey ? `dpf-local-integration-${slotKey}-` : "dpf-local-integration-";
+}
+
+/**
+ * Pure planner: which image tags for THIS slot are superseded by keepTag.
+ *
+ * Scoping matters. With no slotKey the prefix is the bare namespace, which
+ * would also match every slot-scoped tag and let an unslotted build reap the
+ * live images of concurrent slots. Unslotted builds therefore skip slot-scoped
+ * tags, so a slot only ever reaps within its own namespace.
+ */
+export function planSlotImageReaping({ images = [], slotKey = "", keepTag = "" } = {}) {
+  const prefix = slotImagePrefix(slotKey);
+  const slotScoped = Boolean(slotKey);
+  const seen = new Set();
+  return images.filter((tag) => {
+    if (typeof tag !== "string" || tag.length === 0) return false;
+    if (tag === keepTag) return false;
+    if (!tag.startsWith(prefix)) return false;
+    if (!slotScoped && SLOT_SCOPED.test(tag)) return false;
+    if (seen.has(tag)) return false;
+    seen.add(tag);
+    return true;
+  });
+}
+
+/**
+ * Reap superseded images for a slot. Injected listImages/removeImage keep this
+ * unit-testable and keep docker out of the test path.
+ *
+ * Never throws: retention is housekeeping that runs AFTER a green build, and a
+ * docker hiccup here must not turn a passing build red.
+ */
+export function reapSupersededSlotImages({
+  slotKey = "",
+  keepTag = "",
+  listImages,
+  removeImage,
+  log = () => {},
+} = {}) {
+  const result = { planned: [], removed: [], failed: [] };
+  if (!keepTag) return result;
+  let images = [];
+  try {
+    images = listImages() ?? [];
+  } catch (error) {
+    log(`image-listing failed, skipping retention: ${error instanceof Error ? error.message : String(error)}`);
+    return result;
+  }
+  result.planned = planSlotImageReaping({ images, slotKey, keepTag });
+  for (const tag of result.planned) {
+    try {
+      removeImage(tag);
+      result.removed.push(tag);
+    } catch (error) {
+      result.failed.push({ tag, reason: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  if (result.removed.length > 0) {
+    log(`reaped ${result.removed.length} superseded image(s) for ${slotKey || "unslotted"}, kept ${keepTag}`);
+  }
+  return result;
+}

--- a/scripts/lib/local-integration-image-retention.test.mjs
+++ b/scripts/lib/local-integration-image-retention.test.mjs
@@ -1,0 +1,148 @@
+// node --test — matches the bare-runner CI test job that gates scripts/.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  planSlotImageReaping,
+  reapSupersededSlotImages,
+  slotImagePrefix,
+} from "./local-integration-image-retention.mjs";
+
+describe("slotImagePrefix", () => {
+  it("scopes to the slot when a slot key is given", () => {
+    assert.equal(slotImagePrefix("slot-0"), "dpf-local-integration-slot-0-");
+  });
+
+  it("falls back to the bare namespace without a slot key", () => {
+    assert.equal(slotImagePrefix(""), "dpf-local-integration-");
+  });
+});
+
+describe("planSlotImageReaping", () => {
+  it("reaps older images for the slot and keeps the new one", () => {
+    const images = [
+      "dpf-local-integration-slot-0-feat-old-one-build",
+      "dpf-local-integration-slot-0-feat-old-two-build",
+      "dpf-local-integration-slot-0-feat-new-build",
+    ];
+    assert.deepEqual(
+      planSlotImageReaping({ images, slotKey: "slot-0", keepTag: "dpf-local-integration-slot-0-feat-new-build" }),
+      [
+        "dpf-local-integration-slot-0-feat-old-one-build",
+        "dpf-local-integration-slot-0-feat-old-two-build",
+      ],
+    );
+  });
+
+  it("never reaps another slot's images", () => {
+    const images = [
+      "dpf-local-integration-slot-0-feat-old-build",
+      "dpf-local-integration-slot-1-feat-live-build",
+    ];
+    assert.deepEqual(
+      planSlotImageReaping({ images, slotKey: "slot-0", keepTag: "dpf-local-integration-slot-0-feat-new-build" }),
+      ["dpf-local-integration-slot-0-feat-old-build"],
+    );
+  });
+
+  it("an unslotted build leaves slot-scoped images alone", () => {
+    // The bare prefix is a substring of every slot tag; without this guard an
+    // unslotted build would reap the live images of every concurrent slot.
+    const images = [
+      "dpf-local-integration-feat-old-build",
+      "dpf-local-integration-slot-0-feat-live-build",
+      "dpf-local-integration-slot-3-feat-live-build",
+    ];
+    assert.deepEqual(
+      planSlotImageReaping({ images, keepTag: "dpf-local-integration-feat-new-build" }),
+      ["dpf-local-integration-feat-old-build"],
+    );
+  });
+
+  it("ignores unrelated images", () => {
+    const images = ["dpf-portal", "dpf-sandbox", "postgres:16", "dpf-promoter"];
+    assert.deepEqual(
+      planSlotImageReaping({ images, slotKey: "slot-0", keepTag: "dpf-local-integration-slot-0-feat-new-build" }),
+      [],
+    );
+  });
+
+  it("returns nothing when the kept tag is the only image", () => {
+    assert.deepEqual(
+      planSlotImageReaping({
+        images: ["dpf-local-integration-slot-0-feat-new-build"],
+        slotKey: "slot-0",
+        keepTag: "dpf-local-integration-slot-0-feat-new-build",
+      }),
+      [],
+    );
+  });
+
+  it("tolerates empty and malformed entries", () => {
+    assert.deepEqual(
+      planSlotImageReaping({ images: ["", null, undefined, 42], slotKey: "slot-0", keepTag: "x" }),
+      [],
+    );
+  });
+});
+
+describe("reapSupersededSlotImages", () => {
+  const images = [
+    "dpf-local-integration-slot-0-feat-old-build",
+    "dpf-local-integration-slot-0-feat-new-build",
+  ];
+
+  it("removes superseded images and reports them", () => {
+    const removed = [];
+    const result = reapSupersededSlotImages({
+      slotKey: "slot-0",
+      keepTag: "dpf-local-integration-slot-0-feat-new-build",
+      listImages: () => images,
+      removeImage: (tag) => removed.push(tag),
+    });
+    assert.deepEqual(removed, ["dpf-local-integration-slot-0-feat-old-build"]);
+    assert.deepEqual(result.removed, ["dpf-local-integration-slot-0-feat-old-build"]);
+    assert.deepEqual(result.failed, []);
+  });
+
+  it("does nothing without a kept tag, so a failed build reaps nothing", () => {
+    // Retention must only run after a build that produced a working image.
+    // Reaping on failure would delete the last good image for the slot.
+    let called = false;
+    const result = reapSupersededSlotImages({
+      slotKey: "slot-0",
+      keepTag: "",
+      listImages: () => { called = true; return images; },
+      removeImage: () => assert.fail("must not remove anything"),
+    });
+    assert.equal(called, false);
+    assert.deepEqual(result.planned, []);
+  });
+
+  it("survives a docker listing failure without throwing", () => {
+    const result = reapSupersededSlotImages({
+      slotKey: "slot-0",
+      keepTag: "dpf-local-integration-slot-0-feat-new-build",
+      listImages: () => { throw new Error("docker daemon unreachable"); },
+      removeImage: () => assert.fail("must not remove anything"),
+    });
+    assert.deepEqual(result.planned, []);
+    assert.deepEqual(result.removed, []);
+  });
+
+  it("records a removal failure without aborting the rest", () => {
+    const result = reapSupersededSlotImages({
+      slotKey: "slot-0",
+      keepTag: "dpf-local-integration-slot-0-keep-build",
+      listImages: () => [
+        "dpf-local-integration-slot-0-a-build",
+        "dpf-local-integration-slot-0-b-build",
+      ],
+      removeImage: (tag) => {
+        if (tag.endsWith("-a-build")) throw new Error("image is in use");
+      },
+    });
+    assert.deepEqual(result.removed, ["dpf-local-integration-slot-0-b-build"]);
+    assert.equal(result.failed.length, 1);
+    assert.equal(result.failed[0].tag, "dpf-local-integration-slot-0-a-build");
+  });
+});

--- a/scripts/local-ci-bounded-build.mjs
+++ b/scripts/local-ci-bounded-build.mjs
@@ -18,6 +18,7 @@ import {
   monitorControlPlane,
   terminateProcessTreeCommand,
 } from "./lib/local-ci-control-plane-watchdog.mjs";
+import { reapSupersededSlotImages } from "./lib/local-integration-image-retention.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const BUILDKIT_CONFIG = join(SCRIPT_DIR, "config", "local-ci-buildkitd.toml");
@@ -61,6 +62,24 @@ function runDocker(args, timeout = 20_000) {
     windowsHide: true,
     timeout,
   });
+}
+
+// Repository-only listing: `docker images` prints one repository per line, and
+// these build tags carry the implicit `:latest`, so the repository name IS the
+// tag the build produced.
+function listLocalImageTags() {
+  const listed = runDocker(["images", "--format", "{{.Repository}}"], 30_000);
+  if (listed.status !== 0) {
+    throw new Error(listed.stderr?.trim() || "docker images failed");
+  }
+  return (listed.stdout || "").split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function removeLocalImage(tag) {
+  const removed = runDocker(["rmi", tag], 60_000);
+  if (removed.status !== 0) {
+    throw new Error(removed.stderr?.trim() || `docker rmi ${tag} failed`);
+  }
 }
 
 function inspectBuilder(builder) {
@@ -382,6 +401,20 @@ async function main() {
   if (finalStatus === "blocked_control_plane_starvation") {
     process.stderr.write(`[local-ci-bounded-build] ${finalStatus} ${failures.join(",")}\n`);
     return EXIT_CONTROL_PLANE_STARVATION;
+  }
+  // Retention runs ONLY on a green build, so the slot always keeps a working
+  // image: the one just produced supersedes the slot's older images. Gating on
+  // success is what makes this safe — reaping after a failure would delete the
+  // last image that actually worked. Best-effort by construction; it must never
+  // turn a passing build red.
+  if (finalStatus === "healthy") {
+    reapSupersededSlotImages({
+      slotKey,
+      keepTag: tag,
+      listImages: listLocalImageTags,
+      removeImage: removeLocalImage,
+      log: (message) => process.stdout.write(`[local-ci-bounded-build] retention: ${message}\n`),
+    });
   }
   return buildOutcome.exitCode;
 }


### PR DESCRIPTION
## Why

On 2026-07-31 the portal on `:3000` went down. Root cause was not application code: the Docker data disk (`docker_data.vhdx`, 904 GB on drive G:) filled its host volume to **0 bytes free**. The VM's ext4 filesystem went read-only, and **Postgres and Grafana were killed with SIGBUS**.

Two independent defects combined to produce that outage. This PR fixes both.

### 1. Per-branch CI images accumulated without bound

`scripts/local-ci-bounded-build.mjs` tags one full ~5 GB portal image per candidate branch and never removed any. A slot accumulated one image per branch it had ever verified: **72 images / ~212 GB of unique layers**, alongside 187.9 GB of build cache. Image churn was running 25–60 images/day with nothing reclaiming them.

Note: the catalog job named "Infrastructure prune" does **not** cover this — `lib/actions/infra-prune.ts` prunes stale `InfraCI` database records, not Docker disk. Nothing on the platform reclaims Docker disk today.

### 2. The disk alert fired correctly for twelve days and reached nobody

This is the more serious defect. Every layer worked:

- `windows_exporter` installed and scraping; Prometheus job `windows-host` UP
- `WindowsHostDiskCritical` rule correct and **firing**
- `alertDeliveryBridge` cron persisting it to `PortfolioQualityIssue`
- `lib/attention/sources/platform-health.ts` projecting it into the attention inbox

```
health-alert-WindowsHostDiskCritical:windows-host   error   OPEN
"Windows host disk G: above 90% -- immediate attention required"
firstDetectedAt: 2026-07-19 14:00:29   (12 days before the outage)
```

The projection was **read-only**. No producer called the notify spine, so there were **zero `Notification` rows** — no bell, no badge, no SSE event. The alert was visible only to someone who already thought to open that view.

## What changed

**`scripts/lib/local-integration-image-retention.mjs`** (new) — a slot keeps exactly one image: the newest that built successfully. Older images for that slot are superseded and reaped.

**`apps/web/lib/queue/functions/alert-delivery-bridge.ts`** — newly-opened health alerts are pushed to the operator via `notifyAttentionLive`, deep-linked to `/ops/health`.

## Design constraints, each pinned by a test

**Retention runs only on a green build.** Reaping after a failure would delete the last image that actually worked.

**Retention is scoped to one slot.** The unslotted prefix `dpf-local-integration-` is a substring of every slot-scoped tag, so an unslotted build explicitly skips slot-scoped tags rather than deleting concurrent slots' live images.

**Notification fires on TRANSITION, not per cycle.** `notifyAttention` dedupes only while a notification is UNREAD, so pushing every cycle would mint a fresh row the moment the operator reads one — a 5-minute cron that re-nags forever. That is how `taskrun.stalled` reached **5,199 unread rows** and trained the inbox to be ignored. An alerting fix that recreates that failure is not a fix. The bridge therefore snapshots which issues were already open *before* upserting and pushes only genuinely new ones.

**Both paths are best-effort.** A docker error, an unresolvable operator, or a notify failure is recorded and swallowed — housekeeping and notification can never turn a passing build red or fail alert delivery.

## Verification

- `node --test scripts/lib/local-integration-image-retention.test.ts` — 12 new tests, pass
- `vitest run lib/queue/functions/alert-delivery-bridge.test.ts` — 12 pass (7 pre-existing + 5 new)
- 42 tests green across the touched `scripts/lib` modules
- `tsc --noEmit` on `apps/web` — **0 errors**
- Live recovery confirmed: portal healthy on `:3000`, Postgres healthy, ext4 remounted `rw`, backup verified intact by SHA-256

## Not addressed here

Deliberately out of scope, recommended as follow-up work:

- **Notification fatigue** — 5,199 unread `taskrun.stalled` rows. Until that is addressed, any pushed alert lands in an inbox already trained to be ignored.
- **A free-space floor** — a preflight that refuses to start a build below a threshold. Alerts inform; only a gate prevents. This is the control that would actually have stopped this outage.
- **Host-resource ownership** — the active `AI Ops Engineer` coworker already holds `telemetry_read`, `tool_script_exec`, and `backlog_write`, but its charter covers the AI provider layer, not host disk/memory/container sprawl. Nobody owns host resource health.
- **Broader image retention** — 224 images / ~432 GB reclaimable remain in other families.
- **C: is at 89.6%** — `WindowsHostDiskPressure` is pending on the system drive, the same failure mode already queued up.


## Follow-up backlog items filed

- **BI-F3D191A2** — Enforce a host free-space floor before builds start (the only control that would have prevented this outage)
- **BI-2731E2BB** — Reclaim Docker disk: no job prunes images or build cache (incl. the misleadingly-named `infra-prune`)
- **BI-1C88254D** — No coworker owns host resource health
- **BI-15B42AFE** — Notification fatigue: 5199 unread `taskrun.stalled` rows

## Local-CI status

The local-CI gate could not pass on this host. `apps/web` vitest dies non-deterministically — exit `4294967295`, no test summary, no assertion failures, death point varying across runs (374 / 1384 / 3475 lines).

A control run at base `7f63285a08`, with **none** of these commits applied, fails identically. The branch is therefore exonerated; the gate is blocked by a pre-existing host condition affecting any change. Related existing item: **BI-D093CB64**.

Per-commit verification performed instead:
- `node --test scripts/lib/local-integration-image-retention.test.ts` — 12 pass
- `vitest run lib/queue/functions/alert-delivery-bridge.test.ts` — 12 pass
- `tsc --noEmit` on `apps/web` — 0 errors
- Live recovery confirmed on the running install

Worth noting the gate earned its keep before it broke: it caught a real defect in `4080c3c26a` (a static `notify-live` import instantiating Prisma for every importer of the queue registry), fixed in `d51a646158`.

Local-CI-Override: Host-level local-CI failure unrelated to this branch — apps/web vitest dies non-deterministically at the base commit too (control run at 7f63285a08 fails identically with none of these commits). Per-commit verification done: 24 tests green, tsc 0 errors. See BI-D093CB64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
