### PR TITLE
fix(routing): lower tool-action tier floor to strong so restricted-sensitivity work can route

### DIFF
--- a/apps/web/lib/routing/task-requirements.test.ts
+++ b/apps/web/lib/routing/task-requirements.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getTaskRequirement, BUILT_IN_TASK_REQUIREMENTS } from "./task-requirements";
+import { TIER_MINIMUM_DIMENSIONS } from "./quality-tiers";
 
 const { mockPrisma } = vi.hoisted(() => ({
   mockPrisma: {
@@ -26,7 +27,22 @@ describe("BUILT_IN_TASK_REQUIREMENTS", () => {
   it("assigns frontier tier to complex tasks", () => {
     expect(BUILT_IN_TASK_REQUIREMENTS["reasoning"]?.minimumTier).toBe("frontier");
     expect(BUILT_IN_TASK_REQUIREMENTS["code-gen"]?.minimumTier).toBe("frontier");
-    expect(BUILT_IN_TASK_REQUIREMENTS["tool-action"]?.minimumTier).toBe("frontier");
+  });
+
+  // tool-action is deliberately NOT frontier. The tier floor gates on codegen and
+  // reasoning as well as toolFidelity, so a frontier floor excluded models with
+  // perfect tool fidelity for scoring below 85 on reasoning. That left
+  // restricted-sensitivity tool work unroutable: the only provider cleared for
+  // `restricted` data is the bundled local model, which no local model can lift
+  // above an 85 reasoning floor. `strong` still exceeds this requirement's own
+  // preferredMinScores.toolFidelity of 70.
+  it("assigns strong (not frontier) tier to tool-action so local can serve restricted work", () => {
+    expect(BUILT_IN_TASK_REQUIREMENTS["tool-action"]?.minimumTier).toBe("strong");
+    const floor =
+      TIER_MINIMUM_DIMENSIONS[BUILT_IN_TASK_REQUIREMENTS["tool-action"]!.minimumTier!];
+    expect(floor.toolFidelity).toBeLessThanOrEqual(
+      BUILT_IN_TASK_REQUIREMENTS["tool-action"]!.preferredMinScores!.toolFidelity!,
+    );
   });
 
   it("marks cheap tasks as preferCheap=true", () => {

--- a/apps/web/lib/routing/task-requirements.ts
+++ b/apps/web/lib/routing/task-requirements.ts
@@ -7,7 +7,8 @@
  *
  *   greeting / status-query / summarization → adequate (Haiku-equivalent, effort=low)
  *   data-extraction / web-search / creative  → strong  (Sonnet-equivalent, effort=medium)
- *   reasoning / code-gen / tool-action       → frontier (Opus/Sonnet, effort=high)
+ *   tool-action                              → strong  (see the note on its entry)
+ *   reasoning / code-gen                     → frontier (Opus/Sonnet, effort=high)
  */
 
 import { prisma } from "@dpf/db";
@@ -103,10 +104,27 @@ export const BUILT_IN_TASK_REQUIREMENTS: Record<string, TaskRequirement> = {
   "tool-action": {
     taskType: "tool-action",
     description: "Multi-step tool use with external APIs.",
-    selectionRationale: "Requires tool-calling fidelity — frontier only.",
+    // Tool-calling fidelity is what this task actually needs, and the tier floor
+    // is a proxy for it. `frontier` (TIER_MINIMUM_DIMENSIONS: codegen/toolFidelity/
+    // reasoning all >= 85) over-constrained that proxy: it gates on *reasoning*
+    // and *codegen* too, so a model with perfect tool fidelity was excluded for
+    // scoring 79 on reasoning. That made restricted-sensitivity tool work
+    // unroutable by construction — the only provider cleared for `restricted`
+    // data is the bundled local model, and no local model clears an 85 reasoning
+    // floor, so employee/finance requests had zero eligible endpoints and
+    // surfaced as "No AI model can handle this request right now".
+    //
+    // `strong` (>= 70) still comfortably exceeds this requirement's own stated
+    // preferredMinScores.toolFidelity of 70. Cloud endpoints are unaffected in
+    // practice: the Stage-5b tier sort (pipeline-v2.ts) ranks user-configured
+    // endpoints ahead of bundled local ones, so a capable cloud provider is still
+    // chosen first wherever its sensitivity clearance permits. Lowering the floor
+    // only adds a fallback where the alternative was failing outright.
+    selectionRationale:
+      "Requires tool-calling fidelity; strong tier or better, cloud preferred where clearance allows.",
     requiredCapabilities: { supportsToolUse: true },
     preferredMinScores: { toolFidelity: 70 },
-    minimumTier: "frontier",
+    minimumTier: "strong",
     preferCheap: false,
     origin: "system",
   },


### PR DESCRIPTION
Operator-directed. Companion to #3977 — same outage, second independent cause.

## The deadlock

`tool-action` required `minimumTier: frontier`. `TIER_MINIMUM_DIMENSIONS.frontier` is `{ codegen: 85, toolFidelity: 85, reasoning: 85 }` — so the floor gates on **reasoning and codegen**, not just the tool-calling fidelity the task actually needs.

Restricted-sensitivity payloads (employee records, finance) can only be served by a provider holding `restricted` clearance. On this platform that is the bundled local model **alone**:

```
providerId | status | endpointType  | sensitivityClearance
-----------+--------+---------------+------------------------------------------
speaches   | active | transcription | {public,internal,confidential,restricted}
local      | active | llm           | {public,internal,confidential,restricted}
```

`speaches` is a transcription endpoint and never enters the routing candidate set (`MODEL_ROUTING_ENDPOINT_TYPES`). Local `qwen3.6` scores `toolFidelity: 100`, `codegen: 97` — but `reasoning: 79`, under the 85 floor. No local model clears an 85 reasoning floor.

So **restricted + tool-action had zero eligible endpoints by construction**, and every HR request died as:

> No AI model can handle this request right now. This usually means your cloud AI providers are disconnected...

The cloud providers were connected and healthy the entire time. They were excluded by *sensitivity policy* (`anthropic-sub` holds `{public}` clearance only), not by any connection failure.

## Change

`tool-action` → `minimumTier: "strong"` (`>= 70`), which still comfortably exceeds this requirement's own stated `preferredMinScores.toolFidelity: 70`.

**Cloud routing is unaffected in practice.** The Stage-5b tier sort in `pipeline-v2.ts` ranks user-configured endpoints ahead of bundled local ones, so a capable cloud provider is still selected first wherever its sensitivity clearance permits. Lowering the floor only adds a fallback where the alternative was failing outright.

## Why this option

Three ways to break the deadlock; this was the operator's call:

| Option | Trade-off |
|---|---|
| Grant a cloud provider `restricted` clearance | Fastest and highest quality, but employee/payroll data leaves the machine |
| Install a larger local model | Keeps data local; costs disk + RAM (host is already under memory pressure) |
| **Lower the tier floor** ← chosen | Keeps data local, no new model; slightly lower quality bar for tool-calling tasks platform-wide |

## Tests

The existing assertion pinning `tool-action` to `frontier` is updated rather than deleted — it now asserts `strong` **and** that the resulting floor does not exceed the requirement's own `preferredMinScores.toolFidelity`, so the floor and the stated preference can't silently drift apart again.

- `tsc --noEmit` clean (at `--max-old-space-size=8192`)
- 136/136 pass across `task-requirements`, `task-router`, `request-contract`, `pipeline-v2`

The local pregate is being SIGTERM-killed by host memory pressure (DMR holds a 20.6GiB model resident; `tsc` was OOM-killed the same way) — no test failures were observed before termination. Pushed under `operator-emergency` with the targeted verification above; **CI is authoritative**.