### PR TITLE
fix(test): pin the clock in the care-intake grant suite

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getCareIntakeSavedResponse,
@@ -90,6 +90,13 @@ function database() {
 }
 
 describe("issueCareIntakeResumeGrant", () => {
+  // Pinned like every other block in this file. Without it the suite reads the real
+  // clock while its fixtures carry a fixed `expiresAt`, so the test passes only until
+  // that instant and then fails forever — which is exactly what happened at
+  // 2026-08-01T15:00Z.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+  afterEach(() => vi.useRealTimers());
+
   it("issues the raw token once only after an allow decision", async () => {
     const { db, tx } = database();
     const result = await issueCareIntakeResumeGrant(


### PR DESCRIPTION
## This is red on `main` right now and blocks every PR

`Unit Tests (web shard 1/4)` — a REQUIRED check — has been failing since **2026-08-01T15:00:00Z** and will fail forever until this lands.

```
FAIL lib/healthcare/care-intake-api-repository.test.ts
  > issueCareIntakeResumeGrant > issues the raw token once only after an allow decision
Error: Care intake grant expiry must be in the future
```

## Root cause: a time bomb, not a flake

The file has three `describe` blocks. Two pin the clock:

```ts
beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
```

The first one does not — so it read the **real** clock while its fixtures carry a hardcoded `expiresAt: new Date("2026-08-01T15:00:00.000Z")`. The production guard correctly rejects an expiry that is not in the future, so the test passed for exactly as long as wall-clock time was before that instant, then began failing permanently.

**Rerunning cannot help.** The production code is right; only the test was wrong.

## Fix

Pin and restore timers the way the rest of the file already does. **11/11 pass.** No production behaviour changes.

## Confirmed pre-existing

Reproduced on a detached checkout of clean `origin/main` (`8bfa60a7913`) with no other changes. PR #3876 was 34/34 green ~40 minutes before hitting this — green-then-red across two runs of near-identical code is the signature of a time bomb rather than a regression.

Shipped on its own so it merges fast and unblocks the fleet, rather than riding inside a feature PR.

## Follow-up

**BI-6A4F47B9** — including a proposed sweep for the same shape. A fixed future date in a fixture with no `useFakeTimers` in scope is a dormant bomb with a known detonation date, and this failure mode is maximally disruptive (blocks everyone) and maximally confusing (looks like someone's branch broke an unrelated area).

Local-CI-Override: single-file, test-only clock pin unblocking a REQUIRED check that is currently red on `main` for every PR in the repository. Verified locally (11/11) and reproduced on clean `origin/main`. Local-CI evidence would queue behind the same blocked fleet this change exists to unblock.

Seed-Fit-Decision: platform-substrate