### PR TITLE
feat(workbooks): number-format config UI + align column config schema (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/AddColumnButton.tsx
+++ b/apps/web/components/workbooks/AddColumnButton.tsx
@@ -84,6 +84,11 @@ export function AddColumnButton({
   const [lookupRefColumnId, setLookupRefColumnId] = useState("");
   const [lookupTargetField, setLookupTargetField] = useState("");
   const [targetFields, setTargetFields] = useState<ReferenceFieldOption[]>([]);
+  // Number-format config (Excel "Format Cells"): decimals, currency symbol, etc.
+  const [precision, setPrecision] = useState("");
+  const [currencySymbol, setCurrencySymbol] = useState("$");
+  const [durationUnit, setDurationUnit] = useState<"minutes" | "seconds">("minutes");
+  const [ratingMax, setRatingMax] = useState("5");
   const [required, setRequired] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -135,8 +140,20 @@ export function AddColumnButton({
     setLookupRefColumnId("");
     setLookupTargetField("");
     setTargetFields([]);
+    setPrecision("");
+    setCurrencySymbol("$");
+    setDurationUnit("minutes");
+    setRatingMax("5");
     setRequired(false);
     setError(null);
+  }
+
+  // Optional integer from a text input; undefined when blank or unparseable.
+  function intOrUndefined(raw: string): number | undefined {
+    const t = raw.trim();
+    if (t === "") return undefined;
+    const n = Number(t);
+    return Number.isInteger(n) ? n : undefined;
   }
 
   function buildConfig(): FieldConfig | undefined {
@@ -147,6 +164,20 @@ export function AddColumnButton({
     if (fieldType === "formula") return { formula, resultType };
     if (fieldType === "lookup") {
       return { lookup: { referenceColumnId: lookupRefColumnId, targetField: lookupTargetField } };
+    }
+    // Number-format config (persisted to fieldConfig; the grid renderers read it).
+    if (fieldType === "currency") {
+      const p = intOrUndefined(precision);
+      return { currencySymbol: currencySymbol.trim() || "$", ...(p !== undefined ? { precision: p } : {}) };
+    }
+    if (fieldType === "percent" || fieldType === "number") {
+      const p = intOrUndefined(precision);
+      return p !== undefined ? { precision: p } : undefined;
+    }
+    if (fieldType === "duration") return { durationUnit };
+    if (fieldType === "rating") {
+      const m = intOrUndefined(ratingMax);
+      return m !== undefined ? { max: m } : undefined;
     }
     return undefined;
   }
@@ -331,6 +362,62 @@ export function AddColumnButton({
             ))}
           </select>
         </>
+      )}
+      {fieldType === "currency" && (
+        <>
+          <input
+            value={currencySymbol}
+            onChange={(e) => setCurrencySymbol(e.target.value)}
+            placeholder="Symbol"
+            aria-label="Currency symbol"
+            className={`${inputClass} w-20`}
+          />
+          <input
+            type="number"
+            min={0}
+            max={10}
+            value={precision}
+            onChange={(e) => setPrecision(e.target.value)}
+            placeholder="Decimals"
+            aria-label="Decimal places"
+            className={`${inputClass} w-28`}
+          />
+        </>
+      )}
+      {(fieldType === "percent" || fieldType === "number") && (
+        <input
+          type="number"
+          min={0}
+          max={10}
+          value={precision}
+          onChange={(e) => setPrecision(e.target.value)}
+          placeholder="Decimals"
+          aria-label="Decimal places"
+          className={`${inputClass} w-28`}
+        />
+      )}
+      {fieldType === "duration" && (
+        <select
+          value={durationUnit}
+          onChange={(e) => setDurationUnit(e.target.value as "minutes" | "seconds")}
+          className={selectClass}
+          aria-label="Duration unit"
+        >
+          <option value="minutes" className={optionClass}>Minutes</option>
+          <option value="seconds" className={optionClass}>Seconds</option>
+        </select>
+      )}
+      {fieldType === "rating" && (
+        <input
+          type="number"
+          min={1}
+          max={100}
+          value={ratingMax}
+          onChange={(e) => setRatingMax(e.target.value)}
+          placeholder="Max stars"
+          aria-label="Maximum stars"
+          className={`${inputClass} w-28`}
+        />
       )}
       <label className="flex items-center gap-1 text-sm text-[var(--dpf-muted)]">
         <input type="checkbox" checked={required} onChange={(e) => setRequired(e.target.checked)} />

--- a/apps/web/lib/workbooks/column-schema.test.ts
+++ b/apps/web/lib/workbooks/column-schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { addColumnSchema } from "./column-schema";
+
+/** Parse a column create and return the (possibly stripped) config. */
+function parseConfig(fieldType: string, config: unknown) {
+  return addColumnSchema.parse({ name: "Col", fieldType, config }).config;
+}
+
+describe("addColumnSchema — number/format config is preserved (not stripped)", () => {
+  it("keeps currencySymbol + precision on a currency column", () => {
+    expect(parseConfig("currency", { currencySymbol: "€", precision: 2 })).toEqual({
+      currencySymbol: "€",
+      precision: 2,
+    });
+  });
+  it("keeps precision on a percent column", () => {
+    expect(parseConfig("percent", { precision: 1 })).toEqual({ precision: 1 });
+  });
+  it("keeps durationUnit on a duration column", () => {
+    expect(parseConfig("duration", { durationUnit: "seconds" })).toEqual({ durationUnit: "seconds" });
+  });
+  it("keeps max on a rating column", () => {
+    expect(parseConfig("rating", { max: 10 })).toEqual({ max: 10 });
+  });
+});
+
+describe("addColumnSchema — link/rollup config regression (previously stripped)", () => {
+  it("keeps a link column's cardinality + referenceType", () => {
+    expect(parseConfig("link", { link: { cardinality: "many", referenceType: "epic" } })).toEqual({
+      link: { cardinality: "many", referenceType: "epic" },
+    });
+  });
+  it("keeps a rollup column's linkColumnId + op", () => {
+    expect(parseConfig("rollup", { rollup: { linkColumnId: "COL-1", op: "count" } })).toEqual({
+      rollup: { linkColumnId: "COL-1", op: "count" },
+    });
+  });
+});
+
+describe("addColumnSchema — validation bounds", () => {
+  it("rejects an unknown duration unit", () => {
+    expect(() => parseConfig("duration", { durationUnit: "hours" })).toThrow();
+  });
+  it("rejects precision out of range", () => {
+    expect(() => parseConfig("number", { precision: 99 })).toThrow();
+  });
+  it("rejects a non-integer precision", () => {
+    expect(() => parseConfig("number", { precision: 1.5 })).toThrow();
+  });
+  it("rejects an over-long currency symbol", () => {
+    expect(() => parseConfig("currency", { currencySymbol: "toolongsymbol" })).toThrow();
+  });
+  it("strips genuinely unknown keys", () => {
+    // A key in neither the type nor the schema is still dropped.
+    expect(parseConfig("number", { precision: 0, bogusKey: 1 })).toEqual({ precision: 0 });
+  });
+});
+
+describe("addColumnSchema — superRefine still enforces computed-column requirements", () => {
+  it("requires a formula for a formula column", () => {
+    expect(() => addColumnSchema.parse({ name: "F", fieldType: "formula", config: {} })).toThrow();
+  });
+  it("requires a target entity for a reference column", () => {
+    expect(() => addColumnSchema.parse({ name: "R", fieldType: "reference", config: {} })).toThrow();
+  });
+  it("accepts a plain text column with no config", () => {
+    expect(addColumnSchema.parse({ name: "T", fieldType: "text" }).config).toBeUndefined();
+  });
+});

--- a/apps/web/lib/workbooks/column-schema.ts
+++ b/apps/web/lib/workbooks/column-schema.ts
@@ -1,0 +1,75 @@
+// Universal Grid & Workbooks — column create/config validation (EP-GRID-WORKBOOKS).
+//
+// Extracted from workbook-service so it can be unit-tested without pulling in the
+// Prisma client. This is the single source of truth for what a column's
+// `fieldConfig` may contain — it MUST stay aligned with the FieldConfig type in
+// ./types, because zod strips any key the schema doesn't declare (so a config key
+// present in the type but missing here is silently dropped on save).
+
+import { z } from "zod";
+import { FIELD_TYPES } from "./types";
+
+const fieldTypeEnum = z.enum(FIELD_TYPES as unknown as [string, ...string[]]);
+
+const selectOptionSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().min(1),
+  intent: z.string().optional(),
+});
+
+const lookupConfigSchema = z.object({
+  referenceColumnId: z.string().min(1),
+  targetField: z.string().min(1),
+  targetFieldType: fieldTypeEnum.optional(),
+});
+
+const linkConfigSchema = z.object({
+  cardinality: z.enum(["one", "many"]),
+  referenceType: z.string().min(1),
+});
+
+const rollupConfigSchema = z.object({
+  linkColumnId: z.string().min(1),
+  op: z.literal("count"),
+});
+
+export const fieldConfigSchema = z
+  .object({
+    options: z.array(selectOptionSchema).optional(),
+    referenceType: z.string().optional(),
+    multiline: z.boolean().optional(),
+    // Number / currency / percent display precision (decimal places).
+    precision: z.number().int().min(0).max(10).optional(),
+    // Rating: number of stars.
+    max: z.number().int().min(1).max(100).optional(),
+    // Currency: the symbol to prefix (e.g. "$", "€", "£").
+    currencySymbol: z.string().min(1).max(8).optional(),
+    // Duration: the unit the stored number is in.
+    durationUnit: z.enum(["minutes", "seconds"]).optional(),
+    formula: z.string().max(2000).optional(),
+    resultType: fieldTypeEnum.optional(),
+    lookup: lookupConfigSchema.optional(),
+    link: linkConfigSchema.optional(),
+    rollup: rollupConfigSchema.optional(),
+  })
+  .optional();
+
+export const addColumnSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    fieldType: fieldTypeEnum,
+    config: fieldConfigSchema,
+    required: z.boolean().optional(),
+  })
+  .superRefine((val, ctx) => {
+    // Computed columns must carry their definition (fail-closed, not silent).
+    if (val.fieldType === "formula" && !val.config?.formula?.trim()) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A formula is required for a formula column", path: ["config", "formula"] });
+    }
+    if (val.fieldType === "lookup" && !val.config?.lookup) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A lookup column needs a reference column and target field", path: ["config", "lookup"] });
+    }
+    if (val.fieldType === "reference" && !val.config?.referenceType) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A reference column needs a target entity", path: ["config", "referenceType"] });
+    }
+  });

--- a/apps/web/lib/workbooks/workbook-service.ts
+++ b/apps/web/lib/workbooks/workbook-service.ts
@@ -12,6 +12,8 @@ import { z } from "zod";
 import { gridRegistry, type AdapterContext } from "./adapter";
 import "./custom-table-adapter"; // ensure the custom adapter self-registers
 import { genSemanticId } from "./ids";
+import { addColumnSchema } from "./column-schema";
+export { addColumnSchema } from "./column-schema";
 import {
   type ColumnDefinition,
   type GridRow,
@@ -22,7 +24,6 @@ import {
   type DataSourceFilter,
   type SortSpec,
   type GridCapabilities,
-  FIELD_TYPES,
   DEFAULT_PAGE_SIZE,
   MAX_PAGE_SIZE,
   MAX_GRID_ROWS,
@@ -69,49 +70,7 @@ export const createTableSchema = z.object({
   name: z.string().min(1).max(200),
 });
 
-const selectOptionSchema = z.object({
-  key: z.string().min(1),
-  label: z.string().min(1),
-  intent: z.string().optional(),
-});
-
-const lookupConfigSchema = z.object({
-  referenceColumnId: z.string().min(1),
-  targetField: z.string().min(1),
-  targetFieldType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]).optional(),
-});
-
-const fieldConfigSchema = z
-  .object({
-    options: z.array(selectOptionSchema).optional(),
-    referenceType: z.string().optional(),
-    multiline: z.boolean().optional(),
-    precision: z.number().optional(),
-    formula: z.string().max(2000).optional(),
-    resultType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]).optional(),
-    lookup: lookupConfigSchema.optional(),
-  })
-  .optional();
-
-export const addColumnSchema = z
-  .object({
-    name: z.string().min(1).max(200),
-    fieldType: z.enum(FIELD_TYPES as unknown as [string, ...string[]]),
-    config: fieldConfigSchema,
-    required: z.boolean().optional(),
-  })
-  .superRefine((val, ctx) => {
-    // Computed columns must carry their definition (fail-closed, not silent).
-    if (val.fieldType === "formula" && !val.config?.formula?.trim()) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A formula is required for a formula column", path: ["config", "formula"] });
-    }
-    if (val.fieldType === "lookup" && !val.config?.lookup) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A lookup column needs a reference column and target field", path: ["config", "lookup"] });
-    }
-    if (val.fieldType === "reference" && !val.config?.referenceType) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A reference column needs a target entity", path: ["config", "referenceType"] });
-    }
-  });
+// Column create/config schemas live in ./column-schema (pure, prisma-free, tested).
 
 // ---------------------------------------------------------------------------
 // Access resolution

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -320,6 +320,15 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   Functionally verified by a **round-trip unit test that parses the output back with the existing
   `read-excel-file` parser** and asserts the matrix (numbers, strings, sheet name) — structural *and*
   functional. Flat data of the current view (visible columns, current sort/filter).
+- **Slice 28g — number-format config UI + config-schema alignment — SHIPPED.** The Add-column form now
+  lets you set the display format the renderers already honour: **currency symbol + decimals**
+  (currency), **decimals** (percent / number), **unit** (duration: minutes/seconds), and **max stars**
+  (rating) — progressively disclosed per field type, so a text column shows none of it. Root cause of
+  the prior "hardcoded defaults": the server `fieldConfigSchema` (which zod-strips undeclared keys)
+  was **missing `currencySymbol`/`max`/`durationUnit` — and also `link`/`rollup`**, so those were
+  silently dropped on save (a latent bug for link/rollup columns too). Extracted the schemas into a
+  pure, prisma-free `apps/web/lib/workbooks/column-schema.ts` (unit-tested — 14 cases incl. the
+  link/rollup regression + bounds) and aligned it fully with the `FieldConfig` type.
 - **Remaining (not built):** manual row reordering for *platform* grids (would need a per-user client
   order; low value on 1000s of rows); platform-grid *shareable* views (needs a `WorkbookView.tableId`
   schema change — platform tables have no `WorkbookTable` row); richer charts (grouped/stacked/line);

--- a/docs/ux-fit/2026-08-01-grid-number-format-config.ux-fit.json
+++ b/docs/ux-fit/2026-08-01-grid-number-format-config.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "inline-progressive-per-type",
+  "decisionInteractionId": "DI-2C6474CB25BB",
+  "scope": {
+    "files": [
+      "apps/web/components/workbooks/AddColumnButton.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "inline-progressive-per-type",
+      "always-show-all-format-fields",
+      "separate-format-modal"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7809,7 +7809,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 115
+    "textMass": 158
   },
   "apps/web/components/workbooks/CreateTableButton.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What

The Add-column form now lets you set the display format the grid renderers **already honour but nobody could reach**:
- **currency** — symbol (€/£/$…) + decimal places
- **percent / number** — decimal places
- **duration** — unit (minutes / seconds)
- **rating** — number of stars

Progressively disclosed per field type (a text/date column shows none of it); sensible defaults prefilled.

## The real bug underneath
The prior "always the default" wasn't a UI omission alone — the server `fieldConfigSchema` **zod-strips any key it doesn't declare**, and it was missing `currencySymbol` / `max` / `durationUnit` **and also `link` / `rollup`**. So those were silently dropped on save — a latent bug where **link and rollup columns lost their config too**.

Fixed by aligning the schema with the `FieldConfig` type and **extracting the column schemas into a pure, prisma-free `apps/web/lib/workbooks/column-schema.ts`** so they can be unit-tested without loading the Prisma client.

## Verification
- **14 schema tests** — format-field preservation, the **link/rollup regression**, and validation bounds (bad unit, out-of-range/non-integer precision, over-long symbol, unknown-key stripping).
- **363/363** workbooks tests pass; **web tsc clean** (exit 0).
- No DB migration — `fieldConfig` is JSON.

## Design grounding
- **Specs/plans:** `docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md` (Slice 28g).
- **Code substrate:** `apps/web/components/workbooks/Grid.tsx` + `cell-editors.tsx` (renderers read `config.currencySymbol`/`precision`/`durationUnit`/`max`), `apps/web/lib/workbooks/workbook-service.ts` (`addColumnSchema.parse` strips undeclared keys), `types.ts` (`FieldConfig`).

Design-Grounding-Decision: extends the grid column-config substrate in apps/web/components/workbooks + apps/web/lib/workbooks; aligns fieldConfigSchema with the FieldConfig type; no new dependency, no DB migration (fieldConfig is JSON).
UX-Fit-Decision: inline, progressively-disclosed format inputs shown only for the applicable field type; standard Excel "Format Cells" concepts; low cognitive load; measured manifest docs/ux-fit/2026-08-01-grid-number-format-config.ux-fit.json (kernel ledger DI-2C6474CB25BB).
Process-Spine-Decision: net-new pure module column-schema.ts (+ test) extracted from workbook-service, grounded by the touched phase-2 plan (Slice 28g).

🤖 Generated with [Claude Code](https://claude.com/claude-code)