### PR TITLE
fix(healthcare): freeze the clock in the care-intake grant test — main is red

### DIFF
--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -90,6 +90,11 @@ function database() {
 }
 
 describe("issueCareIntakeResumeGrant", () => {
+  // Frozen like every sibling block below. Without this the suite ran on real
+  // wall-clock time against a hardcoded 15:00Z expiry and began failing the moment
+  // that instant passed, wedging the merge queue for the whole repo.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
   it("issues the raw token once only after an allow decision", async () => {
     const { db, tx } = database();
     const result = await issueCareIntakeResumeGrant(


### PR DESCRIPTION
**`main` has been red since 15:00Z today and the merge queue is ejecting every PR as a result.** This is a one-line unblock.

## Root cause

`apps/web/lib/healthcare/care-intake-api-repository.test.ts` asserts an expiry of `2026-08-01T15:00:00.000Z`, but its **first** `describe` block never froze the clock — unlike its siblings at lines 144 and 213, which both do `vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z")`.

So it ran against real wall-clock time and passed only while "now" was earlier than that literal. At 15:00Z today it began throwing:

```
Error: Care intake grant expiry must be in the future
  at issueCareIntakeResumeGrant lib/healthcare/care-intake-api-repository.ts:208
```

## Verified, not assumed

Run on a **clean `origin/main` worktree with no other changes**: `1 failed | 10 passed`. With this fix: `11 passed`. The change simply adds the same `beforeEach` the rest of the file already uses.

## Why it was expensive to find

The failure surfaces in the **merge-queue** build, not on the branch. An author sees their own PR ejected while `mergeStateStatus` still reads `CLEAN`, with a failure in code they never touched — so the diagnosis cost is paid again by every author who hits it.

## Follow-up

This is the **second** hardcoded-date time bomb to wedge the queue in 24 hours; the first was `mcp-api-token.test.ts`, fixed by #3834 at 00:59Z. Filed **BI-BC4AE430** for the suite-wide sweep plus a ratcheted guard, since two instances in fifteen hours is evidence that one-off fixes aren't enough.

Verification: `pnpm run pregate` → `gate passed` (31 guards, full local CI, production build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)