### PR TITLE
feat(workbooks): consolidate CSV/Excel exports into one Export menu (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.test.tsx
+++ b/apps/web/components/workbooks/Grid.test.tsx
@@ -98,12 +98,20 @@ function findBar() {
 }
 
 describe("WorkbookGrid — toolbar", () => {
-  it("renders the CSV, Excel, and Find controls", () => {
+  it("renders the Export, Find, and Add-row controls", () => {
     renderGrid();
-    expect(screen.getByText("Export CSV")).toBeTruthy();
-    expect(screen.getByText("Export Excel")).toBeTruthy();
+    expect(screen.getByText("Export")).toBeTruthy();
     expect(screen.getByText("Find")).toBeTruthy();
     expect(screen.getByText("+ Add row")).toBeTruthy();
+  });
+
+  it("offers CSV and Excel choices behind the single Export button", () => {
+    renderGrid();
+    // formats are hidden until the menu is opened
+    expect(screen.queryByText(/CSV \(\.csv\)/)).toBeNull();
+    fireEvent.click(screen.getByText("Export"));
+    expect(screen.getByText(/CSV \(\.csv\)/)).toBeTruthy();
+    expect(screen.getByText(/Excel \(\.xlsx\)/)).toBeTruthy();
   });
 
   it("does not offer edit-only controls in a read-only grid", () => {

--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -132,6 +132,7 @@ import {
   normalizeViewState,
 } from "./grid-named-views";
 import { GridViewsMenu } from "./GridViewsMenu";
+import { GridExportMenu } from "./GridExportMenu";
 import { type PivotAgg, type SummaryMode } from "./grid-pivot";
 import {
   type CellRange,
@@ -180,7 +181,6 @@ import {
 } from "./grid-footer-summary";
 import { RecordDetailModal } from "./RecordDetailModal";
 import {
-  Download,
   Filter,
   Palette,
   BarChart3,
@@ -1542,26 +1542,11 @@ export function WorkbookGrid({
             onSetDefault={handleSetDefaultView}
           />
         </div>
-        <button
-          type="button"
-          onClick={onExportCsv}
+        <GridExportMenu
           disabled={columns.length === 0}
-          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
-          title="Export the current view to CSV"
-        >
-          <Download size={15} aria-hidden />
-          Export CSV
-        </button>
-        <button
-          type="button"
-          onClick={onExportXlsx}
-          disabled={columns.length === 0}
-          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
-          title="Export the current view to an Excel .xlsx file"
-        >
-          <Download size={15} aria-hidden />
-          Export Excel
-        </button>
+          onExportCsv={onExportCsv}
+          onExportXlsx={onExportXlsx}
+        />
         <button
           type="button"
           onClick={() => setShowFilters((v) => !v)}

--- a/apps/web/components/workbooks/GridExportMenu.test.tsx
+++ b/apps/web/components/workbooks/GridExportMenu.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { GridExportMenu } from "./GridExportMenu";
+
+afterEach(() => cleanup());
+
+describe("GridExportMenu", () => {
+  it("hides the format choices until the Export button is clicked", () => {
+    render(<GridExportMenu onExportCsv={vi.fn()} onExportXlsx={vi.fn()} />);
+    expect(screen.queryByRole("menu")).toBeNull();
+    fireEvent.click(screen.getByText("Export"));
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(screen.getByText(/CSV \(\.csv\)/)).toBeTruthy();
+    expect(screen.getByText(/Excel \(\.xlsx\)/)).toBeTruthy();
+  });
+
+  it("invokes the CSV handler and closes the menu", () => {
+    const onExportCsv = vi.fn();
+    const onExportXlsx = vi.fn();
+    render(<GridExportMenu onExportCsv={onExportCsv} onExportXlsx={onExportXlsx} />);
+    fireEvent.click(screen.getByText("Export"));
+    fireEvent.click(screen.getByText(/CSV \(\.csv\)/));
+    expect(onExportCsv).toHaveBeenCalledTimes(1);
+    expect(onExportXlsx).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("invokes the Excel handler and closes the menu", () => {
+    const onExportCsv = vi.fn();
+    const onExportXlsx = vi.fn();
+    render(<GridExportMenu onExportCsv={onExportCsv} onExportXlsx={onExportXlsx} />);
+    fireEvent.click(screen.getByText("Export"));
+    fireEvent.click(screen.getByText(/Excel \(\.xlsx\)/));
+    expect(onExportXlsx).toHaveBeenCalledTimes(1);
+    expect(onExportCsv).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("does not open when disabled", () => {
+    render(<GridExportMenu disabled onExportCsv={vi.fn()} onExportXlsx={vi.fn()} />);
+    fireEvent.click(screen.getByText("Export"));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/apps/web/components/workbooks/GridExportMenu.tsx
+++ b/apps/web/components/workbooks/GridExportMenu.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+// Universal Grid & Workbooks — the "Export" dropdown (EP-GRID-WORKBOOKS).
+//
+// One export control instead of a button per format: an "Export" button that opens
+// a small menu to pick CSV or Excel (.xlsx). The Grid owns the actual download for
+// each format and passes the handlers here; this is pure UI over them. Mirrors the
+// GridViewsMenu pattern (plain toggle + click-away layer) for a consistent feel.
+
+import { useState, type ReactNode } from "react";
+import { Download } from "lucide-react";
+
+export interface GridExportMenuProps {
+  disabled?: boolean;
+  onExportCsv: () => void;
+  onExportXlsx: () => void;
+}
+
+const ITEM =
+  "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]";
+
+export function GridExportMenu({ disabled, onExportCsv, onExportXlsx }: GridExportMenuProps): ReactNode {
+  const [open, setOpen] = useState(false);
+
+  const pick = (fn: () => void) => {
+    fn();
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
+        title="Export the current view"
+      >
+        <Download size={15} aria-hidden />
+        Export
+        <span aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <>
+          {/* click-away layer */}
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div
+            role="menu"
+            className="absolute right-0 z-20 mt-1 flex w-48 flex-col gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-1 shadow-lg"
+          >
+            <button type="button" role="menuitem" onClick={() => pick(onExportCsv)} className={ITEM}>
+              <Download size={15} aria-hidden className="text-[var(--dpf-muted)]" />
+              CSV (.csv)
+            </button>
+            <button type="button" role="menuitem" onClick={() => pick(onExportXlsx)} className={ITEM}>
+              <Download size={15} aria-hidden className="text-[var(--dpf-muted)]" />
+              Excel (.xlsx)
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -329,6 +329,11 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   silently dropped on save (a latent bug for link/rollup columns too). Extracted the schemas into a
   pure, prisma-free `apps/web/lib/workbooks/column-schema.ts` (unit-tested — 14 cases incl. the
   link/rollup regression + bounds) and aligned it fully with the `FieldConfig` type.
+- **Slice 28h — one Export menu — SHIPPED.** The two adjacent "Export CSV" / "Export Excel" toolbar
+  buttons are consolidated into a single **Export ▾** button that opens a format menu (CSV / Excel),
+  mirroring the `GridViewsMenu` dropdown pattern. Same download handlers; just one control instead of
+  two. New `GridExportMenu.tsx` + component tests; the grid component suite asserts the menu opens and
+  each choice fires its handler and closes.
 - **Remaining (not built):** manual row reordering for *platform* grids (would need a per-user client
   order; low value on 1000s of rows); platform-grid *shareable* views (needs a `WorkbookView.tableId`
   schema change — platform tables have no `WorkbookTable` row); richer charts (grouped/stacked/line);

--- a/docs/ux-fit/2026-08-04-grid-export-menu.ux-fit.json
+++ b/docs/ux-fit/2026-08-04-grid-export-menu.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "single-export-menu",
+  "decisionInteractionId": "DI-A203E8B6CEFB",
+  "scope": {
+    "files": [
+      "apps/web/components/workbooks/Grid.tsx",
+      "apps/web/components/workbooks/GridExportMenu.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "single-export-menu",
+      "two-buttons",
+      "segmented-toggle"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7664,13 +7664,6 @@
     "longSentences": 0,
     "textMass": 150
   },
-  "apps/web/components/twin/rooms/RoomsList.tsx": {
-    "vocabulary": 0,
-    "genericLabels": 0,
-    "readability": 0,
-    "longSentences": 0,
-    "textMass": 4
-  },
   "apps/web/components/twin/rooms/RoomsOperations.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -7886,7 +7879,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 2,
-    "textMass": 512
+    "textMass": 493
   },
   "apps/web/components/workbooks/GridCalendar.tsx": {
     "vocabulary": 0,
@@ -7894,6 +7887,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 22
+  },
+  "apps/web/components/workbooks/GridExportMenu.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
   },
   "apps/web/components/workbooks/GridFindBar.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What

Per operator request: the two adjacent **Export CSV** / **Export Excel** toolbar buttons (visual clutter that grows with each format) become a single **Export ▾** button that opens a small menu to pick the format — **CSV (.csv)** or **Excel (.xlsx)**. Same download handlers, one control instead of two.

`GridExportMenu.tsx` mirrors the existing `GridViewsMenu` dropdown pattern (plain toggle + click-away layer), so it reads as part of the toolbar. Kernel-confirmed design (ledger `DI-A203E8B6CEFB`, high confidence over keep-two-buttons / segmented-toggle).

## Coverage
- `GridExportMenu.test.tsx` — 4 tests: hidden until opened; each choice fires its handler and closes; stays shut when disabled.
- Grid component suite updated to open the menu and see both formats.
- **215/215** workbooks tests pass; web **tsc clean** (exit 0).

No contract, schema, or handler change — pure UI consolidation. Grid.tsx shrinks (two buttons → one component).

## Design grounding
- **Specs/plans:** `docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md` (Slice 28h; Slices 9 + 28f shipped the CSV and .xlsx exports this consolidates).
- **Code substrate:** `apps/web/components/workbooks/Grid.tsx` (export handlers, toolbar), `GridViewsMenu.tsx` (dropdown pattern reused).

Design-Grounding-Decision: extends the grid toolbar by reusing the GridViewsMenu dropdown for a new GridExportMenu; download handlers unchanged; no new dependency, no contract change.
UX-Fit-Decision: collapses two same-icon buttons into one Export ▾ with a CSV/Excel menu — fewer top-level controls, standard export-as affordance; measured manifest docs/ux-fit/2026-08-04-grid-export-menu.ux-fit.json (ledger DI-A203E8B6CEFB).
Process-Spine-Decision: net-new GridExportMenu.tsx + test, grounded by the touched phase-2 plan (Slice 28h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)