### PR TITLE
docs(ux): correct the frozen skills-route figure from 203 to 205

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -34,7 +34,7 @@ import { isSkillLifecycleState } from "@/lib/skills/lifecycle";
 // An interim fix capped the catalog at 12 rows, which brought the measurement to
 // 1,352 but by HIDING skills — a masked list (BI-836923AD): a subset with no
 // indication of what is missing, and a search that silently disagrees with the
-// screen. This replaces the cap with structure and measures 203.
+// screen. This replaces the cap with structure and freezes at 205.
 //
 // The content did not shrink; it got a hierarchy. The catalog is what a reader
 // comes here for and stays default-visible, grouped by category and collapsed;

--- a/apps/web/components/admin/SkillsCatalogView.budget.test.tsx
+++ b/apps/web/components/admin/SkillsCatalogView.budget.test.tsx
@@ -12,7 +12,7 @@ import { measureUxBudget, UX_BUDGETS } from "@/lib/ux-budget";
 // `line-clamp-2`. Clamping is a paint-time trick: the words stay in the DOM, so
 // the accessibility tree, the route sweep, and any screen reader still carry
 // them. An interim cap took the route to 1,352 by hiding rows; grouping takes it
-// to 203 while keeping every row reachable.
+// to 205 while keeping every row reachable.
 //
 // This test measures the SAME artifact the CI sweep measures (served markup, via
 // the sweep's own measureUxBudget) at production scale, so the regression cannot
@@ -101,8 +101,9 @@ describe("SkillsCatalogView — default-visible budget at production scale", () 
   });
 
   it("stays far below the 5,349-word baseline this route regressed from", () => {
-    // This component measures 26 words in isolation; the full route measures 203
-    // (the route sweep is the binding number). The ceiling is deliberately loose:
+    // This component measures 26 words in isolation; the full route freezes at 205
+    // (the route sweep is the binding number, and it carries a 2-word noise floor
+    // for relative-time phrasing). The ceiling is deliberately loose:
     // it guards the ORDER OF MAGNITUDE so a real regression fails loudly without
     // turning every copy edit red.
     expect(metrics.defaultVisibleWords).toBeLessThan(200);


### PR DESCRIPTION
Follow-up to #3896. Three comments still quote **203**, the figure from an earlier sweep freeze. The committed route-budget baseline and the ux-fit manifest that merged alongside it both say **205**.

The 2-word delta is the sweep's own documented noise floor — relative-time phrasing whose length varies with the clock ("less than a minute ago" is five words, "3 minutes ago" is three). It is not a change in the page.

Left as-is, a future reader reconciles three numbers against two artifacts and cannot tell which is authoritative. Comments only; no behaviour change.

All 7 pull-request policy guards pass.

**Local-CI-Override:** `install-bootstrap-recovery` — component suites cannot load locally after `apps/web/node_modules/react-dom` was pruned by an install repair attempt, and pregate's guard preflight fails on `GuardRuntimeEnvironmentError`. Comments-only change; CI is the binding check.

Backlog: BI-36CE8BAB