### PR TITLE
feat: calibrate semantic review enforcement

### DIFF
--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -136,6 +136,14 @@ if git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
   fi
 fi
 
+# Semantic-review freshness is a separate, cheap pre-publication control. It
+# performs no network/model call: it validates only the receipt sidecar minted
+# from review_semantic_change for this exact committed diff. Policy remains
+# shadow until measured external + Build Studio outcomes ratchet it to enforce.
+if [ -f "scripts/semantic-review-gate.mjs" ]; then
+  node scripts/semantic-review-gate.mjs validate || exit $?
+fi
+
 if [ ! -f "$state_file" ]; then
   echo "[pre-push-gate] No local-CI gate record exists for this worktree." >&2
   echo "[pre-push-gate] Run the sandbox gate first:  pnpm run pregate" >&2

--- a/apps/web/components/build/EvidenceSummary.tsx
+++ b/apps/web/components/build/EvidenceSummary.tsx
@@ -3,6 +3,7 @@
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import { safeRenderValue } from "@/lib/safe-render";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { semanticReviewDecisionPresentation } from "@/lib/change-review/review-decision-presentation";
 
 type Props = {
   build: FeatureBuildRow;
@@ -32,7 +33,7 @@ export function EvidenceSummary({ build, loading }: Props) {
     },
     {
       label: "Design Review",
-      status: build.designReview?.decision === "pass" ? "pass" : build.designReview ? "fail" : "missing",
+      status: build.designReview?.decision ?? "missing",
       detail: safeRenderValue(build.designReview?.summary) || "Not reviewed",
     },
     {
@@ -42,7 +43,7 @@ export function EvidenceSummary({ build, loading }: Props) {
     },
     {
       label: "Plan Review",
-      status: build.planReview?.decision === "pass" ? "pass" : build.planReview ? "fail" : "missing",
+      status: build.planReview?.decision ?? "missing",
       detail: safeRenderValue(build.planReview?.summary) || "Not reviewed",
     },
     {
@@ -89,6 +90,7 @@ export function EvidenceSummary({ build, loading }: Props) {
     pass: "var(--dpf-success)",
     complete: "var(--dpf-success)",
     fail: "var(--dpf-error)",
+    inconclusive: "var(--dpf-warning)",
     missing: "var(--dpf-muted)",
   };
 
@@ -103,7 +105,11 @@ export function EvidenceSummary({ build, loading }: Props) {
             title={item.status}
           />
           <span className="text-xs text-[var(--dpf-text)] flex-1">{item.label}</span>
-          <span className="text-[10px] text-[var(--dpf-muted)]">{item.detail}</span>
+          <span className="text-[10px] text-[var(--dpf-muted)]">
+            {item.status === "inconclusive"
+              ? `${semanticReviewDecisionPresentation("inconclusive").title}: ${item.detail}`
+              : item.detail}
+          </span>
         </div>
       ))}
 

--- a/apps/web/components/build/FeatureBriefPanel.tsx
+++ b/apps/web/components/build/FeatureBriefPanel.tsx
@@ -7,6 +7,8 @@ import { customerChangeSummaryText } from "@/lib/build/customer-change-summary";
 import type { AttachmentInfo } from "@/lib/agent-coworker-types";
 import { AgentAttachmentCard } from "@/components/agent/AgentAttachmentCard";
 import { DeliberationSummaryCard } from "@/components/deliberation/DeliberationSummaryCard";
+import { semanticReviewDecisionPresentation } from "@/lib/change-review/review-decision-presentation";
+import type { SemanticReviewDecision } from "@/lib/change-review/semantic-change-review";
 import { EvidenceSummary } from "./EvidenceSummary";
 import { safeRenderValue } from "@/lib/safe-render";
 import { Skeleton } from "@/components/ui/report-kit";
@@ -94,7 +96,10 @@ export function FeatureBriefPanel({ brief, phase, changeNarrative, attachments, 
 
   // Ideate / Plan phase — show design doc if available, otherwise the feature brief
   const designDoc = build?.designDoc as Record<string, unknown> | null | undefined;
-  const designReview = build?.designReview as { decision?: string; summary?: string; issues?: Array<{ severity: string; description: string }> } | null | undefined;
+  const designReview = build?.designReview as { decision?: SemanticReviewDecision; summary?: string; issues?: Array<{ severity: string; description: string }> } | null | undefined;
+  const designReviewPresentation = designReview?.decision
+    ? semanticReviewDecisionPresentation(designReview.decision)
+    : null;
 
   if (designDoc) {
     const issues = designReview?.issues ?? [];
@@ -120,7 +125,7 @@ export function FeatureBriefPanel({ brief, phase, changeNarrative, attachments, 
                 border: `1px solid ${designReview.decision === "pass" ? "var(--dpf-success)" : "var(--dpf-warning)"}`,
               }}
             >
-              Review: {designReview.decision === "pass" ? "Passed" : "Needs revision"}
+              {designReviewPresentation?.title}
             </span>
           )}
         </div>

--- a/apps/web/components/build/ReviewPanel.tsx
+++ b/apps/web/components/build/ReviewPanel.tsx
@@ -18,6 +18,9 @@ import { safeRenderValue } from "@/lib/safe-render";
 import { normalizeTaskResults, type NormalizedTaskResults } from "@/lib/build/task-results";
 import { normalizeVerificationOutput, type NormalizedVerificationOutput } from "@/lib/build/verification-output";
 import { DecompositionCoordinator } from "@/components/build/DecompositionCoordinator";
+import { Notice } from "@/components/ui/report-kit";
+import { semanticReviewDecisionPresentation } from "@/lib/change-review/review-decision-presentation";
+import type { SemanticReviewDecision } from "@/lib/change-review/semantic-change-review";
 
 type Props = {
   build: FeatureBuildRow;
@@ -213,7 +216,7 @@ function DesignDocSection({
   const [isFormatting, startFormatting] = useTransition();
 
   const reviewBadge = review
-    ? review.decision === "pass" ? "Approved" : "Failed"
+    ? semanticReviewDecisionPresentation(review.decision).title
     : doc ? "Not reviewed" : "Missing";
   const reviewColor = review?.decision === "pass"
     ? "var(--dpf-success)"
@@ -864,39 +867,26 @@ function ReviewBadgeBlock({
   summary,
   issues,
 }: {
-  decision: "pass" | "fail";
+  decision: SemanticReviewDecision;
   summary: string;
   issues: Array<{ severity: string; description: string }>;
 }) {
+  const presentation = semanticReviewDecisionPresentation(decision);
+
   return (
-    <div
-      className="mt-2 px-2 py-1.5 rounded border text-xs"
-      style={{
-        borderColor: decision === "pass"
-          ? "color-mix(in srgb, var(--dpf-success) 30%, var(--dpf-border))"
-          : "color-mix(in srgb, var(--dpf-error) 30%, var(--dpf-border))",
-        background: decision === "pass"
-          ? "color-mix(in srgb, var(--dpf-success) 5%, transparent)"
-          : "color-mix(in srgb, var(--dpf-error) 5%, transparent)",
-      }}
+    <Notice
+      className="mt-2 text-xs"
+      variant={presentation.variant}
+      title={`Review status: ${presentation.title}`}
     >
-      <div className="flex items-center gap-1.5">
-        <span
-          className="w-2 h-2 rounded-full"
-          style={{ background: decision === "pass" ? "var(--dpf-success)" : "var(--dpf-error)" }}
-        />
-        <span className="font-medium text-[var(--dpf-text)]">
-          Review: {decision === "pass" ? "Approved" : "Changes requested"}
-        </span>
-      </div>
       {summary && (
-        <p className="text-[10px] text-[var(--dpf-muted)] mt-1 leading-relaxed">{safeRenderValue(summary)}</p>
+        <p className="text-[10px] text-[var(--dpf-muted)] leading-relaxed">{safeRenderValue(summary)}</p>
       )}
       {Array.isArray(issues) && issues.length > 0 && (
         <div className="mt-1 text-[10px] text-[var(--dpf-muted)]">
           {issues.length} issue{issues.length !== 1 ? "s" : ""} noted
         </div>
       )}
-    </div>
+    </Notice>
   );
 }

--- a/apps/web/lib/change-review/build-studio-semantic-review.ts
+++ b/apps/web/lib/change-review/build-studio-semantic-review.ts
@@ -24,7 +24,7 @@ function isReceipt(value: unknown): value is SemanticReviewReceipt {
   return Boolean(
     value &&
     typeof value === "object" &&
-    (value as { schemaVersion?: unknown }).schemaVersion === "semantic-change-review-receipt.v1",
+    (value as { schemaVersion?: unknown }).schemaVersion === "semantic-change-review-receipt.v2",
   );
 }
 

--- a/apps/web/lib/change-review/review-decision-presentation.test.ts
+++ b/apps/web/lib/change-review/review-decision-presentation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { semanticReviewDecisionPresentation } from "./review-decision-presentation";
+
+describe("semantic review decision presentation", () => {
+  it.each([
+    ["pass", { title: "Review approved", variant: "success" }],
+    ["fail", { title: "Changes requested", variant: "error" }],
+    ["inconclusive", { title: "Review incomplete", variant: "warn" }],
+  ] as const)("maps %s without confusing review execution with semantic judgment", (decision, expected) => {
+    expect(semanticReviewDecisionPresentation(decision)).toEqual(expected);
+  });
+});

--- a/apps/web/lib/change-review/review-decision-presentation.ts
+++ b/apps/web/lib/change-review/review-decision-presentation.ts
@@ -1,0 +1,21 @@
+import type { SemanticReviewDecision } from "./semantic-change-review";
+
+export type SemanticReviewDecisionPresentation = {
+  title: string;
+  variant: "success" | "error" | "warn";
+};
+
+const DECISION_PRESENTATION: Record<
+  SemanticReviewDecision,
+  SemanticReviewDecisionPresentation
+> = {
+  pass: { title: "Review approved", variant: "success" },
+  fail: { title: "Changes requested", variant: "error" },
+  inconclusive: { title: "Review incomplete", variant: "warn" },
+};
+
+export function semanticReviewDecisionPresentation(
+  decision: SemanticReviewDecision,
+): SemanticReviewDecisionPresentation {
+  return DECISION_PRESENTATION[decision];
+}

--- a/apps/web/lib/change-review/routed-semantic-review.test.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.test.ts
@@ -24,7 +24,7 @@ describe("routed semantic review", () => {
     expect(result.decision).toBe("pass");
   });
 
-  it("fails closed when any required review branch does not complete", async () => {
+  it("classifies an incomplete required branch as infrastructure-inconclusive", async () => {
     vi.mocked(routeAndCall)
       .mockResolvedValueOnce({
         content: JSON.stringify({ decision: "pass", issues: [], summary: "Pass." }),
@@ -38,8 +38,8 @@ describe("routed semantic review", () => {
       surface: "build-studio",
     });
 
-    expect(result.decision).toBe("fail");
-    expect(result.parseError).toBe(true);
-    expect(result.issues).toContainEqual(expect.objectContaining({ severity: "critical" }));
+    expect(result.decision).toBe("inconclusive");
+    expect(result.inconclusiveReason).toContain("review-branch-capacity-or-transport-failure");
+    expect(result.issues).toEqual([]);
   });
 });

--- a/apps/web/lib/change-review/routed-semantic-review.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.ts
@@ -13,13 +13,19 @@ const SPECIALIST_SYSTEM_PROMPTS: Record<string, string> = {
 function mergeReviewResults(results: SemanticReviewResult[]): SemanticReviewResult {
   const issues = results.flatMap((result) => result.issues);
   const criticals = issues.filter((issue) => issue.severity === "critical").length;
+  const inconclusive = results.filter((result) => result.decision === "inconclusive");
   return {
-    decision: criticals > 0 ? "fail" : "pass",
+    decision: inconclusive.length > 0 ? "inconclusive" : criticals > 0 ? "fail" : "pass",
     issues,
-    summary: results.length === 1
+    summary: inconclusive.length > 0
+      ? `${inconclusive.length} required semantic review branch${inconclusive.length === 1 ? " was" : "es were"} infrastructure-inconclusive; retry without treating capacity as a semantic finding.`
+      : results.length === 1
       ? results[0]!.summary
       : `${results.length} independent review branches completed; ${criticals} blocking finding${criticals === 1 ? "" : "s"}.`,
     ...(results.some((result) => result.parseError) ? { parseError: true as const } : {}),
+    ...(inconclusive.length > 0
+      ? { inconclusiveReason: inconclusive.map((result) => result.inconclusiveReason ?? "review-branch-incomplete").join(",") }
+      : {}),
   };
 }
 
@@ -64,13 +70,10 @@ export async function dispatchRoutedSemanticReview(
   const rejected = settled.filter((branch) => branch.status === "rejected").length;
   if (rejected > 0) {
     completed.push({
-      decision: "fail",
-      issues: [{
-        severity: "critical",
-        description: `${rejected} required semantic review branch${rejected === 1 ? "" : "es"} did not complete`,
-      }],
-      summary: "Semantic review was incomplete — retry before publication.",
-      parseError: true,
+      decision: "inconclusive",
+      issues: [],
+      summary: `${rejected} required semantic review branch${rejected === 1 ? "" : "es"} did not complete.`,
+      inconclusiveReason: "review-branch-capacity-or-transport-failure",
     });
   }
   return mergeReviewResults(completed);

--- a/apps/web/lib/change-review/semantic-change-review-operation.test.ts
+++ b/apps/web/lib/change-review/semantic-change-review-operation.test.ts
@@ -160,4 +160,21 @@ describe("semantic change-review operation", () => {
     expect(out.mayPublish).toBe(true);
     expect(out.nextAction).toBe("shadow-observe");
   });
+
+  it("classifies exhausted review capacity as inconclusive instead of a semantic rejection", async () => {
+    const out = await runSemanticChangeReview(input(), {
+      dispatch: vi.fn().mockResolvedValue({
+        decision: "inconclusive",
+        issues: [],
+        summary: "Two required review branches did not complete.",
+        inconclusiveReason: "review-branch-capacity-exhausted",
+      }),
+    });
+
+    expect(out.receipt.result.decision).toBe("inconclusive");
+    expect(out.receipt.result.issues).toEqual([]);
+    expect(out.mayPublish).toBe(false);
+    expect(out.nextAction).toBe("retry-review");
+    expect(out.repairLimitReached).toBe(false);
+  });
 });

--- a/apps/web/lib/change-review/semantic-change-review-operation.ts
+++ b/apps/web/lib/change-review/semantic-change-review-operation.ts
@@ -62,7 +62,7 @@ export interface SemanticChangeReviewOperationResult {
   reusedFreshReceipt: boolean;
   repairLimitReached: boolean;
   mayPublish: boolean;
-  nextAction: "publish" | "repair" | "operator-review" | "shadow-observe";
+  nextAction: "publish" | "repair" | "retry-review" | "operator-review" | "shadow-observe";
 }
 
 const DOC_ONLY_PATH = /^(?:docs\/|[^/]+\.md$)|\.(?:md|mdx|txt)$/i;
@@ -126,10 +126,13 @@ function resultForReceipt(args: {
   mode: SemanticChangeReviewMode;
 }): SemanticChangeReviewOperationResult {
   const failed = args.receipt.result.decision === "fail";
+  const inconclusive = args.receipt.result.decision === "inconclusive";
   const repairLimitReached = failed && args.repairRound >= SEMANTIC_CHANGE_REVIEW_MAX_REPAIR_ROUNDS;
-  const mayPublish = args.mode === "shadow" || !failed;
-  const nextAction: SemanticChangeReviewOperationResult["nextAction"] = args.mode === "shadow" && failed
+  const mayPublish = args.mode === "shadow" || (!failed && !inconclusive);
+  const nextAction: SemanticChangeReviewOperationResult["nextAction"] = args.mode === "shadow" && (failed || inconclusive)
     ? "shadow-observe"
+    : inconclusive
+      ? "retry-review"
     : repairLimitReached
       ? "operator-review"
       : failed

--- a/apps/web/lib/change-review/semantic-change-review.test.ts
+++ b/apps/web/lib/change-review/semantic-change-review.test.ts
@@ -86,7 +86,9 @@ describe("surface-neutral review compatibility", () => {
   it("parses severity-driven results and fails closed on malformed output", () => {
     expect(parseSemanticReviewResponse('{"decision":"fail","issues":[{"severity":"important","description":"advisory"}],"summary":"ok"}').decision).toBe("pass");
     const malformed = parseSemanticReviewResponse("not json");
-    expect(malformed.decision).toBe("fail");
+    expect(malformed.decision).toBe("inconclusive");
+    expect(malformed.issues).toEqual([]);
+    expect(malformed.inconclusiveReason).toBe("unparseable-review-response");
     expect(malformed.parseError).toBe(true);
   });
 });

--- a/apps/web/lib/change-review/semantic-change-review.ts
+++ b/apps/web/lib/change-review/semantic-change-review.ts
@@ -7,12 +7,12 @@
  * streams without adding another finding or receipt table.
  */
 
-export const CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION = "semantic-change-review-receipt.v1";
-export const CHANGE_REVIEW_POLICY_VERSION = "semantic-change-review-policy.v1";
+export const CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION = "semantic-change-review-receipt.v2";
+export const CHANGE_REVIEW_POLICY_VERSION = "semantic-change-review-policy.v2";
 export const CHANGE_REVIEWER_VERSION = "change-reviewer.v1";
 
 export type SemanticReviewSeverity = "critical" | "important" | "minor";
-export type SemanticReviewDecision = "pass" | "fail";
+export type SemanticReviewDecision = "pass" | "fail" | "inconclusive";
 export type SemanticReviewRisk = "low" | "medium" | "high" | "critical";
 export type SemanticReviewDisposition = "reviewed" | "auto-pass";
 
@@ -28,6 +28,8 @@ export interface SemanticReviewResult {
   issues: SemanticReviewIssue[];
   summary: string;
   parseError?: true;
+  /** Infrastructure/protocol failure, deliberately separate from semantic findings. */
+  inconclusiveReason?: string;
 }
 
 export interface SemanticReviewIdentity {
@@ -50,6 +52,7 @@ export interface SemanticReviewReceipt extends Omit<SemanticReviewIdentity, "spe
 }
 
 export type SemanticReviewStaleReason =
+  | "schema-version-changed"
   | "capsule-changed"
   | "base-tree-changed"
   | "head-tree-changed"
@@ -102,6 +105,7 @@ export function assessSemanticReviewReceiptFreshness(
   current: SemanticReviewIdentity,
 ): { fresh: boolean; reasons: SemanticReviewStaleReason[] } {
   const reasons: SemanticReviewStaleReason[] = [];
+  if (receipt.schemaVersion !== CHANGE_REVIEW_RECEIPT_SCHEMA_VERSION) reasons.push("schema-version-changed");
   if (receipt.capsuleId !== current.capsuleId) reasons.push("capsule-changed");
   if (receipt.baseTreeHash !== current.baseTreeHash) reasons.push("base-tree-changed");
   if (receipt.headTreeHash !== current.headTreeHash) reasons.push("head-tree-changed");
@@ -209,10 +213,11 @@ export function parseSemanticReviewResponse(raw: string): SemanticReviewResult {
     };
   } catch {
     return {
-      decision: "fail",
-      issues: [{ severity: "critical", description: "Review agent returned unparseable response" }],
-      summary: "Review failed — could not parse agent response",
+      decision: "inconclusive",
+      issues: [],
+      summary: "Review was inconclusive — the reviewer response could not be parsed.",
       parseError: true,
+      inconclusiveReason: "unparseable-review-response",
     };
   }
 }

--- a/apps/web/lib/change-review/semantic-review-enforcement.test.ts
+++ b/apps/web/lib/change-review/semantic-review-enforcement.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateSemanticReviewOutcomes,
+  evaluateSemanticReviewPublicationControl,
+  projectSemanticReviewOutcome,
+  type SemanticReviewOutcome,
+} from "./semantic-review-enforcement";
+import {
+  CHANGE_REVIEW_POLICY_VERSION,
+  CHANGE_REVIEWER_VERSION,
+  createSemanticReviewReceipt,
+  type SemanticReviewIdentity,
+  type SemanticReviewReceipt,
+} from "./semantic-change-review";
+
+const now = new Date("2026-08-01T16:00:00.000Z");
+const identity: SemanticReviewIdentity = {
+  capsuleId: "WC-CALIBRATION",
+  baseTreeHash: "a".repeat(40),
+  headTreeHash: "b".repeat(40),
+  diffDigest: "c".repeat(64),
+  policyVersion: CHANGE_REVIEW_POLICY_VERSION,
+  reviewerVersion: CHANGE_REVIEWER_VERSION,
+  specialistIds: ["AGT-181"],
+};
+
+function receipt(overrides: Partial<SemanticReviewReceipt> = {}): SemanticReviewReceipt {
+  return {
+    ...createSemanticReviewReceipt({
+      identity,
+      disposition: "reviewed",
+      risk: "high",
+      result: { decision: "pass", issues: [], summary: "No blocking findings." },
+    }),
+    ...overrides,
+  };
+}
+
+describe("deterministic semantic-review publication control", () => {
+  it("observes a missing receipt in shadow mode and blocks it in enforce mode", () => {
+    expect(evaluateSemanticReviewPublicationControl({ mode: "shadow", identity, receipt: null, now }))
+      .toMatchObject({ disposition: "shadow-observe", reason: "missing-receipt", mayPublish: true });
+    expect(evaluateSemanticReviewPublicationControl({ mode: "enforce", identity, receipt: null, now }))
+      .toMatchObject({ disposition: "block", reason: "missing-receipt", mayPublish: false });
+  });
+
+  it("blocks a stale receipt and allows a fresh completed pass", () => {
+    expect(evaluateSemanticReviewPublicationControl({
+      mode: "enforce",
+      identity,
+      receipt: receipt({ headTreeHash: "d".repeat(40) }),
+      now,
+    })).toMatchObject({ disposition: "block", reason: "stale-receipt", mayPublish: false });
+
+    expect(evaluateSemanticReviewPublicationControl({ mode: "enforce", identity, receipt: receipt(), now }))
+      .toMatchObject({ disposition: "allow", reason: "fresh-receipt", mayPublish: true });
+  });
+
+  it("distinguishes an infrastructure-inconclusive receipt from a semantic failure", () => {
+    const inconclusive = receipt({
+      result: {
+        decision: "inconclusive",
+        issues: [],
+        summary: "Review capacity was unavailable.",
+        inconclusiveReason: "review-branch-capacity-exhausted",
+      },
+    });
+    expect(evaluateSemanticReviewPublicationControl({ mode: "enforce", identity, receipt: inconclusive, now }))
+      .toMatchObject({ disposition: "block", reason: "infrastructure-inconclusive", mayPublish: false });
+  });
+
+  it("allows only a current, expiry-bound, evidenced policy exemption", () => {
+    const exemption = {
+      schemaVersion: "semantic-change-review-exemption.v1" as const,
+      policyVersion: CHANGE_REVIEW_POLICY_VERSION,
+      capsuleId: identity.capsuleId,
+      diffDigest: identity.diffDigest,
+      evidenceId: "cms-evidence-1",
+      reason: "Generated release metadata only; reviewed policy exemption.",
+      expiresAt: "2026-08-01T17:00:00.000Z",
+    };
+    expect(evaluateSemanticReviewPublicationControl({ mode: "enforce", identity, receipt: null, exemption, now }))
+      .toMatchObject({ disposition: "allow", reason: "policy-exemption", mayPublish: true });
+
+    expect(evaluateSemanticReviewPublicationControl({
+      mode: "enforce",
+      identity,
+      receipt: null,
+      exemption: { ...exemption, expiresAt: "2026-08-01T15:00:00.000Z" },
+      now,
+    })).toMatchObject({ disposition: "block", reason: "invalid-exemption", mayPublish: false });
+  });
+});
+
+describe("semantic-review outcome telemetry", () => {
+  const completed = (overrides: Partial<SemanticReviewOutcome> = {}): SemanticReviewOutcome => ({
+    schemaVersion: "semantic-change-review-outcome.v1",
+    receiptId: "receipt-1",
+    capsuleId: "WC-EXTERNAL",
+    surface: "external",
+    reviewDisposition: "reviewed",
+    reviewDecision: "pass",
+    correlationStatus: "completed",
+    acceptedFindingCount: 1,
+    falsePositiveFindingCount: 0,
+    uniqueLocalFindingCount: 1,
+    postPublicationMissCount: 0,
+    correctivePushCount: 1,
+    timeToFirstSignalMs: 1_200,
+    costUsd: 0.04,
+    github: { pullRequestNumber: 4000, ciPassed: true, merged: true },
+    recordedAt: "2026-08-01T16:00:00.000Z",
+    ...overrides,
+  });
+
+  it("excludes infrastructure-inconclusive samples from precision and unique-yield denominators", () => {
+    const metrics = aggregateSemanticReviewOutcomes([
+      completed(),
+      completed({
+        receiptId: "receipt-2",
+        capsuleId: "WC-STUDIO",
+        surface: "build-studio",
+        reviewDecision: "inconclusive",
+        correlationStatus: "infrastructure-inconclusive",
+        acceptedFindingCount: 0,
+        uniqueLocalFindingCount: 0,
+        correctivePushCount: 0,
+        timeToFirstSignalMs: null,
+        costUsd: null,
+      }),
+    ]);
+
+    expect(metrics).toMatchObject({
+      totalSamples: 2,
+      completedSamples: 1,
+      infrastructureInconclusiveSamples: 1,
+      precision: 1,
+      uniqueYieldPerCompletedSample: 1,
+      postPublicationMissRate: 0,
+    });
+  });
+
+  it("projects outcome correlation into the existing evidence and activity streams", () => {
+    const projection = projectSemanticReviewOutcome(completed());
+    expect(projection.externalEvidence.operationType).toBe("semantic-change-review.outcome");
+    expect(projection.externalEvidence.target).toBe("receipt-1");
+    expect(projection.activity.kind).toBe("evidence-recorded");
+    expect(projection.externalEvidence.details).toEqual(projection.activity.payload);
+  });
+});

--- a/apps/web/lib/change-review/semantic-review-enforcement.ts
+++ b/apps/web/lib/change-review/semantic-review-enforcement.ts
@@ -1,0 +1,161 @@
+import {
+  CHANGE_REVIEW_POLICY_VERSION,
+  assessSemanticReviewReceiptFreshness,
+  type SemanticReviewDecision,
+  type SemanticReviewDisposition,
+  type SemanticReviewIdentity,
+  type SemanticReviewReceipt,
+} from "./semantic-change-review";
+import type { SemanticChangeReviewMode, SemanticChangeReviewSurface } from "./semantic-change-review-operation";
+
+export const SEMANTIC_REVIEW_EXEMPTION_SCHEMA_VERSION = "semantic-change-review-exemption.v1";
+export const SEMANTIC_REVIEW_OUTCOME_SCHEMA_VERSION = "semantic-change-review-outcome.v1";
+
+export interface SemanticReviewPolicyExemption {
+  schemaVersion: typeof SEMANTIC_REVIEW_EXEMPTION_SCHEMA_VERSION;
+  policyVersion: string;
+  capsuleId: string;
+  diffDigest: string;
+  evidenceId: string;
+  reason: string;
+  expiresAt: string;
+}
+
+export interface SemanticReviewPublicationControl {
+  disposition: "allow" | "block" | "shadow-observe";
+  reason:
+    | "fresh-receipt"
+    | "missing-receipt"
+    | "stale-receipt"
+    | "semantic-failure"
+    | "infrastructure-inconclusive"
+    | "policy-exemption"
+    | "invalid-exemption";
+  mayPublish: boolean;
+  staleReasons: string[];
+}
+
+function exemptionIsValid(
+  exemption: SemanticReviewPolicyExemption,
+  identity: SemanticReviewIdentity,
+  now: Date,
+): boolean {
+  return exemption.schemaVersion === SEMANTIC_REVIEW_EXEMPTION_SCHEMA_VERSION &&
+    exemption.policyVersion === CHANGE_REVIEW_POLICY_VERSION &&
+    exemption.policyVersion === identity.policyVersion &&
+    exemption.capsuleId === identity.capsuleId &&
+    exemption.diffDigest === identity.diffDigest &&
+    exemption.evidenceId.trim().length > 0 &&
+    exemption.reason.trim().length > 0 &&
+    Number.isFinite(Date.parse(exemption.expiresAt)) &&
+    Date.parse(exemption.expiresAt) > now.getTime();
+}
+
+/** Pure, no-I/O publication control. Safe for hooks and pregate preflight. */
+export function evaluateSemanticReviewPublicationControl(input: {
+  mode: SemanticChangeReviewMode;
+  identity: SemanticReviewIdentity;
+  receipt: SemanticReviewReceipt | null;
+  exemption?: SemanticReviewPolicyExemption | null;
+  now?: Date;
+}): SemanticReviewPublicationControl {
+  const now = input.now ?? new Date();
+  if (!input.receipt) {
+    if (input.exemption) {
+      const valid = exemptionIsValid(input.exemption, input.identity, now);
+      if (valid) return { disposition: "allow", reason: "policy-exemption", mayPublish: true, staleReasons: [] };
+      if (input.mode === "shadow") {
+        return { disposition: "shadow-observe", reason: "invalid-exemption", mayPublish: true, staleReasons: [] };
+      }
+      return { disposition: "block", reason: "invalid-exemption", mayPublish: false, staleReasons: [] };
+    }
+    return input.mode === "shadow"
+      ? { disposition: "shadow-observe", reason: "missing-receipt", mayPublish: true, staleReasons: [] }
+      : { disposition: "block", reason: "missing-receipt", mayPublish: false, staleReasons: [] };
+  }
+
+  const freshness = assessSemanticReviewReceiptFreshness(input.receipt, input.identity);
+  if (!freshness.fresh) {
+    return input.mode === "shadow"
+      ? { disposition: "shadow-observe", reason: "stale-receipt", mayPublish: true, staleReasons: freshness.reasons }
+      : { disposition: "block", reason: "stale-receipt", mayPublish: false, staleReasons: freshness.reasons };
+  }
+  if (input.receipt.result.decision === "inconclusive") {
+    return input.mode === "shadow"
+      ? { disposition: "shadow-observe", reason: "infrastructure-inconclusive", mayPublish: true, staleReasons: [] }
+      : { disposition: "block", reason: "infrastructure-inconclusive", mayPublish: false, staleReasons: [] };
+  }
+  if (input.receipt.result.decision === "fail") {
+    return input.mode === "shadow"
+      ? { disposition: "shadow-observe", reason: "semantic-failure", mayPublish: true, staleReasons: [] }
+      : { disposition: "block", reason: "semantic-failure", mayPublish: false, staleReasons: [] };
+  }
+  return { disposition: "allow", reason: "fresh-receipt", mayPublish: true, staleReasons: [] };
+}
+
+export interface SemanticReviewOutcome {
+  schemaVersion: typeof SEMANTIC_REVIEW_OUTCOME_SCHEMA_VERSION;
+  receiptId: string;
+  capsuleId: string;
+  surface: SemanticChangeReviewSurface;
+  reviewDisposition: SemanticReviewDisposition;
+  reviewDecision: SemanticReviewDecision;
+  correlationStatus: "completed" | "infrastructure-inconclusive";
+  acceptedFindingCount: number;
+  falsePositiveFindingCount: number;
+  uniqueLocalFindingCount: number;
+  postPublicationMissCount: number;
+  correctivePushCount: number;
+  timeToFirstSignalMs: number | null;
+  costUsd: number | null;
+  github: { pullRequestNumber: number; ciPassed: boolean; merged: boolean };
+  recordedAt: string;
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator > 0 ? numerator / denominator : null;
+}
+
+export function aggregateSemanticReviewOutcomes(outcomes: readonly SemanticReviewOutcome[]) {
+  const completed = outcomes.filter((outcome) => outcome.correlationStatus === "completed");
+  const accepted = completed.reduce((sum, outcome) => sum + outcome.acceptedFindingCount, 0);
+  const falsePositives = completed.reduce((sum, outcome) => sum + outcome.falsePositiveFindingCount, 0);
+  const unique = completed.reduce((sum, outcome) => sum + outcome.uniqueLocalFindingCount, 0);
+  const misses = completed.reduce((sum, outcome) => sum + outcome.postPublicationMissCount, 0);
+  return {
+    totalSamples: outcomes.length,
+    completedSamples: completed.length,
+    infrastructureInconclusiveSamples: outcomes.length - completed.length,
+    externalCompletedSamples: completed.filter((outcome) => outcome.surface === "external").length,
+    buildStudioCompletedSamples: completed.filter((outcome) => outcome.surface === "build-studio").length,
+    acceptedFindingCount: accepted,
+    falsePositiveFindingCount: falsePositives,
+    postPublicationMissCount: misses,
+    correctivePushCount: completed.reduce((sum, outcome) => sum + outcome.correctivePushCount, 0),
+    precision: ratio(accepted, accepted + falsePositives),
+    uniqueYieldPerCompletedSample: ratio(unique, completed.length),
+    postPublicationMissRate: ratio(misses, completed.length),
+    averageTimeToFirstSignalMs: ratio(
+      completed.reduce((sum, outcome) => sum + (outcome.timeToFirstSignalMs ?? 0), 0),
+      completed.filter((outcome) => outcome.timeToFirstSignalMs !== null).length,
+    ),
+    totalCostUsd: completed.reduce((sum, outcome) => sum + (outcome.costUsd ?? 0), 0),
+  };
+}
+
+export function projectSemanticReviewOutcome(outcome: SemanticReviewOutcome) {
+  const summary = outcome.correlationStatus === "completed"
+    ? `Semantic review outcome correlated with PR #${outcome.github.pullRequestNumber}.`
+    : `Semantic review outcome excluded from calibration: infrastructure-inconclusive.`;
+  return {
+    externalEvidence: {
+      routeContext: "change-review" as const,
+      operationType: "semantic-change-review.outcome" as const,
+      target: outcome.receiptId,
+      provider: "dpf-change-review" as const,
+      resultSummary: summary,
+      details: outcome,
+    },
+    activity: { kind: "evidence-recorded" as const, summary, payload: outcome },
+  };
+}

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -4,7 +4,7 @@
 import * as crypto from "crypto";
 import type { BuildExecutionState } from "@/lib/build-exec-types";
 import type { DecisionInteractionGateView } from "@/lib/decision-perspective/types";
-import type { SemanticReviewResult } from "@/lib/change-review/semantic-change-review";
+import type { SemanticReviewDecision, SemanticReviewResult } from "@/lib/change-review/semantic-change-review";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -207,7 +207,7 @@ export type ReviewerVerdict = {
   label: string;
   /** "reviewer" verdicts gate via mergeReviews; "architect" is advisory only. */
   role: "reviewer" | "architect";
-  decision: "pass" | "fail";
+  decision: SemanticReviewDecision;
   /** Issue counts by severity — enough to render a chip without the full list. */
   issueCounts: { critical: number; important: number; minor: number };
   /** True when this reviewer's output failed to parse (absent, not dissenting). */

--- a/apps/web/lib/integrate/build-disciplines-integration.test.ts
+++ b/apps/web/lib/integrate/build-disciplines-integration.test.ts
@@ -216,8 +216,12 @@ describe("Build Disciplines — Full Flow Integration", () => {
     it("gracefully handles LLM hallucination (non-JSON response)", () => {
       const raw = "I think this design looks great! The problem statement is clear and the approach is solid. I would recommend proceeding.";
       const result = parseReviewResponse(raw);
-      expect(result.decision).toBe("fail");
-      expect(result.issues[0].description).toContain("unparseable");
+      expect(result).toMatchObject({
+        decision: "inconclusive",
+        issues: [],
+        parseError: true,
+        inconclusiveReason: "unparseable-review-response",
+      });
     });
   });
 

--- a/apps/web/lib/integrate/build-reviewers-inconclusive.test.ts
+++ b/apps/web/lib/integrate/build-reviewers-inconclusive.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReviewResult } from "@/lib/feature-build-types";
+import {
+  buildReviewBranchArtifacts,
+  collectReviewerVerdicts,
+  type ReviewBranchInput,
+} from "./build-reviewers";
+
+const inconclusiveReview: ReviewResult = {
+  decision: "inconclusive",
+  issues: [],
+  summary: "Reviewer capacity was unavailable.",
+  inconclusiveReason: "capacity-exhausted",
+};
+
+describe("infrastructure-inconclusive reviewer results", () => {
+  it("keeps an inconclusive branch out of semantic consensus", () => {
+    const inputs: ReviewBranchInput[] = [
+      {
+        branchNodeId: "reviewer-1",
+        role: "reviewer",
+        review: inconclusiveReview,
+      },
+    ];
+
+    const artifact = buildReviewBranchArtifacts(inputs)[0];
+    expect(artifact).toMatchObject({
+      completed: false,
+      failureReason: "inconclusive: capacity-exhausted",
+    });
+    expect(artifact).not.toHaveProperty("recommendation");
+  });
+
+  it("preserves inconclusive as a third reviewer-verdict state", () => {
+    expect(collectReviewerVerdicts(inconclusiveReview, null, null)[0]).toMatchObject({
+      source: "reviewer-1",
+      decision: "inconclusive",
+      issueCounts: { critical: 0, important: 0, minor: 0 },
+    });
+  });
+});

--- a/apps/web/lib/integrate/build-reviewers.test.ts
+++ b/apps/web/lib/integrate/build-reviewers.test.ts
@@ -385,11 +385,11 @@ describe("parseReviewResponse", () => {
     expect(result.decision).toBe("pass");
   });
 
-  it("returns fail with parseError:true for unparseable response", () => {
+  it("returns inconclusive with parseError:true for unparseable response", () => {
     const result = parseReviewResponse("This is not JSON");
-    expect(result.decision).toBe("fail");
-    expect(result.issues[0].severity).toBe("critical");
-    expect(result.parseError).toBe(true);
+    expect(result.decision).toBe("inconclusive");
+    expect(result.issues).toEqual([]);
+    expect(result).toMatchObject({ parseError: true, inconclusiveReason: "unparseable-review-response" });
   });
 
   it("does not set parseError on a successfully parsed response", () => {

--- a/apps/web/lib/integrate/build-reviewers.ts
+++ b/apps/web/lib/integrate/build-reviewers.ts
@@ -600,19 +600,20 @@ export function buildReviewBranchArtifacts(
     // Treat both null reviews and parse-error results as absent reviewers.
     // A parse-error branch is not a dissenting vote — it is infra noise and
     // must not contribute a "fail" recommendation to consensusState detection.
-    if (!input.review || input.review.parseError) {
+    if (!input.review || input.review.parseError || input.review.decision === "inconclusive") {
       return {
         branchNodeId: input.branchNodeId,
         role: input.role,
         completed: false,
         failureReason: input.review?.parseError
           ? "parse-error: reviewer returned unparseable output"
+          : input.review?.decision === "inconclusive"
+          ? `inconclusive: ${input.review.inconclusiveReason ?? "review did not complete"}`
           : (input.failureReason ?? "Reviewer did not produce a parsed response."),
       };
     }
     const { assertions, objections } = extractClaimsFromReview(input.review);
-    const recommendation =
-      input.review.decision === "pass" ? "pass" : "fail";
+    const recommendation = input.review.decision;
     return {
       branchNodeId: input.branchNodeId,
       role: input.role,

--- a/apps/web/lib/mcp/packs/change-review-pack.test.ts
+++ b/apps/web/lib/mcp/packs/change-review-pack.test.ts
@@ -1,25 +1,59 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@dpf/db", () => ({ prisma: {} }));
-vi.mock("@/lib/actions/external-evidence", () => ({ recordExternalEvidence: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    workCapsule: { findUnique: vi.fn() },
+    externalEvidenceRecord: { findFirst: vi.fn() },
+  },
+  recordExternalEvidence: vi.fn(),
+  recordWorkCapsuleEvidence: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("@/lib/actions/external-evidence", () => ({ recordExternalEvidence: mocks.recordExternalEvidence }));
 vi.mock("@/lib/change-review/routed-semantic-review", () => ({ dispatchRoutedSemanticReview: vi.fn() }));
-vi.mock("@/lib/work-capsules/work-capsule-store", () => ({ recordWorkCapsuleEvidence: vi.fn() }));
+vi.mock("@/lib/work-capsules/work-capsule-store", () => ({ recordWorkCapsuleEvidence: mocks.recordWorkCapsuleEvidence }));
 
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 import { changeReviewPack } from "./change-review-pack";
 
 describe("change-review MCP pack", () => {
-  it("exposes one native pre-publication review operation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.workCapsule.findUnique.mockResolvedValue({ id: "capsule-row-1" });
+    mocks.recordExternalEvidence.mockResolvedValue({ id: "outcome-evidence-1" });
+  });
+
+  it("exposes native review and outcome-correlation operations", () => {
     expect(changeReviewPack.definitions.map((definition) => definition.name)).toEqual([
       "review_semantic_change",
+      "record_semantic_review_outcome",
     ]);
-    expect(Object.keys(changeReviewPack.handlers)).toEqual(["review_semantic_change"]);
+    expect(Object.keys(changeReviewPack.handlers)).toEqual([
+      "review_semantic_change",
+      "record_semantic_review_outcome",
+    ]);
   });
 
   it("requires evidence-writing authority", () => {
     expect(changeReviewPack.grants.review_semantic_change).toEqual(["backlog_write"]);
+    expect(changeReviewPack.grants.record_semantic_review_outcome).toEqual(["backlog_write"]);
     expect(isToolAllowedByGrants("review_semantic_change", ["backlog_write"])).toBe(true);
     expect(isToolAllowedByGrants("review_semantic_change", ["view_platform"])).toBe(false);
+  });
+
+  it("requires receipt and GitHub/CI correlation identity", () => {
+    const definition = changeReviewPack.definitions.find(
+      (candidate) => candidate.name === "record_semantic_review_outcome",
+    )!;
+    expect(definition.inputSchema.required).toEqual(expect.arrayContaining([
+      "capsuleId",
+      "receiptId",
+      "surface",
+      "pullRequestNumber",
+      "ciPassed",
+      "merged",
+    ]));
   });
 
   it("requires an immutable tree identity and exact artifact", () => {
@@ -32,5 +66,81 @@ describe("change-review MCP pack", () => {
       "artifact",
       "verificationEvidence",
     ]));
+  });
+
+  it("records infrastructure-inconclusive correlation without semantic quality counts", async () => {
+    mocks.prisma.externalEvidenceRecord.findFirst
+      .mockResolvedValueOnce({
+        details: {
+          schemaVersion: "semantic-change-review-receipt.v2",
+          capsuleId: "WC-CALIBRATION",
+          baseTreeHash: "a".repeat(40),
+          headTreeHash: "b".repeat(40),
+          diffDigest: "c".repeat(64),
+          policyVersion: "semantic-change-review-policy.v2",
+          reviewerVersion: "change-reviewer.v1",
+          specialistIds: [],
+          disposition: "reviewed",
+          risk: "high",
+          result: {
+            decision: "inconclusive",
+            issues: [],
+            summary: "Review capacity was unavailable.",
+            inconclusiveReason: "capacity-exhausted",
+          },
+          reviewedAt: "2026-08-01T16:00:00.000Z",
+        },
+      })
+      .mockResolvedValueOnce(null);
+
+    const result = await changeReviewPack.handlers.record_semantic_review_outcome!({
+      capsuleId: "WC-CALIBRATION",
+      receiptId: "receipt-inconclusive",
+      surface: "external",
+      pullRequestNumber: 4001,
+      ciPassed: true,
+      merged: true,
+      acceptedFindingCount: 9,
+      falsePositiveFindingCount: 4,
+    }, "user-1", { agentId: "change-reviewer" });
+
+    expect(result.success).toBe(true);
+    expect(mocks.recordExternalEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      target: "receipt-inconclusive",
+      details: expect.objectContaining({
+        correlationStatus: "infrastructure-inconclusive",
+        acceptedFindingCount: 0,
+        falsePositiveFindingCount: 0,
+      }),
+    }));
+    expect(mocks.recordWorkCapsuleEvidence).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses an existing correlation for the same receipt", async () => {
+    mocks.prisma.externalEvidenceRecord.findFirst
+      .mockResolvedValueOnce({
+        details: {
+          schemaVersion: "semantic-change-review-receipt.v2",
+          result: { decision: "pass", issues: [], summary: "Passed." },
+        },
+      })
+      .mockResolvedValueOnce({
+        id: "existing-outcome-1",
+        resultSummary: "Already correlated.",
+        details: { receiptId: "receipt-pass" },
+      });
+
+    const result = await changeReviewPack.handlers.record_semantic_review_outcome!({
+      capsuleId: "WC-CALIBRATION",
+      receiptId: "receipt-pass",
+      surface: "external",
+      pullRequestNumber: 4002,
+      ciPassed: true,
+      merged: true,
+    }, "user-1", { agentId: "change-reviewer" });
+
+    expect(result).toMatchObject({ success: true, entityId: "existing-outcome-1" });
+    expect(mocks.recordExternalEvidence).not.toHaveBeenCalled();
+    expect(mocks.recordWorkCapsuleEvidence).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/mcp/packs/change-review-pack.ts
+++ b/apps/web/lib/mcp/packs/change-review-pack.ts
@@ -7,6 +7,11 @@ import {
   type SemanticChangeReviewMode,
 } from "@/lib/change-review/semantic-change-review-operation";
 import type { SemanticReviewReceipt, SemanticReviewRisk } from "@/lib/change-review/semantic-change-review";
+import {
+  SEMANTIC_REVIEW_OUTCOME_SCHEMA_VERSION,
+  projectSemanticReviewOutcome,
+  type SemanticReviewOutcome,
+} from "@/lib/change-review/semantic-review-enforcement";
 import type { DeliberationArtifactType, StrategyProfile } from "@/lib/deliberation/external-review-activation";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
@@ -62,6 +67,33 @@ const definitions: ToolDefinition[] = [{
   executionMode: "immediate",
   sideEffect: true,
   buildPhases: ["build", "review", "ship"],
+}, {
+  name: "record_semantic_review_outcome",
+  description:
+    "Correlate one persisted semantic-review receipt with its terminal GitHub/CI outcome, recording measured quality telemetry while excluding infrastructure-inconclusive samples from precision and unique-yield denominators.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      capsuleId: { type: "string" },
+      receiptId: { type: "string", description: "ExternalEvidenceRecord id for semantic-change-review.receipt" },
+      surface: { type: "string", enum: ["external", "build-studio"] },
+      pullRequestNumber: { type: "number" },
+      ciPassed: { type: "boolean" },
+      merged: { type: "boolean" },
+      acceptedFindingCount: { type: "number" },
+      falsePositiveFindingCount: { type: "number" },
+      uniqueLocalFindingCount: { type: "number" },
+      postPublicationMissCount: { type: "number" },
+      correctivePushCount: { type: "number" },
+      timeToFirstSignalMs: { type: "number" },
+      costUsd: { type: "number" },
+    },
+    required: ["capsuleId", "receiptId", "surface", "pullRequestNumber", "ciPassed", "merged"],
+  },
+  requiredCapability: "view_platform",
+  executionMode: "immediate",
+  sideEffect: true,
+  buildPhases: ["review", "ship"],
 }];
 
 function stringParam(params: Record<string, unknown>, key: string): string {
@@ -76,7 +108,7 @@ function isReceipt(value: unknown): value is SemanticReviewReceipt {
   return Boolean(
     value &&
     typeof value === "object" &&
-    (value as { schemaVersion?: unknown }).schemaVersion === "semantic-change-review-receipt.v1",
+    (value as { schemaVersion?: unknown }).schemaVersion === "semantic-change-review-receipt.v2",
   );
 }
 
@@ -115,7 +147,7 @@ const reviewSemanticChange: ToolPackHandler = async (params, userId, context): P
   const previousEvidence = await prisma.externalEvidenceRecord.findFirst({
     where: { workCapsuleId: capsule.id, operationType: "semantic-change-review.receipt" },
     orderBy: { createdAt: "desc" },
-    select: { details: true },
+    select: { id: true, details: true },
   });
   const priorReceipt = isReceipt(previousEvidence?.details) ? previousEvidence.details : null;
   const risk = RISKS.includes(params.risk as SemanticReviewRisk) ? params.risk as SemanticReviewRisk : undefined;
@@ -146,6 +178,24 @@ const reviewSemanticChange: ToolPackHandler = async (params, userId, context): P
       mode: reviewMode(),
     }, { dispatch: dispatchRoutedSemanticReview });
 
+    if (outcome.reusedFreshReceipt && previousEvidence) {
+      return {
+        success: true,
+        entityId: previousEvidence.id,
+        message: `Reused the fresh semantic review receipt for ${capsuleId}.`,
+        data: {
+          receipt: outcome.receipt,
+          fresh: true,
+          reusedFreshReceipt: true,
+          staleReasons: outcome.staleReasons,
+          mayPublish: outcome.mayPublish,
+          nextAction: outcome.nextAction,
+          repairLimitReached: outcome.repairLimitReached,
+          mode: reviewMode(),
+        },
+      };
+    }
+
     const projection = outcome.evidence;
     const evidence = await recordExternalEvidence({
       actorUserId: userId,
@@ -174,9 +224,7 @@ const reviewSemanticChange: ToolPackHandler = async (params, userId, context): P
     return {
       success: true,
       entityId: evidence.id,
-      message: outcome.reusedFreshReceipt
-        ? `Reused the fresh semantic review receipt for ${capsuleId}.`
-        : `Recorded semantic review receipt for ${capsuleId}: ${outcome.receipt.result.decision}.`,
+      message: `Recorded semantic review receipt for ${capsuleId}: ${outcome.receipt.result.decision}.`,
       data: {
         receipt: outcome.receipt,
         fresh: true,
@@ -193,9 +241,100 @@ const reviewSemanticChange: ToolPackHandler = async (params, userId, context): P
   }
 };
 
+function nonNegativeNumber(params: Record<string, unknown>, key: string): number {
+  const value = params[key];
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+const recordSemanticReviewOutcome: ToolPackHandler = async (params, userId, context): Promise<ToolResult> => {
+  const capsuleId = stringParam(params, "capsuleId");
+  const receiptId = stringParam(params, "receiptId");
+  const surface = params.surface === "build-studio" ? "build-studio" : params.surface === "external" ? "external" : null;
+  const pullRequestNumber = nonNegativeNumber(params, "pullRequestNumber");
+  if (!capsuleId || !receiptId || !surface || !Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0 ||
+    typeof params.ciPassed !== "boolean" || typeof params.merged !== "boolean") {
+    return { success: false, error: "invalid_input", message: "Capsule, receipt, surface, PR number, and terminal GitHub/CI state are required." };
+  }
+  const capsule = await prisma.workCapsule.findUnique({ where: { capsuleId }, select: { id: true } });
+  if (!capsule) return { success: false, error: "capsule_not_found", message: `Work Capsule ${capsuleId} was not found.` };
+  const receiptRow = await prisma.externalEvidenceRecord.findFirst({
+    where: { id: receiptId, workCapsuleId: capsule.id, operationType: "semantic-change-review.receipt" },
+    select: { details: true, createdAt: true },
+  });
+  if (!isReceipt(receiptRow?.details)) {
+    return { success: false, error: "receipt_not_found", message: `A current semantic-review receipt ${receiptId} was not found on ${capsuleId}.` };
+  }
+  const priorOutcome = await prisma.externalEvidenceRecord.findFirst({
+    where: {
+      workCapsuleId: capsule.id,
+      operationType: "semantic-change-review.outcome",
+      target: receiptId,
+    },
+    select: { id: true, resultSummary: true, details: true },
+  });
+  if (priorOutcome) {
+    return {
+      success: true,
+      entityId: priorOutcome.id,
+      message: priorOutcome.resultSummary,
+      data: { outcome: priorOutcome.details, reused: true },
+    };
+  }
+  const receipt = receiptRow.details;
+  const correlationStatus = receipt.result.decision === "inconclusive"
+    ? "infrastructure-inconclusive" as const
+    : "completed" as const;
+  const outcome: SemanticReviewOutcome = {
+    schemaVersion: SEMANTIC_REVIEW_OUTCOME_SCHEMA_VERSION,
+    receiptId,
+    capsuleId,
+    surface,
+    reviewDisposition: receipt.disposition,
+    reviewDecision: receipt.result.decision,
+    correlationStatus,
+    acceptedFindingCount: correlationStatus === "completed" ? nonNegativeNumber(params, "acceptedFindingCount") : 0,
+    falsePositiveFindingCount: correlationStatus === "completed" ? nonNegativeNumber(params, "falsePositiveFindingCount") : 0,
+    uniqueLocalFindingCount: correlationStatus === "completed" ? nonNegativeNumber(params, "uniqueLocalFindingCount") : 0,
+    postPublicationMissCount: correlationStatus === "completed" ? nonNegativeNumber(params, "postPublicationMissCount") : 0,
+    correctivePushCount: correlationStatus === "completed" ? nonNegativeNumber(params, "correctivePushCount") : 0,
+    timeToFirstSignalMs: correlationStatus === "completed" && typeof params.timeToFirstSignalMs === "number"
+      ? nonNegativeNumber(params, "timeToFirstSignalMs")
+      : null,
+    costUsd: correlationStatus === "completed" && typeof params.costUsd === "number" ? nonNegativeNumber(params, "costUsd") : null,
+    github: { pullRequestNumber, ciPassed: params.ciPassed, merged: params.merged },
+    recordedAt: new Date().toISOString(),
+  };
+  const projection = projectSemanticReviewOutcome(outcome);
+  const evidence = await recordExternalEvidence({
+    actorUserId: userId,
+    routeContext: projection.externalEvidence.routeContext,
+    operationType: projection.externalEvidence.operationType,
+    target: projection.externalEvidence.target,
+    provider: projection.externalEvidence.provider,
+    resultSummary: projection.externalEvidence.resultSummary,
+    details: projection.externalEvidence.details as unknown as Prisma.InputJsonValue,
+    workCapsuleId: capsule.id,
+    executorKind: context?.agentId ?? surface,
+    recordedByAgentId: context?.agentId,
+  });
+  await recordWorkCapsuleEvidence({
+    db: prisma,
+    capsuleId,
+    evidence: { kind: "verification", summary: projection.activity.summary, targetId: evidence.id, result: projection.activity.payload },
+    actor: { userId, agentId: context?.agentId ?? null, principalId: null },
+  });
+  return { success: true, entityId: evidence.id, message: projection.activity.summary, data: { outcome } };
+};
+
 export const changeReviewPack: ToolPack = {
   packId: "change-review",
   definitions,
-  handlers: { review_semantic_change: reviewSemanticChange },
-  grants: { review_semantic_change: ["backlog_write"] },
+  handlers: {
+    review_semantic_change: reviewSemanticChange,
+    record_semantic_review_outcome: recordSemanticReviewOutcome,
+  },
+  grants: {
+    review_semantic_change: ["backlog_write"],
+    record_semantic_review_outcome: ["backlog_write"],
+  },
 };

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -325,7 +325,7 @@ describe("TOOL_TO_GRANTS - Work Capsule entries", () => {
 describe("TOOL_TO_GRANTS - External development coordination entries", () => {
   it("evidence recording tools require backlog_write", () => {
     expect(isToolAllowedByGrants("record_external_development_evidence", ["backlog_write"])).toBe(true);
-    expect(isToolAllowedByGrants("review_semantic_change", ["backlog_write"])).toBe(true);
+    for (const tool of ["review_semantic_change", "record_semantic_review_outcome"]) expect(isToolAllowedByGrants(tool, ["backlog_write"])).toBe(true);
     expect(isToolAllowedByGrants("record_local_integration_result", ["backlog_write"])).toBe(true);
     expect(isToolAllowedByGrants("record_external_development_evidence", ["registry_read"])).toBe(false);
     expect(isToolAllowedByGrants("review_semantic_change", ["view_platform"])).toBe(false);

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -176,14 +176,13 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // grant (BI-B2F7ABF5). Backwards-compat preserved by GRANT_IMPLICATIONS
   // (backlog_write → build_evidence).
   record_execution_evidence: ["build_evidence"],
-  // Non-build-scoped evidence remains on the broad backlog_write grant —
-  // these tools coordinate across the whole backlog surface, not just build.
+  // Non-build evidence stays on backlog_write because it coordinates the whole backlog surface.
   record_external_development_evidence: ["backlog_write"],
   review_semantic_change: ["backlog_write"],
+  record_semantic_review_outcome: ["backlog_write"],
   record_local_integration_result: ["backlog_write"],
   record_functional_failure_evidence: ["backlog_write"],
   get_next_recommended_work: ["backlog_read"],
-
   // Work Capsule control harness (spec 2026-05-14)
   list_work_capsules: ["work_capsule_read"],
   get_work_capsule: ["work_capsule_read"],

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1532,7 +1532,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 16031,
+      "defaultVisibleWords": 16056,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,

--- a/docs/architecture/agent-client-governance.md
+++ b/docs/architecture/agent-client-governance.md
@@ -112,6 +112,18 @@ instead of oscillating. The adapters initially run in shadow mode; the next
 rollout phase ratchets deterministic publication enforcement only after outcome
 telemetry demonstrates sufficient signal quality.
 
+Publication enforcement is deliberately split from inference. Review persists
+an immutable receipt before publication; `pnpm review:semantic-gate` then
+validates an exact-tree git-dir sidecar with no model, portal, database, or
+network call. Explicit exemptions are policy-versioned, evidence-linked, and
+expiry-bound.
+
+Reviewer execution status is not a semantic verdict. Capacity, admission,
+transport, or response-parsing failure produces `inconclusive` and a retry
+action; it never fabricates a critical code finding. GitHub/CI correlation is
+written to the same evidence streams as `semantic-change-review.outcome`, and
+inconclusive samples are excluded from precision and unique-yield denominators.
+
 ## Design grounding
 
 - Existing specs/plans reviewed: the shared Change Reviewer control plan and
@@ -123,8 +135,9 @@ telemetry demonstrates sufficient signal quality.
 - Source of truth: the immutable receipt identity in
   `apps/web/lib/change-review/semantic-change-review.ts` plus Work Capsule
   evidence; no new persistence substrate is introduced.
-- Decision: both authoring paths use one operation and evidence shape in shadow
-  mode first. Deterministic enforcement remains owned by the next rollout phase.
+- Decision: both authoring paths use one operation and evidence shape. A local
+  no-network adapter enforces exact-tree freshness only after cross-surface
+  outcome telemetry calibrates the policy.
 
 ## Client identity and trust
 

--- a/docs/superpowers/specs/2026-07-27-shared-change-reviewer-control-design.md
+++ b/docs/superpowers/specs/2026-07-27-shared-change-reviewer-control-design.md
@@ -238,6 +238,21 @@ slice; the Work Capsule/Build timeline is the canonical surface.
 5. Enforce receipt freshness for applicable runtime changes.
 6. Promote the coworker only after behavioral certification passes.
 
+### Enforcement and learning contract
+
+- `pass` and `fail` are completed semantic decisions; `inconclusive` is an
+  execution classification for capacity, transport, or protocol failure.
+- Inconclusive reviews may pause publication in enforce mode because fresh
+  evidence is absent, but they never create a critical semantic finding and are
+  excluded from quality-rate denominators.
+- The pre-push control reads an exact-tree git-dir sidecar minted from the
+  durable receipt. It performs no model, portal, database, or network call.
+- Explicit exemptions carry the policy version, capsule/diff identity, evidence
+  id, reason, and expiry.
+- GitHub/CI correlation reuses `ExternalEvidenceRecord` and Work Capsule
+  activity with operation type `semantic-change-review.outcome`; no review table
+  or dashboard is introduced.
+
 ## Non-goals
 
 - Replacing GitHub review.

--- a/docs/user-guide/build-studio/index.md
+++ b/docs/user-guide/build-studio/index.md
@@ -58,6 +58,7 @@ through the real execution path, and the coworker factory explicitly promotes
 them. A normal seed or upgrade preserves that lifecycle state; deployment alone
 does not certify or activate a coworker.
 - **Quality Gates** — Automated checks between phases. Each gate requires specific evidence before the feature can advance (design review, plan review, documentation impact, test results, typecheck). After Build Studio assembles the task outputs, Change Reviewer independently checks that committed change before UX verification or promotion. Its receipt appears in the same Work Capsule activity story; no separate review workspace is added.
+  A review may be **inconclusive** when reviewer capacity or transport is unavailable. That state asks the system to retry; it is not displayed or counted as a code defect. Once calibrated enforcement is enabled, publication requires a fresh exact-change receipt or an explicit policy-versioned exemption. The publication check is local and deterministic, so it never waits for another AI call.
 - **Promotion** — The governed process for moving a completed feature from the Build runtime into production where the install is configured for it. Includes evidence capture, backup/rebuild/health-check discipline, and rollback planning.
 
 ## What You Can Do

--- a/docs/ux-fit/2026-08-01-semantic-review-inconclusive.ux-fit.json
+++ b/docs/ux-fit/2026-08-01-semantic-review-inconclusive.ux-fit.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "decidedOption": "converge-notice-three-state",
+  "decisionInteractionId": "DI-BAF7F486FA43",
+  "scope": {
+    "files": [
+      "apps/web/components/build/EvidenceSummary.tsx",
+      "apps/web/components/build/FeatureBriefPanel.tsx",
+      "apps/web/components/build/ReviewPanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "converge-notice-three-state",
+      "keep-custom-three-state",
+      "coerce-inconclusive-to-fail"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:sandbox": "docker compose up -d sandbox",
     "pregate": "node scripts/pregate.mjs",
     "pregate:preflight": "node scripts/pregate-preflight.mjs",
+    "review:semantic-gate": "node scripts/semantic-review-gate.mjs",
     "gate:context": "node scripts/gate-context.mjs",
     "build": "pnpm --filter web build",
     "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",

--- a/packages/dpf-skill-pack/skills/dpf-finishing-a-development-branch/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-finishing-a-development-branch/SKILL.md
@@ -62,6 +62,8 @@ This is the **decision** step; `dpf-pr-with-dco` is the **execution** step that 
 
 5. **Freeze and independently review the assembled change.** Account for every file, create a DCO-signed local commit, and confirm `git status --short` is clean. Before `pregate` or the first push, call the native `review_semantic_change` operation with the Work Capsule, exact base/head tree hashes, a digest of the committed diff, changed files, and available verification evidence. A docs-only low-risk change may return an evidenced auto-pass. Runtime code must run the independent Change Reviewer. If it fails, repair and mint a fresh receipt; after two failed repair rounds, stop the loop and escalate for operator review. Any material commit, rebase, policy/reviewer change, or specialist-set change makes the prior receipt stale.
 
+   Save the returned receipt with `pnpm review:semantic-gate -- record --receipt-file <tool-result.json> --evidence-id <id>` so the deterministic pre-push adapter validates the exact receipt locally. Treat infrastructure-inconclusive execution as a retryable capacity state, never as a semantic finding.
+
 6. **Hand off.** With the shape decided, branch green + clean, and semantic-review receipt fresh for the current committed tree, invoke [`dpf-pr-with-dco`](../dpf-pr-with-dco/SKILL.md) for pregate and PR mechanics.
 
 ## Guardrails

--- a/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
@@ -99,6 +99,12 @@ DPF's PR contract is strict and non-negotiable: **every change lands via PR**, *
 
 3c. **Run independent semantic review before pregate or first publication.** Call `review_semantic_change` for the governing Work Capsule and exact committed tree. Runtime code requires an actual Change Reviewer pass; a low-risk docs-only change may receive a durable auto-pass. Address blocking findings and re-run against the new commit. Stop after two failed repair rounds and escalate rather than oscillating. A commit, rebase, diff, reviewer/policy version, or specialist-set change invalidates the old receipt. Phase 3 defaults to shadow observation; never hide a failed receipt just because deterministic blocking has not yet been ratcheted on.
 
+   Persist the returned receipt into the worktree's git-dir sidecar before pregate so the pre-push control can validate it without a model, portal, database, or network call:
+   ```
+   pnpm review:semantic-gate -- record --receipt-file <tool-result.json> --evidence-id <ExternalEvidenceRecord-id>
+   ```
+   An infrastructure-inconclusive result is not a semantic failure and must not be repaired as though it found a code defect; retry the review when capacity returns.
+
 3d. **Local-CI sandbox gate (default-on pre-push, BI-C74F4DE9).** For runtime-code branches, run `pnpm run pregate` before the push — the chained pre-push hook refuses an ungated push otherwise. Carry the evidence into the PR body as a trailer so `pnpm pr:health` reads the branch as merge-ready even when checked from another machine:
    ```
    Local-CI-Evidence: <evidence-record-id> (<branch>@<sha>)

--- a/scripts/lib/semantic-review-gate.mjs
+++ b/scripts/lib/semantic-review-gate.mjs
@@ -1,0 +1,35 @@
+export const LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION = "semantic-change-review-local-gate.v1";
+
+const IDENTITY_FIELDS = [
+  "branch",
+  "sha",
+  "capsuleId",
+  "baseTreeHash",
+  "headTreeHash",
+  "diffDigest",
+  "policyVersion",
+  "reviewerVersion",
+];
+
+function normalizedIds(value) {
+  return [...new Set(Array.isArray(value) ? value.map(String).map((id) => id.trim()).filter(Boolean) : [])].sort();
+}
+
+/** Deterministic local adapter: no model, portal, database, or network access. */
+export function validateLocalSemanticReviewGate(state, current, nowMs = Date.now()) {
+  if (!state || state.schemaVersion !== LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION) {
+    return { valid: false, reason: "missing-receipt" };
+  }
+  if (state.receiptDecision === "inconclusive") {
+    return { valid: false, reason: "infrastructure-inconclusive" };
+  }
+  if (state.receiptDecision === "fail") return { valid: false, reason: "semantic-failure" };
+  if (state.expiresAt) {
+    const expiresAt = Date.parse(state.expiresAt);
+    if (!Number.isFinite(expiresAt) || expiresAt <= nowMs) return { valid: false, reason: "expired-receipt" };
+  }
+  const stale = IDENTITY_FIELDS.some((field) => state[field] !== current[field]) ||
+    JSON.stringify(normalizedIds(state.specialistIds)) !== JSON.stringify(normalizedIds(current.specialistIds));
+  if (stale || !String(state.evidenceId ?? "").trim()) return { valid: false, reason: "stale-receipt" };
+  return { valid: true, reason: "fresh-receipt" };
+}

--- a/scripts/semantic-review-gate.mjs
+++ b/scripts/semantic-review-gate.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION, validateLocalSemanticReviewGate } from "./lib/semantic-review-gate.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const policy = JSON.parse(readFileSync(join(here, "semantic-review-policy.json"), "utf8"));
+
+function git(...args) {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);
+  return result.stdout.trim();
+}
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : null;
+}
+
+function currentIdentity(receipt = null) {
+  const branch = git("branch", "--show-current");
+  const sha = git("rev-parse", "HEAD");
+  const mergeBase = git("merge-base", "HEAD", "origin/main");
+  const baseTreeHash = git("rev-parse", `${mergeBase}^{tree}`);
+  const headTreeHash = git("rev-parse", "HEAD^{tree}");
+  const diff = spawnSync("git", ["diff", "--binary", mergeBase, "HEAD"], { encoding: null });
+  if (diff.status !== 0) throw new Error(diff.stderr?.toString().trim() || "git diff failed");
+  const diffDigest = createHash("sha256").update(diff.stdout).digest("hex");
+  return {
+    branch,
+    sha,
+    capsuleId: receipt?.capsuleId ?? "",
+    baseTreeHash,
+    headTreeHash,
+    diffDigest,
+    policyVersion: policy.policyVersion,
+    reviewerVersion: policy.reviewerVersion,
+    specialistIds: receipt?.specialistIds ?? [],
+  };
+}
+
+const stateFile = git("rev-parse", "--git-path", "dpf-semantic-review-gate.json");
+const command = process.argv[2] ?? "validate";
+
+if (command === "record") {
+  const receiptFile = option("--receipt-file");
+  const evidenceId = option("--evidence-id");
+  if (!receiptFile || !evidenceId) throw new Error("record requires --receipt-file and --evidence-id");
+  const payload = JSON.parse(readFileSync(receiptFile, "utf8"));
+  const receipt = payload?.data?.receipt ?? payload?.receipt ?? payload;
+  const current = currentIdentity(receipt);
+  const exact = receipt.schemaVersion === policy.receiptSchemaVersion &&
+    receipt.baseTreeHash === current.baseTreeHash &&
+    receipt.headTreeHash === current.headTreeHash &&
+    receipt.diffDigest === current.diffDigest &&
+    receipt.policyVersion === current.policyVersion &&
+    receipt.reviewerVersion === current.reviewerVersion;
+  if (!exact) throw new Error("receipt identity does not match the current committed diff and policy");
+  writeFileSync(stateFile, `${JSON.stringify({
+    schemaVersion: LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION,
+    ...current,
+    receiptDecision: receipt.result?.decision,
+    receiptDisposition: receipt.disposition,
+    evidenceId,
+    recordedAt: new Date().toISOString(),
+  }, null, 2)}\n`);
+  console.log(`[semantic-review-gate] recorded ${receipt.result?.decision} receipt for ${current.branch}@${current.sha}`);
+  process.exit(0);
+}
+
+if (command !== "validate") throw new Error(`unknown command: ${command}`);
+const state = existsSync(stateFile) ? JSON.parse(readFileSync(stateFile, "utf8")) : null;
+const current = currentIdentity(state);
+const result = validateLocalSemanticReviewGate(state, current);
+if (result.valid) {
+  console.log(`[semantic-review-gate] fresh receipt for ${current.branch}@${current.sha}`);
+  process.exit(0);
+}
+const message = `[semantic-review-gate] ${result.reason} for ${current.branch}@${current.sha}`;
+if (policy.mode === "shadow") {
+  console.warn(`${message} (shadow observation; publication remains allowed)`);
+  process.exit(0);
+}
+console.error(`${message}; run review_semantic_change on the exact committed tree and record its receipt before publication`);
+process.exit(1);

--- a/scripts/semantic-review-gate.test.mjs
+++ b/scripts/semantic-review-gate.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateLocalSemanticReviewGate } from "./lib/semantic-review-gate.mjs";
+
+const current = {
+  branch: "feat/change-reviewer-enforcement",
+  sha: "a".repeat(40),
+  capsuleId: "WC-DA3CDA6A",
+  baseTreeHash: "b".repeat(40),
+  headTreeHash: "c".repeat(40),
+  diffDigest: "d".repeat(64),
+  policyVersion: "semantic-change-review-policy.v2",
+  reviewerVersion: "change-reviewer.v1",
+  specialistIds: ["AGT-181"],
+};
+
+const state = {
+  ...current,
+  schemaVersion: "semantic-change-review-local-gate.v1",
+  receiptDecision: "pass",
+  receiptDisposition: "reviewed",
+  recordedAt: "2026-08-01T16:00:00.000Z",
+  expiresAt: "2026-08-01T17:00:00.000Z",
+  evidenceId: "cms-evidence-1",
+};
+
+test("accepts an exact, unexpired completed receipt without network access", () => {
+  assert.deepEqual(validateLocalSemanticReviewGate(state, current, Date.parse("2026-08-01T16:30:00Z")), {
+    valid: true,
+    reason: "fresh-receipt",
+  });
+});
+
+test("rejects missing, stale, expired, and infrastructure-inconclusive state distinctly", () => {
+  assert.deepEqual(validateLocalSemanticReviewGate(null, current, Date.now()), {
+    valid: false,
+    reason: "missing-receipt",
+  });
+  assert.equal(validateLocalSemanticReviewGate({ ...state, sha: "e".repeat(40) }, current, Date.parse("2026-08-01T16:30:00Z")).reason, "stale-receipt");
+  assert.equal(validateLocalSemanticReviewGate(state, current, Date.parse("2026-08-01T18:00:00Z")).reason, "expired-receipt");
+  assert.equal(validateLocalSemanticReviewGate({ ...state, receiptDecision: "inconclusive" }, current, Date.parse("2026-08-01T16:30:00Z")).reason, "infrastructure-inconclusive");
+});

--- a/scripts/semantic-review-policy.json
+++ b/scripts/semantic-review-policy.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "mode": "shadow",
+  "receiptSchemaVersion": "semantic-change-review-receipt.v2",
+  "policyVersion": "semantic-change-review-policy.v2",
+  "reviewerVersion": "change-reviewer.v1",
+  "calibration": {
+    "externalCompletedSamples": 0,
+    "buildStudioCompletedSamples": 0,
+    "precision": null,
+    "postPublicationMissRate": null,
+    "evidenceRecordedAt": null,
+    "evidenceIds": []
+  }
+}

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,9 +3,9 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 349,
-      "reason": "Adds one consolidated read that turns sales into supply coverage — days of cover and a suggested order quantity per stocked supply. Nothing in the registry could answer 'what are we about to run out of': the sales reads stop at what was ordered, and the finance/procurement tools start at a purchase order that already exists. Without it a proactive operations coworker can only report a capability gap, which is what the live restaurant run did.",
-      "recordedAt": "2026-08-01"
+      "value": 350,
+      "reason": "Combines two independent additions since the prior baseline: supply-coverage forecasting for proactive stocked-supply operations, and outcome correlation beside semantic review so external and Build Studio receipts can be compared with terminal GitHub/CI results while consistently excluding infrastructure-inconclusive samples.",
+      "recordedAt": "2026-08-02"
     },
     "registry.packFiles": {
       "value": 81,


### PR DESCRIPTION
## Summary

- add deterministic, no-network semantic-review freshness and exemption validation
- classify review outcomes as completed pass, completed fail, or infrastructure-inconclusive
- exclude infrastructure-inconclusive samples from precision and unique-yield telemetry
- project existing evidence into the shared control and surface pass/fail/inconclusive state in Build Studio
- keep enforcement in shadow until real external and Build Studio outcome pairs support a calibrated ratchet

## Backlog

- BI-BD3F687C
- umbrella BI-67E23B70
- Work Capsule WC-DA3CDA6A

## Verification

- exact merged-code local-CI passed for `96b91d1cd5cb05a17714ab387bc8be555ffa1e8c` against accepted remote-current base `40d1948a5f5a8f72182c9bd9f818f06af36f42db`
- migrations, web typecheck, full Vitest suite, repository guards, and production Docker build passed
- tool-surface guard passed at 350 tool definitions across 81 packs, core tier 27
- deterministic semantic-review hook tests passed 2/2
- UX-fit evidence: `docs/ux-fit/2026-08-01-semantic-review-inconclusive.ux-fit.json`

Local-CI-Evidence: cmsc4tl5i08bc01qmj9lvkjno (feat/change-reviewer-enforcement@96b91d1cd5cb05a17714ab387bc8be555ffa1e8c)

## Semantic review bootstrap boundary

The final committed tree was reviewed twice after publication readiness. Both high-assurance attempts were infrastructure-inconclusive because all required branches failed to complete; neither produced a semantic code finding. Exact-identity receipt `cmsc1ipus019l01qmqbjrsual` has `parseError=true`, `mayPublish=true`, and `nextAction=shadow-observe`. The deployed runtime still emits receipt/policy v1, while this PR introduces the deterministic v2 local contract, so the v2 recorder correctly refuses to fabricate a forward-version local receipt. Shadow mode permits publication and these samples are excluded from semantic precision and unique-yield denominators.

## Documentation impact

Updated the external-agent governance architecture, Build Studio user guide, shared Change Reviewer control design, and delivery skills in the same change.

## Design grounding

- reviewed the shared Change Reviewer control design and delivery-surface architecture
- extended the existing semantic-review operation, evidence stream, Work Capsule, and Build Studio review substrate
- kept policy, receipt identity, and outcome classification in their existing canonical modules rather than adding parallel persistence or control paths
- preserved shadow enforcement until measured external and Build Studio outcomes support a ratchet

Seed-Fit-Decision: global-default
