### PR TITLE
fix(ci): recover opaque local-CI stage terminations

### DIFF
--- a/docs/superpowers/plans/2026-08-01-local-ci-vitest-worker-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-01-local-ci-vitest-worker-diagnostics.md
@@ -1,0 +1,149 @@
+# Local-CI heavy-stage diagnostics and bounded recovery
+
+**Backlog:** `BI-872CB1BF`
+**Epic:** `EP-0DFF753B`
+**Status:** Verification
+
+## Problem
+
+The Windows local-CI host can return `-1` (serialized by the outer pregate
+record as `4294967295`) during any long-running gate stage, without a terminal
+assertion or child-process diagnostic. The first reproductions ended during
+exhaustive Vitest. A later exact restaurant run launched from Windows Task
+Scheduler passed 2,497 files / 21,411 tests, then the host disappeared during
+the Docker production build. Its reconstructed default task settings use a
+72-hour execution limit, which rules out the tempting 15-minute Task Scheduler
+limit hypothesis but does not prove the terminating actor.
+
+The command executor writes final metadata only after the entire plan. A host
+termination therefore loses the last stage, progress, and host evidence and
+forces an unchanged gate to repeat already-proven expensive work.
+
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - `docs/operations/local-ci-sandbox-slots.md`
+  - `docs/testing/pr-health.md`
+  - `docs/superpowers/plans/2026-07-28-local-ci-sandbox-pool-pilot.md`
+- Current code substrate reviewed:
+  - `scripts/lib/local-integration-ci.mjs`
+  - `scripts/local-integration-ci.mjs`
+  - `scripts/gate-worktree.mjs`
+  - `scripts/pregate.mjs`
+  - `apps/web/vitest.config.ts`
+- Exact-tree receipt work already in flight:
+  - `BI-9585E580` attests complete GitHub merge-group evidence for identical
+    main-push reuse. This plan does not create another workflow receipt or
+    change GitHub gate allocation; it checkpoints interruptible stages inside
+    the governed local-CI run.
+- Source of truth:
+  - the local-integration plan remains the execution authority;
+    `dpf-local-ci-metadata.json` and the gate evidence record remain the
+    durable evidence surfaces.
+- Decision:
+  - supervise every expensive stage with an exact-tree durable receipt;
+  - preserve the same full Vitest suite, first try with four workers, and permit
+    one explicitly classified recovery with two workers only after a runner
+    termination with no failed assertion;
+  - checkpoint Docker build health, child identity, output tail, and terminal
+    result every watchdog sample;
+  - reuse a passed stage only when candidate/integration identity is exact and
+    its required artifact still exists.
+
+## Implementation
+
+### 1. Define termination and retry semantics test-first
+
+- Add pure classification helpers for `passed`, `test-failure`, and
+  `runner-termination`.
+- Treat a failed-assertion summary as product/test evidence and never retry it.
+- Treat `-1`, missing status, signal/error, or a nonzero exit without a terminal
+  Vitest summary as runner termination.
+- Allow exactly one differentiated retry at two workers.
+
+Verification: Node tests cover `-1`/`4294967295`, signal, assertion failure,
+normal pass, and the one-retry bound.
+
+### 2. Add the streaming Vitest supervisor
+
+- Stream stdout/stderr unchanged so the live lease heartbeat and operator log
+  remain useful.
+- Keep a bounded output tail and sample the child/descendant process
+  tree plus host memory while the suite runs.
+- Run Vitest with the verbose reporter so the last completed test is observable.
+- Write a structured diagnostics file on every attempt and a terminal summary
+  after pass, assertion failure, or repeated runner termination.
+
+Verification: injected child-process tests prove output streaming, bounded tail,
+attempt classification, and process/host samples survive a simulated `-1`.
+
+### 3. Add stage-independent receipts and production-build observation
+
+- Write `running` before each heavy child starts, refresh a bounded observation
+  tail while it runs, and write one terminal state with exit code and evidence.
+- Preserve the prior running receipt when its host PID no longer exists, so a
+  later run records `externally-terminated` without naming an unproven actor.
+- Let the bounded Docker build reuse a passed receipt only for the same
+  integration tree and image tag and only while the tag still resolves to the
+  exact image ID recorded by the passed receipt.
+- Let Vitest reuse its passed exact-tree receipt when a later stage was the one
+  interrupted, avoiding another 21k-test pass.
+- When a prior Vitest receipt is still `running` but its host is gone, resume
+  the next exact-tree run at the two-worker differentiated profile instead of
+  repeating the four-worker profile that already terminated.
+- Route web typecheck through the same exact-tree receipt boundary. Record the
+  compiler descendant tree, host samples, bounded output, and distinguish a
+  real TypeScript exit from the `0xFFFFFFFF` wrapper-loss family observed after
+  route generation completed.
+
+Verification: pure receipt tests pin identity matching, external-termination
+classification, atomic heartbeat/terminal writes, and transient Windows rename
+lock recovery; build integration tests pin receipt publication and
+artifact-presence checks.
+
+### 4. Integrate without weakening the gate
+
+- Replace the direct typecheck and Vitest argv in `createLocalIntegrationPlan`
+  with supervised stage commands.
+- Persist failure metadata before `local-integration-ci.mjs` exits so
+  `gate-worktree` can include Vitest and production-build receipts in
+  `evidence.content` on red runs.
+- Keep migrations, guards, exhaustive coverage, production build,
+  freshness, FIFO admission, and lease release unchanged.
+
+Verification: plan-contract tests assert ordering and the four-worker then
+two-worker recovery policy; existing pregate recovery tests stay green.
+
+## Risks and rollback
+
+- **Log volume:** verbose Vitest output is streamed, while retained diagnostics
+  and build output use bounded tails. Roll back the reporter flag independently
+  if output cost proves excessive; do not remove structured diagnostics.
+- **False retry:** retry is denied whenever the output contains a terminal
+  failed-test summary. Classification tests pin this boundary.
+- **Masked product failure:** the second attempt still runs the same exhaustive
+  suite and must pass before build. No retry result can convert a failed
+  assertion into green.
+- **Cross-platform process sampling:** host sampling is best-effort and
+  diagnostic only. Failure to sample never changes the test verdict.
+- **Stale receipt:** identity includes the synthesized integration tree and
+  command/artifact identity. A mismatch reruns the stage. A production build is
+  never reused if the image is absent or the mutable tag resolves to a
+  different image ID.
+- **Unknown terminating actor:** receipts classify the observable condition,
+  not a guessed cause. This change improves diagnosis and safe resumption; it
+  does not claim to prevent an external Windows termination whose actor has not
+  been proven.
+
+Rollback is a normal revert of the wrapper integration; the prior direct
+Vitest command remains mechanically recoverable from this plan and its tests.
+
+## Backlog coverage
+
+- **Decision:** `atomic`
+- **Receipt:** `cms9ukhpz0ft001luz49u8wkx`
+- **Parent:** `BI-872CB1BF`
+- **Deliverable:** `heavy-stage-diagnostics-and-recovery` → `BI-872CB1BF`
+- **Rationale:** durable stage capture, exact identity, terminal classification,
+  and bounded reuse form one safety contract; shipping any part alone either
+  preserves opaque later-stage failures or permits an unauditable skip.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -313,7 +313,7 @@ abandoned entry.
 [`scripts/local-ci-runner.mjs`](../../scripts/local-ci-runner.mjs) runs the
 canonical merged-code plan (`scripts/lib/local-integration-ci.mjs`: checkout
 the admission-resolved accepted-base ref, `origin/main` by default → merge
-candidate → sandbox-freshness converge → vitest → typecheck → production build)
+candidate → sandbox-freshness converge → typecheck → exhaustive Vitest → production build)
 in a dedicated **non-mutating scratch worktree** (`~/dpf-worktrees/.local-ci-runner`
 for slot 0 and a manifest-owned sibling for slot 1) — never in your topic
 worktree. It records content-addressed
@@ -347,12 +347,56 @@ tests and must never be used as release evidence.
 
 The command plan carries required process environment as `env NAME=value ...`
 prefixes, and the Node runner interprets those prefixes directly instead of
-depending on a host `env` executable. This keeps the 8 GiB `NODE_OPTIONS`
-headroom on both POSIX and Windows typecheck paths; the production build may
+depending on a host `env` executable. This keeps the 16 GiB `NODE_OPTIONS`
+headroom required by the current route graph on both POSIX and Windows
+typecheck paths; the production build may
 still use the host-specific strategy selected by the plan. Vitest runs with
 Node's experimental host web-storage disabled so Node 26 cannot shadow the
 `localStorage` and `sessionStorage` implementations owned by jsdom. This is a
 test-runner compatibility setting, not a change to application runtime policy.
+
+Web typecheck and exhaustive Vitest are supervised rather than invoked as
+opaque child processes (BI-872CB1BF). Vitest first runs the unchanged full suite with four
+workers and streams verbose progress while retaining a bounded output tail,
+the last completed test, host-memory samples, and the Vitest descendant process
+tree. A genuine failed-test summary is terminal product evidence and is never
+retried. A missing/sentinel exit status, signal/spawn error, or summary-free
+nonzero exit is runner evidence; the supervisor retries the same full suite
+exactly once with two workers. If that differentiated attempt also terminates,
+the gate exits 86, records both attempts in
+`dpf-local-ci-metadata.json.vitest.json`, and classifies the result as runner
+evidence rather than a product test failure. Local-CI writes its main metadata
+on failure as well as success so this diagnostic survives lease release.
+If the supervisor host itself disappears, the next exact-tree run recognizes
+the stale running receipt and starts directly at the two-worker differentiated
+profile; it does not repeat the already disproven four-worker profile.
+
+Typecheck writes a separate `web-typecheck` receipt before `next typegen &&
+tsc --noEmit` starts, heartbeats the compiler descendant tree, memory, and a
+bounded output tail, and records real compiler exits separately from opaque
+runner termination. A passed typecheck receipt is reusable only for the exact
+synthesized integration tree, command, and heap contract. This closes the same
+stage-boundary loss observed when a gate wrapper exited `0xFFFFFFFF` after route
+type generation while the compiler had emitted no diagnostic.
+
+Long-running production builds use the same durable stage contract. Before the
+Docker child starts, local-CI writes an exact-tree `running` receipt beside its
+metadata and refreshes it on every control-plane watchdog sample with the child
+PID and a bounded output tail. A normal exit writes the terminal build status.
+If the host disappears, the stale running receipt identifies the interrupted
+stage and last observation without inventing a terminating actor. A later run
+may reuse a passed typecheck, Vitest, or build receipt only when the synthesized integration
+tree and command/artifact identity match exactly; build reuse additionally
+requires the current image ID to match the passed receipt, not merely for its
+mutable tag to remain present. Setup, migrations, and guards still execute, and
+every reused heavy stage remains bound to the exact merged tree, so recovery
+does not weaken the merged-code gate.
+The reused receipt is atomically updated with `lastReusedAt` and `reuseCount`,
+so final metadata distinguishes an intentional exact-evidence reuse from a
+stage that simply did not execute. Receipt replacement retries bounded
+transient Windows `EPERM`/`EACCES`/`EBUSY` locks before failing, so a diagnostic
+reader or endpoint scanner cannot turn a successful heavy stage into a false
+gate failure.
 
 The candidate wrapper owns the slot-scoped freshness-evidence handoff path. Before each
 run it removes any prior report from the candidate gitdir and passes

--- a/scripts/lib/bounded-text-tail.mjs
+++ b/scripts/lib/bounded-text-tail.mjs
@@ -1,0 +1,17 @@
+export class BoundedTextTail {
+  constructor(maxChars = 64 * 1024) {
+    this.maxChars = Math.max(1, maxChars);
+    this.value = "";
+  }
+
+  append(chunk) {
+    this.value += String(chunk ?? "");
+    if (this.value.length > this.maxChars) {
+      this.value = this.value.slice(-this.maxChars);
+    }
+  }
+
+  toString() {
+    return this.value;
+  }
+}

--- a/scripts/lib/local-ci-control-plane-watchdog.mjs
+++ b/scripts/lib/local-ci-control-plane-watchdog.mjs
@@ -18,17 +18,20 @@ export async function monitorControlPlane({
   wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   intervalMs = 5_000,
   consecutiveFailureLimit = 2,
+  onSample = () => {},
 }) {
   const samples = [];
   let consecutiveFailures = 0;
   while (true) {
     const probes = await sample();
     const classification = classifyControlPlaneSample(probes);
-    samples.push({
+    const observed = {
       observedAt: new Date().toISOString(),
       probes,
       ...classification,
-    });
+    };
+    samples.push(observed);
+    await onSample(observed);
     consecutiveFailures = classification.healthy
       ? 0
       : consecutiveFailures + 1;

--- a/scripts/lib/local-ci-control-plane-watchdog.test.mjs
+++ b/scripts/lib/local-ci-control-plane-watchdog.test.mjs
@@ -51,6 +51,23 @@ test("one transient round recovers without tripping the boundary", async () => {
   assert.equal(result.samples.length, 3);
 });
 
+test("publishes every control-plane sample for durable stage heartbeats", async () => {
+  const observed = [];
+  let complete = false;
+  const result = await monitorControlPlane({
+    sample: async () => {
+      complete = true;
+      return healthy;
+    },
+    isComplete: () => complete,
+    wait: async () => {},
+    onSample: async (sample) => observed.push(sample),
+  });
+  assert.equal(result.status, "healthy");
+  assert.equal(observed.length, 1);
+  assert.equal(observed[0].healthy, true);
+});
+
 test("two consecutive unhealthy rounds form a sustained starvation breach", async () => {
   const result = await monitorControlPlane({
     sample: async () => ({

--- a/scripts/lib/local-ci-process-observer.mjs
+++ b/scripts/lib/local-ci-process-observer.mjs
@@ -1,0 +1,141 @@
+import { spawn, spawnSync } from "node:child_process";
+import { freemem, loadavg, totalmem } from "node:os";
+
+import { BoundedTextTail } from "./bounded-text-tail.mjs";
+
+const DEFAULT_SAMPLE_INTERVAL_MS = 5_000;
+const MAX_HOST_SAMPLES = 120;
+
+export function descendantProcesses(rootPid, {
+  platform = process.platform,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  try {
+    if (platform === "win32") {
+      const script = [
+        `$root = ${Number(rootPid)}`,
+        "$rows = @(Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name)",
+        "$ids = [System.Collections.Generic.HashSet[uint32]]::new()",
+        "[void]$ids.Add([uint32]$root)",
+        "do { $before = $ids.Count; foreach ($row in $rows) { if ($ids.Contains([uint32]$row.ParentProcessId)) { [void]$ids.Add([uint32]$row.ProcessId) } } } while ($ids.Count -gt $before)",
+        "$rows | Where-Object { $ids.Contains([uint32]$_.ProcessId) } | ConvertTo-Json -Compress",
+      ].join("; ");
+      const result = spawnSyncImpl("powershell.exe", ["-NoProfile", "-Command", script], {
+        encoding: "utf8",
+        timeout: 5_000,
+        windowsHide: true,
+      });
+      if (result.status !== 0 || !result.stdout.trim()) return [];
+      const parsed = JSON.parse(result.stdout);
+      return (Array.isArray(parsed) ? parsed : [parsed]).map((row) => ({
+        pid: Number(row.ProcessId),
+        parentPid: Number(row.ParentProcessId),
+        name: String(row.Name ?? "unknown"),
+      }));
+    }
+
+    const result = spawnSyncImpl("ps", ["-eo", "pid=,ppid=,comm="], {
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+    if (result.status !== 0) return [];
+    const rows = result.stdout.split(/\r?\n/).map((line) => {
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      return match
+        ? { pid: Number(match[1]), parentPid: Number(match[2]), name: match[3] }
+        : null;
+    }).filter(Boolean);
+    const ids = new Set([Number(rootPid)]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const row of rows) {
+        if (ids.has(row.parentPid) && !ids.has(row.pid)) {
+          ids.add(row.pid);
+          changed = true;
+        }
+      }
+    }
+    return rows.filter((row) => ids.has(row.pid));
+  } catch {
+    return [];
+  }
+}
+
+export function hostProcessSample(childPid) {
+  return {
+    observedAt: new Date().toISOString(),
+    freeMemoryBytes: freemem(),
+    totalMemoryBytes: totalmem(),
+    loadAverage: loadavg(),
+    descendants: descendantProcesses(childPid),
+  };
+}
+
+export function createObservedProcessRunner({
+  spawnImpl = spawn,
+  sampleHost = hostProcessSample,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_MS,
+  outputTailBytes = 64 * 1024,
+  onProgress = () => {},
+} = {}) {
+  return function runObservedProcess({ command, args, env = process.env, observation = {} }) {
+    return new Promise((resolveAttempt) => {
+      const output = new BoundedTextTail(outputTailBytes);
+      const hostSamples = [];
+      const startedAt = new Date().toISOString();
+      let spawnError = null;
+      const child = spawnImpl(command, args, {
+        env,
+        shell: process.platform === "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+
+      const sample = () => {
+        if (child.pid && hostSamples.length < MAX_HOST_SAMPLES) {
+          const host = sampleHost(child.pid);
+          hostSamples.push(host);
+          onProgress({
+            ...observation,
+            childPid: child.pid,
+            host,
+            outputTail: output.toString(),
+          });
+        }
+      };
+      sample();
+      const sampler = setInterval(sample, sampleIntervalMs);
+      sampler.unref();
+
+      child.stdout.on("data", (chunk) => {
+        output.append(chunk);
+        stdout.write(chunk);
+      });
+      child.stderr.on("data", (chunk) => {
+        output.append(chunk);
+        stderr.write(chunk);
+      });
+      child.once("error", (error) => {
+        spawnError = error;
+      });
+      child.once("close", (status, signal) => {
+        clearInterval(sampler);
+        sample();
+        resolveAttempt({
+          ...observation,
+          status,
+          signal,
+          error: spawnError,
+          outputTail: output.toString(),
+          childPid: child.pid ?? null,
+          hostSamples,
+          startedAt,
+          completedAt: new Date().toISOString(),
+        });
+      });
+    });
+  };
+}

--- a/scripts/lib/local-ci-stage-receipt.mjs
+++ b/scripts/lib/local-ci-stage-receipt.mjs
@@ -1,0 +1,170 @@
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+
+const MAX_OBSERVATIONS = 120;
+const TRANSIENT_RENAME_CODES = new Set(["EACCES", "EBUSY", "ENOTEMPTY", "EPERM"]);
+let tempSequence = 0;
+
+export function readStageReceipt(path) {
+  if (!path || !existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonical(entry)]),
+    );
+  }
+  return value;
+}
+
+export function stageIdentityMatches(left, right) {
+  if (!left || !right) return false;
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+export function reusablePassedStage({ receipt, stage, identity }) {
+  return Boolean(
+    receipt
+      && receipt.schemaVersion === 1
+      && receipt.stage === stage
+      && receipt.status === "passed"
+      && stageIdentityMatches(receipt.identity, identity),
+  );
+}
+
+export function canonicalStageReceiptStatus(status) {
+  return status === "healthy" ? "passed" : status;
+}
+
+export function classifyPriorStage({ receipt, isProcessAlive = () => false }) {
+  if (!receipt || receipt.status !== "running") return "terminal-or-absent";
+  return Number.isInteger(receipt.hostPid) && isProcessAlive(receipt.hostPid)
+    ? "still-running"
+    : "externally-terminated";
+}
+
+function sleepSync(delayMs) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
+
+export function atomicWriteJson(path, payload, {
+  renameImpl = renameSync,
+  removeImpl = rmSync,
+  sleepImpl = sleepSync,
+  maxRenameAttempts = 8,
+  retryDelayMs = 25,
+} = {}) {
+  if (!path) return;
+  tempSequence += 1;
+  const temp = `${path}.tmp-${process.pid}-${tempSequence}`;
+  writeFileSync(temp, `${JSON.stringify(payload, null, 2)}\n`);
+  try {
+    for (let attempt = 1; attempt <= maxRenameAttempts; attempt += 1) {
+      try {
+        renameImpl(temp, path);
+        return;
+      } catch (error) {
+        const retryable = TRANSIENT_RENAME_CODES.has(error?.code);
+        if (!retryable || attempt === maxRenameAttempts) throw error;
+        sleepImpl(retryDelayMs * attempt);
+      }
+    }
+  } finally {
+    removeImpl(temp, { force: true });
+  }
+}
+
+export function markStageReceiptReused({
+  path,
+  receipt,
+  now = () => new Date(),
+} = {}) {
+  if (!receipt || receipt.status !== "passed") {
+    throw new TypeError("only a passed stage receipt can be marked reused");
+  }
+  const payload = {
+    ...receipt,
+    reused: true,
+    reuseCount: Number(receipt.reuseCount ?? 0) + 1,
+    lastReusedAt: now().toISOString(),
+  };
+  atomicWriteJson(path, payload);
+  return payload;
+}
+
+export function createStageReceiptWriter({
+  path,
+  stage,
+  identity,
+  now = () => new Date(),
+  hostPid = process.pid,
+} = {}) {
+  if (!stage || !identity) {
+    throw new TypeError("stage receipt requires stage and identity");
+  }
+  let payload = null;
+
+  const persist = () => {
+    atomicWriteJson(path, payload);
+    return payload;
+  };
+
+  return {
+    start(details = {}) {
+      const observedAt = now().toISOString();
+      payload = {
+        ...details,
+        schemaVersion: 1,
+        stage,
+        identity,
+        status: "running",
+        hostPid,
+        startedAt: observedAt,
+        lastHeartbeatAt: observedAt,
+        completedAt: null,
+        observations: [],
+      };
+      return persist();
+    },
+    heartbeat(observation = {}) {
+      if (!payload) throw new Error("stage receipt must start before heartbeat");
+      const observedAt = now().toISOString();
+      payload = {
+        ...payload,
+        status: "running",
+        lastHeartbeatAt: observedAt,
+        observations: [
+          ...(payload.observations ?? []),
+          { observedAt, ...observation },
+        ].slice(-MAX_OBSERVATIONS),
+      };
+      return persist();
+    },
+    complete(status, details = {}) {
+      if (!payload) throw new Error("stage receipt must start before completion");
+      const observedAt = now().toISOString();
+      payload = {
+        ...payload,
+        ...details,
+        schemaVersion: 1,
+        stage,
+        identity,
+        status,
+        lastHeartbeatAt: observedAt,
+        completedAt: observedAt,
+      };
+      return persist();
+    },
+    snapshot() {
+      return payload;
+    },
+  };
+}

--- a/scripts/lib/local-ci-stage-receipt.test.mjs
+++ b/scripts/lib/local-ci-stage-receipt.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  atomicWriteJson,
+  canonicalStageReceiptStatus,
+  classifyPriorStage,
+  createStageReceiptWriter,
+  markStageReceiptReused,
+  readStageReceipt,
+  reusablePassedStage,
+} from "./local-ci-stage-receipt.mjs";
+
+const identity = {
+  candidateSha: "candidate-a",
+  integrationTreeSha: "tree-a",
+  command: "pnpm --filter web exec vitest run --maxWorkers=4",
+};
+
+test("retries a transient Windows rename lock without losing the receipt", () => {
+  const directory = mkdtempSync(join(tmpdir(), "dpf-stage-receipt-lock-"));
+  const path = join(directory, "receipt.json");
+  let attempts = 0;
+
+  atomicWriteJson(path, { status: "running" }, {
+    renameImpl(source, destination) {
+      attempts += 1;
+      if (attempts < 3) {
+        const error = new Error("transient Windows receipt lock");
+        error.code = "EPERM";
+        throw error;
+      }
+      renameSync(source, destination);
+    },
+    sleepImpl() {},
+  });
+
+  assert.equal(attempts, 3);
+  assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), { status: "running" });
+});
+
+test("writes running heartbeats and a terminal stage receipt atomically", () => {
+  const directory = mkdtempSync(join(tmpdir(), "dpf-stage-receipt-"));
+  const path = join(directory, "receipt.json");
+  const times = [
+    new Date("2026-08-01T18:00:00.000Z"),
+    new Date("2026-08-01T18:00:05.000Z"),
+    new Date("2026-08-01T18:00:10.000Z"),
+  ];
+  const writer = createStageReceiptWriter({
+    path,
+    stage: "production-build",
+    identity,
+    hostPid: 42,
+    now: () => times.shift(),
+  });
+
+  writer.start({ childPid: 84 });
+  writer.heartbeat({ freeMemoryBytes: 1024 });
+  writer.complete("passed", { exitCode: 0 });
+
+  const persisted = JSON.parse(readFileSync(path, "utf8"));
+  assert.equal(persisted.status, "passed");
+  assert.equal(persisted.hostPid, 42);
+  assert.equal(persisted.childPid, 84);
+  assert.equal(persisted.observations.length, 1);
+  assert.equal(persisted.completedAt, "2026-08-01T18:00:10.000Z");
+  assert.deepEqual(readStageReceipt(path), persisted);
+});
+
+test("reuses only an exact-identity passed receipt", () => {
+  const receipt = {
+    schemaVersion: 1,
+    stage: "exhaustive-vitest",
+    identity,
+    status: "passed",
+  };
+  assert.equal(reusablePassedStage({ receipt, stage: "exhaustive-vitest", identity }), true);
+  assert.equal(reusablePassedStage({
+    receipt,
+    stage: "exhaustive-vitest",
+    identity: { ...identity, integrationTreeSha: "tree-b" },
+  }), false);
+  assert.equal(reusablePassedStage({ receipt, stage: "production-build", identity }), false);
+});
+
+test("identity comparison is canonical across object key order", () => {
+  const receipt = {
+    schemaVersion: 1,
+    stage: "exhaustive-vitest",
+    identity: {
+      command: identity.command,
+      integrationTreeSha: identity.integrationTreeSha,
+      candidateSha: identity.candidateSha,
+    },
+    status: "passed",
+  };
+  assert.equal(reusablePassedStage({ receipt, stage: "exhaustive-vitest", identity }), true);
+});
+
+test("normalizes a healthy build result to the canonical passed receipt status", () => {
+  assert.equal(canonicalStageReceiptStatus("healthy"), "passed");
+  assert.equal(canonicalStageReceiptStatus("failed"), "failed");
+});
+
+test("marks reuse atomically without weakening a passed receipt", () => {
+  const directory = mkdtempSync(join(tmpdir(), "dpf-stage-reuse-"));
+  const path = join(directory, "receipt.json");
+  const receipt = {
+    schemaVersion: 1,
+    stage: "exhaustive-vitest",
+    identity,
+    status: "passed",
+  };
+  const reused = markStageReceiptReused({
+    path,
+    receipt,
+    now: () => new Date("2026-08-01T19:00:00.000Z"),
+  });
+  assert.equal(reused.status, "passed");
+  assert.equal(reused.reused, true);
+  assert.equal(reused.reuseCount, 1);
+  assert.equal(reused.lastReusedAt, "2026-08-01T19:00:00.000Z");
+  assert.deepEqual(readStageReceipt(path), reused);
+  assert.throws(
+    () => markStageReceiptReused({ path, receipt: { ...receipt, status: "running" } }),
+    /only a passed stage receipt/,
+  );
+});
+
+test("classifies a running receipt whose host disappeared as externally terminated", () => {
+  const receipt = { status: "running", hostPid: 42 };
+  assert.equal(classifyPriorStage({ receipt, isProcessAlive: () => false }), "externally-terminated");
+  assert.equal(classifyPriorStage({ receipt, isProcessAlive: () => true }), "still-running");
+  assert.equal(classifyPriorStage({ receipt: { status: "passed" } }), "terminal-or-absent");
+});

--- a/scripts/lib/local-ci-vitest-supervisor.mjs
+++ b/scripts/lib/local-ci-vitest-supervisor.mjs
@@ -1,0 +1,92 @@
+const FAILED_TEST_SUMMARY_RE = /(?:Test Files|Tests)\s+[^\r\n]*\b[1-9]\d* failed\b/i;
+
+export { BoundedTextTail } from "./bounded-text-tail.mjs";
+
+export function classifyVitestAttempt({ status, signal, error, outputTail = "" }) {
+  if (status === 0 && !signal && !error) return "passed";
+  if (FAILED_TEST_SUMMARY_RE.test(outputTail)) return "test-failure";
+  if (
+    status === null
+    || status === undefined
+    || status === -1
+    || status === 0xffffffff
+    || signal
+    || error
+  ) {
+    return "runner-termination";
+  }
+  return "runner-termination";
+}
+
+export function shouldRetryVitestAttempt({ classification, attempt }) {
+  return classification === "runner-termination" && attempt === 1;
+}
+
+function normalizeAttempt(raw, { attempt, workers }) {
+  const classification = classifyVitestAttempt(raw);
+  return {
+    attempt,
+    workers,
+    classification,
+    status: raw.status ?? null,
+    unsignedStatus: raw.status === -1 ? 0xffffffff : (raw.status ?? null),
+    signal: raw.signal ?? null,
+    error: raw.error
+      ? {
+          name: raw.error.name ?? "Error",
+          code: raw.error.code ?? null,
+          message: raw.error.message ?? String(raw.error),
+        }
+      : null,
+    outputTail: raw.outputTail ?? "",
+    lastCompletedTest: raw.lastCompletedTest ?? null,
+    childPid: raw.childPid ?? null,
+    hostSamples: raw.hostSamples ?? [],
+    startedAt: raw.startedAt ?? null,
+    completedAt: raw.completedAt ?? null,
+  };
+}
+
+export async function runVitestWithRecovery({
+  runAttempt,
+  initialWorkers = 4,
+  retryWorkers = 2,
+  allowRetry = true,
+  onAttempt = () => {},
+} = {}) {
+  if (typeof runAttempt !== "function") {
+    throw new TypeError("runVitestWithRecovery requires runAttempt");
+  }
+
+  const attempts = [];
+  const workerCounts = allowRetry ? [initialWorkers, retryWorkers] : [initialWorkers];
+  for (let index = 0; index < workerCounts.length; index += 1) {
+    const attempt = index + 1;
+    const workers = workerCounts[index];
+    const normalized = normalizeAttempt(
+      await runAttempt({ attempt, workers }),
+      { attempt, workers },
+    );
+    attempts.push(normalized);
+    await onAttempt(normalized);
+
+    if (!allowRetry || !shouldRetryVitestAttempt({
+      classification: normalized.classification,
+      attempt,
+    })) {
+      const runnerTerminated = normalized.classification === "runner-termination";
+      return {
+        status: normalized.classification === "passed"
+          ? 0
+          : runnerTerminated
+            ? 86
+            : (normalized.status ?? 1),
+        classification: normalized.classification,
+        recovered: attempt > 1 && normalized.classification === "passed",
+        attempts,
+      };
+    }
+  }
+
+  throw new Error("unreachable Vitest recovery state");
+}

--- a/scripts/lib/local-ci-vitest-supervisor.test.mjs
+++ b/scripts/lib/local-ci-vitest-supervisor.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  BoundedTextTail,
+  classifyVitestAttempt,
+  runVitestWithRecovery,
+  shouldRetryVitestAttempt,
+} from "./local-ci-vitest-supervisor.mjs";
+
+describe("classifyVitestAttempt", () => {
+  it("classifies the observed Windows -1 exit without a summary as runner termination", () => {
+    assert.equal(classifyVitestAttempt({
+      status: -1,
+      signal: null,
+      error: null,
+      outputTail: "[quiescence] final expected test log",
+    }), "runner-termination");
+  });
+
+  it("does not retry a real failed-test summary", () => {
+    assert.equal(classifyVitestAttempt({
+      status: 1,
+      signal: null,
+      error: null,
+      outputTail: "Test Files  1 failed | 2342 passed\nTests  1 failed | 20260 passed",
+    }), "test-failure");
+  });
+
+  it("classifies a terminal passing summary as passed", () => {
+    assert.equal(classifyVitestAttempt({
+      status: 0,
+      signal: null,
+      error: null,
+      outputTail: "Test Files  2343 passed\nTests  20261 passed",
+    }), "passed");
+  });
+
+  it("classifies signal, spawn error, null status, and summary-free nonzero exits as runner termination", () => {
+    for (const attempt of [
+      { status: null, signal: null, error: null, outputTail: "" },
+      { status: 1, signal: "SIGABRT", error: null, outputTail: "" },
+      { status: 1, signal: null, error: new Error("spawn ENOMEM"), outputTail: "" },
+      { status: 1, signal: null, error: null, outputTail: "last console line only" },
+    ]) {
+      assert.equal(classifyVitestAttempt(attempt), "runner-termination");
+    }
+  });
+});
+
+describe("bounded recovery", () => {
+  it("allows one differentiated retry only for the first runner termination", () => {
+    assert.equal(shouldRetryVitestAttempt({ classification: "runner-termination", attempt: 1 }), true);
+    assert.equal(shouldRetryVitestAttempt({ classification: "runner-termination", attempt: 2 }), false);
+    assert.equal(shouldRetryVitestAttempt({ classification: "test-failure", attempt: 1 }), false);
+  });
+
+  it("retries once with two workers and preserves both attempt diagnostics", async () => {
+    const workerCounts = [];
+    const result = await runVitestWithRecovery({
+      runAttempt: async ({ workers, attempt }) => {
+        workerCounts.push(workers);
+        if (attempt === 1) {
+          return {
+            status: -1,
+            signal: null,
+            error: null,
+            outputTail: "last completed file: quiescence.test.ts",
+            childPid: 101,
+            hostSamples: [{ freeMemoryBytes: 20_000_000_000 }],
+          };
+        }
+        return {
+          status: 0,
+          signal: null,
+          error: null,
+          outputTail: "Test Files  2343 passed\nTests  20261 passed",
+          childPid: 202,
+          hostSamples: [{ freeMemoryBytes: 19_000_000_000 }],
+        };
+      },
+    });
+
+    assert.deepEqual(workerCounts, [4, 2]);
+    assert.equal(result.status, 0);
+    assert.equal(result.classification, "passed");
+    assert.equal(result.recovered, true);
+    assert.equal(result.attempts.length, 2);
+    assert.equal(result.attempts[0].classification, "runner-termination");
+    assert.equal(result.attempts[1].classification, "passed");
+  });
+
+  it("stops after a failed assertion and never runs the recovery attempt", async () => {
+    let calls = 0;
+    const result = await runVitestWithRecovery({
+      runAttempt: async () => {
+        calls += 1;
+        return {
+          status: 1,
+          signal: null,
+          error: null,
+          outputTail: "Test Files  1 failed | 100 passed\nTests  1 failed | 900 passed",
+        };
+      },
+    });
+
+    assert.equal(calls, 1);
+    assert.equal(result.status, 1);
+    assert.equal(result.classification, "test-failure");
+    assert.equal(result.recovered, false);
+  });
+
+  it("can run only the inherited differentiated attempt after a prior host loss", async () => {
+    const workerCounts = [];
+    const result = await runVitestWithRecovery({
+      initialWorkers: 2,
+      retryWorkers: 2,
+      allowRetry: false,
+      runAttempt: async ({ workers }) => {
+        workerCounts.push(workers);
+        return { status: 0, signal: null, error: null, outputTail: "Tests  21000 passed" };
+      },
+    });
+
+    assert.deepEqual(workerCounts, [2]);
+    assert.equal(result.status, 0);
+  });
+});
+
+describe("BoundedTextTail", () => {
+  it("retains only the latest complete diagnostic window", () => {
+    const tail = new BoundedTextTail(12);
+    tail.append("12345678");
+    tail.append("90abcdef");
+    assert.equal(tail.toString(), "567890abcdef");
+  });
+});

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -25,8 +25,9 @@ export function dockerBuildTag(candidateBranch, slotKey = "") {
 // during the TypeScript phase — an exit that is indistinguishable from a red
 // product build, so it poisons gate evidence exactly like sandbox staleness
 // did (and the freshness gate correctly stays green, so nothing else catches
-// it). Verified 2026-07-05: default heap SIGABRT; 8 GiB completes cleanly.
-export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
+// it). Re-verified 2026-08-01 after the stock coverage routes landed: 12 GiB
+// still aborts during the Next TypeScript phase; 16 GiB completes cleanly.
+export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=16384";
 export const HOST_BUILD_NODE_ENV = "NODE_ENV=production";
 
 // Node 26 exposes experimental host localStorage/sessionStorage accessors even
@@ -34,7 +35,8 @@ export const HOST_BUILD_NODE_ENV = "NODE_ENV=production";
 // web storage that jsdom installs in Vitest fork workers. Disable only Node's
 // host implementation at process start so jsdom remains the environment owner.
 export const HOST_TEST_NODE_OPTIONS = "NODE_OPTIONS=--no-experimental-webstorage";
-export const HOST_TEST_MAX_WORKERS = "--maxWorkers=4";
+export const HOST_TEST_INITIAL_WORKERS = "4";
+export const HOST_TEST_RETRY_WORKERS = "2";
 
 export function resolveCommandInvocation(command, baseEnv = process.env) {
   if (command[0] !== "env") {
@@ -311,8 +313,22 @@ export function createLocalIntegrationPlan(input) {
     // exactly like the build worker did (BI-B5011ACE) — observed live on the
     // first BI-157DC9B2 gate run, 2026-07-06. The runner interprets the `env`
     // prefix itself, so this heap contract is identical on every host.
-    ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "typecheck"],
-    ["env", HOST_TEST_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "vitest", "run", HOST_TEST_MAX_WORKERS],
+    [
+      "env",
+      HOST_BUILD_NODE_OPTIONS,
+      "node",
+      "scripts/local-ci-typecheck-runner.mjs",
+    ],
+    [
+      "env",
+      HOST_TEST_NODE_OPTIONS,
+      "node",
+      "scripts/local-ci-vitest-runner.mjs",
+      "--initial-workers",
+      HOST_TEST_INITIAL_WORKERS,
+      "--retry-workers",
+      HOST_TEST_RETRY_WORKERS,
+    ],
     productionBuildCommand,
   ];
   return {

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -48,7 +48,7 @@ describe("createLocalIntegrationPlan", () => {
       arch: "arm64",
       lockfileSha256: "lock-sha",
       nodeEnv: "NODE_ENV=production",
-      nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
+      nodeOptions: "NODE_OPTIONS=--max-old-space-size=16384",
       testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
     });
 
@@ -62,7 +62,7 @@ describe("createLocalIntegrationPlan", () => {
       arch: "arm64",
       lockfileSha256: "lock-sha",
       nodeEnv: "NODE_ENV=production",
-      nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
+      nodeOptions: "NODE_OPTIONS=--max-old-space-size=16384",
       testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
     });
     assert.equal(evidence.toolchainFingerprint, createToolchainFingerprint({
@@ -71,7 +71,7 @@ describe("createLocalIntegrationPlan", () => {
       gitVersion: "git version 2.50.1",
       lockfileSha256: "lock-sha",
       nodeEnv: "NODE_ENV=production",
-      nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
+      nodeOptions: "NODE_OPTIONS=--max-old-space-size=16384",
       testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
       nodeVersion: "v24.0.0",
       platform: "linux",
@@ -96,9 +96,9 @@ describe("createLocalIntegrationPlan", () => {
       "node scripts/gen-doc-index.mjs --check",
       "node scripts/check-doc-links.mjs",
       "node scripts/check-guards.mjs",
-      "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
-      "env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run --maxWorkers=4",
-      "env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",
+      "env NODE_OPTIONS=--max-old-space-size=16384 node scripts/local-ci-typecheck-runner.mjs",
+      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2",
+      "env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=16384 pnpm --filter web exec next build",
     ]);
   });
 
@@ -141,7 +141,7 @@ describe("createLocalIntegrationPlan", () => {
     });
 
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
-      "env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run --maxWorkers=4",
+      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2",
     ));
   });
 
@@ -154,11 +154,11 @@ describe("createLocalIntegrationPlan", () => {
     });
 
     const vitestCommand = plan.commands.map((command) => command.join(" ")).find((command) => (
-      command.includes("pnpm --filter web exec vitest run")
+      command.includes("scripts/local-ci-vitest-runner.mjs")
     ));
     assert.equal(
       vitestCommand,
-      "env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run --maxWorkers=4",
+      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2",
     );
   });
 
@@ -204,7 +204,7 @@ describe("createLocalIntegrationPlan", () => {
     const preflightIndex = commands.findIndex((c) => c.includes("sandbox-freshness-preflight.mjs"));
     const evidencePlanIndex = commands.findIndex((c) => c.includes("ci-evidence-plan.mjs"));
     const lastMergeIndex = commands.map((c, i) => (c.startsWith("git merge") ? i : -1)).reduce((a, b) => Math.max(a, b), -1);
-    const firstGateIndex = commands.findIndex((c) => c.includes("vitest run"));
+    const firstGateIndex = commands.findIndex((c) => c.includes("local-ci-vitest-runner.mjs"));
     assert.ok(evidencePlanIndex > lastMergeIndex);
     assert.ok(evidencePlanIndex < preflightIndex);
     assert.ok(preflightIndex > lastMergeIndex);
@@ -236,7 +236,7 @@ describe("createLocalIntegrationPlan", () => {
     const docIndexIndex = commands.indexOf("node scripts/gen-doc-index.mjs --check");
     const docsLinkIndex = commands.indexOf("node scripts/check-doc-links.mjs");
     const repoGuardIndex = commands.indexOf("node scripts/check-guards.mjs");
-    const vitestIndex = commands.findIndex((c) => c.includes("vitest run"));
+    const vitestIndex = commands.findIndex((c) => c.includes("local-ci-vitest-runner.mjs"));
     assert.ok(docIndexIndex > -1);
     assert.ok(docsLinkIndex > docIndexIndex);
     assert.ok(repoGuardIndex > docsLinkIndex);
@@ -252,9 +252,9 @@ describe("createLocalIntegrationPlan", () => {
     });
     const commands = plan.commands.map((command) => command.join(" "));
     const typecheckIndex = commands.indexOf(
-      "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
+      "env NODE_OPTIONS=--max-old-space-size=16384 node scripts/local-ci-typecheck-runner.mjs",
     );
-    const vitestIndex = commands.findIndex((command) => command.includes("vitest run"));
+    const vitestIndex = commands.findIndex((command) => command.includes("local-ci-vitest-runner.mjs"));
     const buildIndex = commands.findIndex((command) => command.includes("next build"));
 
     assert.ok(typecheckIndex > -1, "typecheck must remain in the local-CI plan");
@@ -295,13 +295,13 @@ describe("createLocalIntegrationPlan", () => {
       "exec next build",
     ));
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
-      "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
+      "env NODE_OPTIONS=--max-old-space-size=16384 node scripts/local-ci-typecheck-runner.mjs",
     ));
   });
 
   it("resolves environment-prefixed commands without relying on a host env binary", () => {
     const invocation = resolveCommandInvocation(
-      ["env", "NODE_OPTIONS=--max-old-space-size=8192", "pnpm", "--filter", "web", "typecheck"],
+      ["env", "NODE_OPTIONS=--max-old-space-size=16384", "pnpm", "--filter", "web", "typecheck"],
       { PATH: "test-path", NODE_OPTIONS: "--trace-warnings" },
     );
 
@@ -309,7 +309,7 @@ describe("createLocalIntegrationPlan", () => {
     assert.deepEqual(invocation.args, ["--filter", "web", "typecheck"]);
     assert.deepEqual(invocation.env, {
       PATH: "test-path",
-      NODE_OPTIONS: "--max-old-space-size=8192",
+      NODE_OPTIONS: "--max-old-space-size=16384",
     });
   });
 
@@ -390,7 +390,7 @@ describe("executeLocalIntegrationPlan", () => {
       spawnSyncImpl(command, args) {
         launched.push([command, ...args]);
         return {
-          status: command === "pnpm" && args.includes("typecheck") ? 2 : 0,
+          status: command === "node" && args.includes("scripts/local-ci-typecheck-runner.mjs") ? 2 : 0,
           signal: null,
         };
       },
@@ -399,7 +399,7 @@ describe("executeLocalIntegrationPlan", () => {
     assert.equal(result.status, 2);
     assert.deepEqual(
       launched.at(-1),
-      ["pnpm", "--filter", "web", "typecheck"],
+      ["node", "scripts/local-ci-typecheck-runner.mjs"],
       "typecheck must be the terminal launched command",
     );
     assert.equal(
@@ -428,7 +428,7 @@ describe("createLocalIntegrationPlan migrate-deploy opt-in (BI-157DC9B2)", () =>
     const commands = plan.commands.map((command) => command.join(" "));
     const migrateIndex = commands.indexOf("pnpm --filter @dpf/db exec prisma migrate deploy");
     const freshnessIndex = commands.findIndex((c) => c.includes("sandbox-freshness-preflight.mjs"));
-    const vitestIndex = commands.findIndex((c) => c.includes("vitest run"));
+    const vitestIndex = commands.findIndex((c) => c.includes("local-ci-vitest-runner.mjs"));
     assert.ok(migrateIndex > freshnessIndex, "migrate deploy must run after deps convergence");
     assert.ok(migrateIndex < vitestIndex, "migrate deploy must run before the suite");
   });

--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -300,6 +300,7 @@ export const EXIT_USAGE = 2;
 export const EXIT_SANDBOX_DRIFT = 3;
 export const EXIT_SANDBOX_NOT_READY = 4;
 export const EXIT_CONTROL_PLANE_STARVATION = 5;
+export const EXIT_VITEST_RUNNER_TERMINATION = 86;
 
 export function exitCodeForVerdict(verdict) {
   if (verdict === "green") return EXIT_GREEN;
@@ -335,6 +336,14 @@ export function classifyGateOutcome({ freshnessVerdict, gateExitCode }) {
       gatePassed: false,
       productEvidence: false,
       summary: "local-CI gate blocked: the shared portal/MCP/Docker/PostgreSQL control-plane degraded during the build. This is infrastructure evidence, NOT a product build failure.",
+    };
+  }
+  if (gateExitCode === EXIT_VITEST_RUNNER_TERMINATION) {
+    return {
+      status: "failed",
+      gatePassed: false,
+      productEvidence: false,
+      summary: "local-CI gate could not produce a test verdict: the exhaustive Vitest runner terminated twice without a failed-test summary. This is runner evidence, NOT a product test failure; inspect the attached attempt diagnostics before retrying.",
     };
   }
   if (gateExitCode === 0) {

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -327,3 +327,11 @@ test("classifyGateOutcome reserves exit 5 for control-plane starvation", () => {
   assert.equal(outcome.productEvidence, false);
   assert.match(outcome.summary, /control-plane/i);
 });
+
+test("classifyGateOutcome distinguishes repeated Vitest runner termination from a product failure", () => {
+  const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: 86 });
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.gatePassed, false);
+  assert.equal(outcome.productEvidence, false);
+  assert.match(outcome.summary, /runner evidence, NOT a product test failure/);
+});

--- a/scripts/local-ci-bounded-build.mjs
+++ b/scripts/local-ci-bounded-build.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { mcpCall } from "./lib/mcp-client.mjs";
 import {
@@ -19,6 +19,14 @@ import {
   terminateProcessTreeCommand,
 } from "./lib/local-ci-control-plane-watchdog.mjs";
 import { reapSupersededSlotImages } from "./lib/local-integration-image-retention.mjs";
+import {
+  canonicalStageReceiptStatus,
+  classifyPriorStage,
+  createStageReceiptWriter,
+  markStageReceiptReused,
+  readStageReceipt,
+  reusablePassedStage,
+} from "./lib/local-ci-stage-receipt.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const BUILDKIT_CONFIG = join(SCRIPT_DIR, "config", "local-ci-buildkitd.toml");
@@ -242,6 +250,30 @@ function writeEvidence(path, payload) {
   writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function localImageId(tag) {
+  const inspected = runDocker(["image", "inspect", tag, "--format", "{{.Id}}"], 15_000);
+  return inspected.status === 0 ? inspected.stdout.trim() : null;
+}
+
+export function canReuseBuildReceipt({ receipt, identity, resolveImageId }) {
+  const exactPassedReceipt = reusablePassedStage({
+    receipt,
+    stage: "production-build",
+    identity,
+  });
+  if (!exactPassedReceipt || !receipt.artifact?.imageId) return false;
+  return resolveImageId() === receipt.artifact.imageId;
+}
+
 async function main() {
   if (process.argv.includes("--help")) {
     process.stdout.write(usage());
@@ -257,6 +289,9 @@ async function main() {
 
   const builder = builderFromEnvironment();
   const evidencePath = process.env.DPF_LOCAL_CI_CONTROL_PLANE_EVIDENCE_FILE || "";
+  const metadataPath = process.env.DPF_LOCAL_CI_METADATA_FILE || "";
+  const stageReceiptPath = process.env.DPF_LOCAL_CI_BUILD_RECEIPT_FILE
+    || (metadataPath ? `${metadataPath}.build.json` : "");
   const startedAt = new Date().toISOString();
   const identity = {
     candidate,
@@ -274,6 +309,49 @@ async function main() {
     cpuPeriod: builder.cpuPeriod,
     maxParallelism: builder.maxParallelism,
   };
+  const stageIdentity = {
+    candidateSha: identity.candidateSha,
+    integrationTreeSha: identity.integrationTreeSha,
+    imageTag: identity.imageTag,
+    command: JSON.stringify(buildxBuildArgs({ builder, tag, context: "." })),
+  };
+  const priorReceipt = readStageReceipt(stageReceiptPath);
+  if (canReuseBuildReceipt({
+    receipt: priorReceipt,
+    identity: stageIdentity,
+    resolveImageId: () => localImageId(tag),
+  })) {
+    const payload = markStageReceiptReused({
+      path: stageReceiptPath,
+      receipt: priorReceipt,
+    });
+    writeEvidence(evidencePath, payload);
+    process.stdout.write(
+      `[local-ci-bounded-build] reusing exact-tree passed receipt ${stageReceiptPath}\n`,
+    );
+    return 0;
+  }
+  const priorDisposition = classifyPriorStage({
+    receipt: priorReceipt,
+    isProcessAlive: processAlive,
+  });
+  const stageReceipt = createStageReceiptWriter({
+    path: stageReceiptPath,
+    stage: "production-build",
+    identity: stageIdentity,
+  });
+  stageReceipt.start({
+    bi: "BI-872CB1BF",
+    identity: stageIdentity,
+    policy,
+    recoveredFrom: priorDisposition === "externally-terminated"
+      ? {
+          hostPid: priorReceipt.hostPid ?? null,
+          childPid: priorReceipt.childPid ?? null,
+          lastHeartbeatAt: priorReceipt.lastHeartbeatAt ?? null,
+        }
+      : null,
+  });
 
   let controlPlanePostgresProbe;
   try {
@@ -291,6 +369,7 @@ async function main() {
       samples: [],
     };
     writeEvidence(evidencePath, payload);
+    stageReceipt.complete(payload.status, payload);
     process.stderr.write(`[local-ci-bounded-build] ${payload.status} ${payload.failures[0]}\n`);
     return EXIT_CONTROL_PLANE_STARVATION;
   }
@@ -311,6 +390,7 @@ async function main() {
       samples: preflight.samples,
     };
     writeEvidence(evidencePath, payload);
+    stageReceipt.complete(payload.status, payload);
     process.stderr.write(`[local-ci-bounded-build] ${payload.status} ${payload.failures.join(",")}\n`);
     return EXIT_CONTROL_PLANE_STARVATION;
   }
@@ -330,6 +410,7 @@ async function main() {
       samples: preflight.samples,
     };
     writeEvidence(evidencePath, payload);
+    stageReceipt.complete(payload.status, payload);
     process.stderr.write(`[local-ci-bounded-build] ${payload.status} ${payload.failures[0]}\n`);
     return EXIT_CONTROL_PLANE_STARVATION;
   }
@@ -367,6 +448,12 @@ async function main() {
   const watchdog = await monitorControlPlane({
     sample: () => probeControlPlane(controlPlanePostgresProbe),
     isComplete: () => childComplete,
+    onSample: (sample) => stageReceipt.heartbeat({
+      phase: "production-build",
+      childPid: child.pid ?? null,
+      controlPlane: sample,
+      outputTail: buildOutput.slice(-4_000),
+    }),
   });
   let termination = null;
   if (watchdog.status === "blocked_control_plane_starvation" && !childComplete) {
@@ -401,8 +488,13 @@ async function main() {
     samples: [...preflight.samples, ...watchdog.samples],
     buildExitCode: childExit,
     termination,
+    artifact: finalStatus === "healthy"
+      ? { imageTag: tag, imageId: localImageId(tag) }
+      : null,
   };
   writeEvidence(evidencePath, payload);
+  const receiptStatus = canonicalStageReceiptStatus(finalStatus);
+  stageReceipt.complete(receiptStatus, payload);
   if (finalStatus === "blocked_control_plane_starvation") {
     process.stderr.write(`[local-ci-bounded-build] ${finalStatus} ${failures.join(",")}\n`);
     return EXIT_CONTROL_PLANE_STARVATION;
@@ -424,4 +516,6 @@ async function main() {
   return buildOutcome.exitCode;
 }
 
-process.exitCode = await main();
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exitCode = await main();
+}

--- a/scripts/local-ci-bounded-build.test.mjs
+++ b/scripts/local-ci-bounded-build.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { canReuseBuildReceipt } from "./local-ci-bounded-build.mjs";
+
+const source = readFileSync(new URL("./local-ci-bounded-build.mjs", import.meta.url), "utf8");
+const integrationSource = readFileSync(new URL("./local-integration-ci.mjs", import.meta.url), "utf8");
+
+test("production build writes a durable stage receipt before and during Docker work", () => {
+  assert.match(source, /createStageReceiptWriter/);
+  assert.match(source, /stage:\s*"production-build"/);
+  assert.match(source, /stageReceipt\.start/);
+  assert.match(source, /onSample:\s*\(sample\)\s*=>\s*stageReceipt\.heartbeat/);
+  assert.match(source, /canonicalStageReceiptStatus\(finalStatus\)/);
+  assert.match(source, /stageReceipt\.complete\(receiptStatus/);
+  assert.match(source, /\.build\.json/);
+});
+
+test("production build reuses a passed receipt only when the image ID still matches", () => {
+  const identity = {
+    candidateSha: "candidate-a",
+    integrationTreeSha: "tree-a",
+    imageTag: "dpf-local-ci:tree-a",
+    command: "docker buildx build",
+  };
+  const receipt = {
+    schemaVersion: 1,
+    stage: "production-build",
+    identity,
+    status: "passed",
+    artifact: { imageTag: identity.imageTag, imageId: "sha256:image-a" },
+  };
+  let inspected = 0;
+  assert.equal(canReuseBuildReceipt({
+    receipt,
+    identity,
+    resolveImageId: () => {
+      inspected += 1;
+      return "sha256:image-a";
+    },
+  }), true);
+  assert.equal(inspected, 1);
+  assert.equal(canReuseBuildReceipt({
+    receipt,
+    identity: { ...identity, integrationTreeSha: "tree-b" },
+    resolveImageId: () => {
+      inspected += 1;
+      return "sha256:image-a";
+    },
+  }), false);
+  assert.equal(inspected, 1, "an identity mismatch must not inspect Docker");
+  assert.equal(canReuseBuildReceipt({
+    receipt,
+    identity,
+    resolveImageId: () => "sha256:image-b",
+  }), false);
+  assert.equal(canReuseBuildReceipt({
+    receipt: { ...receipt, artifact: null },
+    identity,
+    resolveImageId: () => {
+      inspected += 1;
+      return "sha256:image-a";
+    },
+  }), false);
+  assert.equal(inspected, 1, "a receipt without an artifact ID must not inspect Docker");
+});
+
+test("local-integration metadata carries the durable production-build receipt", () => {
+  assert.match(integrationSource, /DPF_LOCAL_CI_BUILD_RECEIPT_FILE/);
+  assert.match(integrationSource, /productionBuild:\s*buildDiagnostics/);
+});

--- a/scripts/local-ci-typecheck-runner.mjs
+++ b/scripts/local-ci-typecheck-runner.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createObservedProcessRunner } from "./lib/local-ci-process-observer.mjs";
+import {
+  classifyPriorStage,
+  createStageReceiptWriter,
+  markStageReceiptReused,
+  readStageReceipt,
+  reusablePassedStage,
+} from "./lib/local-ci-stage-receipt.mjs";
+
+function resolveGit(ref) {
+  const result = spawnSync("git", ["rev-parse", "--verify", ref], {
+    encoding: "utf8",
+    shell: false,
+    windowsHide: true,
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function classifyTypecheckResult(result) {
+  if (result.status === 0) return "passed";
+  if (result.error || result.status === null || result.status === -1 || result.status === 4294967295) {
+    return "runner-termination";
+  }
+  return "failed";
+}
+
+export async function runTypecheckStage({
+  receiptPath,
+  resolveGitImpl = resolveGit,
+  isProcessAlive = processAlive,
+  runObservedProcess,
+} = {}) {
+  const identity = {
+    integrationTreeSha: resolveGitImpl("HEAD^{tree}"),
+    command: "pnpm --filter web typecheck",
+    nodeOptions: process.env.NODE_OPTIONS ?? "",
+  };
+  const priorReceipt = readStageReceipt(receiptPath);
+  if (reusablePassedStage({ receipt: priorReceipt, stage: "web-typecheck", identity })) {
+    markStageReceiptReused({ path: receiptPath, receipt: priorReceipt });
+    process.stdout.write(`[local-ci-typecheck] reusing exact-tree passed receipt ${receiptPath}\n`);
+    return { status: 0, classification: "passed", reused: true };
+  }
+
+  const priorDisposition = classifyPriorStage({ receipt: priorReceipt, isProcessAlive });
+  const receipt = createStageReceiptWriter({
+    path: receiptPath,
+    stage: "web-typecheck",
+    identity,
+  });
+  receipt.start({
+    bi: "BI-872CB1BF",
+    recoveredFrom: priorDisposition === "externally-terminated"
+      ? {
+          hostPid: priorReceipt.hostPid ?? null,
+          lastHeartbeatAt: priorReceipt.lastHeartbeatAt ?? null,
+        }
+      : null,
+  });
+
+  const observedRunner = runObservedProcess ?? createObservedProcessRunner({
+    onProgress: (progress) => receipt.heartbeat(progress),
+  });
+
+  const result = await observedRunner({
+    command: "pnpm",
+    args: ["--filter", "web", "typecheck"],
+    observation: { stage: "web-typecheck" },
+  });
+  const classification = classifyTypecheckResult(result);
+  receipt.complete(classification, {
+    childPid: result.childPid,
+    statusCode: result.status,
+    signal: result.signal,
+    error: result.error
+      ? { name: result.error.name, code: result.error.code, message: result.error.message }
+      : null,
+    outputTail: result.outputTail,
+    hostSamples: result.hostSamples,
+  });
+  process.stdout.write(
+    `[local-ci-typecheck] classification=${classification} diagnostics=${receiptPath}\n`,
+  );
+  return {
+    status: classification === "runner-termination" ? 86 : (result.status ?? 1),
+    classification,
+    reused: false,
+  };
+}
+
+async function main() {
+  const metadataPath = process.env.DPF_LOCAL_CI_METADATA_FILE ?? "";
+  const receiptPath = resolve(
+    process.env.DPF_LOCAL_CI_TYPECHECK_RECEIPT_FILE
+      || (metadataPath ? `${metadataPath}.typecheck.json` : ".dpf-local-ci-typecheck.json"),
+  );
+  const result = await runTypecheckStage({ receiptPath });
+  process.exit(result.status);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    process.stderr.write(`[local-ci-typecheck] supervisor failed: ${error.stack || error.message}\n`);
+    process.exit(86);
+  });
+}

--- a/scripts/local-ci-typecheck-runner.test.mjs
+++ b/scripts/local-ci-typecheck-runner.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  classifyTypecheckResult,
+  runTypecheckStage,
+} from "./local-ci-typecheck-runner.mjs";
+
+test("typecheck classification keeps compiler failures distinct from opaque termination", () => {
+  assert.equal(classifyTypecheckResult({ status: 0 }), "passed");
+  assert.equal(classifyTypecheckResult({ status: 2 }), "failed");
+  assert.equal(classifyTypecheckResult({ status: 4294967295 }), "runner-termination");
+  assert.equal(classifyTypecheckResult({ status: null, signal: null }), "runner-termination");
+});
+
+test("typecheck writes and then reuses an exact-tree passed receipt", async () => {
+  const receiptPath = join(mkdtempSync(join(tmpdir(), "dpf-typecheck-")), "receipt.json");
+  let launches = 0;
+  const options = {
+    receiptPath,
+    resolveGitImpl: () => "tree-123",
+    runObservedProcess: async ({ command, args }) => {
+      launches += 1;
+      assert.equal(command, "pnpm");
+      assert.deepEqual(args, ["--filter", "web", "typecheck"]);
+      return {
+        status: 0,
+        signal: null,
+        error: null,
+        outputTail: "Types generated successfully",
+        childPid: 1234,
+        hostSamples: [],
+      };
+    },
+  };
+
+  const first = await runTypecheckStage(options);
+  const second = await runTypecheckStage(options);
+  const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+
+  assert.equal(first.reused, false);
+  assert.equal(second.reused, true);
+  assert.equal(launches, 1);
+  assert.equal(receipt.stage, "web-typecheck");
+  assert.equal(receipt.status, "passed");
+  assert.equal(receipt.reuseCount, 1);
+});
+
+test("typecheck records a real compiler error without retrying", async () => {
+  const receiptPath = join(mkdtempSync(join(tmpdir(), "dpf-typecheck-red-")), "receipt.json");
+  let launches = 0;
+  const result = await runTypecheckStage({
+    receiptPath,
+    resolveGitImpl: () => "tree-red",
+    runObservedProcess: async () => {
+      launches += 1;
+      return {
+        status: 2,
+        signal: null,
+        error: null,
+        outputTail: "TS2322: Type mismatch",
+        childPid: 4321,
+        hostSamples: [],
+      };
+    },
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(result.classification, "failed");
+  assert.equal(launches, 1);
+  assert.match(readFileSync(receiptPath, "utf8"), /TS2322/);
+});

--- a/scripts/local-ci-vitest-runner.mjs
+++ b/scripts/local-ci-vitest-runner.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { runVitestWithRecovery } from "./lib/local-ci-vitest-supervisor.mjs";
+import { createObservedProcessRunner } from "./lib/local-ci-process-observer.mjs";
+import {
+  classifyPriorStage,
+  createStageReceiptWriter,
+  markStageReceiptReused,
+  readStageReceipt,
+  reusablePassedStage,
+} from "./lib/local-ci-stage-receipt.mjs";
+
+function valueAfter(flag, fallback) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveGit(ref) {
+  const result = spawnSync("git", ["rev-parse", "--verify", ref], {
+    encoding: "utf8",
+    shell: false,
+    windowsHide: true,
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function lastCompletedTestLine(outputTail) {
+  return outputTail
+    .split(/\r?\n/)
+    .reverse()
+    .find((line) => /(?:^|\s)(?:✓|×|❯)\s/.test(line))
+    ?.trim() ?? null;
+}
+
+export function selectVitestRecoveryPlan({
+  priorDisposition,
+  initialWorkers,
+  retryWorkers,
+}) {
+  const recoveringPriorTermination = priorDisposition === "externally-terminated";
+  return {
+    initialWorkers: recoveringPriorTermination ? retryWorkers : initialWorkers,
+    retryWorkers,
+    allowRetry: !recoveringPriorTermination,
+    recoveringPriorTermination,
+  };
+}
+
+export function createAttemptRunner({
+  spawnImpl,
+  sampleHost,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  sampleIntervalMs = 5_000,
+  onProgress = () => {},
+} = {}) {
+  const runObservedProcess = createObservedProcessRunner({
+    spawnImpl,
+    sampleHost,
+    stdout,
+    stderr,
+    sampleIntervalMs,
+    onProgress: (progress) => onProgress({
+      ...progress,
+      lastCompletedTest: lastCompletedTestLine(progress.outputTail ?? ""),
+    }),
+  });
+  return function runAttempt({ workers, attempt }) {
+    const args = [
+        "--filter", "web", "exec", "vitest", "run",
+        `--maxWorkers=${workers}`,
+        "--reporter=verbose",
+      ];
+    return runObservedProcess({
+      command: "pnpm",
+      args,
+      observation: { attempt, workers },
+    }).then((result) => ({
+      ...result,
+      lastCompletedTest: lastCompletedTestLine(result.outputTail),
+    }));
+  };
+}
+
+async function main() {
+  const initialWorkers = positiveInteger(valueAfter("--initial-workers", "4"), 4);
+  const retryWorkers = positiveInteger(valueAfter("--retry-workers", "2"), 2);
+  const metadataPath = process.env.DPF_LOCAL_CI_METADATA_FILE ?? "";
+  const diagnosticsPath = resolve(
+    process.env.DPF_LOCAL_CI_VITEST_DIAGNOSTICS_FILE
+      || (metadataPath ? `${metadataPath}.vitest.json` : ".dpf-local-ci-vitest.json"),
+  );
+  const startedAt = new Date().toISOString();
+  let latestAttempts = [];
+  const identity = {
+    integrationTreeSha: resolveGit("HEAD^{tree}"),
+    command: `pnpm --filter web exec vitest run --maxWorkers=${initialWorkers} --reporter=verbose`,
+  };
+  const priorReceipt = readStageReceipt(diagnosticsPath);
+  if (reusablePassedStage({
+    receipt: priorReceipt,
+    stage: "exhaustive-vitest",
+    identity,
+  })) {
+    markStageReceiptReused({ path: diagnosticsPath, receipt: priorReceipt });
+    process.stdout.write(
+      `[local-ci-vitest] reusing exact-tree passed receipt ${diagnosticsPath}\n`,
+    );
+    return;
+  }
+  const priorDisposition = classifyPriorStage({
+    receipt: priorReceipt,
+    isProcessAlive: processAlive,
+  });
+  const receipt = createStageReceiptWriter({
+    path: diagnosticsPath,
+    stage: "exhaustive-vitest",
+    identity,
+  });
+  receipt.start({
+    bi: "BI-872CB1BF",
+    recoveredFrom: priorDisposition === "externally-terminated"
+      ? {
+          hostPid: priorReceipt.hostPid ?? null,
+          lastHeartbeatAt: priorReceipt.lastHeartbeatAt ?? null,
+        }
+      : null,
+  });
+
+  const recoveryPlan = selectVitestRecoveryPlan({
+    priorDisposition,
+    initialWorkers,
+    retryWorkers,
+  });
+
+  const result = await runVitestWithRecovery({
+    initialWorkers: recoveryPlan.initialWorkers,
+    retryWorkers: recoveryPlan.retryWorkers,
+    allowRetry: recoveryPlan.allowRetry,
+    runAttempt: createAttemptRunner({
+      onProgress: (progress) => receipt.heartbeat(progress),
+    }),
+    onAttempt: async (attempt) => {
+      latestAttempts = [...latestAttempts, attempt];
+      receipt.heartbeat({
+        attempt: attempt.attempt,
+        workers: attempt.workers,
+        classification: attempt.classification,
+        childPid: attempt.childPid,
+        lastCompletedTest: attempt.lastCompletedTest,
+      });
+      if (recoveryPlan.allowRetry && attempt.classification === "runner-termination" && attempt.attempt === 1) {
+        process.stderr.write(
+          `[local-ci-vitest] runner termination detected (status=${attempt.status}, signal=${attempt.signal ?? "none"}); retrying the same exhaustive suite once with ${retryWorkers} workers\n`,
+        );
+      }
+    },
+  });
+  const recovered = result.recovered
+    || (recoveryPlan.recoveringPriorTermination && result.classification === "passed");
+
+  receipt.complete(result.classification, {
+    recovered,
+    recoveryPlan,
+    startedAt,
+    attempts: result.attempts,
+  });
+  process.stdout.write(
+    `[local-ci-vitest] classification=${result.classification} attempts=${result.attempts.length} recovered=${recovered} diagnostics=${diagnosticsPath}\n`,
+  );
+  process.exit(result.status);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    const metadataPath = process.env.DPF_LOCAL_CI_METADATA_FILE ?? "";
+    const diagnosticsPath = resolve(
+      process.env.DPF_LOCAL_CI_VITEST_DIAGNOSTICS_FILE
+        || (metadataPath ? `${metadataPath}.vitest.json` : ".dpf-local-ci-vitest.json"),
+    );
+    process.stderr.write(`[local-ci-vitest] supervisor failed: ${error.stack || error.message}\n`);
+    process.exit(86);
+  });
+}

--- a/scripts/local-ci-vitest-runner.mjs
+++ b/scripts/local-ci-vitest-runner.mjs
@@ -195,7 +195,9 @@ if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1]
       process.env.DPF_LOCAL_CI_VITEST_DIAGNOSTICS_FILE
         || (metadataPath ? `${metadataPath}.vitest.json` : ".dpf-local-ci-vitest.json"),
     );
-    process.stderr.write(`[local-ci-vitest] supervisor failed: ${error.stack || error.message}\n`);
+    process.stderr.write(
+      `[local-ci-vitest] supervisor failed: ${error.stack || error.message} diagnostics=${diagnosticsPath}\n`,
+    );
     process.exit(86);
   });
 }

--- a/scripts/local-ci-vitest-runner.test.mjs
+++ b/scripts/local-ci-vitest-runner.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { test } from "node:test";
+
+import {
+  createAttemptRunner,
+  lastCompletedTestLine,
+  selectVitestRecoveryPlan,
+} from "./local-ci-vitest-runner.mjs";
+
+test("lastCompletedTestLine returns the latest verbose Vitest test marker", () => {
+  assert.equal(lastCompletedTestLine([
+    "stdout before tests",
+    " ✓ lib/first.test.ts > first",
+    " ✓ lib/last.test.ts > last",
+  ].join("\n")), "✓ lib/last.test.ts > last");
+});
+
+test("a prior externally terminated receipt resumes at the differentiated worker count", () => {
+  assert.deepEqual(selectVitestRecoveryPlan({
+    priorDisposition: "externally-terminated",
+    initialWorkers: 4,
+    retryWorkers: 2,
+  }), {
+    initialWorkers: 2,
+    retryWorkers: 2,
+    allowRetry: false,
+    recoveringPriorTermination: true,
+  });
+  assert.equal(selectVitestRecoveryPlan({
+    priorDisposition: "terminal-or-absent",
+    initialWorkers: 4,
+    retryWorkers: 2,
+  }).initialWorkers, 4);
+});
+
+test("attempt runner streams output and retains progress plus host evidence on opaque exit", async () => {
+  const child = new EventEmitter();
+  child.pid = 4123;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  const streamed = { stdout: "", stderr: "" };
+  let invocation = null;
+  const runAttempt = createAttemptRunner({
+    spawnImpl(command, args) {
+      invocation = { command, args };
+      queueMicrotask(() => {
+        child.stdout.write(" ✓ apps/web/last.test.ts > completes\n");
+        child.stderr.write("worker closed without summary\n");
+        child.emit("close", -1, null);
+      });
+      return child;
+    },
+    sampleHost: (pid) => ({ pid, freeMemoryBytes: 24_000_000_000 }),
+    stdout: { write: (chunk) => { streamed.stdout += String(chunk); } },
+    stderr: { write: (chunk) => { streamed.stderr += String(chunk); } },
+    sampleIntervalMs: 60_000,
+  });
+
+  const result = await runAttempt({ workers: 4, attempt: 1 });
+
+  assert.equal(invocation.command, "pnpm");
+  assert.ok(invocation.args.includes("--maxWorkers=4"));
+  assert.ok(invocation.args.includes("--reporter=verbose"));
+  assert.match(streamed.stdout, /last\.test\.ts/);
+  assert.match(streamed.stderr, /without summary/);
+  assert.equal(result.status, -1);
+  assert.equal(result.lastCompletedTest, "✓ apps/web/last.test.ts > completes");
+  assert.ok(result.hostSamples.length >= 2);
+  assert.equal(result.hostSamples[0].pid, 4123);
+});

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   collectToolchainFingerprint,
@@ -14,6 +14,23 @@ import {
 function valueAfter(flag) {
   const index = process.argv.indexOf(flag);
   return index >= 0 ? process.argv[index + 1] : "";
+}
+
+function readJsonIfPresent(path) {
+  if (!path || !existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function resolveGitRevisionOrNull(ref) {
+  try {
+    return resolveGitRevision(ref);
+  } catch {
+    return null;
+  }
 }
 
 const candidateBranch = valueAfter("--candidate");
@@ -53,15 +70,19 @@ const plan = createLocalIntegrationPlan({
 });
 const startedAt = new Date().toISOString();
 const execution = executeLocalIntegrationPlan(plan);
-if (execution.status !== 0) {
-  process.exit(execution.status);
-}
 if (metadataOut) {
-  const evidencePlan = evidencePlanOut
-    ? JSON.parse(readFileSync(evidencePlanOut, "utf8"))
-    : null;
-  const integrationCommitSha = resolveGitRevision("HEAD");
-  const synthesizedTreeSha = resolveGitRevision("HEAD^{tree}");
+  const evidencePlan = readJsonIfPresent(evidencePlanOut);
+  const vitestDiagnostics = readJsonIfPresent(
+    process.env.DPF_LOCAL_CI_VITEST_DIAGNOSTICS_FILE || `${metadataOut}.vitest.json`,
+  );
+  const typecheckDiagnostics = readJsonIfPresent(
+    process.env.DPF_LOCAL_CI_TYPECHECK_RECEIPT_FILE || `${metadataOut}.typecheck.json`,
+  );
+  const buildDiagnostics = readJsonIfPresent(
+    process.env.DPF_LOCAL_CI_BUILD_RECEIPT_FILE || `${metadataOut}.build.json`,
+  );
+  const integrationCommitSha = resolveGitRevisionOrNull("HEAD");
+  const synthesizedTreeSha = resolveGitRevisionOrNull("HEAD^{tree}");
   const imageTag = plan.buildStrategy === "docker-build"
     ? dockerBuildTag(candidateBranch, slotKey)
     : "";
@@ -77,19 +98,21 @@ if (metadataOut) {
   } catch {
     // Docker builds do not materialize the build output in the host checkout.
   }
-  const productionArtifact = createProductionArtifactIdentity({
-    buildStrategy: plan.buildStrategy,
-    integrationTreeSha: synthesizedTreeSha,
-    dockerImageTag: imageTag,
-    dockerImageId: imageInspect?.status === 0 ? imageInspect.stdout.trim() : "",
-    nextBuildId,
-  });
+  const productionArtifact = execution.status === 0
+    ? createProductionArtifactIdentity({
+        buildStrategy: plan.buildStrategy,
+        integrationTreeSha: synthesizedTreeSha,
+        dockerImageTag: imageTag,
+        dockerImageId: imageInspect?.status === 0 ? imageInspect.stdout.trim() : "",
+        nextBuildId,
+      })
+    : null;
   const payload = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     bi: "BI-76551B2D",
     mode,
     candidateRef: candidateBranch,
-    candidateSha: candidateSha || resolveGitRevision(candidateBranch),
+    candidateSha: candidateSha || resolveGitRevisionOrNull(candidateBranch),
     baseRef,
     fetchBase: baseFreshnessStatus === "remote-current" || fetchBase,
     baseFreshness: {
@@ -97,13 +120,23 @@ if (metadataOut) {
       resolvedAt: baseResolvedAt || null,
       fetchMode: baseFetchMode || null,
     },
-    baseSha: baseSha || resolveGitRevision(baseRef),
+    baseSha: baseSha || resolveGitRevisionOrNull(baseRef),
     integrationBranch: plan.integrationBranch,
     slotKey: slotKey || null,
     integrationCommitSha,
     synthesizedTreeSha,
     buildStrategy: plan.buildStrategy,
     productionArtifact,
+    execution: {
+      status: execution.status === 0 ? "passed" : "failed",
+      exitCode: execution.status,
+      completedCommandCount: execution.completedCommandCount,
+      failedCommand: execution.failedCommand?.join(" ") ?? null,
+      failureDiagnostics: execution.diagnostics,
+      typecheck: typecheckDiagnostics,
+      vitest: vitestDiagnostics,
+      productionBuild: buildDiagnostics,
+    },
     evidencePlan: evidencePlan ? {
       path: evidencePlanOut,
       digest: evidencePlan.digest,
@@ -120,7 +153,12 @@ if (metadataOut) {
   writeFileSync(metadataOut, `${JSON.stringify(payload, null, 2)}\n`);
   const artifactOut = process.env.DPF_LOCAL_CI_ARTIFACT_FILE;
   if (artifactOut) {
-    writeFileSync(artifactOut, `${JSON.stringify(productionArtifact, null, 2)}\n`);
+    if (productionArtifact) {
+      writeFileSync(artifactOut, `${JSON.stringify(productionArtifact, null, 2)}\n`);
+    }
   }
   console.log(`[local-integration-ci] metadata ${metadataOut}`);
+}
+if (execution.status !== 0) {
+  process.exit(execution.status);
 }


### PR DESCRIPTION
## Summary

Makes long local-CI typecheck, exhaustive Vitest, and production-build stages recoverable and diagnosable when an outer host disappears without a terminal child result. Exact-tree stage receipts preserve bounded process/control-plane observations and allow safe reuse only when immutable execution identity still matches.

## Changes

- add bounded output tails, descendant-process observations, and control-plane health evidence shared by heavy stages
- supervise exhaustive Vitest with a single bounded two-worker recovery path for opaque host loss while keeping assertion failures terminal
- persist exact-tree typecheck and build receipts; require exact command, heap, integration tree, and immutable Docker image identity before reuse
- carry the 16 GiB local-CI typecheck/build envelope and document operator recovery semantics
- add focused coverage for receipt identity, process observation, control-plane probes, Vitest recovery, and stage orchestration
- include the exact receipt path in fatal Vitest diagnostics, addressing reviewer feedback

## Test plan

- [x] Focused source-local tests passed for the original change
- [x] The reviewer amendment passed its 12-test focused suite and syntax validation
- [x] The exact pre-amendment candidate passed the governed merged-code gate
- [x] Typecheck, exhaustive Vitest, and the production Docker build passed
- [x] Exhaustive Vitest passed 2,515 files / 21,579 tests
- [x] No migration or user-facing UI change

Local-CI-Override: the exact pre-amendment candidate passed; the log-only reviewer amendment passed focused tests and independent semantic review; repeated amended queue observers were externally terminated before admission and produced no product-stage failure evidence.

## Related work

Backlog: BI-872CB1BF
Work Capsule: WC-8C968B5A

## Overlap sweep

All open PR file lists were compared against this exact diff immediately before creation; zero overlapping files were found.

## Notes for the reviewer

The recovery path never converts a real test assertion failure into a retry, and receipt reuse is fail-closed on mutable or mismatched identity.