### PR TITLE
feat(incumbent): D3 stages 2 (rule) + 3 (AI) — complete the four-stage pipeline (BI-548060D5)

### DIFF
--- a/apps/web/lib/incumbent/coverage-ai.test.ts
+++ b/apps/web/lib/incumbent/coverage-ai.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { assessGapsViaAi, parseAiVerdict, type CoverageProposer } from "./coverage-ai";
+
+// D3 stage 3 (AI) tests. The proposer + db are injected/mocked, so this runs in
+// the source-only worktree; values import via the client-free @dpf/db/incumbent-
+// coverage subpath.
+
+describe("parseAiVerdict", () => {
+  it("parses a valid closed-enum verdict", () => {
+    expect(parseAiVerdict('{"verdict":"provider_led","reason":"vertical OS"}')).toEqual({
+      verdict: "provider_led",
+      reason: "vertical OS",
+    });
+  });
+  it("tolerates a fenced/prose wrapper around the JSON", () => {
+    expect(parseAiVerdict('Here:\n```json\n{"verdict":"gap","reason":"unknown"}\n```')).toEqual({
+      verdict: "gap",
+      reason: "unknown",
+    });
+  });
+  it("rejects an out-of-enum verdict and non-JSON", () => {
+    expect(parseAiVerdict('{"verdict":"totally_native","reason":"x"}')).toBeNull();
+    expect(parseAiVerdict("no json here")).toBeNull();
+  });
+});
+
+function gapDb(opts: { gaps: { assessmentId: string; digitalProductId: string }[]; dp?: { name: string; observationConfig: unknown } | null }) {
+  const update = vi.fn().mockResolvedValue({});
+  const db = {
+    incumbentCoverageAssessment: {
+      findMany: vi.fn().mockResolvedValue(opts.gaps),
+      update,
+    },
+    digitalProduct: {
+      findUnique: vi.fn().mockResolvedValue(opts.dp === undefined ? { name: "Acme", observationConfig: { vendor: "Acme Corp" } } : opts.dp),
+    },
+  };
+  return { db, update };
+}
+
+describe("assessGapsViaAi", () => {
+  const gap = { assessmentId: "assess-dp-acme", digitalProductId: "DP-incumbent-acme" };
+
+  it("writes an AI proposal (assessedVia=ai, always proposed)", async () => {
+    const { db, update } = gapDb({ gaps: [gap] });
+    const propose: CoverageProposer = vi.fn().mockResolvedValue({ verdict: "generic_connector", reason: "has an API" });
+    const result = await assessGapsViaAi(db as never, propose);
+    expect(result.proposed).toBe(1);
+    const data = update.mock.calls[0]![0].data;
+    expect(data.verdict).toBe("generic_connector");
+    expect(data.assessedVia).toBe("ai");
+    expect(data.status).toBe("proposed");
+  });
+
+  it("skips when the proposer returns null", async () => {
+    const { db, update } = gapDb({ gaps: [gap] });
+    const propose: CoverageProposer = vi.fn().mockResolvedValue(null);
+    const result = await assessGapsViaAi(db as never, propose);
+    expect(result.skipped).toBe(1);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("isolates a proposer error (not fatal)", async () => {
+    const { db, update } = gapDb({ gaps: [gap] });
+    const propose: CoverageProposer = vi.fn().mockRejectedValue(new Error("model down"));
+    const result = await assessGapsViaAi(db as never, propose);
+    expect(result.skipped).toBe(1);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("is correct over an empty set (no gaps → no calls)", async () => {
+    const { db } = gapDb({ gaps: [] });
+    const propose: CoverageProposer = vi.fn();
+    const result = await assessGapsViaAi(db as never, propose);
+    expect(result).toEqual({ proposed: 0, skipped: 0 });
+    expect(propose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/incumbent/coverage-ai.ts
+++ b/apps/web/lib/incumbent/coverage-ai.ts
@@ -11,7 +11,12 @@
 // real routeAndCall. Correct over an empty set — 0 gap incumbents → 0 AI calls.
 
 import type { PrismaClient } from "@dpf/db";
-import { ABSORPTION_VERDICTS, assessmentIdFor } from "@dpf/db";
+// Import from NARROW, client-free subpaths — not the root @dpf/db barrel. The
+// barrel pulls client-dependent modules whose init can fail in the test/edge
+// env, leaving later barrel exports undefined; these two pure modules load
+// cleanly on their own.
+import { ABSORPTION_VERDICTS } from "@dpf/db/portfolio-sources/absorption-posture";
+import { assessmentIdFor } from "@dpf/db/portfolio-sources/incumbent-coverage";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 export interface AiVerdictProposal {
@@ -122,10 +127,15 @@ type RouteAndCall = (
   options?: unknown,
 ) => Promise<{ content?: string; text?: string }>;
 
-const AI_SYSTEM_PROMPT =
-  "You classify how a business platform (DPF) should treat a third-party application a customer runs today. " +
-  `Reply ONLY with JSON: {"verdict": one of ${ABSORPTION_VERDICTS.join("|")}, "reason": short justification}. ` +
-  "Default conservatively to provider_led or gap when unsure — never overstate that DPF natively replaces the app.";
+// Built lazily (inside the adapter) so module load never evaluates
+// ABSORPTION_VERDICTS at top level.
+function aiSystemPrompt(): string {
+  return (
+    "You classify how a business platform (DPF) should treat a third-party application a customer runs today. " +
+    `Reply ONLY with JSON: {"verdict": one of ${ABSORPTION_VERDICTS.join("|")}, "reason": short justification}. ` +
+    "Default conservatively to provider_led or gap when unsure — never overstate that DPF natively replaces the app."
+  );
+}
 
 /** Adapter turning routeAndCall into a CoverageProposer. Kept thin — the stage
  *  logic + parsing are the tested parts; this only builds the prompt and reads
@@ -133,7 +143,7 @@ const AI_SYSTEM_PROMPT =
 export function routedInferenceProposer(routeAndCall: RouteAndCall): CoverageProposer {
   return async (incumbent) => {
     const user = `Application: ${incumbent.name}${incumbent.vendor ? ` (vendor: ${incumbent.vendor})` : ""}.`;
-    const res = await routeAndCall([{ role: "user", content: user }], AI_SYSTEM_PROMPT, "internal");
+    const res = await routeAndCall([{ role: "user", content: user }], aiSystemPrompt(), "internal");
     const text = res.content ?? res.text ?? "";
     return parseAiVerdict(text);
   };

--- a/apps/web/lib/incumbent/coverage-ai.ts
+++ b/apps/web/lib/incumbent/coverage-ai.ts
@@ -1,0 +1,140 @@
+// Incumbent coverage — stage 3 (AI proposal) of the D3 pipeline (BI-548060D5).
+//
+// Spec 2026-07-23 §5.4 stage 3: for incumbents neither the posture matrix (stage
+// 1) nor the rule stage (stage 2) could classify, an AI assessment PROPOSAL with
+// an evidence trail. assessedVia=ai, ALWAYS status=proposed, never auto-confirmed
+// (spec §7). Lives in apps/web because it needs the inference chain; packages/db
+// must not depend on apps/web.
+//
+// The LLM call is injected (CoverageProposer) so the stage logic is unit-testable
+// without inference; routedInferenceProposer is the thin adapter that wires the
+// real routeAndCall. Correct over an empty set — 0 gap incumbents → 0 AI calls.
+
+import type { PrismaClient } from "@dpf/db";
+import { ABSORPTION_VERDICTS, assessmentIdFor } from "@dpf/db";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+export interface AiVerdictProposal {
+  verdict: string;
+  reason: string;
+}
+
+/** Parse + validate an LLM response into a verdict proposal. Pure. Tolerates a
+ *  fenced/` ```json ` wrapper. Returns null if no valid closed-enum verdict. */
+export function parseAiVerdict(text: string): AiVerdictProposal | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[0]);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  const verdict = typeof obj.verdict === "string" ? obj.verdict : "";
+  if (!(ABSORPTION_VERDICTS as readonly string[]).includes(verdict)) return null;
+  const reason = typeof obj.reason === "string" ? obj.reason : "";
+  return { verdict, reason };
+}
+
+export interface IncumbentForProposal {
+  name: string;
+  vendor: string | null;
+}
+
+/** Proposes a verdict for one incumbent. Injected so the stage is testable. */
+export type CoverageProposer = (incumbent: IncumbentForProposal) => Promise<AiVerdictProposal | null>;
+
+export interface AiStageResult {
+  /** Gap assessments upgraded to an AI proposal. */
+  proposed: number;
+  /** Left as gap (no proposal / error / confirmed). */
+  skipped: number;
+}
+
+/**
+ * Stage 3 — AI proposal for gap incumbents. Reads the current gap assessments
+ * (never human-confirmed ones), asks the proposer, and writes the proposed
+ * verdict with `assessedVia=ai`, `status=proposed` (never confirmed) and an
+ * evidence trail. A proposer error on one incumbent is isolated, not fatal.
+ */
+export async function assessGapsViaAi(
+  db: PrismaClient,
+  propose: CoverageProposer,
+): Promise<AiStageResult> {
+  const result: AiStageResult = { proposed: 0, skipped: 0 };
+
+  const gaps = await db.incumbentCoverageAssessment.findMany({
+    where: { verdict: "gap", status: { not: "superseded" }, assessedVia: { not: "human_confirmed" } },
+    select: { assessmentId: true, digitalProductId: true },
+  });
+
+  for (const gap of gaps) {
+    const dp = await db.digitalProduct.findUnique({
+      where: { productId: gap.digitalProductId },
+      select: { name: true, observationConfig: true },
+    });
+    if (!dp) {
+      result.skipped += 1;
+      continue;
+    }
+    const cfg = dp.observationConfig;
+    const vendor =
+      cfg && typeof cfg === "object" && !Array.isArray(cfg) && typeof (cfg as Record<string, unknown>).vendor === "string"
+        ? ((cfg as Record<string, unknown>).vendor as string)
+        : null;
+
+    let proposal: AiVerdictProposal | null = null;
+    try {
+      proposal = await propose({ name: dp.name, vendor });
+    } catch (e) {
+      proposal = null;
+      console.error(`[coverage-ai] proposer failed for ${gap.digitalProductId}: ${getErrorMessage(e)}`);
+    }
+    if (!proposal) {
+      result.skipped += 1;
+      continue;
+    }
+
+    await db.incumbentCoverageAssessment.update({
+      where: { assessmentId: assessmentIdFor(gap.digitalProductId) },
+      data: {
+        verdict: proposal.verdict,
+        assessedVia: "ai",
+        status: "proposed",
+        confidence: 0.5,
+        evidence: { via: "ai", provider: vendor ?? dp.name, reason: proposal.reason },
+      },
+    });
+    result.proposed += 1;
+  }
+
+  return result;
+}
+
+// ─── Thin adapter: wire the real inference chain as a CoverageProposer ───────
+
+type RouteAndCall = (
+  messages: { role: "user" | "system" | "assistant"; content: string }[],
+  systemPrompt: string,
+  sensitivity?: "internal",
+  options?: unknown,
+) => Promise<{ content?: string; text?: string }>;
+
+const AI_SYSTEM_PROMPT =
+  "You classify how a business platform (DPF) should treat a third-party application a customer runs today. " +
+  `Reply ONLY with JSON: {"verdict": one of ${ABSORPTION_VERDICTS.join("|")}, "reason": short justification}. ` +
+  "Default conservatively to provider_led or gap when unsure — never overstate that DPF natively replaces the app.";
+
+/** Adapter turning routeAndCall into a CoverageProposer. Kept thin — the stage
+ *  logic + parsing are the tested parts; this only builds the prompt and reads
+ *  the response text. */
+export function routedInferenceProposer(routeAndCall: RouteAndCall): CoverageProposer {
+  return async (incumbent) => {
+    const user = `Application: ${incumbent.name}${incumbent.vendor ? ` (vendor: ${incumbent.vendor})` : ""}.`;
+    const res = await routeAndCall([{ role: "user", content: user }], AI_SYSTEM_PROMPT, "internal");
+    const text = res.content ?? res.text ?? "";
+    return parseAiVerdict(text);
+  };
+}

--- a/docs/superpowers/plans/2026-08-01-incumbent-coverage-assessment.md
+++ b/docs/superpowers/plans/2026-08-01-incumbent-coverage-assessment.md
@@ -52,11 +52,12 @@ Closed enums (`verdict`, `assessedVia`, `status`) guarded by predicates + a pari
 - **Accessor:** `coverageForIncumbent` / `listCoverageAssessments` (the typed read D6 consumes).
 - **Acceptance:** enum predicates; stage-1 matching (hit → posture verdict; miss → gap; idempotent supersede); confirm transitions provenance; unit-tested with mock prisma; governance battery green; `prisma validate` clean.
 
-### P2 — Stage 2 (rule) — `CatalogIdentity → taxonomy node → capability`
-Deterministic rule matching using the taxonomy the portfolio already carries, for incumbents the posture matrix does not name. `assessedVia=rule`. Follow-on.
+### P2 — Stage 2 (rule) — covering capability via the category corpus — **SHIPPED**
+Deterministic covering-capability resolution using the taxonomy the portfolio already carries. `assessIncumbentsViaRule` derives an incumbent's archetype category (posture `archetypeIds` → `StorefrontArchetype.category`) and resolves the covering **business** capability via the existing `CATEGORY_BUSINESS_CAPABILITY_PERSPECTIVES` corpus (`coveringBusinessCapabilityForCategory`) — no authored crosswalk. Enriches `coveringBusinessCapabilityId`; idempotent; never clobbers a human-confirmed row.
+**Scope note:** a rule stage that produces a VERDICT for gap incumbents the posture matrix never named needs a crosswalk between the incumbent identity vocabulary (`CatalogIdentity` CPE `category`) and the archetype/capability vocabulary — that crosswalk does not exist and is a separate authoring effort. This stage resolves what the existing substrate deterministically supports.
 
-### P3 — Stage 3 (AI)
-An AI assessment proposal with an evidence trail for still-unmatched entries. `assessedVia=ai`, always `status=proposed`, never auto-confirmed (spec §7). Follow-on.
+### P3 — Stage 3 (AI) — inference-backed proposal — **SHIPPED**
+`assessGapsViaAi` (apps/web, needs the inference chain) asks an injected proposer to classify gap incumbents; writes `assessedVia=ai`, always `status=proposed`, never auto-confirmed (spec §7). The LLM call is behind `routedInferenceProposer` (thin adapter over `routeAndCall`); `parseAiVerdict` validates against the closed verdict enum. Proposer errors are isolated. Correct over an empty set.
 
 ## 5. Verification
 - Unit: enum predicates; stage-1 matching + gap + idempotent supersede; confirm; the accessor — all with mock prisma (source-only worktree).

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -64,6 +64,8 @@
     "./seed-skills": "./src/seed-skills.ts",
     "./portfolio-sources/types": "./src/portfolio-sources/types.ts",
     "./portfolio-sources/vertical-incumbents-manifest": "./src/portfolio-sources/vertical-incumbents-manifest.ts",
+    "./portfolio-sources/absorption-posture": "./src/portfolio-sources/absorption-posture.ts",
+    "./portfolio-sources/incumbent-coverage": "./src/portfolio-sources/incumbent-coverage.ts",
     "./patch": "./src/patch/index.ts"
   },
   "scripts": {

--- a/packages/db/src/portfolio-sources/incumbent-coverage.test.ts
+++ b/packages/db/src/portfolio-sources/incumbent-coverage.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import {
   ASSESSMENT_VIA_METHODS,
   assessIncumbentsViaPostureMatrix,
+  assessIncumbentsViaRule,
   assessmentIdFor,
   confirmCoverageAssessment,
+  coveringBusinessCapabilityForCategory,
   isAssessmentVia,
   isCoverageVerdict,
   providerOfIncumbent,
@@ -122,6 +124,60 @@ describe("assessIncumbentsViaPostureMatrix", () => {
     expect(result.assessed).toBe(1);
     expect(create).not.toHaveBeenCalled();
     expect(update.mock.calls[0]![0].data.verdict).toBe("generic_connector");
+  });
+});
+
+describe("stage 2 — rule (covering business capability)", () => {
+  it("resolves the covering capability for a covered category via the corpus", () => {
+    const covering = coveringBusinessCapabilityForCategory("fitness-recreation");
+    expect(covering).not.toBeNull();
+    expect(covering!.category).toBe("fitness-recreation");
+    expect(typeof covering!.businessCapabilityId).toBe("string");
+  });
+
+  it("returns null for an uncovered or missing category", () => {
+    expect(coveringBusinessCapabilityForCategory("not-a-category")).toBeNull();
+    expect(coveringBusinessCapabilityForCategory(null)).toBeNull();
+  });
+
+  function ruleDb(opts: { existing: { coveringBusinessCapabilityId: string | null; status: string } | null }) {
+    const update = vi.fn().mockResolvedValue({});
+    const db = {
+      digitalProduct: {
+        findMany: vi.fn().mockResolvedValue([
+          { productId: "DP-incumbent-mindbody", name: "Mindbody", observationConfig: { vendor: "Mindbody" } },
+        ]),
+      },
+      absorptionPosture: { findFirst: vi.fn().mockResolvedValue({ archetypeIds: ["gym", "yoga-studio"] }) },
+      storefrontArchetype: { findFirst: vi.fn().mockResolvedValue({ category: "fitness-recreation" }) },
+      incumbentCoverageAssessment: {
+        findUnique: vi.fn().mockResolvedValue(opts.existing),
+        update,
+      },
+    };
+    return { db, update };
+  }
+
+  it("enriches an existing assessment's covering capability", async () => {
+    const { db, update } = ruleDb({ existing: { coveringBusinessCapabilityId: null, status: "proposed" } });
+    const result = await assessIncumbentsViaRule(db as never);
+    expect(result.enriched).toBe(1);
+    expect(update.mock.calls[0]![0].data.coveringBusinessCapabilityId).toBeTruthy();
+  });
+
+  it("is idempotent when the covering capability is already set", async () => {
+    const perspective = coveringBusinessCapabilityForCategory("fitness-recreation")!;
+    const { db, update } = ruleDb({ existing: { coveringBusinessCapabilityId: perspective.businessCapabilityId, status: "proposed" } });
+    const result = await assessIncumbentsViaRule(db as never);
+    expect(result.skipped).toBe(1);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("never clobbers a human-confirmed assessment", async () => {
+    const { db, update } = ruleDb({ existing: { coveringBusinessCapabilityId: null, status: "confirmed" } });
+    const result = await assessIncumbentsViaRule(db as never);
+    expect(result.skipped).toBe(1);
+    expect(update).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/db/src/portfolio-sources/incumbent-coverage.ts
+++ b/packages/db/src/portfolio-sources/incumbent-coverage.ts
@@ -15,6 +15,7 @@
 
 import type { PrismaClient } from "../../generated/client/client";
 import { ABSORPTION_VERDICTS, type AbsorptionVerdict } from "./absorption-posture";
+import { CATEGORY_BUSINESS_CAPABILITY_PERSPECTIVES } from "../business-capability-category-corpus";
 
 /** How a verdict was reached — provenance (spec §5.2). Closed enum. */
 export const ASSESSMENT_VIA_METHODS = [
@@ -200,4 +201,124 @@ export async function listCoverageAssessments(
       coveringCapabilityKey: true,
     },
   });
+}
+
+// ─── Stage 2 — rule (spec §5.4) ──────────────────────────────────────────────
+//
+// The deterministic covering-capability resolution: an incumbent's archetype
+// (carried by its matched posture's archetypeIds) → the archetype's category →
+// the business-capability the category corpus already maps
+// (CATEGORY_BUSINESS_CAPABILITY_PERSPECTIVES, keyed by archetype category). This
+// traverses EXISTING substrate (ALL_ARCHETYPES + the corpus), no authored
+// crosswalk. It populates coveringBusinessCapabilityId that stage 1 leaves
+// unresolved; it does NOT change the verdict or its posture_matrix provenance
+// (the verdict is still the authored posture default awaiting confirmation).
+//
+// Scope honesty: a rule stage that produces a VERDICT for gap incumbents (ones
+// the posture matrix never named) needs a crosswalk between the incumbent
+// identity vocabulary (CatalogIdentity CPE category) and the archetype/capability
+// vocabulary — that crosswalk does not exist and is a separate authoring effort.
+// This stage resolves what the existing substrate deterministically supports.
+
+/** The covering business capability for an archetype category, via the corpus
+ *  (CATEGORY_BUSINESS_CAPABILITY_PERSPECTIVES). Pure — no client, no cross-package
+ *  import. Returns null when the category is not one the corpus covers. */
+export function coveringBusinessCapabilityForCategory(
+  category: string | null | undefined,
+): { businessCapabilityId: string; category: string } | null {
+  if (!category) return null;
+  const perspective = CATEGORY_BUSINESS_CAPABILITY_PERSPECTIVES[category];
+  if (!perspective) return null;
+  // The covering capability is the perspective's root (level-1) business
+  // capability; fall back to the perspective id if the tree shape ever changes.
+  const root = perspective.capabilities.find((c) => c.level === 1);
+  return { businessCapabilityId: root?.key ?? perspective.perspectiveId, category };
+}
+
+export interface RuleStageResult {
+  /** Assessments whose coveringBusinessCapabilityId was resolved/updated. */
+  enriched: number;
+  /** Left untouched (no posture, no covered archetype, already set, or confirmed). */
+  skipped: number;
+}
+
+/**
+ * Stage 2 — resolve the covering business capability for each incumbent via the
+ * category corpus (deterministic, existing substrate). Enriches the current
+ * assessment produced by stage 1; never clobbers a human-confirmed row; idempotent.
+ * Correct over an empty set — 0 incumbents / no covered archetype → 0 enriched.
+ */
+export async function assessIncumbentsViaRule(db: PrismaClient): Promise<RuleStageResult> {
+  const result: RuleStageResult = { enriched: 0, skipped: 0 };
+
+  const incumbents = await db.digitalProduct.findMany({
+    where: { coverageStatus: "incumbent" },
+    select: { productId: true, name: true, observationConfig: true },
+  });
+
+  for (const incumbent of incumbents) {
+    const provider = providerOfIncumbent(incumbent);
+    const posture = await db.absorptionPosture.findFirst({
+      where: { providerName: { equals: provider, mode: "insensitive" } },
+      select: { archetypeIds: true },
+    });
+    if (!posture || posture.archetypeIds.length === 0) {
+      result.skipped += 1;
+      continue;
+    }
+    // archetypeId → category via StorefrontArchetype (the DB the pipeline already
+    // holds), then category → covering business capability via the corpus.
+    const archetype = await db.storefrontArchetype.findFirst({
+      where: { archetypeId: { in: posture.archetypeIds } },
+      select: { category: true },
+    });
+    const covering = coveringBusinessCapabilityForCategory(archetype?.category);
+    if (!covering) {
+      result.skipped += 1;
+      continue;
+    }
+
+    const assessmentId = assessmentIdFor(incumbent.productId);
+    const existing = await db.incumbentCoverageAssessment.findUnique({
+      where: { assessmentId },
+      select: { coveringBusinessCapabilityId: true, status: true },
+    });
+    // Stage 1 must have created the row; never touch a confirmed one; idempotent.
+    if (
+      !existing ||
+      existing.status === "confirmed" ||
+      existing.coveringBusinessCapabilityId === covering.businessCapabilityId
+    ) {
+      result.skipped += 1;
+      continue;
+    }
+
+    await db.incumbentCoverageAssessment.update({
+      where: { assessmentId },
+      data: { coveringBusinessCapabilityId: covering.businessCapabilityId },
+    });
+    result.enriched += 1;
+  }
+
+  return result;
+}
+
+export interface CoveragePipelineResult {
+  postureMatrix: CoverageAssessmentRunResult;
+  rule: RuleStageResult;
+}
+
+/**
+ * Run the deterministic stages of the coverage pipeline in the spec's order —
+ * cheapest and most trustworthy first: stage 1 (posture_matrix) then stage 2
+ * (rule). Stage 3 (AI) is a separate apps/web concern (it needs the inference
+ * chain) and runs after these; stage 4 (human) is on-demand via
+ * confirmCoverageAssessment.
+ */
+export async function runCoverageAssessmentPipeline(
+  db: PrismaClient,
+): Promise<CoveragePipelineResult> {
+  const postureMatrix = await assessIncumbentsViaPostureMatrix(db);
+  const rule = await assessIncumbentsViaRule(db);
+  return { postureMatrix, rule };
 }


### PR DESCRIPTION
## What

Completes `BI-548060D5`'s **four-stage** matching pipeline — stages 2 (rule) and 3 (AI) on top of P1 (stages 1 & 4, merged `93d5f39135`). Settles the goal toward the full four-stage scope.

## Stages

- **Stage 2 (rule)** — `packages/db` `assessIncumbentsViaRule`: resolves an incumbent's covering **business** capability deterministically via *existing* substrate — posture `archetypeIds` → `StorefrontArchetype.category` → `CATEGORY_BUSINESS_CAPABILITY_PERSPECTIVES` corpus (`coveringBusinessCapabilityForCategory`). No authored crosswalk. Idempotent; never clobbers a human-confirmed row. `runCoverageAssessmentPipeline` sequences stages 1→2.
- **Stage 3 (AI)** — `apps/web` `assessGapsViaAi`: proposes verdicts for gap incumbents via an **injected** proposer (`routedInferenceProposer` thinly wires `routeAndCall`); `parseAiVerdict` validates against the closed verdict enum; `assessedVia=ai`, **always `proposed`**, never auto-confirmed (spec §7); proposer errors isolated. Correct over an empty set.

## Scope honesty

A rule stage producing a *verdict* for gap incumbents the posture matrix never named needs a `CatalogIdentity` CPE-category → archetype-category **crosswalk** that doesn't exist (a separate authoring effort). Stage 2 resolves what the substrate deterministically supports (covering-capability enrichment).

## Test plan

- 15/15 db unit tests (stages 1+2) in the source-only worktree.
- Stage-3 logic mock-tested (`coverage-ai.test.ts` runs in CI — the worktree cannot resolve `@dpf/db` value imports).
- **No new Prisma model, migration, or substrate change** → the model-governance battery does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
