### PR TITLE
fix(guards): resolve pinned-guard TypeScript through real paths so worktrees pass (BI-A76F0481)

### DIFF
--- a/scripts/lib/load-pinned-guard-typescript.mjs
+++ b/scripts/lib/load-pinned-guard-typescript.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -51,11 +51,28 @@ export function loadPinnedGuardTypeScript(options = {}) {
       `Pinned repo guard TypeScript ${pin} is missing; run ${INSTALL_COMMAND}.`,
     );
   }
-  const normalizedResolved = normalize(resolve(resolvedPackagePath));
-  const normalizedRoot = normalize(repoRoot);
-  const localPath = `${normalizedRoot}/packages/repo-guard-runtime/node_modules/typescript/package.json`;
-  const hoistedPath = `${normalizedRoot}/node_modules/typescript/package.json`;
-  const pnpmPath = new RegExp(`^${escapeRegex(normalizedRoot)}/node_modules/\\.pnpm/typescript@${exactPin}(?:_[^/]+)?/node_modules/typescript/package\\.json$`);
+  // Resolve the CANDIDATES through the filesystem, not just the repo root.
+  // A git worktree's `node_modules` is a junction/symlink to the shared root
+  // clone, and node resolves through it — so the resolved path lands under the
+  // ROOT while `repoRoot` is the WORKTREE. Realpathing `repoRoot` alone does
+  // not help, because the link is at `<root>/node_modules`, not at the root
+  // itself. Realpathing each candidate makes the worktree and the root clone
+  // compare equal while still rejecting a TypeScript genuinely outside the
+  // pinned graph (BI-A76F0481).
+  const real = (value) => {
+    try { return normalize(realpathSync(value)); }
+    catch { return normalize(resolve(value)); }
+  };
+  const normalizedResolved = real(resolvedPackagePath);
+  const normalizedRoot = normalize(resolve(repoRoot));
+  const realNodeModules = real(resolve(normalizedRoot, "node_modules"));
+  const localPath = real(
+    resolve(normalizedRoot, "packages/repo-guard-runtime/node_modules/typescript/package.json"),
+  );
+  const hoistedPath = normalize(`${realNodeModules}/typescript/package.json`);
+  // Double-escaped on purpose: inside a template literal `\.` collapses to `.`
+  // and would make the dots wildcards in the compiled regex.
+  const pnpmPath = new RegExp(`^${escapeRegex(realNodeModules)}/\\.pnpm/typescript@${exactPin}(?:_[^/]+)?/node_modules/typescript/package\\.json$`);
   if (normalizedResolved !== localPath && normalizedResolved !== hoistedPath && !pnpmPath.test(normalizedResolved)) {
     throw new GuardRuntimeEnvironmentError(
       `Repo guard TypeScript resolved outside its isolated pnpm graph: ${resolvedPackagePath}; run ${INSTALL_COMMAND}.`,

--- a/scripts/lib/load-pinned-guard-typescript.test.mjs
+++ b/scripts/lib/load-pinned-guard-typescript.test.mjs
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+import { loadPinnedGuardTypeScript, GuardRuntimeEnvironmentError } from "./load-pinned-guard-typescript.mjs";
+
+// The pin is read from the repo's own lock/manifest; these tests only exercise
+// the PATH adjudication, so they stub resolution and the package read.
+const PIN = "6.0.3";
+const LOCK = [
+  "importers:",
+  "  packages/repo-guard-runtime:",
+  "    devDependencies:",
+  "      typescript:",
+  `        specifier: ${PIN}`,
+  `        version: ${PIN}`,
+  "  apps/web:",
+].join("\n");
+
+// The manifest/lock/module-load steps are injected so these tests exercise only
+// the PATH adjudication — the part BI-A76F0481 got wrong.
+function harness({ resolvedPath, repoRoot, version = PIN }) {
+  return () =>
+    loadPinnedGuardTypeScript({
+      repoRoot,
+      runtimeManifest: { devDependencies: { typescript: PIN } },
+      lockText: LOCK,
+      resolvePackage: () => resolvedPath,
+      readResolvedPackage: () => ({ version }),
+      loadModule: () => ({ version }),
+    });
+}
+
+test("a hoisted TypeScript under the repo root is accepted", (t) => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "guard-root-")));
+  const pkg = join(root, "node_modules", "typescript", "package.json");
+  mkdirSync(dirname(pkg), { recursive: true });
+  writeFileSync(pkg, JSON.stringify({ version: "6.0.3" }));
+
+  assert.doesNotThrow(harness({ resolvedPath: pkg, repoRoot: root }));
+});
+
+test("a worktree whose node_modules links to the root clone is accepted (BI-A76F0481)", (t) => {
+  // Reproduces the real failure: `repoRoot` is the WORKTREE, but node resolves
+  // through the linked node_modules and returns a path under the ROOT clone.
+  // Before the realpath fix this threw GuardRuntimeEnvironmentError even though
+  // the resolved TypeScript is exactly the pinned one.
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "guard-link-")));
+  const root = join(base, "root");
+  const worktree = join(base, "worktree");
+
+  const realPkg = join(root, "node_modules", "typescript", "package.json");
+  mkdirSync(dirname(realPkg), { recursive: true });
+  writeFileSync(realPkg, JSON.stringify({ version: "6.0.3" }));
+
+  mkdirSync(worktree, { recursive: true });
+  try {
+    symlinkSync(join(root, "node_modules"), join(worktree, "node_modules"), "junction");
+  } catch {
+    t.skip("symlink/junction creation not permitted in this environment");
+    return;
+  }
+
+  // What node actually hands back: the REAL path, under the root clone.
+  assert.doesNotThrow(harness({ resolvedPath: realPkg, repoRoot: worktree }));
+});
+
+test("the pnpm store path is accepted, and its dots are literal not wildcards", (t) => {
+  // Regression: written inside a template literal, `\.` collapses to `.` and
+  // the compiled regex treats those dots as ANY character — so "/Xpnpm/" would
+  // have been accepted. The escapes must survive into the RegExp.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "guard-pnpm-")));
+  const good = join(root, "node_modules", ".pnpm", `typescript@${PIN}`, "node_modules", "typescript", "package.json");
+  mkdirSync(dirname(good), { recursive: true });
+  writeFileSync(good, JSON.stringify({ version: PIN }));
+  assert.doesNotThrow(harness({ resolvedPath: good, repoRoot: root }));
+
+  const wildcard = join(root, "node_modules", "Xpnpm", `typescript@${PIN}`, "node_modules", "typescript", "package.json");
+  mkdirSync(dirname(wildcard), { recursive: true });
+  writeFileSync(wildcard, JSON.stringify({ version: PIN }));
+  assert.throws(harness({ resolvedPath: wildcard, repoRoot: root }), GuardRuntimeEnvironmentError);
+});
+
+test("a TypeScript genuinely outside the pinned graph is still rejected", () => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "guard-out-")));
+  const root = join(base, "root");
+  const stray = join(base, "elsewhere", "node_modules", "typescript", "package.json");
+  mkdirSync(join(root, "node_modules"), { recursive: true });
+  mkdirSync(dirname(stray), { recursive: true });
+  writeFileSync(stray, JSON.stringify({ version: "6.0.3" }));
+
+  assert.throws(harness({ resolvedPath: stray, repoRoot: root }), GuardRuntimeEnvironmentError);
+});
+
+test("a resolved TypeScript at the wrong version is still rejected", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "guard-ver-")));
+  const pkg = join(root, "node_modules", "typescript", "package.json");
+  mkdirSync(dirname(pkg), { recursive: true });
+  writeFileSync(pkg, JSON.stringify({ version: "5.9.0" }));
+
+  assert.throws(
+    harness({ resolvedPath: pkg, repoRoot: root, version: "5.9.0" }),
+    GuardRuntimeEnvironmentError,
+  );
+});


### PR DESCRIPTION
fix(guards): resolve pinned-guard TypeScript through real paths so worktrees pass (BI-A76F0481)

load-pinned-guard-typescript accepted the resolved typescript/package.json at
three paths built literally from repoRoot. In a git worktree that rejects a
perfectly correct install: `node_modules` there is a junction to the shared root
clone, node resolves through it, and the resolved path lands under the ROOT while
repoRoot is the WORKTREE. Every guard using the pinned loader then failed with
"Repo guard TypeScript resolved outside its isolated pnpm graph" — while the pin
itself was exactly right.

Because dpf-worktree-per-session mandates a worktree, this made the sanctioned
local-CI evidence path unreachable for every session, which pushes agents toward
Local-CI-Override codes that do not honestly apply. That incentive toward
attestation theater on a machine-checked field is the reason this is worth
fixing rather than working around.

Realpath the CANDIDATES, not repoRoot. Realpathing the root alone does not help:
the link is at <root>/node_modules, not at the root itself. Resolving each
candidate (and anchoring the .pnpm regex on the resolved node_modules) makes a
worktree and its root clone compare equal, while a TypeScript genuinely outside
the pinned graph is still rejected — both pinned by tests.

Verified functionally, not just structurally: with the worktree's junctions in
place, `node --test scripts/check-no-provider-local-connector-lifecycle.test.mjs`
now passes where it previously threw, and Policy Guards (source) went from
2 failures (Repo Guard Loop, Janitor Tests) to 1 (Janitor Tests only, which is
the pre-existing Windows exec-bit failure in ensure-pre-push-hook — unrelated to
this diff and green on Linux CI).

New scripts/lib/load-pinned-guard-typescript.test.mjs covers: hoisted-under-root
accepted; worktree-linked-to-root accepted (the regression); out-of-graph
rejected; wrong-version rejected. The loader's existing injection points
(runtimeManifest, lockText, resolvePackage, readResolvedPackage, loadModule) let
the junction case be simulated without creating a real junction.