### PR TITLE
fix: advance terminal local-CI claim attempts

### DIFF
--- a/docs/operations/local-ci-sandbox-slots.md
+++ b/docs/operations/local-ci-sandbox-slots.md
@@ -144,11 +144,15 @@ A lost database heartbeat and a live local process fence is an unhealthy slot,
 not evidence that the slot is free. Admission fails closed until the owner is
 terminated or the dead fence is reaped.
 
-Portal quiescence can outlast a queued claim's short heartbeat window. The gate
-re-establishes queue intent with a new idempotency key only when live responses
-prove that the prior claim was queued, portal quiescence interrupted it, and
-the resulting terminal reason is `expired`. Recovery remains inside the
-original admission deadline; other terminal claims fail closed.
+Portal quiescence can outlast a queued claim's short heartbeat window, and a
+later process can encounter terminal claim keys left by earlier attempts. The
+gate uses one deterministic `rerun-N` sequence for every terminal result
+(`released`, `cancelled`, or `expired`). It probes existing terminal attempts
+monotonically until a fresh claim is accepted, always inside the original
+admission deadline and with the same owner session. Every fresh attempt enters
+at the FIFO tail; it never inherits a terminal row's former position. Durable
+lease events record the prior and replacement claim keys, terminal reason, and
+whether portal quiescence interrupted the queued observation.
 
 Port reachability is also not resource ownership. The runner verifies the exact
 manifest-named PostgreSQL container before reuse. If the assigned port is

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -290,6 +290,137 @@ test("released terminal claim from a prior run gets a fresh rerun claimKey", asy
   }
 });
 
+test("terminal claim replacement advances past an expired rerun from a prior process", async () => {
+  const claims = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      const tool = payload.params.name;
+      if (tool === "claim_nonprod_environment_lease") {
+        claims.push(payload.params.arguments);
+      }
+      const claimNumber = claims.length;
+      const result = tool === "claim_nonprod_environment_lease" && claimNumber === 1
+        ? {
+          success: false,
+          error: "lease_terminal",
+          entityId: "NPEL-PRIOR-RUN",
+          data: {
+            reason: "released",
+            lease: {
+              leaseId: "NPEL-PRIOR-RUN",
+              claimKey: claims[0].claimKey,
+              status: "released",
+            },
+          },
+        }
+        : tool === "claim_nonprod_environment_lease" && claimNumber === 2
+          ? {
+            success: false,
+            error: "lease_terminal",
+            entityId: "NPEL-EXPIRED-RERUN",
+            data: {
+              reason: "expired",
+              lease: {
+                leaseId: "NPEL-EXPIRED-RERUN",
+                claimKey: claims[1].claimKey,
+                status: "expired",
+              },
+            },
+          }
+          : tool === "claim_nonprod_environment_lease"
+            ? {
+              success: true,
+              entityId: "NPEL-FRESH-RERUN",
+              data: {
+                lease: { leaseId: "NPEL-FRESH-RERUN" },
+                admission: { status: "admitted", slotKey: "slot-0", waitAgeMs: 0 },
+              },
+            }
+            : tool === "record_local_integration_result"
+              ? { success: true, entityId: "EVIDENCE-FRESH-RERUN" }
+              : { success: true };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const worktree = makeTempWorktree();
+  const stateFile = join(worktree, ".git", "dpf-local-ci-gate.json");
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "fix/sandbox-lease-fencing",
+      "--worktree", worktree,
+      "--expires-minutes", "0.05",
+      "--poll-seconds", "0.01",
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_GATE_RETRY_JITTER: "0",
+        DPF_GATE_OWNER_PROVIDER: "codex",
+        DPF_GATE_OWNER_SESSION_ID: "test-terminal-claim-owner",
+        DPF_LOCAL_SANDBOX_FENCE_PATH: isolatedFencePath(),
+      },
+    });
+
+    assert.ok([0, 3].includes(result.code), result.output);
+    assert.equal(claims.length, 3);
+    assert.match(claims[0].claimKey, /^local-ci:[^:]+:[0-9a-f]{40}$/);
+    assert.match(claims[1].claimKey, /:rerun-1$/);
+    assert.match(claims[2].claimKey, /:rerun-2$/);
+    assert.ok(claims.every((claim) => claim.ownerProvider === "codex"));
+    assert.ok(claims.every(
+      (claim) => claim.ownerSessionId === "test-terminal-claim-owner",
+    ));
+    assert.match(result.output, /creating fresh admission attempt 2/);
+    const state = JSON.parse(readFileSync(stateFile, "utf8"));
+    assert.deepEqual(
+      state.leaseEvents
+        .filter((event) => event.type === "terminal-claim-replaced")
+        .map((event) => ({
+          terminalReason: event.terminalReason,
+          terminalAttemptSequence: event.terminalAttemptSequence,
+          priorClaimKey: event.priorClaimKey,
+          replacementClaimKey: event.replacementClaimKey,
+          interruptedByQuiescence: event.interruptedByQuiescence,
+        })),
+      [
+        {
+          terminalReason: "released",
+          terminalAttemptSequence: 1,
+          priorClaimKey: claims[0].claimKey,
+          replacementClaimKey: claims[1].claimKey,
+          interruptedByQuiescence: false,
+        },
+        {
+          terminalReason: "expired",
+          terminalAttemptSequence: 2,
+          priorClaimKey: claims[1].claimKey,
+          replacementClaimKey: claims[2].claimKey,
+          interruptedByQuiescence: false,
+        },
+      ],
+    );
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
 test("cancelled terminal claim from an interrupted run gets a fresh rerun claimKey", async () => {
   const claims = [];
   const server = createServer((request, response) => {
@@ -498,12 +629,14 @@ test("a queued observer re-establishes intent after quiescence expires its claim
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
+  const worktree = makeTempWorktree();
+  const stateFile = join(worktree, ".git", "dpf-local-ci-gate.json");
 
   try {
     const result = await run(process.execPath, [
       "scripts/gate-worktree.mjs",
       "--branch", "fix/sandbox-lease-fencing",
-      "--worktree", process.cwd(),
+      "--worktree", worktree,
       "--expires-minutes", "0.05",
       "--poll-seconds", "0.01",
       "--mcp-url", `http://127.0.0.1:${address.port}`,
@@ -524,8 +657,27 @@ test("a queued observer re-establishes intent after quiescence expires its claim
     assert.equal(claims[0].claimKey, claims[1].claimKey);
     assert.equal(claims[1].claimKey, claims[2].claimKey);
     assert.notEqual(claims[2].claimKey, claims[3].claimKey);
-    assert.match(claims[3].claimKey, /:recovery-1$/);
+    assert.match(claims[3].claimKey, /:rerun-1$/);
     assert.match(result.output, /re-establishing queue intent/);
+    const recoveryEvent = JSON.parse(readFileSync(stateFile, "utf8"))
+      .leaseEvents
+      .find((event) => event.type === "queue-intent-reestablished");
+    assert.deepEqual(
+      {
+        terminalReason: recoveryEvent?.terminalReason,
+        terminalAttemptSequence: recoveryEvent?.terminalAttemptSequence,
+        priorClaimKey: recoveryEvent?.priorClaimKey,
+        replacementClaimKey: recoveryEvent?.replacementClaimKey,
+        interruptedByQuiescence: recoveryEvent?.interruptedByQuiescence,
+      },
+      {
+        terminalReason: "expired",
+        terminalAttemptSequence: 1,
+        priorClaimKey: claims[2].claimKey,
+        replacementClaimKey: claims[3].claimKey,
+        interruptedByQuiescence: true,
+      },
+    );
   } finally {
     server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -858,8 +858,7 @@ async function main() {
   let leaseReleased = false;
   let receivedSignal = "";
   let queuedClaimInterruptedByQuiescence = false;
-  let claimRecoverySequence = 0;
-  let terminalClaimRerunSequence = 0;
+  let terminalClaimAttemptSequence = 0;
   const leaseEvents = [];
   const hostPressureSamples = [];
   let admissionPoolPolicy = null;
@@ -1089,48 +1088,42 @@ async function main() {
       ?? claimResponse?.data?.lease?.status;
     if (
       claimResponse?.error === "lease_terminal"
-      && terminalReason === "expired"
-      && queuedClaimInterruptedByQuiescence
-    ) {
-      if (Date.now() >= deadline) {
-        die("local-CI queue claim expired during quiescence at the admission deadline");
-      }
-      claimRecoverySequence += 1;
-      claimKey = `${baseClaimKey}:recovery-${claimRecoverySequence}`;
-      leaseEvents.push({
-        type: "queue-intent-reestablished",
-        at: new Date().toISOString(),
-        priorLeaseId: leaseId,
-        recoverySequence: claimRecoverySequence,
-      });
-      leaseId = "";
-      queuedClaimInterruptedByQuiescence = false;
-      process.stdout.write(
-        `queued claim expired during portal quiescence; re-establishing queue intent with recovery ${claimRecoverySequence}...\n`,
-      );
-      continue;
-    }
-    if (
-      claimResponse?.error === "lease_terminal"
-      && ["released", "cancelled"].includes(terminalReason)
+      && ["released", "cancelled", "expired"].includes(terminalReason)
     ) {
       if (Date.now() >= deadline) {
         die(`previous local-CI lease claim was already ${terminalReason} at the admission deadline`);
       }
-      terminalClaimRerunSequence += 1;
-      claimKey = `${baseClaimKey}:rerun-${terminalClaimRerunSequence}`;
+      const priorClaimKey = claimKey;
+      const terminalAttemptPrefix = `${baseClaimKey}:rerun-`;
+      const priorAttemptText = priorClaimKey.startsWith(terminalAttemptPrefix)
+        ? priorClaimKey.slice(terminalAttemptPrefix.length)
+        : "";
+      const priorAttemptSequence = /^\d+$/.test(priorAttemptText)
+        ? Number.parseInt(priorAttemptText, 10)
+        : 0;
+      terminalClaimAttemptSequence = Math.max(
+        terminalClaimAttemptSequence,
+        Number.isSafeInteger(priorAttemptSequence) ? priorAttemptSequence : 0,
+      ) + 1;
+      claimKey = `${baseClaimKey}:rerun-${terminalClaimAttemptSequence}`;
+      const interruptedByQuiescence = queuedClaimInterruptedByQuiescence;
       leaseEvents.push({
-        type: "terminal-claim-replaced",
+        type: interruptedByQuiescence
+          ? "queue-intent-reestablished"
+          : "terminal-claim-replaced",
         at: new Date().toISOString(),
         priorLeaseId: leaseId,
+        priorClaimKey,
+        replacementClaimKey: claimKey,
         terminalReason,
-        rerunSequence: terminalClaimRerunSequence,
+        terminalAttemptSequence: terminalClaimAttemptSequence,
+        interruptedByQuiescence,
       });
       leaseId = "";
       queuedClaimInterruptedByQuiescence = false;
-      process.stdout.write(
-        `previous local-CI lease claim was ${terminalReason}; creating fresh admission attempt ${terminalClaimRerunSequence}...\n`,
-      );
+      process.stdout.write(interruptedByQuiescence
+        ? `queued claim ${terminalReason} during portal quiescence; re-establishing queue intent with terminal attempt ${terminalClaimAttemptSequence}...\n`
+        : `previous local-CI lease claim was ${terminalReason}; creating fresh admission attempt ${terminalClaimAttemptSequence}...\n`);
       continue;
     }
     die(`failed to claim local-CI lease: ${JSON.stringify(claimResponse)}`);


### PR DESCRIPTION
## Summary

- unify released, cancelled, and expired local-CI lease recovery behind one deterministic `rerun-N` attempt sequence
- probe prior terminal attempts monotonically within the original deadline while preserving the real owner session and FIFO-tail admission
- persist prior/replacement claim keys, terminal reason, attempt sequence, and quiescence context in durable lease events
- document the shared recovery contract

## Why

After a process restart, the gate could reuse `:rerun-1` for a released base claim and then stop when that prior rerun was already expired. The terminal reason incorrectly selected separate recovery paths, so attempt identity was neither monotonic nor collision-tolerant across restarts.

## Verification

- regression-first lease harness: 21 passed, 0 failed, 1 Windows POSIX-signal skip
- exact reboot sequence covered: released base → expired `rerun-1` → admitted `rerun-2`
- unchanged owner provider/session and durable transition receipts asserted
- docs index and link checks passed
- independent high-assurance semantic review passed
- exact-tree local CI passed freshness, 489 migrations, repository guards, typecheck, exhaustive Vitest, and Dockerized Next.js production build

Linked backlog: BI-872CB1BF follow-up reliability defect.
