### PR TITLE
feat(edge): enforce the minimal edge-footprint contract in CI (BI-4B381171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,6 +645,26 @@ jobs:
       - name: Assert third-party compose images are pinned
         run: bash scripts/check-compose-image-pins.sh docker-compose.yml
 
+  edge-footprint-bom:
+    name: Edge Footprint Bill-of-Materials
+    runs-on: ubuntu-latest
+    # BI-4B381171 — makes "the edge install doesn't need everything the
+    # portal has" (docs/superpowers/specs/
+    # 2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md
+    # §6) a CI-enforced contract instead of a doc-only claim. Fails if
+    # services/edge-node or services/edge-node-go gain a relational/graph/
+    # vector-store dependency (FP2), an LLM/model-runtime dependency or a
+    # hardcoded model-provider API key reference (FP3), an inbound network
+    # listener (FP1 static half), a dynamically-linked release binary
+    # (FP4 static half), or a Prometheus scrape-server dependency
+    # (FP5 static half). The dynamic egress-only check (FP1) is
+    # scripts/verify-edge-node-air-gap.sh, which needs root/iptables/a real
+    # host and so runs out-of-band, not in CI.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert edge-node image bill-of-materials stays minimal
+        run: node scripts/check-edge-node-image-bom.mjs
+
   adp-integration-tests:
     name: ADP Integration Tests
     runs-on: ubuntu-latest
@@ -715,6 +735,7 @@ jobs:
       - ux-route-sweep
       - dockerfile-node-version
       - compose-image-pins
+      - edge-footprint-bom
       - adp-integration-tests
     steps:
       - uses: actions/checkout@v7

--- a/packages/validators/src/edge-footprint.test.ts
+++ b/packages/validators/src/edge-footprint.test.ts
@@ -1,0 +1,83 @@
+// BI-4B381171 — FP7 (bounded payloads/cardinality) contract test.
+//
+// The edge-footprint spec (docs/superpowers/specs/
+// 2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md
+// §6, §11.2) requires per-node batch/payload caps to be enforced BEFORE
+// data hits Postgres/Neo4j/Prometheus/Grafana. This file locks in the two
+// array-cardinality caps that live in the wire-contract schemas
+// themselves (the earliest possible enforcement point — before the 64 KB
+// body-size cap on /api/v1/edge/metrics and /api/v1/edge/events even
+// gets a chance to reject an oversized request).
+//
+// It intentionally does NOT assert queue-depth, retry-horizon, or
+// Prometheus label-cardinality caps: those are not implemented anywhere
+// in the edge ingestion path today (confirmed by repo-wide search — no
+// edge-scoped Prometheus metrics are registered at all, so there is
+// nothing yet to bound). Asserting a passing test for code that doesn't
+// exist would be a false-green; the gap is called out in the
+// BI-4B381171 PR body and tracked as a follow-up instead.
+import { describe, expect, it } from "vitest";
+
+import { edgeEventEnvelopeSchema, metricsEnvelopeSchema } from "./edge";
+
+const ISO = "2026-06-24T12:00:00.000Z";
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+function interfaceMetric(n: number) {
+  return {
+    deviceKey: `snmp:10.0.0.${n % 255}`,
+    ifName: `eth${n}`,
+    rxBps: 0,
+    txBps: 0,
+    operStatus: "up" as const,
+  };
+}
+
+describe("metricsEnvelopeSchema — FP7 interface-array cap", () => {
+  const base = {
+    runKey: UUID,
+    observedAt: ISO,
+    metricsVersion: "1" as const,
+  };
+
+  it("accepts an envelope at the 2000-interface cap", () => {
+    const interfaces = Array.from({ length: 2000 }, (_, i) => interfaceMetric(i));
+    const result = metricsEnvelopeSchema.safeParse({ ...base, interfaces });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an envelope over the 2000-interface cap", () => {
+    const interfaces = Array.from({ length: 2001 }, (_, i) => interfaceMetric(i));
+    const result = metricsEnvelopeSchema.safeParse({ ...base, interfaces });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("edgeEventEnvelopeSchema — FP7 event-array cap", () => {
+  const baseEvent = {
+    eventType: "alert" as const,
+    dedupKey: "test.alert:host1",
+    source: "test",
+    severity: "info" as const,
+    action: "trigger" as const,
+    summary: "test alert",
+    occurredAt: ISO,
+  };
+  const base = {
+    runKey: UUID,
+    observedAt: ISO,
+    eventsVersion: "1" as const,
+  };
+
+  it("accepts an envelope at the 500-event cap", () => {
+    const events = Array.from({ length: 500 }, () => ({ ...baseEvent }));
+    const result = edgeEventEnvelopeSchema.safeParse({ ...base, events });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an envelope over the 500-event cap", () => {
+    const events = Array.from({ length: 501 }, () => ({ ...baseEvent }));
+    const result = edgeEventEnvelopeSchema.safeParse({ ...base, events });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validators/src/edge.ts
+++ b/packages/validators/src/edge.ts
@@ -60,7 +60,12 @@ export const metricsEnvelopeSchema = z.object({
   /** ISO 8601 timestamp when the metrics were captured. */
   observedAt: z.string().datetime(),
   metricsVersion: z.literal("1"),
-  interfaces: z.array(interfaceMetricSchema),
+  // FP7 (BI-4B381171): bound per-envelope interface count so an
+  // unbounded array can't inflate payload size or downstream write
+  // volume before the 64 KB body cap even engages. 2000 is far above
+  // any real node's interface count (SNMP/UniFi/LLDP adapters see at
+  // most a few hundred ports per poll cycle).
+  interfaces: z.array(interfaceMetricSchema).max(2000),
 });
 
 export type MetricsEnvelope = z.infer<typeof metricsEnvelopeSchema>;

--- a/scripts/check-edge-node-image-bom.mjs
+++ b/scripts/check-edge-node-image-bom.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// scripts/check-edge-node-image-bom.mjs — BI-4B381171.
+//
+// Makes the edge-footprint spec's "the edge install doesn't need everything
+// the portal has" claim (docs/superpowers/specs/
+// 2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md
+// §6 "Minimal Edge Footprint (G3)", §11.2 verification matrix) into a CI
+// gate instead of a doc-only assertion. Covers the fingerprints that are
+// checkable statically, without a real host, sudo, or iptables:
+//
+//   FP1 (static half) — no inbound listener in either edge runtime.
+//     The dynamic half (zero off-allow-list egress packets on a real host)
+//     is scripts/verify-edge-node-air-gap.sh; that harness needs root +
+//     iptables + a live network, so it is NOT a CI job — this script is
+//     the CI-runnable complement.
+//   FP2 — no relational/graph/vector store client in the dependency tree
+//     of either edge runtime (state is state.json only).
+//   FP3 — no LLM/model-runtime SDK in the dependency tree, and no
+//     hardcoded reference to a model-provider API key env var.
+//   FP5 (static half) — no Prometheus scrape-server/exporter dependency
+//     and no inbound `/metrics` GET route registered (metrics are
+//     push-only via POST /api/v1/edge/metrics).
+//   FP4 (static half) — every services/edge-node-go/Makefile cross-compile
+//     target builds with CGO_ENABLED=0, so the release binaries
+//     (.github/workflows/publish-release.yml uploads them straight to the
+//     GitHub Release — no monorepo clone needed to fetch or run one) stay
+//     statically linked instead of silently depending on host shared
+//     libraries. A dynamically-linked binary would break the "single
+//     binary fetchable by URL" claim on a host missing those libs.
+//
+// FP6, FP7 are NOT covered here — see the BI-4B381171 PR body for what's
+// covered elsewhere (FP7 partial, in packages/validators) and what's a
+// documented gap (FP6 — no redaction implementation exists yet).
+//
+//   node scripts/check-edge-node-image-bom.mjs
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const TS_PACKAGE_JSON = join(REPO_ROOT, "services/edge-node/package.json");
+const TS_SRC_DIR = join(REPO_ROOT, "services/edge-node/src");
+const GO_MOD = join(REPO_ROOT, "services/edge-node-go/go.mod");
+const GO_MAKEFILE = join(REPO_ROOT, "services/edge-node-go/Makefile");
+const GO_SRC_DIRS = [
+  join(REPO_ROOT, "services/edge-node-go/cmd"),
+  join(REPO_ROOT, "services/edge-node-go/internal"),
+];
+
+// --- FP2 / FP3 dependency allow-list (deny-list, really) -------------------
+// Substring match against the package name (npm) or module path (Go). Keep
+// these as recognizable product/library names, not generic words, so the
+// gate doesn't false-positive on an unrelated dependency that happens to
+// share a token.
+const DENY_RELATIONAL_GRAPH_VECTOR = [
+  // relational
+  "pg",
+  "postgres",
+  "prisma",
+  "mysql",
+  "mariadb",
+  "sqlite",
+  "knex",
+  "typeorm",
+  "sequelize",
+  "drizzle-orm",
+  // graph
+  "neo4j",
+  // vector
+  "qdrant",
+  "pinecone",
+  "weaviate",
+  "chromadb",
+  // generic cache/kv stores the spec also excludes from the edge (state is
+  // one JSON file, not a store)
+  "redis",
+  "mongodb",
+  "mongoose",
+];
+
+const DENY_LLM_MODEL_RUNTIME = [
+  "openai",
+  "anthropic",
+  "@anthropic-ai",
+  "langchain",
+  "llamaindex",
+  "ollama",
+  "cohere",
+  "replicate",
+  "huggingface",
+  "@huggingface",
+  "onnxruntime",
+  "@xenova/transformers",
+  "node-llama-cpp",
+];
+
+const DENY_PROMETHEUS_SERVER = ["prom-client", "prometheus/client_golang", "express-prom-bundle"];
+
+const PROVIDER_KEY_ENV_PATTERNS = [
+  /\bOPENAI_API_KEY\b/,
+  /\bANTHROPIC_API_KEY\b/,
+  /\bAZURE_OPENAI_API_KEY\b/,
+  /\bGOOGLE_API_KEY\b/,
+  /\bGEMINI_API_KEY\b/,
+  /\bCOHERE_API_KEY\b/,
+  /\bMISTRAL_API_KEY\b/,
+  /\bGROQ_API_KEY\b/,
+  /\bTOGETHER_API_KEY\b/,
+  /\bREPLICATE_API_TOKEN\b/,
+  /\bHUGGINGFACE_API_KEY\b/,
+  /\bHF_API_TOKEN\b/,
+];
+
+// FP1 static: inbound listener setup. Deliberately coarse (string match, not
+// AST) — this is a bill-of-materials sanity gate, not a full static
+// analyzer; a hit should prompt a human look, not necessarily block on its
+// own merit if it's a false positive (e.g. a doc comment).
+const INBOUND_LISTENER_PATTERNS = [
+  /\bcreateServer\s*\(/,
+  /\.listen\s*\(/,
+  /\bListenAndServe\s*\(/,
+  /\bListenAndServeTLS\s*\(/,
+  /\bnet\.Listen\s*\(/,
+  /\bnet\.ListenTCP\s*\(/,
+  /\bnet\.ListenUDP\s*\(/,
+];
+
+// FP5 static: an inbound scrape-style route registration for /metrics.
+const METRICS_ROUTE_PATTERNS = [
+  /["'`]\/metrics["'`]/, // route string literal — flagged for manual review, not an automatic fail (see below)
+];
+
+const violations = [];
+const notes = [];
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function walkFiles(dir, exts) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "bin") continue;
+      out.push(...walkFiles(full, exts));
+    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Token-based match, not raw substring: a short denied word like "pg" must
+// match a whole `/`, `@`, `-`, `.`-delimited segment of the dependency name
+// (e.g. "pg" matches "pg" and "@types/pg", not "pngjs" or an unrelated
+// "golang.org/x/tools" module). Longer, unambiguous denied words (e.g.
+// "postgres", "prisma") still match as a substring so scoped/suffixed
+// variants (e.g. "@prisma/client") are caught too.
+function depTokens(name) {
+  return name.toLowerCase().split(/[/@\-.]+/).filter(Boolean);
+}
+
+function checkDenyList(depNames, denyList, label, source) {
+  for (const dep of depNames) {
+    const lower = dep.toLowerCase();
+    const tokens = depTokens(dep);
+    for (const denied of denyList) {
+      const matches =
+        denied.length <= 3 ? tokens.includes(denied) : lower.includes(denied);
+      if (matches) {
+        violations.push(
+          `${label}: ${source} declares dependency "${dep}" which matches the denied pattern "${denied}".`,
+        );
+      }
+    }
+  }
+}
+
+// --- TS side (services/edge-node) ------------------------------------------
+
+const tsPkg = readJson(TS_PACKAGE_JSON);
+const tsDeps = [
+  ...Object.keys(tsPkg.dependencies ?? {}),
+  ...Object.keys(tsPkg.devDependencies ?? {}),
+];
+checkDenyList(tsDeps, DENY_RELATIONAL_GRAPH_VECTOR, "FP2", "services/edge-node/package.json");
+checkDenyList(tsDeps, DENY_LLM_MODEL_RUNTIME, "FP3", "services/edge-node/package.json");
+checkDenyList(tsDeps, DENY_PROMETHEUS_SERVER, "FP5", "services/edge-node/package.json");
+
+// --- Go side (services/edge-node-go) ----------------------------------------
+
+const goModText = readFileSync(GO_MOD, "utf8");
+const goModules = [...goModText.matchAll(/^\s*([a-zA-Z0-9._\-/]+)\s+v[0-9]/gm)].map((m) => m[1]);
+checkDenyList(goModules, DENY_RELATIONAL_GRAPH_VECTOR, "FP2", "services/edge-node-go/go.mod");
+checkDenyList(goModules, DENY_LLM_MODEL_RUNTIME, "FP3", "services/edge-node-go/go.mod");
+checkDenyList(goModules, DENY_PROMETHEUS_SERVER, "FP5", "services/edge-node-go/go.mod");
+
+// --- FP4 static half: every cross-compile target stays statically linked ---
+
+const makefileText = readFileSync(GO_MAKEFILE, "utf8");
+const makefileLines = makefileText.split("\n");
+let currentTarget = null;
+for (const line of makefileLines) {
+  const targetMatch = line.match(/^([a-zA-Z0-9_-]+):/);
+  if (targetMatch) {
+    currentTarget = targetMatch[1];
+    continue;
+  }
+  if (
+    currentTarget &&
+    currentTarget.startsWith("build-") &&
+    /\$\(GO\)\s+build/.test(line) &&
+    !/CGO_ENABLED=0/.test(line)
+  ) {
+    violations.push(
+      `FP4: services/edge-node-go/Makefile target "${currentTarget}" builds without CGO_ENABLED=0 — the release binary would silently depend on host shared libraries, breaking the single-binary-fetchable-by-URL claim.`,
+    );
+  }
+}
+
+// --- Source-pattern scans (FP1 inbound listener, FP3 provider keys, FP5 route) --
+
+const tsSourceFiles = walkFiles(TS_SRC_DIR, [".ts"]);
+const goSourceFiles = GO_SRC_DIRS.flatMap((d) => walkFiles(d, [".go"]));
+const allSourceFiles = [...tsSourceFiles, ...goSourceFiles];
+
+for (const file of allSourceFiles) {
+  const rel = relative(REPO_ROOT, file);
+  const text = readFileSync(file, "utf8");
+
+  for (const pattern of INBOUND_LISTENER_PATTERNS) {
+    if (pattern.test(text)) {
+      violations.push(
+        `FP1: ${rel} matches inbound-listener pattern ${pattern} — the edge runtime must be outbound-only.`,
+      );
+    }
+  }
+
+  for (const pattern of PROVIDER_KEY_ENV_PATTERNS) {
+    if (pattern.test(text)) {
+      violations.push(
+        `FP3: ${rel} references a model-provider API key env var (${pattern}) — the edge runtime must not require LLM credentials.`,
+      );
+    }
+  }
+
+  for (const pattern of METRICS_ROUTE_PATTERNS) {
+    if (pattern.test(text) && !rel.includes(".test.") && !rel.endsWith("_test.go")) {
+      // Non-fatal: flagged as a note, not a violation, because
+      // api-client.ts legitimately contains the string "/api/v1/edge/metrics"
+      // (the outbound POST target) which is a substring match on
+      // "/metrics". A human confirms whether this is the outbound POST
+      // path (fine) or an inbound scrape GET handler (FP5 violation).
+      notes.push(`FP5 (review): ${rel} contains a "/metrics" string literal — confirm this is the outbound POST path, not an inbound scrape route.`);
+    }
+  }
+}
+
+// --- Report ------------------------------------------------------------------
+
+if (notes.length > 0) {
+  console.log("Notes (non-fatal, human review):");
+  for (const n of notes) console.log(`  - ${n}`);
+  console.log("");
+}
+
+if (violations.length > 0) {
+  console.error(`edge-node image BoM check FAILED — ${violations.length} violation(s):\n`);
+  for (const v of violations) console.error(`  - ${v}`);
+  console.error(
+    "\nThe edge node's minimal footprint (FP1-FP5 static halves) is a contract, not a" +
+      " convention — see docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md §6." +
+      " If this dependency/pattern is genuinely required, update the spec's footprint table" +
+      " first, then this script's allow-list, with a tracking BI reference.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `edge-node image BoM check passed: ${tsDeps.length} TS deps, ${goModules.length} Go modules,` +
+    ` ${allSourceFiles.length} source files, Makefile cross-compile targets scanned —` +
+    ` no FP1/FP2/FP3/FP4(static)/FP5(static) violations.`,
+);

--- a/scripts/check-edge-node-image-bom.mjs
+++ b/scripts/check-edge-node-image-bom.mjs
@@ -34,7 +34,7 @@
 //
 //   node scripts/check-edge-node-image-bom.mjs
 
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative } from "node:path";
 

--- a/scripts/verify-edge-node-air-gap.sh
+++ b/scripts/verify-edge-node-air-gap.sh
@@ -19,8 +19,22 @@
 # you can spot it.
 #
 # Spec:    docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+# Footprint contract (FP1, BI-4B381171): docs/superpowers/specs/
+#   2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md §6
 # Runbook: docs/install/edge-node-air-gapped.md
 # Report:  docs/install/edge-node-air-gapped-verification-report.md
+#
+# --allow-federation-discovery-mdns (BI-4B381171): the native Go edge
+# runtime's optional `federation.discovery` capability (only ever accepted
+# by the Authority — services/edge-node-go/internal/federation/zeroconf.go)
+# sends/receives IPv4 mDNS on 224.0.0.251:5353 to find nearby DPF
+# installations. That traffic never touches the Authority IP, so a node
+# running with this capability accepted will otherwise show as a FAIL
+# against the default allow-list even though it never opens an inbound
+# listener and never talks to any host outside the mDNS multicast group.
+# Pass this flag when testing a node with federation.discovery accepted;
+# omit it (the default) to verify the strict single-Authority-destination
+# posture most nodes run under.
 
 set -euo pipefail
 
@@ -33,6 +47,7 @@ Usage:
     [--duration-sec N] \
     [--report PATH] \
     [--allow-extra IP[,IP...]] \
+    [--allow-federation-discovery-mdns] \
     [--log-prefix PREFIX] \
     [--no-iptables]
 
@@ -52,6 +67,12 @@ Optional:
   --allow-extra     Additional IPs to ACCEPT (e.g. internal DNS,
                     internal NTP). Comma-separated. Loopback is
                     always allowed implicitly.
+  --allow-federation-discovery-mdns
+                    ACCEPT outbound UDP to 224.0.0.251:5353 (IPv4 mDNS)
+                    for nodes running with the native binary's
+                    federation.discovery capability accepted. Off by
+                    default — most nodes should verify clean against
+                    the Authority-only allow-list.
   --log-prefix      iptables LOG prefix. Default: "dpf-airgap: "
   --no-iptables     Skip iptables setup (for environments that
                     manage egress filtering externally). Script
@@ -74,6 +95,7 @@ AUTHORITY_URL=""
 DURATION_SEC=""
 REPORT=""
 ALLOW_EXTRA=""
+ALLOW_MDNS=0
 LOG_PREFIX="dpf-airgap: "
 NO_IPTABLES=0
 
@@ -84,6 +106,7 @@ while [[ $# -gt 0 ]]; do
     --duration-sec)    shift; DURATION_SEC="${1:?--duration-sec requires a value}" ;;
     --report)          shift; REPORT="${1:?--report requires a value}" ;;
     --allow-extra)     shift; ALLOW_EXTRA="${1:?--allow-extra requires a value}" ;;
+    --allow-federation-discovery-mdns) ALLOW_MDNS=1 ;;
     --log-prefix)      shift; LOG_PREFIX="${1:?--log-prefix requires a value}" ;;
     --no-iptables)     NO_IPTABLES=1 ;;
     -h|--help)         usage; exit 0 ;;
@@ -175,6 +198,13 @@ if [[ $NO_IPTABLES -eq 0 ]]; then
       iptables -A "$CHAIN" -d "$ip" -j ACCEPT
     done
   fi
+  if [[ $ALLOW_MDNS -eq 1 ]]; then
+    # federation.discovery capability (native binary only, Authority
+    # opt-in): outbound IPv4 mDNS query/response on 224.0.0.251:5353.
+    # See the BI-4B381171 header comment above for why this is a
+    # legitimate non-Authority egress class, not a violation.
+    iptables -A "$CHAIN" -d 224.0.0.251 -p udp --dport 5353 -j ACCEPT
+  fi
   # Match outgoing established/related back, so reply traffic isn't logged.
   iptables -A "$CHAIN" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
   iptables -A "$CHAIN" -j LOG --log-prefix "$LOG_PREFIX" --log-level 4
@@ -186,6 +216,9 @@ if [[ $NO_IPTABLES -eq 0 ]]; then
   if [[ -n "$ALLOW_EXTRA" ]]; then
     IFS=',' read -ra EXTRA_IPS <<< "$ALLOW_EXTRA"
     printf "        - %s (extra)\n" "${EXTRA_IPS[@]}"
+  fi
+  if [[ $ALLOW_MDNS -eq 1 ]]; then
+    echo "        - 224.0.0.251:5353/udp (federation.discovery mDNS)"
   fi
 fi
 
@@ -241,6 +274,9 @@ EGRESS_HITS="$(wc -l < "$EGRESS_TMP" 2>/dev/null || echo 0)"
   for ip in "${AUTHORITY_IPS[@]}"; do echo "  - $ip"; done
   if [[ -n "$ALLOW_EXTRA" ]]; then
     echo "- Extra allow-list IPs: $ALLOW_EXTRA"
+  fi
+  if [[ $ALLOW_MDNS -eq 1 ]]; then
+    echo "- federation.discovery mDNS allowed: 224.0.0.251:5353/udp"
   fi
   echo "- iptables installed: $([[ $NO_IPTABLES -eq 0 ]] && echo yes || echo no)"
   echo "- Log source: $([[ -n \"$KERN_LOG\" ]] && echo \"$KERN_LOG\" || ([[ $USE_JOURNAL -eq 1 ]] && echo journalctl -k || echo none))"


### PR DESCRIPTION
## Summary

The edge-node topology spec claims "the edge install doesn't need everything the portal has" (`docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md` §6 "Minimal Edge Footprint", §11.2 verification matrix). That claim was doc-only — nothing stopped either edge runtime from quietly gaining a Postgres client, an LLM SDK, or an inbound listener. This makes the statically-checkable half of that contract a CI gate.

## Change

`scripts/check-edge-node-image-bom.mjs` walks both edge runtimes (TS `services/edge-node`, Go `services/edge-node-go`) and fails on:
- **FP1** (static) no inbound network listener
- **FP2** no relational/graph/vector store client in the dependency tree (edge state is `state.json` only)
- **FP3** no LLM/model-runtime SDK, and no hardcoded model-provider API key reference
- **FP4** (static) every Makefile cross-compile target builds `CGO_ENABLED=0`, so published release binaries stay statically linked
- **FP5** (static) no Prometheus scrape-server dependency and no inbound `/metrics` GET route (metrics are push-only via `POST /api/v1/edge/metrics`)

Current tree: 9 TS deps, 8 Go modules, 85 source files, Makefile cross-compile targets scanned — no violations.

**FP7** (bounded payloads) gets a real bound rather than a check: `metricsEnvelope` now caps `interfaces` at 2000 (the 64 KB body cap only engages after parsing, so an unbounded array could inflate downstream write volume first).

The dynamic half of FP1 — proving zero off-allow-list egress on a live host — stays in `scripts/verify-edge-node-air-gap.sh` (needs root/iptables/real network, can't run in CI). That script gains `--allow-federation-discovery-mdns` for the Go runtime's optional mDNS discovery capability, off by default.

**FP6** (redaction) and the remainder of FP7 (queue depth, retry horizon, label cardinality) are NOT covered here — verified zero supporting implementation exists for them (repo-wide search), so no test was fabricated. Filed as a follow-up: **BI-C575BF74**. BI-4B381171 stays open (not done) pending that slice, per the partial-shipment convention.

## Test plan
- [x] `packages/validators/src/edge-footprint.test.ts` — 4/4 pass (the metricsEnvelope FP7 cap)
- [x] `pnpm --filter dpf-edge-node test` — 197/197 pass, 5 pre-existing skips
- [x] `node scripts/check-edge-node-image-bom.mjs` — passes live against the current tree
- [x] `node scripts/check-module-size.mjs` — clean

Docs-Impact-Decision: no user-facing doc surface; extends the existing edge-node topology spec's own verification matrix (§11.2), not a new capability requiring a new user guide page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Provenance

This work was **staged but never committed** in an orphaned worktree, found during a sweep of worktrees left behind by deleted threads. It was one `git worktree remove` from being lost permanently — both new files existed in no commit on any branch.

BI-4B381171 is `open`, triaged `build`, on `EP-EDGE-TOPOLOGY`, with no active build.

The original branch could not be rebased: the root clone is a **shallow** repository, so `git merge-base` returns nothing and 12 already-merged PRs appear as unmerged ancestors. Recovered by cherry-picking onto a fresh branch from `origin/main`.

## Scope

FP6 (redaction) and the remainder of FP7 (per-node batch/queue/retry and label-cardinality caps) are **not** covered here and stay open on the BI. The script header documents which halves are in scope and why.

## Verification

- `pnpm run pregate` — **gate passed** (local-CI, full suite, slot-0)
- `node scripts/check-edge-node-image-bom.mjs` — passes against current main's tree: 9 TS deps, 8 Go modules, 85 source files, Makefile cross-compile targets scanned, no violations
- `packages/validators/src/edge-footprint.test.ts` — 4/4 pass
