### PR TITLE
fix(ux): ratchet lead-band adoption by presence

### DIFF
--- a/apps/web/lib/ux-budget/ratchet.test.ts
+++ b/apps/web/lib/ux-budget/ratchet.test.ts
@@ -63,6 +63,33 @@ describe("regression ratchet on a pre-existing route", () => {
     expect(verdictForRoute(after, baselineFrom(before).routes["/workspace"]).ok).toBe(true);
   });
 
+  it("passes when a legacy route adds a compliant lead band", () => {
+    const leadCopy = "clear next step ".repeat(10);
+    const before = measurement({ html: `<main><h1>Your day</h1><p>${leadCopy}</p></main>` });
+    const after = measurement({ html: `<main data-dpf-lead><h1>Your day</h1><p>${leadCopy}</p></main>` });
+
+    const v = verdictForRoute(after, baselineFrom(before).routes["/workspace"]);
+    expect(v.ok, v.regressions.join("; ")).toBe(true);
+    expect(v.regressions.join(" ")).not.toMatch(/lead-band words/);
+  });
+
+  it("catches when a legacy route removes its established lead band", () => {
+    const leadCopy = "clear next step ".repeat(10);
+    const before = measurement({ html: `<main data-dpf-lead><h1>Your day</h1><p>${leadCopy}</p></main>` });
+    const after = measurement({ html: `<main><h1>Your day</h1><p>${leadCopy}</p></main>` });
+
+    const v = verdictForRoute(after, baselineFrom(before).routes["/workspace"]);
+    expect(v.ok).toBe(false);
+    expect(v.regressions.join(" ")).toMatch(/lead-band words/);
+  });
+
+  it("does not punish shorter lead-band copy while the lead band remains present", () => {
+    const before = measurement({ html: `<main data-dpf-lead><h1>Your day</h1><p>${"word ".repeat(40)}</p></main>` });
+    const after = measurement({ html: `<main data-dpf-lead><h1>Your day</h1><p>Two things need you.</p></main>` });
+
+    expect(verdictForRoute(after, baselineFrom(before).routes["/workspace"]).ok).toBe(true);
+  });
+
   it("never blocks a pre-existing route on debt the PR did not make worse", () => {
     // A legacy surface that already violates its budget — over the word budget AND
     // over the deferred-detail threshold with no disclosure. Frozen as-is. An

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -69,7 +69,7 @@ export type BaselineFile = {
   routes: Record<string, RouteBaseline>;
 };
 
-/** Axes where MORE is a regression. Ordered for a readable report. */
+/** Ordered for a readable report. Each axis declares how regression is detected. */
 export const RATCHET_AXES = [
   "defaultVisibleWords",
   "leadBandWords",
@@ -81,6 +81,19 @@ export const RATCHET_AXES = [
   "axeViolations",
 ] as const;
 export type RatchetAxis = (typeof RATCHET_AXES)[number];
+
+type RatchetAxisPolarity = "max" | "presence";
+
+const RATCHET_AXIS_POLARITY: Record<RatchetAxis, RatchetAxisPolarity> = {
+  defaultVisibleWords: "max",
+  leadBandWords: "presence",
+  primaryActions: "max",
+  visibleFields: "max",
+  maxChoicesPerControl: "max",
+  subLegibleControls: "max",
+  buriedPrimaryAction: "max",
+  axeViolations: "max",
+};
 
 /**
  * Measured noise floor per axis — the residue that survives normalisation.
@@ -138,6 +151,17 @@ function measurementValue(m: RouteMeasurement, axis: RatchetAxis): number {
   return axis === "axeViolations" ? m.axeViolations : m.metrics[axis];
 }
 
+function ratchetAxisRegressed(axis: RatchetAxis, was: number, now: number): boolean {
+  switch (RATCHET_AXIS_POLARITY[axis]) {
+    case "max":
+      return now > was + NOISE_FLOOR[axis];
+    case "presence":
+      // Lead-band adoption is the retrofit path for legacy routes. Adding one is
+      // improvement; removing an established one is the regression the ratchet catches.
+      return was > 0 && now === 0;
+  }
+}
+
 /** Compare one route against its baseline (or judge it as net-new). */
 export function verdictForRoute(
   measurement: RouteMeasurement,
@@ -162,7 +186,7 @@ export function verdictForRoute(
       // the scan works — 0 > -1 is not an increase in violations, it is a scan that
       // recovered. Skip the axis and let the run that measured it decide.
       if (now < 0 || was < 0) continue;
-      if (now > was + NOISE_FLOOR[axis]) {
+      if (ratchetAxisRegressed(axis, was, now)) {
         regressions.push(`${AXIS_LABEL[axis]}: ${was} → ${now}`);
       }
     }

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -78,6 +78,12 @@ read, the CI checkers, and the migration league table. Intended shell per route 
 | Deferred detail | Above a per-shell word threshold the surface **must** use disclosure |
 | Primary action reachable | A marked primary action (`data-dpf-primary-action` / `data-owner-first-next-action`) may not be buried behind a collapsed disclosure on action shells (cockpit/detail/settings/form) |
 
+**Lead-band adoption is presence-positive.** Adding a compliant `data-dpf-lead` to a
+pre-existing route is a retrofit improvement, not a regression, even though the measured
+lead-band word count rises from zero. The ratchet catches removal of an established lead
+band; absolute `maxLeadBandWords` budgets still report overlong copy and block net-new
+routes.
+
 **Hiding the primary action is a regression the word budgets cannot see.** Moving a
 trigger behind an "Advanced" collapse *reduces* the default-visible word and control
 counts, so the volume budgets read it as an improvement. The reachability axis is the
@@ -131,9 +137,10 @@ Three enforcement modes, decided by `lib/ux-budget/ratchet.ts`:
 
 1. **Pre-existing route → regression ratchet.** A changed route may not exceed its own
    frozen baseline on words, controls, fields, choices, sub-legible controls or axe
-   violations. Existing debt is reported every run but never blocks a PR that did not make
-   it worse. That restraint is deliberate: a gate that fails unrelated PRs on legacy debt
-   forces a blind mass-rewrite and gets switched off.
+   violations, and may not remove an established lead band. Existing debt is reported
+   every run but never blocks a PR that did not make it worse. That restraint is
+   deliberate: a gate that fails unrelated PRs on legacy debt forces a blind mass-rewrite
+   and gets switched off.
 2. **Net-new route → absolute budgets block.** No baseline to hide behind.
 3. **Structure → the ARIA snapshot must not drift.** Heading levels, landmarks and
    accessible names, as a diffable YAML projection. "This PR flattened the h2/h3 structure


### PR DESCRIPTION
## Summary
- Add per-axis ratchet polarity for the UX route-budget regression gate.
- Treat `leadBandWords` as a presence-quality axis: adding a compliant lead band to a pre-existing route is allowed, removing an established lead band is blocked.
- Document the lead-band adoption rule in the platform usability standards.

## Verification
- `pnpm --filter web exec vitest run lib/ux-budget/ratchet.test.ts` — 38 passed.
- `pnpm --filter web exec vitest run lib/ux-budget` — 113 passed.
- `$env:NODE_OPTIONS='--max-old-space-size=8192'; pnpm --filter web typecheck` — passed.
- `$env:CIRCLE_NODE_TOTAL='2'; pnpm --filter web build` — passed with existing Edge-runtime warnings.
- `pnpm gate:context` — passed; noted doc-index as the relevant derived artifact.
- `pnpm run pregate:preflight` — 32 guards clean.
- `pnpm run pregate` — passed; local-CI evidence `cmsb9a59u0bqm01tcfbh5mbux` for `fix/ux-budget-lead-band-polarity@597d5d37be458a9dd89b73f1672eecca47c5284c`.

## Notes
- Linked backlog item: `BI-E7F6C76E`.
- No runtime UX walkthrough required: this changes the CI UX-budget verdict policy and its unit-tested documentation contract, not a portal route or visual component.

Local-CI-Evidence: cmsb9a59u0bqm01tcfbh5mbux (fix/ux-budget-lead-band-polarity@597d5d37be458a9dd89b73f1672eecca47c5284c)
