### PR TITLE
fix(infra): sweep tagged per-branch images, and stop the sweep failing silently

### DIFF
--- a/apps/web/lib/infra/docker-image-retention.test.ts
+++ b/apps/web/lib/infra/docker-image-retention.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  imageGroupKey,
+  isManagedImage,
+  parseDockerImageRows,
+  planStaleImageReaping,
+  type DockerImageRow,
+} from "./docker-image-retention";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 100 * DAY;
+
+function img(repository: string, ageDays: number): DockerImageRow {
+  return { repository, tag: `${repository}:latest`, createdAt: NOW - ageDays * DAY };
+}
+
+describe("the namespace allowlist is the load-bearing safety property", () => {
+  it("leaves everything outside the managed namespaces alone, however old", () => {
+    // Without this, an age sweep would delete postgres, grafana, and the portal
+    // image itself — turning a housekeeping job into an outage.
+    const result = planStaleImageReaping({
+      images: [
+        img("postgres", 400),
+        img("dpf-portal", 400),
+        img("dpf-sandbox", 400),
+        img("dpf-promoter", 400),
+        img("grafana/grafana-oss", 400),
+        img("inngest/inngest", 400),
+      ],
+      now: NOW,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("recognises exactly the two managed shapes", () => {
+    expect(isManagedImage("dpf-local-integration-slot-0-foo-build")).toBe(true);
+    expect(isManagedImage("dpf-local-integration-foo-build")).toBe(true);
+    expect(isManagedImage("dpf-hotel-room-ux-local-ci-portal")).toBe(true);
+    expect(isManagedImage("dpf-portal")).toBe(false);
+    expect(isManagedImage("dpf-promoter")).toBe(false);
+    expect(isManagedImage("postgres")).toBe(false);
+  });
+});
+
+describe("never reap something a container references", () => {
+  it("skips an in-use image however old, matched by repository", () => {
+    const result = planStaleImageReaping({
+      images: [img("dpf-local-integration-slot-0-live-build", 90), img("dpf-local-integration-slot-0-newer-build", 1)],
+      inUse: ["dpf-local-integration-slot-0-live-build"],
+      now: NOW,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("also matches an in-use reference given as repository:tag", () => {
+    const result = planStaleImageReaping({
+      images: [img("dpf-local-integration-slot-0-live-build", 90), img("dpf-local-integration-slot-0-newer-build", 1)],
+      inUse: ["dpf-local-integration-slot-0-live-build:latest"],
+      now: NOW,
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+describe("keep one warm image per group", () => {
+  it("keeps the newest in a group even when it is ancient", () => {
+    // Reaping a live slot's only image forces a cold rebuild next run — the
+    // cost this retention exists to stop paying repeatedly.
+    expect(
+      planStaleImageReaping({ images: [img("dpf-local-integration-slot-0-only-build", 400)], now: NOW }),
+    ).toEqual([]);
+  });
+
+  it("reaps the older sibling once a newer one exists", () => {
+    expect(
+      planStaleImageReaping({
+        images: [
+          img("dpf-local-integration-slot-0-old-build", 30),
+          img("dpf-local-integration-slot-0-new-build", 1),
+        ],
+        now: NOW,
+      }),
+    ).toEqual(["dpf-local-integration-slot-0-old-build:latest"]);
+  });
+
+  it("treats each slot as its own group so one slot cannot starve another", () => {
+    expect(
+      planStaleImageReaping({
+        images: [
+          img("dpf-local-integration-slot-0-a-build", 30),
+          img("dpf-local-integration-slot-0-b-build", 29),
+          img("dpf-local-integration-slot-1-c-build", 28),
+        ],
+        now: NOW,
+      }),
+    ).toEqual(["dpf-local-integration-slot-0-a-build:latest"]);
+  });
+
+  it("groups a one-off local-ci-portal image by itself, so age alone never reaps the last copy", () => {
+    expect(
+      planStaleImageReaping({
+        images: [img("dpf-hotel-room-ux-local-ci-portal", 60), img("dpf-other-local-ci-portal", 60)],
+        now: NOW,
+      }),
+    ).toEqual([]);
+  });
+
+  it("groups unslotted local-integration images by repository", () => {
+    expect(imageGroupKey("dpf-local-integration-slot-3-x-build")).toBe("dpf-local-integration-slot-3");
+    expect(imageGroupKey("dpf-local-integration-x-build")).toBe("dpf-local-integration-x-build");
+  });
+});
+
+describe("age threshold", () => {
+  const images = [
+    img("dpf-local-integration-slot-0-old-build", 3),
+    img("dpf-local-integration-slot-0-new-build", 1),
+  ];
+
+  it("keeps a superseded image that is still inside the window", () => {
+    expect(planStaleImageReaping({ images, now: NOW, maxAgeMs: 7 * DAY })).toEqual([]);
+  });
+
+  it("reaps it once past the window", () => {
+    expect(planStaleImageReaping({ images, now: NOW, maxAgeMs: 2 * DAY })).toEqual([
+      "dpf-local-integration-slot-0-old-build:latest",
+    ]);
+  });
+});
+
+describe("parseDockerImageRows", () => {
+  it("parses the docker format string this job uses", () => {
+    const rows = parseDockerImageRows(
+      "dpf-local-integration-slot-0-a-build||dpf-local-integration-slot-0-a-build:latest||2026-08-01 10:00:00 -0500 CDT",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].repository).toBe("dpf-local-integration-slot-0-a-build");
+    expect(Number.isFinite(rows[0].createdAt)).toBe(true);
+  });
+
+  it("DROPS a row with an unparseable date rather than treating it as epoch 0", () => {
+    // An NaN date coerced to 0 would look infinitely old and be reaped first —
+    // exactly backwards.
+    expect(parseDockerImageRows("repo||repo:latest||not-a-date")).toEqual([]);
+  });
+
+  it("is safe on empty and ragged input", () => {
+    expect(parseDockerImageRows("")).toEqual([]);
+    expect(parseDockerImageRows("\n\n")).toEqual([]);
+    expect(parseDockerImageRows("only-one-field")).toEqual([]);
+  });
+});
+
+describe("malformed input cannot crash the sweep", () => {
+  it("survives nulls and wrong types", () => {
+    const images = [null, undefined, {}, { repository: 5 }, { repository: "x" }] as unknown as DockerImageRow[];
+    expect(planStaleImageReaping({ images, now: NOW })).toEqual([]);
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(planStaleImageReaping({ images: [] })).toEqual([]);
+  });
+});

--- a/apps/web/lib/infra/docker-image-retention.ts
+++ b/apps/web/lib/infra/docker-image-retention.ts
@@ -1,0 +1,124 @@
+// Age-based retention for tagged per-branch Docker images (BI-A53DFC81).
+//
+// WHY THIS IS SEPARATE FROM scripts/lib/local-integration-image-retention.mjs:
+// that module reaps a slot's SUPERSEDED images and runs host-side from
+// local-ci-bounded-build.mjs immediately after a green build. It is the right
+// mechanism for the case it covers, and this does not replace it.
+//
+// What it cannot cover is the long tail. It only reaps a slot when that slot
+// BUILDS AGAIN, so a branch that built a few times and then merged keeps its
+// ~5GB image forever — nothing ever supersedes it. That tail is unbounded in
+// branches-ever-verified rather than in active slots.
+//
+// And `docker image prune` does not catch them either: it removes only DANGLING
+// images, and every one of these is TAGGED. So the weekly sweep could run
+// perfectly, every week, forever, and never touch the category that filled the
+// Docker data disk to zero on 2026-07-31, took the ext4 filesystem read-only,
+// and killed Postgres with SIGBUS. Measured 2026-08-04: 0 dangling images
+// alongside 105 tagged ones at ~5GB each.
+
+export type DockerImageRow = {
+  /** Repository without the tag, e.g. `dpf-local-integration-slot-0-foo-build`. */
+  repository: string;
+  /** Full `repository:tag` reference used for removal. */
+  tag: string;
+  /** Creation time in epoch ms. */
+  createdAt: number;
+};
+
+export type StaleImagePlanInput = {
+  images: readonly DockerImageRow[];
+  /** Image references held by ANY container, running or stopped. */
+  inUse?: readonly string[];
+  now?: number;
+  maxAgeMs?: number;
+};
+
+/** Default retention window. A week is long enough that an active branch keeps
+ *  its warm image across a normal working pause, short enough that the tail
+ *  cannot reach the volumes that caused the outage. */
+export const DEFAULT_IMAGE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Namespaces this sweep owns. Everything else is left strictly alone — a
+ *  blanket age sweep here would happily delete postgres, grafana, or the portal
+ *  image itself, so the allowlist is the load-bearing safety property. */
+const MANAGED_PATTERNS: readonly RegExp[] = [
+  /^dpf-local-integration-/,
+  /-local-ci-portal$/,
+];
+
+export function isManagedImage(repository: string): boolean {
+  return MANAGED_PATTERNS.some((pattern) => pattern.test(repository));
+}
+
+/**
+ * Group key for "keep the newest of these".
+ *
+ * A slot-scoped repository groups by its slot, so each slot retains a warm
+ * image. Anything else is its own group, which means a one-off portal image is
+ * never reaped by age alone — only once a newer one supersedes it.
+ */
+export function imageGroupKey(repository: string): string {
+  const slot = /^(dpf-local-integration-slot-\d+)-/.exec(repository);
+  return slot ? slot[1] : repository;
+}
+
+/**
+ * Which managed images are stale enough to reap. Pure — docker stays in the caller.
+ *
+ * Three guards, all of which must pass:
+ *  1. the image is in a namespace this sweep owns
+ *  2. it is referenced by no container, running or stopped
+ *  3. it is not the newest in its group AND it is older than `maxAgeMs`
+ *
+ * Guard 3 keeps the newest per group even when that image is ancient: reaping a
+ * live slot's only image forces a cold rebuild on its next run, which is the
+ * cost this retention exists to stop paying repeatedly.
+ */
+export function planStaleImageReaping(input: StaleImagePlanInput): string[] {
+  const now = input.now ?? Date.now();
+  const maxAgeMs = input.maxAgeMs ?? DEFAULT_IMAGE_MAX_AGE_MS;
+  const referenced = new Set(input.inUse ?? []);
+
+  const managed = (input.images ?? []).filter(
+    (image): image is DockerImageRow =>
+      Boolean(image) &&
+      typeof image.repository === "string" &&
+      typeof image.tag === "string" &&
+      isManagedImage(image.repository) &&
+      !referenced.has(image.repository) &&
+      !referenced.has(image.tag),
+  );
+
+  const newestPerGroup = new Map<string, DockerImageRow>();
+  for (const image of managed) {
+    const key = imageGroupKey(image.repository);
+    const current = newestPerGroup.get(key);
+    if (!current || image.createdAt > current.createdAt) newestPerGroup.set(key, image);
+  }
+
+  return managed
+    .filter((image) => {
+      if (newestPerGroup.get(imageGroupKey(image.repository)) === image) return false;
+      return now - image.createdAt > maxAgeMs;
+    })
+    .map((image) => image.tag);
+}
+
+/** Parse `docker images --format '{{.Repository}}||{{.Repository}}:{{.Tag}}||{{.CreatedAt}}'`.
+ *  Rows with an unparseable date are dropped rather than treated as epoch 0,
+ *  which would make them look infinitely old and therefore reapable. */
+export function parseDockerImageRows(stdout: string): DockerImageRow[] {
+  return (stdout ?? "")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [repository, tag, created] = line.split("||");
+      return { repository, tag, createdAt: new Date(created).getTime() };
+    })
+    .filter(
+      (row) =>
+        Boolean(row.repository) && Boolean(row.tag) && Number.isFinite(row.createdAt),
+    );
+}

--- a/apps/web/lib/queue/functions/infra-prune.ts
+++ b/apps/web/lib/queue/functions/infra-prune.ts
@@ -37,35 +37,104 @@ export const infraPrune = inngest.createFunction(
       const { exec } = await import("child_process");
       const util = await import("util");
       const execAsync = util.promisify(exec);
+      const { planStaleImageReaping } = await import(
+        "@/lib/infra/docker-image-retention"
+      );
 
-      // Keep recent promoter images (last 3 tags)
+      // Every category reports what it actually did. The previous version wrapped
+      // each block in `catch { /* Ignore errors */ }` and returned a flat
+      // `{ prunedDockerDisk: true }`, so a run that deleted 200 images and a run
+      // that silently failed were indistinguishable — which is why nobody could
+      // tell that 68 promoter images had accumulated under a rule capping them at
+      // 3 (BI-A53DFC81, `make-silent-failures-observable`).
+      const outcome: Record<string, unknown> = {};
+
+      // Keep recent promoter images (last 3 tags).
       try {
-        const { stdout } = await execAsync("docker images dpf-promoter --format '{{.Repository}}:{{.Tag}}||{{.CreatedAt}}'");
-        if (stdout) {
-          const lines = stdout.trim().split("\n").filter(Boolean);
-          const parsed = lines.map(line => {
+        const { stdout } = await execAsync(
+          "docker images dpf-promoter --format '{{.Repository}}:{{.Tag}}||{{.CreatedAt}}'",
+        );
+        const parsed = (stdout ?? "")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => {
             const [tag, created] = line.split("||");
             return { tag, created: new Date(created).getTime() };
-          }).sort((a, b) => b.created - a.created);
-          
-          const toDelete = parsed.slice(3).map(p => p.tag);
-          for (const tag of toDelete) {
-            await execAsync(`docker image rm -f ${tag}`).catch(() => {});
+          })
+          .sort((a, b) => b.created - a.created);
+
+        const toDelete = parsed.slice(3).map((p) => p.tag);
+        const removed: string[] = [];
+        const failed: string[] = [];
+        for (const tag of toDelete) {
+          try {
+            await execAsync(`docker image rm -f ${tag}`);
+            removed.push(tag);
+          } catch {
+            failed.push(tag);
           }
         }
+        outcome.promoter = { found: parsed.length, removed: removed.length, failed: failed.length };
       } catch (err) {
-        // Ignore errors
+        outcome.promoter = { error: err instanceof Error ? err.message : String(err) };
       }
 
-      // Prune dangling images and build cache
+      // Per-branch local-integration images. `docker image prune` below removes
+      // only DANGLING images, and every one of these is TAGGED — so without this
+      // block they are structurally invisible to this job and accumulate at ~5GB
+      // each until the disk fills. That is what took the filesystem read-only and
+      // killed Postgres on 2026-07-31.
+      try {
+        const [{ stdout: imageOut }, { stdout: containerOut }] = await Promise.all([
+          execAsync(
+            "docker images --format '{{.Repository}}||{{.Repository}}:{{.Tag}}||{{.CreatedAt}}'",
+          ),
+          execAsync("docker ps -a --format '{{.Image}}'"),
+        ]);
+
+        const images = (imageOut ?? "")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => {
+            const [repository, tag, created] = line.split("||");
+            return { repository, tag, createdAt: new Date(created).getTime() };
+          });
+        const inUse = (containerOut ?? "").trim().split("\n").filter(Boolean);
+
+        const stale = planStaleImageReaping({ images, inUse, now: Date.now() });
+        const removed: string[] = [];
+        const failed: string[] = [];
+        for (const tag of stale) {
+          try {
+            // No -f: if something unexpectedly references it, refusing is correct.
+            await execAsync(`docker image rm ${tag}`);
+            removed.push(tag);
+          } catch {
+            failed.push(tag);
+          }
+        }
+        outcome.staleBranchImages = {
+          scanned: images.length,
+          planned: stale.length,
+          removed: removed.length,
+          failed: failed.length,
+        };
+      } catch (err) {
+        outcome.staleBranchImages = { error: err instanceof Error ? err.message : String(err) };
+      }
+
+      // Dangling images and build cache.
       try {
         await execAsync("docker image prune -f --filter until=48h");
         await execAsync("docker builder prune -f --keep-storage 20gb");
+        outcome.danglingAndCache = "pruned";
       } catch (err) {
-        // Ignore errors
+        outcome.danglingAndCache = { error: err instanceof Error ? err.message : String(err) };
       }
 
-      return { prunedDockerDisk: true };
+      return { prunedDockerDisk: true, ...outcome };
     });
 
     // Defense-in-depth: pollDeviceFlow self-deletes its session on the

--- a/docs/superpowers/plans/2026-08-04-docker-image-retention-sweep.md
+++ b/docs/superpowers/plans/2026-08-04-docker-image-retention-sweep.md
@@ -1,0 +1,68 @@
+# Plan — Docker image retention sweep (BI-A53DFC81)
+
+Work Capsule: WC-03F189C6 · Branch: `fix/image-retention-sweep`
+
+One concern: **the weekly Docker sweep cannot see the images that fill the disk, and cannot tell you when it fails.**
+
+## What was actually wrong
+
+The item as I first filed it was partly wrong, and the correction is recorded on it
+(activity `cmsezd3hp1ho601qzg08dkqkk`). `infra-prune` *does* prune Docker disk and *does*
+cap promoter images at 3. Two things are genuinely broken:
+
+1. **Tagged per-branch images are invisible to it.** The job's only broad sweep is
+   `docker image prune -f --filter until=48h`, which removes **dangling** images. Every
+   `dpf-local-integration-*-build` and `*-local-ci-portal` image is **tagged**. Measured on
+   2026-08-04: **0 dangling images alongside 105 tagged ones at ~5 GB each.** The job could
+   run perfectly every week forever and never touch the category that filled the disk to
+   zero on 2026-07-31, took the ext4 filesystem read-only, and killed Postgres with SIGBUS.
+
+2. **The step cannot report what it did.** Three `catch { /* Ignore errors */ }` blocks and
+   a flat `return { prunedDockerDisk: true }`. A run that removed 200 images and a run that
+   silently failed are indistinguishable — which is why nobody could tell that 68 promoter
+   images had accumulated under a rule capping them at 3. Direct instance of
+   `make-silent-failures-observable`.
+
+## Why not extend the existing script module
+
+`scripts/lib/local-integration-image-retention.mjs` reaps a slot's **superseded** images,
+host-side, right after a green build. It is correct for the case it covers and is not
+changed here. Its limit is structural: it only reaps a slot when that slot **builds again**,
+so a branch that built a few times then merged keeps its image forever. That tail is
+unbounded in branches-ever-verified, not in active slots.
+
+The age sweep has a different consumer (the scheduled job, inside the portal container), so
+it lives in `apps/web/lib/infra/`. Putting it in the `.mjs` would have meant either a second
+copy or an import across the script/app boundary. One planner, one consumer each.
+
+## Implementation
+
+1. `apps/web/lib/infra/docker-image-retention.ts` — pure planner.
+   - `planStaleImageReaping` with three guards, all of which must pass: managed namespace,
+     referenced by no container, and neither newest-in-group nor within the age window.
+   - **The namespace allowlist is the load-bearing safety property.** A blanket age sweep
+     would delete postgres, grafana, and the portal image itself.
+   - **Keep the newest per group even when ancient** — reaping a live slot's only image
+     forces a cold rebuild, the cost this retention exists to avoid.
+   - `parseDockerImageRows` drops rows with an unparseable date rather than coercing to
+     epoch 0, which would make them look infinitely old and be reaped first.
+2. `infra-prune.ts` — call it, and record per-category outcomes (`found/planned/removed/
+   failed`, or the error) instead of swallowing. Remove uses no `-f`: if something
+   unexpectedly references an image, refusing is correct.
+
+## Verification
+
+- 16 unit tests on the planner, weighted to the safety properties rather than the happy path.
+- Typecheck + CI.
+- Functional: the manual reclaim on 2026-08-04 already proved the selection rule against the
+  real estate — 175 images removed, 0 refused, platform healthy throughout.
+
+## Deliberately not in scope
+
+- Changing the success-gating on the existing per-slot reap. Reaping after a failed build
+  would delete the last known-good image.
+- A vhdx compact. Deleting images frees space *inside* Docker's virtual disk, which is what
+  the outage actually exhausted; returning it to the host needs Docker stopped and is an
+  operator decision.
+- Disk-pressure alerting (item acceptance criterion 4) — that belongs with the health-alert
+  path, not this sweep, and is left as a follow-up rather than smuggled in here.


### PR DESCRIPTION
## The weekly sweep cannot see the images that fill the disk

**Correction to my own filing first:** I filed `BI-A53DFC81` after reading only the retention module, and got two claims wrong — `infra-prune` *does* prune Docker disk, and it *does* cap promoter images at 3. The correction is recorded on the item. What's actually broken is narrower and more certain.

### 1. Tagged images are invisible to it

The job's only broad sweep is `docker image prune -f --filter until=48h`, which removes **dangling** images. Every `dpf-local-integration-*-build` and `*-local-ci-portal` image is **tagged**.

Measured 2026-08-04:

```
0    dangling images
105  tagged local-integration / local-ci-portal images  (~5 GB each)
```

So the job could run perfectly, every week, forever, and never touch the category that filled the Docker data disk to zero on 2026-07-31 — taking the ext4 filesystem read-only and killing Postgres with SIGBUS.

The July fix capped that category's growth *rate* via the per-slot reap. It never addressed the *stock*, because that reap only fires when a slot **builds again** — a branch that built a few times then merged keeps its image forever. That tail is unbounded in branches-ever-verified, not in active slots. It had reached **105**, up from the **72** that caused the outage.

### 2. The step cannot report what it did

Three `catch { /* Ignore errors */ }` blocks and a flat `return { prunedDockerDisk: true }`. A run that removed 200 images and a run that silently failed were indistinguishable — which is precisely why nobody could tell that **68 promoter images** had accumulated under a rule capping them at 3.

That's `make-silent-failures-observable`, and here the observability *is* the diagnostic: I could not determine whether the promoter block was failing or simply not firing, because the code was written so that neither leaves a trace.

## What lands

`apps/web/lib/infra/docker-image-retention.ts` — a pure planner with three guards, **all** of which must pass:

1. the image is in a managed namespace
2. it is referenced by no container, running **or stopped**
3. it is neither newest-in-group nor inside the age window

**The namespace allowlist is the load-bearing safety property.** A blanket age sweep would delete postgres, grafana, and the portal image itself. Six tests assert exactly that, because it's the failure that turns housekeeping into an outage.

Two deliberate choices, each with a test:

- **Keep the newest per group even when ancient.** Reaping a live slot's only image forces a cold rebuild — the cost this retention exists to stop paying repeatedly.
- **Drop rows with an unparseable date** rather than coercing to epoch 0, which would make them look infinitely old and reap them *first* — exactly backwards.

`infra-prune` now records per-category outcomes (`found/planned/removed/failed`, or the error), and removes without `-f`: if something unexpectedly references an image, refusing is correct.

## Deliberately not changed

The success-gating on the existing per-slot reap in `scripts/lib/local-integration-image-retention.mjs`. Reaping after a failed build would delete the last known-good image. That module is correct for the case it covers; this adds the tail it structurally cannot reach — different consumer, so one planner each rather than a third ad-hoc pruning path.

Also out of scope: a vhdx compact (frees host space, needs Docker stopped — operator's call), and disk-pressure alerting, which belongs with the health-alert path rather than smuggled in here.

## Verification

- **16 unit tests**, weighted to the safety properties rather than the happy path
- `tsc --noEmit` — 0 errors
- **The selection rule is already proven against the real estate.** An operator-approved manual reclaim on 2026-08-04 applied exactly this rule: **175 images removed, 0 refused**, platform healthy throughout (234 → 59 images, 507.7 → 134.4 GB).

Local-CI-Override: the local gate is OOM-unavailable on this host — three prior runs killed at exit `4294967295` (a kill, not a verdict) with `com.docker.llama-server` holding 16.8 GB of 63.7 GB against a preflight typecheck needing 8–12 GB. CI is the authoritative gate.

Seed-Fit-Decision: platform-substrate