### PR TITLE
chore(agents): give AI Ops platform-engineer host resource health mandate

### DIFF
--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -3149,7 +3149,7 @@
       "tier": "specialist",
       "value_stream": "cross-cutting",
       "role": "operator",
-      "capability_domain": "AI Ops Engineer. AI layer as a network of providers, models, costs, capabilities. Cost optimization, capability matching, failover design, profiling, workforce planning. Manages provider/model assignments and routing. Also owns host resource health (disk, filesystem free-space floors, Docker/container sprawl signals, and critical host alerts) — charter mandate so firing host alerts are owned, not orphaned (BI-1C88254D).",
+      "capability_domain": "AI Ops Engineer: providers, models, costs, capability matching, failover, routing, workforce planning. Owns host resource health — disk free-space floors, Docker/container sprawl, and critical host alerts (BI-1C88254D).",
       "human_supervisor_id": "HR-500",
       "hitl_tier_default": 1,
       "delegates_to": [],

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -3149,7 +3149,7 @@
       "tier": "specialist",
       "value_stream": "cross-cutting",
       "role": "operator",
-      "capability_domain": "AI Ops Engineer. AI layer as a network of providers, models, costs, capabilities. Cost optimization, capability matching, failover design, profiling, workforce planning. Manages provider/model assignments and routing.",
+      "capability_domain": "AI Ops Engineer. AI layer as a network of providers, models, costs, capabilities. Cost optimization, capability matching, failover design, profiling, workforce planning. Manages provider/model assignments and routing. Also owns host resource health (disk, filesystem free-space floors, Docker/container sprawl signals, and critical host alerts) — charter mandate so firing host alerts are owned, not orphaned (BI-1C88254D).",
       "human_supervisor_id": "HR-500",
       "hitl_tier_default": 1,
       "delegates_to": [],

--- a/packages/db/src/agent-host-resource-charter.test.ts
+++ b/packages/db/src/agent-host-resource-charter.test.ts
@@ -1,0 +1,24 @@
+// packages/db/src/agent-host-resource-charter.test.ts — BI-1C88254D
+// Platform engineer (AI Ops) must own host resource health in its seed charter.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const registryPath = join(root, "data", "agent_registry.json");
+
+test("AGT-WS-PLATFORM charter mandates host resource health ownership", () => {
+  const registry = JSON.parse(readFileSync(registryPath, "utf8"));
+  const agents = registry.agents ?? registry;
+  const list = Array.isArray(agents) ? agents : Object.values(agents);
+  const platform = list.find(
+    (a: { agent_id?: string }) => a.agent_id === "AGT-WS-PLATFORM",
+  );
+  assert.ok(platform, "AGT-WS-PLATFORM must exist in agent_registry.json");
+  const domain = String(platform.capability_domain ?? "");
+  assert.match(domain, /host resource health/i);
+  assert.match(domain, /disk/i);
+  assert.match(domain, /BI-1C88254D/);
+});

--- a/scripts/agent-host-resource-charter.contract.test.mjs
+++ b/scripts/agent-host-resource-charter.contract.test.mjs
@@ -1,21 +1,17 @@
-// packages/db/src/agent-host-resource-charter.test.ts — BI-1C88254D
+// scripts/agent-host-resource-charter.contract.test.mjs — BI-1C88254D
 // Platform engineer (AI Ops) must own host resource health in its seed charter.
+// Lives under scripts/ so packages/db vitest does not load node:test suites.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const registryPath = join(root, "data", "agent_registry.json");
+const registryPath = "packages/db/data/agent_registry.json";
 
 test("AGT-WS-PLATFORM charter mandates host resource health ownership", () => {
   const registry = JSON.parse(readFileSync(registryPath, "utf8"));
   const agents = registry.agents ?? registry;
   const list = Array.isArray(agents) ? agents : Object.values(agents);
-  const platform = list.find(
-    (a: { agent_id?: string }) => a.agent_id === "AGT-WS-PLATFORM",
-  );
+  const platform = list.find((a) => a.agent_id === "AGT-WS-PLATFORM");
   assert.ok(platform, "AGT-WS-PLATFORM must exist in agent_registry.json");
   const domain = String(platform.capability_domain ?? "");
   assert.match(domain, /host resource health/i);


### PR DESCRIPTION
## Summary

Closes BI-1C88254D by extending the platform-engineer (AI Ops) seed charter so host resource health is an explicit mandate, not an unowned side-effect of telemetry grants.

## Changes

- Expand `AGT-WS-PLATFORM` `capability_domain` to include disk/filesystem free-space, Docker/container sprawl, and critical host alerts
- Contract test under `scripts/agent-host-resource-charter.contract.test.mjs` (node:test; not packages/db vitest)

## Test plan

- [x] node --test scripts/agent-host-resource-charter.contract.test.mjs

## Related

- BI-1C88254D

## Documentation impact

Charter is seed data consumed by coworkers; no separate user guide.

## Data and migration impact

Seed JSON only; live installs pick up via next seed/self-upgrade path for agent registry.

Process-Spine-Decision: seed charter text + contract test; no UX surface.

Seed-Fit-Decision: global-default

Local-CI-Override: packages/db seed JSON + scripts node:test only; no web UI

Design-Grounding-Decision: reviewed agent_registry seed substrate and host free-space / disk-floor related BIs; charter text only, no portal routing or UX contract change.