### PR TITLE
test(build): make two apps/web vitest shard flakes deterministic

### DIFF
--- a/apps/web/components/build/ParentDesignAmendmentCoordinator.test.tsx
+++ b/apps/web/components/build/ParentDesignAmendmentCoordinator.test.tsx
@@ -69,11 +69,14 @@ describe("ParentDesignAmendmentCoordinator", () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(contextMock).toHaveBeenCalledWith({ childBuildId: "FB-CHILD2" });
-    });
+    // The dialog shell mounts synchronously on open, but the parent summary and
+    // form fields render only after the async context action resolves (a
+    // transition update). Wait for context-dependent content with findBy* rather
+    // than asserting synchronously after a bare "contextMock was called" wait —
+    // that gap is the shard-timing race that made this suite flaky.
+    expect(await screen.findByText("Truck inventory")).toBeInTheDocument();
+    expect(contextMock).toHaveBeenCalledWith({ childBuildId: "FB-CHILD2" });
     expect(screen.getByRole("dialog", { name: "Amend parent design" })).toBeInTheDocument();
-    expect(screen.getByText("Truck inventory")).toBeInTheDocument();
     expect(screen.getByText("Read parts")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Proposed approach"), {
@@ -129,9 +132,11 @@ describe("ParentDesignAmendmentCoordinator", () => {
         detail: { buildId: "FB-CHILD2" },
       }),
     );
-    await screen.findByRole("dialog", { name: "Amend parent design" });
-
-    fireEvent.change(screen.getByLabelText("Amendment rationale"), {
+    // Wait for the context-loaded form field itself — not just the dialog shell,
+    // which renders synchronously on open before the async context resolves.
+    // getByLabelText immediately after findByRole("dialog") could run before the
+    // input mounted; that was the intermittent failure at this line.
+    fireEvent.change(await screen.findByLabelText("Amendment rationale"), {
       target: { value: "Adjust parent contract safely." },
     });
     fireEvent.click(screen.getByRole("button", { name: "Apply parent amendment" }));

--- a/apps/web/lib/integrate/build-phase-run.test.ts
+++ b/apps/web/lib/integrate/build-phase-run.test.ts
@@ -17,6 +17,22 @@ vi.mock("@/lib/self-upgrade/quiescence", () => ({
   },
 }));
 
+// completeBuildPhaseRun fires the Ring 1→2 / Ring 2→3 gear emitters
+// fire-and-forget (`void emit(...).catch(...)`). Left real, they run against
+// this file's deliberately-narrow @dpf/db mock (no featureBuild model), reject,
+// and log "[gear-interface] … emit failed" via their .catch AFTER the test has
+// already resolved. That late console.warn leaves an onUserConsoleLog RPC
+// pending at worker teardown — the intermittent EnvironmentTeardownError that
+// fails the shard with 0 failed tests + exit 1 (same hazard build-governed.test
+// documents for autoExecuteBuild). Mocking the emitters to no-ops keeps the
+// fire-and-forget a clean resolved promise; the emitters have their own tests.
+vi.mock("@/lib/gear-interface/emit-ring-1-2", () => ({
+  emitRing12FromCompletedPhase: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/gear-interface/emit-ring-2-3", () => ({
+  emitRing23FromCompletedShip: vi.fn().mockResolvedValue(undefined),
+}));
+
 // ── Mock Prisma ──────────────────────────────────────────────────────────────
 const phaseRuns = new Map<string, Record<string, unknown>>();
 


### PR DESCRIPTION
## What & why

Two intermittent failures in the `apps/web` vitest unit shards forced CI re-runs — both passed on a plain re-run with no code change — eroding CI signal and slowing the merge queue. This makes both deterministic. Pre-existing; surfaced (not caused) by unrelated work.

**1. `components/build/ParentDesignAmendmentCoordinator.test.tsx` (RTL race).** The panel renders its dialog shell synchronously on open but mounts the form fields only after the async context action resolves (a transition re-render). The tests queried context-dependent content synchronously (`getByLabelText` / `getByText`) right after awaiting the dialog shell or a bare "action was called" wait — so under shard CPU contention the query could run before the field mounted and throw. Fix: `findBy*` so the query waits for the loaded form.

**2. `lib/integrate/build-phase-run.test.ts` (unhandled error → teardown).** `completeBuildPhaseRun` fires the Ring 1→2 / 2→3 gear emitters fire-and-forget; against this file's narrow `@dpf/db` mock they reject and `console.warn` *after* the test resolves, leaving an `onUserConsoleLog` RPC pending at worker teardown → `EnvironmentTeardownError` (all tests pass, 1 unhandled error, exit 1). Fix: mock the emitter modules to no-ops so the fire-and-forget produces no post-test console output — the same isolation `build-governed.test.ts` already documents for `autoExecuteBuild`. The emitters keep their own dedicated tests.

## Verification (local, vs current `origin/main`)
- `build-phase-run.test.ts`: 12 late `[gear-interface]` warns → **0**; 10/10 tests pass across 5 runs.
- `ParentDesignAmendmentCoordinator.test.tsx`: **10/10** runs green. Reproduced the race deterministically under a delayed-context harness (old synchronous query throws; `findBy*` waits), then confirmed the fix.
- `build-governed.test.ts` (untouched): 21/21 pass, 0 leaks — the sibling `createFeatureBuild`/`startBuildPhaseRun` teardown leak is already fixed upstream, so no change is needed there.

## Local-CI-Override
Test-only change (2 vitest files; no source, schema, or runtime changes). The pre-push local-CI gate was overridden because `pregate` is impractical in this junctioned source-only worktree; the change is verified-clean per the targeted runs above, and full-repo CI runs authoritatively on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
