### PR TITLE
fix(hooks): make the Claude plugin reconcile idempotent and wire it to SessionStart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,6 +90,11 @@
             "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/hooks/run-hook.mjs\" hooks/janitor-throttle",
             "async": false
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/hooks/run-hook.mjs\" hooks/reconcile-claude-plugin",
+            "async": true
           }
         ]
       }

--- a/scripts/hooks/reconcile-claude-plugin.ps1
+++ b/scripts/hooks/reconcile-claude-plugin.ps1
@@ -31,31 +31,65 @@ try {
     $want = (Get-Content -Raw $manifest | ConvertFrom-Json).version
     if (-not $want) { exit 0 }
 
-    # Decide ok|drift.
-    $state = 'drift'
-    if (Test-Path $installed) {
+    # Decide ok|drift for THIS repo. Used both before reconcile and again after,
+    # to verify convergence rather than trust the install call.
+    function Get-DriftState {
+        if (-not (Test-Path $installed)) { return 'drift' }
         try {
             $data = Get-Content -Raw $installed | ConvertFrom-Json
-            $entries = $data.plugins.$pluginKey
-            foreach ($e in $entries) {
+            foreach ($e in @($data.plugins.$pluginKey)) {
                 if ($e.projectPath -and
                     ([IO.Path]::GetFullPath($e.projectPath).TrimEnd('\') -ieq [IO.Path]::GetFullPath($repoRoot).TrimEnd('\'))) {
-                    if ($e.version -ne $want) { $state = 'drift'; break }
-                    if (-not $e.installPath -or -not (Test-Path $e.installPath)) { $state = 'drift'; break }
-                    $state = 'ok'; break
+                    if ($e.version -ne $want) { return 'drift' }
+                    if (-not $e.installPath -or -not (Test-Path $e.installPath)) { return 'drift' }
+                    return 'ok'
                 }
             }
-        } catch { $state = 'drift' }
+        } catch { return 'drift' }
+        return 'drift'
     }
-    if ($state -ne 'drift') { exit 0 }
+
+    if ((Get-DriftState) -ne 'drift') { exit 0 }
+
+    # Prune every install record for THIS repo before reinstalling. `claude
+    # plugin install` no-ops when ANY project record for this key exists (it
+    # checks presence, not version) and never removes stale-version records, so
+    # a naive reinstall neither converges to a new committed version nor cleans
+    # up -- accumulating a fresh duplicate on every version bump. Pruning first
+    # gives install a clean slate. Records for OTHER repos are left untouched.
+    function Remove-RepoRecords {
+        if (-not (Test-Path $installed)) { return }
+        try {
+            $data = Get-Content -Raw $installed | ConvertFrom-Json
+            if (-not $data.plugins.$pluginKey) { return }
+            $kept = @($data.plugins.$pluginKey | Where-Object {
+                -not ($_.projectPath -and
+                    ([IO.Path]::GetFullPath($_.projectPath).TrimEnd('\') -ieq [IO.Path]::GetFullPath($repoRoot).TrimEnd('\')))
+            })
+            if ($kept.Count -eq @($data.plugins.$pluginKey).Count) { return }  # nothing for this repo
+            if ($kept.Count -gt 0) { $data.plugins.$pluginKey = $kept }
+            else { $data.plugins.PSObject.Properties.Remove($pluginKey) }
+            # Atomic replace so a racing SessionStart hook never reads a half file.
+            $tmp = "$installed.tmp$PID"
+            ($data | ConvertTo-Json -Depth 100) | Set-Content -Path $tmp -Encoding UTF8
+            Move-Item -Force -Path $tmp -Destination $installed
+        } catch { }
+    }
 
     Push-Location $repoRoot
     try {
         & $claude plugin marketplace add ./ --scope local *> $null
         & $claude plugin marketplace update $marketplace *> $null
+        Remove-RepoRecords
         & $claude plugin install $pluginKey --scope project *> $null
     } finally { Pop-Location }
 
-    Write-Output "DPF platform plugin synced to v$want. Restart Claude Code to load the updated skills/hooks."
+    # Verify convergence before announcing it -- a reported install is not a
+    # converged version (the false-success this hook exists to prevent).
+    if ((Get-DriftState) -eq 'ok') {
+        Write-Output "DPF platform plugin synced to v$want. Restart Claude Code to load the updated skills/hooks."
+    } else {
+        Write-Output "DPF platform plugin reconcile could NOT converge to v$want (still drifted). Run: $claude plugin install $pluginKey --scope project"
+    }
 } catch { }
 exit 0

--- a/scripts/hooks/reconcile-claude-plugin.sh
+++ b/scripts/hooks/reconcile-claude-plugin.sh
@@ -53,9 +53,11 @@ fi
 WANT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$MANIFEST" 2>/dev/null)" || exit 0
 [ -n "$WANT" ] || exit 0
 
-# Decide ok|drift. Drift = no entry for this repo, version mismatch, or a
-# missing installPath (wiped cache -- the exact "failed to load" failure).
-STATE="$(python3 - "$INSTALLED" "$REPO_ROOT" "$WANT" <<'PY' 2>/dev/null
+# Decide ok|drift for THIS repo. Drift = no entry for this repo, version
+# mismatch, or a missing installPath (wiped cache -- the "failed to load"
+# failure). Used both before reconcile and again after, to verify convergence.
+drift_state() {
+  python3 - "$INSTALLED" "$REPO_ROOT" "$WANT" <<'PY' 2>/dev/null
 import json, os, sys
 installed, repo, want = sys.argv[1], sys.argv[2], sys.argv[3]
 def norm(p): return os.path.normcase(os.path.normpath(p))
@@ -75,8 +77,50 @@ for e in entries:
         print("ok"); sys.exit(0)
 print("drift")
 PY
-)"
-[ "$STATE" = "drift" ] || exit 0
+}
+
+[ "$(drift_state)" = "drift" ] || exit 0
+
+# Prune every install record for THIS repo before reinstalling. This is the
+# load-bearing fix: `claude plugin install` no-ops when ANY project record for
+# this key already exists (it checks presence, not version) and never removes
+# stale-version records -- so a naive reinstall neither converges to a new
+# committed version nor cleans up after itself. Left unchecked that appended a
+# fresh record on every version bump, accumulating hundreds of duplicates.
+# Pruning first gives install a clean slate to materialize exactly one record
+# at the committed version. Records for OTHER repos are left untouched.
+prune_repo_records() {
+  python3 - "$INSTALLED" "$REPO_ROOT" <<'PY' 2>/dev/null || true
+import json, os, sys, tempfile
+installed, repo = sys.argv[1], sys.argv[2]
+def norm(p): return os.path.normcase(os.path.normpath(p))
+try:
+    data = json.load(open(installed))
+except Exception:
+    sys.exit(0)
+plugins = data.get("plugins")
+if not isinstance(plugins, dict):
+    sys.exit(0)
+key = "dpf-platform@dpf-platform-local"
+entries = plugins.get(key)
+if not isinstance(entries, list):
+    sys.exit(0)
+kept = [e for e in entries
+        if not (isinstance(e, dict) and e.get("projectPath")
+                and norm(e["projectPath"]) == norm(repo))]
+if len(kept) == len(entries):
+    sys.exit(0)  # nothing for this repo to prune
+if kept:
+    plugins[key] = kept
+else:
+    plugins.pop(key, None)
+# Atomic replace so a racing SessionStart hook never reads a half-written file.
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(installed))
+with os.fdopen(fd, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, installed)
+PY
+}
 
 # Reconcile. The directory-source marketplace validates live, so add/update +
 # install re-materialize the cache at the committed version. `add` is for the
@@ -85,10 +129,16 @@ PY
   cd "$REPO_ROOT" 2>/dev/null || exit 0
   "$CLAUDE_BIN" plugin marketplace add ./ --scope local >/dev/null 2>&1 || true
   "$CLAUDE_BIN" plugin marketplace update "$MARKETPLACE" >/dev/null 2>&1 || true
+  prune_repo_records
   "$CLAUDE_BIN" plugin install "$PLUGIN_KEY" --scope project >/dev/null 2>&1 || true
 )
 
-# SessionStart stdout is added to the session context, so the assistant can
-# relay this. Kept to a single line; only ever prints on real drift.
-printf 'DPF platform plugin synced to v%s. Restart Claude Code to load the updated skills/hooks.\n' "$WANT"
+# Verify convergence before announcing it: a reported install is not a
+# converged version (the exact false-success this hook exists to prevent).
+# SessionStart stdout is added to session context so the assistant can relay it.
+if [ "$(drift_state)" = "ok" ]; then
+  printf 'DPF platform plugin synced to v%s. Restart Claude Code to load the updated skills/hooks.\n' "$WANT"
+else
+  printf 'DPF platform plugin reconcile could NOT converge to v%s (still drifted). Run: %s plugin install %s --scope project\n' "$WANT" "$CLAUDE_BIN" "$PLUGIN_KEY"
+fi
 exit 0


### PR DESCRIPTION
## Problem
The plugin **load** defect (`hooks` key) was fixed earlier and the reconcile *engine* (`scripts/hooks/reconcile-claude-plugin.{sh,ps1}`) merged — but it was **never wired to a trigger**, and its reinstall **could not converge**:

- `claude plugin install` **no-ops on record presence, not version** — so a drifted install never moved to the committed version while any project record existed.
- It **never prunes stale-version records**, so each version bump appended a new one.
- The hook printed `synced to vX` **regardless of the result** (false success — same class as the embed-model false-success lesson).

Observed on a live install: **532 duplicate `dpf-platform` records** (441×0.2.1 / 55×0.2.2 / 36×0.2.4) while `main` was at **0.2.5**, `installed_plugins.json` bloated to 231 KB, machine stuck at 0.2.4.

## Fix
- **Prune every install record for the current repo before reinstalling** → install gets a clean slate and materializes exactly one record at the committed version. Other repos' records untouched; written via atomic replace so a racing `SessionStart` hook can't read a half file.
- **Gate the success message on a post-install re-check** of drift state. A reported install ≠ a converged version; on failure it now prints an actionable alert instead of a false `synced`.
- **Wire `hooks/reconcile-claude-plugin` into `SessionStart` (async)** — the durable self-healing trigger that was originally blocked from being added. It lands here through PR review rather than being auto-authored into a live session.
- PowerShell twin kept at parity.

## Verification (live install)
- **Idempotent** — re-running adds no duplicate record.
- **No-op** — an already-converged project path runs silently.
- **Drift re-converges** — injecting a stale version prunes + reinstalls back to **exactly one** `0.2.5` record.

Local machine state was also repaired out-of-band (532 → 1 clean `0.2.5` record); this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)