### PR TITLE
fix(ci): recompute a live base SHA for Policy Guards (PR) instead of trusting a stale event field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,30 @@ jobs:
         uses: actions/setup-node@v7.0.0
         with:
           node-version: 24
+      - name: Resolve a trustworthy base SHA
+        # github.event.pull_request.base.sha can go stale relative to the
+        # actual main tip and NOT self-refresh on a later push, an
+        # empty-commit-forced synchronize event, or even a close+reopen
+        # (observed live on PR #3893, BI-9E5E6063) — main on this repo
+        # advances too fast for whatever caches that field. A stale base
+        # makes every downstream gate that diffs BASE_SHA...HEAD (seed-fit,
+        # ux-fit, docs-impact) misattribute every real change from the
+        # intervening PRs to whichever PR happens to run this job. This step
+        # already has full history via fetch-depth:0 above, so recompute a
+        # live merge-base and use it whenever it disagrees with the event.
+        id: base_sha
+        env:
+          EVENT_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --quiet origin main
+          FRESH_BASE="$(git merge-base HEAD origin/main)"
+          if [ "$EVENT_BASE" != "$FRESH_BASE" ]; then
+            echo "::notice::github.event.pull_request.base.sha ($EVENT_BASE) disagrees with a freshly computed merge-base ($FRESH_BASE) — using the fresh one. See BI-9E5E6063."
+          fi
+          echo "sha=$FRESH_BASE" >> "$GITHUB_OUTPUT"
       - name: Run named pull-request policy guards
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.base_sha.outputs.sha }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## Summary

`github.event.pull_request.base.sha` does not reliably track `main`'s actual tip on this repo. Observed live on PR #3893 (BI-91077E80): the value stayed frozen at a commit from days earlier across 3 separate pushes, an empty-commit-forced `synchronize` event, and even a full close+reopen of the PR. `main` merges dozens of PRs per hour here — faster than whatever GitHub-side process is supposed to keep that event field current.

Because `policy-guards-pr` diffs `BASE_SHA...HEAD` to scope its seed-fit/ux-fit/docs-impact gates, a stale base makes it misattribute every real change from the intervening PRs to whichever PR's branch happens to run the job. PR #3893 (a 6-file mobile dependency bump) was flagged for touching `apps/web/components/finance/InvoiceDocumentTable.tsx` and half a dozen unrelated `SKILL.md` files it never came near — confirmed via `gh pr diff 3893 --name-only`.

## Fix

Add a step that recomputes the base via a live `git merge-base HEAD origin/main` (the job already checks out with `fetch-depth: 0`, so this is cheap) and uses it whenever it disagrees with the event-provided SHA, logging a `::notice::` when it does. The untrusted event value is only ever read through `env:` (never interpolated into the `run:` script body), matching this repo's own Actions Injection Audit convention.

## Test plan
- [x] YAML parses clean (`js-yaml`)
- [x] Diff is scoped to the one workflow file
- [x] `node scripts/check-module-size.mjs` passes
- [ ] Live verification: this fix can only be truly proven by a real PR run picking up the corrected base — will confirm on PR #3893 once this merges and that PR re-runs

BI-9E5E6063 (root cause, evidence, and this fix documented there).

Docs-Impact-Decision: CI workflow fix only, no user-facing documentation change.
Process-Spine-Decision: narrow, well-evidenced infra bug fix; the BI is the durable record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)