### PR TITLE
feat(ux): report WHAT the accessibility tree changed, not just that it did

### DIFF
--- a/apps/web/lib/ux-budget/ratchet.test.ts
+++ b/apps/web/lib/ux-budget/ratchet.test.ts
@@ -13,6 +13,8 @@ import {
   mergeReproducibleBaselines,
   normaliseSnapshot,
   normaliseVolatileText,
+  summariseStructureDiff,
+  STRUCTURE_DIFF_LIMIT,
   verdictForRoute,
   type BaselineFile,
   type RouteMeasurement,
@@ -396,5 +398,86 @@ describe("same-SHA baseline reproducibility", () => {
     expect(compareBaselineReproducibility(source, missing)).toMatchObject([
       { routePath: "/a", axis: "route", second: "missing" },
     ]);
+  });
+});
+
+describe("structural diff reporting", () => {
+  // Why this exists: a structureChanged failure used to report only THAT the shape
+  // moved. The report artifact carries no snapshot, so diagnosing one meant
+  // reproducing the route against a live portal by hand (the /platform/ai/
+  // operations-map investigation, PR #3901). The diff makes it readable from CI.
+
+  it("names the landmark that disappeared", () => {
+    const before = measurement({ ariaSnapshot: "- banner\n- main:\n  - heading [level=1]" });
+    const after = measurement({ ariaSnapshot: "- main:\n  - heading [level=1]" });
+
+    const v = verdictForRoute(after, baselineFrom(before).routes["/workspace"]);
+    expect(v.structureChanged).toBe(true);
+    expect(v.structureDiff).toContain("[-] banner");
+  });
+
+  it("names a heading that flattened into text", () => {
+    const before = measurement({ ariaSnapshot: "- main:\n  - heading [level=2]" });
+    const after = measurement({ ariaSnapshot: "- main:\n  - text" });
+
+    const v = verdictForRoute(after, baselineFrom(before).routes["/workspace"]);
+    expect(v.structureDiff.map((d) => d.trim())).toEqual(
+      expect.arrayContaining(["[-] heading [level=2]", "[+] text"]),
+    );
+  });
+
+  it("stays EMPTY when the structure held — no diff noise on a passing route", () => {
+    const m = measurement();
+    const v = verdictForRoute(m, baselineFrom(m).routes["/workspace"]);
+    expect(v.structureChanged).toBe(false);
+    expect(v.structureDiff).toEqual([]);
+  });
+
+  it("reports nothing for row-count churn, because the gate ignores it too", () => {
+    // The diff must describe what the gate COMPARED, not the raw tree — otherwise it
+    // sends the reader chasing repetition that collapseRepeatedSiblings discarded.
+    const oneRow = "- table:\n  - row:\n    - cell";
+    const manyRows = "- table:\n  - row:\n    - cell\n  - row:\n    - cell";
+    const v = verdictForRoute(
+      measurement({ ariaSnapshot: manyRows }),
+      baselineFrom(measurement({ ariaSnapshot: oneRow })).routes["/workspace"],
+    );
+    expect(v.structureChanged).toBe(false);
+    expect(v.structureDiff).toEqual([]);
+  });
+
+  it("truncates a large diff instead of flooding the log", () => {
+    const before = measurement({ ariaSnapshot: "- main:\n  - heading [level=1]" });
+    const after = measurement({
+      ariaSnapshot: [
+        "- main:",
+        ...Array.from({ length: 40 }, (_, i) => `  - heading [level=${(i % 6) + 1}]`),
+      ].join("\n"),
+    });
+
+    const diff = verdictForRoute(after, baselineFrom(before).routes["/workspace"]).structureDiff;
+    expect(diff.length).toBe(STRUCTURE_DIFF_LIMIT + 1);
+    expect(diff[diff.length - 1]).toMatch(/more structural line\(s\)/);
+  });
+
+  it("surfaces the diff in the human report under the REGRESSION line", () => {
+    const before = measurement({ ariaSnapshot: "- banner\n- main:\n  - heading [level=1]" });
+    const after = measurement({ ariaSnapshot: "- main:\n  - heading [level=1]" });
+
+    const report = formatSweepReport(evaluateSweep([after], baselineFrom(before)));
+    expect(report).toMatch(/accessibility tree changed shape/);
+    expect(report).toMatch(/\[-\] banner/);
+  });
+
+  it("still reports a first-divergence hint when the projection is too large to diff", () => {
+    // Distinct adjacent roles so collapseRepeatedSiblings cannot shrink it, nested
+    // under main so the projection keeps them.
+    const wide = (n: number) =>
+      Array.from({ length: n }, (_, i) => `  - heading [level=${(i % 6) + 1}]`).join("\n");
+    const diff = summariseStructureDiff(
+      `- banner\n- main:\n${wide(2100)}`,
+      `- main:\n${wide(2100)}`,
+    );
+    expect(diff.join(" ")).toMatch(/first divergence|too large/);
   });
 });

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -142,6 +142,14 @@ export type RouteVerdict = {
   advisoryBudgetFailures: string[];
   /** True when the accessibility tree changed shape. */
   structureChanged: boolean;
+  /**
+   * WHAT changed in that tree, as `-` baseline / `+` measured lines — empty unless
+   * structureChanged. Without this the gate says only "shape changed" and the failure
+   * is undiagnosable from CI: the report artifact carries no snapshot, so finding the
+   * cause meant reproducing the route against a live portal by hand. Safe to publish
+   * — the projection is roles-only and VOLATILE_PATTERNS has already redacted names.
+   */
+  structureDiff: string[];
   ok: boolean;
   findings: BudgetFinding[];
   metrics: UxBudgetMetrics;
@@ -176,6 +184,7 @@ export function verdictForRoute(
 
   const regressions: string[] = [];
   let structureChanged = false;
+  let structureDiff: string[] = [];
 
   if (baseline) {
     for (const axis of RATCHET_AXES) {
@@ -192,6 +201,9 @@ export function verdictForRoute(
     }
     // Whitespace-only reformatting of the YAML projection is not a hierarchy change.
     structureChanged = normaliseSnapshot(measurement.ariaSnapshot) !== normaliseSnapshot(baseline.ariaSnapshot);
+    if (structureChanged) {
+      structureDiff = summariseStructureDiff(baseline.ariaSnapshot, measurement.ariaSnapshot);
+    }
   }
 
   const failed = report.findings.filter((f) => !f.ok);
@@ -221,6 +233,7 @@ export function verdictForRoute(
     blockingBudgetFailures,
     advisoryBudgetFailures,
     structureChanged,
+    structureDiff,
     ok: regressions.length === 0 && !structureChanged && blockingBudgetFailures.length === 0,
     findings: report.findings,
     metrics: measurement.metrics,
@@ -396,6 +409,88 @@ function collapseRepeatedSiblings(lines: string[]): string[] {
   const flat: string[] = [];
   flatten(dedupe(toTree(lines)), flat);
   return flat;
+}
+
+/** Diff lines emitted into the report before truncating. Enough to name the cause. */
+export const STRUCTURE_DIFF_LIMIT = 12;
+
+/**
+ * A line-level diff of the two NORMALISED projections, as `-` baseline / `+` measured.
+ *
+ * Both sides are already collapsed and redacted by normaliseSnapshot, so this reports
+ * the same thing the gate actually compared — not the raw tree, which would show
+ * repetition the gate deliberately ignores and send the reader chasing row counts.
+ *
+ * Longest-common-subsequence, with a size guard: the projections are roles-only and
+ * collapsed (hundreds of lines), but a pathological surface must not turn a reporting
+ * nicety into a quadratic blowup inside the gate. Past the guard, fall back to naming
+ * the first point of divergence, which is still strictly better than a bare boolean.
+ */
+export function summariseStructureDiff(
+  baselineSnapshot: string,
+  measuredSnapshot: string,
+  limit: number = STRUCTURE_DIFF_LIMIT,
+): string[] {
+  const was = normaliseSnapshot(baselineSnapshot).split("\n");
+  const now = normaliseSnapshot(measuredSnapshot).split("\n");
+  if (was.join("\n") === now.join("\n")) return [];
+
+  const truncate = (out: string[]): string[] =>
+    out.length > limit
+      ? [...out.slice(0, limit), `… ${out.length - limit} more structural line(s)`]
+      : out;
+
+  // Replace the projection's own `- ` bullet rather than prefixing it: a `- ` diff
+  // marker in front of a `- role` line reads as `- - banner`. Indentation is kept,
+  // because depth is how the reader locates the node in the tree.
+  const render = (marker: "[-]" | "[+]", line: string): string => {
+    const indent = line.slice(0, line.length - line.trimStart().length);
+    return `${indent}${marker} ${line.trimStart().replace(/^-\s*/, "")}`;
+  };
+
+  const LCS_GUARD = 4_000_000; // cells; ~2000x2000 lines
+  if (was.length * now.length > LCS_GUARD) {
+    let i = 0;
+    while (i < was.length && i < now.length && was[i] === now[i]) i++;
+    return truncate(
+      [
+        `first divergence at line ${i + 1} (diff truncated — projection too large)`,
+        ...(was[i] === undefined ? [] : [render("[-]", was[i])]),
+        ...(now[i] === undefined ? [] : [render("[+]", now[i])]),
+      ].filter(Boolean),
+    );
+  }
+
+  // lcs[i][j] = length of the longest common subsequence of was[i..] and now[j..].
+  const lcs: number[][] = Array.from({ length: was.length + 1 }, () =>
+    new Array<number>(now.length + 1).fill(0),
+  );
+  for (let i = was.length - 1; i >= 0; i--) {
+    for (let j = now.length - 1; j >= 0; j--) {
+      lcs[i][j] =
+        was[i] === now[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const out: string[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < was.length && j < now.length) {
+    if (was[i] === now[j]) {
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push(render("[-]", was[i]));
+      i++;
+    } else {
+      out.push(render("[+]", now[j]));
+      j++;
+    }
+  }
+  for (; i < was.length; i++) out.push(render("[-]", was[i]));
+  for (; j < now.length; j++) out.push(render("[+]", now[j]));
+
+  return truncate(out);
 }
 
 export function normaliseSnapshot(snapshot: string): string {
@@ -613,6 +708,9 @@ export function formatSweepReport(sweep: SweepVerdict): string {
     for (const r of v.regressions) lines.push(`  REGRESSION  ${r}`);
     if (v.structureChanged) {
       lines.push("  REGRESSION  accessibility tree changed shape (heading/landmark structure)");
+      // The diff is the whole point of the line above: without it the reader knows
+      // only THAT the shape moved, and the log tail is where they look first.
+      for (const d of v.structureDiff) lines.push(`                ${d}`);
     }
     for (const f of v.blockingBudgetFailures) lines.push(`  BLOCKING    ${f}`);
     for (const f of v.advisoryBudgetFailures) lines.push(`  advisory    ${f}`);


### PR DESCRIPTION
When the UX route sweep blocks on `structureChanged`, it currently tells you only *that* the shape moved. The report artifact carries the verdict but **no snapshot**, so the only way to learn what actually changed is to reproduce the route against a live portal and diff two captures by hand. That is what diagnosing `/platform/ai/operations-map` cost in #3901 — an afternoon, for information the gate already had and threw away.

## Before / after

```
  REGRESSION  accessibility tree changed shape (heading/landmark structure)
```

```
  REGRESSION  accessibility tree changed shape (heading/landmark structure)
                    [-] heading [level=2]
                    [+] button
```

## Design notes

- **Diffs the NORMALISED projections, not the raw trees.** The diff must describe what the gate actually compared. Reporting the raw tree would surface repetition that `collapseRepeatedSiblings` deliberately discards, sending the reader chasing row counts the gate never blocked on. A route whose only drift is row count therefore reports an *empty* diff — because it also reports `structureChanged: false`. There's a test for exactly that.
- **Replaces the projection's own `- ` bullet rather than prefixing it.** A `- ` marker in front of `- banner` reads as `- - banner`. Indentation is preserved, because depth is how you locate the node.
- **Bounded.** LCS diff, capped at `STRUCTURE_DIFF_LIMIT = 12` lines with a `… N more` tail so a large change can't flood the log, and guarded at ~4M DP cells so a pathological projection can't turn a reporting nicety into a quadratic cost inside the gate. Past the guard it names the first point of divergence — still strictly better than a bare boolean.
- **Safe to publish.** The projection is roles-only and `VOLATILE_PATTERNS` has already redacted names, ids, SHAs and timestamps before comparison.

## No behaviour change

`structureChanged` is computed exactly as before, and the diff is derived from the same two normalised strings. Nothing new blocks.

## Verification

- `apps/web` `lib/ux-budget/` + `scripts/ux-route-sweep.test.ts` — **136 passed** (7 new).
- `pnpm --filter web typecheck` — exit 0.
- `pnpm run pregate` — **gate passed** (`classification=passed attempts=1`).

Docs-Impact-Decision: none — no user-facing route page changes.
Design-Grounding-Decision: not applicable — no UX surface changes; this edits the sweep's own verdict reporting under `apps/web/lib/ux-budget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)