### PR TITLE
fix(healthcare): pin the clock in the care-intake grant tests (BI-E104FBCC)

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getCareIntakeSavedResponse,
@@ -90,6 +90,15 @@ function database() {
 }
 
 describe("issueCareIntakeResumeGrant", () => {
+  // Every other block in this file pins the clock; this one did not, so its
+  // hardcoded 2026-08-01T15:00Z expiries were validated against the REAL clock
+  // and the suite detonated the moment wall-clock passed that instant — the same
+  // class of failure as the mcp-api-token rotation bomb (#3834). Pinning the
+  // clock here matches the file's existing convention and makes the block
+  // deterministic forever (BI-E104FBCC).
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+  afterEach(() => vi.useRealTimers());
+
   it("issues the raw token once only after an allow decision", async () => {
     const { db, tx } = database();
     const result = await issueCareIntakeResumeGrant(


### PR DESCRIPTION
`care-intake-api-repository.test.ts` started failing on **every open PR** at 2026-08-01T15:00Z.

```
FAIL lib/healthcare/care-intake-api-repository.test.ts > issueCareIntakeResumeGrant
     > issues the raw token once only after an allow decision
Error: Care intake grant expiry must be in the future
  at issueCareIntakeResumeGrant lib/healthcare/care-intake-api-repository.ts:208
```

The test passes `expiresAt: new Date("2026-08-01T15:00:00.000Z")`, and the code under test rejects an expiry that is not in the future.

Four of the file's five `describe` blocks pin the clock with `vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z")`. The `issueCareIntakeResumeGrant` block did **not**, so its expiries were validated against the real clock and went invalid the moment wall-clock passed them.

**Not a flake, and not caused by any PR.** A date rollover detonated it, and it blocks the merge queue for everyone until it lands.

## Fix

Pin the clock in that block too, matching the convention the rest of the file already uses, plus `afterEach(vi.useRealTimers)` so it cannot leak into neighbouring suites. The block is now deterministic regardless of when it runs.

## Verification

- `lib/healthcare` — 8 test files / 48 tests pass (11/11 in the file itself)
- `tsc --noEmit` — 0 errors

## This is the second one in days

#3834 de-bombed the mcp-api-token rotation test over a hardcoded 2026-08-01 expiry. Same shape.

**BI-E104FBCC** carries the systemic follow-up: ~20 `apps/web` test files hold hardcoded `2026-08`..`2026-12` dates with no `useFakeTimers` call, concentrated in exactly the domains where a date gets compared against `Date.now()` — expiry, validity window, certificate lifetime, deployment window. Most are probably inert fixture data; the hit rate is unlikely to be zero.

The proposal recorded there is a repo guard that fails a hardcoded future date without a pinned clock in the same `describe`, backed by an audit of the existing list — so the next one surfaces as a pre-commit finding rather than a red merge queue.

## Design grounding

- **Existing specs/plans reviewed:** searched `docs/superpowers/specs` and `docs/superpowers/plans` — no design artifact governs test clock discipline. Recording that gap in BI-E104FBCC rather than inventing an artifact for a test-only fix.
- **Current code substrate reviewed:** `apps/web/lib/healthcare/care-intake-api-repository.ts` (the future-expiry validation at line 208) and the four already-pinned `describe` blocks in the same test file.
- **Decision:** no contract change — a test-only determinism fix restoring the file's own convention.

Local-CI-Override: shared sandbox is memory-starved on this host (available memory below the pool's 8 GB floor); a separate thread owns that. Source-local gates green above; CI is the enforcing backstop.

Closes BI-E104FBCC's immediate breakage; the systemic sweep stays open on that item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
