### PR TITLE
fix(discovery): evaluate quality against the persisted row, not the sweep payload

### DIFF
--- a/packages/db/src/discovery-sync-contracts.ts
+++ b/packages/db/src/discovery-sync-contracts.ts
@@ -70,8 +70,26 @@ export type DiscoverySyncTx = InventoryEntityHeapIntegrityTx & {
       where: { entityKey: string };
       create: Record<string, unknown>;
       update: Record<string, unknown>;
-      select: { id: true; entityKey: true };
-    }): Promise<{ id: string; entityKey: string }>;
+      // Identity columns are selected back so quality evaluation can read the
+      // PERSISTED row. `manufacturer` / `supportStatus` are sticky across sources
+      // while `properties` is replaced each sweep, so the row is the only complete
+      // view of what discovery has established about an entity.
+      select: {
+        id: true;
+        entityKey: true;
+        manufacturer: true;
+        observedVersion: true;
+        normalizedVersion: true;
+        supportStatus: true;
+      };
+    }): Promise<{
+      id: string;
+      entityKey: string;
+      manufacturer: string | null;
+      observedVersion: string | null;
+      normalizedVersion: string | null;
+      supportStatus: string;
+    }>;
     updateMany(args: {
       where: { scopeKey?: string; entityKey: { in: string[] } };
       data: { status: string; lastSeenAt: Date };

--- a/packages/db/src/discovery-sync.persisted-identity.test.ts
+++ b/packages/db/src/discovery-sync.persisted-identity.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { persistBootstrapDiscoveryRun } from "./discovery-sync";
+import { heapIntegrityRaw } from "../test/discovery-sync-test-support";
+
+// Quality must be evaluated against the PERSISTED row, not this sweep's payload.
+//
+// `manufacturer` / `supportStatus` are written only when a sweep's enrichment
+// produces them, so they are STICKY across sources. `properties` is REPLACED on
+// every sweep. A rich source (UniFi, carrying a MAC OUI vendor) therefore
+// identifies an entity permanently, while a later poor source (an ARP scan with
+// no MAC) starves `deriveInventoryEnrichment` — and evaluating against that
+// sweep alone re-raises an identity issue for an entity the row already
+// identifies.
+//
+// Measured on the live install after the previous fix (evaluate against this
+// sweep's enrichment) deployed and ran: lifecycle_unverified 166 -> 177,
+// catalog_match_ambiguous 196 -> 210. Still climbing. This is why.
+
+type QualityIssue = { issueKey: string; issueType: string };
+
+/** Runs one sweep whose payload carries NO identity signal, against a persisted
+ *  row that already holds one. Returns what quality did. */
+async function sweepAgainstPersisted(persistedIdentity: {
+  manufacturer: string | null;
+  observedVersion: string | null;
+  normalizedVersion: string | null;
+  supportStatus: string;
+}) {
+  const upserted: QualityIssue[] = [];
+  const resolvedKeys: string[] = [];
+
+  const db = {
+    $transaction: async <T>(fn: (tx: any) => Promise<T>): Promise<T> => fn({
+      ...heapIntegrityRaw(),
+      discoveryRun: { create: async () => ({ id: "run-persisted" }) },
+      inventoryEntity: {
+        findMany: async () => [],
+        // The row already carries identity from an earlier, richer sweep.
+        upsert: async ({ where }: { where: { entityKey: string } }) => ({
+          id: `entity:${where.entityKey}`,
+          entityKey: where.entityKey,
+          ...persistedIdentity,
+        }),
+        updateMany: async () => ({ count: 0 }),
+      },
+      discoveredItem: {
+        create: async ({ data }: { data: { observedKey: string } }) => ({
+          id: `discovered:${data.observedKey}`,
+        }),
+      },
+      discoveredSoftwareEvidence: { upsert: async () => ({}) },
+      inventoryRelationship: {
+        findMany: async () => [],
+        upsert: async () => ({ id: "rel", relationshipKey: "rel" }),
+        updateMany: async () => ({ count: 0 }),
+      },
+      discoveredRelationship: { create: async () => ({}) },
+      portfolioQualityIssue: {
+        findMany: async () => [],
+        upsert: async ({ create }: { create: QualityIssue }) => {
+          upserted.push({ issueKey: create.issueKey, issueType: create.issueType });
+          return {};
+        },
+        updateMany: async ({ where }: { where: { issueKey?: { in: string[] } } }) => {
+          if (where.issueKey?.in) resolvedKeys.push(...where.issueKey.in);
+          return { count: where.issueKey?.in?.length ?? 0 };
+        },
+      },
+    }),
+  };
+
+  await persistBootstrapDiscoveryRun(
+    db as never,
+    {
+      discoveredItems: [{
+        discoveredKey: "dk:arp",
+        sourceKind: "arp_scan",
+        itemType: "host",
+        name: "192.168.0.42",
+        externalRef: "dk:arp",
+        attributes: {},
+      }],
+      // Sparse payload: no MAC vendor, no image tag, no name hint, no evidence.
+      // This is what an ARP sweep of an already-identified host looks like.
+      inventoryEntities: [{
+        entityKey: "organization:internal:host:arp:192.168.0.42",
+        entityType: "host",
+        name: "192.168.0.42",
+        discoveredKey: "dk:arp",
+        portfolioSlug: "foundational",
+        taxonomyNodeId: "foundational/compute/servers",
+        attributionStatus: "attributed" as const,
+        attributionMethod: "rule" as const,
+        attributionConfidence: 0.98,
+        providerView: "foundational",
+        properties: {},
+      }],
+      inventoryRelationships: [],
+      softwareEvidence: [],
+    } as never,
+    { runKey: "run-persisted", sourceSlug: "arp_scan" },
+    {
+      projectInventoryEntity: async () => undefined,
+      projectInventoryRelationship: async () => undefined,
+    },
+  );
+
+  return { raised: upserted.map((i) => i.issueType), resolvedKeys };
+}
+
+describe("quality evaluation reads the persisted row, not the sweep payload", () => {
+  it("does not re-raise identity/lifecycle for an entity the row already identifies", async () => {
+    const { raised, resolvedKeys } = await sweepAgainstPersisted({
+      manufacturer: "postgres",
+      observedVersion: "16.3",
+      normalizedVersion: "16.3",
+      supportStatus: "supported",
+    });
+
+    expect(raised).not.toContain("catalog_match_ambiguous");
+    expect(raised).not.toContain("lifecycle_unverified");
+
+    // And the reconcile reports them closable, so rows opened by earlier sweeps drain.
+    const key = (suffix: string) =>
+      `inventory_entity:organization:internal:host:arp:192.168.0.42:${suffix}`;
+    expect(resolvedKeys).toContain(key("catalog_match_ambiguous"));
+    expect(resolvedKeys).toContain(key("lifecycle_unverified"));
+  });
+
+  it("still raises for an entity nothing has ever identified", async () => {
+    // A genuinely unidentified ARP neighbour: the row is as empty as the sweep.
+    // Suppressing this would be a worse bug than the one being fixed.
+    const { raised, resolvedKeys } = await sweepAgainstPersisted({
+      manufacturer: null,
+      observedVersion: null,
+      normalizedVersion: null,
+      supportStatus: "unknown",
+    });
+
+    expect(raised).toContain("catalog_match_ambiguous");
+    expect(raised).toContain("lifecycle_unverified");
+    expect(resolvedKeys).not.toContain(
+      "inventory_entity:organization:internal:host:arp:192.168.0.42:catalog_match_ambiguous",
+    );
+  });
+
+  it("treats a persisted supportStatus of 'unknown' as unknown, not as a known value", async () => {
+    // supportStatus is non-nullable with default "unknown", so a plain ?? chain
+    // would stop at the persisted default and never consult the sweep — silently
+    // suppressing lifecycle issues for every entity.
+    const { raised } = await sweepAgainstPersisted({
+      manufacturer: "postgres",
+      observedVersion: null,
+      normalizedVersion: null,
+      supportStatus: "unknown",
+    });
+
+    expect(raised).toContain("lifecycle_unverified");
+    // Identity is known, so that one must NOT be raised.
+    expect(raised).not.toContain("catalog_match_ambiguous");
+  });
+});

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -226,6 +226,12 @@ export async function persistBootstrapDiscoveryRun(
     let updatedEntities = 0;
 
     const enrichmentByEntityKey = new Map<string, ReturnType<typeof deriveInventoryEnrichment>>();
+    const persistedIdentityByEntityKey = new Map<string, {
+      manufacturer: string | null;
+      observedVersion: string | null;
+      normalizedVersion: string | null;
+      supportStatus: string;
+    }>();
     for (const entity of normalized.inventoryEntities) {
       const existed = existingEntityKeys.has(entity.entityKey);
       const evidenceSnapshot = deriveInventoryEvidenceSnapshot(
@@ -349,8 +355,19 @@ export async function persistBootstrapDiscoveryRun(
           lastSeenAt: now,
           lastConfirmedRun: { connect: { id: run.id } },
         },
-        select: { id: true, entityKey: true },
+        // Identity columns come back so quality can be evaluated against the
+        // PERSISTED row — see persistedIdentityByEntityKey below.
+        select: {
+          id: true,
+          entityKey: true,
+          manufacturer: true,
+          observedVersion: true,
+          normalizedVersion: true,
+          supportStatus: true,
+        },
       });
+
+      persistedIdentityByEntityKey.set(entity.entityKey, persistedEntity);
 
       entityIdsByDiscoveredKey.set(entity.discoveredKey, persistedEntity.id);
       entityIdsByEntityKey.set(entity.entityKey, persistedEntity.id);
@@ -640,6 +657,7 @@ export async function persistBootstrapDiscoveryRun(
             softwareEvidenceByEntityKey.get(entity.entityKey) ?? [],
           );
           const enriched = enrichmentByEntityKey.get(entity.entityKey);
+          const persisted = persistedIdentityByEntityKey.get(entity.entityKey);
           const qualityEntity = {
             entityKey: entity.entityKey,
             entityType: entity.entityType,
@@ -652,15 +670,30 @@ export async function persistBootstrapDiscoveryRun(
             })) ?? null,
             taxonomyNodeId: entity.taxonomyNodeId ?? null,
             digitalProductId: null,
-            // Enriched values, NOT the raw evidence snapshot. `enrichment` is what
-            // the upsert above writes to the row, so evaluating against anything
-            // else lets discovery enrich an entity and then re-raise an identity
-            // or lifecycle issue about the very fields it just populated. Fall
-            // back to the snapshot only where enrichment produced nothing.
-            manufacturer: enriched?.manufacturer ?? evidenceSnapshot.manufacturer,
-            observedVersion: enriched?.observedVersion ?? evidenceSnapshot.observedVersion,
-            normalizedVersion: enriched?.normalizedVersion ?? evidenceSnapshot.normalizedVersion,
-            supportStatus: enriched?.supportStatus ?? evidenceSnapshot.supportStatus,
+            // PERSISTED row first, then this sweep's enrichment, then the snapshot.
+            // manufacturer/supportStatus are sticky across sources (written only
+            // when enrichment yields them) while `properties` is replaced every
+            // sweep — so a poor source (ARP, no MAC) starves enrichment and, judged
+            // on this sweep alone, re-raises an issue for an entity the row already
+            // identifies. That is why the previous enrichment-only fix did not
+            // drain the queues. See BI-A3D12F85.
+            manufacturer:
+              persisted?.manufacturer ?? enriched?.manufacturer ?? evidenceSnapshot.manufacturer,
+            observedVersion:
+              persisted?.observedVersion
+              ?? enriched?.observedVersion
+              ?? evidenceSnapshot.observedVersion,
+            normalizedVersion:
+              persisted?.normalizedVersion
+              ?? enriched?.normalizedVersion
+              ?? evidenceSnapshot.normalizedVersion,
+            // supportStatus is non-nullable and defaults to "unknown", so a plain
+            // ?? chain would stop at the persisted default and never consult the
+            // sweep. Take the first value that is actually known.
+            supportStatus:
+              [persisted?.supportStatus, enriched?.supportStatus, evidenceSnapshot.supportStatus]
+                .find((value) => value && value !== "unknown")
+              ?? "unknown",
             hasSoftwareEvidence: evidenceSnapshot.hasSoftwareEvidence,
             normalizationStatus: evidenceSnapshot.normalizationStatus,
           };


### PR DESCRIPTION
## The previous fix was right in concept, wrong in timing — and did nothing

#3912 fed `deriveInventoryEnrichment` into the quality evaluator so the detector could see what discovery had established. It deployed, a sweep ran, and the queues **went up**:

| | before #3912 | after |
|---|---|---|
| `lifecycle_unverified` | 166 | **177** |
| `catalog_match_ambiguous` | 196 | **210** |

## Why

Look at how the upsert writes identity:

```ts
...(enrichment.manufacturer ? { manufacturer: enrichment.manufacturer } : {}),
...(enrichment.supportStatus !== "unknown" ? { supportStatus: ... } : {}),
properties: entity.properties,          // <- unconditional
```

`manufacturer` and `supportStatus` are written **only when this sweep's enrichment produced them** — so they are **sticky**. A UniFi sweep carrying a MAC OUI vendor identifies an entity permanently.

`properties` is written **unconditionally** — replaced by whatever the current sweep saw.

So an ARP scan of an already-identified host overwrites `properties` with sparse data, `deriveInventoryEnrichment` yields nothing, and evaluating against *that sweep's* enrichment re-raises an identity issue for an entity whose row still says `postgres`.

**Enrichment is starved exactly when the sweeping source is the poor one** — which on this install is most sweeps. That is why #3912 changed nothing.

## The fix

Select the identity columns back from the upsert and prefer the **persisted row**: `persisted → this sweep's enrichment → raw snapshot`. The row is the accumulated truth across sources, and it is what an operator or coworker actually sees in the UI.

### One subtlety that would have been a silent disaster

`supportStatus` is non-nullable with default `"unknown"`, so a `??` chain stops at the persisted default and never consults the sweep — **silently suppressing lifecycle issues for every entity**. It needs:

```ts
[persisted?.supportStatus, enriched?.supportStatus, evidenceSnapshot.supportStatus]
  .find((value) => value && value !== "unknown") ?? "unknown"
```

The canary proves this is load-bearing: reverting the fix fails that specific test.

## What I got wrong, and why it repeated

I predicted #3912 would close 124 of 174 rows. It closed none.

My dry-run ran the right function against the **wrong inputs** — persisted `properties` from the database rather than the sparse payload a real sweep carries. That is the same error as two earlier magnitude misses in this arc: validating against stored data instead of what the code receives at runtime.

The tests here run the **real persistence path** with a sweep payload carrying no identity signal, against a persisted row that already holds one. That is the production case, not a reconstruction of it.

## Guard against over-suppression

A test pins that an entity **nothing has ever identified** — row as empty as the sweep — still raises both issue types. Suppressing genuinely unidentifiable estate would be a worse bug than the one being fixed.

## Verification

- 3 new tests, **CANARIED** — reverting the fix fails 2 of 3, including the `supportStatus` guard.
- Full `packages/db` suite: **1830 pass, 0 failures**.
- `packages/db` typechecks clean. (The 7 `incumbentCoverageAssessment` errors are **pre-existing** — confirmed identical on an unmodified tree; stale generated client in this worktree.)
- **Local sandbox gate: `gate passed`** — a real pass, no override.
- Module-size: `discovery-sync.ts` 795 LOC, under the 800 ceiling; baseline ratcheted **69 → 68**.

**NOT YET VERIFIED LIVE** — needs deploy plus a sweep per source. I am not predicting a row count this time; the last three predictions were wrong.

Refs: BI-A3D12F85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
