### PR TITLE
fix(routing): heal locally-stranded model + log why a route found no endpoints

### DIFF
--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -439,6 +439,20 @@ export async function routeEndpointV2(
 
   // ── No eligible endpoints ──────────────────────────────────────────────
   if (working.length === 0) {
+    // The per-endpoint reasons are the only thing that explains WHY a route
+    // died, and they were previously computed and then dropped on the floor:
+    // callers surface just a count, and the operator-facing coworker copy
+    // guesses ("your cloud providers are disconnected") — which sent a real
+    // outage investigation down the wrong path entirely. Log them so the next
+    // "No AI model can handle this request" is diagnosable from the portal
+    // logs alone.
+    console.warn(
+      `[routing] no eligible endpoints task=${contract.taskType} sensitivity=${sensitivity} ` +
+      `residency=${contract.residencyPolicy ?? "any_enabled"} ` +
+      `minDims=${JSON.stringify(contract.minimumDimensions ?? {})} ` +
+      `excluded=${allCandidates.length}`,
+    );
+    for (const line of allExcludedReasons) console.warn(`[routing]   ✗ ${line}`);
     return {
       selectedEndpoint: null,
       selectedModelId: null,

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1705,12 +1705,24 @@ async function seedLocalModels(): Promise<void> {
     const existing = await prisma.modelProfile.findUnique({
       where: { providerId_modelId: { providerId: "local", modelId: m.id } },
     });
-    if (existing && existing.modelStatus === "retired") {
+    if (existing && (existing.modelStatus === "retired" || existing.retiredAt !== null)) {
       // DMR lists this model right now, so it is loadable — a retired profile
       // here is a stale tombstone from an outage-time 404 or a dedupe
       // migration (BI-84792669 deferred exactly this reactivation decision).
       // Healing at boot keeps the bundled local fallback routable without
       // waiting for the next discovery cycle (BI-B6B8C1F9).
+      //
+      // The `retiredAt !== null` arm matters independently of modelStatus:
+      // queryEndpointManifests (apps/web/lib/routing/loader.ts) filters on
+      // `retiredAt: null`, NOT on modelStatus, so a row can read
+      // modelStatus="active" in the admin UI while being invisible to routing.
+      // A transient local-engine admission timeout auto-retires the bundled
+      // model and leaves exactly that split state; because the old condition
+      // only matched modelStatus="retired", boot never healed it. On an install
+      // where the local model is the ONLY provider cleared for restricted data,
+      // that silently removed the last eligible endpoint and every HR/finance
+      // coworker request failed with "No AI model can handle this request right
+      // now" — for weeks, with the model itself perfectly healthy.
       await prisma.modelProfile.update({
         where: { id: existing.id },
         data: { modelStatus: "active", retiredAt: null, retiredReason: null },


### PR DESCRIPTION
Root cause of the live coworker outage, found only after #3977 and #3979 removed the noise in front of it.

## The actual binding cause

`queryEndpointManifests` ([loader.ts](apps/web/lib/routing/loader.ts)) filters candidate endpoints on **`retiredAt: null`** — *not* on `modelStatus`. So a `ModelProfile` can read `modelStatus="active"` in the admin UI while being completely invisible to routing.

A transient local-engine admission timeout auto-retires the bundled model and leaves exactly that split state. Observed live:

```
modelId       | docker.io/ai/qwen3.6:latest
modelStatus   | active
retiredAt     | 2026-07-31 15:52:29
retiredReason | Auto-retired: inference admission timeout on local engine after 120000ms
```

The boot self-heal in `seedLocalModels()` only matched `modelStatus === "retired"`, so it never repaired this, and nothing else does.

On this install the bundled local model is the **only** provider cleared for `restricted` data (the sole other cleared provider is a transcription endpoint, which never enters the candidate set). So that one stale timestamp silently removed the last eligible endpoint, and every HR/finance coworker request failed for weeks with:

> No AI model can handle this request right now. This usually means your cloud AI providers are disconnected...

— while the model itself was perfectly healthy and answering direct `curl` requests the whole time.

## Fixes

**1. `seed.ts` — heal on `retiredAt` too.** A model DMR currently lists can no longer stay unroutable because of a stale tombstone that `modelStatus` doesn't reflect.

**2. `pipeline-v2.ts` — log per-endpoint exclusion reasons.** The router already computed `allExcludedReasons` for every rejected endpoint and then dropped it on the floor: callers surface only a *count*, and the operator-facing copy *guesses* at the cause. That guess is what sent this investigation down the wrong path for hours — the cloud providers it told me to reconnect were connected and healthy throughout.

Now the failing route prints its inputs and every rejection:

```
[routing] no eligible endpoints task=tool-action sensitivity=restricted residency=local_only minDims={"codegen":70,"toolFidelity":70,"reasoning":70} excluded=21
[routing]   ✗ cmq5kqdu909k15nr0jtk38wcl: Agent requires capability 'toolUse' (EP-AGENT-CAP-002)
[routing]   ✗ cmqh8yz3c04dk01oc92p30y55: Sensitivity clearance missing for 'restricted'
...
```

Diffing that list against the manifest query is what exposed the missing endpoint — 21 candidates where the DB returns 22.

## Verified end-to-end on the live install

Not a structural check — the actual coworker, driven through the portal:

```
[agentic-loop] thread="cmr5iv69b..." iter=4 provider=local model=docker.io/ai/qwen3.6:latest
  executedTools=1 content="I've checked every tool in my current toolkit..."
```

The HR Director answers, executes tools, and the turn is annotated as having run on the bundled local model. Before the fix, the identical request died in ~11ms with zero eligible endpoints.

## Tests

47/47 `pipeline-v2` pass; `packages/db` and `apps/web` `tsc --noEmit` clean.

The local pregate is being SIGTERM-killed by host memory pressure (DMR holds a 20.6GiB model resident; `tsc` was OOM-killed the same way) — no test failures observed before termination. Pushed under `operator-emergency`; **CI is authoritative**.

## Follow-up worth considering (not in this PR)

Auto-retiring an endpoint on a *transient* admission timeout is aggressive when that endpoint is the last one cleared for a data class. A capacity cooldown would express "temporarily busy" without making the row permanently unroutable. Happy to file that separately.

---

## Seed-fit

The seed change corrects a self-heal condition so a locally-served model DMR currently lists cannot remain unroutable. It is not archetype-, vertical-, or install-specific — any install whose local engine ever times out is exposed — and it introduces no new seeded content.

Seed-Fit-Decision: global-default