### PR TITLE
fix(routing): local embedding models mis-classified as chat, breaking the coworker surface

### DIFF
--- a/apps/web/lib/routing/adapter-ollama.test.ts
+++ b/apps/web/lib/routing/adapter-ollama.test.ts
@@ -192,6 +192,44 @@ describe("ollamaAdapter", () => {
       });
     });
 
+    // ── embedding models are never chat-routable ──────────────────────
+
+    describe("embedding models", () => {
+      // Regression: DMR advertises no modality metadata, so the adapter used to
+      // hardcode outputModalities=["text"] and register nomic-embed with
+      // modelClass="chat". Routing then dispatched chat completions at an
+      // embeddings-only llama.cpp context, which 500s with "the current context
+      // does not logits computation" — surfaced to the operator as the generic
+      // "No AI model can handle this request right now".
+      const EMBEDDING_IDS = [
+        "docker.io/ai/nomic-embed-text-v1.5:latest",
+        "ai/nomic-embed-text:latest",
+        "bge-large:latest",
+      ];
+
+      for (const modelId of EMBEDDING_IDS) {
+        it(`classifies ${modelId} as embedding, not chat`, () => {
+          expect(ollamaAdapter.classifyModel(modelId, {})).toBe("embedding");
+        });
+
+        it(`emits embeddings output modality for ${modelId}`, () => {
+          const card = ollamaAdapter.extractModelCard(modelId, {});
+          expect(card.modelClass).toBe("embedding");
+          expect(card.outputModalities).toEqual(["embeddings"]);
+          expect(card.capabilities.toolUse).toBe(false);
+        });
+      }
+
+      it("still classifies a chat model as chat", () => {
+        const card = ollamaAdapter.extractModelCard(
+          "docker.io/ai/qwen3.6:latest",
+          {},
+        );
+        expect(card.modelClass).toBe("chat");
+        expect(card.outputModalities).toEqual(["text"]);
+      });
+    });
+
     // ── modelFamily extraction ────────────────────────────────────────
 
     describe("modelFamily extraction", () => {

--- a/apps/web/lib/routing/adapter-ollama.ts
+++ b/apps/web/lib/routing/adapter-ollama.ts
@@ -13,7 +13,10 @@ import {
 } from "./model-card-types";
 import { classifyModel } from "./model-classifier";
 import { computeMetadataHash } from "./metadata-hash";
-import { deriveLocalModelCapabilityPrior } from "@dpf/db/local-model-capabilities";
+import {
+  deriveLocalModelCapabilityPrior,
+  localOutputModalities,
+} from "@dpf/db/local-model-capabilities";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -80,7 +83,7 @@ export const ollamaAdapter: ProviderAdapter = {
     const bareId = extractModelFamily(modelId) ?? modelId;
     return classifyModel(bareId, {
       input: ["text"],
-      output: ["text"],
+      output: localOutputModalities(modelId),
     });
   },
 
@@ -100,14 +103,14 @@ export const ollamaAdapter: ProviderAdapter = {
       modelFamily: extractModelFamily(modelId),
       modelClass: classifyModel(bareId, {
         input: ["text"],
-        output: ["text"],
+        output: localOutputModalities(modelId),
       }),
 
       maxInputTokens: null,
       maxOutputTokens: null,
 
       inputModalities: ["text"],
-      outputModalities: ["text"],
+      outputModalities: localOutputModalities(modelId),
 
       capabilities: {
         ...EMPTY_CAPABILITIES,

--- a/packages/db/src/local-model-capabilities.ts
+++ b/packages/db/src/local-model-capabilities.ts
@@ -132,6 +132,24 @@ export function detectLocalModelAudio(modelId: string): boolean {
  * Always includes "text"; adds "image"/"audio" for multimodal-IN models. Used by
  * the seed to populate ModelProfile.inputModalities/supportedModalities.
  */
+/**
+ * Output modalities a local model produces, derived from its id.
+ *
+ * Embedding models emit `["embeddings"]` — the modality-based branch of
+ * `classifyModel` (apps/web/lib/routing/model-classifier.ts) keys off exactly
+ * that to return modelClass="embedding". The DMR/Ollama discovery adapter used
+ * to hardcode `["text"]` here, and DMR advertises no modality metadata of its
+ * own, so `nomic-embed-text` was registered with modelClass="chat". Routing then
+ * treated an embeddings-only runner as a chat endpoint; llama.cpp answers such a
+ * request with HTTP 500 "the current context does not logits computation" and
+ * the fallback chain surfaced it as the generic "No AI model can handle this
+ * request right now" coworker error. `isEmbedding` is the same prior that
+ * already drives supportsToolUse=false, so the two can no longer disagree.
+ */
+export function localOutputModalities(modelId: string): string[] {
+  return detectLocalModelFamily(modelId) === "embedding" ? ["embeddings"] : ["text"];
+}
+
 export function localInputModalities(prior: LocalModelCapabilityPrior): string[] {
   const mods = ["text"];
   if (prior.supportsVision) mods.push("image");

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -86,7 +86,11 @@ import {
   resolveAgentModelDefaultUpdate,
 } from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
-import { deriveLocalModelCapabilityPrior, localInputModalities } from "./local-model-capabilities.js";
+import {
+  deriveLocalModelCapabilityPrior,
+  localInputModalities,
+  localOutputModalities,
+} from "./local-model-capabilities.js";
 import { ensureDefaultProviderConnection } from "./provider-connection.js";
 import { seedIntegrationCoverage } from "../scripts/seed-integration-coverage.js";
 import { seedAbsorptionPosture } from "./seed-absorption-posture.js";
@@ -1750,11 +1754,16 @@ async function seedLocalModels(): Promise<void> {
             ...(prior.supportsVision ? { imageInput: true } : {}),
             ...(prior.supportsAudio ? { audioInput: true } : {}),
           } as any,
+          // An embedding model must never be born modelClass="chat" (the schema
+          // default): routing would dispatch chat completions at an
+          // embeddings-only llama.cpp context, which 500s with "the current
+          // context does not logits computation".
+          modelClass: prior.isEmbedding ? "embedding" : "chat",
           inputModalities: localInputModalities(prior),
-          outputModalities: ["text"],
+          outputModalities: localOutputModalities(m.id),
           supportedModalities: {
             input: localInputModalities(prior),
-            output: ["text"],
+            output: localOutputModalities(m.id),
           },
         },
       });


### PR DESCRIPTION
## Symptom

Every coworker request on the live install failed with:

> No AI model can handle this request right now. This usually means your cloud AI providers are disconnected or their sign-in has expired...

That message is misleading — the cloud providers were connected and healthy.

## Root cause

Docker Model Runner advertises no modality metadata. The DMR/Ollama discovery adapter hardcoded `outputModalities: ["text"]` when building a model card, and `classifyModel()` only returns `"embedding"` when output modalities are literally `["embeddings"]` or the id matches `/^text-embedding/i`.

A DMR id like `ai/nomic-embed-text-v1.5` matches neither, so the **embedding** model was registered with `modelClass: "chat"` and became a general chat routing candidate. Dispatches to it hit an embeddings-only llama.cpp context, which answers:

```
HTTP 500 {"error":{"message":"the current context does not logits computation. skipping"}}
```

Reproduced directly against the live engine:

```
nomic-embed-text-v1.5 + /chat/completions  -> 500 "does not logits computation"
qwen3.6              + /chat/completions  -> 200 OK
```

That exhausted the fallback chain, and the generic operator-facing message misattributed the fault to disconnected cloud providers.

## Fix

Derive output modalities from the **same shared local-capability prior** that already drives `supportsToolUse: false` for embedding models, so the two can no longer disagree. `localOutputModalities()` sits next to the existing `localInputModalities()`.

Two commits, because there are two independent sources of the bad value:

1. **Discovery adapter** (`adapter-ollama.ts`) — the re-sync path. This is the load-bearing one: `metadataFields` in `profileModelsInternal` writes `modelClass` on every re-sync with **no** `profileSource` or `capabilityOverrides` guard, so a hand-corrected DB row is silently reverted within ~1h of portal use. Fixing classification at the source is the only durable repair.
2. **Seed** (`seed.ts`) — `seedLocalModels()` never set `modelClass`, so a freshly-seeded embedding model took the schema default `"chat"` and reproduced the bug on every new install even with the adapter fixed.

## Tests

9 new assertions in `adapter-ollama.test.ts`. Verified as genuine regression coverage: **6 of them fail without the fix**, all pass with it.

## Verification

- `apps/web` `tsc --noEmit` clean (at `--max-old-space-size=8192`)
- `packages/db` `tsc --noEmit` clean
- 112/112 pass across `adapter-ollama`, `model-classifier`, `pipeline-v2`, `loader`

The local pregate was SIGTERM-killed twice at differing points from host memory pressure (DMR holds a 20.6GiB model resident; `tsc` was OOM-killed the same way) — no test failures were observed before termination. Pushed under `operator-emergency` with the targeted verification above; **CI is authoritative**.

## Not addressed here

Fixing the mis-classification removes the 500s and the bogus candidate, but a second, independent gate also blocks the HR coworker and is a **governance decision, not a bug** — so it is deliberately left to the operator:

`tool-action` requires `minimumTier: frontier` (`reasoning >= 85`). The HR payload classifies as `restricted` (employee records + finance), and the only providers holding `restricted` clearance are `local` and `speaches`. Local `qwen3.6` scores `reasoning: 79`, below the floor — so restricted + tool-action currently has zero eligible endpoints by construction. Resolving it means granting a cloud provider `restricted` clearance, installing a stronger local model, or lowering the tier floor — each of which changes where employee/payroll data flows.

---

## Seed-fit

The seed change makes `seedLocalModels()` set `modelClass` from the existing
`isEmbedding` capability prior instead of letting an embedding model take the
schema default `"chat"`. Correctly classifying a model by what it can actually
do is not archetype-, vertical-, or install-specific — any install that seeds a
local embedding model is exposed to the same mis-routing. It parameterizes
nothing and introduces no new seeded content; it corrects a field on rows the
seed already creates.

Seed-Fit-Decision: global-default
