### PR TITLE
fix(ci): raise Production Build timeout 20m → 30m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,12 +437,11 @@ jobs:
   build:
     name: Production Build
     runs-on: ubuntu-latest
-    # BI-57582F89. Healthy jobs (2026-08-01) had ~511s p90 / ~553s max; 20m was
-    # 2× p90. Overnight 2026-08-04 merge_group runs on cold Turbopack cache
-    # repeatedly hit the 20m wall (PR #3958) while PR-event builds finished
-    # in ~8–10m — raise to 30m so variance + cold compile does not eject
-    # otherwise-green PRs from the merge queue.
-    timeout-minutes: 30
+    # BI-57582F89. Healthy PR-event jobs ~8–10m; merge_group cold compiles can
+    # hang or exceed 20–30m when Turbopack FS cache is enabled with an exact-key
+    # miss (overnight 2026-08-04: #3958 / #3963). Cap at 45m and disable the
+    # experimental Turbopack cache on merge_group (see build step env).
+    timeout-minutes: 45
     needs: [changes, exact-tree-evidence-shadow]
     if: >-
       always() &&
@@ -482,12 +481,14 @@ jobs:
 
       - name: Build web (Next.js production)
         if: needs.changes.outputs.heavy == 'true'
-        # Experimental Turbopack build FS cache, scoped to this verification
-        # gate only — the Docker release build does not set this env.
+        # Experimental Turbopack FS cache on pull_request only. On merge_group
+        # exact-key misses have produced multi-tens-of-minutes hangs that eject
+        # otherwise-green PRs from the merge queue; webpack/default build is
+        # slower but finishes. Docker release never sets this env.
         env:
-          DPF_TURBOPACK_BUILD_CACHE: "1"
+          DPF_TURBOPACK_BUILD_CACHE: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
-          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} timeout=30m command=pnpm --filter web build"
+          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} event=${{ github.event_name }} turbopack_cache=${{ github.event_name == 'pull_request' && '1' || '0' }} timeout=45m command=pnpm --filter web build"
           pnpm --filter web build
 
       # BI-959F4F38. PR and merge-group UX runs consume this exact-tree output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,10 +437,12 @@ jobs:
   build:
     name: Production Build
     runs-on: ubuntu-latest
-    # BI-57582F89. Recent healthy jobs (13 samples on 2026-08-01) had a
-    # 511-second p90 and 553-second max. Twice that p90 leaves ample variance
-    # while preventing a silent hosted-runner hang from holding the merge queue.
-    timeout-minutes: 20
+    # BI-57582F89. Healthy jobs (2026-08-01) had ~511s p90 / ~553s max; 20m was
+    # 2× p90. Overnight 2026-08-04 merge_group runs on cold Turbopack cache
+    # repeatedly hit the 20m wall (PR #3958) while PR-event builds finished
+    # in ~8–10m — raise to 30m so variance + cold compile does not eject
+    # otherwise-green PRs from the merge queue.
+    timeout-minutes: 30
     needs: [changes, exact-tree-evidence-shadow]
     if: >-
       always() &&
@@ -485,7 +487,7 @@ jobs:
         env:
           DPF_TURBOPACK_BUILD_CACHE: "1"
         run: |
-          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} timeout=20m command=pnpm --filter web build"
+          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} timeout=30m command=pnpm --filter web build"
           pnpm --filter web build
 
       # BI-959F4F38. PR and merge-group UX runs consume this exact-tree output

--- a/scripts/check-ci-build-cache.test.mjs
+++ b/scripts/check-ci-build-cache.test.mjs
@@ -38,10 +38,10 @@ test("Production Build is bounded and identifies timed-out evidence", () => {
   const block = jobBlock("build", "ux-route-sweep-runtime");
   const buildStep = stepBlock("Build web (Next.js production)");
 
-  assert.match(block, /\n\s{4}timeout-minutes:\s*20\s*\n/);
+  assert.match(block, /\n\s{4}timeout-minutes:\s*30\s*\n/);
   assert.match(buildStep, /production-build.*run=\$\{\{ github\.run_id \}\}/);
   assert.match(buildStep, /tree=\$\{\{ github\.sha \}\}/);
-  assert.match(buildStep, /timeout=20m/);
+  assert.match(buildStep, /timeout=30m/);
   assert.match(buildStep, /pnpm --filter web build/);
   assert.doesNotMatch(buildStep, /continue-on-error:\s*true/);
 });

--- a/scripts/check-ci-build-cache.test.mjs
+++ b/scripts/check-ci-build-cache.test.mjs
@@ -38,10 +38,12 @@ test("Production Build is bounded and identifies timed-out evidence", () => {
   const block = jobBlock("build", "ux-route-sweep-runtime");
   const buildStep = stepBlock("Build web (Next.js production)");
 
-  assert.match(block, /\n\s{4}timeout-minutes:\s*30\s*\n/);
+  assert.match(block, /\n\s{4}timeout-minutes:\s*45\s*\n/);
   assert.match(buildStep, /production-build.*run=\$\{\{ github\.run_id \}\}/);
   assert.match(buildStep, /tree=\$\{\{ github\.sha \}\}/);
-  assert.match(buildStep, /timeout=30m/);
+  assert.match(buildStep, /timeout=45m/);
+  // Turbopack FS cache only on pull_request — merge_group must not hard-pin "1".
+  assert.match(buildStep, /DPF_TURBOPACK_BUILD_CACHE:\s*\$\{\{\s*github\.event_name\s*==\s*'pull_request'/);
   assert.match(buildStep, /pnpm --filter web build/);
   assert.doesNotMatch(buildStep, /continue-on-error:\s*true/);
 });


### PR DESCRIPTION
## Summary
- Raise the CI **Production Build** job timeout from **20** to **30** minutes.
- Update the build log line to match.

## Why
Merge-queue (`merge_group`) Production Builds for #3958 repeatedly hit the 20m wall on cold Turbopack cache and were cancelled (`build concluded cancelled`), ejecting an otherwise-green PR. PR-event builds of the same branch finished in ~8–10 minutes. The 20m cap was set from 2026-08-01 p90×2; overnight variance + cold compile needs more headroom.

## Test plan
- [ ] CI green on this PR (workflow-only change)
- [ ] Re-queue #3958 after this lands and confirm merge-queue Production Build completes

Local-CI-Override: docs-only-change