### PR TITLE
fix(test): remove care intake expiry time bomb

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -101,7 +101,7 @@ describe("issueCareIntakeResumeGrant", () => {
         granteePrincipalId: "principal-patient-a",
         issuedByPrincipalId: "principal-patient-a",
         permittedOperations: ["view", "save", "submit"],
-        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
         authorityDecision: { effect: "allow", reasonCodes: ["patient-self-access"] },
       },
       db,


### PR DESCRIPTION
## Summary

- replace the expired wall-clock fixture with a future-relative expiry
- preserve the production guard and the existing expired-grant test
- unblock Work Room cycles and every other repo-wide gate after 2026-08-01T15:00Z

## Verification

- governed sandbox targeted test: 1 file, 11 tests passed (lease NPEL-AEE385A41C)
- exact merged-tree gate passed merge, freshness, Prisma generate/migrate, docs/guards, and typecheck
- the repo-wide Vitest worker was terminated without an assertion by the shared host; GitHub CI is the authoritative full-suite runner for this one-line test-only fix
- production build impact: none; only a Vitest fixture changed

## Documentation impact

No user, operator, architecture, setup, or AI-coworker documentation changes. This removes an expired test literal only.

Design-Grounding-Decision: preserve-production-expiry-contract
Docs-Impact-Decision: no-docs-test-fixture-only
Local-CI-Override: shared-vitest-worker-terminated-without-assertion