### PR TITLE
feat(compliance): functional-domain attribution + by-function posture (BI-0B867B67, phase 1)

### DIFF
--- a/apps/web/app/(shell)/compliance/posture/page.tsx
+++ b/apps/web/app/(shell)/compliance/posture/page.tsx
@@ -74,6 +74,33 @@ export default async function PosturePage() {
         </div>
       </div>
 
+      {/* By Function (domain) — the centralized rollup of what each functional context must apply */}
+      <section className="mb-8">
+        <h2 className="text-xs text-[var(--dpf-muted)] uppercase tracking-widest mb-3">By Function</h2>
+        {posture.domainScores.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)]">No applicable regulations yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {posture.domainScores.map((d) => (
+              <div key={d.domain} className="p-3 rounded-lg border border-[var(--dpf-border)] flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-[var(--dpf-text)]">{d.label}</span>
+                  <StatusBadge intent="neutral"
+                    label={`${d.regulationCount} regulation${d.regulationCount !== 1 ? "s" : ""}`}
+                    variant="soft" uppercase={false} />
+                </div>
+                <div className="flex items-center gap-4 text-xs text-[var(--dpf-muted)]">
+                  <span>{d.coveredObligations}/{d.totalObligations} covered</span>
+                  <span className="font-semibold" style={{ color: intentStyle(scoreIntent(d.coveragePercent)).fg }}>
+                    {d.coveragePercent}%
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
       {/* Per-Regulation Breakdown */}
       <section className="mb-8">
         <h2 className="text-xs text-[var(--dpf-muted)] uppercase tracking-widest mb-3">By Regulation</h2>

--- a/apps/web/lib/actions/reporting.ts
+++ b/apps/web/lib/actions/reporting.ts
@@ -8,7 +8,7 @@ import {
   getSessionEmployeeId, logComplianceAction,
 } from "@/lib/actions/compliance-helpers";
 import {
-  generateSnapshotId, calculatePostureScore,
+  generateSnapshotId, calculatePostureScore, calculateDomainScores,
   isValidSubmissionTransition,
   type RegulationGapSummary, type ObligationGap, type ObligationGapStatus,
 } from "@/lib/reporting-types";
@@ -77,6 +77,7 @@ export async function getGapAssessment(): Promise<RegulationGapSummary[]> {
       id: reg.id,
       shortName: reg.shortName,
       jurisdiction: reg.jurisdiction,
+      domain: reg.domain,
       totalObligations: obligations.length,
       coveredObligations: covered,
       partialObligations: partial,
@@ -92,6 +93,11 @@ export async function getGapAssessment(): Promise<RegulationGapSummary[]> {
 export async function getCompliancePosture() {
   await requireViewCompliance();
 
+  // Scope regulation/obligation counts to what APPLIES to this install, so the
+  // headline stat cards match the applicability-scoped by-regulation table
+  // below them (previously these counts were org-wide — a discrepancy).
+  const applicableRegulationIds = await resolveApplicableRegulationDbIds();
+
   const [
     totalRegulations,
     totalObligations,
@@ -102,8 +108,8 @@ export async function getCompliancePosture() {
     publishedPolicies,
     pendingAlerts,
   ] = await Promise.all([
-    prisma.regulation.count({ where: { status: "active" } }),
-    prisma.obligation.count({ where: { status: "active" } }),
+    prisma.regulation.count({ where: { status: "active", id: { in: applicableRegulationIds } } }),
+    prisma.obligation.count({ where: { status: "active", regulationId: { in: applicableRegulationIds } } }),
     prisma.control.count({ where: { status: "active" } }),
     prisma.control.count({ where: { status: "active", implementationStatus: "implemented" } }),
     prisma.complianceIncident.count({ where: { status: { in: ["open", "investigating"] } } }),
@@ -112,10 +118,11 @@ export async function getCompliancePosture() {
     prisma.regulatoryAlert.count({ where: { status: "pending" } }),
   ]);
 
-  // Covered obligations: those with at least one implemented control
+  // Covered obligations: those (in an applicable regulation) with at least one implemented control
   const coveredObligations = await prisma.obligation.count({
     where: {
       status: "active",
+      regulationId: { in: applicableRegulationIds },
       controls: {
         some: {
           control: { implementationStatus: "implemented", status: "active" },
@@ -142,6 +149,10 @@ export async function getCompliancePosture() {
     uncoveredObligations: r.uncoveredObligations,
   }));
 
+  // By-function (domain) breakdown — the centralized rollup of what each
+  // functional context must apply, over the same applicable-scoped gap data.
+  const domainScores = calculateDomainScores(gapData);
+
   return {
     overallScore,
     totalRegulations,
@@ -154,6 +165,7 @@ export async function getCompliancePosture() {
     publishedPolicies,
     pendingAlerts,
     regulationScores,
+    domainScores,
   };
 }
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10142,6 +10142,7 @@
         "use-this-doc-for",
         "purpose",
         "how-coverage-is-classified",
+        "by-function",
         "review-workflow",
         "decisions-and-consequences",
         "what-to-watch",

--- a/apps/web/lib/reporting-types.test.ts
+++ b/apps/web/lib/reporting-types.test.ts
@@ -2,7 +2,57 @@
 import { describe, expect, it } from "vitest";
 import {
   generateSnapshotId, calculatePostureScore, isValidSubmissionTransition, SUBMISSION_STATUS_FLOW,
+  calculateDomainScores, type RegulationGapSummary,
 } from "./reporting-types";
+
+function gap(overrides: Partial<RegulationGapSummary>): RegulationGapSummary {
+  return {
+    id: "r", shortName: "R", jurisdiction: "US", domain: "privacy-security",
+    totalObligations: 0, coveredObligations: 0, partialObligations: 0, uncoveredObligations: 0,
+    coveragePercent: 100, obligations: [], ...overrides,
+  };
+}
+
+describe("calculateDomainScores (by-function rollup)", () => {
+  it("groups regulations by domain and sums their obligations", () => {
+    const scores = calculateDomainScores([
+      gap({ id: "a", domain: "privacy-security", totalObligations: 4, coveredObligations: 2, uncoveredObligations: 2 }),
+      gap({ id: "b", domain: "privacy-security", totalObligations: 6, coveredObligations: 3, uncoveredObligations: 3 }),
+      gap({ id: "c", domain: "hr-employment", totalObligations: 2, coveredObligations: 2, uncoveredObligations: 0 }),
+    ]);
+    const privacy = scores.find((s) => s.domain === "privacy-security")!;
+    expect(privacy.regulationCount).toBe(2);
+    expect(privacy.totalObligations).toBe(10);
+    expect(privacy.coveredObligations).toBe(5);
+    expect(privacy.coveragePercent).toBe(50);
+    const hr = scores.find((s) => s.domain === "hr-employment")!;
+    expect(hr.coveragePercent).toBe(100);
+    expect(hr.label).toBe("HR & Employment");
+  });
+
+  it("folds NULL/unknown domain into cross-cutting", () => {
+    const scores = calculateDomainScores([
+      gap({ id: "a", domain: null, totalObligations: 1 }),
+      gap({ id: "b", domain: "not-a-real-domain", totalObligations: 1 }),
+    ]);
+    expect(scores).toHaveLength(1);
+    expect(scores[0].domain).toBe("cross-cutting");
+    expect(scores[0].regulationCount).toBe(2);
+  });
+
+  it("a domain with no obligations reports 100% (nothing outstanding)", () => {
+    const scores = calculateDomainScores([gap({ domain: "finance", totalObligations: 0 })]);
+    expect(scores[0].coveragePercent).toBe(100);
+  });
+
+  it("orders domains by the canonical enum order", () => {
+    const scores = calculateDomainScores([
+      gap({ id: "a", domain: "sector", totalObligations: 1 }),
+      gap({ id: "b", domain: "privacy-security", totalObligations: 1 }),
+    ]);
+    expect(scores.map((s) => s.domain)).toEqual(["privacy-security", "sector"]);
+  });
+});
 
 describe("ID generator", () => {
   it("generates snapshot IDs with SNAP- prefix", () => {

--- a/apps/web/lib/reporting-types.ts
+++ b/apps/web/lib/reporting-types.ts
@@ -1,5 +1,10 @@
 // apps/web/lib/reporting-types.ts
 import * as crypto from "crypto";
+import {
+  isRegulationDomain,
+  REGULATION_DOMAINS,
+  type RegulationDomain,
+} from "@dpf/db/regulation-applicability";
 
 function genId(prefix: string): string {
   return `${prefix}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
@@ -44,7 +49,74 @@ export type ObligationGap = {
 
 export type RegulationGapSummary = {
   id: string; shortName: string; jurisdiction: string;
+  /** Functional domain this regulation is attributed to (null → cross-cutting). */
+  domain: string | null;
   totalObligations: number; coveredObligations: number;
   partialObligations: number; uncoveredObligations: number;
   coveragePercent: number; obligations: ObligationGap[];
 };
+
+// ── By-function (domain) rollup ──────────────────────────────────────────────
+// Aggregates the per-regulation gap data into one row per functional domain, so
+// the central posture surface shows what each context (HR, finance, security…)
+// must apply and how covered it is. Pure — no DB access; groups the gapData the
+// reporting layer already fetched.
+
+export const DOMAIN_LABEL: Record<RegulationDomain, string> = {
+  "privacy-security": "Privacy & Security",
+  "hr-employment": "HR & Employment",
+  finance: "Finance",
+  "ai-governance": "AI Governance",
+  "consumer-marketing": "Consumer & Marketing",
+  accessibility: "Accessibility",
+  "corporate-governance": "Corporate Governance",
+  sector: "Sector-specific",
+  "cross-cutting": "Cross-cutting",
+};
+
+export type DomainScore = {
+  domain: RegulationDomain;
+  label: string;
+  regulationCount: number;
+  totalObligations: number;
+  coveredObligations: number;
+  uncoveredObligations: number;
+  coveragePercent: number;
+};
+
+/**
+ * Group applicable regulations by functional domain. A NULL or unrecognized
+ * domain folds into `cross-cutting` (guarded via isRegulationDomain) so a
+ * between-deploy-and-backfill window degrades gracefully instead of dropping
+ * regulations. Empty domains are omitted; coverage is covered/total (100 when
+ * a domain has no obligations), matching the per-regulation coveragePercent.
+ */
+export function calculateDomainScores(gapData: RegulationGapSummary[]): DomainScore[] {
+  const buckets = new Map<RegulationDomain, DomainScore>();
+  for (const reg of gapData) {
+    const domain: RegulationDomain = isRegulationDomain(reg.domain) ? reg.domain : "cross-cutting";
+    let b = buckets.get(domain);
+    if (!b) {
+      b = {
+        domain,
+        label: DOMAIN_LABEL[domain],
+        regulationCount: 0,
+        totalObligations: 0,
+        coveredObligations: 0,
+        uncoveredObligations: 0,
+        coveragePercent: 100,
+      };
+      buckets.set(domain, b);
+    }
+    b.regulationCount += 1;
+    b.totalObligations += reg.totalObligations;
+    b.coveredObligations += reg.coveredObligations;
+    b.uncoveredObligations += reg.uncoveredObligations;
+  }
+  const scores = [...buckets.values()].map((b) => ({
+    ...b,
+    coveragePercent: b.totalObligations > 0 ? Math.round((b.coveredObligations / b.totalObligations) * 100) : 100,
+  }));
+  // Stable, meaningful order: by the canonical domain enum order.
+  return scores.sort((a, b) => REGULATION_DOMAINS.indexOf(a.domain) - REGULATION_DOMAINS.indexOf(b.domain));
+}

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -377,7 +377,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text"
     },
     "/compliance/posture": {
-      "defaultVisibleWords": 133,
+      "defaultVisibleWords": 139,
       "leadBandWords": 0,
       "primaryActions": 2,
       "visibleFields": 0,
@@ -385,7 +385,7 @@
       "subLegibleControls": 3,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/compliance/regulations": {
       "defaultVisibleWords": 146,

--- a/docs/data-impact/2026-08-04-regulation-domain.data-impact.json
+++ b/docs/data-impact/2026-08-04-regulation-domain.data-impact.json
@@ -1,0 +1,34 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Regulation compliance-library registry (new domain attribution column)",
+    "Compliance posture / gap reporting projections (by-function rollup)",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260805100000_add_regulation_domain + 20260805100100_backfill_regulation_domain",
+    "backfill": "Additive only: adds Regulation.domain TEXT NULL, then a data-only backfill (WHERE domain IS NULL, one UPDATE per functional-domain bucket) assigning every seeded regulationId its primary domain. No column dropped or rewritten; no row deleted. The IS-NULL guard preserves any operator/seed-set value and is a no-op on fresh installs (rows are seeded after migrations run). Seed writers also carry domain so fresh installs and re-seeds stay authoritative. domain is attribution/reporting only — it never affects applicability. Verified on scratch Postgres: NULL rows backfilled to the correct domain, a pre-set value left untouched."
+  },
+  "tests": [
+    "packages/db/src/seed-regulation-domain.test.ts",
+    "apps/web/lib/reporting-types.test.ts",
+    "apps/web/lib/actions/reporting.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:regulation#functional-domain-attribution",
+      "prismaModel": "Regulation",
+      "lifecycleDisposition": "Additive nullable column with a data-only backfill. Existing rows are untouched and remain valid; the field is curated in the seed packs and backfilled for existing installs. No lifecycle transition, no supersession, no deletion.",
+      "fields": [
+        {
+          "fieldId": "data:regulation#domain",
+          "resolution": "governed",
+          "reason": "The functional domain (privacy-security, hr-employment, finance, ai-governance, consumer-marketing, accessibility, corporate-governance, sector, cross-cutting) that owns tracking a regulation. Lets each functional context see its contextual compliance while everything rolls up to one central posture. Attribution/reporting only — it does not affect which triggers put a regulation in scope.",
+          "provenance": "BI-0B867B67; kernel principle_decide chose explicit-domain-tag (composite 14.6, high confidence); closed REGULATION_DOMAINS enum guard + backfill-lockstep tests."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/functional-compliance-domains.md
+++ b/docs/superpowers/plans/functional-compliance-domains.md
@@ -1,0 +1,29 @@
+# Centralized compliance with contextual functional variants
+
+**BI:** BI-0B867B67 · **Epic follow-up to:** BI-242F344C (horizontal software pack), BI-9DED0CE8 (archetype scoping)
+**Kernel decision:** `principle_decide` chose `explicit-domain-tag` (high confidence, composite 14.6 vs 8.75 vs 7.05, no commandment conflict) over derive-from-trigger and owner/department attribution.
+
+## Problem
+
+The applicability engine (#2766/#3831) gives every install one central registry of what it must comply with, scoped by what the business does and where it operates. Two gaps remain: (1) the data-handling triggers have no operator-facing capture (they were DB-set to prove the mechanism); (2) there is no **functional attribution** — no way for each functional context (HR, finance, security…) to own its contextual compliance while everything rolls up to one central posture. `Obligation.category` holds workflow-type, not domain; the `employing` applicability basis is wired but unused; the seeded `compliance-officer` coworker is orphaned (bound to no route).
+
+## Approach
+
+Add a functional dimension on top of the (unchanged) applicability engine. `domain` is **attribution/reporting only** — it never enters `RegulationApplicability` and never affects `regulationApplies`.
+
+- **`REGULATION_DOMAINS`** closed enum (`privacy-security`, `hr-employment`, `finance`, `ai-governance`, `consumer-marketing`, `accessibility`, `corporate-governance`, `sector`, `cross-cutting`) + `isRegulationDomain` guard in `regulation-applicability.ts`. `Regulation.domain` column; obligations inherit their regulation's domain (no second column). Additive migration + IS-NULL-guarded backfill (reuses the `20260710150000` regulationId lists); all seed packs carry `domain`.
+- **By-function rollup**: `DomainScore` + pure `calculateDomainScores` in `reporting-types.ts`; `getCompliancePosture` returns `domainScores`; a "By Function" section on `/compliance/posture`. Also fixes a scoping bug where posture stat-cards counted org-wide while the by-regulation table was applicability-scoped.
+- **Operator capture** (phase 2): finish the data-handling capture in `BusinessContextForm` + `/api/business-context/setup` + the business-settings page — the engine already reads `BusinessContext.dataHandling`, this writes it.
+- **HR variant + coworker** (phase 3): a cited employment-law pack (`seed-hr-employment-compliance.ts`) gated on the `employing` basis, `domain: hr-employment`; wire the orphaned `compliance-officer` coworker to `/compliance` (`ROUTE_AGENT_MAP`) with a `record_compliance_scope` MCP tool so it captures the profile conversationally; per-domain review visibility.
+
+## Phasing
+
+Three independently-shippable PRs: (1) central domain model + by-function reporting; (2) operator capture; (3) HR pack + coworker + capture tool.
+
+## Verification
+
+Unit: domain guard + all-pack domain integrity + backfill lockstep; `calculateDomainScores`; HR pack integrity; capture-tool grant/coercion. Live: run migrations+seed, confirm `/compliance/posture` By-Function renders and stat cards match the by-regulation totals; capture a data-handling profile through the form and the coworker; confirm HR regs flip review→applies once `employsIn` is declared. Each phase: DCO PR, babysit to green, redeploy live and verify (as done for #2766/#3831).
+
+## Out of scope (follow-ups)
+
+Controls + control-obligation links for the horizontal/HR regs (coverage stays honestly 0% until implemented); per-state privacy-threshold refinement; a `secondaryDomains` array if genuine multi-domain reporting is later required (single primary domain for now).

--- a/docs/user-guide/compliance/posture-and-gaps.md
+++ b/docs/user-guide/compliance/posture-and-gaps.md
@@ -26,6 +26,17 @@ The gap view evaluates regulations applicable to the current install. It does
 not judge whether an implemented control is legally sufficient or whether its
 evidence is current.
 
+## By Function
+
+The posture view groups applicable regulations by **functional domain**
+(Privacy & Security, HR & Employment, Finance, AI Governance, Consumer &
+Marketing, Accessibility, Corporate Governance, Sector-specific, Cross-cutting),
+so each functional context sees the compliance it owns while everything still
+rolls up to one posture. Each domain row shows how many regulations apply and
+their combined obligation coverage. A regulation is attributed to a single
+primary domain; this grouping is for tracking and reporting and does not change
+which regulations apply.
+
 ## Review Workflow
 
 1. Open `/compliance/posture` and note the overall score, obligation coverage,

--- a/packages/db/prisma/migrations/20260805100000_add_regulation_domain/migration.sql
+++ b/packages/db/prisma/migrations/20260805100000_add_regulation_domain/migration.sql
@@ -1,0 +1,6 @@
+-- Functional-domain attribution on Regulation (BI-0B867B67).
+-- Which part of the business owns tracking a regulation (privacy-security,
+-- hr-employment, finance, ai-governance, …). ATTRIBUTION/REPORTING ONLY — does
+-- NOT affect applicability. Additive + nullable: existing rows tolerate NULL
+-- (treated as cross-cutting) until the companion backfill sets them.
+ALTER TABLE "Regulation" ADD COLUMN "domain" TEXT;

--- a/packages/db/prisma/migrations/20260805100100_backfill_regulation_domain/migration.sql
+++ b/packages/db/prisma/migrations/20260805100100_backfill_regulation_domain/migration.sql
@@ -1,0 +1,38 @@
+-- Data-only backfill: functional domain for every seeded regulation (BI-0B867B67).
+-- On an EXISTING install the seeded regulations sit with domain = NULL between
+-- deploy and the next seed run; backfill here so per-function reporting is in
+-- effect the instant this migration applies, independent of seed timing.
+-- Guarded on IS NULL: a later seed upsert or operator edit stays authoritative,
+-- and this is a no-op on a fresh install (rows are seeded after migrations run).
+-- One primary domain per regulation (tie-breaks: GLBA→finance as a
+-- financial-institution regime; HIPAA/FERPA/FedRAMP→privacy-security as
+-- data-protection/security regimes).
+
+UPDATE "Regulation" SET "domain" = 'privacy-security'
+ WHERE "domain" IS NULL AND "regulationId" IN (
+   'REG-US-CCPA','REG-US-STATE-PRIVACY','REG-US-STATE-BREACH-NOTIFICATION',
+   'REG-FRAMEWORK-SOC2','REG-FRAMEWORK-ISO-27001',
+   'REG-US-HIPAA','REG-US-FERPA','REG-US-FEDRAMP','REG-EU-GDPR','REG-UK-GDPR');
+
+UPDATE "Regulation" SET "domain" = 'ai-governance'
+ WHERE "domain" IS NULL AND "regulationId" IN (
+   'REG-FRAMEWORK-NIST-AI-RMF','REG-US-TX-TRAIGA','REG-US-CO-AI-ACT','REG-EU-AI-ACT');
+
+UPDATE "Regulation" SET "domain" = 'consumer-marketing'
+ WHERE "domain" IS NULL AND "regulationId" IN ('REG-US-CAN-SPAM','REG-US-TCPA');
+
+UPDATE "Regulation" SET "domain" = 'accessibility'
+ WHERE "domain" IS NULL AND "regulationId" IN ('REG-US-ADA-WCAG');
+
+UPDATE "Regulation" SET "domain" = 'finance'
+ WHERE "domain" IS NULL AND "regulationId" IN (
+   'REG-US-GLBA','REG-US-BSA-AML','REG-US-NCUA','REG-US-FDIC-CRA','REG-US-IRS-SUBCHAPTER-T');
+
+UPDATE "Regulation" SET "domain" = 'corporate-governance'
+ WHERE "domain" IS NULL AND "regulationId" IN ('REG-UK-CORP-GOV-CODE','REG-US-COOP-GOVERNANCE');
+
+UPDATE "Regulation" SET "domain" = 'sector'
+ WHERE "domain" IS NULL AND "regulationId" IN (
+   'REG-US-STATE-OPEN-MEETINGS','REG-US-STATE-PUBLIC-RECORDS','REG-US-STATE-MUNI-FINANCE',
+   'REG-US-EPA-SDWA','REG-US-EPA-NPDES',
+   'REG-US-STATE-POST','REG-US-LE-POLICY-ATTESTATION','REG-US-CJIS-READINESS');

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -9146,6 +9146,13 @@ model Regulation {
   // adding a governance requirement is a data operation, not a code change.
   // Null → fall back to the legacy jurisdiction/industry string matcher.
   applicability     Json?
+  // Functional domain that owns tracking this regulation (REGULATION_DOMAINS in
+  // regulation-applicability.ts: privacy-security | hr-employment | finance |
+  // ai-governance | consumer-marketing | accessibility | corporate-governance |
+  // sector | cross-cutting). ATTRIBUTION/REPORTING ONLY — it does NOT affect
+  // applicability. Lets each functional context own its slice while everything
+  // rolls up to one posture. Null → treated as cross-cutting until backfilled.
+  domain            String?
   sourceType        String                 @default("external")
   effectiveDate     DateTime?
   reviewDate        DateTime?

--- a/packages/db/src/regulation-applicability.ts
+++ b/packages/db/src/regulation-applicability.ts
@@ -64,6 +64,34 @@ export function isDataHandlingPredicate(value: string | null | undefined): value
   return typeof value === "string" && (DATA_HANDLING_PREDICATES as readonly string[]).includes(value);
 }
 
+/**
+ * The FUNCTIONAL DOMAIN a regulation belongs to — which part of the business
+ * owns tracking and satisfying it. This is an ATTRIBUTION / REPORTING dimension
+ * ONLY: it never enters {@link RegulationApplicability} and never affects
+ * {@link regulationApplies}. A regulation is put in scope by its triggers
+ * (basis/jurisdiction/archetype/data-handling); `domain` is orthogonal — it lets
+ * each functional context (HR, finance, security…) see its own contextual
+ * compliance while everything rolls up to one central posture. Obligations
+ * inherit their regulation's domain (no separate column). Closed set — a new
+ * domain is a data-model change, so the taxonomy stays curated, not free-text.
+ */
+export const REGULATION_DOMAINS = [
+  "privacy-security", // data protection, breach notification, information security
+  "hr-employment", // employment law, wage/hour, leave, workplace safety
+  "finance", // banking/financial-services supervision, tax, financial reporting
+  "ai-governance", // automated-decisioning / AI transparency & risk regimes
+  "consumer-marketing", // marketing, telemarketing, consumer-protection
+  "accessibility", // digital/physical accessibility
+  "corporate-governance", // board/entity governance, listing, cooperative governance
+  "sector", // industry-vertical regimes tied to an archetype (public-sector, law-enforcement, …)
+  "cross-cutting", // spans functions or not yet attributed
+] as const;
+export type RegulationDomain = (typeof REGULATION_DOMAINS)[number];
+
+export function isRegulationDomain(value: string | null | undefined): value is RegulationDomain {
+  return typeof value === "string" && (REGULATION_DOMAINS as readonly string[]).includes(value);
+}
+
 /** An org's regional footprint + archetype. Jurisdiction values are bloc slugs (e.g. "eu", "us", "uk"). */
 export interface RegionProfile {
   operatesIn: string[];

--- a/packages/db/src/seed-banking-compliance.ts
+++ b/packages/db/src/seed-banking-compliance.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
-import { type RegulationApplicability } from "./regulation-applicability";
+import { type RegulationApplicability, type RegulationDomain } from "./regulation-applicability";
 
 // BI-D9ACE184 + BI-E677F250 — banking deltas compliance pack (civic spec §10).
 // industry "financial". The recurring-obligation regimes the BIAN leaf work
@@ -36,6 +36,8 @@ type RegulationSeed = {
   industry: string;
   /** Data-driven applicability spec — scopes the regime to matching archetypes. */
   applicability: RegulationApplicability;
+  /** Functional domain (attribution/reporting only). */
+  domain: RegulationDomain;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
@@ -45,6 +47,7 @@ type RegulationSeed = {
 export const BANKING_REGULATIONS: RegulationSeed[] = [
   {
     regulationId: "REG-US-BSA-AML",
+    domain: "finance",
     name: "Bank Secrecy Act / Anti-Money Laundering",
     shortName: "BSA/AML",
     jurisdiction: "US-federal",
@@ -118,6 +121,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-NCUA",
+    domain: "finance",
     name: "NCUA Regulatory Requirements (federally insured credit unions)",
     shortName: "NCUA",
     jurisdiction: "US-federal",
@@ -178,6 +182,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-FDIC-CRA",
+    domain: "finance",
     name: "FDIC/OCC Bank Supervision — Call Report, CRA & Fair Lending",
     shortName: "Bank Supervision",
     jurisdiction: "US-federal",
@@ -322,6 +327,7 @@ export async function seedBankingCompliance(prisma: PrismaClient): Promise<void>
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
         applicability,
+        domain: regData.domain,
       },
       create: { ...regData, applicability },
     });

--- a/packages/db/src/seed-cooperative-compliance.ts
+++ b/packages/db/src/seed-cooperative-compliance.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
-import { type RegulationApplicability } from "./regulation-applicability";
+import { type RegulationApplicability, type RegulationDomain } from "./regulation-applicability";
 
 // BI-AFC178F3 — cooperative compliance pack (civic spec §10).
 // Same global-Regulation pattern as the public-sector pack, industry
@@ -32,6 +32,8 @@ type RegulationSeed = {
   industry: string;
   /** Data-driven applicability spec — scopes the regime to matching archetypes. */
   applicability: RegulationApplicability;
+  /** Functional domain (attribution/reporting only). */
+  domain: RegulationDomain;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
@@ -47,6 +49,7 @@ const COOPERATIVE_APPLICABILITY: RegulationApplicability = {
 export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
   {
     regulationId: "REG-US-IRS-SUBCHAPTER-T",
+    domain: "finance",
     name: "IRC Subchapter T — Cooperative Patronage Taxation",
     shortName: "Subchapter T",
     jurisdiction: "US-federal",
@@ -110,6 +113,7 @@ export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-COOP-GOVERNANCE",
+    domain: "corporate-governance",
     name: "Cooperative Governance Requirements (state co-op statutes & bylaws)",
     shortName: "Co-op Governance",
     jurisdiction: "US-state",
@@ -233,6 +237,7 @@ export async function seedCooperativeCompliance(prisma: PrismaClient): Promise<v
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
         applicability,
+        domain: regData.domain,
       },
       create: { ...regData, applicability },
     });

--- a/packages/db/src/seed-law-enforcement-compliance.ts
+++ b/packages/db/src/seed-law-enforcement-compliance.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
-import { type RegulationApplicability } from "./regulation-applicability";
+import { type RegulationApplicability, type RegulationDomain } from "./regulation-applicability";
 
 // BI-C1578821 — law-enforcement compliance pack (civic spec §10).
 // industry "public-safety". Phase 1 is NO-CJI by design: this pack covers POST
@@ -34,6 +34,8 @@ type RegulationSeed = {
   industry: string;
   /** Data-driven applicability spec — scopes the regime to matching archetypes. */
   applicability: RegulationApplicability;
+  /** Functional domain (attribution/reporting only). */
+  domain: RegulationDomain;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
@@ -49,6 +51,7 @@ const LAW_ENFORCEMENT_APPLICABILITY: RegulationApplicability = {
 export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
   {
     regulationId: "REG-US-STATE-POST",
+    domain: "sector",
     name: "Peace Officer Standards & Training (state POST)",
     shortName: "POST",
     jurisdiction: "US-state",
@@ -113,6 +116,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-LE-POLICY-ATTESTATION",
+    domain: "sector",
     name: "Law Enforcement Policy Issuance & Attestation",
     shortName: "LE Policy",
     jurisdiction: "US-state",
@@ -164,6 +168,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-CJIS-READINESS",
+    domain: "sector",
     name: "FBI CJIS Security Policy — Readiness Gate (Phase 2 prerequisite)",
     shortName: "CJIS Gate",
     jurisdiction: "US-federal",
@@ -260,6 +265,7 @@ export async function seedLawEnforcementCompliance(prisma: PrismaClient): Promis
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
         applicability,
+        domain: regData.domain,
       },
       create: { ...regData, applicability },
     });

--- a/packages/db/src/seed-public-sector-compliance.ts
+++ b/packages/db/src/seed-public-sector-compliance.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
-import { type RegulationApplicability } from "./regulation-applicability";
+import { type RegulationApplicability, type RegulationDomain } from "./regulation-applicability";
 
 // BI-8D477188 Phase 2 — town/public-body compliance pack (civic spec §10).
 // Seeds the universal state-law FAMILIES as global Regulation rows (industry
@@ -36,6 +36,8 @@ type RegulationSeed = {
   industry: string;
   /** Data-driven applicability spec — scopes the regime to matching archetypes. */
   applicability: RegulationApplicability;
+  /** Functional domain (attribution/reporting only). */
+  domain: RegulationDomain;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
@@ -59,6 +61,7 @@ const MUNICIPAL_APPLICABILITY: RegulationApplicability = {
 export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
   {
     regulationId: "REG-US-STATE-OPEN-MEETINGS",
+    domain: "sector",
     name: "State Open Meetings Law (Sunshine Law)",
     shortName: "Open Meetings",
     jurisdiction: "US-state",
@@ -122,6 +125,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-STATE-PUBLIC-RECORDS",
+    domain: "sector",
     name: "State Public Records Law (FOIA equivalent)",
     shortName: "Public Records",
     jurisdiction: "US-state",
@@ -175,6 +179,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-STATE-MUNI-FINANCE",
+    domain: "sector",
     name: "State Municipal Finance, Audit & Procurement Requirements",
     shortName: "Municipal Finance",
     jurisdiction: "US-state",
@@ -249,6 +254,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-EPA-SDWA",
+    domain: "sector",
     name: "Safe Drinking Water Act (via state primacy agency)",
     shortName: "SDWA",
     jurisdiction: "US-federal",
@@ -314,6 +320,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-EPA-NPDES",
+    domain: "sector",
     name: "Clean Water Act — NPDES Discharge Permits",
     shortName: "NPDES",
     jurisdiction: "US-federal",
@@ -448,6 +455,7 @@ export async function seedPublicSectorCompliance(prisma: PrismaClient): Promise<
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
         applicability,
+        domain: regData.domain,
       },
       create: { ...regData, applicability },
     });

--- a/packages/db/src/seed-regulation-domain.test.ts
+++ b/packages/db/src/seed-regulation-domain.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { isRegulationDomain, REGULATION_DOMAINS } from "./regulation-applicability";
+import { BANKING_REGULATIONS } from "./seed-banking-compliance";
+import { PUBLIC_SECTOR_REGULATIONS } from "./seed-public-sector-compliance";
+import { LAW_ENFORCEMENT_REGULATIONS } from "./seed-law-enforcement-compliance";
+import { COOPERATIVE_REGULATIONS } from "./seed-cooperative-compliance";
+import { UK_CORP_GOV_REGULATIONS } from "./seed-uk-corp-gov-compliance";
+import { SOFTWARE_HORIZONTAL_REGULATIONS } from "./seed-software-horizontal-compliance";
+
+// BI-0B867B67 — every seeded regulation must carry a valid functional domain so
+// it rolls up under exactly one bucket in the by-function posture. A NULL/typo'd
+// domain would create an orphan bucket; the backfill migration must also cover
+// every seeded regulationId so existing installs classify the instant it runs.
+
+const ALL_PACKS = [
+  ["banking", BANKING_REGULATIONS],
+  ["public-sector", PUBLIC_SECTOR_REGULATIONS],
+  ["law-enforcement", LAW_ENFORCEMENT_REGULATIONS],
+  ["cooperative", COOPERATIVE_REGULATIONS],
+  ["uk-corp-gov", UK_CORP_GOV_REGULATIONS],
+  ["software-horizontal", SOFTWARE_HORIZONTAL_REGULATIONS],
+] as const;
+
+describe("every seeded regulation carries a valid functional domain", () => {
+  for (const [pack, regulations] of ALL_PACKS) {
+    it(`${pack}: all domains are in the closed REGULATION_DOMAINS set`, () => {
+      for (const reg of regulations) {
+        expect(
+          isRegulationDomain((reg as { domain?: string }).domain),
+          `${reg.regulationId} domain '${(reg as { domain?: string }).domain}' must be a valid RegulationDomain`,
+        ).toBe(true);
+      }
+    });
+  }
+
+  it("REGULATION_DOMAINS is a stable closed set (guards reject unknowns)", () => {
+    expect(isRegulationDomain("hr-employment")).toBe(true);
+    expect(isRegulationDomain("not-a-domain")).toBe(false);
+    expect(isRegulationDomain(null)).toBe(false);
+    expect(REGULATION_DOMAINS).toContain("cross-cutting");
+  });
+});
+
+describe("domain backfill migration covers every seeded regulation", () => {
+  const sql = readFileSync(
+    join(__dirname, "../prisma/migrations/20260805100100_backfill_regulation_domain/migration.sql"),
+    "utf8",
+  );
+
+  // Parse `SET "domain" = '<d>' … "regulationId" IN ('A','B',…)` blocks.
+  const backfilled = new Map<string, string>();
+  const stmt = /SET "domain" = '([^']+)'[\s\S]*?"regulationId" IN \(([^)]+)\)/g;
+  for (const m of sql.matchAll(stmt)) {
+    const domain = m[1]!;
+    for (const id of m[2]!.split(",").map((s) => s.trim().replace(/^'|'$/g, ""))) {
+      backfilled.set(id, domain);
+    }
+  }
+
+  it("only assigns valid domains", () => {
+    for (const [id, domain] of backfilled) {
+      expect(isRegulationDomain(domain), `${id} backfilled to invalid domain '${domain}'`).toBe(true);
+    }
+  });
+
+  for (const [pack, regulations] of ALL_PACKS) {
+    it(`${pack}: migration domain matches the seed domain for every reg`, () => {
+      for (const reg of regulations) {
+        const seedDomain = (reg as { domain?: string }).domain;
+        expect(
+          backfilled.get(reg.regulationId),
+          `${reg.regulationId} must be backfilled to its seed domain`,
+        ).toBe(seedDomain);
+      }
+    });
+  }
+});

--- a/packages/db/src/seed-software-horizontal-compliance.ts
+++ b/packages/db/src/seed-software-horizontal-compliance.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
-import { type RegulationApplicability } from "./regulation-applicability";
+import { type RegulationApplicability, type RegulationDomain } from "./regulation-applicability";
 
 // BI-242F344C — HORIZONTAL compliance pack. Unlike the vertical packs (banking,
 // public-sector, …) these regimes bind on WHAT an org does with data, not on its
@@ -45,6 +45,8 @@ type RegulationSeed = {
   sourceType: "external" | "framework";
   sourceUrl: string | null;
   applicability: RegulationApplicability;
+  /** Functional domain that owns tracking this regulation (attribution/reporting only). */
+  domain: RegulationDomain;
   notes: string;
   obligations: ObligationSeed[];
 };
@@ -70,6 +72,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 1 — US state comprehensive privacy ──
   {
     regulationId: "REG-US-CCPA",
+    domain: "privacy-security",
     name: "California Consumer Privacy Act (as amended by CPRA)",
     shortName: "CCPA/CPRA",
     jurisdiction: "US-state",
@@ -142,6 +145,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-STATE-PRIVACY",
+    domain: "privacy-security",
     name: "US State Comprehensive Privacy Laws (VCDPA family — 19+ states)",
     shortName: "State Privacy",
     jurisdiction: "US-state",
@@ -203,6 +207,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 2 — breach notification ──
   {
     regulationId: "REG-US-STATE-BREACH-NOTIFICATION",
+    domain: "privacy-security",
     name: "US State Data Breach Notification Laws (all 50 states + DC)",
     shortName: "Breach Notification",
     jurisdiction: "US-state",
@@ -264,6 +269,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 3 — security frameworks / attestation (NOT law) ──
   {
     regulationId: "REG-FRAMEWORK-SOC2",
+    domain: "privacy-security",
     name: "SOC 2 — AICPA System and Organization Controls 2 (Trust Services Criteria)",
     shortName: "SOC 2",
     jurisdiction: "global",
@@ -310,6 +316,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-FRAMEWORK-ISO-27001",
+    domain: "privacy-security",
     name: "ISO/IEC 27001:2022 — Information Security Management System",
     shortName: "ISO 27001",
     jurisdiction: "global",
@@ -354,6 +361,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 4 — AI governance ──
   {
     regulationId: "REG-FRAMEWORK-NIST-AI-RMF",
+    domain: "ai-governance",
     name: "NIST AI Risk Management Framework (AI RMF 1.0 + Generative AI Profile)",
     shortName: "NIST AI RMF",
     jurisdiction: "global",
@@ -396,6 +404,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-TX-TRAIGA",
+    domain: "ai-governance",
     name: "Texas Responsible AI Governance Act (TRAIGA)",
     shortName: "TX TRAIGA",
     jurisdiction: "US-state",
@@ -433,6 +442,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-CO-AI-ACT",
+    domain: "ai-governance",
     name: "Colorado Artificial Intelligence Act (SB 24-205, as amended)",
     shortName: "CO AI Act",
     jurisdiction: "US-state",
@@ -469,6 +479,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 5 — consumer / marketing ──
   {
     regulationId: "REG-US-CAN-SPAM",
+    domain: "consumer-marketing",
     name: "CAN-SPAM Act",
     shortName: "CAN-SPAM",
     jurisdiction: "US-federal",
@@ -514,6 +525,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-TCPA",
+    domain: "consumer-marketing",
     name: "Telephone Consumer Protection Act",
     shortName: "TCPA",
     jurisdiction: "US-federal",
@@ -551,6 +563,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 6 — accessibility ──
   {
     regulationId: "REG-US-ADA-WCAG",
+    domain: "accessibility",
     name: "ADA Title III + WCAG (digital accessibility)",
     shortName: "ADA/WCAG",
     jurisdiction: "US-federal",
@@ -600,6 +613,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 7 — sector overlays (dormant until the data type / customer is onboarded) ──
   {
     regulationId: "REG-US-HIPAA",
+    domain: "privacy-security",
     name: "Health Insurance Portability and Accountability Act (HIPAA)",
     shortName: "HIPAA",
     jurisdiction: "US-federal",
@@ -647,6 +661,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-GLBA",
+    domain: "finance",
     name: "Gramm-Leach-Bliley Act + FTC Safeguards Rule",
     shortName: "GLBA",
     jurisdiction: "US-federal",
@@ -693,6 +708,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-FERPA",
+    domain: "privacy-security",
     name: "Family Educational Rights and Privacy Act (FERPA)",
     shortName: "FERPA",
     jurisdiction: "US-federal",
@@ -730,6 +746,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-US-FEDRAMP",
+    domain: "privacy-security",
     name: "FedRAMP (cloud authorization for US federal customers)",
     shortName: "FedRAMP",
     jurisdiction: "US-federal",
@@ -768,6 +785,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   // ── Family 8 — EU / UK (dormant until an EU/UK nexus is captured) ──
   {
     regulationId: "REG-EU-GDPR",
+    domain: "privacy-security",
     name: "EU General Data Protection Regulation (2016/679)",
     shortName: "GDPR",
     jurisdiction: "EU",
@@ -815,6 +833,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-UK-GDPR",
+    domain: "privacy-security",
     name: "UK GDPR + Data Protection Act 2018",
     shortName: "UK GDPR",
     jurisdiction: "UK",
@@ -851,6 +870,7 @@ export const SOFTWARE_HORIZONTAL_REGULATIONS: RegulationSeed[] = [
   },
   {
     regulationId: "REG-EU-AI-ACT",
+    domain: "ai-governance",
     name: "EU Artificial Intelligence Act (Regulation 2024/1689)",
     shortName: "EU AI Act",
     jurisdiction: "EU",
@@ -908,6 +928,7 @@ export async function seedSoftwareHorizontalCompliance(prisma: PrismaClient): Pr
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
         applicability,
+        domain: regData.domain,
       },
       create: { ...regData, applicability },
     });

--- a/packages/db/src/seed-uk-corp-gov-compliance.ts
+++ b/packages/db/src/seed-uk-corp-gov-compliance.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
-import { UK_CORP_GOV_CODE_APPLICABILITY } from "./regulation-applicability";
+import { UK_CORP_GOV_CODE_APPLICABILITY, type RegulationDomain } from "./regulation-applicability";
 
 // UK Corporate Governance Code (FRC, 2024 edition) compliance pack, focused on
 // Provision 29 — the board internal-controls accountability declaration. This is
@@ -38,6 +38,8 @@ type RegulationSeed = {
   industry: string | null;
   sourceType: "external";
   sourceUrl: string | null;
+  /** Functional domain (attribution/reporting only). */
+  domain: RegulationDomain;
   notes: string;
   obligations: ObligationSeed[];
 };
@@ -46,6 +48,7 @@ type RegulationSeed = {
 export const UK_CORP_GOV_REGULATIONS: RegulationSeed[] = [
   {
     regulationId: "REG-UK-CORP-GOV-CODE",
+    domain: "corporate-governance",
     name: "UK Corporate Governance Code (2024) — Provision 29 board internal-controls declaration",
     shortName: "UK Corp Gov Code / Provision 29",
     jurisdiction: "UK",
@@ -165,6 +168,7 @@ export async function seedUkCorpGovCompliance(prisma: PrismaClient): Promise<voi
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
         applicability,
+        domain: regData.domain,
       },
       create: { ...regData, applicability },
     });

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -445,7 +445,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 34
+    "textMass": 40
   },
   "apps/web/app/(shell)/compliance/regulations/[id]/page.tsx": {
     "vocabulary": 0,
@@ -7663,13 +7663,6 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 150
-  },
-  "apps/web/components/twin/rooms/RoomsList.tsx": {
-    "vocabulary": 0,
-    "genericLabels": 0,
-    "readability": 0,
-    "longSentences": 0,
-    "textMass": 4
   },
   "apps/web/components/twin/rooms/RoomsOperations.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Context

Phase 1 of the centralized-compliance-with-contextual-variants build (approved plan). The applicability engine (#2766/#3831) already gives every install one central registry of what it must comply with. This adds the **functional dimension**: each functional context (HR, finance, security…) owns its contextual compliance while everything rolls up to **one central posture**.

Kernel `principle_decide` ratified **explicit-domain-tag** (high confidence, composite 14.6 vs 8.75 vs 7.05, no conflict).

## Changes

- **`REGULATION_DOMAINS`** closed enum + `isRegulationDomain` guard. `domain` is **attribution/reporting only** — it never enters `RegulationApplicability` and never affects `regulationApplies`, so the engine is unchanged. Obligations inherit their regulation's domain (no second column).
- **`Regulation.domain`** additive/nullable column + data-only IS-NULL-guarded backfill assigning every seeded `regulationId` its primary domain (verified on scratch Postgres: NULLs backfilled, operator-set value preserved). All 6 seed packs carry `domain` so fresh installs stay authoritative.
- **By-function rollup:** `DomainScore` + pure `calculateDomainScores` (NULL/unknown → `cross-cutting`); `getCompliancePosture` returns `domainScores`; a **"By Function"** section on `/compliance/posture`.
- **Bug fix:** `getCompliancePosture` counted regulations/obligations **org-wide** while the by-regulation table was applicability-scoped — the headline stat cards now scope too, so they match the breakdown below them. (Note: historic snapshots stored org-wide totals → one-time trend discontinuity; snapshots are immutable, not backfilled.)

## Verification

- Unit: domain guard + all-6-pack domain integrity + backfill lockstep (53 db tests); `calculateDomainScores` grouping/NULL-fold/order (web). Standalone `@dpf/db` + `web` `tsc --noEmit` clean. Migration verified on scratch Postgres.
- **Local-CI pregate PASSED** (2546 tests, production build compiled, all deterministic guards green).

## Follow-ups (this epic)

Phase 2: finish the operator data-handling capture (form + route). Phase 3: HR employment-law pack on the `employing` basis + wire the orphaned compliance-officer coworker to `/compliance` + `record_compliance_scope` conversational capture.

BI-0B867B67 · WC-EA12DE12

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)