### PR TITLE
feat(decisions): author the stance→axis map, inert and guarded (BI-E1427A3E Phase 0)

### DIFF
--- a/apps/web/lib/decision-perspective/stance-dimension-map.test.ts
+++ b/apps/web/lib/decision-perspective/stance-dimension-map.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { PRINCIPLE_COST_DIMENSIONS, PRINCIPLE_DIMENSIONS } from "@dpf/db/wiki-taxonomy";
+
+import { STANCE_VECTOR_KEYS } from "@/lib/onboarding/archetype-business-context";
+import {
+  findStanceDimensionMapViolations,
+  isStanceForbiddenDimension,
+  STANCE_DIMENSION_MAP,
+  STANCE_FORBIDDEN_DIMENSIONS,
+  STANCE_MAX_MAGNITUDE,
+  type StanceAxisEdge,
+} from "./stance-dimension-map";
+
+// BI-E1427A3E Phase 0. These are the guard the spec (§4.3) requires: the map is
+// the reviewable artifact, so its invariants must fail loudly in CI rather than
+// be discovered when a derived vector starts scoring real decisions.
+
+describe("stance-dimension-map: the live map is well-formed", () => {
+  it("passes every invariant (signs, caps, forbidden axes, rationales)", () => {
+    expect(findStanceDimensionMapViolations()).toEqual([]);
+  });
+
+  it("maps every stance key — an unmapped stance is a silent no-op", () => {
+    for (const key of STANCE_VECTOR_KEYS) {
+      expect(STANCE_DIMENSION_MAP[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("only ever targets axes in the closed registry", () => {
+    const registry = new Set<string>(PRINCIPLE_DIMENSIONS);
+    for (const key of STANCE_VECTOR_KEYS) {
+      for (const edge of STANCE_DIMENSION_MAP[key] as readonly StanceAxisEdge[]) {
+        expect(registry.has(edge.dimension)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("stance-dimension-map: kernel ruling DI-A01830820221 (never derive safety)", () => {
+  it("declares public_safety forbidden", () => {
+    expect(STANCE_FORBIDDEN_DIMENSIONS).toContain("public_safety");
+    expect(isStanceForbiddenDimension("public_safety")).toBe(true);
+    expect(isStanceForbiddenDimension("cost_efficiency")).toBe(false);
+  });
+
+  it("no stance derives public_safety — including quality-bar, the tempting case", () => {
+    for (const key of STANCE_VECTOR_KEYS) {
+      const dimensions = (STANCE_DIMENSION_MAP[key] as readonly StanceAxisEdge[]).map(
+        (edge) => edge.dimension,
+      );
+      expect(dimensions).not.toContain("public_safety");
+    }
+  });
+});
+
+describe("stance-dimension-map: kernel ruling DI-687A1094E253 (cap below doctrine)", () => {
+  it("caps strictly below the commandment magnitude of 1.0", () => {
+    expect(STANCE_MAX_MAGNITUDE).toBeLessThan(1);
+  });
+
+  it("keeps every edge within the cap", () => {
+    for (const key of STANCE_VECTOR_KEYS) {
+      for (const edge of STANCE_DIMENSION_MAP[key] as readonly StanceAxisEdge[]) {
+        expect(Math.abs(edge.weight)).toBeLessThanOrEqual(STANCE_MAX_MAGNITUDE);
+      }
+    }
+  });
+});
+
+describe("stance-dimension-map: sign convention (the never-wipe-db inversion class)", () => {
+  it("never assigns a positive weight to a cost axis", () => {
+    const costs = new Set<string>(PRINCIPLE_COST_DIMENSIONS);
+    const offenders: string[] = [];
+    for (const key of STANCE_VECTOR_KEYS) {
+      for (const edge of STANCE_DIMENSION_MAP[key] as readonly StanceAxisEdge[]) {
+        if (costs.has(edge.dimension) && edge.weight > 0) {
+          offenders.push(`${key} -> ${edge.dimension} = ${edge.weight}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("scores the cost axes it does use in the negative direction", () => {
+    // Guards against the map quietly dropping its cost edges to dodge the sign
+    // rule — the inversion's lazier cousin.
+    const used = new Set<string>();
+    for (const key of STANCE_VECTOR_KEYS) {
+      for (const edge of STANCE_DIMENSION_MAP[key] as readonly StanceAxisEdge[]) {
+        if (PRINCIPLE_COST_DIMENSIONS.includes(edge.dimension as never)) {
+          used.add(edge.dimension);
+          expect(edge.weight).toBeLessThan(0);
+        }
+      }
+    }
+    expect(used.size).toBeGreaterThan(0);
+  });
+});
+
+describe("stance-dimension-map: profession-local edges are declared", () => {
+  it("flags capacity_utilization as profession-local so derivation cannot leak it", () => {
+    const edge = (STANCE_DIMENSION_MAP["growth-vs-stability"] as readonly StanceAxisEdge[]).find(
+      (candidate) => candidate.dimension === "capacity_utilization",
+    );
+    expect(edge?.professionLocal).toBe(true);
+  });
+});
+
+describe("stance-dimension-map: the guard can actually fail", () => {
+  // A checker only ever run against a known-good map proves nothing. These feed
+  // the REAL function deliberately-broken maps and assert it catches each one.
+  const OK = "a sufficiently long rationale string to pass review";
+  const mapWith = (edges: StanceAxisEdge[]) => ({ "quality-bar": edges });
+  const violationsFor = (edges: StanceAxisEdge[]) =>
+    findStanceDimensionMapViolations(mapWith(edges)).filter((v) => v.startsWith("quality-bar"));
+
+  it("catches a positive weight on a cost axis", () => {
+    const found = violationsFor([{ dimension: "blast_radius", weight: 0.3, rationale: OK }]);
+    expect(found.some((v) => v.includes("POSITIVE"))).toBe(true);
+  });
+
+  it("catches an over-cap weight", () => {
+    const found = violationsFor([{ dimension: "cost_efficiency", weight: 0.9, rationale: OK }]);
+    expect(found.some((v) => v.includes("STANCE_MAX_MAGNITUDE"))).toBe(true);
+  });
+
+  it("catches a forbidden axis", () => {
+    const found = violationsFor([{ dimension: "public_safety", weight: 0.2, rationale: OK }]);
+    expect(found.some((v) => v.includes("forbidden"))).toBe(true);
+  });
+
+  it("catches a missing rationale", () => {
+    const found = violationsFor([{ dimension: "cost_efficiency", weight: 0.2, rationale: "short" }]);
+    expect(found.some((v) => v.includes("rationale"))).toBe(true);
+  });
+
+  it("catches a zero weight and a duplicate edge", () => {
+    const zero = violationsFor([{ dimension: "cost_efficiency", weight: 0, rationale: OK }]);
+    expect(zero.some((v) => v.includes("non-zero"))).toBe(true);
+
+    const dupe = violationsFor([
+      { dimension: "cost_efficiency", weight: 0.2, rationale: OK },
+      { dimension: "cost_efficiency", weight: 0.3, rationale: OK },
+    ]);
+    expect(dupe.some((v) => v.includes("duplicate"))).toBe(true);
+  });
+
+  it("catches a stance mapped to nothing", () => {
+    const found = findStanceDimensionMapViolations({}).filter((v) => v.includes("no edges"));
+    expect(found.length).toBe(STANCE_VECTOR_KEYS.length);
+  });
+
+  it("passes a well-formed synthetic map, so it is not simply always failing", () => {
+    expect(violationsFor([{ dimension: "cost_efficiency", weight: 0.2, rationale: OK }])).toEqual([]);
+  });
+});

--- a/apps/web/lib/decision-perspective/stance-dimension-map.ts
+++ b/apps/web/lib/decision-perspective/stance-dimension-map.ts
@@ -1,0 +1,300 @@
+// Stance → decision-axis mapping (BI-E1427A3E, Phase 0).
+//
+// Spec: docs/superpowers/specs/2026-07-31-stance-derived-dimension-vectors-design.md
+//
+// WHY THIS EXISTS. The platform has two things called "vectors" and until now
+// they were not connected. The 20-axis registry (`PRINCIPLE_DIMENSIONS`) is what
+// options are scored against. The five business stance vectors are the only
+// layer a business owner ever edits — and `seed-org-wwwd-corpus.ts` seeds them
+// as `pageKind: "stance"` with no principle block, so their
+// `principleDimensionVector` is null in every install. An owner could say "we
+// honour a quote we got wrong" and it moved no axis on any option a coworker
+// weighed; the stance only ever reached a decision through retrieval and the
+// semantic-alignment fallback.
+//
+// This module is the MAP ONLY. Phase 0 deliberately ships no derivation and
+// writes nothing: authoring the edges is the reviewable act, and wiring them to
+// live scoring is Phase 2 behind the simulation gate in the spec (§6).
+//
+// PLATFORM-OWNED, IDENTICAL IN EVERY INSTALL. An install re-weights the shared
+// registry; it never declares axes. Per-org axes would make each install's
+// judgement incomparable with every other's and destroy the hive's ability to
+// generalise (tier-rebalance design §2.3). Only the RESOLVED weights differ per
+// org — never the map.
+
+import {
+  PRINCIPLE_COST_DIMENSIONS,
+  type PrincipleDimension,
+} from "@dpf/db/wiki-taxonomy";
+
+import {
+  STANCE_VECTOR_KEYS,
+  type StanceVectorKey,
+} from "@/lib/onboarding/archetype-business-context";
+
+/**
+ * The ceiling on any stance-derived weight magnitude.
+ *
+ * KERNEL RULING DI-687A1094E253 (2026-08-01, `cap-below-doctrine`, margin
+ * 6.52, no commandment conflict): an organization's stance is authoritative
+ * WITHIN its scope but never doctrine-tier — not even at the `ruled` tier where
+ * a human has ruled on a real decision. Subsidiarity gives the org the decision
+ * it owns; it does not let commercial policy outweigh a universal obligation
+ * (safety, privacy, never-wipe-db) that the commandments carry at magnitude 1.0.
+ *
+ * Set to the core-tier default (0.4) so a stance can genuinely move a ranking
+ * while one commandment at full alignment still outweighs it decisively.
+ */
+export const STANCE_MAX_MAGNITUDE = 0.4;
+
+/**
+ * Axes a stance may NEVER derive a weight on, whatever its wording.
+ *
+ * KERNEL RULING DI-A01830820221 (2026-08-01, `never-derive-safety`, margin
+ * 2.65, no commandment conflict): `public_safety` is on the spine as a
+ * UNIVERSAL OBLIGATION rather than by usage frequency. Some archetype
+ * `quality-bar` defaults do name safety ("patient safety and clinical quality
+ * are never traded for speed or margin"), which is exactly why deriving from
+ * them is tempting — and exactly why it is refused. Safety weight comes from
+ * profession corpora and kernel principles, never from an owner-authored
+ * COMMERCIAL stance, so no org can dilute or manufacture a safety weight by
+ * editing its quality bar.
+ */
+export const STANCE_FORBIDDEN_DIMENSIONS = [
+  "public_safety",
+] as const satisfies readonly PrincipleDimension[];
+
+export type StanceForbiddenDimension =
+  (typeof STANCE_FORBIDDEN_DIMENSIONS)[number];
+
+/** One stance → axis edge. */
+export type StanceAxisEdge = {
+  /** The axis this stance speaks to. Constrained to the closed registry. */
+  dimension: PrincipleDimension;
+  /**
+   * Signed base weight, magnitude <= STANCE_MAX_MAGNITUDE. A COST axis must be
+   * negative: option features are non-negative, so the only way to express
+   * "this stance pulls against the cost" is a negative weight. A positive
+   * weight on a cost axis makes the scorer reward the very harm the stance
+   * opposes — the `never-wipe-db` inversion (2026-06-14 sign audit).
+   *
+   * `ceilingUsd` scaling on top of this base is Phase 1 (spec §4.2); it is
+   * deliberately not applied here.
+   */
+  weight: number;
+  /**
+   * Why this edge exists, traceable to the stance defaults' own wording rather
+   * than to what the axis NAME suggests (spec §5.1).
+   */
+  rationale: string;
+  /**
+   * True when the axis is profession-local. Such an edge may only be scored
+   * inside its owning profession; outside it, the axis projects onto its spine
+   * target. Derivation (Phase 2) must honour this — it is declared here so the
+   * constraint is reviewable rather than implicit.
+   */
+  professionLocal?: true;
+};
+
+/**
+ * The map. `satisfies Record<StanceVectorKey, ...>` is the enforcement: adding
+ * a stance key without mapping it is a COMPILE error, not a silently unmapped
+ * stance — the same discipline as `PRINCIPLE_DIMENSION_SCOPE`.
+ */
+export const STANCE_DIMENSION_MAP = {
+  "customer-goodwill": [
+    {
+      dimension: "cost_efficiency",
+      weight: -0.3,
+      rationale:
+        "Every default frames goodwill as absorbing cost to keep a relationship: 'a redo, replacement, refund, or credit'. Negative because this stance deliberately trades money away — it is not the cheap option, and scoring it as one would invert the owner's intent.",
+    },
+    {
+      dimension: "long_term_maintainability",
+      weight: 0.35,
+      rationale:
+        "What the money buys is relationship durability — 'a comped meal that wins the next three visits is cheap'. Durability is the axis every profession can weigh that against.",
+    },
+    {
+      dimension: "speed_to_value",
+      weight: 0.3,
+      rationale:
+        "'Resolve it on the spot' / 'fix the visit while the guest is still at the table' / 'same-day response' — immediacy is explicit in the generic default and every override.",
+    },
+    {
+      dimension: "operator_effort",
+      weight: -0.25,
+      rationale:
+        "COST axis. 'Without making the customer fight for it' and 'not the argument' are demands to keep the operations-to-resolution low, so the stance pulls against effort.",
+    },
+  ],
+  "pricing-integrity": [
+    {
+      dimension: "governance_compliance",
+      weight: 0.4,
+      rationale:
+        "'We honor the prices we quote, including our own mistakes' is commitment-keeping — the obligation-satisfaction axis. Public sector sharpens it: fees change 'by public decision, not a service gesture'.",
+    },
+    {
+      dimension: "evidence_density",
+      weight: 0.3,
+      rationale:
+        "The quoted record is what binds; the stance is that the record wins over convenience, which is the verifiable-backing axis rather than assertion.",
+    },
+    {
+      dimension: "cost_efficiency",
+      weight: -0.25,
+      rationale:
+        "Negative: honouring our own error, and refusing to 'price below what the work costs us', both decline the locally cheaper move.",
+    },
+  ],
+  "growth-vs-stability": [
+    {
+      dimension: "long_term_maintainability",
+      weight: 0.4,
+      rationale:
+        "'Existing commitments get first call on our capacity' — the stance protects the durable book of work over the new opportunity.",
+    },
+    {
+      dimension: "speed_to_value",
+      weight: -0.3,
+      rationale:
+        "Negative on a benefit axis, and legitimately so: 'at the pace quality allows, not faster' is an explicit trade of speed. This is the clearest case in the map of a stance buying something by giving up speed.",
+    },
+    {
+      dimension: "capacity_utilization",
+      weight: 0.25,
+      professionLocal: true,
+      rationale:
+        "The stance is literally about how capacity is allocated between new and existing work. Profession-local to operations; projects onto cost_efficiency when the decision leaves operations.",
+    },
+  ],
+  "quality-bar": [
+    {
+      dimension: "long_term_maintainability",
+      weight: 0.4,
+      rationale:
+        "'A redo is cheaper than a lost reputation' is durability reasoning: pay now to stay correct later.",
+    },
+    {
+      dimension: "evidence_density",
+      weight: 0.3,
+      rationale:
+        "'Work that leaves our hands meets our standard' presumes a checkable standard rather than an asserted one.",
+    },
+    {
+      dimension: "speed_to_value",
+      weight: -0.3,
+      rationale:
+        "Negative: 'if it isn't right, it doesn't leave the pass' declines speed at the margin, however urgent the job.",
+    },
+    // NO public_safety edge. Several archetype quality-bar defaults DO name
+    // safety, which is precisely the tempting case the kernel refused — see
+    // STANCE_FORBIDDEN_DIMENSIONS and ruling DI-A01830820221.
+  ],
+  "spend-authority": [
+    {
+      dimension: "cost_efficiency",
+      weight: 0.4,
+      rationale:
+        "The stance is directly about money discipline — what may be spent, and up to what ceiling, without the owner.",
+    },
+    {
+      dimension: "blast_radius",
+      weight: -0.3,
+      rationale:
+        "COST axis. 'Anything novel, recurring, or above the ceiling goes to the owner' is a REACH limit, not merely a price limit: recurring and novel commitments reach further than their sticker price.",
+    },
+    {
+      dimension: "reversibility",
+      weight: 0.3,
+      rationale:
+        "Routine budgeted purchases are the reversible ones; the ceiling is where irreversibility begins, which is why crossing it needs the owner.",
+    },
+    {
+      dimension: "legibility_of_consequence",
+      weight: 0.35,
+      rationale:
+        "A ceiling exists so the owner can foresee what proceeds without them — the precondition-of-informed-authorization axis.",
+    },
+  ],
+} as const satisfies Record<StanceVectorKey, readonly StanceAxisEdge[]>;
+
+const COST_DIMENSIONS = new Set<string>(PRINCIPLE_COST_DIMENSIONS);
+const FORBIDDEN = new Set<string>(STANCE_FORBIDDEN_DIMENSIONS);
+
+/** Whether an axis is one a stance may never derive a weight on. */
+export function isStanceForbiddenDimension(
+  dimension: string,
+): dimension is StanceForbiddenDimension {
+  return FORBIDDEN.has(dimension);
+}
+
+/**
+ * Assert a map's invariants. Defaults to the live map, so the guard test calls
+ * it bare and a violating edge cannot reach main; Phase 2 calls it before any
+ * write so a violating vector is never persisted.
+ *
+ * Takes the map as a parameter specifically so the guard can be tested against
+ * deliberately-broken maps. A checker only ever run against a known-good input
+ * proves nothing about whether it can actually fail.
+ *
+ * Returns the list of violations rather than throwing, so a caller can report
+ * every problem at once instead of one per run.
+ */
+export function findStanceDimensionMapViolations(
+  map: Partial<Record<StanceVectorKey, readonly StanceAxisEdge[]>> = STANCE_DIMENSION_MAP,
+): string[] {
+  const violations: string[] = [];
+
+  for (const stanceKey of STANCE_VECTOR_KEYS) {
+    const edges: readonly StanceAxisEdge[] = map[stanceKey] ?? [];
+
+    if (edges.length === 0) {
+      violations.push(`${stanceKey}: has no edges (an unmapped stance is a silent no-op)`);
+      continue;
+    }
+
+    const seen = new Set<string>();
+    for (const edge of edges) {
+      const where = `${stanceKey} -> ${edge.dimension}`;
+
+      if (seen.has(edge.dimension)) {
+        violations.push(`${where}: duplicate edge (weights would be ambiguous)`);
+      }
+      seen.add(edge.dimension);
+
+      if (isStanceForbiddenDimension(edge.dimension)) {
+        violations.push(
+          `${where}: forbidden axis — a commercial stance may never derive this ` +
+            `(kernel ruling DI-A01830820221)`,
+        );
+      }
+
+      if (edge.weight === 0 || !Number.isFinite(edge.weight)) {
+        violations.push(`${where}: weight must be a non-zero finite number (got ${edge.weight})`);
+      }
+
+      if (Math.abs(edge.weight) > STANCE_MAX_MAGNITUDE) {
+        violations.push(
+          `${where}: |weight| ${Math.abs(edge.weight)} exceeds STANCE_MAX_MAGNITUDE ` +
+            `${STANCE_MAX_MAGNITUDE} — org stance is never doctrine-tier ` +
+            `(kernel ruling DI-687A1094E253)`,
+        );
+      }
+
+      if (COST_DIMENSIONS.has(edge.dimension) && edge.weight > 0) {
+        violations.push(
+          `${where}: cost axis carries a POSITIVE weight (${edge.weight}) — this ` +
+            `rewards the very cost the stance opposes (the never-wipe-db inversion)`,
+        );
+      }
+
+      if (edge.rationale.trim().length < 20) {
+        violations.push(`${where}: rationale is missing or too short to review`);
+      }
+    }
+  }
+
+  return violations;
+}

--- a/docs/superpowers/plans/2026-08-01-stance-derived-dimension-vectors.md
+++ b/docs/superpowers/plans/2026-08-01-stance-derived-dimension-vectors.md
@@ -1,0 +1,113 @@
+---
+title: Stance-Derived Dimension Vectors — implementation plan
+authoredAt: 2026-08-01
+authoredBy: mark-bodman
+backlogItem: BI-E1427A3E
+epic: EP-DECISION-TIER-REBALANCE
+design: docs/superpowers/specs/2026-07-31-stance-derived-dimension-vectors-design.md
+---
+
+# Stance-Derived Dimension Vectors — implementation plan
+
+Design: [2026-07-31-stance-derived-dimension-vectors-design.md](../specs/2026-07-31-stance-derived-dimension-vectors-design.md)
+(merged as #3845). This plan sequences the build and records what each phase may
+NOT do, because the risk here is not difficulty — it is a mapping that silently
+starts moving real decisions before anyone has reviewed the edges.
+
+## Kernel rulings that fix the contract
+
+Two of the design's §10 questions were put through `principle_decide` before any
+code, per `consult-the-governed-scopes-before-asking-a-human`. Both returned
+**high confidence with no commandment conflict**, and both confirmed the design's
+proposed default:
+
+| Question | Ruling | Interaction | Margin |
+|---|---|---|---|
+| §10 Q3 — may a commercial `quality-bar` stance derive `public_safety`? | **`never-derive-safety`** | `DI-A01830820221` | 2.65 |
+| §10 Q1 — may a `ruled` stance reach commandment magnitude in its own class? | **`cap-below-doctrine`** | `DI-687A1094E253` | 6.52 |
+
+Both are now encoded as enforced constants rather than prose:
+`STANCE_FORBIDDEN_DIMENSIONS` and `STANCE_MAX_MAGNITUDE`.
+
+Still open, and NOT blocking Phase 0: **Q2** (does `ceilingUsd` scale magnitude
+at all, or only gate autonomy?) gates Phase 1, and **Q4** (BI-DF87F8D2's fate)
+gates Phase 4. Both want founder input rather than a kernel score, because they
+are investment calls rather than principle conflicts.
+
+## Phase 0 — the map (this PR)
+
+**Ships:** `apps/web/lib/decision-perspective/stance-dimension-map.ts` — the
+platform-owned map, 17 edges across the five stances, each with a signed weight
+and a rationale traceable to the stance defaults' own wording; plus
+`findStanceDimensionMapViolations()` and its guard test.
+
+**Deliberately does NOT ship:** any derivation, any write to
+`principleDimensionVector`, any change to scoring. Nothing about a live decision
+changes in this PR. The map is inert until Phase 2.
+
+**Enforcement landed here:**
+- `satisfies Record<StanceVectorKey, …>` — an unmapped stance is a compile error.
+- Cost axes must carry negative weights (the `never-wipe-db` inversion class).
+- `|weight| <= STANCE_MAX_MAGNITUDE` (0.4, the core-tier default) — org stance
+  is never doctrine-tier.
+- `public_safety` is refused outright, including on `quality-bar` where several
+  archetype defaults do name safety — the tempting case the kernel refused.
+- Every edge needs a reviewable rationale.
+- The violation checker is itself tested against synthetic bad edges: a guard
+  that cannot fail is not a guard.
+
+**Exit criteria:** guard test green; typecheck clean; no behaviour change
+observable anywhere in the portal.
+
+## Phase 1 — calibrate the magnitude curve
+
+Resolve §10 Q2 first. If `ceilingUsd` scales magnitude, fix the curve, base,
+floor and cap against the archetype default ratio (design §4.2) — sublinear and
+clamped, so an extreme owner entry cannot dominate the ledger. Extend
+`stance-onboarding.simulation.test.ts` to prove no decision class drops below its
+recommend band once derived vectors join the mean.
+
+**Still no writes.** Calibration is a simulation exercise.
+
+## Phase 2 — wire derivation
+
+Derive on confirmation only (`stance-confirm.ts`), writing
+`principleDimensionVector` + a generated `principleWeightRationale` to the org's
+stance page. `principleTier` stays unset — a stance is not a kernel principle.
+Backfill existing confirmed stances. Honour `professionLocal` on the
+`capacity_utilization` edge, and the `STANCE_VECTOR_BUNDLES` class scoping, so a
+stance cannot reach decisions it does not own.
+
+**Exit criteria (the falsifiable ones from design §9):** `cost_efficiency` —
+scored by ZERO principles at today's baseline — is measurably scored afterwards,
+and at least one option ranking demonstrably changes versus the semantic-only
+path. If neither moves, the work was decorative and should be reverted rather
+than shipped.
+
+## Phase 3 — show the owner
+
+Surface which decision factors their stance moved, on
+`/coworker-decisions/stance`. Not cosmetic: the platform's stated differentiator
+is the inspectable contribution ledger, and a derived weight the owner cannot see
+is exactly the opaque scoring this architecture exists to avoid. Needs a UX-fit
+review.
+
+## Phase 4 — resolve the DF87F8D2 overlap
+
+Decide explicitly whether pairwise elicitation becomes a refinement step or is
+closed as superseded (design §7). Founder ratification.
+
+## Risks
+
+- **The map starts scoring before review.** Mitigated structurally: Phase 0
+  writes nothing, and derivation is a separate phase behind a simulation gate.
+- **Sign inversion.** Three edges are negative-by-design; the guard covers the
+  map now and must cover derived vectors at write time in Phase 2.
+- **Scope leak.** A stance must never weight WWMD doctrine or WSID craft floors.
+  `professionLocal` and the bundle binding are declared in Phase 0 so Phase 2 has
+  something to honour rather than infer.
+- **Rank-deficiency relocation.** If every derived edge lands on
+  `long_term_maintainability` (already loaded by 68% of principles) we deepen the
+  concentration instead of fixing it. The map spreads deliberately across
+  `cost_efficiency`, `governance_compliance`, `reversibility`,
+  `legibility_of_consequence`, and `evidence_density`.

--- a/docs/superpowers/specs/2026-07-31-stance-derived-dimension-vectors-design.md
+++ b/docs/superpowers/specs/2026-07-31-stance-derived-dimension-vectors-design.md
@@ -313,13 +313,29 @@ forces that call explicitly rather than letting two overlapping mechanisms accre
 
 ## 10. Open questions for founder ratification
 
-1. **Should a *ruled* stance be able to reach commandment-level magnitude in its own class?** The
-   ladder gives it A/1.0 material weight, but that is material confidence, not principle magnitude.
-   Proposed: no — org policy is authoritative within its scope but never doctrine-tier.
+**Q1 and Q3 are now RESOLVED by kernel ruling** (2026-08-01), before any code was written, per
+`consult-the-governed-scopes-before-asking-a-human`. Both returned high confidence with no
+commandment conflict, and both confirmed this spec's proposed default. They are encoded as enforced
+constants in `apps/web/lib/decision-perspective/stance-dimension-map.ts`, not left as prose.
+
+1. ~~**Should a *ruled* stance be able to reach commandment-level magnitude in its own class?**~~
+   **RESOLVED — `cap-below-doctrine`** (`DI-687A1094E253`, margin 6.52). An org stance is
+   authoritative *within its scope* but never doctrine-tier, even at `ruled`. Subsidiarity grants the
+   org the decision it owns; it does not let commercial policy outweigh the universal obligations
+   commandments carry at magnitude 1.0. Encoded as `STANCE_MAX_MAGNITUDE = 0.4` (the core-tier
+   default), enforced per edge.
 2. **Does `ceilingUsd` scale magnitude at all, or only gate autonomy?** §4.2 proposes it scales,
    sublinearly. The conservative alternative is that it stays purely an autonomy threshold and every
-   derived edge uses the base magnitude.
-3. **Is `public_safety` on `quality-bar` conditional (per archetype) or never derived?** Deriving a
-   safety weight from a commercial quality stance is the most aggressive edge proposed; it may
-   belong to profession corpora only.
-4. **DF87F8D2** — reduce to a refinement step, or close as superseded (§7)?
+   derived edge uses the base magnitude. **Still open — gates Phase 1.** Left to founder input rather
+   than kernel scoring: this is an investment/calibration call, not a principle conflict.
+3. ~~**Is `public_safety` on `quality-bar` conditional (per archetype) or never derived?**~~
+   **RESOLVED — `never-derive-safety`** (`DI-A01830820221`, margin 2.65). `public_safety` sits on the
+   spine as a *universal obligation*, not by usage frequency. That several archetype `quality-bar`
+   defaults explicitly name safety is exactly why deriving from them is tempting, and exactly why it
+   is refused: safety weight comes from profession corpora and kernel principles, so no organization
+   can manufacture or dilute one by editing its commercial quality bar. Encoded as
+   `STANCE_FORBIDDEN_DIMENSIONS`.
+4. **DF87F8D2** — reduce to a refinement step, or close as superseded (§7)? **Still open — gates
+   Phase 4.**
+
+Implementation plan: [2026-08-01-stance-derived-dimension-vectors.md](../plans/2026-08-01-stance-derived-dimension-vectors.md).

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,6 +32,7 @@
     "./federated-record-sync": "./src/federated-record-sync.ts",
     "./discovery-triage": "./src/discovery-triage.ts",
     "./discovery-triage-enums": "./src/discovery-triage-enums.ts",
+    "./wiki-taxonomy": "./src/wiki-taxonomy.ts",
     "./discovery-collectors-arp-scan": "./src/discovery-collectors/arp-scan.ts",
     "./discovery-collectors-snmp": "./src/discovery-collectors/snmp.ts",
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,7 +32,6 @@
     "./federated-record-sync": "./src/federated-record-sync.ts",
     "./discovery-triage": "./src/discovery-triage.ts",
     "./discovery-triage-enums": "./src/discovery-triage-enums.ts",
-    "./wiki-taxonomy": "./src/wiki-taxonomy.ts",
     "./discovery-collectors-arp-scan": "./src/discovery-collectors/arp-scan.ts",
     "./discovery-collectors-snmp": "./src/discovery-collectors/snmp.ts",
     "./discovery-collectors-unifi": "./src/discovery-collectors/unifi.ts",


### PR DESCRIPTION
## What

Phase 0 of the design merged in [#3845](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3845). Ships **the map only** — no derivation, no writes to `principleDimensionVector`, no change to how any decision is scored today. Authoring the edges is the reviewable act; wiring them to live scoring is Phase 2, behind a simulation gate.

## Two open questions resolved by kernel ruling, before any code

Per `consult-the-governed-scopes-before-asking-a-human`, the two §10 questions that gated Phase 0 went through `principle_decide` first. Both returned **high confidence, no commandment conflict**, and both confirmed the spec's proposed default — now encoded as enforced constants rather than prose:

| Question | Ruling | Interaction | Margin | Encoded as |
|---|---|---|---|---|
| May a commercial `quality-bar` stance derive `public_safety`? | **never-derive-safety** | `DI-A01830820221` | 2.65 | `STANCE_FORBIDDEN_DIMENSIONS` |
| May a `ruled` stance reach commandment magnitude? | **cap-below-doctrine** | `DI-687A1094E253` | 6.52 | `STANCE_MAX_MAGNITUDE = 0.4` |

The safety one is the load-bearing call: several archetype `quality-bar` defaults *do* name safety ("patient safety and clinical quality are never traded for speed or margin"), which is exactly why deriving from them is tempting — and exactly why it's refused. No organization can manufacture or dilute a safety weight by editing its commercial quality bar.

§10 Q2 (does `ceilingUsd` scale magnitude?) gates Phase 1 and **remains open for founder input** — it's a calibration/investment call, not a principle conflict, so the kernel is the wrong instrument.

## The map

17 edges across the five stances, each with a rationale traceable to the stance defaults' own **wording** rather than to what the axis name suggests. Spread deliberately across `cost_efficiency`, `governance_compliance`, `reversibility`, `legibility_of_consequence` and `evidence_density` — piling every edge onto `long_term_maintainability` (already loaded by 68% of principles) would deepen the rank-deficiency this work exists to fix.

**Guard enforces:** unmapped stance = compile error (`satisfies Record<…>`); cost axes must be negative (three edges here are negative by design — the `never-wipe-db` inversion class); `|weight|` within cap; forbidden axes refused; every edge carries a reviewable rationale.

`findStanceDimensionMapViolations()` takes the map as a parameter specifically so the guard is tested against deliberately-broken maps. A checker only ever run against known-good input proves nothing about whether it can fail.

Imports the cost list from a new `@dpf/db/wiki-taxonomy` subpath rather than the package root: a pure constant shouldn't drag in the Prisma client, and going through the root made the test unrunnable locally.

## Verification — stated honestly

**Passing locally:** 17/17 guard tests, and `tsc --noEmit` clean on both new files (worktree made compile-ready via the junction recipe).

**The local gate did not pass, and I'm not claiming it did.** It was pushed with a *recorded* override (`DPF_SKIP_PREPUSH_GATE`), not a hook bypass. `vitest` was **killed** — exit `4294967295`, printing `undefined` — on three consecutive gate runs across two branches, one of which was a **single markdown file** that cannot break vitest. No log contains a single `FAIL` or assertion error; the `Qdrant down` / `db down` / `reconcileBuildCompletion` lines are deliberate fail-open fixtures. This matches the host-resource-kill class already recorded from a peer session. CI runs on clean infra and is authoritative here.

Pre-existing `tsc` errors in `lib/capacity/*` and `lib/compliance-library.ts` are **not** from this change: `isDataHandlingPredicate` exists in this worktree's source yet resolves as missing, because the junctioned `node_modules` points `@dpf/*` at the root clone, which sits on another branch.

Backlog item: BI-E1427A3E (EP-DECISION-TIER-REBALANCE). Plan: `docs/superpowers/plans/2026-08-01-stance-derived-dimension-vectors.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Local-CI-Override: local-CI vitest is killed by host resource pressure on this machine (exit 4294967295, no test failure in any log) — the runner defect is already tracked as BI-872CB1BF. Verified instead by 17/17 guard tests and a clean `tsc --noEmit` on both new files; CI is authoritative for this PR.
