### PR TITLE
fix(ux): repair workspace provider recovery link

### DIFF
--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import { FileText, PlugZap } from "lucide-react";
 import type { AgentMessageProvider, AgentMessageRow } from "@/lib/agent-coworker-types";
+import { AI_PROVIDER_CONNECTIONS_ROUTE } from "@/lib/ai-provider-routes";
 import type { ReactNode } from "react";
 import { AgentAttachmentCard } from "./AgentAttachmentCard";
 import { providerModelLabel } from "@/lib/agent/provider-model-label";
@@ -106,7 +107,7 @@ function extractManagedDocumentIds(content: string): string[] {
 }
 
 /** Deep-link target for the AI provider reconnect / activation surface. */
-export const PROVIDER_ROUTING_ROUTE = "/platform/ai/providers";
+export const PROVIDER_ROUTING_ROUTE = AI_PROVIDER_CONNECTIONS_ROUTE;
 
 /**
  * True when an assistant message steers the operator to reconnect or activate an

--- a/apps/web/components/workspace-home/LocalOnlyProviderNotice.test.tsx
+++ b/apps/web/components/workspace-home/LocalOnlyProviderNotice.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import routeManifest from "@/lib/ea/route-manifest.json";
+import { AI_PROVIDER_CONNECTIONS_ROUTE } from "@/lib/ai-provider-routes";
+import { PLATFORM_FAMILIES } from "@/components/platform/platform-nav";
+import { LocalOnlyProviderNotice } from "./LocalOnlyProviderNotice";
+
+type RouteManifest = {
+  routes?: Array<{ routePath?: string }>;
+};
+
+describe("LocalOnlyProviderNotice", () => {
+  it("links provider recovery to the canonical provider connections route", () => {
+    const html = renderToStaticMarkup(<LocalOnlyProviderNotice />);
+
+    expect(html).toContain(`href="${AI_PROVIDER_CONNECTIONS_ROUTE}"`);
+    expect(html).not.toContain("/platform/ai-operations/providers");
+  });
+
+  it("keeps the recovery target registered as the AI Operations provider surface", () => {
+    const routes = new Set(
+      ((routeManifest as RouteManifest).routes ?? []).map((route) => route.routePath),
+    );
+    const aiFamily = PLATFORM_FAMILIES.find((family) => family.key === "ai");
+
+    expect(routes.has(AI_PROVIDER_CONNECTIONS_ROUTE)).toBe(true);
+    expect(aiFamily?.subItems).toContainEqual(
+      expect.objectContaining({
+        href: AI_PROVIDER_CONNECTIONS_ROUTE,
+        label: "Providers & Routing",
+      }),
+    );
+  });
+});

--- a/apps/web/components/workspace-home/LocalOnlyProviderNotice.tsx
+++ b/apps/web/components/workspace-home/LocalOnlyProviderNotice.tsx
@@ -1,3 +1,5 @@
+import { AI_PROVIDER_CONNECTIONS_ROUTE } from "@/lib/ai-provider-routes";
+
 export function LocalOnlyProviderNotice() {
   return (
     <section
@@ -13,7 +15,7 @@ export function LocalOnlyProviderNotice() {
           </p>
         </div>
         <a
-          href="/platform/ai-operations/providers"
+          href={AI_PROVIDER_CONNECTIONS_ROUTE}
           className="inline-flex min-h-9 items-center justify-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm font-semibold text-[var(--dpf-text)]"
         >
           Connect a provider

--- a/apps/web/lib/ai-provider-routes.ts
+++ b/apps/web/lib/ai-provider-routes.ts
@@ -1,0 +1,1 @@
+export const AI_PROVIDER_CONNECTIONS_ROUTE = "/platform/ai/providers";

--- a/apps/web/lib/attention/sources/provider-credential.ts
+++ b/apps/web/lib/attention/sources/provider-credential.ts
@@ -35,6 +35,7 @@
 // choice to turn a provider off, not a failure.
 
 import { getProviders } from "@/lib/ai-provider-data";
+import { AI_PROVIDER_CONNECTIONS_ROUTE } from "@/lib/ai-provider-routes";
 import type { prisma } from "@dpf/db";
 import {
   detectProviderSuitabilityDrift,
@@ -44,7 +45,7 @@ import {
 import type { AttentionItem } from "../types";
 
 /** Reconnect surface — the same target the honest failure message points at. */
-export const PROVIDER_RECONNECT_ROUTE = "/platform/ai/providers";
+export const PROVIDER_RECONNECT_ROUTE = AI_PROVIDER_CONNECTIONS_ROUTE;
 
 export type ExpiredCredentialProvider = {
   providerId: string;

--- a/docs/ux-fit/2026-08-02-workspace-provider-recovery-link.ux-fit.json
+++ b/docs/ux-fit/2026-08-02-workspace-provider-recovery-link.ux-fit.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "decidedOption": "canonical-provider-connections-route",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace-home/LocalOnlyProviderNotice.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "held",
+    "measured": {
+      "/workspace": {
+        "defaultVisibleWords": 199,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the workspace provider-recovery CTA so it targets the canonical AI provider surface at `/platform/ai/providers` instead of the nonexistent `/platform/ai-operations/providers` route.
- Adds `AI_PROVIDER_CONNECTIONS_ROUTE` as the single source for provider reconnect links used by the workspace notice, attention items, and agent message bubble.
- Adds a regression test that proves the workspace notice target exists in the route manifest and remains registered under AI Operations as “Providers & Routing”.

## Linked BI

BI-6E096DD1

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-05-26-pipedrive-crm-marketing-slice-1.md`
- Current code substrate reviewed:
  - `apps/web/components/platform/platform-nav.tsx`
  - `apps/web/lib/ea/route-manifest.json`
  - `apps/web/components/workspace-home/LocalOnlyProviderNotice.tsx`
  - `apps/web/lib/attention/sources/provider-credential.ts`
  - `apps/web/components/agent/AgentMessageBubble.tsx`
- Source of truth:
  - `apps/web/lib/ai-provider-routes.ts`
- Decision:
  - Reuse the existing Providers & Routing destination and do not introduce a peer provider-navigation surface.

## Verification

- `node D:\DPF\node_modules\vitest\vitest.mjs run --root D:\DPF-worktrees\workspace-provider-recovery-link\apps\web components/workspace-home/LocalOnlyProviderNotice.test.tsx lib/attention/sources/provider-credential.test.ts components/agent/AgentMessageBubble.test.tsx` — 3 files / 48 tests passed.
- `pnpm --filter web typecheck` — passed.
- `node scripts/check-spec-plan-doc.mjs` — passed.
- `node scripts/check-ux-fit-decision.mjs` — passed.
- `node scripts/check-design-grounding-decision.mjs` — passed.
- Clean validator `pnpm run pregate:preflight` — 34 guards passed.
- Clean validator `pnpm --filter web build` — passed; existing unrelated Edge-runtime diagnostics were emitted, command exited 0.
- `pnpm run pregate -- --branch fix/workspace-provider-recovery-link --worktree D:\DPF-worktrees\workspace-provider-recovery-link-build` — passed.
- Migration check: local-CI `prisma migrate deploy` found no pending migrations.
- UX path: regression test verifies the provider recovery link resolves to the canonical registered route. Live installed-portal verification is deferred until the governed self-upgrade path advances the install to this commit.

Local-CI-Evidence: cmsbijpqb0uuh01tca9f5pwm1 (fix/workspace-provider-recovery-link@c88a39b05f35febffec5fc85d07861c1af6e807f)