### PR TITLE
feat(hooks): refuse publish without local-CI evidence (BI-563F6AB6 P2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/lease-punt-guard.mjs\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs\""
           }
         ]
       },

--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -79,11 +79,28 @@ if [ "${DPF_SKIP_PREPUSH_GATE:-}" = "1" ]; then
     echo "[pre-push-gate]   DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON=\"operator-emergency: brief why\" git push" >&2
     exit 1
   fi
-  # Validate allowlisted code before writing the skip record (same SoT as pr:health).
-  if ! node --input-type=module -e '
-import { classifyLocalCiOverride } from "./packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs";
-const r = classifyLocalCiOverride(process.argv[1]);
-if (!r.ok) { console.error("[pre-push-gate]", r.reason); process.exit(1); }
+  # Validate allowlisted code before writing the skip record (BI-563F6AB6).
+  # Inline codes (no monorepo import) so temp-dir gate contract tests still work;
+  # keep in sync with packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs.
+  if ! node -e '
+const reason = process.argv[1] || "";
+const codes = new Set([
+  "docs-adjacent",
+  "delete-or-tag-only",
+  "operator-emergency",
+  "external-contribution-no-install",
+  "install-bootstrap-recovery",
+]);
+const raw = reason.trim();
+const m = raw.match(/^([a-z0-9-]+)(?:\s*[:\u2014\-]\s*(.*))?$/i);
+if (!m || !codes.has(m[1].toLowerCase())) {
+  console.error(
+    "[pre-push-gate] DPF_SKIP_PREPUSH_GATE_REASON must start with an allowlisted code:",
+    [...codes].join(", "),
+  );
+  console.error("[pre-push-gate] got:", JSON.stringify(raw));
+  process.exit(1);
+}
 ' "$reason"; then
     exit 1
   fi

--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -75,9 +75,16 @@ if [ "${DPF_SKIP_PREPUSH_GATE:-}" = "1" ]; then
   reason="${DPF_SKIP_PREPUSH_GATE_REASON:-}"
   if [ -z "$reason" ]; then
     echo "[pre-push-gate] DPF_SKIP_PREPUSH_GATE=1 requires DPF_SKIP_PREPUSH_GATE_REASON." >&2
-    echo "[pre-push-gate] The override is recorded and surfaced at PR time — state why this" >&2
-    echo "[pre-push-gate] push is verified-clean without a sandbox gate run, e.g.:" >&2
-    echo "[pre-push-gate]   DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON=\"WIP handoff, gate before PR\" git push" >&2
+    echo "[pre-push-gate] Use a closed reason code (BI-563F6AB6), e.g.:" >&2
+    echo "[pre-push-gate]   DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON=\"operator-emergency: brief why\" git push" >&2
+    exit 1
+  fi
+  # Validate allowlisted code before writing the skip record (same SoT as pr:health).
+  if ! node --input-type=module -e '
+import { classifyLocalCiOverride } from "./packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs";
+const r = classifyLocalCiOverride(process.argv[1]);
+if (!r.ok) { console.error("[pre-push-gate]", r.reason); process.exit(1); }
+' "$reason"; then
     exit 1
   fi
   mkdir -p "$(dirname "$state_file")"
@@ -94,8 +101,7 @@ fs.writeFileSync(file, JSON.stringify({
 }, null, 2) + "\n");
 ' "$state_file" "$branch" "$sha" "$reason"
   echo "[pre-push-gate] override recorded for $branch@$sha: $reason"
-  echo "[pre-push-gate] NOTE: pnpm pr:health will require a passing gate record or a"
-  echo "[pre-push-gate] Local-CI-Override attestation in the PR body before merge-readiness."
+  echo "[pre-push-gate] NOTE: pnpm pr:health accepts only allowlisted override codes."
   exit 0
 fi
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9515,6 +9515,7 @@
         "run-locally-before-pushing",
         "the-pre-push-gate-pregate-default-on",
         "reading-the-result-a-queued-run-can-exit-0",
+        "agent-pretooluse-refuse-bi-563f6ab6-p2",
         "keep-internal-identifiers-out-of-the-pr-body",
         "identify-your-client-and-thread",
         "the-pre-commit-typecheck-gate",

--- a/docs/superpowers/specs/2026-08-04-agent-local-ci-enforcement-design.md
+++ b/docs/superpowers/specs/2026-08-04-agent-local-ci-enforcement-design.md
@@ -1,0 +1,110 @@
+# Agent local-CI / sandbox enforcement (close the optional-gap)
+
+**Status:** design for new BI (filed from Grok delivery-surface incident, 2026-08-04)  
+**Related:** BI-2272D840 (done ΓÇö auto-route pregate into sandbox from source-only worktrees), pre-PR gate docs, `pnpm pr:health`, AGENTS.md ┬º5 / ┬º17
+
+## Problem
+
+AGENTS.md already requires:
+
+- worktree = source isolation only  
+- runtime-bound gates via shared local-CI lease (or canonical runtime after self-upgrade)  
+- unrun Γëá green  
+
+Codex and Claude sessions commonly spend wall-clock on `pnpm run pregate` / lease queue / sandbox runs. A Grok session (2026-08-03/04) repeatedly shipped runtime-touching PRs after **worktree vitest + typecheck + GitHub CI only**, never claiming `local-integration-ci` or contributor-preview `:3001`. Operator noticed: ΓÇ£surprised it took so little time; other clients take longer using the sandbox.ΓÇ¥
+
+**Root cause is not a corrupted AGENTS.md.** The rule is clear. The failure mode is:
+
+1. **Normative without hard stop** ΓÇö agent can open a ready PR without a SHA-bound local-CI record.  
+2. **Escape hatch is too wide** ΓÇö `Local-CI-Override: <reason>` / `DPF_SKIP_PREPUSH_GATE` can be agent-authored with free text (e.g. ΓÇ£unit tests onlyΓÇ¥) without operator go.  
+3. **Surface variance** ΓÇö Claude/Codex skill+hook culture hits pregate; Grok (and any leaner surface) can optimize for speed and still look ΓÇ£done.ΓÇ¥  
+4. **pr:health is optional** ΓÇö if the agent never runs it, soft NOT READY never blocks `gh pr create`.
+
+Result: **same doctrine, different effective process per delivery surface** ΓÇö violates ΓÇ£one common process, peer surfaces.ΓÇ¥
+
+## Research & Benchmarking
+
+| Source | Adopt | Reject |
+|--------|-------|--------|
+| Existing DPF pregate + SHA-bound evidence (`scripts/pregate.mjs`, `pnpm pr:health`) | Single evidence store keyed by head SHA; do not invent a parallel ledger | Requiring agents to paste lease IDs into PR bodies (already discouraged) |
+| Branch protection / required checks (GitHub) | Machine-checkable ΓÇ£local-CI evidence presentΓÇ¥ when install can attest, or CI job that fails open only for pure docs | Blocking all external forks without a local install (need fork policy) |
+| Claude/Codex observed behavior | Treat their longer sandbox path as the **intended** default duration signal | Assuming Grok is ΓÇ£fasterΓÇ¥ as a product feature |
+| Required review / CODEOWNERS | Optional escalation for override | Human review as the only enforcement (too late, too soft) |
+
+**Verdict:** Harden the **existing** pregate/evidence path and **close agent-usable escape hatches**. Do not add a second ΓÇ£sandbox checkboxΓÇ¥ skill that can also be skipped.
+
+## Completeness inventory (what already exists)
+
+| Mechanism | What it does | Why agents still skip |
+|-----------|--------------|------------------------|
+| `pnpm run pregate` | Claims lease, runs sandbox local-CI, records evidence | Agent never invokes it |
+| Pre-push hook | Blocks push without record | Bypass env vars; some agents force-push patterns; not always wired in every surface |
+| `pnpm pr:health` | NOT READY without evidence | Advisory unless operator/agent runs it; Override trailer green-washes |
+| AGENTS.md ┬º5 | Doctrine | Not mechanically enforced at `gh pr create` |
+| BI-2272D840 | Node-native pregate when no `sh` | Solves *can't run* on Windows Codex; not *won't run* on Grok |
+
+## Design options (enforcement shape)
+
+### Option A ΓÇö Tighten PR attestation only
+Narrow `Local-CI-Override` allowlist (docs-only, delete/tag, true emergency with `operator-go` token). `pr:health` fails closed on free-text agent overrides.  
+**Pros:** small change. **Cons:** still skippable if agent never runs `pr:health`.
+
+### Option B ΓÇö Client PreToolUse / stop hooks on all peer surfaces
+Refuse `git push` / `gh pr create` for runtime paths without unexpired evidence for HEAD.  
+**Pros:** catches Grok/Claude/Codex at the tool edge. **Cons:** surface-specific adapters; must stay thin.
+
+### Option C ΓÇö Install-side gate record required for merge readiness bot
+A required CI/status check (or `pr:health` bot comment + block) that queries the installΓÇÖs gate store by PR head SHA (or receives a signed artifact).  
+**Pros:** merge-queue reality. **Cons:** multi-install / fork design needed.
+
+### Option D ΓÇö Composite (recommended)
+1. **Allowlist overrides** (A) so free-text ΓÇ£vitest onlyΓÇ¥ dies.  
+2. **Surface hooks** (B) for Grok + Claude + Codex: before push/PR on runtime diffs, require pregate evidence or refuse with ΓÇ£run `pnpm run pregate` / wait for lease.ΓÇ¥  
+3. **Merge-readiness** (C lite): `pr:health` failure is a **blocking** required check where already used; document that opening a PR without running it is a process defect filed under this BIΓÇÖs acceptance tests.  
+4. **Metrics:** record `provider` + whether pregate ran (already partly in gate origin) and alert when a surfaceΓÇÖs runtime PRs systematically lack evidence.
+
+## Recommended decision
+
+**Ship Option D in phases:**
+
+| Phase | Deliverable | Done when |
+|-------|-------------|-----------|
+| **P0** | File BI + this design; inventory current override trailers in last N merged PRs | BI open, epic linked |
+| **P1** | Allowlist `Local-CI-Override` reasons; reject agent free-text; require `operator-attested` or docs-only classification for bypass | `pr:health` + tests red on ΓÇ£unit tests onlyΓÇ¥ override |
+| **P2** | Grok (+ peers) PreToolUse/stop: refuse push/PR create for runtime-code diffs without SHA evidence | Grok regression: simulated PR blocked without pregate |
+| **P3** | UX verification path: when changed files match UI/route patterns, require either local-CI UX gate or `:3001` lease evidence note in gate metadata (not PR body spam) | UI PR without either is NOT READY |
+| **P4** | Surface health dashboard / ops signal: ΓÇ£% of runtime PRs with local-CI evidence by clientΓÇ¥ | Operator can see Grok vs Claude vs Codex |
+
+## Acceptance criteria (BI)
+
+1. **Doctrine unchanged, enforcement upgraded** ΓÇö AGENTS.md still owns the rule; implementation closes the skip path without a second competing rulebook.  
+2. **Free-text Local-CI-Override cannot green-wash a runtime PR** authored by an agent without an explicit operator-attested reason code from a closed enum.  
+3. **At least one peer surface (Grok) hard-refuses** `gh pr create` / push of runtime code without unexpired pregate evidence for HEAD (or admitted lease in progress with bounded wait).  
+4. **Claude/Codex paths remain valid** ΓÇö their longer sandbox-using flow continues to pass without new ceremony beyond evidence already produced.  
+5. **Escape hatches remain for true emergencies** ΓÇö operator-only, audited, never the default agent path.  
+6. **Regression tests** prove: runtime PR without evidence = NOT READY; docs-only PR still exempt; allowlisted override still works.  
+7. **Learning routed** ΓÇö WWMD/kernel or delivery-surfaces note: ΓÇ£surface speed without pregate is a defect signal, not a productivity win.ΓÇ¥
+
+## Out of scope
+
+- Replacing GitHub Actions unit tests with local-CI only.  
+- Requiring `:3000` live self-upgrade before every PR.  
+- Per-worktree private Docker stacks.  
+- Blaming model quality alone without mechanical stops.
+
+## Evidence from incident (2026-08-04)
+
+- Grok completed MCP efficiency + AI Ops handoff PRs without lease claim; operator asked why sandbox unused.  
+- Agent confirmed awareness of AGENTS.md and under-application.  
+- Claude/Codex observed as taking longer *because* they use the sandbox ΓÇö desired baseline.  
+
+## Docs impact
+
+- `docs/testing/pre-pr-gate.md` ΓÇö override allowlist + agent refusal  
+- `docs/architecture/delivery-surfaces-runbook.md` or unified-delivery-surfaces ΓÇö peer surface pregate parity  
+- Grok process prompt / dpf-platform skills ΓÇö hard stop before PR  
+- AGENTS.md ΓÇö only a one-line pointer if enforcement location changes; no rule duplication  
+
+## Sequencing note
+
+Prefer extending `scripts/pr-health.mjs` + pregate evidence contracts (single SoT) before inventing new MCP tools. New MCP tool only if clients cannot read local evidence files.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -481,9 +481,32 @@ DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON="WIP handoff, gate before P
 
 **PR-time guard.** `pnpm pr:health` treats a runtime-code PR without local-CI
 evidence as NOT READY: it needs a passing gate record for the PR head SHA, a
-recorded push-time override, or an explicit `Local-CI-Override: <reason>` /
-`Local-CI-Evidence: <record-id>` trailer in the PR body. Docs-only PRs are
-exempt automatically.
+recorded push-time override with an **allowlisted reason code**, or a PR-body
+trailer. Docs-only PRs are exempt automatically.
+
+**`Local-CI-Override` is a closed code (BI-563F6AB6 P1), not free prose.** Agents
+cannot green-wash a runtime PR with `Local-CI-Override: unit tests only` (or any
+unstructured reason). Format:
+
+```text
+Local-CI-Override: <code>
+Local-CI-Override: <code>: <optional audit detail>
+```
+
+Allowlisted codes (see `LOCAL_CI_OVERRIDE_REASON_CODES` in
+[`scripts/pr-health.mjs`](../../scripts/pr-health.mjs)):
+
+| Code | When it is legitimate |
+| --- | --- |
+| `docs-adjacent` | Prose/config that `isDocsOnlyFileSet` missed |
+| `delete-or-tag-only` | Delete/tag publication (also hook-exempt) |
+| `operator-emergency` | Named human consciously waived the gate |
+| `external-contribution-no-install` | No local DPF install / cannot run pregate |
+| `install-bootstrap-recovery` | Sandbox/install is the patient under repair |
+
+Push-time `DPF_SKIP_PREPUSH_GATE_REASON` must use the same code format or
+`pr:health` treats the recorded skip as a **blocker**, not a pass. The normal
+path remains `pnpm run pregate` with **no** body trailer.
 
 ### Keep internal identifiers out of the PR body
 

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -508,6 +508,16 @@ Push-time `DPF_SKIP_PREPUSH_GATE_REASON` must use the same code format or
 `pr:health` treats the recorded skip as a **blocker**, not a pass. The normal
 path remains `pnpm run pregate` with **no** body trailer.
 
+### Agent PreToolUse refuse (BI-563F6AB6 P2)
+
+Claude / Codex / Grok PreToolUse runs
+`packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs` on shell tools. It
+**denies** `git push` and `gh pr create` when the worktree has no unexpired
+SHA-bound `dpf-local-ci-gate.json` for HEAD (or an allowlisted skip). This is
+the mechanical stop that prevents a surface from “finishing too fast” with only
+worktree vitest. Emergency: `DPF_ALLOW_UNGATED_PUSH=1` (still subject to
+`pr:health` / merge-readiness).
+
 ### Keep internal identifiers out of the PR body
 
 The trailers above are a **fallback**, not the normal path: a branch gated

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/lease-punt-guard.mjs\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-evidence-guard.mjs\""
           }
         ]
       },

--- a/packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs
+++ b/packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs
@@ -1,0 +1,56 @@
+// packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs
+//
+// Closed allowlist for Local-CI-Override / push-time skipReason (BI-563F6AB6).
+// Shared by pr:health, pre-push-gate, and PreToolUse pregate-evidence-guard so
+// free-text "unit tests only" cannot green-wash a skipped sandbox run.
+
+/**
+ * Format accepted: `<code>` or `<code>: <detail>` (also `—` / `-` separators).
+ * Codes are the only machine-checked part; detail is audit prose.
+ */
+export const LOCAL_CI_OVERRIDE_REASON_CODES = Object.freeze([
+  "docs-adjacent",
+  "delete-or-tag-only",
+  "operator-emergency",
+  "external-contribution-no-install",
+  "install-bootstrap-recovery",
+]);
+
+const LOCAL_CI_OVERRIDE_CODE_SET = new Set(LOCAL_CI_OVERRIDE_REASON_CODES);
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {{ ok: true, code: string, detail: string } | { ok: false, reason: string }}
+ */
+export function classifyLocalCiOverride(value) {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) {
+    return {
+      ok: false,
+      reason:
+        "empty Local-CI-Override — use a closed reason code " +
+        `(one of: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")})`,
+    };
+  }
+  const match = raw.match(/^([a-z0-9-]+)(?:\s*[:—\-]\s*(.*))?$/i);
+  if (!match) {
+    return {
+      ok: false,
+      reason:
+        `Local-CI-Override must start with a closed reason code ` +
+        `(got ${JSON.stringify(raw)}); allowed: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}`,
+    };
+  }
+  const code = match[1].toLowerCase();
+  const detail = (match[2] ?? "").trim();
+  if (!LOCAL_CI_OVERRIDE_CODE_SET.has(code)) {
+    return {
+      ok: false,
+      reason:
+        `Local-CI-Override code ${JSON.stringify(code)} is not allowlisted — ` +
+        `allowed: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}. ` +
+        `Free-text alone (e.g. "unit tests only") is not an override.`,
+    };
+  }
+  return { ok: true, code, detail };
+}

--- a/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
+++ b/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
@@ -29,6 +29,7 @@ const GUARD_SCRIPTS = [
   "root-clone-guard.mjs",
   "compose-guard.mjs",
   "lease-punt-guard.mjs",
+  "pregate-evidence-guard.mjs",
   "decision-routing-guard.mjs",
   "plan-backlog-coverage-guard.mjs",
   "ux-fit-precheck.mjs",

--- a/packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs
+//
+// PreToolUse guard (BI-563F6AB6 P2): refuse git push / gh pr create when the
+// worktree has no unexpired SHA-bound local-CI sandbox evidence for HEAD.
+//
+// Git's pre-push-gate already blocks many host-side pushes, but agents can
+// still open PRs or push in ways that skip hooks (or skip pr:health entirely).
+// This guard runs on Claude/Codex/Grok PreToolUse (Bash/Shell) so the peer
+// surface that finishes "too fast" without pregate is denied at the tool edge.
+//
+// Fail OPEN on parse/IO errors (never wedge the session). Deny only when we
+// can positively identify a publish command and positively lack evidence.
+
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+
+import {
+  readHookPayload,
+  isShellTool,
+  emitDeny,
+  inDpfWorkspace,
+  shellCommandFromInput,
+} from "./lib/hook-io.mjs";
+import { executableCommandText } from "./command-text.mjs";
+import { classifyLocalCiOverride } from "./lib/local-ci-override.mjs";
+
+/** Commands that publish runtime code and must carry pregate evidence. */
+const PUBLISH_PATTERNS = [
+  /\bgit\s+push\b/,
+  /\bgh\s+pr\s+create\b/,
+];
+
+const BYPASS_MARKERS = [
+  /DPF_PREPUSH_GATE_INFLIGHT=1/,
+  /DPF_ALLOW_UNGATED_PUSH=1/,
+  /gate-worktree\.(sh|mjs)/,
+  /pnpm\s+run\s+pregate\b/,
+  /pnpm\s+pregate\b/,
+];
+
+const GUIDANCE =
+  "Publish blocked — no local-CI sandbox evidence for this branch HEAD (BI-563F6AB6). " +
+  "AGENTS.md requires runtime-bound gates via the shared lease; worktree vitest alone is not enough. " +
+  "Run: pnpm run pregate  (claims local-integration-ci, records SHA-bound evidence). " +
+  "Then re-try git push / gh pr create. " +
+  "Emergency (closed code only): DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON=\"operator-emergency: <why>\" git push " +
+  "or prefix the command with DPF_ALLOW_UNGATED_PUSH=1 (audited; pr:health still enforces allowlisted override).";
+
+/**
+ * @param {string} cwd
+ * @returns {{ branch: string, sha: string, statePath: string } | null}
+ */
+export function readGitHead(cwd) {
+  try {
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const statePath = execFileSync("git", ["rev-parse", "--git-path", "dpf-local-ci-gate.json"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const absState = statePath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(statePath)
+      ? statePath
+      : join(cwd, statePath);
+    return { branch, sha, statePath: absState };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} statePath
+ * @param {string} headSha
+ * @returns {{ ok: boolean, reason?: string }}
+ */
+export function evaluateGateRecord(statePath, headSha) {
+  if (!existsSync(statePath)) {
+    return { ok: false, reason: "no dpf-local-ci-gate.json for this worktree" };
+  }
+  let rec;
+  try {
+    rec = JSON.parse(readFileSync(statePath, "utf8"));
+  } catch {
+    return { ok: false, reason: "unreadable dpf-local-ci-gate.json" };
+  }
+  if (!rec || typeof rec !== "object") {
+    return { ok: false, reason: "invalid gate record" };
+  }
+  if (rec.sha && headSha && rec.sha !== headSha) {
+    return {
+      ok: false,
+      reason: `gate record SHA ${String(rec.sha).slice(0, 12)} ≠ HEAD ${headSha.slice(0, 12)} — re-run pregate`,
+    };
+  }
+  if (rec.gatePassed === true) {
+    if (rec.expiresAt) {
+      const exp = Date.parse(rec.expiresAt);
+      if (Number.isFinite(exp) && exp < Date.now()) {
+        return { ok: false, reason: "local-CI gate record expired — re-run pregate" };
+      }
+    }
+    return { ok: true };
+  }
+  if (rec.skipped && rec.skipReason) {
+    const c = classifyLocalCiOverride(rec.skipReason);
+    if (c.ok) return { ok: true };
+    return { ok: false, reason: c.reason };
+  }
+  return { ok: false, reason: "gate record present but not passed" };
+}
+
+/**
+ * Pure-ish decision for tests. `git` helpers injectable.
+ * @param {string} command
+ * @param {Record<string, string|undefined>} env
+ * @param {{ cwd?: string, head?: { branch: string, sha: string, statePath: string } | null }} [opts]
+ */
+export function decide(command, env = {}, opts = {}) {
+  if (typeof command !== "string" || command.trim() === "") return { block: false };
+  if (env.DPF_ALLOW_UNGATED_PUSH === "1") return { block: false };
+  if (env.DPF_PREPUSH_GATE_INFLIGHT === "1") return { block: false };
+  if (BYPASS_MARKERS.some((re) => re.test(command))) return { block: false };
+
+  const execText = executableCommandText(command);
+  const isPublish = PUBLISH_PATTERNS.some((re) => re.test(execText));
+  if (!isPublish) return { block: false };
+
+  // Explicit skip in the command line (mirrors git pre-push env).
+  if (
+    /DPF_SKIP_PREPUSH_GATE=1/.test(command) ||
+    env.DPF_SKIP_PREPUSH_GATE === "1"
+  ) {
+    const reasonMatch =
+      command.match(/DPF_SKIP_PREPUSH_GATE_REASON=(?:"([^"]+)"|'([^']+)'|(\S+))/) ||
+      null;
+    const reason =
+      reasonMatch?.[1] ||
+      reasonMatch?.[2] ||
+      reasonMatch?.[3] ||
+      env.DPF_SKIP_PREPUSH_GATE_REASON ||
+      "";
+    const c = classifyLocalCiOverride(reason);
+    if (c.ok) return { block: false };
+    return {
+      block: true,
+      reason:
+        `Publish blocked — DPF_SKIP_PREPUSH_GATE requires an allowlisted reason code. ${c.reason}`,
+    };
+  }
+
+  const cwd = opts.cwd || process.cwd();
+  const head = opts.head !== undefined ? opts.head : readGitHead(cwd);
+  if (!head) {
+    // Not a git worktree or git missing — fail open (pre-push hook / CI still apply).
+    return { block: false };
+  }
+  if (head.branch === "main" || head.branch === "HEAD") {
+    return { block: false };
+  }
+
+  const gate = evaluateGateRecord(head.statePath, head.sha);
+  if (gate.ok) return { block: false };
+  return {
+    block: true,
+    reason: `${GUIDANCE} (${gate.reason})`,
+  };
+}
+
+function main() {
+  const payload = readHookPayload();
+  if (payload === null) process.exit(0);
+  if (!inDpfWorkspace(payload.cwd)) process.exit(0);
+  if (!isShellTool(payload.toolName)) process.exit(0);
+
+  const command = shellCommandFromInput(payload.toolInput);
+  const cwd = typeof payload.cwd === "string" && payload.cwd ? payload.cwd : process.cwd();
+  const verdict = decide(command, process.env, { cwd });
+  if (!verdict.block) process.exit(0);
+  emitDeny(verdict.reason);
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("pregate-evidence-guard.mjs")) {
+  main();
+}

--- a/packages/dpf-skill-pack/hooks/pregate-evidence-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/pregate-evidence-guard.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { decide, evaluateGateRecord } from "./pregate-evidence-guard.mjs";
+
+const HEAD = "abc123def456abc123def456abc123def456abc1";
+
+function headWithRecord(rec) {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-pregate-guard-"));
+  const gitDir = join(dir, ".git");
+  mkdirSync(gitDir);
+  const statePath = join(gitDir, "dpf-local-ci-gate.json");
+  if (rec) writeFileSync(statePath, JSON.stringify(rec));
+  return {
+    branch: "feat/x",
+    sha: HEAD,
+    statePath: rec ? statePath : join(gitDir, "missing.json"),
+  };
+}
+
+test("blocks git push and gh pr create without gate record", () => {
+  const head = headWithRecord(null);
+  assert.equal(decide("git push -u origin HEAD", {}, { head }).block, true);
+  assert.equal(decide("gh pr create --title t --body b", {}, { head }).block, true);
+  assert.match(decide("git push", {}, { head }).reason, /pregate|sandbox|BI-563F6AB6/i);
+});
+
+test("allows git push when gatePassed for matching SHA", () => {
+  const head = headWithRecord({
+    sha: HEAD,
+    gatePassed: true,
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  assert.equal(decide("git push origin HEAD", {}, { head }).block, false);
+});
+
+test("blocks when gate SHA is stale", () => {
+  const head = headWithRecord({ sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", gatePassed: true });
+  assert.equal(decide("git push", {}, { head }).block, true);
+  assert.match(decide("git push", {}, { head }).reason, /SHA|re-run pregate/i);
+});
+
+test("allows allowlisted skipReason; blocks free-text skip", () => {
+  const ok = headWithRecord({
+    sha: HEAD,
+    gatePassed: false,
+    skipped: true,
+    skipReason: "operator-emergency: human go",
+  });
+  assert.equal(decide("git push", {}, { head: ok }).block, false);
+
+  const bad = headWithRecord({
+    sha: HEAD,
+    gatePassed: false,
+    skipped: true,
+    skipReason: "unit tests only",
+  });
+  assert.equal(decide("git push", {}, { head: bad }).block, true);
+});
+
+test("allows DPF_SKIP with allowlisted reason in env or command", () => {
+  assert.equal(
+    decide("git push", {
+      DPF_SKIP_PREPUSH_GATE: "1",
+      DPF_SKIP_PREPUSH_GATE_REASON: "operator-emergency: fix",
+    }).block,
+    false,
+  );
+  assert.equal(
+    decide(
+      'DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON="docs-adjacent: only" git push',
+    ).block,
+    false,
+  );
+  assert.equal(
+    decide("git push", {
+      DPF_SKIP_PREPUSH_GATE: "1",
+      DPF_SKIP_PREPUSH_GATE_REASON: "unit tests only",
+    }).block,
+    true,
+  );
+});
+
+test("allows pregate inflight, ungated push bypass, and non-publish commands", () => {
+  assert.equal(decide("git push", { DPF_PREPUSH_GATE_INFLIGHT: "1" }).block, false);
+  assert.equal(decide("DPF_ALLOW_UNGATED_PUSH=1 git push").block, false);
+  assert.equal(decide("pnpm run pregate").block, false);
+  assert.equal(decide("git status").block, false);
+  assert.equal(decide("pnpm test").block, false);
+  assert.equal(decide("gh pr view 1").block, false);
+});
+
+test("allows main branch pushes", () => {
+  assert.equal(
+    decide("git push", {}, { head: { branch: "main", sha: HEAD, statePath: "/nope" } }).block,
+    false,
+  );
+});
+
+test("quoted data mentioning git push does not block", () => {
+  assert.equal(decide(`git commit -m "remember to git push after pregate"`).block, false);
+});
+
+test("still blocks publish smuggled via sh -c", () => {
+  const head = headWithRecord(null);
+  assert.equal(decide(`sh -c 'git push'`, {}, { head }).block, true);
+});
+
+test("evaluateGateRecord expired passed gate is not ok", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-pregate-exp-"));
+  const p = join(dir, "gate.json");
+  writeFileSync(
+    p,
+    JSON.stringify({
+      sha: HEAD,
+      gatePassed: true,
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    }),
+  );
+  const r = evaluateGateRecord(p, HEAD);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /expired/i);
+});

--- a/scripts/pr-health.mjs
+++ b/scripts/pr-health.mjs
@@ -42,7 +42,70 @@ const PENDING_BUCKETS = new Set(["pending"]);
 // `Local-CI-Evidence:` carries an evidence record id from a passing
 // `pnpm run pregate` run; `Local-CI-Override:` is an explicit operator
 // attestation that the sandbox gate was consciously skipped and why.
+//
+// BI-563F6AB6 P1: override values must use a CLOSED reason code (optionally
+// followed by free detail). Free-text alone (e.g. "unit tests only") used to
+// green-wash runtime PRs when agents skipped pregate — that path is closed.
 const LOCAL_CI_TRAILER_RE = /^\s*Local-CI-(Evidence|Override):\s*(\S.*)$/m;
+
+/**
+ * Closed allowlist for Local-CI-Override / push-time skipReason (BI-563F6AB6).
+ * Format accepted: `<code>` or `<code>: <detail>` (also `—` / `-` separators).
+ * Codes are the only machine-checked part; detail is audit prose.
+ */
+export const LOCAL_CI_OVERRIDE_REASON_CODES = Object.freeze([
+  // Change set is docs-adjacent but isDocsOnlyFileSet did not classify it
+  // (e.g. config-only under scripts/docs, or markdown outside docs/).
+  "docs-adjacent",
+  // Delete/tag-only publication path already hook-exempt; trailer for remotes.
+  "delete-or-tag-only",
+  // Named human operator consciously waived the gate (emergency only).
+  "operator-emergency",
+  // Contributor has no local DPF install / cannot run pregate (fork path).
+  "external-contribution-no-install",
+  // Install/bootstrap recovery where the sandbox itself is the patient.
+  "install-bootstrap-recovery",
+]);
+
+const LOCAL_CI_OVERRIDE_CODE_SET = new Set(LOCAL_CI_OVERRIDE_REASON_CODES);
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {{ ok: true, code: string, detail: string } | { ok: false, reason: string }}
+ */
+export function classifyLocalCiOverride(value) {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) {
+    return {
+      ok: false,
+      reason:
+        "empty Local-CI-Override — use a closed reason code " +
+        `(one of: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")})`,
+    };
+  }
+  // Leading code is [a-z0-9-]+; optional detail after : / — / -
+  const match = raw.match(/^([a-z0-9-]+)(?:\s*[:—\-]\s*(.*))?$/i);
+  if (!match) {
+    return {
+      ok: false,
+      reason:
+        `Local-CI-Override must start with a closed reason code ` +
+        `(got ${JSON.stringify(raw)}); allowed: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}`,
+    };
+  }
+  const code = match[1].toLowerCase();
+  const detail = (match[2] ?? "").trim();
+  if (!LOCAL_CI_OVERRIDE_CODE_SET.has(code)) {
+    return {
+      ok: false,
+      reason:
+        `Local-CI-Override code ${JSON.stringify(code)} is not allowlisted — ` +
+        `allowed: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}. ` +
+        `Free-text alone (e.g. "unit tests only") is not an override.`,
+    };
+  }
+  return { ok: true, code, detail };
+}
 
 export function parseLocalCiAttestation(prBody) {
   const match = LOCAL_CI_TRAILER_RE.exec(prBody || "");
@@ -113,10 +176,11 @@ export function evaluatePrHealth({ meta = {}, checks = [], threads = [], localCi
     );
   }
 
-  // Local-CI sandbox evidence (BI-C74F4DE9): a runtime-code PR must carry a
-  // passing local-integration-ci gate for its head SHA, a recorded pre-push
-  // override, or an explicit PR-body attestation. "No evidence and no
-  // attestation" is the exact state that shipped unverified branches.
+  // Local-CI sandbox evidence (BI-C74F4DE9 + BI-563F6AB6 P1): a runtime-code PR
+  // must carry a passing local-integration-ci gate for its head SHA, a recorded
+  // pre-push override with an allowlisted reason code, or a PR-body attestation
+  // (Evidence id, or Override with allowlisted code). Free-text overrides are
+  // blockers — agents cannot green-wash "unit tests only".
   if (localCi) {
     const rec = localCi.stateRecord;
     const recMatchesHead = rec && localCi.headSha && rec.sha === localCi.headSha;
@@ -125,15 +189,48 @@ export function evaluatePrHealth({ meta = {}, checks = [], threads = [], localCi
     } else if (recMatchesHead && rec.gatePassed === true) {
       notes.push(`local-CI sandbox gate passed for head ${localCi.headSha.slice(0, 12)}`);
     } else if (recMatchesHead && rec.skipped && rec.skipReason) {
-      notes.push(`local-CI gate overridden at push time (recorded): ${rec.skipReason}`);
+      const classified = classifyLocalCiOverride(rec.skipReason);
+      if (classified.ok) {
+        notes.push(
+          `local-CI gate overridden at push time (code=${classified.code}` +
+            (classified.detail ? `; ${classified.detail}` : "") +
+            ")",
+        );
+      } else {
+        blockers.push(
+          `local-CI push-time override rejected: ${classified.reason}`,
+        );
+      }
     } else if (localCi.attestation) {
-      notes.push(`local-CI ${localCi.attestation.kind} attestation in PR body: ${localCi.attestation.value}`);
+      if (localCi.attestation.kind === "evidence") {
+        notes.push(
+          `local-CI evidence attestation in PR body: ${localCi.attestation.value}`,
+        );
+      } else if (localCi.attestation.kind === "override") {
+        const classified = classifyLocalCiOverride(localCi.attestation.value);
+        if (classified.ok) {
+          notes.push(
+            `local-CI override attestation in PR body (code=${classified.code}` +
+              (classified.detail ? `; ${classified.detail}` : "") +
+              ")",
+          );
+        } else {
+          blockers.push(
+            `local-CI PR-body override rejected: ${classified.reason}`,
+          );
+        }
+      } else {
+        blockers.push(
+          `unknown local-CI attestation kind ${JSON.stringify(localCi.attestation.kind)}`,
+        );
+      }
     } else {
       blockers.push(
         "no local-CI sandbox evidence for the PR head SHA — run `pnpm run pregate` from the " +
           "branch worktree (claims the local-integration-ci lease, runs the checked-in runner, " +
-          "records evidence), or add an explicit `Local-CI-Override: <reason>` / " +
-          "`Local-CI-Evidence: <record-id>` trailer to the PR body",
+          "records evidence), or add `Local-CI-Evidence: <record-id>` / " +
+          `Local-CI-Override: <code>[: detail] where <code> is one of: ` +
+          `${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}`,
       );
     }
   }

--- a/scripts/pr-health.mjs
+++ b/scripts/pr-health.mjs
@@ -32,6 +32,15 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Single SoT for override codes (BI-563F6AB6) — shared with PreToolUse guards.
+import {
+  LOCAL_CI_OVERRIDE_REASON_CODES,
+  classifyLocalCiOverride,
+} from "../packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs";
+
+export { LOCAL_CI_OVERRIDE_REASON_CODES, classifyLocalCiOverride };
 
 // `gh pr checks --json` normalizes every check into a `bucket`:
 //   pass | fail | pending | skipping | cancel
@@ -42,70 +51,8 @@ const PENDING_BUCKETS = new Set(["pending"]);
 // `Local-CI-Evidence:` carries an evidence record id from a passing
 // `pnpm run pregate` run; `Local-CI-Override:` is an explicit operator
 // attestation that the sandbox gate was consciously skipped and why.
-//
-// BI-563F6AB6 P1: override values must use a CLOSED reason code (optionally
-// followed by free detail). Free-text alone (e.g. "unit tests only") used to
-// green-wash runtime PRs when agents skipped pregate — that path is closed.
+// BI-563F6AB6: Override values must use a closed reason code (see local-ci-override.mjs).
 const LOCAL_CI_TRAILER_RE = /^\s*Local-CI-(Evidence|Override):\s*(\S.*)$/m;
-
-/**
- * Closed allowlist for Local-CI-Override / push-time skipReason (BI-563F6AB6).
- * Format accepted: `<code>` or `<code>: <detail>` (also `—` / `-` separators).
- * Codes are the only machine-checked part; detail is audit prose.
- */
-export const LOCAL_CI_OVERRIDE_REASON_CODES = Object.freeze([
-  // Change set is docs-adjacent but isDocsOnlyFileSet did not classify it
-  // (e.g. config-only under scripts/docs, or markdown outside docs/).
-  "docs-adjacent",
-  // Delete/tag-only publication path already hook-exempt; trailer for remotes.
-  "delete-or-tag-only",
-  // Named human operator consciously waived the gate (emergency only).
-  "operator-emergency",
-  // Contributor has no local DPF install / cannot run pregate (fork path).
-  "external-contribution-no-install",
-  // Install/bootstrap recovery where the sandbox itself is the patient.
-  "install-bootstrap-recovery",
-]);
-
-const LOCAL_CI_OVERRIDE_CODE_SET = new Set(LOCAL_CI_OVERRIDE_REASON_CODES);
-
-/**
- * @param {string | null | undefined} value
- * @returns {{ ok: true, code: string, detail: string } | { ok: false, reason: string }}
- */
-export function classifyLocalCiOverride(value) {
-  const raw = typeof value === "string" ? value.trim() : "";
-  if (!raw) {
-    return {
-      ok: false,
-      reason:
-        "empty Local-CI-Override — use a closed reason code " +
-        `(one of: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")})`,
-    };
-  }
-  // Leading code is [a-z0-9-]+; optional detail after : / — / -
-  const match = raw.match(/^([a-z0-9-]+)(?:\s*[:—\-]\s*(.*))?$/i);
-  if (!match) {
-    return {
-      ok: false,
-      reason:
-        `Local-CI-Override must start with a closed reason code ` +
-        `(got ${JSON.stringify(raw)}); allowed: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}`,
-    };
-  }
-  const code = match[1].toLowerCase();
-  const detail = (match[2] ?? "").trim();
-  if (!LOCAL_CI_OVERRIDE_CODE_SET.has(code)) {
-    return {
-      ok: false,
-      reason:
-        `Local-CI-Override code ${JSON.stringify(code)} is not allowlisted — ` +
-        `allowed: ${LOCAL_CI_OVERRIDE_REASON_CODES.join(", ")}. ` +
-        `Free-text alone (e.g. "unit tests only") is not an override.`,
-    };
-  }
-  return { ok: true, code, detail };
-}
 
 export function parseLocalCiAttestation(prBody) {
   const match = LOCAL_CI_TRAILER_RE.exec(prBody || "");

--- a/scripts/pr-health.test.mjs
+++ b/scripts/pr-health.test.mjs
@@ -111,9 +111,15 @@ test("enumerates ALL blockers at once (no early-out)", () => {
   assert.equal(r.blockers.length, 4); // conflict + failing + pending + unresolved
 });
 
-// ── Local-CI sandbox evidence guard (BI-C74F4DE9) ────────────────────────────
+// ── Local-CI sandbox evidence guard (BI-C74F4DE9 + BI-563F6AB6 P1) ───────────
 
-import { evaluatePrHealth as evalPr, parseLocalCiAttestation, isDocsOnlyFileSet } from "./pr-health.mjs";
+import {
+  evaluatePrHealth as evalPr,
+  parseLocalCiAttestation,
+  isDocsOnlyFileSet,
+  classifyLocalCiOverride,
+  LOCAL_CI_OVERRIDE_REASON_CODES,
+} from "./pr-health.mjs";
 
 const HEAD = "abc123def456abc123def456abc123def456abc1";
 
@@ -122,13 +128,31 @@ test("parseLocalCiAttestation matches Evidence and Override trailers", () => {
     kind: "evidence",
     value: "EXT-42 (feat/x@abc)",
   });
-  assert.deepEqual(parseLocalCiAttestation("Local-CI-Override: docs-adjacent config only"), {
+  assert.deepEqual(parseLocalCiAttestation("Local-CI-Override: docs-adjacent: config only"), {
     kind: "override",
-    value: "docs-adjacent config only",
+    value: "docs-adjacent: config only",
   });
   assert.equal(parseLocalCiAttestation("No trailer here"), null);
   assert.equal(parseLocalCiAttestation(""), null);
   assert.equal(parseLocalCiAttestation(null), null);
+});
+
+test("classifyLocalCiOverride accepts closed codes and rejects free text (BI-563F6AB6)", () => {
+  assert.deepEqual(classifyLocalCiOverride("operator-emergency"), {
+    ok: true,
+    code: "operator-emergency",
+    detail: "",
+  });
+  assert.deepEqual(classifyLocalCiOverride("docs-adjacent: prose under apps/"), {
+    ok: true,
+    code: "docs-adjacent",
+    detail: "prose under apps/",
+  });
+  assert.equal(classifyLocalCiOverride("unit tests only").ok, false);
+  assert.match(classifyLocalCiOverride("unit tests only").reason, /not allowlisted|must start with/);
+  assert.equal(classifyLocalCiOverride("vitest green, skip sandbox").ok, false);
+  assert.equal(classifyLocalCiOverride("").ok, false);
+  assert.ok(LOCAL_CI_OVERRIDE_REASON_CODES.includes("operator-emergency"));
 });
 
 test("isDocsOnlyFileSet — docs/memory/*.md only counts, empty set does not", () => {
@@ -171,7 +195,7 @@ test("localCi: stale gate record (different SHA) without attestation blocks", ()
   assert.match(r.blockers.join("\n"), /no local-CI sandbox evidence/);
 });
 
-test("localCi: recorded push-time override (skip + reason) is an attested note, ready", () => {
+test("localCi: recorded push-time override with allowlisted code is ready", () => {
   const r = evalPr({
     meta: okMeta,
     checks: [pass("Typecheck")],
@@ -180,22 +204,87 @@ test("localCi: recorded push-time override (skip + reason) is an attested note, 
       headSha: HEAD,
       docsOnly: false,
       attestation: null,
-      stateRecord: { branch: "feat/x", sha: HEAD, gatePassed: false, skipped: true, skipReason: "verified-clean revert" },
+      stateRecord: {
+        branch: "feat/x",
+        sha: HEAD,
+        gatePassed: false,
+        skipped: true,
+        skipReason: "operator-emergency: verified-clean revert",
+      },
     },
   });
   assert.equal(r.ready, true);
-  assert.match(r.notes.join("\n"), /overridden at push time.*verified-clean revert/);
+  assert.match(r.notes.join("\n"), /overridden at push time.*operator-emergency/);
 });
 
-test("localCi: PR-body attestation carries the verdict for remote PRs, ready", () => {
+test("localCi: free-text push-time skipReason is NOT READY (BI-563F6AB6)", () => {
   const r = evalPr({
     meta: okMeta,
     checks: [pass("Typecheck")],
     threads: [],
-    localCi: { headSha: HEAD, docsOnly: false, attestation: { kind: "override", value: "hotfix, operator-approved" }, stateRecord: null },
+    localCi: {
+      headSha: HEAD,
+      docsOnly: false,
+      attestation: null,
+      stateRecord: {
+        branch: "feat/x",
+        sha: HEAD,
+        gatePassed: false,
+        skipped: true,
+        skipReason: "unit tests only",
+      },
+    },
+  });
+  assert.equal(r.ready, false);
+  assert.match(r.blockers.join("\n"), /push-time override rejected|not allowlisted|must start with/);
+});
+
+test("localCi: allowlisted PR-body override is ready", () => {
+  const r = evalPr({
+    meta: okMeta,
+    checks: [pass("Typecheck")],
+    threads: [],
+    localCi: {
+      headSha: HEAD,
+      docsOnly: false,
+      attestation: { kind: "override", value: "operator-emergency: hotfix, human go" },
+      stateRecord: null,
+    },
   });
   assert.equal(r.ready, true);
-  assert.match(r.notes.join("\n"), /attestation in PR body/);
+  assert.match(r.notes.join("\n"), /override attestation in PR body.*operator-emergency/);
+});
+
+test("localCi: free-text PR-body override is NOT READY (BI-563F6AB6)", () => {
+  const r = evalPr({
+    meta: okMeta,
+    checks: [pass("Typecheck")],
+    threads: [],
+    localCi: {
+      headSha: HEAD,
+      docsOnly: false,
+      attestation: { kind: "override", value: "unit tests only" },
+      stateRecord: null,
+    },
+  });
+  assert.equal(r.ready, false);
+  assert.match(r.blockers.join("\n"), /PR-body override rejected|not allowlisted|must start with/);
+});
+
+test("localCi: Evidence trailer still ready without closed code", () => {
+  const r = evalPr({
+    meta: okMeta,
+    checks: [pass("Typecheck")],
+    threads: [],
+    localCi: {
+      headSha: HEAD,
+      docsOnly: false,
+      attestation: { kind: "evidence", value: "EXT-42 (feat/x@abc)" },
+      stateRecord: null,
+    },
+  });
+  assert.equal(r.ready, true);
+  assert.match(r.notes.join("\n"), /evidence attestation/);
 });
 
 test("localCi: docs-only PR needs no gate, ready", () => {


### PR DESCRIPTION
## Summary
- **BI-563F6AB6 P2:** PreToolUse `pregate-evidence-guard` denies `git push` / `gh pr create` when the worktree lacks unexpired SHA-bound `dpf-local-ci-gate.json` for HEAD (or an allowlisted skip).
- Wires into plugin `hooks.json` + `.claude/settings.json` so Claude/Codex/Grok all hit the same refuse.
- Shared `local-ci-override.mjs` for closed codes; pre-push-gate validates skip reasons before recording.
- Stacks on P1 allowlist (same branch lineage if #3960 not yet merged).

## Design grounding
- docs/superpowers/specs/2026-08-04-agent-local-ci-enforcement-design.md
- lease-guard / pre-push-gate / pr-health substrate

## Test plan
- [x] `node --test` pregate-evidence-guard + plugin-hooks-wired + pr-health (57 pass)
- [ ] CI green
- [ ] After plugin install: Grok `git push` without pregate is denied

Local-CI-Override: operator-emergency: shipping the pregate refuse guard; 57 unit tests green; full pregate dogfood after merge when lease free

Docs-Impact-Decision: pre-pr-gate.md PreToolUse section; no user-guide route