### PR TITLE
test(release): reject runGateAsync on child spawn error

### DIFF
--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -105,12 +105,17 @@ function runGate(args, env) {
 // its entire duration, which would starve the very http.Server the child
 // needs to reach (self-deadlock — the child would hang until it times out).
 function runGateAsync(args, env) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [gateScript, ...args], { env });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => { stdout += chunk; });
     child.stderr.on("data", (chunk) => { stderr += chunk; });
+    // Without this, a spawn failure (ENOENT/EACCES, or EAGAIN/EMFILE under heavy
+    // CI parallelism) would surface as an uncaughtException that crashes the
+    // test subprocess and leaves this Promise forever pending. Reject instead so
+    // it lands as a clean test failure.
+    child.on("error", reject);
     child.on("close", (status) => resolve({ status, stdout, stderr }));
   });
 }


### PR DESCRIPTION
## What

`runGateAsync` in `tests/release/pregate-node-gate-contract.test.mjs` (the async spawner used across the source policy-guard profile) registered only a `'close'` listener on the child process.

If `spawn` emits an `'error'` event — `ENOENT`/`EACCES`, or `EAGAIN`/`EMFILE` under heavy CI parallelism — Node re-throws it as an `uncaughtException` that crashes the test-file subprocess, while the `'close'`-based Promise stays **forever pending**. A spawn failure would present as an opaque process crash rather than a named test failure.

## Fix

Give the Promise executor a `reject` and register `child.on("error", reject)`. All 9 call sites `await runGateAsync(...)` inside async tests, so a rejection propagates as a normal failed assertion — clean and attributable.

## Verification

- `node --test tests/release/pregate-node-gate-contract.test.mjs` — 19/19 pass
- Local-CI pregate (shared sandbox) — `gate passed`

Pre-existing robustness gap; the only unguarded async spawn in the source policy-guard profile. Found while investigating a "Policy Guards (source)" exit-1 misdiagnosis (the real failure there was the module-size ratchet, unrelated to this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)