### PR TITLE
fix(graph-explorer): show the human type name in the focus chip, not the raw label (BI-AB7FE57B)

### DIFF
--- a/apps/web/components/inventory/RelationshipGraph.focus-label.test.tsx
+++ b/apps/web/components/inventory/RelationshipGraph.focus-label.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// BI-AB7FE57B — the focus chip must show the operator-facing type name, never the
+// raw `graph_node.labels` storage value.
+//
+// `node.label` is the legend KEY: the show/hide filters match on it, so for the
+// graph explorer it is deliberately the raw storage value ("PrismaModel",
+// "ArchiMate__DataObject"). It reached the operator as prose in the focus chip,
+// which the BI-89A149A9 ratified purpose contract forbids:
+//   "No raw storage label (for example ArchiMate__DataObject) is shown to the
+//    operator."
+// Found by driving the live install, not by a test — hence this one.
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { RelationshipGraph } from "./RelationshipGraph";
+import type { GraphData } from "@/lib/actions/graph";
+
+// The component drives a <canvas> force simulation; jsdom has no 2D context.
+// Stub just enough that render + click-to-focus work.
+// Reset per test: the budget is consumed by each render, and a later test that
+// starts at zero never lays out its nodes, so the click would silently miss.
+let framesLeft = 60;
+beforeEach(() => {
+  // Auto-cleanup is not configured for this file, so renders would otherwise
+  // accumulate and every query would match the previous test's DOM too.
+  cleanup();
+  framesLeft = 60;
+});
+
+beforeAll(() => {
+  const noop = () => {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLCanvasElement.prototype as any).getContext = () => ({
+    clearRect: noop, beginPath: noop, arc: noop, fill: noop, stroke: noop,
+    moveTo: noop, lineTo: noop, fillText: noop,
+    set fillStyle(_v: string) {}, set strokeStyle(_v: string) {},
+    set lineWidth(_v: number) {}, set globalAlpha(_v: number) {},
+    set font(_v: string) {}, set textAlign(_v: string) {},
+  });
+  // The component's tick() re-arms rAF, so a synchronous stub would recurse
+  // forever. Run a bounded number of frames — enough for the layout to assign
+  // coordinates, which click hit-testing needs — then stop.
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    if (framesLeft-- > 0) cb(0);
+    return 0;
+  }) as never;
+  globalThis.cancelAnimationFrame = noop as never;
+  globalThis.ResizeObserver = class {
+    observe() {} unobserve() {} disconnect() {}
+  } as never;
+
+  // Seed positions are `centre + (Math.random() - 0.5) * 300`. Pinning random to
+  // 0.5 puts the node exactly at the canvas centre, so the click below is a
+  // deterministic hit rather than a race with force-layout convergence.
+  Math.random = () => 0.5;
+});
+
+const DATA: GraphData = {
+  nodes: [
+    { id: "source-code:prisma-model:BacklogItem", name: "BacklogItem", label: "PrismaModel", color: "#fbbf24", size: 9 },
+  ],
+  links: [],
+};
+
+/** Click the canvas at the node's simulated position to focus it. */
+function focusTheNode(container: HTMLElement) {
+  const canvas = container.querySelector("canvas");
+  if (!canvas) throw new Error("canvas did not render");
+  canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 500 }) as DOMRect;
+  // The single node settles at the centre of the default 800x500 canvas.
+  fireEvent.click(canvas, { clientX: 400, clientY: 250 });
+}
+
+describe("focus chip type name (BI-AB7FE57B)", () => {
+  it("shows the legend's human name, not the raw storage label", () => {
+    const { container } = render(
+      <RelationshipGraph
+        data={DATA}
+        nodeLegend={[{ key: "PrismaModel", label: "Data model", color: "#fbbf24" }]}
+        linkLegend={[]}
+      />,
+    );
+
+    focusTheNode(container);
+
+    // Scope to the focus row: "Data model" also appears as a legend toggle, so a
+    // bare text query would match twice and prove nothing about the chip.
+    const focusRow = screen.getByText("Focus:").parentElement;
+    expect(focusRow?.textContent).toContain("Data model");
+    expect(focusRow?.textContent).not.toContain("PrismaModel");
+  });
+
+  it("falls back to the raw value when the type has no legend entry", () => {
+    // Degrade visibly rather than render an empty chip: an unmapped type should
+    // still tell the operator something.
+    const { container } = render(
+      <RelationshipGraph data={DATA} nodeLegend={[]} linkLegend={[]} />,
+    );
+
+    focusTheNode(container);
+
+    const focusRow = screen.getByText("Focus:").parentElement;
+    expect(focusRow?.textContent).toContain("PrismaModel");
+  });
+});

--- a/apps/web/components/inventory/RelationshipGraph.tsx
+++ b/apps/web/components/inventory/RelationshipGraph.tsx
@@ -323,6 +323,16 @@ export function RelationshipGraph({
 
   const focusNode = data.nodes.find((n) => n.id === focusNodeId);
 
+  // `node.label` is the legend KEY — it is what the show/hide filters match on,
+  // and for the graph explorer that key is the raw `graph_node.labels` value
+  // ("PrismaModel", "ArchiMate__DataObject"). It must never reach the operator as
+  // prose: the legend already carries the human name for exactly this key, so
+  // resolve through it and fall back to the raw value only for a node whose type
+  // has no legend entry (BI-AB7FE57B).
+  const focusTypeName = focusNode
+    ? (nodeLegend.find((entry) => entry.key === focusNode.label)?.label ?? focusNode.label)
+    : "";
+
   return (
     <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
       {/* Controls toolbar */}
@@ -338,7 +348,7 @@ export function RelationshipGraph({
               <span className="text-[10px] text-[var(--dpf-muted)]">Focus:</span>
               <span className="text-xs text-[var(--dpf-text)] font-medium">{focusNode.name}</span>
               <span className="text-[9px] px-1 rounded" style={{ background: `${focusNode.color}20`, color: focusNode.color }}>
-                {focusNode.label}
+                {focusTypeName}
               </span>
               <button
                 type="button"

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5513,7 +5513,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 75
+    "textMass": 79
   },
   "apps/web/components/inventory/SavedConnectionRow.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Found by driving the live install after self-upgrade — not by a test.

Clicking a node on `/admin/graph-explorer` rendered:

```
Focus: BacklogItem  [PrismaModel]  clear
```

`PrismaModel` is the raw `graph_node.labels` storage value. Search results, the legend, and the inspector all correctly showed **"Data model"** — only the focus chip leaked.

This is a violation of a contract this repo already ratified, not a preference. BI-89A149A9's page-purpose contract (`apps/web/lib/ux-budget/purpose-contracts/graph-explorer.ts`) states:

> No raw storage label (for example ArchiMate\_\_DataObject) is shown to the operator.

## Cause

The chip rendered `focusNode.label`. That field is the legend **key** — what the show/hide filters match on — and for the explorer the key is deliberately the raw storage value. It was never meant to be displayed.

## Fix

Resolve the display name through `nodeLegend`, which already carries the key → human-name mapping. Falls back to the raw value only when a node's type has no legend entry, so an unmapped type still says something rather than rendering an empty chip.

No new prop, no type change. It also improves the pre-existing `/inventory` surface, whose chip showed `DigitalProduct` rather than "Product".

## Regression test

Added, and **verified to fail against the unfixed component** — both cases go red when the fix is reverted.

No existing test caught this: both consumers are canvas surfaces, the chip is the only place the key reaches the DOM as prose, and the UX sweep measures word counts and reading grade rather than label provenance.

Three non-obvious mechanics are commented in the test because they cost time to work out:
- `requestAnimationFrame` is stubbed with a **per-test** frame budget — the component re-arms it, so a synchronous stub recurses forever, and a shared counter leaves later tests with no layout at all
- `Math.random` is pinned so the node lands at a deterministic canvas centre for the click hit-test
- `cleanup()` runs between tests because auto-cleanup is not configured for this file

## Verification

- `tsc --noEmit` — 0 errors
- vitest — 23 files / 212 tests pass across `components/inventory`, `lib/graph`, `lib/ux-budget`
- Style drift, token drift, module size, prose lint, UX-Fit gate — clean
- Prose baseline diff scoped to one line; four unrelated drift entries reverted

Local-CI-Override: the shared sandbox remains memory-starved on this host (available memory below the pool's own 8 GB floor, `hostSafeCapacity` rolled to 1). A separate thread owns that issue. All source-local gates are green above and CI is the enforcing backstop.

Closes BI-AB7FE57B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Design grounding

- **Existing specs/plans reviewed:** `docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md` — the design doc for this surface. Its display-vocabulary layer ("this module is the one place that turns storage labels into operator-facing names") is precisely the rule this fix restores. Also the ratified page-purpose contract `apps/web/lib/ux-budget/purpose-contracts/graph-explorer.ts`, whose acceptance threshold states no raw storage label may be shown to the operator.
- **Current code substrate reviewed:** `apps/web/components/inventory/RelationshipGraph.tsx` (the chip and the legend-filter contract that made `label` a key), `apps/web/components/admin/GraphExplorer.tsx` (which sets `label` to the descriptor key), `apps/web/lib/graph/explorer-vocabulary.ts` (where the key→name mapping already lives).
- **Source of truth:** the two artifacts above. No new artifact — they already specify the behaviour.
- **Decision:** no contract change. A defect fix restoring behaviour the existing spec and ratified contract already require, plus a regression test proven to fail without it.

