### PR TITLE
feat(mcp): close efficiency loop with AI Ops BI filing and dispatch (BI-A08EBAEC)

### DIFF
--- a/apps/web/lib/mcp/packs/optimization-pack.ts
+++ b/apps/web/lib/mcp/packs/optimization-pack.ts
@@ -30,7 +30,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "analyze_mcp_call_efficiency",
     description:
-      "Analyze ToolExecution thrash, retries, high volume, and failures. Recommends skill, tool-merge, or webhook fixes to cut agent token waste. notify=true posts AI Ops alerts.",
+      "Analyze ToolExecution thrash, retries, high volume, and failures. Recommends skill, tool-merge, or webhook fixes to cut agent token waste. notify=true posts AI Ops alerts; dispatchAiOps=true files critical BIs and queues a one-shot platform-engineer review.",
     inputSchema: {
       type: "object",
       properties: {
@@ -47,13 +47,19 @@ const definitions: ToolDefinition[] = [
           description:
             "When true, create PlatformNotification rows for warning/critical findings (deduped 24h). Default false.",
         },
+        dispatchAiOps: {
+          type: "boolean",
+          description:
+            "When true, file critical findings as backlog items, record ImprovementSignals, and queue a one-shot AI Ops (platform-engineer) review task. Default false (daily cron enables this).",
+        },
       },
       required: [],
     },
     requiredCapability: "view_platform",
     executionMode: "immediate",
-    sideEffect: false,
-    annotations: { readOnlyHint: true, idempotentHint: true },
+    // notify/dispatchAiOps write platform rows; default path is read-only analysis.
+    sideEffect: true,
+    annotations: { readOnlyHint: false, idempotentHint: true },
   },
 ];
 
@@ -93,6 +99,7 @@ async function dispatchBet(
 
 async function analyzeMcpCallEfficiency(
   params: Record<string, unknown>,
+  userId: string,
 ): Promise<ToolResult> {
   const { runCallEfficiencyReport } = await import("@/lib/operate/mcp-call-efficiency/report");
   const windowHours =
@@ -102,11 +109,14 @@ async function analyzeMcpCallEfficiency(
       ? params["thrashThreshold"]
       : undefined;
   const notify = params["notify"] === true;
+  const dispatchAiOps = params["dispatchAiOps"] === true;
 
-  const { report, notified } = await runCallEfficiencyReport({
+  const { report, notified, aiOps } = await runCallEfficiencyReport({
     windowHours,
     thrashThreshold,
     notify,
+    dispatchAiOps,
+    ownerUserId: dispatchAiOps ? userId : undefined,
   });
 
   const top = report.findings
@@ -114,17 +124,26 @@ async function analyzeMcpCallEfficiency(
     .map((f) => `${f.severity}:${f.kind}:${f.toolName}→${f.recommendedAction}`)
     .join("; ");
 
+  const aiOpsNote =
+    aiOps == null
+      ? ""
+      : aiOps.skipped
+        ? `; aiOps skipped (${aiOps.reason})`
+        : `; aiOps task=${aiOps.agentTaskId} bis=${aiOps.backlogItemsFiled.length}`;
+
   return {
     success: true,
     message:
       `${report.totalCalls} call(s) in window; ${(report.successRate * 100).toFixed(0)}% success; ` +
       `${report.findings.length} finding(s)` +
       (notified ? `; notified ${notified}` : "") +
+      aiOpsNote +
       (top ? ` — ${top}` : "") +
       `. ${report.ledgerSufficiency.note}`,
     data: {
       ...report,
       notified,
+      aiOps,
     } as unknown as Record<string, unknown>,
   };
 }
@@ -134,7 +153,8 @@ export const optimizationPack: ToolPack = {
   definitions,
   handlers: {
     dispatch_consolidation_bet: (params, userId) => dispatchBet(params, userId),
-    analyze_mcp_call_efficiency: (params) => analyzeMcpCallEfficiency(params),
+    analyze_mcp_call_efficiency: (params, userId) =>
+      analyzeMcpCallEfficiency(params, userId),
   },
   grants: {
     dispatch_consolidation_bet: ["build_promote"],

--- a/apps/web/lib/operate/mcp-call-efficiency/aiops-handoff.test.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/aiops-handoff.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { CallEfficiencyReport, EfficiencyFinding } from "./analysis";
+import {
+  actionToWorkType,
+  actionableFindings,
+  buildAiOpsReviewPrompt,
+  dailyAiOpsTaskId,
+  findingSourceId,
+  oneShotCronFor,
+  SIGNAL_SOURCE_TYPE,
+} from "./aiops-handoff";
+import { isOneShotCron } from "@/lib/operate/cron-next-run";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: { create: vi.fn() },
+    taskArtifact: { create: vi.fn() },
+    improvementSignal: { update: vi.fn() },
+    scheduledAgentTask: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    scheduledJob: { upsert: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/improvement-flywheel/signals", () => ({
+  createOrTouchImprovementSignal: vi.fn(),
+}));
+
+vi.mock("@/lib/operate/backlog-ingest", () => ({
+  ingestBacklogItem: vi.fn(),
+}));
+
+import { prisma } from "@dpf/db";
+import { createOrTouchImprovementSignal } from "@/lib/improvement-flywheel/signals";
+import { ingestBacklogItem } from "@/lib/operate/backlog-ingest";
+import { dispatchMcpEfficiencyAiOps } from "./aiops-handoff";
+
+function finding(
+  partial: Partial<EfficiencyFinding> &
+    Pick<EfficiencyFinding, "kind" | "toolName" | "severity">,
+): EfficiencyFinding {
+  return {
+    title: `${partial.kind} on ${partial.toolName}`,
+    detail: "detail",
+    evidence: { count: 20, sampleIds: ["a"] },
+    recommendedAction: "add_skill",
+    wasteCallEstimate: 12,
+    ...partial,
+  };
+}
+
+function report(findings: EfficiencyFinding[]): CallEfficiencyReport {
+  return {
+    windowStart: "2026-08-03T00:00:00.000Z",
+    windowEnd: "2026-08-04T00:00:00.000Z",
+    totalCalls: 100,
+    successRate: 0.9,
+    bySurface: [],
+    topTools: [],
+    findings,
+    ledgerSufficiency: { usable: true, note: "ok" },
+  };
+}
+
+describe("mcp-call-efficiency AI Ops handoff helpers", () => {
+  it("maps recommended actions to backlog work types", () => {
+    expect(actionToWorkType("add_skill")).toBe("skill");
+    expect(actionToWorkType("merge_tools")).toBe("tool");
+    expect(actionToWorkType("webhook_or_event")).toBe("tool");
+    expect(actionToWorkType("fix_instructions")).toBe("doc");
+    expect(actionToWorkType("investigate")).toBe("chore");
+  });
+
+  it("builds stable source ids and filters actionable findings", () => {
+    expect(findingSourceId({ kind: "thrash", toolName: "get_x" })).toBe(
+      "thrash:get_x",
+    );
+    const all = [
+      finding({ kind: "thrash", toolName: "a", severity: "info" }),
+      finding({ kind: "high_volume", toolName: "b", severity: "warning" }),
+      finding({ kind: "retry_storm", toolName: "c", severity: "critical" }),
+    ];
+    expect(actionableFindings(all).map((f) => f.toolName)).toEqual(["b", "c"]);
+  });
+
+  it("builds a one-shot cron for the UTC calendar day", () => {
+    const now = new Date("2026-08-04T06:15:00.000Z");
+    const cron = oneShotCronFor(now);
+    expect(cron).toBe("15 6 4 8 *");
+    expect(isOneShotCron(cron)).toBe(true);
+    expect(dailyAiOpsTaskId(now)).toBe("mcp-efficiency-aiops-20260804");
+  });
+
+  it("builds an AI Ops review prompt with filed BIs and mandate", () => {
+    const findings = [
+      finding({ kind: "thrash", toolName: "get_backlog_item", severity: "critical" }),
+    ];
+    const prompt = buildAiOpsReviewPrompt(report(findings), {
+      taskRunPublicId: "TR-MCP-EFF-TEST",
+      backlogItemsFiled: ["BI-MCP-EFF-1"],
+      findings,
+    });
+    expect(prompt).toContain("AI Ops Engineer");
+    expect(prompt).toContain("get_backlog_item");
+    expect(prompt).toContain("BI-MCP-EFF-1");
+    expect(prompt).toContain("create_backlog_item");
+    expect(prompt).toContain("TR-MCP-EFF-TEST");
+  });
+});
+
+describe("dispatchMcpEfficiencyAiOps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "cuid-tr",
+      taskRunId: "TR-MCP-EFF-ABCD1234",
+    } as never);
+    vi.mocked(prisma.taskArtifact.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.improvementSignal.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.scheduledAgentTask.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.scheduledAgentTask.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.scheduledJob.upsert).mockResolvedValue({} as never);
+    vi.mocked(createOrTouchImprovementSignal).mockResolvedValue({
+      signalId: "IS-1",
+      isNew: true,
+    });
+    vi.mocked(ingestBacklogItem).mockResolvedValue({
+      itemId: "BI-MCP-EFF-ABCD",
+      id: "cuid-bi",
+      created: true,
+    });
+  });
+
+  it("skips when there are no warning/critical findings", async () => {
+    const result = await dispatchMcpEfficiencyAiOps({
+      report: report([
+        finding({ kind: "high_volume", toolName: "x", severity: "info" }),
+      ]),
+      ownerUserId: "user-1",
+      now: new Date("2026-08-04T06:15:00.000Z"),
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("no-warning-or-critical-findings");
+    expect(prisma.taskRun.create).not.toHaveBeenCalled();
+  });
+
+  it("files critical BIs, touches signals, and creates a one-shot AI Ops task", async () => {
+    const now = new Date("2026-08-04T06:15:00.000Z");
+    const result = await dispatchMcpEfficiencyAiOps({
+      report: report([
+        finding({
+          kind: "thrash",
+          toolName: "get_backlog_item",
+          severity: "critical",
+          recommendedAction: "add_skill",
+        }),
+        finding({
+          kind: "high_volume",
+          toolName: "list_items",
+          severity: "warning",
+          recommendedAction: "merge_tools",
+        }),
+      ]),
+      ownerUserId: "user-super",
+      now,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.taskRunPublicId).toMatch(/^TR-MCP-EFF-/);
+    expect(result.reportArtifactId).toMatch(/^ta_/);
+    expect(result.signalsTouched).toBe(2);
+    expect(result.backlogItemsFiled).toEqual(["BI-MCP-EFF-ABCD"]);
+    expect(result.agentTaskId).toBe("mcp-efficiency-aiops-20260804");
+    expect(result.agentTaskCreated).toBe(true);
+
+    expect(createOrTouchImprovementSignal).toHaveBeenCalledTimes(2);
+    expect(createOrTouchImprovementSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: SIGNAL_SOURCE_TYPE,
+        sourceId: "thrash:get_backlog_item",
+        agentId: "platform-engineer",
+      }),
+    );
+
+    expect(ingestBacklogItem).toHaveBeenCalledTimes(1);
+    expect(ingestBacklogItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workType: "skill",
+        source: "automated-detection",
+        agentId: "platform-engineer",
+        origin: { kind: SIGNAL_SOURCE_TYPE, id: "thrash:get_backlog_item" },
+      }),
+    );
+
+    expect(prisma.scheduledAgentTask.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          taskId: "mcp-efficiency-aiops-20260804",
+          agentId: "platform-engineer",
+          ownerUserId: "user-super",
+          schedule: "15 6 4 8 *",
+          nextRunAt: now,
+          isActive: true,
+        }),
+      }),
+    );
+  });
+
+  it("re-arms an existing same-day AI Ops task instead of duplicating", async () => {
+    vi.mocked(prisma.scheduledAgentTask.findUnique).mockResolvedValue({
+      taskId: "mcp-efficiency-aiops-20260804",
+      isActive: false,
+    } as never);
+
+    const now = new Date("2026-08-04T06:15:00.000Z");
+    const result = await dispatchMcpEfficiencyAiOps({
+      report: report([
+        finding({ kind: "retry_storm", toolName: "create_x", severity: "warning" }),
+      ]),
+      ownerUserId: "user-super",
+      now,
+    });
+
+    expect(result.agentTaskCreated).toBe(false);
+    expect(prisma.scheduledAgentTask.create).not.toHaveBeenCalled();
+    expect(prisma.scheduledAgentTask.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: "mcp-efficiency-aiops-20260804" },
+        data: expect.objectContaining({ isActive: true, nextRunAt: now }),
+      }),
+    );
+    // Warnings do not auto-file BIs
+    expect(ingestBacklogItem).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/operate/mcp-call-efficiency/aiops-handoff.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/aiops-handoff.ts
@@ -1,0 +1,354 @@
+/**
+ * AI Ops closed loop for MCP call efficiency (BI-A08EBAEC slice 2).
+ *
+ * After the daily scan (or an on-demand run with dispatchAiOps), critical
+ * findings become backlog items immediately, every warning+ finding is recorded
+ * as an ImprovementSignal, the full report is persisted as a TaskArtifact under
+ * a proactive TaskRun owned by platform-engineer, and a one-shot ScheduledAgentTask
+ * dispatches the AI Ops coworker to review remaining findings and file any gaps.
+ */
+
+import { randomUUID } from "crypto";
+
+import type { Prisma } from "@dpf/db";
+import { prisma } from "@dpf/db";
+
+import { createOrTouchImprovementSignal } from "@/lib/improvement-flywheel/signals";
+import type { BacklogWorkType } from "@/lib/explore/backlog";
+import { ingestBacklogItem } from "@/lib/operate/backlog-ingest";
+import { isOneShotCron } from "@/lib/operate/cron-next-run";
+
+import type {
+  CallEfficiencyReport,
+  EfficiencyActionKind,
+  EfficiencyFinding,
+} from "./analysis";
+
+export const EFFICIENCY_REPORT_KIND = "mcp-call-efficiency-report";
+export const AIOPS_AGENT_ID = "platform-engineer";
+export const AIOPS_ROUTE = "/platform/ai";
+export const SIGNAL_SOURCE_TYPE = "mcp-call-efficiency";
+
+/** Max findings filed/dispatched per run (noise ceiling). */
+const MAX_ACTIONABLE = 10;
+
+export type AiOpsHandoffResult = {
+  skipped: boolean;
+  reason?: string;
+  taskRunPublicId: string | null;
+  reportArtifactId: string | null;
+  signalsTouched: number;
+  backlogItemsFiled: string[];
+  agentTaskId: string | null;
+  agentTaskCreated: boolean;
+};
+
+export type DispatchMcpEfficiencyAiOpsInput = {
+  report: CallEfficiencyReport;
+  /** Real User.id that owns the TaskRun / ScheduledAgentTask (superuser). */
+  ownerUserId: string;
+  now?: Date;
+};
+
+export function findingSourceId(f: Pick<EfficiencyFinding, "kind" | "toolName">): string {
+  return `${f.kind}:${f.toolName}`;
+}
+
+export function actionToWorkType(action: EfficiencyActionKind): BacklogWorkType {
+  if (action === "add_skill") return "skill";
+  if (action === "merge_tools" || action === "webhook_or_event") return "tool";
+  if (action === "fix_instructions") return "doc";
+  return "chore";
+}
+
+export function actionableFindings(findings: EfficiencyFinding[]): EfficiencyFinding[] {
+  return findings
+    .filter((f) => f.severity === "warning" || f.severity === "critical")
+    .slice(0, MAX_ACTIONABLE);
+}
+
+export function dailyAiOpsTaskId(now: Date): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
+  return `mcp-efficiency-aiops-${y}${m}${d}`;
+}
+
+/** One-shot cron for "today UTC" so the task deactivates after a single fire. */
+export function oneShotCronFor(now: Date): string {
+  // minute hour day-of-month month day-of-week — concrete mon+dom ⇒ one-shot
+  return `${now.getUTCMinutes()} ${now.getUTCHours()} ${now.getUTCDate()} ${now.getUTCMonth() + 1} *`;
+}
+
+export function buildAiOpsReviewPrompt(
+  report: CallEfficiencyReport,
+  opts: {
+    taskRunPublicId: string | null;
+    backlogItemsFiled: string[];
+    findings: EfficiencyFinding[];
+  },
+): string {
+  const lines = opts.findings.map(
+    (f, i) =>
+      `${i + 1}. [${f.severity}] ${f.kind} on \`${f.toolName}\` → ${f.recommendedAction}\n` +
+      `   ${f.title}\n` +
+      `   ${f.detail}\n` +
+      `   wasteCalls≈${f.wasteCallEstimate}; sourceId=${findingSourceId(f)}`,
+  );
+
+  const already = opts.backlogItemsFiled.length
+    ? opts.backlogItemsFiled.join(", ")
+    : "(none yet — file critical and durable warning findings)";
+
+  return [
+    "You are the AI Ops Engineer (platform-engineer). A governed MCP call-efficiency scan just completed.",
+    "",
+    `Window: ${report.windowStart} → ${report.windowEnd}`,
+    `Total calls: ${report.totalCalls}; success rate: ${(report.successRate * 100).toFixed(0)}%`,
+    `Ledger usable: ${report.ledgerSufficiency.usable} — ${report.ledgerSufficiency.note}`,
+    opts.taskRunPublicId
+      ? `Report TaskRun: ${opts.taskRunPublicId} (artifact kind=${EFFICIENCY_REPORT_KIND})`
+      : null,
+    "",
+    "Actionable findings:",
+    lines.length ? lines.join("\n") : "(none)",
+    "",
+    `Backlog items already auto-filed this run: ${already}`,
+    "",
+    "Your mandate:",
+    "1. Review each finding. Prefer skills, tool merges, webhooks/events, or instruction fixes over vague chores.",
+    "2. For any CRITICAL finding without a filed BI, create a backlog item via create_backlog_item (workType skill|tool|doc|chore from the recommended action). Include origin marker and sourceId in the body.",
+    "3. For WARNING findings that recur or clearly waste tokens, file or update BIs; skip one-off noise.",
+    "4. Do NOT re-file a finding whose sourceId already has an open BI from this scan.",
+    "5. Summarize what you filed and what you deferred, with tool names and recommended actions.",
+  ]
+    .filter((x) => x !== null)
+    .join("\n");
+}
+
+function findingBody(f: EfficiencyFinding): string {
+  return [
+    f.detail,
+    `Recommended action: ${f.recommendedAction}`,
+    `Severity: ${f.severity}; kind: ${f.kind}; tool: ${f.toolName}`,
+    `Waste call estimate: ${f.wasteCallEstimate}`,
+    f.evidence.threadId ? `Sample thread: ${f.evidence.threadId}` : null,
+    f.evidence.agentId ? `Sample agent: ${f.evidence.agentId}` : null,
+    `Evidence count: ${f.evidence.count}` +
+      (f.evidence.failCount != null ? `; fails: ${f.evidence.failCount}` : ""),
+    `Source: MCP call efficiency scan (BI-A08EBAEC); sourceId=${findingSourceId(f)}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Persist report + signals + critical BIs + one-shot AI Ops coworker task.
+ */
+export async function dispatchMcpEfficiencyAiOps(
+  input: DispatchMcpEfficiencyAiOpsInput,
+): Promise<AiOpsHandoffResult> {
+  const now = input.now ?? new Date();
+  const findings = actionableFindings(input.report.findings);
+
+  if (findings.length === 0) {
+    return {
+      skipped: true,
+      reason: "no-warning-or-critical-findings",
+      taskRunPublicId: null,
+      reportArtifactId: null,
+      signalsTouched: 0,
+      backlogItemsFiled: [],
+      agentTaskId: null,
+      agentTaskCreated: false,
+    };
+  }
+
+  const taskRunPublicId = `TR-MCP-EFF-${randomUUID().slice(0, 8).toUpperCase()}`;
+  const taskRun = await prisma.taskRun.create({
+    data: {
+      taskRunId: taskRunPublicId,
+      userId: input.ownerUserId,
+      title: "MCP call efficiency scan — AI Ops handoff",
+      objective:
+        "Review ToolExecution thrash/volume findings; ensure critical token-waste issues have backlog items.",
+      source: "proactive",
+      status: "completed",
+      authorityScope: [],
+      a2aMetadata: {
+        trigger: "mcp-call-efficiency-scan",
+        findingCount: findings.length,
+      } as Prisma.InputJsonValue,
+      currentAgentId: AIOPS_AGENT_ID,
+      initiatingAgentId: AIOPS_AGENT_ID,
+      routeContext: AIOPS_ROUTE,
+      completedAt: now,
+    },
+    select: { id: true, taskRunId: true },
+  });
+
+  const artifactId = `ta_${randomUUID()}`;
+  await prisma.taskArtifact.create({
+    data: {
+      id: randomUUID(),
+      artifactId,
+      taskRunId: taskRun.id,
+      name: "MCP call efficiency report",
+      description: `${input.report.totalCalls} calls; ${findings.length} actionable finding(s)`,
+      parts: [
+        {
+          type: EFFICIENCY_REPORT_KIND,
+          mimeType: "application/json",
+          data: input.report,
+        },
+      ] as unknown as Prisma.InputJsonValue,
+      metadata: { kind: EFFICIENCY_REPORT_KIND } as Prisma.InputJsonValue,
+    },
+  });
+
+  let signalsTouched = 0;
+  const backlogItemsFiled: string[] = [];
+
+  for (const f of findings) {
+    const sourceId = findingSourceId(f);
+    const signal = await createOrTouchImprovementSignal({
+      sourceType: SIGNAL_SOURCE_TYPE,
+      sourceId,
+      title: `[MCP efficiency] ${f.title}`,
+      description: f.detail,
+      evidence: {
+        kind: f.kind,
+        severity: f.severity,
+        toolName: f.toolName,
+        recommendedAction: f.recommendedAction,
+        wasteCallEstimate: f.wasteCallEstimate,
+        count: f.evidence.count,
+        failCount: f.evidence.failCount ?? null,
+        sampleIds: f.evidence.sampleIds.slice(0, 5),
+      },
+      routeContext: AIOPS_ROUTE,
+      agentId: AIOPS_AGENT_ID,
+      toolName: f.toolName,
+      suspectedRootCause: `${f.kind} on ${f.toolName}`,
+      objectiveImpactHypothesis: `Recommended: ${f.recommendedAction}; wasteCalls≈${f.wasteCallEstimate}`,
+    });
+    signalsTouched += 1;
+
+    // Critical findings file immediately (do not wait for recurrence threshold).
+    if (f.severity === "critical" && !signal.backlogItemId) {
+      try {
+        const res = await ingestBacklogItem({
+          title: `[MCP efficiency] ${f.title}`,
+          body: findingBody(f),
+          workType: actionToWorkType(f.recommendedAction),
+          source: "automated-detection",
+          type: "portfolio",
+          status: "triaging",
+          priority: 1,
+          agentId: AIOPS_AGENT_ID,
+          itemIdPrefix: "MCP-EFF",
+          origin: { kind: SIGNAL_SOURCE_TYPE, id: sourceId },
+        });
+        backlogItemsFiled.push(res.itemId);
+        await prisma.improvementSignal.update({
+          where: {
+            sourceType_sourceId: {
+              sourceType: SIGNAL_SOURCE_TYPE,
+              sourceId,
+            },
+          },
+          data: { backlogItemId: res.itemId },
+        });
+      } catch (err) {
+        console.warn(
+          "[mcp-call-efficiency] critical BI file failed for",
+          sourceId,
+          err,
+        );
+      }
+    } else if (signal.backlogItemId) {
+      backlogItemsFiled.push(signal.backlogItemId);
+    }
+  }
+
+  // One-shot coworker dispatch (picked up by agent/task-dispatch within ~5 min).
+  const agentTaskId = dailyAiOpsTaskId(now);
+  const schedule = oneShotCronFor(now);
+  if (!isOneShotCron(schedule)) {
+    // Defensive: never leave a misclassified recurring task.
+    console.warn(
+      "[mcp-call-efficiency] one-shot cron classification failed:",
+      schedule,
+    );
+  }
+
+  const prompt = buildAiOpsReviewPrompt(input.report, {
+    taskRunPublicId,
+    backlogItemsFiled: [...new Set(backlogItemsFiled)],
+    findings,
+  });
+
+  const existing = await prisma.scheduledAgentTask.findUnique({
+    where: { taskId: agentTaskId },
+    select: { taskId: true, isActive: true },
+  });
+
+  let agentTaskCreated = false;
+  if (existing) {
+    await prisma.scheduledAgentTask.update({
+      where: { taskId: agentTaskId },
+      data: {
+        isActive: true,
+        nextRunAt: now,
+        prompt,
+        title: "MCP call efficiency — AI Ops review",
+        agentId: AIOPS_AGENT_ID,
+        routeContext: AIOPS_ROUTE,
+        schedule,
+        timezone: "UTC",
+        ownerUserId: input.ownerUserId,
+      },
+    });
+  } else {
+    await prisma.scheduledAgentTask.create({
+      data: {
+        taskId: agentTaskId,
+        agentId: AIOPS_AGENT_ID,
+        title: "MCP call efficiency — AI Ops review",
+        prompt,
+        routeContext: AIOPS_ROUTE,
+        schedule,
+        timezone: "UTC",
+        ownerUserId: input.ownerUserId,
+        nextRunAt: now,
+        isActive: true,
+      },
+    });
+    agentTaskCreated = true;
+  }
+
+  await prisma.scheduledJob.upsert({
+    where: { jobId: agentTaskId },
+    create: {
+      jobId: agentTaskId,
+      name: "Agent: MCP call efficiency — AI Ops review",
+      schedule,
+      nextRunAt: now,
+    },
+    update: {
+      name: "Agent: MCP call efficiency — AI Ops review",
+      schedule,
+      nextRunAt: now,
+    },
+  });
+
+  return {
+    skipped: false,
+    taskRunPublicId,
+    reportArtifactId: artifactId,
+    signalsTouched,
+    backlogItemsFiled: [...new Set(backlogItemsFiled)],
+    agentTaskId,
+    agentTaskCreated,
+  };
+}

--- a/apps/web/lib/operate/mcp-call-efficiency/report.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/report.ts
@@ -9,6 +9,7 @@ import {
   type CallEfficiencyReport,
   type EfficiencyFinding,
 } from "./analysis";
+import type { AiOpsHandoffResult } from "./aiops-handoff";
 
 export type LoadCallEfficiencyOptions = AnalyzeCallEfficiencyOptions & {
   /** Lookback hours (default 24, max 168). */
@@ -17,11 +18,20 @@ export type LoadCallEfficiencyOptions = AnalyzeCallEfficiencyOptions & {
   limit?: number;
   /** When true, create PlatformNotification for warning+ findings. */
   notify?: boolean;
+  /**
+   * When true, run the AI Ops closed loop: ImprovementSignals, critical BIs,
+   * TaskRun report artifact, and one-shot platform-engineer review task.
+   * Requires `ownerUserId` (scheduled owner). Cron enables this daily.
+   */
+  dispatchAiOps?: boolean;
+  /** Real User.id owning proactive TaskRun / ScheduledAgentTask. */
+  ownerUserId?: string;
 };
 
 export type CallEfficiencyRunResult = {
   report: CallEfficiencyReport;
   notified: number;
+  aiOps: AiOpsHandoffResult | null;
 };
 
 function clampWindowHours(raw: unknown): number {
@@ -112,7 +122,7 @@ async function notifyFindings(findings: EfficiencyFinding[]): Promise<number> {
 }
 
 /**
- * Full report load + optional platform notifications for AI Ops follow-up.
+ * Full report load + optional platform notifications + AI Ops handoff.
  */
 export async function runCallEfficiencyReport(
   opts: LoadCallEfficiencyOptions = {},
@@ -128,5 +138,25 @@ export async function runCallEfficiencyReport(
       console.warn("[mcp-call-efficiency] notify failed:", err);
     }
   }
-  return { report, notified };
+
+  let aiOps: AiOpsHandoffResult | null = null;
+  if (opts.dispatchAiOps) {
+    if (!opts.ownerUserId) {
+      console.warn(
+        "[mcp-call-efficiency] dispatchAiOps requested without ownerUserId; skipping handoff",
+      );
+    } else {
+      try {
+        const { dispatchMcpEfficiencyAiOps } = await import("./aiops-handoff");
+        aiOps = await dispatchMcpEfficiencyAiOps({
+          report,
+          ownerUserId: opts.ownerUserId,
+        });
+      } catch (err) {
+        console.warn("[mcp-call-efficiency] AI Ops handoff failed:", err);
+      }
+    }
+  }
+
+  return { report, notified, aiOps };
 }

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -522,7 +522,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     inngestId: "ops/mcp-call-efficiency-scan",
     name: "MCP call efficiency scan",
     purpose:
-      "BI-A08EBAEC: analyzes ToolExecution thrash, retry storms, and high-volume/failure tools; notifies AI Ops so agent token waste can be cut via skills, tool merges, or webhooks.",
+      "BI-A08EBAEC: analyzes ToolExecution thrash, retry storms, and high-volume/failure tools; notifies, files critical BIs, and dispatches a one-shot AI Ops (platform-engineer) review so token waste is cut via skills, tool merges, or webhooks.",
     cron: "15 6 * * *",
     cadence: "Daily at 06:15",
     category: "editable",

--- a/apps/web/lib/queue/functions/mcp-call-efficiency-scan.ts
+++ b/apps/web/lib/queue/functions/mcp-call-efficiency-scan.ts
@@ -6,7 +6,8 @@ import { gateAtEntry } from "../quiescence-gates";
  * Daily MCP / governed-tool call efficiency scan (BI-A08EBAEC).
  * Runs at 06:15 UTC — after skill metrics (05:00) and before business hours.
  * Emits PlatformNotification rows for warning/critical thrash, retry storms,
- * and high-volume/failure tools so AI Ops can act (skills, webhooks, tools).
+ * and high-volume/failure tools; then closes the loop by filing critical BIs
+ * and dispatching a one-shot platform-engineer (AI Ops) review task.
  */
 export const mcpCallEfficiencyScan = inngest.createFunction(
   {
@@ -19,21 +20,29 @@ export const mcpCallEfficiencyScan = inngest.createFunction(
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
-    return step.run("analyze-and-notify", async () => {
+    return step.run("analyze-notify-and-dispatch-aiops", async () => {
+      const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
       const { runCallEfficiencyReport } = await import(
         "@/lib/operate/mcp-call-efficiency/report"
       );
-      const { report, notified } = await runCallEfficiencyReport({
+      const ownerUserId = await resolveScheduledOwnerUserId();
+      const { report, notified, aiOps } = await runCallEfficiencyReport({
         windowHours: 24,
         notify: true,
+        dispatchAiOps: true,
+        ownerUserId,
       });
       console.log(
-        `[mcp-call-efficiency] calls=${report.totalCalls} findings=${report.findings.length} notified=${notified} usable=${report.ledgerSufficiency.usable}`,
+        `[mcp-call-efficiency] calls=${report.totalCalls} findings=${report.findings.length} notified=${notified} usable=${report.ledgerSufficiency.usable}` +
+          (aiOps
+            ? ` aiOps=${aiOps.skipped ? `skip:${aiOps.reason}` : `task=${aiOps.agentTaskId} bis=${aiOps.backlogItemsFiled.length}`}`
+            : ""),
       );
       return {
         totalCalls: report.totalCalls,
         findingCount: report.findings.length,
         notified,
+        aiOps,
         topFindings: report.findings.slice(0, 5).map((f) => ({
           kind: f.kind,
           toolName: f.toolName,

--- a/docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
+++ b/docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
@@ -52,9 +52,14 @@ External MCP clients (Claude/Codex/Grok) and in-portal coworkers burn tokens via
 
 1. **On demand:** MCP tool `analyze_mcp_call_efficiency` (optimization pack).  
 2. **Scheduled:** daily Inngest job (06:15 UTC) runs same analysis; posts `PlatformNotification` when high-severity findings exist.  
-3. **Human/AI Ops:** act on findings → skill, pack, or webhook BI.  
+3. **Closed loop (slice 2):** when warning/critical findings exist:
+   - Persist full report as `TaskArtifact` (`metadata.kind=mcp-call-efficiency-report`) under a proactive `TaskRun` owned by `platform-engineer`.
+   - Touch `ImprovementSignal` rows (`sourceType=mcp-call-efficiency`, `sourceId=kind:toolName`) for every actionable finding.
+   - **Immediately file backlog items** for **critical** findings via `ingestBacklogItem` (prefix `BI-MCP-EFF-*`, workType from recommended action).
+   - Enqueue a **one-shot** `ScheduledAgentTask` (`mcp-efficiency-aiops-YYYYMMDD`) for the AI Ops coworker with a mandate prompt; `agent/task-dispatch` runs it within ~5 minutes; task deactivates after one fire.
+4. **Human/AI Ops:** coworker reviews remaining warnings, avoids re-filing already-sourced BIs, proposes skill/tool/webhook work.
 
-Later slices: file `ImprovementProposal` / backlog automatically; tools/list metrics_only; OTel export; authority UI panel.
+Later slices: tools/list metrics_only; OTel export; authority UI panel; auto-promote selected BIs to Build Studio.
 
 ## Slice 1 deliverables
 
@@ -64,6 +69,15 @@ Later slices: file `ImprovementProposal` / backlog automatically; tools/list met
 - Design + unit tests  
 - No new Prisma models  
 
+## Slice 2 deliverables (this PR)
+
+- `dispatchMcpEfficiencyAiOps` handoff module + unit tests  
+- Cron wires `dispatchAiOps: true` + scheduled owner principal  
+- Critical BI auto-file + ImprovementSignals + TaskRun artifact  
+- One-shot platform-engineer review task  
+- MCP tool gains optional `dispatchAiOps`  
+- Catalog purpose updated  
+
 ## Docs impact
 
-Operator-facing: tool appears in MCP tool list for agents with `agent_control_read`. Architecture: this design note. No user-guide route until a portal page ships.
+Operator-facing: tool appears in MCP tool list for agents with `agent_control_read`; daily job purpose describes AI Ops dispatch. Architecture: this design note. No user-guide route until a portal page ships.


### PR DESCRIPTION
## Summary
- Closes BI-A08EBAEC improvement loop: after the daily MCP call-efficiency scan, **critical** findings are filed as backlog items, every warning+ finding becomes an `ImprovementSignal`, the full report is persisted under a proactive `platform-engineer` TaskRun artifact, and a **one-shot** AI Ops scheduled task is queued for coworker review within ~5 minutes.
- On-demand MCP tool `analyze_mcp_call_efficiency` gains optional `dispatchAiOps` (uses the calling user as owner).
- Design doc updated for slice 2; catalog purpose reflects auto-dispatch.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
- Current code substrate reviewed:
  - apps/web/lib/skills/curator.ts
  - apps/web/lib/improvement-flywheel/signals.ts
  - apps/web/lib/operate/backlog-ingest.ts
  - apps/web/lib/actions/agent-task-scheduler.ts
  - apps/web/lib/queue/functions/mcp-call-efficiency-scan.ts
  - apps/web/lib/mcp/packs/optimization-pack.ts
- Source of truth:
  - ToolExecution ledger + ingestBacklogItem + ScheduledAgentTask dispatch
- Decision:
  - Extend the daily scan with deterministic critical BI filing and a one-shot platform-engineer review task; no new Prisma models

## Test plan
- [x] `pnpm --filter web exec vitest run lib/operate/mcp-call-efficiency` (11 tests)
- [x] Scoped typecheck (apps/web)
- [x] `node scripts/check-tool-surface.mjs`
- [x] `node scripts/check-module-size.mjs`
- [x] `node scripts/check-design-grounding-decision.mjs`
- [ ] CI green on PR
- [ ] After merge + self-upgrade: next 06:15 UTC scan (or manual analyze with dispatchAiOps=true)

Docs-Impact-Decision: design spec + scheduled-jobs catalog purpose only; no user-guide route