### PR TITLE
docs: recover seven orphaned specs/plans and the CADA forum deck from deleted-thread worktrees

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,7 @@ docker-entrypoint.sh text eol=lf
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.xlsx filter=lfs diff=lfs merge=lfs -text
 *.docx filter=lfs diff=lfs merge=lfs -text
+*.pptx filter=lfs diff=lfs merge=lfs -text
 
 # Upstream Model Context Protocol spec — preserve LF line endings so the local
 # copy stays byte-identical to upstream and refresh diffs are clean.

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -7449,6 +7449,32 @@
         "11-definition-of-done"
       ]
     },
+    "docs/strategy/2026-09-cada-architects-forum-deck.md": {
+      "publicHref": "/strategy/2026-09-cada-architects-forum-deck/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "architects-forum-cada-cloud-sovereignty-deck-outline-speaker-notes",
+        "slide-1-title",
+        "slide-2-the-shift-from-politics-to-procurement-law",
+        "slide-3-hero-the-four-tier-sovereignty-ladder-the-four-tier-ladder-visual",
+        "slide-4-why-hyperscaler-ai-is-capped-at-l1l2",
+        "slide-5-whos-in-scope-and-the-cascade",
+        "slide-6-the-architecture-that-can-reach-the-top",
+        "slide-7-sovereign-by-construction-how-dpf-embodies-it",
+        "slide-8-the-evidence-trail-what-auditorsprocurement-now-demand",
+        "slide-9-live-demo-what-tier-is-this-install",
+        "slide-10-the-partner-reference-stack",
+        "slide-11-beyond-the-platform-governing-the-whole-estate",
+        "slide-12-honest-caveats-credibility-with-this-audience",
+        "slide-13-call-to-action",
+        "slide-14-appendix-pointer-qa",
+        "appendix-a-legislation-references",
+        "appendix-b-dpf-architecture-references",
+        "appendix-c-live-demo-script"
+      ]
+    },
     "docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md": {
       "publicHref": "/strategy/2026-09-cada-cloud-sovereignty-architects-forum/",
       "portalHref": null,

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 600,
+  "pageCount": 601,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",

--- a/docs/strategy/2026-09-cada-architects-forum-deck.md
+++ b/docs/strategy/2026-09-cada-architects-forum-deck.md
@@ -1,0 +1,113 @@
+# Architects forum — CADA & cloud sovereignty: deck outline + speaker notes
+
+*Prepared 2026-06-19 for the September 2026 architects forum. Companion to the [strategy briefing](2026-09-cada-cloud-sovereignty-architects-forum.md). Every claim is referenced — see Appendix A (legislation) and Appendix B (DPF architecture). Target length ~25–30 min + Q&A; ~14 slides.*
+
+**How to use:** each slide block below has **On slide** (what the audience sees — keep it sparse), **Say** (speaker notes), and **Refs** (drill-down citations, keyed to the appendices). The hero slide (3) is the four-tier ladder visual already produced in this work (re-exportable on request).
+
+---
+
+### Slide 1 — Title
+- **On slide:** "Cloud & data sovereignty just became law. What it means for how we architect." · subtitle: *The EU Cloud and AI Development Act (CADA) and a sovereign-by-construction reference architecture.*
+- **Say:** Two weeks before this was drafted, the Commission turned a decade of voluntary sovereignty initiatives into a binding, tiered law. The job today: understand the ladder, and show an architecture that can actually reach the top of it.
+- **Refs:** A1, A2.
+
+### Slide 2 — The shift: from politics to procurement law
+- **On slide:** Timeline — GDPR (2018) → Data Act/DGA → EUCS (sovereignty stripped, 2024) → **CADA proposed 3 June 2026**. One line: *"sovereignty moved from aspiration to binding procurement + infrastructure law."*
+- **Say:** EU providers' share of the European cloud fell from ~29% (2017) to ~15% (2022); the Commission frames that dependence as an autonomy risk. EUCS was meant to certify sovereignty and failed after a 5-year deadlock — CADA exists to fill exactly that gap. It's a **proposal**: Parliament/Council/trilogue ahead, realistic application 2027–2028. Architect's takeaway: don't wait for final text — GDPR taught us that late-start rework is expensive.
+- **Refs:** A1, A3, A5 (EUCS/CSF backstory), A6.
+
+### Slide 3 — HERO: the four-tier sovereignty ladder *(the four-tier ladder visual)*
+- **On slide:** the ladder — L1 residency / L2 independence + SBOM / L3 EU-owned / L4 no third-country interference — with the red line between L2 and L3: *"US-owned cloud cannot cross this."*
+- **Say:** The whole law reduces to one question you can apply to any "sovereign cloud" claim: **who ultimately owns the operating entity, and what law reaches them?** Data location is the floor (L1), never sufficient for the top. L3 gates on EU *ownership*; L4 on *no third-country interference possible*. The Commission estimates L4 applies to ~1% of public services — but L2/L3 will cascade widely.
+- **Refs:** A2, A3 (tier criteria), A4 (the ownership argument), B1 (our architecture note encodes these as REQ-CADA-1…8).
+
+### Slide 4 — Why hyperscaler AI is capped at L1–L2
+- **On slide:** CLOUD Act §2713 + FISA 702 → reach the US parent regardless of EU datacenter. Quote: Microsoft's legal director, under oath to the French Senate (June 2025), could not guarantee French data against US authorities.
+- **Say:** An EU subsidiary 100%-owned by a US parent doesn't break the chain — data location is "legally irrelevant when the provider is subject to US jurisdiction." AWS and Oracle decline to claim CLOUD Act immunity at all. So Copilot / Gemini Enterprise / Bedrock are structurally L1–L2. This is a corporate-law fact, not an engineering gap — which is *why the architecture has to be different*.
+- **Refs:** A4, A7 (Microsoft under oath), A8 (Schrems III instability).
+
+### Slide 5 — Who's in scope, and the cascade
+- **On slide:** Mandatory: EU public-sector cloud procurement. Cascades: NIS2 essential entities (energy/health/transport/water), DORA-regulated finance, and **their suppliers**. Affected countries: 27 EU + 3 EEA-EFTA; everyone else = "third country."
+- **Say:** Even private firms not directly named get pulled in two ways: bidding for public contracts (sovereignty terms get embedded contractually before CADA is even binding), and subcontracting to regulated entities. It interlocks with DORA, NIS2, the AI Act (high-risk from 2 Aug 2026), and GDPR adequacy. The architect's point: **applicability is region- and archetype-scoped** — CADA only bites if you operate in or sell to the EU, the same way GDPR keys off selling and PCI is global. So the first question for any regulation isn't "what tier" — it's "does this even apply to us, given where we operate/sell and what kind of business we are." Our platform gates on exactly that before it assesses.
+- **Refs:** A3 (scope + cascade), B6 (affected countries as data — `eu-jurisdictions.ts`), B12 (region/archetype applicability gating — `regulation-applicability.ts`).
+
+### Slide 6 — The architecture that *can* reach the top
+- **On slide:** Four moves: **self-host** (L1 by construction) · **open source** (L2 transparency + neutralizes L3/L4 vendor-control) · **local AI** (the L4 "no inference egress" test) · **EU-held keys + EU-native infra** (L3/L4 ownership).
+- **Say:** None of these is exotic — but together they're the only combination that crosses the red line. Open source is the multiplier: it satisfies supply-chain transparency *and* removes the "a foreign vendor controls the software" objection, because the customer can run, audit, and fork. This is the general pattern any architect can apply — and it's the pattern our platform is built on.
+- **Refs:** B2 (principle: *data sovereignty follows control, not location*), B3 (prefer-self-hosted), A3 (L2/L4 criteria).
+
+### Slide 7 — Sovereign by construction (how DPF embodies it)
+- **On slide:** DPF = the AI-native platform that **runs on the customer's own infrastructure** → *inherits* the tier of where it's deployed. Single-tenant, self-hosted, open source, local-only-capable inference.
+- **Say:** The key architectural insight: we're not a SaaS that has to certify itself as sovereign — we're the application layer that inherits the infrastructure's tier. On EU-owned infra with local AI, a DPF install is part of an L3/L4 solution a US SaaS can never be. The local-only switch is real and load-bearing: it pins inference to local providers and **fails loudly** rather than silently reaching a cloud — that *is* the L4 no-egress control.
+- **Refs:** B1, B4 (deployment contracts: single-tenant self-hosted), B5 (`local-only.ts`, `pipeline-v2.ts:136` — the residency gate + loud failure).
+
+### Slide 8 — The evidence trail (what auditors/procurement now demand)
+- **On slide:** `RouteDecisionLog` (which model/provider served each request) · `ChangeRequest` (ITIL change register) · `ToolExecution` (every tool call) · retention governance.
+- **Say:** Sovereignty claims have to be *provable*, not asserted. We emit the route-decision log that proves local-only routing actually held, an immutable change register, and a full tool-execution audit — exactly the evidence the CSA control matrices (AICM/CCM, STAR for AI) and BSI C5 / SecNumCloud assessments ask for. The CADA-readiness assessment (next slide) reads these.
+- **Refs:** B1 (REQ-CADA-5), A3 (CSA evidence expectations).
+
+### Slide 9 — LIVE DEMO: "what tier is this install?"
+- **On slide:** terminal output of `check-cada-readiness.ts` — three beats: **applicability** (does CADA apply?), **signal-based tier** (Level 3), and **governance control coverage** (4/8 implemented; planned = the L4 build-out).
+- **Say:** This isn't a slide of aspirations — it's running on the platform today. First beat lands the region-specificity point live: with no EU nexus declared the tool says **"not applicable — out of scope"**; toggle `--operates-in eu` and it flips to an in-scope assessment. Then it reads the *real* local-only setting + the registered CADA controls: an EU-deployed install with local-only on is **Level 3**; the path to **Level 4** is exactly the three planned controls — signed SBOM, EU-held keys, an EU steward. The honest gap, surfaced automatically. *(Run the demo; have a screenshot fallback.)*
+- **Refs:** B7 (`cada-readiness.ts`, `check-cada-readiness.ts`, the `assessCadaReadiness` action), B8 (governance seed), B11 (PRs), B12 (applicability gating).
+
+### Slide 10 — The partner reference stack
+- **On slide:** layered table — IaaS: OVHcloud / StackIT / Scaleway · AI: Mistral-on-vLLM · keys: Thales / Cosmian · confidential compute: Edgeless + SEV-SNP/TDX · rubric: CSF/SEAL 0–4.
+- **Say:** You don't build sovereign infrastructure — you deploy onto the EU-sovereign layer and bundle the right AI + key partners. Hyperscaler "sovereign" tiers are L1–L2 only; for L3+ the relationship must shift to the EU operator (T-Systems, S3NS/Thales, Bleu, Delos). Map your own self-assessment to the Commission's CSF/SEAL — it's the rubric they actually procure against (€180M awarded under it in April 2026).
+- **Refs:** A5 (CSF/SEAL), strategy briefing §5 (full provider analysis).
+
+### Slide 11 — Beyond the platform: governing the whole estate
+- **On slide:** the bigger play — assess/plan/manage sovereignty across discovered infrastructure, edge nodes, and the external apps a company runs *outside* the platform. Epic `EP-ESTATE-SOVEREIGNTY`.
+- **Say:** CADA's obligation isn't limited to one platform — it spans the estate. The same scoring primitive that grades this install can grade every host, edge node, and third-party SaaS a company depends on, and file the gaps as tracked work. That's the roadmap: turn the readiness assessment into estate-wide posture management.
+- **Refs:** B9 (estate-sovereignty design spec), B10 (the scoring primitive that generalizes).
+
+### Slide 12 — Honest caveats (credibility with this audience)
+- **On slide:** CADA is a *proposal* (tiers may shift in trilogue) · nothing is "CADA-certified" yet · confidential computing ≠ a substitute for EU ownership · the NVIDIA-GPU supply chain is an industry-wide caveat — disclose, don't overclaim.
+- **Say:** Architects will test for overclaiming, so name the limits first. We map to proxies that exist today (BSI C5, SecNumCloud, CSF/SEAL), and we're explicit that our own L4 story needs a governance step (EU steward + signed SBOM) we haven't shipped yet — the readiness tool says so itself. Credibility comes from showing the gaps.
+- **Refs:** A2 (proposal status), strategy briefing §6 (caveats), B1 (planned vs green in the arch note).
+
+### Slide 13 — Call to action
+- **On slide:** "Start with a CADA-readiness assessment." Three steps: map your estate to the four tiers → identify the ownership cap → place sovereignty-sensitive workloads accordingly.
+- **Say:** Whatever stack you run, the first move is the assessment the CSA says every enterprise should do now: which of your providers can reach which tier, and where does foreign ownership cap you? We can run that assessment — and for AI workloads, offer an architecture that reaches L3/L4 where hyperscaler AI can't.
+- **Refs:** A3 (CSA readiness guidance), B7 (our assessment).
+
+### Slide 14 — Appendix pointer / Q&A
+- **On slide:** "References: legislation + architecture" · contact / repo pointers.
+- **Say:** Everything in this talk is sourced — primary legislation and our shipped, verified architecture. Happy to go deep on any tier, the routing internals, or the estate roadmap.
+
+---
+
+## Appendix A — Legislation references
+
+- **A1** — [European Commission · Cloud and AI Development Act (policy)](https://digital-strategy.ec.europa.eu/en/policies/cloud-and-ai-development-act)
+- **A2** — [European Commission · Proposal for the CADA (library)](https://digital-strategy.ec.europa.eu/en/library/proposal-cloud-and-ai-development-act-cada)
+- **A3** — [Covington / Inside Global Tech · "The EU Cloud and AI Development Act in Depth"](https://www.insideglobaltech.com/2026/06/11/the-eu-cloud-and-ai-development-act-in-depth/) (scope, four levels, obligations, cascade) · [Cloud Security Alliance · CADA enterprise-compliance note](https://labs.cloudsecurityalliance.org/research/csa-research-note-eu-cloud-ai-development-act-cada-complianc/) (readiness, evidence, controls)
+- **A4** — [Jones Day · proposed sovereignty framework / compliance tiers](https://www.jonesday.com/en/insights/2026/06/european-commissions-proposed-cloud-sovereignty-framework-creates-new-compliance-tiers-for-software-providers) · [Wilson Sonsini · Commission proposes Act to reduce reliance on foreign cloud and AI](https://www.wsgr.com/en/insights/european-commission-publishes-proposal-for-act-to-reduce-reliance-on-foreign-cloud-and-ai.html)
+- **A5** — [EC · Sovereign Cloud Framework explained (CSF / SEAL 0–4)](https://commission.europa.eu/news-and-media/news/sovereign-cloud-framework-explained-2026-06-01_en)
+- **A6** — [Global Policy Watch · The EU Cloud and AI Development Act in depth](https://www.globalpolicywatch.com/2026/06/the-eu-cloud-and-ai-development-act-in-depth/) (market-share, package context)
+- **A7** — [The Register · Microsoft sovereignty / cannot guarantee data vs US authorities](https://www.theregister.com/2025/11/07/microsoft_announces_strengthening_of_sovereignty/)
+- **A8** — [Stanford Law · Schrems III and the future of transatlantic privacy](https://law.stanford.edu/publications/no-151-schrems-iii-the-future-of-transatlantic-privacy-law-after-latombe-v-commission/) · [Raconteur · what sovereign cloud means in new laws](https://www.raconteur.net/global-business/eu-cloud-and-ai-development-act-what-sovereign-cloud-means-in-new-laws)
+- Related frameworks: **DORA** (Reg. 2022/2554, in force 2025-01-17), **NIS2** (Oct 2024), **EU AI Act** (high-risk from 2026-08-02), **GDPR** adequacy.
+
+## Appendix B — DPF architecture references
+
+- **B1** — Architecture note: [`docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md`](../architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md) — REQ-CADA-1…8, CON-CADA-1, allocations, verification cases.
+- **B2** — Principle: [`data-sovereignty-follows-control`](../founder-kernel/wiki/principles/data-sovereignty-follows-control.md).
+- **B3** — Principle: [`prefer-self-hosted-infrastructure`](../founder-kernel/wiki/principles/prefer-self-hosted-infrastructure.md).
+- **B4** — Deployment doctrine: [`docs/superpowers/specs/2026-05-09-deployment-contracts.md`](../superpowers/specs/2026-05-09-deployment-contracts.md) (single-tenant, self-hosted; `docker-compose.yml`).
+- **B5** — Local-only inference gate: [`apps/web/lib/inference/local-only.ts`](../../apps/web/lib/inference/local-only.ts), [`apps/web/lib/routing/pipeline-v2.ts:136`](../../apps/web/lib/routing/pipeline-v2.ts) — the residency filter that fails loudly.
+- **B6** — Affected-countries reference: [`packages/db/src/eu-jurisdictions.ts`](../../packages/db/src/eu-jurisdictions.ts) (27 EU + 3 EEA, `isThirdCountryForCada`).
+- **B7** — Readiness assessment: [`packages/db/src/cada-readiness.ts`](../../packages/db/src/cada-readiness.ts), operator script [`packages/db/scripts/check-cada-readiness.ts`](../../packages/db/scripts/check-cada-readiness.ts), action [`apps/web/lib/actions/sovereignty.ts`](../../apps/web/lib/actions/sovereignty.ts).
+- **B8** — Scoring primitive: [`packages/db/src/sovereignty-assessment.ts`](../../packages/db/src/sovereignty-assessment.ts) (CON-CADA-1; third-country operator capped at L2).
+- **B8b** — Governance registration: [`packages/db/scripts/seed-cada-regulation.ts`](../../packages/db/scripts/seed-cada-regulation.ts) + corpus page [`docs/professions/legal-compliance/wiki/eu-cada-cloud-sovereignty.md`](../professions/legal-compliance/wiki/eu-cada-cloud-sovereignty.md).
+- **B9** — Estate roadmap: [`docs/superpowers/specs/2026-06-19-estate-sovereignty-governance-design.md`](../superpowers/specs/2026-06-19-estate-sovereignty-governance-design.md) (epic `EP-ESTATE-SOVEREIGNTY`).
+- **B10** — Strategy briefing (partner stack, marketing, full analysis): [`docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md`](2026-09-cada-cloud-sovereignty-architects-forum.md).
+- **B11** — Shipped + CI-verified: PRs [#2080](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2080), [#2084](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2084), [#2089](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2089), [#2095](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2095).
+- **B12** — Region/archetype applicability gating: [`packages/db/src/regulation-applicability.ts`](../../packages/db/src/regulation-applicability.ts) — `regulationApplies` reuses `PROFESSION_JURISDICTION_BASES`; CADA assessed only on an EU operating/selling nexus. Generalizes to GDPR (selling), DORA (operating + archetype), PCI-DSS (global).
+
+## Appendix C — Live demo script
+
+1. On the install host: `cd packages/db && npx tsx scripts/check-cada-readiness.ts --operator DE --data-in-eea`
+2. Talking point as it prints: real `local-only=ON` is read from `PlatformConfig`; the EU-declared scenario lands at **Level 3**; **governance controls 4/8 implemented**, the 3 planned being the Level-4 build-out.
+3. Fallback if offline: screenshot of the above output (capture beforehand).
+4. Optional contrast: `--operator US` → capped at **Level 2** with the ownership-cap message — drives home the red line on the hero slide.

--- a/docs/strategy/2026-09-cada-architects-forum.pptx
+++ b/docs/strategy/2026-09-cada-architects-forum.pptx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1031cece65ce5e87fcf2304b7b1159f6b08cba469d5722b651baf69c44661c4e
+size 287072

--- a/docs/superpowers/plans/2026-06-12-value-stream-p0-capture-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-12-value-stream-p0-capture-implementation-plan.md
@@ -1,6 +1,8 @@
 # Value Stream P0 Capture Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Recovery note (2026-08-01):** this plan was written 2026-06-12 and stranded uncommitted in a deleted thread's worktree. Only the preamble above was rewritten on recovery — it originally invoked the `superpowers:*` skills, which have since been retired. The plan body is unchanged from 2026-06-12 and predates two months of platform change; re-verify against current `main` before executing.
 
 **Goal:** At storefront setup and archetype reset, derive the org's Operational Value Stream Model (OVSM), persist it as an EA value-stream view, list it on the existing `/ea/value-streams` surface, render it on `/ea/views/[id]`, and keep ArchiMate export working through the existing view export path.
 

--- a/docs/superpowers/plans/2026-06-12-value-stream-p0-capture-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-12-value-stream-p0-capture-implementation-plan.md
@@ -1,0 +1,560 @@
+# Value Stream P0 Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** At storefront setup and archetype reset, derive the org's Operational Value Stream Model (OVSM), persist it as an EA value-stream view, list it on the existing `/ea/value-streams` surface, render it on `/ea/views/[id]`, and keep ArchiMate export working through the existing view export path.
+
+**Architecture:** Derive, do not author: the OVSM is a pure projection of existing archetype substrate (`OperatingModelAxes`, `ActivationProfile`, `SchedulingDefaults`, `BillingPatternProfile`, `PortfolioDecomposition`). Persist it as existing EA substrate (`EaElement`, `EaView`, `EaViewElement`, `EaRelationship`) with projection metadata and no new Prisma table. Reuse the current EA swimlane renderer by setting `properties.projection.layoutRole` to `stream_band` / `stream_stage`.
+
+**Tech Stack:** Next.js app router, Prisma 7, pnpm workspaces, Vitest, `@dpf/storefront-templates`, `@dpf/db`, existing EA ArchiMate renderer/export pipeline.
+
+---
+
+## Review Corrections Applied
+
+This revision turns the prior slice outline into an executable plan.
+
+- Corrected scope to the current branch substrate: `ALL_ARCHETYPES` now has 56 archetypes, including `equipment-rental`, `self-storage`, and `agricultural-cooperative`.
+- Added the required agentic-worker plan header and chunk/task structure.
+- Split the work into test-first chunks with exact files, commands, and expected evidence.
+- Made the projection service accept a Prisma client/transaction dependency so setup and archetype reset can both call it safely.
+- Added package export changes that the first draft omitted.
+- Kept the UI scope narrow: one widened list page plus optional metadata badges only if existing EA canvas data already supports them.
+- Named runtime-bound verification separately from source-local tests, per AGENTS.md build-gate rules.
+
+## Source Context
+
+- Design spec: `docs/superpowers/specs/2026-06-12-value-stream-architecture-platform-design.md` §11 P0.
+- Source artefact: `docs/architecture/archetype-business-value-streams.md` §3, §5, §7, §8.7, §8.8, §10.1.
+- Backlog anchor: [opendigitalproductfactory#1724](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/1724), epic `EP-ARCH-8D4F2A`.
+- Verified substrate in this worktree:
+  - `packages/storefront-templates/src/archetypes/index.ts` includes 56 archetypes.
+  - Rental/shared-asset archetypes and capabilities exist.
+  - `packages/db/src/reference-model-projection.ts` already persists value-stream bands, stages, view elements, and `flows_to` relationships.
+  - `apps/web/app/(shell)/ea/value-streams/page.tsx` currently filters only `scopeType: "reference_model_projection"`.
+  - Setup hook is `apps/web/app/api/storefront/admin/setup/route.ts`.
+  - Reset hook is `apps/web/lib/storefront/archetype-reset.ts`.
+
+## File Map
+
+- Create: `packages/storefront-templates/src/operational-value-stream.ts`
+  - Pure OVSM derivation from `ArchetypeDefinition`.
+- Create: `packages/storefront-templates/src/operational-value-stream.test.ts`
+  - Tests every archetype plus representative commercial/rental/governance cases.
+- Modify: `packages/storefront-templates/src/index.ts`
+  - Export the derivation API.
+- Create: `packages/db/src/archetype-value-stream-projection.ts`
+  - Persist OVSM to EA elements/views/relationships.
+- Create: `packages/db/src/archetype-value-stream-projection.test.ts`
+  - Idempotency and relationship/view-element tests.
+- Modify: `packages/db/package.json`
+  - Add export path `./archetype-value-stream-projection`.
+- Modify: `packages/db/src/index.ts` only if an existing app import needs the barrel; prefer the explicit package export path.
+- Create: `apps/web/lib/storefront/project-operational-value-stream.ts`
+  - App-layer orchestration: resolve the template archetype, derive OVSM, call the DB projector.
+- Create: `apps/web/lib/storefront/project-operational-value-stream.test.ts`
+  - Mock derivation/projector and assert setup/reset call shape.
+- Modify: `apps/web/app/api/storefront/admin/setup/route.ts`
+  - Call the app-layer orchestration after `StorefrontConfig` and `BusinessContext` are persisted.
+- Modify: `apps/web/lib/storefront/archetype-reset.ts`
+  - Call the app-layer orchestration inside the existing transaction after the target archetype is selected and capability perspective is applied.
+- Modify: `apps/web/app/(shell)/ea/value-streams/page.tsx`
+  - Widen list query and distinguish operational vs reference value-stream views.
+- Create or modify tests near existing route/page tests as needed:
+  - `apps/web/app/api/storefront/admin/setup/route.test.ts` if practical in existing pattern.
+  - `apps/web/lib/storefront/archetype-reset.test.ts`.
+  - `apps/web/app/(shell)/ea/value-streams/page.test.tsx` only if a local server-component test pattern already exists; otherwise cover with a focused data helper test and runtime UX verification.
+
+---
+
+## Chunk 1: Pure OVSM Derivation
+
+### Task 1: Add the derivation contract
+
+**Files:**
+- Create: `packages/storefront-templates/src/operational-value-stream.ts`
+- Create: `packages/storefront-templates/src/operational-value-stream.test.ts`
+- Modify: `packages/storefront-templates/src/index.ts`
+
+- [ ] **Step 1: Write failing tests for representative archetypes**
+
+Test these cases by loading from `ALL_ARCHETYPES`:
+
+- `hair-salon`: `appointment-checkout`, load-bearing stage `qualify`, capacity unit `slot-hours`.
+- `veterinary-clinic`: `encounter-based`, load-bearing stage `deliver`, trust gate includes `clinical-adjacent`.
+- `bakery`: transactional/point-of-sale, load-bearing stage `capture`, capacity unit includes durable/perishable stock as applicable from artefact category.
+- `gym`: `subscription`, load-bearing stage `retain`, capacity unit `physical-capacity`.
+- `it-managed-services`: `recurring-agreement`, load-bearing stage `deliver`, trust gate includes strict estate separation.
+- `community-bank`: `account-based-fees`, trust gate before `qualify`, KYC/disclosure signal present.
+- `small-town-municipality`: statutory/public-body, trust gate includes universal-service obligation.
+- `charity`: donation, load-bearing stage `capture`, no purchase artefact.
+- `equipment-rental`: reservation-and-return, stage extension includes `return-inspect` or equivalent rental-specific stage metadata.
+- `self-storage`: rental/subscription occupancy, capacity unit `reusable-pooled-asset` or `physical-hard-cap` with occupancy semantics.
+- `agricultural-cooperative`: member-owned + reservation-and-return, trust/governance signal includes equitable allocation.
+
+Run:
+
+```powershell
+pnpm --filter @dpf/storefront-templates exec vitest run src/operational-value-stream.test.ts
+```
+
+Expected: FAIL because `deriveOperationalValueStream` does not exist.
+
+- [ ] **Step 2: Implement the public types and six-stage backbone**
+
+Define narrow string unions in `operational-value-stream.ts`, not loose `string` fields:
+
+```ts
+export type OperationalValueStreamStageKey =
+  | "attract"
+  | "capture"
+  | "qualify"
+  | "deliver"
+  | "settle"
+  | "retain"
+  | "trust-compliance"
+  | "operate-improve"
+  | "return-inspect";
+
+export type CapacityUnitType =
+  | "slot-hours"
+  | "service-throughput"
+  | "durable-stock"
+  | "perishable-stock"
+  | "physical-hard-cap"
+  | "billable-hours"
+  | "volunteer-or-bed-capacity"
+  | "loan-processing-throughput"
+  | "statutory-throughput"
+  | "reusable-pooled-asset"
+  | "governance-cycle";
+
+export type DemandSignature =
+  | "steady"
+  | "seasonal"
+  | "weekly"
+  | "event-driven"
+  | "fiscal-calendar"
+  | "rate-sensitive"
+  | "emergency-reactive"
+  | "synchronized-contention";
+```
+
+Keep the model explicit enough for TypeScript and tests:
+
+```ts
+export interface OperationalValueStreamStage {
+  key: OperationalValueStreamStageKey;
+  label: string;
+  order: number;
+  loadBearing: boolean;
+  capabilityBindings: ArchetypeModule[];
+  metricBindings: string[];
+  trustGateKeys: string[];
+}
+
+export interface OperationalValueStream {
+  archetypeId: string;
+  archetypeName: string;
+  category: string;
+  stages: OperationalValueStreamStage[];
+  loadBearingStageKeys: OperationalValueStreamStageKey[];
+  capacityUnit: CapacityUnitType;
+  demandSignature: DemandSignature;
+  trustGates: string[];
+  it4itStageBinding: It4ItStage[];
+}
+```
+
+- [ ] **Step 3: Implement the mapping conservatively**
+
+Rules:
+
+- Start from the universal six stages plus two cross-cuts.
+- Bind capabilities from the existing source fields named in the artefact §5.
+- Use lookup maps keyed by `commercialModel`, `category`, `provisioning`, `governance`, and rental-specific `provisioning: "reservation-and-return"`.
+- Do not add fields to `ArchetypeDefinition`.
+- Do not parse prose from the markdown artefact at runtime.
+- Include rental's `return-inspect` stage only for `reservation-and-return` archetypes; do not add it globally.
+
+- [ ] **Step 4: Export the API**
+
+Modify `packages/storefront-templates/src/index.ts`:
+
+```ts
+export * from "./operational-value-stream";
+```
+
+- [ ] **Step 5: Verify derivation**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/storefront-templates exec vitest run src/operational-value-stream.test.ts
+pnpm --filter @dpf/storefront-templates typecheck
+```
+
+Expected: tests PASS; typecheck exits 0.
+
+- [ ] **Step 6: Commit the pure derivation slice**
+
+```powershell
+git add packages/storefront-templates/src/operational-value-stream.ts packages/storefront-templates/src/operational-value-stream.test.ts packages/storefront-templates/src/index.ts
+git commit -s -m "feat: derive operational value streams from archetypes"
+```
+
+---
+
+## Chunk 2: Persist OVSM to EA Substrate
+
+### Task 2: Add the EA projection service
+
+**Files:**
+- Create: `packages/db/src/archetype-value-stream-projection.ts`
+- Create: `packages/db/src/archetype-value-stream-projection.test.ts`
+- Modify: `packages/db/package.json`
+- Modify: `packages/db/src/index.ts` only if needed
+
+- [ ] **Step 1: Write failing projection tests**
+
+Use `reference-model-projection.test.ts` as the structural precedent. Tests must cover:
+
+- First projection creates one `EaView` with `scopeType: "archetype_value_stream"` and `scopeRef: "<orgId>:operational"`.
+- Projection creates one `value_stream` band plus all OVSM stages as `value_stream_stage` elements.
+- Stage elements carry `properties.projection.layoutRole`, `properties.operationalValueStream.loadBearing`, `capacityUnit`, `demandSignature`, `trustGates`, `stageKey`, and `orgId`.
+- Sequential primary stages have `flows_to` relationships in order.
+- Re-running the same projection updates in place and creates no duplicate elements/views/view-elements/relationships.
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec vitest run src/archetype-value-stream-projection.test.ts
+```
+
+Expected: FAIL because the service does not exist.
+
+- [ ] **Step 2: Implement the service with an injectable DB dependency**
+
+Do not hardcode the package singleton inside the service. Reset runs inside `prisma.$transaction`, so the function must accept a client-like dependency.
+
+Shape:
+
+```ts
+export interface ProjectArchetypeValueStreamInput {
+  db?: Prisma.TransactionClient | PrismaClient;
+  orgId: string;
+  ovsm: OperationalValueStream;
+}
+
+export async function projectArchetypeValueStream(input: ProjectArchetypeValueStreamInput): Promise<ProjectionResult>;
+```
+
+Implementation rules:
+
+- Default `db` to package `prisma` for setup callers that do not pass a transaction.
+- Look up `archimate4`, `value_stream`, `value_stream_stage`, `flows_to`, and the `Business Architecture` viewpoint exactly like `reference-model-projection.ts`.
+- Use metadata to resolve idempotency:
+  - `properties.projection.source = "archetype-ovsm"`
+  - `properties.projection.orgId = input.orgId`
+  - `properties.projection.stageKey = stage.key`
+  - `properties.projection.archetypeId = ovsm.archetypeId`
+- Use `EaView.scopeType = "archetype_value_stream"` and `scopeRef = "<orgId>:operational"`.
+- Name the view `"<Archetype Name> — Operational Value Stream"`.
+- Preserve `layoutType: "graph"` so existing canvas layout can take over.
+- Add `itValueStream` when the schema field exists and current `EaElement` create/update patterns support it; otherwise store the IT4IT binding under `properties.operationalValueStream.it4itStageBinding` and leave a comment in the test.
+
+- [ ] **Step 3: Keep projection helper refactor small**
+
+If extracting shared helper functions from `reference-model-projection.ts` takes less than 20% of this slice, extract a small internal helper module such as `packages/db/src/ea-projection-helpers.ts`. Otherwise mirror the idempotency pattern locally and defer shared-helper cleanup. This is the planned refactoring budget for this slice.
+
+- [ ] **Step 4: Export the service**
+
+Modify `packages/db/package.json`:
+
+```json
+"./archetype-value-stream-projection": "./src/archetype-value-stream-projection.ts"
+```
+
+Only add a barrel export to `packages/db/src/index.ts` if an app import path needs it. Prefer:
+
+```ts
+import { projectArchetypeValueStream } from "@dpf/db/archetype-value-stream-projection";
+```
+
+- [ ] **Step 5: Verify projection**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/db exec vitest run src/archetype-value-stream-projection.test.ts src/reference-model-projection.test.ts
+pnpm --filter @dpf/db typecheck
+```
+
+Expected: tests PASS; typecheck exits 0.
+
+- [ ] **Step 6: Commit the projection slice**
+
+```powershell
+git add packages/db/src/archetype-value-stream-projection.ts packages/db/src/archetype-value-stream-projection.test.ts packages/db/package.json packages/db/src/index.ts
+git commit -s -m "feat: project archetype value streams into EA"
+```
+
+---
+
+## Chunk 3: Wire Setup and Archetype Reset
+
+### Task 3: Add app-layer orchestration and call it from setup/reset
+
+**Files:**
+- Create: `apps/web/lib/storefront/project-operational-value-stream.ts`
+- Create: `apps/web/lib/storefront/project-operational-value-stream.test.ts`
+- Modify: `apps/web/app/api/storefront/admin/setup/route.ts`
+- Modify: `apps/web/lib/storefront/archetype-reset.ts`
+- Modify existing tests where practical.
+
+- [ ] **Step 1: Write failing orchestration tests**
+
+Test the app helper with mocks:
+
+- It finds the template archetype by `archetypeId` from `ALL_ARCHETYPES`.
+- It calls `deriveOperationalValueStream(template)`.
+- It calls `projectArchetypeValueStream({ db, orgId, ovsm })`.
+- It throws a useful error if a DB archetype exists but the template archetype is missing.
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/storefront/project-operational-value-stream.test.ts
+```
+
+Expected: FAIL because the helper does not exist.
+
+- [ ] **Step 2: Implement the helper**
+
+Suggested signature:
+
+```ts
+export async function projectOperationalValueStreamForArchetype(input: {
+  db?: Prisma.TransactionClient | PrismaClient;
+  organizationId: string;
+  archetypeId: string;
+}) {
+  const template = ALL_ARCHETYPES.find((a) => a.archetypeId === input.archetypeId);
+  if (!template) throw new Error(`Template archetype ${input.archetypeId} not found`);
+  const ovsm = deriveOperationalValueStream(template);
+  return projectArchetypeValueStream({ db: input.db, orgId: input.organizationId, ovsm });
+}
+```
+
+- [ ] **Step 3: Wire setup**
+
+In `apps/web/app/api/storefront/admin/setup/route.ts`, call the helper after `businessContext.upsert` and before returning success. Use the DB archetype's public `archetypeId` string from the request/template, not the internal row id.
+
+Non-fatal or fatal? Make it fatal for P0. If the OVSM cannot project, setup has not completed the architecture contract.
+
+- [ ] **Step 4: Wire reset inside the existing transaction**
+
+In `apps/web/lib/storefront/archetype-reset.ts`, call:
+
+```ts
+await projectOperationalValueStreamForArchetype({
+  db: tx,
+  organizationId,
+  archetypeId: targetArchetype.archetypeId,
+});
+```
+
+Place it after `applyBusinessCapabilityPerspective(tx, ...)` and before returning the reset result.
+
+- [ ] **Step 5: Extend reset tests**
+
+In `apps/web/lib/storefront/archetype-reset.test.ts`, mock the helper and assert reset calls it with the transaction-like client, organization id, and target archetype id. If the current test harness does not expose the transaction object cleanly, assert call count and semantic arguments.
+
+- [ ] **Step 6: Verify setup/reset wiring**
+
+Run:
+
+```powershell
+pnpm --filter web exec vitest run lib/storefront/project-operational-value-stream.test.ts lib/storefront/archetype-reset.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: tests PASS; typecheck exits 0.
+
+- [ ] **Step 7: Commit the wiring slice**
+
+```powershell
+git add apps/web/lib/storefront/project-operational-value-stream.ts apps/web/lib/storefront/project-operational-value-stream.test.ts apps/web/app/api/storefront/admin/setup/route.ts apps/web/lib/storefront/archetype-reset.ts apps/web/lib/storefront/archetype-reset.test.ts
+git commit -s -m "feat: generate operational value stream during setup"
+```
+
+---
+
+## Chunk 4: Surface on Existing EA Value Streams UI
+
+### Task 4: Widen the value-stream list and preserve theme-aware UI
+
+**Files:**
+- Modify: `apps/web/app/(shell)/ea/value-streams/page.tsx`
+- Add tests only if existing patterns support this server component cleanly.
+
+- [ ] **Step 1: Write or identify the smallest UI/data test**
+
+If a server-component test pattern exists, add a test that asserts `prisma.eaView.findMany` receives:
+
+```ts
+where: { scopeType: { in: ["reference_model_projection", "archetype_value_stream"] } }
+```
+
+If no pattern exists, extract the view query into a small helper under `apps/web/lib/ea/value-stream-views.ts` and test that helper.
+
+- [ ] **Step 2: Update the query**
+
+Change the list query from:
+
+```ts
+where: { scopeType: "reference_model_projection" }
+```
+
+to:
+
+```ts
+where: { scopeType: { in: ["reference_model_projection", "archetype_value_stream"] } }
+```
+
+Select `scopeType` so cards can label operational vs reference views.
+
+- [ ] **Step 3: Update card copy without creating a new surface**
+
+Requirements:
+
+- Keep `/ea/value-streams` as the only list route.
+- Keep cards theme-aware: use `text-[var(--dpf-text)]`, `text-[var(--dpf-muted)]`, `bg-[var(--dpf-surface-1)]`, `bg-[var(--dpf-surface-2)]`, and `border-[var(--dpf-border)]`.
+- Label operational views as `Operational — your business`.
+- Label reference projections as `Reference model`.
+- Empty state must mention both ways a view can appear: setup-generated operational stream or reference-model projection.
+- Do not add hardcoded colors or new card-within-card layouts.
+
+- [ ] **Step 4: Optional badge only if data already flows**
+
+If `getEaView()` already serializes `properties.operationalValueStream`, add a small label/badge on the canvas or card for load-bearing/capacity. Use existing styling tokens only. If this requires new renderer plumbing, defer to P1 and do not expand P0.
+
+- [ ] **Step 5: Verify UI source**
+
+Run:
+
+```powershell
+pnpm --filter web typecheck
+```
+
+Expected: typecheck exits 0.
+
+- [ ] **Step 6: Commit the UI slice**
+
+```powershell
+git add 'apps/web/app/(shell)/ea/value-streams/page.tsx' apps/web/lib/ea/value-stream-views.ts apps/web/lib/ea/value-stream-views.test.ts
+git commit -s -m "feat: list operational value streams in EA"
+```
+
+Only include `apps/web/lib/ea/value-stream-views.*` if those files were created.
+
+---
+
+## Chunk 5: Verification and Evidence
+
+### Task 5: Run source-local and runtime-bound gates
+
+**Files:**
+- No new files unless recording evidence through MCP/backlog tooling is available.
+
+- [ ] **Step 1: Run targeted source-local tests**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/storefront-templates exec vitest run src/operational-value-stream.test.ts
+pnpm --filter @dpf/db exec vitest run src/archetype-value-stream-projection.test.ts src/reference-model-projection.test.ts
+pnpm --filter web exec vitest run lib/storefront/project-operational-value-stream.test.ts lib/storefront/archetype-reset.test.ts
+```
+
+Expected: all targeted tests PASS in the worktree.
+
+- [ ] **Step 2: Run source-local typechecks**
+
+Run:
+
+```powershell
+pnpm --filter @dpf/storefront-templates typecheck
+pnpm --filter @dpf/db typecheck
+pnpm --filter web typecheck
+```
+
+Expected: all typechecks exit 0 in the worktree.
+
+- [ ] **Step 3: Run production build on the required substrate**
+
+Per AGENTS.md, do not treat a worktree-local runtime as canonical evidence. Run `pnpm --filter web build` through the shared local-CI convergence sandbox lease or canonical local install after governed advance.
+
+Evidence must name the substrate:
+
+- `shared local-CI convergence sandbox lease`, or
+- `canonical local install after governed self-upgrade`.
+
+- [ ] **Step 4: UX verification**
+
+Against the required runtime substrate:
+
+1. Complete storefront setup for a representative archetype such as `equipment-rental` or `hair-salon`.
+2. Open `/ea/value-streams`.
+3. Confirm one operational value-stream view appears and is labeled distinctly from reference-model projections.
+4. Open the view.
+5. Confirm the EA canvas renders a nonblank swimlane with the value stream band and stages.
+6. Export via the existing ArchiMate view export path and confirm the generated file includes value-stream elements.
+7. Run archetype reset to another archetype and confirm the operational view updates idempotently rather than duplicating.
+
+- [ ] **Step 5: Record evidence**
+
+If DPF MCP write scope is available, record execution evidence for:
+
+- targeted tests,
+- typechecks,
+- production build substrate,
+- UX verification substrate,
+- export verification.
+
+If MCP is unavailable, include the command output and substrate names in the PR body.
+
+- [ ] **Step 6: Final commit/push/PR**
+
+Only after all required gates pass:
+
+```powershell
+git status --short
+git push
+```
+
+Open a regular ready-for-review PR only after build and UX evidence are complete. Do not open a draft PR.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `deriveOperationalValueStream()` returns deterministic OVSM data for all 56 archetypes in `ALL_ARCHETYPES`.
+- [ ] Rental/shared-asset archetypes carry the return/inspect and reusable-pooled-asset semantics without leaking that stage into non-rental archetypes.
+- [ ] Setup creates exactly one `archetype_value_stream` EA view for the org.
+- [ ] Archetype reset regenerates that view idempotently and does not duplicate elements, view elements, or relationships.
+- [ ] `/ea/value-streams` lists both reference-model projections and the org operational stream.
+- [ ] `/ea/views/[id]` renders the operational stream with existing swimlane layout.
+- [ ] Existing ArchiMate export works for the generated operational value-stream view.
+- [ ] No new Prisma table.
+- [ ] No new route.
+- [ ] UI remains theme-aware and avoids hardcoded colors.
+- [ ] Targeted tests, typechecks, production build, UX verification, and export verification have named-substrate evidence.
+
+## Out of Scope
+
+- Stage KPI dashboards and headline metrics (P1 Measure).
+- Coworker prompts, business handoffs, WWWD profile consultation (P2 Facilitate).
+- Demand-calendar/capacity look-ahead and DAP proactivity (P3 Proactive-optimize).
+- Full rental-family asset-pool capacity engine beyond storing the rental OVSM semantics.
+- New EA routes or new standalone architecture surfaces.

--- a/docs/superpowers/plans/2026-06-13-value-stream-p1-measure-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-13-value-stream-p1-measure-implementation-plan.md
@@ -1,6 +1,8 @@
 # Value Stream P1 (Measure) - Operator Value Stream Headline: Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use `superpowers:subagent-driven-development` (if subagents are available) or `superpowers:executing-plans` to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Recovery note (2026-08-01):** this plan was written 2026-06-13 and stranded uncommitted in a deleted thread's worktree. Only the preamble above was rewritten on recovery — it originally invoked the `superpowers:*` skills, which have since been retired. The plan body is unchanged from 2026-06-13 and predates two months of platform change; re-verify against current `main` before executing.
 
 ## Goal
 

--- a/docs/superpowers/plans/2026-06-13-value-stream-p1-measure-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-13-value-stream-p1-measure-implementation-plan.md
@@ -1,0 +1,656 @@
+# Value Stream P1 (Measure) - Operator Value Stream Headline: Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use `superpowers:subagent-driven-development` (if subagents are available) or `superpowers:executing-plans` to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Goal
+
+Surface each organization's operational value stream on `/workspace` in a form that works for both architects and non-technical operators:
+
+1. A compact **operator value-stream strip** that visually organizes the business's primary value delivery flow separately from supporting/trust functions.
+2. A first **load-bearing headline KPI** that measures the stage most likely to break the archetype's business model.
+3. An **operational summary of the whole business**: immediate needs, active work, pending needs, and developing situations, assembled from data the platform already defines.
+4. Honest metric maturity: direct measures when the platform has the data; clearly labelled proxies when it does not.
+
+This is still a P1 measure slice: no new route, no new table, no generic dashboard builder. It derives from the OVSM that P0 persists and reuses the existing workspace command-center surface plus report-kit `StatCard`.
+
+## Review Corrections Folded Into This Plan
+
+The original plan was directionally sound, but too narrow around "one headline metric." The hard product problem is that a business operator needs to see **what part of the business is being measured and why it matters**, not just a tile with a number.
+
+This revision applies three lenses:
+
+| Lens | Correction folded into the plan |
+|------|---------------------------------|
+| Enterprise architecture | Keep the canonical OVSM as the single source of truth. The workspace renders a projection of it; it does not create a second business-process model. |
+| Operations | The surface is organized by operating urgency first: what needs attention now, what work is in motion, what is pending, and what situation is forming. Measures are then grouped by canonical axes: process time, queue size/WIP, quality, throughput/capacity, value, and trust/compliance. |
+| Archetype context | The same six stages exist across archetypes, but the load-bearing question differs: a salon worries about slot load; a bakery worries about captured demand and perishability; an MSP worries about service load and estate separation; a bank or public body worries about trust gates first. |
+
+The workspace visual follows the useful part of Porter's value chain: separate the **main value delivery/income flow** from **supporting functions**. DPF does not copy Porter's generic labels into the UI. Operators see archetype language; architects can drill into canonical stage keys and capability bindings.
+
+### Second Review Guardrails
+
+This review keeps the plan viable for non-technical operations and aligned to the current codebase:
+
+- `StatCard` already supports `hint`, `intent`, `delta`, and `href`. This plan extends the workspace `SnapshotItem` contract and passes those existing report-kit props through; it does not build another card primitive.
+- `STATUS_INTENT` currently has `readiness` and `severity`, but not the exact good/concern/acute/in-motion/unknown operating vocabulary. Add an explicit `operationalStatus` domain and test it.
+- Loader code must accept `now` and avoid hidden global dates so the 30-day, upcoming, overdue, and revenue windows are deterministic in tests.
+- A missing direct measure is not success. If the archetype and OVSM are known but the measure cannot be safely computed, show an `unknown`/neutral headline such as "Not measured" with proxy/unavailable wording, rather than omitting the operating context or turning it green.
+- P1 reads the current single primary `StorefrontConfig.archetype`. Do not bake "exactly one business line forever" into copy or types; use language like "primary business flow" so the view can later become one service-line panel inside the multi-archetype composition model.
+
+## Standards Grounding
+
+| Standard / reference | What this plan adopts |
+|----------------------|-----------------------|
+| Lean Enterprise Institute value-stream mapping | Stage measures must include operational signals such as cycle/process time, lead time, and percent complete and accurate; queue/WIP and availability are valid stage-health signals. See [Value Stream Mapping](https://www.lean.org/lexicon-terms/value-stream-mapping/). |
+| Business Architecture Guild value-stream guidance | Value streams express stakeholder value and stages realize value items; capabilities are cross-mapped to the stages that enable value. See the Guild's [value streams and business processes paper](https://cdn.ymaws.com/www.businessarchitectureguild.org/resource/resmgr/public_resources/bpm_paper_final_dec2019.pdf). |
+| ArchiMate value-stream element | The architecture view keeps value streams as ordered activities that create an overall result for a customer, stakeholder, or end user. See the [ArchiMate 3.2 reference card](https://www.opengroup.org/sites/default/files/docs/downloads/n221p.pdf). |
+| Porter value chain | The operator view borrows the separation between primary value activities and support activities, but substitutes DPF's archetype-specific operational stages for generic Porter labels. See HBS Online's overview of [primary and support activities](https://online.hbs.edu/blog/post/what-is-value-chain-analysis). |
+
+## Scope & Non-Scope
+
+**In scope (this PR):**
+
+- Derive an operator-readable workspace value-stream view from `deriveOperationalValueStream()`.
+- Show the primary flow (`Attract -> Capture -> Qualify -> Deliver -> Settle -> Retain`, plus `Return & Inspect` for rental/shared-asset archetypes) separately from support/trust stages (`Trust & Compliance`, `Operate & Improve`).
+- Promote the load-bearing stage's best available P1 measure into the first workspace `StatCard`.
+- Keep the workspace home as an operational surface by preserving and summarizing current operational data already defined across the platform: command strip, snapshot, work in motion, calendar agenda, activity feed, sections, finance, compliance, customer, people, and AI/coworker signals.
+- Extend the existing command-center snapshot contract just enough for `hint`, `intent`, and `delta` to reach `StatCard`.
+- Test every archetype in `ALL_ARCHETYPES`; do not hard-code the seeded count.
+
+**Deferred (later P1.x/P2 slices, called out so they are not silently dropped):**
+
+- Full per-stage KPI overlays on `/finance`, `/customer`, `/storefront`, and `/compliance`.
+- True stage process-time and `% complete-and-accurate` metrics where the current data model lacks enter/exit timestamps or validation outcomes.
+- S1 Attract analytics (portal-view capture is not present today).
+- True S3 utilization (`booked capacity / available capacity`); this slice uses an upcoming-demand proxy and labels it honestly.
+- Rental/shared-asset engine metrics: asset utilization, turnaround time, reservation conflicts, overdue returns, and damage/deposit exposure.
+- The full optimization loop (`measure -> propose lever -> WWWD gate -> human decision -> track effect`).
+
+## Source Context
+
+- Design: `docs/superpowers/specs/2026-06-12-value-stream-architecture-platform-design.md` Section 5 (measurement), Section 6 (surface reuse), Section 11 (P1).
+- Source artefact: `docs/architecture/archetype-business-value-streams.md` Sections 6-8 (load-bearing stage, demand/capacity, EA/workspace presentation).
+- Workspace design: `docs/superpowers/specs/2026-05-31-archetype-aware-workspace-design.md` (operator-first, archetype-aware workspace; no dashboard-builder substrate).
+- Report-kit contract: `apps/web/components/ui/report-kit/README.md` (`StatCard`, `StatusBadge`, `DataTable`, `FilterBar`, `Chart`, token-backed intents).
+- P0 substrate: `deriveOperationalValueStream()` in `packages/storefront-templates/src/operational-value-stream.ts` returns `{ stages[], loadBearingStageKeys[], capacityUnit, demandSignature, trustGates[] }`. Current tests assert `ALL_ARCHETYPES.length >= 56`, so this plan must iterate `ALL_ARCHETYPES` rather than saying "53" in implementation logic.
+- Verified integration points:
+  - `apps/web/lib/workspace-home/platform-loader.ts` loads `storefrontConfig.archetype { archetypeId, category, name, activationProfile }` and `workspaceCommandCenter`.
+  - `apps/web/lib/workspace/command-center.ts` currently defines `SnapshotItem` as `{ id, label, value, href }` and builds the snapshot.
+  - `apps/web/lib/workspace/command-center.ts` already classifies immediate operational signals through `commandStrip`, `snapshot`, `workInMotion`, `attentionItems`, and the platform-readiness matrix.
+  - `apps/web/lib/workspace-home/platform-loader.ts` already returns `calendarEvents`, `feedItems`, and permission-derived `workspaceSections`.
+  - `apps/web/components/workspace/BusinessCommandCenter.tsx` currently renders `snapshot[]` as `StatCard`s but only passes `label`, `value`, and `href`.
+  - `apps/web/components/ui/report-kit/StatCard.tsx` already accepts `hint`, `intent`, `delta`, `href`, and `className`. The required work is a pass-through contract from command-center data to this existing primitive.
+  - `apps/web/components/ui/report-kit/statusColors.ts` already contains `readiness` and `severity`, but not the exact operating status vocabulary in this plan.
+  - `apps/web/app/(shell)/workspace/calendar/page.tsx`, `/storefront/inbox`, `/customer`, `/finance`, and `/compliance` exist as drill destinations.
+  - Template resolution precedent: `apps/web/lib/storefront/project-operational-value-stream.ts` resolves templates by `ALL_ARCHETYPES.find(a => a.archetypeId === id)`.
+
+## Refactoring Reserve
+
+Spend the first ~20 percent of implementation on the command-center seam before adding new value-stream-specific logic:
+
+- Extend `SnapshotItem` with optional `hint`, `intent`, and `delta` so the existing `StatCard` capability reaches the workspace.
+- Add an optional `valueStream` property to `WorkspaceCommandCenterView` rather than creating a parallel workspace dashboard model.
+- Add an optional `operationalSummary` property to `WorkspaceCommandCenterView` if the existing `commandStrip` / `workInMotion` / `attentionItems` cannot express immediate, pending, and situational groupings cleanly. This is a view projection only, not persistence.
+- Update `BusinessCommandCenter` to pass all `StatCard` props and render the compact value-stream strip from the same view object.
+- Keep data loaders behind narrow structural interfaces. Do not type hot paths as the full Prisma client type unless unavoidable.
+- Keep existing workspace tile status color APIs out of scope unless they are directly touched. New value-stream/status rendering must use report-kit status semantics instead of copying tile color conventions.
+
+This is the useful refactor: it removes the awkwardness that would otherwise force the headline metric to be a visually disconnected number.
+
+## Workspace Visual Contract
+
+The first viewport must make the business shape legible without architecture training.
+
+```text
+TRUST & COMPLIANCE        (support / constraint band, visible when relevant)
+
+Attract -> Capture -> Qualify -> Deliver -> Settle -> Retain
+                      ^ load-bearing stage highlighted
+
+OPERATE & IMPROVE        (support / feedback band)
+```
+
+Rules:
+
+- Operator language first: "Bookings needing a slot" beats `S3 Qualify`.
+- Canonical stage keys may exist in data/test IDs and admin drill-downs, but should not be the main worker-facing copy.
+- Highlight exactly the OVSM load-bearing stage(s); regulated archetypes may highlight trust first.
+- The first `StatCard` must read as the measured headline for the highlighted stage, with a hint that names the capacity unit, demand signature, and whether the measure is a proxy.
+- The strip and cards use DPF tokens and report-kit primitives; no local color maps.
+- On mobile, the strip becomes an ordered, wrap-safe list. No clipping, overlapping text, or card-inside-card layout.
+
+## Visual Activity Layer
+
+The value-stream view must be visually meaningful before it is textually explained. A non-technical operator should be able to glance at the workspace and recognize the business situation: who/what is waiting, what is occupied, what is moving, what is blocked, and what is likely to need attention next.
+
+This is not a decorative image requirement. For an operational surface, useful visuals are structured, data-backed views: map pins, schedules, occupancy boards, floor/room grids, queue lanes, asset pools, stock/reorder boards, inspection/turnover boards, and trust-gate boards. Use real source geometry or records when available; otherwise use a schematic visual with honest labels. Do not use stock imagery or invented photos as a substitute for operating data.
+
+| Archetype or situation | Visual primitive | At-a-glance operator meaning | Supporting streams shown nearby |
+|------------------------|------------------|------------------------------|---------------------------------|
+| Field service, trades, mobile care | Map dispatch + schedule lane | Crews/jobs by location, route window, arrival risk, unassigned work. | Supplies, invoicing, permits, follow-up, customer contact. |
+| Barber, salon, spa, clinic slots | Chair/room/provider slot board | Which spaces are occupied, next free slot, late/no-show risk, for-rent booth state where applicable. | Cleaning/reset, supplies, payments, retention. |
+| Hotel, rental property, cleaning turnover | Unit/room turnover board | Occupied, checkout due, clean, inspect, ready, blocked. | Housekeeping, maintenance, replenishment, guest/customer issue follow-up. |
+| Equipment rental, self-storage, shared assets | Asset pool board | Available, reserved, out, due back, inspect/repair, ready to re-pool. | Deposit/payment, maintenance, customer pickup/return. |
+| Retail, bakery, florist, food service | Stock/reorder and freshness board | Demand, low stock, spoilage/perishable risk, reorder needed after job/order. | Purchasing, supplier lead time, sales/orders. |
+| Vet, healthcare, legal, MSP, case-heavy services | Case/account queue | Waiting, in progress, blocked for information, escalation, follow-up due. | Compliance, customer communication, billing, staff capacity. |
+| Bank, municipality, charity, regulated/public work | Trust-gate board | Open obligation, review, approval, submitted, acknowledged, breached. | Service queue, stakeholder/customer communication, audit trail. |
+
+Implementation rules:
+
+- Select the visual primitive from OVSM context (`capacityUnit`, `demandSignature`, load-bearing stage, supporting stages) plus archetype metadata. Do not scatter archetype-specific visual logic inside page components.
+- Represent icons as stable icon names in the view model and render with the existing icon library, preferring lucide icons where available.
+- Every visual item must have a short label, status, intent, icon, optional href, and accessible name. Color is never the only meaning.
+- Maps, schedules, floor/slot boards, and asset grids must be compact and operational. They should answer "what do I act on?" before they explain "what is this architecture stage?"
+- Supporting streams may appear as small overlay markers or adjacent lanes, but they must remain derived from the same OVSM and existing operational signals.
+
+## Operational Status Semantics
+
+Standardize status language across the value-stream strip, operational summary, visual activity layer, headline metric, maps/boards, and support streams:
+
+| Operator status | Meaning | Report-kit intent | Example labels |
+|-----------------|---------|-------------------|----------------|
+| `good` | Ready, healthy, complete, available, on track. | `success` | Ready, paid, staffed, clean, available, complete. |
+| `concern` | Needs attention soon, nearing limit, incomplete, at risk, waiting too long. | `warning` | Low stock, due soon, needs review, capacity tight, delayed. |
+| `acute` | Blocking value delivery, overdue, breached, failed, unsafe, unavailable when needed. | `danger` | Blocked, overdue, failed, breached, no coverage, cannot dispatch. |
+| `in-motion` | Normal active work that is neither good nor bad yet. | `info` or `accent` | In progress, en route, occupied, scheduled, assigned. |
+| `unknown` | Not configured, unavailable, not measured, or insufficient data. | `neutral` | Not measured, no data, unavailable, setup needed. |
+
+Implementation rules:
+
+- Extend `apps/web/components/ui/report-kit/statusColors.ts` with an explicit `operationalStatus` domain. Do not reuse `readiness` or `severity` for this vocabulary; those domains are adjacent but not exact enough for operating states such as `in-motion` and `unknown`.
+- Add or extend `apps/web/components/ui/report-kit/statusColors.test.ts` so `good`, `concern`, `acute`, `in-motion`, and `unknown` resolve to the intended report-kit intents.
+- Use `resolveIntent(domain, status)` and `intentStyle(intent)` or report-kit primitives for all status color application. Raw hex, raw Tailwind palette colors, and per-page status maps are out of scope.
+- Pair every status color with an icon and visible text. For compact markers, the visible text can be short, but the accessible name must carry the full meaning.
+- Treat "no data" as `unknown`, not `good`. Green means evidence of readiness or health, not absence of evidence.
+- Keep severity and lifecycle distinct. Example: "occupied" is `in-motion`; "occupied past checkout" is `concern` or `acute` based on business rules.
+
+### Composition Readiness Constraint
+
+The current workspace resolves one active storefront archetype from `StorefrontConfig.archetype`. This P1 slice should stay scoped to that current reality, but avoid making the UI or types hostile to later multi-archetype composition:
+
+- Use copy such as "Primary business flow" rather than "the only business flow."
+- Keep `WorkspaceValueStreamView` pure and serializable so it can later be repeated per service line or operating unit.
+- Do not persist UI-only process stages or service-line names in this slice.
+- Tests should prove today's single-archetype view remains stable; they do not need to implement the later composition engine.
+
+## Operational Surface Contract
+
+The `/workspace` home is the operating desk for the business. Its first job is not to explain architecture or show analytics breadth; its first job is to answer the operator's live questions:
+
+| Operating question | Existing signal family | First-viewport treatment |
+|--------------------|------------------------|--------------------------|
+| What needs attention now? | `commandStrip`, `attentionItems`, overdue finance/compliance/cadence/task-run signals | Top "Needs attention" strip, ordered by severity and actionability. |
+| What is happening right now? | `workInMotion`, active task runs, pending action proposals, scheduled coworker cadence, calendar events | "Work in motion" and agenda, with actor/status/href. |
+| What is pending or forming? | upcoming bookings/events, pending alerts, open obligations, unpaid bills, overdue actions, low-confidence coworker assessments, open capability needs | Short "Pending needs" / "situations forming" summaries. Avoid burying these below generic counts. |
+| How does this map to the business model? | OVSM value-stream strip, load-bearing stage, capacity unit, demand signature, trust gates | Value-stream strip plus headline metric. This gives the operational facts their business context. |
+| Where do I act? | Existing route hrefs (`/storefront/inbox`, `/workspace/calendar`, `/customer`, `/finance`, `/compliance`, `/platform/ai`, `/ops`) | Every item drills into an existing route; no new screen or dead-end card. |
+
+The surface should feel like the daily operating view into the entire organization: customers and delivery, schedule/capacity, finance, compliance, people, AI coworkers, and platform delivery. It should not show the full platform-readiness matrix on the business home. Readiness can still be summarized when it creates an operational need, but the detailed 6x6 maturity view stays on the platform surface.
+
+### Current Data To Reuse Before Adding Any New Signal
+
+| Data already loaded or cheaply available | Operational meaning |
+|------------------------------------------|---------------------|
+| `commandStrip` | Immediate exceptions and warnings already ranked by severity. |
+| `snapshot` | Current scale/health facts; now gains the load-bearing headline first. |
+| `workInMotion` | Active AI/human work, pending approvals, scheduled cadences. |
+| `attentionItems` | Actionable follow-up list behind workspace tiles. |
+| `calendarEvents` | Near-term scheduled work and capacity pressure. |
+| `feedItems` | Recent business activity and changes worth scanning. |
+| `workspaceSections` | Permission-safe navigation into available operating areas. |
+| Finance metrics | Overdue invoices, outstanding receivables, unpaid bills, P&L revenue. |
+| Compliance metrics | Open incidents, active obligations, overdue actions, pending alerts, implemented controls. |
+| Customer/delivery metrics | Customer accounts, delivery/build counts, in-flight work. |
+| People metrics | Active team members and employee profile state. |
+| AI/coworker metrics | Active coworkers, broken providers, failed task runs, pending proposals, recent receipts, low-confidence assessments. |
+
+If a proposed value-stream summary cannot be built from these sources, it is deferred or labelled unavailable. Do not add a new signal just to make the first viewport look complete.
+
+## Canonical Measure Taxonomy
+
+P1 only computes the headline measure, but the model must name the measure axis now so later overlays converge instead of inventing local KPI language.
+
+| Axis | Operator question | P1 status |
+|------|-------------------|-----------|
+| `queue-size` | "How much demand/work is waiting or in flight?" | Direct or proxy from bookings, inquiries, orders, donations, obligations, alerts, customer accounts. |
+| `process-time` | "How long does demand take to move through the stage?" | Mostly deferred until stage enter/exit timestamps exist. |
+| `quality` | "Did the handoff arrive complete and accurate the first time?" | Deferred except where existing statuses make a safe proxy possible. |
+| `throughput` | "How much work/value moved through the stage in the window?" | Direct/proxy from counts and finance reports. |
+| `capacity-utilization` | "Are we over- or under-using the constrained unit?" | Proxy in P1; true utilization requires available-capacity denominator. |
+| `value` | "What income, receipt, or settlement did this stage create?" | Direct where finance data exists. |
+| `trust` | "What trust/compliance work is open before value can safely move?" | Direct/proxy from obligations, incidents, corrective actions, and regulatory alerts. |
+
+Every metric spec returns a `measureAxis` and `measureMaturity`:
+
+```ts
+export type CanonicalMeasureAxis =
+  | "queue-size"
+  | "process-time"
+  | "quality"
+  | "throughput"
+  | "capacity-utilization"
+  | "value"
+  | "trust";
+
+export type MeasureMaturity = "direct" | "proxy" | "unavailable";
+```
+
+## Archetype Measurement Lens
+
+| Archetype family | Load-bearing reality | P1 headline kind | Canonical axis |
+|------------------|----------------------|------------------|----------------|
+| Appointment and slot-bound services (salon, barber, spa, trainer, tutoring, pet services) | The calendar/capacity unit is the business promise. | `schedule-load` | `queue-size` / `capacity-utilization` proxy |
+| Retail, bakery, florist, donation, and order-led businesses | Lost capture is lost value; perishables make late demand expensive. | `capture-volume` | `throughput` / `queue-size` |
+| Trades and quote-led services | Capture quality matters more than raw volume: urgency, property, scope, and contactability. | `capture-volume` with quality limitation in the hint | `queue-size` now, `quality` later |
+| Encounter/care and estate-led services (vet, dental, MSP, facilities) | Delivery needs the right record/account/asset context. | `delivery-load` | `queue-size` / `throughput` |
+| Subscription and member models (gym, yoga, clubs) | Renewal/retention is the business, not the first sign-up. | `retention` | `throughput` now, `quality`/churn later |
+| Regulated, public-body, and statutory services | Trust gates and universal-service obligations precede normal flow. | `trust-status` | `trust` |
+| Rental/shared-asset archetypes | A reusable pooled asset must be reserved, returned, inspected, and re-pooled. | `asset-reservation-load` | `capacity-utilization` proxy |
+| Settle-led archetypes, where OVSM resolves `settle` as load-bearing | The money/receipt/accounting stage carries the model. | `revenue` | `value` |
+
+## File Map
+
+- Create: `apps/web/lib/value-stream/workspace-value-stream-view.ts` - pure OVSM -> operator workspace strip view.
+- Create: `apps/web/lib/value-stream/workspace-value-stream-view.test.ts` - covers all archetypes and primary/support separation.
+- Create: `apps/web/lib/value-stream/workspace-operational-summary.ts` - pure existing workspace data -> immediate / active / pending / situation summaries, if the current command-center shape needs a thin projection.
+- Create: `apps/web/lib/value-stream/workspace-operational-summary.test.ts` - verifies no new data dependency is required and summaries are ordered by urgency.
+- Create: `apps/web/lib/value-stream/workspace-visual-activity.ts` - pure OVSM + existing operational summary -> visual primitive, icon names, status domain/status, and supporting overlays.
+- Create: `apps/web/lib/value-stream/workspace-visual-activity.test.ts` - verifies representative archetypes select map/slot/turnover/asset/stock/case/trust primitives and never rely on color alone.
+- Create: `apps/web/lib/value-stream/headline-metric-spec.ts` - pure OVSM -> headline metric spec (`kind`, `measureAxis`, `measureMaturity`, labels, hint, drill href).
+- Create: `apps/web/lib/value-stream/headline-metric-spec.test.ts` - covers every archetype and each metric kind, including rental/shared-asset.
+- Create: `apps/web/lib/value-stream/load-headline-metric.ts` - loads the stage value from existing data and returns a `SnapshotItem | null` plus value-stream context. `null` is reserved for no storefront/archetype/template; known-but-unmeasured cases return a neutral `unknown` snapshot.
+- Create: `apps/web/lib/value-stream/load-headline-metric.test.ts` - mocked DB + reused loaders; asserts values and graceful fallback.
+- Modify: `apps/web/components/ui/report-kit/statusColors.ts` - add an `operationalStatus` domain for good/concern/acute/in-motion/unknown.
+- Modify/add: `apps/web/components/ui/report-kit/statusColors.test.ts` - assert the new domain maps to token-backed report-kit intents.
+- Modify: `apps/web/lib/workspace/command-center.ts` - extend `SnapshotItem`; add optional `valueStream` to `WorkspaceCommandCenterView`; expose a helper to prepend the headline without mutating unrelated snapshot construction.
+- Modify: `apps/web/components/workspace/BusinessCommandCenter.tsx` - render the value-stream strip and pass `hint`, `intent`, `delta` through to `StatCard`.
+- Modify: `apps/web/lib/workspace-home/platform-loader.ts` - resolve/load value-stream context after storefront config, then prepend the headline metric. Thread `now` into value-stream loaders for deterministic tests.
+- Modify/add tests: `apps/web/components/workspace/BusinessCommandCenter.test.tsx` and `apps/web/lib/workspace-home/platform-loader.test.ts` where practical.
+
+---
+
+## Chunk 1: Pure Workspace Value-Stream View
+
+### Task 1: Derive the operator strip from OVSM
+
+**Files:** create `workspace-value-stream-view.ts` + `.test.ts`.
+
+- [ ] **Step 1: Write failing tests**:
+  - Every archetype in `ALL_ARCHETYPES` yields a non-null `WorkspaceValueStreamView`.
+  - Primary stages render in OVSM order and exclude `trust-compliance` / `operate-improve`.
+  - Support stages render as separate bands.
+  - Rental/shared-asset archetypes include `Return & Inspect` in the primary flow.
+  - Load-bearing stages are marked, and the first selected stage follows the regulated-first priority.
+  - Worker-facing labels are business-readable and do not rely only on raw stage codes.
+  - Copy and types identify the current flow as the primary business flow, not as the only possible business line forever.
+  - The resulting view can be displayed alongside the existing command-center summary without requiring new persistence or a new route.
+
+  Run: `pnpm --filter web exec vitest run lib/value-stream/workspace-value-stream-view.test.ts` -> FAIL (module missing).
+
+- [ ] **Step 2: Implement**:
+
+  ```ts
+  export type ValueStreamStageRole = "primary-delivery" | "supporting-function";
+
+  export interface WorkspaceValueStreamStageView {
+    stageKey: OperationalValueStreamStageKey;
+    stageLabel: string;
+    operatorLabel: string;
+    role: ValueStreamStageRole;
+    loadBearing: boolean;
+    href: string;
+    measureAxis: CanonicalMeasureAxis;
+    whatToWatch: string;
+  }
+
+  export interface WorkspaceValueStreamView {
+    archetypeId: string;
+    archetypeName: string;
+    operatorHeadline: string;
+    capacityUnit: CapacityUnitType;
+    demandSignature: DemandSignature;
+    primaryStages: WorkspaceValueStreamStageView[];
+    supportStages: WorkspaceValueStreamStageView[];
+    selectedStageKey: OperationalValueStreamStageKey;
+  }
+  ```
+
+  - Use the OVSM stage list; do not parse prose docs.
+  - Operator labels should explain the work ("Capture demand", "Schedule capacity", "Deliver service", "Settle money", "Retain relationship") while preserving `stageKey` for tests and architecture drill-downs.
+  - `operatorHeadline` should be phrased for the primary flow, e.g. "Primary business flow", with archetype-specific words in supporting labels.
+  - `selectedStageKey` priority: `trust-compliance` -> `return-inspect` -> `capture` -> `qualify` -> `deliver` -> `settle` -> `retain` -> first load-bearing key.
+  - `href` must point to existing routes only.
+
+- [ ] **Step 3: Verify**:
+  - `pnpm --filter web exec vitest run lib/value-stream/workspace-value-stream-view.test.ts`
+  - `pnpm --filter web typecheck` (source-local if available; otherwise CI/shared lease per verification section).
+
+- [ ] **Step 4: Commit** `feat(value-stream): derive the workspace value-stream view`.
+
+### Task 1b: Summarize existing operational signals by urgency
+
+**Files:** create `workspace-operational-summary.ts` + `.test.ts` if the current command-center shape is not enough.
+
+- [ ] **Step 1: Write failing tests**:
+  - Existing `commandStrip` items become `immediateNeeds`.
+  - Existing `workInMotion` items become `activeWork`.
+  - Existing `attentionItems`, upcoming calendar events, pending alerts, overdue actions, unpaid bills, and pending proposals become `pendingNeeds` or `situationsForming`.
+  - Empty inputs render honest empty states rather than fabricated green status.
+  - The helper accepts plain view objects; it does not import Prisma or call data loaders.
+
+- [ ] **Step 2: Implement** a pure projection:
+
+  ```ts
+  export interface WorkspaceOperationalSummary {
+    immediateNeeds: OperationalSummaryItem[];
+    activeWork: OperationalSummaryItem[];
+    pendingNeeds: OperationalSummaryItem[];
+    situationsForming: OperationalSummaryItem[];
+  }
+  ```
+
+  - Keep labels operational: "3 overdue invoices", "2 bookings this week", "1 compliance alert pending", "AI work blocked".
+  - Preserve existing `href`s.
+  - Use severity/urgency ordering already present in the command center where available.
+  - Do not show the platform-readiness matrix on the business home; only project readiness issues that create immediate/pending operating needs.
+
+- [ ] **Step 3: Verify**:
+  - `pnpm --filter web exec vitest run lib/value-stream/workspace-operational-summary.test.ts`
+  - `pnpm --filter web typecheck`
+
+- [ ] **Step 4: Commit** `feat(value-stream): summarize workspace operational signals by urgency`.
+
+### Task 1c: Derive the visual activity layer and status semantics
+
+**Files:** create `workspace-visual-activity.ts` + `.test.ts`; modify `statusColors.ts` and its tests to add the `operationalStatus` domain.
+
+- [ ] **Step 1: Write failing tests**:
+  - Representative archetypes select the expected visual primitive:
+    - field/trades -> `map-dispatch`.
+    - hair salon / appointment services -> `slot-board`.
+    - hotel/rental/cleaning turnover -> `turnover-board`.
+    - equipment rental / self-storage / shared assets -> `asset-pool-board`.
+    - retail/bakery/florist/field supplies -> `stock-reorder-board`.
+    - vet/legal/MSP/case-heavy services -> `case-queue`.
+    - bank/municipality/charity/regulated work -> `trust-gate-board`.
+  - Every visual item has `label`, `iconName`, `statusDomain`, `status`, `intent`, and accessible text.
+  - `good`, `concern`, `acute`, `in-motion`, and `unknown` resolve through report-kit status semantics, not a local color map.
+  - Empty or unavailable signals map to `unknown`, not `good`.
+  - Supporting streams attach as overlays or adjacent lanes without creating a second process model.
+
+- [ ] **Step 2: Implement** a pure projection:
+
+  ```ts
+  export type OperationalStatusLevel =
+    | "good"
+    | "concern"
+    | "acute"
+    | "in-motion"
+    | "unknown";
+
+  export type OperationalVisualPatternKind =
+    | "map-dispatch"
+    | "slot-board"
+    | "turnover-board"
+    | "asset-pool-board"
+    | "stock-reorder-board"
+    | "case-queue"
+    | "trust-gate-board"
+    | "standard-flow";
+
+  export interface OperationalVisualItem {
+    id: string;
+    label: string;
+    iconName: string;
+    statusDomain: "operationalStatus";
+    status: OperationalStatusLevel;
+    intent: SnapshotItem["intent"];
+    href?: string;
+    accessibleName: string;
+  }
+
+  export interface WorkspaceVisualActivity {
+    patternKind: OperationalVisualPatternKind;
+    title: string;
+    items: OperationalVisualItem[];
+    supportingStreams: OperationalVisualItem[];
+  }
+  ```
+
+  - Prefer visual pattern selection from `capacityUnit`, `demandSignature`, and load-bearing stage. Use archetype IDs only as a final tie-breaker where the template metadata cannot distinguish the situation.
+  - Add `operationalStatus` to `STATUS_INTENT`:
+    - `good -> success`
+    - `concern -> warning`
+    - `acute -> danger`
+    - `in-motion -> info`
+    - `unknown -> neutral`
+  - Add or extend `statusColors.test.ts` so the mapping is enforced by the shared report-kit contract.
+  - Use lucide icon names where available (`MapPin`, `CalendarDays`, `Armchair`, `Building2`, `PackageCheck`, `ClipboardList`, `ShieldCheck`, `AlertTriangle`, `CheckCircle2`, `Clock`, `HelpCircle` are examples, not a required closed set).
+  - Keep text short enough for compact boards. Long explanations belong in hints/tooltips or drill-in routes, not visible paragraphs.
+
+- [ ] **Step 3: Verify**:
+  - `pnpm --filter web exec vitest run lib/value-stream/workspace-visual-activity.test.ts`
+  - `pnpm --filter web exec vitest run components/ui/report-kit/statusColors.test.ts`
+  - `pnpm --filter web typecheck`
+
+- [ ] **Step 4: Commit** `feat(value-stream): derive operational visual activity semantics`.
+
+---
+
+## Chunk 2: Pure Headline Metric Spec
+
+### Task 2: Map load-bearing stage -> metric spec
+
+**Files:** create `headline-metric-spec.ts` + `.test.ts`.
+
+- [ ] **Step 1: Write failing tests** for the spec across archetypes loaded from `ALL_ARCHETYPES` + `deriveOperationalValueStream`:
+  - `hair-salon` (load-bearing `qualify`) -> `metricKind: "schedule-load"`, `measureAxis: "queue-size"` or `capacity-utilization` proxy, label mentions bookings/appointments, hint carries `slot-hours`.
+  - `bakery` / `charity` / `plumber` capture-led cases -> `metricKind: "capture-volume"`.
+  - `gym` -> `metricKind: "retention"`.
+  - `veterinary-clinic` / `it-managed-services` -> `metricKind: "delivery-load"`.
+  - `community-bank` / `small-town-municipality` -> `metricKind: "trust-status"` and trust wins over normal flow.
+  - `equipment-rental`, `self-storage`, and `agricultural-cooperative` -> `metricKind: "asset-reservation-load"` and the hint names the reusable pooled asset limitation.
+  - Any archetype whose selected load-bearing stage resolves to `settle` -> `metricKind: "revenue"`.
+  - Every archetype yields a non-null spec with a stable `metricKind`, `measureAxis`, `measureMaturity`, human label, operator hint, and existing-route drill `href`.
+
+  Run: `pnpm --filter web exec vitest run lib/value-stream/headline-metric-spec.test.ts` -> FAIL (module missing).
+
+- [ ] **Step 2: Implement**:
+
+  ```ts
+  export type HeadlineMetricKind =
+    | "capture-volume"
+    | "schedule-load"
+    | "asset-reservation-load"
+    | "delivery-load"
+    | "revenue"
+    | "retention"
+    | "trust-status";
+
+  export interface HeadlineMetricSpec {
+    stageKey: OperationalValueStreamStageKey;
+    metricKind: HeadlineMetricKind;
+    measureAxis: CanonicalMeasureAxis;
+    measureMaturity: MeasureMaturity;
+    label: string;
+    hint: string;
+    href: string;
+  }
+  ```
+
+  - Map stage + capacity context, not raw archetype IDs:
+    - `trust-compliance` -> `trust-status`, `trust`, `/compliance`.
+    - `capture` -> `capture-volume`, `throughput` or `queue-size`, `/storefront/inbox`.
+    - `qualify` + `capacityUnit === "reusable-pooled-asset"` -> `asset-reservation-load`, `capacity-utilization` proxy, `/workspace/calendar`.
+    - `qualify` otherwise -> `schedule-load`, `queue-size` proxy, `/workspace/calendar`.
+    - `deliver` -> `delivery-load`, `queue-size` / `throughput`, `/customer`.
+    - `settle` -> `revenue`, `value`, `/finance`.
+    - `retain` -> `retention`, `throughput`, `/customer`.
+  - Compose `hint` from capacity unit, demand signature, measure maturity, and proxy limitation. Example: `Capacity: slot-hours; demand pattern: weekly; proxy: upcoming bookings, not true utilization.`
+  - Keep business language in `label`; keep architecture keys in data/test IDs only.
+
+- [ ] **Step 3: Verify**:
+  - `pnpm --filter web exec vitest run lib/value-stream/headline-metric-spec.test.ts`
+  - `pnpm --filter web typecheck`
+
+- [ ] **Step 4: Commit** `feat(value-stream): map load-bearing stages to headline metric specs`.
+
+---
+
+## Chunk 3: Load the Headline Metric Value
+
+### Task 3: Per-kind data loaders -> SnapshotItem
+
+**Files:** create `load-headline-metric.ts` + `.test.ts`.
+
+- [ ] **Step 1: Write failing tests** with a mocked narrow DB interface + stubbed finance loader:
+  - For each `metricKind`, assert the loader returns a `SnapshotItem` whose `label`, `value`, `hint`, `href`, and `intent` match the spec.
+  - Returns `null` when no `StorefrontConfig` or archetype exists.
+  - Returns a neutral `unknown` snapshot such as "Not measured" when the archetype and OVSM are known but the existing data cannot safely compute the selected measure.
+  - `trust-status` reuses obligation/alert counts.
+  - `revenue` reuses `getProfitAndLoss`.
+  - Proxy metrics include proxy wording in the hint so the UI does not imply false precision.
+  - Date-window tests pass a fixed `now` and do not depend on the system clock.
+
+- [ ] **Step 2: Implement** `loadHeadlineMetric({ db, now }): Promise<SnapshotItem | null>`:
+  - Resolve `StorefrontConfig -> StorefrontArchetype.archetypeId`; if none -> `null`.
+  - Resolve template with `ALL_ARCHETYPES.find(...)`; if none -> `null` and log once.
+  - `ovsm = deriveOperationalValueStream(template)`.
+  - `spec = headlineMetricSpec(ovsm)`.
+  - Compute value by `spec.metricKind` from existing data:
+    - `capture-volume`: count `StorefrontBooking + StorefrontOrder + StorefrontInquiry + StorefrontDonation` created in the last 30 days.
+    - `schedule-load`: count upcoming `confirmed`/`pending` `StorefrontBooking`; hint says this is upcoming demand, not utilization.
+    - `asset-reservation-load`: count upcoming rental/reservation demand from available booking/order/inquiry data; hint says the asset-pool engine is deferred.
+    - `delivery-load`: count active customer accounts or in-flight delivery records that already exist cheaply for the archetype family.
+    - `revenue`: use `getProfitAndLoss(windowStart, now).revenue`.
+    - `retention`: count repeat customers from paid invoices where safe; otherwise return an honest proxy.
+    - `trust-status`: open obligations + pending regulatory alerts.
+  - If a known spec cannot be safely measured or proxied from existing data, return a `SnapshotItem` with `value: "Not measured"`, `intent: "neutral"`, `href: spec.href`, and a hint that names the missing direct measure.
+  - Build a `SnapshotItem` with optional `hint`, `intent`, and `delta` only when the data supports them.
+  - Type `db` as a narrow structural interface, not `PrismaClient` / `Prisma.TransactionClient` across the module boundary. P0 already exposed typecheck heap risk from inferred Prisma query types.
+
+- [ ] **Step 3: Verify**:
+  - `pnpm --filter web exec vitest run lib/value-stream/load-headline-metric.test.ts`
+  - `pnpm --filter web typecheck`
+
+- [ ] **Step 4: Commit** `feat(value-stream): load the workspace headline metric value`.
+
+---
+
+## Chunk 4: Wire Into the Workspace Home
+
+### Task 4: Render the value-stream strip and prepend the headline
+
+**Files:** modify `command-center.ts`, `BusinessCommandCenter.tsx`, `platform-loader.ts`, tests.
+
+- [ ] **Step 1: Write/extend failing tests**:
+  - `SnapshotItem` optional `hint` / `intent` / `delta` pass through to `StatCard`.
+  - `BusinessCommandCenter` renders the value-stream strip when `view.valueStream` exists.
+  - `BusinessCommandCenter` renders immediate, active, pending, and situation summaries when `view.operationalSummary` exists, or preserves the current sections when it does not.
+  - `BusinessCommandCenter` renders the visual activity layer when `view.visualActivity` exists, with icon + label + status intent for each marker.
+  - Good/concern/acute/in-motion/unknown statuses use `statusColors.ts` semantics and never appear as color-only markers.
+  - The load-bearing stage has a stable marker (`aria-current`, data attribute, or equivalent) for testability.
+  - Given a storefront archetype, `loadPlatformWorkspaceHomeData` returns `workspaceCommandCenter.commandCenter.snapshot[0]` as the value-stream headline.
+  - Given a known archetype with an unavailable measure, the first snapshot card renders a neutral `unknown`/not-measured state rather than disappearing or showing green.
+  - When the headline loader throws, `/workspace` data still returns the normal command center and logs the failure once.
+  - `loadPlatformWorkspaceHomeData` threads its `now` value into value-stream helpers so calendar and metric windows are deterministic.
+
+- [ ] **Step 2: Refactor command-center types**:
+  - Extend `SnapshotItem`:
+    ```ts
+    export type SnapshotItem = {
+      id: string;
+      label: string;
+      value: string | number;
+      href: string;
+      hint?: string;
+      intent?: "success" | "warning" | "danger" | "info" | "neutral" | "accent";
+      delta?: { label: string; direction: "up" | "down" | "flat"; intent?: SnapshotItem["intent"] };
+    };
+  ```
+  - Add `valueStream?: WorkspaceValueStreamView` to `WorkspaceCommandCenterView`.
+  - Add `operationalSummary?: WorkspaceOperationalSummary` only if needed for the urgency grouping. Keep it derived from existing loaded data.
+  - Add `visualActivity?: WorkspaceVisualActivity` only if the visual layer cannot be expressed cleanly from `valueStream` and `operationalSummary` at render time.
+  - Add a small pure helper, e.g. `withHeadlineSnapshot(view, headline, valueStream)`, rather than mutating the object inline in the loader.
+  - The helper should preserve existing `commandStrip`, `workInMotion`, `readiness`, and snapshot order after the new headline.
+
+- [ ] **Step 3: Update `BusinessCommandCenter`**:
+  - Render the strip above the snapshot and below "Needs attention".
+  - Keep "Needs attention" as the first operating band. Follow with the value-stream strip/headline, then active work and pending/situation summaries.
+  - Render the visual activity layer as a compact operational board, not a marketing hero or decorative image. Pattern examples: map dispatch, slot board, turnover board, asset pool board, stock/reorder board, case queue, trust-gate board.
+  - Use a non-card layout: one compact band for primary stages, one smaller support row when support stages exist.
+  - Use token-backed borders/text/backgrounds only.
+  - Resolve status colors through report-kit intent semantics. Pair every good/concern/acute/in-motion/unknown status with an icon and visible label.
+  - Use `aria-current` or `aria-label` so the highlighted load-bearing stage is accessible.
+  - Pass `hint`, `intent`, and `delta` to `StatCard`.
+
+- [ ] **Step 4: Update `platform-loader.ts`**:
+  - After loading `workspaceCommandCenter` and `storefrontConfig`, call the headline loader.
+  - If non-null, prepend it and attach the `WorkspaceValueStreamView`.
+  - Build the operational summary from already-loaded command-center summary (`commandCenter`, `attentionItems`), calendar, feed, and section data; do not introduce another DB fan-out for this slice unless a missing signal is proven necessary.
+  - Build the visual activity layer from OVSM context plus the operational summary. Do not query new data just to fill a visual board in P1.
+  - Pass the loader's `now` argument into the headline metric loader and any visual/summary helper that computes time windows.
+  - Wrap value-stream loading in a non-fatal `try/catch`. Workspace home is load-bearing UX; it must degrade gracefully.
+
+- [ ] **Step 5: Verify**:
+  - `pnpm --filter web exec vitest run lib/value-stream/workspace-value-stream-view.test.ts lib/value-stream/workspace-operational-summary.test.ts lib/value-stream/workspace-visual-activity.test.ts lib/value-stream/headline-metric-spec.test.ts lib/value-stream/load-headline-metric.test.ts components/ui/report-kit/statusColors.test.ts components/workspace/BusinessCommandCenter.test.tsx lib/workspace-home/platform-loader.test.ts`
+  - `pnpm --filter web typecheck`
+
+- [ ] **Step 6: Commit** `feat(value-stream): show the operator value-stream headline on workspace`.
+
+---
+
+## Chunk 5: Verification & Evidence
+
+- [ ] **Source-local unit tests**: the value-stream view, metric spec, loader, command-center helper, and BusinessCommandCenter tests pass in the worktree or source-local toolchain.
+- [ ] **Typecheck**: `pnpm --filter web typecheck` passes. If local dependencies are unavailable, record that the gate is unrun locally and run it through CI/shared lease per AGENTS.md.
+- [ ] **Production build**: `pnpm --filter web build` passes on the canonical runtime or shared local-CI convergence sandbox, not a stale worktree-local harness.
+- [ ] **UX verification**: on a running install, open `/workspace` for representative archetypes:
+  - `hair-salon`: stage strip highlights schedule/capacity; first card is schedule load.
+  - `hair-salon`: visual layer shows a slot/chair/provider-style board, including occupied/free/next-needed states where data exists.
+  - `community-bank`: trust/compliance is visible and first card is trust status.
+  - `bakery`: capture demand is highlighted and first card is capture volume.
+  - `bakery` or `florist`: visual layer shows stock/order/reorder style operational cues where data exists.
+  - `equipment-rental` or `self-storage`: reusable-asset context is visible and proxy wording is explicit.
+  - `field-service` or equivalent trades archetype when available: visual layer uses dispatch/map/schedule semantics rather than generic cards.
+- [ ] **Operations verification**: confirm the first viewport answers: what needs attention now, what is in motion, what is pending/forming, and which value-stream stage explains the priority.
+- [ ] **Status semantics verification**: scan the implemented files for local color maps and raw palette colors; good/concern/acute/in-motion/unknown statuses must resolve through report-kit and include icon + text/aria, not color alone.
+- [ ] **Status registry verification**: `STATUS_INTENT.operationalStatus` exists and maps `good`, `concern`, `acute`, `in-motion`, and `unknown` to the expected token-backed intents.
+- [ ] **Mobile UX**: verify `/workspace` at a narrow viewport. The strip wraps/scrolls cleanly and text does not overlap.
+- [ ] **PR**: when CI is green and UX evidence is captured, open a ready PR (not draft) and include the measured archetypes plus any proxy limitations in the body.
+
+## Acceptance Criteria
+
+- [ ] `/workspace` shows a compact value-stream strip derived from the active org's OVSM, with primary value stages separated from trust/support stages.
+- [ ] `/workspace` remains an operational surface: immediate needs, active work, pending needs, and developing situations are visible from existing platform-defined data.
+- [ ] `/workspace` includes an archetype-appropriate visual activity layer where existing data supports one: map dispatch, slot board, turnover board, asset pool board, stock/reorder board, case queue, trust-gate board, or standard flow.
+- [ ] The load-bearing stage is visibly and accessibly highlighted, in operator language.
+- [ ] The first snapshot card is the load-bearing headline metric, rendered through report-kit `StatCard` with `label`, `value`, `hint`, `href`, and token-backed `intent`.
+- [ ] Good, concern, acute, in-motion, and unknown states are standardized across value streams, operational summaries, visual markers, and headline metrics through `STATUS_INTENT.operationalStatus`.
+- [ ] Every operational status marker has iconography plus visible or accessible text. Color alone is never the signal.
+- [ ] Every archetype in `ALL_ARCHETYPES` yields a stable view and metric spec; implementation does not hard-code the archetype count.
+- [ ] The current single-archetype workspace is described as the primary business flow and remains adaptable to later multi-archetype/service-line composition.
+- [ ] Rental/shared-asset archetypes are handled explicitly and do not collapse into generic booking language.
+- [ ] Proxy measures are labelled as proxies. Unavailable measures render as `unknown` / not measured, not as green or as silent omission. The UI does not imply true utilization, process time, or quality where the platform lacks the data.
+- [ ] No new Prisma table, no new top-level route, no generic dashboard/widget substrate.
+- [ ] No new data signal is added unless the plan first proves the existing command-center, calendar, feed, finance, compliance, customer, people, and coworker signals cannot answer the operating question.
+- [ ] No local status color maps or hardcoded UI colors; reporting/data-display UI composes report-kit.
+- [ ] Failure to compute the headline metric degrades gracefully and does not block `/workspace`.
+- [ ] CI typecheck and production build pass without a Prisma type-inference heap regression.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| The feature becomes a generic architecture diagram that operators do not understand. | Operator labels first; stage keys hidden behind data/test/admin details; business examples covered in tests. |
+| A single metric tile feels disconnected from the value stream. | Render the value-stream strip and headline metric from one `WorkspaceCommandCenterView` object. |
+| The page becomes analytics-first instead of operations-first. | Organize by urgency: immediate needs, active work, pending needs, situations forming, then supporting metrics. |
+| The visual layer turns into decoration instead of operations. | Only render structured, data-backed visuals: maps, schedules, occupancy/turnover/asset/stock/case/trust boards. No stock-image substitutes. |
+| Per-archetype visual logic becomes a new dialect per page. | Derive visual pattern from OVSM context and shared `WorkspaceVisualActivity`; use archetype IDs only as tested tie-breakers. |
+| Color becomes the only status signal. | Standardize good/concern/acute/in-motion/unknown through report-kit, and require icon + label + accessible name for every marker. |
+| Proxy data creates false confidence. | `measureMaturity` and hint text are mandatory; direct vs proxy vs unavailable is tested. |
+| Workspace first viewport becomes cluttered. | Compact band, no nested cards, no extra route, mobile wrap/scroll test. |
+| The plan bakes in today's single-archetype assumption and blocks future composition. | Use primary-flow copy and pure serializable view models; do not persist UI-only process stages. |
+| Archetype count drifts. | Iterate `ALL_ARCHETYPES`; never write "53" into tests or implementation. |
+| Typecheck/build OOM from Prisma generics. | Narrow structural DB types and explicit return interfaces. |
+| Supporting-function view becomes a second source of truth. | Derive every stage and support band from OVSM; no persisted UI-only process model. |

--- a/docs/superpowers/specs/2026-05-24-portfolio-gear-convergence-design.md
+++ b/docs/superpowers/specs/2026-05-24-portfolio-gear-convergence-design.md
@@ -1,0 +1,307 @@
+---
+title: Portfolio × Gear Convergence — binding shared substrate between the four-portfolio maturity model and the reduction-gear architecture
+authoredAt: 2026-05-24
+authoredBy: mark-bodman
+status: draft
+specKind: convergence
+parentSpecs:
+  - docs/superpowers/specs/2026-05-21-four-portfolio-agent-control-plane-maturity-design.md
+  - docs/superpowers/specs/2026-05-24-reduction-gear-architecture-design.md
+relatedSpecs:
+  - docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md
+  - docs/superpowers/specs/2026-05-24-runtime-kernel-commandments.md
+  - docs/superpowers/specs/2026-05-16-ux-auditor-coworker-design.md
+relatedPrinciples:
+  - docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md
+  - docs/founder-kernel/wiki/principles/consult-specs-first.md
+  - docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
+  - docs/founder-kernel/wiki/principles/structural-verification-is-not-functional.md
+---
+
+# Portfolio × Gear Convergence
+
+## Role of this spec
+
+This is a **convergence spec**. It does not own any schema, route, or backlog mutation. It exists to bind two simultaneously-authored operating models — the four-portfolio agent control plane maturity design and the reduction-gear architecture — so that the substrate they share is implemented once, not twice.
+
+Neither parent spec owns this binding because the binding outcome may amend either parent. Both authors retain veto on convergence proposals; the binding decisions in §4 are subject to operator ratification and may flow back as amendments to either parent before any implementation slice lands.
+
+**Pre-condition for any implementation work touching either parent:** consult §4 and §6 of this spec. Implementation that violates a §4 binding decision is rejected at review regardless of which parent it cites.
+
+## 1. The two operating models
+
+| Operating model | Axis 1 | Axis 2 | Operator question answered |
+|-----------------|--------|--------|---------------------------|
+| **Four-Portfolio Maturity** ([spec](2026-05-21-four-portfolio-agent-control-plane-maturity-design.md)) | Breadth — the four portfolio roots (Foundational, Manufacturing & Delivery, For Employees, Products & Services Sold) | Investment posture — 0–5 `maturityScore`, `confidenceGrade ∈ {verified, evidenced, claimed, stale}`, `effectiveMaturity` dependency cascade | "Where do we own, build, buy, or avoid? Where is the platform investment-ready, operations-ready, or productize-ready?" |
+| **Reduction Gear Architecture** ([spec](2026-05-24-reduction-gear-architecture-design.md)) | Depth — five concentric rings (Coworker → Workflow → Archetype → Sandbox→Prod → Hive) | Trust ladder — HITL-required → HITL-fallback → auto-confirm → auto-silent, with explicit graduation events keyed by `{agent_id, capability_name, archetype_context}` | "Where is torque being lost in the gear train right now? Which triples are ready to graduate? What does the operator need to lubricate?" |
+
+By construction these axes are orthogonal — neither parent spec mentions the other, and neither needs to. They are two diagnostic surfaces over one capability fabric. The platform must not pay for that fabric twice.
+
+```
+                      INVESTMENT POSTURE (Four-Portfolio)
+                      claimed → evidenced → verified
+                          ↑
+                          │
+                          │   capability fabric
+   BREADTH ◄──── Foundational ─┼─ M&D ─ Employees ─ Sold ────► (Four-Portfolio)
+   axis                       │
+                              │
+   DEPTH ◄──── Ring 1 ─ Ring 2 ─ Ring 3 ─ Ring 4 ─ Ring 5 ────► (Reduction Gear)
+   axis                       │
+                              │
+                              ↓
+                      TRUST LADDER (Reduction Gear)
+                      HITL-required → hitl-fallback → auto-confirm → auto-silent
+```
+
+Both axes index the same set of capabilities, archetypes, agents, and evidence rows. The convergence question is which substrate they share and which they keep local.
+
+## 2. Why this spec exists separately
+
+A unified spec would force one author to pick architectural sides on day one. A pair of amendments to the parents would scatter the binding across two files and lose coordination. A separate convergence spec:
+
+- gives both parent authors a neutral surface to negotiate the shared decisions;
+- gives implementation reviewers a single page to cite when a slice in either parent forks a shared substrate;
+- gives operators a single page to read when they want to understand how the two diagnostic surfaces compose;
+- gives the next coordination wave (cross-customer, hive federation, productization) a stable contract to extend.
+
+If this spec is wrong, both parents stay correct. If a parent is wrong, this spec absorbs the correction without re-opening the other parent. Convergence is the cheap, recoverable layer.
+
+## 3. Substrate ownership map
+
+This table inventories every load-bearing primitive named by either parent and assigns ownership. **Shared** means both surfaces read from one source; **local** means each parent keeps its own. The §4 binding decisions resolve every disputed row.
+
+| Primitive | Owned by | Four-Portfolio role | Reduction Gear role | Convergence decision |
+|-----------|----------|---------------------|---------------------|----------------------|
+| Capability vocabulary | **Shared** (new module) | `capabilityCategory` enumerated set | `capability_name` derived vocabulary | §4.1 |
+| Archetype-scoped runtime state | **Shared** | `installScope = customer_overlay` + `archetypeScope` on `CapabilityMaturityAssessment` | `ArchetypeCapabilityProfile` (proposed) | §4.2 |
+| Trust + maturity relationship | **Shared formula** | `maturityScore`, `effectiveMaturity` | autonomy tier, graduation events | §4.3 |
+| Evidence ledger feed | **Shared (gear → maturity)** | `evidenceFreshness` → `confidenceGrade` | `GearInterface` rows are emission events | §4.4 |
+| WWMD governance engine | **Shared** | Quarterly capability reviewer | Per-execution Autonomy Governor | §4.5 |
+| Operator surface composition | **Shared component layer** | `/portfolio` per-portfolio maturity overlay | Cockpit cross-ring gear view | §4.6 |
+| MCP / tool gateway policy | Four-Portfolio (`tool_gateway` category) | Maturity-scored | Consumed by gear as a capability | (no fork) |
+| Identity / authority | Four-Portfolio (`identity_authority` category) | Maturity-scored | `actorPrincipalId` on every GearInterface row | (no fork) |
+| Append-only mutation log | **Shared substrate** | `MaturityScoreEvent` (per spec §8.1.A) | Graduation events (per gear §3.4, §6.4) | §4.7 (downstream of §4.4) |
+| Productization gate | Four-Portfolio (`productizationStatus` lifecycle) | Owns the gate | Hive contribution must compose it | §5.1 |
+| Hive contribution package | Reduction Gear (`CalibratedCapabilityPack`) | Productize gate is a pre-condition | Owns the format | §5.1 |
+| External coordination adapter | Reduction Gear (bridged-mode shims) | Classified as `boundary_adapter` per Four-Portfolio §11 | Owns the adapter substrate | §5.2 |
+| Theme tokens / audit-lens helpers | **Shared `packages/maturity-ui`** | `/portfolio` consumes | Cockpit consumes | §4.6 + §5.3 |
+
+## 4. The six binding decisions
+
+Each decision is written as a single sentence that any implementation reviewer can cite. The rationale paragraphs explain the trade-off; the binding sentence is what governs code.
+
+### 4.1 Capability vocabulary
+
+**Binding decision:** Capability names live in one module — proposed `packages/capability-taxonomy` — owned by neither parent. Both `CapabilityMaturityAssessment.capabilityCategory` and `GearInterface.capabilityName` import from this module. No surface authors a parallel enum.
+
+*Rationale.* Four-Portfolio §8 enumerates seven categories (`runtime`, `identity_authority`, `tool_gateway`, `data_plane`, `budget_spend`, `evidence_eval`, `human_override`) plus an `composition_helper` escape hatch. Reduction Gear §3.3 + §11(1) calls for a derived vocabulary from `AgentModelConfig.minimumCapabilities`, `SkillDefinition.allowedTools`, `TOOL_TO_GRANTS`, task types, and route outcomes. These are not the same granularity — Four-Portfolio names categories; Reduction Gear names leaf capabilities. The convergence is hierarchical: Four-Portfolio's eight values are the **parent categories**; Reduction Gear's leaves are the **operationally-emitted names**. The shared module exports both, with a typed parent-of relationship. Neither parent can amend the enum unilaterally.
+
+*Implementation hook.* `packages/maturity` (per Four-Portfolio §17 #6) imports from `packages/capability-taxonomy`. Reduction Gear's GearInterface writer imports from the same. Migrations that add a leaf without a parent category, or a category not previously declared, fail review.
+
+### 4.2 Archetype-scoped runtime state
+
+**Binding decision:** Archetype-scoped capability state lives in one table consumed by both surfaces. The proposed `ArchetypeCapabilityProfile` (Reduction Gear §4.2) is the runtime-evolving projection; the Four-Portfolio `CapabilityMaturityAssessment` row with `installScope = customer_overlay` and `archetypeScope` set is the management-evaluation projection of the same state. They reconcile through the `archetypeId` + canonical capability key, not through parallel writes.
+
+*Rationale.* Both specs correctly refuse to aggregate across archetypes silently (Reduction Gear §7.3, Four-Portfolio §10.2 + AC #15). But each introduces its own carrier — `ArchetypeCapabilityProfile` (Reduction Gear) vs `customer_overlay` rows (Four-Portfolio). Two carriers of the same archetype-scoped truth means two writers, two staleness profiles, two drift surfaces. The convergence picks one carrier as authoritative (`ArchetypeCapabilityProfile` for live calibration state) and treats the maturity-overlay row as the **derived management view** computed from it on demand.
+
+*Implementation hook.* The Four-Portfolio writer module (`packages/maturity`) reads `ArchetypeCapabilityProfile` when constructing customer-overlay rows; it never writes to `ArchetypeCapabilityProfile`. The single-writer discipline in Four-Portfolio AC #20 extends across the boundary — only the gear ingestion writer mutates the profile.
+
+### 4.3 Trust ↔ maturity relationship
+
+**Binding decision:** `effectiveMaturity` is capped by the **median autonomy tier** of the graduated triples under its capability category, computed by the maturity writer at evaluation time. Specifically: a capability category cannot show `effectiveMaturity ≥ 4` unless the median triple under it has graduated past `hitl-required`. A category at `maturityScore = 4` with zero `auto-confirm` triples is rendered as `effectiveMaturity = 3` with a "no graduated triples" annotation.
+
+*Rationale.* Today neither spec relates the two scoring systems, so a category could sit at `maturityScore = 4` while no agent has graduated past HITL on a single triple in the category — vanity maturity. The convergence makes the relationship one-directional and conservative: graduation density is a necessary signal for high maturity, but maturity does not imply autonomy for any specific triple. The reverse direction (maturity cap on autonomy elevation) is rejected — the Autonomy Governor must remain free to escalate or block any individual triple regardless of category maturity.
+
+*Implementation hook.* `packages/maturity` adds `deriveAutonomyFloorContribution(capabilityCategory, calibrator): { medianTier, sampleSize, contributesCap }` consulted before `effectiveMaturity` is finalized. Test: a category with five `hitl-required` triples and no graduations cannot render above effective 3 regardless of seeded `maturityScore`.
+
+### 4.4 Evidence ledger feed
+
+**Binding decision:** `GearInterface` is the **primary** feed into Four-Portfolio's `evidenceFreshness` and `lastAssessmentAt`. Other evidence sources (PRs, tests, user outcomes) remain valid but are secondary — a capability whose GearInterface stream has been silent for > 30 days demotes to `stale` regardless of other evidence types. This is the same anti-rot rule already in Four-Portfolio §5.3, with `GearInterface` named as the canonical staleness signal.
+
+*Rationale.* Four-Portfolio's `evidenceSources` is a heterogeneous list; without a canonical primary, the `confidenceGrade` calculation has to weight types it doesn't fully understand. Reduction Gear's GearInterface is exactly the right shape for this: a typed, indexed, idempotent record per capability emission. Naming it primary closes the rot vector and ties the two specs' staleness rules to one signal.
+
+*Implementation hook.* `packages/maturity` queries `GearInterface` by `capabilityName` to compute `evidenceFreshness`. The Phase 0 Ring 1→2 pilot in Reduction Gear (§9.1) is the **earliest** that maturity scoring can transition from "claimed bootstrap" to "evidenced" for the capabilities Build Studio covers. Capabilities not on Build Studio's path stay `claimed` until their own ring emitter ships.
+
+### 4.5 WWMD governance engine
+
+**Binding decision:** The Autonomy Governor (Reduction Gear §6.2) and the quarterly maturity reviewer (Four-Portfolio §8.1) are the **same WWMD engine instantiated at two cadences**. The quarterly review consumes the Autonomy Governor's graduation log as primary evidence for score and `vendorReplacementConfidence` updates.
+
+*Rationale.* Both surfaces correctly delegate decisions to WWMD-arbitrated coworkers per the [WWMD decision-perspective kernel](2026-05-17-wwmd-decision-perspective-kernel-design.md). Without naming them as one engine, two reviewer personas drift, two evidence-citation patterns emerge, and the quarterly review loses the per-execution signal that proves capability health. Naming them as one engine with two cadences keeps the trust loop closed.
+
+*Implementation hook.* The quarterly review job (Four-Portfolio §8.1 critical/elevated cadence) queries the graduation log from the Calibrator (Reduction Gear §6.1) as its primary input. "This capability graduated 14 triples to `auto-confirm` last quarter" is a stronger maturity signal than any seeded score and overrides `claimed` on its own. Human escalation per Four-Portfolio §8.1 applies identically to both cadences.
+
+### 4.6 Operator surface composition
+
+**Binding decision:** `/portfolio` and the Cockpit are **sister surfaces sharing a component library** (`packages/maturity-ui`). The Cockpit lives at its own route (`/platform/ai/cockpit` or similar) because it is cross-portfolio by construction; the maturity view lives at `/portfolio` per the Four-Portfolio §12.4 layer-on-existing-nav invariant. Both consume the same theme tokens, drill paths, and §12.5 audit-lens test helpers.
+
+*Rationale.* The Cockpit cannot live under `/portfolio` because it spans all four portfolios — it would violate the per-portfolio scope of that route. The maturity surface cannot move to the Cockpit because Four-Portfolio §12.4 forbids inventing new top-level nav for the maturity view. Resolution: two routes, one component library. Drill paths cross-link: a maturity row's "show me what's actually happening" button opens the Cockpit filtered to that capability's gear-train segment; a Cockpit triple's "show me management context" button opens the maturity row in `/portfolio`.
+
+*Implementation hook.* The §12.5 audit-lens assertions from PR #1004 become test helpers exported from `packages/maturity-ui` and consumed by both Cockpit and `/portfolio` test suites. AGT-906 (UX auditor coworker) is the gating reviewer for both surfaces.
+
+### 4.7 Append-only mutation log
+
+**Binding decision:** `MaturityScoreEvent` (per Four-Portfolio §8.1.A) and graduation events (per Reduction Gear §3.4 / §6.4) emit to **one append-only event substrate** with a discriminator field. They are two `eventKind` values, not two tables. The substrate enforces immutability for both kinds and supports compensating events as the only correction path.
+
+*Rationale.* Both are: immutable, evidence-linked, governance-relevant, queried by operator UIs. Two tables would re-fragment the audit trail the gear spec is trying to consolidate. One table with a discriminator preserves both specs' invariants (Four-Portfolio AC #19 + #20, Reduction Gear §3.4 idempotency) under a single writer.
+
+*Implementation hook.* Schema: one Prisma model `PlatformMutationEvent` with `eventKind ∈ {maturity-score, graduation, veto, autonomy-change, ...}` and discriminator-specific payload. Both writer modules (`packages/maturity` and the Calibrator) import the same event writer. Migrations that introduce a second event table for either purpose are rejected.
+
+## 5. Downstream composing decisions
+
+These follow from §4 once it is ratified. They are recorded here for visibility but do not introduce additional binding contracts beyond what §4 already implies.
+
+### 5.1 Productize gate composes Hive federation gate
+
+`productizationStatus = candidate` (Four-Portfolio §10.4) requires, in addition to its existing criteria, a minimum graduated-triple count from the Calibrator: the capability has graduated at least N triples to `auto-confirm` across at least one archetype. `CalibratedCapabilityPack` (Reduction Gear §7.1) cannot ship for a capability whose `productizationStatus` is `not_eligible`. The two gates are layered: productize gates "may we offer this for sale?"; CalibratedCapabilityPack additionally gates "may we ship calibrated trust about this to peer installs?". A capability that has graduated triples internally but is not productized may still ship code via the existing `FeaturePack` path; the trust payload is what requires productization.
+
+### 5.2 Boundary adapters are bridged-mode external coordination
+
+Reduction Gear §8.2 (bridged mode adapters: EDI, OAGIS, FHIR, etc.) and Four-Portfolio §11 (`strategicOwnership = boundary_adapter`) name the same artifact. A bridged adapter is a `boundary_adapter` capability under the `tool_gateway` parent category, with the §11 qualifying criteria (customer-owned counterparty, open/multi-vendor protocol, DPF retains source-of-truth, swap-out testable, attributable evidence) as its gate. Adapters that fail those criteria are downgraded to `avoid`, not embedded as `boundary_adapter` by default.
+
+### 5.3 BI-CTRL-2B7F31 reconciliation
+
+The "unified control plane" backlog item (BI-CTRL-2B7F31, surfaced in Reduction Gear §9.7) is also functionally what Four-Portfolio §12 describes for `/portfolio`. Three things converging on the same epic risk three parallel implementations. The item should be retitled to make the composition explicit ("Unified Control Plane = Cockpit + Maturity Surface + sharing `packages/maturity-ui`") and the two parent specs both cite it as the integration point. If the item is currently scoped only to Cockpit, it should expand; the maturity surface PRs #1001/#1004 already published its component layer needs.
+
+## 6. Impacted endpoints — coordination inventory
+
+The following endpoints MUST be coordinated when any §4 binding decision is implemented. This list is the contract for the next planning pass.
+
+### 6.1 Specs
+
+- [Four-Portfolio Agent Control Plane Maturity Design](2026-05-21-four-portfolio-agent-control-plane-maturity-design.md) — must reference this spec in its frontmatter and §8 (capability vocabulary), §10 (archetype scope), §5.3 (evidence staleness), §8.1 (reviewer cadence), §10.4 (productize gate), §12 (operator surface)
+- [Reduction Gear Architecture Design](2026-05-24-reduction-gear-architecture-design.md) — must reference this spec in its frontmatter and §3.3 (capability vocabulary), §4.2 (archetype profile carrier), §5 (operator surface), §6 (governance), §7 (hive composition), §8 (external coordination)
+- [WWMD Decision-Perspective Kernel Design](2026-05-17-wwmd-decision-perspective-kernel-design.md) — governs both cadences per §4.5; no edit required unless reviewer persona templates expand
+- [Runtime Kernel Commandments](2026-05-24-runtime-kernel-commandments.md) — composes with the Autonomy Governor per the gear spec; commandment additions for §4.3 autonomy-floor rule may follow
+- [UX Auditor Coworker (AGT-906) Design](2026-05-16-ux-auditor-coworker-design.md) — must gate both surfaces (§4.6); audit-lens assertions live in `packages/maturity-ui` per §5.3
+
+### 6.2 Schema (Prisma)
+
+- `CapabilityMaturityAssessment` (Four-Portfolio §8) — adds dependency on canonical capability key from `packages/capability-taxonomy`; loses any local enum for `capabilityCategory`
+- `GearInterface` (Reduction Gear §3.1) — adds dependency on canonical capability key from `packages/capability-taxonomy`; `capabilityName` becomes a typed foreign key, not free text
+- `ArchetypeCapabilityProfile` (proposed in Reduction Gear §4.2) — becomes the **single** archetype-scoped runtime state table per §4.2
+- `MaturityScoreEvent` (Four-Portfolio §8.1.A) — folded into `PlatformMutationEvent` per §4.7
+- Graduation events (Reduction Gear §3.4 / §6.4) — folded into `PlatformMutationEvent` per §4.7
+- `StorefrontArchetype` — read by both writer modules; not mutated by either; the existing JSON fields (`activationProfile`, `customVocabulary`, `marketingSkillRules`) remain bootstrap, per the seed-is-bootstrap principle and Reduction Gear §1.2.1
+- `FeaturePack` / `CalibratedCapabilityPack` — `CalibratedCapabilityPack` creation gated by `productizationStatus` per §5.1
+
+### 6.3 Modules
+
+- `packages/capability-taxonomy` — **new**, owned by neither parent, exports the canonical capability hierarchy (parent categories from Four-Portfolio §8; leaf names from Reduction Gear's normalization pass)
+- `packages/maturity` (proposed in Four-Portfolio §17 #6) — single writer for `CapabilityMaturityAssessment`; reads `ArchetypeCapabilityProfile`, the Calibrator graduation log, and `GearInterface` evidence stream
+- `packages/maturity-ui` — **new**, shared component library for `/portfolio` and Cockpit
+- Calibrator service (Reduction Gear §6.1) — single writer for `ArchetypeCapabilityProfile`; emits to `PlatformMutationEvent`
+- Autonomy Governor (Reduction Gear §6.2) — consumes the Calibrator; also serves as the per-execution arm of the WWMD reviewer of record per §4.5
+- `PlatformMutationEvent` writer — single writer for §4.7 substrate; mutation logic for either eventKind goes through it
+
+### 6.4 Routes / UI
+
+- `/portfolio` (Four-Portfolio §12) — consumes `packages/maturity-ui`; renders maturity overlay per §12.0–§12.5
+- `/platform/ai/cockpit` (Reduction Gear §5; proposed route) — consumes `packages/maturity-ui`; renders gear train + drill paths
+- Cross-links between the two surfaces are first-class affordances, not afterthoughts
+
+### 6.5 Coworkers / governance
+
+- WWMD reviewer of record (Four-Portfolio §8.1 + Reduction Gear §6.2) — one persona, two cadences
+- AGT-906 UX auditor (referenced by both surfaces via §12.5 / §4.6) — gating reviewer for both `/portfolio` and Cockpit
+
+### 6.6 Backlog items / epics
+
+- `BI-CTRL-2B7F31` (unified control plane) — retitle per §5.3
+- `EP-WWMD-MCP` — Autonomy Governor implementation
+- `EP-BUILD-9DB5B0` — Calibrator's first consumer, also the natural anchor for the Phase 0 Ring 1→2 pilot
+- `EP-ASSURANCE-LEDGER` — `PlatformMutationEvent` substrate
+- `EP-COST-001` — cost-as-torque integration on `GearInterface`
+- New umbrella `EP-PORTFOLIO-GEAR-CONVERGENCE` (governance epic) — owns this spec; does NOT own implementation work, only the §4 binding decisions and their ratification trail
+
+### 6.7 Hive / external coordination
+
+- `contribute_to_hive` — gates `CalibratedCapabilityPack` creation per §5.1
+- `hive-scout-ingest` — Bayesian prior merge per Reduction Gear §7.2; no convergence amendment required
+- Bridged adapters (Reduction Gear §8.2) — classified per §5.2 boundary_adapter criteria before any adapter ships
+
+## 7. Phased convergence sequencing
+
+Convergence does not block either parent's Phase 0 if the §4 decisions are ratified before code lands. The sequencing below is what implementation should follow.
+
+### 7.1 Pre-Phase-0 (now, before any code)
+
+- Operator ratifies this spec (or amends §4 and re-ratifies)
+- Both parents add this spec to their frontmatter and reference §4 at the relevant sections
+- `EP-PORTFOLIO-GEAR-CONVERGENCE` filed as governance-only epic
+- `packages/capability-taxonomy` skeleton created (no enum content yet; just the module shape)
+
+### 7.2 Phase 0 — Foundation (both parents in parallel)
+
+- `packages/capability-taxonomy` lands with the Four-Portfolio eight parent categories + the Reduction Gear normalization pass produces the leaf vocabulary; both surfaces import
+- `PlatformMutationEvent` schema + writer lands per §4.7
+- `packages/maturity-ui` skeleton (just the audit-lens assertion helpers ported from PR #1004's §12.5)
+- Reduction Gear's Ring 1→2 pilot (gear §9.1) lands; capabilities on Build Studio's path become first evidenced-tier maturity rows
+- Four-Portfolio's slice 1 (per its merged plan + Task 8) lands; reads from `packages/capability-taxonomy` and consults `GearInterface` for `evidenceFreshness`
+
+### 7.3 Phase 1 — Calibration ↔ Maturity link
+
+- Calibrator service lands (gear §9.2); maturity quarterly review begins consuming the graduation log per §4.5
+- `ArchetypeCapabilityProfile` lands as the single archetype-scoped table per §4.2; Four-Portfolio's customer-overlay rows derive from it
+- The §4.3 autonomy-floor cap on `effectiveMaturity` lands in `packages/maturity`
+
+### 7.4 Phase 2 — Cockpit + `/portfolio` sister surfaces
+
+- Cockpit MVP and `/portfolio` maturity overlay both consume `packages/maturity-ui`
+- Cross-links between the two routes ship together
+- AGT-906 gates both surfaces
+
+### 7.5 Phase 3 — Productize ⊃ Hive federation
+
+- `productizationStatus = candidate` requires graduated-triple count per §5.1
+- `CalibratedCapabilityPack` creation gates on `productizationStatus`
+- Hive federation ships with the composed gate, not before
+
+### 7.6 Phase 4 — Bridged external coordination = boundary adapters
+
+- Each bridged adapter (EDI 850/810 first per gear §9.5) classified per §5.2 / Four-Portfolio §11 before shipping
+- `strategicOwnership = boundary_adapter` becomes the contract surface for these adapters
+
+## 8. Acceptance criteria
+
+### 8.1 Functional (the convergence is real for operators)
+
+1. An operator navigating from `/portfolio` to a capability row can cross-link to its Cockpit gear-train segment in one click; the reverse path also exists.
+2. The quarterly maturity review for any capability shows graduation-log evidence from the Calibrator as the primary source.
+3. A capability scored at `maturityScore ≥ 4` with no graduated triples renders at `effectiveMaturity = 3` with a "no graduated triples" annotation.
+4. `productizationStatus = candidate` cannot be set on a capability without minimum graduated-triple coverage from the Calibrator.
+5. Bridged-mode adapters appear in `/portfolio` under their `tool_gateway` parent with `strategicOwnership = boundary_adapter` and the §11 qualifying-criteria checklist.
+
+### 8.2 Architectural (invariants the implementation must preserve)
+
+6. **One capability vocabulary** — `packages/capability-taxonomy` is imported by every surface touching capability identity; no parallel enum exists in either parent's schema.
+7. **One archetype-scoped runtime carrier** — `ArchetypeCapabilityProfile` is the single live store; `customer_overlay` maturity rows are derived, not authored.
+8. **One mutation event substrate** — `PlatformMutationEvent` carries both maturity score changes and graduation events under one writer.
+9. **One evidence-staleness signal** — `evidenceFreshness` on the maturity record is computed from `GearInterface` query; other evidence sources are secondary.
+10. **One WWMD reviewer persona** — the quarterly review and the Autonomy Governor are the same WWMD-arbitrated coworker at two cadences.
+11. **One UI component library** — `packages/maturity-ui` is the shared layer between `/portfolio` and Cockpit; neither surface owns a private copy.
+12. **No third "unified control plane" candidate** — BI-CTRL-2B7F31 retitled and scoped per §5.3; no new epic claims that title.
+
+## 9. Open questions / deferred to ratification
+
+These are decisions where the convergence spec deliberately stops short of binding, because operator input is required:
+
+1. **Naming of `packages/capability-taxonomy`** — could be `capability-vocabulary` or `capability-ontology`. Defer to first PR.
+2. **Granularity of the §4.3 autonomy-floor formula** — "median of constituent triples" is one choice; alternatives include "minimum tier with sample size ≥ N" or "weighted by archetype coverage". Pick at Phase 1 plan time with calibration data in view.
+3. **Cockpit route slug** — `/platform/ai/cockpit`, `/platform/cockpit`, or `/cockpit`. Decide with the operator and AGT-906 in the loop.
+4. **`PlatformMutationEvent` discriminator naming** — `eventKind` values for graduation vs maturity score change vs veto vs autonomy-change. Catalog at §4.7 implementation time.
+5. **Cross-archetype trust transfer** — Reduction Gear §7.3 / §11 already defers this; the convergence spec inherits the deferral.
+6. **Productize-eligible graduated-triple minimum (N) in §5.1** — picking N requires calibration data we do not yet have. Phase 3 plan time, with operator on the call.
+7. **Migration path for any existing `BacklogItemActivity` / `WorkCapsuleActivity` / `BuildActivity` reads** — Reduction Gear §9.6 already defers; the convergence spec inherits.
+
+## 10. What this spec is NOT
+
+- Not a substrate redesign — both parents stand on their own merits; this spec binds where they touch.
+- Not a phasing override — both parents' phase plans remain authoritative for their own phases.
+- Not a re-scoping — neither parent loses or gains scope; capability-fabric ownership is named, not moved.
+- Not a UI design — `packages/maturity-ui` is named here but its component contracts are specified in PR #1004 and the gear spec §5.4.
+- Not a migration plan — Phase 5 of the gear spec retains ownership of legacy event-table sunset; the convergence spec only requires that no new fragmentation is introduced.
+
+## 11. Ratification trail
+
+This spec is ratified when both parent specs reference it in their frontmatter, `EP-PORTFOLIO-GEAR-CONVERGENCE` is filed, and the operator approves the §4 binding decisions in writing (PR review comment is sufficient). Any §4 amendment after ratification requires re-approval. The ratification trail is itself an entry in `PlatformMutationEvent` once that substrate exists; until then, the trail lives in the governance epic's activity log.

--- a/docs/superpowers/specs/2026-06-01-build-studio-business-mode-runner-abstraction-design.md
+++ b/docs/superpowers/specs/2026-06-01-build-studio-business-mode-runner-abstraction-design.md
@@ -1,0 +1,892 @@
+---
+title: Build Studio Business Mode and Runner Abstraction
+authoredAt: 2026-06-01
+authoredBy: codex
+status: draft-for-operator-review
+specKind: design
+relatedSpecs:
+  - docs/superpowers/specs/2026-04-25-build-studio-redesign-design.md
+  - docs/superpowers/specs/2026-05-20-build-studio-layout-redesign-design.md
+  - docs/superpowers/specs/2026-05-09-build-execution-provider-design.md
+  - docs/superpowers/specs/2026-04-29-coworker-execution-adapter-substrate-design.md
+  - docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
+  - docs/superpowers/specs/2026-04-23-a2a-aligned-coworker-runtime-design.md
+  - docs/superpowers/specs/2026-05-31-pseudo-user-contract-design.md
+  - docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
+  - docs/superpowers/specs/2026-05-30-dpf-native-skill-equivalents-design.md
+  - docs/superpowers/specs/2026-05-19-build-studio-single-status-command-spine-design.md
+relatedEpics:
+  - EP-BUILD-STUDIO-UX
+  - EP-BUILD-STUDIO
+  - EP-9FC5D2FD
+  - EP-GROK-001
+  - EP-COWORKER-INTERACTIVITY
+  - EP-A2A
+relatedPrinciples:
+  - docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md
+  - docs/founder-kernel/wiki/principles/single-source-of-truth.md
+  - docs/founder-kernel/wiki/principles/never-fabricate.md
+  - docs/founder-kernel/wiki/principles/research-and-use-standards.md
+  - docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
+  - docs/founder-kernel/wiki/principles/no-assumptions.md
+externalReferences:
+  - https://microsoft.github.io/autogen/dev/index.html
+  - https://microsoft.github.io/autogen/dev/user-guide/agentchat-user-guide/index.html
+  - https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/index.html
+  - https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/design-patterns/handoffs.html
+  - https://docs.langchain.com/oss/python/langchain/multi-agent/index
+  - https://docs.langchain.com/oss/python/langgraph/overview
+  - https://docs.langchain.com/oss/python/langgraph/interrupts
+  - https://docs.langchain.com/oss/python/langchain/frontend/human-in-the-loop
+  - https://adk.dev/workflows/
+  - https://docs.crewai.com/en/introduction
+  - https://docs.aws.amazon.com/bedrock/latest/userguide/agents-multi-agent-collaboration.html
+  - https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/agent-orchestration/group-chat
+  - https://developers.openai.com/api/docs/guides/agents/orchestration
+  - https://developers.openai.com/api/docs/guides/agents/guardrails-approvals
+  - https://developers.openai.com/api/docs/guides/agents/integrations-observability
+  - https://developers.openai.com/api/docs/guides/agent-evals
+  - https://code.claude.com/docs/en/legal-and-compliance
+  - https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan
+  - https://docs.x.ai/build/overview
+  - https://docs.x.ai/build/cli/headless-scripting
+  - https://docs.x.ai/developers/models/grok-build-0.1
+  - https://docs.github.com/en/actions/how-tos/monitor-workflows/use-workflow-run-logs
+  - https://docs.gitlab.com/ci/pipelines/
+  - https://docs.gitlab.com/ci/jobs/
+  - https://docs.replit.com/core-concepts/agent/
+  - https://linear.app/docs
+---
+
+# Build Studio Business Mode and Runner Abstraction
+
+## Executive decision
+
+Build Studio should split into two experience levels over one execution engine:
+
+1. **Business Mode** is the default for install owners and non-developer users. It is coworker-led, artifact-first, and approval-oriented. It hides code, terminal output, branches, internal IDs, model/provider names, MCP tool names, and workflow graphs unless the user explicitly opens advanced details.
+2. **Power Mode** is for Mark, developers, platform operators, and support. It preserves the current operational Build Studio surface: workflow graph, fleet rail, node inspectors, details drawer, dispatch history, source diffs, runner/session data, skills, MCP tools, and technical traces.
+
+The execution layer becomes provider-neutral. Claude Code, Codex, Grok, and DPF-native runners all feed the same normalized Build Studio event projection. The UI renders business artifacts, questions, screenshots, verification, and approval states from those projected events.
+
+This spec is a UX/projection amendment over the existing Build Studio, Pseudo-User Contract, A2A/TaskRun, coworker-substrate, and CLI-adapter work. It must not introduce a parallel approval system, workflow database, task graph, or provider-specific UX surface.
+
+The guiding acceptance test is the operator's "wife test":
+
+> A capable non-developer can describe desired platform functionality, answer business questions, inspect a working result visually, request changes conversationally, and approve the outcome without seeing code, terminal output, model names, git concepts, or raw tool traces.
+
+## Problem
+
+Build Studio's current surface is too technical for the intended audience.
+
+The repository already contains strong operational machinery:
+
+- `apps/web/components/build/BuildStudio.tsx` renders the current active-build shell with fleet rail, workflow graph, node inspector, details drawer, action card, assurance row, release panel, and shared sandbox footer.
+- `apps/web/components/build-studio/BuildStudioV2.tsx` prototypes a calmer conversational/artifact shell with business brief, preview, walkthrough, plain change, and diff tabs.
+- `apps/web/lib/integrate/build-orchestrator.ts` dispatches specialist tasks and can route through `BuildAgentRunner` implementations.
+- `apps/web/lib/integrate/sandbox/agent-runner-types.ts` already defines `BuildAgentId = "codex" | "claude" | "dpf-native"` with provider compatibility checks.
+- `packages/db/prisma/schema.prisma` already has durable sources: `FeatureBuild`, `BusinessBuildBrief`, `BuildActivity`, `BuildDispatchAttempt`, `BuildPhaseRun`, `ToolExecution`, `WorkCapsule`, `WorkCapsuleActivity`, `AgentThread` CLI session fields, and `SkillDefinition`.
+- The Pseudo-User Contract already defines the delegated-coworker approval, screen-manifest, and audit-envelope direction for user-visible actions.
+- The A2A-aligned coworker runtime already identifies `TaskRun`/`TaskNode` as the long-term task and handoff substrate.
+- The CLI execution adapter routing spec already defines adapter event normalization, capability profiles, and `CliSessionService` direction for Claude/Codex-style execution surfaces.
+
+The product problem is not lack of power. It is that Build Studio exposes too much of the machinery in the default experience.
+
+The Dale dogfood run captured this clearly:
+
+- internal identifiers leaked (`FB-*`, `WC-*`, branch names)
+- "sandbox", "capsule", "code intel", "BOM", model registry paths, tool names, and status internals appeared in business-facing copy
+- progress visibility failed around long-running async tools
+- a non-developer user could not tell whether the coworker was working, blocked, or asking for a business decision
+- when the strong-provider gate was fixed, the successful behavior was plain-English questioning and progress, not more technical detail
+
+This spec makes that split explicit: business users get outcomes and decisions; power users get machinery and traceability.
+
+## Current functionality audit
+
+### Current `apps/web/components/build/` surface
+
+Keep, but reclassify most of it as Power Mode or advanced drill-in.
+
+| Current function | Current code | Future disposition |
+| --- | --- | --- |
+| Create build from plain-English textarea | `BuildStudio.tsx` sidebar | Move into Business Mode main CTA and coworker intake. Preserve current action. |
+| Build list / fleet rail | `FleetRailZone`, `BuildListItem`, `deriveQueueState` | Business Mode shows "My builds" only when needed. Power Mode keeps fleet rail. |
+| Portal context strip | `PortalContextStrip` | Hide internals in Business Mode. Preserve in Power Mode. |
+| Header IDs / branch badges | `activeBuild.buildId`, originator item ID, `branchBadge` | Hide by default. Show human-readable title/status. IDs move to technical details. |
+| Action command spine | `BuildStudioWorkflowActionCard` | Keep. Render business-language action in Business Mode and technical command in Power Mode. |
+| Workflow graph | `ProcessGraph`, `NodeInspector` | Power Mode primary surface. Business Mode collapses it into simple current step and progress. |
+| Details drawer | `DetailsDrawer`, `BuildProgressOperationalPanel`, `ReviewPanel`, `FeatureBriefPanel` | Power Mode drawer. Business Mode consumes selected plain summaries only. |
+| Assurance row | `CodeIntelligenceStatusCard`, `BuildAssuranceGateCard` | Business Mode shows only "Build health" when actionable. Power Mode keeps full detail. |
+| Release decision | `ReleaseDecisionPanel` | Business Mode transforms into outcome approval. Power Mode keeps release mechanics. |
+| Shared preview footer | `OpenSandboxButton` | Rename to "Live preview"; bind to active build context; keep technical sandbox state in Power Mode. |
+
+### Current `apps/web/components/build-studio/` V2 surface
+
+Reuse as the Business Mode component vocabulary, but do not introduce a second chat paradigm.
+
+| Current V2 piece | Future use |
+| --- | --- |
+| `BusinessBriefPanel` | Keep as Business Mode "What we understood" artifact. Simplify "How DPF will likely build this" copy for non-developers. |
+| `PreviewFrame` | Make the primary inspection surface once preview exists. |
+| `ArtifactPane` | Keep as default center pane: brief, preview, walkthrough, what changed, technical change. |
+| `ConversationPane` | Do not duplicate the existing AI coworker rail in production. Use its cards/types as reusable message card renderers inside the current coworker UX. |
+| Cards: plan summary, verification strip, decision, files touched | Reuse. Hide `files-touched` in Business Mode unless translated to "What changed". |
+
+### Current execution substrate
+
+Keep the existing separation and extend it.
+
+| Current substrate | Future disposition |
+| --- | --- |
+| `BuildExecutionProvider` | Keep as the substrate boundary. Local Docker remains the reference provider. |
+| `BuildAgentRunner` | Extend to include `grok`. Add normalized event emission and technical trace references. |
+| Claude/Codex CLI dispatch | Allowed as runner adapters, but not as user-visible UX. Avoid subscription/OAuth automation as the default unattended Claude path after the June 15, 2026 Anthropic licensing change. |
+| `dpf-native` | Strategic default for governed unattended Build Studio work where possible. |
+| `AgentThread.cliSession*` fields | Use for supervised/persistent CLI sessions and Power Mode technical cockpit. |
+| MCP/skills | Business Mode receives the benefit through capability context. Power Mode can inspect and tune them. |
+
+## Research and benchmarking
+
+The design follows common patterns from established workflow and AI-build tools:
+
+| System | Relevant pattern | Adopt | Reject |
+| --- | --- | --- | --- |
+| GitHub Actions | Workflow runs expose status first; job logs are searchable/downloadable drill-ins. | Status/result first, logs behind drill-in. | Do not make logs the default user experience. |
+| GitLab CI/CD | Pipelines are composed of stages and jobs; jobs run on runners and have full logs. Mini graphs sort by severity for compact attention. | Separate execution graph from attention surface; keep logs for Power Mode. | Do not require business users to understand jobs/runners. |
+| Replit Agent | User starts from plain language and inspects generated apps through a preview. | Plain-language intake plus preview-first inspection. | Do not couple DPF to one hosted IDE mental model or hide verification evidence. |
+| Linear | Issues/projects/views can be filtered and shaped for different roles. | Role-appropriate views over the same data. | Do not fork Build Studio into separate products. |
+| Claude Code / Codex / Grok Build | Powerful coding agents can run from CLI/API contexts and support headless or scripted work. | Treat them as runner adapters behind Build Studio. | Do not expose terminal sessions to business users or rely on consumer-plan automation as the default product substrate. |
+
+Provider-specific notes as of 2026-06-01:
+
+- Anthropic's Claude Code legal docs state that third-party developers should not route requests through Free/Pro/Max credentials on behalf of users and should use API keys for products/services. This makes unattended Build Studio automation via subscription OAuth a licensing risk.
+- OpenAI's Codex help states ChatGPT-plan Codex usage counts toward agentic usage limits. This can work as a runner, but Build Studio should still abstract it behind the same event contract.
+- xAI's Grok Build docs support CLI/headless/API-key patterns. Grok should be integrated as another runner, not as a separate Build Studio UX.
+
+### Multi-agent orchestration benchmarking
+
+The multi-agent frameworks are converging on a few repeatable patterns. DPF should borrow the patterns, not import another framework as the product architecture.
+
+| Source | Pattern | What it teaches Build Studio |
+| --- | --- | --- |
+| Microsoft AutoGen | Two layers: `AgentChat` for high-level multi-agent apps, `Core` for event-driven, distributed agent systems. AutoGen also distinguishes patterns such as handoffs, group chat, reflection, and code execution. | Keep Business Mode high-level and calm, but build the runner/event layer as an explicit event-driven substrate. AutoGen's layered split validates our Business Mode / Power Mode split. |
+| AutoGen handoffs | Delegate tools transfer a task to another agent; human agents can be part of the topology for complex requests. | Build Studio should model specialist transfer as structured events and typed ownership changes, not as raw chat text. A human/operator is another participant in the event topology, not a last-minute side channel. |
+| LangChain / LangGraph | Multi-agent is optional; use it when context management, distributed development, parallelization, specialized tools, or sequential constraints justify it. LangGraph focuses on durable execution, streaming, persistence, and human-in-the-loop. | Avoid "multi-agent by default." Use one strong runner or one loaded skill when enough. Use subagents only when context isolation, parallel work, or gate discipline pays for the overhead. |
+| LangGraph HITL | Interrupts pause execution, surface a payload, persist state, and resume with a command. Frontend guidance renders an approval card and resumes the stream after a decision. | Business questions and approval cards should be typed resumable events. Do not rely on "ask in chat and hope the next turn resumes correctly." |
+| Google ADK | Workflows can be graph-based, dynamic, collaborative, or templated; templates cover sequential, loop, and parallel execution. Agent routing is a runtime choice for fallback/A-B/auto-routing. | DPF's right-sizing matrix should select a workflow shape. Small fixes can use a light sequence; larger builds can use graph/parallel/review flows. Runner/provider routing stays behind the workflow. |
+| CrewAI | Distinguishes Flows as structured state/control scaffolding from Crews as autonomous collaborative agent teams. | Build Studio should put deterministic process, state, gates, and persistence in the Flow-equivalent layer; crews/runners operate inside that scaffold. |
+| Amazon Bedrock Agents | Uses a supervisor/collaborator hierarchy where the supervisor plans, routes, and interacts with the user; collaborators are domain specialists. | Business Mode should keep one visible coworker/supervisor. Specialists help behind the curtain unless Power Mode opens the machinery. |
+| Microsoft Semantic Kernel | Group chat orchestration uses a manager to control conversation flow, agent turns, human input, and result collection; docs explicitly position this for debate/collaboration. | Group chat/debate is useful for plan/review deliberation and Power Mode, not as the default business-user interface. |
+| OpenAI Agents SDK | Makes the key design choice explicit: handoffs when a specialist should take over the conversation, agents-as-tools when the manager should stay in control. Guardrails and approvals pause sensitive tool calls and resume from saved state; tracing captures model calls, tool calls, handoffs, guardrails, and spans. | Business Mode should mostly use "agents as tools": the Build Studio coworker stays responsible for the user-facing answer. Handoffs are internal unless a human specialist truly needs to own the conversation. Approval and trace state need to be first-class. |
+
+DPF-specific conclusion:
+
+1. **Use manager-owned UX by default.** The visible Build Studio coworker remains responsible for the user-facing interaction. Specialists are internal capabilities.
+2. **Use handoffs sparingly.** Handoffs are for true ownership changes: support escalation, Power Mode intervention, or a domain coworker that must converse directly with the user.
+3. **Use workflow policy for right-sizing.** The process matrix chooses sequence, loop, parallel, review, and HITL gates based on work type, size, risk, and uncertainty.
+4. **Use typed resumable events for HITL.** Business decisions, approvals, and technical escalations are resumable events with payloads and source refs.
+5. **Use group chat/reflection as internal review.** Multi-reviewer deliberation is a trust signal and evidence source, not a wall of agent debate in Business Mode.
+6. **Use tracing/evals as acceptance infrastructure.** Every runner/subagent path should emit traceable events that can be inspected in Power Mode and evaluated over time.
+
+## Design principles
+
+1. **Business users approve outcomes, not implementation.** The default approval object is a preview, screenshot walkthrough, and plain-English summary.
+2. **One coworker paradigm.** Build Studio uses the existing AI coworker experience. It does not create a second chat/terminal product.
+3. **One engine, two lenses.** Business Mode and Power Mode read the same build, event, artifact, and runner records.
+4. **No raw machinery by default.** Code, diffs, logs, terminal text, MCP calls, model names, IDs, and branch names are hidden unless the user opens technical details.
+5. **Structured events over raw output.** Runners emit normalized events. The UI does not parse stdout directly.
+6. **Skills and MCP remain capability substrate.** Business users see "I checked the backlog" or "I verified the screen", not `list_backlog_items` or `run_ux_test`.
+7. **Licensing-safe unattended automation.** API-native or provider-supported automation is the default for autonomous work; supervised CLI sessions are power-user tools.
+8. **Process is internal characterization.** The process matrix exists so Build Studio knows how to do the work; Business Mode shows progress, confidence, and requests for input, not the full internal machinery.
+9. **Autonomy is earned by low risk and low uncertainty.** Full autonomy is appropriate for low-risk, well-understood work. Higher risk, higher uncertainty, destructive change, customer-facing ambiguity, data migration, security impact, or weak evidence moves the build toward business decision gates or Power Mode review.
+10. **Projection over substrate replacement.** Build Studio events are a view-model projection over existing durable records, adapter/substrate events, Pseudo-User envelopes, and task lineage. They are not a new work-unit substrate.
+11. **Approvals use the Pseudo-User Contract.** Business questions can be lightweight UI events. Any delegated action, destructive action, phase advance, submission, or approval-sensitive continuation uses the Pseudo-User Contract envelope and audit path.
+
+## Personas and modes
+
+### Business Mode
+
+Default for install owners, line-of-business users, and non-developer administrators.
+
+Business Mode shows:
+
+- feature title and business goal
+- current plain-English step
+- simple confidence/process posture: `quick change`, `standard build`, `careful review`, or `needs your decision`
+- the one thing needed from the user, if any
+- business questions with answer choices
+- plan in plain English
+- live preview
+- screenshot walkthrough
+- "what changed" in business language
+- verification status as pass/fail/needs attention
+- approval actions: `Looks good`, `Change this`, `Pause`, `Ask a question`
+
+Business Mode hides by default:
+
+- `FB-*`, `WC-*`, branch names, commit hashes
+- workflow graph and node/task topology
+- specialist/task names unless summarized as trust signals
+- terminal output and raw logs
+- source code and diffs
+- MCP tool names and JSON payloads
+- provider/model names
+- cost/token detail
+- internal queue/fleet mechanics
+
+### Power Mode
+
+Available by role or explicit advanced toggle. Power Mode is not a new product.
+It is the technical lens over the same build.
+
+Power Mode shows:
+
+- existing workflow graph and anchored inspectors
+- compact fleet rail and queue state
+- selected process policy: work type, size, risk, uncertainty, visible phases, gates, review intensity, and autonomy level
+- details drawer
+- technical trace
+- runner selection and fallback state
+- active skills and MCP servers/tools
+- branch/worktree/session data
+- file diff and changed files
+- ToolExecution / BuildActivity / BuildDispatchAttempt records
+- terminal/PTY transcript when a CLI runner is used
+- verification logs and retry/fallback controls
+
+## User experience
+
+### Business Mode layout
+
+The Build Studio route keeps the existing AI coworker rail. The central build pane becomes artifact-first.
+
+```text
++--------------------------------------------------------------++
+|| Build title + simple status + advanced toggle               ||
++--------------------------------------------------------------++
+|| Current step: Understand | Decide | Build | Try it | Approve ||
++------------------------------++------------------------------++
+|| What I need from you         || Artifact pane                ||
+|| - business question          || - What we understood         ||
+|| - answer buttons             || - Live preview               ||
+|| - coworker summary           || - Screenshot walkthrough     ||
+||                              || - What changed               ||
+||                              || - Verification               ||
++------------------------------++------------------------------++
+|| Existing AI coworker rail remains the conversational surface ||
++--------------------------------------------------------------++
+```
+
+The current step labels are:
+
+| Internal phase | Business label | User meaning |
+| --- | --- | --- |
+| ideate | Understand | We are clarifying the outcome. |
+| plan | Decide | We are turning the outcome into a plan and resolving business choices. |
+| build | Build | We are making the change. |
+| review | Try it | We are checking the result and showing evidence. |
+| ship | Approve | You decide whether the result is ready. |
+
+### Process visibility and right-sizing
+
+The process is still real, but it is an internal operating model. Build Studio needs it because a typo fix, a small defect repair, a workflow change, and a large new capability should not all run the same playbook.
+
+This spec composes with `2026-05-30-build-studio-right-sizing-design.md`:
+
+- `workType` and `effortSize` select a `LifecyclePolicy`
+- `LifecyclePolicy` selects phases, gate evidence, prompt variant, and review intensity
+- `BusinessBuildBrief.riskProfile`, implementation uncertainty, data sensitivity, reversibility, and verification confidence select an autonomy level
+- Business Mode translates that into a plain posture, not a process diagram
+- Power Mode exposes the actual policy and all gates
+
+Business Mode examples:
+
+| Internal policy | Business Mode copy |
+| --- | --- |
+| `fix + small + low risk + high confidence` | "This looks like a quick fix. I can make it, check it, and show you the result." |
+| `feature + medium + standard risk` | "I will sketch the plan, ask about the business choices, then build a preview." |
+| `feature + large` or `xlarge` | "This is big enough to split into smaller builds before we start." |
+| `customer-facing + uncertain behavior` | "I need one decision from you before I build this." |
+| `data migration/security/destructive change` | "This needs careful review before I make changes." |
+
+### Autonomy levels
+
+Autonomy is separate from provider choice. Claude, Codex, Grok, and DPF-native runners all obey the same autonomy policy.
+
+| Level | When used | Business Mode behavior | Power Mode behavior |
+| --- | --- | --- | --- |
+| `explain_only` | unclear request, missing capability, no safe action yet | asks clarifying question or explains blocker | shows missing evidence/tool/provider |
+| `business_decision_required` | business ambiguity blocks a safe build | asks a plain-English question with choices | shows the gated decision and source evidence |
+| `bounded_autonomous` | moderate confidence; safe to make progress but pause before risky gates | builds/updates preview, then asks before approval-sensitive step | shows gates, runner trace, and rollback/retry options |
+| `full_autonomous_build` | low risk, low uncertainty, strong verification path | builds and verifies, then presents result for approval | shows why autonomy was allowed |
+| `power_review_required` | high risk, high uncertainty, destructive/data/security/cross-tenant impact | says a technical review is needed before continuing | routes to Power Mode/operator review |
+
+`full_autonomous_build` means the system can perform the build and verification work without interruption. It does not mean silent production shipment. Business users still approve the visible outcome unless a separate deployment policy explicitly permits automatic release.
+
+Autonomy must be derived once, then consumed everywhere.
+
+```ts
+export type BuildAutonomyLevel =
+  | "explain_only"
+  | "business_decision_required"
+  | "bounded_autonomous"
+  | "full_autonomous_build"
+  | "power_review_required";
+
+export type BuildAutonomyPolicy = {
+  level: BuildAutonomyLevel;
+  posture: "quick change" | "standard build" | "careful review" | "needs your decision";
+  reasons: string[];
+  requiredBusinessDecisions: Array<{
+    questionId: string;
+    prompt: string;
+    choices?: string[];
+  }>;
+  requiredPowerReviewReasons: string[];
+  approvalEnvelopeRequired: boolean;
+  runnerConstraints: Array<
+    | "api_supported_automation_only"
+    | "no_consumer_oauth_unattended"
+    | "canonical_runtime_verification_required"
+    | "power_mode_supervision_required"
+  >;
+};
+
+export function deriveBuildAutonomyPolicy(input: {
+  lifecyclePolicy: LifecyclePolicy;
+  businessBrief: BusinessBuildBrief | null;
+  processType: BuildProcessType;
+  processSize: BuildProcessSize;
+  verificationConfidence: "none" | "weak" | "standard" | "strong";
+  destructiveChange: boolean;
+  dataMigration: boolean;
+  securityImpact: boolean;
+  crossTenantImpact: boolean;
+  reversible: boolean;
+}): BuildAutonomyPolicy;
+```
+
+`deriveBuildAutonomyPolicy()` is the single source of truth for Business Mode posture, Power Mode gate reasons, runner constraints, and approval policy. The event projector may display its output; runners may enforce its output; neither may independently recalculate autonomy from local heuristics.
+
+### Business Mode primary cards
+
+| Card | Purpose |
+| --- | --- |
+| `BusinessQuestionCard` | A decision the user can answer without technical knowledge. |
+| `PlanSummaryCard` | Plain-English plan with optional "technical details" expansion. |
+| `PrototypeReadyCard` | Live preview or screenshot is ready. |
+| `ScreenshotWalkthroughCard` | Shows before/after or step-by-step screenshots. |
+| `PlainChangeCard` | "What changed" in business terms. |
+| `VerificationCard` | Checks passed/failed/blocked with non-technical explanations. |
+| `ApprovalCard` | Final outcome approval and change-request path. Approval-sensitive actions are backed by a `CoworkerActionEnvelope`, not a Build-Studio-only approval mechanism. |
+| `TechnicalTraceAvailableCard` | Small power-user affordance, hidden from default attention flow. |
+
+### Approval and human-in-the-loop integration
+
+Business Mode cards split into two classes:
+
+| Card class | Substrate |
+| --- | --- |
+| Informational cards (`PlanSummaryCard`, `PrototypeReadyCard`, `PlainChangeCard`, most `VerificationCard` states) | `BuildStudioEvent` projection only. |
+| Decision/action cards (`BusinessQuestionCard`, `ApprovalCard`, destructive/retry/phase-advance actions, "keep going" continuations) | Pseudo-User Contract screen action or `CoworkerActionEnvelope`, then projected back into `BuildStudioEvent`. |
+
+This preserves one approval/audit path across the platform. Business Mode may make the card feel simpler, but the underlying action still carries delegating user, coworker agent, thread, envelope, source refs, and outcome.
+
+### Power Mode relationship
+
+Power Mode can be opened from:
+
+- a role-gated `Advanced` toggle in Build Studio
+- a technical details drawer from any business card
+- operator/support routes
+
+Power Mode authorization is a product decision in this spec, not an implementation afterthought:
+
+- `view_platform` remains sufficient to reach platform/operator routes where Build Studio appears.
+- `operate_build_studio_power_mode` is required to open Power Mode controls, runner/session state, retry/fallback controls, and terminal/session intervention.
+- `view_build_studio_trace` is required to open raw technical trace material: terminal transcript, raw logs, MCP payloads, provider/model identifiers, source diffs, command output, and cost/token detail.
+- Superusers inherit both capabilities through the normal `PERMISSIONS` path.
+- If these capabilities do not exist when implementation starts, Phase 0 adds them to the canonical permissions registry and agent-grant mapping before any UI toggle ships.
+- Opening raw trace material writes an authority/audit record with user, build, trace ref, reason surface, and timestamp. Summary-level Power Mode panels can render without a trace-view audit row; raw transcript/log/diff/payload access cannot.
+
+Power Mode should default back to Business Mode for non-developer roles on later sessions unless the role grants advanced Build Studio operation.
+
+## Event contract
+
+Build Studio needs a provider-neutral event vocabulary, but this vocabulary is a projection boundary, not a new durable workflow engine.
+
+`BuildStudioEvent` is derived from:
+
+- durable Build Studio records (`FeatureBuild`, `BuildActivity`, `BuildArtifactRevision`, `BuildPhaseRun`, etc.)
+- Pseudo-User Contract envelopes for delegated approvals and screen actions
+- normalized adapter/substrate events from the CLI/routing and coworker-substrate layers
+- `TaskRun`/`TaskNode`/`AgentThread` lineage where a build uses internal handoff, specialist, or multi-agent execution
+
+The existing DOM `CustomEvent` bridge in `apps/web/lib/build-events.ts` remains a local sibling-component bridge during migration. It is not the durable event contract and should be treated as a UI transport detail.
+
+### Type shape
+
+```ts
+export type BuildStudioAudience = "business" | "power" | "audit";
+
+export type BuildStudioEventKind =
+  | "intake_received"
+  | "capability_check"
+  | "process_policy_selected"
+  | "autonomy_policy_selected"
+  | "business_question"
+  | "plan_summary"
+  | "progress_summary"
+  | "prototype_ready"
+  | "screenshot_captured"
+  | "plain_change"
+  | "verification_step"
+  | "approval_request"
+  | "blocked"
+  | "handoff_ready"
+  | "technical_trace_available";
+
+export type BuildStudioSourceRef =
+  | { type: "feature_build"; id: string }
+  | { type: "business_brief"; id: string }
+  | { type: "build_activity"; id: string }
+  | { type: "tool_execution"; id: string }
+  | { type: "dispatch_attempt"; id: string }
+  | { type: "artifact_revision"; id: string }
+  | { type: "phase_run"; id: string }
+  | { type: "runtime_verification"; id: string }
+  | { type: "assurance_run"; id: string }
+  | { type: "coworker_action_envelope"; id: string }
+  | { type: "task_run"; id: string }
+  | { type: "task_node"; id: string }
+  | { type: "agent_thread"; id: string }
+  | { type: "adapter_event"; id: string }
+  | { type: "runner_trace"; id: string };
+
+export type BuildStudioArtifactRef = {
+  type: "preview" | "screenshot" | "walkthrough" | "diff" | "log" | "trace";
+  label: string;
+  href?: string;
+  storageKey?: string;
+};
+
+export type BuildStudioEventPayloads = {
+  intake_received: { businessOutcome: string; source: "direct" | "backlog" | "issue" | "coworker" };
+  capability_check: { label: string; status: "passed" | "blocked" | "unknown" };
+  process_policy_selected: { policyLabel: string; type: BuildProcessType; size: BuildProcessSize };
+  autonomy_policy_selected: BuildAutonomyPolicy;
+  business_question: { questionId: string; prompt: string; choices?: string[]; envelopeId?: string };
+  plan_summary: { bullets: string[]; confidence: "low" | "medium" | "high" };
+  progress_summary: { state: "working" | "possibly_stalled" | "waiting" | "done"; message: string };
+  prototype_ready: { previewUrl?: string; screenshotRef?: string };
+  screenshot_captured: { screenshotRef: string; caption: string };
+  plain_change: { changes: string[]; userImpact: string };
+  verification_step: { label: string; status: "passed" | "failed" | "blocked" | "skipped"; explanation: string };
+  approval_request: { envelopeId: string; prompt: string; approveLabel: string; rejectLabel: string };
+  blocked: { blockerKind: "business_input" | "power_review" | "tooling" | "provider" | "verification"; message: string };
+  handoff_ready: { from: string; to: string; reason: string; taskRunId?: string; agentThreadId?: string };
+  technical_trace_available: { traceId: string; traceKind: "cli-transcript" | "api-transcript" | "tool-ledger" };
+};
+
+export type BuildStudioEvent<K extends BuildStudioEventKind = BuildStudioEventKind> = {
+  id: string;
+  buildId: string;
+  createdAt: string;
+  kind: K;
+  audience: BuildStudioAudience;
+  title: string;
+  summary: string;
+  payload: BuildStudioEventPayloads[K];
+  artifactRefs?: BuildStudioArtifactRef[];
+  sourceRefs: BuildStudioSourceRef[];
+};
+```
+
+The implementation should encode the payload registry as TypeScript types plus runtime validators. Business-audience events must pass a sanitizer that rejects raw internal IDs, branch names, provider/model names, terminal excerpts, raw tool names, command strings, JSON payload dumps, and raw MCP arguments.
+
+### Event sourcing strategy
+
+Do not add a new table in Slice 1.
+
+Create a projector under `apps/web/lib/build-studio/events/` that derives `BuildStudioEvent[]` from existing durable sources:
+
+- `FeatureBuild`
+- `BusinessBuildBrief`
+- `BuildActivity`
+- `BuildDispatchAttempt`
+- `BuildArtifactRevision`
+- `BuildPhaseRun`
+- `ToolExecution`
+- `RuntimeVerification`
+- `AssuranceRun`
+- `WorkCapsuleActivity`
+- `CoworkerActionEnvelope`
+- `TaskRun`
+- `TaskNode`
+- `AgentThread`
+
+The projector owns three separable responsibilities:
+
+1. **Projection.** Convert durable records, adapter/substrate events, and task lineage into `BuildStudioEvent` values.
+2. **Redaction.** Produce business-safe text and payloads for `audience = "business"`.
+3. **Lineage.** Preserve enough source refs that Power Mode and audit views can reconstruct the technical path without exposing it by default.
+
+If the projector becomes expensive or lossy, Slice 2 may extend `BuildActivity` with nullable envelope fields instead of creating a parallel event table:
+
+```prisma
+model BuildActivity {
+  // existing fields retained
+  eventKind  String?
+  audience   String?
+  payload    Json @default("{}")
+  sourceRefs Json @default("[]")
+}
+```
+
+That extension is allowed only after the typed event registry and validators exist. `eventKind` and `audience` remain string columns in Prisma for migration flexibility, but application code treats them as closed unions. Any new event kind must update the registry, validator, projector tests, and business-redaction tests in the same change.
+
+That keeps `BuildActivity` as the single Build Studio activity stream instead of introducing a competing durable record. `TaskRun` remains the task/handoff substrate; `CoworkerActionEnvelope` remains the approval substrate; `BuildStudioEvent` remains the Build Studio view model over those records.
+
+## Runner abstraction
+
+### Runner IDs
+
+Extend the existing runner ID union:
+
+```ts
+export type BuildAgentId =
+  | "codex"
+  | "claude"
+  | "grok"
+  | "dpf-native";
+```
+
+### Runner result
+
+Extend `AgentRunResult` so every runner can return normalized technical events and trace references. Runners do not author business-facing `BuildStudioEvent` records directly; the Build Studio projector converts normalized runner/substrate events plus durable records into business, power, and audit views.
+
+```ts
+export type RunnerNormalizedEvent = {
+  kind:
+    | "message"
+    | "tool"
+    | "artifact"
+    | "approval"
+    | "plan"
+    | "todo"
+    | "subagent"
+    | "hook"
+    | "health";
+  emittedAt: string;
+  summary: string;
+  payload: Record<string, unknown>;
+  taskRunId?: string;
+  taskNodeId?: string;
+  agentThreadId?: string;
+};
+
+export type AgentRunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  toolExecutionId: string;
+  agentId: BuildAgentId;
+  providerId: BuildExecutionProviderId;
+  normalizedEvents?: RunnerNormalizedEvent[];
+  technicalTraceRef?: {
+    kind: "cli-transcript" | "api-transcript" | "tool-ledger";
+    storageKey?: string;
+    toolExecutionId?: string;
+    dispatchAttemptId?: string;
+    taskRunId?: string;
+    agentThreadId?: string;
+  };
+};
+```
+
+For CLI-backed runners, `normalizedEvents` should be produced by the same adapter-normalization family used by the coworker CLI routing substrate whenever practical. Build Studio may add build-specific source refs, but it should not create a second parser for Claude/Codex/Grok streams if the routing adapter already knows how to normalize them.
+
+### Capability context
+
+Every runner receives a capability bundle assembled by Build Studio:
+
+```ts
+export type BuildCapabilityContext = {
+  skills: Array<{ skillId: string; name: string; summary: string }>;
+  mcpTools: Array<{ name: string; grant: string; businessLabel: string }>;
+  toolGrants: string[];
+  repoInstructionsDigest: string;
+  buildPolicyDigest: string;
+  lifecyclePolicy: LifecyclePolicy;
+  autonomyPolicy: BuildAutonomyPolicy;
+  currentBusinessBrief?: BusinessBuildBrief;
+};
+```
+
+Business Mode never renders this directly. It turns this into user-facing claims like:
+
+- "I checked the current backlog item."
+- "I used the build verification tools."
+- "I found one setup question before I build."
+
+Power Mode can inspect the actual skills, MCP servers, grants, and tool calls.
+
+### Provider policy
+
+| Runner | Business Mode default? | Power Mode? | Notes |
+| --- | --- | --- | --- |
+| `dpf-native` | Yes, target default for unattended governed builds. | Yes. | Uses DPF inference/tooling/audit directly. |
+| `codex` | Yes, where configured and allowed. | Yes. | Treat as runner adapter; usage counts against relevant plan/API limits. |
+| `claude` | API-key/API-native preferred for unattended automation. | Yes. | Claude Code CLI can remain excellent for supervised/power-user work. Do not make consumer subscription OAuth automation the product default. |
+| `grok` | Yes, via API-key/provider-supported automation once approved. | Yes. | Add as first-class runner behind same event contract. |
+
+## Technical trace model
+
+The technical trace is not the product. It is evidence and support material.
+
+Trace sources include:
+
+- CLI transcript
+- API/tool transcript
+- MCP calls
+- file diffs
+- dispatch attempts
+- verification logs
+- ToolExecution rows
+- WorkCapsule activity
+
+Business Mode shows only `technical_trace_available` when useful. Power Mode opens the trace.
+
+For CLI/PTY sessions, use the existing `AgentThread.cliSession*` substrate and add a `CliSessionService`-backed gateway. The gateway captures transcript and status, but does not expose the terminal to business users.
+
+Computer-use automation is acceptable for QA/recovery/operator-assist. It is not the default Build Studio product substrate because it is brittle, hard to audit, and too close to recreating hidden UI automation around tools that already expose CLI/API surfaces.
+
+## Data and component mapping
+
+| Business Mode need | Existing source | Notes |
+| --- | --- | --- |
+| Business outcome | `BusinessBuildBrief.businessOutcome`, `FeatureBuild.title/description` | Already present. |
+| Business questions | `BusinessBuildBrief.openQuestions`, future event payloads | Render as choices in coworker rail. |
+| Current step | `FeatureBuild.phase`, `BuildFlowState`, `BuildPhaseRun` | Collapse to five business labels. |
+| Process posture | right-sizing `LifecyclePolicy`, `BusinessBuildBrief.riskProfile`, `deriveBuildAutonomyPolicy()` | Business Mode shows a simple posture; Power Mode shows policy detail. |
+| Plain plan | `FeatureBuild.designDoc`, `FeatureBuild.buildPlan`, `planReview` | Summarize, do not show raw JSON. |
+| Preview | `Sandbox.previewUrl`, `sandboxPort`, `RuntimeTarget` | Label as Live Preview, not sandbox. |
+| Screenshot walkthrough | `uxTestResults`, browser evidence | Promote from detail drawer into artifact pane. |
+| What changed | `diffSummary`, `BuildArtifactRevision`, migrations | Business summary first; diff in Power Mode. |
+| Verification | `verificationOut`, `uxVerificationStatus`, `RuntimeVerification`, `AssuranceRun` | Show pass/fail/business risk. |
+| Approval and HITL | `CoworkerActionEnvelope`, Pseudo-User `screen_*` actions, `ToolExecution.envelopeId` | Business Mode renders simple approval cards; audit path stays platform-wide. |
+| Handoff and specialist lineage | `TaskRun`, `TaskNode`, `AgentThread.parentThreadId`, `BuildDispatchAttempt` | Business Mode summarizes ownership changes; Power Mode shows lineage. |
+| Technical trace | `ToolExecution`, `BuildDispatchAttempt`, `BuildActivity`, runner transcript | Power Mode only. |
+| Skills/MCP | `SkillDefinition`, runtime skill usage, `ToolExecution.skillId`, tool grants | Power Mode detail; business claims in summaries. |
+
+## Implementation plan
+
+### Phase 0 - ratify product boundary
+
+- Mark this spec as the governing amendment to the April 25 and May 20 Build Studio UX specs.
+- Decide that Business Mode is the default route experience.
+- Decide that the May 20 workflow-primary canvas becomes Power Mode.
+- Do not create a new epic. Extend the existing Build Studio UX and Build Studio platform epics.
+- Ratify that Business Mode approvals compose with the Pseudo-User Contract, not a Build-Studio-only approval channel.
+- Ratify that `TaskRun`/`TaskNode`/`AgentThread` remain the handoff and specialist-lineage substrate.
+- Add `operate_build_studio_power_mode` and `view_build_studio_trace` to the canonical permissions registry and agent-grant mapping if they are not already present.
+
+### Phase 1 - mode resolver and component split
+
+- Rename or wrap the current `apps/web/components/build/BuildStudio.tsx` implementation as `PowerBuildStudio` internally.
+- Add `BusinessBuildStudio` as the default renderer.
+- Add a `resolveBuildStudioExperienceMode(user, route, preference)` helper.
+- Use role/grant/pref to expose Power Mode, with `operate_build_studio_power_mode` for controls and `view_build_studio_trace` for raw trace.
+- Preserve the current route and active build selection.
+
+Acceptance:
+
+- non-developer role lands in Business Mode
+- platform operator can switch to Power Mode
+- users without `operate_build_studio_power_mode` cannot open controls even if they can view platform routes
+- users without `view_build_studio_trace` cannot open raw logs/transcripts/diffs/payloads
+- no build data is duplicated
+- active build/coworker thread routing still works
+
+### Phase 2 - normalized event projector
+
+- Add `apps/web/lib/build-studio/events/types.ts`.
+- Add `apps/web/lib/build-studio/events/project-build-studio-events.ts`.
+- Add runtime validators for every `BuildStudioEventKind` payload.
+- Project events from existing `FeatureBuild`, `BusinessBuildBrief`, `BuildActivity`, `BuildDispatchAttempt`, `ToolExecution`, `BuildArtifactRevision`, `BuildPhaseRun`, `RuntimeVerification`, `AssuranceRun`, `CoworkerActionEnvelope`, `TaskRun`, `TaskNode`, and `AgentThread` rows.
+- Project `process_policy_selected` from the right-sizing matrix.
+- Project `autonomy_policy_selected` only from `deriveBuildAutonomyPolicy()`.
+- Add sanitizers that reject raw tool names, raw IDs, provider names, branch names, and terminal output for `audience = "business"`.
+- Keep the existing DOM event bridge as UI transport only; do not treat it as the durable event source.
+
+Acceptance:
+
+- every active build produces a business event stream
+- every active build has a business-safe process posture and power-mode policy detail
+- every event payload validates against the event-kind registry
+- no business event summary contains `FB-`, `WC-`, raw branch names, `reviewBuildPlan`, `saveBuildEvidence`, provider IDs, or command output
+- power/audit events retain source refs for traceability
+- events linked to approvals carry `CoworkerActionEnvelope` source refs
+- multi-agent/specialist events carry `TaskRun`/`TaskNode`/`AgentThread` lineage when present
+
+### Phase 3 - Business Mode artifact-first UI
+
+- Reuse `BusinessBriefPanel`, `ArtifactPane`, `PreviewFrame`, and card components from `apps/web/components/build-studio/`.
+- Replace duplicate chat with card renderers inside the existing AI coworker shell.
+- Add Business Mode center sections: current step, what I need from you, live preview, walkthrough, what changed, verification, approval.
+- Render `BusinessQuestionCard` and `ApprovalCard` from Pseudo-User decisions/envelopes where action or continuation authority is involved.
+- Show process status as posture copy, not a workflow graph: quick change, standard build, careful review, needs your decision.
+- Rename "sandbox" to "Live preview".
+- Hide graph/fleet/details unless advanced mode is active.
+
+Acceptance:
+
+- a user can start a build from plain language without seeing branch/build/capsule IDs
+- user sees a clear "working / needs you / ready to try / ready to approve" state
+- user can understand whether the system is acting autonomously, asking a business question, or waiting for power-user review
+- preview and screenshots are first-class artifacts
+- business approvals are auditable through the same Pseudo-User Contract path as other coworker-driven actions
+- graph is not visible by default in Business Mode
+
+### Phase 4 - Power Mode cockpit
+
+- Keep the current graph-first implementation and make it explicitly Power Mode.
+- Add a technical trace drawer fed by source refs from the event projector.
+- Add runner/session panel: active runner, provider, auth mode, session ID, CLI/API mode, skills, MCP tools, grants.
+- Add process/autonomy panel: work type, size, risk, uncertainty, selected lifecycle, allowed autonomy, and gate reasons.
+- Add task/handoff lineage panel: parent/child `AgentThread`, `TaskRun`, `TaskNode`, specialist owner, and handoff reason.
+- Wire existing dispatch history, ToolExecution, BuildActivity, and verification logs into this drawer.
+- Audit every raw trace open.
+
+Acceptance:
+
+- Mark/operator can inspect everything currently available
+- runner/provider state is inspectable without leaking to Business Mode
+- technical trace is role-gated
+- raw trace access writes an authority/audit row
+- handoff lineage is inspectable without adding a second task graph
+
+### Phase 5 - runner event contract
+
+- Extend `BuildAgentId` with `"grok"`.
+- Extend `AgentRunSpec` with `capabilityContext`.
+- Extend `AgentRunResult` with normalized runner events and trace refs.
+- Update Codex and Claude runners to emit normalized runner events even if they still capture stdout/stderr.
+- Reuse CLI/routing adapter event normalizers where available rather than creating Build-Studio-only parsers.
+- Add Grok runner skeleton behind feature/provider availability.
+- Keep `dpf-native` as strategic unattended path.
+
+Acceptance:
+
+- Claude, Codex, Grok, and DPF-native can all satisfy the same UI event contract
+- swapping runner does not change Business Mode UX
+- stdout/stderr never flows directly into Business Mode
+- runner output is projected into `BuildStudioEvent` by the projector, not rendered directly
+
+### Phase 6 - supervised CLI session support
+
+- Implement or finish `CliSessionService` around `AgentThread.cliSession*`.
+- Capture CLI transcripts as technical traces.
+- Allow Power Mode operator intervention where policy permits.
+- Link supervised sessions to `AgentThread` and `TaskRun` lineage when present.
+- Do not drive Claude/Codex/Grok TUI through computer-use for normal product automation.
+
+Acceptance:
+
+- a power user can inspect/resume a supervised session
+- a business user sees only progress, questions, artifacts, and approvals
+- transcript is stored as trace evidence, not conversation copy
+
+### Phase 7 - cleanup and dogfood hardening
+
+- Remove or hide default displays of internal IDs, branch chips, provider/model chips, and tool names.
+- Rename remaining user-facing "sandbox" copy to "Live preview" unless the user is in Power Mode.
+- Replace "reviewBuildPlan" and similar tool names with business copy.
+- Hide minimap and code-intel/assurance rows in Business Mode unless actionable.
+- Add a wife-test/Dale-test QA script.
+
+Acceptance:
+
+- Business Mode can complete the Dale truck-stock flow without technical leakage
+- Power Mode still exposes all audit and debugging detail
+- small fixes can take a visibly lighter path than medium/large features
+- low-risk/low-uncertainty changes can proceed through autonomous build/verification while preserving final outcome approval
+- no duplicate command/status spine is introduced
+
+## Backlog mapping
+
+Use existing live epics rather than creating a new one:
+
+- `EP-BUILD-STUDIO-UX`: Business Mode / Power Mode UX split.
+- `EP-BUILD-STUDIO`: runner event contract, orchestration, progress visibility, task routing.
+- `EP-9FC5D2FD`: Dale/persona leakage and first-customer simplification defects.
+- `EP-GROK-001`: Grok runner/provider-specific work.
+- `EP-COWORKER-INTERACTIVITY`: Pseudo-User Contract envelopes, screen actions, and delegated approval audit.
+- `EP-A2A`: task/handoff lineage and agent-to-agent projection work.
+
+Recommended backlog slices:
+
+1. Business Mode shell and mode resolver.
+2. Power Mode permission capabilities and trace-view audit.
+3. Normalized Build Studio event projector with typed payload validators.
+4. Process posture and canonical autonomy policy derivation.
+5. Pseudo-User-backed Business Mode question/approval cards.
+6. Business artifact pane and coworker card renderers.
+7. Power Mode technical trace, task lineage, and runner cockpit.
+8. Runner normalized-event contract and adapter-normalizer reuse.
+9. Grok runner adapter and provider gate.
+10. CLI session trace capture for supervised power-user mode.
+11. Business-mode leakage cleanup and Dale/wife-test QA.
+
+## Acceptance criteria
+
+### Product acceptance
+
+- A non-developer can create a new platform capability from plain language.
+- The system asks only business-understandable questions on the default path.
+- The user can inspect the result through preview and screenshots.
+- The user can request changes conversationally.
+- The user can approve based on outcome evidence.
+- The user can tell whether Build Studio is working autonomously, waiting for a business decision, or paused for technical review.
+- Approval-sensitive actions are visible as simple Business Mode cards while remaining auditable through Pseudo-User Contract envelopes.
+- The default experience contains no raw code, terminal output, branch names, internal IDs, model names, tool names, or JSON payloads.
+
+### Engineering acceptance
+
+- Business Mode and Power Mode read the same build records.
+- The event projector has typed payload validators and tests for redacting business-inappropriate content.
+- Process/right-sizing policy is projected from the lifecycle matrix.
+- Autonomy policy is projected from `deriveBuildAutonomyPolicy()` and consumed by both UI and runners.
+- Current graph/details/dispatch functionality remains available in Power Mode.
+- Runner adapters emit the same normalized runner-event contract.
+- Build Studio projects runner/substrate events into `BuildStudioEvent`; runners do not render business events directly.
+- All runner traces remain available for audit/debugging.
+- Raw technical trace access is role-gated and audited.
+- Pseudo-User Contract remains the delegated approval substrate.
+- `TaskRun`/`TaskNode`/`AgentThread` lineage is preserved for handoffs and multi-agent work.
+- Build Studio still uses the existing AI coworker rail and route context.
+
+### Licensing/provider acceptance
+
+- Claude unattended automation uses provider-approved API/API-key paths, not consumer subscription OAuth as the default product substrate.
+- Codex is treated as a runner with plan/API usage constraints, not as a UI dependency.
+- Grok is treated as a runner with API-key/provider-supported operation.
+- Provider choice never changes the Business Mode interaction model.
+
+## Open questions
+
+1. Should Business Mode and Power Mode be a user preference or route query (`?mode=power`) with preference memory?
+2. Should Slice 2 extend `BuildActivity`, or is a derived projector sufficient long-term once projector cost is measured?
+3. What is the first mandatory wife-test scenario: Dale truck stock, customer appointment request, or platform self-upgrade UX?
+4. What exact threshold promotes a build from `bounded_autonomous` to `full_autonomous_build`: confidence score, risk band, verification coverage, or a composite?
+5. Should `deriveBuildAutonomyPolicy()` live beside the right-sizing matrix under `apps/web/lib/explore/`, or in a Build-Studio-specific policy module under `apps/web/lib/build-studio/policy/`?
+
+## Non-goals
+
+- No separate terminal product for business users.
+- No new route that bypasses the existing AI coworker paradigm.
+- No removal of existing operational Build Studio capabilities.
+- No hidden computer-use automation as the default integration strategy.
+- No provider-specific UX forks.

--- a/docs/superpowers/specs/2026-06-02-dpf-client-hook-plane-design.md
+++ b/docs/superpowers/specs/2026-06-02-dpf-client-hook-plane-design.md
@@ -1,0 +1,283 @@
+---
+title: DPF client-side governance plane — Phase 1 (β-bundle) six-event lifecycle hook bundle
+status: draft-for-operator-review
+author: Claude (Opus 4.8)
+reviewers:
+  - Mark (operator review pending)
+date: 2026-06-02
+backlog:
+  - BI-A56D77B6 (parent — this spec)
+epics:
+  - EP-CLIENT-HOOK-PLANE
+related:
+  - scripts/hooks/run-hook.mjs
+  - .claude/settings.json
+  - .claude/settings.local.json.example
+  - apps/web/lib/mcp-governed-execute.ts
+  - apps/web/lib/tak/agent-grants.ts
+  - apps/web/lib/agent-coworker-context.ts
+  - AGENTS.md
+related_backlog:
+  - "BI-0F7C7464 (DONE, PR #1281 — cross-platform hook launcher this spec builds on)"
+  - "BI-A56D77B6 (parent BI requesting this spec)"
+  - "BI-E1FB2307 (Phase-2 γ-upgrade blocker — Decision Perspective Gate consolidation)"
+  - "BI-5FE9DF99 (sibling — MCP tool-surface audit; different plane, complementary work)"
+  - "BI-CE49D82E (PR #1367 — Build Studio design-review iteration tracking; informs why Slice 1 routes direct rather than via BS)"
+kernel_consultations:
+  - "callingSurface=slice-1-client-hook-plane-design (2026-06-02): γ-population-aware destination ratified, composite 6.05, margin 0.66, HIGH confidence. β-then-γ phasing."
+  - "callingSurface=slice-1-epic-selection (2026-06-02): new EP-CLIENT-HOOK-PLANE ratified vs fold-under alternatives, composite 5.54, margin 1.09, HIGH confidence."
+prs: []
+---
+
+# DPF client-side governance plane — Phase 1 spec
+
+## Execution note (operator decision, 2026-06-02)
+
+**This work is done directly in this repo, not promoted to Build Studio.** Build Studio's design-review loop is currently fragile (BI-CE49D82E iteration tracking landed in PR #1367 but is still in-flight; agentic-loop sticky-veto deadlock BI-6FE34236 remains open). Per memory rule [[build-studio-down-route-direct-pr]], routing this spec directly is the safer choice. Build Studio testing is deferred to a lower-stakes BI once the iteration-tracking fix is merged. Claude authors the spec directly; the normal BS Ideate→Build→Verify gates are replaced by operator review of this spec plus the per-event acceptance criteria below.
+
+## Purpose
+
+DPF has two governance planes by deliberate architectural choice: the **server-side tool boundary** (`apps/web/lib/mcp-governed-execute.ts` + `apps/web/lib/tak/agent-grants.ts`) covers MCP tool calls; the **client-side lifecycle** (Claude Code hooks via `scripts/hooks/run-hook.mjs`) covers everything else — `Edit`, `Write`, `Bash`, `Read`, `SessionStart`, `PreCompact`, `Stop`. The server boundary is strong; the client boundary today wires only `PostToolUse` and `SessionEnd` (both forwarding to a single `safety/transcript-snapshot` script). This leaves the rest of the client lifecycle blind to client-side guards.
+
+Phase 1 (this spec) extends the client plane to a full six-event lifecycle bundle, deliberately framed as **the second governance plane**, not as ad-hoc convenience scripts. Phase 2 (γ-upgrade, separate spec) later wires `agent-coworker-context` through and routes ambiguous decisions through the Decision Perspective Gate.
+
+## Phase-1 invariants (★ kernel-ratified)
+
+These are non-negotiable for Phase 1. Phase 2 lifts each as appropriate.
+
+1. **Contributor-scope only.** Slice 1 hooks fire strictly under `in_platform_coworker` sessions on DPF contributor machines. They MUST NOT be installed into customer-coworker (in-portal) sessions until Phase 2 lands. Phase 1 enforces this by **not being part of the customer install profile** — hooks live in the contributor `.claude/settings.json`, never in any path the customer install touches.
+2. **No `principle_decide` calls from the hook layer.** WWMD/WWWD lane purity per AGENTS.md §16: until BI-E1FB2307 consolidates the Decision Perspective Gate, hooks must not invoke the kernel directly. Hooks remain population-blind.
+3. **Hook blocks emit `ToolExecution` rows.** Every block is auditable on equal footing with other governed tool calls. Blocks write a row via the same governance ledger `mcp-governed-execute` writes to (DPF MCP, not raw DB) — see §"Telemetry contract" below.
+4. **Inline scripts, not skill shims.** Each hook is a `scripts/governance/<name>.{ps1,sh}` script invoked by the existing `run-hook.mjs` launcher. Promotion to a DPF skill (`dpf-config-protection`, etc.) only happens when the pattern repeats across ≥3 hooks. Phase 1 has no skills.
+5. **Claude-Code-only Phase 1.** Cross-harness reach (Codex, Cursor) is Slice 2 under a future separate epic. This spec does not block on harness portability.
+6. **Launcher-contract amendment is explicit.** `run-hook.mjs` today exits 0 ALWAYS. Phase 1 requires a documented `BLOCK` mode for `PreToolUse:*` events — see §"Launcher contract amendment" below. Existing PostToolUse/SessionEnd behavior must not change.
+
+## Substrate this spec extends
+
+| Surface | Path | What's there today | What this spec adds |
+|---|---|---|---|
+| Launcher | `scripts/hooks/run-hook.mjs` | Node launcher, exit 0 ALWAYS, dispatches to per-OS sibling | Block-mode amendment (non-zero exit propagation for PreToolUse) |
+| Settings | `.claude/settings.json` | PostToolUse + SessionEnd → `safety/transcript-snapshot` | Six new hook wirings (see below) |
+| Hook scripts | `scripts/safety/transcript-snapshot.{ps1,sh}` | One existing hook script | Six new `scripts/governance/<name>.{ps1,sh}` pairs |
+| Telemetry | `mcp__dpf__record_tool_execution` (via MCP) | Server-side tool-call rows | Hook-block rows tagged `source=client-hook` |
+
+Nothing in `apps/web/` changes for Phase 1. All the work is in `scripts/`, `.claude/`, plus a documentation update to `AGENTS.md` adding the client-plane framing.
+
+## Launcher contract amendment
+
+The current launcher contract: missing target / spawn error / non-zero child exit ALL resolve to exit 0. That contract is correct for PostToolUse/SessionEnd snapshot hooks (you never want a transcript-snapshot failure to break a tool call).
+
+PreToolUse hooks need the opposite for block decisions: a non-zero exit from the child script must reach Claude Code so the tool call is blocked. The launcher amendment is narrow:
+
+- A new optional CLI flag `--may-block` makes the launcher propagate the child's non-zero exit. Without the flag, current behavior holds.
+- The flag is opt-in per hook in `settings.json`. Existing PostToolUse + SessionEnd wirings get no flag (no behavior change).
+- The launcher continues to exit 0 on missing target / spawn error / traversal — only the *legitimate child non-zero exit* propagates. (A missing PreToolUse hook script must not silently block; it must no-op.)
+
+This keeps the launcher's "never break a workflow accidentally" guarantee while enabling deliberate blocks.
+
+## The six events
+
+Each event has a fixed contract: pass/fail definition, install path, telemetry shape, test plan, and the kernel principle it enforces.
+
+### 1. PreToolUse: config-protection
+
+**Purpose.** Block `Edit` / `Write` operations targeting CI-meaningful config files. Today these only fail in CI — hours after the change. The hook turns the failure pre-run.
+
+**Targets (Phase 1 closed list).** `.eslintrc*`, `.prettierrc*`, `tsconfig.json` (and `tsconfig.*.json`), `package.json` (only the `dependencies` / `devDependencies` / `peerDependencies` / `scripts` keys), `pnpm-workspace.yaml`, `turbo.json`, `.github/workflows/*.yml`.
+
+**Pass/fail contract.**
+- **Pass (exit 0)**: target file is not in the closed list, OR target file is in the list but the proposed edit is a comment-only / formatting-only change (Phase 2 may relax further; Phase 1 keeps it strict).
+- **Block (exit 1)**: target file is in the closed list and the edit changes substantive content. The hook prints a one-line operator-facing message: `BLOCKED: <path> is governance-protected — file BI or use --override-config-protection to acknowledge`.
+- **Override.** Setting env var `DPF_HOOK_ALLOW_CONFIG_EDIT=1` for the session bypasses the block (with a `governance.override` row written). Operator escape hatch; not for routine use.
+
+**Install path.** `scripts/governance/config-protection.{ps1,sh}` invoked by `run-hook.mjs --may-block governance/config-protection`. Settings.json wiring matches PreToolUse with `matcher: "Edit|Write"`.
+
+**Telemetry.** On block, write `record_tool_execution(toolName="hook:config-protection", status="blocked", details={path, reason, override_available: true})` via the DPF MCP tool. On override, write `status="override"`.
+
+**Test plan.**
+- Unit (vitest): `scripts/governance/config-protection.test.ts` — table-driven cases for protected-path / non-protected-path / override / comment-only-edit.
+- Integration: a fixture `.claude/settings.json` with the hook wired, run via the `run-hook.mjs` launcher harness; assert exit codes match the contract.
+- Functional: opening Claude Code in a worktree, attempting `Edit` on `.eslintrc.json`, asserting the block fires.
+
+**Kernel principle citation.** `architecture-over-shortcuts` (CI failures are a shortcut; pre-run blocks are the architecture). `evidence-before-diagnosis` (a config-edit block is itself evidence the contributor needs to file a BI).
+
+---
+
+### 2. PreToolUse: bash-allowlist-validator
+
+**Purpose.** Content-based Bash gate beyond static permission rules. Catches BSD-vs-GNU sed footguns (`sed -i` without `''`), `git` without `--no-pager`, `rm -rf` outside the worktree, `npm install` (DPF is pnpm-only), `git config` modifications, etc. — patterns DPF has hit repeatedly per memory ([[bsd-sed-gnu-portability]], [[macos-first-run-cross-platform]]).
+
+**Pass/fail contract.**
+- **Pass**: Bash command matches none of the closed deny-patterns AND is on an allow-list of common forms (or matches a pattern the operator has approved via `DPF_HOOK_BASH_OVERRIDE`).
+- **Block**: command matches a deny-pattern. Hook prints `BLOCKED: <pattern-name> — <one-line explanation> — see <kernel-rule-or-memory-link>`.
+
+**Deny-pattern closed list (Phase 1).** `sed -i ''` missing (macOS BSD sed), `git` invocations missing `--no-pager` for query commands (per AGENTS.md), `rm -rf /`, `rm -rf ~`, any `rm -rf` outside `$CLAUDE_PROJECT_DIR`, `npm install` / `yarn install` (DPF is pnpm), `git config --global`, `chmod 777`, curl piped to sh.
+
+**Install path.** `scripts/governance/bash-allowlist.{ps1,sh}` with `run-hook.mjs --may-block governance/bash-allowlist`. Matcher: `"Bash"`.
+
+**Telemetry.** Block writes `toolName="hook:bash-allowlist"`, `details={command, pattern, suggestion}`. The hook's own block message is reused in the row's `details.suggestion`.
+
+**Test plan.**
+- Unit: table-driven cases per deny-pattern.
+- Integration: a fixture invocation harness routes synthetic Bash payloads through the hook.
+- Functional: a known-bad pattern (e.g. `sed -i 's/foo/bar/' file`) blocks; same with `sed -i '' 's/foo/bar/' file` passes.
+
+**Kernel principle citation.** `never-assume-verify` (verify the command shape before letting it run). `never-fabricate` (a broken `sed -i` produces fabricated state).
+
+---
+
+### 3. SessionStart: memory-load
+
+**Purpose.** Auto-load DPF memory + recent backlog context at session start so the operator doesn't manually re-orient. Solves the "every fresh session re-reads MEMORY.md by hand" pattern.
+
+**Pass/fail contract.**
+- **Pass (always — this is a load, not a block)**: prints a one-screen context summary to stdout, which Claude Code surfaces as a SessionStart system message.
+- **Content emitted**: contents of `~/.claude/projects/<project-hash>/memory/MEMORY.md` (the index), trimmed; the top 10 open BIs by `updatedAt` from `mcp__dpf__query_backlog`; current branch + last 3 commits; any open Build Studio build IDs from `mcp__dpf__list_work_capsules`.
+- **Failure mode**: if MCP is unreachable, falls back to MEMORY.md + git only; never exit non-zero.
+
+**Install path.** `scripts/governance/memory-load.{ps1,sh}`. No `--may-block`. Matcher: `SessionStart`.
+
+**Telemetry.** Writes `toolName="hook:memory-load"`, `status="ok"`, `details={memoryBytes, openBiCount, currentBranch}`. On MCP-unreachable fallback, `status="degraded"`.
+
+**Test plan.**
+- Unit: stub `mcp__dpf__query_backlog` and assert the script emits expected sections.
+- Integration: against a live DPF MCP (in-process), assert the SessionStart payload contains all four sections.
+- Functional: open Claude Code on the dev portal worktree, assert the first system message includes the MEMORY.md index entries.
+
+**Kernel principle citation.** `live-state-over-seed-data` (load live backlog, not a cached snapshot). `do-the-work-dont-task-the-operator` (the operator should not have to re-orient by hand each session).
+
+---
+
+### 4. PreCompact: save-state
+
+**Purpose.** Durable handoff record before context compaction. Today compaction loses thread state silently — decisions made mid-context vanish from the post-compact prompt unless they were already in memory or a BI.
+
+**Pass/fail contract.**
+- **Pass**: writes a `SessionDigest` row capturing: last 20 tool calls (names + status), files edited this session, BIs touched, MCP evidence rows created, current branch + dirty/clean status, and a 200-word LLM-emitted summary of the active task. Always exits 0.
+- **No block path.** PreCompact is informational; we never want compaction to fail because the hook failed.
+
+**Install path.** `scripts/governance/save-state.{ps1,sh}`. Matcher: `PreCompact`.
+
+**Telemetry.** Writes `toolName="hook:pre-compact-save"`, `status="ok"`, `details={digestRowId, taskSummary, fileCount, biCount}`. The `SessionDigest` row itself is a new lightweight table (one-time migration; see "Schema additions" below).
+
+**Test plan.**
+- Unit: digest-builder unit tests cover each input class (tool calls, file diff, BI touch).
+- Integration: a stubbed PreCompact event triggers the hook, the SessionDigest row appears in the test DB.
+- Functional: trigger compaction in a real session, verify the digest row + that the post-compact session can read it via SessionStart's memory-load.
+
+**Kernel principle citation.** `single-source-of-truth` (post-compact context has ONE place to recover from). `evidence-before-diagnosis` (the SessionDigest is the evidence base for "what happened in the lost context window").
+
+**Schema additions.** New table `SessionDigest` — `(id, sessionId, recordedAt, summary, toolCallsJson, filesJson, bisTouchedJson, branch, isDirty)`. Migration is a small Prisma add; spec'd in the child BI but not blocking other events.
+
+---
+
+### 5. Stop: session-summary
+
+**Purpose.** On session Stop, append a final `SessionDigest` row tying the conversation to BIs touched, files changed, decisions recorded — separate from the PreCompact digest because Stop is the terminal record.
+
+**Pass/fail contract.**
+- **Pass**: writes a `SessionDigest` row with `kind="stop"` containing the same shape as PreCompact, plus an `outcome` field (`completed-task | abandoned | crashed | unknown`). Always exits 0.
+- **No block path.**
+
+**Install path.** `scripts/governance/session-summary.{ps1,sh}`. Matcher: `Stop`. **Coexists with the existing `safety/transcript-snapshot` SessionEnd hook**; that one stays for raw transcript persistence, this one writes the structured digest.
+
+**Telemetry.** Writes `toolName="hook:session-summary"`, `details={digestRowId, outcome, durationMs}`.
+
+**Test plan.**
+- Unit: digest shape + outcome classification rules.
+- Integration: synthetic Stop payload, assert the row + the `outcome` heuristic match.
+- Functional: complete a real task session, verify the row.
+
+**Kernel principle citation.** `live-state-over-seed-data`. `evidence-before-diagnosis` (every session leaves a final ledger entry).
+
+---
+
+### 6. PostToolUse: governance-capture
+
+**Purpose.** Log secret-handling, policy-touching, and substrate-mutating tool calls to a per-session governance ledger. Precursor to Slice 4 (session-as-corpus mining loop) — when that arrives, this is the data it mines.
+
+**Pass/fail contract.**
+- **Pass**: writes a `GovernanceEvent` row when a triggering tool was used. Triggers (Phase 1 closed list): any `mcp__dpf__*` write tool, any `Bash` matching secret-handling patterns (env var writes containing TOKEN/SECRET/KEY substrings), any `Write`/`Edit` to `.env*` files, any tool returning `status="blocked"` or `"override"` from other hooks.
+- **No block path.**
+
+**Install path.** `scripts/governance/governance-capture.{ps1,sh}`. Matcher: `PostToolUse`. Coexists with existing `safety/transcript-snapshot` PostToolUse — both fire; both are async.
+
+**Telemetry.** Writes `toolName="hook:governance-capture"`, plus the actual `GovernanceEvent` row (new lightweight table — see "Schema additions" below). Async; failure to write the row is logged but doesn't block.
+
+**Test plan.**
+- Unit: trigger-classifier table-driven cases.
+- Integration: fire synthetic PostToolUse events, assert GovernanceEvent rows for the triggering classes.
+- Functional: run a real session that touches `.env`, asserts a row.
+
+**Kernel principle citation.** `evidence-before-diagnosis` (governance events ARE the evidence base for "what did the session touch"). `single-source-of-truth` (one ledger for all client-plane policy-touching tool use).
+
+**Schema additions.** New table `GovernanceEvent` — `(id, sessionId, recordedAt, kind, toolName, payloadJson, sensitive)`. Same migration window as `SessionDigest`.
+
+---
+
+## Telemetry contract (cross-event)
+
+All six hooks emit telemetry through the **DPF MCP server**, not direct DB writes — even though it's tempting to write directly from a shell script. Rationale: every governance event must pass through `mcp-governed-execute` so the server-plane and client-plane share one audit ledger. The hook scripts shell out to:
+
+```
+dpf-mcp-call record_tool_execution --tool hook:<name> --status <ok|blocked|override|degraded> --details <json>
+```
+
+A thin CLI wrapper `scripts/governance/dpf-mcp-call.{ps1,sh}` is filed as its own child BI (cross-cutting, see §"Child BI decomposition" below) so all six hooks share one MCP-call mechanism.
+
+If the MCP is unreachable, telemetry falls back to appending a JSONL line to `.claude/governance-fallback.jsonl` in the project root; a future hook reconciles those rows once MCP is back.
+
+## Phase-2 forward-looking (γ-upgrade, NOT decomposed)
+
+Phase 2 lifts invariants 1, 2, and 5. Sketched here so child BIs don't accidentally close them off.
+
+- **Phase-2.1**: hooks consume `apps/web/lib/agent-coworker-context.ts` to learn `callingPopulation` + active coworker identity. The launcher receives this context via a SessionStart-set environment.
+- **Phase-2.2**: ambiguous decisions (e.g. "should THIS coworker be allowed to edit `.eslintrc` given THIS task?") route through the **Decision Perspective Gate** (BI-E1FB2307) — NOT raw `principle_decide`. The Gate enforces the WWMD/WWWD lane split.
+- **Phase-2.3**: hooks become part of the customer install profile, scoped to `in_platform_coworker` AND `human` populations on customer machines. External agents (`external_coding_agent`) get a different scope based on their grant trees.
+- **Phase-2.4**: cross-harness reach (Slice 2) generalizes the launcher to invoke from Codex/Cursor adapters.
+
+None of the Phase-1 work conflicts with the above — Phase-1 hooks ship as population-blind scripts; Phase 2 wraps them with context-aware preludes. No rewrites required.
+
+## Acceptance (for the parent BI-A56D77B6)
+
+- This spec committed at `docs/superpowers/specs/2026-06-02-dpf-client-hook-plane-design.md` (this file).
+- 5-7 child BIs filed under EP-CLIENT-HOOK-PLANE — one per event (6) plus 1 cross-cutting (the `dpf-mcp-call` wrapper + `--may-block` launcher amendment).
+- Each child BI cites its event's pass/fail contract and the kernel principles above.
+- `AGENTS.md` updated with a brief client-plane framing in §X (TBD — operator picks the section number during review).
+- Parent BI-A56D77B6 moves to `done` once children are filed and AGENTS.md update is in PR.
+
+## Child BI decomposition (proposed)
+
+| Child | Title (proposed) | Event | Sizing | Notes |
+|---|---|---|---|---|
+| Child-1 | Launcher `--may-block` amendment + `dpf-mcp-call` wrapper | (cross-cutting) | small | Must land first; all PreToolUse events depend on it |
+| Child-2 | PreToolUse: config-protection | event 1 | small | |
+| Child-3 | PreToolUse: bash-allowlist-validator | event 2 | medium | Deny-pattern catalog needs review |
+| Child-4 | SessionStart: memory-load | event 3 | medium | Calls 3-4 MCP tools; shape matters for token budget |
+| Child-5 | PreCompact: save-state + SessionDigest table | event 4 | medium | Includes Prisma migration |
+| Child-6 | Stop: session-summary | event 5 | small | Reuses event 4's table |
+| Child-7 | PostToolUse: governance-capture + GovernanceEvent table | event 6 | medium | Includes Prisma migration |
+
+7 children; sum of sizing ≈ 1.5 large (medium ×4 + small ×3). Reasonable for a Phase-1 epic.
+
+## Out of scope (Phase 2 γ-upgrade)
+
+- Wiring `agent-coworker-context` through the hook layer.
+- Hooks consuming `callingPopulation` and routing through the Decision Perspective Gate.
+- Customer-coworker (in-portal) hook firing.
+- Cross-harness adapters (Codex / Cursor / OpenCode).
+- Session-as-corpus mining loop (Slice 4 — consumes Phase-1 PostToolUse:governance-capture telemetry).
+- Eval harness for hooks (Slice 3 — depends on Phase-1 telemetry surface).
+
+Each of the above re-enters scope as a Phase-2 follow-on BI under EP-CLIENT-HOOK-PLANE, post BI-E1FB2307 landing.
+
+## Cross-refs
+
+- Kernel consultations recorded in BI-A56D77B6 and in `mcp__dpf__record_external_development_evidence` rows (sessionId=`ecc-investigation-2026-06-02`).
+- Parent BI: BI-A56D77B6.
+- Epic: EP-CLIENT-HOOK-PLANE.
+- Predecessor (cross-platform plumbing): BI-0F7C7464 / PR #1281.
+- Phase-2 blocker: BI-E1FB2307 (Decision Perspective Gate).
+- Sibling work, different plane: BI-5FE9DF99 (MCP tool-surface ergonomics audit).
+- Skills composed: [`dpf-writing-plans`](../../../packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md) (this spec's authoring), [`dpf-decision-via-kernel`](../../../packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md) (γ destination + new-epic kernel calls), [`dpf-record-decision-outcome`](../../../packages/dpf-skill-pack/skills/dpf-record-decision-outcome/SKILL.md) (audit-trail discipline).
+- Source memory note (provenance): [ecc-everything-claude-code-evaluation](file:///Users/markbodman/.claude/projects/-Users-markbodman-dpf/memory/ecc-everything-claude-code-evaluation.md). The four-event-class taxonomy idea surfaced through ECC; the architectural framing, the scope, and the destination are DPF-native and would have arrived independently as Build Studio scale increased.

--- a/docs/superpowers/specs/2026-06-07-feedback-relay-service-phase-b-design.md
+++ b/docs/superpowers/specs/2026-06-07-feedback-relay-service-phase-b-design.md
@@ -1,0 +1,86 @@
+# Feedback Intake Relay Service — Phase B Design Note
+
+| Field | Value |
+| ----- | ----- |
+| Status | Decision note (awaiting operator hosting decision) |
+| Date | 2026-06-07 |
+| Backlog item | `BI-6D45BA27` (Phase B) |
+| Builds on | [Zero-config upstream feedback escalation (Phase A, merged PR #1629)](2026-06-06-zero-config-upstream-feedback-escalation-design.md) |
+| Decision owner | Mark Bodman |
+
+## Purpose
+
+Phase A shipped everything **inside the portal**: an install-authenticated client that POSTs a redacted report to `upstreamRelayUrl`. What does not yet exist is the **thing on the other end of that URL** — the hosted service that holds the GitHub credential and files the issue. Until it exists, a consumer install (no GitHub token) reaches `skipped`, not `filed`. Phase B builds that service.
+
+This note exists to get **one decision from the operator: where the relay runs and how it authenticates to GitHub** — the rest follows.
+
+## What the relay must do (contract — already fixed by Phase A)
+
+Accept `POST <relayUrl>`:
+
+```
+Headers: X-DPF-Install-Id: dpf-agent-<shortId>   (Phase A; hardened below)
+Body:    { title, body, labels[], pseudonym, localRef }   (already redacted client-side)
+→ 201   { issueNumber: number, url: string }
+→ 4xx/5xx { error: string }
+```
+
+The portal already handles every response shape (`feedback-transport.ts` `RelayTransport`). So the relay is a small, well-bounded service: validate → re-redact (defense in depth) → file a GitHub issue → return the number/url.
+
+## Decision 1 — Where it runs (pick one)
+
+| Option | What it is | Pros | Cons |
+| ------ | ---------- | ---- | ---- |
+| **A. Serverless endpoint (Recommended)** | A single function (Cloudflare Worker / Vercel Edge / AWS Lambda) at e.g. `relay.opendigitalproductfactory.org` | Scales to zero (~free at this volume); minimal ops; secret stored in the platform's secret manager; trivial to stand up | One more deployable + domain + secret to own |
+| **B. Route on existing hive/back-office infra** | Add `POST /relay/feedback` to whatever already hosts the hive/community backend | Reuses existing ops, secrets, monitoring; no new deployable | Couples feedback availability to that service; only viable if such a service already exists |
+| **C. GitHub Actions `repository_dispatch`** | Relay is a thin proxy that triggers a workflow which opens the issue | No long-lived server | Awkward (needs a dispatch token anyway), slow, poor error surface — not recommended |
+
+**Recommendation: A.** It's the smallest, cheapest, most isolated option and matches the "conduit, not broker" stance. B is fine *if* a suitable hosted service already exists — worth confirming before defaulting to A.
+
+## Decision 2 — How the relay authenticates to GitHub
+
+| Option | Notes |
+| ------ | ----- |
+| **GitHub App installation token (Recommended)** | Scoped to `issues:write` on the upstream repo only; auto-rotating short-lived tokens; per-repo; higher rate limits; revocable without rotating a shared PAT. Standard for server-to-server GitHub automation. |
+| Fine-grained PAT | Simpler to set up, but a long-lived secret to rotate manually; lower rate limits. Acceptable interim. |
+
+**Recommendation: GitHub App.** The credential lives only in the relay's secret store and never touches any customer install — which is the whole point of Phase A's design.
+
+## Decision 3 — Install → relay authentication (hardening Phase A)
+
+Phase A sends the pseudonym in `X-DPF-Install-Id` (semi-public). For a feedback channel that's low-stakes, but Phase B should harden it. Options, cheapest first:
+
+1. **Open + rate-limited + moderated (Recommended for v1).** No per-install secret. The relay applies: per-pseudonym and per-IP rate limits, payload size caps, content/spam heuristics, dedup by a payload hash, and files issues with a `hive:unverified` label (or into a triage queue) rather than straight to the public list. Simplest; abuse is contained server-side where we can actually react.
+2. **Bundled relay API key.** A rotatable shared key shipped with installs. Slightly raises the bar but is still a shared secret on every machine (the exact thing Phase A avoided for GitHub) — low marginal value.
+3. **Per-install signed payload (HMAC/JWT).** Strongest, but requires an install-registration step so the relay can verify signatures — more moving parts than a feedback channel warrants at v1. Revisit if abuse appears.
+
+**Recommendation: start with (1).** It needs no new install-side credential, keeps all abuse controls server-side, and the `hive:unverified` label + dedup keep the public issue list clean.
+
+## Abuse / safety controls (relay-side)
+
+- Rate limits: per-pseudonym (e.g. 5/min, 30/hr — mirrors the portal-side limit) and per-IP.
+- Payload caps: title/body length, label whitelist.
+- Re-redaction: run the same hostname/PII scrub server-side (defense in depth; never trust the client).
+- Dedup: drop repeats by content hash within a window.
+- Triage gate: file with `hive:unverified`; a maintainer/automation promotes real ones — keeps spam out of the canonical list.
+- No PII at rest: log only the pseudonym + hash, never raw report bodies.
+
+## Reseller seam (Phase C preview)
+
+The relay is **the same code a reseller deploys**, pointed at their own repo or configured to forward upstream after curation. Because `upstreamRelayUrl` is already per-install config, no portal change is needed to support a reseller — they hand their customers a relay URL. Phase C adds the curation/forwarding workflow and the reverse-channel acknowledgement (ties into `BI-FBDC0861`).
+
+## Default wiring
+
+Once the relay exists, set the **default `upstreamRelayUrl`** for consumer installs to it (the OpenDigitalProductFactory relay), so the consumer path is truly zero-config. Contributor/admin installs with a GitHub token continue to use the direct bridge unchanged.
+
+## Failure behavior (already handled by Phase A)
+
+If the relay is down, `RelayTransport` returns `failed` → the portal reports "couldn't send" and the report **stays local** (nothing lost). A store-and-retry queue is a possible Phase C refinement, not required for v1.
+
+## Open decisions for the operator
+
+1. **Hosting:** Option A (serverless) vs B (existing infra)? → confirm whether a suitable hosted service already exists.
+2. **GitHub auth:** GitHub App (recommended) vs PAT?
+3. **Install auth for v1:** open + rate-limited + moderated (recommended) vs a bundled key?
+
+With those three answered, Phase B is a small build: one function, the GitHub App registration, the abuse controls, and flipping the default `upstreamRelayUrl`.

--- a/docs/superpowers/specs/2026-06-19-local-first-development-workflow-and-public-private-demarcation-design.md
+++ b/docs/superpowers/specs/2026-06-19-local-first-development-workflow-and-public-private-demarcation-design.md
@@ -1,0 +1,242 @@
+# Local-First Development Workflow & the Public/Private Demarcation — Program Design
+
+**Date:** 2026-06-19
+**Status:** Program synthesis (pre-epic). Connects and extends existing per-area specs; identifies the unowned cross-cutting concern; proposes the epic/BI structure.
+**Author:** Investigation per operator goal (local git + multi-tool AI CLI workflow; opt-in share vs keep-local with guided determination; GitHub-feature delta; Build Studio as the model; code-graph/SysML and archetype demarcation).
+**Predecessors (authoritative, do not contradict):**
+- [`2026-06-18-local-git-and-private-public-segregation-analysis.md`](2026-06-18-local-git-and-private-public-segregation-analysis.md) — operator decision: private git home ships *inside* the install, invisible by default; bare remote default; Gitea opt-in; GitLab external-only via a future `GitForgeProvider`.
+- [`2026-06-18-private-public-change-segregation-design.md`](2026-06-18-private-public-change-segregation-design.md) — Phase 1: `FeatureBuild.disposition` (private default, fail-closed), `.dpf/private-paths`, local-changes ledger, plain-language ship UX.
+- [`2026-06-19-hive-contribution-architecture-and-egress-model.md`](2026-06-19-hive-contribution-architecture-and-egress-model.md) — the boundary applies only at public-hive egress; hive = git + GitHub API + Postgres ledger; pseudonymous identity.
+- [`2026-06-16-living-architecture-graph-and-operational-bridge-design.md`](2026-06-16-living-architecture-graph-and-operational-bridge-design.md) — the EA/SysML graph; **Open Question 3** (customer-scoped discovery: platform graph or per-tenant sub-graph?) is still open.
+- [`2026-06-19-estate-sovereignty-governance-design.md`](2026-06-19-estate-sovereignty-governance-design.md) — sovereignty assessment (`EP-ESTATE-SOVEREIGNTY`).
+
+---
+
+## 0. The operator's goal, restated as one concern
+
+The operator described what reads as six topics. Investigation shows they are **one axis seen from several surfaces**:
+
+> A customer installs DPF and runs it **locally**. They develop with **multiple AI coding CLIs** (Claude, Codex, OpenCode, Grok) against a **local git substrate**. They **opt in to share some things and keep others private** — but *they don't always know what is appropriate to share*. Going local trades away **GitHub features** that must be accommodated. **Build Studio** is the most self-contained development path and should be the **model** for the external (CLI) paths. The **code graph** and **SysML** must distinguish what is public/shipped from what is the customer's private estate. And a single company should not drown in **archetypes outside its domain** — that machinery becomes noise.
+
+The throughline is a **demarcation**: every artifact DPF produces or holds sits on one axis —
+
+```
+   PRIVATE / LOCAL  ◄──────────────────────────────►  SHARED / PUBLIC
+   (this install's          (genuinely install-          (the commons / upstream /
+    proprietary content)     specific config)             platform-shipped baseline)
+```
+
+…with a **companion relevance axis** for surfacing —
+
+```
+   IN-DOMAIN (this install's archetype + universal)  ◄──►  OUT-OF-DOMAIN (other archetypes = noise)
+```
+
+Everything below is about making **one** demarcation primitive real and applying it consistently across four planes — **code, knowledge, architecture-graph/SysML, and UI relevance** — inside a local-first multi-tool workflow. Today each plane treats the axis differently or not at all.
+
+---
+
+## 1. What already exists (the substrate — do NOT rebuild)
+
+DPF is far denser here than a first read suggests. The investigation confirmed working substrate on every dimension.
+
+### 1.1 Local git + multi-tool AI CLI — largely SHIPPED
+- **Local git substrate exists.** The self-upgrade path maintains a durable per-install branch `dpf/install` in `~/.dpf/install/`, merging upstream via `git merge --no-ff` inside an isolated workspace, deferring on conflict ([`apps/web/lib/self-upgrade/prepare-source.ts:373`](apps/web/lib/self-upgrade/prepare-source.ts)). **There is no need to install a second git server for "local checkin."**
+- **All four CLIs are real, not aspirational.** A unified runner registry registers `codex, claude, grok, dpf-native, opencode` ([`apps/web/lib/integrate/sandbox/agents/index.ts:8`](apps/web/lib/integrate/sandbox/agents/index.ts); `BuildAgentId` at [`agent-runner-types.ts:9`](apps/web/lib/integrate/sandbox/agent-runner-types.ts)). Each has a dispatcher + runner (`{claude,codex,grok,opencode}-dispatch.ts`). OpenCode is the **credential-free local-LLM** path (points at the install's own OpenAI-compatible endpoint, [`opencode-dispatch.ts:15`](apps/web/lib/integrate/opencode-dispatch.ts)); Grok has device-code OAuth ([`grok-device-login.ts:34`](apps/web/lib/actions/grok-device-login.ts)).
+- **Build Studio CLI path** = the orchestrator dispatch branch at [`build-orchestrator.ts:793`](apps/web/lib/integrate/build-orchestrator.ts) (resolves a runner, calls `runner.run(...)`), with the legacy agentic loop as fallback. Lifecycle `ideate → plan → build → review → ship` is checkpoint-resumable ([`build-pipeline.ts:71`](apps/web/lib/integrate/build-pipeline.ts)).
+- **Contributor-side toolchain bootstrap** writes per-CLI MCP config (`planCodexConfig`/`planClaudePluginConfig`/`planGrokConfig`) in `@dpf/bootstrap`; docs for Claude/Codex/Grok dev environments already landed (PRs #2051, #2053).
+
+### 1.2 The private lane + egress boundary — partially built
+- `PlatformDevConfig.contributionMode` ∈ `fork_only | selective | contribute_all`.
+- The boundary applies **only at public-hive egress** — a diff to the install's own repo is unfiltered; only public-hive egress is gated (`classifyEgress()`, [`contribution-egress.ts:46`](apps/web/lib/integrate/contribution-egress.ts), PR #2079).
+- **Structural strip:** `.dpf/private-paths` (gitignore-style, fail-closed) strips matching hunks before any push (`stripPrivatePathsFromDiff`, [`private-paths.ts:209`](apps/web/lib/integrate/private-paths.ts)). Ships **empty** (no-op until an operator opts in).
+- **Reactive scans:** secret scan ([`security-scan.ts:45`](apps/web/lib/integrate/security-scan.ts)), org-identity sanitization ([`contribution-review.ts:114`](apps/web/lib/integrate/contribution-review.ts)), hostname/identity redaction + pseudonymous `dpf-agent-<shortId>`.
+- **Hive consent surface:** device-fingerprint opt-in (default ON, PII-free), source/improvement (follows `contributionMode`), master pause ([`HiveContributionsPanel.tsx:60`](apps/web/components/admin/HiveContributionsPanel.tsx)).
+
+### 1.3 Knowledge demarcation — the proven pattern
+- **WikiPage kernel/org-overlay:** kernel rows (`organizationId = NULL`, `isKernel = true`) are global/public; org-overlay rows are proprietary/local. `principlePublic` marks a principle shareable. This is the **canonical demarcation pattern** the egress spec already names as the reuse target (`hive-contribution…:46-61`).
+- Learning routing WWMD/WWWD/WSID → `principle_decide` / `propose_improvement` / `propose_skill_improvement` → `contribute_to_hive` (kernel principle `learnings-belong-in-the-shared-commons`; skill `dpf-route-learning-to-commons`).
+
+### 1.4 Architecture graph / SysML — built, but NO demarcation
+- EA graph in Postgres (`EaElement` [`schema.prisma:5775`](packages/db/prisma/schema.prisma), `EaRelationship`, `EaView`, `EaSnapshot`), layers in `properties.layer`; Neo4j code graph (`CodeFile`/`CodeSymbol`/…) bridged in. Nightly extractor/reconcile **Parity Engine** pattern (`reconcileSysmlProjections`, `runArchitectureParitySteward`). SysML v2 is an internal viewpoint over the same substrate (notation `sysml2`), not user-facing.
+- **The only origin tag is `provenance` (`deterministic` | `architect`)** — orthogonal to public/private. There is **no `visibility`/`origin`/`scopeKey`/`organizationId`** on graph elements.
+
+### 1.5 Archetype / domain model — known, but only corpus consumes it
+- Install archetype is known: `StorefrontConfig.archetypeId` ([`schema.prisma:7061`](packages/db/prisma/schema.prisma)); regional/compliance profile on `BusinessContext` (`operatesIn/sellsTo/employsIn/dataResidency`).
+- **The bridge exists:** `resolveInstallVariantContext` ([`install-variant-context.ts:44`](apps/web/lib/decision-perspective/install-variant-context.ts)) turns the install's declared domain into a scoping context. **Only the profession-corpus retrieval path consumes it** (`pageEligibleForInstall`, [`profession-corpus.ts:219`](apps/web/lib/decision-perspective/profession-corpus.ts)).
+- `EP-WSID` (corpus) is **done**; `EP-ARCH-8D4F2A` (Archetype Model V2) is in-progress.
+
+### 1.6 GitHub-equivalent work-management substrate — already local-capable
+DPF already owns local equivalents for most of what GitHub provides (see §4 delta table): backlog `BacklogItem`/`Epic` ≈ issues; Build Studio phase gates + `reviewDesignDoc`/`saveBuildEvidence` ≈ PR review; leased local-CI sandbox + `run_sandbox_tests`/`run_release_gate` ≈ Actions; `ChangeRequest` register ≈ PR audit trail; AES-256-GCM credential vault ≈ Actions secrets; `ReleaseBundle` ≈ releases (diff-level).
+
+---
+
+## 2. The unowned concern: one demarcation primitive, four planes
+
+The substrate is dense but the **demarcation axis is implemented four different ways** — and on two planes it does not exist at all:
+
+| Plane | Demarcation today | State |
+|---|---|---|
+| **Code changes** | `FeatureBuild.disposition` + `.dpf/private-paths` (fail-closed) | **Specced** (2026-06-18 Phase 1), `disposition` not yet in schema |
+| **Knowledge / learnings** | WikiPage kernel vs org-overlay; `contributionStatus` local→contributed | **Built** (the proven pattern) |
+| **Architecture graph / SysML** | *(none)* — no visibility/origin/scope field; customer discovery leaks into the global graph | **GAP — explicit open question** |
+| **UI relevance (domain)** | `resolveInstallVariantContext` → corpus only | **GAP — one consumer, starved of content** |
+
+**Plus three cross-cutting gaps the operator named directly:**
+
+1. **No guided "what's appropriate to share" determination.** Everything today is *reactive* (post-hoc secret/identity scans) or a *bare per-build human choice*. Nothing proactively tells a non-technical user "this looks proprietary — keep it" or "this is a reusable fix — the platform wants it." The Phase-1 spec itself says scans "catch secrets, not proprietary intent."
+2. **No `GitForgeProvider` abstraction.** `GitProvider = "github"` is a one-value union; `parseGitHubRepo()` returns `null` for non-GitHub URLs. This blocks the bundled private remote and any non-GitHub forge. The GitHub-feature delta (§4) has no abstraction seam.
+3. **Consistency defects** found in flight: the **master "Pause all contributions" toggle does not gate the `source`/`improvement` `contribute_to_hive` path** ([`mcp-tools.ts:11328`](apps/web/lib/mcp-tools.ts) never checks `hiveContributionsPaused`) — the UI claims it stops *every* type; the **network-bridge reconcile drops scope** ([`reconcile-network-bridge.ts:22`](apps/web/lib/ea/reconcile-network-bridge.ts) reads all `EdgeNode`/`InventoryEntity` with no `where`), leaking customer-scoped discovery into the global graph against its own header and spec.
+
+**No epic frames the demarcation as one axis.** `EP-UPGRADE-LIFECYCLE` owns the code/upstream slice; `EP-LEARNING-COMMONS` the knowledge slice; `EP-ARCH-GRAPH-LIVE`/`EP-PARITY-ENGINE` the graph; `EP-ARCH-8D4F2A` archetypes; `EP-ESTATE-SOVEREIGNTY` sovereignty. The connective tissue — **the shared primitive + the guided advisor + the graph/domain application** — is unowned.
+
+---
+
+## 3. Design — the demarcation primitive and the workflow around it
+
+### 3.1 One classification primitive (`DispositionClass`) reused on every plane
+
+Define a single resolver that, given any artifact, returns a recommended placement on the axis with a reason and the signals behind it. This is the **Share-Determination Advisor** — the answer to "the user may not know what's appropriate to share."
+
+```
+classifyDisposition(artifact) -> {
+  recommended: "keep_private" | "share_public",
+  confidence:  "high" | "medium" | "low",
+  reasonPlain: string,        // "This changes pricing logic specific to your business."
+  signals: {
+    artifactKind,             // platform_improvement | proprietary_content | install_config | unknown
+    privatePathMatch: bool,   // .dpf/private-paths → forces keep_private
+    secretOrPii: bool,        // security-scan → blocks share entirely
+    orgIdentityLeak: [...],   // sanitization scan → must-fix before share
+    provenance,               // kernel/platform-shipped → already public; org-overlay → proprietary
+    domainSpecific: bool,     // tied to this install's archetype only?
+    sovereigntyTarget,        // BusinessContext.dataResidency / targetAssuranceLevel tightens default
+  },
+  decidable: bool             // false → must escalate to a human (PAR)
+}
+```
+
+Design rules:
+- **Fail-closed.** Default `keep_private`; an artifact only becomes shareable on an explicit human acknowledgement (PAR — propose/acknowledge/reassign). This matches the Phase-1 `disposition default "private"`.
+- **Doctrine-aware.** The platform-improvement vs proprietary-content distinction is the doctrine's core (AGENTS.md §1: "platform improvements flow to the hive; proprietary content stays local"). For a clear platform improvement the advisor *nudges toward share* (local-only is the defect); for proprietary content it defaults keep and explains why.
+- **Sovereignty-aware.** An install with a high `targetAssuranceLevel` / strict `dataResidency` gets a stricter default and clearer warnings. This is the missing link between `EP-ESTATE-SOVEREIGNTY` and the sharing decision.
+- **Reuses existing scanners** — it *orchestrates* `security-scan`, `contribution-review` sanitization, `private-paths`, and the WikiPage kernel/overlay flag rather than replacing them. It turns three reactive gates into one proactive recommendation.
+- **Plain-language, progressive disclosure.** Non-technical users see "Keep on my system" / "Share with the community" + a one-line reason; git/forge controls stay admin-gated (per Phase-1 §3.3 and the operator's invisible-by-default constraint).
+- **Records the why.** Persists `dispositionReason` (Phase-1 field) so "what have we kept private, and why?" is answerable.
+
+The same resolver is invoked at every share decision point: Build Studio/CLI **ship phase** (code), **learning routing** (`contribute_to_hive`/`propose_improvement`), the **graph contribution** path (new, §3.4), and the **hive consent** surface.
+
+### 3.2 Workstream A — local-first multi-tool development workflow
+
+- **Build Studio is the model; the CLI path is the same orchestrator.** Codex/Claude/Grok/OpenCode already run through `runner.run()` at the same orchestrator seam ([`build-orchestrator.ts:793`](apps/web/lib/integrate/build-orchestrator.ts)) and through the same `ideate→plan→build→review→ship` gates. The external-development guidance should state this explicitly: **the gates are tool-agnostic; the CLI is just the implementer.** No new pipeline.
+- **Converge the dispatch/runner duplication.** Both `*-dispatch.ts` and `sandbox/agents/*-agent-runner.ts` exist per CLI ("one concept, N parallel impls" debt). The orchestrator uses the runner path; the standalone dispatch fns should be folded behind the runner contract. Routing-adapter coverage is asymmetric (Claude/Codex CLI adapters exist; Grok/OpenCode are Build-Studio-only) — close or document the gap. → `EP-ROUTING-11` / arch-convergence.
+- **The local git substrate is `dpf/install`** — no second git server. The bundled **bare private remote** (operator decision §5.2 of the analysis) gives proprietary work a durable off-box home; Gitea is the opt-in technical UI.
+
+### 3.3 Workstream B — accommodate the GitHub-feature delta
+
+The delta is concentrated in the **git-host transport** half; the **work-management** half is already local-capable. The accommodation is the `GitForgeProvider` abstraction (analysis Phase 2.1) plus an explicit map of what each lost GitHub feature falls back to locally.
+
+| GitHub feature | What it provides | DPF local accommodation |
+|---|---|---|
+| Central repo / remote | Canonical origin | `dpf/install` + bundled **bare private remote** (no new service) |
+| PR object + review UI | Reviewable diff, approvals | Build Studio phase gates + `reviewDesignDoc`/`saveBuildEvidence`; PR API behind `GitForgeProvider` (Gitea MRs for the technical tier) |
+| CI runners (Actions) | Tests/build/audits on push | Leased local-CI sandbox (`claim_nonprod_environment_lease("local-integration-ci")`) + `run_sandbox_tests`/`run_release_gate`; **gap: event-driven trigger** off a local push (today the trigger is the GitHub webhook) — add a local `post-receive` hook posting the payload the portal already understands |
+| Merge gating / branch protection | Server blocks merge until checks pass | Pre-PR `block` gates + `.githooks/pre-push-gate`; **gap: server-side enforcement** on a bare remote → pre-receive hook or Build-Studio discipline |
+| Issue tracking | Work queue | `BacklogItem`/`Epic` in Postgres — full equivalent |
+| Releases / artifacts | `gh release`, GHCR images | `ReleaseBundle` (diff-level); **gap: binary/image hosting** → local registry or pre-loaded image for self-upgrade |
+| SAST / code scanning | CodeQL + SARIF dashboard | Gitleaks + 8 `audit-*` script guards run locally; **gap: hosted CodeQL dashboard** — keep script audits, lose the dashboard |
+| DCO bot | Blocks unsigned commits | `git commit -s` discipline; pre-receive hook for server-side; moot for `fork_only` non-contributed work |
+| Webhooks | Signed event delivery | Handler exists ([`route.ts`](apps/web/app/api/platform/git/updates/route.ts)); reuse via a local post-receive hook |
+
+**The honest "what you lose" statement** (the operator asked for the delta explicitly): going fully local, you lose the *hosted* conveniences — a web PR-review UI (until Gitea), hosted CI runners, the CodeQL/SARIF dashboard, GHCR image hosting, and GitHub-App identity for DCO. You do **not** lose review, gating, issues, change-audit, secrets, or test execution — those are already local. The accommodation is: forge-abstract the transport, reuse the local equivalents, and surface the two genuine gaps (local CI trigger + local image registry) as scoped BIs.
+
+### 3.4 Workstream D — code-graph / SysML public/private demarcation (resolves Open Question 3)
+
+Adopt the **proven knowledge pattern** for the graph:
+- Add an **origin/visibility tag** to `EaElement`/`EaRelationship` mirroring WikiPage kernel/overlay: `platform_shipped` (public — the DPF reference architecture, shareable to the commons) vs `install_private` (the customer's actual estate, local-only by default). Reuse the nullable-`organizationId` shape the egress spec already endorses.
+- **Resolve Open Question 3:** customer-scoped discovery is a **per-tenant private overlay**, not part of the platform graph. The public graph = `platform_shipped` elements; the customer's living graph = their private overlay. SysML follows automatically (same substrate, notation `sysml2`).
+- **Fix the leak (consistency defect):** carry `scopeKey`/`customerAccountId` from `EdgeNode`/`InventoryEntity` onto the emitted `EaElement`, and add the missing `where` scope filter in `reconcileNetworkTopology` ([`reconcile-network-bridge.ts:22`](apps/web/lib/ea/reconcile-network-bridge.ts)) so customer discovery does not project into the global graph. This is required before any graph element could ever be shared upstream.
+- The **Share-Determination Advisor (§3.1) gates graph contribution** exactly like code: only `platform_shipped` elements are ever eligible; `install_private` is structurally excluded. → `EP-ARCH-GRAPH-LIVE` / `EP-PARITY-ENGINE`.
+
+### 3.5 Workstream E — domain relevance / noise reduction
+
+Generalize the **already-present bridge** beyond corpus:
+- Promote `resolveInstallVariantContext` into an **install-domain-relevance service** consumed by nav, the agent/coworker roster, the skills surface, marketing surfaces, and the EA graph views — not just corpus injection.
+- **Default behavior:** surface the install's archetype(s) + `universal`; **collapse (not delete)** out-of-domain archetype machinery behind an explicit "explore other business types" affordance. **Fail-open** — never hide something the user explicitly needs; relevance filtering reduces noise, it does not remove capability.
+- Seed the corpus archetype axis with real per-archetype content (the shielding mechanism works but is starved — most pages are tagged `universal`).
+- Reconcile the two parallel archetype taxonomies (`ArchetypeCategory` vs `PROFESSION_ARCHETYPES`, kept in sync by a test, not a type) as part of `EP-ARCH-8D4F2A`. → `EP-ARCH-8D4F2A`.
+
+### 3.6 Workstream F — consistency fixes (small, high-value, fileable now)
+
+1. **Master-pause gating bug.** Make the `source`/`improvement` `contribute_to_hive` path honor `hiveContributionsPaused` (call `isContributionEnabled`/`resolveHiveContributionStatuses` like the device-fingerprint and feedback-escalation paths do). The UI promises it; the handler must keep the promise. → `EP-LEARNING-COMMONS` (safety).
+2. **Network-bridge scope leak** (see §3.4) → `EP-ARCH-GRAPH-LIVE`.
+
+---
+
+## 4. Build Studio as the model for external development
+
+Build Studio is the most self-contained path and is the reference for the external (Claude/Codex/OpenCode/Grok) paths because **both already share the orchestrator and the gates**. The external-development contract should make this explicit:
+
+- **Same gates, tool-agnostic.** `ideate→plan→build→review→ship` evidence gates apply regardless of who implements; the CLI is the implementer at `code_generated`. External work records the same evidence (`record_external_development_evidence` already exists).
+- **Same demarcation.** The ship-phase Share-Determination Advisor (§3.1) is invoked identically whether BS or a CLI produced the diff. Disposition defaults private; fail-closed egress is shared.
+- **Same coordination plane.** Work capsules, nonprod leases, change-register — the MCP coordination plane is the source of truth ("if it isn't in the MCP plane, it didn't happen").
+
+This means *no new external-dev pipeline* — the work is to **document the contract** and ensure the CLI paths invoke the same gates/advisor, not to build a parallel system.
+
+---
+
+## 5. Research & standards (AGENTS.md §10)
+
+Extends the Phase-1 spec's benchmarking (GitHub private-fork visibility; GitLab project visibility + CODEOWNERS; inner-source upstream-first classification; DLP default-deny) with the planes this program adds:
+
+- **Data classification taxonomies (NIST SP 800-60 / ISO 27001 A.8 information classification).** The `DispositionClass` artifactKind (`platform_improvement | proprietary_content | install_config`) is a lightweight, doctrine-aligned classification scheme — confirm against the standard rather than inventing categories.
+- **Multi-tenant graph scoping (row-level security / tenant tagging).** The `platform_shipped` vs `install_private` overlay mirrors the standard "shared baseline + tenant overlay" pattern; reuses DPF's own WikiPage precedent rather than per-row ACLs.
+- **Forge abstraction (libraries like `go-git`/`gitea-sdk` and the GitLab/GitHub API shapes).** The `GitForgeProvider` surface (`parseRepo`, `createBranch`, `commit`, `openChangeRequest`, `readChangeRequests`, webhook verify) is the minimal common denominator.
+- **Inner-source relevance filtering.** Collapsing out-of-domain content (not deleting) is the standard progressive-disclosure pattern; fail-open preserves discoverability.
+
+(The chief-architect lens, `dpf-architecture-review`, should sharpen each area spec before its build.)
+
+---
+
+## 6. Epic & BI structure (substrate-verified; file via `dpf-file-backlog-item`)
+
+**Proposed connective epic — `EP-DEMARCATION` (new):** *"The Public/Private Demarcation — one classification primitive applied across code, knowledge, the architecture graph, and UI relevance, with guided share-determination."* Justification for a new epic (per `verify-substrate-before-proposing-new`): no existing epic frames the axis as one primitive or owns the Share-Determination Advisor; the adjacent epics own per-plane slices only.
+
+| BI (candidate) | Workstream | Home epic |
+|---|---|---|
+| Share-Determination Advisor: `classifyDisposition` primitive + plain-language ship/route UX (orchestrates existing scans; fail-closed; sovereignty-aware) | A/C | **EP-DEMARCATION** |
+| Phase-1 segregation build (`FeatureBuild.disposition`, `.dpf/private-paths` DB override, ledger) — the 2026-06-18 design | C | EP-UPGRADE-LIFECYCLE |
+| `GitForgeProvider` abstraction behind existing GitHub call sites (pays down `parseGitHubRepo` duplication) | B | EP-UPGRADE-LIFECYCLE |
+| Bundled bare private remote as `dpf/install` push target (no new service) | B | EP-UPGRADE-LIFECYCLE |
+| Local CI trigger (post-receive hook → existing webhook handler) + local image registry for self-upgrade | B | EP-UPGRADE-LIFECYCLE / EP-INSTALLER |
+| Graph origin/visibility tag (`platform_shipped`/`install_private`) on `EaElement`/`EaRelationship`; resolve Open Question 3 | D | EP-ARCH-GRAPH-LIVE |
+| Fix network-bridge scope leak (carry `scopeKey`, add `where`) | D/F | EP-ARCH-GRAPH-LIVE |
+| Install-domain-relevance service (generalize `resolveInstallVariantContext`) consumed by nav/agents/skills/graph; collapse out-of-domain | E | EP-ARCH-8D4F2A |
+| Seed per-archetype corpus content; reconcile dual archetype taxonomies | E | EP-ARCH-8D4F2A |
+| Master-pause gating fix on `contribute_to_hive` source/improvement path | F | EP-LEARNING-COMMONS |
+| External-development contract doc: BS gates are tool-agnostic; CLI paths invoke the same gates + advisor | A | EP-BUILD-STUDIO |
+
+---
+
+## 7. Phasing
+
+- **Phase 0 (now, low-risk, high-value):** the two consistency fixes (§3.6) — master-pause gating + network-bridge scope leak. Independent, small, fixable as direct maintenance PRs.
+- **Phase 1:** the Share-Determination Advisor (§3.1) + the 2026-06-18 Phase-1 segregation build. Delivers the operator's core ask ("help the user know what to share") with no forge work.
+- **Phase 2:** `GitForgeProvider` + bundled bare private remote + local CI trigger / image registry (the GitHub-delta accommodation).
+- **Phase 3:** graph/SysML demarcation (origin tag + Open Question 3 resolution).
+- **Phase 4:** domain-relevance service rollout + corpus seeding.
+- **On demand:** first-class GitLab/Gitea forge providers (external integration only).
+
+---
+
+## 8. Open questions resolved / remaining
+
+**Resolved by this program:**
+- *Where do `fork_only` changes go?* → the bundled bare private remote on `dpf/install` (operator decision); the advisor records why each is private.
+- *How does a user know what to share?* → the Share-Determination Advisor (proactive, doctrine- and sovereignty-aware, fail-closed).
+- *Living-graph Open Question 3 (customer discovery: platform graph or per-tenant?)* → per-tenant private overlay; only `platform_shipped` elements are public/shareable.
+
+**Remaining for operator:**
+1. **Scope of Phase 0 now.** The two consistency fixes are independent and shippable immediately — proceed as direct PRs, or fold into the epic?
+2. **New epic vs anchor-only.** Create `EP-DEMARCATION` as the connective owner, or route every BI to existing epics and track the axis as a cross-epic theme?
+3. **Graph contribution appetite.** Is sharing *platform_shipped* graph/SysML elements to the commons actually desired, or is the graph demarcation purely about keeping the customer estate private (no upstream graph contribution at all)? This changes whether the origin tag needs the full egress path or just a local privacy boundary.


### PR DESCRIPTION
## What this is

A sweep of all 252 registered git worktrees, prompted by an operator hitting "uncommitted work" warnings when trying to remove worktrees whose Claude threads had been deleted.

Deleting a thread does not delete its worktree. The worktree stays registered with whatever the thread never committed, and git's refusal to remove a dirty worktree was the only thing preserving that content.

49 worktrees were dirty. After filtering gate logs and generated artifacts, **16 files existed in no commit on any branch** — each verified absent from `origin/main` and from `git log --all`.

This PR lands the durable-knowledge half.

### Specs
| File | Size |
|---|---|
| `2026-06-01-build-studio-business-mode-runner-abstraction-design.md` | 54 KB |
| `2026-05-24-portfolio-gear-convergence-design.md` | 31 KB |
| `2026-06-19-local-first-development-workflow-and-public-private-demarcation-design.md` | 28 KB |
| `2026-06-02-dpf-client-hook-plane-design.md` | 23 KB |
| `2026-06-07-feedback-relay-service-phase-b-design.md` | 6.6 KB |

### Plans
| File | Size |
|---|---|
| `2026-06-13-value-stream-p1-measure-implementation-plan.md` | 53 KB |
| `2026-06-12-value-stream-p0-capture-implementation-plan.md` | 23 KB |

### Strategy
`2026-09-cada-architects-forum-deck.md` + `.pptx`

## Why these specifically

Two are load-bearing rather than merely interesting.

The 06-19 local-first spec is a program synthesis citing six predecessor specs — **all six are on main**. Only the document connecting them was stranded.

The CADA deck is the explicit companion to `docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md`, which also shipped. The deck it links to did not, and the forum is still ahead of us in September 2026.

The value-stream plans are the P0/P1 plans for `2026-06-12-value-stream-architecture-platform-design.md`, which sits on main with no plans beside it.

## Recovering old content into a moved-on repo

Every failure hit here was an artifact of the recovery, not of the content:

- **Retired skill references.** Both plans opened with `superpowers:subagent-driven-development`, retired since June. Retargeted at the DPF-native preamble already used on main (`dpf-tdd` / `dpf-local-merge-ci-before-push` / `dpf-pr-with-dco`). Worth noting the guard is a ratchet with 277 grandfathered files — identical preambles sit on main today. Recovered documents enter as *new* files, so they are held to the current standard rather than the one in force when written. That is correct behaviour.
- **Stale doc index.** After rebasing onto five commits that added docs, six preflight guards failed — all cascading from one stale artifact, not six problems.

Both plans carry a visible recovery note stating that only the preamble changed, the body is unchanged from June, and the content predates two months of platform change and must be re-verified before execution. Landing a stale plan that looks current would be worse than not landing it.

## Deliberately not included

Orphaned source and test files from the same sweep. They are 6–10 weeks old and predate substantial change around them; landing them as-is would be worse than not landing them. Preserved with a manifest at `backups/orphaned-worktree-work-2026-08-01/`.

## `.gitattributes`

Gains a `*.pptx` LFS rule. The policy already routes `*.pdf`, `*.xlsx` and `*.docx` through LFS; `*.pptx` was simply never needed until now. The deck is committed as a 287 KB LFS pointer, not a raw blob.

## Cleanup performed alongside

12 worktrees removed once their unique content was preserved. All 12 branch refs verified intact at recorded SHAs (none existed on the remote, so their commits are local-only — SHAs recorded in the backup manifest).

One hazard worth recording: two of those worktrees had `node_modules` **junctions pointing at the root clone**. A plain recursive delete would have followed the link and destroyed `D:\DPF\node_modules`. Safe order is to `cmd /c rmdir` the reparse point (no `/s` — removes the link, never the target), verify the target, then `git worktree remove`. A canary on the root entry count held at 1,174 throughout.

## Local-CI-Override

**Attestation:** the sandbox gate could not be run for this branch.

Six `pnpm run pregate` attempts were killed while queued for the `local-integration-ci` pool. The pool reports `manifestCapacity: 2` but `hostSafeCapacity: 1` / `effectiveCapacity: 1` (`rollbackReason: "requested-singleton"`), so it is a single slot with real contention — at query time, one active lease plus three legitimate jobs queued ahead. Each kill left a cancelled lease, and because `claimKey = local-ci:${ownerSessionId}:${sha}`, a same-SHA retry collides with it (`lease_terminal`); retries used fresh session ids. Running fully detached from the harness extended survival from ~2.5 to ~13 minutes but did not resolve it.

**Verification actually performed:**
- `pregate-preflight`: **31 guards clean**, repeatedly and across rebases.
- Guard loop: 1/24 failing — `check-no-provider-local-connector-lifecycle.test.mjs`, which passes 8/8 standalone on clean `main` and fails here only as `GuardRuntimeEnvironmentError: Repo guard TypeScript resolved outside its isolated pnpm graph`. Pregate's own preflight classifies this as environment-skipped with "CI will still enforce it."
- Individually re-run and passing: doc link integrity, doc reference integrity, derived-artifact registry, prose lint, UX-fit, design grounding, retired-skills guard.

This is a docs-only change. CI enforces the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
