### PR TITLE
feat: add AI-assisted restaurant host stand

### DIFF
--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -47,6 +47,7 @@ export default async function WorkspacePage() {
     archetypeRef?.archetypeId ?? null,
     archetypeRef?.name ?? null,
   );
+  const restaurantShift = Boolean(twinPresentation?.restaurantFloor);
 
   const hasCloudProvider =
     (await prisma.modelProvider.count({
@@ -73,10 +74,10 @@ export default async function WorkspacePage() {
   // it never adds an empty panel to the surface we are decluttering.
   const cockpit = (
     <>
-      <WorkspaceStorefrontAttention density={simpleHome ? "simple" : "full"} />
+      <WorkspaceStorefrontAttention density={simpleHome || restaurantShift ? "simple" : "full"} />
       <OperatorCockpit
         userId={session.user.id}
-        audience={simpleHome ? "worker" : "operator"}
+        audience={simpleHome || restaurantShift ? "worker" : "operator"}
       />
     </>
   );

--- a/apps/web/components/twin/cartesian/CartesianSceneCanvas.test.tsx
+++ b/apps/web/components/twin/cartesian/CartesianSceneCanvas.test.tsx
@@ -15,6 +15,11 @@ vi.mock("@xyflow/react", async () => {
         data-testid="react-flow"
         data-nodes-draggable={String(props.nodesDraggable)}
         data-elements-selectable={String(props.elementsSelectable)}
+        data-pan-on-scroll={String(props.panOnScroll)}
+        data-pan-on-drag={String(props.panOnDrag)}
+        data-zoom-on-scroll={String(props.zoomOnScroll)}
+        data-zoom-on-pinch={String(props.zoomOnPinch)}
+        data-zoom-on-double-click={String(props.zoomOnDoubleClick)}
       >
         {props.nodes.map((node: Record<string, any>) => {
           const NodeComponent = props.nodeTypes[node.type];
@@ -189,6 +194,45 @@ describe("CartesianSceneCanvas", () => {
     expect(
       screen.getByRole("list", { name: "Dining room layout details" }),
     ).toHaveTextContent("Table 1: Turning soon — Free in 8 minutes");
+  });
+
+  it("supports a chrome-free locked embed while keeping resource activation", () => {
+    const onActivate = vi.fn();
+    render(
+      <CartesianSceneCanvas
+        ariaLabel="Host stand floor"
+        mode="operate"
+        scene={scene()}
+        chrome="embedded"
+        navigation="locked"
+        bindings={{
+          "table:resource-1": {
+            label: "Table 1",
+            statusLabel: "Available",
+            intent: "success",
+          },
+        }}
+        onActivate={onActivate}
+      />,
+    );
+
+    const flow = screen.getByTestId("react-flow");
+    expect(flow).toHaveAttribute("data-pan-on-scroll", "false");
+    expect(flow).toHaveAttribute("data-pan-on-drag", "false");
+    expect(flow).toHaveAttribute("data-zoom-on-scroll", "false");
+    expect(flow).toHaveAttribute("data-zoom-on-pinch", "false");
+    expect(flow).toHaveAttribute("data-zoom-on-double-click", "false");
+    expect(screen.queryByText("Live operation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("controls")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("list", { name: "Host stand floor details" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Table 1.*Available/i }));
+    expect(onActivate).toHaveBeenCalledWith("table-1", {
+      kind: "table",
+      id: "resource-1",
+    });
   });
 
   it("has no mutation or activation affordance in read-only mode", () => {

--- a/apps/web/components/twin/cartesian/CartesianSceneCanvas.tsx
+++ b/apps/web/components/twin/cartesian/CartesianSceneCanvas.tsx
@@ -81,6 +81,10 @@ export interface CartesianSceneCanvasProps {
   empty?: ReactNode;
   height?: number;
   className?: string;
+  /** Hide mode and list chrome when a parent owns those controls. */
+  chrome?: "full" | "embedded";
+  /** Lock viewport gestures while preserving activation of resource nodes. */
+  navigation?: "interactive" | "locked";
 }
 
 function toFlowNodes(
@@ -136,6 +140,8 @@ export function CartesianSceneCanvas({
   empty,
   height = 520,
   className = "",
+  chrome = "full",
+  navigation = "interactive",
 }: CartesianSceneCanvasProps) {
   const versionRef = useRef(persistence?.version ?? 1);
   useEffect(() => {
@@ -245,6 +251,7 @@ export function CartesianSceneCanvas({
       aria-label={ariaLabel}
       className={`flex flex-col gap-dpf-sm ${className}`.trim()}
     >
+      {chrome === "full" ? (
       <div className="flex min-h-11 flex-wrap items-center justify-between gap-dpf-sm">
         {onModeChange && modeOptions && modeOptions.length > 1 ? (
           <label className="flex items-center gap-dpf-xs text-dpf-body font-dpf-medium text-dpf-text">
@@ -281,6 +288,7 @@ export function CartesianSceneCanvas({
           />
         ) : null}
       </div>
+      ) : null}
 
       {mode === "configure" && !persistence ? (
         <Notice variant="warn" title="Layout editing unavailable">
@@ -307,14 +315,21 @@ export function CartesianSceneCanvas({
           elementsSelectable={effectiveMode !== "read-only"}
           snapToGrid={effectiveMode === "configure"}
           snapGrid={[8, 8]}
-          panOnScroll
+          panOnScroll={navigation === "interactive"}
+          panOnDrag={navigation === "interactive"}
+          zoomOnScroll={navigation === "interactive"}
+          zoomOnPinch={navigation === "interactive"}
+          zoomOnDoubleClick={navigation === "interactive"}
           proOptions={{ hideAttribution: true }}
         >
           <Background gap={24} color="var(--dpf-border)" />
-          <Controls showInteractive={false} />
+          {navigation === "interactive" ? (
+            <Controls showInteractive={false} />
+          ) : null}
         </ReactFlow>
       </div>
 
+      {chrome === "full" ? (
       <details className="rounded-dpf-md border border-dpf-border bg-dpf-surface-1">
         <summary className="dpf-tap-target cursor-pointer px-dpf-md py-dpf-xs text-dpf-body font-dpf-medium text-dpf-text">
           View layout as a list
@@ -337,6 +352,7 @@ export function CartesianSceneCanvas({
           ))}
         </ul>
       </details>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import "@testing-library/jest-dom/vitest";
+
 import {
   cleanup,
   fireEvent,
@@ -16,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   advance: vi.fn(),
   move: vi.fn(),
   refresh: vi.fn(),
+  canvasProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,13 +32,49 @@ vi.mock("@/lib/twin/restaurant-floor-actions", () => ({
 }));
 
 vi.mock("@/components/twin/cartesian/CartesianSceneCanvas", () => ({
-  CartesianSceneCanvas: () => <div>interactive floor canvas</div>,
+  CartesianSceneCanvas: (canvasProps: Record<string, unknown>) => {
+    mocks.canvasProps = canvasProps;
+    return (
+      <div
+        data-testid="restaurant-floor-canvas"
+        data-chrome={String(canvasProps.chrome)}
+        data-navigation={String(canvasProps.navigation)}
+      >
+        interactive floor canvas
+      </div>
+    );
+  },
 }));
 
 import { RestaurantFloorOperations } from "./RestaurantFloorOperations";
 
 const props: RestaurantFloorOperationsProps = {
-  scene: null,
+  scene: {
+    id: "scene-1",
+    version: 1,
+    createdFromStarter: false,
+    layout: {
+      schemaVersion: 1,
+      spaceKind: "cartesian-interior",
+      viewport: { x: 0, y: 0, zoom: 1 },
+      zones: [],
+      placements: [
+        {
+          id: "table-placement-1",
+          label: "Table 1",
+          entityRef: { kind: "table", id: "table-1" },
+          geometry: {
+            x: 20,
+            y: 20,
+            width: 72,
+            height: 72,
+            rotation: 0,
+            shapeKind: "square-table",
+          },
+        },
+      ],
+    },
+  },
   view: {
     floor: {
       asOf: "2026-07-31T18:14:00.000Z",
@@ -122,6 +161,7 @@ describe("RestaurantFloorOperations", () => {
     mocks.advance.mockReset();
     mocks.move.mockReset();
     mocks.refresh.mockReset();
+    mocks.canvasProps = null;
     mocks.execute.mockResolvedValue({
       status: "confirmed",
       idempotencyKey: "seat-key",
@@ -156,15 +196,107 @@ describe("RestaurantFloorOperations", () => {
     });
   });
 
+  it("puts the pressure-mode host console in one bounded first viewport", () => {
+    render(
+      <RestaurantFloorOperations
+        {...props}
+        serviceAttention={<div>Takeout order needs confirmation</div>}
+      />,
+    );
+
+    const console = screen.getByTestId("restaurant-host-command-center");
+    expect(console).toHaveAttribute("data-dpf-density", "compact");
+    expect(console.className).toContain("overflow-hidden");
+    expect(screen.getByRole("heading", { name: "Host stand" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Waiting now" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "AI host recommends" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Floor" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Table list" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.queryByRole("heading", { name: "All tables" })).toBeNull();
+    expect(
+      screen.getByText("Orders, calls and messages"),
+    ).toBeTruthy();
+    expect(screen.getByText("Takeout order needs confirmation")).toBeTruthy();
+  });
+
+  it("locks embedded floor navigation so table activation wins over canvas movement", () => {
+    render(<RestaurantFloorOperations {...props} />);
+
+    expect(screen.getByTestId("restaurant-floor-canvas")).toHaveAttribute(
+      "data-chrome",
+      "embedded",
+    );
+    expect(screen.getByTestId("restaurant-floor-canvas")).toHaveAttribute(
+      "data-navigation",
+      "locked",
+    );
+  });
+
+  it("uses coworker ranking to prepare the next safe seating confirmation", () => {
+    render(<RestaurantFloorOperations {...props} />);
+
+    expect(screen.getByText("Table 1 fits 2 and is open now.")).toBeTruthy();
+    expect(screen.getByText(/Seat Alex Kim \(2\) at Table 1/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Confirm seating" })).toBeTruthy();
+  });
+
+  it("keeps late reservations and their held capacity visible during service", () => {
+    render(
+      <RestaurantFloorOperations
+        {...props}
+        view={{
+          ...props.view,
+          reservationWatch: [
+            {
+              id: "reservation-late",
+              name: "Taylor Morgan",
+              covers: 4,
+              scheduledAt: "2026-07-31T18:04:00.000Z",
+              lateMinutes: 10,
+              state: "late",
+              tableLabels: ["Table 4"],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Reservations to watch" }),
+    ).toBeTruthy();
+    expect(screen.getByText(/Taylor Morgan · 4 guests/)).toBeTruthy();
+    expect(screen.getByText(/holding Table 4/)).toBeTruthy();
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    expect(screen.getByText("10 min late")).toBeTruthy();
+  });
+
+  it("switches the center pane between the floor and the equivalent table list", () => {
+    render(<RestaurantFloorOperations {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Table list" }));
+    expect(screen.queryByTestId("restaurant-floor-canvas")).toBeNull();
+    expect(screen.getByRole("table")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Floor" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
   it("provides equivalent list controls for selecting and confirming a table", async () => {
     render(<RestaurantFloorOperations {...props} />);
 
     expect(screen.getByText(/waiting 14 min/)).toBeTruthy();
     expect(screen.getAllByText("Jordan Rivera").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("button", { name: /Alex Kim/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+    fireEvent.click(screen.getByRole("button", { name: "Table list" }));
+    expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Selected" })).toBeTruthy();
 
     expect(screen.getByText(/Seat Alex Kim \(2\) at Table 1/)).toBeTruthy();
     fireEvent.click(
@@ -188,6 +320,7 @@ describe("RestaurantFloorOperations", () => {
   it("keeps compatibility and assignment state in text, not color alone", () => {
     render(<RestaurantFloorOperations {...props} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Table list" }));
     expect(screen.getByText("Available")).toBeTruthy();
     expect(screen.getByText("Available for seating now")).toBeTruthy();
     expect(screen.getByText("Walk-in")).toBeTruthy();

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -196,7 +196,7 @@ describe("RestaurantFloorOperations", () => {
     });
   });
 
-  it("puts the pressure-mode host console in one bounded first viewport", () => {
+  it("bounds the desktop pressure-mode console while preserving document flow below desktop", () => {
     render(
       <RestaurantFloorOperations
         {...props}
@@ -206,7 +206,8 @@ describe("RestaurantFloorOperations", () => {
 
     const console = screen.getByTestId("restaurant-host-command-center");
     expect(console).toHaveAttribute("data-dpf-density", "compact");
-    expect(console.className).toContain("overflow-hidden");
+    expect(console.className).toContain("overflow-visible");
+    expect(console.className).toContain("lg:overflow-hidden");
     expect(screen.getByRole("heading", { name: "Host stand" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Waiting now" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "AI host recommends" })).toBeTruthy();
@@ -243,7 +244,10 @@ describe("RestaurantFloorOperations", () => {
 
     expect(screen.getByText("Table 1 fits 2 and is open now.")).toBeTruthy();
     expect(screen.getByText(/Seat Alex Kim \(2\) at Table 1/)).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Confirm seating" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Confirm seating" })).toHaveAttribute(
+      "data-owner-first-next-action",
+      "restaurant-confirm-seating",
+    );
   });
 
   it("keeps late reservations and their held capacity visible during service", () => {
@@ -461,9 +465,10 @@ describe("RestaurantFloorOperations", () => {
 
     render(<RestaurantFloorOperations {...moveProps} />);
     fireEvent.click(screen.getByRole("button", { name: "Move party" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: "Move to Table 2" }),
-    );
+    const moveOption = screen.getByRole("button", { name: "Move to Table 2" });
+    expect(moveOption.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(moveOption);
+    expect(moveOption.getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByText(/Move Morgan Lee to Table 2/)).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Confirm move" }));
 

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 
 import { LocalTime } from "@/components/ui/LocalTime";
+import { InlineBusy } from "@/components/ui/InlineBusy";
 import { DataTable, type Column } from "@/components/ui/report-kit/DataTable";
 import { Notice } from "@/components/ui/report-kit/Notice";
 import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
@@ -328,7 +329,7 @@ export function RestaurantFloorOperations({
   return (
     <section
       aria-labelledby="restaurant-host-heading"
-      className="flex h-[clamp(38rem,calc(100dvh-8rem),64rem)] min-w-0 flex-col gap-dpf-sm overflow-hidden rounded-dpf-xl border border-dpf-border bg-dpf-bg p-dpf-sm shadow-dpf-sm"
+      className="flex min-w-0 flex-col gap-dpf-sm overflow-visible rounded-dpf-xl border border-dpf-border bg-dpf-bg p-dpf-sm shadow-dpf-sm lg:h-[clamp(38rem,calc(100dvh-8rem),64rem)] lg:overflow-hidden"
       data-testid="restaurant-host-command-center"
       data-dpf-density="compact"
     >
@@ -343,7 +344,7 @@ export function RestaurantFloorOperations({
               </p>
               {serviceAttention ? (
                 <details className="relative mt-1">
-                  <summary className="cursor-pointer text-dpf-caption font-dpf-semibold text-dpf-accent hover:underline">
+                  <summary className="dpf-tap-target cursor-pointer text-dpf-caption font-dpf-semibold text-dpf-accent hover:underline">
                     Orders, calls and messages
                   </summary>
                   <div className="absolute left-0 top-full z-30 mt-dpf-xs max-h-[min(32rem,70dvh)] w-[min(36rem,82vw)] overflow-y-auto rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 p-dpf-md shadow-dpf-lg">
@@ -379,8 +380,8 @@ export function RestaurantFloorOperations({
 
       {resultNotice(result)}
 
-      <div className="grid min-h-0 flex-1 gap-dpf-sm lg:grid-cols-[minmax(15rem,0.72fr)_minmax(28rem,1.65fr)_minmax(18rem,0.9fr)]">
-        <section aria-labelledby="waiting-now-heading" className="flex min-h-0 flex-col overflow-hidden rounded-dpf-lg border border-dpf-border bg-dpf-surface-1">
+      <div className="grid min-h-0 gap-dpf-sm lg:flex-1 lg:grid-cols-[minmax(15rem,0.72fr)_minmax(28rem,1.65fr)_minmax(18rem,0.9fr)]">
+        <section aria-labelledby="waiting-now-heading" className="flex min-h-[18rem] max-h-[28rem] flex-col overflow-hidden rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 lg:min-h-0 lg:max-h-none">
           <div className="shrink-0 border-b border-dpf-border p-dpf-sm">
             <div className="flex items-center justify-between gap-dpf-sm">
               <h3 id="waiting-now-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">Waiting now</h3>
@@ -392,7 +393,7 @@ export function RestaurantFloorOperations({
                   key={filter}
                   type="button"
                   aria-pressed={queueFilter === filter}
-                  className="min-h-8 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-medium text-dpf-text aria-pressed:bg-dpf-accent-soft aria-pressed:text-dpf-accent"
+                  className="dpf-tap-target rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-medium text-dpf-text aria-pressed:bg-dpf-accent-soft aria-pressed:text-dpf-accent"
                   onClick={() => setQueueFilter(filter)}
                 >
                   {filter === "all" ? "All" : filter === "walk-in" ? "Walk-ins" : "Reservations"}
@@ -410,7 +411,7 @@ export function RestaurantFloorOperations({
                     <button
                       type="button"
                       aria-pressed={selectedDemandId === demand.id}
-                      className="grid min-h-14 w-full grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-dpf-xs rounded-dpf-md border border-transparent px-dpf-xs py-dpf-xs text-left text-dpf-text hover:bg-dpf-surface-2 aria-pressed:border-dpf-accent aria-pressed:bg-dpf-accent-soft"
+                      className="dpf-tap-target grid min-h-14 w-full grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-dpf-xs rounded-dpf-md border border-transparent px-dpf-xs py-dpf-xs text-left text-dpf-text hover:bg-dpf-surface-2 aria-pressed:border-dpf-accent aria-pressed:bg-dpf-accent-soft"
                       onClick={() => chooseDemand(demand.id)}
                     >
                       <span className="text-center text-dpf-caption font-dpf-semibold text-dpf-muted">{index + 1}</span>
@@ -434,7 +435,7 @@ export function RestaurantFloorOperations({
           </div>
         </section>
 
-        <section aria-label="Floor and tables" className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-dpf-lg border border-dpf-border bg-dpf-surface-1">
+        <section aria-label="Floor and tables" className="flex min-h-[30rem] min-w-0 flex-col overflow-hidden rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 lg:min-h-0">
           <div className="flex shrink-0 items-center justify-between gap-dpf-sm border-b border-dpf-border p-dpf-xs">
             <div className="flex gap-1" aria-label="Floor view">
               <button type="button" aria-pressed={centerView === "floor"} className="dpf-tap-target rounded-dpf-md px-dpf-sm text-dpf-body font-dpf-semibold text-dpf-text aria-pressed:bg-dpf-accent-soft aria-pressed:text-dpf-accent" onClick={() => setCenterView("floor")}>Floor</button>
@@ -465,7 +466,7 @@ export function RestaurantFloorOperations({
           </div>
         </section>
 
-        <aside className="grid min-h-0 content-start gap-dpf-sm overflow-y-auto">
+        <aside className="grid min-h-0 content-start gap-dpf-sm overflow-visible lg:overflow-y-auto">
           <section aria-labelledby="ai-host-heading" className="rounded-dpf-lg border border-dpf-accent bg-dpf-accent-soft p-dpf-sm">
             <div className="flex items-center gap-dpf-xs">
               <span aria-hidden="true">✦</span>
@@ -480,7 +481,7 @@ export function RestaurantFloorOperations({
                   <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Best safe fit from live capacity, timing, and server load.</p>
                 )}
                 <p className="mt-dpf-sm text-dpf-body text-dpf-text">Seat {selectedDemand.name} ({selectedDemand.covers}) at {selectedOption.label}.</p>
-                <button type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-md font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:opacity-60" disabled={pending} onClick={confirm}>{pending ? "Confirming…" : "Confirm seating"}</button>
+                <button aria-busy={pending} type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-md font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:opacity-60" data-dpf-primary-action="true" data-owner-first-next-action="restaurant-confirm-seating" disabled={pending} onClick={confirm}>{pending ? <InlineBusy label="Confirming…" tone="current" /> : "Confirm seating"}</button>
               </>
             ) : (
               <p className="mt-dpf-sm text-dpf-body text-dpf-muted">Choose a party to see the safest live seating choice.</p>
@@ -560,10 +561,10 @@ export function RestaurantFloorOperations({
                         <StatusBadge intent={resolveIntent("restaurantFloor", turn.stage)} label={turn.stage === "dirty" ? "Needs clearing" : turn.stage} variant="soft" />
                       </div>
                       <div className="mt-dpf-xs flex gap-1">
-                        {next ? <button type="button" className="min-h-8 flex-1 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-semibold text-dpf-text" disabled={pending} onClick={() => advanceTurn(turn, next)}>{next.label}</button> : null}
-                        {move?.options.length ? <button type="button" aria-expanded={choosingMove} className="min-h-8 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-semibold text-dpf-text" onClick={() => { setSelectedMoveTurnId(choosingMove ? null : turn.id); setSelectedMoveOption(null); }}>Move party</button> : null}
+                        {next ? <button type="button" className="dpf-tap-target flex-1 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-semibold text-dpf-text" disabled={pending} onClick={() => advanceTurn(turn, next)}>{next.label}</button> : null}
+                        {move?.options.length ? <button type="button" aria-expanded={choosingMove} className="dpf-tap-target rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-semibold text-dpf-text" disabled={pending} onClick={() => { setSelectedMoveTurnId(choosingMove ? null : turn.id); setSelectedMoveOption(null); }}>Move party</button> : null}
                       </div>
-                      {choosingMove && move ? <div className="mt-dpf-xs grid gap-1">{move.options.map((option) => <button key={option.resourceIds.join(",")} type="button" className="min-h-8 rounded-dpf-md bg-dpf-surface-2 px-dpf-xs text-left text-dpf-caption text-dpf-text" onClick={() => setSelectedMoveOption(option)}>Move to {option.label}</button>)}</div> : null}
+                      {choosingMove && move ? <div className="mt-dpf-xs grid gap-1">{move.options.map((option) => <button key={option.resourceIds.join(",")} type="button" aria-pressed={selectedMoveOption?.resourceIds.join(",") === option.resourceIds.join(",")} className="dpf-tap-target rounded-dpf-md bg-dpf-surface-2 px-dpf-xs text-left text-dpf-caption text-dpf-text aria-pressed:outline-2 aria-pressed:outline-dpf-accent" disabled={pending} onClick={() => setSelectedMoveOption(option)}>Move to {option.label}</button>)}</div> : null}
                     </li>
                   );
                 })}
@@ -575,7 +576,7 @@ export function RestaurantFloorOperations({
             <section aria-labelledby="move-preview-heading" className="rounded-dpf-lg border border-dpf-accent bg-dpf-surface-1 p-dpf-sm">
               <h3 id="move-preview-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">Confirm table move</h3>
               <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Move {selectedMoveTurn.party?.name ?? "this party"} to {selectedMoveOption.label}. The current table releases only after confirmation.</p>
-              <button type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-sm font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))]" disabled={pending} onClick={confirmMove}>{pending ? "Moving…" : "Confirm move"}</button>
+              <button aria-busy={pending} type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-sm font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))]" disabled={pending} onClick={confirmMove}>{pending ? <InlineBusy label="Moving…" tone="current" /> : "Confirm move"}</button>
             </section>
           ) : null}
 

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -1,35 +1,48 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useMemo, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 
-import {
-  DataTable,
-  type Column,
-} from "@/components/ui/report-kit/DataTable";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { DataTable, type Column } from "@/components/ui/report-kit/DataTable";
 import { Notice } from "@/components/ui/report-kit/Notice";
 import { StatusBadge } from "@/components/ui/report-kit/StatusBadge";
-import { resolveIntent } from "@/components/ui/report-kit/statusColors";
+import {
+  intentStyle,
+  resolveIntent,
+  type Intent,
+} from "@/components/ui/report-kit/statusColors";
 import { CartesianSceneCanvas } from "@/components/twin/cartesian/CartesianSceneCanvas";
-import type {
-  RestaurantFloorCommandDemand,
-  RestaurantFloorCommandOption,
-  RestaurantFloorOperationalView,
-} from "@/lib/twin/restaurant-floor-loader.server";
+import type { HospitalityServiceTurnStage } from "@/lib/storefront/hospitality-service-turn";
 import {
   advanceRestaurantServiceTurn,
   executeRestaurantFloorCommand,
   moveRestaurantParty,
 } from "@/lib/twin/restaurant-floor-actions";
-import type { HospitalityServiceTurnStage } from "@/lib/storefront/hospitality-service-turn";
-import type { RestaurantOperationalScene } from "@/lib/twin/restaurant-scene-layout";
+import type {
+  RestaurantFloorCommandDemand,
+  RestaurantFloorCommandOption,
+  RestaurantFloorOperationalView,
+} from "@/lib/twin/restaurant-floor-loader.server";
 import type { RestaurantFloorTable } from "@/lib/twin/restaurant-floor-projection";
+import {
+  deriveRestaurantHostPulse,
+  deriveRestaurantHostTurns,
+  deriveRestaurantServerLoad,
+  rankRestaurantDemand,
+} from "@/lib/twin/restaurant-host-console";
+import type { RestaurantOperationalScene } from "@/lib/twin/restaurant-scene-layout";
 import type { OperationalCommandResult } from "@/lib/twin/operations-command";
 
 export interface RestaurantFloorOperationsProps {
   view: RestaurantFloorOperationalView;
   scene: RestaurantOperationalScene | null;
+  /** Parent-owned cross-channel attention; rendered as an in-console overlay. */
+  serviceAttention?: ReactNode;
 }
+
+type QueueFilter = "all" | "walk-in" | "reservation";
+type CenterView = "floor" | "list";
 
 function commandFor(
   commands: readonly RestaurantFloorCommandDemand[],
@@ -38,12 +51,22 @@ function commandFor(
   return commands.find((command) => command.demandId === demandId) ?? null;
 }
 
+function recommendedOption(
+  view: RestaurantFloorOperationalView,
+  demandId: string | null,
+): RestaurantFloorCommandOption | null {
+  const demand = view.floor.demand.find((candidate) => candidate.id === demandId);
+  const command = commandFor(view.commands, demandId);
+  if (!command) return null;
+  return command.options.find((option) =>
+    demand?.recommendation?.tableIds.every((id) => option.resourceIds.includes(id))
+  ) ?? command.options[0] ?? null;
+}
+
 function resultNotice(result: OperationalCommandResult | null) {
   if (!result) return null;
   if (result.status === "confirmed") {
-    const stageChanged = result.changedFacts.some(
-      (fact) => fact.field === "stage",
-    );
+    const stageChanged = result.changedFacts.some((fact) => fact.field === "stage");
     const resourcesChanged = result.changedFacts.some(
       (fact) => fact.field === "resourceIds",
     );
@@ -53,42 +76,21 @@ function resultNotice(result: OperationalCommandResult | null) {
     return (
       <Notice
         variant="success"
-        title={
-          stageChanged
-            ? "Table status updated"
-            : partySeated
-              ? "Party seated"
-              : resourcesChanged
-              ? "Party moved"
-                : "Party seated"
-        }
+        title={stageChanged ? "Table status updated" : partySeated ? "Party seated" : resourcesChanged ? "Party moved" : "Party seated"}
       >
-        {stageChanged
-          ? "The service stage is confirmed and the live floor is refreshing."
-          : partySeated
-            ? "The table assignment is confirmed and the live floor is refreshing."
-            : resourcesChanged
-            ? "The new table assignment is confirmed and the live floor is refreshing."
-              : "The table assignment is confirmed and the live floor is refreshing."}
+        The change is confirmed and the live floor is refreshing.
       </Notice>
     );
   }
   if (result.status === "conflict") {
     return (
       <Notice variant="warn" title="Floor changed before confirmation">
-        <span>
-          Nothing changed.{" "}
-          {result.alternatives.length > 0
-            ? `Available alternatives: ${result.alternatives
-                .map((alternative) => alternative.label)
-                .join(", ")}.`
-            : "Review the refreshed table choices and confirm again."}
-        </span>
+        Nothing changed. Review the refreshed choices and confirm again.
       </Notice>
     );
   }
   return (
-    <Notice variant="warn" title="Assignment not made">
+    <Notice variant="warn" title="Change not made">
       {result.message}
     </Notice>
   );
@@ -111,61 +113,73 @@ function nextTurnAction(
   }
 }
 
+function pulseIntent(
+  value: number,
+  kind: "waiting" | "action" | "positive",
+): Intent {
+  if (kind === "positive") return value > 0 ? "success" : "neutral";
+  return value > 0 ? (kind === "action" ? "warning" : "info") : "neutral";
+}
+
 export function RestaurantFloorOperations({
   view,
   scene,
+  serviceAttention,
 }: RestaurantFloorOperationsProps) {
   const router = useRouter();
-  const [selectedDemandId, setSelectedDemandId] = useState<string | null>(null);
+  const rankedDemand = useMemo(() => rankRestaurantDemand(view.floor), [view.floor]);
+  const initialDemandId = rankedDemand[0]?.id ?? null;
+  const [selectedDemandId, setSelectedDemandId] = useState<string | null>(
+    initialDemandId,
+  );
   const [selectedOption, setSelectedOption] =
-    useState<RestaurantFloorCommandOption | null>(null);
+    useState<RestaurantFloorCommandOption | null>(() =>
+      recommendedOption(view, initialDemandId)
+    );
+  const [queueFilter, setQueueFilter] = useState<QueueFilter>("all");
+  const [centerView, setCenterView] = useState<CenterView>("floor");
   const [result, setResult] = useState<OperationalCommandResult | null>(null);
-  const [selectedMoveTurnId, setSelectedMoveTurnId] =
-    useState<string | null>(null);
+  const [selectedMoveTurnId, setSelectedMoveTurnId] = useState<string | null>(null);
   const [selectedMoveOption, setSelectedMoveOption] =
     useState<RestaurantFloorCommandOption | null>(null);
   const [pending, startTransition] = useTransition();
+
   const selectedDemand = view.floor.demand.find(
     (demand) => demand.id === selectedDemandId,
   ) ?? null;
   const availableCommand = commandFor(view.commands, selectedDemandId);
-  const selectedMoveCommand =
-    (view.moves ?? []).find(
-      (move) => move.serviceTurnId === selectedMoveTurnId,
-    ) ?? null;
-
-  const bindings = useMemo(
-    () =>
-      Object.fromEntries(
-        view.floor.tables.map((table) => [
-          `table:${table.id}`,
-          {
-            label: table.label,
-            statusLabel: table.statusLabel,
-            sublabel: [
-              `${table.capacity} seats`,
-              table.server?.name ?? "Server not assigned",
-              table.availability.minutes != null
-                ? `${table.availability.minutes} min`
-                : null,
-            ]
-              .filter((value): value is string => value !== null)
-              .join(" · "),
-            intent: resolveIntent("restaurantFloor", table.state),
-          },
-        ]),
-      ),
+  const selectedMoveCommand = (view.moves ?? []).find(
+    (move) => move.serviceTurnId === selectedMoveTurnId,
+  ) ?? null;
+  const pulse = useMemo(() => deriveRestaurantHostPulse(view.floor), [view.floor]);
+  const reservationWatch = view.reservationWatch ?? [];
+  const lateReservationCount = reservationWatch.filter(
+    (reservation) => reservation.state === "late",
+  ).length;
+  const actionsNow = pulse.needsAction + lateReservationCount;
+  const servers = useMemo(
+    () => deriveRestaurantServerLoad(view.floor.tables),
     [view.floor.tables],
+  );
+  const activeTurns = useMemo(
+    () => deriveRestaurantHostTurns(view.floor.tables),
+    [view.floor.tables],
+  );
+  const selectedMoveTurn = activeTurns.find(
+    (turn) => turn.id === selectedMoveTurnId,
+  ) ?? null;
+  const filteredDemand = rankedDemand.filter(
+    (demand) => queueFilter === "all" || demand.kind === queueFilter,
   );
 
   const chooseDemand = (demandId: string) => {
     setSelectedDemandId(demandId);
-    setSelectedOption(null);
+    setSelectedOption(recommendedOption(view, demandId));
     setResult(null);
   };
+
   const chooseTable = (resourceId: string) => {
-    if (!availableCommand) return;
-    const option = availableCommand.options.find((candidate) =>
+    const option = availableCommand?.options.find((candidate) =>
       candidate.resourceIds.includes(resourceId)
     );
     if (option) {
@@ -174,110 +188,91 @@ export function RestaurantFloorOperations({
     }
   };
 
-  const tableColumns = useMemo<Column<RestaurantFloorTable>[]>(
-    () => [
+  const bindings = useMemo(
+    () => Object.fromEntries(view.floor.tables.map((table) => [
+      `table:${table.id}`,
       {
-        key: "table",
-        header: "Table",
-        cell: (table) => (
-          <span>
-            <span className="block font-medium">{table.label}</span>
-            <span className="text-xs text-[var(--dpf-muted)]">
-              {table.capacity} seats · {table.serviceArea}
-            </span>
-          </span>
-        ),
-        sortAccessor: (table) => table.label,
+        label: table.label,
+        statusLabel: table.statusLabel,
+        sublabel: [
+          `${table.capacity} seats`,
+          table.server?.name ?? "No server",
+          table.availability.minutes != null
+            ? `${table.availability.minutes} min`
+            : null,
+        ].filter((value): value is string => value !== null).join(" · "),
+        intent: resolveIntent("restaurantFloor", table.state),
+        cogSuggested: selectedOption?.resourceIds.includes(table.id) ?? false,
       },
-      {
-        key: "state",
-        header: "State",
-        cell: (table) => (
-          <StatusBadge
-            intent={resolveIntent("restaurantFloor", table.state)}
-            label={table.statusLabel}
-            variant="soft"
-          />
-        ),
-        sortAccessor: (table) => table.statusLabel,
-      },
-      {
-        key: "server",
-        header: "Server",
-        cell: (table) => table.server?.name ?? "Not assigned",
-      },
-      {
-        key: "availability",
-        header: "Next availability",
-        cell: (table) => table.availability.reason,
-      },
-      {
-        key: "action",
-        header: "Assignment",
-        cell: (table) => {
-          const option = availableCommand?.options.find((candidate) =>
-            candidate.resourceIds.includes(table.id)
-          );
-          const selected = selectedOption?.resourceIds.includes(table.id);
-          return option ? (
-            <button
-              type="button"
-              aria-pressed={selected}
-              className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-sm font-medium hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={pending}
-              onClick={() => chooseTable(table.id)}
-            >
-              {selected ? "Selected" : "Choose"}
-            </button>
-          ) : (
-            <span className="text-xs text-[var(--dpf-muted)]">
-              {selectedDemand ? "Not compatible" : "Choose a party first"}
-            </span>
-          );
-        },
-      },
-    ],
-    [availableCommand, pending, selectedDemand, selectedOption],
+    ])),
+    [selectedOption, view.floor.tables],
   );
 
-  const servers = [
-    ...new Map(
-      view.floor.tables.flatMap((table) =>
-        table.server ? [[table.server.id, table.server] as const] : []
+  const tableColumns = useMemo<Column<RestaurantFloorTable>[]>(() => [
+    {
+      key: "table",
+      header: "Table",
+      cell: (table) => (
+        <span>
+          <span className="block font-dpf-medium">{table.label}</span>
+          <span className="text-dpf-caption text-dpf-muted">
+            {table.capacity} seats · {table.serviceArea}
+          </span>
+        </span>
       ),
-    ).values(),
-  ];
-  const activeTurns = [
-    ...new Map(
-      view.floor.tables.flatMap((table) =>
-        table.turn
-          ? [[
-              table.turn.id,
-              {
-                ...table.turn,
-                party: table.party,
-                tableLabels: view.floor.tables
-                  .filter(
-                    (candidate) => candidate.turn?.id === table.turn?.id,
-                  )
-                  .map((candidate) => candidate.label),
-              },
-            ] as const]
-          : []
+      sortAccessor: (table) => table.label,
+    },
+    {
+      key: "state",
+      header: "State",
+      cell: (table) => (
+        <StatusBadge
+          intent={resolveIntent("restaurantFloor", table.state)}
+          label={table.statusLabel}
+          variant="soft"
+        />
       ),
-    ).values(),
-  ];
-  const selectedMoveTurn =
-    activeTurns.find((turn) => turn.id === selectedMoveTurnId) ?? null;
+    },
+    {
+      key: "server",
+      header: "Server",
+      cell: (table) => table.server?.name ?? "Not assigned",
+    },
+    {
+      key: "availability",
+      header: "Ready",
+      cell: (table) => table.availability.reason,
+    },
+    {
+      key: "action",
+      header: "Seat here",
+      cell: (table) => {
+        const option = availableCommand?.options.find((candidate) =>
+          candidate.resourceIds.includes(table.id)
+        );
+        return option ? (
+          <button
+            type="button"
+            aria-pressed={selectedOption?.resourceIds.includes(table.id)}
+            className="dpf-tap-target rounded-dpf-md border border-dpf-border px-dpf-sm text-dpf-body font-dpf-medium hover:bg-dpf-surface-2"
+            disabled={pending}
+            onClick={() => chooseTable(table.id)}
+          >
+            {selectedOption?.resourceIds.includes(table.id) ? "Selected" : "Choose"}
+          </button>
+        ) : (
+          <span className="text-dpf-caption text-dpf-muted">Not compatible</span>
+        );
+      },
+    },
+  ], [availableCommand, pending, selectedOption]);
 
   const confirm = () => {
     if (!selectedDemand || !selectedOption) return;
-    const idempotencyKey =
-      `seat:${selectedDemand.id}:${Date.now()}:${crypto.randomUUID()}`;
     startTransition(async () => {
       const next = await executeRestaurantFloorCommand({
         kind: "assign",
-        idempotencyKey,
+        idempotencyKey: `seat:${selectedDemand.id}:${Date.now()}:${crypto.randomUUID()}`,
         expectedVersion: selectedOption.expectedVersion,
         interval: selectedOption.interval,
         entityRefs: {
@@ -298,11 +293,9 @@ export function RestaurantFloorOperations({
     turn: (typeof activeTurns)[number],
     next: { stage: HospitalityServiceTurnStage; label: string },
   ) => {
-    const idempotencyKey =
-      `turn:${turn.id}:${next.stage}:${turn.version}:${crypto.randomUUID()}`;
     startTransition(async () => {
       const nextResult = await advanceRestaurantServiceTurn({
-        idempotencyKey,
+        idempotencyKey: `turn:${turn.id}:${next.stage}:${turn.version}:${crypto.randomUUID()}`,
         serviceTurnId: turn.id,
         expectedVersion: turn.version,
         stage: next.stage,
@@ -314,11 +307,9 @@ export function RestaurantFloorOperations({
 
   const confirmMove = () => {
     if (!selectedMoveCommand || !selectedMoveOption) return;
-    const idempotencyKey =
-      `move:${selectedMoveCommand.serviceTurnId}:${selectedMoveCommand.expectedTurnVersion}:${crypto.randomUUID()}`;
     startTransition(async () => {
       const nextResult = await moveRestaurantParty({
-        idempotencyKey,
+        idempotencyKey: `move:${selectedMoveCommand.serviceTurnId}:${selectedMoveCommand.expectedTurnVersion}:${crypto.randomUUID()}`,
         serviceTurnId: selectedMoveCommand.serviceTurnId,
         expectedTurnVersion: selectedMoveCommand.expectedTurnVersion,
         expectedSeatingVersion: selectedMoveOption.expectedVersion,
@@ -336,298 +327,264 @@ export function RestaurantFloorOperations({
 
   return (
     <section
-      aria-labelledby="restaurant-floor-heading"
-      className="grid gap-4"
-      data-testid="restaurant-floor-operations"
+      aria-labelledby="restaurant-host-heading"
+      className="flex h-[clamp(38rem,calc(100dvh-8rem),64rem)] min-w-0 flex-col gap-dpf-sm overflow-hidden rounded-dpf-xl border border-dpf-border bg-dpf-bg p-dpf-sm shadow-dpf-sm"
+      data-testid="restaurant-host-command-center"
+      data-dpf-density="compact"
     >
-      <header className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h2 id="restaurant-floor-heading" className="text-lg font-semibold">
-            Floor right now
-          </h2>
-          <p className="text-sm text-[var(--dpf-muted)]">
-            Choose a waiting party, review compatible tables, then confirm.
-          </p>
+      <header className="grid shrink-0 gap-dpf-sm rounded-dpf-lg bg-dpf-surface-1 px-dpf-md py-dpf-sm lg:grid-cols-[minmax(15rem,1fr)_auto] lg:items-center">
+        <div className="min-w-0">
+          <div className="flex items-center gap-dpf-sm">
+            <span className="inline-flex size-8 items-center justify-center rounded-full bg-dpf-accent-soft text-dpf-accent" aria-hidden="true">✦</span>
+            <div>
+              <h2 id="restaurant-host-heading" className="text-dpf-title font-dpf-semibold text-dpf-text">Host stand</h2>
+              <p className="text-dpf-caption text-dpf-muted">
+                AI-ranked service decisions · updated <LocalTime value={view.floor.asOf} mode="time" />
+              </p>
+              {serviceAttention ? (
+                <details className="relative mt-1">
+                  <summary className="cursor-pointer text-dpf-caption font-dpf-semibold text-dpf-accent hover:underline">
+                    Orders, calls and messages
+                  </summary>
+                  <div className="absolute left-0 top-full z-30 mt-dpf-xs max-h-[min(32rem,70dvh)] w-[min(36rem,82vw)] overflow-y-auto rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 p-dpf-md shadow-dpf-lg">
+                    {serviceAttention}
+                  </div>
+                </details>
+              ) : null}
+            </div>
+          </div>
         </div>
-        <p className="text-xs text-[var(--dpf-muted)]">
-          Updated {new Date(view.floor.asOf).toLocaleTimeString()}
-        </p>
+        <dl className="grid grid-cols-4 gap-dpf-xs" aria-label="Restaurant pulse">
+          {[
+            ["Waiting", pulse.waiting, pulseIntent(pulse.waiting, "waiting")],
+            ["Open now", pulse.availableNow, pulseIntent(pulse.availableNow, "positive")],
+            ["Turning", pulse.turningSoon, "info"],
+            ["Act now", actionsNow, pulseIntent(actionsNow, "action")],
+          ].map(([label, value, intent]) => (
+            <div
+              key={label}
+              className="min-w-[5.25rem] rounded-dpf-md border bg-dpf-bg px-dpf-sm py-dpf-xs text-center"
+              data-intent={intent}
+              style={{
+                borderColor: intentStyle(intent as Intent).border,
+                backgroundColor: intentStyle(intent as Intent).softBg,
+              }}
+            >
+              <dt className="text-dpf-caption text-dpf-muted">{label}</dt>
+              <dd className="text-dpf-title font-dpf-semibold text-dpf-text">{value}</dd>
+            </div>
+          ))}
+        </dl>
       </header>
 
       {resultNotice(result)}
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
-        <div className="grid min-w-0 gap-4">
-          {scene ? (
-            <CartesianSceneCanvas
-              ariaLabel="Live restaurant floor"
-              scene={scene.layout}
-              bindings={bindings}
-              mode="operate"
-              onActivate={(_placementId, entityRef) => {
-                if (entityRef.kind === "table") chooseTable(entityRef.id);
-              }}
-              height={500}
-            />
-          ) : (
-            <Notice variant="warn" title="Floor drawing unavailable">
-              Use the equivalent table list below while the saved layout is
-              repaired.
-            </Notice>
-          )}
-
-          <div>
-            <h3 className="mb-2 text-sm font-semibold">
-              All tables
-            </h3>
-            <DataTable
-              columns={tableColumns}
-              rows={view.floor.tables}
-              getRowKey={(table) => table.id}
-              empty="No tables are configured."
-              dense
-            />
+      <div className="grid min-h-0 flex-1 gap-dpf-sm lg:grid-cols-[minmax(15rem,0.72fr)_minmax(28rem,1.65fr)_minmax(18rem,0.9fr)]">
+        <section aria-labelledby="waiting-now-heading" className="flex min-h-0 flex-col overflow-hidden rounded-dpf-lg border border-dpf-border bg-dpf-surface-1">
+          <div className="shrink-0 border-b border-dpf-border p-dpf-sm">
+            <div className="flex items-center justify-between gap-dpf-sm">
+              <h3 id="waiting-now-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">Waiting now</h3>
+              <span className="text-dpf-caption text-dpf-muted">Priority order</span>
+            </div>
+            <div className="mt-dpf-xs flex gap-1" aria-label="Filter waiting parties">
+              {(["all", "walk-in", "reservation"] as const).map((filter) => (
+                <button
+                  key={filter}
+                  type="button"
+                  aria-pressed={queueFilter === filter}
+                  className="min-h-8 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-medium text-dpf-text aria-pressed:bg-dpf-accent-soft aria-pressed:text-dpf-accent"
+                  onClick={() => setQueueFilter(filter)}
+                >
+                  {filter === "all" ? "All" : filter === "walk-in" ? "Walk-ins" : "Reservations"}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
-
-        <aside className="grid content-start gap-4">
-          {activeTurns.length > 0 ? (
-            <section
-              aria-labelledby="active-tables-heading"
-              className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
-            >
-              <h3 id="active-tables-heading" className="text-sm font-semibold">
-                Active tables
-              </h3>
-              <ul className="mt-2 grid gap-2">
-                {activeTurns.map((turn) => {
-                  const next = nextTurnAction(turn.stage);
-                  const move = (view.moves ?? []).find(
-                    (candidate) => candidate.serviceTurnId === turn.id,
-                  );
-                  const choosingMove = selectedMoveTurnId === turn.id;
-                  return (
-                    <li
-                      key={turn.id}
-                      className="rounded-md border border-[var(--dpf-border)] p-3"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <span>
-                          <span className="block font-medium">
-                            {turn.tableLabels.join(" + ")}
-                          </span>
-                          <span className="text-xs text-[var(--dpf-muted)]">
-                            {turn.party
-                              ? `${turn.party.name} · ${turn.party.covers} guests`
-                              : "Party details unavailable"}
-                          </span>
-                        </span>
-                        <StatusBadge
-                          intent={resolveIntent(
-                            "restaurantFloor",
-                            turn.stage,
-                          )}
-                          label={
-                            turn.stage === "dirty"
-                              ? "Needs clearing"
-                              : turn.stage.charAt(0).toUpperCase() +
-                                turn.stage.slice(1)
-                          }
-                          variant="soft"
-                        />
-                      </div>
-                      <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                        {next ? (
-                          <button
-                            type="button"
-                            className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-sm font-semibold hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-60"
-                            disabled={pending}
-                            onClick={() => advanceTurn(turn, next)}
-                          >
-                            {pending ? "Updating…" : next.label}
-                          </button>
-                        ) : null}
-                        {move && move.options.length > 0 ? (
-                          <button
-                            type="button"
-                            aria-expanded={choosingMove}
-                            className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-sm font-semibold hover:bg-[var(--dpf-surface-2)] disabled:cursor-not-allowed disabled:opacity-60"
-                            disabled={pending}
-                            onClick={() => {
-                              setSelectedMoveTurnId(
-                                choosingMove ? null : turn.id,
-                              );
-                              setSelectedMoveOption(null);
-                              setResult(null);
-                            }}
-                          >
-                            Move party
-                          </button>
-                        ) : null}
-                      </div>
-                      {choosingMove && move ? (
-                        <div className="mt-2 grid gap-2">
-                          <p className="text-xs text-[var(--dpf-muted)]">
-                            Choose a compatible destination:
-                          </p>
-                          {move.options.map((option) => (
-                            <button
-                              key={option.resourceIds.join(",")}
-                              type="button"
-                              className="min-h-11 rounded-md border border-[var(--dpf-border)] px-3 text-left text-sm hover:bg-[var(--dpf-surface-2)]"
-                              onClick={() => setSelectedMoveOption(option)}
-                            >
-                              Move to {option.label}
-                            </button>
-                          ))}
-                        </div>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
-          ) : null}
-
-          {selectedMoveCommand &&
-          selectedMoveTurn &&
-          selectedMoveOption ? (
-            <section
-              aria-labelledby="move-preview-heading"
-              className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-3"
-            >
-              <h3 id="move-preview-heading" className="text-sm font-semibold">
-                Confirm table move
-              </h3>
-              <p className="mt-2 text-sm">
-                Move {selectedMoveTurn.party?.name ?? "this party"} to{" "}
-                {selectedMoveOption.label}.
-              </p>
-              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-                Their current table will be released only after the new
-                assignment commits.
-              </p>
-              <button
-                type="button"
-                className="mt-3 min-h-11 w-full rounded-md bg-[var(--dpf-accent)] px-4 font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={pending}
-                onClick={confirmMove}
-              >
-                {pending ? "Moving…" : "Confirm move"}
-              </button>
-            </section>
-          ) : null}
-
-          <section
-            aria-labelledby="waiting-parties-heading"
-            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
-          >
-            <h3 id="waiting-parties-heading" className="text-sm font-semibold">
-              Waiting parties
-            </h3>
-            {view.floor.demand.length === 0 ? (
-              <p className="mt-2 text-sm text-[var(--dpf-muted)]">
-                No party is waiting.
-              </p>
+          <div className="min-h-0 flex-1 overflow-y-auto p-dpf-xs">
+            {filteredDemand.length === 0 ? (
+              <p className="p-dpf-sm text-dpf-body text-dpf-muted">No party is waiting.</p>
             ) : (
-              <ul className="mt-2 grid gap-2">
-                {view.floor.demand.map((demand) => (
+              <ol className="grid gap-1">
+                {filteredDemand.map((demand, index) => (
                   <li key={demand.id}>
                     <button
                       type="button"
                       aria-pressed={selectedDemandId === demand.id}
-                      className="flex min-h-12 w-full items-center justify-between gap-3 rounded-md border border-[var(--dpf-border)] px-3 py-2 text-left hover:bg-[var(--dpf-surface-2)]"
+                      className="grid min-h-14 w-full grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-dpf-xs rounded-dpf-md border border-transparent px-dpf-xs py-dpf-xs text-left text-dpf-text hover:bg-dpf-surface-2 aria-pressed:border-dpf-accent aria-pressed:bg-dpf-accent-soft"
                       onClick={() => chooseDemand(demand.id)}
                     >
-                      <span>
-                        <span className="block font-medium">{demand.name}</span>
-                        <span className="text-xs text-[var(--dpf-muted)]">
-                          {demand.covers} guests
-                          {demand.waitedMinutes != null
-                            ? ` · waiting ${demand.waitedMinutes} min`
-                            : ""}
-                          {demand.hasDietaryNote
-                            ? " · dietary note"
-                            : ""}
+                      <span className="text-center text-dpf-caption font-dpf-semibold text-dpf-muted">{index + 1}</span>
+                      <span className="min-w-0">
+                        <span className="block truncate text-dpf-body font-dpf-semibold">{demand.name}</span>
+                        <span className="block truncate text-dpf-caption text-dpf-muted">
+                          {demand.covers} guests · {demand.waitedMinutes != null ? `waiting ${demand.waitedMinutes} min` : demand.scheduledAt ? <>due <LocalTime value={demand.scheduledAt} mode="time" /></> : "reserved"}
+                          {demand.hasDietaryNote ? " · dietary note" : ""}
                         </span>
                       </span>
                       <StatusBadge
-                        intent={
-                          demand.waitedMinutes != null &&
-                            demand.waitedMinutes >= 15
-                            ? "warning"
-                            : "info"
-                        }
+                        intent={demand.waitedMinutes != null && demand.waitedMinutes >= 15 ? "warning" : "info"}
                         label={demand.kind === "walk-in" ? "Walk-in" : "Reserved"}
                         variant="soft"
                       />
                     </button>
                   </li>
                 ))}
-              </ul>
+              </ol>
+            )}
+          </div>
+        </section>
+
+        <section aria-label="Floor and tables" className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-dpf-lg border border-dpf-border bg-dpf-surface-1">
+          <div className="flex shrink-0 items-center justify-between gap-dpf-sm border-b border-dpf-border p-dpf-xs">
+            <div className="flex gap-1" aria-label="Floor view">
+              <button type="button" aria-pressed={centerView === "floor"} className="dpf-tap-target rounded-dpf-md px-dpf-sm text-dpf-body font-dpf-semibold text-dpf-text aria-pressed:bg-dpf-accent-soft aria-pressed:text-dpf-accent" onClick={() => setCenterView("floor")}>Floor</button>
+              <button type="button" aria-pressed={centerView === "list"} className="dpf-tap-target rounded-dpf-md px-dpf-sm text-dpf-body font-dpf-semibold text-dpf-text aria-pressed:bg-dpf-accent-soft aria-pressed:text-dpf-accent" onClick={() => setCenterView("list")}>Table list</button>
+            </div>
+            <p className="text-dpf-caption text-dpf-muted">Tap a table to change the suggestion</p>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-dpf-xs">
+            {centerView === "floor" ? scene ? (
+              <CartesianSceneCanvas
+                ariaLabel="Live restaurant floor"
+                scene={scene.layout}
+                bindings={bindings}
+                mode="operate"
+                chrome="embedded"
+                navigation="locked"
+                onActivate={(_placementId, entityRef) => {
+                  if (entityRef.kind === "table") chooseTable(entityRef.id);
+                }}
+                height={500}
+                className="h-full"
+              />
+            ) : (
+              <Notice variant="warn" title="Floor drawing unavailable">Use the equivalent table list while the saved layout is repaired.</Notice>
+            ) : (
+              <DataTable columns={tableColumns} rows={view.floor.tables} getRowKey={(table) => table.id} empty="No tables are configured." dense />
+            )}
+          </div>
+        </section>
+
+        <aside className="grid min-h-0 content-start gap-dpf-sm overflow-y-auto">
+          <section aria-labelledby="ai-host-heading" className="rounded-dpf-lg border border-dpf-accent bg-dpf-accent-soft p-dpf-sm">
+            <div className="flex items-center gap-dpf-xs">
+              <span aria-hidden="true">✦</span>
+              <h3 id="ai-host-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">AI host recommends</h3>
+            </div>
+            {selectedDemand?.recommendation && selectedOption ? (
+              <>
+                <p className="mt-dpf-sm text-dpf-body font-dpf-semibold text-dpf-text">{selectedDemand.recommendation.reason}</p>
+                {selectedDemand.recommendation.warning ? (
+                  <p className="mt-dpf-xs text-dpf-caption text-dpf-warning">Check: {selectedDemand.recommendation.warning}</p>
+                ) : (
+                  <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Best safe fit from live capacity, timing, and server load.</p>
+                )}
+                <p className="mt-dpf-sm text-dpf-body text-dpf-text">Seat {selectedDemand.name} ({selectedDemand.covers}) at {selectedOption.label}.</p>
+                <button type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-md font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:opacity-60" disabled={pending} onClick={confirm}>{pending ? "Confirming…" : "Confirm seating"}</button>
+              </>
+            ) : (
+              <p className="mt-dpf-sm text-dpf-body text-dpf-muted">Choose a party to see the safest live seating choice.</p>
             )}
           </section>
 
-          <section
-            aria-labelledby="server-load-heading"
-            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
-          >
-            <h3 id="server-load-heading" className="text-sm font-semibold">
-              Server load
-            </h3>
-            {servers.length === 0 ? (
-              <p className="mt-2 text-sm text-[var(--dpf-muted)]">
-                Server not assigned.
-              </p>
-            ) : (
-              <ul className="mt-2 grid gap-2">
-                {servers.map((server) => (
+          {reservationWatch.length > 0 ? (
+            <section
+              aria-labelledby="reservation-watch-heading"
+              className="rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 p-dpf-sm"
+            >
+              <div className="flex items-center justify-between gap-dpf-sm">
+                <h3
+                  id="reservation-watch-heading"
+                  className="text-dpf-body font-dpf-semibold text-dpf-text"
+                >
+                  Reservations to watch
+                </h3>
+                {lateReservationCount > 0 ? (
+                  <StatusBadge
+                    intent="warning"
+                    label={`${lateReservationCount} late`}
+                    variant="soft"
+                  />
+                ) : null}
+              </div>
+              <ul className="mt-dpf-xs grid gap-1">
+                {reservationWatch.map((reservation) => (
                   <li
-                    key={server.id}
-                    className="flex min-h-11 items-center justify-between rounded-md border border-[var(--dpf-border)] px-3"
+                    key={reservation.id}
+                    className="rounded-dpf-md border border-dpf-border px-dpf-xs py-1"
                   >
-                    <span>
-                      <span className="block font-medium">{server.name}</span>
-                      <span className="text-xs text-[var(--dpf-muted)]">
-                        {server.sectionLabel}
+                    <div className="flex items-center justify-between gap-dpf-xs">
+                      <span className="min-w-0">
+                        <span className="block truncate text-dpf-caption font-dpf-semibold text-dpf-text">
+                          {reservation.name} · {reservation.covers} guests
+                        </span>
+                        <span className="block truncate text-dpf-caption text-dpf-muted">
+                          <LocalTime value={reservation.scheduledAt} mode="time" />
+                          {reservation.tableLabels.length > 0
+                            ? ` · holding ${reservation.tableLabels.join(" + ")}`
+                            : " · table not held"}
+                        </span>
                       </span>
-                    </span>
-                    <span className="text-sm">{server.tableCount} tables</span>
+                      <StatusBadge
+                        intent={reservation.state === "late" ? "warning" : "info"}
+                        label={reservation.lateMinutes != null ? `${reservation.lateMinutes} min late` : "Upcoming"}
+                        variant="soft"
+                      />
+                    </div>
                   </li>
                 ))}
               </ul>
+              {lateReservationCount > 0 ? (
+                <p className="mt-dpf-xs text-dpf-caption text-dpf-warning">
+                  Confirm guest status before releasing held capacity.
+                </p>
+              ) : null}
+            </section>
+          ) : null}
+
+          <section aria-labelledby="turns-heading" className="rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 p-dpf-sm">
+            <div className="flex items-center justify-between gap-dpf-sm">
+              <h3 id="turns-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">Turns needing action</h3>
+              <span className="text-dpf-caption text-dpf-muted">{activeTurns.length} active</span>
+            </div>
+            {activeTurns.length === 0 ? <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">No active tables.</p> : (
+              <ul className="mt-dpf-xs grid gap-1">
+                {activeTurns.map((turn) => {
+                  const next = nextTurnAction(turn.stage);
+                  const move = (view.moves ?? []).find((candidate) => candidate.serviceTurnId === turn.id);
+                  const choosingMove = selectedMoveTurnId === turn.id;
+                  return (
+                    <li key={turn.id} className="rounded-dpf-md border border-dpf-border p-dpf-xs">
+                      <div className="flex items-center justify-between gap-dpf-xs">
+                        <span className="min-w-0"><span className="block truncate text-dpf-body font-dpf-semibold text-dpf-text">{turn.tableLabels.join(" + ")}</span><span className="block truncate text-dpf-caption text-dpf-muted">{turn.party?.name ?? "Party"} · {turn.party?.covers ?? "?"} guests</span></span>
+                        <StatusBadge intent={resolveIntent("restaurantFloor", turn.stage)} label={turn.stage === "dirty" ? "Needs clearing" : turn.stage} variant="soft" />
+                      </div>
+                      <div className="mt-dpf-xs flex gap-1">
+                        {next ? <button type="button" className="min-h-8 flex-1 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-semibold text-dpf-text" disabled={pending} onClick={() => advanceTurn(turn, next)}>{next.label}</button> : null}
+                        {move?.options.length ? <button type="button" aria-expanded={choosingMove} className="min-h-8 rounded-dpf-md border border-dpf-border px-dpf-xs text-dpf-caption font-dpf-semibold text-dpf-text" onClick={() => { setSelectedMoveTurnId(choosingMove ? null : turn.id); setSelectedMoveOption(null); }}>Move party</button> : null}
+                      </div>
+                      {choosingMove && move ? <div className="mt-dpf-xs grid gap-1">{move.options.map((option) => <button key={option.resourceIds.join(",")} type="button" className="min-h-8 rounded-dpf-md bg-dpf-surface-2 px-dpf-xs text-left text-dpf-caption text-dpf-text" onClick={() => setSelectedMoveOption(option)}>Move to {option.label}</button>)}</div> : null}
+                    </li>
+                  );
+                })}
+              </ul>
             )}
           </section>
 
-          {selectedDemand && selectedOption ? (
-            <section
-              aria-labelledby="assignment-preview-heading"
-              className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-3"
-            >
-              <h3
-                id="assignment-preview-heading"
-                className="text-sm font-semibold"
-              >
-                Confirm assignment
-              </h3>
-              <p className="mt-2 text-sm">
-                Seat {selectedDemand.name} ({selectedDemand.covers}) at{" "}
-                {selectedOption.label}.
-              </p>
-              <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-                This starts the table turn and removes the party from the
-                waiting queue.
-              </p>
-              <button
-                type="button"
-                className="mt-3 min-h-11 w-full rounded-md bg-[var(--dpf-accent)] px-4 font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={pending}
-                onClick={confirm}
-              >
-                {pending ? "Confirming…" : "Confirm seating"}
-              </button>
+          {selectedMoveCommand && selectedMoveTurn && selectedMoveOption ? (
+            <section aria-labelledby="move-preview-heading" className="rounded-dpf-lg border border-dpf-accent bg-dpf-surface-1 p-dpf-sm">
+              <h3 id="move-preview-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">Confirm table move</h3>
+              <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Move {selectedMoveTurn.party?.name ?? "this party"} to {selectedMoveOption.label}. The current table releases only after confirmation.</p>
+              <button type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-sm font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))]" disabled={pending} onClick={confirmMove}>{pending ? "Moving…" : "Confirm move"}</button>
             </section>
           ) : null}
+
+          <section aria-labelledby="server-load-heading" className="rounded-dpf-lg border border-dpf-border bg-dpf-surface-1 p-dpf-sm">
+            <h3 id="server-load-heading" className="text-dpf-body font-dpf-semibold text-dpf-text">Server load</h3>
+            {servers.length === 0 ? <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Server not assigned.</p> : (
+              <ul className="mt-dpf-xs grid gap-1">{servers.map((server) => <li key={server.id} className="flex items-center justify-between gap-dpf-sm rounded-dpf-md bg-dpf-surface-2 px-dpf-xs py-1"><span className="min-w-0"><span className="block truncate text-dpf-caption font-dpf-semibold text-dpf-text">{server.name}</span><span className="block truncate text-dpf-caption text-dpf-muted">{server.sectionLabel}</span></span><span className="text-dpf-caption font-dpf-semibold text-dpf-text">{server.tableCount} tables</span></li>)}</ul>
+            )}
+          </section>
         </aside>
       </div>
     </section>

--- a/apps/web/components/workspace-home/WorkspaceTwinHero.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinHero.tsx
@@ -47,6 +47,24 @@ export function WorkspaceTwinHero({
   const simple = density === "simple";
   const operatingQuestion = contribution?.primaryOperatingQuestion ?? null;
 
+  if (presentation.restaurantFloor) {
+    return (
+      <div className="flex flex-col gap-dpf-sm">
+        <h1 className="sr-only">{presentation.archetypeName} operations</h1>
+        <WorkspaceTwinPanel
+          presentation={presentation}
+          serviceAttention={cockpit}
+        />
+        <details className="rounded-dpf-lg border border-dpf-border bg-dpf-surface-1">
+          <summary className="dpf-tap-target cursor-pointer px-dpf-md py-dpf-sm text-dpf-body font-dpf-semibold text-dpf-text">
+            All workspace areas
+          </summary>
+          <div className="border-t border-dpf-border p-dpf-md">{platformBody}</div>
+        </details>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6">
       <section

--- a/apps/web/components/workspace-home/WorkspaceTwinPanel.test.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinPanel.test.tsx
@@ -62,11 +62,15 @@ describe("WorkspaceTwinPanel restaurant scene", () => {
     } as unknown as WorkspaceTwinPresentation;
 
     const html = renderToStaticMarkup(
-      <WorkspaceTwinPanel presentation={presentation} />,
+      <WorkspaceTwinPanel
+        presentation={presentation}
+        serviceAttention={<div>cross-channel service work</div>}
+      />,
     );
 
     expect(html).toContain("live restaurant host stand");
     expect(captured.restaurant?.view).toBe(presentation.restaurantFloor);
+    expect(captured.restaurant?.serviceAttention).toBeTruthy();
   });
 
   it("replaces the generic resource grid with the authored floor and live bindings", () => {

--- a/apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
@@ -13,19 +13,26 @@ import { RestaurantFloorOperations } from "@/components/twin/restaurant/Restaura
 import { RoomsOperations } from "@/components/twin/rooms";
 import type { WorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
 import type { CartesianScenePresentationMap } from "@/lib/twin/cartesian-scene";
+import type { ReactNode } from "react";
 
 export interface WorkspaceTwinPanelProps {
   presentation: WorkspaceTwinPresentation;
   className?: string;
+  serviceAttention?: ReactNode;
 }
 
-export function WorkspaceTwinPanel({ presentation, className = "" }: WorkspaceTwinPanelProps) {
+export function WorkspaceTwinPanel({
+  presentation,
+  className = "",
+  serviceAttention,
+}: WorkspaceTwinPanelProps) {
   if (presentation.restaurantFloor) {
     return (
       <div className={className}>
         <RestaurantFloorOperations
           view={presentation.restaurantFloor}
           scene={presentation.scene}
+          serviceAttention={serviceAttention}
         />
       </div>
     );

--- a/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
@@ -262,6 +262,51 @@ describe("restaurant floor operational loader", () => {
     ]);
   });
 
+  it("surfaces a late confirmed reservation and the capacity it still holds", async () => {
+    const db = database();
+    db.storefrontBooking.findMany.mockResolvedValue([
+      {
+        ...waitingBooking,
+        id: "booking-late",
+        bookingRef: "BOOK-LATE",
+        customerName: "Taylor Morgan",
+        demandKind: "reservation",
+        status: "confirmed",
+        scheduledAt: new Date("2026-07-31T18:04:00.000Z"),
+      },
+    ]);
+    db.hospitalityCapacityAllocation.findMany.mockResolvedValue([
+      {
+        id: "allocation-late",
+        resourceId: "table-2",
+        startsAt: new Date("2026-07-31T18:04:00.000Z"),
+        endsAt: new Date("2026-07-31T19:04:00.000Z"),
+        lifecycle: "reserved",
+        version: 1,
+        demandRef: "BOOK-LATE",
+        serviceTurn: null,
+      },
+    ]);
+
+    const view = await loadRestaurantFloorOperationalView(db, {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      now,
+    });
+
+    expect(view.reservationWatch).toEqual([
+      {
+        id: "booking-late",
+        name: "Taylor Morgan",
+        covers: 2,
+        scheduledAt: "2026-07-31T18:04:00.000Z",
+        lateMinutes: 10,
+        state: "late",
+        tableLabels: ["Table 2"],
+      },
+    ]);
+  });
+
   it("loads an allow-listed public snapshot by slug without exposing operator facts", async () => {
     const availability = await loadPublicRestaurantAvailabilityBySlug(
       database(),

--- a/apps/web/lib/twin/restaurant-floor-loader.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.ts
@@ -121,10 +121,21 @@ export interface RestaurantFloorMoveCommand {
   options: RestaurantFloorCommandOption[];
 }
 
+export interface RestaurantReservationWatch {
+  id: string;
+  name: string;
+  covers: number;
+  scheduledAt: string;
+  lateMinutes: number | null;
+  state: "upcoming" | "late";
+  tableLabels: string[];
+}
+
 export interface RestaurantFloorOperationalView {
   floor: RestaurantFloorProjection;
   commands: RestaurantFloorCommandDemand[];
   moves: RestaurantFloorMoveCommand[];
+  reservationWatch?: RestaurantReservationWatch[];
   telemetry: {
     durationMs: number;
     queryCount: number;
@@ -589,10 +600,48 @@ export async function loadRestaurantFloorOperationalView(
     }];
   });
 
+  const reservationWatch = bookings
+    .filter(
+      (booking) =>
+        booking.demandKind !== "walk-in" &&
+        ["confirmed", "scheduled"].includes(booking.status),
+    )
+    .map((booking): RestaurantReservationWatch => {
+      const minutesPast = Math.max(
+        0,
+        Math.round((now.getTime() - booking.scheduledAt.getTime()) / 60_000),
+      );
+      const tableLabels = allocations.flatMap((allocation) => {
+        if (
+          allocation.demandRef !== booking.bookingRef ||
+          !allocation.resourceId
+        ) {
+          return [];
+        }
+        const label = resourceById.get(allocation.resourceId)?.label;
+        return label ? [label] : [];
+      });
+      return {
+        id: booking.id,
+        name: booking.customerName,
+        covers: booking.covers ?? 0,
+        scheduledAt: booking.scheduledAt.toISOString(),
+        lateMinutes: minutesPast > 0 ? minutesPast : null,
+        state: minutesPast > 0 ? "late" : "upcoming",
+        tableLabels: [...new Set(tableLabels)],
+      };
+    })
+    .sort(
+      (left, right) =>
+        (right.lateMinutes ?? -1) - (left.lateMinutes ?? -1) ||
+        left.scheduledAt.localeCompare(right.scheduledAt),
+    );
+
   return attachExactPayloadBytes({
     floor,
     commands,
     moves,
+    reservationWatch,
     telemetry: {
       durationMs: Math.max(0, clock() - startedAt),
       queryCount,

--- a/apps/web/lib/twin/restaurant-host-console.test.ts
+++ b/apps/web/lib/twin/restaurant-host-console.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { RestaurantFloorProjection } from "./restaurant-floor-projection";
+import {
+  deriveRestaurantHostPulse,
+  rankRestaurantDemand,
+} from "./restaurant-host-console";
+
+const floor = {
+  asOf: "2026-08-01T18:20:00.000Z",
+  staffingAvailable: true,
+  tables: [
+    { state: "available", timing: null },
+    { state: "ordered", timing: { kind: "turning", minutes: 8 } },
+    { state: "dirty", timing: null },
+    { state: "late-turn", timing: { kind: "late", minutes: 12 } },
+  ],
+  demand: [
+    {
+      id: "walk-in",
+      kind: "walk-in",
+      name: "Walk-in party",
+      covers: 2,
+      waitedMinutes: 22,
+      scheduledAt: null,
+      hasDietaryNote: false,
+      vip: false,
+      compatibleTableIds: [],
+      recommendation: null,
+    },
+    {
+      id: "late-reservation",
+      kind: "reservation",
+      name: "Late reservation",
+      covers: 4,
+      waitedMinutes: null,
+      scheduledAt: "2026-08-01T17:55:00.000Z",
+      hasDietaryNote: false,
+      vip: false,
+      compatibleTableIds: [],
+      recommendation: null,
+    },
+  ],
+} as unknown as RestaurantFloorProjection;
+
+describe("restaurant host console selectors", () => {
+  it("puts an overdue reservation ahead of a long-waiting walk-in", () => {
+    expect(rankRestaurantDemand(floor).map((demand) => demand.id)).toEqual([
+      "late-reservation",
+      "walk-in",
+    ]);
+  });
+
+  it("summarizes the first-screen pressure signals", () => {
+    expect(deriveRestaurantHostPulse(floor)).toEqual({
+      waiting: 2,
+      availableNow: 1,
+      turningSoon: 1,
+      needsAction: 2,
+    });
+  });
+});

--- a/apps/web/lib/twin/restaurant-host-console.ts
+++ b/apps/web/lib/twin/restaurant-host-console.ts
@@ -1,0 +1,96 @@
+import type {
+  RestaurantFloorDemand,
+  RestaurantFloorProjection,
+  RestaurantFloorTable,
+} from "./restaurant-floor-projection";
+
+export interface RestaurantHostPulse {
+  waiting: number;
+  availableNow: number;
+  turningSoon: number;
+  needsAction: number;
+}
+
+export interface RestaurantHostTurn
+  extends NonNullable<RestaurantFloorTable["turn"]> {
+  party: RestaurantFloorTable["party"];
+  tableLabels: string[];
+}
+
+function urgencyScore(demand: RestaurantFloorDemand, asOf: string): number {
+  const waited = demand.waitedMinutes ?? 0;
+  const scheduled = demand.scheduledAt
+    ? Math.max(
+        0,
+        Math.round(
+          (Date.parse(asOf) - Date.parse(demand.scheduledAt)) / 60_000,
+        ),
+      )
+    : 0;
+  return waited + scheduled * 2 + (demand.vip ? 30 : 0) +
+    (demand.hasDietaryNote ? 1 : 0);
+}
+
+export function rankRestaurantDemand(
+  floor: RestaurantFloorProjection,
+): RestaurantFloorDemand[] {
+  return [...floor.demand].sort((left, right) => {
+    const urgency = urgencyScore(right, floor.asOf) -
+      urgencyScore(left, floor.asOf);
+    if (urgency !== 0) return urgency;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function deriveRestaurantHostPulse(
+  floor: RestaurantFloorProjection,
+): RestaurantHostPulse {
+  return {
+    waiting: floor.demand.length,
+    availableNow: floor.tables.filter((table) => table.state === "available")
+      .length,
+    turningSoon: floor.tables.filter(
+      (table) => table.timing?.kind === "turning",
+    ).length,
+    needsAction: floor.tables.filter((table) =>
+      table.state === "dirty" || table.state === "late-turn" ||
+      table.state === "blocked"
+    ).length,
+  };
+}
+
+export function deriveRestaurantHostTurns(
+  tables: readonly RestaurantFloorTable[],
+): RestaurantHostTurn[] {
+  return [
+    ...new Map(
+      tables.flatMap((table) =>
+        table.turn
+          ? [[
+              table.turn.id,
+              {
+                ...table.turn,
+                party: table.party,
+                tableLabels: tables
+                  .filter((candidate) => candidate.turn?.id === table.turn?.id)
+                  .map((candidate) => candidate.label),
+              },
+            ] as const]
+          : []
+      ),
+    ).values(),
+  ];
+}
+
+export function deriveRestaurantServerLoad(
+  tables: readonly RestaurantFloorTable[],
+): Array<NonNullable<RestaurantFloorTable["server"]>> {
+  return [
+    ...new Map(
+      tables.flatMap((table) =>
+        table.server ? [[table.server.id, table.server] as const] : []
+      ),
+    ).values(),
+  ].sort((left, right) => right.tableCount - left.tableCount ||
+    left.name.localeCompare(right.name));
+}

--- a/docs/superpowers/plans/2026-07-31-restaurant-business-grade-floor.md
+++ b/docs/superpowers/plans/2026-07-31-restaurant-business-grade-floor.md
@@ -12,6 +12,106 @@
 | Operational precedent | `restaurant-floor` (Toast and OpenTable, accessed 2026-07-28) |
 | Coverage receipt | `cms89c2jv031001qo7gezoyzm` (`atomic`) |
 
+## Pressure-mode refinement — 2026-08-01
+
+Operator review of the merged surface found that the architecture was sound but
+the first-viewport operating hierarchy was not: the generic attention stack
+buried the floor, the 500px canvas plus a second full table report forced page
+scrolling, and the operable canvas accepted navigation gestures before the host
+understood that tables were the action targets. This follow-on stays inside the
+same atomic `BI-287AA5F7` workflow and ships on
+`feat/restaurant-host-command-center`.
+
+### Research & Benchmarking
+
+- **Toast Tables** keeps waiting parties beside the live floor and lets the host
+  seat, notify, pre-assign, manage reservations, check server rotation/covers,
+  and act on table states from the host home. It also demonstrates a failure
+  mode DPF will not copy: long-press/drag and a navigable floor can compete with
+  the primary seat-party action under pressure.
+- **OpenTable** treats floor, waitlist, assignment recommendations, pacing, and
+  flexible inventory as the shift command surface. DPF adopts recommendation
+  with operator confirmation and explicit constraint explanation.
+- **SevenRooms** brings reservations, walk-ins, table availability, and guest
+  conversations into one host-stand surface. DPF adopts the one-place operating
+  boundary while retaining its own canonical hospitality, staffing, and
+  customer-privacy authorities.
+- **DPF distinction:** the AI coworker continuously ranks the next party/table
+  match and explains server-load or capacity warnings, but never seats, moves,
+  releases, or changes a turn without the host's explicit confirmation.
+
+Current primary sources (accessed 2026-08-01):
+
+- https://support.toasttab.com/en/article/Using-Toast-Tables-Waitlist?lang=en_US
+- https://www.opentable.com/restaurant-solutions/products/table-management/
+- https://sevenrooms.com/platform/table-management/
+
+### UX fit review — restaurant shift console
+
+- **Decision:** `fits-with-guardrails`.
+- **Owning area:** Workspace; `/workspace` remains the canonical live-operation
+  home and `/storefront/tables` remains configuration.
+- **Primary persona:** hostess or shift manager with a line at the door, phone
+  demand arriving, reservations due, and tables changing state concurrently.
+- **Navigation layer:** local view mode and contextual commands only; no new
+  route, global nav item, or second restaurant dashboard.
+- **First viewport:** compact shift pulse, ranked party queue, locked floor or
+  equivalent table list, AI recommendation/confirmation, turn exceptions, and
+  server load must fit inside the available host-stand viewport. Pane contents
+  may scroll independently; the operator must not page-scroll to find the
+  floor or the next seating action.
+- **Progressive disclosure:** floor and accessible table list occupy the same
+  center pane rather than stacking. Generic owner decisions and workspace-area
+  launchers remain reachable below the shift console through secondary
+  disclosures and do not precede the hostess task.
+- **Interaction:** operate mode locks pan/zoom/drag by default for this embedded
+  floor. Table activation remains a normal button action with text status and a
+  visible focus state. Layout navigation and geometry editing stay in
+  `/storefront/tables`.
+- **AI boundary:** the coworker selects the most urgent waiting party, proposes
+  the best compatible table, exposes timing/server warnings, and prepares the
+  preview. The primary action remains explicit `Confirm seating`; conflict
+  results preserve the queue and return alternatives.
+- **Source truth:** the existing restaurant operating projection and versioned
+  command adapters remain authoritative. No new dashboard DTO, reservation
+  table, status map, or AI-only state is introduced.
+- **Empty/failure behavior:** missing scene uses the operable table list in the
+  same center pane; missing staffing is stated; no compatible table becomes an
+  explicit coworker hold/watch recommendation rather than a disabled mystery.
+- **Evidence before merge:** first-viewport component assertions, locked-canvas
+  interaction tests, queue/recommendation/confirmation tests, table-list parity,
+  theme scan, measured UX-fit manifest, and served desktop/tablet/200% browser
+  exercises.
+- **Kernel choice:** `DI-8AC53E1793E6` compared compressing the old stack, an
+  in-place restaurant shift console, and a new dedicated host route. It chose
+  `restaurant-shift-console` with high confidence (composite `3.560`, margin
+  `2.303`, strong structured coverage, no commandment conflict). The main
+  positive pull was durable reuse of the existing Workspace/scene/command
+  contracts; the main rejected cost was the cognitive load of the existing
+  vertical stack and the duplicate-home blast radius of a new route.
+
+### Architecture review (advisory)
+
+- **Alignment:** aligned with guardrails. This is a presentation and interaction
+  refinement over the merged read model and commands, not a new operating
+  substrate.
+- **Important:** do not move generic owner attention into a restaurant-only
+  data model. The Workspace hero may change hierarchy for a physical-operation
+  archetype, but the existing attention projection stays canonical and remains
+  reachable through secondary disclosure.
+- **Important:** do not fork `CartesianSceneCanvas`. Add a reusable embedded,
+  navigation-locked presentation option so other pressure-mode physical twins
+  can make activation primary without inheriting accidental canvas movement.
+- **Important:** do not fabricate phone-order, no-show, or POS state that the
+  restaurant operating projection does not currently carry. Surface only
+  canonical demand, turn, table, staffing, and storefront attention facts; add
+  new commands only through their existing versioned authorities.
+- **Refactor allocation:** extract pure host-priority/summary selectors and the
+  reusable embedded-canvas contract, and remove the duplicate always-visible
+  table report from the restaurant component. These changes satisfy the
+  approximately 20% refactor allocation while reducing rather than growing the
+  visual dialect.
+
 > **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
 
 ## Outcome

--- a/docs/user-guide/storefront/team-and-fulfilment.md
+++ b/docs/user-guide/storefront/team-and-fulfilment.md
@@ -50,14 +50,34 @@ capacity:
 - **List** — the same live facts as a scannable alternative when the drawing is
   unavailable or a list is easier to operate.
 
-Use `/workspace` during service. The restaurant floor there joins the saved
-layout to waiting and reserved parties, active service turns, server sections,
-table availability, and workload. To seat a party:
+Use `/workspace` during service. A restaurant opens directly into the compact
+**Host stand** console, even when simple navigation is enabled. It keeps the
+ranked waiting queue, floor, live pulse, AI seating recommendation, active
+turns, reservations to watch, and server load in one bounded working area.
+Late reservations show the capacity they still hold so the host can confirm
+guest status before releasing it. Each pane scrolls
+independently when demand is high; the hostess does not have to scroll the page
+to find the floor.
 
-1. Choose a waiting party and review only compatible table choices.
-2. Check the table, timing, and server-load explanation.
-3. Preview and explicitly confirm the assignment.
-4. Advance the table through seated, ordered, paid, clearing, and cleared as
+The floor is locked against accidental pan and zoom during service, so tapping
+a table selects it instead of moving the drawing. Switch **Floor** to **Table
+list** in the same center pane when a list is faster or the drawing is
+unavailable. **Orders, calls and messages** opens the existing attention
+surface as an overlay inside the console, keeping takeout and customer contact
+in reach without displacing the floor. The rest of Operations remains in the
+disclosure directly below the host console.
+
+To seat a party:
+
+1. Start with the AI-ranked party selected at the top of **Waiting now**, or
+   choose another party.
+2. Review the coworker's recommended compatible table and its capacity,
+   timing, and server-load explanation.
+3. Tap a different table on the floor or in **Table list** when service judgment
+   calls for it.
+4. Explicitly choose **Confirm seating**. The coworker never seats a party
+   without host approval.
+5. Advance the table through seated, ordered, paid, clearing, and cleared as
    service progresses.
 
 To move an active party, choose **Move party**, select a compatible destination,

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -35,9 +35,15 @@ Full navigation exposes both when the signed-in role is permitted.
 Operations changes its primary visual model to match the business instead of
 forcing every physical resource into the same card grid.
 
-- Restaurants use a two-dimensional floor plan for table position, availability,
-  service state, and server load. An accessible list exposes the same facts
-  without relying on position or color alone.
+- Restaurants open into a compact **Host stand** that keeps the ranked waiting
+  queue, two-dimensional floor plan, server load, active turns, and reservations
+  to watch in one bounded working area. The floor shows table position,
+  availability, service state, and server load; **Table list** exposes the same
+  facts without relying on position or color alone.
+- The restaurant coworker recommends a compatible table and explains capacity,
+  timing, and server-load tradeoffs, but the host must choose **Confirm seating**
+  before anything changes. The embedded floor is locked against accidental pan
+  and zoom during service so selecting a table does not move the drawing.
 - Hotels and other room-based businesses use a **Room rack** first: rooms run
   down the page and dates run across it, so continuous availability, arrivals,
   departures, and assignment conflicts remain visible together.

--- a/docs/ux-fit/2026-08-01-restaurant-host-command-center.ux-fit.json
+++ b/docs/ux-fit/2026-08-01-restaurant-host-command-center.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "restaurant-shift-console",
+  "decisionInteractionId": "DI-8AC53E1793E6",
+  "scope": {
+    "files": [
+      "apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx",
+      "apps/web/components/workspace-home/WorkspaceTwinHero.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "restaurant-shift-console",
+      "compress-existing-stack",
+      "dedicated-host-route"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7669,7 +7669,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 150
+    "textMass": 218
   },
   "apps/web/components/twin/rooms/RoomsOperations.tsx": {
     "vocabulary": 0,
@@ -8061,7 +8061,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 5
+    "textMass": 8
   },
   "apps/web/components/workspace-home/WorkspaceTwinPanel.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

- add a one-screen restaurant Host stand that combines the seating queue, floor plan, table state, server load, reservation watch, and turn pacing
- add an explicit AI seating recommendation and confirmation flow while keeping the host in control
- lock embedded floor-plan navigation so table selection remains reliable without accidental pan or zoom
- route restaurant operators directly into the Host stand and document the spatial operating workflow

## Verification

- exact merged-code local CI passed for the published branch SHA, including typecheck, exhaustive Vitest, and the production Docker build
- authenticated UX verification passed at desktop and tablet widths, including dark mode and a bounded first viewport
- focused restaurant, workspace, loader, and Cartesian canvas coverage is included in the branch

## Documentation impact

- updated the restaurant business-grade floor plan and the storefront team-and-fulfilment user guide
- added the governed UX-fit manifest for the Host stand surface

## Backlog

- BI-287AA5F7
- WC-8550281A
