### PR TITLE
fix(hr): close the timesheet approval authorization hole, share one authority rule (BI-HCM-004)

### DIFF
--- a/apps/web/lib/actions/leave.ts
+++ b/apps/web/lib/actions/leave.ts
@@ -6,11 +6,7 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import * as crypto from "crypto";
-import {
-  describeUnresolvedRouting,
-  resolveAccountableApprover,
-} from "@/lib/workforce/approval-routing";
-import type { WorkforceStatus } from "@/lib/workforce/workforce-types";
+import { authorizeApprovalDecision } from "@/lib/workforce/approval-authority";
 
 // ─── Leave Request Flow ──────────────────────────────────────────────────────
 
@@ -67,72 +63,6 @@ export async function submitLeaveRequest(input: {
   return { success: true, requestId };
 }
 
-/**
- * Decide whether the signed-in user may rule on this employee's leave (BI-HCM-004).
- *
- * Before this existed, `approveLeaveRequest` and `rejectLeaveRequest` loaded the requester's
- * `managerEmployeeId` and never compared it to anything: any signed-in user could approve
- * anyone's leave, and `approverEmployeeId` recorded whoever happened to click — or null.
- *
- * Authority now comes from the org chart via the shared approval walk, so leave, timesheets,
- * and anything else route the same way instead of each inventing a single-hop rule.
- */
-async function authorizeLeaveDecision(
-  userId: string,
-  subjectEmployeeProfileId: string,
-): Promise<
-  | { ok: true; approverEmployeeId: string; onBehalfOf: string | null }
-  | { ok: false; error: string }
-> {
-  const actor = await prisma.employeeProfile.findUnique({
-    where: { userId },
-    select: { id: true },
-  });
-  if (!actor) {
-    return { ok: false, error: "You do not have an employee profile, so you cannot decide leave." };
-  }
-
-  const rows = await prisma.employeeProfile.findMany({
-    select: { id: true, managerEmployeeId: true, status: true },
-  });
-
-  const routing = resolveAccountableApprover(
-    rows.map((r) => ({
-      id: r.id,
-      managerEmployeeId: r.managerEmployeeId,
-      status: r.status as WorkforceStatus,
-    })),
-    subjectEmployeeProfileId,
-  );
-
-  if (!routing.resolved) {
-    // Fail loudly with the reason and the fix, rather than letting the request sit unexplained.
-    const names = new Map(rows.map((r) => [r.id, r.id]));
-    const withNames = await prisma.employeeProfile.findMany({
-      where: { id: { in: [subjectEmployeeProfileId] } },
-      select: { id: true, displayName: true },
-    });
-    for (const r of withNames) names.set(r.id, r.displayName);
-    return {
-      ok: false,
-      error: describeUnresolvedRouting(
-        routing,
-        (id) => names.get(id) ?? "This employee",
-        subjectEmployeeProfileId,
-      ),
-    };
-  }
-
-  if (routing.approverEmployeeId !== actor.id) {
-    return {
-      ok: false,
-      error: "You are not the accountable approver for this request.",
-    };
-  }
-
-  return { ok: true, approverEmployeeId: actor.id, onBehalfOf: routing.onBehalfOf };
-}
-
 export async function approveLeaveRequest(
   requestId: string,
 ): Promise<{ success: boolean; error?: string }> {
@@ -145,7 +75,7 @@ export async function approveLeaveRequest(
 
   // Authority check BEFORE any state change — the balance deduction below is not something to
   // do on behalf of someone who may not decide this.
-  const authorized = await authorizeLeaveDecision(session.user.id, request.employeeProfileId);
+  const authorized = await authorizeApprovalDecision(session.user.id, request.employeeProfileId, "leave");
   if (!authorized.ok) return { success: false, error: authorized.error };
   const approverProfile = { id: authorized.approverEmployeeId };
 
@@ -195,7 +125,7 @@ export async function rejectLeaveRequest(
   if (!request) return { success: false, error: "Request not found" };
   if (request.status !== "pending") return { success: false, error: "Request already decided" };
 
-  const authorized = await authorizeLeaveDecision(session.user.id, request.employeeProfileId);
+  const authorized = await authorizeApprovalDecision(session.user.id, request.employeeProfileId, "leave");
   if (!authorized.ok) return { success: false, error: authorized.error };
   const approverProfile = { id: authorized.approverEmployeeId };
 

--- a/apps/web/lib/actions/timesheet.ts
+++ b/apps/web/lib/actions/timesheet.ts
@@ -6,6 +6,7 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import * as crypto from "crypto";
+import { authorizeApprovalDecision } from "@/lib/workforce/approval-authority";
 
 // ─── Save timesheet entries ──────────────────────────────────────────────────
 
@@ -179,16 +180,20 @@ export async function approveTimesheet(
   if (!period) return { success: false, error: "Timesheet not found" };
   if (period.status !== "submitted") return { success: false, error: "Timesheet not in submitted status" };
 
-  const approverProfile = await prisma.employeeProfile.findUnique({
-    where: { userId: session.user.id },
-    select: { id: true },
-  });
+  // Authority comes from the org chart, not from merely being signed in (BI-HCM-004).
+  const authorized = await authorizeApprovalDecision(
+    session.user.id,
+    period.employeeProfileId,
+    "this timesheet",
+  );
+  if (!authorized.ok) return { success: false, error: authorized.error };
+  const approverProfile = { id: authorized.approverEmployeeId };
 
   await prisma.timesheetPeriod.update({
     where: { periodId },
     data: {
       status: "approved",
-      approvedById: approverProfile?.id ?? null,
+      approvedById: approverProfile.id,
       approvedAt: new Date(),
     },
   });
@@ -210,16 +215,19 @@ export async function rejectTimesheet(
   if (!period) return { success: false, error: "Timesheet not found" };
   if (period.status !== "submitted") return { success: false, error: "Timesheet not in submitted status" };
 
-  const approverProfile = await prisma.employeeProfile.findUnique({
-    where: { userId: session.user.id },
-    select: { id: true },
-  });
+  const authorized = await authorizeApprovalDecision(
+    session.user.id,
+    period.employeeProfileId,
+    "this timesheet",
+  );
+  if (!authorized.ok) return { success: false, error: authorized.error };
+  const approverProfile = { id: authorized.approverEmployeeId };
 
   await prisma.timesheetPeriod.update({
     where: { periodId },
     data: {
       status: "rejected",
-      approvedById: approverProfile?.id ?? null,
+      approvedById: approverProfile.id,
       rejectionReason: reason,
     },
   });

--- a/apps/web/lib/workforce/approval-authority.ts
+++ b/apps/web/lib/workforce/approval-authority.ts
@@ -1,0 +1,73 @@
+// Server-side authority check for workforce approvals (BI-HCM-004).
+//
+// The DB-facing companion to the pure walk in `approval-routing.ts`. It exists so leave,
+// timesheets, and future approval surfaces share ONE authority rule instead of each writing
+// their own — which is how both surfaces ended up with no rule at all.
+//
+// Not a `"use server"` module: it is a helper that server actions call, so it may export
+// non-action functions.
+
+import { prisma } from "@dpf/db";
+import { describeUnresolvedRouting, resolveAccountableApprover } from "./approval-routing";
+import type { WorkforceStatus } from "./workforce-types";
+
+export type ApprovalAuthority =
+  | { ok: true; approverEmployeeId: string; onBehalfOf: string | null }
+  | { ok: false; error: string };
+
+/**
+ * May this signed-in user decide something on `subjectEmployeeProfileId`'s behalf?
+ *
+ * Authority comes from the org chart: the subject's manager, or the first person above them
+ * who can act. An unresolvable chain fails with operator-facing copy that names the fix rather
+ * than leaving the request to sit unexplained.
+ *
+ * @param decisionNoun what the caller is deciding, for the "no employee profile" message.
+ */
+export async function authorizeApprovalDecision(
+  userId: string,
+  subjectEmployeeProfileId: string,
+  decisionNoun = "this",
+): Promise<ApprovalAuthority> {
+  const actor = await prisma.employeeProfile.findUnique({
+    where: { userId },
+    select: { id: true },
+  });
+  if (!actor) {
+    return {
+      ok: false,
+      error: `You do not have an employee profile, so you cannot decide ${decisionNoun}.`,
+    };
+  }
+
+  const rows = await prisma.employeeProfile.findMany({
+    select: { id: true, managerEmployeeId: true, status: true, displayName: true },
+  });
+
+  const routing = resolveAccountableApprover(
+    rows.map((r) => ({
+      id: r.id,
+      managerEmployeeId: r.managerEmployeeId,
+      status: r.status as WorkforceStatus,
+    })),
+    subjectEmployeeProfileId,
+  );
+
+  if (!routing.resolved) {
+    const names = new Map(rows.map((r) => [r.id, r.displayName]));
+    return {
+      ok: false,
+      error: describeUnresolvedRouting(
+        routing,
+        (id) => names.get(id) ?? "This employee",
+        subjectEmployeeProfileId,
+      ),
+    };
+  }
+
+  if (routing.approverEmployeeId !== actor.id) {
+    return { ok: false, error: "You are not the accountable approver for this request." };
+  }
+
+  return { ok: true, approverEmployeeId: actor.id, onBehalfOf: routing.onBehalfOf };
+}

--- a/docs/superpowers/specs/2026-08-01-approval-routing-design.md
+++ b/docs/superpowers/specs/2026-08-01-approval-routing-design.md
@@ -98,3 +98,27 @@ path to anyone accountable.
   attribution (single, multiple, and permanent-departure cases), all four unresolved reasons, loop
   handling, and the operator copy.
 - Typecheck clean; 150 tests green across the affected suites.
+
+## Addendum — same day: second consumer, and the same hole again
+
+Timesheets were the planned next consumer. Sweeping the approval surfaces first (because
+`leave.ts` having *zero* authorization meant none could be assumed sound) found
+`approveTimesheet` and `rejectTimesheet` carrying the **identical defect**: no authorization
+beyond an authenticated session, `approvedById` recording whoever clicked or `null`. Timesheets
+feed payroll.
+
+Both now route through the org chart. The authority check moved out of `leave.ts` into
+`apps/web/lib/workforce/approval-authority.ts` so the two surfaces share ONE rule — writing a
+second private copy is how the codebase arrived at two surfaces with no rule at all.
+
+### Sweep result, for whoever picks this up next
+
+Counting authorization references across the action files that export `approve*`/`reject*`:
+
+| Zero references | Has references |
+| --- | --- |
+| `civic-governance`, `compliance-proposals`, `crm`, `research-proposals` | `build`, `change-management`, `decomposition-actions`, `edge-nodes`, `federation-links`, `federation-proposals`, `finance`, `organization-join`, `promotions`, `proposals`, `skill-proposal-actions` |
+
+`leave` and `timesheet` were in the left column and are now fixed. **A zero count is a signal to
+look, not proof of a hole** — some surfaces may authorize by another route. The four remaining
+have not been read and are not claimed to be defective; they are the next place to look.


### PR DESCRIPTION
Follows #3897. Part of **BI-HCM-004**.

## The same hole, on a surface that feeds payroll

`approveTimesheet` and `rejectTimesheet` had **no authorization beyond an authenticated
session** — the identical defect fixed in leave by #3897. Any signed-in user could approve or
reject anyone's timesheet, with `approvedById` recording whoever clicked, or `null` if they had
no employee profile at all.

Found by sweeping rather than assuming. After `leave.ts` turned out to have zero authorization
checks, no approval surface could be presumed sound.

## One authority rule, not a third private copy

The check moves out of `leave.ts` into `apps/web/lib/workforce/approval-authority.ts`, the
DB-facing companion to the pure walk in `approval-routing.ts`.

Writing a second private helper in `timesheet.ts` is precisely how this codebase arrived at two
approval surfaces with no rule at all. Both now share one, routing through the org chart:
the subject's manager, or the first person above them who can act; unresolvable chains fail
loudly with operator copy naming the fix.

- `leave.ts` rewired to the shared helper — behaviour unchanged.
- `timesheet.ts` gains the check on both approve and reject, **before** the status write.
- `approvedById` / `approverEmployeeId` are no longer `?? null` — the approver is now known.

## Sweep result, recorded for whoever continues

Authorization references across action files exporting `approve*`/`reject*`:

| Zero references | Has references |
| --- | --- |
| `civic-governance`, `compliance-proposals`, `crm`, `research-proposals` | `build`, `change-management`, `decomposition-actions`, `edge-nodes`, `federation-links`, `federation-proposals`, `finance`, `organization-join`, `promotions`, `proposals`, `skill-proposal-actions` |

`leave` and `timesheet` were in the left column; both are now fixed. **A zero count is a signal
to look, not proof of a hole** — some surfaces may authorize by another route. The four
remaining have not been read and are **not** claimed to be defective. They are the next place
to look.

> **No local-CI override is claimed.** The sandbox gate record is still being pursued for this
> head SHA; the closed reason codes the gate accepts (`docs-adjacent`, `delete-or-tag-only`,
> `operator-emergency`, `external-contribution-no-install`, `install-bootstrap-recovery`) do not
> honestly describe sandbox contention, so none is asserted.

## Verification — and its limits, stated plainly

- 58 pure-logic tests green (`approval-routing`, `org-chart-model`, `patch-optional`, layout).
- 23/24 repo guards pass. The 24th (Repo Guard Loop) cannot run here: `@dpf/repo-guard-runtime`
  is not materialized in the shared root clone, so its TypeScript resolves outside the isolated
  pnpm graph. Installing into the root clone that peer worktrees resolve `@dpf/*` through is not
  acceptable.
- **The full local typecheck and DB-backed suites did not run.** The root clone was 52 commits
  behind `origin/main`, which broke `@dpf/db` resolution through the worktree junctions; it has
  since been fast-forwarded (fixing resolution for every worktree on the host), but the sandbox
  gate is the real signal and it kept being interrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
