### PR TITLE
fix(ci): prune the last three stale frozen baselines for sweep-excluded routes (BI-0C6C2153)

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -156,17 +156,6 @@
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
-    "/admin/scheduled-jobs": {
-      "defaultVisibleWords": 1542,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - text\n          - button\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - text\n          - button\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - button\n      - row\n        - cell\n          - text\n      - row\n        - cell\n          - text\n        - cell\n          - button"
-    },
     "/admin/settings": {
       "defaultVisibleWords": 482,
       "leadBandWords": 0,
@@ -1333,17 +1322,6 @@
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
-    "/ops/self-upgrade": {
-      "defaultVisibleWords": 397,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 1,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - text\n  - link\n  - text\n  - link\n  - text\n  - link\n  - region\n    - note\n      - paragraph\n        - text\n    - paragraph\n      - text\n    - text\n    - paragraph\n      - text\n    - list\n      - listitem\n    - text\n    - checkbox\n    - text\n    - button\n  - group [expanded]\n    - button\n      - text\n    - text\n    - link\n    - text\n    - button\n    - text\n    - heading [level=3]\n    - paragraph\n      - text"
-    },
     "/performance": {
       "defaultVisibleWords": 95,
       "leadBandWords": 9,
@@ -2157,17 +2135,6 @@
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text"
-    },
-    "/workspace": {
-      "defaultVisibleWords": 199,
-      "leadBandWords": 0,
-      "primaryActions": 1,
-      "visibleFields": 0,
-      "maxChoicesPerControl": 0,
-      "subLegibleControls": 0,
-      "buriedPrimaryAction": 0,
-      "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - region\n    - paragraph\n      - text\n    - link\n  - heading [level=2]\n  - link\n  - paragraph\n    - text\n  - complementary\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - region\n    - heading [level=2]\n    - paragraph\n      - text\n    - text\n    - link\n      - paragraph\n        - text\n    - paragraph\n      - text\n    - link\n      - paragraph\n        - text\n      - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - link\n    - list\n      - listitem\n        - paragraph\n          - text\n        - list\n          - listitem\n            - text\n  - paragraph\n    - text\n  - button\n    - text\n  - region\n    - paragraph\n      - text\n    - heading [level=2]\n    - button"
     },
     "/workspace/documents": {
       "defaultVisibleWords": 109,

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -438,6 +438,26 @@ describe("generated route-shell registry", () => {
     }
   });
 
+  it("holds no frozen baseline for a route the sweep does not measure", () => {
+    // BI-0C6C2153. The sweep only compares routes it measures, so a leftover
+    // baseline entry for an EXCLUDED route is inert — and therefore invisible.
+    // It stops being inert the moment the route is re-included: the sweep would
+    // then diff a live measurement against a months-stale frozen structure and
+    // report a regression that is really just the age of the entry. The prune
+    // must happen at exclusion time, and #3719 already missed three routes once
+    // (/admin/scheduled-jobs, /ops/self-upgrade, /workspace) while pruning the
+    // other three in the same cohort. This test is why it cannot happen twice:
+    // re-inclusion must go through a fresh freeze, never a resurrected one.
+    const baseline = JSON.parse(
+      readFileSync(resolve(__dirname, "route-budget-baseline.json"), "utf8"),
+    ) as { routes: Record<string, unknown> };
+
+    const excluded = new Set(
+      registry.routes.filter((route) => !route.sweepEligible).map((route) => route.routePath),
+    );
+    expect(Object.keys(baseline.routes).filter((routePath) => excluded.has(routePath))).toEqual([]);
+  });
+
   it("the committed registry is in sync with its generator", async () => {
     // The assertion `pnpm --filter web check:route-shells` makes in CI, repeated here
     // so staleness fails the REQUIRED Unit check too — not only the advisory workflow.


### PR DESCRIPTION
## What

PR #3719 (commit f08555c35) introduced the `wall-clock-collection` sweep exclusion and pruned the frozen word baselines for `/platform/schedule`, `/workspace/calendar` and `/platform/development/change-lanes` — but the same cohort's other three routes kept their entries:

- `/admin/scheduled-jobs`
- `/ops/self-upgrade`
- `/workspace`

All three are `sweepEligible: false` with `sweepExclusionReason: wall-clock-collection` in `route-shells.generated.json`, so the sweep never measures them and never compares them.

## Why it matters

The entries are **inert today** — which is exactly why nobody noticed. They stop being inert the moment BI-0C6C2153 re-includes these routes (once the sweep fixture can pin the app-visible clock and isolate platform state): the sweep would then diff a live measurement against a months-stale frozen structure and report a regression that is really just the age of the entry, rather than re-freezing from a fresh measurement. A confusing false regression on a route nobody touched is the same failure mode #3719 was opened to fix.

## Change

- Pruned the three entries from `route-budget-baseline.json` (33 lines — the same shape as #3719's own prune). Baseline goes 200 → 197 routes, now exactly 1:1 with the 197 sweep-eligible routes the registry already asserts.
- Added an invariant test in `ux-budget.test.ts`: **no route with `sweepEligible: false` may hold an entry in `route-budget-baseline.json`**. The prune now has to happen at exclusion time and cannot drift again; re-inclusion must go through a fresh freeze, never a resurrected one.

The test lives in the existing `generated route-shell registry` describe block, which already parses the registry, so it costs one extra JSON read.

## Verification

- `cd apps/web && pnpm vitest run lib/ux-budget/` → **3 files / 116 tests green**.
- Confirmed the new test is load-bearing, not decorative: restoring the three entries and re-running fails it, naming exactly those three routes; pruning them passes it again.
- `apps/web` `tsc --noEmit` clean.

## Local-CI note

The local sandbox gate could not complete on this host: swap was exhausted (51.4G of 52.2G used, load ~10) and the gate's hardcoded 16GB-heap typecheck stage was SIGTERM'd by the OS on 3 consecutive attempts, at a different point each time. Not related to this change — the gate's own guard loop passed 24/24 on the merged-onto-`origin/main` worktree before the OOM, and `tsc --noEmit` is clean at an 8GB heap.

Local-CI-Override: operator-emergency: host swap exhausted, gate 16GB typecheck SIGTERM'd 3/3; vitest 116/116 + tsc clean + guard loop 24/24 verified instead

Docs-Impact-Decision: CI baseline hygiene + test, no user-facing change.
Process-Spine-Decision: narrow completion of the prune #3719 began, under the same BI-0C6C2153 that already tracks re-inclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)