### PR TITLE
feat(ci): detect time bombs dynamically, before they block the fleet (BI-6A4F47B9)

### DIFF
--- a/.github/workflows/audit-time-bombs.yml
+++ b/.github/workflows/audit-time-bombs.yml
@@ -58,7 +58,9 @@ jobs:
         with:
           node-version: 24
 
-      - uses: pnpm/action-setup@v4
+      # Pinned to a commit, not a tag: a mutable tag on a third-party action is a
+      # supply-chain hole (CodeQL `actions/unpinned-tag`). Same pin as mobile-ci.yml.
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/audit-time-bombs.yml
+++ b/.github/workflows/audit-time-bombs.yml
@@ -72,12 +72,21 @@ jobs:
       - name: Detect time bombs
         id: detect
         continue-on-error: true
+        # `workflow_dispatch` input is attacker-influenced text. It reaches the
+        # shell ONLY through env, never through `${{ }}` interpolation into the
+        # run block — that form is CWE-094 run-block injection, which the Actions
+        # Injection Audit correctly rejects.
+        env:
+          INPUT_DAYS: ${{ github.event.inputs.days }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -uo pipefail
-          DAYS="${{ github.event.inputs.days || '30,90,365' }}"
+          DAYS="${INPUT_DAYS:-30,90,365}"
           # On PRs to the detector itself, one near horizon is enough to prove it
           # runs; the scheduled job carries the full sweep.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then DAYS="30"; fi
+          if [ "$EVENT_NAME" = "pull_request" ]; then DAYS="30"; fi
+          # The script itself validates --days and rejects anything non-numeric,
+          # so a hostile value fails the audit rather than reaching a shell.
           node scripts/detect-time-bombs.mjs --days "$DAYS" | tee time-bomb-report.txt
           echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
@@ -99,6 +108,7 @@ jobs:
         if: github.event_name == 'schedule' && steps.detect.outputs.status == '1'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
           TITLE="fix(test): time bomb(s) will block the fleet on a known date"
@@ -114,7 +124,7 @@ jobs:
             cat time-bomb-report.txt
             echo '```'
             echo ""
-            echo "_Filed by .github/workflows/audit-time-bombs.yml — run ${{ github.run_id }}. Context: BI-6A4F47B9._"
+            echo "_Filed by .github/workflows/audit-time-bombs.yml — run ${RUN_ID}. Context: BI-6A4F47B9._"
           } > "$BODY_FILE"
           EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then

--- a/.github/workflows/audit-time-bombs.yml
+++ b/.github/workflows/audit-time-bombs.yml
@@ -1,0 +1,128 @@
+name: Time-Bomb Audit
+
+# Finds tests that pass today and fail on a known future date (BI-6A4F47B9).
+#
+# On 2026-08-01T15:00Z a single test with a hardcoded `expiresAt` went red at the
+# instant it encoded and BLOCKED EVERY PR in the repository, because the unit
+# shards are required checks. It was not flaky and could not self-recover.
+#
+# The obvious static sweep was measured on this repo and over-reports ~6:1 (29
+# files matched; the 5 most imminent, one already past its date, all PASSED) —
+# because a future date in a fixture is inert unless the code under test compares
+# it to now. So detection is dynamic instead: run the suite normally, run it again
+# with the clock shifted forward, and report the set difference. A test that
+# passes now and fails later IS a bomb, by definition — no heuristic to tune.
+#
+# SCHEDULED, NOT PER-PR, deliberately: it runs the suite once per horizon plus a
+# baseline, which is far too slow for the merge path. Weekly is early enough —
+# the failure it prevents is one a horizon of 30+ days would have caught long
+# before it reached the fleet.
+
+on:
+  schedule:
+    - cron: "17 5 * * 1" # Mondays — a week's notice on the nearest horizon
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Comma-separated horizons in days"
+        required: false
+        default: "30,90,365"
+  pull_request:
+    branches: [main]
+    # Only when the detector itself changes: this guards the guard, and keeps the
+    # expensive double-suite off every other PR.
+    paths:
+      - "scripts/detect-time-bombs.mjs"
+      - "apps/web/vitest.clock-shift-setup.ts"
+      - "apps/web/lib/testing/clock-shift.test.ts"
+      - ".github/workflows/audit-time-bombs.yml"
+
+permissions:
+  contents: read
+  issues: write # file the finding
+
+concurrency:
+  group: time-bomb-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Time-bomb audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Guard the guard. If the shim stopped shifting the clock, the audit would
+      # report "clean" forever — the worst outcome for a detector, so prove it
+      # still works before trusting a green result.
+      - name: Verify the clock shim
+        run: pnpm --filter web exec vitest run lib/testing/clock-shift.test.ts
+
+      - name: Detect time bombs
+        id: detect
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          DAYS="${{ github.event.inputs.days || '30,90,365' }}"
+          # On PRs to the detector itself, one near horizon is enough to prove it
+          # runs; the scheduled job carries the full sweep.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then DAYS="30"; fi
+          node scripts/detect-time-bombs.mjs --days "$DAYS" | tee time-bomb-report.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish report to the run summary
+        if: always()
+        run: |
+          { echo '```'; cat time-bomb-report.txt 2>/dev/null || echo "No report produced."; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+
+      # Exit 2 is a harness failure (zero tests collected, unreadable report).
+      # It must never be reported as "clean" — a detector that silently stops
+      # detecting is worse than no detector.
+      - name: Fail on harness error
+        if: steps.detect.outputs.status == '2'
+        run: |
+          echo "::error::The time-bomb audit could not run to completion — its result is not trustworthy."
+          exit 1
+
+      - name: File the finding
+        if: github.event_name == 'schedule' && steps.detect.outputs.status == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="fix(test): time bomb(s) will block the fleet on a known date"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "The weekly time-bomb audit found test(s) that pass against the current clock and fail against a future one."
+            echo ""
+            echo "Each will go red on a fixed date and STAY red. If it sits on a required shard it blocks every PR in the repository, and rerunning cannot help."
+            echo ""
+            echo "Fix: pin the clock in the enclosing \`describe\` (\`vi.useFakeTimers().setSystemTime(\"…\")\` plus \`afterEach(() => vi.useRealTimers())\`), or make the fixture relative to now."
+            echo ""
+            echo '```'
+            cat time-bomb-report.txt
+            echo '```'
+            echo ""
+            echo "_Filed by .github/workflows/audit-time-bombs.yml — run ${{ github.run_id }}. Context: BI-6A4F47B9._"
+          } > "$BODY_FILE"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+          else
+            gh issue create --title "$TITLE" --body-file "$BODY_FILE"
+          fi
+
+      - name: Fail the run when bombs are present
+        if: steps.detect.outputs.status == '1'
+        run: exit 1

--- a/apps/web/lib/testing/clock-shift.test.ts
+++ b/apps/web/lib/testing/clock-shift.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Tests for the clock-shift setup used by the time-bomb detector (BI-6A4F47B9).
+//
+// The setup file installs itself at import time from an env var, so these
+// exercise it by re-importing under a controlled environment rather than by
+// calling a function. `vi.resetModules()` is what makes each case a fresh
+// install.
+
+const ORIGINAL_DATE = Date;
+
+async function loadSetupWith(shift: string | undefined) {
+  globalThis.Date = ORIGINAL_DATE;
+  if (shift === undefined) delete process.env.DPF_CLOCK_SHIFT_DAYS;
+  else process.env.DPF_CLOCK_SHIFT_DAYS = shift;
+  vi.resetModules();
+  await import("../../vitest.clock-shift-setup");
+}
+
+afterEach(() => {
+  globalThis.Date = ORIGINAL_DATE;
+  delete process.env.DPF_CLOCK_SHIFT_DAYS;
+  vi.resetModules();
+});
+
+describe("clock-shift setup: inert unless explicitly enabled", () => {
+  // This is the load-bearing property. The setup file runs for EVERY test in the
+  // repo, so if it shifted time by accident it would not detect bombs — it would
+  // become one.
+  it("does not touch Date when the env var is unset", async () => {
+    await loadSetupWith(undefined);
+    expect(globalThis.Date).toBe(ORIGINAL_DATE);
+  });
+
+  it("does not touch Date for zero, empty, or non-numeric values", async () => {
+    for (const value of ["0", "", "   ", "soon", "NaN"]) {
+      await loadSetupWith(value);
+      expect(globalThis.Date, `value: ${JSON.stringify(value)}`).toBe(ORIGINAL_DATE);
+    }
+  });
+});
+
+describe("clock-shift setup: shifts 'now' only", () => {
+  it("moves Date.now() and bare new Date() forward by the requested days", async () => {
+    const before = ORIGINAL_DATE.now();
+    await loadSetupWith("90");
+    const shiftedNow = Date.now();
+    const after = ORIGINAL_DATE.now();
+
+    const ninetyDays = 90 * 24 * 60 * 60 * 1000;
+    // Bounded by the real clock either side, so this cannot pass by coincidence.
+    expect(shiftedNow).toBeGreaterThanOrEqual(before + ninetyDays);
+    expect(shiftedNow).toBeLessThanOrEqual(after + ninetyDays);
+    expect(new Date().getTime()).toBeGreaterThanOrEqual(before + ninetyDays);
+  });
+
+  it("accepts a negative shift, for checking whether something already detonated", async () => {
+    const before = ORIGINAL_DATE.now();
+    await loadSetupWith("-30");
+    expect(Date.now()).toBeLessThan(before);
+  });
+
+  it("leaves an explicitly-constructed date untouched", async () => {
+    // The fixture under test is exactly what must NOT move: shifting it too
+    // would keep the comparison in the same relative position and hide the bomb.
+    await loadSetupWith("90");
+    expect(new Date("2030-01-01T00:00:00.000Z").toISOString()).toBe("2030-01-01T00:00:00.000Z");
+    expect(new Date(0).getTime()).toBe(0);
+  });
+
+  it("keeps Date's static and instance surface working", async () => {
+    await loadSetupWith("90");
+    expect(Date.UTC(2030, 0, 1)).toBe(ORIGINAL_DATE.UTC(2030, 0, 1));
+    expect(Date.parse("2030-01-01T00:00:00.000Z")).toBe(
+      ORIGINAL_DATE.parse("2030-01-01T00:00:00.000Z"),
+    );
+    expect(new Date("2030-06-15T12:00:00.000Z") instanceof Date).toBe(true);
+    expect(new Date("2030-06-15T12:00:00.000Z").getUTCFullYear()).toBe(2030);
+  });
+});
+
+describe("clock-shift setup: this is what a bomb looks like", () => {
+  // Demonstrates the detector's premise end to end: the same assertion passes
+  // unshifted and fails shifted, which is the signal the runner diffs on.
+  const expiresAt = new Date(ORIGINAL_DATE.now() + 60 * 60 * 1000); // one hour out
+  const guard = () => {
+    if (expiresAt.getTime() <= Date.now()) throw new Error("expiry must be in the future");
+  };
+
+  it("passes against the current clock", async () => {
+    await loadSetupWith(undefined);
+    expect(guard).not.toThrow();
+  });
+
+  it("fails against a shifted clock — exactly the care-intake failure mode", async () => {
+    await loadSetupWith("90");
+    expect(guard).toThrow("expiry must be in the future");
+  });
+});

--- a/apps/web/vitest.clock-shift-setup.ts
+++ b/apps/web/vitest.clock-shift-setup.ts
@@ -40,14 +40,18 @@ if (rawDays.trim() !== "" && Number.isFinite(shiftDays) && shiftDays !== 0) {
   const RealDate = Date;
 
   class ShiftedDate extends RealDate {
-    constructor(...args: ConstructorParameters<typeof Date>) {
+    // `unknown[]`, not `ConstructorParameters<typeof Date>`: that helper resolves
+    // to a single fixed-arity overload, so TypeScript proves `args.length === 0`
+    // impossible and rejects the zero-arg branch (TS2367) — the one branch this
+    // shim exists to implement. At runtime the arguments are forwarded verbatim.
+    constructor(...args: unknown[]) {
       // Only a bare `new Date()` means "now" and gets shifted. An explicit
       // argument is the caller's own instant and must be preserved verbatim —
       // shifting it would move the very fixture we are testing and mask the bomb.
       if (args.length === 0) {
         super(RealDate.now() + offsetMs);
       } else {
-        super(...args);
+        super(...(args as ConstructorParameters<typeof Date>));
       }
     }
 

--- a/apps/web/vitest.clock-shift-setup.ts
+++ b/apps/web/vitest.clock-shift-setup.ts
@@ -1,0 +1,60 @@
+// Clock-shift setup for time-bomb detection (BI-6A4F47B9).
+//
+// A "time bomb" is a test whose fixture carries a hardcoded future date that the
+// code under test compares against the CURRENT time. It passes until that
+// instant, then fails permanently — and because the unit shards are required
+// checks, a single one blocks every PR in the repository. That is exactly what
+// `care-intake-api-repository.test.ts` did at 2026-08-01T15:00Z (fixed in
+// #3885/#3883).
+//
+// WHY NOT A STATIC GREP. The obvious sweep — "find fixtures with a future
+// `new Date("20…")` and no `useFakeTimers`" — was tried and measured on this
+// repo: 29 files matched, and the 5 most imminent (one already past its date)
+// were run and ALL PASSED. A future date in a fixture is inert unless something
+// compares it to now, so the heuristic over-reports roughly 6:1. Acting on it
+// would mean churn across several teams' tests, would prevent nothing, and
+// would manufacture confidence that the class was handled.
+//
+// WHAT ACTUALLY WORKS. Run the suite twice — once normally, once with the clock
+// shifted forward — and take the set difference. A test that passes now and
+// fails at now+90d IS a bomb, by definition, with no heuristic and no judgement.
+// Benign fixtures stay green and produce no noise. `scripts/detect-time-bombs.mjs`
+// drives that comparison; this file is the shift half.
+//
+// DESIGN NOTES.
+//   * Off unless `DPF_CLOCK_SHIFT_DAYS` is set to a non-zero finite number, so
+//     every normal run — CI, pregate, a developer's `vitest` — is unaffected
+//     beyond one cheap import.
+//   * Shifts `Date` only, never timers. Faking timers across a whole suite
+//     changes async scheduling and would produce failures that are artifacts of
+//     the harness rather than real bombs.
+//   * A test that pins its own clock (`vi.useFakeTimers().setSystemTime(...)`)
+//     overrides this shim entirely — which is correct: pinning is precisely what
+//     makes a test immune, so it should report clean.
+
+const rawDays = process.env.DPF_CLOCK_SHIFT_DAYS ?? "";
+const shiftDays = Number.parseFloat(rawDays);
+
+if (rawDays.trim() !== "" && Number.isFinite(shiftDays) && shiftDays !== 0) {
+  const offsetMs = shiftDays * 24 * 60 * 60 * 1000;
+  const RealDate = Date;
+
+  class ShiftedDate extends RealDate {
+    constructor(...args: ConstructorParameters<typeof Date>) {
+      // Only a bare `new Date()` means "now" and gets shifted. An explicit
+      // argument is the caller's own instant and must be preserved verbatim —
+      // shifting it would move the very fixture we are testing and mask the bomb.
+      if (args.length === 0) {
+        super(RealDate.now() + offsetMs);
+      } else {
+        super(...args);
+      }
+    }
+
+    static now(): number {
+      return RealDate.now() + offsetMs;
+    }
+  }
+
+  globalThis.Date = ShiftedDate as DateConstructor;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
     // default and times out (~5.3s observed across mcp-tools-*.test.ts). Raise
     // the per-test budget so the cold import has headroom; real hangs still fail.
     testTimeout: 15_000,
+    // Time-bomb detection (BI-6A4F47B9). A strict no-op unless
+    // DPF_CLOCK_SHIFT_DAYS is set, so normal runs pay only the import. See the
+    // file header for why a static grep does not work here.
+    setupFiles: ["./vitest.clock-shift-setup.ts"],
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
     // Each test file gets its own worker process. Without forks, React 18's

--- a/docs/superpowers/plans/2026-08-01-time-bomb-detection.md
+++ b/docs/superpowers/plans/2026-08-01-time-bomb-detection.md
@@ -1,0 +1,83 @@
+---
+title: Time-bomb detection — dynamic, not static
+authoredAt: 2026-08-01
+authoredBy: mark-bodman
+backlogItem: BI-6A4F47B9
+---
+
+# Time-bomb detection
+
+## What happened
+
+At **2026-08-01T15:00:00Z** `apps/web/lib/healthcare/care-intake-api-repository.test.ts`
+began failing on every branch simultaneously. Its fixture carried
+`expiresAt: new Date("2026-08-01T15:00:00.000Z")` while the code under test rejects an
+expiry that is not in the future, and its `describe` was the only block in the file that did
+not pin the clock. At that instant the literal became the past.
+
+`Unit Tests (web shard 1/4)` is a required check, so **every PR in the repository was
+blocked**, and rerunning could not help. Three sessions converged on it independently
+(#3883, #3885, and a third closed as duplicate) — which is itself evidence of how much
+confusion it caused: it presents as "my branch broke an unrelated area".
+
+The one-line fix shipped. This plan covers the part that stops the next one.
+
+## Why the obvious sweep was rejected
+
+The natural follow-up is "grep for fixtures with a future `new Date("20…")` and no
+`useFakeTimers`". That was **measured on this repo, not assumed**:
+
+- 29 files matched.
+- The 5 most imminent were run — including one whose date had **already elapsed**.
+- **38 tests, all passing.**
+
+A future date in a fixture is inert unless something compares it to the current time. The
+heuristic over-reports roughly 6:1. Acting on it would mean churn across several teams'
+tests, would prevent nothing, and — worst — would manufacture confidence that the class had
+been dealt with.
+
+## What is built instead
+
+Run the suite twice and take the set difference. A test that passes now and fails at now+N
+**is** a bomb, by definition. No heuristic, no judgement, and benign fixtures produce no
+noise.
+
+| Piece | What it does |
+|---|---|
+| `apps/web/vitest.clock-shift-setup.ts` | Shifts `Date.now()` and bare `new Date()` by `DPF_CLOCK_SHIFT_DAYS`. A strict no-op when the var is unset. |
+| `scripts/detect-time-bombs.mjs` | Runs baseline + each horizon, diffs failing test ids, reports only the difference. |
+| `apps/web/lib/testing/clock-shift.test.ts` | Proves the shim shifts *now* only, leaves explicit dates alone, and stays inert when disabled. |
+| `.github/workflows/audit-time-bombs.yml` | Weekly at +30/+90/+365d; files a tracking issue; also runs on PRs that touch the detector. |
+
+### Design decisions worth keeping
+
+**Shift `Date`, never timers.** Faking timers across a whole suite changes async scheduling
+and would produce failures that are artifacts of the harness rather than real bombs.
+
+**Only a bare `new Date()` moves.** An explicitly-constructed date is the fixture under
+test; shifting it too would keep the comparison in the same relative position and hide the
+very thing being looked for.
+
+**A test that pins its own clock is immune, and should be.** Pinning is the fix, so a pinned
+test correctly reports clean.
+
+**Scheduled, not per-PR.** It runs the suite once per horizon plus a baseline — far too slow
+for the merge path, and a 30-day horizon gives weeks of warning.
+
+**A harness failure is not a clean result.** Zero collected tests or an unreadable report
+exits 2 and fails the workflow. A detector that silently stops detecting is worse than none,
+so the workflow also re-runs the shim's own tests before trusting a green sweep.
+
+## Verified functionally, not structurally
+
+- Planted a probe with a bomb **and a benign control** in one file. The detector reported
+  the bomb and **not** the control — the precise over-reporting failure the static sweep had
+  — and exited 1.
+- Removed the probe: exits 0, reports clean.
+- Shim unit tests: 8/8.
+
+## Not done
+
+- Only `apps/web` is swept. `packages/**` suites have their own vitest configs and would
+  each need the setup file wired; worth doing if a bomb ever lands there.
+- The horizons (30/90/365) are a guess at useful lead time, not a measured choice.

--- a/scripts/detect-time-bombs.mjs
+++ b/scripts/detect-time-bombs.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// Time-bomb detector (BI-6A4F47B9).
+//
+// Runs the web unit suite twice — once normally, once with the clock shifted
+// forward — and reports the SET DIFFERENCE: tests that pass now and fail later.
+// That difference is the definition of a time bomb, so there is no heuristic to
+// tune and no false-positive class to triage.
+//
+// Context: on 2026-08-01 a single test with a hardcoded `expiresAt` went red at
+// the instant it encoded and blocked every PR in the repo (a required shard).
+// The obvious static sweep was measured on this repo and over-reports ~6:1 — 29
+// files matched, the 5 most imminent all passed — because a future date is inert
+// unless something compares it to now. Hence this dynamic check.
+//
+// Usage:
+//   node scripts/detect-time-bombs.mjs                  # +90d (default)
+//   node scripts/detect-time-bombs.mjs --days 30,90,365 # several horizons
+//   node scripts/detect-time-bombs.mjs --days 90 --filter lib/healthcare
+//
+// Exit codes: 0 = no bombs found, 1 = bombs found, 2 = harness failure.
+// Intended for a SCHEDULED job, not per-PR: it runs the suite once per horizon
+// plus a baseline, so it is deliberately not on the critical path of a merge.
+
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const WEB_DIR = path.join(REPO_ROOT, "apps", "web");
+const VITEST_BIN = path.join(REPO_ROOT, "node_modules", "vitest", "vitest.mjs");
+
+function parseArgs(argv) {
+  const options = { days: [90], filter: "" };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--days") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      options.days = raw
+        .split(",")
+        .map((value) => Number.parseFloat(value.trim()))
+        .filter((value) => Number.isFinite(value) && value !== 0);
+      if (options.days.length === 0) {
+        throw new Error(`--days needs at least one non-zero number (got "${raw}")`);
+      }
+    } else if (argv[i] === "--filter") {
+      options.filter = argv[i + 1] ?? "";
+      i += 1;
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      options.help = true;
+    }
+  }
+  return options;
+}
+
+/**
+ * Run the suite once and return the set of failing test ids.
+ *
+ * Uses vitest's JSON reporter rather than scraping stdout: the human reporter's
+ * shape is not a contract, and a parser that silently matches nothing would
+ * report "no bombs" — the worst possible failure for a guard whose whole job is
+ * to notice something.
+ */
+async function runSuite({ shiftDays, filter, outFile }) {
+  // Invoke vitest's entry directly with the current node binary rather than
+  // going through `pnpm` + a shell. On Windows `pnpm` needs `shell: true`, which
+  // concatenates arguments instead of escaping them — so a `--filter` value
+  // would be interpreted by the shell. This form takes no shell at all.
+  const args = [VITEST_BIN, "run", "--reporter=json", `--outputFile=${outFile}`];
+  if (filter) args.push(filter);
+
+  const env = { ...process.env };
+  if (shiftDays) env.DPF_CLOCK_SHIFT_DAYS = String(shiftDays);
+  else delete env.DPF_CLOCK_SHIFT_DAYS;
+
+  const label = shiftDays ? `+${shiftDays}d` : "baseline";
+  process.stdout.write(`[time-bombs] running suite (${label})…\n`);
+
+  const exitCode = await new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: WEB_DIR,
+      env,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    child.on("close", (code) => resolve(code ?? 1));
+    child.on("error", () => resolve(1));
+  });
+
+  let report;
+  try {
+    report = JSON.parse(await readFile(outFile, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `could not read the ${label} JSON report — the run produced no parseable ` +
+        `output, so its result cannot be trusted (${String(error)})`,
+    );
+  }
+
+  const failures = new Set();
+  for (const suite of report.testResults ?? []) {
+    for (const test of suite.assertionResults ?? []) {
+      if (test.status === "failed") {
+        failures.add(`${suite.name ?? "(unknown file)"} :: ${test.fullName ?? test.title}`);
+      }
+    }
+  }
+  return { failures, exitCode, total: report.numTotalTests ?? 0 };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(
+      "Usage: node scripts/detect-time-bombs.mjs [--days 30,90,365] [--filter <path>]\n",
+    );
+    return 0;
+  }
+
+  const workDir = await mkdtemp(path.join(tmpdir(), "dpf-time-bombs-"));
+  try {
+    const baseline = await runSuite({
+      shiftDays: 0,
+      filter: options.filter,
+      outFile: path.join(workDir, "baseline.json"),
+    });
+
+    if (baseline.total === 0) {
+      process.stderr.write(
+        "[time-bombs] the baseline run reported ZERO tests — the harness is broken, " +
+          "not the clock. Refusing to report a clean result.\n",
+      );
+      return 2;
+    }
+
+    // A red baseline is not this job's business, but it must be said out loud:
+    // silently subtracting pre-existing failures could hide a bomb that is
+    // already failing for a second reason.
+    if (baseline.failures.size > 0) {
+      process.stdout.write(
+        `[time-bombs] note: ${baseline.failures.size} test(s) already fail unshifted; ` +
+          "they are excluded from the diff below and need fixing on their own merits.\n",
+      );
+    }
+
+    const bombs = [];
+    for (const days of options.days) {
+      const shifted = await runSuite({
+        shiftDays: days,
+        filter: options.filter,
+        outFile: path.join(workDir, `shift-${days}.json`),
+      });
+
+      if (shifted.total === 0) {
+        process.stderr.write(`[time-bombs] the +${days}d run reported ZERO tests — aborting.\n`);
+        return 2;
+      }
+
+      for (const id of shifted.failures) {
+        if (!baseline.failures.has(id)) bombs.push({ days, id });
+      }
+    }
+
+    if (bombs.length === 0) {
+      process.stdout.write(
+        `[time-bombs] clean — ${baseline.total} tests pass at every horizon checked ` +
+          `(+${options.days.join("d, +")}d).\n`,
+      );
+      return 0;
+    }
+
+    process.stdout.write(`\n[time-bombs] ${bombs.length} TIME BOMB(S) FOUND\n\n`);
+    for (const { days, id } of bombs) {
+      process.stdout.write(`  detonates within +${days}d:  ${id}\n`);
+    }
+    process.stdout.write(
+      "\nEach passes against the current clock and fails against a future one, so each " +
+        "will go red on a known date and stay red — blocking every PR if it sits on a " +
+        "required shard.\n" +
+        "Fix: pin the clock in the enclosing describe " +
+        '(`vi.useFakeTimers().setSystemTime("…")` + `afterEach(() => vi.useRealTimers())`), ' +
+        "or make the fixture relative to now.\n",
+    );
+    return 1;
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    process.stderr.write(`[time-bombs] harness failure: ${error?.message ?? String(error)}\n`);
+    process.exitCode = 2;
+  });


### PR DESCRIPTION
## Why

On **2026-08-01T15:00Z** a single test with a hardcoded `expiresAt` went red at the instant it encoded and **blocked every PR in the repository** — the unit shards are required checks, it wasn't flaky, and rerunning couldn't help. Three sessions diagnosed it independently (#3883, #3885, and a third closed as duplicate), which is a fair measure of what it cost: it presents as *"my branch broke an unrelated area."*

The one-line fix shipped. This is the part that stops the next one.

## Why not the obvious static sweep

"Grep for a future `new Date("20…")` with no `useFakeTimers`" was **measured on this repo, not assumed**:

- 29 files matched
- The 5 most imminent were run — including one whose date had **already elapsed**
- **38 tests, all passing**

A future date in a fixture is inert unless the code under test compares it to *now*. The heuristic over-reports ~6:1. Acting on it would mean churn across several teams' tests, would prevent nothing, and — worst — would manufacture confidence that the class had been handled.

## What this does instead

Runs the suite normally, runs it again with the clock shifted forward, reports the **set difference**. A test that passes now and fails at now+N *is* a bomb, by definition. No heuristic to tune; benign fixtures generate no noise.

| Piece | Role |
|---|---|
| `apps/web/vitest.clock-shift-setup.ts` | Shifts `Date.now()` / bare `new Date()` by `DPF_CLOCK_SHIFT_DAYS`. **Strict no-op** when unset. |
| `scripts/detect-time-bombs.mjs` | Baseline + each horizon, diffs failing test ids. |
| `apps/web/lib/testing/clock-shift.test.ts` | Proves the shim shifts *now* only, leaves explicit dates alone, stays inert when disabled. |
| `.github/workflows/audit-time-bombs.yml` | Weekly at +30/+90/+365d, files a tracking issue; also runs on PRs touching the detector. |

**Decisions worth reviewing:**
- **Shifts `Date`, never timers** — faking timers suite-wide changes async scheduling and would produce failures that are artifacts of the harness, not real bombs.
- **Only a bare `new Date()` moves.** An explicitly-constructed date *is* the fixture under test; shifting it too would keep the comparison in the same relative position and hide the bomb.
- **A test that pins its own clock is immune** and reports clean — pinning is the fix.
- **Scheduled, not per-PR** — it runs the suite once per horizon plus a baseline, far too slow for the merge path. A 30-day horizon gives weeks of warning.
- **A harness failure is not a clean result.** Exit 2 (zero tests collected, unreadable report) fails the workflow, and the workflow re-runs the shim's own tests before trusting a green sweep. A detector that silently stops detecting is worse than none.

## Verification — functional, not structural

Planted a probe containing **a bomb and a benign control in one file**:
- Detector reported the bomb, **did not** report the control — the exact over-reporting failure the static sweep had — and exited **1**.
- Probe removed: exits **0**, reports clean.
- Shim unit tests: **8/8**.
- Because the setup file now loads for every test, also ran a **65-file / 708-test** sample: all passing.

The local-CI gate itself is unusable on this host — `vitest` is killed by resource pressure (exit `4294967295`, no test failure in any log), tracked as BI-872CB1BF. Pushed with a recorded override, not a hook bypass.

## Not done

Only `apps/web` is swept; `packages/**` suites have their own vitest configs. Horizons are a guess at useful lead time, not a measured choice. Both noted in the plan.

Backlog item: BI-6A4F47B9 (BI-AA333AB3 merged into it as a duplicate).

Local-CI-Override: local-CI vitest is killed by host resource pressure (BI-872CB1BF); verified instead by functional bomb/control probe, shim unit tests, and a 708-test sample. CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
