### PR TITLE
fix(coworkers): resolve certification tools under the journey's route (BI-8D5BB185)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -242,6 +242,38 @@ describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => 
   });
 });
 
+describe("certification tool resolution carries the journey route (BI-8D5BB185)", () => {
+  // The runner computes routeContext via certificationRouteFor() and passes it to
+  // resolveAgent and to runLoop — but omitted it when resolving TOOLS. routeContext
+  // is what force-attaches a route's declared domain tools (tier 0), so without it
+  // the journey's central tool is absent from the available list and the loop
+  // refuses the call with "requires the `view_marketing` capability, which is not
+  // available on this page". Observed live on 2026-08-01: the
+  // marketing-specialist/campaign-readiness-review journey emitted a well-formed
+  // get_marketing_summary call and was refused, so the journey could never pass.
+  it("passes the journey's routeContext to resolveTools", async () => {
+    const { deps } = makeDeps();
+
+    await runCoworkerCertificationSweep({ agentIds: ["marketing-specialist"], deps });
+
+    expect(deps.resolveTools).toHaveBeenCalled();
+    const call = (deps.resolveTools as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(call.routeContext).toBe("/customer/marketing");
+  });
+
+  it("resolves tools and the agent under the SAME route", async () => {
+    const { deps } = makeDeps();
+
+    await runCoworkerCertificationSweep({ agentIds: ["marketing-specialist"], deps });
+
+    const toolCall = (deps.resolveTools as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    const agentCall = (deps.resolveAgent as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    // A split here is the defect: the agent is resolved for the route while its
+    // tools are resolved for nowhere.
+    expect(toolCall.routeContext).toBe(agentCall.routeContext);
+  });
+});
+
 describe("certification state derivation", () => {
   const now = new Date("2026-07-08T12:00:00Z");
 

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -182,6 +182,13 @@ async function executeJourney(
       userContext,
       mode: journey.mode,
       agentId: journey.agentId,
+      // The journey MUST resolve its tools under the same route the agent was
+      // resolved for. routeContext is what force-attaches a route's declared
+      // domain tools (tier 0); without it the journey's central tool is absent
+      // from the available list and the loop refuses the call as "not available
+      // on this page" — so the journey can never pass, for reasons unrelated to
+      // the coworker, its grants, or the tool (BI-8D5BB185).
+      routeContext,
     });
     // Non-destructive surface: certification only ever offers read-only tools.
     const readOnlyTools = resolved.tools.filter((t) => !t.sideEffect);


### PR DESCRIPTION
Tracked by **BI-8D5BB185** under **EP-COWORKER-RT**.

## The defect

The nightly certification sweep computes `routeContext` via `certificationRouteFor()` and passes it to `resolveAgent` **and** to `runLoop` — but omitted it when resolving **tools**:

```ts
const resolved = await deps.resolveTools({
  userContext, mode: journey.mode, agentId: journey.agentId,   // ← no routeContext
});
```

`routeContext` is what **force-attaches a route's declared domain tools (tier 0)**. Without it the journey's central tool never enters the available list, and the agentic loop refuses the call:

```
[agentic-tool] NOT_AVAILABLE iter=0 tool=get_marketing_summary
  reason=requires the `view_marketing` capability, which is not available on this page
```

Observed live 2026-08-01 on `thread=certification:marketing-specialist/campaign-readiness-review`: the coworker emitted a well-formed `get_marketing_summary` call and was refused. **The coworker was resolved *for* the route while its tools were resolved for nowhere.**

## Why it matters

Certification gates `certified → active` in the coworker lifecycle. A journey that cannot execute its central tool cannot pass — and the reason has nothing to do with the coworker, its grants, or the tool. Verified `marketing-specialist` holds `marketing_read`/`marketing_write`, and that on the real route the same install attaches all 15 tools correctly (`authorized=106 attached=15 cap=15`).

## Deliberately not a bypass

A certification-only capability bypass would make the sweep stop testing the thing it exists to test — a green certification that skipped the real gate is worse than a red one. This keeps **one** capability-resolution path and simply feeds it the route the journey actually runs under.

## Tests

Two assertions: the route reaches `resolveTools`, and tools and agent resolve under the **same** route (a split there *is* the defect).

My first red was a **false red** — a Prisma error from a test-harness mistake of my own, not the assertion. I reverted the fix and re-ran to confirm a genuine red (`expected undefined to be '/customer/marketing'`) before trusting the test.

- **57 tests pass across 6 `coworker-lifecycle` files**; `autonomous-work-run` green (15).
- **24 repo guards** passed (18 self-tests) in the sandbox guard loop; **31 pregate-preflight guards** clean.
- Module-size ratchet OK; substrate-regression guard OK.

### Runtime-bound gates

Two sandbox attempts failed at **different environmental points**, neither implicating this change:

1. `tsc` exited `4294967295` (`-1`, a kill) immediately after "Types generated successfully" — **zero type errors printed**; real type errors exit 1.
2. Re-run: `fatal: Unable to create 'D:/DPF/.git/shallow.lock': File exists` — a concurrent unshallow on the root clone.

A failure point that moves between identical reruns is environmental. This change adds one optional property (`routeContext?: string`, already on the input type) to an existing call — it cannot plausibly produce a type error. CI is the authoritative gate.

Local-CI-Override: two sandbox gate attempts failed at different environmental points (tsc killed with exit -1 and zero type errors; then a concurrent root-clone shallow.lock); 24 repo guards, 31 preflight guards and 57 unit tests green locally; typecheck and build deferred to CI.
Process-Spine-Decision: narrow defect fix under BI-8D5BB185; no contract, schema or policy change.
Docs-Impact-Decision: no docs affected — internal certification wiring; no user-facing behaviour or route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)