### PR TITLE
fix(healthcare): pin the clock in issueCareIntakeResumeGrant tests — repo-wide CI blocker (BI-AA333AB3)

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -90,6 +90,14 @@ function database() {
 }
 
 describe("issueCareIntakeResumeGrant", () => {
+  // Pin the clock, exactly as every other describe in this file does. Without
+  // it these cases ran against the REAL clock while asserting on a hardcoded
+  // `expiresAt` of 2026-08-01T15:00Z, and `issueCareIntakeResumeGrant` rejects
+  // an expiry that is not in the future. At 15:00Z on 2026-08-01 that literal
+  // became the past and the block began failing on every branch at once — a
+  // time bomb, not a regression from any change.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
   it("issues the raw token once only after an allow decision", async () => {
     const { db, tx } = database();
     const result = await issueCareIntakeResumeGrant(


### PR DESCRIPTION
## Repo-wide CI blocker — a time bomb, not a regression

`issueCareIntakeResumeGrant` rejects an expiry that is not in the future ([care-intake-api-repository.ts:207](apps/web/lib/healthcare/care-intake-api-repository.ts:207)). Its `describe` block was the **only one in the file without a fake-timer `beforeEach`**, so it ran against the real clock while asserting a hardcoded `expiresAt: 2026-08-01T15:00:00.000Z`.

At 15:00Z on 2026-08-01 that literal became the past, and the block began failing on **every branch at once**.

## Evidence it is base-wide, not any one PR

| PR | shard 1/4 | Failing assertion |
|---|---|---|
| #3879 | FAIL | `issueCareIntakeResumeGrant > issues the raw token once only after an allow decision` |
| #3880 | FAIL | *(identical)* |
| #3881 | FAIL | *(identical)* |
| #3882 | FAIL | *(identical)* |
| #3877, #3878, #3883 | pass | their shard ran **before** 15:00Z |

622 tests passed alongside the single failure, and #3880 touches zero healthcare files. Main's own runs at 14:20/14:53/14:56 passed for the same clock reason.

## The fix

Adds the same `vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z")` that `submitCareIntakePacket`, `saveCareIntakePartialResponse`, `getCareIntakeSavedResponse` and `getCareIntakePacketProjection` already use in this file. Consistent with the file's own convention, deterministic, and it cannot rot into the past again.

## Verification

**Red-green, locally:**
- Without the change: `1 failed | 10 passed` — reproducing the CI failure exactly.
- With the change: `11 passed`.

The local-CI gate itself could not be used: `vitest` is being killed by host resource pressure on this machine (exit `4294967295`, no test failure in any log), already tracked as BI-872CB1BF. Pushed with a recorded override, not a hook bypass.

## Noted, deliberately not fixed here

This file has no `afterEach` restoring real timers, so fake time leaks across describes in declaration order. Benign today because every block now pins the same instant — but worth a follow-up. Likewise, the same hardcoded-future-date pattern appears in other test files; BI-AA333AB3 records the sweep.

Backlog item: BI-AA333AB3.

Local-CI-Override: repo-wide CI blocker fixed as a single-test change, red-green verified locally (1 failed → 11 passed); the local-CI runner itself is killed by host resource pressure per BI-872CB1BF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
