### PR TITLE
fix(ci): surface the failing policy guard at the log tail

### DIFF
--- a/scripts/ci-policy-guards.mjs
+++ b/scripts/ci-policy-guards.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   POLICY_GUARD_PROFILES,
+  formatRunSummary,
   runPolicyProfile,
 } from "./lib/ci-policy-guards.mjs";
 
@@ -68,6 +69,13 @@ export async function main() {
       "utf8",
     );
   }
+
+  // Consolidated summary at the LOG TAIL (outside any collapsed `::group`), so
+  // the failing guard is never hidden behind the last guard's output.
+  const summary = formatRunSummary(profile, result);
+  console.log(`\n${summary.text}`);
+  if (summary.annotation) console.error(summary.annotation);
+
   if (!result.ok) process.exitCode = 1;
 }
 

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 
 import {
   POLICY_GUARD_PROFILES,
+  formatRunSummary,
   resolvePolicyGuardInvocation,
   runPolicyProfile,
 } from "./lib/ci-policy-guards.mjs";
@@ -128,6 +129,39 @@ describe("CI policy guard registry", () => {
         { id: "second", status: "passed" },
       ],
     );
+  });
+
+  it("names every failed guard and its command in the tail summary", () => {
+    const result = {
+      ok: false,
+      entries: [
+        { name: "Module Size Guard", status: "failed", failedCommand: "node scripts/check-module-size.mjs" },
+        { name: "Janitor Tests", status: "passed", failedCommand: null },
+        { name: "Doc Reference Integrity", status: "failed", failedCommand: "node scripts/check-doc-reference-integrity.mjs" },
+      ],
+    };
+    const summary = formatRunSummary("source", result);
+    // The failing guards — not the last (passing) guard — must be surfaced.
+    assert.match(summary.text, /2 of 3 guard\(s\) FAILED \(1 passed\)/);
+    assert.match(summary.text, /✗ Module Size Guard — node scripts\/check-module-size\.mjs/);
+    assert.match(summary.text, /✗ Doc Reference Integrity — node scripts\/check-doc-reference-integrity\.mjs/);
+    assert.doesNotMatch(summary.text, /Janitor Tests/);
+    assert.equal(
+      summary.annotation,
+      "::error title=Policy Guards (source)::2 guard(s) failed: Module Size Guard, Doc Reference Integrity",
+    );
+  });
+
+  it("emits a clean pass line and no annotation when every guard passes", () => {
+    const summary = formatRunSummary("source", {
+      ok: true,
+      entries: [
+        { name: "Repo Guard Loop", status: "passed", failedCommand: null },
+        { name: "Janitor Tests", status: "passed", failedCommand: null },
+      ],
+    });
+    assert.equal(summary.text, "Policy guards (source): all 2 guard(s) passed.");
+    assert.equal(summary.annotation, null);
   });
 
   it("wires blocking source, workspace, and pull-request profiles in CI", () => {

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -303,6 +303,49 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
   ]),
 });
 
+/**
+ * Build the consolidated end-of-run summary for a policy-guard profile.
+ *
+ * The per-guard logger in the CLI only annotates a failure INSIDE the guard's
+ * `::group::…::endgroup::` block, which GitHub collapses by default. Because
+ * `runPolicyProfile` runs every guard even after one fails, the last guard's
+ * output (for `source`, the janitor `--help` USAGE text) is what a reader sees
+ * at the tail — with no hint of which earlier guard actually failed. That gap
+ * caused a real misdiagnosis (a module-size ratchet failure read as a janitor
+ * flake). This summary is printed OUTSIDE any group so the failing guard(s) and
+ * their exact failing command are always the last thing in the log.
+ *
+ * Returns `{ text, annotation }`: `text` is the human block for the log tail;
+ * `annotation` is a single `::error` workflow command (null when everything
+ * passed) so the failing guards also surface as a GitHub annotation.
+ */
+export function formatRunSummary(profile, result) {
+  const failed = result.entries.filter((entry) => entry.status === "failed");
+  const total = result.entries.length;
+  const passed = total - failed.length;
+
+  if (failed.length === 0) {
+    return {
+      text: `Policy guards (${profile}): all ${total} guard(s) passed.`,
+      annotation: null,
+    };
+  }
+
+  const lines = [
+    `Policy guards (${profile}): ${failed.length} of ${total} guard(s) FAILED (${passed} passed):`,
+    ...failed.map(
+      (entry) =>
+        `  ✗ ${entry.name} — ${entry.failedCommand ?? "(command not recorded)"}`,
+    ),
+  ];
+  return {
+    text: lines.join("\n"),
+    annotation: `::error title=Policy Guards (${profile})::${failed.length} guard(s) failed: ${failed
+      .map((entry) => entry.name)
+      .join(", ")}`,
+  };
+}
+
 export async function runPolicyProfile({
   entries,
   execute = (command, args) => {


### PR DESCRIPTION
## Problem

"Policy Guards (source)" intermittently *looked* like it failed with no visible cause: exit code 1, the last log line the `runtime-artifact-janitor --help` USAGE text, and no failing subtest anywhere near the tail. That shape was misread as an intermittent Janitor Tests / unhandled-rejection flake.

## What the CI logs actually show

Pulling the failed `Policy Guards (source)` runs on #3884 (`gh run view --job … --log`):

- The real failure is the **Module Size Guard** — `##[error]node scripts/check-module-size.mjs failed`, *"Module-size ratchet failed … run `--update` to re-baseline"* — ~600 log lines **above** the exit, inside a collapsed `##[group]Module Size Guard`. It is **deterministic**: #3884 changes `apps/web/lib/mcp/tool-tier.ts` + `scripts/module-size-baseline.txt`, so bundle sizes legitimately shift.
- **Janitor Tests passed.** Its group ran to completion and printed the `--help` USAGE right before the exit.
- `[doc-reference-integrity] FAILED …` lines are that guard's own red/green **test fixtures**; the guard passes.

## Root cause of the *misdiagnosis*

`runPolicyProfile` runs **every** guard even after one fails, and each failure is annotated only **inside** the guard's collapsed `::group::…::endgroup::` block. Because "Janitor Tests" is the **last** source guard and its last command prints the janitor USAGE, that USAGE is the tail on *every* run where the janitor passes — pass or fail overall. The pass/fail table only goes to the Step Summary tab and the `--results` JSON artifact — **nothing at the log tail names the failing guard.**

Node-24 forensics (CI pins `node-version: 24`): every `node --test` crash mode yields `✖ + # fail ≥ 1`, and an open handle *hangs* (timeout-kill, not exit 1). So "exit 1 / no ✖ / no # fail N" is never a `node --test` guard. `--test-force-exit` was rejected as a fix — it **masks** real late-rejection failures.

## Fix

Add a consolidated end-of-run summary printed **outside** any group, so the failing guard(s) and their exact failing command are always the log tail, plus a single `::error` annotation naming them:

```
Policy guards (source): 1 of 2 guard(s) FAILED (1 passed):
  ✗ Module Size Guard — node scripts/check-module-size.mjs
::error title=Policy Guards (source)::1 guard(s) failed: Module Size Guard
```

- Pure `formatRunSummary()` in the shared lib (`scripts/lib/ci-policy-guards.mjs`), unit-tested.
- CLI (`scripts/ci-policy-guards.mjs`) prints it after the run. Additive console output only; the `--results` JSON and Step-Summary markdown are unchanged.

## Verification

- `node --test scripts/ci-policy-guards.test.mjs` — green (new failed-summary + all-pass cases).
- `pnpm run pregate` **preflight** ran all 31 policy guards clean (the modified path included).
- End-to-end simulation of the #3884 log confirmed the failing guard is now the tail.

Local-CI-Override: Scripts-only ESM change (no app build/schema). pregate-preflight ran all 31 policy guards clean and node --test unit tests pass; the heavy local-CI gate cannot provision node_modules in this source-only worktree and the shared lease was queued at position 7. Operator-authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
