### PR TITLE
fix(hooks): bound run-hook stdin and child lifetime

### DIFF
--- a/docs/operations/session-transcript-recovery.md
+++ b/docs/operations/session-transcript-recovery.md
@@ -88,6 +88,7 @@ Edit `.claude/settings.json` and remove the `PostToolUse` + `SessionEnd` entries
 - **The hook fires AFTER each tool call.** The snapshot from just BEFORE a destructive action survives; nothing captures the state during the action itself (irrelevant — there's nothing to snapshot at the moment of destruction).
 - **The throttle means up to 2 minutes of conversation can be lost** during a crash mid-session-burst. The BI accepts this trade-off — "worst-case data loss is the last N actions, not the entire session" was the explicit ask.
 - **Snapshots include conversation contents.** If a session contained secrets / credentials, they will be on disk under `$DPF_BACKUPS_HOST_PATH`. Protect that directory the same way you protect any backup tree.
+- **Launcher bounds child lifetime (BI-BDA89375).** Hooks run through `scripts/hooks/run-hook.mjs`, which reads the payload once, pipes it into the target script, and kills the child tree if it exceeds `DPF_HOOK_TIMEOUT_MS` (default 15s). A hung snapshot never blocks the tool call and cannot pile up hundreds of Node/PowerShell processes.
 
 ## Composition with other DR-hardening features
 

--- a/scripts/hooks/run-hook.mjs
+++ b/scripts/hooks/run-hook.mjs
@@ -15,40 +15,150 @@
 // where <script-base> is a path under scripts/ WITHOUT extension, e.g.
 //   safety/transcript-snapshot  ->  scripts/safety/transcript-snapshot.{ps1,sh}
 //
-// The hook's stdin JSON payload is forwarded to the target script unchanged
-// (stdio: 'inherit'), and the target's stdout/stderr pass straight back to
-// Claude Code (so e.g. a WorktreeCreate script can still print its path).
+// Stdin contract (BI-BDA89375):
+//   The launcher owns stdin forwarding and child lifetime. It reads the hook
+//   payload once, spawns the OS target with an explicit stdin pipe, writes and
+//   ends the pipe, then enforces a short bounded timeout. Children never
+//   inherit the long-lived Claude Code stdin (which previously left
+//   PowerShell `[Console]::In.ReadToEnd()` hung for tens of minutes).
+//
+// Stdout/stderr still inherit so WorktreeCreate-style hooks can print a path.
 //
 // This launcher NEVER blocks the triggering action: a missing target script,
-// a spawn error, or a non-zero child exit all resolve to exit 0 -- matching
-// the "exit 0 ALWAYS" contract of the snapshot scripts it fronts.
+// a spawn error, a non-zero child exit, or a timeout all resolve to exit 0.
 
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const base = process.argv[2];
-// No hook named, or a traversal attempt -> no-op.
-if (!base || base.includes("..")) process.exit(0);
+/** Conservative default: enough for a transcript copy, short enough to protect host process pressure. */
+const DEFAULT_TIMEOUT_MS = 15_000;
 
-// Repo root: prefer Claude Code's per-invocation env var; fall back to this
-// file's location (scripts/hooks/run-hook.mjs -> repo root is two dirs up).
-const here = dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.CLAUDE_PROJECT_DIR
-  ? resolve(process.env.CLAUDE_PROJECT_DIR)
-  : resolve(here, "..", "..");
+/**
+ * @returns {Promise<Buffer>}
+ */
+function readStdinOnce() {
+  return new Promise((resolveBuf) => {
+    // No piped payload (interactive shell / empty) -> empty buffer.
+    if (process.stdin.isTTY) {
+      resolveBuf(Buffer.alloc(0));
+      return;
+    }
 
-const isWindows = process.platform === "win32";
-const target = join(repoRoot, "scripts", `${base}${isWindows ? ".ps1" : ".sh"}`);
+    /** @type {Buffer[]} */
+    const chunks = [];
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolveBuf(Buffer.concat(chunks));
+    };
 
-// No OS-appropriate script for this hook on this platform -> no-op.
-if (!existsSync(target)) process.exit(0);
+    process.stdin.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    process.stdin.on("end", finish);
+    process.stdin.on("error", finish);
+    // Safety: if stdin never ends, still unblock the launcher promptly.
+    // Hook payloads are small JSON; multi-second stall means a stuck parent.
+    setTimeout(finish, 2_000).unref?.();
+  });
+}
 
-const [cmd, args] = isWindows
-  ? ["powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", target]]
-  : ["sh", [target]];
+/**
+ * Terminate the exact child process tree cross-platform.
+ * @param {number | undefined} pid
+ */
+function killChildTree(pid) {
+  if (!pid || !Number.isFinite(pid)) return;
 
-const child = spawn(cmd, args, { stdio: "inherit" });
-child.on("error", () => process.exit(0));
-child.on("exit", () => process.exit(0));
+  if (process.platform === "win32") {
+    // /T kills the tree; /F forces. Best-effort — never throw from a hook.
+    spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already exited
+  }
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {number}
+ */
+function resolveTimeoutMs(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_TIMEOUT_MS;
+  // Cap at 5 minutes so a misconfigured env var cannot reintroduce the leak.
+  return Math.min(Math.floor(n), 5 * 60_000);
+}
+
+async function main() {
+  const base = process.argv[2];
+  // No hook named, or a traversal attempt -> no-op.
+  if (!base || base.includes("..")) process.exit(0);
+
+  // Repo root: prefer Claude Code's per-invocation env var; fall back to this
+  // file's location (scripts/hooks/run-hook.mjs -> repo root is two dirs up).
+  const here = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = process.env.CLAUDE_PROJECT_DIR
+    ? resolve(process.env.CLAUDE_PROJECT_DIR)
+    : resolve(here, "..", "..");
+
+  const isWindows = process.platform === "win32";
+  const target = join(repoRoot, "scripts", `${base}${isWindows ? ".ps1" : ".sh"}`);
+
+  // No OS-appropriate script for this hook on this platform -> no-op.
+  if (!existsSync(target)) process.exit(0);
+
+  const payload = await readStdinOnce();
+  const timeoutMs = resolveTimeoutMs(process.env.DPF_HOOK_TIMEOUT_MS);
+
+  const [cmd, args] = isWindows
+    ? ["powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", target]]
+    : ["sh", [target]];
+
+  const child = spawn(cmd, args, {
+    stdio: ["pipe", "inherit", "inherit"],
+    windowsHide: true,
+  });
+
+  let settled = false;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timer;
+
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    process.exit(0);
+  };
+
+  child.on("error", finish);
+  child.on("exit", finish);
+
+  timer = setTimeout(() => {
+    killChildTree(child.pid);
+    // Brief grace so the kill can land before we force-exit.
+    setTimeout(finish, 150);
+  }, timeoutMs);
+
+  if (child.stdin) {
+    child.stdin.on("error", () => {
+      // EPIPE when child exits before write completes — ignore.
+    });
+    if (payload.length > 0) {
+      child.stdin.write(payload);
+    }
+    child.stdin.end();
+  }
+}
+
+main().catch(() => process.exit(0));

--- a/scripts/hooks/run-hook.test.mjs
+++ b/scripts/hooks/run-hook.test.mjs
@@ -1,0 +1,291 @@
+// scripts/hooks/run-hook.test.mjs
+//
+// BI-BDA89375 — launcher must own stdin forwarding and child lifetime so
+// transcript-snapshot (and every other run-hook target) cannot exhaust the
+// host process table by hanging on inherited Claude Code stdin.
+//
+// Run: node --test scripts/hooks/run-hook.test.mjs
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const launcher = join(here, "run-hook.mjs");
+const isWindows = process.platform === "win32";
+
+/**
+ * @param {{
+ *   scriptBody: string,
+ *   payload?: string,
+ *   timeoutMs?: number,
+ *   base?: string,
+ *   maxWaitMs?: number,
+ * }} opts
+ */
+function runLauncher(opts) {
+  const base = opts.base ?? "hooks-fixtures/probe";
+  const repoRoot = mkdtempSync(join(tmpdir(), "run-hook-"));
+  const scriptRel = `${base}${isWindows ? ".ps1" : ".sh"}`;
+  const scriptPath = join(repoRoot, "scripts", scriptRel);
+  mkdirSync(dirname(scriptPath), { recursive: true });
+  writeFileSync(scriptPath, opts.scriptBody, "utf8");
+  if (!isWindows) {
+    // sh targets need execute bit only if invoked directly; we invoke via `sh`.
+  }
+
+  const env = {
+    ...process.env,
+    CLAUDE_PROJECT_DIR: repoRoot,
+    DPF_HOOK_TIMEOUT_MS: String(opts.timeoutMs ?? 15_000),
+  };
+
+  return new Promise((resolvePromise) => {
+    const child = spawn(process.execPath, [launcher, base], {
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    /** @type {Buffer[]} */
+    const out = [];
+    /** @type {Buffer[]} */
+    const err = [];
+    child.stdout.on("data", (c) => out.push(c));
+    child.stderr.on("data", (c) => err.push(c));
+
+    const maxWait = opts.maxWaitMs ?? Math.max((opts.timeoutMs ?? 15_000) + 5_000, 10_000);
+    const watchdog = setTimeout(() => {
+      child.kill("SIGKILL");
+      cleanup();
+      resolvePromise({
+        code: child.exitCode ?? 1,
+        timedOutWatchdog: true,
+        stdout: Buffer.concat(out).toString("utf8"),
+        stderr: Buffer.concat(err).toString("utf8"),
+        repoRoot,
+        scriptPath,
+        pid: child.pid,
+      });
+    }, maxWait);
+
+    const cleanup = () => {
+      clearTimeout(watchdog);
+      try {
+        rmSync(repoRoot, { recursive: true, force: true });
+      } catch {
+        // best-effort temp cleanup
+      }
+    };
+
+    child.on("error", (error) => {
+      cleanup();
+      resolvePromise({
+        code: 1,
+        error,
+        stdout: Buffer.concat(out).toString("utf8"),
+        stderr: Buffer.concat(err).toString("utf8"),
+        repoRoot,
+        scriptPath,
+        pid: child.pid,
+      });
+    });
+
+    child.on("exit", (code) => {
+      const result = {
+        code: code ?? 0,
+        timedOutWatchdog: false,
+        stdout: Buffer.concat(out).toString("utf8"),
+        stderr: Buffer.concat(err).toString("utf8"),
+        repoRoot,
+        scriptPath,
+        pid: child.pid,
+      };
+      // Delay cleanup until caller can inspect written fixture files when needed.
+      resolvePromise({
+        ...result,
+        cleanup,
+      });
+    });
+
+    if (opts.payload != null) {
+      child.stdin.write(opts.payload);
+    }
+    child.stdin.end();
+  });
+}
+
+/**
+ * @param {number | undefined} pid
+ * @returns {boolean}
+ */
+function processAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * On Windows, PowerShell children can outlive a killed node if we only
+ * killed the node wrapper. Probe by command line via tasklist is heavy;
+ * instead fixture scripts write a PID file we can check.
+ * @param {string} pidFile
+ * @returns {boolean}
+ */
+function fixtureChildAlive(pidFile) {
+  if (!existsSync(pidFile)) return false;
+  const pid = Number(readFileSync(pidFile, "utf8").trim());
+  return processAlive(pid);
+}
+
+test("forwards payload bytes unchanged to an EOF-reading child and exits 0", async () => {
+  const markerDir = mkdtempSync(join(tmpdir(), "run-hook-payload-"));
+  const outFile = join(markerDir, "payload.txt");
+  const pidFile = join(markerDir, "child.pid");
+
+  const payload = JSON.stringify({
+    session_id: "sess-test-1",
+    transcript_path: "C:/tmp/does-not-matter.jsonl",
+    hook_event_name: "PostToolUse",
+  });
+
+  const scriptBody = isWindows
+    ? `#Requires -Version 5.1
+$ErrorActionPreference = 'Continue'
+$raw = [Console]::In.ReadToEnd()
+$pid | Set-Content -LiteralPath '${pidFile.replace(/'/g, "''")}'
+$raw | Set-Content -LiteralPath '${outFile.replace(/'/g, "''")}' -NoNewline
+exit 0
+`
+    : `#!/bin/sh
+printf '%s' "$$" > '${pidFile.replace(/'/g, "'\\''")}'
+cat > '${outFile.replace(/'/g, "'\\''")}'
+exit 0
+`;
+
+  const result = await runLauncher({
+    scriptBody,
+    payload,
+    timeoutMs: 5_000,
+    maxWaitMs: 12_000,
+  });
+
+  assert.equal(result.timedOutWatchdog, false, "launcher must complete without test watchdog");
+  assert.equal(result.code, 0, `launcher must exit 0; stderr=${result.stderr}`);
+  assert.equal(readFileSync(outFile, "utf8"), payload, "payload must be forwarded unchanged");
+  assert.equal(fixtureChildAlive(pidFile), false, "child must not survive after launcher exit");
+  result.cleanup?.();
+  rmSync(markerDir, { recursive: true, force: true });
+});
+
+test("timeout kills an EOF-waiting hang that never finishes and still exits 0", async () => {
+  // Simulate the pre-fix failure mode: child blocks forever after reading
+  // stdin (or on a long sleep). Launcher must bound the wait and reap the tree.
+  const markerDir = mkdtempSync(join(tmpdir(), "run-hook-hang-"));
+  const pidFile = join(markerDir, "child.pid");
+  const startedFile = join(markerDir, "started");
+
+  const scriptBody = isWindows
+    ? `#Requires -Version 5.1
+$ErrorActionPreference = 'Continue'
+$raw = [Console]::In.ReadToEnd()
+$pid | Set-Content -LiteralPath '${pidFile.replace(/'/g, "''")}'
+'started' | Set-Content -LiteralPath '${startedFile.replace(/'/g, "''")}'
+Start-Sleep -Seconds 120
+exit 0
+`
+    : `#!/bin/sh
+cat >/dev/null
+printf '%s' "$$" > '${pidFile.replace(/'/g, "'\\''")}'
+printf started > '${startedFile.replace(/'/g, "'\\''")}'
+sleep 120
+exit 0
+`;
+
+  const started = Date.now();
+  const result = await runLauncher({
+    scriptBody,
+    payload: '{"hook_event_name":"PostToolUse"}',
+    timeoutMs: 800,
+    maxWaitMs: 15_000,
+  });
+  const elapsed = Date.now() - started;
+
+  assert.equal(result.timedOutWatchdog, false, "launcher timeout path must finish before test watchdog");
+  assert.equal(result.code, 0, `launcher must exit 0 on timeout; stderr=${result.stderr}`);
+  assert.ok(elapsed < 8_000, `must bound completion (elapsed ${elapsed}ms)`);
+  assert.ok(existsSync(startedFile), "hanging child should have started before timeout");
+  // Give Windows taskkill a moment to reap the tree.
+  await new Promise((r) => setTimeout(r, 400));
+  assert.equal(fixtureChildAlive(pidFile), false, "timed-out child tree must not survive");
+  result.cleanup?.();
+  rmSync(markerDir, { recursive: true, force: true });
+});
+
+test("missing target script exits 0 without spawning", async () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "run-hook-missing-"));
+  mkdirSync(join(repoRoot, "scripts"), { recursive: true });
+
+  const result = await new Promise((resolvePromise) => {
+    const child = spawn(process.execPath, [launcher, "hooks-fixtures/does-not-exist"], {
+      env: {
+        ...process.env,
+        CLAUDE_PROJECT_DIR: repoRoot,
+        DPF_HOOK_TIMEOUT_MS: "1000",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    child.stdin.end();
+    child.on("exit", (code) => {
+      resolvePromise({ code: code ?? 0 });
+    });
+  });
+
+  assert.equal(result.code, 0);
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test("child non-zero exit still yields launcher exit 0", async () => {
+  const scriptBody = isWindows
+    ? `#Requires -Version 5.1
+$raw = [Console]::In.ReadToEnd()
+exit 7
+`
+    : `#!/bin/sh
+cat >/dev/null
+exit 7
+`;
+
+  const result = await runLauncher({
+    scriptBody,
+    payload: "{}",
+    timeoutMs: 5_000,
+    maxWaitMs: 12_000,
+  });
+
+  assert.equal(result.code, 0, "non-zero child must not fail the hook contract");
+  result.cleanup?.();
+});
+
+test("traversal or empty base is a no-op exit 0", async () => {
+  for (const base of ["", "../etc/passwd", "foo/../../bar"]) {
+    const result = await new Promise((resolvePromise) => {
+      const child = spawn(process.execPath, base ? [launcher, base] : [launcher], {
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      child.stdin.end();
+      child.on("exit", (code) => resolvePromise({ code: code ?? 0 }));
+    });
+    assert.equal(result.code, 0, `base=${JSON.stringify(base)}`);
+  }
+});


### PR DESCRIPTION
## Summary

Bounds `scripts/hooks/run-hook.mjs` so transcript-snapshot (and every run-hook target) cannot hang on Claude Code's long-lived stdin and exhaust the host process table (BI-BDA89375).

## Changes

- Read the hook payload once, spawn the OS target with an explicit stdin pipe, write and end the pipe
- Enforce `DPF_HOOK_TIMEOUT_MS` (default 15s) and kill the child process tree on timeout
- Preserve the non-blocking contract: success, non-zero child exit, spawn error, missing target, and timeout all exit 0
- Add node:test coverage for payload forwarding, timeout reaping, missing targets, non-zero exits, and path traversal
- Document the launcher bound in the session-transcript recovery operator guide

## Test plan

- [x] `node --test scripts/hooks/run-hook.test.mjs` (5/5 pass)
- [x] Smoke: real `safety/transcript-snapshot` via launcher exits 0 (~268ms) with missing transcript path

## Related

- BI-BDA89375
- Epic: EP-0DFF753B

## Documentation impact

Updates `docs/operations/session-transcript-recovery.md` with the launcher timeout/stdin contract.

## Data and migration impact

No schema or migration change.

Local-CI-Override: scripts/hooks launcher only; verified with node --test scripts/hooks/run-hook.test.mjs (5/5) and real safety/transcript-snapshot smoke exit 0; no apps/web runtime surface
