### PR TITLE
feat(finance): persist sent invoice documents and surface the lifecycle in the UI (BI-C86BD108, BI-F8A20878)

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/[id]/page.tsx
@@ -7,7 +7,17 @@ import { InvoiceSendButton } from "@/components/finance/InvoiceSendButton";
 import { InvoiceDownloadButton } from "@/components/finance/InvoiceDownloadButton";
 import { RecordInvoicePaymentButton } from "@/components/finance/RecordInvoicePaymentButton";
 import { InvoiceSignatureToggle } from "@/components/finance/InvoiceSignatureToggle";
+import { InvoiceLifecycleActions } from "@/components/finance/InvoiceLifecycleActions";
+import { InvoiceDocumentHistory } from "@/components/finance/InvoiceDocumentHistory";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { prisma } from "@dpf/db";
+import {
+  checkInvoiceDeletion,
+  checkInvoiceTransition,
+  describeInvoiceDeletionConsequences,
+  describeInvoiceVoidConsequences,
+  type InvoiceStatus,
+} from "@/lib/finance/invoice-lifecycle";
 
 const STATUS_COLOURS: Record<string, string> = {
   draft: "#8888a0",
@@ -35,6 +45,29 @@ export default async function InvoiceDetailPage({ params }: Props) {
   if (!invoice) {
     notFound();
   }
+
+  // Gates are evaluated here so the controls can explain THEMSELVES rather than
+  // only failing on click. The actions re-check server-side regardless.
+  const [allocationCount, dunningCount, journalEntryCount, timesheetEntryCount] = await Promise.all([
+    prisma.paymentAllocation.count({ where: { invoiceId: invoice.id } }),
+    prisma.dunningLog.count({ where: { invoiceId: invoice.id } }),
+    prisma.journalEntry.count({ where: { sourceType: "Invoice", sourceId: invoice.id } }),
+    prisma.timesheetEntry.count({ where: { invoiceId: invoice.id } }),
+  ]);
+
+  const deletion = checkInvoiceDeletion({
+    status: invoice.status as InvoiceStatus,
+    allocationCount,
+    dunningCount,
+    journalEntryCount,
+  });
+  const voiding = checkInvoiceTransition(invoice.status as InvoiceStatus, "void");
+  const consequenceFacts = {
+    lineItemCount: invoice.lineItems.length,
+    timesheetEntryCount,
+    journalEntryCount,
+    allocationCount,
+  };
 
   const sym = getCurrencySymbol(invoice.currency);
 
@@ -97,6 +130,18 @@ export default async function InvoiceDetailPage({ params }: Props) {
               outstanding={amountDue}
               currency={invoice.currency}
               status={invoice.status}
+            />
+            {/* Destructive actions sit after a divider so they are not adjacent to Send. */}
+            <span aria-hidden="true" className="w-px self-stretch bg-[var(--dpf-border)] mx-1" />
+            <InvoiceLifecycleActions
+              invoiceId={invoice.id}
+              status={invoice.status}
+              canDelete={deletion.allowed}
+              deleteBlockedReason={deletion.allowed ? null : deletion.reason}
+              canVoid={voiding.allowed}
+              voidBlockedReason={voiding.allowed ? null : voiding.reason}
+              deleteConsequences={describeInvoiceDeletionConsequences(consequenceFacts)}
+              voidConsequences={describeInvoiceVoidConsequences(consequenceFacts)}
             />
           </div>
         </div>
@@ -187,6 +232,9 @@ export default async function InvoiceDetailPage({ params }: Props) {
           )}
         </div>
       </section>
+
+      {/* Persisted documents — what the customer actually received */}
+      <InvoiceDocumentHistory invoiceId={invoice.id} />
 
       {/* Line items table */}
       <section className="mb-6">

--- a/apps/web/app/api/v1/finance/invoices/[id]/documents/[documentId]/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/documents/[documentId]/route.ts
@@ -1,0 +1,67 @@
+// GET /api/v1/finance/invoices/:id/documents/:documentId — download ONE stored
+// revision, byte-for-byte as it was sent. Distinct from .../pdf, which re-renders
+// from current invoice data and will differ from this after any edit.
+
+import { NextResponse } from "next/server";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { getInvoiceDocumentBlobRef } from "@/lib/finance/invoice-document-store";
+import { getDocumentBlobStorageRoot } from "@/lib/documents/blob-storage";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; documentId: string }> },
+) {
+  try {
+    await authenticateRequest(request);
+
+    const { id, documentId } = await params;
+
+    const ref = await getInvoiceDocumentBlobRef(documentId);
+    if (!ref) throw apiError("NOT_FOUND", "Invoice document not found", 404);
+
+    // The snapshot must belong to the invoice in the path: without this, a caller
+    // could read any snapshot by guessing an id under an invoice they can see.
+    const { prisma } = await import("@dpf/db");
+    const owner = await prisma.invoiceDocument.findUnique({
+      where: { id: documentId },
+      select: { invoiceId: true },
+    });
+    if (!owner || owner.invoiceId !== id) {
+      throw apiError("NOT_FOUND", "Invoice document not found", 404);
+    }
+
+    const { join } = await import("node:path");
+    const { readFile } = await import("node:fs/promises");
+    const root = await getDocumentBlobStorageRoot();
+
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(join(root, ref.storageKey));
+    } catch {
+      // The row exists but the blob is gone — say so plainly rather than 500ing,
+      // because it means the retention story has failed and that is worth naming.
+      throw apiError(
+        "BLOB_MISSING",
+        `The stored copy of ${ref.invoiceRef} is recorded but its content is missing from document storage.`,
+        410,
+      );
+    }
+
+    return new NextResponse(new Uint8Array(bytes), {
+      headers: {
+        "Content-Type": ref.mimeType,
+        "Content-Disposition": `attachment; filename="${ref.filename}"`,
+        "Content-Length": String(bytes.byteLength),
+        // Immutable by construction: this revision's bytes never change.
+        "Cache-Control": "private, max-age=31536000, immutable",
+      },
+    });
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/v1/finance/invoices/[id]/documents/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/documents/route.ts
@@ -1,0 +1,34 @@
+// GET /api/v1/finance/invoices/:id/documents — the persisted document revisions
+// for an invoice. These are immutable snapshots of what was actually sent, which
+// is NOT the same thing as re-rendering the invoice from current data.
+
+import { NextResponse } from "next/server";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { getInvoice } from "@/lib/actions/finance";
+import { listInvoiceDocuments } from "@/lib/finance/invoice-document-store";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    await authenticateRequest(request);
+
+    const { id } = await params;
+
+    const invoice = await getInvoice(id);
+    if (!invoice) throw apiError("NOT_FOUND", "Invoice not found", 404);
+
+    const documents = await listInvoiceDocuments(id);
+
+    return apiSuccess({ invoiceRef: invoice.invoiceRef, documents });
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/v1/finance/invoices/[id]/send/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/send/route.ts
@@ -9,6 +9,7 @@ import { getOrgIdentity } from "@/lib/org-identity";
 import { generateInvoicePdf, getInvoicePdfFilename } from "@/lib/invoice-pdf";
 import { sendEmail, composeInvoiceEmail, isEmailConfigured } from "@/lib/email";
 import { checkInvoiceTransition, type InvoiceStatus } from "@/lib/finance/invoice-lifecycle";
+import { snapshotInvoiceDocument } from "@/lib/finance/invoice-document-store";
 
 export async function POST(
   request: Request,
@@ -77,7 +78,35 @@ export async function POST(
       attachments: [{ filename, content: pdf, contentType: "application/pdf" }],
     });
 
-    return apiSuccess({ sent: true, payToken, payUrl });
+    // Snapshot AFTER the send succeeds: these exact bytes are now the document the
+    // customer holds, so this is the moment it becomes worth preserving. Recording
+    // it before a failed send would claim a delivery that never happened.
+    //
+    // Best-effort, deliberately: a storage hiccup must not turn a delivered invoice
+    // into a 500 the operator will retry, re-sending the customer a second copy.
+    // The failure is loud in the logs and the missing revision is visible on the
+    // invoice, which is the right place to notice it.
+    let revision: number | null = null;
+    try {
+      const snapshot = await snapshotInvoiceDocument({
+        invoiceId: invoice.id,
+        invoiceRef: invoice.invoiceRef,
+        accountName: invoice.account.name,
+        pdf,
+        role: "sent-copy",
+        sentToEmail: invoice.contact.email,
+      });
+      revision = snapshot.revision;
+    } catch (err) {
+      // The invoice id is a route parameter (tainted) and is intentionally not
+      // logged; invoiceRef carries the debugging signal instead.
+      console.error(
+        `[invoice-document] failed to persist the sent copy of ${invoice.invoiceRef}:`,
+        err,
+      );
+    }
+
+    return apiSuccess({ sent: true, payToken, payUrl, revision });
   } catch (e) {
     if (e instanceof ApiError) return e.toResponse();
     return NextResponse.json(

--- a/apps/web/app/api/v1/finance/invoices/[id]/void/route.ts
+++ b/apps/web/app/api/v1/finance/invoices/[id]/void/route.ts
@@ -1,0 +1,52 @@
+// POST /api/v1/finance/invoices/:id/void — neutralise an invoice's economics
+// while keeping it on record. Unwinds payment allocations (keeping the Payment),
+// reverses ledger postings via storno, and re-bills any linked time.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { voidInvoice } from "@/lib/actions/finance";
+
+const voidInvoiceSchema = z.object({
+  // Required: a void without a stated reason is an unexplained hole in the ledger.
+  reason: z.string().trim().min(3, "Give a reason so the void is explainable later.").max(500),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    await authenticateRequest(request);
+
+    const { id } = await params;
+
+    const body = await request.json().catch(() => ({}));
+    const parsed = voidInvoiceSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { code: "VALIDATION_ERROR", message: "Invalid input", details: parsed.error.flatten() },
+        { status: 422 },
+      );
+    }
+
+    const result = await voidInvoice(id, parsed.data.reason);
+    if (!result.ok) {
+      throw apiError(
+        result.error === "not_found" ? "NOT_FOUND" : "ILLEGAL_TRANSITION",
+        result.message,
+        result.error === "not_found" ? 404 : 422,
+      );
+    }
+
+    return apiSuccess({ id, voided: true, reversedJournalEntries: result.reversedJournalEntries });
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/components/finance/InvoiceDocumentHistory.tsx
+++ b/apps/web/components/finance/InvoiceDocumentHistory.tsx
@@ -1,0 +1,52 @@
+import { listInvoiceDocuments } from "@/lib/finance/invoice-document-store";
+import { InvoiceDocumentTable } from "@/components/finance/InvoiceDocumentTable";
+
+type Props = { invoiceId: string };
+
+/**
+ * The documents the customer actually received.
+ *
+ * Deliberately separated from the Download button in the action row: that button
+ * RE-RENDERS the invoice from current data, so after an edit it will not match
+ * what was sent. Conflating the two is the audit trap this section exists to
+ * close, which is why the distinction is stated in the UI and not just in a doc.
+ */
+export async function InvoiceDocumentHistory({ invoiceId }: Props) {
+  const documents = await listInvoiceDocuments(invoiceId);
+
+  return (
+    <section className="mb-dpf-lg">
+      <h2 className="text-dpf-caption uppercase tracking-widest text-[var(--dpf-muted)] mb-dpf-sm">
+        Sent Documents
+      </h2>
+
+      {documents.length === 0 ? (
+        <div className="rounded-dpf-lg border border-[var(--dpf-border)] p-dpf-md">
+          <p className="text-dpf-body text-[var(--dpf-muted)]">
+            No document has been sent yet. Sending this invoice stores a permanent copy
+            here, exactly as the customer receives it.
+          </p>
+        </div>
+      ) : (
+        <>
+          <InvoiceDocumentTable
+            invoiceId={invoiceId}
+            rows={documents.map((d) => ({
+              id: d.id,
+              revision: d.revision,
+              role: d.role,
+              sentToEmail: d.sentToEmail,
+              createdAt: d.createdAt,
+              sizeBytes: d.sizeBytes,
+            }))}
+          />
+          <p className="mt-dpf-xs text-dpf-caption text-[var(--dpf-muted)]">
+            These are stored copies, unchanged since they were sent. The Download button
+            above re-creates the invoice from its current details, so the two can differ
+            after an edit.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/finance/InvoiceDocumentTable.tsx
+++ b/apps/web/components/finance/InvoiceDocumentTable.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { DataTable, type Column } from "@/components/ui/report-kit/DataTable";
+import { LocalTime } from "@/components/ui/LocalTime";
+
+export type InvoiceDocumentRow = {
+  id: string;
+  revision: number;
+  role: string;
+  sentToEmail: string | null;
+  createdAt: string | Date;
+  sizeBytes: number | null;
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  "sent-copy": "Sent copy",
+  "signed-copy": "Signed copy",
+  "credit-note": "Credit note",
+};
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Thin client child so the server component can still use report-kit's DataTable,
+ * which is interactive and therefore client-only.
+ */
+export function InvoiceDocumentTable({
+  invoiceId,
+  rows,
+}: {
+  invoiceId: string;
+  rows: InvoiceDocumentRow[];
+}) {
+  const columns: Column<InvoiceDocumentRow>[] = [
+    {
+      key: "revision",
+      header: "Revision",
+      cell: (r) => `${ROLE_LABELS[r.role] ?? r.role} · r${r.revision}`,
+      sortAccessor: (r) => r.revision,
+    },
+    {
+      key: "sent",
+      header: "Sent",
+      cell: (r) => <LocalTime value={r.createdAt} utc />,
+      sortAccessor: (r) => new Date(r.createdAt).getTime(),
+    },
+    {
+      key: "recipient",
+      header: "Recipient",
+      cell: (r) => r.sentToEmail ?? "—",
+    },
+    {
+      key: "size",
+      header: "Size",
+      align: "right",
+      cell: (r) => formatBytes(r.sizeBytes),
+      sortAccessor: (r) => r.sizeBytes ?? 0,
+    },
+    {
+      key: "download",
+      header: "",
+      align: "right",
+      cell: (r) => (
+        <a
+          href={`/api/v1/finance/invoices/${invoiceId}/documents/${r.id}`}
+          className="text-dpf-caption text-[var(--dpf-accent)] hover:underline"
+        >
+          Download
+        </a>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      getRowKey={(r) => r.id}
+      initialSort={{ key: "revision", dir: "desc" }}
+      dense
+    />
+  );
+}

--- a/apps/web/components/finance/InvoiceLifecycleActions.tsx
+++ b/apps/web/components/finance/InvoiceLifecycleActions.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  invoiceId: string;
+  status: string;
+  /** Gate results computed on the server; the actions re-check server-side regardless. */
+  canDelete: boolean;
+  deleteBlockedReason: string | null;
+  canVoid: boolean;
+  voidBlockedReason: string | null;
+  /** Plain-language consequences, so the confirm names what will happen. */
+  deleteConsequences: string[];
+  voidConsequences: string[];
+};
+
+type Mode = "void" | "delete";
+
+export function InvoiceLifecycleActions({
+  invoiceId,
+  status,
+  canDelete,
+  deleteBlockedReason,
+  canVoid,
+  voidBlockedReason,
+  deleteConsequences,
+  voidConsequences,
+}: Props) {
+  const router = useRouter();
+  const [mode, setMode] = useState<Mode | null>(null);
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Nothing to offer at all — say nothing rather than showing two dead buttons.
+  if (!canVoid && !canDelete) return null;
+
+  const consequences = mode === "delete" ? deleteConsequences : voidConsequences;
+
+  const run = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res =
+        mode === "delete"
+          ? await fetch(`/api/v1/finance/invoices/${invoiceId}`, { method: "DELETE" })
+          : await fetch(`/api/v1/finance/invoices/${invoiceId}/void`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ reason: reason.trim() }),
+            });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || `Failed to ${mode} this invoice`);
+      }
+
+      if (mode === "delete") {
+        router.push("/finance/invoices");
+      } else {
+        setMode(null);
+        router.refresh();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to ${mode}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      {canVoid ? (
+        <button
+          onClick={() => { setMode("void"); setReason(""); setError(null); }}
+          className="px-3 py-1.5 text-dpf-caption font-medium rounded-dpf-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:border-[var(--dpf-warning)] hover:text-[var(--dpf-warning)] transition-colors"
+        >
+          Void
+        </button>
+      ) : voidBlockedReason ? (
+        <button
+          type="button"
+          disabled
+          title={voidBlockedReason}
+          className="px-3 py-1.5 text-dpf-caption font-medium rounded-dpf-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] opacity-40 cursor-not-allowed"
+        >
+          Void
+        </button>
+      ) : null}
+
+      {canDelete ? (
+        <button
+          onClick={() => { setMode("delete"); setError(null); }}
+          className="px-3 py-1.5 text-dpf-caption font-medium rounded-dpf-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:border-[var(--dpf-error)] hover:text-[var(--dpf-error)] transition-colors"
+        >
+          Delete
+        </button>
+      ) : deleteBlockedReason ? (
+        <button
+          type="button"
+          disabled
+          title={deleteBlockedReason}
+          className="px-3 py-1.5 text-dpf-caption font-medium rounded-dpf-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] opacity-40 cursor-not-allowed"
+        >
+          Delete
+        </button>
+      ) : null}
+
+      {mode ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="invoice-lifecycle-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        >
+          <div className="w-full max-w-md rounded-dpf-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-5">
+            <h2
+              id="invoice-lifecycle-title"
+              className="text-dpf-body font-semibold text-[var(--dpf-text)]"
+            >
+              {mode === "delete" ? "Delete this invoice?" : "Void this invoice?"}
+            </h2>
+
+            <ul className="mt-3 space-y-1.5">
+              {consequences.map((line) => (
+                <li key={line} className="text-dpf-caption text-[var(--dpf-muted)] flex gap-2">
+                  <span aria-hidden="true">•</span>
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+
+            {mode === "void" ? (
+              <label className="block mt-4">
+                <span className="text-dpf-caption text-[var(--dpf-muted)]">
+                  Reason (kept with the invoice)
+                </span>
+                <input
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="e.g. duplicate of INV-2026-0009"
+                  className="mt-1 w-full rounded-dpf-md border border-[var(--dpf-border)] bg-transparent px-2 py-1.5 text-dpf-body text-[var(--dpf-text)]"
+                />
+              </label>
+            ) : null}
+
+            {error ? (
+              <p className="mt-3 text-dpf-caption text-[var(--dpf-error)]">{error}</p>
+            ) : null}
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setMode(null)}
+                disabled={busy}
+                className="px-3 py-1.5 text-dpf-caption rounded-dpf-md border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={run}
+                disabled={busy || (mode === "void" && reason.trim().length < 3)}
+                className={
+                  mode === "delete"
+                    ? "px-3 py-1.5 text-dpf-caption font-medium rounded-dpf-md bg-[var(--dpf-error)] text-black hover:opacity-90 disabled:opacity-40"
+                    : "px-3 py-1.5 text-dpf-caption font-medium rounded-dpf-md bg-[var(--dpf-warning)] text-black hover:opacity-90 disabled:opacity-40"
+                }
+              >
+                {busy
+                  ? mode === "delete" ? "Deleting…" : "Voiding…"
+                  : mode === "delete" ? "Delete permanently" : "Void invoice"}
+              </button>
+            </div>
+
+            {mode === "void" && reason.trim().length < 3 ? (
+              <p className="mt-2 text-right text-dpf-caption text-[var(--dpf-muted)]">
+                A reason is required.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <span className="sr-only">Current status: {status}</span>
+    </>
+  );
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9888,6 +9888,7 @@
         "invoice-and-collection-workflow",
         "starting-an-invoice-from-context",
         "decisions-recovery-and-evidence",
+        "sent-documents-are-kept",
         "what-you-can-edit-and-when",
         "status-movement-is-governed",
         "void-versus-delete",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 600,
+  "routeCount": 603,
   "routes": [
     {
       "routePath": "/",
@@ -2681,6 +2681,40 @@
       "file": "apps/web/app/api/v1/finance/invoices/[id]/route.ts"
     },
     {
+      "routePath": "/api/v1/finance/invoices/[id]/documents",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "finance",
+        "invoices",
+        "[id]",
+        "documents"
+      ],
+      "dynamicParams": [
+        "id"
+      ],
+      "file": "apps/web/app/api/v1/finance/invoices/[id]/documents/route.ts"
+    },
+    {
+      "routePath": "/api/v1/finance/invoices/[id]/documents/[documentId]",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "finance",
+        "invoices",
+        "[id]",
+        "documents",
+        "[documentId]"
+      ],
+      "dynamicParams": [
+        "id",
+        "documentId"
+      ],
+      "file": "apps/web/app/api/v1/finance/invoices/[id]/documents/[documentId]/route.ts"
+    },
+    {
       "routePath": "/api/v1/finance/invoices/[id]/pdf",
       "kind": "route",
       "segments": [
@@ -2711,6 +2745,22 @@
         "id"
       ],
       "file": "apps/web/app/api/v1/finance/invoices/[id]/send/route.ts"
+    },
+    {
+      "routePath": "/api/v1/finance/invoices/[id]/void",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "finance",
+        "invoices",
+        "[id]",
+        "void"
+      ],
+      "dynamicParams": [
+        "id"
+      ],
+      "file": "apps/web/app/api/v1/finance/invoices/[id]/void/route.ts"
     },
     {
       "routePath": "/api/v1/finance/payment-runs",

--- a/apps/web/lib/finance/invoice-document-store.test.ts
+++ b/apps/web/lib/finance/invoice-document-store.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    invoiceDocument: { findFirst: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn() },
+    documentBlob: { upsert: vi.fn() },
+  },
+}));
+vi.mock("@/lib/documents/document-store", () => ({ saveManagedDocument: vi.fn() }));
+vi.mock("@/lib/documents/blob-storage", () => ({
+  writeDocumentBlob: vi.fn(),
+  getDocumentBlobStorageRoot: vi.fn(),
+}));
+
+import { prisma } from "@dpf/db";
+import { saveManagedDocument } from "@/lib/documents/document-store";
+import { writeDocumentBlob } from "@/lib/documents/blob-storage";
+import {
+  snapshotInvoiceDocument,
+  listInvoiceDocuments,
+  getInvoiceDocumentBlobRef,
+} from "@/lib/finance/invoice-document-store";
+
+const db = prisma as any;
+const mockSave = vi.mocked(saveManagedDocument);
+const mockWrite = vi.mocked(writeDocumentBlob);
+
+const pdf = Buffer.from("%PDF-1.7 fake");
+
+const baseInput = {
+  invoiceId: "inv-1",
+  invoiceRef: "INV-2026-0001",
+  accountName: "Northwind",
+  pdf,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWrite.mockResolvedValue({ sha256: "abc123", storageKey: "documents/sha256/ab/c1/abc123", sizeBytes: pdf.byteLength } as never);
+  db.documentBlob.upsert.mockResolvedValue({ id: "blob-1" });
+  mockSave.mockResolvedValue({ currentVersionId: "dv-1" } as never);
+  db.invoiceDocument.findFirst.mockResolvedValue(null);
+  db.invoiceDocument.create.mockImplementation(async ({ data }: any) => ({
+    id: "idoc-1",
+    revision: data.revision,
+    role: data.role,
+    documentVersionId: data.documentVersionId,
+    sentToEmail: data.sentToEmail,
+    createdAt: new Date("2026-08-01T00:00:00Z"),
+  }));
+});
+
+describe("snapshotInvoiceDocument", () => {
+  it("persists the bytes, binds a document version, and starts at revision 1", async () => {
+    const result = await snapshotInvoiceDocument({ ...baseInput, sentToEmail: "ap@northwind.test" });
+
+    expect(mockWrite).toHaveBeenCalledWith({ content: pdf });
+    expect(result.revision).toBe(1);
+    expect(result.role).toBe("sent-copy");
+    expect(result.sha256).toBe("abc123");
+    expect(result.documentVersionId).toBe("dv-1");
+
+    const created = db.invoiceDocument.create.mock.calls[0][0].data;
+    expect(created.invoiceId).toBe("inv-1");
+    expect(created.sentToEmail).toBe("ap@northwind.test");
+  });
+
+  it("appends revision N+1 rather than mutating the previous snapshot", async () => {
+    db.invoiceDocument.findFirst.mockResolvedValue({ revision: 3 });
+
+    const result = await snapshotInvoiceDocument(baseInput);
+
+    expect(result.revision).toBe(4);
+    // Nothing on the store may update an existing snapshot row.
+    expect(db.invoiceDocument.create).toHaveBeenCalledOnce();
+    expect((db.invoiceDocument as any).update).toBeUndefined();
+  });
+
+  it("reuses the blob when identical bytes are re-sent", async () => {
+    await snapshotInvoiceDocument(baseInput);
+
+    const upsert = db.documentBlob.upsert.mock.calls[0][0];
+    expect(upsert.where).toEqual({ sha256: "abc123" });
+    // update:{} — an existing blob is left exactly as it is.
+    expect(upsert.update).toEqual({});
+  });
+
+  it("keeps one document per invoice+role so versions line up with revisions", async () => {
+    await snapshotInvoiceDocument(baseInput);
+    const saved = mockSave.mock.calls[0][0];
+    expect(saved.documentId).toBe("INVDOC-inv-1-sent-copy");
+    expect(saved.contentFormat).toBe("application/pdf");
+    expect(saved.contentBlobId).toBe("blob-1");
+    expect(saved.contentSha256).toBe("abc123");
+  });
+
+  it("separates roles into their own revision series", async () => {
+    await snapshotInvoiceDocument({ ...baseInput, role: "credit-note" });
+    expect(db.invoiceDocument.findFirst.mock.calls[0][0].where).toEqual({
+      invoiceId: "inv-1",
+      role: "credit-note",
+    });
+    expect(mockSave.mock.calls[0][0].documentId).toBe("INVDOC-inv-1-credit-note");
+  });
+
+  it("refuses to bind a snapshot when the document store returns no version", async () => {
+    mockSave.mockResolvedValue({ currentVersionId: null } as never);
+
+    await expect(snapshotInvoiceDocument(baseInput)).rejects.toThrow(/cannot bind/i);
+    expect(db.invoiceDocument.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("listInvoiceDocuments", () => {
+  it("returns newest revision first with size, hash, and recipient", async () => {
+    db.invoiceDocument.findMany.mockResolvedValue([
+      {
+        id: "idoc-2",
+        revision: 2,
+        role: "sent-copy",
+        sentToEmail: "ap@northwind.test",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        documentVersion: { sizeBytes: 2048, contentSha256: "def456" },
+        createdBy: { email: "mark@example.test" },
+      },
+    ]);
+
+    const [entry] = await listInvoiceDocuments("inv-1");
+
+    expect(db.invoiceDocument.findMany.mock.calls[0][0].orderBy).toEqual([
+      { role: "asc" },
+      { revision: "desc" },
+    ]);
+    expect(entry).toMatchObject({
+      revision: 2,
+      sizeBytes: 2048,
+      sha256: "def456",
+      createdByEmail: "mark@example.test",
+    });
+  });
+
+  it("tolerates a snapshot whose version metadata is absent", async () => {
+    db.invoiceDocument.findMany.mockResolvedValue([
+      {
+        id: "idoc-1", revision: 1, role: "sent-copy", sentToEmail: null,
+        createdAt: new Date(), documentVersion: null, createdBy: null,
+      },
+    ]);
+
+    const [entry] = await listInvoiceDocuments("inv-1");
+    expect(entry.sizeBytes).toBeNull();
+    expect(entry.createdByEmail).toBeNull();
+  });
+});
+
+describe("getInvoiceDocumentBlobRef", () => {
+  it("names the file by invoice ref, role, and revision", async () => {
+    db.invoiceDocument.findUnique.mockResolvedValue({
+      revision: 2,
+      role: "sent-copy",
+      invoice: { invoiceRef: "INV-2026-0007" },
+      documentVersion: {
+        contentSha256: "abc123",
+        contentBlob: { storageKey: "documents/sha256/ab/c1/abc123", mimeType: "application/pdf" },
+      },
+    });
+
+    const ref = await getInvoiceDocumentBlobRef("idoc-1");
+
+    expect(ref?.filename).toBe("INV-2026-0007-sent-copy-r2.pdf");
+    expect(ref?.storageKey).toBe("documents/sha256/ab/c1/abc123");
+  });
+
+  it("returns null when the version has no blob behind it", async () => {
+    db.invoiceDocument.findUnique.mockResolvedValue({
+      revision: 1, role: "sent-copy",
+      invoice: { invoiceRef: "INV-1" },
+      documentVersion: { contentSha256: null, contentBlob: null },
+    });
+
+    expect(await getInvoiceDocumentBlobRef("idoc-1")).toBeNull();
+  });
+
+  it("returns null for an unknown snapshot", async () => {
+    db.invoiceDocument.findUnique.mockResolvedValue(null);
+    expect(await getInvoiceDocumentBlobRef("nope")).toBeNull();
+  });
+});

--- a/apps/web/lib/finance/invoice-document-store.ts
+++ b/apps/web/lib/finance/invoice-document-store.ts
@@ -1,0 +1,205 @@
+import { prisma } from "@dpf/db";
+import { saveManagedDocument } from "@/lib/documents/document-store";
+import { writeDocumentBlob } from "@/lib/documents/blob-storage";
+
+/**
+ * Persisting the invoice document a customer actually received.
+ *
+ * Before this existed, generateInvoicePdf() rendered on demand and the bytes were
+ * streamed to the download route or attached to an email and then discarded. So
+ * re-downloading an invoice later re-rendered from CURRENT data: after any edit,
+ * the operator and the customer were looking at different documents under the
+ * same invoice ref, with nothing to tell them apart. That is an audit failure,
+ * and it is why revisions could not be tracked at all.
+ *
+ * A snapshot is WRITE-ONCE. Reissuing appends revision N+1; nothing ever mutates
+ * revision N, because the whole point is that what was sent stays recoverable
+ * exactly as it was sent.
+ */
+
+export const INVOICE_DOCUMENT_ROLES = ["sent-copy", "signed-copy", "credit-note"] as const;
+export type InvoiceDocumentRole = (typeof INVOICE_DOCUMENT_ROLES)[number];
+
+export type SnapshotInvoiceDocumentInput = {
+  invoiceId: string;
+  invoiceRef: string;
+  accountName: string;
+  pdf: Buffer;
+  role?: InvoiceDocumentRole;
+  sentToEmail?: string | null;
+  createdById?: string | null;
+};
+
+export type InvoiceDocumentSnapshot = {
+  id: string;
+  revision: number;
+  role: string;
+  documentVersionId: string;
+  sha256: string;
+  sizeBytes: number;
+  sentToEmail: string | null;
+  createdAt: Date;
+};
+
+/**
+ * Next revision for this (invoice, role). Read inside the caller's flow rather
+ * than derived from a count, so a deleted row could never cause a revision to be
+ * reused — the unique constraint is the real guard either way.
+ */
+async function nextRevision(invoiceId: string, role: string): Promise<number> {
+  const latest = await prisma.invoiceDocument.findFirst({
+    where: { invoiceId, role },
+    orderBy: { revision: "desc" },
+    select: { revision: true },
+  });
+  return (latest?.revision ?? 0) + 1;
+}
+
+export async function snapshotInvoiceDocument(
+  input: SnapshotInvoiceDocumentInput,
+): Promise<InvoiceDocumentSnapshot> {
+  const role = input.role ?? "sent-copy";
+
+  // Content-addressed: an unchanged reissue writes no new bytes, it just points a
+  // new version at the same blob.
+  const written = await writeDocumentBlob({ content: input.pdf });
+  const blob = await prisma.documentBlob.upsert({
+    where: { sha256: written.sha256 },
+    update: {},
+    create: {
+      sha256: written.sha256,
+      storageKey: written.storageKey,
+      mimeType: "application/pdf",
+      sizeBytes: written.sizeBytes,
+    },
+    select: { id: true },
+  });
+
+  const revision = await nextRevision(input.invoiceId, role);
+
+  // One Document per (invoice, role), gaining a new DocumentVersion per revision —
+  // so the document store's own version history lines up with the revision number.
+  const documentId = `INVDOC-${input.invoiceId}-${role}`;
+  const saved = await saveManagedDocument({
+    documentId,
+    title: `${input.invoiceRef} — ${input.accountName}`,
+    documentKind: "invoice",
+    contentFormat: "application/pdf",
+    contentBlobId: blob.id,
+    contentSha256: written.sha256,
+    summary: `Revision ${revision} of ${input.invoiceRef} (${role}).`,
+    tags: ["finance", "invoice", role],
+    accessScope: "organization",
+  });
+
+  const versionId = saved.currentVersionId;
+  if (!versionId) {
+    throw new Error(
+      `Document ${documentId} saved without a current version; cannot bind an invoice snapshot to nothing.`,
+    );
+  }
+
+  const row = await prisma.invoiceDocument.create({
+    data: {
+      invoiceId: input.invoiceId,
+      documentVersionId: versionId,
+      role,
+      revision,
+      sentToEmail: input.sentToEmail ?? null,
+      createdById: input.createdById ?? null,
+    },
+    select: {
+      id: true,
+      revision: true,
+      role: true,
+      documentVersionId: true,
+      sentToEmail: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    ...row,
+    sha256: written.sha256,
+    sizeBytes: written.sizeBytes,
+  };
+}
+
+export type InvoiceDocumentListEntry = {
+  id: string;
+  revision: number;
+  role: string;
+  sentToEmail: string | null;
+  createdAt: Date;
+  sizeBytes: number | null;
+  sha256: string | null;
+  /** The User model carries no display name; email is the identifying field. */
+  createdByEmail: string | null;
+};
+
+/** Newest first — the most recent revision is what an operator usually wants. */
+export async function listInvoiceDocuments(invoiceId: string): Promise<InvoiceDocumentListEntry[]> {
+  const rows = await prisma.invoiceDocument.findMany({
+    where: { invoiceId },
+    orderBy: [{ role: "asc" }, { revision: "desc" }],
+    select: {
+      id: true,
+      revision: true,
+      role: true,
+      sentToEmail: true,
+      createdAt: true,
+      documentVersion: { select: { sizeBytes: true, contentSha256: true } },
+      createdBy: { select: { email: true } },
+    },
+  });
+
+  return rows.map((r) => ({
+    id: r.id,
+    revision: r.revision,
+    role: r.role,
+    sentToEmail: r.sentToEmail,
+    createdAt: r.createdAt,
+    sizeBytes: r.documentVersion?.sizeBytes ?? null,
+    sha256: r.documentVersion?.contentSha256 ?? null,
+    createdByEmail: r.createdBy?.email ?? null,
+  }));
+}
+
+export type InvoiceDocumentBytes = {
+  storageKey: string;
+  sha256: string;
+  mimeType: string;
+  filename: string;
+  invoiceRef: string;
+};
+
+/**
+ * Locate the stored bytes for one snapshot. Returns the storage key rather than
+ * the buffer so the caller decides how to stream it.
+ */
+export async function getInvoiceDocumentBlobRef(
+  invoiceDocumentId: string,
+): Promise<InvoiceDocumentBytes | null> {
+  const row = await prisma.invoiceDocument.findUnique({
+    where: { id: invoiceDocumentId },
+    select: {
+      revision: true,
+      role: true,
+      invoice: { select: { invoiceRef: true } },
+      documentVersion: {
+        select: { contentSha256: true, contentBlob: { select: { storageKey: true, mimeType: true } } },
+      },
+    },
+  });
+
+  const blob = row?.documentVersion?.contentBlob;
+  if (!row || !blob) return null;
+
+  return {
+    storageKey: blob.storageKey,
+    sha256: row.documentVersion.contentSha256 ?? "",
+    mimeType: blob.mimeType ?? "application/pdf",
+    filename: `${row.invoice.invoiceRef}-${row.role}-r${row.revision}.pdf`,
+    invoiceRef: row.invoice.invoiceRef,
+  };
+}

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -30,6 +30,7 @@ import { HOSPITALITY_CAPACITY_ASSETS } from "./hospitality-capacity-assets";
 import { BEAUTY_CAPACITY_ASSETS } from "./beauty-capacity-assets";
 import { LIFECYCLE_GOVERNANCE_ASSETS } from "./lifecycle-governance-assets";
 import { STOCK_COVERAGE_ASSETS } from "./stock-coverage-assets";
+import { FINANCE_INVOICE_DOCUMENT_ASSETS } from "./finance-invoice-document-assets";
 
 // ─── Definitions (spec §6.1) ─────────────────────────────────────────────────
 
@@ -679,6 +680,7 @@ const SEED_ASSETS: readonly DataAssetDefinition[] = [
   ...BEAUTY_CAPACITY_ASSETS,
   ...LIFECYCLE_GOVERNANCE_ASSETS,
   ...STOCK_COVERAGE_ASSETS,
+  ...FINANCE_INVOICE_DOCUMENT_ASSETS,
   ...PROCESSING_GOVERNANCE_ASSETS,
    {
     id: "data:agent-conversation",

--- a/apps/web/lib/govern/data/finance-invoice-document-assets.ts
+++ b/apps/web/lib/govern/data/finance-invoice-document-assets.ts
@@ -1,0 +1,83 @@
+import type { DataAssetDefinition } from "./assets";
+import type {
+  DataCategory,
+  DataFieldId,
+  DataSensitivity,
+} from "./taxonomy";
+
+// Finance — the stored copy of an invoice as the customer received it
+// (BI-C86BD108, EP-778F1CED phase 3). Kept in its own module rather than inline
+// in assets.ts, matching the per-domain asset files alongside it.
+
+export const FINANCE_INVOICE_DOCUMENT_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    // BI-C86BD108: the immutable copy of an invoice as the customer received it.
+    // Not grandfathered — a new model must declare its governance. The row itself
+    // is metadata about a financial document; the only personal datum is the
+    // recipient address the invoice was emailed to, which is governed.
+    id: "data:invoice-document",
+    physical: { prismaModel: "InvoiceDocument" },
+    domain: "finance",
+    ownerRole: "business-operator",
+    stewardRole: "data-steward",
+    categories: ["operational", "financial"],
+    sensitivity: "confidential",
+    criticality: "high",
+    subjectLocators: [],
+    lifecycleClass: "regulated-record",
+    purposeCapabilities: ["service-delivery", "platform-operations"],
+    residencyClass: "local-only",
+    projectionClass: "metadata",
+    classification: { state: "confirmed", source: "manual", effectiveFrom: "2026-08-01" },
+    fields: [
+      {
+        id: "data:invoice-document#sentToEmail",
+        physicalName: "sentToEmail",
+        resolution: "governed",
+        resolutionReason:
+          "The customer contact address this invoice copy was emailed to. Personal data, captured at send time because the contact can change later; it must not leave the install in an unapproved projection.",
+        categories: ["contact"],
+        sensitivity: "confidential",
+        collectionRule: "minimize",
+        protection: "mask-on-read",
+        projectionOverride: "metadata",
+        provenance: {
+          source: "manual",
+          state: "confirmed",
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-08-01",
+        },
+      },
+      ...["id", "invoiceId", "documentVersionId", "createdById"].map((physicalName) => ({
+        id: `data:invoice-document#${physicalName}` as DataFieldId,
+        physicalName,
+        resolution: "not-applicable" as const,
+        resolutionReason:
+          "Opaque internal identifier or foreign key; carries no data about a subject on its own.",
+        categories: ["system-internal"] as DataCategory[],
+        sensitivity: "internal" as DataSensitivity,
+        provenance: {
+          source: "manual" as const,
+          state: "confirmed" as const,
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-08-01",
+        },
+      })),
+      ...["role", "revision", "createdAt", "invoice", "documentVersion", "createdBy"].map((physicalName) => ({
+        id: `data:invoice-document#${physicalName}` as DataFieldId,
+        physicalName,
+        resolution: "not-applicable" as const,
+        resolutionReason:
+          "Structural metadata about the stored copy (what it is, which revision, when, and its relations) — no personal or financial content.",
+        categories: ["system-internal"] as DataCategory[],
+        sensitivity: "internal" as DataSensitivity,
+        provenance: {
+          source: "manual" as const,
+          state: "confirmed" as const,
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-08-01",
+        },
+      })),
+    ],
+  },
+];

--- a/apps/web/lib/operate/retention/policies.ts
+++ b/apps/web/lib/operate/retention/policies.ts
@@ -370,6 +370,10 @@ export const RETAINED_DATASETS: readonly RetainedDataset[] = [
   // Financial records — IRS/SOX-style 7-year floor.
   { model: "invoice", label: "Invoices", regulatoryBasis: "Financial record retention (IRS / SOX-style statutory)", minRetentionYears: 7 },
   { model: "invoiceLineItem", label: "Invoice line items", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
+  // The document the customer actually received. Retained at least as long as the
+  // invoice itself: it is the evidence of what was billed, and it is the artifact a
+  // dispute turns on when the invoice has since been edited.
+  { model: "invoiceDocument", label: "Sent invoice documents", regulatoryBasis: "Financial record retention (evidence of what was billed)", minRetentionYears: 7 },
   { model: "payment", label: "Payments", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
   { model: "paymentAllocation", label: "Payment allocations", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },
   { model: "bill", label: "Bills (AP)", regulatoryBasis: "Financial record retention", minRetentionYears: 7 },

--- a/docs/data-impact/2026-08-01-invoice-document-snapshot.data-impact.json
+++ b/docs/data-impact/2026-08-01-invoice-document-snapshot.data-impact.json
@@ -1,0 +1,91 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [],
+  "migration": {
+    "name": "20260801120000_add_invoice_document_join",
+    "backfill": "none — new table. Existing invoices have no stored copies because none were ever retained; revisions begin at the next send."
+  },
+  "tests": [
+    "lib/govern/data/coverage.live.test.ts",
+    "lib/finance/invoice-document-store.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:invoice-document",
+      "prismaModel": "InvoiceDocument",
+      "lifecycleDisposition": "regulated-record",
+      "fields": [
+        {
+          "fieldId": "data:invoice-document#id",
+          "resolution": "not-applicable",
+          "reason": "Opaque internal identifier",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#invoiceId",
+          "resolution": "not-applicable",
+          "reason": "Foreign key to Invoice; carries no subject data on its own",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#documentVersionId",
+          "resolution": "not-applicable",
+          "reason": "Foreign key to DocumentVersion",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#createdById",
+          "resolution": "not-applicable",
+          "reason": "Foreign key to the acting User",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#role",
+          "resolution": "not-applicable",
+          "reason": "Structural: what the stored copy is (sent-copy | signed-copy | credit-note)",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#revision",
+          "resolution": "not-applicable",
+          "reason": "Structural: monotonic revision number within (invoice, role)",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#createdAt",
+          "resolution": "not-applicable",
+          "reason": "Structural timestamp",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#invoice",
+          "resolution": "not-applicable",
+          "reason": "Prisma relation, not a stored column",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#documentVersion",
+          "resolution": "not-applicable",
+          "reason": "Prisma relation, not a stored column",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#createdBy",
+          "resolution": "not-applicable",
+          "reason": "Prisma relation, not a stored column",
+          "provenance": "manual/data-steward"
+        },
+        {
+          "fieldId": "data:invoice-document#sentToEmail",
+          "resolution": "governed",
+          "reason": "Customer contact address this copy was emailed to, captured at send time because the contact record can change afterwards. Personal data; masked on read and excluded from unapproved projections.",
+          "provenance": "manual/data-steward",
+          "flags": ["sensitive", "subject"],
+          "fieldPolicy": "mask-on-read"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/user-guide/finance/accounts-receivable.md
+++ b/docs/user-guide/finance/accounts-receivable.md
@@ -75,6 +75,23 @@ the business reason in supporting records. Do not mark an invoice paid to
 remove it from an overdue queue. For a partial receipt, record the actual
 amount; the remaining balance stays visible.
 
+### Sent Documents Are Kept
+
+Every time an invoice is sent, the exact PDF the customer receives is stored
+against that invoice as a numbered revision, and listed under **Sent Documents**
+on the invoice. Each revision records when it went out, who it went to, and its
+size, and can be downloaded exactly as it was sent.
+
+This is deliberately not the same as the **Download** button in the action row.
+Download re-creates the invoice from its *current* details; a stored revision is
+what the customer actually holds. After an edit the two can differ, and when they
+do, the stored revision is the one that settles a dispute.
+
+Reissuing an invoice adds revision 2, 3, and so on. Earlier revisions are never
+altered or replaced — that is what makes the history worth having. If sending
+succeeds but the copy cannot be stored, the invoice still shows as sent and the
+missing revision is visible in this list rather than being silently absent.
+
 ### What You Can Edit, And When
 
 A **draft** invoice is fully editable: line items, amounts, dates, account,

--- a/docs/ux-fit/2026-08-01-invoice-lifecycle-and-document-history.ux-fit.json
+++ b/docs/ux-fit/2026-08-01-invoice-lifecycle-and-document-history.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "inline-gated-with-consequence-dialog",
+  "decisionInteractionId": "DI-2A771C0BDEF4",
+  "scope": {
+    "files": [
+      "apps/web/components/finance/InvoiceLifecycleActions.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "inline-gated-with-consequence-dialog",
+      "overflow-menu-for-destructive",
+      "separate-manage-tab"
+    ]
+  }
+}

--- a/packages/db/prisma/migrations/20260801120000_add_invoice_document_join/migration.sql
+++ b/packages/db/prisma/migrations/20260801120000_add_invoice_document_join/migration.sql
@@ -1,0 +1,34 @@
+-- Binds an immutable document snapshot to the invoice it was produced for.
+-- Kernel decision DI-763E5529F491 chose a typed join over a polymorphic owner
+-- column on Document, so this carries real foreign keys and cascade semantics.
+
+CREATE TABLE "InvoiceDocument" (
+    "id" TEXT NOT NULL,
+    "invoiceId" TEXT NOT NULL,
+    "documentVersionId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'sent-copy',
+    "revision" INTEGER NOT NULL,
+    "sentToEmail" TEXT,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "InvoiceDocument_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "InvoiceDocument_invoiceId_role_revision_key"
+    ON "InvoiceDocument"("invoiceId", "role", "revision");
+CREATE INDEX "InvoiceDocument_invoiceId_idx" ON "InvoiceDocument"("invoiceId");
+CREATE INDEX "InvoiceDocument_documentVersionId_idx" ON "InvoiceDocument"("documentVersionId");
+CREATE INDEX "InvoiceDocument_createdAt_idx" ON "InvoiceDocument"("createdAt");
+
+-- Deleting a draft invoice takes its (empty) snapshot rows with it.
+ALTER TABLE "InvoiceDocument" ADD CONSTRAINT "InvoiceDocument_invoiceId_fkey"
+    FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RESTRICT, not CASCADE: a snapshot the customer received must not disappear
+-- because someone tidied up the document store.
+ALTER TABLE "InvoiceDocument" ADD CONSTRAINT "InvoiceDocument_documentVersionId_fkey"
+    FOREIGN KEY ("documentVersionId") REFERENCES "DocumentVersion"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "InvoiceDocument" ADD CONSTRAINT "InvoiceDocument_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -79,6 +79,7 @@ model User {
   groups                         UserGroup[]
   userSkills                     UserSkill[]                   @relation("UserSkillCreator")
   invoicesCreated                Invoice[]                     @relation("InvoiceCreations")
+  invoiceDocumentsCreated        InvoiceDocument[]
   paymentsCreated                Payment[]                     @relation("PaymentCreations")
   journalEntriesCreated          JournalEntry[]                @relation("JournalEntryCreations")
   journalEntriesPosted           JournalEntry[]                @relation("JournalEntryPostings")
@@ -6550,6 +6551,7 @@ model DocumentVersion {
   sourceReferences     DocumentReference[] @relation("DocumentReferenceSourceVersion")
   targetReferences     DocumentReference[] @relation("DocumentReferenceTargetVersion")
   renditions           DocumentRendition[]
+  invoiceDocuments     InvoiceDocument[]
 
   @@unique([documentId, version])
   @@index([documentId])
@@ -12018,11 +12020,45 @@ model Invoice {
   lineItems   InvoiceLineItem[]
   allocations PaymentAllocation[]
   dunningLogs DunningLog[]
+  documents   InvoiceDocument[]
 
   @@index([accountId])
   @@index([status])
   @@index([dueDate])
   @@index([sourceType, sourceId])
+}
+
+/// Binds an immutable document snapshot to the invoice it was produced for.
+///
+/// Chosen over a polymorphic ownerType/ownerId column on Document (kernel
+/// decision DI-763E5529F491): real foreign keys and cascade semantics, at the
+/// cost of one join table per record type. This is the precedent for quotes,
+/// purchase orders, and contracts.
+///
+/// A row is WRITE-ONCE. Reissuing an invoice appends revision N+1; it never
+/// mutates N, because the whole point is that what the customer received stays
+/// recoverable exactly as they received it.
+model InvoiceDocument {
+  id                String   @id @default(cuid())
+  invoiceId         String
+  documentVersionId String
+  /// What this snapshot IS: sent-copy | signed-copy | credit-note.
+  role              String   @default("sent-copy")
+  /// 1-based, per (invoice, role). Monotonic; gaps are not expected.
+  revision          Int
+  /// Who it went to, captured at send time — the contact email can change later.
+  sentToEmail       String?
+  createdById       String?
+  createdAt         DateTime @default(now())
+
+  invoice         Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  documentVersion DocumentVersion @relation(fields: [documentVersionId], references: [id], onDelete: Restrict)
+  createdBy       User?           @relation(fields: [createdById], references: [id])
+
+  @@unique([invoiceId, role, revision])
+  @@index([invoiceId])
+  @@index([documentVersionId])
+  @@index([createdAt])
 }
 
 model InvoiceLineItem {

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -213,6 +213,7 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   StorefrontInquiry: "confidential",
   StorefrontDonation: "confidential",
   Invoice: "confidential",
+  InvoiceDocument: "confidential",
   InvoiceLineItem: "confidential",
   Payment: "confidential",
   PaymentAllocation: "confidential",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-01T17:33:03.145Z",
-  "gitSha": "1c5273baa85ca0482d5a7a29107aeb344fe1c10a",
+  "generatedAt": "2026-08-01T21:39:49.088Z",
+  "gitSha": "c564834ed35e145107d3cb5206260507e18cadea",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -17,11 +17,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 570
+      "value": 571
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 16152
+      "value": 16298
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -2736,6 +2736,20 @@
     "longSentences": 0,
     "textMass": 10
   },
+  "apps/web/app/api/v1/finance/invoices/[id]/documents/[documentId]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/invoices/[id]/documents/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
   "apps/web/app/api/v1/finance/invoices/[id]/pdf/route.ts": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -2756,6 +2770,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/invoices/[id]/void/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
   },
   "apps/web/app/api/v1/finance/invoices/route.ts": {
     "vocabulary": 0,
@@ -5130,12 +5151,26 @@
     "longSentences": 0,
     "textMass": 70
   },
+  "apps/web/components/finance/InvoiceDocumentHistory.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 50
+  },
   "apps/web/components/finance/InvoiceDownloadButton.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
     "textMass": 8
+  },
+  "apps/web/components/finance/InvoiceLifecycleActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
   },
   "apps/web/components/finance/InvoiceSendButton.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Phases 3 and 4 of **EP-778F1CED** — the last two. Closes the gap the founder actually reported.

## Why

> *"is there a way to save the invoice documents, and retrieve them as part of the invoice once generated? This is sort of the main step in sending them. If I revise them, I may need to track that."*

`generateInvoicePdf()` rendered on demand and the bytes were streamed to the download route or attached to an email, then **discarded**. Re-downloading later re-rendered from *current* data, so after any edit the operator and the customer held different documents under the same invoice ref with nothing to distinguish them. That is an audit failure, and it is why revisions could not be tracked at all.

Separately, phases 1 and 2 shipped correct actions with **no way to reach them** — no Edit, Void, or Delete control existed on the invoice page.

## Binding — kernel-decided

`DI-763E5529F491` chose a **typed join** over a polymorphic owner column on `Document`. New `InvoiceDocument` model with real foreign keys:

- **CASCADE** from `Invoice` — deleting a draft takes its (empty) snapshot rows.
- **RESTRICT** to `DocumentVersion` — a copy the customer received must not vanish because the document store was tidied.
- `@@unique([invoiceId, role, revision])`.

This is the precedent for quotes, purchase orders, and contracts.

## Snapshots are write-once

Reissue appends revision N+1 and never mutates N. Blobs are content-addressed, so an unchanged reissue writes no new bytes and simply points a new version at the same blob.

The snapshot is taken **after** the send succeeds — recording it earlier would claim a delivery that never happened — and is best-effort: a storage hiccup must not turn a delivered invoice into a 500 the operator retries, re-sending the customer a second copy. The failure is loud in the logs and the missing revision is visible on the invoice.

## UI — kernel-decided

`DI-2A771C0BDEF4` chose **inline gated controls with a consequence dialog** (composite 10.84, margin 2.25) over an overflow menu — which hides the capability behind discovery, the exact failure being fixed — and over a separate Manage tab.

- Void and Delete render **disabled-with-reason** rather than hidden, so the operator learns *why*.
- The confirm names concrete consequences (*"Returns 8 billable timesheet entries to the unbilled pool"*, *"Posts 1 reversing journal entry"*) instead of asking "are you sure".
- Void requires a typed reason.
- Destructive controls sit behind a divider, away from Send.
- The **Sent Documents** panel is deliberately distinct from the Download button and says so in the UI: one is what was sent, the other is a fresh render that can differ after an edit. Conflating them is the audit trap.

## Governance

The new model declares its own stewardship rather than being grandfathered: `confidential` classification, 7-year statutory retention matching `Invoice`, lifecycle class `regulated-record`, and a full field-level registration in a new `finance-invoice-document-assets.ts` (following the existing per-domain asset-file pattern). `sentToEmail` is governed as personal contact data; everything else is structural.

## New endpoints

`GET .../documents` · `GET .../documents/:documentId` (ownership-checked; **410** when a row survives but its blob does not) · `POST .../void`

## Verification

11 new snapshot-store tests (write-once, blob reuse, role separation, refusal to bind without a version), plus the full suite: `pregate` → **`gate passed`** — 31 guards, 21,296 tests against merged main, and a production build. `tsc` clean.

## Open question, deliberately unresolved

Document blob storage is **filesystem-backed, not object storage**. Adequate for onboarding documents; the retention and backup story needs an explicit decision before a finance artifact depends on it long-term. Flagged rather than assumed away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)