### PR TITLE
feat(inference): reconcile declared-vs-measured route sensitivity (BI-CF3049E7)

### DIFF
--- a/apps/web/lib/actions/route-decision-logs.ts
+++ b/apps/web/lib/actions/route-decision-logs.ts
@@ -10,6 +10,10 @@ import {
   rollUpProviderRoutingTelemetry,
   type ProviderRoutingTelemetryRollup,
 } from "@/lib/inference/provider-routing-rollup";
+import {
+  rollUpSensitivityDrift,
+  type SensitivityDriftRollup,
+} from "@/lib/inference/sensitivity-drift-rollup";
 
 export interface RouteDecisionLogRow {
   id: string;
@@ -61,6 +65,39 @@ export async function getRouteDecisionLogs(limit = 100): Promise<RouteDecisionLo
     inferenceDataScreenReceipt: r.inferenceDataScreenReceipt as InferenceDataScreenReceipt | null,
     createdAt: r.createdAt,
   }));
+}
+
+/**
+ * BI-CF3049E7: which agent/task pairings routed above what their payload
+ * measured. Reads only the two levels and the floor flag off each receipt —
+ * no payload text — so the rollup is as safe to surface as the receipt itself.
+ *
+ * Attribution is per agent + task type, not per route: RouteDecisionLog has no
+ * routeContext column, and the route is only visible here as the declared level
+ * it contributed. Adding that column is the next slice; until then a drifting
+ * agent points at its route via tak/route-context-map rather than naming it.
+ */
+export async function getSensitivityDriftRollup(
+  limit = 500,
+): Promise<SensitivityDriftRollup> {
+  const rows = await prisma.routeDecisionLog.findMany({
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: { taskType: true, agentId: true, inferenceDataScreenReceipt: true },
+  });
+
+  return rollUpSensitivityDrift(
+    rows.map((r) => {
+      const receipt = r.inferenceDataScreenReceipt as InferenceDataScreenReceipt | null;
+      return {
+        taskType: r.taskType,
+        agentId: r.agentId,
+        declaredSensitivity: receipt?.declaredSensitivity,
+        measuredSensitivity: receipt?.measuredSensitivity,
+        sensitivityFloorApplied: receipt?.sensitivityFloorApplied,
+      };
+    }),
+  );
 }
 
 export async function getRouteDecisionStats(): Promise<RouteDecisionStats> {

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -17,6 +17,7 @@ import type {
   InferencePolicyVersionSnapshot,
 } from "./types";
 import { hasVerticalPolicyPacks } from "./vertical-policy-packs";
+import { SENSITIVITY_RANK } from "./sensitivity-rank";
 
 const DEFAULT_ORGANIZATION_ID = "org:local-install";
 
@@ -35,12 +36,9 @@ function dedupeMatchProvenance(
   );
 }
 
-const SENSITIVITY_RANK: Readonly<Record<RequestContract["sensitivity"], number>> = {
-  public: 0,
-  internal: 1,
-  confidential: 2,
-  restricted: 3,
-};
+// Shared with the drift rollup, which must agree on what "above" means when it
+// decides whether a declared route label sits higher than its measured payload.
+
 
 type ScreenRouteContextInput = Partial<InferenceDataScreenResult["routeContext"]> & {
   sensitivity?: string;

--- a/apps/web/lib/inference/data-screening/sensitivity-rank.ts
+++ b/apps/web/lib/inference/data-screening/sensitivity-rank.ts
@@ -1,0 +1,34 @@
+/**
+ * The one ordering of sensitivity levels.
+ *
+ * `screen-inference-payload` uses it to apply the declared route label as a
+ * FLOOR over the measured payload level; the drift rollup uses it to decide
+ * whether a declared label sits above what its payload actually measures.
+ * Both must agree on "above", so the rank lives here rather than being
+ * restated per caller.
+ *
+ * Kept in its own module rather than in `types.ts` because that file is
+ * type-only, and giving it a runtime export would turn every `import type`
+ * of it into a value import.
+ */
+import type { InferencePayloadSensitivity } from "./types";
+
+export const SENSITIVITY_RANK: Readonly<Record<InferencePayloadSensitivity, number>> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  restricted: 3,
+};
+
+/**
+ * How many levels `declared` sits above `measured`, or 0 when it does not.
+ *
+ * Never negative: a payload measuring ABOVE its declared label is the screen
+ * doing its job (the floor only ever raises), not a mislabelled route.
+ */
+export function sensitivityLevelsAbove(
+  declared: InferencePayloadSensitivity,
+  measured: InferencePayloadSensitivity,
+): number {
+  return Math.max(0, SENSITIVITY_RANK[declared] - SENSITIVITY_RANK[measured]);
+}

--- a/apps/web/lib/inference/sensitivity-drift-rollup.test.ts
+++ b/apps/web/lib/inference/sensitivity-drift-rollup.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  rollUpSensitivityDrift,
+  type SensitivityDriftSample,
+} from "./sensitivity-drift-rollup";
+
+function sample(over: Partial<SensitivityDriftSample> = {}): SensitivityDriftSample {
+  return {
+    taskType: "creative",
+    agentId: "marketing-specialist",
+    declaredSensitivity: "confidential",
+    measuredSensitivity: "internal",
+    sensitivityFloorApplied: true,
+    ...over,
+  };
+}
+
+describe("rollUpSensitivityDrift", () => {
+  it("flags a group whose declared label sits above what its payload measures", () => {
+    const rollup = rollUpSensitivityDrift([sample(), sample(), sample()]);
+
+    expect(rollup.drifting).toHaveLength(1);
+    const [group] = rollup.drifting;
+    expect(group.agentId).toBe("marketing-specialist");
+    expect(group.taskType).toBe("creative");
+    expect(group.declared).toBe("confidential");
+    expect(group.measured).toBe("internal");
+    expect(group.observations).toBe(3);
+    expect(group.flooredObservations).toBe(3);
+    // One level of over-declaration: internal -> confidential.
+    expect(group.levelsAbove).toBe(1);
+  });
+
+  it("does not flag a payload that justifies its declared level", () => {
+    const rollup = rollUpSensitivityDrift([
+      sample({ measuredSensitivity: "confidential", sensitivityFloorApplied: false }),
+    ]);
+
+    expect(rollup.drifting).toEqual([]);
+    expect(rollup.aligned).toBe(1);
+  });
+
+  it("never flags a payload measuring ABOVE its declared label", () => {
+    // The floor only raises. A payload measuring higher than the route label is
+    // the screen doing its job, not a mislabelled route — reporting it as drift
+    // would invert the meaning and invite someone to lower a correct label.
+    const rollup = rollUpSensitivityDrift([
+      sample({ declaredSensitivity: "internal", measuredSensitivity: "restricted" }),
+    ]);
+
+    expect(rollup.drifting).toEqual([]);
+    expect(rollup.aligned).toBe(1);
+  });
+
+  it("separates receipts predating the drift fields from genuinely aligned ones", () => {
+    // Receipts written before the drift fields shipped carry neither level.
+    // Counting them as "aligned" would report a clean estate that was never
+    // measured, so they are held in their own bucket.
+    const rollup = rollUpSensitivityDrift([
+      { taskType: "creative", agentId: "a" },
+      sample(),
+    ]);
+
+    expect(rollup.observationsMissingDriftFields).toBe(1);
+    expect(rollup.observationsWithDriftFields).toBe(1);
+    expect(rollup.aligned).toBe(0);
+  });
+
+  it("groups independently per agent and task type", () => {
+    const rollup = rollUpSensitivityDrift([
+      sample(),
+      sample({ agentId: "finance-analyst" }),
+      sample({ taskType: "summarize" }),
+    ]);
+
+    expect(rollup.drifting).toHaveLength(3);
+    expect(rollup.drifting.every((g) => g.observations === 1)).toBe(true);
+  });
+
+  it("ranks the worst over-declaration first, then by how often it is observed", () => {
+    const rollup = rollUpSensitivityDrift([
+      // 1 level above, seen twice
+      sample({ agentId: "a", declaredSensitivity: "confidential", measuredSensitivity: "internal" }),
+      sample({ agentId: "a", declaredSensitivity: "confidential", measuredSensitivity: "internal" }),
+      // 3 levels above, seen once — the more severe mislabel
+      sample({ agentId: "b", declaredSensitivity: "restricted", measuredSensitivity: "public" }),
+    ]);
+
+    expect(rollup.drifting.map((g) => g.agentId)).toEqual(["b", "a"]);
+    expect(rollup.drifting[0].levelsAbove).toBe(3);
+  });
+
+  it("reports an empty estate without inventing a clean bill of health", () => {
+    const rollup = rollUpSensitivityDrift([]);
+
+    expect(rollup.drifting).toEqual([]);
+    expect(rollup.aligned).toBe(0);
+    expect(rollup.observationsWithDriftFields).toBe(0);
+    expect(rollup.observationsMissingDriftFields).toBe(0);
+  });
+});

--- a/apps/web/lib/inference/sensitivity-drift-rollup.ts
+++ b/apps/web/lib/inference/sensitivity-drift-rollup.ts
@@ -1,0 +1,119 @@
+/**
+ * BI-CF3049E7 — declared-vs-measured sensitivity drift.
+ *
+ * A route's sensitivity is a hardcoded static label in `tak/route-context-map`,
+ * and `screen-inference-payload` applies it as a FLOOR over whatever the payload
+ * actually measures. Nothing reconciled the two, so a label set higher than the
+ * data it carries silently narrowed that route's endpoint pool — surfacing to
+ * the user as "the AI provider is temporarily unavailable", which points at
+ * providers rather than at the label that caused it.
+ *
+ * Since #3919 every screen receipt records both levels plus whether the floor
+ * bound. This rolls those receipts up so a persistent over-declaration shows as
+ * a repeated observation rather than something an operator has to re-derive by
+ * hand-composing a payload.
+ *
+ * Pure: takes already-loaded samples, touches no database. Levels only — no
+ * payload text passes through here, so a rollup is as safe to surface as the
+ * receipts it reads.
+ */
+import { sensitivityLevelsAbove } from "./data-screening/sensitivity-rank";
+import type { InferencePayloadSensitivity } from "./data-screening/types";
+
+export type SensitivityDriftSample = {
+  taskType: string;
+  agentId: string | null;
+  /** Absent on receipts written before the drift fields shipped (#3919). */
+  declaredSensitivity?: InferencePayloadSensitivity;
+  measuredSensitivity?: InferencePayloadSensitivity;
+  sensitivityFloorApplied?: boolean;
+};
+
+export type SensitivityDriftGroup = {
+  taskType: string;
+  agentId: string | null;
+  declared: InferencePayloadSensitivity;
+  measured: InferencePayloadSensitivity;
+  /** How far the declared label sits above the measured payload. Always ≥ 1. */
+  levelsAbove: number;
+  observations: number;
+  flooredObservations: number;
+};
+
+export type SensitivityDriftRollup = {
+  /** Receipts carrying both levels — the only ones that can be adjudicated. */
+  observationsWithDriftFields: number;
+  /**
+   * Receipts predating the drift fields. Held separately rather than folded
+   * into `aligned`, because counting unmeasured receipts as agreeing would
+   * report a clean estate that was never actually checked.
+   */
+  observationsMissingDriftFields: number;
+  /** Groups whose declared label sits strictly above the measured payload. */
+  drifting: SensitivityDriftGroup[];
+  /** Observations whose declared label the payload justifies. */
+  aligned: number;
+};
+
+// JSON rather than a delimiter: agent ids and task types are free-form, so any
+// separator character could collide and silently merge two distinct groups.
+function groupKey(parts: readonly (string | null)[]): string {
+  return JSON.stringify(parts);
+}
+
+export function rollUpSensitivityDrift(
+  samples: readonly SensitivityDriftSample[],
+): SensitivityDriftRollup {
+  const groups = new Map<string, SensitivityDriftGroup>();
+  let observationsWithDriftFields = 0;
+  let observationsMissingDriftFields = 0;
+  let aligned = 0;
+
+  for (const sample of samples) {
+    const { declaredSensitivity: declared, measuredSensitivity: measured } = sample;
+    if (!declared || !measured) {
+      observationsMissingDriftFields += 1;
+      continue;
+    }
+    observationsWithDriftFields += 1;
+
+    const levelsAbove = sensitivityLevelsAbove(declared, measured);
+    if (levelsAbove === 0) {
+      aligned += 1;
+      continue;
+    }
+
+    // Key on the declared/measured pair as well as the agent: an agent whose
+    // payload sometimes genuinely carries records would otherwise have its
+    // real findings averaged away by its clean turns.
+    const key = groupKey([sample.agentId, sample.taskType, declared, measured]);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.observations += 1;
+      if (sample.sensitivityFloorApplied) existing.flooredObservations += 1;
+      continue;
+    }
+    groups.set(key, {
+      taskType: sample.taskType,
+      agentId: sample.agentId,
+      declared,
+      measured,
+      levelsAbove,
+      observations: 1,
+      flooredObservations: sample.sensitivityFloorApplied ? 1 : 0,
+    });
+  }
+
+  // Worst over-declaration first — a route stranded three levels above its data
+  // is a harder failure than one sitting a single level high, however often the
+  // milder one is seen. Observation count breaks ties.
+  const drifting = [...groups.values()].sort(
+    (a, b) =>
+      b.levelsAbove - a.levelsAbove ||
+      b.observations - a.observations ||
+      (a.agentId ?? "").localeCompare(b.agentId ?? "") ||
+      a.taskType.localeCompare(b.taskType),
+  );
+
+  return { observationsWithDriftFields, observationsMissingDriftFields, drifting, aligned };
+}

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -136,6 +136,16 @@ type InferenceDataScreenResult = {
 };
 ```
 
+#### Reading the declared-vs-measured fields back (BI-CF3049E7)
+
+Recording both levels only helps if something reconciles them. `apps/web/lib/inference/sensitivity-drift-rollup.ts` rolls receipts up into the groups whose declared label sits **above** what their payload measured, worst over-declaration first; `getSensitivityDriftRollup()` in `apps/web/lib/actions/route-decision-logs.ts` is the DB-backed accessor. Three properties are deliberate:
+
+- **Drift is one-directional.** A payload measuring *above* its declared label is the screen working as intended (the floor only raises), so it is never reported as drift — reporting it would invite someone to lower a correct label.
+- **Receipts predating these fields are held in their own bucket**, not counted as aligned. Treating unmeasured receipts as agreeing would report a clean estate that was never checked.
+- **Levels only.** No payload text passes through the rollup, so it is as safe to surface as the receipts it reads.
+
+Attribution is per agent + task type rather than per route, because `RouteDecisionLog` has no `routeContext` column — the route is visible only as the declared level it contributed. Adding that column is the next slice; until then a drifting agent is traced back to its route through `tak/route-context-map`. The measured case that motivated this: `/customer/marketing` declares `confidential` at `route-context-map.ts:351` while every assembled context tier measures `internal` with zero governed data classes, which left exactly one eligible endpoint (BI-8058697C).
+
 The screen runs before `inferContract()` when possible so route previews match live dispatch, and it must also guard the final dispatch seam so no alternate caller can bypass it. The default insertion points are:
 
 - `apps/web/lib/inference/routed-inference.ts`: screen before `inferContract()` / `prepareRoute()` output and attach the receipt to route evidence.


### PR DESCRIPTION
Tracked by BI-CF3049E7. Follows #3919 (`d0c0f89b3703`), which made the screen receipt record declared-vs-measured sensitivity. Nothing read those fields back — this does.

## The defect being reconciled

A route's sensitivity is a hardcoded static label in `tak/route-context-map`, and `screen-inference-payload` applies it as a **floor** over whatever the payload measures. A label set higher than the data it carries silently narrows that route's endpoint pool, and surfaces to the user as *"the AI provider is temporarily unavailable"* — pointing at providers rather than at the label that caused it.

Measured case: `/customer/marketing` declares `confidential` at [`route-context-map.ts:351`](apps/web/lib/tak/route-context-map.ts#L351) while every assembled context tier measures `internal` with **zero** governed data classes. Result was 11 cloud endpoints excluded, residency pinned `local_only`, exactly one candidate ranked, and a self-referential `fallbackChain` (BI-8058697C).

## The change

`rollUpSensitivityDrift()` — a pure rollup over already-loaded receipts, reporting the agent/task groups whose declared label sits **above** what their payload measured, worst over-declaration first. `getSensitivityDriftRollup()` is the DB-backed accessor, added alongside the existing provider-routing rollup rather than as a parallel query path.

Three properties are deliberate, each pinned by a test:

- **Drift is one-directional.** A payload measuring *above* its declared label is the screen working as intended — the floor only ever raises. Reporting that as drift would invert the meaning and invite someone to lower a correct label.
- **Receipts predating the drift fields get their own bucket**, not counted as aligned. Folding them in would report a clean estate that was never measured.
- **Levels only, never payload text** — the rollup is as safe to surface as the receipts it reads.

Groups key on the declared/measured **pair** as well as the agent, so an agent whose payload sometimes genuinely carries records doesn't have its real findings averaged away by its clean turns. The key is `JSON.stringify([...])` rather than a delimiter: agent ids and task types are free-form, so any separator could collide and silently merge two distinct groups.

Also removes a duplicated sensitivity ordering — `screen-inference-payload` had a private `SENSITIVITY_RANK`, and the rollup needs the same notion of "above". Both now import `data-screening/sensitivity-rank`. Kept out of `types.ts` on purpose: that file is type-only, and a runtime export there would turn every `import type` of it into a value import.

## Scope

Attribution is per **agent + task type**, not per route: `RouteDecisionLog` has no `routeContext` column, so the route is visible only as the declared level it contributed. Adding that column is the next slice; the plan records the gap explicitly rather than leaving it implied.

Choosing what any route's label *should* be stays an operator data-sovereignty decision (BI-8058697C). Note for anyone reading that item: **downgrading a label does not restore Claude** — `anthropic-sub` and `chatgpt` hold `public` clearance only.

## Verification

- 7 new tests; **442 tests / 43 files** pass across `lib/inference` — no regressions from the rank de-duplication.
- `tsc -p apps/web --noEmit` exits **0**, confirmed non-vacuous by a positive control (an injected type error surfaced exactly one diagnostic naming it).

**The local pre-push gate could not complete, and I am not claiming that it did.** Three attempts, three distinct environment failures, none reaching `gate passed`:

1. OOM kill inside the sandbox during the production build (`4294967295`, host at 5.3 GB free of 63.7 GB).
2. Stale root clone (BI-A900EA3F) — fixed via `git merge --ff-only origin/main` on the root.
3. `check-no-provider-local-connector-lifecycle` guard self-test: `GuardRuntimeEnvironmentError` — the pinned guard TypeScript resolves to `D:\DPF\node_modules\typescript` because node follows the worktree's `node_modules` junction to its real path, which cannot match the worktree-relative paths `load-pinned-guard-typescript` accepts. The hoisted TypeScript **is** the correct `6.0.3` pin, so this guard passes from the root clone and fails from any junctioned worktree, independent of this diff.

I deliberately did not use a `Local-CI-Override:` code. None of the five closed codes describes an OOM kill or a junction-resolution mismatch, and asserting one would be attestation theater on a machine-checked field. CI is the binding gate here.
