### PR TITLE
fix(test): freeze the clock for the care-intake resume-grant block (BI-6EAEE330)

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -90,6 +90,15 @@ function database() {
 }
 
 describe("issueCareIntakeResumeGrant", () => {
+  // Freeze the clock like every other block in this file. issueCareIntakeResumeGrant
+  // rejects an expiry that is not in the future, and these cases pass a hardcoded
+  // expiresAt of 2026-08-01T15:00Z. Without a frozen clock that literal was in the
+  // future only until 2026-08-01T15:00Z real time, at which point the block began
+  // failing on main for every PR whose shard included it (BI-6EAEE330). The other
+  // four blocks were immune purely because their frozen 14:00 clock keeps the same
+  // literal ahead of "now" — this block was the one that never got the treatment.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
   it("issues the raw token once only after an allow decision", async () => {
     const { db, tx } = database();
     const result = await issueCareIntakeResumeGrant(


### PR DESCRIPTION
**`main` is red**, and this unblocks it.

`care-intake-api-repository.test.ts › issueCareIntakeResumeGrant › "issues the raw token once only after an allow decision"` fails with:

```
Error: Care intake grant expiry must be in the future
  at issueCareIntakeResumeGrant (care-intake-api-repository.ts:208)
```

It sits in **Unit Tests (web shard 1/4)**, so it fails CI for *any* PR whose shard includes it, regardless of what that PR changed. It blocked #3882 — a coworker-lifecycle change touching no healthcare file — twice, including after a re-run.

## A time bomb, now detonated

The source rejects an expiry that isn't in the future. **Four of the five** describe blocks in this file freeze the clock:

```ts
beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));  // lines 144, 213, 380, 435
```

This block never did. It ran against the **real** clock while still passing a hardcoded `expiresAt` of `2026-08-01T15:00:00.000Z` — comfortably ahead of "now" when written, and the past as of today. The other four are immune only because their frozen 14:00 clock keeps that same literal in the future.

Fixed by giving this block the same frozen clock, matching the file's own convention. **Deliberately not** by pushing the literal further out — that re-arms the bomb for a later date instead of removing the real-clock dependency.

## Proof it's pre-existing

Checked out `8bfa60a7913` (current `origin/main`) with #3882's commit absent and reproduced the identical single failure in isolation — 1 failed, 10 passed. Not shard ordering, not mock bleed, not any in-flight branch.

**Why `main` looked green:** the full CI workflow doesn't run on main pushes, only on pull requests and `merge_group`. main's HEAD carries no direct Unit Tests signal, so this reads as "the PR broke it" when it didn't.

## Scope

I swept for the same pattern (hardcoded future date + no fake timers) — 22 candidate files — and **ran them**: 34 files / 232 tests pass. Only this block had actually detonated, so no speculative changes are bundled here. The pattern is still worth watching: a hardcoded future date plus a real clock is a dated landmine wherever it appears.

`care-intake-api-repository.test.ts` 11/11; `lib/healthcare` 8 files / 48 tests green.

Local-CI-Override: test-only determinism fix unblocking a red main; healthcare suite and all swept candidate files green locally; shared sandbox contended, CI authoritative.
Docs-Impact-Decision: none — test-only, no product behaviour or user-facing surface changed.
Process-Spine-Decision: unblocking defect fix under BI-6EAEE330; no contract, schema or policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)