### PR TITLE
Skip CodeQL PR scans when only documentation changed (API rate-limit relief)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,26 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Skip PR scans when NOTHING analysable changed. CodeQL analyses four
+    # languages here, and every analysis ends in a SARIF upload + fingerprinting
+    # call — the most API-expensive step in the repo. A documentation-only PR was
+    # running the full matrix over unchanged code: #3982 (two markdown files)
+    # triggered seven analyses, three of which then died on
+    # "API rate limit exceeded for installation" AFTER the analysis had already
+    # succeeded. Markdown contains nothing these analysers can inspect, so the
+    # scan has no result to lose.
+    #
+    # Safe to skip because CodeQL is NOT a required check: config/merge-readiness-policy.json
+    # lists exactly ["Merge Readiness", "UX Route Budget Sweep", "DCO"], and
+    # `Analyze` is not among Merge Readiness's `needs`. That matters — a skipped
+    # REQUIRED check never reports and would deadlock the PR forever. Re-verify
+    # that manifest before adding a paths filter to any other workflow.
+    #
+    # `push: [main]` above is deliberately NOT filtered: the default-branch scan
+    # keeps the code-scanning baseline and its alerts fresh.
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   schedule:
     # Weekly re-scan to catch new CodeQL queries / model updates.
     - cron: "23 4 * * 1"


### PR DESCRIPTION
## Summary

The installation's GitHub API rate limit has been exhausted twice in the last four days (2026-08-01 ~20:11, 2026-08-04 ~19:49–19:55), and it fails in three different disguises: CodeQL "configuration error", telemetry warnings, and — worst — **silently dropped workflow dispatch**, which looks identical to "checks pending" and left #3907 sitting with 5 checks instead of 36.

This PR fixes the part that is a code change. The larger part is a settings change and is reported below, not fixed here.

## Changes

`codeql.yml` had **no `paths` filter**, so a documentation-only PR ran the full four-language matrix over unchanged code. **#3982, whose diff was two markdown files, triggered seven CodeQL analyses** — and three of them then died on `API rate limit exceeded for installation` *after the analysis had already succeeded and exported its SARIF*.

Added `paths-ignore` for `docs/**` and `**/*.md` on the `pull_request` trigger only.

## Why this is safe, and why the usual trap doesn't apply

The standard danger with `paths-ignore` is that a **required** check which never reports deadlocks the PR forever. That cannot happen here:

```json
// config/merge-readiness-policy.json
"requiredContexts": ["Merge Readiness", "UX Route Budget Sweep", "DCO"]
```

`Analyze` is not required, and it is not among `Merge Readiness`'s `needs` either. I verified the manifest rather than assuming, and the inline comment records that it must be re-checked before any *other* workflow gets a paths filter.

Two deliberate non-changes:
- **`push: [main]` is left unfiltered**, so the default-branch code-scanning baseline and its alerts stay fresh.
- **The weekly scheduled re-scan is untouched**, so new CodeQL queries still sweep everything.

Markdown contains nothing these four analysers can inspect, so the skipped scans have no result to lose.

## Test plan

- [x] **Source-only change** (one workflow trigger filter; no server route, MCP tool, runtime wiring, migration, or UX surface)

### Verification evidence

```
$ node scripts/security/check-actions-injection.mjs
    ✓ Actions injection audit PASSED — no new run-block injection or malformed expressions.
$ node scripts/check-guards.mjs                        → Guard loop OK — 24 guards passed.
$ node --test scripts/merge-readiness-policy.test.mjs  # 3/3
$ node --test scripts/lib/ci-evidence-receipt.test.mjs # 8/8
$ python3 -c "yaml.safe_load(...)"
    YAML parses OK
    push:         {"branches": ["main"]}                      ← unchanged
    pull_request: {"branches": ["main"], "paths-ignore": [...]}
    schedule:     [{"cron": "23 4 * * 1"}]                    ← unchanged
    languages:    ['actions', 'javascript-typescript', 'python', 'go']  ← unchanged
```

**This PR self-tests.** Its diff is a `.yml`, not markdown, so CodeQL still runs — including the `actions` analyser over the very file being changed.

- [x] **Verification-harness limitation acknowledged** — no runtime-bound gate applies to this diff.

## Pre-PR readiness

Local-CI-Override: single workflow-trigger change; no application code in the diff, all applicable source-local gates captured above.

## Related issues / Epic

Follows the CI-reliability findings in #3982. Related: BI-A08EBAEC.

## Overlap sweep

One `paths-ignore` block plus its comment in `.github/workflows/codeql.yml`. No application code, no other workflow, no guard script.

## Notes for the reviewer

### The bigger half is a settings change — please check this

**CodeQL appears to be running twice per push.** There is exactly one CodeQL workflow file, yet every push produces:

- one run with **4** Analyze jobs *including* `actions` → the `codeql.yml` matrix
- one run with **3** Analyze jobs, **no** `actions` → not this workflow
- plus a bare `CodeQL` check whose URL is `/runs/…`, not `/actions/runs/…/job/…`

I ruled out the obvious alternative: `codeql.yml` triggers only on `push` to `main` and on `pull_request`, and its concurrency group is event-scoped, so a feature branch cannot produce two runs of it.

That signature is **Code Scanning default setup enabled alongside the advanced workflow**. This is inference from run shape — I cannot read repository settings — so please confirm at **Settings → Code security → Code scanning**. If both are on, disabling default setup halves the repo's most API-expensive job class, and the duplicated step is exactly the SARIF upload that throws the rate-limit error.

### A finding worth knowing independently of this fix

**Three of the seven red checks on #3982 could never have blocked the merge.** The CodeQL rate-limit failures were genuinely red and entirely non-gating. A reviewer seeing seven reds reasonably assumes the author broke something; each one cost a log fetch to disprove. The check surface does not distinguish *fails the gate* from *cosmetically red*, and that gap is worth closing separately.

### Two hypotheses I tested and discarded

Recorded so nobody re-runs them:

- **Concurrency is already correct** — `cancel-in-progress: true` on `ci.yml`, `codeql.yml`, `secrets-scan.yml`, and the audit workflows. Superseded runs are not a multiplier.
- **The Go and Python matrix entries are legitimate** — 50 real Go files under `services/edge-node-go`, 20 Python. Trimming the matrix would cut genuine coverage, so I didn't.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX2tk9whhQLGawaEYKRF13)_