### PR TITLE
fix(a2a): make delegation-receipt signing host-independent and require a secret

### DIFF
--- a/apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts
+++ b/apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
   createCoworkerA2aTask,
@@ -6,6 +6,19 @@ import {
   readCoworkerA2aTask,
 } from "./a2a-tasks";
 import type { CreateCoworkerEngagementInput, CoworkerEngagementResult } from "./engagements";
+
+// These tests exercise the RECEIPT-BEARING path, which requires a signing secret.
+// Without one, createCoworkerA2aTask deliberately omits the receipt rather than
+// signing with an untrustworthy value (BI-2F318FB3), so the assertions below
+// would be testing the unsigned path by accident.
+const savedAuthSecret = process.env.AUTH_SECRET;
+beforeAll(() => {
+  process.env.AUTH_SECRET = "a2a-task-test-secret";
+});
+afterAll(() => {
+  if (savedAuthSecret === undefined) delete process.env.AUTH_SECRET;
+  else process.env.AUTH_SECRET = savedAuthSecret;
+});
 
 function db() {
   const engagement = {

--- a/apps/web/lib/coworker-service-catalog/a2a-tasks.ts
+++ b/apps/web/lib/coworker-service-catalog/a2a-tasks.ts
@@ -5,6 +5,7 @@ import {
   type CreateCoworkerEngagementInput,
 } from "./engagements";
 import {
+  canSignDelegationReceipts,
   createCoworkerDelegationReceipt,
   type CoworkerDelegationReceipt,
   type CoworkerDelegationReceiptAccessProfile,
@@ -113,7 +114,10 @@ export async function createCoworkerA2aTask(
     throw new Error("Cross-boundary A2A tasks require delegatedAgentId and delegatedAgentGaid.");
   }
 
-  const delegationReceipt = actingAgentGaid && delegatingAgentGaid && input.delegatedAgentId && input.delegatedAgentGaid
+  // No signing secret => no receipt. Not an error: a receipt that cannot be
+  // trusted is worse than none, and refusing the task would make a config gap an
+  // outage of the whole A2A path.
+  const delegationReceipt = canSignDelegationReceipts() && actingAgentGaid && delegatingAgentGaid && input.delegatedAgentId && input.delegatedAgentGaid
     ? createCoworkerDelegationReceipt({
         protocol: "a2a",
         accessProfile,

--- a/apps/web/lib/coworker-service-catalog/delegation-receipt.test.ts
+++ b/apps/web/lib/coworker-service-catalog/delegation-receipt.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  canSignDelegationReceipts,
   createCoworkerDelegationReceipt,
   verifyCoworkerDelegationReceipt,
 } from "./delegation-receipt";
@@ -183,5 +184,39 @@ describe("signing secret must be configured (BI-2F318FB3)", () => {
         {},
       ),
     ).toThrow(/signing secret/i);
+  });
+});
+
+describe("canSignDelegationReceipts (BI-2F318FB3)", () => {
+  const saved = {
+    receipt: process.env.DPF_DELEGATION_RECEIPT_SECRET,
+    auth: process.env.AUTH_SECRET,
+    nextAuth: process.env.NEXTAUTH_SECRET,
+  };
+
+  afterEach(() => {
+    if (saved.receipt === undefined) delete process.env.DPF_DELEGATION_RECEIPT_SECRET;
+    else process.env.DPF_DELEGATION_RECEIPT_SECRET = saved.receipt;
+    if (saved.auth === undefined) delete process.env.AUTH_SECRET;
+    else process.env.AUTH_SECRET = saved.auth;
+    if (saved.nextAuth === undefined) delete process.env.NEXTAUTH_SECRET;
+    else process.env.NEXTAUTH_SECRET = saved.nextAuth;
+  });
+
+  it("reports false when nothing is configured, so callers can decide explicitly", () => {
+    // Exposed as a predicate rather than left as an exception: A2A task creation
+    // omits the receipt instead of either emitting an untrustworthy one or
+    // failing the whole task.
+    delete process.env.DPF_DELEGATION_RECEIPT_SECRET;
+    delete process.env.AUTH_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+    expect(canSignDelegationReceipts()).toBe(false);
+  });
+
+  it("reports true once any accepted source is set", () => {
+    delete process.env.DPF_DELEGATION_RECEIPT_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+    process.env.AUTH_SECRET = "configured";
+    expect(canSignDelegationReceipts()).toBe(true);
   });
 });

--- a/apps/web/lib/coworker-service-catalog/delegation-receipt.test.ts
+++ b/apps/web/lib/coworker-service-catalog/delegation-receipt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   createCoworkerDelegationReceipt,
@@ -84,5 +84,104 @@ describe("coworker delegation receipts", () => {
       ok: false,
       reason: "signature_mismatch",
     });
+  });
+});
+
+describe("canonicalisation is host-independent (BI-2F318FB3)", () => {
+  const base = {
+    protocol: "a2a" as const,
+    accessProfile: "internal-a2a" as const,
+    offerId: "offer-1",
+    serviceId: "service-1",
+    actingAgentGaid: "gaid-acting",
+    delegatingAgentGaid: "gaid-delegating",
+    delegatedAgentId: "coworker-1",
+    delegatedAgentGaid: "gaid-delegated",
+    requestedOutcome: "do the thing",
+    authorityBoundary: "bounded",
+    riskTier: "low",
+  };
+
+  it("signs identically regardless of the host locale", () => {
+    // The old canonicaliser sorted keys with `localeCompare`, which resolves
+    // against the host's default locale and ICU data. A receipt signed on one
+    // machine could then fail verification on another — and the failure looks
+    // exactly like tampering, which is the worst possible way for a trust
+    // primitive to break.
+    const original = String.prototype.localeCompare;
+    const issuedAt = new Date("2026-08-04T00:00:00.000Z");
+
+    const underDefaultLocale = createCoworkerDelegationReceipt(base, {
+      issuedAt,
+      secret: "test-secret",
+      keyId: "k",
+    });
+
+    // Simulate a host whose collation orders differently. If canonicalisation
+    // still consulted the locale, this would change the signature.
+    // eslint-disable-next-line no-extend-native
+    String.prototype.localeCompare = function reversed(this: string, other: string) {
+      return other < this ? -1 : other > this ? 1 : 0;
+    } as typeof String.prototype.localeCompare;
+    try {
+      const underOtherLocale = createCoworkerDelegationReceipt(base, {
+        issuedAt,
+        secret: "test-secret",
+        keyId: "k",
+      });
+      expect(underOtherLocale.signature.value).toBe(underDefaultLocale.signature.value);
+    } finally {
+      // eslint-disable-next-line no-extend-native
+      String.prototype.localeCompare = original;
+    }
+  });
+
+  it("still verifies a receipt it just issued", () => {
+    const receipt = createCoworkerDelegationReceipt(base, { secret: "test-secret", keyId: "k" });
+    expect(verifyCoworkerDelegationReceipt(receipt, { secret: "test-secret" })).toEqual({ ok: true });
+  });
+});
+
+describe("signing secret must be configured (BI-2F318FB3)", () => {
+  const saved = {
+    receipt: process.env.DPF_DELEGATION_RECEIPT_SECRET,
+    auth: process.env.AUTH_SECRET,
+    nextAuth: process.env.NEXTAUTH_SECRET,
+  };
+
+  beforeEach(() => {
+    delete process.env.DPF_DELEGATION_RECEIPT_SECRET;
+    delete process.env.AUTH_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+  });
+
+  afterEach(() => {
+    if (saved.receipt === undefined) delete process.env.DPF_DELEGATION_RECEIPT_SECRET;
+    else process.env.DPF_DELEGATION_RECEIPT_SECRET = saved.receipt;
+    if (saved.auth === undefined) delete process.env.AUTH_SECRET;
+    else process.env.AUTH_SECRET = saved.auth;
+    if (saved.nextAuth === undefined) delete process.env.NEXTAUTH_SECRET;
+    else process.env.NEXTAUTH_SECRET = saved.nextAuth;
+  });
+
+  it("throws rather than signing with a constant anyone can read in this repository", () => {
+    expect(() =>
+      createCoworkerDelegationReceipt(
+        {
+          protocol: "a2a",
+          accessProfile: "internal-a2a",
+          offerId: "o",
+          serviceId: "s",
+          actingAgentGaid: "a",
+          delegatingAgentGaid: "d",
+          delegatedAgentId: "c",
+          delegatedAgentGaid: "g",
+          requestedOutcome: "x",
+          authorityBoundary: "b",
+          riskTier: "low",
+        },
+        {},
+      ),
+    ).toThrow(/signing secret/i);
   });
 });

--- a/apps/web/lib/coworker-service-catalog/delegation-receipt.ts
+++ b/apps/web/lib/coworker-service-catalog/delegation-receipt.ts
@@ -1,5 +1,7 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 
+import { canonicalJson } from "@/lib/shared/canonical-json";
+
 export type CoworkerDelegationReceiptAccessProfile = "internal-a2a" | "partner-a2a" | "external-a2a";
 
 export type CoworkerDelegationReceiptInput = {
@@ -123,24 +125,36 @@ function digest(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+/**
+ * Signing secret. Throws when unset — there is deliberately NO fallback constant.
+ *
+ * The previous default was a literal in this file, so anyone who could read the
+ * repository could mint a receipt that verified. A receipt exists to let a
+ * RECEIVING party trust a delegation they did not witness; one signed with a
+ * public constant carries no such assurance while looking exactly like one that
+ * does. Failing to start is the correct behaviour (BI-2F318FB3).
+ */
 function receiptSecret(): string {
-  return process.env.DPF_DELEGATION_RECEIPT_SECRET
-    ?? process.env.AUTH_SECRET
-    ?? process.env.NEXTAUTH_SECRET
-    ?? "dpf-local-delegation-receipt";
+  const secret =
+    process.env.DPF_DELEGATION_RECEIPT_SECRET ??
+    process.env.AUTH_SECRET ??
+    process.env.NEXTAUTH_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    throw new Error(
+      "Coworker delegation receipts require a signing secret: set DPF_DELEGATION_RECEIPT_SECRET (or AUTH_SECRET / NEXTAUTH_SECRET).",
+    );
+  }
+  return secret;
 }
 
 function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
-}
+// Canonicalisation is delegated to the shared helper. The local copy sorted keys
+// with `localeCompare`, which resolves against the host's default locale and ICU
+// data — so the same receipt could canonicalise differently on two machines,
+// producing a signature mismatch that looks exactly like tampering. That is the
+// worst possible way for this to fail: the receipt exists to establish trust, and
+// the failure mode accuses the counterparty of forging it (BI-2F318FB3).
+const stableJson = canonicalJson;

--- a/apps/web/lib/coworker-service-catalog/delegation-receipt.ts
+++ b/apps/web/lib/coworker-service-catalog/delegation-receipt.ts
@@ -126,6 +126,25 @@ function digest(value: string): string {
 }
 
 /**
+ * Whether this install can sign a receipt at all.
+ *
+ * Exposed so callers can decide EXPLICITLY rather than by catching an exception.
+ * A2A task creation uses it to omit the receipt when no secret is configured:
+ * emitting no receipt is truthful, whereas emitting one signed with a guessable
+ * value is a lie that looks exactly like the real thing — and failing task
+ * creation outright would turn a configuration gap into an outage of the whole
+ * collaboration path (BI-2F318FB3).
+ */
+export function canSignDelegationReceipts(): boolean {
+  try {
+    receiptSecret();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Signing secret. Throws when unset — there is deliberately NO fallback constant.
  *
  * The previous default was a literal in this file, so anyone who could read the


### PR DESCRIPTION
Two defects in the same signing path. One is reachable **today** through a caller-supplied key space.

## 1. Locale-dependent canonicalisation

The receipt payload was canonicalised before HMAC signing with:

```ts
.sort(([left], [right]) => left.localeCompare(right))
```

`localeCompare` with no explicit locale resolves against the host's default locale and ICU data. Two machines can order the same keys differently → different canonical string → **different signature**. A receipt signed on one host **fails verification on another**.

That's the worst available failure mode here. A delegation receipt exists so a receiving party can trust a delegation it did not witness. When canonicalisation drifts, the receipt doesn't merely stop working — **it accuses the counterparty of forging it**. And it would surface first in exactly the cross-host case receipts exist to serve.

### How reachable is it, actually

I measured rather than assumed, because it changes how alarmed to be:

- For the receipt's **own fixed keys** — all lowercase-initial camelCase ASCII — locale and code-unit ordering are **identical**. No receipt issued today is at risk from those.
- But **`contractContext` is typed `{ [key: string]: unknown }`**, is part of the signed payload, and the canonicaliser recurses into it. A caller passing a key that collates differently hits the divergence immediately:

```
[a,B,_x,Z,0]  →  locale: _x0aBZ    code-unit: 0BZ_xa
```

So: a **live defect behind an open key space**, not a latent one behind a future code change.

**Fix:** delegate to the shared `canonicalJson` (code-unit ordering), which also removes one of six hand-rolled copies. The regression test overrides `String.prototype.localeCompare` with a reversed comparator and asserts the signature is unchanged — it fails on the old implementation.

## 2. Signing secret fell back to a public constant

```ts
?? "dpf-local-delegation-receipt"
```

With no env var set, receipts were signed with a literal in this file — forgeable by anyone who can read the repository, while looking exactly like one that isn't.

Verified before changing it that this is operationally free: `AUTH_SECRET` is **SET** on the running portal, so that branch is already unreachable here.

## The mistake I made, and the correction

My first commit made `receiptSecret()` throw and I did not follow the throw to its callers. It propagated into `createCoworkerA2aTask`, so an install without a secret would lose the **entire A2A path**. `a2a-tasks.test.ts` went red and caught it.

That trade is wrong in both directions — signing with a public constant is a lie, but refusing the task turns a config gap into an outage. The honest third option is to emit **no receipt**: a receiving party can distinguish "no receipt" from "a receipt", but cannot distinguish a real receipt from one signed with a published constant.

Implemented as an explicit `canSignDelegationReceipts()` predicate, not a try/catch at the call site — exception-driven control flow here would be the same swallow-and-continue pattern I removed from `infra-prune` in #3973.

## Deliberately not done

- **The other four hand-rolled canonicalisers.** `hive/result-intake.ts` already sorts by code unit and its output is baked into persisted payload hashes; migrating each needs a per-caller decision about whether its output is compared across time. `BI-2F318FB3` carries that.
- **No compatibility shim for issued receipts.** `verifyCoworkerDelegationReceipt` has no in-tree caller, so nothing this repository ships would reject an old one.

## Verification

- **128 tests green** across `lib/coworker-service-catalog` + `canonical-json`
- `tsc --noEmit` — 0 errors
- `a2a-tasks.test.ts` now sets a secret in `beforeAll` **with a comment saying why**: it asserts the receipt-bearing path, so without one it would have been silently testing the unsigned path instead

Local-CI-Override: local gate OOM-unavailable on this host (prior runs killed at exit `4294967295`, llama-server holding ~17 GB of 63.7 GB against a preflight typecheck needing 8–12 GB). CI is authoritative.

Seed-Fit-Decision: platform-substrate