### PR TITLE
feat: externalize the ux-design critic and put the skills catalog on a page shell

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
@@ -59,28 +59,73 @@ vi.mock("@/components/platform/SkillLifecycleControls", () => ({
   SkillLifecycleControls: () => <div>skills-lifecycle-controls</div>,
 }));
 
+// Forward every prop, not just href: the shell stamps structural markers
+// (data-owner-first-next-action, data-dpf-primary-action) onto links, and a mock
+// that swallows them makes the page measure as if it had no next action. The
+// fixture must not be the thing that fails the check.
 vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
+  default: ({
+    href,
+    children,
+    ...rest
+  }: { href: string; children: React.ReactNode } & Record<string, unknown>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
   ),
 }));
 
 import { getSkillReviewDetail } from "@/lib/actions/skills-observatory";
 
 describe("PlatformAiSkillsPage", () => {
-  it("renders catalog, observability, and curator under AI Operations", async () => {
+  // BI-36CE8BAB: the page now declares a shell. The contract under test is the
+  // READING ORDER — the catalog is what the reader came for and stays on
+  // arrival; observability and the curator report are diagnostics and are
+  // deferred. Everything still renders; nothing was removed.
+  it("leads with the catalog and defers the diagnostics", async () => {
     const { default: PlatformAiSkillsPage } = await import("./page");
     const html = renderToStaticMarkup(await PlatformAiSkillsPage({}));
 
-    expect(html).toContain("AI Operations");
-    expect(html).toContain("Catalog");
-    expect(html).toContain("Route Skills");
-    expect(html).toContain("Observability");
-    expect(html).toContain('href="/platform/ai/prompts"');
+    // Adopts the L1 shell, with a measurable lead band and one h1.
+    expect(html).toContain('data-dpf-shell="list"');
+    expect(html).toContain("data-dpf-lead");
+    expect(html.split("<h1").length - 1).toBe(1);
+    expect(html).toContain(">Skills</h1>");
+
+    // The catalog is default-visible.
     expect(html).toContain("skills-catalog-view");
-    expect(html).toContain("skills-observatory-panel");
-    expect(html).toContain("Curator");
-    expect(html).toContain("skills-curator-report-panel");
+
+    // The diagnostics still render — inside the closed technical disclosure.
+    const disclosure = html.slice(html.indexOf("data-dpf-disclosure"));
+    expect(disclosure).toContain("Route skills");
+    expect(disclosure).toContain("Observability");
+    expect(disclosure).toContain("skills-observatory-panel");
+    expect(disclosure).toContain("Curator");
+    expect(disclosure).toContain("skills-curator-report-panel");
+
+    // Closed by default, or it defers nothing.
+    expect(html).not.toMatch(/<details[^>]*\sopen/);
+
+    expect(html).toContain('href="/platform/ai/prompts"');
+  });
+
+  // The route is in MIGRATED_ROUTES, which strips its pre-migration exemptions —
+  // so it is now held to the FULL shell contract. This asserts that with the
+  // sweep's own evaluator, so the claim cannot rot into a comment.
+  it("passes every budget check for the shell it resolves to", async () => {
+    const { auditUxBudget } = await import("@/lib/ux-budget");
+    const { default: PlatformAiSkillsPage } = await import("./page");
+    const html = renderToStaticMarkup(await PlatformAiSkillsPage({}));
+
+    // `detail` is what shellForRoute derives for this route (admin +
+    // advanced-diagnostic) and it is the stricter budget.
+    const report = auditUxBudget(html, "detail", {
+      exemptChecks: [],
+      routeStatus: "pre-existing",
+    });
+
+    const failing = report.findings.filter((f) => !f.ok);
+    expect(failing.map((f) => `${f.check}: ${f.detail}`)).toEqual([]);
   });
 
   it("renders scoped evidence for a focused skill detail", async () => {

--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -26,16 +26,21 @@ import { isSkillLifecycleState } from "@/lib/skills/lifecycle";
 
 // Migrated to the L1 `list` shell (BI-36CE8BAB, EP-UX-SYSTEM §6 L1).
 //
-// This route measured 5,349 default-visible words against a 450-word budget —
-// the 2nd-worst surface in the portal and 28x the 192-word median across the
-// 201 routes swept — with ZERO lead-band words and an accessibility tree that
-// was a flat run of ~150 sibling paragraphs. It stacked five unrelated panels
-// vertically with no way to skip any of them.
+// This route was the portal's second-worst surface at 5,349 default-visible
+// words against a 450-word budget, with ZERO lead-band words and an
+// accessibility tree that was a flat run of ~150 sibling paragraphs. It stacked
+// five unrelated panels vertically with no way to skip any of them.
+//
+// An interim fix capped the catalog at 12 rows, which brought the measurement to
+// 1,352 but by HIDING skills — a masked list (BI-836923AD): a subset with no
+// indication of what is missing, and a search that silently disagrees with the
+// screen. This replaces the cap with structure and measures 203.
 //
 // The content did not shrink; it got a hierarchy. The catalog is what a reader
-// comes here for and stays default-visible; observability, the curator report
-// and seed-drift detail are diagnostics and now sit behind one disclosure.
-// Nothing was removed and every control remains reachable.
+// comes here for and stays default-visible, grouped by category and collapsed;
+// observability, the curator report and seed-drift detail are diagnostics and
+// now sit behind one disclosure. Nothing was removed and every control and every
+// skill remains reachable.
 
 export default async function SkillsObservatoryPage({
   searchParams,

--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ListShell } from "@/components/page-shells";
 import { SkillsCatalogView } from "@/components/admin/SkillsCatalogView";
 import { SkillsObservatoryPanel } from "@/components/platform/SkillsObservatoryPanel";
 import { SkillProposalsPanel } from "@/components/platform/SkillProposalsPanel";
@@ -22,6 +23,19 @@ import {
   getSkillSeedWarnings,
 } from "@/lib/actions/skills-observatory";
 import { isSkillLifecycleState } from "@/lib/skills/lifecycle";
+
+// Migrated to the L1 `list` shell (BI-36CE8BAB, EP-UX-SYSTEM §6 L1).
+//
+// This route measured 5,349 default-visible words against a 450-word budget —
+// the 2nd-worst surface in the portal and 28x the 192-word median across the
+// 201 routes swept — with ZERO lead-band words and an accessibility tree that
+// was a flat run of ~150 sibling paragraphs. It stacked five unrelated panels
+// vertically with no way to skip any of them.
+//
+// The content did not shrink; it got a hierarchy. The catalog is what a reader
+// comes here for and stays default-visible; observability, the curator report
+// and seed-drift detail are diagnostics and now sit behind one disclosure.
+// Nothing was removed and every control remains reachable.
 
 export default async function SkillsObservatoryPage({
   searchParams,
@@ -88,96 +102,92 @@ export default async function SkillsObservatoryPage({
       : null;
 
   return (
-    <div>
-      <div className="mb-6">
-        <h1 className="text-xl font-bold text-[var(--dpf-text)]">AI Operations</h1>
-        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          Skills — {catalogStats.total} catalog entries and {stats.totalSkills} route-visible skills across {stats.routes} routes
-        </p>
-      </div>
+    <ListShell
+      title="Skills"
+      lead={`What your coworkers know how to do. ${catalogStats.total} skills in the catalog.`}
+      // Granting a skill is the verb people come here for, and it lives on the
+      // coworker's record rather than on this page. It used to be a sentence of
+      // prose in the middle of a banner; making it the marked next action is
+      // both the honest hierarchy and what makes "this screen says what to do
+      // next" measurable instead of asserted.
+      nextAction={{
+        label: "Grant a skill to a coworker",
+        href: "/platform/ai/overview",
+        hint: "You grant skills one coworker at a time, on their record.",
+      }}
+      // Rendered only when something is genuinely wrong. A permanent "all clear"
+      // banner trains people to skip the band that carries the real warnings.
+      attention={
+        seedWarnings.length > 0 ? (
+          <>
+            {seedWarnings.length} skill{seedWarnings.length !== 1 ? "s have" : " has"} drifted from
+            the seed, so a fresh install would not match this one. Detail is under Technical details.
+          </>
+        ) : undefined
+      }
+      actions={[{ label: "Prompts", href: "/platform/ai/prompts" }]}
+      technicalDetails={
+        <div className="space-y-6">
+          <section>
+            <h2 className="mb-1 text-sm font-semibold text-[var(--dpf-text)]">Route skills</h2>
+            <p className="text-xs text-[var(--dpf-muted)]">
+              {stats.totalSkills} route-visible skills across {stats.routes} routes — what coworkers
+              can surface in context.
+            </p>
+          </section>
 
-      {/* Catalog framing (coworker-management-consolidation WS3): this is the
-          GLOBAL skills catalog / observatory. Granting or revoking skills for a
-          single coworker lives on that coworker's record, reached from the
-          directory. */}
-      <div className="mb-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3 text-xs text-[var(--dpf-muted)]">
-        This is the <strong className="text-[var(--dpf-text)]">global skills catalog and observatory</strong>. To grant
-        or revoke skills for a single coworker, open that coworker&rsquo;s record from the{" "}
-        <Link href="/platform/ai/overview" className="underline text-[var(--dpf-accent)]">
-          AI Workforce directory
-        </Link>{" "}
-        and use its Capabilities tab.
-      </div>
-
-      {seedWarnings.length > 0 && (
-        <div
-          className="mb-6 rounded border p-4"
-          style={{
-            borderColor: "color-mix(in srgb, var(--dpf-warning) 40%, var(--dpf-border))",
-            background: "color-mix(in srgb, var(--dpf-warning) 8%, var(--dpf-surface-1))",
-          }}
-        >
-          <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Seed Warnings</h2>
-          <div className="space-y-2">
-            {seedWarnings.map((warning) => (
-              <div
-                key={warning.warningId}
-                className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="font-semibold text-[var(--dpf-text)]">{warning.skillId}</span>
-                  <span className="font-mono text-[10px] text-[var(--dpf-muted)]">
-                    {warning.warningType}
-                  </span>
-                </div>
-                <p className="mt-1 text-[var(--dpf-muted)]">{warning.message}</p>
-                <p className="mt-1 font-mono text-[10px] text-[var(--dpf-muted)]">
-                  {warning.legacyPath}{" -> "}{warning.pluginPath}
-                </p>
+          {seedWarnings.length > 0 && (
+            <section>
+              <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Seed drift</h2>
+              <div className="space-y-2">
+                {seedWarnings.map((warning) => (
+                  <div
+                    key={warning.warningId}
+                    className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-semibold text-[var(--dpf-text)]">{warning.skillId}</span>
+                      <span className="font-mono text-[10px] text-[var(--dpf-muted)]">
+                        {warning.warningType}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-[var(--dpf-muted)]">{warning.message}</p>
+                    <p className="mt-1 font-mono text-[10px] text-[var(--dpf-muted)]">
+                      {warning.legacyPath}
+                      {" -> "}
+                      {warning.pluginPath}
+                    </p>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </section>
+          )}
+
+          <section>
+            <h2 className="mb-3 text-sm font-semibold text-[var(--dpf-text)]">Observability</h2>
+            <SkillsObservatoryPanel
+              skills={skills}
+              finishingPasses={JSON.parse(JSON.stringify(finishingPasses))}
+              specialistExecutions={JSON.parse(JSON.stringify(executions))}
+              stats={stats}
+              telemetry={telemetry}
+            />
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-sm font-semibold text-[var(--dpf-text)]">Curator</h2>
+            <SkillCuratorReportPanel report={curatorReport} />
+          </section>
         </div>
-      )}
+      }
+    >
+      <SkillsCatalogView
+        skills={JSON.parse(JSON.stringify(catalogSkills))}
+        stats={JSON.parse(JSON.stringify(catalogStats))}
+      />
 
-      <div className="mb-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-        <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Catalog</h2>
-        <p className="mb-3 text-xs text-[var(--dpf-muted)]">
-          Skills are user-triggerable or agent-triggerable actions with capability gates and tool access.
-          Prompts remain the system instructions that shape coworker behavior and now live under{" "}
-          <Link href="/platform/ai/prompts" className="underline text-[var(--dpf-accent)]">
-            Prompts
-          </Link>.
-        </p>
-        <SkillsCatalogView
-          skills={JSON.parse(JSON.stringify(catalogSkills))}
-          stats={JSON.parse(JSON.stringify(catalogStats))}
-        />
-      </div>
-
-      <div className="mb-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-        <h2 className="mb-2 text-sm font-semibold text-[var(--dpf-text)]">Route Skills</h2>
-        <p className="text-xs text-[var(--dpf-muted)]">
-          Route-level and universal skills describe what coworkers can surface in-context across the platform.
-        </p>
-      </div>
-
-      <div>
-        <h2 className="mb-3 text-sm font-semibold text-[var(--dpf-text)]">Observability</h2>
-        <SkillsObservatoryPanel
-          skills={skills}
-          finishingPasses={JSON.parse(JSON.stringify(finishingPasses))}
-          specialistExecutions={JSON.parse(JSON.stringify(executions))}
-          stats={stats}
-          telemetry={telemetry}
-        />
-      </div>
-
-      <div className="mt-6">
-        <h2 className="mb-3 text-sm font-semibold text-[var(--dpf-text)]">Curator</h2>
-        <SkillCuratorReportPanel report={curatorReport} />
-      </div>
-
+      {/* When ?skill= is set, that skill IS why the reader is here — so it stays
+          default-visible rather than being demoted with the diagnostics. */}
       {focusedSkillId && (
         <div className="mt-6 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
           <div className="mb-3 flex items-baseline justify-between gap-3">
@@ -192,7 +202,6 @@ export default async function SkillsObservatoryPage({
             </Link>
           </div>
 
-          {/* Slice 4: lifecycle controls */}
           {focusedLifecycleState && (
             <div className="mb-4">
               <SkillLifecycleControls
@@ -202,7 +211,6 @@ export default async function SkillsObservatoryPage({
             </div>
           )}
 
-          {/* Slice 3: seed drift, proposals, revisions */}
           {review ? (
             <>
               {!review.seedDrift.inSync && review.seedDrift.seedBody !== null && (
@@ -263,6 +271,6 @@ export default async function SkillsObservatoryPage({
           )}
         </div>
       )}
-    </div>
+    </ListShell>
   );
 }

--- a/apps/web/components/admin/SkillsCatalogView.budget.test.tsx
+++ b/apps/web/components/admin/SkillsCatalogView.budget.test.tsx
@@ -7,11 +7,12 @@ import { measureUxBudget, UX_BUDGETS } from "@/lib/ux-budget";
 // BI-36CE8BAB / BI-1D718FCA — the wall-of-text regression guard for the catalog.
 //
 // `/platform/ai/skills` measured 5,349 default-visible words: the 2nd-worst
-// surface in the portal, ~12x its budget, 28x the 192-word median across the 201
-// routes swept. Nearly all of it came from ONE component — a card grid rendering
-// all 92 skills' full descriptions with `line-clamp-2`. Clamping is a paint-time
-// trick: the words stay in the DOM, so the reader's accessibility tree, the
-// route sweep, and any screen reader all still carry them.
+// surface in the portal and ~12x its budget. Nearly all of it came from ONE
+// component — a card grid rendering all 92 skills' full descriptions with
+// `line-clamp-2`. Clamping is a paint-time trick: the words stay in the DOM, so
+// the accessibility tree, the route sweep, and any screen reader still carry
+// them. An interim cap took the route to 1,352 by hiding rows; grouping takes it
+// to 203 while keeping every row reachable.
 //
 // This test measures the SAME artifact the CI sweep measures (served markup, via
 // the sweep's own measureUxBudget) at production scale, so the regression cannot
@@ -100,7 +101,8 @@ describe("SkillsCatalogView — default-visible budget at production scale", () 
   });
 
   it("stays far below the 5,349-word baseline this route regressed from", () => {
-    // Measured at 26 words when this landed. The ceiling is deliberately loose:
+    // This component measures 26 words in isolation; the full route measures 203
+    // (the route sweep is the binding number). The ceiling is deliberately loose:
     // it guards the ORDER OF MAGNITUDE so a real regression fails loudly without
     // turning every copy edit red.
     expect(metrics.defaultVisibleWords).toBeLessThan(200);

--- a/apps/web/components/admin/SkillsCatalogView.budget.test.tsx
+++ b/apps/web/components/admin/SkillsCatalogView.budget.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SkillsCatalogView } from "./SkillsCatalogView";
+import { measureUxBudget, UX_BUDGETS } from "@/lib/ux-budget";
+
+// BI-36CE8BAB / BI-1D718FCA — the wall-of-text regression guard for the catalog.
+//
+// `/platform/ai/skills` measured 5,349 default-visible words: the 2nd-worst
+// surface in the portal, ~12x its budget, 28x the 192-word median across the 201
+// routes swept. Nearly all of it came from ONE component — a card grid rendering
+// all 92 skills' full descriptions with `line-clamp-2`. Clamping is a paint-time
+// trick: the words stay in the DOM, so the reader's accessibility tree, the
+// route sweep, and any screen reader all still carry them.
+//
+// This test measures the SAME artifact the CI sweep measures (served markup, via
+// the sweep's own measureUxBudget) at production scale, so the regression cannot
+// return quietly. It is deliberately not a snapshot — a snapshot would happily
+// record a wall of text as the new normal.
+
+/** Production shape as of 2026-07-31: 92 catalog entries, ~238-char descriptions. */
+const SKILL_COUNT = 92;
+const DESCRIPTION = // ~238 chars, the measured live average
+  "Use this skill when the operator needs a governed path through the workflow, including the " +
+  "preconditions that must hold before it runs, the evidence it records on completion, and the " +
+  "escalation route when a precondition cannot be satisfied safely.";
+
+/** Eight categories, the shape a real catalog has. */
+const CATEGORIES = [
+  "operations",
+  "governance",
+  "delivery",
+  "finance",
+  "marketing",
+  "platform",
+  "people",
+  "support",
+];
+
+const skills = Array.from({ length: SKILL_COUNT }, (_, i) => ({
+  id: `id-${i}`,
+  skillId: `skill-${i}`,
+  name: `Governed workflow skill ${i}`,
+  description: DESCRIPTION,
+  version: "1.0.0",
+  sourceType: "builtin",
+  sourceRegistry: null,
+  category: CATEGORIES[i % CATEGORIES.length],
+  tags: ["governance", "workflow", "evidence"],
+  author: "dpf",
+  license: "MIT",
+  riskBand: "low",
+  status: "active",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  _count: { assignments: 3 },
+}));
+
+const stats = {
+  total: SKILL_COUNT,
+  byStatus: [{ status: "active", _count: SKILL_COUNT }],
+  bySource: [{ sourceType: "builtin", _count: SKILL_COUNT }],
+};
+
+describe("SkillsCatalogView — default-visible budget at production scale", () => {
+  const html = renderToStaticMarkup(<SkillsCatalogView skills={skills} stats={stats} />);
+  const metrics = measureUxBudget(html);
+
+  it("keeps every skill reachable — nothing is dropped to win the budget", () => {
+    // The fix must be DISCLOSURE, not truncation. A capped list that silently
+    // shows a subset would trade one usability defect for a worse one.
+    expect(html).toContain("Governed workflow skill 0");
+    expect(html).toContain(`Governed workflow skill ${SKILL_COUNT - 1}`);
+    expect(html).toContain(DESCRIPTION);
+  });
+
+  it("defers the descriptions rather than clamping them", () => {
+    // One closed <details> per row plus one per category group. The words all
+    // exist; none of them are on arrival.
+    expect(html.split("<details").length - 1).toBe(SKILL_COUNT + CATEGORIES.length);
+    expect(html).not.toMatch(/<details[^>]*\sopen/);
+    // The old shape — every word in the DOM behind a CSS clamp.
+    expect(html).not.toContain("line-clamp-2");
+  });
+
+  it("groups rather than truncates, so arrival costs a few category headers", () => {
+    expect(metrics.disclosureRegions).toBe(CATEGORIES.length);
+    for (const category of CATEGORIES) expect(html).toContain(category);
+  });
+
+  it("lands inside the budget of the shell this route resolves to", () => {
+    // /platform/ai/skills derives the `detail` shell (advanced-diagnostic), which
+    // is STRICTER than `list`. Hold it to the stricter of the two so the local
+    // assertion cannot pass while CI fails.
+    const budget = Math.min(
+      UX_BUDGETS.detail.maxDefaultVisibleWords,
+      UX_BUDGETS.list.maxDefaultVisibleWords,
+    );
+    expect(metrics.defaultVisibleWords).toBeLessThanOrEqual(budget);
+  });
+
+  it("stays far below the 5,349-word baseline this route regressed from", () => {
+    // Measured at 26 words when this landed. The ceiling is deliberately loose:
+    // it guards the ORDER OF MAGNITUDE so a real regression fails loudly without
+    // turning every copy edit red.
+    expect(metrics.defaultVisibleWords).toBeLessThan(200);
+  });
+});

--- a/apps/web/components/admin/SkillsCatalogView.tsx
+++ b/apps/web/components/admin/SkillsCatalogView.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useMemo } from "react";
 
-const INITIAL_SKILL_COUNT = 12;
-
 // ---------------------------------------------------------------------------
 // Types matching the server query shape
 // ---------------------------------------------------------------------------
@@ -70,7 +68,6 @@ export function SkillsCatalogView({
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
   const [sourceFilter, setSourceFilter] = useState("");
-  const [visibleCount, setVisibleCount] = useState(INITIAL_SKILL_COUNT);
 
   // Derive unique values for filter dropdowns
   const statuses = useMemo(
@@ -99,8 +96,30 @@ export function SkillsCatalogView({
     }
     return list;
   }, [skills, search, statusFilter, sourceFilter]);
-  const visible = filtered.slice(0, visibleCount);
-  const remaining = filtered.length - visible.length;
+
+  // When any filter is active the reader has already narrowed the set, so the
+  // groups open — collapsing a 3-result search behind category headers would be
+  // disclosure working against the reader instead of for them.
+  const isFiltering = Boolean(search || statusFilter || sourceFilter);
+
+  /**
+   * Grouped by category, because 92 flat rows is still a wall.
+   *
+   * Measured: the flat list rendered 562 default-visible words against this
+   * shell's 450-word budget — better than the 5,349 it replaced, but still over.
+   * Grouping defers the rows behind ~8 category headers, so arrival costs a few
+   * dozen words and every skill is two clicks away at worst. Nothing is dropped;
+   * a capped or paged list would trade this defect for a worse one (BI-836923AD).
+   */
+  const grouped = useMemo(() => {
+    const byCategory = new Map<string, SkillRow[]>();
+    for (const skill of filtered) {
+      const bucket = byCategory.get(skill.category);
+      if (bucket) bucket.push(skill);
+      else byCategory.set(skill.category, [skill]);
+    }
+    return [...byCategory.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [filtered]);
 
   return (
     <div>
@@ -126,18 +145,12 @@ export function SkillsCatalogView({
           type="text"
           placeholder="Search skills..."
           value={search}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            setVisibleCount(INITIAL_SKILL_COUNT);
-          }}
+          onChange={(e) => setSearch(e.target.value)}
           className="px-3 py-1.5 rounded-md text-xs bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] border border-[var(--dpf-border)] focus:outline-none focus:ring-1 focus:ring-[var(--dpf-accent)] w-56"
         />
         <select
           value={statusFilter}
-          onChange={(e) => {
-            setStatusFilter(e.target.value);
-            setVisibleCount(INITIAL_SKILL_COUNT);
-          }}
+          onChange={(e) => setStatusFilter(e.target.value)}
           className="px-3 py-1.5 rounded-md text-xs bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] border border-[var(--dpf-border)]"
         >
           <option value="">All statuses</option>
@@ -149,10 +162,7 @@ export function SkillsCatalogView({
         </select>
         <select
           value={sourceFilter}
-          onChange={(e) => {
-            setSourceFilter(e.target.value);
-            setVisibleCount(INITIAL_SKILL_COUNT);
-          }}
+          onChange={(e) => setSourceFilter(e.target.value)}
           className="px-3 py-1.5 rounded-md text-xs bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] border border-[var(--dpf-border)]"
         >
           <option value="">All sources</option>
@@ -175,110 +185,108 @@ export function SkillsCatalogView({
             : "No skills match the current filters."}
         </p>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {visible.map((skill) => (
-            <div
-              key={skill.id}
-              className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
-              style={{
-                borderLeftColor: STATUS_COLOURS[skill.status] ?? "var(--dpf-muted)",
-              }}
+        // One row per skill, detail deferred (BI-36CE8BAB).
+        //
+        // This used to be a 3-column card grid rendering every skill's FULL
+        // description. `line-clamp-2` hid the overflow visually but left every
+        // word in the DOM, which is how one catalog of 92 skills put 5,349
+        // words on arrival — 12x this route's budget and the 2nd-worst surface
+        // in the portal. Clamping is a paint-time trick; it is not disclosure.
+        //
+        // Each row is now a closed <details>: the summary carries what you scan
+        // by (name, status, category), and description, provenance and tags
+        // live one click away. The sweep excises closed disclosures, so the
+        // route is measured on what a reader actually meets.
+        <div className="space-y-2">
+          {grouped.map(([category, rows]) => (
+            <details
+              key={category}
+              open={isFiltering}
+              className="group/cat rounded border border-[var(--dpf-border)]"
             >
-              {/* Header */}
-              <div className="flex items-start justify-between gap-2 mb-1.5">
-                <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight truncate">
-                  {skill.name}
-                </p>
+              <summary className="dpf-tap-target flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium text-[var(--dpf-text)] marker:hidden hover:bg-[var(--dpf-surface-2)] [&::-webkit-details-marker]:hidden">
                 <span
-                  className="text-[9px] px-1.5 py-0.5 rounded-full shrink-0"
-                  style={{
-                    background: `color-mix(in srgb, ${STATUS_COLOURS[skill.status] ?? "var(--dpf-muted)"} 13%, transparent)`,
-                    color: STATUS_COLOURS[skill.status] ?? "var(--dpf-muted)",
-                  }}
+                  aria-hidden
+                  className="text-[var(--dpf-muted)] transition-transform group-open/cat:rotate-90"
                 >
-                  {skill.status}
+                  ▸
                 </span>
-              </div>
+                <span className="flex-1">{category}</span>
+                <span className="text-xs text-[var(--dpf-muted)]">{rows.length}</span>
+              </summary>
 
-              {/* Description */}
-              <p className="text-[11px] text-[var(--dpf-muted)] line-clamp-2 mb-2">
-                {skill.description}
-              </p>
-
-              {/* Meta row */}
-              <div className="flex flex-wrap items-center gap-1.5 text-[9px]">
-                <span className="font-mono text-[var(--dpf-muted)]">
-                  v{skill.version}
-                </span>
-                <span
-                  className="px-1 py-0.5 rounded"
-                  style={{
-                    background: `color-mix(in srgb, ${RISK_COLOURS[skill.riskBand] ?? "var(--dpf-muted)"} 10%, transparent)`,
-                    color: RISK_COLOURS[skill.riskBand] ?? "var(--dpf-muted)",
-                  }}
+              <ul className="divide-y divide-[var(--dpf-border)] border-t border-[var(--dpf-border)]">
+                {rows.map((skill) => (
+            <li key={skill.id}>
+              <details className="group">
+                <summary
+                  className="dpf-tap-target flex cursor-pointer list-none items-center gap-3 px-3 py-2 marker:hidden hover:bg-[var(--dpf-surface-2)] [&::-webkit-details-marker]:hidden"
+                  style={{ borderLeft: `3px solid ${STATUS_COLOURS[skill.status] ?? "var(--dpf-muted)"}` }}
                 >
-                  {skill.riskBand} risk
-                </span>
-                <span className="text-[var(--dpf-muted)]">
-                  {skill.sourceType}
-                  {skill.sourceRegistry ? ` / ${skill.sourceRegistry}` : ""}
-                </span>
-                <span className="text-[var(--dpf-muted)]">
-                  {skill.category}
-                </span>
-              </div>
+                  <span
+                    aria-hidden
+                    className="text-[var(--dpf-muted)] transition-transform group-open:rotate-90"
+                  >
+                    ▸
+                  </span>
+                  <span className="flex-1 truncate text-sm text-[var(--dpf-text)]">{skill.name}</span>
+                  <span
+                    className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px]"
+                    style={{
+                      background: `color-mix(in srgb, ${STATUS_COLOURS[skill.status] ?? "var(--dpf-muted)"} 13%, transparent)`,
+                      color: STATUS_COLOURS[skill.status] ?? "var(--dpf-muted)",
+                    }}
+                  >
+                    {skill.status}
+                  </span>
+                </summary>
 
-              {/* Tags */}
-              {skill.tags.length > 0 && (
-                <div className="flex flex-wrap gap-1 mt-2">
-                  {skill.tags.slice(0, 5).map((tag) => (
+                <div className="border-t border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-3">
+                  <p className="mb-2 text-xs text-[var(--dpf-muted)]">{skill.description}</p>
+
+                  <div className="flex flex-wrap items-center gap-2 text-[10px]">
+                    <span className="font-mono text-[var(--dpf-muted)]">v{skill.version}</span>
                     <span
-                      key={tag}
-                      className="text-[9px] px-1.5 py-0.5 rounded bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]"
+                      className="rounded px-1 py-0.5"
+                      style={{
+                        background: `color-mix(in srgb, ${RISK_COLOURS[skill.riskBand] ?? "var(--dpf-muted)"} 10%, transparent)`,
+                        color: RISK_COLOURS[skill.riskBand] ?? "var(--dpf-muted)",
+                      }}
                     >
-                      {tag}
+                      {skill.riskBand} risk
                     </span>
-                  ))}
-                  {skill.tags.length > 5 && (
-                    <span className="text-[9px] text-[var(--dpf-muted)]">
-                      +{skill.tags.length - 5}
+                    <span className="text-[var(--dpf-muted)]">
+                      {skill.sourceType}
+                      {skill.sourceRegistry ? ` / ${skill.sourceRegistry}` : ""}
                     </span>
+                    <span className="text-[var(--dpf-muted)]">
+                      {skill._count.assignments} agent{skill._count.assignments !== 1 ? "s" : ""} assigned
+                    </span>
+                    {skill.author ? (
+                      <span className="text-[var(--dpf-muted)]">by {skill.author}</span>
+                    ) : null}
+                  </div>
+
+                  {skill.tags.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {skill.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-muted)]"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
                   )}
                 </div>
-              )}
-
-              {/* Skill quality indicators */}
-              <div className="flex flex-wrap gap-1 mt-2">
-                {skill.description.length > 50 && (
-                  <span className="text-[8px] px-1 py-0.5 rounded bg-[color-mix(in_srgb,var(--dpf-success)_10%,transparent)] text-[var(--dpf-success)]">
-                    rich description
-                  </span>
-                )}
-              </div>
-
-              {/* Footer */}
-              <div className="flex items-center justify-between mt-3 pt-2 border-t border-[var(--dpf-border)]">
-                <span className="text-[9px] text-[var(--dpf-muted)]">
-                  {skill._count.assignments} agent{skill._count.assignments !== 1 ? "s" : ""} assigned
-                </span>
-                {skill.author && (
-                  <span className="text-[9px] text-[var(--dpf-muted)] truncate max-w-[120px]">
-                    by {skill.author}
-                  </span>
-                )}
-              </div>
-            </div>
+              </details>
+            </li>
+                ))}
+              </ul>
+            </details>
           ))}
         </div>
-      )}
-      {remaining > 0 && (
-        <button
-          type="button"
-          onClick={() => setVisibleCount((count) => count + INITIAL_SKILL_COUNT)}
-          className="mt-4 rounded border border-[var(--dpf-border)] px-3 py-1.5 text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
-        >
-          Show {remaining} more
-        </button>
       )}
     </div>
   );

--- a/apps/web/components/admin/catalog-progressive-disclosure.test.tsx
+++ b/apps/web/components/admin/catalog-progressive-disclosure.test.tsx
@@ -57,7 +57,17 @@ describe("AI catalog progressive disclosure", () => {
     expect(html).not.toContain("Weekly product review");
   });
 
-  it("limits the initial skills catalog instead of rendering every skill", () => {
+  // Was: "limits the initial skills catalog instead of rendering every skill",
+  // asserting a 12-item cap with a "Show 3 more" control.
+  //
+  // The cap traded one usability defect for a worse one. A capped list is a
+  // MASKED list (BI-836923AD): the reader is shown a subset with no way to know
+  // what is missing, and search over the full set silently disagrees with what
+  // is on screen. The catalog now groups by category and collapses the groups
+  // (BI-36CE8BAB), which costs the reader a few category headers on arrival
+  // instead of hiding rows — and measured better doing it: 5,349 default-visible
+  // words down to 26 for this component, versus the ~500 the cap still rendered.
+  it("groups the catalog rather than hiding rows behind a cap", () => {
     const html = renderToStaticMarkup(
       <SkillsCatalogView
         skills={Array.from({ length: 15 }, (_, index) => catalogSkill(index + 1))}
@@ -69,9 +79,16 @@ describe("AI catalog progressive disclosure", () => {
       />,
     );
 
+    // Every skill is reachable — nothing is dropped to win the budget.
     expect(html).toContain("Catalog skill 12");
-    expect(html).not.toContain("Catalog skill 13");
-    expect(html).toContain("Show 3 more");
+    expect(html).toContain("Catalog skill 13");
+    expect(html).toContain("Catalog skill 15");
+    expect(html).not.toContain("Show 3 more");
+
+    // Deferred, not merely hidden: the group is a closed <details>, so the rows
+    // are excised from the measured default-visible scope.
+    expect(html).toContain("product-management");
+    expect(html).not.toMatch(/<details[^>]*\sopen/);
   });
 
   it("limits route skills and defers the high-cardinality route filter", () => {

--- a/apps/web/components/page-shells/PageShell.test.tsx
+++ b/apps/web/components/page-shells/PageShell.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ListShell, PageShell } from "./PageShell";
+import { DISCLOSURE_ATTR, LEAD_ATTR } from "@/lib/ux-budget/scope";
+import { PRIMARY_ACTION_ATTR } from "@/lib/ux-budget/measure";
+
+// BI-36CE8BAB. These tests pin the CONTRACT, not the styling: a shell is only
+// worth having if the structural markers the route sweep measures are actually
+// emitted, and if deferred content is genuinely deferred rather than merely
+// visually hidden. The failure this whole epic exists to stop was a card grid
+// that used `line-clamp-2` — the words stayed in the DOM and the route measured
+// 5,349 of them.
+//
+// Rendered to static markup rather than through jsdom, deliberately: the sweep
+// measures served HTML, so asserting on the same artifact keeps the test and the
+// gate looking at the same thing.
+
+/** Count non-overlapping occurrences of a needle. */
+const count = (html: string, needle: string) => html.split(needle).length - 1;
+
+describe("PageShell — the structural contract the sweep measures", () => {
+  it("stamps the lead band so it can be measured", () => {
+    const html = renderToStaticMarkup(
+      <ListShell title="Skills" lead="What coworkers can do.">
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(html).toContain(`${LEAD_ATTR}=""`);
+    expect(html).toContain("What coworkers can do.");
+  });
+
+  it("renders exactly one h1 — the page's own name", () => {
+    const html = renderToStaticMarkup(
+      <ListShell title="Skills" lead="lead">
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(count(html, "<h1")).toBe(1);
+    expect(html).toContain(">Skills</h1>");
+  });
+
+  it("marks a primary action so 'the verb is buried' is measurable, not a matter of taste", () => {
+    const html = renderToStaticMarkup(
+      <ListShell
+        title="Skills"
+        lead="lead"
+        actions={[
+          { label: "Start", href: "/start", primary: true },
+          { label: "Prompts", href: "/prompts" },
+        ]}
+      >
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(count(html, `${PRIMARY_ACTION_ATTR}=""`)).toBe(1);
+    expect(html).toContain("Start");
+    expect(html).toContain("Prompts");
+  });
+
+  it("defers technical detail into a CLOSED disclosure, not a visual clamp", () => {
+    const html = renderToStaticMarkup(
+      <ListShell title="Skills" lead="lead" technicalDetails={<p>diagnostics</p>}>
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(count(html, "<details")).toBe(1);
+    expect(html).toContain(DISCLOSURE_ATTR);
+    // Closed by default is the whole point: the sweep excises closed <details>,
+    // so an open-by-default "disclosure" would defer nothing and score nothing.
+    expect(html).not.toMatch(/<details[^>]*\sopen/);
+    expect(html).toContain("diagnostics");
+  });
+
+  it("omits the disclosure entirely when there is no technical detail", () => {
+    const html = renderToStaticMarkup(
+      <ListShell title="Skills" lead="lead">
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(html).not.toContain("<details");
+  });
+
+  it("shows the attention line only when something is actually wrong", () => {
+    const quiet = renderToStaticMarkup(
+      <ListShell title="Skills" lead="lead">
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(quiet).not.toContain("drifted");
+
+    const loud = renderToStaticMarkup(
+      <ListShell title="Skills" lead="lead" attention={<>3 skills have drifted</>}>
+        <p>body</p>
+      </ListShell>,
+    );
+    expect(loud).toContain("3 skills have drifted");
+  });
+
+  it("records which reading contract the surface claims", () => {
+    const html = renderToStaticMarkup(
+      <PageShell kind="settings" title="Config" lead="lead">
+        <p>body</p>
+      </PageShell>,
+    );
+    expect(html).toContain('data-dpf-shell="settings"');
+  });
+});

--- a/apps/web/components/page-shells/PageShell.tsx
+++ b/apps/web/components/page-shells/PageShell.tsx
@@ -1,0 +1,203 @@
+// apps/web/components/page-shells/PageShell.tsx
+//
+// L1 page shells (EP-UX-SYSTEM spec §6 L1, BI-36CE8BAB).
+//
+// WHY THIS EXISTS. The platform could already MEASURE that its surfaces were
+// walls of text — the route sweep baselined 201 routes and found a median of
+// 192 default-visible words against outliers of 5,349 and 15,517 — but nothing
+// made the good structure the path of least resistance, so every new surface
+// regressed to the model's house style by default (spec RC6). Budgets without
+// primitives just tell you afterwards that you did it wrong again.
+//
+// A shell is not a layout wrapper. It is a CONTRACT about what a reader meets
+// on arrival:
+//
+//   1. a lead band — the short answer to "what is this and what needs me",
+//      stamped `data-dpf-lead` so the sweep can measure it;
+//   2. at most a couple of primary actions, stamped `data-dpf-primary-action`
+//      so "the verb is buried" is a finding rather than a matter of opinion;
+//   3. the default-visible body, which is what the reader came for;
+//   4. everything else — inventories, diagnostics, history, raw identifiers —
+//      behind ONE disclosure, closed by default.
+//
+// The measurement-scope rule makes that fourth slot pay: the sweep excises
+// closed `<details>` and `data-dpf-disclosure` subtrees before counting, so
+// deferring detail IMPROVES a route's score instead of being taxed by it.
+// Progressive disclosure is the budget's grain, not its victim.
+//
+// Deliberately "shell", never "archetype" — archetype already means the
+// industry vertical on this platform, and the two must not collide.
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+/** Which reading contract this surface is honouring. Mirrors UX_SHELLS. */
+export type PageShellKind = "cockpit" | "list" | "detail" | "settings";
+
+export type PageShellAction = {
+  label: string;
+  href: string;
+  /** Marks the one action the reader most likely came to take. */
+  primary?: boolean;
+};
+
+export type PageShellProps = {
+  kind: PageShellKind;
+  /** The page's own name. Rendered as the single h1. */
+  title: string;
+  /**
+   * The lead band: one or two plain sentences answering "what is this, and is
+   * anything waiting on me". Keep it short — the budget for this band is tens
+   * of words, not hundreds, because it is the part everyone actually reads.
+   */
+  lead: ReactNode;
+  /**
+   * Optional attention line. Render ONLY when something genuinely needs the
+   * reader; a permanent "all clear" banner is noise that trains people to skip
+   * the whole band.
+   */
+  attention?: ReactNode;
+  /**
+   * The one thing the reader most likely came to DO. Rendered in the lead band
+   * and stamped `data-owner-first-next-action`, which is what makes "this screen
+   * tells you what to do next" a measurable property rather than a claim.
+   *
+   * Omit it when the surface genuinely has no single next move — a marked
+   * next action that is not really the next action is worse than none, because
+   * it teaches readers the marker means nothing.
+   */
+  nextAction?: { label: string; href: string; hint?: string };
+  actions?: PageShellAction[];
+  /** What the reader came for. Stays default-visible. */
+  children: ReactNode;
+  /**
+   * Technical inventories, diagnostics, raw identifiers, history. Rendered
+   * inside one closed disclosure. Nothing is removed from the page — it stops
+   * competing with the reason the reader is here.
+   */
+  technicalDetails?: ReactNode;
+  /** Label for the disclosure. Defaults to the conventional wording. */
+  technicalDetailsLabel?: string;
+};
+
+/**
+ * The shared frame every concrete shell composes. Exported for surfaces that
+ * genuinely need to name their own `kind`; prefer the named shells below so the
+ * intent is legible at the call site.
+ */
+export function PageShell({
+  kind,
+  title,
+  lead,
+  attention,
+  nextAction,
+  actions = [],
+  children,
+  technicalDetails,
+  technicalDetailsLabel = "Technical details",
+}: PageShellProps) {
+  const primary = actions.filter((a) => a.primary);
+  const secondary = actions.filter((a) => !a.primary);
+
+  return (
+    <div data-dpf-shell={kind}>
+      <header data-dpf-lead="" className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">{title}</h1>
+        <div className="mt-1 text-sm text-[var(--dpf-muted)]">{lead}</div>
+
+        {attention ? (
+          <div
+            className="mt-3 rounded border px-3 py-2 text-sm"
+            style={{
+              borderColor: "color-mix(in srgb, var(--dpf-warning) 40%, var(--dpf-border))",
+              background: "color-mix(in srgb, var(--dpf-warning) 8%, var(--dpf-surface-1))",
+              color: "var(--dpf-text)",
+            }}
+          >
+            {attention}
+          </div>
+        ) : null}
+
+        {nextAction ? (
+          <div className="mt-3 flex flex-wrap items-baseline gap-2">
+            <Link
+              href={nextAction.href}
+              data-owner-first-next-action=""
+              data-dpf-primary-action=""
+              className="dpf-tap-target inline-flex items-center rounded border border-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[color-mix(in_srgb,var(--dpf-accent)_10%,transparent)]"
+            >
+              {nextAction.label}
+            </Link>
+            {nextAction.hint ? (
+              <span className="text-xs text-[var(--dpf-muted)]">{nextAction.hint}</span>
+            ) : null}
+          </div>
+        ) : null}
+
+        {actions.length > 0 ? (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {primary.map((a) => (
+              <Link
+                key={a.href}
+                href={a.href}
+                data-dpf-primary-action=""
+                className="dpf-tap-target inline-flex items-center rounded border border-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[color-mix(in_srgb,var(--dpf-accent)_10%,transparent)]"
+              >
+                {a.label}
+              </Link>
+            ))}
+            {secondary.map((a) => (
+              <Link
+                key={a.href}
+                href={a.href}
+                className="dpf-tap-target inline-flex items-center rounded border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+              >
+                {a.label}
+              </Link>
+            ))}
+          </div>
+        ) : null}
+      </header>
+
+      <main>{children}</main>
+
+      {technicalDetails ? (
+        // Closed by default, and marked twice on purpose: the sweep excises a
+        // closed <details> anyway, but the explicit attribute keeps the intent
+        // readable to a human diffing the markup.
+        <details
+          data-dpf-disclosure=""
+          className="group mt-8 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+        >
+          <summary className="dpf-tap-target flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-medium text-[var(--dpf-text)] marker:hidden [&::-webkit-details-marker]:hidden">
+            <span aria-hidden className="text-[var(--dpf-muted)] transition-transform group-open:rotate-90">
+              ▸
+            </span>
+            <span>{technicalDetailsLabel}</span>
+          </summary>
+          <div className="border-t border-[var(--dpf-border)] p-4">{technicalDetails}</div>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+/** The owner's home base: status at a glance, one obvious next move. */
+export function CockpitShell(props: Omit<PageShellProps, "kind">) {
+  return <PageShell kind="cockpit" {...props} />;
+}
+
+/** Scanning many rows: the rows carry the words, so the chrome stays thin. */
+export function ListShell(props: Omit<PageShellProps, "kind">) {
+  return <PageShell kind="list" {...props} />;
+}
+
+/** One thing in depth — the shell where disclosure earns its keep. */
+export function DetailShell(props: Omit<PageShellProps, "kind">) {
+  return <PageShell kind="detail" {...props} />;
+}
+
+/** Config surfaces: a few essentials, the rest deferred. */
+export function SettingsShell(props: Omit<PageShellProps, "kind">) {
+  return <PageShell kind="settings" {...props} />;
+}

--- a/apps/web/components/page-shells/index.ts
+++ b/apps/web/components/page-shells/index.ts
@@ -1,0 +1,14 @@
+// L1 page shells (BI-36CE8BAB). Import a shell from here so the adoption
+// ratchet can see it: a route that composes a shell indirectly does not count,
+// because the point is that the reading contract is declared at the top of the
+// page, where a reviewer reads it.
+export {
+  PageShell,
+  CockpitShell,
+  ListShell,
+  DetailShell,
+  SettingsShell,
+  type PageShellKind,
+  type PageShellAction,
+  type PageShellProps,
+} from "./PageShell";

--- a/apps/web/lib/decision-perspective/material.ts
+++ b/apps/web/lib/decision-perspective/material.ts
@@ -367,22 +367,50 @@ export async function resolveProfileMaterialForProfession(input: {
     roleSlug?: string | null;
     slugId?: string | null;
   };
+  /**
+   * Declared borrow (BI-52839DEA). When set, the profession is named by the
+   * caller instead of derived from an agent identity — the path an external
+   * development surface (Claude Code / Codex / Grok) takes, since it holds no
+   * coworker identity to resolve from.
+   *
+   * FAIL-CLOSED BY CONTRACT: an unrecognised key THROWS rather than falling
+   * through to identity resolution or to platform doctrine. A borrow that
+   * silently degraded to generic doctrine would return platform defaults
+   * wearing a profession's name, which is exactly the silent-success failure
+   * mode the UX-quality program exists to outlaw.
+   *
+   * The caller decides whether a borrow is permitted; this function only
+   * honours it. The gate is what refuses a borrow from a caller that already
+   * carries an agent identity.
+   */
+  declaredProfessionKey?: string | null;
   domainClass: DecisionDomainClass;
   fallbackProfileId?: string;
   maxDepth?: number;
 }): Promise<
   ResolvedProfileMaterial & { professionProfileSelected: boolean; professionKey: string | null }
 > {
-  const { findProfessionFamilyForAgentIdentity, professionProfileId } = await import(
-    "./resolve-profession-profile"
-  );
+  const { findProfessionFamilyForAgentIdentity, findProfessionFamilyByKey, professionProfileId } =
+    await import("./resolve-profession-profile");
 
-  const family = findProfessionFamilyForAgentIdentity({
-    agentId: input.agentIdentity.agentId ?? null,
-    name: input.agentIdentity.agentName ?? null,
-    roleSlug: input.agentIdentity.roleSlug ?? null,
-    slugId: input.agentIdentity.slugId ?? null,
-  });
+  const declaredKey = input.declaredProfessionKey?.trim() || null;
+  let family: ReturnType<typeof findProfessionFamilyForAgentIdentity>;
+  if (declaredKey) {
+    family = findProfessionFamilyByKey(declaredKey);
+    if (!family) {
+      throw new Error(
+        `Unknown professionKey "${declaredKey}". A declared borrow must name a profession family ` +
+          `registered in docs/professions/registry.json; it does not fall back to platform doctrine.`,
+      );
+    }
+  } else {
+    family = findProfessionFamilyForAgentIdentity({
+      agentId: input.agentIdentity.agentId ?? null,
+      name: input.agentIdentity.agentName ?? null,
+      roleSlug: input.agentIdentity.roleSlug ?? null,
+      slugId: input.agentIdentity.slugId ?? null,
+    });
+  }
 
   const professionKey = family?.professionKey ?? null;
   const entryProfileId = professionKey

--- a/apps/web/lib/decision-perspective/profession-gate.test.ts
+++ b/apps/web/lib/decision-perspective/profession-gate.test.ts
@@ -405,3 +405,131 @@ describe("resolveProfileMaterialForProfession", () => {
     expect(resolved.professionProfileSelected).toBe(false);
   });
 });
+
+// BI-52839DEA — declared borrow. An external development surface holds no
+// coworker identity, so it names the craft it wants to consult. The invariants
+// that matter are: the real profile still decides, the ledger can always tell a
+// borrow from the coworker's own reasoning, an in-portal caller cannot borrow,
+// and an unknown craft fails rather than quietly becoming platform doctrine.
+describe("evaluateProfessionDecisionGate — declared borrow", () => {
+  const externalBase = {
+    // No agentId/slugId: this is what an external MCP caller actually looks like.
+    agentIdentity: {},
+    question: "Adopt a reusable page shell, or restructure this one page bespoke?",
+    options: ["Reusable shell", "Bespoke tabs"],
+    domainClass: DOMAIN,
+    riskTier: "medium" as const,
+    routeContext: "/external/claude-code",
+  };
+
+  it("resolves the named craft and stamps the borrow on the ledger", async () => {
+    const db = makeDb();
+    const resolver = fakeResolver({ professionKey: "ux-design" });
+
+    const result = await evaluateProfessionDecisionGate({
+      ...externalBase,
+      db: db as never,
+      declaredBorrow: {
+        callingPopulation: "external_coding_agent",
+        professionKey: "ux-design",
+      },
+      resolver: resolver as never,
+      evaluator: () => makeEval({ outcomeType: "recommend" }),
+    });
+
+    // The craft profile decided — not a platform fallback wearing its name.
+    expect(result.professionProfileSelected).toBe(true);
+    expect(result.professionKey).toBe("ux-design");
+
+    // The resolver was asked for the DECLARED craft, not one derived from identity.
+    expect(resolver.mock.calls[0]![0]).toMatchObject({ declaredProfessionKey: "ux-design" });
+
+    // The ledger row is distinguishable from the coworker's own reasoning.
+    // This is the calibration invariant: a judge calibrated against rows it
+    // cannot tell apart from its own output is calibrated against itself.
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    const payload = data.outcomePayload as Record<string, unknown>;
+    expect(payload.declaredBorrow).toBe(true);
+    expect(payload.borrowedProfessionKey).toBe("ux-design");
+    expect(payload.callingPopulation).toBe("external_coding_agent");
+    expect(data.gateKey).toBe("profession");
+  });
+
+  it("marks declaredBorrow=false for an ordinary in-portal consult", async () => {
+    const db = makeDb();
+    await evaluateProfessionDecisionGate({
+      ...base,
+      db: db as never,
+      resolver: fakeResolver() as never,
+      evaluator: () => makeEval({ outcomeType: "recommend" }),
+    });
+
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    const payload = data.outcomePayload as Record<string, unknown>;
+    expect(payload.declaredBorrow).toBe(false);
+    expect(payload.borrowedProfessionKey).toBeUndefined();
+  });
+
+  it("refuses a borrow from a caller that already has an agent identity", async () => {
+    const db = makeDb();
+    const resolver = fakeResolver();
+
+    const result = await evaluateProfessionDecisionGate({
+      ...base, // carries agentId AGT-DATA-ARCH
+      db: db as never,
+      declaredBorrow: {
+        callingPopulation: "external_coding_agent",
+        professionKey: "ux-design",
+      },
+      resolver: resolver as never,
+      evaluator: () => makeEval({ outcomeType: "recommend" }),
+    });
+
+    // A coworker reasons from the craft it practises, never from one it names.
+    // Founder decision on BI-52839DEA was declared borrow, NOT impersonation —
+    // and impersonation in this direction is what would break it.
+    expect(resolver.mock.calls[0]![0]).toMatchObject({ declaredProfessionKey: null });
+    expect(result.professionKey).toBe("data-architect");
+
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    expect((data.outcomePayload as Record<string, unknown>).declaredBorrow).toBe(false);
+  });
+
+  it("fails closed when the borrowed craft is not a registered profession", async () => {
+    const db = {
+      decisionPerspectiveProfile: { findUnique: vi.fn().mockResolvedValue(null) },
+      perspectiveMaterial: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+
+    await expect(
+      resolveProfileMaterialForProfession({
+        db: db as never,
+        agentIdentity: {},
+        declaredProfessionKey: "not-a-real-craft",
+        domainClass: DOMAIN,
+      }),
+    ).rejects.toThrow(/Unknown professionKey/);
+  });
+
+  it("resolves a real registered craft by key without any agent identity", async () => {
+    const db = {
+      decisionPerspectiveProfile: {
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+      perspectiveMaterial: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+
+    const resolved = await resolveProfileMaterialForProfession({
+      db: db as never,
+      agentIdentity: {},
+      declaredProfessionKey: "ux-design",
+      domainClass: DOMAIN,
+    });
+
+    // The key resolved through the registry to the wsid-* profile convention.
+    expect(resolved.professionKey).toBe("ux-design");
+    expect(db.decisionPerspectiveProfile.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { profileId: "wsid-ux-design" } }),
+    );
+  });
+});

--- a/apps/web/lib/decision-perspective/profession-gate.ts
+++ b/apps/web/lib/decision-perspective/profession-gate.ts
@@ -131,6 +131,26 @@ function failClosedEvaluation(input: {
 export async function evaluateProfessionDecisionGate(input: {
   db: ProfessionGateClient;
   agentIdentity: ProfessionAgentIdentityInput;
+  /**
+   * Declared borrow (BI-52839DEA). Set only when an EXTERNAL caller — a Claude
+   * Code / Codex / Grok development session — consults a profession it does not
+   * hold an identity for. The gate resolves the named craft profile and its
+   * corpus exactly as it would for the coworker, and stamps the ledger so the
+   * borrow is never mistaken for the coworker's own reasoning.
+   *
+   * That stamp is load-bearing, not bookkeeping: the critique corpus calibrates
+   * a judge against founder verdicts, and a judge calibrated on rows it cannot
+   * distinguish from its own output is calibrated against itself.
+   *
+   * Refused when the caller already carries an agent identity — an in-portal
+   * coworker reasons from the craft it practises, never from one it names.
+   */
+  declaredBorrow?: {
+    /** Which population is borrowing. Mirrors principle_decide's callingPopulation. */
+    callingPopulation: string;
+    /** professionKey from docs/professions/registry.json. */
+    professionKey: string;
+  } | null;
   question: string;
   options: string[];
   /**
@@ -167,6 +187,23 @@ export async function evaluateProfessionDecisionGate(input: {
   const { question, options, domainClass, riskTier } = input;
   const resolve = input.resolver ?? resolveProfileMaterialForProfession;
 
+  // A borrow is only honoured for a caller with no craft identity of its own.
+  // An in-portal coworker naming a profession would be impersonation, and the
+  // founder decision on BI-52839DEA was explicitly declared-borrow, not
+  // impersonation.
+  const hasAgentIdentity = Boolean(
+    input.agentIdentity.agentId ?? input.agentIdentity.slugId ?? input.agentIdentity.roleSlug,
+  );
+  const borrow = input.declaredBorrow && !hasAgentIdentity ? input.declaredBorrow : null;
+  /** Ledger stamp: present and true only on a real borrow. */
+  const borrowLedgerFields = borrow
+    ? {
+        declaredBorrow: true,
+        borrowedProfessionKey: borrow.professionKey,
+        callingPopulation: borrow.callingPopulation,
+      }
+    : { declaredBorrow: false };
+
   let resolved: Awaited<ReturnType<typeof resolveProfileMaterialForProfession>> | undefined;
   let profile: DecisionPerspectiveProfile = MARK_DPF_PLATFORM_PROFILE;
   let professionProfileSelected = false;
@@ -176,6 +213,7 @@ export async function evaluateProfessionDecisionGate(input: {
     resolved = await resolve({
       db: input.db,
       agentIdentity: input.agentIdentity,
+      declaredProfessionKey: borrow?.professionKey ?? null,
       domainClass,
       fallbackProfileId: input.fallbackProfileId,
     });
@@ -222,6 +260,7 @@ export async function evaluateProfessionDecisionGate(input: {
         professionProfileSelected,
         professionKey,
         caller: input.caller ?? null,
+        ...borrowLedgerFields,
       },
     });
     traceWsid("wsid.ledger.written", { interactionId, outcomeType: evaluation.outcomeType });
@@ -238,6 +277,7 @@ export async function evaluateProfessionDecisionGate(input: {
   traceWsid("wsid.profession-gate.invoked", {
     interactionId,
     agentIdentity: input.agentIdentity,
+    ...borrowLedgerFields,
     profileId: profile.profileId,
     professionKey,
     professionProfileSelected,
@@ -333,6 +373,7 @@ export async function evaluateProfessionDecisionGate(input: {
       professionProfileSelected,
       professionKey,
       caller: input.caller ?? null,
+      ...borrowLedgerFields,
     },
   });
   traceWsid("wsid.ledger.written", {

--- a/apps/web/lib/decision-perspective/resolve-profession-profile.ts
+++ b/apps/web/lib/decision-perspective/resolve-profession-profile.ts
@@ -75,6 +75,23 @@ export function findProfessionFamily(agentIdOrSlug: string): ProfessionFamily | 
   return PROFESSION_REGISTRY.families.find((f) => f.roles.includes(agentIdOrSlug)) ?? null;
 }
 
+/**
+ * Find a family by its professionKey rather than by a role binding (BI-52839DEA).
+ *
+ * The identity-driven lookups above answer "which craft does THIS coworker
+ * practise". This one answers "does this named craft exist at all", which is
+ * what a declared borrow needs: an external development surface has no agent
+ * identity to resolve from, so it names the profession it wants to consult and
+ * the registry either recognises the name or the call fails closed. Deliberately
+ * NOT a fallback for the identity path — an in-portal coworker still resolves
+ * from who it is, never from what it asks for.
+ */
+export function findProfessionFamilyByKey(professionKey: string): ProfessionFamily | null {
+  const key = professionKey.trim();
+  if (!key) return null;
+  return PROFESSION_REGISTRY.families.find((f) => f.professionKey === key) ?? null;
+}
+
 function professionIdentityCandidates(identity: ProfessionAgentIdentity): string[] {
   const seen = new Set<string>();
   const candidates: string[] = [];

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9799,6 +9799,7 @@
         "find-and-work-with-a-coworker",
         "key-concepts",
         "what-you-can-do",
+        "reading-the-skills-catalog",
         "related-routes",
         "reading-runtime-health",
         "context-budget-what-recent-turns-were-given",

--- a/apps/web/lib/mcp/packs/profession-decision-pack.ts
+++ b/apps/web/lib/mcp/packs/profession-decision-pack.ts
@@ -7,6 +7,16 @@
 // craft profile, with platform doctrine as advisory fallback only), and
 // records it to the DecisionInteraction ledger. Advisory: it returns a
 // recommendation; consequential actions still pass their own authority gates.
+//
+// BI-52839DEA — declared borrow. WSID used to be reachable ONLY from an
+// in-portal coworker session, while its WWMD sibling `principle_decide` had
+// accepted an explicit `callingPopulation` from external development surfaces
+// all along. That asymmetry meant a coworker's craft judgment could not
+// participate in the Claude Code / Codex / Grok review process at all. An
+// external caller now declares its population and NAMES the craft it wants to
+// consult; the gate serves the real profile and corpus and stamps the ledger
+// with `declaredBorrow`. What crosses the boundary is a consult, never a copy —
+// the coworker definition stays single-homed in the platform.
 
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack } from "../tool-pack";
@@ -45,6 +55,17 @@ const definitions: ToolDefinition[] = [
           enum: ["low", "medium", "high", "critical"],
           description:
             "How consequential the decision is; higher tiers require more confidence before a recommendation.",
+        },
+        callingPopulation: {
+          type: "string",
+          enum: ["in_platform_coworker", "external_coding_agent", "human"],
+          description:
+            "Who is calling. In-platform coworkers may omit this — the profession is derived from their own identity. An EXTERNAL development surface (Claude Code / Codex / Grok) has no coworker identity, so it declares its population here and names `professionKey` to borrow that craft's judgment. The borrow is stamped on the decision ledger; it is never recorded as the coworker's own reasoning.",
+        },
+        professionKey: {
+          type: "string",
+          description:
+            "Required for a declared borrow (external population, no coworker identity): the professionKey to consult, e.g. 'ux-design'. Must be a family registered in docs/professions/registry.json — an unknown key fails rather than degrading to platform defaults. Ignored for in-platform callers, who always reason from the craft they practise.",
         },
       },
       required: ["question", "options", "domainClass", "riskTier"],
@@ -100,27 +121,57 @@ async function evaluateProfessionDecision(
     return { success: false, error: "invalid_params", message: parsedFeatures.message };
   }
 
-  if (!context?.agentId) {
+  // Declared borrow (BI-52839DEA). An external development surface holds no
+  // coworker identity, so it names the population it belongs to and the craft it
+  // wants to consult. `principle_decide` already externalizes WWMD this way;
+  // this closes the same door on WSID.
+  const declaredPopulation = String(params["callingPopulation"] ?? "").trim();
+  const declaredProfessionKey = String(params["professionKey"] ?? "").trim();
+  const isExternalPopulation =
+    declaredPopulation === "external_coding_agent" || declaredPopulation === "human";
+
+  if (!context?.agentId && !isExternalPopulation) {
     return {
       success: false,
       error: "no_agent_identity",
       message:
-        "A profession decision is scoped to the calling coworker, but no agent identity reached the tool. Route the call through a coworker session.",
+        "A profession decision is scoped to the calling coworker, but no agent identity reached the tool. " +
+        "Route the call through a coworker session, or — from an external development surface — declare " +
+        "callingPopulation ('external_coding_agent' or 'human') together with the professionKey to consult.",
     };
   }
 
-  const agent = await prisma.agent.findFirst({
-    where: { OR: [{ agentId: context.agentId }, { slugId: context.agentId }] },
-    select: { agentId: true, name: true, slugId: true },
-  });
+  if (!context?.agentId && isExternalPopulation && !declaredProfessionKey) {
+    return {
+      success: false,
+      error: "no_profession_declared",
+      message:
+        "A declared borrow must name the craft it is consulting. Pass professionKey (e.g. 'ux-design'); " +
+        "there is no default profession, because borrowing an unnamed craft would return platform doctrine " +
+        "wearing a profession's name.",
+    };
+  }
+
+  const agent = context?.agentId
+    ? await prisma.agent.findFirst({
+        where: { OR: [{ agentId: context.agentId }, { slugId: context.agentId }] },
+        select: { agentId: true, name: true, slugId: true },
+      })
+    : null;
 
   const decision = await evaluateProfessionDecisionGate({
     db: prisma,
     agentIdentity: {
-      agentId: agent?.agentId ?? context.agentId,
+      agentId: agent?.agentId ?? context?.agentId ?? null,
       agentName: agent?.name ?? null,
-      slugId: agent?.slugId ?? context.agentId,
+      slugId: agent?.slugId ?? context?.agentId ?? null,
     },
+    // The gate itself refuses a borrow from a caller that already carries an
+    // agent identity, so an in-portal coworker cannot name its way into another
+    // craft even if it passes these fields.
+    declaredBorrow: isExternalPopulation
+      ? { callingPopulation: declaredPopulation, professionKey: declaredProfessionKey }
+      : null,
     question,
     options,
     scoredOptions: parsedFeatures.scoredOptions,
@@ -149,6 +200,9 @@ async function evaluateProfessionDecision(
       confidenceScore: decision.evaluation.confidenceScore,
       professionKey: decision.professionKey,
       professionProfileSelected: decision.professionProfileSelected,
+      // Echoed so an external caller can see, without reading the ledger, that
+      // it consulted a real craft profile rather than platform doctrine.
+      declaredBorrow: !context?.agentId && isExternalPopulation,
       recommendedOptionId: decision.evaluation.recommendedOptionId ?? null,
       rationale: rationale.length > 500 ? `${rationale.slice(0, 500)}...` : rationale,
     },

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -3,7 +3,7 @@
   "generator": "apps/web/scripts/ux-route-sweep.ts",
   "routes": {
     "/admin": {
-      "defaultVisibleWords": 178,
+      "defaultVisibleWords": 212,
       "leadBandWords": 0,
       "primaryActions": 3,
       "visibleFields": 5,
@@ -80,7 +80,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button"
     },
     "/admin/diagnostics": {
-      "defaultVisibleWords": 154,
+      "defaultVisibleWords": 156,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -90,8 +90,19 @@
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - checkbox\n  - text"
     },
+    "/admin/graph-explorer": {
+      "defaultVisibleWords": 174,
+      "leadBandWords": 20,
+      "primaryActions": 1,
+      "visibleFields": 1,
+      "maxChoicesPerControl": 0,
+      "subLegibleControls": 0,
+      "buriedPrimaryAction": 0,
+      "axeViolations": 2,
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - text\n  - searchbox\n  - text\n  - button [pressed]\n  - button\n  - button [disabled]\n  - button\n  - text\n  - complementary\n    - heading [level=2]\n    - paragraph\n      - text"
+    },
     "/admin/hive": {
-      "defaultVisibleWords": 384,
+      "defaultVisibleWords": 386,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -102,7 +113,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - switch\n  - heading [level=3]\n  - text\n  - paragraph\n    - text\n  - switch [checked]\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - heading [level=3]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n  - heading [level=2]\n  - paragraph\n    - text\n  - text"
     },
     "/admin/issue-reports": {
-      "defaultVisibleWords": 211,
+      "defaultVisibleWords": 213,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -113,7 +124,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n    - text\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=3]\n  - button\n  - paragraph\n    - text"
     },
     "/admin/platform-development": {
-      "defaultVisibleWords": 311,
+      "defaultVisibleWords": 313,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 5,
@@ -212,7 +223,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text"
     },
     "/build": {
-      "defaultVisibleWords": 166,
+      "defaultVisibleWords": 169,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -410,7 +421,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/coworker-decisions": {
-      "defaultVisibleWords": 280,
+      "defaultVisibleWords": 304,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -465,7 +476,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link"
     },
     "/coworker-decisions/proactivity": {
-      "defaultVisibleWords": 1027,
+      "defaultVisibleWords": 1028,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -498,7 +509,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - list\n    - listitem\n      - text\n      - button\n      - paragraph\n        - text\n  - button\n  - text\n  - heading [level=2]\n  - list\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - link\n      - paragraph\n        - text\n    - listitem\n      - link\n      - text\n      - paragraph\n        - text\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - text\n  - paragraph\n    - text\n    - link\n    - text"
     },
     "/customer": {
-      "defaultVisibleWords": 115,
+      "defaultVisibleWords": 122,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -553,7 +564,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/customer/marketing": {
-      "defaultVisibleWords": 229,
+      "defaultVisibleWords": 240,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -663,7 +674,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - link\n  - text\n  - button\n  - paragraph\n    - text\n  - button\n  - link\n    - paragraph\n      - text"
     },
     "/ea/capabilities": {
-      "defaultVisibleWords": 1333,
+      "defaultVisibleWords": 1335,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -718,7 +729,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n    - text"
     },
     "/employee": {
-      "defaultVisibleWords": 289,
+      "defaultVisibleWords": 297,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 5,
@@ -729,7 +740,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - list\n      - listitem\n        - paragraph\n          - text\n        - link\n        - paragraph\n          - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - checkbox\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option [selected]\n  - paragraph\n    - text\n  - group\n    - text\n    - radio [checked]\n    - text\n    - radio\n    - text\n  - text\n  - spinbutton\n  - button\n  - group\n    - button\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - combobox\n      - option [selected]\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - checkbox [checked]\n    - text\n    - paragraph\n      - text\n    - group\n      - button\n        - text\n      - text\n    - button\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/finance": {
-      "defaultVisibleWords": 229,
+      "defaultVisibleWords": 245,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1191,7 +1202,7 @@
       "ariaSnapshot": "- heading [level=1]\n- paragraph\n  - text\n- text\n- textbox\n- button\n- paragraph\n  - text"
     },
     "/inventory": {
-      "defaultVisibleWords": 687,
+      "defaultVisibleWords": 693,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -1213,7 +1224,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - link\n  - paragraph\n    - text"
     },
     "/knowledge/new": {
-      "defaultVisibleWords": 533,
+      "defaultVisibleWords": 534,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 5,
@@ -1268,7 +1279,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - link\n    - heading [level=3]\n    - paragraph\n      - text\n    - paragraph\n      - text\n      - link\n  - paragraph\n    - text"
     },
     "/ops/dev-loop": {
-      "defaultVisibleWords": 190,
+      "defaultVisibleWords": 195,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1279,7 +1290,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - group\n    - button\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - cell\n            - text\n  - strong\n    - text\n  - list\n    - listitem\n      - strong\n        - text\n  - paragraph\n    - text\n    - code\n      - text\n    - text\n    - code\n      - text\n    - text"
     },
     "/ops/journeys": {
-      "defaultVisibleWords": 210,
+      "defaultVisibleWords": 214,
       "leadBandWords": 14,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1345,7 +1356,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - main\n    - heading [level=1]\n    - paragraph\n      - text"
     },
     "/platform": {
-      "defaultVisibleWords": 455,
+      "defaultVisibleWords": 458,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1389,7 +1400,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n    - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - text\n  - textbox\n  - button\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/ai/build-studio": {
-      "defaultVisibleWords": 371,
+      "defaultVisibleWords": 372,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 6,
@@ -1411,7 +1422,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - heading [level=2]\n  - link"
     },
     "/platform/ai/catalog": {
-      "defaultVisibleWords": 597,
+      "defaultVisibleWords": 603,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1444,7 +1455,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/ai/overview": {
-      "defaultVisibleWords": 2995,
+      "defaultVisibleWords": 3010,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 5,
@@ -1477,7 +1488,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - strong\n    - text\n  - text\n  - link\n  - text\n  - paragraph\n    - text\n    - link\n    - text\n  - navigation\n    - button\n      - text\n  - text"
     },
     "/platform/ai/providers": {
-      "defaultVisibleWords": 329,
+      "defaultVisibleWords": 344,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1499,7 +1510,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - link"
     },
     "/platform/ai/runtime-health": {
-      "defaultVisibleWords": 515,
+      "defaultVisibleWords": 526,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1510,15 +1521,15 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - button\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - heading [level=2]\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - code\n    - text\n  - text\n  - group\n    - button\n    - list\n      - listitem\n  - link\n  - text\n  - code\n    - text\n  - text\n  - group\n    - button\n    - paragraph\n      - text"
     },
     "/platform/ai/skills": {
-      "defaultVisibleWords": 1352,
-      "leadBandWords": 0,
+      "defaultVisibleWords": 205,
+      "leadBandWords": 31,
       "primaryActions": 1,
       "visibleFields": 3,
       "maxChoicesPerControl": 3,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 3,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - strong\n    - text\n  - text\n  - link\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - link\n    - text\n  - text\n  - textbox\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - text\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - tablist\n    - tab [selected]\n      - text\n    - tab\n      - text\n  - button\n  - button\n    - text\n  - button\n  - heading [level=2]\n  - heading [level=3]\n  - paragraph\n    - text\n  - button"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - text\n  - link\n  - text\n  - link\n  - main\n    - text\n    - textbox\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - group\n      - button\n        - text\n      - list\n        - listitem\n          - group\n            - button\n              - text\n            - paragraph\n              - text\n            - text\n  - group\n    - button\n      - text\n    - heading [level=2]\n    - paragraph\n      - text\n    - heading [level=2]\n    - text\n    - tablist\n      - tab [selected]\n        - text\n      - tab\n        - text\n    - button\n    - button\n      - text\n    - button\n    - heading [level=2]\n    - heading [level=3]\n    - paragraph\n      - text\n    - button"
     },
     "/platform/audit": {
       "defaultVisibleWords": 203,
@@ -1532,7 +1543,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 16056,
+      "defaultVisibleWords": 3437,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,
@@ -1708,7 +1719,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - text"
     },
     "/platform/identity/groups": {
-      "defaultVisibleWords": 316,
+      "defaultVisibleWords": 309,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -1752,8 +1763,8 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - paragraph\n    - text"
     },
     "/platform/tools/built-ins": {
-      "defaultVisibleWords": 278,
-      "leadBandWords": 37,
+      "defaultVisibleWords": 280,
+      "leadBandWords": 39,
       "primaryActions": 1,
       "visibleFields": 1,
       "maxChoicesPerControl": 0,
@@ -1785,7 +1796,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n            - option\n        - cell\n          - text\n        - cell\n          - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup"
     },
     "/platform/tools/discovery": {
-      "defaultVisibleWords": 708,
+      "defaultVisibleWords": 714,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -2181,7 +2192,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - list\n      - listitem"
     },
     "/workspace/my-queue": {
-      "defaultVisibleWords": 116,
+      "defaultVisibleWords": 114,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,7 +1,7 @@
 {
   "generator": "apps/web/scripts/build-route-shells.ts",
   "pageRouteCount": 318,
-  "migratedCount": 0,
+  "migratedCount": 1,
   "summary": {
     "cockpit": 16,
     "list": 6,
@@ -2285,11 +2285,8 @@
       "routePath": "/platform/ai/skills",
       "shell": "detail",
       "audience": "admin",
-      "migrated": false,
-      "exemptChecks": [
-        "next-action-marker",
-        "lead-band"
-      ],
+      "migrated": true,
+      "exemptChecks": [],
       "sweepEligible": true,
       "confidence": "high"
     },

--- a/apps/web/lib/ux-budget/route-shells.ts
+++ b/apps/web/lib/ux-budget/route-shells.ts
@@ -47,16 +47,21 @@ export function shellForRoute(c: ShellClassifiable): UxShell {
 /**
  * Routes that have actually adopted their L1 page shell.
  *
- * INTENTIONALLY EMPTY. The shells themselves are BI-36CE8BAB (Phase 2) — nothing has
- * migrated yet, and saying so in code is the point: spec §7.1 requires pre-migration
- * debt to be RECORDED, not hidden behind a check that quietly passes. Until a route
- * appears here it is exempt from the shell-structure expectations below, and the
- * regression ratchet is what actually holds it.
+ * Until a route appears here it is exempt from the shell-structure expectations
+ * below, and the regression ratchet is what actually holds it. Spec §7.1 requires
+ * pre-migration debt to be RECORDED, not hidden behind a check that quietly passes.
  *
  * Each migration PR (spec §7.2) adds its route here in the same change that adopts
  * the shell, so the exemption list shrinks visibly as the redesign lands.
+ *
+ * Cohort 0 — the worst-measured surface first, which is the ordering the league
+ * table exists to give. `/platform/ai/skills` measured 5,349 default-visible
+ * words against a 450-word budget with zero lead band; it is the proof that the
+ * shells actually move the number, not just the markup.
  */
-export const MIGRATED_ROUTES: ReadonlySet<string> = new Set<string>([]);
+export const MIGRATED_ROUTES: ReadonlySet<string> = new Set<string>([
+  "/platform/ai/skills",
+]);
 
 /** Checks a pre-migration route is not yet expected to satisfy. */
 export const PRE_MIGRATION_EXEMPT_CHECKS = ["next-action-marker", "lead-band"] as const;

--- a/apps/web/lib/ux-budget/scope.ts
+++ b/apps/web/lib/ux-budget/scope.ts
@@ -233,7 +233,44 @@ export function isDisclosureRegion(tag: TagToken): boolean {
  */
 export function defaultVisibleHtml(html: string): string {
   const rendered = removeSubtrees(html, (tag) => NON_RENDERED.has(tag.name));
-  return removeSubtrees(rendered, isStructurallyHidden);
+  return removeSubtrees(promoteClosedSummaries(rendered), isStructurallyHidden);
+}
+
+/**
+ * A closed `<details>` still SHOWS its `<summary>` — that label is the row the
+ * reader scans. Excising the whole subtree therefore under-counts every
+ * disclosure-based list, and rewards the wrong thing: a page could hide 92 rows
+ * behind 92 collapsed summaries and measure as if the screen were empty.
+ *
+ * Found while migrating `/platform/ai/skills` (BI-36CE8BAB): the redesigned
+ * catalog measured 10 default-visible words, when a reader actually meets 92 row
+ * labels. Lifting the summaries out before the disclosure pass keeps the
+ * deferred BODY excised — which is the behaviour progressive disclosure should
+ * earn — while still counting what is on screen.
+ */
+function promoteClosedSummaries(html: string): string {
+  // Depth-aware, not a regex: these nest. A collapsed category containing
+  // collapsed rows is the exact shape a grouped catalog produces, and a lazy
+  // regex matches the first `</details>` it sees — which belongs to the INNER
+  // element — mangling the parse and inventing a word count.
+  //
+  // extractSubtrees captures outermost-first and skips nested matches, which is
+  // precisely right here: rows inside a COLLAPSED group are not on screen, so
+  // they disappear with the group. If the group is open the predicate misses it,
+  // the scan descends, and each row is then judged on its own.
+  const closedDetails = extractSubtrees(
+    html,
+    (tag) => tag.name === "details" && !("open" in tag.attrs),
+  );
+
+  let out = html;
+  for (const block of closedDetails) {
+    const summary = extractSubtrees(block, (tag) => tag.name === "summary")[0];
+    // A <details> with no <summary> shows a UA-default label; nothing of the
+    // author's to count, so let the normal excision handle it.
+    out = out.replace(block, summary ? `<div data-dpf-was-summary="">${summary}</div>` : "");
+  }
+  return out;
 }
 
 /** The lead band(s) — concatenated, already scoped to what is visible. */

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -372,11 +372,25 @@ describe("generated route-shell registry", () => {
   });
 
   it("records pre-migration debt rather than hiding it", () => {
-    // Nothing has adopted an L1 shell yet (shells are Phase 2, BI-36CE8BAB), so every
-    // route must carry its exemptions explicitly. When this starts failing, the
-    // migration has begun — update MIGRATED_ROUTES, do not weaken the check.
-    expect(registry.migratedCount).toBe(0);
-    expect(registry.routes.every((r) => r.exemptChecks.length > 0)).toBe(true);
+    // The migration has begun (BI-36CE8BAB). Cohort 0 is `/platform/ai/skills`,
+    // the worst-measured surface in the portal — 5,349 default-visible words
+    // against a 450-word budget — chosen worst-first, which is the ordering the
+    // league table exists to give.
+    //
+    // The invariant this test protects is unchanged: a route is either MIGRATED
+    // (and therefore held to the full shell contract) or it carries its
+    // exemptions EXPLICITLY. What must never happen is a route that is neither —
+    // debt that passes because nobody wrote it down.
+    const migrated = registry.routes.filter((r) => r.migrated);
+    expect(migrated.map((r) => r.routePath)).toEqual(["/platform/ai/skills"]);
+    expect(registry.migratedCount).toBe(migrated.length);
+
+    // A migrated route has earned its way out of the exemptions.
+    expect(migrated.every((r) => r.exemptChecks.length === 0)).toBe(true);
+    // Everything not yet migrated still declares its debt.
+    expect(
+      registry.routes.filter((r) => !r.migrated).every((r) => r.exemptChecks.length > 0),
+    ).toBe(true);
   });
 
   it("summary totals reconcile with the route list", () => {

--- a/docs/superpowers/plans/2026-07-28-externalize-ux-design-critic-wsid.md
+++ b/docs/superpowers/plans/2026-07-28-externalize-ux-design-critic-wsid.md
@@ -1,0 +1,86 @@
+# Externalize the ux-design critic — declared-borrow WSID consults, local axes, and a grounded corpus
+
+**Backlog:** BI-52839DEA (externalization) · BI-F405AC58 (ux-design local axes) · BI-36CE8BAB (L1 page shells, the proving job)
+
+**Epic:** EP-UX-SYSTEM
+
+**Branch:** `claude/portal-ux-progressive-disclosure-6ac55f`
+
+**Decision evidence:** DI-F20DB14D1B92 (mechanism: `served-judgment`, high confidence, margin 2.84) · DI-D4E46B42E22B (scope: `shells-then-migrate`, high confidence, margin 3.79)
+
+**Founder decisions, 2026-07-28:** declared borrow (not impersonation) · advisory authority until the corpus grounds it · seed the corpus from this session's work.
+
+## Outcome
+
+AGT-906 `ux-design-critic` becomes a real participant in the external review process — Claude Code, Codex, and Grok sessions and the PRs they open — without leaving the platform. What crosses the boundary is a **consult**, never a copy: external surfaces call the live `wsid-ux-design` profile and its craft corpus, and every consult lands in the `DecisionInteraction` ledger marked as a borrow.
+
+The first job it reviews is the surface that prompted this work: `/platform/ai/skills`, measured at 5,349 default-visible words against a 450-word budget.
+
+## Grounding — verified live, 2026-07-28
+
+Everything below was measured on this install, not inferred.
+
+| Fact | Evidence |
+|---|---|
+| WSID is closed to external callers | `evaluate_profession_decision` → `{success:false, error:"no_agent_identity"}`; guard at `apps/web/lib/mcp/packs/profession-decision-pack.ts` `if (!context?.agentId)` |
+| WWMD is already open to them | `principle_decide` with `callingPopulation: "external_coding_agent"` succeeded twice, recording DI-D4E46B42E22B and DI-F20DB14D1B92 |
+| The coworker exists | `Agent` AGT-906 `ux-design-critic`, active since 2026-07-23 |
+| The profile exists | `DecisionPerspectiveProfile` `wsid-ux-design`, kind `profession`, active |
+| The craft corpus exists | 11 published pages under `professions/ux-design/` — Nielsen's heuristics, WCAG 1.4.3 / 2.5.8, POUR, hierarchy & density, heuristic-evaluation method, critique-corpus method, critique-calibration gate |
+| The critique corpus is EMPTY | `SELECT ... WHERE slug LIKE 'craft/%'` → 0 rows |
+| Local axes registry is empty and waiting | `PROFESSION_LOCAL_AXES = []` in `packages/db/src/profession-local-axes.ts`; header names the UX hierarchy-vs-density collapse as its motivating case |
+| Axis blockers are cleared | BI-E1267C6D, BI-AA7D80FE, BI-106C2585 all `done` |
+| Design-intelligence retrieval is generic | query `"information hierarchy progressive disclosure density"` → Breadcrumbs, Color Only, Heading Hierarchy, Font Size Scale, Progress Indicators |
+| Identity is ambiguous | two active `Agent` rows for one coworker: `AGT-906` and `ux-design-critic`; `resolveProfessionProfile` matches `OR: [{agentId},{slugId}]` |
+
+## Why not a skill
+
+The obvious alternative — generate a skill body into `packages/dpf-skill-pack` and let external surfaces load it — scored 7.34 against 15.77 (DI-F20DB14D1B92). The decisive ledger entries were Single Source of Truth (0.35 vs 0.62) and evidence density (0.30 vs 0.85). A skill body is a snapshot of a corpus that keeps moving; prompt-versus-reality drift is root cause RC5 in the holistic-UX spec, and this platform has already been bitten by it twice (design-intelligence CSVs drifting +2 rows from the skill's copy; `specialist-prompts.ts` teaching utilities that no longer exist).
+
+The skill-pack still has a role: it is where the *procedure* for consulting the critic lives. It must not become a second home for the critic's *knowledge*.
+
+## Deliverables
+
+### 1. Declared-borrow WSID (BI-52839DEA)
+
+- `evaluate_profession_decision` accepts `callingPopulation` and `professionKey`. With no `context.agentId` and an external population declared, resolve the profile by key through `resolveProfileMaterialForProfession`. With `context.agentId` present, behaviour is unchanged and the caller may not override the profession it is bound to.
+- Ledger rows record the borrow distinguishably: `authSource` external, `caller.client`, `consultedProfile`, and an explicit borrow flag. **This is load-bearing, not bookkeeping** — corpus calibration depends on separating the critic's own judgment from an external agent borrowing the profile. If those rows are indistinguishable, the calibration reference is corrupted at the source.
+- Fail-closed preserved: unknown or unpublished `professionKey` errors rather than silently degrading to platform doctrine; low confidence still escalates.
+- Converge the duplicate `Agent` rows to one identity before external callers start naming it.
+
+### 2. Corpus reachability from external surfaces (BI-52839DEA)
+
+- Read: craft corpus + critique corpus, for retrieval-augmented grounding.
+- Write: critique entries as drafts only. The authority contract in `apps/web/lib/ux-critique/critique-entry.ts` is preserved exactly — an agent caller can only ever produce `verdictAuthority: "agent-proposed"`, which is never calibration-eligible, and `callerKind` is derived from the authenticated principal, never from a client-supplied field.
+
+### 3. ux-design profession-local axes (BI-F405AC58)
+
+Four axes, each sourced, each projecting onto the spine in one hop: `ux-design/hierarchy_clarity`, `ux-design/content_density`, `ux-design/disclosure_quality`, `ux-design/perceptual_coherence`. Provenance and projection targets are already specified on the BI. `content_density` must be labelled platform calibration, not validated science; `perceptual_coherence` is the one validated member (CHI 2015) and may carry more weight.
+
+Constraint carried from the BI: **axes weigh options, they do not set thresholds.** The critique calibration gate's promotion threshold stays a founder risk-appetite call stated in advance, and the critic may not score its own promotion.
+
+### 4. Corpus seeding from live work
+
+As `/platform/ai/skills` is redesigned, capture before/after entries — route, commit sha, viewport, colour scheme, lens, screenshot — drafted `agent-proposed`, with founder verdicts attached through the existing wiki-overlay path. This is the flywheel: every founder review from here becomes calibration data instead of evaporating the way the EP-UX-COGLOAD findings did.
+
+### 5. The proving job — shells, then migrate (BI-36CE8BAB)
+
+Build the L1 page shells and migrate `/platform/ai/skills` onto one, adding it to `MIGRATED_ROUTES` so its absolute budget starts blocking. The critic reviews the redesign through the externalized path; if that consult produces nothing useful, the externalization is wrong and gets reworked before more surfaces depend on it.
+
+## Authority — explicit
+
+The externalized critic is **advisory**. It reports in session and on PRs and blocks nothing. Rationale: an ungrounded design judge is the UICrit zero-shot case at 13.1% comment validity, and a UX signal that cries wolf gets disabled — the failure mode that killed the checks catalogued in spec §2.
+
+The flip to blocking stays owned by BI-8316AC0C's data criteria and BI-42892849's entry condition. **Externalization must not become a back door around the staged authority grant.** The deterministic gates — route-budget regression ratchet, ARIA snapshot, axe — keep blocking throughout; they need no calibration and are unaffected by this plan.
+
+## Verification
+
+1. Unit tests for external-population resolution, the unchanged in-portal path, ledger borrow-marking, and fail-closed on unknown profession.
+2. `assertProfessionLocalAxisIntegrity` over the four new axes (sourcing, namespacing, one-hop spine projection).
+3. Authority-contract tests: an agent-population caller cannot produce a founder/designer verdict by any input path.
+4. **Functional proof from a real external session:** `evaluate_profession_decision` called from Claude Code returns a `wsid-ux-design`-grounded recommendation, and the resulting `DecisionInteraction` row shows the borrow. A structural pass is not verification.
+5. Route sweep re-measured on the migrated skills route; the new number recorded against the 5,349 baseline.
+
+## Documentation impact
+
+`docs/professions/` gains the axis declarations. The dual-surface skill (`dpf-ux-fit-review` or a sibling) gains the consult procedure — procedure only, never a copy of the corpus. No schema change beyond what the ledger borrow-marking requires; that is decided in the BI.

--- a/docs/superpowers/plans/2026-07-31-externalize-ux-design-critic-wsid.md
+++ b/docs/superpowers/plans/2026-07-31-externalize-ux-design-critic-wsid.md
@@ -8,7 +8,7 @@
 
 **Decision evidence:** DI-F20DB14D1B92 (mechanism: `served-judgment`, high confidence, margin 2.84) · DI-D4E46B42E22B (scope: `shells-then-migrate`, high confidence, margin 3.79)
 
-**Founder decisions, 2026-07-28:** declared borrow (not impersonation) · advisory authority until the corpus grounds it · seed the corpus from this session's work.
+**Founder decisions, 2026-07-31:** declared borrow (not impersonation) · advisory authority until the corpus grounds it · seed the corpus from this session's work.
 
 ## Outcome
 
@@ -16,7 +16,7 @@ AGT-906 `ux-design-critic` becomes a real participant in the external review pro
 
 The first job it reviews is the surface that prompted this work: `/platform/ai/skills`, measured at 5,349 default-visible words against a 450-word budget.
 
-## Grounding — verified live, 2026-07-28
+## Grounding — verified live, 2026-07-31
 
 Everything below was measured on this install, not inferred.
 
@@ -72,6 +72,29 @@ Build the L1 page shells and migrate `/platform/ai/skills` onto one, adding it t
 The externalized critic is **advisory**. It reports in session and on PRs and blocks nothing. Rationale: an ungrounded design judge is the UICrit zero-shot case at 13.1% comment validity, and a UX signal that cries wolf gets disabled — the failure mode that killed the checks catalogued in spec §2.
 
 The flip to blocking stays owned by BI-8316AC0C's data criteria and BI-42892849's entry condition. **Externalization must not become a back door around the staged authority grant.** The deterministic gates — route-budget regression ratchet, ARIA snapshot, axe — keep blocking throughout; they need no calibration and are unaffected by this plan.
+
+## Verification result — deliverable 1, 2026-07-31
+
+Run against `dpf_local_ci_0` (a real Postgres carrying the real schema and seed), driving
+`evaluateProfessionDecisionGate` with no agent identity and a declared borrow of `ux-design`.
+Deliberately not the production database: the point was to prove the code path, not to write
+borrow rows into the founder's live ledger.
+
+- Resolved `wsid-ux-design`, `professionProfileSelected: true`, **`materialCount: 8`** — the real
+  craft corpus was retrieved, not a fallback (sources included `critique-calibration-gate`,
+  `information-hierarchy-and-density`, `heuristic-evaluation-method`, `error-prevention-and-recovery`).
+- Ledger row `DI-E42BC51C3BE0`: `profileId: wsid-ux-design`, `gateKey: profession`,
+  `declaredBorrow: true`, `borrowedProfessionKey: ux-design`, `callingPopulation: external_coding_agent`.
+- Unknown craft `not-a-real-craft` → `escalate` with "does not fall back to platform doctrine". Fail-closed holds.
+
+**The verdict was `escalate`** — "profile confidence 0.35 is below the recommendation threshold 0.55",
+every material sitting at `effectiveWeight 0.45`. That is the design working, not a defect: the craft
+corpus is not yet strong enough for the critic to arbitrate, which is exactly the advisory posture this
+plan commits to and the reason the corpus is the gating asset.
+
+Not covered by this run: the MCP transport itself (`context.agentId` plumbing through the tool pack),
+which stays unit-covered until `:3001` frees or the portal image is rebuilt. The lease was held by
+another contributor throughout (`feat/restaurant-host-command-center`, to 2026-08-01T17:00Z).
 
 ## Verification
 

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -72,8 +72,19 @@ Model assignments explicitly saved by an operator remain unchanged during upgrad
 - Connect external coding surfaces such as Claude, Codex, and Grok while keeping the same MCP, evidence, documentation, and PR gates as Build Studio
 - Open **Runtime Health** to see which local services are required by enabled capabilities and which AI runtimes are managed by configured providers
 
+## Reading the Skills Catalog
+
+`/platform/ai/skills` answers one question on arrival: what your coworkers know how to do. It opens with a short summary, the count of catalog entries, and one action — **Grant a skill to a coworker**, which takes you to the directory, because skills are granted per coworker on their own record rather than from the catalog.
+
+Skills are grouped by category and collapsed. Open a category to see its skills; open a skill to read its description, version, risk band, source, tags, and how many coworkers it is assigned to. Nothing is hidden from you and nothing is truncated — the grouping means you choose what to read instead of scrolling past everything.
+
+Search and the status/source filters work across the whole catalog, and the groups open automatically when a filter is active so you see matches straight away.
+
+If any skill has drifted from the seed, a warning appears under the summary: a fresh install would not match this one. The drift detail, along with route-level skills, observability, and the curator report, sits under **Technical details** — one control at the foot of the page. Those are diagnostics for when you are investigating something specific, not part of reading the catalog.
+
 ## Related Routes
 
+- `/platform/ai/skills` — the global skills catalog and observatory
 - `/platform/ai/overview` — customer-first coworker directory
 - `/platform/ai/agent/[agentId]` — selected coworker record and work entry
 - `/platform/ai/providers/[providerId]` — provider setup and the Finance Bridge panel

--- a/docs/ux-fit/2026-08-04-skills-catalog-page-shell.ux-fit.json
+++ b/docs/ux-fit/2026-08-04-skills-catalog-page-shell.ux-fit.json
@@ -1,0 +1,26 @@
+{
+  "version": "1",
+  "decidedOption": "group-and-defer-behind-a-page-shell",
+  "scope": {
+    "files": [
+      "apps/web/components/admin/SkillsCatalogView.tsx",
+      "apps/web/components/page-shells/PageShell.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "improved",
+    "measured": {
+      "/platform/ai/skills": {
+        "defaultVisibleWords": 203,
+        "leadBandWords": 31,
+        "primaryActions": 1,
+        "visibleFields": 3,
+        "maxChoicesPerControl": 3,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 3
+      }
+    }
+  }
+}

--- a/docs/ux-fit/2026-08-04-skills-catalog-page-shell.ux-fit.json
+++ b/docs/ux-fit/2026-08-04-skills-catalog-page-shell.ux-fit.json
@@ -12,7 +12,7 @@
     "baselineComparison": "improved",
     "measured": {
       "/platform/ai/skills": {
-        "defaultVisibleWords": 203,
+        "defaultVisibleWords": 205,
         "leadBandWords": 31,
         "primaryActions": 1,
         "visibleFields": 3,

--- a/packages/db/src/profession-local-axes.test.ts
+++ b/packages/db/src/profession-local-axes.test.ts
@@ -105,18 +105,6 @@ describe("assertProfessionLocalAxisIntegrity — the rules that keep axes commen
     expect(() => check({ projectsOnto: ["schema_grounding"] })).toThrow(/terminate on the spine/);
   });
 
-  it("rejects a benefit axis projected onto a cost spine axis (BI-72E8FF05)", () => {
-    // The exact shape that shipped as the worked example and would have scored
-    // backwards: projection does not invert, so the kinds must agree.
-    expect(() => check({ kind: "benefit" })).toThrow(/score backwards/);
-  });
-
-  it("rejects a cost axis projected onto a benefit spine axis", () => {
-    expect(() =>
-      check({ kind: "cost", projectsOnto: ["long_term_maintainability"] }),
-    ).toThrow(/score backwards/);
-  });
-
   it("rejects a duplicate key", () => {
     expect(() =>
       assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS, [EXAMPLE, EXAMPLE]),

--- a/packages/db/src/profession-local-axes.test.ts
+++ b/packages/db/src/profession-local-axes.test.ts
@@ -37,15 +37,31 @@ const EXAMPLE: ProfessionLocalAxis = {
   kind: "cost",
   highMeans: "the option makes the visual hierarchy HARDER to parse at a glance",
   projectsOnto: ["human_cognitive_load"],
-  source: "nng/visual-hierarchy",
+  source: "arxiv/2403.03163-design2code",
 };
 
 describe("PROFESSION_LOCAL_AXES registry", () => {
-  it("ships empty — machinery lands before any axis scores", () => {
-    expect(PROFESSION_LOCAL_AXES).toHaveLength(0);
+  it("carries ux-design's axes — the first profession to need local resolution", () => {
+    const ux = localAxesFor("ux-design");
+    expect(ux.map((a) => a.key).sort()).toEqual([
+      "ux-design/content_density",
+      "ux-design/disclosure_debt",
+      "ux-design/hierarchy_flatness",
+      "ux-design/perceptual_clutter",
+    ]);
   });
 
-  it("passes integrity against the real profession registry (empty is valid)", () => {
+  it("declares every ux-design axis cost-framed, matching its cost-axis target", () => {
+    // The BI-72E8FF05 invariant, asserted on the SHIPPED registry rather than
+    // only on a fixture: all four roll up onto human_cognitive_load, so a
+    // benefit framing here would score the better option worse.
+    for (const axis of localAxesFor("ux-design")) {
+      expect(axis.kind).toBe("cost");
+      expect(axis.projectsOnto).toEqual(["human_cognitive_load"]);
+    }
+  });
+
+  it("passes integrity for the shipped registry", () => {
     expect(() => assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS)).not.toThrow();
   });
 
@@ -87,6 +103,18 @@ describe("assertProfessionLocalAxisIntegrity — the rules that keep axes commen
   it("rejects a projection onto a profession-local target (must hit the spine)", () => {
     // schema_grounding is profession-local as of BI-AA7D80FE.
     expect(() => check({ projectsOnto: ["schema_grounding"] })).toThrow(/terminate on the spine/);
+  });
+
+  it("rejects a benefit axis projected onto a cost spine axis (BI-72E8FF05)", () => {
+    // The exact shape that shipped as the worked example and would have scored
+    // backwards: projection does not invert, so the kinds must agree.
+    expect(() => check({ kind: "benefit" })).toThrow(/score backwards/);
+  });
+
+  it("rejects a cost axis projected onto a benefit spine axis", () => {
+    expect(() =>
+      check({ kind: "cost", projectsOnto: ["long_term_maintainability"] }),
+    ).toThrow(/score backwards/);
   });
 
   it("rejects a duplicate key", () => {

--- a/packages/db/src/profession-local-axes.ts
+++ b/packages/db/src/profession-local-axes.ts
@@ -71,12 +71,76 @@ export type ProfessionLocalAxis = {
 };
 
 /**
- * The registry. Ships EMPTY: the machinery lands proven, and the first real
- * axis lands with the profession that needs it (same discipline as
- * WIKI_SLUG_MIGRATIONS). A worked example lives only in the test, so this array
- * is never non-empty without a corresponding corpus that scores it.
+ * The registry. Shipped empty until a profession needed it; ux-design is the
+ * first (BI-F405AC58), which is what the module header anticipated — "a UX
+ * judgment about typographic hierarchy vs information density collapses into
+ * `human_cognitive_load` and becomes indistinguishable from a build-queue
+ * latency concern".
+ *
+ * ALL FOUR ARE COST-FRAMED, and deliberately so (BI-72E8FF05, DI-C8DD9DD0F9F8).
+ * They all roll up onto `human_cognitive_load`, a cost axis, and projection does
+ * not invert — so each axis measures the DEFICIT: high means more of the bad
+ * thing. The BI's original candidate names were benefit-framed
+ * (hierarchy_clarity, disclosure_quality, perceptual_coherence) and would have
+ * scored backwards; `content_density` needed no rename because it already read
+ * as a cost.
+ *
+ * Every one is scored on the DEFAULT-VISIBLE surface with collapsed disclosure
+ * excised, matching the measurement-scope rule the route sweep already applies —
+ * so deferring detail improves these scores instead of being taxed by them.
  */
-export const PROFESSION_LOCAL_AXES: readonly ProfessionLocalAxis[] = [];
+export const PROFESSION_LOCAL_AXES: readonly ProfessionLocalAxis[] = [
+  {
+    profession: "ux-design",
+    key: "ux-design/hierarchy_flatness",
+    kind: "cost",
+    highMeans:
+      "the option leaves the screen structurally flat — a long run of sibling content with no " +
+      "heading levels or grouping to navigate by, so the reader must scan everything to find anything",
+    projectsOnto: ["human_cognitive_load"],
+    // Hierarchy is the dominant failure mode of generated UI, and it is readable
+    // from the accessibility tree rather than a matter of taste.
+    source: "arxiv/2403.03163-design2code",
+  },
+  {
+    profession: "ux-design",
+    key: "ux-design/content_density",
+    kind: "cost",
+    highMeans:
+      "the option puts more words and controls in front of the reader on arrival, competing for " +
+      "the same attention",
+    // PLATFORM CALIBRATION, NOT SCIENCE. No surviving evidence validates
+    // words-per-screen or control-count thresholds against user outcomes, so
+    // this axis is honest about being DPF's own calibration — it may weigh an
+    // option, and it may not be presented as a measured human effect.
+    projectsOnto: ["human_cognitive_load"],
+    source: "dpf/platform-calibration-ux-budgets",
+  },
+  {
+    profession: "ux-design",
+    key: "ux-design/disclosure_debt",
+    kind: "cost",
+    highMeans:
+      "the option leaves detail undeferred that the reader did not ask for — advanced, diagnostic " +
+      "or exhaustive content sitting in the default view instead of behind a disclosure",
+    projectsOnto: ["human_cognitive_load"],
+    source: "nng/progressive-disclosure",
+  },
+  {
+    profession: "ux-design",
+    key: "ux-design/perceptual_clutter",
+    kind: "cost",
+    highMeans:
+      "the rendered pixels are more visually cluttered — weak grid alignment, little white space, " +
+      "many competing dominant colours, poor figure-ground contrast",
+    projectsOnto: ["human_cognitive_load"],
+    // The one VALIDATED member of this set: computational clutter/grid/white-space
+    // metrics explained up to 49% of variance in human aesthetic ratings, and they
+    // are deterministic — same pixels, same score — so unlike the calibration axes
+    // this one can carry weight on measured grounds.
+    source: "acm/10.1145-2702123.2702575-miniukovich-2015",
+  },
+];
 
 /** Namespaced key for a profession-local axis. */
 export function localAxisKey(profession: string, axis: string): string {

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -94,6 +94,37 @@ export const MEASURED_AXES = [
   "axeViolations",
 ];
 
+/**
+ * Per-axis polarity. Mirrors RATCHET_AXIS_POLARITY in lib/ux-budget/ratchet.ts —
+ * and it has to, because this gate compares the SAME numbers against the SAME
+ * frozen baseline. It previously mirrored only the axis LIST and applied
+ * `now > was` to all of them, so the leadBandWords fix (BI-E7F6C76E) landed in
+ * the ratchet and left this second consumer still failing the change it exists
+ * to encourage: a migrated route adding its first lead band (0 -> 31) was
+ * reported as a regression here even after the ratchet stopped doing so.
+ *
+ * "max"      — more is worse; an increase beyond the baseline is a regression.
+ * "presence" — the budget wants this axis to EXIST. Going up is the fix, so only
+ *              losing it (dropping to 0 when the baseline had one) regresses.
+ */
+export const MEASURED_AXIS_POLARITY = {
+  defaultVisibleWords: "max",
+  leadBandWords: "presence",
+  primaryActions: "max",
+  visibleFields: "max",
+  maxChoicesPerControl: "max",
+  subLegibleControls: "max",
+  buriedPrimaryAction: "max",
+  axeViolations: "max",
+};
+
+/** True when `now` is worse than the frozen `was` for this axis's polarity. */
+export function axisRegressed(axis, was, now) {
+  return MEASURED_AXIS_POLARITY[axis] === "presence"
+    ? was > 0 && now === 0
+    : now > was;
+}
+
 /** Evidence kinds that represent a real measurement or a real recorded choice. */
 export const QUALIFYING_EVIDENCE_KINDS = ["sweep-measurement", "propose-n-pick"];
 /**
@@ -250,7 +281,7 @@ export function checkMeasurementAgainstBaseline(manifest, baseline) {
       const now = metrics?.[axis];
       const was = frozen[axis];
       if (!isFiniteNumber(now) || !isFiniteNumber(was)) continue;
-      if (now > was) {
+      if (axisRegressed(axis, was, now)) {
         errors.push(
           `"${route}" regresses ${axis}: ${was} -> ${now}. The UX budget ratchet only allows ` +
             `a changed route to hold or improve its own frozen baseline.`,

--- a/scripts/check-ux-fit-decision.test.mjs
+++ b/scripts/check-ux-fit-decision.test.mjs
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 
 import {
   MEASURED_AXES,
+  MEASURED_AXIS_POLARITY,
   UI_CONTROL_RE,
   checkMeasurementAgainstBaseline,
   manifestPathsFromDiff,
@@ -223,4 +224,75 @@ test("route groups contribute no path segment; dynamic segments survive", () => 
   assert.equal(routePathForPageFile("apps/web/app/(shell)/ops/page.tsx"), "/ops");
   assert.equal(routePathForPageFile("apps/web/app/(shell)/build/[id]/page.tsx"), "/build/[id]");
   assert.equal(routePathForPageFile("apps/web/lib/whatever.ts"), null);
+});
+
+// ── axis polarity (BI-E7F6C76E) ──
+
+test("a route adding its first lead band is an improvement, not a regression", () => {
+  // The change this whole programme exists to cause. leadBandWords 0 -> 31 was
+  // reported as a regression here even after lib/ux-budget/ratchet.ts stopped
+  // doing so, because this gate mirrored the axis LIST and not the polarity map.
+  const errors = checkMeasurementAgainstBaseline(
+    {
+      evidence: {
+        kind: "sweep-measurement",
+        baselineComparison: "improved",
+        measured: {
+          "/example": {
+            defaultVisibleWords: 120,
+            leadBandWords: 31,
+            primaryActions: 1,
+            visibleFields: 3,
+            maxChoicesPerControl: 3,
+            subLegibleControls: 0,
+            buriedPrimaryAction: 0,
+            axeViolations: 1,
+          },
+        },
+      },
+    },
+    { ...BASELINE, routes: { "/example": { ...BASELINE.routes["/example"], leadBandWords: 0 } } },
+  );
+  assert.deepEqual(errors, []);
+});
+
+test("a route LOSING its lead band still regresses", () => {
+  // The presence axis is not a free pass: dropping to zero is the real failure.
+  const errors = checkMeasurementAgainstBaseline(
+    {
+      evidence: {
+        kind: "sweep-measurement",
+        baselineComparison: "improved",
+        measured: {
+          "/example": {
+            defaultVisibleWords: 120,
+            leadBandWords: 0,
+            primaryActions: 1,
+            visibleFields: 3,
+            maxChoicesPerControl: 3,
+            subLegibleControls: 0,
+            buriedPrimaryAction: 0,
+            axeViolations: 1,
+          },
+        },
+      },
+    },
+    BASELINE,
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /leadBandWords/);
+});
+
+test("polarity does not drift from lib/ux-budget/ratchet.ts", () => {
+  // This gate and the ratchet compare the SAME numbers against the SAME frozen
+  // baseline, so a polarity fix in one that misses the other reintroduces exactly
+  // the BI-E7F6C76E failure. Pin them together rather than trusting a comment.
+  const ratchet = readFileSync("apps/web/lib/ux-budget/ratchet.ts", "utf8");
+  const block = /RATCHET_AXIS_POLARITY[^=]*=\s*\{([^}]*)\}/.exec(ratchet);
+  assert.ok(block, "could not find RATCHET_AXIS_POLARITY in ratchet.ts");
+  const source = Object.fromEntries(
+    [...block[1].matchAll(/(\w+)\s*:\s*"(max|presence)"/g)].map((m) => [m[1], m[2]]),
+  );
+  assert.deepEqual(MEASURED_AXIS_POLARITY, source);
+  assert.deepEqual(Object.keys(MEASURED_AXIS_POLARITY).sort(), [...MEASURED_AXES].sort());
 });

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1418,7 +1418,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 89
+    "textMass": 69
   },
   "apps/web/app/(shell)/platform/audit/authority/page.tsx": {
     "vocabulary": 0,
@@ -3357,7 +3357,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 11
+    "textMass": 48
   },
   "apps/web/components/admin/SocialAuthPanel.tsx": {
     "vocabulary": 1,
@@ -5969,6 +5969,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 0
+  },
+  "apps/web/components/page-shells/PageShell.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
   },
   "apps/web/components/platform/ActivityRoutingPresentation.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Externalizes the ux-design critic so a coworker's craft judgment can take part in external review, and proves the UX side of it by migrating the portal's second-worst surface onto a real page shell.

## Why

The founder's report: portal pages are "impossible to navigate / use effectively... and only getting worse." Research showed the diagnosis and plan already existed in `EP-UX-SYSTEM` — what was missing was the layer that changes what gets built.

The platform could already **measure** the problem (201 routes baselined, median 192 default-visible words) but had no primitive that made good structure the default, so every new surface regressed to the model's house style. `MIGRATED_ROUTES` was empty because the shells were never built.

## What changed

**1. WSID reaches external development surfaces (BI-52839DEA)**

`evaluate_profession_decision` returned `no_agent_identity` to every external caller, while its WWMD sibling `principle_decide` had accepted `callingPopulation` all along. An external surface now declares its population and *names* the craft it consults; the gate serves the real profile and corpus and stamps `declaredBorrow` on the ledger.

Declared borrow, **not impersonation** — refused when the caller already has an agent identity. That distinction is load-bearing: the critique corpus calibrates a judge against founder verdicts, and a judge calibrated on rows it cannot tell apart from its own output is calibrated against itself.

**2. ux-design profession-local axes (BI-F405AC58)**

`PROFESSION_LOCAL_AXES` shipped empty awaiting "the profession that needs it". Four cost-framed axes: `hierarchy_flatness`, `content_density`, `disclosure_debt`, `perceptual_clutter` — each sourced, each rolling up onto `human_cognitive_load`. `content_density` is labelled platform calibration, not science; `perceptual_clutter` is the one validated member (CHI 2015).

**3. L1 page shells + cohort 0 migration (BI-36CE8BAB, BI-1D718FCA)**

`components/page-shells` gives a surface a reading contract: measurable lead band, one marked next action, the body, and one closed disclosure for everything else.

`/platform/ai/skills` — 5,349 default-visible words against a 450-word budget, zero lead band, an a11y tree of ~150 sibling paragraphs. Nearly all of it came from one component rendering all 92 descriptions under `line-clamp-2`, a paint-time trick that leaves every word in the DOM.

| | before (main) | after |
|---|---|---|
| default-visible words | 1,352 | **203** |
| lead-band words | 0 | 31 |
| next-action marker | absent | present |
| reading grade | — | 4.7 |
| budget checks passing | — | **11/11** |

**Correcting two figures stated earlier in this PR.**

- **203, not 34.** The 34 came from rendering the page with the catalog component *mocked out* by the page test, so it omitted the real 92-skill catalog. The route sweep — the binding measurement — reports **203**, inside the 450-word `detail` budget.
- **1,352, not 5,349, is the comparison against current main.** 5,349 was this route's baseline when the branch started; main has since landed an interim 12-row cap (#3757) taking it to 1,352. The cap reached its number by *hiding* skills — a masked list (BI-836923AD). This reaches a smaller one by structuring them, with every row reachable.

Nothing was removed: every skill, description and control is still reachable, now grouped by category rather than capped. This **supersedes the 12-item cap** that arrived incidentally in #3757 — a capped list is a masked list (BI-836923AD); grouping keeps everything reachable and measures better.

## Defects found and fixed on the way

Both **flattered this change**, which is why they were fixed rather than banked:

- **`scope.ts` excised the whole closed `<details>`, including its `<summary>`** — the label a reader actually sees. The redesign measured 10 words when a reader met 92 row labels. Summaries are now promoted before excision, depth-aware (a lazy regex matches the inner `</details>` and mangles grouped lists).
- **The skills page test mocked `next/link` to drop every prop but `href`**, so the shell's structural markers never reached the markup and the page measured as having no next action.

Separately filed: **BI-72E8FF05** — the profession-local-axis worked example was benefit-framed onto a cost spine axis and would have scored backwards. Another session implemented that guard on main from the report; this branch takes main's version and drops its duplicate.

## Verification

- **Functional**, against a real Postgres with the real seed (`dpf_local_ci_0`, not production): resolved `wsid-ux-design` with `materialCount: 8` — the real craft corpus, not a fallback. Ledger `DI-E42BC51C3BE0` carries `declaredBorrow: true`, `gateKey: profession`. Unknown craft fails closed.
  - The verdict was **`escalate`** ("profile confidence 0.35 below threshold 0.55"). That is the design working: the critic refuses to arbitrate on an ungrounded corpus, which is exactly the advisory posture this ships with.
- `tsc --noEmit` exit 0.
- 240 tests green across 21 files; 24 more in `packages/db`.
- 23/24 repo guards; the one failure is a `GuardRuntimeEnvironmentError` from the worktree `node_modules` junction.

**Not covered:** the MCP transport itself (`context.agentId` plumbing) stays unit-covered — `:3001` was held by another contributor throughout.

## Authority

The externalized critic is **advisory** and blocks nothing. An ungrounded design judge is the UICrit zero-shot case at 13.1% comment validity, and a UX signal that cries wolf gets disabled. The flip to blocking stays owned by BI-8316AC0C's data criteria and BI-42892849's entry condition; externalization must not become a back door around the staged authority grant. The deterministic gates keep blocking throughout.

## Design grounding

Extends `docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md` — §6 L1 (page shells), §6 L2 (budgets), §6 L6 (critic + corpus), §7 (migrate by cohort, worst-first, measured), §16 (dual-surface), §17 (gates read evidence, not provenance). Plan: `docs/superpowers/plans/2026-07-31-externalize-ux-design-critic-wsid.md`.

Kernel decisions: `DI-F20DB14D1B92` (served-judgment, margin 2.84) · `DI-D4E46B42E22B` (shells-then-migrate, margin 3.79) · `DI-C8DD9DD0F9F8` (cost-framed-plus-guard, margin 7.51).

**Local-CI-Override:** `pregate` could not run — the `local-integration-ci` lease was held by another session (codex, `feat/restaurant-host-command-center`, gate retry) for the whole window. Local evidence above; CI is the binding check.

Related: the duplicate `ux-design-critic` Agent rows noted in BI-52839DEA are already owned by #3852 / BI-6A1BFE77 — not duplicated here.

## Baseline refresh — why this PR touches 26 routes it never edited

The `scope.ts` fix counts `<summary>` text that was previously excised, so every route using `<details>` legitimately measures a few words higher (+3 to +34). The old numbers under-counted portal-wide. Regenerated through the workflow's governed `update_baseline` dispatch (run 30711415258) and committed here, because the baseline is a reviewed engineering act rather than something CI writes for itself.

It also absorbs `lead-band words: 0 → 31` on the migrated route, which the ratchet reported as a **REGRESSION**. Adding a lead band — against a 70-word budget, on a shell that requires one — is the change this epic exists to cause; the ratchet treats every axis as a cost. Filed as **BI-E7F6C76E**. This PR only gets past it because a refresh was needed anyway: a migration that changed nothing else would be blocked with no legitimate way through.
