### PR TITLE
fix(ux): route EA agents to identity surface

### DIFF
--- a/apps/web/app/(shell)/ea/agents/page.test.tsx
+++ b/apps/web/app/(shell)/ea/agents/page.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const redirectMock = vi.hoisted(() =>
+  vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+);
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+import EaAgentsPage from "./page";
+
+const AI_COWORKER_IDENTITY_ROUTE = "/platform/identity/agents";
+
+describe("/ea/agents legacy route", () => {
+  beforeEach(() => {
+    redirectMock.mockClear();
+  });
+
+  it("redirects to the canonical AI coworker identity surface", () => {
+    expect(() => EaAgentsPage()).toThrow(
+      `redirect:${AI_COWORKER_IDENTITY_ROUTE}`,
+    );
+    expect(redirectMock).toHaveBeenCalledWith(AI_COWORKER_IDENTITY_ROUTE);
+  });
+});

--- a/apps/web/app/(shell)/ea/agents/page.tsx
+++ b/apps/web/app/(shell)/ea/agents/page.tsx
@@ -2,5 +2,5 @@
 import { redirect } from "next/navigation";
 
 export default function EaAgentsPage() {
-  redirect("/admin/agents");
+  redirect("/platform/identity/agents");
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9754,6 +9754,7 @@
         "overview",
         "key-concepts",
         "what-you-can-do",
+        "ai-coworker-identity",
         "following-a-concern-across-views"
       ]
     },

--- a/apps/web/lib/ea/navigation-inventory-gate.test.ts
+++ b/apps/web/lib/ea/navigation-inventory-gate.test.ts
@@ -77,6 +77,24 @@ describe("navigation inventory gate (EP-NAV-COHERENCE P7)", () => {
     expect(entries.every((e) => e.path.startsWith("/"))).toBe(true);
   });
 
+  it("keeps the legacy EA agents route pointed at the canonical identity surface", () => {
+    const legacyRoute = (manifest.routes ?? []).find(
+      (r) => r.routePath === "/ea/agents",
+    );
+
+    expect(legacyRoute?.redirectTo).toBe("/platform/identity/agents");
+    expect((manifest.routes ?? []).some((r) => r.routePath === "/admin/agents")).toBe(
+      false,
+    );
+    expect(
+      entries.some(
+        (entry) =>
+          entry.path === "/admin/agents" ||
+          entry.effectivePath === "/admin/agents",
+      ),
+    ).toBe(false);
+  });
+
   it("counts converged per-domain section routes as navigable, not orphans (P3)", () => {
     for (const p of [
       "/finance/invoices", "/finance/bills", "/finance/reports", "/finance/banking",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -4335,7 +4335,7 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/ea/agents/page.tsx",
-      "redirectTo": "/admin/agents"
+      "redirectTo": "/platform/identity/agents"
     },
     {
       "routePath": "/ea/capabilities",

--- a/docs/user-guide/architecture/index.md
+++ b/docs/user-guide/architecture/index.md
@@ -32,6 +32,14 @@ The EA Modeler is a canvas-based tool for building and maintaining your organiza
 - Use **Refresh live projections** when you are authorized to rebuild governed
   BPMN, SysML, and ArchiMate views from their canonical sources
 
+## AI Coworker Identity
+
+Architecture views may still contain older `/ea/agents` links from governance
+and route projections. Those links are compatibility paths. They now open
+`/platform/identity/agents`, the canonical **AI Coworker Identity** page for
+principal coverage, portable identity metadata, and authorization inspection.
+Use the AI Workforce area for everyday coworker discovery and work assignment.
+
 ## Following a Concern Across Views
 
 Select an element on an architecture canvas and open **Architecture context** in


### PR DESCRIPTION
## Summary
- Preserve `/ea/agents` as a legacy compatibility path, but redirect it to `/platform/identity/agents` instead of the missing `/admin/agents` route.
- Add page-level and navigation-inventory coverage so the redirect target stays canonical and no nav/redirect path points at `/admin/agents`.
- Update the Architecture user guide and generated docs index so documented route behavior matches the platform.

## Design grounding
Reviewed `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`, `docs/platform-usability-standards.md`, `/ea/agents`, `/platform/identity/agents`, the Identity & Access home, `platform-nav`, and the route manifest. Decision: `/ea/agents` is compatibility-only; the canonical destination is `/platform/identity/agents` because this job is principal/authorization inspection, not workforce discovery.

## Verification
- `pnpm --filter web exec vitest run "app/(shell)/ea/agents/page.test.tsx" "lib/ea/navigation-inventory-gate.test.ts" "lib/ea/navigation-conformance.test.ts"`
- `pnpm --filter web check:route-manifest`
- `pnpm --filter web check:route-audience`
- `pnpm run pregate:preflight`
- `pnpm run pregate -- --branch fix/stale-ea-agents-redirect --worktree D:\DPF-worktrees\stale-ea-agents-redirect`

Local-CI evidence: `cmsblz1bn105r01tc666raprb` for SHA `8eb48900e73f42825cb140052f36239d29f223f1`, lease `NPEL-F1B43ECA74`, status `passed`.