### PR TITLE
fix(local-ci): harden runner database and gate reruns

### DIFF
--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -201,11 +201,235 @@ test("durable queue observation reuses claimKey and grants a fresh admitted TTL"
     assert.equal(claims[0].args.claimKey, claims[1].args.claimKey);
     assert.match(
       claims[0].args.claimKey,
-      /^local-ci:gate-v2-[0-9a-f-]{36}-\d+:/,
+      /^local-ci:[^:]+:[0-9a-f]{40}$/,
     );
     const grantedMs = Date.parse(claims[1].args.expiresAt) - claims[1].receivedAt;
     assert.ok(grantedMs >= 2_800, `expected a fresh ~3s TTL, got ${grantedMs}ms`);
     assert.match(result.output, /queued at position 2/);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("released terminal claim from a prior run gets a fresh rerun claimKey", async () => {
+  const claims = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      if (tool === "claim_nonprod_environment_lease") {
+        claims.push(payload.params.arguments);
+      }
+      const result = tool === "claim_nonprod_environment_lease" && claims.length === 1
+        ? {
+          success: false,
+          error: "lease_terminal",
+          entityId: "NPEL-PRIOR-RUN",
+          data: {
+            reason: "released",
+            lease: {
+              leaseId: "NPEL-PRIOR-RUN",
+              status: "released",
+            },
+          },
+        }
+        : tool === "claim_nonprod_environment_lease"
+          ? {
+            success: true,
+            entityId: "NPEL-RERUN",
+            data: {
+              lease: { leaseId: "NPEL-RERUN" },
+              admission: { status: "admitted", slotKey: "slot-0", waitAgeMs: 0 },
+            },
+          }
+          : tool === "record_local_integration_result"
+            ? { success: true, entityId: "EVIDENCE-RERUN" }
+            : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", makeTempWorktree(),
+      "--expires-minutes", "0.05",
+      "--poll-seconds", "0.01",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_GATE_RETRY_JITTER: "0",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    assert.equal(claims.length, 2);
+    assert.notEqual(claims[0].claimKey, claims[1].claimKey);
+    assert.match(claims[1].claimKey, /:rerun-1$/);
+    assert.match(result.output, /creating fresh admission attempt 1/);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("cancelled terminal claim from an interrupted run gets a fresh rerun claimKey", async () => {
+  const claims = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      if (tool === "claim_nonprod_environment_lease") {
+        claims.push(payload.params.arguments);
+      }
+      const result = tool === "claim_nonprod_environment_lease" && claims.length === 1
+        ? {
+          success: false,
+          error: "lease_terminal",
+          entityId: "NPEL-INTERRUPTED-RUN",
+          data: {
+            reason: "cancelled",
+            lease: {
+              leaseId: "NPEL-INTERRUPTED-RUN",
+              status: "cancelled",
+            },
+          },
+        }
+        : tool === "claim_nonprod_environment_lease"
+          ? {
+            success: true,
+            entityId: "NPEL-RERUN",
+            data: {
+              lease: { leaseId: "NPEL-RERUN" },
+              admission: { status: "admitted", slotKey: "slot-0", waitAgeMs: 0 },
+            },
+          }
+          : tool === "record_local_integration_result"
+            ? { success: true, entityId: "EVIDENCE-RERUN" }
+            : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", makeTempWorktree(),
+      "--expires-minutes", "0.05",
+      "--poll-seconds", "0.01",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_GATE_RETRY_JITTER: "0",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    assert.equal(claims.length, 2);
+    assert.notEqual(claims[0].claimKey, claims[1].claimKey);
+    assert.match(claims[1].claimKey, /:rerun-1$/);
+    assert.match(result.output, /previous local-CI lease claim was cancelled/);
+    assert.match(result.output, /creating fresh admission attempt 1/);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("queued admission writes recoverable gate state before waiting", async () => {
+  const claims = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      if (tool === "claim_nonprod_environment_lease") {
+        claims.push(payload.params.arguments);
+      }
+      const result = tool === "claim_nonprod_environment_lease"
+        ? {
+          success: true,
+          entityId: "NPEL-QUEUED-STATE",
+          data: {
+            lease: { leaseId: "NPEL-QUEUED-STATE" },
+            admission: { status: "queued", queuePosition: 1, waitAgeMs: 10 },
+          },
+        }
+        : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const worktree = makeTempWorktree();
+  const stateFile = join(worktree, ".git", "dpf-local-ci-gate.json");
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", worktree,
+      "--lease-wait-seconds", "0.02",
+      "--expires-minutes", "0.05",
+      "--poll-seconds", "0.01",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_GATE_RETRY_JITTER: "0",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.notEqual(result.code, 0, result.output);
+    assert.ok(claims.length >= 1);
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.equal(state.status, "queued");
+    assert.equal(state.leaseId, "NPEL-QUEUED-STATE");
+    assert.equal(state.leaseEvents.at(-1).type, "queued");
   } finally {
     server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -629,20 +629,29 @@ async function cancelDeadLocalQueueObservers({
       );
       continue;
     }
-    releaseLocalQueueObserver({
-      path: resolvePath(directory, `${candidate.livenessProof.observerToken}.json`),
-      token: candidate.livenessProof.observerToken,
-    });
+    const proofs = Array.isArray(candidate.livenessProofs) && candidate.livenessProofs.length > 0
+      ? candidate.livenessProofs
+      : [candidate.livenessProof];
+    for (const proof of proofs) {
+      releaseLocalQueueObserver({
+        path: resolvePath(directory, `${proof.observerToken}.json`),
+        token: proof.observerToken,
+      });
+    }
     const event = {
       type: "dead_queue_observer_cancelled",
       leaseId: candidate.leaseId,
       reason: candidate.reason,
       livenessProof: candidate.livenessProof,
+      ...(proofs.length > 1 ? { livenessProofs: proofs } : {}),
       at: new Date().toISOString(),
     };
     leaseEvents.push(event);
+    const proofText = proofs.length === 1
+      ? `pid ${candidate.livenessProof.pid}`
+      : `${proofs.length} dead observer records`;
     process.stdout.write(
-      `cancelled dead same-host queue observer ${candidate.leaseId} (${candidate.reason}; pid ${candidate.livenessProof.pid})\n`,
+      `cancelled dead same-host queue observer ${candidate.leaseId} (${candidate.reason}; ${proofText})\n`,
     );
   }
 }
@@ -850,9 +859,18 @@ async function main() {
   let receivedSignal = "";
   let queuedClaimInterruptedByQuiescence = false;
   let claimRecoverySequence = 0;
+  let terminalClaimRerunSequence = 0;
   const leaseEvents = [];
   const hostPressureSamples = [];
   let admissionPoolPolicy = null;
+  const queueObserverState = () => queueObserverPath
+    ? {
+      path: queueObserverPath,
+      token: gateObserverIdentity.token,
+      pid: gateObserverIdentity.pid,
+      ownerSessionId,
+    }
+    : null;
   const signalHandlers = Object.fromEntries(["SIGINT", "SIGTERM"].map((signal) => [
     signal,
     () => {
@@ -995,11 +1013,32 @@ async function main() {
         resilience: null,
         leaseEvents,
         evidencePending: false,
+        queueObserver: queueObserverState(),
       });
       break;
     }
     if (claimResponse?.success === true && admission?.status === "queued") {
       queuedClaimInterruptedByQuiescence = false;
+      leaseEvents.push({
+        type: "queued",
+        at: new Date().toISOString(),
+        queuePosition: admission.queuePosition ?? null,
+        waitAgeMs: admission.waitAgeMs ?? null,
+        expiresAt,
+      });
+      writeState(stateFile, {
+        branch,
+        sha,
+        gatePassed: false,
+        leaseId,
+        evidenceId: "",
+        status: "queued",
+        expiresAt,
+        resilience: null,
+        leaseEvents,
+        evidencePending: false,
+        queueObserver: queueObserverState(),
+      });
       if (Date.now() >= deadline) {
         await releaseLeaseOnce();
         die("local-CI admission queue wait timed out");
@@ -1046,7 +1085,8 @@ async function main() {
       continue;
     }
     const terminalReason = claimResponse?.data?.reason
-      ?? claimResponse?.data?.lease?.reason;
+      ?? claimResponse?.data?.lease?.reason
+      ?? claimResponse?.data?.lease?.status;
     if (
       claimResponse?.error === "lease_terminal"
       && terminalReason === "expired"
@@ -1067,6 +1107,29 @@ async function main() {
       queuedClaimInterruptedByQuiescence = false;
       process.stdout.write(
         `queued claim expired during portal quiescence; re-establishing queue intent with recovery ${claimRecoverySequence}...\n`,
+      );
+      continue;
+    }
+    if (
+      claimResponse?.error === "lease_terminal"
+      && ["released", "cancelled"].includes(terminalReason)
+    ) {
+      if (Date.now() >= deadline) {
+        die(`previous local-CI lease claim was already ${terminalReason} at the admission deadline`);
+      }
+      terminalClaimRerunSequence += 1;
+      claimKey = `${baseClaimKey}:rerun-${terminalClaimRerunSequence}`;
+      leaseEvents.push({
+        type: "terminal-claim-replaced",
+        at: new Date().toISOString(),
+        priorLeaseId: leaseId,
+        terminalReason,
+        rerunSequence: terminalClaimRerunSequence,
+      });
+      leaseId = "";
+      queuedClaimInterruptedByQuiescence = false;
+      process.stdout.write(
+        `previous local-CI lease claim was ${terminalReason}; creating fresh admission attempt ${terminalClaimRerunSequence}...\n`,
       );
       continue;
     }
@@ -1243,6 +1306,7 @@ async function main() {
       { type: "started", at: new Date().toISOString() },
     ],
     evidencePending: false,
+    queueObserver: queueObserverState(),
   });
 
   // The preflight executes in the shared scratch integration worktree, whose

--- a/scripts/lib/local-ci-gate-state.mjs
+++ b/scripts/lib/local-ci-gate-state.mjs
@@ -11,6 +11,7 @@ import {
 import { basename, dirname, join } from "node:path";
 
 export const NONTERMINAL_LOCAL_CI_GATE_STATUSES = Object.freeze(new Set([
+  "queued",
   "admitted",
   "running",
 ]));
@@ -47,6 +48,7 @@ export function writeLocalCiGateState(stateFile, {
   evidencePendingReason = "",
   quiescence = null,
   recovery = null,
+  queueObserver = null,
 }) {
   mkdirSync(dirname(stateFile), { recursive: true });
   const payload = {
@@ -65,6 +67,7 @@ export function writeLocalCiGateState(stateFile, {
   if (evidencePending) payload.evidencePendingReason = evidencePendingReason || "unknown";
   if (quiescence) payload.quiescence = quiescence;
   if (recovery) payload.recovery = recovery;
+  if (queueObserver) payload.queueObserver = queueObserver;
   writeGateStateAtomically(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
 }
 

--- a/scripts/lib/local-ci-gate-state.test.mjs
+++ b/scripts/lib/local-ci-gate-state.test.mjs
@@ -24,6 +24,12 @@ test("local-CI gate state helper writes and reads the shared evidence shape", ()
     resilience: null,
     leaseEvents: [{ type: "admitted", at: "2026-07-30T05:00:00.000Z" }],
     recovery: { reason: "test" },
+    queueObserver: {
+      path: "/tmp/dpf-local-ci-queue-observers/observer.json",
+      token: "observer-token",
+      pid: 12345,
+      ownerSessionId: "codex-thread",
+    },
   });
 
   const raw = JSON.parse(readFileSync(stateFile, "utf8"));
@@ -31,9 +37,10 @@ test("local-CI gate state helper writes and reads the shared evidence shape", ()
   assert.equal(raw.status, "running");
   assert.deepEqual(state, raw);
   assert.equal(state.recovery.reason, "test");
+  assert.equal(state.queueObserver.token, "observer-token");
 });
 
-test("only matching admitted/running gate states are recoverable", () => {
+test("only matching queued/admitted/running gate states are recoverable", () => {
   const base = {
     branch: "fix/local-ci-descendant-fence",
     sha: "d".repeat(40),
@@ -41,6 +48,10 @@ test("only matching admitted/running gate states are recoverable", () => {
     evidencePending: false,
   };
 
+  assert.equal(isRecoverableInterruptedGateState(
+    { ...base, status: "queued" },
+    { branch: base.branch, sha: base.sha },
+  ), true);
   assert.equal(isRecoverableInterruptedGateState(
     { ...base, status: "running" },
     { branch: base.branch, sha: base.sha },

--- a/scripts/lib/local-queue-observer.mjs
+++ b/scripts/lib/local-queue-observer.mjs
@@ -34,6 +34,34 @@ function isProcessAlive(pid) {
   }
 }
 
+function readObserverRecords(directory) {
+  let entries;
+  try {
+    entries = readdirSync(directory);
+  } catch {
+    return [];
+  }
+  const records = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const token = entry.slice(0, -".json".length);
+    const path = observerPath(directory, token);
+    const record = readObserver(path);
+    if (
+      record?.schema !== OBSERVER_SCHEMA
+      || record.observerToken !== token
+      || !Number.isInteger(record.pid)
+      || record.pid <= 0
+      || typeof record.ownerSessionId !== "string"
+      || typeof record.registeredAt !== "string"
+    ) {
+      continue;
+    }
+    records.push({ path, record });
+  }
+  return records;
+}
+
 export function createGateObserverIdentity({
   pid = process.pid,
   token = randomUUID(),
@@ -90,36 +118,11 @@ export function registerLocalQueueObserver({
  * required to be a substring of the lease's identity.
  */
 function readObserversBySession(directory) {
-  let entries;
-  try {
-    entries = readdirSync(directory);
-  } catch {
-    return new Map();
-  }
   const bySession = new Map();
-  for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    const token = entry.slice(0, -".json".length);
-    const record = readObserver(observerPath(directory, token));
-    if (
-      record?.schema !== OBSERVER_SCHEMA
-      // The file name is the token: a record claiming a different one is not
-      // trustworthy liveness proof.
-      || record.observerToken !== token
-      || !Number.isInteger(record.pid)
-      || record.pid <= 0
-      || typeof record.ownerSessionId !== "string"
-      || typeof record.registeredAt !== "string"
-    ) {
-      continue;
-    }
-    // A duplicate session id would make "which process owns this?" ambiguous,
-    // so refuse to treat either as proof rather than guessing.
-    if (bySession.has(record.ownerSessionId)) {
-      bySession.set(record.ownerSessionId, null);
-      continue;
-    }
-    bySession.set(record.ownerSessionId, record);
+  for (const { record } of readObserverRecords(directory)) {
+    const records = bySession.get(record.ownerSessionId) || [];
+    records.push(record);
+    bySession.set(record.ownerSessionId, records);
   }
   return bySession;
 }
@@ -139,19 +142,21 @@ export function findDeadLocalQueueObservers({
     ) {
       continue;
     }
-    const record = bySession.get(lease.ownerSessionId);
-    if (!record) continue;
-    if (processAlive(record.pid)) continue;
+    const records = bySession.get(lease.ownerSessionId);
+    if (!Array.isArray(records) || records.length === 0) continue;
+    if (records.some((record) => processAlive(record.pid))) continue;
+    const livenessProofs = records.map((record) => ({
+      schema: OBSERVER_SCHEMA,
+      observerToken: record.observerToken,
+      pid: record.pid,
+      registeredAt: record.registeredAt,
+    }));
     dead.push({
       leaseId: lease.leaseId,
       ownerSessionId: lease.ownerSessionId,
       reason: "same_host_observer_process_not_running",
-      livenessProof: {
-        schema: OBSERVER_SCHEMA,
-        observerToken: record.observerToken,
-        pid: record.pid,
-        registeredAt: record.registeredAt,
-      },
+      livenessProof: livenessProofs[0],
+      ...(livenessProofs.length > 1 ? { livenessProofs } : {}),
     });
   }
   return dead;
@@ -165,4 +170,35 @@ export function releaseLocalQueueObserver({ path, token }) {
   }
   unlinkSync(path);
   return { status: "released" };
+}
+
+export function releaseDeadLocalQueueObserversForGate({
+  directory,
+  branch,
+  sha,
+  ownerSessionId = "",
+  processAlive = isProcessAlive,
+}) {
+  const released = [];
+  for (const { path, record } of readObserverRecords(directory)) {
+    if (branch && record.branch !== branch) continue;
+    if (sha && record.sha !== sha) continue;
+    if (ownerSessionId && record.ownerSessionId !== ownerSessionId) continue;
+    if (processAlive(record.pid)) continue;
+    const result = releaseLocalQueueObserver({
+      path,
+      token: record.observerToken,
+    });
+    released.push({
+      schema: OBSERVER_SCHEMA,
+      observerToken: record.observerToken,
+      pid: record.pid,
+      ownerSessionId: record.ownerSessionId,
+      branch: record.branch,
+      sha: record.sha,
+      registeredAt: record.registeredAt,
+      releaseStatus: result.status,
+    });
+  }
+  return released;
 }

--- a/scripts/lib/local-queue-observer.test.mjs
+++ b/scripts/lib/local-queue-observer.test.mjs
@@ -8,6 +8,7 @@ import {
   createGateObserverIdentity,
   findDeadLocalQueueObservers,
   registerLocalQueueObserver,
+  releaseDeadLocalQueueObserversForGate,
   releaseLocalQueueObserver,
 } from "./local-queue-observer.mjs";
 
@@ -149,6 +150,55 @@ test("observer cleanup is token-fenced", () => {
   assert.equal(existsSync(registered.path), false);
 });
 
+test("fallback cleanup releases only dead observers for the same gate", () => {
+  const directory = observerDirectory();
+  const targetBranch = "fix/current";
+  const targetSha = "c".repeat(40);
+  const deadTarget = registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: 606,
+      token: "66666666-6666-4666-8666-666666666666",
+    }),
+    ownerSessionId: "codex-thread",
+    branch: targetBranch,
+    sha: targetSha,
+  });
+  const liveTarget = registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: 707,
+      token: "77777777-7777-4777-8777-777777777777",
+    }),
+    ownerSessionId: "codex-thread",
+    branch: targetBranch,
+    sha: targetSha,
+  });
+  const otherBranch = registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: 808,
+      token: "88888888-8888-4888-8888-888888888888",
+    }),
+    ownerSessionId: "codex-thread",
+    branch: "fix/other",
+    sha: targetSha,
+  });
+
+  const released = releaseDeadLocalQueueObserversForGate({
+    directory,
+    branch: targetBranch,
+    sha: targetSha,
+    processAlive: (pid) => pid === 707,
+  });
+
+  assert.equal(released.length, 1);
+  assert.equal(released[0].observerToken, "66666666-6666-4666-8666-666666666666");
+  assert.equal(existsSync(deadTarget.path), false);
+  assert.equal(existsSync(liveTarget.path), true);
+  assert.equal(existsSync(otherBranch.path), true);
+});
+
 test("a lease named after its real client thread is still reconcilable (BI-3A34D7A9)", () => {
   // Liveness used to be proved by PARSING the lease's ownerSessionId for
   // gate-v2-<token>-<pid>. Once the lease carries the honest client thread id,
@@ -219,9 +269,9 @@ test("a live attributed waiter is never cancelled", () => {
   assert.deepEqual(dead, []);
 });
 
-test("two observers claiming one thread fail closed rather than guess", () => {
-  // One thread re-gating concurrently would make "which process owns this?"
-  // ambiguous; cancelling on a coin flip could kill a live waiter's lease.
+test("duplicate dead observers for one thread are still eligible for queue cancellation", () => {
+  // Hard-killed gate wrappers can leave old observer records behind. Duplicates
+  // are safe to reconcile when every recorded process is proven dead.
   const directory = observerDirectory();
   const shared = "thread-with-two-processes";
   for (const [pid, token] of [
@@ -246,6 +296,41 @@ test("two observers claiming one thread fail closed rather than guess", () => {
       ownerSessionId: shared,
     }],
     processAlive: () => false,
+  });
+
+  assert.equal(dead.length, 1);
+  assert.equal(dead[0].leaseId, "NPEL-AMBIGUOUS");
+  assert.deepEqual(
+    dead[0].livenessProofs.map((proof) => proof.pid).sort((a, b) => a - b),
+    [404, 505],
+  );
+});
+
+test("duplicate observers fail closed when any recorded process is alive", () => {
+  const directory = observerDirectory();
+  const shared = "thread-with-one-live-process";
+  for (const [pid, token] of [
+    [606, "66666666-6666-4666-8666-666666666666"],
+    [707, "77777777-7777-4777-8777-777777777777"],
+  ]) {
+    registerLocalQueueObserver({
+      directory,
+      identity: createGateObserverIdentity({ pid, token }),
+      ownerSessionId: shared,
+      branch: "feat/y",
+      sha: "e".repeat(40),
+    });
+  }
+
+  const dead = findDeadLocalQueueObservers({
+    directory,
+    queuedLeases: [{
+      leaseId: "NPEL-LIVE-DUPLICATE",
+      environmentKey: "local-integration-ci",
+      status: "queued",
+      ownerSessionId: shared,
+    }],
+    processAlive: (pid) => pid === 707,
   });
 
   assert.deepEqual(dead, []);

--- a/scripts/local-ci-runner.mjs
+++ b/scripts/local-ci-runner.mjs
@@ -160,6 +160,44 @@ function resolveRootClone(repoTop) {
   return "";
 }
 
+export const LOCAL_CI_MISSING_DATABASE_URL = "postgresql://dpf:dpf_dev@127.0.0.1:1/dpf_local_ci_missing_database";
+
+export function createLocalIntegrationChildInvocation({
+  repoTop,
+  candidate,
+  baseRef,
+  candidateSha,
+  baseSha,
+  baseFreshness,
+  slotKey,
+  metadataFile,
+  testDatabaseUrl,
+  env = process.env,
+}) {
+  const childEnv = { ...env };
+  const args = [
+    join(repoTop, "scripts", "local-integration-ci.mjs"),
+    "--candidate", candidate,
+    "--base-ref", baseRef,
+    "--candidate-sha", candidateSha,
+    "--base-sha", baseSha,
+    "--base-freshness-status", baseFreshness.status,
+    "--base-resolved-at", baseFreshness.resolvedAt || "",
+    "--base-fetch-mode", baseFreshness.fetchMode || "",
+    "--slot-key", slotKey,
+    "--metadata-out", metadataFile,
+  ];
+  if (testDatabaseUrl) {
+    args.push("--migrate-deploy");
+    childEnv.DATABASE_URL = testDatabaseUrl;
+  } else {
+    // Do not let a host env var or preserved scratch .env silently become the
+    // gate database when the runner did not prove ownership of the slot DB.
+    childEnv.DATABASE_URL = LOCAL_CI_MISSING_DATABASE_URL;
+  }
+  return { args, env: childEnv };
+}
+
 function ensureScratchWorkspace(root, workspace) {
   if (existsSync(join(workspace, ".git"))) return;
   mkdirSync(dirname(workspace), { recursive: true });
@@ -305,29 +343,26 @@ async function main() {
   cleanScratchWorkspace(workspace, manifest);
 
   const slotEnv = localCiSlotEnvironment(manifest);
-  const childEnv = { ...env, ...slotEnv };
   const testDatabaseUrl = await resolveDatabaseUrl(env, manifest);
-  const args = [
-    join(repoTop, "scripts", "local-integration-ci.mjs"),
-    "--candidate", candidate,
-    "--base-ref", baseRef,
-    "--candidate-sha", candidateSha,
-    "--base-sha", baseSha,
-    "--base-freshness-status", baseFreshness.status,
-    "--base-resolved-at", baseFreshness.resolvedAt || "",
-    "--base-fetch-mode", baseFreshness.fetchMode || "",
-    "--slot-key", manifest.slotKey,
-    "--metadata-out", metadataFile,
-  ];
+  const invocation = createLocalIntegrationChildInvocation({
+    repoTop,
+    candidate,
+    baseRef,
+    candidateSha,
+    baseSha,
+    baseFreshness,
+    slotKey: manifest.slotKey,
+    metadataFile,
+    testDatabaseUrl,
+    env: { ...env, ...slotEnv },
+  });
   if (testDatabaseUrl) {
-    args.push("--migrate-deploy");
-    childEnv.DATABASE_URL = testDatabaseUrl;
     process.stdout.write(`local-ci-runner: test database ${redactUrl(testDatabaseUrl)}\n`);
   } else {
     process.stderr.write("local-ci-runner: WARNING no test database resolved — running without migrate deploy; Prisma-touching tests will fail loud\n");
   }
 
-  const result = spawnSync(process.execPath, args, { cwd: workspace, stdio: "inherit", env: childEnv });
+  const result = spawnSync(process.execPath, invocation.args, { cwd: workspace, stdio: "inherit", env: invocation.env });
   process.exit(result.status ?? 1);
 }
 

--- a/scripts/local-ci-runner.test.mjs
+++ b/scripts/local-ci-runner.test.mjs
@@ -3,7 +3,11 @@ import { spawnSync } from "node:child_process";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { planPostgresOwnership } from "./local-ci-runner.mjs";
+import {
+  LOCAL_CI_MISSING_DATABASE_URL,
+  createLocalIntegrationChildInvocation,
+  planPostgresOwnership,
+} from "./local-ci-runner.mjs";
 
 const cli = fileURLToPath(new URL("./local-ci-runner.mjs", import.meta.url));
 
@@ -68,6 +72,44 @@ test("offline accepted-base operation requires an explicit flag", () => {
   assert.equal(run.baseFreshnessStatus, "offline-accepted");
   assert.equal(run.fetchBase, "0");
   assert.doesNotMatch(run.plan, /--fetch-base/);
+});
+
+test("child local-integration invocation uses only the runner-owned test database", () => {
+  const base = {
+    repoTop: "/repo",
+    candidate: "feat/topic",
+    baseRef: "refs/dpf/integration/main",
+    candidateSha: "candidate-sha",
+    baseSha: "base-sha",
+    baseFreshness: {
+      status: "remote-current",
+      resolvedAt: "2026-08-01T00:00:00.000Z",
+      fetchMode: "fetch",
+    },
+    slotKey: "slot-0",
+    metadataFile: "/repo/.git/dpf-local-ci-metadata.json",
+  };
+
+  const withOwnedDb = createLocalIntegrationChildInvocation({
+    ...base,
+    testDatabaseUrl: "postgresql://dpf:dpf_dev@127.0.0.1:54329/dpf_local_ci_slot_0",
+    env: { DATABASE_URL: "postgresql://dpf:dpf_dev@127.0.0.1:5432/root" },
+  });
+
+  assert.ok(withOwnedDb.args.includes("--migrate-deploy"));
+  assert.equal(
+    withOwnedDb.env.DATABASE_URL,
+    "postgresql://dpf:dpf_dev@127.0.0.1:54329/dpf_local_ci_slot_0",
+  );
+
+  const withoutOwnedDb = createLocalIntegrationChildInvocation({
+    ...base,
+    testDatabaseUrl: "",
+    env: { DATABASE_URL: "postgresql://dpf:dpf_dev@127.0.0.1:5432/root" },
+  });
+
+  assert.ok(!withoutOwnedDb.args.includes("--migrate-deploy"));
+  assert.equal(withoutOwnedDb.env.DATABASE_URL, LOCAL_CI_MISSING_DATABASE_URL);
 });
 
 test("a foreign listener never satisfies manifest Postgres ownership", () => {

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -27,9 +27,14 @@ import {
   readLocalCiGateState,
   writeLocalCiGateState,
 } from "./lib/local-ci-gate-state.mjs";
+import {
+  releaseDeadLocalQueueObserversForGate,
+  releaseLocalQueueObserver,
+} from "./lib/local-queue-observer.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
+export const WINDOWS_WRAPPER_TERMINATED_STATUS = 4294967295;
 
 // Host-side guard parity preflight (BI-D35433FB): run the deterministic CI
 // policy guards before lease admission so a doomed gate never occupies a
@@ -134,6 +139,9 @@ export async function recoverInterruptedGateState({
   mcpUrl = process.env.DPF_MCP_URL || "http://127.0.0.1:3000/api/mcp/v1",
   bearerToken = process.env.DPF_MCP_BEARER_TOKEN,
   mcpCallImpl = mcpCall,
+  releaseLocalQueueObserverImpl = releaseLocalQueueObserver,
+  releaseDeadLocalQueueObserversForGateImpl = releaseDeadLocalQueueObserversForGate,
+  queueObserverFallbackDirectory = "",
   writeStateImpl = writeLocalCiGateState,
   now = () => new Date().toISOString(),
 } = {}) {
@@ -169,6 +177,53 @@ export async function recoverInterruptedGateState({
   };
   if (releaseError) recoveryEvent.releaseError = releaseError;
 
+  let queueObserverReleaseAttempted = false;
+  let queueObserverReleaseStatus = "";
+  let queueObserverReleaseError = "";
+  let queueObserverFallbackReleases = [];
+  const queueObserver = state.queueObserver;
+  if (
+    queueObserver
+    && typeof queueObserver.path === "string"
+    && typeof queueObserver.token === "string"
+  ) {
+    queueObserverReleaseAttempted = true;
+    try {
+      const released = releaseLocalQueueObserverImpl({
+        path: queueObserver.path,
+        token: queueObserver.token,
+      });
+      queueObserverReleaseStatus = released?.status || "unknown";
+    } catch (error) {
+      queueObserverReleaseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+  if (!queueObserverReleaseAttempted && queueObserverFallbackDirectory) {
+    try {
+      queueObserverFallbackReleases = releaseDeadLocalQueueObserversForGateImpl({
+        directory: queueObserverFallbackDirectory,
+        branch,
+        sha,
+      });
+      if (queueObserverFallbackReleases.length > 0) {
+        queueObserverReleaseAttempted = true;
+        queueObserverReleaseStatus = `fallback-released:${queueObserverFallbackReleases.length}`;
+      }
+    } catch (error) {
+      queueObserverReleaseAttempted = true;
+      queueObserverReleaseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+  if (queueObserverReleaseAttempted) {
+    recoveryEvent.queueObserverReleaseStatus = queueObserverReleaseStatus;
+    if (queueObserverFallbackReleases.length > 0) {
+      recoveryEvent.queueObserverFallbackReleases = queueObserverFallbackReleases;
+    }
+    if (queueObserverReleaseError) {
+      recoveryEvent.queueObserverReleaseError = queueObserverReleaseError;
+    }
+  }
+
   const leaseEvents = [
     ...(Array.isArray(state.leaseEvents) ? state.leaseEvents : []),
     recoveryEvent,
@@ -190,6 +245,10 @@ export async function recoverInterruptedGateState({
       childSignal: childSignal || "",
       releaseSucceeded,
       releaseError,
+      queueObserverReleaseAttempted,
+      queueObserverReleaseStatus,
+      queueObserverReleaseError,
+      queueObserverFallbackReleases,
     },
   });
   return {
@@ -198,6 +257,164 @@ export async function recoverInterruptedGateState({
     releaseError,
     leaseId: state.leaseId,
   };
+}
+
+export async function reviveInterruptedQueuedGateState({
+  stateFile,
+  state,
+  branch,
+  sha,
+  childStatus = null,
+  childSignal = "",
+  releaseLocalQueueObserverImpl = releaseLocalQueueObserver,
+  releaseDeadLocalQueueObserversForGateImpl = releaseDeadLocalQueueObserversForGate,
+  queueObserverFallbackDirectory = "",
+  writeStateImpl = writeLocalCiGateState,
+  now = () => new Date().toISOString(),
+} = {}) {
+  if (!isRecoverableInterruptedGateState(state, { branch, sha }) || state.status !== "queued") {
+    return { revived: false, reason: "state-not-queued-revivable" };
+  }
+  if (childStatus !== WINDOWS_WRAPPER_TERMINATED_STATUS) {
+    return { revived: false, reason: "status-not-wrapper-termination" };
+  }
+
+  let queueObserverReleaseAttempted = false;
+  let queueObserverReleaseStatus = "";
+  let queueObserverReleaseError = "";
+  let queueObserverFallbackReleases = [];
+  const queueObserver = state.queueObserver;
+  if (
+    queueObserver
+    && typeof queueObserver.path === "string"
+    && typeof queueObserver.token === "string"
+  ) {
+    queueObserverReleaseAttempted = true;
+    try {
+      const released = releaseLocalQueueObserverImpl({
+        path: queueObserver.path,
+        token: queueObserver.token,
+      });
+      queueObserverReleaseStatus = released?.status || "unknown";
+    } catch (error) {
+      queueObserverReleaseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+  if (!queueObserverReleaseAttempted && queueObserverFallbackDirectory) {
+    try {
+      queueObserverFallbackReleases = releaseDeadLocalQueueObserversForGateImpl({
+        directory: queueObserverFallbackDirectory,
+        branch,
+        sha,
+      });
+      if (queueObserverFallbackReleases.length > 0) {
+        queueObserverReleaseAttempted = true;
+        queueObserverReleaseStatus = `fallback-released:${queueObserverFallbackReleases.length}`;
+      }
+    } catch (error) {
+      queueObserverReleaseAttempted = true;
+      queueObserverReleaseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const revivalEvent = {
+    type: "pregate_interrupted_queue_revival",
+    at: now(),
+    childStatus,
+    childSignal: childSignal || "",
+    leasePreserved: true,
+    queueObserverReleaseAttempted,
+    queueObserverReleaseStatus,
+  };
+  if (queueObserverFallbackReleases.length > 0) {
+    revivalEvent.queueObserverFallbackReleases = queueObserverFallbackReleases;
+  }
+  if (queueObserverReleaseError) revivalEvent.queueObserverReleaseError = queueObserverReleaseError;
+
+  const leaseEvents = [
+    ...(Array.isArray(state.leaseEvents) ? state.leaseEvents : []),
+    revivalEvent,
+  ];
+  writeStateImpl(stateFile, {
+    branch,
+    sha,
+    gatePassed: false,
+    leaseId: state.leaseId,
+    evidenceId: "",
+    status: "queued",
+    expiresAt: state.expiresAt || "",
+    resilience: state.resilience ?? null,
+    leaseEvents,
+    evidencePending: false,
+    recovery: {
+      reason: "queued-gate-wrapper-exited-resuming",
+      childStatus,
+      childSignal: childSignal || "",
+      leasePreserved: true,
+      queueObserverReleaseAttempted,
+      queueObserverReleaseStatus,
+      queueObserverReleaseError,
+      queueObserverFallbackReleases,
+    },
+  });
+  return {
+    revived: true,
+    leaseId: state.leaseId,
+    queueObserverReleaseStatus,
+    queueObserverReleaseError,
+  };
+}
+
+export async function reviveInterruptedQueuedGate({
+  args = [],
+  result,
+  cwd = process.cwd(),
+  spawnSyncImpl = spawnSync,
+  releaseLocalQueueObserverImpl = releaseLocalQueueObserver,
+  releaseDeadLocalQueueObserversForGateImpl = releaseDeadLocalQueueObserversForGate,
+  writeStateImpl = writeLocalCiGateState,
+  stderr = process.stderr,
+} = {}) {
+  const status = result?.status ?? 1;
+  if (
+    status !== WINDOWS_WRAPPER_TERMINATED_STATUS
+    || args.includes("--dry-run")
+    || args.includes("--finalize-evidence")
+  ) {
+    return { revived: false, reason: "not-a-queued-revival-invocation" };
+  }
+  let context;
+  try {
+    context = resolvePregateGateContext({ args, cwd, spawnSyncImpl });
+  } catch (error) {
+    stderr.write(`pregate: queued gate revival skipped (${error.message}).\n`);
+    return { revived: false, reason: "context-unavailable" };
+  }
+
+  const candidates = findRecoverableInterruptedGateStates({ context })
+    .filter((candidate) => candidate.state.status === "queued");
+  for (const candidate of candidates) {
+    const revived = await reviveInterruptedQueuedGateState({
+      stateFile: candidate.stateFile,
+      state: candidate.state,
+      branch: context.branch,
+      sha: context.sha,
+      childStatus: result?.status ?? null,
+      childSignal: result?.signal || "",
+      releaseLocalQueueObserverImpl,
+      releaseDeadLocalQueueObserversForGateImpl,
+      queueObserverFallbackDirectory: process.env.DPF_LOCAL_QUEUE_OBSERVER_DIR
+        || resolvePath(context.gitCommonDir, "dpf-local-ci-queue-observers"),
+      writeStateImpl,
+    });
+    if (revived.revived) {
+      stderr.write(
+        `pregate: revived interrupted queued local-CI gate for ${context.branch} @ ${context.sha}; preserved lease ${revived.leaseId}; restarting gate observer.\n`,
+      );
+      return revived;
+    }
+  }
+  return { revived: false, reason: "no-queued-state" };
 }
 
 export async function recoverInterruptedGate({
@@ -233,6 +450,8 @@ export async function recoverInterruptedGate({
       mcpUrl: env.DPF_MCP_URL || "http://127.0.0.1:3000/api/mcp/v1",
       bearerToken: env.DPF_MCP_BEARER_TOKEN,
       mcpCallImpl,
+      queueObserverFallbackDirectory: env.DPF_LOCAL_QUEUE_OBSERVER_DIR
+        || resolvePath(context.gitCommonDir, "dpf-local-ci-queue-observers"),
     });
     if (recovered.recovered) {
       const releaseText = recovered.releaseSucceeded
@@ -271,23 +490,35 @@ async function main() {
   const useShell = shouldUseShell();
 
   let result;
-  if (useShell) {
-    process.stderr.write("pregate: DPF_PREGATE_FORCE_SH=1 set — routing through compatibility shell entry point.\n");
-    result = spawnSync("sh", [join(SCRIPT_DIR, "gate-worktree.sh"), ...args], { stdio: "inherit" });
-  } else {
-    process.stderr.write("pregate: routing through the Node-native gate (scripts/gate-worktree.mjs).\n");
-    result = spawnSync(process.execPath, [join(SCRIPT_DIR, "gate-worktree.mjs"), ...args], { stdio: "inherit" });
-  }
+  let queuedRevivals = 0;
+  const maxQueuedRevivals = Number.parseInt(process.env.DPF_PREGATE_MAX_QUEUE_REVIVALS || "6", 10);
+  for (;;) {
+    if (useShell) {
+      process.stderr.write("pregate: DPF_PREGATE_FORCE_SH=1 set — routing through compatibility shell entry point.\n");
+      result = spawnSync("sh", [join(SCRIPT_DIR, "gate-worktree.sh"), ...args], { stdio: "inherit" });
+    } else {
+      process.stderr.write("pregate: routing through the Node-native gate (scripts/gate-worktree.mjs).\n");
+      result = spawnSync(process.execPath, [join(SCRIPT_DIR, "gate-worktree.mjs"), ...args], { stdio: "inherit" });
+    }
 
-  if (result.error) {
-    process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
-    process.exit(1);
-  }
-  const status = result.status ?? 1;
-  if (status !== 0) {
+    if (result.error) {
+      process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
+      process.exit(1);
+    }
+    const status = result.status ?? 1;
+    if (status === 0) break;
+    if (queuedRevivals < maxQueuedRevivals) {
+      const revived = await reviveInterruptedQueuedGate({ args, result });
+      if (revived.revived) {
+        queuedRevivals += 1;
+        process.stderr.write(`pregate: queued gate revival ${queuedRevivals}/${maxQueuedRevivals}; continuing without losing FIFO position.\n`);
+        continue;
+      }
+    }
     await recoverInterruptedGate({ args, result });
+    process.exit(status);
   }
-  process.exit(status);
+  process.exit(0);
 }
 
 // Guard against side effects on import (e.g. from tests importing routing

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  WINDOWS_WRAPPER_TERMINATED_STATUS,
   detectWorkingShell,
   recoverInterruptedGateState,
+  reviveInterruptedQueuedGateState,
   shouldUseShell,
 } from "./pregate.mjs";
 
@@ -75,6 +77,202 @@ test("pregate recovery releases an interrupted running gate and marks it failed"
   assert.equal(written.gatePassed, false);
   assert.equal(written.leaseEvents.at(-1).type, "pregate_interrupted_gate_recovery");
   assert.equal(written.recovery.reason, "gate-wrapper-exited-before-terminal-state");
+});
+
+test("pregate recovery releases an interrupted queued gate and marks it failed", async () => {
+  const calls = [];
+  let written = null;
+  const recovered = await recoverInterruptedGateState({
+    stateFile: "/tmp/dpf-local-ci-gate.json",
+    state: {
+      branch: "fix/local-ci-queued-recovery",
+      sha: "c".repeat(40),
+      gatePassed: false,
+      leaseId: "NPEL-QUEUED",
+      evidenceRecordId: "",
+      status: "queued",
+      expiresAt: "2026-07-30T06:00:00.000Z",
+      leaseEvents: [{ type: "queued", at: "2026-07-30T05:00:00.000Z" }],
+      evidencePending: false,
+      queueObserver: {
+        path: "/tmp/dpf-local-ci-observer.json",
+        token: "observer-token",
+        pid: 12345,
+        ownerSessionId: "test-owner",
+      },
+    },
+    branch: "fix/local-ci-queued-recovery",
+    sha: "c".repeat(40),
+    childStatus: 4294967295,
+    bearerToken: "test-token",
+    mcpCallImpl: async (tool, args) => {
+      calls.push({ tool, args });
+      return { success: true };
+    },
+    releaseLocalQueueObserverImpl: (args) => {
+      calls.push({ tool: "releaseLocalQueueObserver", args });
+      return { status: "released" };
+    },
+    writeStateImpl: (_stateFile, payload) => {
+      written = payload;
+    },
+    now: () => "2026-07-30T05:02:00.000Z",
+  });
+
+  assert.equal(recovered.recovered, true);
+  assert.equal(recovered.releaseSucceeded, true);
+  assert.deepEqual(calls, [
+    {
+      tool: "release_nonprod_environment_lease",
+      args: { leaseId: "NPEL-QUEUED" },
+    },
+    {
+      tool: "releaseLocalQueueObserver",
+      args: {
+        path: "/tmp/dpf-local-ci-observer.json",
+        token: "observer-token",
+      },
+    },
+  ]);
+  assert.equal(written.status, "failed");
+  assert.equal(written.leaseEvents.at(-1).type, "pregate_interrupted_gate_recovery");
+  assert.equal(written.recovery.childStatus, 4294967295);
+  assert.equal(written.recovery.queueObserverReleaseStatus, "released");
+});
+
+test("pregate recovery falls back to dead observer cleanup by gate identity", async () => {
+  const calls = [];
+  let written = null;
+  const recovered = await recoverInterruptedGateState({
+    stateFile: "/tmp/dpf-local-ci-gate.json",
+    state: {
+      branch: "fix/local-ci-fallback-cleanup",
+      sha: "d".repeat(40),
+      gatePassed: false,
+      leaseId: "NPEL-FALLBACK",
+      evidenceRecordId: "",
+      status: "queued",
+      expiresAt: "2026-07-30T06:00:00.000Z",
+      leaseEvents: [{ type: "queued", at: "2026-07-30T05:00:00.000Z" }],
+      evidencePending: false,
+    },
+    branch: "fix/local-ci-fallback-cleanup",
+    sha: "d".repeat(40),
+    childStatus: 1,
+    bearerToken: "test-token",
+    mcpCallImpl: async (tool, args) => {
+      calls.push({ tool, args });
+      return { success: true };
+    },
+    releaseDeadLocalQueueObserversForGateImpl: (args) => {
+      calls.push({ tool: "releaseDeadLocalQueueObserversForGate", args });
+      return [{
+        observerToken: "fallback-token",
+        pid: 12345,
+        branch: args.branch,
+        sha: args.sha,
+        releaseStatus: "released",
+      }];
+    },
+    queueObserverFallbackDirectory: "/tmp/dpf-local-ci-queue-observers",
+    writeStateImpl: (_stateFile, payload) => {
+      written = payload;
+    },
+    now: () => "2026-07-30T05:02:30.000Z",
+  });
+
+  assert.equal(recovered.recovered, true);
+  assert.deepEqual(calls, [
+    {
+      tool: "release_nonprod_environment_lease",
+      args: { leaseId: "NPEL-FALLBACK" },
+    },
+    {
+      tool: "releaseDeadLocalQueueObserversForGate",
+      args: {
+        directory: "/tmp/dpf-local-ci-queue-observers",
+        branch: "fix/local-ci-fallback-cleanup",
+        sha: "d".repeat(40),
+      },
+    },
+  ]);
+  assert.equal(written.recovery.queueObserverReleaseStatus, "fallback-released:1");
+  assert.equal(written.recovery.queueObserverFallbackReleases.length, 1);
+});
+
+test("pregate revival preserves an interrupted queued gate lease", async () => {
+  const calls = [];
+  let written = null;
+  const revived = await reviveInterruptedQueuedGateState({
+    stateFile: "/tmp/dpf-local-ci-gate.json",
+    state: {
+      branch: "fix/local-ci-queued-revival",
+      sha: "e".repeat(40),
+      gatePassed: false,
+      leaseId: "NPEL-QUEUED-REVIVE",
+      evidenceRecordId: "",
+      status: "queued",
+      expiresAt: "2026-07-30T06:00:00.000Z",
+      leaseEvents: [{ type: "queued", at: "2026-07-30T05:00:00.000Z" }],
+      evidencePending: false,
+      queueObserver: {
+        path: "/tmp/dpf-local-ci-observer.json",
+        token: "observer-token",
+        pid: 12345,
+        ownerSessionId: "test-owner",
+      },
+    },
+    branch: "fix/local-ci-queued-revival",
+    sha: "e".repeat(40),
+    childStatus: WINDOWS_WRAPPER_TERMINATED_STATUS,
+    releaseLocalQueueObserverImpl: (args) => {
+      calls.push({ tool: "releaseLocalQueueObserver", args });
+      return { status: "released" };
+    },
+    writeStateImpl: (_stateFile, payload) => {
+      written = payload;
+    },
+    now: () => "2026-07-30T05:03:00.000Z",
+  });
+
+  assert.equal(revived.revived, true);
+  assert.equal(revived.leaseId, "NPEL-QUEUED-REVIVE");
+  assert.deepEqual(calls, [{
+    tool: "releaseLocalQueueObserver",
+    args: {
+      path: "/tmp/dpf-local-ci-observer.json",
+      token: "observer-token",
+    },
+  }]);
+  assert.equal(written.status, "queued");
+  assert.equal(written.gatePassed, false);
+  assert.equal(written.leaseId, "NPEL-QUEUED-REVIVE");
+  assert.equal(written.leaseEvents.at(-1).type, "pregate_interrupted_queue_revival");
+  assert.equal(written.recovery.reason, "queued-gate-wrapper-exited-resuming");
+  assert.equal(written.recovery.leasePreserved, true);
+});
+
+test("pregate revival refuses non-queued interrupted states", async () => {
+  let wrote = false;
+  const revived = await reviveInterruptedQueuedGateState({
+    stateFile: "/tmp/dpf-local-ci-gate.json",
+    state: {
+      branch: "fix/local-ci-running-recovery",
+      sha: "f".repeat(40),
+      leaseId: "NPEL-RUNNING",
+      status: "running",
+      evidencePending: false,
+    },
+    branch: "fix/local-ci-running-recovery",
+    sha: "f".repeat(40),
+    childStatus: WINDOWS_WRAPPER_TERMINATED_STATUS,
+    writeStateImpl: () => {
+      wrote = true;
+    },
+  });
+
+  assert.equal(revived.revived, false);
+  assert.equal(wrote, false);
 });
 
 test("pregate recovery ignores terminal gate states", async () => {


### PR DESCRIPTION
## Summary
- Harden local-CI runner database ownership so child integration runs either use the runner-owned slot database or a sentinel missing-DB URL, never inherited ambient root/scratch credentials.
- Make queued/admitted/running local-CI gate state recoverable across Windows wrapper interruption, terminal lease reuse, and duplicate dead queue observers.
- Add focused regression coverage for queue revival, observer cleanup, lease rerun keys, persisted queue metadata, and runner-owned DB invocation.

## Verification
- `node --test scripts/gate-worktree-lease.test.mjs scripts/lib/local-ci-gate-state.test.mjs scripts/pregate.test.mjs scripts/lib/local-queue-observer.test.mjs` — 39 passed, 1 expected Windows signal-handler skip.
- `node --test scripts/local-ci-runner.test.mjs scripts/local-ci-slot-surface-contract.test.mjs scripts/lib/local-integration-ci.test.mjs` — 31 passed.
- `git diff --check origin/main..HEAD` — clean.
- `pnpm run pregate:preflight` — 32 guards clean.
- Governed local-CI `cmsb26xcr06x801qtil9asanj` passed for `fix/local-ci-coworker-readiness-current@cef06efc5635a3fefecb4b4f2965926d0f09bfc9`, accepted base `origin/main@e80f17dccdf7e93bd67408723825c91903690509`: Prisma migrate deploy clean, docs/guards/typecheck clean, full Vitest `2516 passed | 4 skipped` test files and `21588 passed | 19 skipped | 18 todo` tests, production Docker build completed.

## Notes
- Semantic-review receipt `cmsb0vzaz038o01qtmgxkp85r` is fresh for the pre-push tree but shadow-mode failed because one required reviewer branch did not complete (`parseError=true`). The server returned `mayPublish=true` / `nextAction=shadow-observe`; this is carried as calibration evidence for BI-BD3F687C rather than hidden.

Local-CI-Evidence: cmsb26xcr06x801qtil9asanj (fix/local-ci-coworker-readiness-current@cef06efc5635a3fefecb4b4f2965926d0f09bfc9)
