### PR TITLE
fix(discovery): let the quality detector see the enrichment it just persisted

### DIFF
--- a/packages/db/src/discovery-sync.enrichment-visible.test.ts
+++ b/packages/db/src/discovery-sync.enrichment-visible.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveInventoryEnrichment } from "./inventory-enrichment";
+import { deriveInventoryEvidenceSnapshot } from "./discovery-evidence";
+import { evaluateInventoryQuality } from "./discovery-attribution";
+
+// THE DETECTOR MUST SEE WHAT THE ROW HOLDS.
+//
+// discovery-sync persists `deriveInventoryEnrichment(...)` onto InventoryEntity
+// (manufacturer from MAC OUI vendor / container image tag / service-name hints,
+// supportStatus, versions) but evaluated quality against
+// `deriveInventoryEvidenceSnapshot(...)` — package-manager software evidence
+// ONLY. So discovery could enrich an entity and then, in the same transaction,
+// re-raise `catalog_match_ambiguous` / `lifecycle_unverified` about the very
+// fields it had just populated.
+//
+// That made those queues self-sustaining: enrichment can never satisfy a
+// condition evaluated without it. Observed live on 2026-08-01 — of five sampled
+// open lifecycle_unverified rows whose entity the sweep HAD just re-observed and
+// whose persisted supportStatus was `supported`, four had ZERO
+// DiscoveredSoftwareEvidence rows (postgres-exporter, prometheus, redis-exporter,
+// inngest). The reconcile shipped in #3873 correctly declined to close them:
+// from the detector's blinded view they were still warranted.
+
+/** A service entity with NO package-manager evidence — the live shape. */
+const SERVICE_WITH_NO_SOFTWARE_EVIDENCE = {
+  entityKey: "service:prom:redis:redis-exporter:9121",
+  entityType: "service",
+  name: "redis-exporter",
+  properties: { job: "redis", vendor: "Redis" },
+};
+
+function qualityInput(useEnrichment: boolean) {
+  const evidenceSnapshot = deriveInventoryEvidenceSnapshot([]);
+  const enriched = deriveInventoryEnrichment({
+    entityType: SERVICE_WITH_NO_SOFTWARE_EVIDENCE.entityType,
+    name: SERVICE_WITH_NO_SOFTWARE_EVIDENCE.name,
+    manufacturer: evidenceSnapshot.manufacturer,
+    productModel: evidenceSnapshot.productModel,
+    observedVersion: evidenceSnapshot.observedVersion,
+    normalizedVersion: evidenceSnapshot.normalizedVersion,
+    iconKey: null,
+    supportStatus: evidenceSnapshot.supportStatus,
+    properties: SERVICE_WITH_NO_SOFTWARE_EVIDENCE.properties as never,
+  });
+
+  return {
+    entityKey: SERVICE_WITH_NO_SOFTWARE_EVIDENCE.entityKey,
+    entityType: SERVICE_WITH_NO_SOFTWARE_EVIDENCE.entityType,
+    attributionStatus: "attributed" as const,
+    attributionConfidence: 0.99,
+    candidateTaxonomy: [],
+    taxonomyNodeId: "foundational/platform_services/container_platform",
+    digitalProductId: null,
+    // This is the line under test: enriched values, or the blinded snapshot.
+    manufacturer: useEnrichment
+      ? enriched.manufacturer ?? evidenceSnapshot.manufacturer
+      : evidenceSnapshot.manufacturer,
+    observedVersion: useEnrichment
+      ? enriched.observedVersion ?? evidenceSnapshot.observedVersion
+      : evidenceSnapshot.observedVersion,
+    normalizedVersion: useEnrichment
+      ? enriched.normalizedVersion ?? evidenceSnapshot.normalizedVersion
+      : evidenceSnapshot.normalizedVersion,
+    supportStatus: useEnrichment
+      ? enriched.supportStatus ?? evidenceSnapshot.supportStatus
+      : evidenceSnapshot.supportStatus,
+    hasSoftwareEvidence: evidenceSnapshot.hasSoftwareEvidence,
+    normalizationStatus: evidenceSnapshot.normalizationStatus,
+    enriched,
+  };
+}
+
+describe("quality evaluation sees the enrichment the row was given", () => {
+  it("enrichment genuinely populates a manufacturer with no software evidence", () => {
+    // Guards the premise: if enrichment stopped inferring here the test below
+    // would pass vacuously.
+    const { enriched } = qualityInput(true);
+    expect(enriched.manufacturer).toBeTruthy();
+  });
+
+  it("evaluating on the BLINDED snapshot re-raises identity for an enriched entity", () => {
+    const { enriched: _e, ...blinded } = qualityInput(false);
+    const { issues } = evaluateInventoryQuality([blinded]);
+
+    // This is the bug, pinned: the row will be written with a manufacturer, yet
+    // the detector raises "still needs identity review" in the same transaction.
+    expect(issues.map((i) => i.issueType)).toContain("catalog_match_ambiguous");
+  });
+
+  it("evaluating on the ENRICHED values resolves identity instead of re-raising", () => {
+    const { enriched: _e, ...withEnrichment } = qualityInput(true);
+    const { issues, resolvedIssueKeys } = evaluateInventoryQuality([withEnrichment]);
+
+    expect(issues.map((i) => i.issueType)).not.toContain("catalog_match_ambiguous");
+    expect(resolvedIssueKeys).toContain(
+      `inventory_entity:${SERVICE_WITH_NO_SOFTWARE_EVIDENCE.entityKey}:catalog_match_ambiguous`,
+    );
+  });
+
+  it("keeps raising identity when enrichment ALSO cannot determine a manufacturer", () => {
+    // A bare ARP neighbour: no vendor property, no name hint, no evidence. The
+    // fix must not paper over genuinely unidentifiable estate.
+    const evidenceSnapshot = deriveInventoryEvidenceSnapshot([]);
+    const enriched = deriveInventoryEnrichment({
+      entityType: "host",
+      name: "192.168.0.184",
+      manufacturer: evidenceSnapshot.manufacturer,
+      productModel: evidenceSnapshot.productModel,
+      observedVersion: evidenceSnapshot.observedVersion,
+      normalizedVersion: evidenceSnapshot.normalizedVersion,
+      iconKey: null,
+      supportStatus: evidenceSnapshot.supportStatus,
+      properties: {} as never,
+    });
+
+    const { issues } = evaluateInventoryQuality([
+      {
+        entityKey: "organization:internal:host:arp:192.168.0.184",
+        entityType: "host",
+        attributionStatus: "attributed" as const,
+        attributionConfidence: 0.9,
+        candidateTaxonomy: [],
+        taxonomyNodeId: "foundational/compute/servers",
+        digitalProductId: null,
+        manufacturer: enriched.manufacturer ?? evidenceSnapshot.manufacturer,
+        observedVersion: enriched.observedVersion ?? evidenceSnapshot.observedVersion,
+        normalizedVersion: enriched.normalizedVersion ?? evidenceSnapshot.normalizedVersion,
+        supportStatus: enriched.supportStatus ?? evidenceSnapshot.supportStatus,
+        hasSoftwareEvidence: evidenceSnapshot.hasSoftwareEvidence,
+        normalizationStatus: evidenceSnapshot.normalizationStatus,
+      },
+    ]);
+
+    expect(issues.map((i) => i.issueType)).toContain("catalog_match_ambiguous");
+  });
+});

--- a/packages/db/src/discovery-sync.test.ts
+++ b/packages/db/src/discovery-sync.test.ts
@@ -235,8 +235,24 @@ describe("persistBootstrapDiscoveryRun", () => {
         "catalog_match_ambiguous",
       ]),
     );
-    expect(qualityIssues.find((issue) => issue.issueKey === "inventory_entity:host:hostname:dpf-dev:lifecycle_unverified")).toMatchObject({
-      taxonomyNode: { connect: { nodeId: "foundational/compute/servers" } },
+    // Retargeted from `host:hostname:dpf-dev`, which no longer raises either
+    // issue and SHOULD NOT: this fixture gives it postgres software evidence, so
+    // enrichment identifies it as PostgreSQL 16.3 and sets supportStatus
+    // "supported" on the persisted row. The quality evaluator used to score the
+    // raw evidence snapshot instead of the enriched values, so it raised "still
+    // needs support lifecycle verification" against an entity it had just
+    // identified — precisely the false nagging inventory-enrichment.ts exists to
+    // stop ("if we know who made it, we know enough to stop nagging the
+    // operator"). This assertion had codified that blindness; the taxonomyNode
+    // linkage it actually guards is checked here on an issue that still warrants
+    // raising.
+    expect(
+      qualityIssues.find(
+        (issue) =>
+          issue.issueKey === "inventory_entity:runtime:socket:/var/run/docker.sock:lifecycle_unverified",
+      ),
+    ).toMatchObject({
+      taxonomyNode: { connect: { nodeId: "foundational/platform_services/container_platform" } },
     });
   });
 

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -225,6 +225,7 @@ export async function persistBootstrapDiscoveryRun(
     let createdEntities = 0;
     let updatedEntities = 0;
 
+    const enrichmentByEntityKey = new Map<string, ReturnType<typeof deriveInventoryEnrichment>>();
     for (const entity of normalized.inventoryEntities) {
       const existed = existingEntityKeys.has(entity.entityKey);
       const evidenceSnapshot = deriveInventoryEvidenceSnapshot(
@@ -247,6 +248,18 @@ export async function persistBootstrapDiscoveryRun(
         supportStatus: evidenceSnapshot.supportStatus,
         properties: entity.properties as unknown as import("../generated/client/client").Prisma.JsonValue,
       });
+      // The quality evaluator ran on `evidenceSnapshot` alone — package-manager
+      // software evidence — while THESE enriched values are what actually land
+      // on the persisted row. So discovery could enrich an entity
+      // (manufacturer=postgres, supportStatus=supported) and then immediately
+      // re-raise `catalog_match_ambiguous` / `lifecycle_unverified` against a
+      // snapshot that still said null/unknown. The detector was blind to the
+      // enrichment, which made those queues self-sustaining: enrichment could
+      // never satisfy a condition evaluated without it. Observed live — four of
+      // five sampled rows had a persisted manufacturer and ZERO
+      // DiscoveredSoftwareEvidence rows. Captured here so the evaluation below
+      // sees exactly what the row holds.
+      enrichmentByEntityKey.set(entity.entityKey, enrichment);
       const persistedEntity = await tx.inventoryEntity.upsert({
         where: { entityKey: entity.entityKey },
         create: {
@@ -626,6 +639,7 @@ export async function persistBootstrapDiscoveryRun(
           const evidenceSnapshot = deriveInventoryEvidenceSnapshot(
             softwareEvidenceByEntityKey.get(entity.entityKey) ?? [],
           );
+          const enriched = enrichmentByEntityKey.get(entity.entityKey);
           const qualityEntity = {
             entityKey: entity.entityKey,
             entityType: entity.entityType,
@@ -638,10 +652,15 @@ export async function persistBootstrapDiscoveryRun(
             })) ?? null,
             taxonomyNodeId: entity.taxonomyNodeId ?? null,
             digitalProductId: null,
-            manufacturer: evidenceSnapshot.manufacturer,
-            observedVersion: evidenceSnapshot.observedVersion,
-            normalizedVersion: evidenceSnapshot.normalizedVersion,
-            supportStatus: evidenceSnapshot.supportStatus,
+            // Enriched values, NOT the raw evidence snapshot. `enrichment` is what
+            // the upsert above writes to the row, so evaluating against anything
+            // else lets discovery enrich an entity and then re-raise an identity
+            // or lifecycle issue about the very fields it just populated. Fall
+            // back to the snapshot only where enrichment produced nothing.
+            manufacturer: enriched?.manufacturer ?? evidenceSnapshot.manufacturer,
+            observedVersion: enriched?.observedVersion ?? evidenceSnapshot.observedVersion,
+            normalizedVersion: enriched?.normalizedVersion ?? evidenceSnapshot.normalizedVersion,
+            supportStatus: enriched?.supportStatus ?? evidenceSnapshot.supportStatus,
             hasSoftwareEvidence: evidenceSnapshot.hasSoftwareEvidence,
             normalizationStatus: evidenceSnapshot.normalizationStatus,
           };


### PR DESCRIPTION
## The queues were self-sustaining by construction

`discovery-sync` persists `deriveInventoryEnrichment(...)` onto `InventoryEntity` — manufacturer from MAC OUI vendor / container image tag / service-name hints, plus versions and `supportStatus`. But it built the quality-evaluation input from `deriveInventoryEvidenceSnapshot(...)`, which sees **package-manager software evidence only**.

So discovery could identify an entity and then, **in the same transaction**, re-raise `catalog_match_ambiguous` / `lifecycle_unverified` about the very fields it had just populated.

**Enrichment could never satisfy a condition evaluated without it.**

## Live evidence

After #3873 deployed (lineage `847bdb972`), the 21:10 sweep ran the new reconcile and closed almost nothing. Of five sampled open `lifecycle_unverified` rows whose entity that sweep **had just re-observed**, and whose **persisted** `supportStatus` was `supported`, four had **zero** `DiscoveredSoftwareEvidence` rows:

| entityKey | persisted supportStatus | persisted manufacturer | software-evidence rows |
|---|---|---|---|
| `database:prom:postgres:postgres-exporter:9187` | supported | postgres | **0** |
| `monitoring_service:prom:prometheus:localhost:9090` | supported | prometheus | **0** |
| `service:prom:redis:redis-exporter:9121` | supported | redis | **0** |
| `service:prom:inngest:inngest:8288` | supported | inngest | **0** |

#3873's reconcile correctly **declined** to close them — from the detector's blinded view they were still warranted. The bug was upstream of the reconcile the whole time.

## This corrects my own earlier claim

BI-A3D12F85 said *"134 of 196 open rows (68%) have their close-condition already satisfied."* That measured the **persisted row** against the contract prose. The detector never reads the persisted row, so those rows were never satisfied from its point of view. The BI is updated with the correction.

## The fix

Capture the enrichment per `entityKey` in the upsert loop; build `qualityEntity` from it, falling back to the snapshot only where enrichment produced nothing.

Done in **one place** — where `qualityEntity` is built — so emit and resolve keep evaluating identical facts, preserving the invariant #3873 established. Bolting it onto the resolver alone would have reintroduced exactly the raise/resolve drift that arc exists to prevent.

## An existing test had codified the blindness

`discovery-sync.test.ts` asserted `host:hostname:dpf-dev` raises `lifecycle_unverified`. That fixture supplies **postgres software evidence**, so enrichment identifies it as PostgreSQL 16.3 and writes `supportStatus: "supported"`. The old behaviour raised *"still needs support lifecycle verification"* against an entity it had **just identified**.

That is precisely the false nagging `inventory-enrichment.ts` documents itself as existing to stop:

> *"if we know who made it, we know enough to stop nagging the operator with 'unknown support posture'"*

Genuine support concerns (EOL, expired warranty) come from `lifecycle-evaluation.ts` and are untouched — `deriveSupportStatus` never downgrades a non-unknown status. The assertion's real subject (taxonomyNode linkage) is retargeted onto an issue that still warrants raising.

This is the **fourth** test in this arc found pinning a defect in place rather than catching it.

## Guard against over-suppression

The new suite pins that a bare ARP neighbour — no vendor property, no name hint, no evidence — **still raises** `catalog_match_ambiguous`. Papering over genuinely unidentifiable estate would be a worse bug than the one being fixed.

## Verification

- 4 new tests; full `packages/db` suite **1824 pass**.
- The 1 failure in `inventory-entity-canonical-read-completeness` is a **pre-existing load-dependent timeout** — passes in isolation at ~9s against a 5s per-test limit, and fails identically on an unmodified tree.
- Both `packages/db` typecheck configs clean; `apps/web` clean.
- **Local sandbox gate: `gate passed`** (real pass, no override).
- Module-size and spec-plan-doc guards green.

**NOT YET OBSERVED ON THE LIVE INSTALL** — takes effect on each source's next discovery sweep after deploy. This is expected to be the change that actually drains the `lifecycle_unverified` / `catalog_match_ambiguous` queues, which #3873's mechanism alone could not.

Refs: BI-A3D12F85, BI-01630E24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
