### PR TITLE
feat(inference): record WHY a payload classified, not just THAT it did (BI-8058697C)

### DIFF
--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -13,11 +13,27 @@ import type {
   InferenceDataScreenReceipt,
   InferenceDataScreenResult,
   InferencePayloadSensitivity,
+  InferenceMatchProvenance,
   InferencePolicyVersionSnapshot,
 } from "./types";
 import { hasVerticalPolicyPacks } from "./vertical-policy-packs";
 
 const DEFAULT_ORGANIZATION_ID = "org:local-install";
+
+/** Collapse repeat matches of the same rule at the same path; a payload that
+ *  trips one rule fifty times needs one provenance row, not fifty. */
+function dedupeMatchProvenance(
+  rows: readonly InferenceMatchProvenance[],
+): InferenceMatchProvenance[] {
+  const seen = new Map<string, InferenceMatchProvenance>();
+  for (const row of rows) {
+    const key = `${row.dataClass}|${row.path}|${row.reason}|${row.confidence}`;
+    if (!seen.has(key)) seen.set(key, row);
+  }
+  return [...seen.values()].sort((a, b) =>
+    a.dataClass.localeCompare(b.dataClass) || a.path.localeCompare(b.path) || a.reason.localeCompare(b.reason),
+  );
+}
 
 const SENSITIVITY_RANK: Readonly<Record<RequestContract["sensitivity"], number>> = {
   public: 0,
@@ -157,6 +173,17 @@ export function screenInferencePayload(
         ...policy.obligations.map((obligation) => obligation.kind),
       ]),
       policyPackVersions: policy.policyPackVersions,
+      // Path + rule + confidence only — never the matched value, so the receipt
+      // stays rawPayloadStored:false while a local-only verdict becomes
+      // diagnosable from the record instead of by re-deriving the payload.
+      matchProvenance: dedupeMatchProvenance(
+        classification.matches.map((match) => ({
+          dataClass: match.dataClass,
+          path: match.path,
+          reason: match.reason,
+          confidence: match.confidence,
+        })),
+      ),
       rawPayloadStored: false,
     },
     classification,

--- a/apps/web/lib/inference/data-screening/screen-receipt-provenance.test.ts
+++ b/apps/web/lib/inference/data-screening/screen-receipt-provenance.test.ts
@@ -1,0 +1,80 @@
+// Screen receipts must say WHY a payload classified, not just THAT it did.
+//
+// A live local-only routing verdict recorded classifiedDataClasses
+// ["customer-records","employee-records"] and nothing about what tripped it.
+// Diagnosing that took hours of re-deriving the payload by hand — persona,
+// tool schemas, business context and full thread history all had to be probed
+// separately to find the trigger. The receipt already carried the verdict; it
+// just could not explain it.
+//
+// The hard constraint: provenance must never carry the matched VALUE. A path
+// and a rule name locate the source; the value itself is precisely what
+// rawPayloadStored:false exists to keep out of the record.
+
+import { describe, expect, it } from "vitest";
+import { screenInferencePayload } from "./screen-inference-payload";
+
+const SECRET_EMAIL = "jane.doe@acme-corp.example";
+const SECRET_PHONE = "(415) 555-0142";
+
+function screen(systemPrompt: string) {
+  return screenInferencePayload({ systemPrompt, messages: [], tools: [] }).receipt;
+}
+
+describe("inference screen receipt — match provenance", () => {
+  it("records the path, rule and confidence that produced a data class", () => {
+    const receipt = screen(`Inbound enquiry from ${SECRET_EMAIL} about catering.`);
+
+    expect(receipt.classifiedDataClasses).toContain("customer-records");
+    const provenance = receipt.matchProvenance ?? [];
+    expect(provenance.length).toBeGreaterThan(0);
+
+    const match = provenance.find((row) => row.dataClass === "customer-records");
+    expect(match).toBeDefined();
+    expect(match!.path).toBe("systemPrompt");
+    expect(match!.reason).toBe("contact-detail");
+    expect(match!.confidence).toBe("deterministic");
+  });
+
+  it("NEVER carries the matched value — the receipt stays free of payload text", () => {
+    const receipt = screen(`Contact ${SECRET_EMAIL} or ${SECRET_PHONE} for the campaign.`);
+    const serialized = JSON.stringify(receipt);
+
+    expect(serialized).not.toContain(SECRET_EMAIL);
+    expect(serialized).not.toContain(SECRET_PHONE);
+    expect(serialized).not.toContain("jane.doe");
+    expect(serialized).not.toContain("555-0142");
+    expect(receipt.rawPayloadStored).toBe(false);
+  });
+
+  it("distinguishes an inferred escalation from a deterministic one", () => {
+    // Generic employment vocabulary escalates on INFERRED confidence alone. That
+    // is exactly the case an operator needs to see spelled out before treating a
+    // restricted verdict as evidence of real employee data.
+    const receipt = screen("Team: 3 employees on the roster; payroll runs monthly.");
+    const provenance = receipt.matchProvenance ?? [];
+
+    const employee = provenance.find((row) => row.dataClass === "employee-records");
+    expect(employee?.confidence).toBe("inferred");
+    expect(employee?.path).toBe("systemPrompt");
+  });
+
+  it("emits no provenance for a clean payload", () => {
+    const receipt = screen("Campaigns: 0. Pending drafts: 1. Next step: establish one campaign.");
+
+    expect(receipt.classifiedDataClasses).toEqual([]);
+    expect(receipt.matchProvenance ?? []).toEqual([]);
+  });
+
+  it("collapses repeat hits of the same rule at the same path", () => {
+    const receipt = screen(
+      `Contacts: a@x.example, b@y.example, c@z.example, d@w.example, e@v.example.`,
+    );
+    const rows = (receipt.matchProvenance ?? []).filter(
+      (row) => row.dataClass === "customer-records" && row.path === "systemPrompt",
+    );
+
+    // Five addresses, one rule, one path — one provenance row, not five.
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/inference/data-screening/types.ts
+++ b/apps/web/lib/inference/data-screening/types.ts
@@ -77,7 +77,27 @@ export type InferenceDataScreenReceipt = {
   obligationKinds: string[];
   /** Present for policy-pack-aware screens; absent on pre-pack v1 receipts. */
   policyPackVersions?: string[];
+  /**
+   * WHY each data class was detected: the probe path, the rule that fired, and
+   * its confidence — never the matched value. Without this a receipt records
+   * that a payload classified as, say, customer-records but not what tripped it,
+   * so a local-only routing decision cannot be diagnosed without re-deriving the
+   * payload by hand. Deliberately excludes matched text so `rawPayloadStored`
+   * stays false: a path plus a rule name is enough to locate the source, and the
+   * value itself is exactly what must not be persisted.
+   */
+  matchProvenance?: InferenceMatchProvenance[];
   rawPayloadStored: false;
+};
+
+/** Provenance for one classifier match. Carries no payload values. */
+export type InferenceMatchProvenance = {
+  dataClass: InferenceDataClass;
+  /** Probe path, e.g. "systemPrompt" or "messages[3].content". Never the value. */
+  path: string;
+  /** The rule that fired, e.g. "contact-detail" or "employee-record-text". */
+  reason: string;
+  confidence: InferencePayloadMatch["confidence"];
 };
 
 export type InferenceDataScreenResult = {


### PR DESCRIPTION
## The problem this solves

A live routing verdict pinned **every** Marketing Strategist turn to `local-only`. The screen receipt recorded:

```json
"classifiedDataClasses": ["customer-records", "employee-records"],
"routeEffect": "local-only"
```

…and nothing about *what tripped it*.

Diagnosing that meant re-deriving the payload by hand — probing the persona prompt, all fifteen tool schemas, the universal business-context block, and the full thread history separately, one at a time. **Every one came back clean, and the trigger still isn't isolated.** The receipt held the verdict but couldn't explain it.

## What changed

`matchProvenance` on the screen receipt: for each classifier match, the **probe path**, the **rule** that fired, and its **confidence**.

That turns *"this classified as customer-records"* into *"customer-records, `contact-detail` rule, deterministic, at `messages[3].content`"* — one query instead of an afternoon.

## The constraint that shapes it

**Provenance carries no matched value.** A path and a rule name locate the source; the value itself is precisely what `rawPayloadStored: false` exists to keep out of the record. A test asserts the serialized receipt contains neither the email nor the phone number that produced the match, and that `rawPayloadStored` stays `false`.

Repeat hits of the same rule at the same path collapse to one row — a payload listing fifty addresses needs one entry, not fifty.

## A judgement this makes visible

Whether a class arrived by **deterministic** evidence or **inferred**. Generic employment vocabulary — *"3 employees on the roster; payroll runs monthly"* — escalates a payload to `restricted` on inferred confidence alone. That may well be correct, but an operator judging a `restricted` verdict should be able to see it, not have it look identical to a real PII hit. `classify-payload.ts` already flags this hazard in its own comments; this makes it legible in the record.

## Verification

- **100 tests pass** across 9 `data-screening` + `routing/fallback` files, including 5 new ones.
- Confirmed **genuinely red** before the change — 3 failures on real assertions (`expected 0 to be greater than 0`, `expected undefined to be 'inferred'`), not red from an unrelated error.
- Module-size ratchet OK.

Additive and optional (`matchProvenance?`), so existing receipts and consumers are unaffected. **No routing verdict changes** — this only records why one was reached.

Local-CI-Override: additive optional receipt field; 100 tests green across data-screening and routing/fallback; shared sandbox contended, CI authoritative.
Docs-Impact-Decision: none — internal governance record, no user-facing surface or documented behaviour change.
Process-Spine-Decision: diagnosability improvement supporting BI-8058697C; no policy, contract or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)