### PR TITLE
ci: automate dated checkpoint tags, replacing manual version stamping

### DIFF
--- a/.github/workflows/daily-checkpoint-tag.yml
+++ b/.github/workflows/daily-checkpoint-tag.yml
@@ -1,0 +1,78 @@
+name: Daily Checkpoint Tag
+
+# Cuts a dated checkpoint tag (v<YYYY.MM.DD>) once per day WHEN main has new
+# commits since the previous checkpoint. Replaces manual version stamping.
+#
+# WHY THESE TAGS EXIST — they are "how far behind" markers, NOT releases:
+#   Every DPF instance self-upgrades continuously. The real drift signal is the
+#   number of merged commits an install is behind main, already computed by
+#   apps/web/lib/self-upgrade/release-batch.ts, which also decides when the next
+#   batch is worth taking (~10 merged PRs, or 7 days). These tags do NOT drive
+#   that. They give humans clean, dated anchors instead of PR numbers, and they
+#   reset `git describe` so any build reads like `v2026.08.01-12-g<sha>`
+#   ("12 commits past the Aug 1 checkpoint") — the counter, baked into the label.
+#
+# INTENTIONALLY TAG-ONLY. Tags are pushed with the built-in GITHUB_TOKEN, which
+# by GitHub's design does NOT trigger tag-push workflows — so a daily checkpoint
+# does NOT kick the heavier publish-release.yml (Edge-binary build). That path
+# stays for deliberate releases. Cutting a full downloadable Release per
+# checkpoint would be a separate, explicit change (it needs a PAT to chain the
+# release build, and would run that build 365x/year).
+
+on:
+  schedule:
+    - cron: "40 6 * * *" # daily at 06:40 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write # push the checkpoint tag
+
+concurrency:
+  group: daily-checkpoint-tag
+  cancel-in-progress: false
+
+jobs:
+  checkpoint:
+    name: Cut daily checkpoint tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history + tags for describe / rev-list
+
+      - name: Cut checkpoint tag if main advanced
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+
+          today="v$(date -u +%Y.%m.%d)"
+
+          # Idempotent: never cut the same day twice (re-runs / dispatch).
+          if git rev-parse -q --verify "refs/tags/${today}" >/dev/null; then
+            echo "Checkpoint ${today} already exists - nothing to do."
+            exit 0
+          fi
+
+          # Most recent existing dated checkpoint (v20YY.MM.DD), if any. Zero-
+          # padded dates sort chronologically under -refname.
+          prev="$(git tag --list 'v20[0-9][0-9].[0-1][0-9].[0-3][0-9]' --sort=-refname | head -n1 || true)"
+
+          if [ -n "${prev}" ]; then
+            new_commits="$(git rev-list --count "${prev}..HEAD")"
+            if [ "${new_commits}" -eq 0 ]; then
+              echo "No new commits since ${prev} - skipping today's checkpoint."
+              exit 0
+            fi
+            msg="Daily checkpoint ${today} - ${new_commits} commit(s) since ${prev}."
+          else
+            new_commits="$(git rev-list --count HEAD)"
+            msg="Daily checkpoint ${today} - first dated checkpoint (${new_commits} commits on main)."
+          fi
+
+          git config user.name "dpf-checkpoint-bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${today}" -m "${msg}"
+          git push origin "refs/tags/${today}"
+          echo "${msg}"


### PR DESCRIPTION
## What

Adds `.github/workflows/daily-checkpoint-tag.yml` — a scheduled workflow that cuts a **dated checkpoint tag `v<YYYY.MM.DD>`** once a day when `main` has new commits, replacing manual version stamping.

## Why (the reframe)

The ask was to stop hand-stamping versions and instead have an automatic **"how far behind" counter** — because these versions aren't really releases, they mark how current an instance is (every install self-upgrades continuously).

Key finding while scoping this: **the platform already measures drift by commit count, not tags.** `apps/web/lib/self-upgrade/release-batch.ts` counts merged commits an install is behind `main` and already decides when the next batch is worth taking (~10 merged PRs, or 7 days). So these tags don't need to *drive* anything — they just give humans clean, dated anchors instead of PR numbers, and reset `git describe` so any build reads like `v2026.08.01-12-g<sha>` = "12 commits past the Aug 1 checkpoint."

## Behaviour

- **Daily** (06:40 UTC) + manual dispatch.
- Cuts `v<today>` **only if** there are new commits since the previous dated checkpoint (quiet days produce nothing).
- **Idempotent** — never cuts the same day twice.
- Annotated tag message records the delta: *"Daily checkpoint v2026.08.01 — 12 commit(s) since v2026.07.31."*

## Deliberately tag-only (not a Release per day)

- A checkpoint is a lightweight marker — instant, free, can't fail a build.
- Tags are pushed with `GITHUB_TOKEN`, which by GitHub's design **does not trigger tag-push workflows** — so a daily checkpoint does **not** kick the heavy `publish-release.yml` Edge-binary build (which would otherwise run 365×/year and multiply its failure surface). Deliberate releases still go through `publish-release.yml` as before.

## Safety / blast radius (verified)

Date tags coexist with the legacy `vX.Y.Z` tags without breaking version display or comparison:
- `readPlatformVersionTag` (`image-version.ts`) returns the tag **verbatim** (only strips a leading `v`) — no semver validation on the tag path.
- `compare_versions` / the version-history tools operate on **git refs and DB dates**, not by parsing/ordering version strings — so mixed formats can't confuse "what changed between X and Y."
- Self-upgrade drift is **SHA/commit-count** based — unaffected by tag format.
- The only semver-strict spot (`version.json`'s fallback value) is untouched.
- Verified the selection glob excludes existing `v6.5.x` tags (0 false matches).

## Note

You can now stop stamping versions by hand — this takes over. Your existing `publish-release.yml` (deliberate releases + download-counted binaries) is unchanged.

https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2

---
_Generated by [Claude Code](https://claude.ai/code/session_016113Pf7CKx2DRVvQYvfJE2)_