### PR TITLE
feat(inference): record declared-vs-measured sensitivity on the screen receipt (BI-CF3049E7)

### DIFF
--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -189,10 +189,13 @@ export function screenInferencePayload(
       // — plus whether the floor actually bound — makes that drift visible in
       // the record instead of only re-derivable by re-composing the payload.
       // Levels, never values: rawPayloadStored stays false.
+      //
+      // declaredSensitivity is always present: normalizeSensitivity defaults a
+      // missing/unrecognised route label to "internal", and that default is
+      // exactly what the floor above used — so recording it unconditionally
+      // reports the value routing actually applied.
       measuredSensitivity: routedPayloadSensitivity,
-      ...(originalSensitivity !== undefined
-        ? { declaredSensitivity: originalSensitivity }
-        : {}),
+      declaredSensitivity: originalSensitivity,
       sensitivityFloorApplied: sensitivity !== routedPayloadSensitivity,
       rawPayloadStored: false,
     },

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -184,6 +184,16 @@ export function screenInferencePayload(
           confidence: match.confidence,
         })),
       ),
+      // The declared route label is a floor (strongestSensitivity above), so a
+      // route can route above what its payload measures. Recording both sides
+      // — plus whether the floor actually bound — makes that drift visible in
+      // the record instead of only re-derivable by re-composing the payload.
+      // Levels, never values: rawPayloadStored stays false.
+      measuredSensitivity: routedPayloadSensitivity,
+      ...(originalSensitivity !== undefined
+        ? { declaredSensitivity: originalSensitivity }
+        : {}),
+      sensitivityFloorApplied: sensitivity !== routedPayloadSensitivity,
       rawPayloadStored: false,
     },
     classification,

--- a/apps/web/lib/inference/data-screening/screen-receipt-sensitivity-drift.test.ts
+++ b/apps/web/lib/inference/data-screening/screen-receipt-sensitivity-drift.test.ts
@@ -67,6 +67,11 @@ describe("inference screen receipt — declared vs measured sensitivity", () => 
 
     expect(receipt.measuredSensitivity).toBe("internal");
     expect(receipt.sensitivityFloorApplied).toBe(false);
+    // No route label still records a declared level: normalizeSensitivity
+    // defaults to "internal" and the floor uses that default, so the receipt
+    // reports the level routing actually applied rather than omitting the
+    // field and leaving a reader to guess.
+    expect(receipt.declaredSensitivity).toBe("internal");
   });
 
   it("keeps the receipt free of payload text", () => {

--- a/apps/web/lib/inference/data-screening/screen-receipt-sensitivity-drift.test.ts
+++ b/apps/web/lib/inference/data-screening/screen-receipt-sensitivity-drift.test.ts
@@ -1,0 +1,83 @@
+// A receipt must say whether its sensitivity came from the PAYLOAD or from the
+// route's DECLARED label.
+//
+// route-context-map.ts declares a static sensitivity per route, and
+// screenInferencePayload treats it as a floor: strongestSensitivity(declared,
+// measured). So a route labelled `confidential` routes as confidential even
+// when the payload it assembles measures `internal` with zero data classes.
+//
+// Live 2026-08-01, /customer/marketing: every assembled tier — persona, tool
+// schemas, business context, page data, thread history, user facts,
+// profession-corpus — classified internal with NO data classes, yet the turn
+// ran at confidential. That excluded 11 cloud endpoints for "Sensitivity
+// clearance missing for 'confidential'", pinned residency local_only, and left
+// exactly one ranked candidate whose fallbackChain referenced only itself. The
+// coworker then failed, and the user-facing message blamed the provider.
+//
+// The receipt recorded the resulting sensitivity and nothing about which side
+// produced it, so the label was indistinguishable from a genuine payload
+// finding. Recording both makes declared-vs-measured drift observable from real
+// traffic instead of re-derivable only by hand.
+//
+// Same constraint as match provenance: these are LEVELS, never payload values,
+// so rawPayloadStored stays false.
+
+import { describe, expect, it } from "vitest";
+import { screenInferencePayload } from "./screen-inference-payload";
+
+describe("inference screen receipt — declared vs measured sensitivity", () => {
+  it("records that a clean payload was raised by the route's declared label", () => {
+    // The shape of a real /customer/marketing turn: campaign state only, no
+    // contact details, no employment vocabulary.
+    const receipt = screenInferencePayload({
+      systemPrompt:
+        "Marketing workspace. Campaigns: 3 drafts, 1 scheduled. Pipeline: 4 open, 2 closed.",
+      messages: [],
+      tools: [],
+      routeContext: { sensitivity: "confidential" },
+    }).receipt;
+
+    expect(receipt.classifiedDataClasses).toEqual([]);
+    expect(receipt.measuredSensitivity).toBe("internal");
+    expect(receipt.declaredSensitivity).toBe("confidential");
+    // The declaration, not the payload, is what raised this turn.
+    expect(receipt.sensitivityFloorApplied).toBe(true);
+  });
+
+  it("does not flag a floor when the payload itself justifies the level", () => {
+    const receipt = screenInferencePayload({
+      systemPrompt: "Inbound enquiry from jane.doe@acme-corp.example about catering.",
+      messages: [],
+      tools: [],
+      routeContext: { sensitivity: "internal" },
+    }).receipt;
+
+    expect(receipt.classifiedDataClasses).toContain("customer-records");
+    // Measured meets or exceeds the declaration, so nothing was raised by label.
+    expect(receipt.sensitivityFloorApplied).toBe(false);
+    expect(receipt.declaredSensitivity).toBe("internal");
+  });
+
+  it("reports both levels even when no route context is supplied", () => {
+    const receipt = screenInferencePayload({
+      systemPrompt: "Draft a campaign brief for the autumn menu.",
+      messages: [],
+      tools: [],
+    }).receipt;
+
+    expect(receipt.measuredSensitivity).toBe("internal");
+    expect(receipt.sensitivityFloorApplied).toBe(false);
+  });
+
+  it("keeps the receipt free of payload text", () => {
+    const receipt = screenInferencePayload({
+      systemPrompt: "Contact jane.doe@acme-corp.example for the campaign.",
+      messages: [],
+      tools: [],
+      routeContext: { sensitivity: "restricted" },
+    }).receipt;
+
+    expect(receipt.rawPayloadStored).toBe(false);
+    expect(JSON.stringify(receipt)).not.toContain("jane.doe@acme-corp.example");
+  });
+});

--- a/apps/web/lib/inference/data-screening/types.ts
+++ b/apps/web/lib/inference/data-screening/types.ts
@@ -87,6 +87,27 @@ export type InferenceDataScreenReceipt = {
    * value itself is exactly what must not be persisted.
    */
   matchProvenance?: InferenceMatchProvenance[];
+  /**
+   * What the PAYLOAD measured, before the route's declared label was applied as
+   * a floor. Absent on pre-drift v1 receipts.
+   */
+  measuredSensitivity?: InferencePayloadSensitivity;
+  /**
+   * What the ROUTE declared, independent of the payload — the static
+   * `sensitivity` on its route-context entry. Absent when the caller supplied
+   * no route context.
+   */
+  declaredSensitivity?: InferencePayloadSensitivity;
+  /**
+   * True when the declaration RAISED this turn above what the payload measured,
+   * i.e. the routing sensitivity came from the label rather than from the data.
+   *
+   * Without this the two are indistinguishable in the record, and an over-broad
+   * route label reads exactly like a genuine payload finding — while silently
+   * collapsing that route's endpoint pool and surfacing to the user as a
+   * provider outage.
+   */
+  sensitivityFloorApplied?: boolean;
   rawPayloadStored: false;
 };
 

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -125,6 +125,11 @@ type InferenceDataScreenResult = {
     classifiedDataClasses: string[];
     obligations: string[];
     transformation: "none" | "masked" | "tokenized" | "blocked";
+    // Declared-vs-measured, so an over-broad route label is distinguishable
+    // from a genuine payload finding. Levels only, never values.
+    measuredSensitivity?: SensitivityLevel;
+    declaredSensitivity?: SensitivityLevel;
+    sensitivityFloorApplied?: boolean;
     rawPayloadStored: false;
   };
   rehydrationHandle?: string;


### PR DESCRIPTION
Tracked by BI-CF3049E7.

## The defect

A route's sensitivity is a hardcoded static label in `route-context-map.ts`, and `screenInferencePayload` applies it as a **floor**:

```ts
const sensitivity = strongestSensitivity(originalSensitivity, routedPayloadSensitivity);
```

So a route routes at its declared label even when the payload it assembles measures lower — and the receipt recorded only the **result**, never which side produced it. An over-broad route label was therefore indistinguishable in the record from a genuine payload finding.

## Measured, not inferred

Live 2026-08-01, `/customer/marketing`. Every assembled context tier classified against `classifyInferencePayload` on the live DB:

| tier | result |
| --- | --- |
| persona / system prompt | `classes=[] internal` |
| tool schemas (15 tools) | `classes=[] internal` |
| business-context block | `classes=[] internal` |
| route page data (675 chars) | `classes=[] internal` |
| thread messages (16) | `classes=[] internal` |
| user facts (149 rows) | `classes=[] internal` |
| profession-corpus (4811 chars) | `classes=[] internal` |
| semantic-memory, governed facts | EMPTY |
| knowledge pointers | empty **by construction** — only fires on `/portfolio/*` |
| portal-context | null **by construction** — only `/build`, `/platform/ai*` |

Declared `confidential`, measured `internal`, **zero governed data classes**.

Consequence, from `RouteDecisionLog`: 11 cloud endpoints excluded for `Sensitivity clearance missing for 'confidential'`, residency pinned `local_only`, exactly one candidate ranked, `fallbackChain` referencing only itself. The coworker failed and the user-facing message blamed the provider.

## The change

Adds `measuredSensitivity`, `declaredSensitivity` and `sensitivityFloorApplied` to the `inference-data-screen/v1` receipt. Both values are **already computed** at the point the floor is applied — this records what was known and discarded.

- Levels only, never values. `rawPayloadStored` stays `false`, asserted by test.
- Additive optional fields on a `Json` column: **no migration**, pre-drift receipts remain valid.
- Same rationale as `matchProvenance` (#3911): a routing verdict must be diagnosable from the record rather than by re-composing the payload by hand.

## Verification

- Red first: initial run failed on the new assertions (`expected undefined to be 'internal'`); the `RUN` line confirmed the correct worktree.
- Green: **63 tests / 7 files** pass across the whole `data-screening` suite — no regressions.
- `tsc -p apps/web --noEmit` exit **0**.
- Local integration gate: **passed** (real image build, lease released).

## Scope

Deliberately **not** included:

- **Surfacing to owners.** `downgrade-explanation.ts` is the right consumer — it already maps `clearance`/`residency` exclusions to owner-facing causes, and its header explicitly rails against guessing when the pipeline already knows. Kept out so user-facing copy (prose-lint, UX route-budget ratchet) doesn't ride along with a substrate change.
- **Changing any route's label.** What `/customer/marketing` *should* declare is an operator data-sovereignty decision, tracked on BI-8058697C. Kernel ledger `DI-7761D17E0F61` scored an agent making that edit unilaterally 3.69 vs 11.73 for this reconciliation, penalised by *Outbound and irreversible actions require explicit go*.

Note for anyone reading BI-8058697C: **downgrading the label does not restore Claude.** `anthropic-sub` and `chatgpt` hold `public` clearance only, so `confidential` → `internal` adds only `codex-agent`.
