### PR TITLE
fix(healthcare): stop the care-intake grant tests expiring on the calendar

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -89,6 +89,16 @@ function database() {
   };
 }
 
+// WALL-CLOCK TIME BOMB, fixed. Every grant fixture here hard-coded an expiry of
+// 2026-08-01T15:00:00Z. That moment passed on 2026-08-01 and `issueCareIntakeResumeGrant`
+// rejects a non-future expiry, so the suite began failing for everyone on a date rather
+// than on a change — the same class as the wall-clock UX-sweep flake (BI-0C6C2153).
+// Anchoring to `now` keeps the fixture meaning "a valid, unexpired grant" whenever the
+// suite runs. Any future test that needs an EXPIRED grant should say so explicitly with a
+// past date, not rely on the calendar catching up.
+const futureExpiry = () => new Date(Date.now() + 60 * 60 * 1000);
+
+
 describe("issueCareIntakeResumeGrant", () => {
   it("issues the raw token once only after an allow decision", async () => {
     const { db, tx } = database();
@@ -101,7 +111,7 @@ describe("issueCareIntakeResumeGrant", () => {
         granteePrincipalId: "principal-patient-a",
         issuedByPrincipalId: "principal-patient-a",
         permittedOperations: ["view", "save", "submit"],
-        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        expiresAt: futureExpiry(),
         authorityDecision: { effect: "allow", reasonCodes: ["patient-self-access"] },
       },
       db,
@@ -130,7 +140,7 @@ describe("issueCareIntakeResumeGrant", () => {
           granteePrincipalId: "principal-proxy",
           issuedByPrincipalId: "principal-proxy",
           permittedOperations: ["view"],
-          expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+          expiresAt: futureExpiry(),
           authorityDecision: { effect: "deny", reasonCodes: ["authority-not-found"] },
         },
         db,
@@ -148,14 +158,14 @@ describe("submitCareIntakePacket", () => {
     const issued = await issueCareIntakeResumeGrant({
       organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
       packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
-      permittedOperations: ["submit"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      permittedOperations: ["submit"], expiresAt: futureExpiry(),
       authorityDecision: { effect: "allow", reasonCodes: [] },
     }, db);
     tx.careIntakePacket.findFirst.mockResolvedValue({ ...packet, status: "in-progress", version: 2 });
     tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
       grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
       granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
-      permittedOperations: ["submit"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+      permittedOperations: ["submit"], expiresAt: futureExpiry(), revokedAt: null,
     });
     return { db, tx, token: issued.token };
   }
@@ -223,7 +233,7 @@ describe("saveCareIntakePartialResponse", () => {
         granteePrincipalId: "principal-patient-a",
         issuedByPrincipalId: "principal-patient-a",
         permittedOperations: ["save"],
-        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        expiresAt: futureExpiry(),
         authorityDecision: { effect: "allow", reasonCodes: [] },
       },
       db,
@@ -235,7 +245,7 @@ describe("saveCareIntakePartialResponse", () => {
       granteePrincipalId: "principal-patient-a",
       tokenDigest: digestCareIntakeResumeToken(issued.token),
       permittedOperations: ["save"],
-      expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      expiresAt: futureExpiry(),
       revokedAt: null,
     });
 
@@ -297,13 +307,13 @@ describe("saveCareIntakePartialResponse", () => {
     const issued = await issueCareIntakeResumeGrant({
       organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
       packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
-      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      permittedOperations: ["save"], expiresAt: futureExpiry(),
       authorityDecision: { effect: "allow", reasonCodes: [] },
     }, db);
     tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
       grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
       granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
-      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+      permittedOperations: ["save"], expiresAt: futureExpiry(), revokedAt: null,
     });
 
     const result = await saveCareIntakePartialResponse({
@@ -323,13 +333,13 @@ describe("saveCareIntakePartialResponse", () => {
     const issued = await issueCareIntakeResumeGrant({
       organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
       packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
-      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      permittedOperations: ["save"], expiresAt: futureExpiry(),
       authorityDecision: { effect: "allow", reasonCodes: [] },
     }, db);
     tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
       grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
       granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
-      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+      permittedOperations: ["save"], expiresAt: futureExpiry(), revokedAt: null,
     });
     tx.careIntakeResponse.findFirst.mockResolvedValue({
       id: "response-row-a", responseId: "intake-response-a", version: 3,
@@ -357,14 +367,14 @@ describe("saveCareIntakePartialResponse", () => {
       {
         organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
         packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
-        permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        permittedOperations: ["save"], expiresAt: futureExpiry(),
         authorityDecision: { effect: "allow", reasonCodes: [] },
       }, db,
     );
     tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
       grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
       granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
-      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+      permittedOperations: ["save"], expiresAt: futureExpiry(), revokedAt: null,
     });
     await expect(saveCareIntakePartialResponse({
       packetId: "intake-a", formId: "medical-history", token: issued.token,
@@ -390,7 +400,7 @@ describe("getCareIntakePacketProjection", () => {
         granteePrincipalId: "principal-patient-a",
         issuedByPrincipalId: "principal-patient-a",
         permittedOperations: ["view"],
-        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        expiresAt: futureExpiry(),
         authorityDecision: { effect: "allow", reasonCodes: [] },
       },
       db,
@@ -401,7 +411,7 @@ describe("getCareIntakePacketProjection", () => {
       patientProfileId: "patient-a",
       tokenDigest: digestCareIntakeResumeToken(issued.token),
       permittedOperations: ["view"],
-      expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      expiresAt: futureExpiry(),
       revokedAt: null,
     });
 
@@ -439,13 +449,13 @@ describe("getCareIntakeSavedResponse", () => {
     const issued = await issueCareIntakeResumeGrant({
       organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
       packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
-      permittedOperations: ["view"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      permittedOperations: ["view"], expiresAt: futureExpiry(),
       authorityDecision: { effect: "allow", reasonCodes: [] },
     }, db);
     tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
       grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
       granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
-      permittedOperations: ["view"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+      permittedOperations: ["view"], expiresAt: futureExpiry(), revokedAt: null,
     });
     tx.careIntakeResponse.findFirst.mockResolvedValue({
       id: "response-row-a", responseId: "response-a", version: 2,
@@ -466,13 +476,13 @@ describe("getCareIntakeSavedResponse", () => {
     const issued = await issueCareIntakeResumeGrant({
       organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
       packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
-      permittedOperations: ["view"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      permittedOperations: ["view"], expiresAt: futureExpiry(),
       authorityDecision: { effect: "allow", reasonCodes: [] },
     }, db);
     tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
       grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
       granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
-      permittedOperations: ["view"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+      permittedOperations: ["view"], expiresAt: futureExpiry(), revokedAt: null,
     });
 
     await expect(getCareIntakeSavedResponse({


### PR DESCRIPTION
Every grant fixture in `care-intake-api-repository.test.ts` hard-coded an expiry of `2026-08-01T15:00:00Z` — **18 occurrences of the same literal**. That moment passed on 2026-08-01, and `issueCareIntakeResumeGrant` rejects a non-future expiry, so the suite began failing for **everyone on a date rather than on a change**.

It is currently red on main and blocking unrelated PRs — I hit it on a change that touches nothing in `lib/healthcare`, which is exactly why this class is worse than an ordinary flake: **the failure looks like the PR under review caused it.** Same shape as the wall-clock UX-sweep flake (BI-0C6C2153).

## Fix

Anchored to `Date.now() + 1h` via a single `futureExpiry()` helper, so the fixture keeps meaning *"a valid, unexpired grant"* whenever the suite runs.

All 18 sites used the **identical** literal, so none was deliberately testing an *expired* grant — the helper preserves intent rather than changing it. A test that genuinely needs an expired grant should say so with an explicit past date, and the comment says so.

**Verification:** 11/11 green in that file (was 1 failed / 10 passed).

Docs-Impact-Decision: test-only fixture repair, no route or user-visible behaviour changes.

Process-Spine-Decision: one-line-class test repair unblocking main; no capability or contract change, so no plan or spec is warranted.

Seed-Fit-Decision: global-default

No canonical seed content changed; recorded as global-default because the test fixture is platform substrate on every install.

Local-CI-Override: Test-only fixture repair unblocking main. 11/11 green in the affected file; no runtime, schema, or contract surface. GitHub CI runs the full suite here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)