### PR TITLE
chore(routes): one pnpm route:sync for page-route companions

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -931,6 +931,7 @@
       "publishedPortal": false,
       "anchors": [
         "contributor-procedure-runbook",
+        "new-page-routes-regenerate-companions-bi-206dab95",
         "3-strongly-typed-string-enums-mandatory",
         "13-login-local-qa",
         "9-external-tools",

--- a/docs/architecture/contributor-procedure-runbook.md
+++ b/docs/architecture/contributor-procedure-runbook.md
@@ -2,6 +2,27 @@
 
 **Status:** procedure reference. Collected from `AGENTS.md` §3, §7, §9, §13, §14 and §15 by BI-0020D511 Phase 1. The *rules* from each stay always-on in their original section; everything here is how-to, reference tables, and rationale. No rule was dropped.
 
+## New page routes — regenerate companions (BI-206DAB95)
+
+Adding `apps/web/app/**/page.tsx` requires regenerating **four** derived artifacts. CI fails opaquely if any is stale. One command regenerates all of them against the **current** tree:
+
+```bash
+pnpm route:sync
+```
+
+That runs, in order:
+
+| Artifact | Generator |
+| --- | --- |
+| `apps/web/lib/ea/route-manifest.json` | `pnpm --filter web build:route-manifest` |
+| `apps/web/lib/ux-budget/route-shells.generated.json` | `pnpm --filter web build:route-shells` |
+| `apps/web/lib/navigation/route-audience.generated.json` | `pnpm --filter web build:route-audience` |
+| `apps/web/lib/docs/doc-index.generated.json` | `node scripts/gen-doc-index.mjs` |
+
+**Base-drift trap:** regenerate **after** rebasing onto current `origin/main`. Checking/regenerating on a pre-rebase tree reports “fresh” and still fails CI on the merged tree.
+
+**Typecheck heap:** if pre-commit typecheck OOMs, use `NODE_OPTIONS=--max-old-space-size=8192` (or `DPF_SKIP_TYPECHECK=1` only when justified and attested).
+
 ## 3. Strongly-Typed String Enums (mandatory)
 
 → [kernel principle](../professions/data-architect/wiki/strongly-typed-string-enums.md)

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "check:singletons": "node scripts/sbom/check-singleton-safety.mjs",
     "docs:index": "node scripts/gen-doc-index.mjs",
     "docs:index:check": "node scripts/gen-doc-index.mjs --check",
+    "route:sync": "pnpm --filter web build:route-manifest && pnpm --filter web build:route-shells && pnpm --filter web build:route-audience && node scripts/gen-doc-index.mjs",
+    "route:sync:check": "pnpm --filter web check:route-manifest && pnpm --filter web build:route-shells -- --check && pnpm --filter web build:route-audience -- --check && node scripts/gen-doc-index.mjs --check",
     "docs:links": "node scripts/check-doc-links.mjs",
     "docs:links:test": "node --test scripts/check-doc-links.test.mjs",
     "docs:links:fix": "node scripts/fix-doc-links.mjs",

--- a/scripts/route-sync-contract.test.mjs
+++ b/scripts/route-sync-contract.test.mjs
@@ -1,0 +1,26 @@
+// scripts/route-sync-contract.test.mjs — BI-206DAB95
+// Ensures the single contributor command for route-derived artifacts stays wired.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+
+test("pnpm route:sync regenerates all four route companions", () => {
+  const script = pkg.scripts?.["route:sync"];
+  assert.ok(script, "package.json must define scripts.route:sync");
+  assert.match(script, /build:route-manifest/);
+  assert.match(script, /build:route-shells/);
+  assert.match(script, /build:route-audience/);
+  assert.match(script, /gen-doc-index/);
+});
+
+test("contributor runbook documents route:sync and base-drift trap", () => {
+  const doc = readFileSync(
+    "docs/architecture/contributor-procedure-runbook.md",
+    "utf8",
+  );
+  assert.match(doc, /pnpm route:sync/);
+  assert.match(doc, /BI-206DAB95/);
+  assert.match(doc, /Base-drift trap/i);
+});


### PR DESCRIPTION
## Summary

Closes BI-206DAB95: one command regenerates the four companions a new page route requires, and the contributor runbook documents the base-drift trap.

## Changes

- Add root `pnpm route:sync` (and `route:sync:check`) wiring all four generators
- Document the checklist and base-drift trap in contributor-procedure-runbook
- Contract test so the script wiring cannot silently disappear

## Test plan

- [x] node --test scripts/route-sync-contract.test.mjs (2/2)

## Related

- BI-206DAB95 / EP-WORKTREE-HYGIENE

## Documentation impact

Updates contributor procedure runbook with the route:sync path.

## Data and migration impact

None.

Process-Spine-Decision: contributor ergonomics; no product UX surface.

Local-CI-Override: scripts/docs only; host contract tests green
