### PR TITLE
docs(kernel): add the gate-coverage-matches-blast-radius principle

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 623,
+  "pageCount": 624,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -3388,6 +3388,21 @@
     },
     "docs/founder-kernel/wiki/principles/findability-is-part-of-capture.md": {
       "publicHref": "/founder-kernel/wiki/principles/findability-is-part-of-capture/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md": {
+      "publicHref": "/founder-kernel/wiki/principles/gate-coverage-matches-blast-radius/",
       "portalHref": null,
       "publishedPublic": true,
       "publishedPortal": false,

--- a/docs/founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md
+++ b/docs/founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md
@@ -1,0 +1,65 @@
+---
+title: A Gate's Coverage Must Match The Blast Radius Of What It Governs
+pageKind: principle
+status: published
+abstract: A gate scoped narrower than the thing it governs produces false assurance — the green check is read as "this is covered" when whole classes of the subject were never looked at.
+principleTier: core
+principleDirection: Scope a gate to everything its subject can break, and derive that scope from the artifact that already decides it — a gate narrower than its blast radius reports safety it never checked.
+principleDimensionVector: {"long_term_maintainability": 0.5, "governance_compliance": 0.5, "evidence_density": 0.4, "blast_radius": -0.4, "human_cognitive_load": -0.2}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - ring-2-workflow
+principleConsumerArchetype: universal
+principleConsumerContexts: []
+principlePublic: false
+principlePublicRationale: ""
+sources: []
+---
+
+## Rule
+
+When you build a gate, scope it to everything its subject can break — not to the part you were looking at when you wrote it. Derive the scope from the artifact that already decides it rather than restating it, and prefer a rule the gate can decide without anyone remembering to annotate.
+
+## Why
+
+A gate is read as a claim about its subject, not about its implementation. "Docs Impact: green" is heard as *the documentation is consistent with this change* — not as *the subset of documentation this script happens to walk is consistent with this change*. When those diverge, the check is worse than absent: absence prompts a human to look, while a green check actively suppresses that instinct. The narrower scope is invisible at exactly the moment it matters.
+
+The failure is not that someone scoped a gate badly once. It is that scope is usually set from whatever the author had in view, and the subject then grows past it silently. Nothing fails when a new directory, surface, or corpus falls outside the walk — the gate keeps passing, because passing is what it does when it sees nothing.
+
+Two properties make the divergence self-correcting. **Derive, don't restate:** if the gate reads its scope from the artifact that genuinely determines it, the scope cannot drift without the subject drifting too. **Decide, don't ask:** a gate that only inspects things someone opted into protects the cases someone already thought about, which are not the cases that hurt. Opt-in coverage reproduces the very "somebody must remember" failure the gate exists to remove.
+
+The corollary is a discipline about scope reduction. Narrowing a gate — a path exclusion, a baseline entry, a skip — is a governance act, not a maintenance one. It is legitimate, often necessary, and must leave a reviewable trace. A hardcoded exemption buried in the checker is the same defect as the original narrow walk: an unreviewed decision presented as coverage.
+
+## Applies To
+
+Anyone authoring or narrowing an automated check: CI gates, guards, ratchets, freshness checks, lint rules, policy validators, and the attestations that stand in for them. It applies most sharply when the gate's subject spans more than one corpus, surface, or repository area.
+
+It does not demand that every gate be exhaustive. A deliberately partial gate is fine — a fast pre-check, a sampled audit, a single-dimension lint. What the principle forbids is a partial gate whose *name and result* imply completeness, and a scope that narrowed by accretion rather than by decision.
+
+## How To Apply
+
+Before you finish a gate, state what its subject can break and check the walk covers it. Ask where the scope comes from: if it is a literal in the checker, look for the artifact that already answers the question — a site config, a manifest, a route map, a package graph — and read from that instead. Then ask what the gate does about a case nobody annotated; if the answer is "passes", you have an opt-in gate, and you should either add a decidable rule alongside it or say plainly in the gate's own output that coverage is opt-in.
+
+When you must narrow, put the narrowing somewhere a reviewer will see it: a baseline file, a registry entry, an explicit attestation — never a path exclusion inside the checker. And when the same fact is consulted by two checkers, extract it once; two scripts answering "what counts as published?" independently will disagree eventually, and the disagreement will be silent. This composes with [[principles/single-source-of-truth]] (one home per fact) and [[principles/governance-approves-evidence-not-provenance]] (a gate reads evidence, never who produced it).
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.5` — a derived scope keeps matching its subject as the codebase grows; a restated one silently rots and must be re-audited by hand.
+- `governance_compliance: 0.5` — the check's claim and its actual coverage stay aligned, which is what makes a green result usable as evidence at all.
+- `evidence_density: 0.4` — a gate whose scope is grounded in a real artifact yields findings that can be trusted without re-deriving what it looked at.
+- `blast_radius: -0.4` — this pulls *against* blast radius: the whole point is that the region a change can damage is the region the gate inspects, so damage stops being discovered downstream.
+- `human_cognitive_load: -0.2` — nobody has to remember which corpora a gate covers, or to annotate a page for it to be protected.
+
+## Examples
+
+- **Positive:** A documentation-impact gate derives its corpus from the site config's own exclude list — the artifact the publisher already obeys — so a newly added doc directory is covered the day it lands, with no script to remember to widen.
+- **Positive:** A guard that must exempt a page records the exemption in a ratcheted baseline file rather than a path check inside the checker, so every exemption stays countable and can only shrink.
+- **Counterexample:** A doc gate walks only the user-guide corpus while the published site also serves architecture and operations pages. A datastore is retired; the architecture page describing it and the incident runbook instructing operators to restore it both go stale, and the gate reports green throughout — because it never looked. Worse, a sibling script in the same repository already scanned both corpora and said so in a comment; the two had drifted apart with nothing to notice.
+- **Counterexample:** A gate that only flags files a page opted into via frontmatter. It protects the pages someone already thought carefully about, and is structurally blind to the ones nobody remembered — which is the population the gate was built for.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)


### PR DESCRIPTION
## Summary

Adds the durable doctrine behind the BET-5 doc-staleness incident (#3871). Two guards now encode the lesson mechanically — the widened doc-impact corpus and the Retired Substrate Guard — but nothing stated it as a rule for the next person designing a gate.

**The rule:** scope a gate to everything its subject can break; derive that scope from the artifact that already decides it rather than restating it; and prefer a rule the gate can decide over one that waits to be annotated.

## Changes

- `docs/founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md` — new `core`-tier principle.
- `apps/web/lib/docs/doc-index.generated.json` — regenerated for the new page.

Written from what actually happened rather than in the abstract. Both counterexamples in the page are the real incident: the doc-impact graph walked only `docs/user-guide` while the published site also served `docs/architecture` and `docs/operations`, so a datastore retirement left the architecture page describing it *and* the incident runbook telling operators to restore it both stale — with the gate green throughout, because it never looked. A sibling script in the same repo already scanned both corpora and said so in a comment; the two had drifted with nothing to notice.

## Deliberate scope decisions

- **Not added to `AGENTS.md` §1.** Only ~15 of 86 principles are surfaced there; the rest are retrieved via `wiki_query` per §16. Adding a line would move the instruction-plane size and rule-coverage baselines for no retrieval gain — a larger blast radius than the change warrants, which is the principle's own test applied to itself.
- **No `embeddings.jsonl` / `manifest.json` change.** Checked how principles actually land (`a8895df9`, the most recent principle addition): neither file is touched, and no CI gate references `embeddings.jsonl`. Embeddings are rebuilt out of band.

## Test plan

- [x] **Source-only change** (doc page + regenerated index)
  - [x] Frontmatter validated against the corpus: `principleTier: core` and all five dimension axes are values already in use; cost axes (`blast_radius`, `human_cognitive_load`) carry negative signs, meaning the principle *reduces* those costs — per AGENTS.md §16, higher is worse on cost axes.
  - [x] Both wikilink targets resolve (`single-source-of-truth`, `governance-approves-evidence-not-provenance`).
  - [x] Full `pull-request` policy-guard profile reproduced locally: 7/7 guards pass with this trailer present.

### Verification evidence

```
gen-doc-index.mjs --check             PASS
gen-doc-impact.mjs --check            PASS
check-doc-links.mjs                   PASS
check-doc-reference-integrity.mjs     PASS
check-retired-substrate.mjs           PASS
render-doc-diagrams.mjs --check       PASS
derived-artifacts-gate.mjs check-all  PASS

policy-guards --profile pull-request  7 of 7 passed
  [seed-fit-gate] Seeded-content decision is global-default. OK.
```

The seed-fit trailer was verified in both directions before being applied — the gate accepts this wording, and still reports `missing-decision` without it.

## Notes for the reviewer

- **No backlog coverage.** Authored in a cloud session with no DPF MCP connector and no database, so `Epic`/`BacklogItem` could not be read or written. This needs a BI attached retrospectively, along with one covering #3871 and the Retired Substrate Guard.
- **A correction to my own earlier claim.** In #3871 I said this principle "requires regenerating `embeddings.jsonl`, which needs a running embedding model," and deferred it on that basis. That was wrong — principles land without touching embeddings, which is why it was straightforward to do here.
- **One sibling item needed nothing.** A fourth follow-up — sweeping pinned wall-clock test fixtures after the 2026-08-01T15:00Z queue outage — turned out to be **already shipped** as `audit-time-bombs.yml` (BI-6A4F47B9), with a dynamic clock-shift detector. My own static scan of the corpus (150 future-dated literals, 121 in files with no clock control) confirms that workflow's stated ~6:1 over-report rate for the static approach, so its dynamic design is the right one and I added nothing.

Seed-Fit-Decision: global-default — a kernel principle is durable doctrine retrieved by coworkers on every install; it carries no install-specific, archetype-specific or vertical-specific values.