### PR TITLE
fix(ux): hide long owner option lists

### DIFF
--- a/apps/web/components/admin/OperatingHoursEditor.test.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
@@ -28,23 +29,25 @@ describe("OperatingHoursEditor save feedback", () => {
 describe("OperatingHoursEditor timezone options", () => {
   it("labels zones with a UTC-offset prefix and a de-underscored name", () => {
     render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/New_York" onSave={vi.fn()} />);
-    const select = screen.getByLabelText(/Business timezone/i) as HTMLSelectElement;
-    const selected = Array.from(select.options).find((o) => o.value === "America/New_York");
+    const picker = screen.getByRole("combobox", { name: /Business timezone/i }) as HTMLInputElement;
     // Orthodox: "(UTC−05:00) America/New York" — offset prefix, no underscore.
-    expect(selected?.textContent).toMatch(/^\(UTC[+−±]\d{2}:\d{2}\) America\/New York$/);
-    expect(selected?.textContent).not.toContain("_");
+    expect(picker.value).toMatch(/^\(UTC[+−±]\d{2}:\d{2}\) America\/New York$/);
+    expect(picker.value).not.toContain("_");
   });
 
-  it("orders options by UTC offset, not raw alphabetical", () => {
+  it("keeps the full timezone corpus hidden until the picker is opened and searched", () => {
     render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/Chicago" onSave={vi.fn()} />);
-    const select = screen.getByLabelText(/Business timezone/i) as HTMLSelectElement;
-    const offsets = Array.from(select.options).map((o) => {
-      const m = o.textContent?.match(/^\(UTC([+−±])(\d{2}):(\d{2})\)/);
-      if (!m) return 0;
-      const sign = m[1] === "−" ? -1 : 1;
-      return sign * (parseInt(m[2], 10) * 60 + parseInt(m[3], 10));
+    const picker = screen.getByRole("combobox", { name: /Business timezone/i });
+
+    expect(screen.queryByRole("option", { name: /Europe\/London/ })).not.toBeInTheDocument();
+
+    fireEvent.click(picker);
+    expect(screen.getAllByRole("option")).toHaveLength(12);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search timezones" }), {
+      target: { value: "London" },
     });
-    const sorted = [...offsets].sort((a, b) => a - b);
-    expect(offsets).toEqual(sorted);
+
+    expect(screen.getByRole("option", { name: /Europe\/London/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/components/admin/OperatingHoursEditor.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, useTransition } from "react";
 import type { WeeklySchedule, DaySchedule } from "@/lib/operating-hours-types";
+import { SearchableSelect } from "@/components/ui/form";
 
 const DAY_ORDER = [
   "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
@@ -119,6 +120,10 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
     timezone && timezone !== "UTC" ? timezone : detected ?? timezone,
   );
   const zones = useMemo(() => buildZoneOptions(tz, detected), [tz, detected]);
+  const preferredTimeZones = useMemo(
+    () => [tz, detected, ...FALLBACK_TIMEZONES].filter((zone): zone is string => Boolean(zone)),
+    [detected, tz],
+  );
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -178,23 +183,23 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
           <label htmlFor="op-hours-tz" className="text-sm font-medium text-[var(--dpf-text)]">
             Timezone
           </label>
-          <select
+          <SearchableSelect
             id="op-hours-tz"
             name="operatingHoursTimezone"
             value={tz}
-            onChange={(e) => {
-              setTz(e.target.value);
+            onValueChange={(nextTimezone) => {
+              setTz(nextTimezone);
               setSaved(false);
             }}
-            aria-label="Business timezone — bookings and the maintenance window use this zone"
-            className="min-h-[44px] max-w-full px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
-          >
-            {zones.map((z) => (
-              <option key={z.value} value={z.value} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
-                {z.label}
-              </option>
-            ))}
-          </select>
+            ariaLabel="Business timezone — bookings and the maintenance window use this zone"
+            searchLabel="Search timezones"
+            placeholder="Choose timezone"
+            options={zones}
+            preferredValues={preferredTimeZones}
+            maxVisibleOptions={12}
+            className="min-w-[min(28rem,100%)] max-w-full"
+            controlClassName="bg-[var(--dpf-surface-2)]"
+          />
           {detected && detected !== tz && (
             <button
               type="button"

--- a/apps/web/components/storefront-admin/ServiceLinesPanel.test.tsx
+++ b/apps/web/components/storefront-admin/ServiceLinesPanel.test.tsx
@@ -84,13 +84,16 @@ describe("ServiceLinesPanel action safety (BI-7D7EE150)", () => {
 
   it("never adds a cross-archetype service line on a single unconfirmed click", async () => {
     confirmMock.mockResolvedValueOnce(false);
-    render(
+    const { container } = render(
       <ServiceLinesPanel
         storefrontId="sf-1"
         view={view}
         availableArchetypes={availableArchetypes}
       />,
     );
+
+    expect(container.querySelectorAll("option")).toHaveLength(0);
+    expect(screen.queryByRole("option", { name: /3PL Contract Warehousing/ })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Add service line" }));
 
@@ -120,6 +123,37 @@ describe("ServiceLinesPanel action safety (BI-7D7EE150)", () => {
 
     await waitFor(() =>
       expect(addMock).toHaveBeenCalledWith("sf-1", "third-party-logistics"),
+    );
+  });
+
+  it("searches the service-line catalog before adding a non-default option", async () => {
+    confirmMock.mockResolvedValueOnce(true);
+    render(
+      <ServiceLinesPanel
+        storefrontId="sf-1"
+        view={view}
+        availableArchetypes={[
+          ...availableArchetypes,
+          {
+            archetypeSlug: "software-platform",
+            name: "Software Platform",
+            category: "software-platform",
+            itemCount: 2,
+            sectionCount: 2,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Service line to add" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Search service lines" }), {
+      target: { value: "software" },
+    });
+    fireEvent.click(screen.getByRole("option", { name: /Software Platform/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Add service line" }));
+
+    await waitFor(() =>
+      expect(addMock).toHaveBeenCalledWith("sf-1", "software-platform"),
     );
   });
 

--- a/apps/web/components/storefront-admin/ServiceLinesPanel.tsx
+++ b/apps/web/components/storefront-admin/ServiceLinesPanel.tsx
@@ -8,6 +8,7 @@ import {
 import type { StorefrontCompositionView, StorefrontServiceLineView } from "@/lib/storefront/composition-view";
 import { intentStyle } from "@/components/ui/report-kit/statusColors";
 import { confirmDialog } from "@/components/ui/Dialog";
+import { SearchableSelect } from "@/components/ui/form";
 
 interface AvailableArchetype {
   archetypeSlug: string;
@@ -161,25 +162,24 @@ export function ServiceLinesPanel({ storefrontId, view, availableArchetypes }: P
             flexWrap: "wrap",
           }}
         >
-          <select
+          <SearchableSelect
             value={selectedSlug}
-            onChange={(e) => setSelectedSlug(e.target.value)}
             disabled={isPending}
-            className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)]"
-            style={{
-              flex: 1,
-              minWidth: 180,
-              padding: "7px 10px",
-              borderRadius: 6,
-              fontSize: 13,
-            }}
-          >
-            {availableArchetypes.map((a) => (
-              <option key={a.archetypeSlug} value={a.archetypeSlug}>
-                {a.name}
-              </option>
-            ))}
-          </select>
+            onValueChange={setSelectedSlug}
+            ariaLabel="Service line to add"
+            searchLabel="Search service lines"
+            placeholder="Choose service line"
+            options={availableArchetypes.map((a) => ({
+              value: a.archetypeSlug,
+              label: a.name,
+              description: `${plural(a.itemCount, "item")} · ${plural(a.sectionCount, "section")}`,
+              searchText: a.category,
+            }))}
+            preferredValues={[selectedSlug]}
+            maxVisibleOptions={8}
+            className="min-w-[180px] flex-1"
+            controlClassName="bg-[var(--dpf-surface-1)] text-sm"
+          />
           <button
             onClick={handleAdd}
             disabled={isPending || !selectedSlug}

--- a/apps/web/components/ui/form/SearchableSelect.test.tsx
+++ b/apps/web/components/ui/form/SearchableSelect.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchableSelect } from "./SearchableSelect";
+
+const options = [
+  { value: "America/Chicago", label: "(UTC-06:00) America/Chicago" },
+  { value: "Europe/London", label: "(UTC+00:00) Europe/London" },
+  { value: "Asia/Tokyo", label: "(UTC+09:00) Asia/Tokyo" },
+];
+
+afterEach(cleanup);
+
+describe("SearchableSelect", () => {
+  it("keeps the option corpus out of the closed page", () => {
+    const { container } = render(
+      <>
+        <label htmlFor="timezone">Timezone</label>
+        <SearchableSelect
+          id="timezone"
+          name="timezone"
+          value="America/Chicago"
+          onValueChange={vi.fn()}
+          options={options}
+        />
+      </>,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Timezone" })).toHaveValue("(UTC-06:00) America/Chicago");
+    expect(screen.queryByRole("option", { name: /Europe\/London/ })).not.toBeInTheDocument();
+    expect(container.querySelectorAll("option")).toHaveLength(0);
+  });
+
+  it("opens a bounded searchable list and returns the selected value", () => {
+    const onValueChange = vi.fn();
+    render(
+      <SearchableSelect
+        ariaLabel="Timezone"
+        value="America/Chicago"
+        onValueChange={onValueChange}
+        options={options}
+        maxVisibleOptions={2}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Timezone" }));
+
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+    fireEvent.change(screen.getByRole("textbox", { name: "Search choices" }), {
+      target: { value: "tokyo" },
+    });
+    fireEvent.click(screen.getByRole("option", { name: /Asia\/Tokyo/ }));
+
+    expect(onValueChange).toHaveBeenCalledWith("Asia/Tokyo");
+  });
+});

--- a/apps/web/components/ui/form/SearchableSelect.tsx
+++ b/apps/web/components/ui/form/SearchableSelect.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { Check, ChevronDown, Search } from "lucide-react";
+import { cx, fieldControlClass } from "./styles";
+
+export type SearchableSelectOption = {
+  value: string;
+  label: string;
+  description?: string;
+  searchText?: string;
+  disabled?: boolean;
+};
+
+export type SearchableSelectProps = {
+  id?: string;
+  name?: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: SearchableSelectOption[];
+  placeholder?: string;
+  searchLabel?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+  preferredValues?: readonly string[];
+  maxVisibleOptions?: number;
+  emptyMessage?: string;
+  className?: string;
+  controlClassName?: string;
+};
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase().replace(/[_/.-]+/g, " ");
+}
+
+function optionHaystack(option: SearchableSelectOption): string {
+  return normalize([option.label, option.value, option.description, option.searchText].filter(Boolean).join(" "));
+}
+
+export function SearchableSelect({
+  id,
+  name,
+  value,
+  onValueChange,
+  options,
+  placeholder = "Select...",
+  searchLabel = "Search choices",
+  ariaLabel,
+  disabled = false,
+  preferredValues = [],
+  maxVisibleOptions = 10,
+  emptyMessage = "No matches",
+  className,
+  controlClassName,
+}: SearchableSelectProps) {
+  const generatedId = useId().replace(/:/g, "");
+  const controlId = id ?? `searchable-select-${generatedId}`;
+  const listboxId = `${controlId}-listbox`;
+  const optionId = (index: number) => `${controlId}-option-${index}`;
+  const rootRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const selected = options.find((option) => option.value === value);
+  const selectedLabel = selected?.label ?? "";
+
+  const preferenceRank = useMemo(() => {
+    const rank = new Map<string, number>();
+    [value, ...preferredValues].filter(Boolean).forEach((preferred, index) => {
+      if (!rank.has(preferred)) rank.set(preferred, index);
+    });
+    return rank;
+  }, [preferredValues, value]);
+
+  const visibleOptions = useMemo(() => {
+    const tokens = normalize(query).split(/\s+/).filter(Boolean);
+    return options
+      .map((option, index) => ({ option, index, haystack: optionHaystack(option) }))
+      .filter(({ option, haystack }) => {
+        if (option.disabled) return false;
+        return tokens.every((token) => haystack.includes(token));
+      })
+      .sort((a, b) => {
+        const aRank = preferenceRank.get(a.option.value) ?? Number.MAX_SAFE_INTEGER;
+        const bRank = preferenceRank.get(b.option.value) ?? Number.MAX_SAFE_INTEGER;
+        return aRank - bRank || a.index - b.index;
+      })
+      .slice(0, maxVisibleOptions)
+      .map(({ option }) => option);
+  }, [maxVisibleOptions, options, preferenceRank, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    setActiveIndex(visibleOptions.length > 0 ? 0 : -1);
+  }, [open, query, visibleOptions.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    searchRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [open]);
+
+  function openPicker(nextQuery = "") {
+    if (disabled) return;
+    setQuery(nextQuery);
+    setOpen(true);
+  }
+
+  function closePicker() {
+    setOpen(false);
+    setQuery("");
+  }
+
+  function selectOption(option: SearchableSelectOption) {
+    onValueChange(option.value);
+    closePicker();
+  }
+
+  function handleControlKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (disabled) return;
+    if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openPicker();
+      return;
+    }
+    if (event.key === "Escape") {
+      closePicker();
+      return;
+    }
+    if (event.key.length === 1 && !event.metaKey && !event.ctrlKey && !event.altKey) {
+      openPicker(event.key);
+    }
+  }
+
+  function handleSearchKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setActiveIndex((current) => {
+          if (visibleOptions.length === 0) return -1;
+          return current + 1 < visibleOptions.length ? current + 1 : 0;
+        });
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setActiveIndex((current) => {
+          if (visibleOptions.length === 0) return -1;
+          return current - 1 >= 0 ? current - 1 : visibleOptions.length - 1;
+        });
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (activeIndex >= 0 && visibleOptions[activeIndex]) {
+          selectOption(visibleOptions[activeIndex]);
+        }
+        break;
+      case "Escape":
+        event.preventDefault();
+        closePicker();
+        break;
+    }
+  }
+
+  return (
+    <div ref={rootRef} className={cx("relative", className)}>
+      {name ? <input type="hidden" name={name} value={value} /> : null}
+      <div className="relative">
+        <input
+          id={controlId}
+          type="text"
+          role="combobox"
+          readOnly
+          disabled={disabled}
+          aria-label={ariaLabel}
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-controls={listboxId}
+          aria-activedescendant={open && activeIndex >= 0 ? optionId(activeIndex) : undefined}
+          value={selectedLabel}
+          placeholder={placeholder}
+          onClick={() => openPicker()}
+          onKeyDown={handleControlKeyDown}
+          className={cx(fieldControlClass, "min-h-[44px] cursor-pointer pr-10", controlClassName)}
+        />
+        <ChevronDown
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-[var(--dpf-muted)]"
+        />
+      </div>
+
+      {open ? (
+        <div
+          className="absolute z-50 mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] shadow-dpf-md"
+          role="presentation"
+        >
+          <div className="relative border-b border-[var(--dpf-border)]">
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--dpf-muted)]"
+            />
+            <input
+              ref={searchRef}
+              type="text"
+              aria-label={searchLabel}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              className="min-h-[44px] w-full rounded-t-md border-0 bg-[var(--dpf-surface-1)] px-9 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+              placeholder="Search..."
+            />
+          </div>
+          <ul
+            id={listboxId}
+            role="listbox"
+            className="max-h-72 overflow-auto py-1"
+            aria-label={searchLabel}
+          >
+            {visibleOptions.length > 0 ? (
+              visibleOptions.map((option, index) => {
+                const active = index === activeIndex;
+                const selectedOption = option.value === value;
+                return (
+                  <li
+                    key={option.value}
+                    id={optionId(index)}
+                    role="option"
+                    aria-selected={selectedOption}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => selectOption(option)}
+                    className={cx(
+                      "flex cursor-pointer items-start gap-2 px-3 py-2 text-sm",
+                      active
+                        ? "bg-[var(--dpf-accent)] text-[var(--dpf-on-accent,var(--dpf-surface-1))]"
+                        : "text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]",
+                    )}
+                  >
+                    <Check
+                      aria-hidden="true"
+                      className={cx("mt-0.5 size-4 shrink-0", selectedOption ? "opacity-100" : "opacity-0")}
+                    />
+                    <span className="min-w-0">
+                      <span className="block truncate font-medium">{option.label}</span>
+                      {option.description ? (
+                        <span className={cx("block truncate text-xs", active ? "opacity-80" : "text-[var(--dpf-muted)]")}>
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </span>
+                  </li>
+                );
+              })
+            ) : (
+              <li className="px-3 py-3 text-sm text-[var(--dpf-muted)]">{emptyMessage}</li>
+            )}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/ui/form/index.ts
+++ b/apps/web/components/ui/form/index.ts
@@ -9,6 +9,11 @@ export { FormField, type FormFieldProps, type FieldControlProps } from "./FormFi
 export { TextField, type TextFieldProps } from "./TextField";
 export { EmailField, type EmailFieldProps } from "./EmailField";
 export { SelectField, type SelectFieldProps, type SelectOption } from "./SelectField";
+export {
+  SearchableSelect,
+  type SearchableSelectOption,
+  type SearchableSelectProps,
+} from "./SearchableSelect";
 export { TextareaField, type TextareaFieldProps } from "./TextareaField";
 export { CheckboxField, type CheckboxFieldProps } from "./CheckboxField";
 export { FormStatus, type FormStatusProps } from "./FormStatus";

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4731,6 +4731,7 @@
         "color-system",
         "design-token-scales-l0",
         "ux-budgets-l2",
+        "design-grounding",
         "contrast-requirements",
         "form-elements",
         "user-facing-form-contract-mandatory",

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -2104,15 +2104,15 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - text"
     },
     "/storefront/settings/operations": {
-      "defaultVisibleWords": 1462,
+      "defaultVisibleWords": 145,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 11,
-      "maxChoicesPerControl": 419,
+      "maxChoicesPerControl": 0,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n    - option\n    - option [selected]\n    - option\n  - paragraph\n    - text\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch\n  - text\n  - switch\n  - text\n  - button"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - navigation\n    - link\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - combobox\n  - paragraph\n    - text\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch [checked]\n  - text\n  - textbox\n  - text\n  - textbox\n  - switch\n  - text\n  - switch\n  - text\n  - button"
     },
     "/storefront/setup": {
       "defaultVisibleWords": 473,

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -149,6 +149,22 @@ describe("budget axes", () => {
     expect(maxChoicesPerControl(html)).toBe(9);
   });
 
+  it("flags owner setup pages that dump hundreds of closed choices into the visible DOM", () => {
+    const html = `<main data-dpf-lead><p>Set business hours.</p><select aria-label="Timezone">${"<option>Zone</option>".repeat(200)}</select></main>`;
+    const report = auditUxBudget(html, "settings", { routeStatus: "net-new", audience: "owner" });
+    const finding = report.findings.find((f) => f.check === "choices-per-control");
+
+    expect(finding?.ok).toBe(false);
+    expect(finding?.severity).toBe("blocking");
+    expect(finding?.detail).toContain("200 choices");
+  });
+
+  it("does not count a closed searchable picker as if its full corpus were visible", () => {
+    const html = `<main><input role="combobox" value="(UTC-06:00) America/Chicago"><input type="hidden" name="timezone" value="America/Chicago"></main>`;
+    expect(measureUxBudget(html).maxChoicesPerControl).toBe(0);
+    expect(measureUxBudget(html).visibleFields).toBe(1);
+  });
+
   it("does not fabricate a reading grade for an empty surface", () => {
     expect(measureUxBudget("<div></div>").readingGradeLevel).toBe(0);
   });

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -84,6 +84,20 @@ lead-band word count rises from zero. The ratchet catches removal of an establis
 band; absolute `maxLeadBandWords` budgets still report overlong copy and block net-new
 routes.
 
+**Long option lists use a searchable picker, not a native closed select.** Timezones,
+regions, currencies, integrations, industries, archetypes and service-line catalogs must
+render only the current value on arrival, then expose a bounded searchable list after the
+owner opens the picker. Use `SearchableSelect` for static closed sets so the route sweep
+does not count hundreds of hidden choices as default-visible text or `choices-per-control`
+debt.
+
+### Design grounding
+
+- Existing specs/plans reviewed: `BI-0EC59231`, EP-UX-SYSTEM UX budget guidance in this document, and `docs/architecture/build-gate-runbook.md`.
+- Current code substrate reviewed: `apps/web/components/admin/OperatingHoursEditor.tsx`, `apps/web/components/storefront-admin/ServiceLinesPanel.tsx`, `apps/web/components/ui/form/SelectField.tsx`, and `apps/web/lib/ux-budget/measure.ts`.
+- Source of truth: long static catalogs belong in `SearchableSelect`; route-level choice pressure is measured by `maxChoicesPerControl`.
+- Decision: replace long native owner-facing selects with a closed searchable picker, keep common/current choices first, and preserve native form posting through a hidden value field.
+
 **Hiding the primary action is a regression the word budgets cannot see.** Moving a
 trigger behind an "Advanced" collapse *reduces* the default-visible word and control
 counts, so the volume budgets read it as an improvement. The reachability axis is the
@@ -196,6 +210,7 @@ consequence banner; a form that re-implements these is a defect (BI-8E74C749).
 |---|---|
 | `FormField` | Labeled-control wrapper (render-prop). Owns `<label htmlFor>`↔`id`, required/optional marker, `aria-required`, `aria-invalid`, hint + error wired via `aria-describedby`, and `role="alert"` on the error. |
 | `TextField` / `EmailField` / `SelectField` / `TextareaField` / `CheckboxField` | Typed controls built on `FormField`. `EmailField` also normalizes on blur via `EmailInput`. |
+| `SearchableSelect` | Static closed-set picker for long catalogs. Renders a single combobox value on arrival, hides the option corpus until opened/searched, and posts the selected value through a hidden field when `name` is provided. |
 | `SubmitButton` | Primary action with a first-class pending state (`aria-busy` + `InlineBusy`); disables to prevent double-submit. |
 | `FormStatus` | Settled outcome region — error is assertive (`role="alert"`), success is polite (`role="status"` + `aria-live`). |
 | `ConsequenceNotice` | Risk-proportional consequence copy behind progressive disclosure (native `<details>`): what changes, who's affected, reversibility, recovery. |

--- a/docs/ux-fit/2026-08-02-searchable-long-option-controls.ux-fit.json
+++ b/docs/ux-fit/2026-08-02-searchable-long-option-controls.ux-fit.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "decidedOption": "closed-searchable-picker",
+  "scope": {
+    "files": [
+      "apps/web/components/ui/form/SearchableSelect.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "improved",
+    "measured": {
+      "/storefront/settings/operations": {
+        "defaultVisibleWords": 145,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 11,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      }
+    }
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -3273,7 +3273,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 91
+    "textMass": 82
   },
   "apps/web/components/admin/PlatformDevelopmentForm.tsx": {
     "vocabulary": 0,
@@ -5506,7 +5506,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 122
+    "textMass": 120
   },
   "apps/web/components/inventory/DiscoveryRunSummary.tsx": {
     "vocabulary": 0,
@@ -7382,7 +7382,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 20
+    "textMass": 23
   },
   "apps/web/components/storefront-admin/SetupWizard.tsx": {
     "vocabulary": 7,
@@ -7712,6 +7712,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 67
+  },
+  "apps/web/components/ui/form/SearchableSelect.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
   },
   "apps/web/components/ui/form/SelectField.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary
- Add a shared `SearchableSelect` primitive for closed, static option sets so owner-facing setup flows do not expose hundreds of native `<option>` choices.
- Replace the operations timezone selector and storefront service-line archetype selector with the searchable picker, keeping current/common choices first and preserving submitted hidden form values.
- Ratchet UX budget coverage so net-new native selects with hundreds of options are blocking, and document the long-option-list standard.
- Update the frozen `/storefront/settings/operations` UX route baseline for the measured improvement: default-visible words `1462 -> 145`, choices per control `419 -> 0`, with the accessibility tree updated from native select options to the closed combobox shape.

## Verification
- Focused tests: `pnpm --filter web exec vitest run components/ui/form/SearchableSelect.test.tsx components/admin/OperatingHoursEditor.test.tsx components/storefront-admin/ServiceLinesPanel.test.tsx lib/ux-budget/ux-budget.test.ts` — 57 passed.
- UX-fit guard: `node scripts/check-ux-fit-decision.mjs` — passed.
- Design grounding guard: `node scripts/check-design-grounding-decision.mjs` — passed.
- Prose lint: `pnpm run check:prose-lint` — passed.
- Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed.
- Production build: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed with existing Edge-runtime warnings.
- Pregate/local-CI: `NODE_OPTIONS=--max-old-space-size=8192 pnpm run pregate` — passed for `1010044b565f08e93d44590ccf5be8822a7aad75` against accepted base `2afbe6c5d55a30c87fb9991aea9d9ce4e4be9db3`; evidence `cmsbfz9e40qea01tcunvl4cpz`; lease `NPEL-6AB9875D66`.

## UX Evidence
- UX-fit evidence recorded in `docs/ux-fit/2026-08-02-searchable-long-option-controls.ux-fit.json`.
- Design grounding added to `docs/platform-usability-standards.md`.
- First GitHub CI run correctly flagged the intentional `/storefront/settings/operations` accessibility-shape change; this revision scopes that baseline update to the measured route improvement.

## Residual Risk
- Runtime preview reached health 200 under a governed nonprod lease, but authenticated owner-route driving was blocked by unavailable seeded-persona credentials. No auth bypass or password reset was used.
- The canonical live install is still behind the merged UX commits; post-merge live verification still requires governed self-upgrade before the feature can be exercised on `:3000`.
