### PR TITLE
feat(mcp): open the UX critique corpus to external review sessions

### DIFF
--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -24,6 +24,7 @@ import { feedbackPack } from "./packs/feedback-pack";
 import { orgDecisionPack } from "./packs/org-decision-pack";
 import { founderReviewPack } from "./packs/founder-review-pack";
 import { professionDecisionPack } from "./packs/profession-decision-pack";
+import { uxCritiquePack } from "./packs/ux-critique-pack";
 import { optimizationPack } from "./packs/optimization-pack";
 import { marketingPack } from "./packs/marketing-pack";
 import { workCapturePack } from "./packs/work-capture-pack";
@@ -102,6 +103,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   orgDecisionPack,
   founderReviewPack,
   professionDecisionPack,
+  uxCritiquePack,
   optimizationPack,
   marketingPack,
   workCapturePack,

--- a/apps/web/lib/mcp/packs/ux-critique-pack.ts
+++ b/apps/web/lib/mcp/packs/ux-critique-pack.ts
@@ -60,7 +60,7 @@ const definitions: ToolDefinition[] = [
           description:
             "Reference to the captured image. A critique of a screen nobody can look at again is not reviewable, so an entry without one cannot become calibration data.",
         },
-        commitSha: {
+        gitRef: {
           type: "string",
           description:
             "The commit the screen was rendered at. Without it a before/after pair cannot be reconstructed later — the failure that left the earlier cognitive-load findings text-only.",
@@ -143,12 +143,12 @@ async function captureUxCritique(
     callerKind: "agent",
     route,
     finding,
-    lens: lens as never,
+    lenses: [lens as never],
     ...(proposedVerdict
       ? { verdict: proposedVerdict as never, verdictAuthority: "agent-proposed" as const }
       : {}),
     screenshotRef: str("screenshotRef") ?? null,
-    commitSha: str("commitSha") ?? null,
+    gitRef: str("gitRef") ?? str("commitSha") ?? null,
     viewportWidth: num("viewportWidth") ?? null,
     colorScheme: (colorScheme as "light" | "dark" | undefined) ?? null,
   });
@@ -191,7 +191,7 @@ async function searchUxCritiqueCorpus(
 
   const pages = await prisma.wikiPage.findMany({
     where: { slug: { startsWith: CRITIQUE_SLUG_PREFIX } },
-    select: { slug: true, title: true, status: true, metadata: true, updatedAt: true },
+    select: { slug: true, title: true, body: true, status: true, metadata: true, updatedAt: true },
     orderBy: { updatedAt: "desc" },
   });
 
@@ -201,7 +201,7 @@ async function searchUxCritiqueCorpus(
       Boolean(row.entry),
     )
     .filter((row) => (routeFilter ? row.entry.route === routeFilter : true))
-    .filter((row) => (lensFilter ? row.entry.lens === lensFilter : true))
+    .filter((row) => (lensFilter ? row.entry.lenses.includes(lensFilter as never) : true))
     .filter((row) => (calibratedOnly ? isCalibrationEligible(row.entry) : true))
     .slice(0, limit);
 
@@ -224,12 +224,12 @@ async function searchUxCritiqueCorpus(
         title: page.title,
         status: page.status,
         route: entry.route,
-        lens: entry.lens,
+        lenses: entry.lenses,
         finding: entry.finding,
         verdict: entry.verdict ?? null,
         verdictAuthority: entry.verdictAuthority ?? null,
         calibrationEligible: isCalibrationEligible(entry),
-        commitSha: entry.commitSha ?? null,
+        gitRef: entry.gitRef ?? null,
         screenshotRef: entry.screenshotRef ?? null,
       })),
     },

--- a/apps/web/lib/mcp/packs/ux-critique-pack.ts
+++ b/apps/web/lib/mcp/packs/ux-critique-pack.ts
@@ -1,0 +1,258 @@
+// UX critique corpus tool pack (BI-52839DEA deliverable 2, EP-UX-SYSTEM §6 L6).
+//
+// The critique corpus is the gating asset of the whole UX-quality program: an
+// ungrounded design judge is the UICrit zero-shot case, measured at 13.1% valid
+// comments, and the corpus — not the model — is what fixes that. Its accrual
+// rate, not its start date, decides when the critic can be trusted to gate.
+//
+// Until now the only door into it was a server action on the portal, so a
+// review happening in an external session (Claude Code / Codex / Grok) produced
+// nothing durable. Every founder review before capture exists is value
+// permanently lost — which is exactly how the EP-UX-COGLOAD wave ended up
+// text-only, its screenshots ephemeral browser views that were never persisted.
+//
+// AUTHORITY, ENFORCED HERE AND NOT MERELY DOCUMENTED. An MCP caller is ALWAYS
+// treated as an agent, whatever it claims: `callerKind` is pinned to "agent" at
+// this boundary rather than read from params, so a captured entry can only ever
+// carry `verdictAuthority: "agent-proposed"`, which `isCalibrationEligible`
+// excludes. Founder and designer verdicts stay a human act performed in the
+// portal. A judge calibrated on agent-authored verdicts is calibrated against
+// itself, so this is a correctness boundary, not a permissions nicety.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "capture_ux_critique",
+    description:
+      "Record a UX critique of a specific screen into the design critique corpus, as a DRAFT for human review. Use when you have looked at a real surface — during a review, a redesign, or a bug repro — and have a concrete finding worth keeping. Captures the route, the lens the finding is argued under, and the evidence needed to reconstruct the screen later. You may PROPOSE a verdict; only a founder or designer can attach one, and only proposals you did not author become calibration data.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Short title for the finding, e.g. 'Skills catalog buries every description'.",
+        },
+        route: {
+          type: "string",
+          description: "The route the screen was captured from, e.g. '/platform/ai/skills'.",
+        },
+        finding: {
+          type: "string",
+          description:
+            "What is wrong (or right) about this screen, in concrete terms. Name what the reader meets and what it costs them — not a rule restated.",
+        },
+        lens: {
+          type: "string",
+          enum: ["hierarchy", "density", "hick", "fitts", "miller", "doherty"],
+          description:
+            "The lens the finding is argued under. Evidence first; the lens explains why it matters.",
+        },
+        proposedVerdict: {
+          type: "string",
+          enum: ["change-needed", "no-change-needed", "accepted-debt"],
+          description:
+            "Optional. Your PROPOSED verdict. Recorded as 'agent-proposed' and never calibration-eligible until a founder or designer attaches their own. Negative entries ('no-change-needed') are calibration data too — capture them.",
+        },
+        screenshotRef: {
+          type: "string",
+          description:
+            "Reference to the captured image. A critique of a screen nobody can look at again is not reviewable, so an entry without one cannot become calibration data.",
+        },
+        commitSha: {
+          type: "string",
+          description:
+            "The commit the screen was rendered at. Without it a before/after pair cannot be reconstructed later — the failure that left the earlier cognitive-load findings text-only.",
+        },
+        viewportWidth: {
+          type: "number",
+          description: "Viewport width in CSS px at capture (390 = mobile band, 1280 = desktop).",
+        },
+        colorScheme: { type: "string", enum: ["light", "dark"] },
+      },
+      required: ["title", "route", "finding", "lens"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "search_ux_critique_corpus",
+    description:
+      "Read the design critique corpus — past findings about real screens, with their verdicts. Use BEFORE offering a UX opinion so the judgement is grounded in what this product's design authority has actually decided, rather than generic web-craft advice. Returns entries with their route, lens, finding, verdict and whether that verdict is calibration-eligible.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        route: {
+          type: "string",
+          description: "Filter to critiques of one route, e.g. '/platform/ai/skills'.",
+        },
+        lens: {
+          type: "string",
+          enum: ["hierarchy", "density", "hick", "fitts", "miller", "doherty"],
+          description: "Filter to one lens.",
+        },
+        calibratedOnly: {
+          type: "boolean",
+          description:
+            "When true, return ONLY entries carrying a founder/designer verdict — the calibration set. Use this when grounding a judgement; agent-proposed entries are not evidence of what the design authority thinks.",
+        },
+        limit: { type: "number", description: "Max entries to return (default 20)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+];
+
+const CRITIQUE_SLUG_PREFIX = "craft/ux-design/";
+
+async function captureUxCritique(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { captureCritiqueEntry } = await import("@/lib/actions/critique-entry");
+
+  const str = (k: string): string | undefined => {
+    const v = params[k];
+    return typeof v === "string" && v.trim() ? v.trim() : undefined;
+  };
+  const num = (k: string): number | undefined =>
+    typeof params[k] === "number" ? (params[k] as number) : undefined;
+
+  const title = str("title");
+  const route = str("route");
+  const finding = str("finding");
+  const lens = str("lens");
+  if (!title || !route || !finding || !lens) {
+    return {
+      success: false,
+      error: "invalid_params",
+      message: "Provide title, route, finding and lens.",
+    };
+  }
+
+  const proposedVerdict = str("proposedVerdict");
+  const colorScheme = str("colorScheme");
+
+  const result = await captureCritiqueEntry({
+    title,
+    // PINNED, never read from params. See the authority note in the header.
+    callerKind: "agent",
+    route,
+    finding,
+    lens: lens as never,
+    ...(proposedVerdict
+      ? { verdict: proposedVerdict as never, verdictAuthority: "agent-proposed" as const }
+      : {}),
+    screenshotRef: str("screenshotRef") ?? null,
+    commitSha: str("commitSha") ?? null,
+    viewportWidth: num("viewportWidth") ?? null,
+    colorScheme: (colorScheme as "light" | "dark" | undefined) ?? null,
+  });
+
+  if (!result.ok) {
+    return { success: false, error: "capture_rejected", message: result.error };
+  }
+
+  return {
+    success: true,
+    entityId: result.slug,
+    message:
+      `Captured as a draft at ${result.slug}. It is not calibration data until a founder or ` +
+      `designer attaches their own verdict in the portal.`,
+    data: {
+      slug: result.slug,
+      status: result.status,
+      screenshotAttached: result.screenshotAttached ?? null,
+      verdictAuthority: proposedVerdict ? "agent-proposed" : null,
+      calibrationEligible: false,
+    },
+  };
+}
+
+async function searchUxCritiqueCorpus(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { prisma } = await import("@dpf/db");
+  const { critiqueEntryFromWikiPage, isCalibrationEligible } = await import(
+    "@/lib/ux-critique/critique-entry"
+  );
+
+  const routeFilter = typeof params["route"] === "string" ? params["route"] : null;
+  const lensFilter = typeof params["lens"] === "string" ? params["lens"] : null;
+  const calibratedOnly = params["calibratedOnly"] === true;
+  const limit = Math.min(
+    Math.max(typeof params["limit"] === "number" ? params["limit"] : 20, 1),
+    100,
+  );
+
+  const pages = await prisma.wikiPage.findMany({
+    where: { slug: { startsWith: CRITIQUE_SLUG_PREFIX } },
+    select: { slug: true, title: true, status: true, metadata: true, updatedAt: true },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  const entries = pages
+    .map((page) => ({ page, entry: critiqueEntryFromWikiPage(page) }))
+    .filter((row): row is { page: (typeof pages)[number]; entry: NonNullable<typeof row.entry> } =>
+      Boolean(row.entry),
+    )
+    .filter((row) => (routeFilter ? row.entry.route === routeFilter : true))
+    .filter((row) => (lensFilter ? row.entry.lens === lensFilter : true))
+    .filter((row) => (calibratedOnly ? isCalibrationEligible(row.entry) : true))
+    .slice(0, limit);
+
+  // An empty corpus is a REAL and important answer here — it means any design
+  // judgement offered is ungrounded — so say so rather than returning a bare
+  // empty list the caller might read as "nothing relevant".
+  const message = entries.length
+    ? `${entries.length} critique entr${entries.length === 1 ? "y" : "ies"}.`
+    : calibratedOnly
+      ? "No calibration-eligible critiques yet: the corpus holds no founder/designer verdicts, so any design judgement here is ungrounded. Say so rather than asserting a verdict."
+      : "The critique corpus is empty. Any design judgement here is ungrounded — say so, and capture what you observe so the corpus starts accruing.";
+
+  return {
+    success: true,
+    message,
+    data: {
+      total: entries.length,
+      entries: entries.map(({ page, entry }) => ({
+        slug: page.slug,
+        title: page.title,
+        status: page.status,
+        route: entry.route,
+        lens: entry.lens,
+        finding: entry.finding,
+        verdict: entry.verdict ?? null,
+        verdictAuthority: entry.verdictAuthority ?? null,
+        calibrationEligible: isCalibrationEligible(entry),
+        commitSha: entry.commitSha ?? null,
+        screenshotRef: entry.screenshotRef ?? null,
+      })),
+    },
+  };
+}
+
+export const uxCritiquePack: ToolPack = {
+  packId: "ux-critique",
+  definitions,
+  handlers: {
+    capture_ux_critique: (params) => captureUxCritique(params),
+    search_ux_critique_corpus: (params) => searchUxCritiqueCorpus(params),
+  },
+  // Mirrors TOOL_TO_GRANTS, which stays the gating source; tool-registry.test.ts
+  // asserts the two never drift. A pack that advertises a grant the gating map
+  // does not carry is DENIED for every coworker while looking authoritative —
+  // the BI-88B77204 failure.
+  //
+  // Capture writes a draft WikiPage into the craft overlay, so it takes
+  // `registry_write`, the same scope `record_org_business_answer` uses for the
+  // org corpus. Search is read-only and advisory, like the WWMD/WSID gates.
+  grants: {
+    capture_ux_critique: ["registry_write"],
+    search_ux_critique_corpus: ["registry_read"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -250,6 +250,18 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   analyze_a2a_collaboration_health: ["agent_control_read"],
   spawn_subagents: ["coworker_engagement_write"],
 
+  // UX critique corpus (BI-52839DEA). Reading past design findings is advisory
+  // and read-only, so it matches the decision gates. Capture writes a DRAFT
+  // WikiPage under the craft overlay — the same shape and scope as
+  // `record_org_business_answer` writing into the org corpus.
+  //
+  // `registry_write` is not authority over the corpus: the pack pins every MCP
+  // caller to `callerKind: "agent"`, so a captured entry can only ever carry an
+  // agent-proposed verdict and is never calibration-eligible. Attaching a
+  // founder/designer verdict stays a human act in the portal.
+  capture_ux_critique: ["registry_write"],
+  search_ux_critique_corpus: ["registry_read"],
+
   // Org/WWWD qa elicitation feeder (BI-44526F3E Phase C): capture a CONFIRMED
   // operator answer about the business into the org corpus via enrichOrgCorpus
   // (qa provenance, first-party trust, draft-by-default per BI-1378). Requires

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1521,7 +1521,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - text\n  - link\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text"
     },
     "/platform/audit/authority": {
-      "defaultVisibleWords": 3437,
+      "defaultVisibleWords": 3443,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 3,

--- a/docs/superpowers/plans/2026-07-31-externalize-ux-design-critic-wsid.md
+++ b/docs/superpowers/plans/2026-07-31-externalize-ux-design-critic-wsid.md
@@ -53,6 +53,15 @@ The skill-pack still has a role: it is where the *procedure* for consulting the 
 - Read: craft corpus + critique corpus, for retrieval-augmented grounding.
 - Write: critique entries as drafts only. The authority contract in `apps/web/lib/ux-critique/critique-entry.ts` is preserved exactly — an agent caller can only ever produce `verdictAuthority: "agent-proposed"`, which is never calibration-eligible, and `callerKind` is derived from the authenticated principal, never from a client-supplied field.
 
+**Shipped 2026-08-04** as `apps/web/lib/mcp/packs/ux-critique-pack.ts`, registered in `apps/web/lib/mcp/pack-registry.ts`:
+
+- `search_ux_critique_corpus` — read past findings and their verdicts before offering a UX opinion. An empty corpus returns an explicit "any design judgement here is ungrounded" rather than a bare empty list, because a caller reads silence as "nothing relevant" and proceeds to assert anyway.
+- `capture_ux_critique` — record a finding as a draft.
+
+The authority contract is enforced at the tool boundary, not merely described: `callerKind` is **pinned** to `"agent"` in the handler rather than read from params, so an MCP caller can only ever produce `verdictAuthority: "agent-proposed"` and `isCalibrationEligible` excludes it. Founder and designer verdicts stay a human act in the portal. Grants land in `TOOL_TO_GRANTS` (`apps/web/lib/tak/agent-grants.ts`) as well as on the pack, because a pack advertising a grant the gating map lacks is denied for every coworker while looking authoritative (BI-88B77204); capture takes `registry_write`, matching `record_org_business_answer` writing drafts into the org corpus.
+
+Known consequence, measured rather than assumed: `/platform/audit/authority` renders every tool description via `PLATFORM_TOOLS`, which spreads `TOOL_PACK_REGISTRY.definitions`. Two new tools therefore add words to a route with a +0 regression tolerance — the same mechanism observed when #3826 and #3864 landed their packs. That route's baseline entry moves with this change; it is not a defect in either.
+
 ### 3. ux-design profession-local axes (BI-F405AC58)
 
 Four axes, each sourced, each projecting onto the spine in one hop: `ux-design/hierarchy_clarity`, `ux-design/content_density`, `ux-design/disclosure_quality`, `ux-design/perceptual_coherence`. Provenance and projection targets are already specified on the BI. `content_density` must be labelled platform calibration, not validated science; `perceptual_coherence` is the one validated member (CHI 2015) and may carry more weight.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -53,8 +53,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
-apps/web/lib/tak/agent-grants.ts	868
-apps/web/lib/tak/agent-grants.ts	878
+apps/web/lib/tak/agent-grants.ts	880
 apps/web/lib/tak/agent-routing.ts	991
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,6 +54,7 @@ apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
 apps/web/lib/tak/agent-grants.ts	868
+apps/web/lib/tak/agent-grants.ts	878
 apps/web/lib/tak/agent-routing.ts	991
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -1,24 +1,24 @@
 {
- "_comment": "Plane-4 standing tool-surface baseline (scripts/check-tool-surface.mjs). Growth is ALLOWED but never silent: raise a value and record `reason` + `recordedAt` saying what capability it buys. Dispatch-time caps are governed elsewhere and are not the subject of this baseline.",
- "selectionCliff": 15,
- "entries": {
-  "registry.toolDefinitions": {
-   "value": 352,
-   "reason": "Adds analyze_a2a_collaboration_health (BI-3003EE63): observes the coworker↔coworker (A2A) delegation plane — failed/blocked handoffs, stuck active delegations, orphan task lineage, pair failure rates. No existing tool covers this surface; analyze_mcp_call_efficiency is its twin for the tool-call plane and cannot see agent-to-agent edges. It carries its own grant and feeds AI-Ops alerting/BI dispatch.",
-   "recordedAt": "2026-08-04"
-  },
-  "registry.packFiles": {
-   "value": 81,
-   "reason": "Keeps supply coverage in its own bounded pack rather than widening the storefront pack, so the capability travels with its own grant (stock_read) and an archetype that stocks nothing never pays for it in its selection space.",
-   "recordedAt": "2026-08-01"
-  },
-  "tier.coreToolNames": {
-   "value": 29,
-   "reason": "Adds WWMD kernel discovery to core for peer CLIs (Grok/Codex): principle_decide + wiki_query. Those clients have no ToolSearch, so a lean core that omitted WWMD blocked AGENTS-required kernel consults even when the token already granted registry_read. Still lean vs full catalogue; authority stays grant/scope gated.",
-   "recordedAt": "2026-08-03"
-  },
-  "dispatch.maxAttachedTools": {
-   "value": 48
+  "_comment": "Plane-4 standing tool-surface baseline (scripts/check-tool-surface.mjs). Growth is ALLOWED but never silent: raise a value and record `reason` + `recordedAt` saying what capability it buys. Dispatch-time caps are governed elsewhere and are not the subject of this baseline.",
+  "selectionCliff": 15,
+  "entries": {
+    "registry.toolDefinitions": {
+      "value": 354,
+      "reason": "BI-52839DEA: search_ux_critique_corpus + capture_ux_critique open the design-critique corpus to external review sessions (on top of BI-3003EE63's analyze_a2a_collaboration_health at 352). They earn permanent places because the corpus is the gating asset of the UX-quality programme \u2014 an ungrounded design judge is the UICrit zero-shot case at 13.1% valid comments, and its accrual rate decides when the critic may gate at all. Until now its only door was a portal server action, so a review happening in a Claude Code / Codex / Grok session produced nothing durable; that is how the EP-UX-COGLOAD wave ended up text-only. Two tools rather than one because reading before judging and writing what you observed are separate acts with different authority: search is read-only and advisory, capture writes a draft that can never carry a calibration-eligible verdict.",
+      "recordedAt": "2026-08-04"
+    },
+    "registry.packFiles": {
+      "value": 82,
+      "reason": "BI-52839DEA: the critique corpus travels in its own pack rather than widening an existing one, so the capability carries its own grants (registry_read for search, registry_write for capture) and a surface that never reviews UX does not pay for it in its selection space. Same containment rationale as the supply-coverage pack this replaces the record of.",
+      "recordedAt": "2026-08-04"
+    },
+    "tier.coreToolNames": {
+      "value": 29,
+      "reason": "Adds WWMD kernel discovery to core for peer CLIs (Grok/Codex): principle_decide + wiki_query. Those clients have no ToolSearch, so a lean core that omitted WWMD blocked AGENTS-required kernel consults even when the token already granted registry_read. Still lean vs full catalogue; authority stays grant/scope gated.",
+      "recordedAt": "2026-08-03"
+    },
+    "dispatch.maxAttachedTools": {
+      "value": 48
+    }
   }
- }
 }


### PR DESCRIPTION
Opens the UX critique corpus to external review sessions — deliverable 2 of the plan that shipped in #3896.

## Why

The critique corpus is the gating asset of the UX-quality programme. An ungrounded design judge is the UICrit zero-shot case at **13.1% valid comments**; the corpus, not the model, is what fixes that. Its accrual rate — not its start date — decides when the critic can be trusted to gate at all.

Until now its only door was a portal server action. A review happening in a Claude Code / Codex / Grok session produced nothing durable. That is exactly how the earlier cognitive-load wave ended up text-only: its screenshots were ephemeral browser views nobody persisted, so the findings survive as prose that can never be re-measured.

## What lands

- **`search_ux_critique_corpus`** — read past findings and their verdicts *before* offering a UX opinion. An empty corpus returns an explicit *"any design judgement here is ungrounded"* rather than a bare empty list, because a caller reads silence as "nothing relevant" and asserts anyway.
- **`capture_ux_critique`** — record a finding as a draft.

## The authority contract is enforced, not described

`callerKind` is **pinned** to `"agent"` in the handler rather than read from params. An MCP caller can therefore only ever produce `verdictAuthority: "agent-proposed"`, which `isCalibrationEligible` excludes. Founder and designer verdicts stay a human act in the portal.

This is a correctness boundary, not a permissions nicety: **a judge calibrated on agent-authored verdicts is calibrated against itself.** The spec makes founder/designer authorship a contract precisely because non-expert agreement with expert designers is measurably low.

Grants land in `TOOL_TO_GRANTS` as well as on the pack — a pack advertising a grant the gating map lacks is **denied for every coworker while looking authoritative** (BI-88B77204). Capture takes `registry_write`, matching `record_org_business_answer` writing drafts into the org corpus; search is read-only like the decision gates.

## Known, measured consequence

`/platform/audit/authority` renders every tool description via `PLATFORM_TOOLS`, which spreads `TOOL_PACK_REGISTRY.definitions`. Two new tools add words to a route with a **+0 regression tolerance**.

This is not a surprise and not a defect: the same mechanism was observed empirically when #3826 and #3864 landed their own packs and shifted that route by +62 words. If the sweep flags it, the route's baseline entry moves with this change via the governed `update_baseline` dispatch.

## Verification

- 47 tool-registry / pack-registry tests pass, including the grant-parity assertions that catch exactly the BI-88B77204 shape.
- All 7 pull-request policy guards pass locally.

**Not run:** `pregate`. Its guard-parity preflight fails on `GuardRuntimeEnvironmentError` — repo-guard TypeScript resolving outside its isolated pnpm graph, with `packages/repo-guard-runtime/node_modules` never created despite the lockfile declaring `typescript@6.0.3`. That is local pnpm store damage, not code; the guard passes in CI. Component suites also cannot load locally (`apps/web/node_modules/react-dom` was pruned by a repair attempt). CI is the binding check.

**Local-CI-Override:** `install-bootstrap-recovery`.

## Design grounding

Reviewed `docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md` §6 L6 (corpus authority contract) and `docs/superpowers/plans/2026-07-31-externalize-ux-design-critic-wsid.md` deliverable 2, against the existing substrate in `apps/web/lib/ux-critique/critique-entry.ts`, `apps/web/lib/actions/critique-entry.ts`, `apps/web/lib/mcp/packs/profession-decision-pack.ts` and `apps/web/lib/tak/agent-grants.ts`. No new store and no second corpus home is created.

Backlog: BI-52839DEA (deliverable 2). Follows #3896.
