### PR TITLE
feat(ops): A2A collaboration health scan slice 1 (BI-3003EE63)

### DIFF
--- a/apps/web/lib/operate/a2a-collaboration-health/analysis.test.ts
+++ b/apps/web/lib/operate/a2a-collaboration-health/analysis.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeCollaborationHealth,
+  type CollaborationEdgeEvent,
+} from "./analysis";
+import {
+  EFFICIENCY_PLANE_MAPPING,
+  EFFICIENCY_SHARED_DIMENSIONS,
+} from "./dimensions";
+
+function edge(
+  partial: Partial<CollaborationEdgeEvent> &
+    Pick<CollaborationEdgeEvent, "id" | "edgeKind" | "fromAgentId" | "toAgentId">,
+): CollaborationEdgeEvent {
+  return {
+    state: "completed",
+    occurredAt: new Date("2026-08-04T12:00:00.000Z"),
+    completedAt: new Date("2026-08-04T12:05:00.000Z"),
+    orphanParent: false,
+    ...partial,
+  };
+}
+
+describe("analyzeCollaborationHealth (BI-3003EE63)", () => {
+  it("exports shared dimensions with MCP twin plane mapping", () => {
+    expect(EFFICIENCY_SHARED_DIMENSIONS).toContain("session");
+    expect(EFFICIENCY_PLANE_MAPPING.mcp.plane).toBe("mcp-tool");
+    expect(EFFICIENCY_PLANE_MAPPING.a2a.plane).toBe("a2a-collaboration");
+  });
+
+  it("flags failed and blocked edges", () => {
+    const events: CollaborationEdgeEvent[] = [
+      edge({
+        id: "f1",
+        edgeKind: "a2a-task-lineage",
+        fromAgentId: "ceo",
+        toAgentId: "eng",
+        state: "failed",
+      }),
+      edge({
+        id: "b1",
+        edgeKind: "a2a-handoff",
+        fromAgentId: "plan",
+        toAgentId: "build",
+        state: "blocked",
+      }),
+      edge({
+        id: "ok",
+        edgeKind: "a2a-delegation",
+        fromAgentId: "ceo",
+        toAgentId: "ops",
+        state: "completed",
+      }),
+    ];
+    // Pad to usable threshold
+    for (let i = 0; i < 4; i++) {
+      events.push(
+        edge({
+          id: `pad${i}`,
+          edgeKind: "a2a-delegation",
+          fromAgentId: "a",
+          toAgentId: "b",
+          state: "completed",
+        }),
+      );
+    }
+    const report = analyzeCollaborationHealth(events);
+    expect(report.findings.some((f) => f.kind === "failed_edge")).toBe(true);
+    expect(report.findings.some((f) => f.kind === "blocked_edge")).toBe(true);
+    expect(report.ledgerSufficiency.usable).toBe(true);
+    expect(report.plane).toBe("a2a-collaboration");
+  });
+
+  it("flags stuck active delegations", () => {
+    const nowMs = Date.parse("2026-08-04T18:00:00.000Z");
+    const events: CollaborationEdgeEvent[] = [
+      edge({
+        id: "stuck1",
+        edgeKind: "a2a-delegation",
+        fromAgentId: "ceo",
+        toAgentId: "eng",
+        state: "active",
+        occurredAt: new Date("2026-08-04T10:00:00.000Z"),
+        completedAt: null,
+      }),
+      edge({
+        id: "fresh",
+        edgeKind: "a2a-delegation",
+        fromAgentId: "ceo",
+        toAgentId: "ops",
+        state: "active",
+        occurredAt: new Date("2026-08-04T17:30:00.000Z"),
+        completedAt: null,
+      }),
+      ...Array.from({ length: 4 }, (_, i) =>
+        edge({
+          id: `c${i}`,
+          edgeKind: "a2a-handoff",
+          fromAgentId: "a",
+          toAgentId: "b",
+          state: "completed",
+        }),
+      ),
+    ];
+    const report = analyzeCollaborationHealth(events, {
+      stuckActiveMs: 4 * 60 * 60 * 1000,
+      nowMs,
+    });
+    const stuck = report.findings.find((f) => f.kind === "stuck_active");
+    expect(stuck).toBeDefined();
+    expect(stuck!.evidence.count).toBe(1);
+    expect(stuck!.recommendedAction).toBe("clear_stuck_delegation");
+  });
+
+  it("flags orphan lineage and pair failure rate", () => {
+    const events: CollaborationEdgeEvent[] = [
+      edge({
+        id: "orphan1",
+        edgeKind: "a2a-task-lineage",
+        fromAgentId: "parent-missing",
+        toAgentId: "child",
+        state: "completed",
+        orphanParent: true,
+      }),
+      ...Array.from({ length: 4 }, (_, i) =>
+        edge({
+          id: `pair-bad-${i}`,
+          edgeKind: "a2a-handoff",
+          fromAgentId: "scrum",
+          toAgentId: "eng",
+          state: i < 3 ? "failed" : "completed",
+        }),
+      ),
+    ];
+    const report = analyzeCollaborationHealth(events, {
+      pairFailureMinSamples: 4,
+      pairFailureRate: 0.5,
+      minEdgesForUsable: 5,
+    });
+    expect(report.findings.some((f) => f.kind === "orphan_lineage")).toBe(true);
+    expect(
+      report.findings.find((f) => f.kind === "orphan_lineage")!.recommendedAction,
+    ).toBe("fix_capture");
+    expect(report.findings.some((f) => f.kind === "pair_failure_rate")).toBe(
+      true,
+    );
+  });
+
+  it("reports sparse capture as unusable — does not claim healthy multi-agent ops", () => {
+    const report = analyzeCollaborationHealth([
+      edge({
+        id: "one",
+        edgeKind: "a2a-delegation",
+        fromAgentId: "a",
+        toAgentId: "b",
+        state: "completed",
+      }),
+    ]);
+    expect(report.totalEdges).toBe(1);
+    expect(report.ledgerSufficiency.usable).toBe(false);
+    expect(report.ledgerSufficiency.note).toMatch(/Too few|empty capture/i);
+    expect(report.findings.length).toBe(0);
+  });
+});

--- a/apps/web/lib/operate/a2a-collaboration-health/analysis.ts
+++ b/apps/web/lib/operate/a2a-collaboration-health/analysis.ts
@@ -1,0 +1,373 @@
+/**
+ * Pure A2A collaboration health analysis (BI-3003EE63).
+ *
+ * Operates on in-memory edge events (no I/O) so unit tests stay hermetic.
+ * Mirrors the MCP call-efficiency analyzer shape (BI-A08EBAEC) for the
+ * coworker↔coworker plane: failed/blocked edges, stuck delegations, orphan
+ * lineage, and sparse capture honesty.
+ *
+ * Does not fabricate deliberation identity — callers only pass edges with
+ * known agent endpoints.
+ */
+
+import { EFFICIENCY_PLANE_MAPPING } from "./dimensions";
+
+export type CollaborationEdgeKind =
+  | "a2a-delegation"
+  | "a2a-handoff"
+  | "a2a-task-lineage"
+  | "a2a-deliberation";
+
+export type CollaborationEdgeState =
+  | "active"
+  | "completed"
+  | "failed"
+  | "blocked"
+  | "unknown";
+
+export type CollaborationEdgeEvent = {
+  id: string;
+  edgeKind: CollaborationEdgeKind;
+  fromAgentId: string;
+  toAgentId: string;
+  state: CollaborationEdgeState;
+  occurredAt: Date;
+  completedAt?: Date | null;
+  /** Present when lineage claims a parent task but parent agent could not be resolved. */
+  orphanParent?: boolean;
+  skillId?: string | null;
+  title?: string | null;
+  sessionId?: string | null;
+  durationMs?: number | null;
+};
+
+export type CollaborationFindingKind =
+  | "failed_edge"
+  | "blocked_edge"
+  | "stuck_active"
+  | "orphan_lineage"
+  | "pair_failure_rate";
+
+export type CollaborationActionKind =
+  | "fix_capture"
+  | "investigate_handoff"
+  | "clear_stuck_delegation"
+  | "improve_gate"
+  | "investigate";
+
+export type CollaborationFinding = {
+  kind: CollaborationFindingKind;
+  severity: "info" | "warning" | "critical";
+  edgeKind: CollaborationEdgeKind | "any";
+  title: string;
+  detail: string;
+  evidence: {
+    count: number;
+    fromAgentId?: string;
+    toAgentId?: string;
+    sampleIds: string[];
+  };
+  recommendedAction: CollaborationActionKind;
+  wasteEdgeEstimate: number;
+};
+
+export type CollaborationHealthReport = {
+  windowStart: string;
+  windowEnd: string;
+  totalEdges: number;
+  successRate: number;
+  byKind: Array<{
+    edgeKind: CollaborationEdgeKind;
+    count: number;
+    failed: number;
+    blocked: number;
+    active: number;
+  }>;
+  topPairs: Array<{
+    fromAgentId: string;
+    toAgentId: string;
+    count: number;
+    failedOrBlocked: number;
+    successRate: number;
+  }>;
+  findings: CollaborationFinding[];
+  /** Operator-facing: whether edge density supports optimization claims. */
+  ledgerSufficiency: {
+    usable: boolean;
+    note: string;
+  };
+  /** Shared dimension plane id for MCP twin reports. */
+  plane: typeof EFFICIENCY_PLANE_MAPPING.a2a.plane;
+};
+
+export type AnalyzeCollaborationHealthOptions = {
+  /** Min edges for usable ledger. Default 5. */
+  minEdgesForUsable?: number;
+  /** Active longer than this (ms) → stuck_active. Default 4h. */
+  stuckActiveMs?: number;
+  /** Pair total samples for pair_failure_rate. Default 4. */
+  pairFailureMinSamples?: number;
+  /** Fail+blocked rate (0–1) for pair_failure_rate. Default 0.5. */
+  pairFailureRate?: number;
+  /** Max findings. Default 25. */
+  maxFindings?: number;
+  /** Wall clock for stuck detection (tests inject). Default Date.now(). */
+  nowMs?: number;
+};
+
+function severityRank(s: CollaborationFinding["severity"]): number {
+  return s === "critical" ? 0 : s === "warning" ? 1 : 2;
+}
+
+function isBadState(state: CollaborationEdgeState): boolean {
+  return state === "failed" || state === "blocked";
+}
+
+function pairKey(from: string, to: string): string {
+  return `${from}→${to}`;
+}
+
+/**
+ * Analyze a bag of A2A edge events and produce ranked collaboration findings.
+ */
+export function analyzeCollaborationHealth(
+  events: CollaborationEdgeEvent[],
+  opts: AnalyzeCollaborationHealthOptions = {},
+): CollaborationHealthReport {
+  const minEdgesForUsable = opts.minEdgesForUsable ?? 5;
+  const stuckActiveMs = opts.stuckActiveMs ?? 4 * 60 * 60 * 1000;
+  const pairFailureMinSamples = opts.pairFailureMinSamples ?? 4;
+  const pairFailureRate = opts.pairFailureRate ?? 0.5;
+  const maxFindings = opts.maxFindings ?? 25;
+  const nowMs = opts.nowMs ?? Date.now();
+
+  const sorted = [...events].sort(
+    (a, b) => a.occurredAt.getTime() - b.occurredAt.getTime(),
+  );
+
+  const windowStart =
+    sorted[0]?.occurredAt.toISOString() ?? new Date(0).toISOString();
+  const windowEnd =
+    sorted[sorted.length - 1]?.occurredAt.toISOString() ??
+    new Date(0).toISOString();
+
+  const totalEdges = sorted.length;
+  const goodCount = sorted.filter((e) => e.state === "completed").length;
+  const successRate = totalEdges > 0 ? goodCount / totalEdges : 1;
+
+  const kindOrder: CollaborationEdgeKind[] = [
+    "a2a-delegation",
+    "a2a-handoff",
+    "a2a-task-lineage",
+    "a2a-deliberation",
+  ];
+  const kindMap = new Map<
+    CollaborationEdgeKind,
+    { count: number; failed: number; blocked: number; active: number }
+  >();
+  for (const k of kindOrder) {
+    kindMap.set(k, { count: 0, failed: 0, blocked: 0, active: 0 });
+  }
+  for (const e of sorted) {
+    const row = kindMap.get(e.edgeKind) ?? {
+      count: 0,
+      failed: 0,
+      blocked: 0,
+      active: 0,
+    };
+    row.count += 1;
+    if (e.state === "failed") row.failed += 1;
+    if (e.state === "blocked") row.blocked += 1;
+    if (e.state === "active") row.active += 1;
+    kindMap.set(e.edgeKind, row);
+  }
+  const byKind = kindOrder.map((edgeKind) => ({
+    edgeKind,
+    ...(kindMap.get(edgeKind) ?? {
+      count: 0,
+      failed: 0,
+      blocked: 0,
+      active: 0,
+    }),
+  }));
+
+  const pairMap = new Map<
+    string,
+    {
+      fromAgentId: string;
+      toAgentId: string;
+      count: number;
+      failedOrBlocked: number;
+    }
+  >();
+  for (const e of sorted) {
+    if (!e.fromAgentId || !e.toAgentId) continue;
+    const key = pairKey(e.fromAgentId, e.toAgentId);
+    const row = pairMap.get(key) ?? {
+      fromAgentId: e.fromAgentId,
+      toAgentId: e.toAgentId,
+      count: 0,
+      failedOrBlocked: 0,
+    };
+    row.count += 1;
+    if (isBadState(e.state)) row.failedOrBlocked += 1;
+    pairMap.set(key, row);
+  }
+  const topPairs = Array.from(pairMap.values())
+    .map((v) => ({
+      fromAgentId: v.fromAgentId,
+      toAgentId: v.toAgentId,
+      count: v.count,
+      failedOrBlocked: v.failedOrBlocked,
+      successRate:
+        v.count > 0 ? (v.count - v.failedOrBlocked) / v.count : 1,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+
+  const findings: CollaborationFinding[] = [];
+
+  // Failed edges (global + sample)
+  const failed = sorted.filter((e) => e.state === "failed");
+  if (failed.length > 0) {
+    findings.push({
+      kind: "failed_edge",
+      severity: failed.length >= 5 ? "critical" : "warning",
+      edgeKind: "any",
+      title: `Failed A2A edges: ${failed.length}`,
+      detail:
+        `${failed.length} coworker↔coworker edge(s) ended failed in the window. ` +
+        `Inspect handoff gates, delegation status, and task lineage failures.`,
+      evidence: {
+        count: failed.length,
+        sampleIds: failed.slice(0, 5).map((e) => e.id),
+      },
+      recommendedAction: "investigate_handoff",
+      wasteEdgeEstimate: failed.length,
+    });
+  }
+
+  // Blocked edges
+  const blocked = sorted.filter((e) => e.state === "blocked");
+  if (blocked.length > 0) {
+    findings.push({
+      kind: "blocked_edge",
+      severity: blocked.length >= 5 ? "critical" : "warning",
+      edgeKind: "any",
+      title: `Blocked A2A edges: ${blocked.length}`,
+      detail:
+        `${blocked.length} edge(s) are blocked (e.g. phase gate failure or canceled task). ` +
+        `Fix gate criteria or clear blocked handoffs.`,
+      evidence: {
+        count: blocked.length,
+        sampleIds: blocked.slice(0, 5).map((e) => e.id),
+      },
+      recommendedAction: "improve_gate",
+      wasteEdgeEstimate: blocked.length,
+    });
+  }
+
+  // Stuck active delegations
+  const stuck = sorted.filter((e) => {
+    if (e.edgeKind !== "a2a-delegation" || e.state !== "active") return false;
+    const age = nowMs - e.occurredAt.getTime();
+    return age >= stuckActiveMs;
+  });
+  if (stuck.length > 0) {
+    findings.push({
+      kind: "stuck_active",
+      severity: stuck.length >= 3 ? "critical" : "warning",
+      edgeKind: "a2a-delegation",
+      title: `Stuck active delegations: ${stuck.length}`,
+      detail:
+        `${stuck.length} delegation(s) still active longer than ${Math.round(stuckActiveMs / 3600000)}h. ` +
+        `Complete, fail, or cancel the chain so authority envelopes do not linger.`,
+      evidence: {
+        count: stuck.length,
+        sampleIds: stuck.slice(0, 5).map((e) => e.id),
+        fromAgentId: stuck[0]?.fromAgentId,
+        toAgentId: stuck[0]?.toAgentId,
+      },
+      recommendedAction: "clear_stuck_delegation",
+      wasteEdgeEstimate: stuck.length,
+    });
+  }
+
+  // Orphan lineage
+  const orphans = sorted.filter(
+    (e) => e.edgeKind === "a2a-task-lineage" && e.orphanParent === true,
+  );
+  if (orphans.length > 0) {
+    findings.push({
+      kind: "orphan_lineage",
+      severity: orphans.length >= 3 ? "critical" : "warning",
+      edgeKind: "a2a-task-lineage",
+      title: `Orphan task lineage: ${orphans.length}`,
+      detail:
+        `${orphans.length} task lineage row(s) reference a parent task without a resolvable parent agent. ` +
+        `Improve capture of parent/initiating agent ids (BI-9DB7C332).`,
+      evidence: {
+        count: orphans.length,
+        sampleIds: orphans.slice(0, 5).map((e) => e.id),
+      },
+      recommendedAction: "fix_capture",
+      wasteEdgeEstimate: orphans.length,
+    });
+  }
+
+  // Pair failure rate
+  for (const p of topPairs) {
+    if (p.count < pairFailureMinSamples) continue;
+    const rate = p.failedOrBlocked / p.count;
+    if (rate < pairFailureRate) continue;
+    findings.push({
+      kind: "pair_failure_rate",
+      severity: rate >= 0.75 ? "critical" : "warning",
+      edgeKind: "any",
+      title: `Pair failure rate: ${p.fromAgentId} → ${p.toAgentId} (${(rate * 100).toFixed(0)}%)`,
+      detail:
+        `${p.failedOrBlocked}/${p.count} edges between this coworker pair failed or blocked. ` +
+        `Review authority, skills, or phase gates on that path.`,
+      evidence: {
+        count: p.count,
+        fromAgentId: p.fromAgentId,
+        toAgentId: p.toAgentId,
+        sampleIds: sorted
+          .filter(
+            (e) =>
+              e.fromAgentId === p.fromAgentId &&
+              e.toAgentId === p.toAgentId &&
+              isBadState(e.state),
+          )
+          .slice(0, 5)
+          .map((e) => e.id),
+      },
+      recommendedAction: "investigate_handoff",
+      wasteEdgeEstimate: p.failedOrBlocked,
+    });
+  }
+
+  findings.sort((a, b) => {
+    const sr = severityRank(a.severity) - severityRank(b.severity);
+    if (sr !== 0) return sr;
+    return b.wasteEdgeEstimate - a.wasteEdgeEstimate;
+  });
+
+  const usable = totalEdges >= minEdgesForUsable;
+  return {
+    windowStart,
+    windowEnd,
+    totalEdges,
+    successRate,
+    byKind,
+    topPairs,
+    findings: findings.slice(0, maxFindings),
+    ledgerSufficiency: {
+      usable,
+      note: usable
+        ? "A2A edge volume is sufficient for failure/stuck/orphan findings. Sparse capture still under-reports real collaboration (see BI-9DB7C332)."
+        : "Too few coworker↔coworker edges in window for reliable collaboration optimization; do not claim healthy multi-agent ops from empty capture.",
+    },
+    plane: EFFICIENCY_PLANE_MAPPING.a2a.plane,
+  };
+}

--- a/apps/web/lib/operate/a2a-collaboration-health/dimensions.ts
+++ b/apps/web/lib/operate/a2a-collaboration-health/dimensions.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared efficiency window vocabulary for MCP tool calls and A2A edges
+ * (BI-3003EE63 / BI-A08EBAEC inventory P2).
+ *
+ * Both planes report the same operator-facing dimensions so thrash on tools
+ * and thrash on handoffs can be compared without two dialects.
+ */
+
+export const EFFICIENCY_SHARED_DIMENSIONS = [
+  "windowStart",
+  "windowEnd",
+  "actor",
+  "session",
+  "success",
+  "durationMs",
+  "surface",
+] as const;
+
+export type EfficiencySharedDimension =
+  (typeof EFFICIENCY_SHARED_DIMENSIONS)[number];
+
+/** How each plane maps into the shared dimensions. */
+export const EFFICIENCY_PLANE_MAPPING = {
+  mcp: {
+    plane: "mcp-tool",
+    actor: "agentId (tool caller)",
+    session: "threadId",
+    success: "ToolExecution.success",
+    durationMs: "ToolExecution.durationMs",
+    surface: "executionMode / external-pat",
+  },
+  a2a: {
+    plane: "a2a-collaboration",
+    actor: "fromAgentId → toAgentId pair",
+    session: "taskRunId | chainId | buildId",
+    success: "edge state completed vs failed|blocked",
+    durationMs: "completedAt − occurredAt when known",
+    surface: "edgeKind (delegation|handoff|lineage|deliberation)",
+  },
+} as const;

--- a/apps/web/lib/operate/a2a-collaboration-health/load-events.ts
+++ b/apps/web/lib/operate/a2a-collaboration-health/load-events.ts
@@ -1,0 +1,192 @@
+/**
+ * Load A2A-relevant substrate rows into CollaborationEdgeEvent (BI-3003EE63).
+ * Maps the same sources as ops-map projection without React/UI deps.
+ */
+import { prisma } from "@dpf/db";
+import type {
+  CollaborationEdgeEvent,
+  CollaborationEdgeState,
+} from "./analysis";
+
+function mapDelegationState(status: string): CollaborationEdgeState {
+  const s = status.toLowerCase();
+  if (s === "completed" || s === "success") return "completed";
+  if (s === "failed" || s === "error") return "failed";
+  if (s === "blocked" || s === "canceled" || s === "cancelled") return "blocked";
+  if (s === "active" || s === "running" || s === "pending") return "active";
+  return "unknown";
+}
+
+function mapTaskState(status: string): CollaborationEdgeState {
+  const s = status.toLowerCase();
+  if (s === "completed" || s === "archived") return "completed";
+  if (s === "failed" || s === "rejected") return "failed";
+  if (s === "canceled" || s === "cancelled") return "blocked";
+  if (s === "active" || s === "working" || s === "submitted" || s === "awaiting_human")
+    return "active";
+  return "unknown";
+}
+
+function durationMs(
+  start: Date,
+  end: Date | null | undefined,
+): number | null {
+  if (!end) return null;
+  const d = end.getTime() - start.getTime();
+  return d >= 0 ? d : null;
+}
+
+export async function loadCollaborationEdgeEvents(
+  windowHours = 24,
+  limit = 3000,
+): Promise<CollaborationEdgeEvent[]> {
+  const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+  const take = Math.min(10_000, Math.max(50, limit));
+  const events: CollaborationEdgeEvent[] = [];
+
+  const [delegations, handoffs, taskRuns] = await Promise.all([
+    prisma.delegationChain.findMany({
+      where: { startedAt: { gte: since } },
+      select: {
+        id: true,
+        chainId: true,
+        fromAgentId: true,
+        toAgentId: true,
+        skillId: true,
+        status: true,
+        startedAt: true,
+        completedAt: true,
+      },
+      orderBy: { startedAt: "asc" },
+      take,
+    }),
+    prisma.phaseHandoff.findMany({
+      where: { createdAt: { gte: since } },
+      select: {
+        id: true,
+        buildId: true,
+        fromAgentId: true,
+        toAgentId: true,
+        gateResult: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+      take,
+    }),
+    prisma.taskRun.findMany({
+      where: { startedAt: { gte: since } },
+      select: {
+        id: true,
+        taskRunId: true,
+        initiatingAgentId: true,
+        currentAgentId: true,
+        parentTaskRunId: true,
+        title: true,
+        status: true,
+        startedAt: true,
+        completedAt: true,
+      },
+      orderBy: { startedAt: "asc" },
+      take,
+    }),
+  ]);
+
+  for (const row of delegations) {
+    if (!row.fromAgentId || !row.toAgentId || row.fromAgentId === row.toAgentId)
+      continue;
+    events.push({
+      id: `delegation:${row.id}`,
+      edgeKind: "a2a-delegation",
+      fromAgentId: row.fromAgentId,
+      toAgentId: row.toAgentId,
+      state: mapDelegationState(row.status),
+      occurredAt: row.startedAt,
+      completedAt: row.completedAt,
+      skillId: row.skillId,
+      sessionId: row.chainId,
+      durationMs: durationMs(row.startedAt, row.completedAt),
+    });
+  }
+
+  for (const row of handoffs) {
+    if (!row.fromAgentId || !row.toAgentId || row.fromAgentId === row.toAgentId)
+      continue;
+    // gateResult may be JSON or string; treat explicit false / failed as blocked
+    let gatePassed: boolean | null = null;
+    const gr = row.gateResult as unknown;
+    if (typeof gr === "boolean") gatePassed = gr;
+    else if (gr && typeof gr === "object" && "passed" in gr) {
+      gatePassed = Boolean((gr as { passed?: unknown }).passed);
+    } else if (typeof gr === "string") {
+      const lower = gr.toLowerCase();
+      if (lower.includes("fail") || lower.includes("block")) gatePassed = false;
+      else if (lower.includes("pass")) gatePassed = true;
+    }
+    events.push({
+      id: `handoff:${row.id}`,
+      edgeKind: "a2a-handoff",
+      fromAgentId: row.fromAgentId,
+      toAgentId: row.toAgentId,
+      state: gatePassed === false ? "blocked" : "completed",
+      occurredAt: row.createdAt,
+      completedAt: row.createdAt,
+      sessionId: row.buildId,
+      durationMs: null,
+    });
+  }
+
+  // Parent agent resolution within the fetched set
+  const byTaskRunId = new Map(
+    taskRuns.map((t) => [t.taskRunId ?? t.id, t] as const),
+  );
+  for (const row of taskRuns) {
+    const current = row.currentAgentId;
+    if (!current) continue;
+    let from: string | null = row.initiatingAgentId;
+    let orphanParent = false;
+    if (row.parentTaskRunId) {
+      const parent = byTaskRunId.get(row.parentTaskRunId);
+      if (parent) {
+        from = parent.currentAgentId ?? parent.initiatingAgentId;
+      } else {
+        orphanParent = true;
+        from = row.initiatingAgentId ?? "unknown-parent";
+      }
+    }
+    if (!from || from === current) {
+      if (orphanParent) {
+        events.push({
+          id: `lineage:${row.id}`,
+          edgeKind: "a2a-task-lineage",
+          fromAgentId: from ?? "unknown-parent",
+          toAgentId: current,
+          state: mapTaskState(row.status),
+          occurredAt: row.startedAt,
+          completedAt: row.completedAt,
+          orphanParent: true,
+          title: row.title,
+          sessionId: row.taskRunId ?? row.id,
+          durationMs: durationMs(row.startedAt, row.completedAt),
+        });
+      }
+      continue;
+    }
+    events.push({
+      id: `lineage:${row.id}`,
+      edgeKind: "a2a-task-lineage",
+      fromAgentId: from,
+      toAgentId: current,
+      state: mapTaskState(row.status),
+      occurredAt: row.startedAt,
+      completedAt: row.completedAt,
+      orphanParent,
+      title: row.title,
+      sessionId: row.taskRunId ?? row.id,
+      durationMs: durationMs(row.startedAt, row.completedAt),
+    });
+  }
+
+  return events.sort(
+    (a, b) => a.occurredAt.getTime() - b.occurredAt.getTime(),
+  );
+}

--- a/apps/web/lib/operate/a2a-collaboration-health/report.ts
+++ b/apps/web/lib/operate/a2a-collaboration-health/report.ts
@@ -1,0 +1,35 @@
+/**
+ * Load A2A edges and run collaboration health analysis (BI-3003EE63 slice 1).
+ * Notify / ImprovementSignal / AI Ops handoff land in slice 2.
+ */
+import {
+  analyzeCollaborationHealth,
+  type AnalyzeCollaborationHealthOptions,
+  type CollaborationHealthReport,
+} from "./analysis";
+import { loadCollaborationEdgeEvents } from "./load-events";
+
+export type RunCollaborationHealthOptions = AnalyzeCollaborationHealthOptions & {
+  windowHours?: number;
+  limit?: number;
+};
+
+export type CollaborationHealthRunResult = {
+  report: CollaborationHealthReport;
+  /** Slice 2 will increment when PlatformNotification is wired. */
+  notified: number;
+};
+
+function clampWindowHours(raw: unknown): number {
+  const n = typeof raw === "number" && Number.isFinite(raw) ? raw : 24;
+  return Math.min(168, Math.max(1, Math.floor(n)));
+}
+
+export async function runCollaborationHealthReport(
+  opts: RunCollaborationHealthOptions = {},
+): Promise<CollaborationHealthRunResult> {
+  const windowHours = clampWindowHours(opts.windowHours);
+  const events = await loadCollaborationEdgeEvents(windowHours, opts.limit);
+  const report = analyzeCollaborationHealth(events, opts);
+  return { report, notified: 0 };
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -530,6 +530,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "a2a-collaboration-health-scan",
+    inngestId: "ops/a2a-collaboration-health-scan",
+    name: "A2A collaboration health scan",
+    purpose:
+      "BI-3003EE63: analyzes coworker↔coworker edges (delegation, handoff, task lineage) for failed/blocked paths, stuck active delegations, and orphan lineage; slice 1 logs findings — notify/BI/AI Ops handoff in slice 2 (MCP-efficiency twin).",
+    cron: "25 6 * * *",
+    cadence: "Daily at 06:25",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "queue-metrics-aggregator",
     inngestId: "queue/metrics-aggregator",
     name: "Queue metrics aggregator",

--- a/apps/web/lib/queue/functions/a2a-collaboration-health-scan.ts
+++ b/apps/web/lib/queue/functions/a2a-collaboration-health-scan.ts
@@ -1,0 +1,47 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+/**
+ * Daily A2A collaboration health scan (BI-3003EE63).
+ * Runs at 06:25 UTC — after MCP call efficiency (06:15).
+ * Slice 1: load edges → pure analyzer → log rollup.
+ * Slice 2: PlatformNotification, ImprovementSignal, critical BI, AI Ops handoff.
+ */
+export const a2aCollaborationHealthScan = inngest.createFunction(
+  {
+    id: "ops/a2a-collaboration-health-scan",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("25 6 * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("analyze-a2a-collaboration-health", async () => {
+      const { runCollaborationHealthReport } = await import(
+        "@/lib/operate/a2a-collaboration-health/report"
+      );
+      const { report, notified } = await runCollaborationHealthReport({
+        windowHours: 24,
+      });
+      console.log(
+        `[a2a-collaboration-health] edges=${report.totalEdges} findings=${report.findings.length} usable=${report.ledgerSufficiency.usable} notified=${notified}`,
+      );
+      return {
+        totalEdges: report.totalEdges,
+        findingCount: report.findings.length,
+        usable: report.ledgerSufficiency.usable,
+        successRate: report.successRate,
+        notified,
+        topFindings: report.findings.slice(0, 5).map((f) => ({
+          kind: f.kind,
+          severity: f.severity,
+          title: f.title,
+          action: f.recommendedAction,
+        })),
+      };
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -43,6 +43,7 @@ import { skillMetricsAggregator } from "./skill-metrics-aggregator";
 import { queueMetricsAggregator } from "./queue-metrics-aggregator";
 import { skillCurator } from "./skill-curator";
 import { mcpCallEfficiencyScan } from "./mcp-call-efficiency-scan";
+import { a2aCollaborationHealthScan } from "./a2a-collaboration-health-scan";
 import { workPatternProfileReview } from "./work-pattern-profile-review";
 import {
   allBackupsDailyScheduled,
@@ -128,6 +129,7 @@ export const scheduledFunctions = [
   queueMetricsAggregator, // EP-3516E23D P1: hourly QueueTelemetryEvent → QueueMetricSnapshot rollup
   skillCurator,
   mcpCallEfficiencyScan, // BI-A08EBAEC: daily ToolExecution thrash/volume/failure findings → PlatformNotification
+  a2aCollaborationHealthScan, // BI-3003EE63: daily A2A edge health (failed/blocked/stuck/orphan) — slice 1 analyze+log
 
   workPatternProfileReview,
   researchScheduleScan,

--- a/docs/superpowers/plans/2026-08-04-a2a-collaboration-health-scan.md
+++ b/docs/superpowers/plans/2026-08-04-a2a-collaboration-health-scan.md
@@ -1,0 +1,59 @@
+# Plan: A2A collaboration health scan (BI-3003EE63)
+
+| Field | Value |
+|-------|-------|
+| **BI** | BI-3003EE63 |
+| **Epic** | EP-COWORKER-INTERACTIVITY |
+| **Date** | 2026-08-04 |
+| **Related** | BI-A08EBAEC (MCP twin, done), BI-D5348705 (inventory, done), BI-9DB7C332 (capture), BI-65B0D697 (ops-map) |
+| **Pattern** | `apps/web/lib/operate/mcp-call-efficiency/*` + `ops/mcp-call-efficiency-scan` |
+
+## Goal
+
+Daily (or on-demand) pass over coworker↔coworker substrate that **finds collaboration waste/failure**, emits operator-safe signals, and optionally hands off to AI Ops — **without** inventing a second bus or fabricating deliberation agent identity.
+
+## Shared dimensions (with MCP efficiency)
+
+| Dimension | MCP unit | A2A unit |
+|-----------|----------|----------|
+| Window | `windowStart` / `windowEnd` ISO | Same |
+| Actor | `agentId` (tool caller) | `fromAgentId` / `toAgentId` pair |
+| Session | `threadId` | `taskRunId` / `chainId` / `buildId` when present |
+| Success | `success` boolean | edge `state` ∈ completed vs failed/blocked |
+| Duration | `durationMs` | `completedAt − occurredAt` when both known |
+| Surface | executionMode / PAT | edgeKind (delegation, handoff, lineage, deliberation) |
+
+## Phases
+
+### Slice 1 (this PR) — analyzer + registration
+
+1. Pure `analyzeCollaborationHealth(events)` — hermetic, no Prisma/React.
+2. Unit tests: failed/blocked density, stuck active delegations, orphan lineage, sparse capture honesty.
+3. Job catalog row + Inngest function that loads recent rows → pure analyzer → logs rollup (notify/BI deferred).
+4. This plan + pointer from inventory follow-on language (optional body note only if inventory already merged).
+
+### Slice 2 — closed loop
+
+1. PlatformNotification for warning+ findings.
+2. ImprovementSignal `sourceType: a2a-collaboration-health`.
+3. Critical auto-BI `BI-A2A-EFF-*` + optional platform-engineer one-shot (copy MCP aiops-handoff).
+4. MCP tool `analyze_a2a_collaboration_health` in optimization pack.
+
+### Slice 3 — polish
+
+1. Ops-map deep links (filter types/states).
+2. Shared dimension labels in user-guide AI Ops section.
+3. Capture incompleteness metrics surfaced next to findings.
+
+## Non-goals
+
+- Public A2A wire protocol.
+- Fabricating `a2a-deliberation` edges without branch `agentId`.
+- Replacing MCP tool plane.
+
+## Verification
+
+1. `pnpm --filter web exec vitest run lib/operate/a2a-collaboration-health`
+2. Catalog lists `a2a-collaboration-health-scan`.
+3. Inngest function registered in `scheduledFunctions`.
+4. Empty install: `ledgerSufficiency.usable === false`, no fake “green collaboration”.


### PR DESCRIPTION
## Summary
Slice 1 of **BI-3003EE63** — MCP-efficiency twin for **A2A coworker↔coworker** edges.

- Plan: `docs/superpowers/plans/2026-08-04-a2a-collaboration-health-scan.md`
- Pure analyzer + shared dimension vocabulary with BI-A08EBAEC
- Unit tests (5) for failed/blocked, stuck active, orphan lineage, pair failure, sparse capture honesty
- Loader from DelegationChain / PhaseHandoff / TaskRun
- Scheduled job `ops/a2a-collaboration-health-scan` (daily 06:25 UTC) — analyze + log
- Catalog entry for operator visibility

## Non-goals (later slices)
PlatformNotification, ImprovementSignal, critical `BI-A2A-EFF-*`, AI Ops handoff, MCP tool, ops-map deep links.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/operate/a2a-collaboration-health` — 5/5 pass
- [ ] CI green
- [ ] Empty install: job logs `usable=false` without fake healthy multi-agent claims

Local-CI-Override: agent-runtime-unit-only