### PR TITLE
fix(security): authorize the quote and research approval surfaces (BI-1017777D)

### DIFF
--- a/apps/web/lib/actions/crm-commercial.test.ts
+++ b/apps/web/lib/actions/crm-commercial.test.ts
@@ -38,6 +38,16 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+// acceptQuote is capability-guarded (BI-1017777D); these cases exercise the
+// commercial lineage behind the guard, so sign in as a role holding
+// operate_customer. Authorization itself is covered by
+// crm-quote-authorization.test.ts.
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "u-revenue", platformRole: "HR-200", isSuperuser: false },
+  })),
+}));
+
 vi.mock("@/lib/actions/finance", () => ({
   generateInvoiceFromSalesOrder: vi.fn(),
 }));

--- a/apps/web/lib/actions/crm-general.test.ts
+++ b/apps/web/lib/actions/crm-general.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// crm.ts's quote decision actions are capability-guarded (BI-1017777D), which
+// pulls next-auth into this module graph. Stub it: these cases cover CRM
+// behaviour, not authorization (see crm-quote-authorization.test.ts).
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "u-revenue", platformRole: "HR-200", isSuperuser: false },
+  })),
+}));
+
 vi.mock("@dpf/db", () => ({
   prisma: {
     // Default $transaction invokes its callback with a raw-capable tx so the

--- a/apps/web/lib/actions/crm-quote-authorization.test.ts
+++ b/apps/web/lib/actions/crm-quote-authorization.test.ts
@@ -1,0 +1,94 @@
+// Regression test for BI-1017777D — the quote decision surface (acceptQuote /
+// rejectQuote) shipped with NO authorization of any kind: not a capability
+// check, not even a session check. Accepting a quote is not a draft edit — it
+// creates a SalesOrder, closes the opportunity WON, and auto-generates an
+// invoice, so it must be gated like the other commit-grade CRM surfaces.
+//
+// The counterpart at the bottom pins the deliberate exception: the PUBLIC
+// accept-link flow is authorized by accept-token possession and must keep
+// working with no session at all.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authMock, acceptQuoteImplMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  acceptQuoteImplMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: authMock }));
+vi.mock("./crm-quote-acceptance", () => ({ acceptQuoteImpl: acceptQuoteImplMock }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  Prisma: {},
+  prisma: {
+    quote: { update: vi.fn(), findUnique: vi.fn() },
+    activity: { create: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { acceptQuote, rejectQuote } from "./crm";
+
+const p = prisma as unknown as {
+  quote: { update: ReturnType<typeof vi.fn>; findUnique: ReturnType<typeof vi.fn> };
+};
+
+/** HR-200 (Customer/Revenue) holds operate_customer; HR-400 does not. */
+const CAPABLE = { user: { id: "u-capable", platformRole: "HR-200", isSuperuser: false } };
+const SIGNED_IN_WITHOUT_CAPABILITY = {
+  user: { id: "u-warehouse", platformRole: "HR-400", isSuperuser: false },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  acceptQuoteImplMock.mockResolvedValue({ quote: { id: "q1" }, salesOrder: { id: "so1" } });
+  p.quote.update.mockResolvedValue({
+    id: "q1",
+    quoteNumber: "QUO-2026-0009",
+    accountId: "a1",
+    opportunityId: "o1",
+    account: { id: "a1", accountId: "ACC-1", name: "Emma3D" },
+  });
+});
+
+describe("acceptQuote authorization", () => {
+  it("refuses an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    await expect(acceptQuote("q1")).rejects.toThrow(/unauthorized/i);
+    // The point of the test: no sales order, no invoice, no closed-won.
+    expect(acceptQuoteImplMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a signed-in user who lacks operate_customer", async () => {
+    authMock.mockResolvedValue(SIGNED_IN_WITHOUT_CAPABILITY);
+    await expect(acceptQuote("q1")).rejects.toThrow(/unauthorized/i);
+    expect(acceptQuoteImplMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a user holding operate_customer", async () => {
+    authMock.mockResolvedValue(CAPABLE);
+    await acceptQuote("q1");
+    expect(acceptQuoteImplMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("rejectQuote authorization", () => {
+  it("refuses an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    await expect(rejectQuote("q1")).rejects.toThrow(/unauthorized/i);
+    expect(p.quote.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses a signed-in user who lacks operate_customer", async () => {
+    authMock.mockResolvedValue(SIGNED_IN_WITHOUT_CAPABILITY);
+    await expect(rejectQuote("q1", { reason: "too expensive" })).rejects.toThrow(/unauthorized/i);
+    expect(p.quote.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a user holding operate_customer", async () => {
+    authMock.mockResolvedValue(CAPABLE);
+    await rejectQuote("q1", { reason: "too expensive" });
+    expect(p.quote.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -6,6 +6,12 @@ import crypto from "crypto";
 import { STAGE_DEFAULT_PROBABILITY } from "@dpf/validators";
 import { revalidatePath } from "next/cache";
 import { acceptQuoteImpl } from "./crm-quote-acceptance";
+import { requireCapability } from "./shared/guards";
+import {
+  logActivity as logActivityImpl,
+  logSystemActivity,
+  type ActivityInput,
+} from "@/lib/crm/crm-activity";
 import {
   checkCustomerAccountDuplicates,
   customerAccountNormalizedColumns,
@@ -50,53 +56,8 @@ export async function updateCustomerSite(
 
 // ─── Activity Logging (used by all other actions) ───────────────────────────
 
-export async function logActivity(input: {
-  type: string;
-  subject: string;
-  body?: string;
-  scheduledAt?: string;
-  completedAt?: string;
-  accountId?: string;
-  contactId?: string;
-  opportunityId?: string;
-  createdById?: string | null;
-}) {
-  return prisma.activity.create({
-    data: {
-      activityId: `ACT-${crypto.randomUUID()}`,
-      type: input.type,
-      subject: input.subject,
-      body: input.body || null,
-      scheduledAt: input.scheduledAt ? new Date(input.scheduledAt) : null,
-      completedAt: input.completedAt ? new Date(input.completedAt) : null,
-      accountId: input.accountId || null,
-      contactId: input.contactId || null,
-      opportunityId: input.opportunityId || null,
-      createdById: input.createdById || null,
-    },
-  });
-}
-
-/** Auto-log a system event (no user attribution) */
-async function logSystemActivity(
-  subject: string,
-  opts: {
-    type?: string;
-    body?: string;
-    accountId?: string;
-    contactId?: string;
-    opportunityId?: string;
-  } = {},
-) {
-  return logActivity({
-    type: opts.type || "system",
-    subject,
-    body: opts.body,
-    accountId: opts.accountId,
-    contactId: opts.contactId,
-    opportunityId: opts.opportunityId,
-    createdById: null,
-  });
+export async function logActivity(input: ActivityInput) {
+  return logActivityImpl(input);
 }
 
 // ─── Customer Account Actions ───────────────────────────────────────────────
@@ -1060,7 +1021,16 @@ export async function sendQuote(quoteId: string, userId?: string) {
   return quote;
 }
 
+// The quote DECISION surface. Unlike the draft-grade CRM writes above, accepting
+// commits: a SalesOrder is created, the opportunity closes WON, and an invoice is
+// auto-generated. Both decisions therefore take the shared capability guard —
+// `operate_customer`, the CRM authority, NOT the workforce org-chart approver walk
+// (there is no "accountable manager" for a customer's quote). Every entry point
+// carries its own authority: the /api/v1 route authenticates separately, and the
+// public accept-link flow authorizes by token possession and calls
+// `acceptQuoteImpl` directly rather than through this guarded action.
 export async function acceptQuote(quoteId: string, userId?: string) {
+  await requireCapability("operate_customer");
   return acceptQuoteImpl(quoteId, userId, logSystemActivity);
 }
 
@@ -1068,6 +1038,8 @@ export async function rejectQuote(
   quoteId: string,
   opts: { reason?: string; userId?: string } = {},
 ) {
+  await requireCapability("operate_customer");
+
   const quote = await prisma.quote.update({
     where: { id: quoteId },
     data: { status: "rejected", rejectedAt: new Date() },

--- a/apps/web/lib/actions/quote-accept-public.test.ts
+++ b/apps/web/lib/actions/quote-accept-public.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { acceptQuoteMock } = vi.hoisted(() => ({ acceptQuoteMock: vi.fn() }));
-vi.mock("@/lib/actions/crm", () => ({ acceptQuote: acceptQuoteMock }));
+// The public flow calls the IMPL, bypassing acceptQuote's internal capability
+// guard on purpose — token possession is the authority (BI-1017777D).
+vi.mock("@/lib/actions/crm-quote-acceptance", () => ({ acceptQuoteImpl: acceptQuoteMock }));
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -36,7 +38,7 @@ beforeEach(() => {
 describe("acceptQuoteByToken", () => {
   it("accepts a sent, in-date quote and records the acceptor on the timeline", async () => {
     const res = await acceptQuoteByToken({ token: "t".repeat(32), acceptedByName: "Ian Pruden", acceptedByEmail: "Ian@Emma3D.com" });
-    expect(acceptQuoteMock).toHaveBeenCalledWith("q1");
+    expect(acceptQuoteMock).toHaveBeenCalledWith("q1", undefined, expect.any(Function));
     const act = p.activity.create.mock.calls[0][0].data;
     expect(act.subject).toContain("Ian Pruden");
     expect(act.subject).toContain("ian@emma3d.com");

--- a/apps/web/lib/actions/quote-accept-public.ts
+++ b/apps/web/lib/actions/quote-accept-public.ts
@@ -2,13 +2,20 @@
 
 import crypto from "crypto";
 import { prisma } from "@dpf/db";
-import { acceptQuote } from "@/lib/actions/crm";
+import { acceptQuoteImpl } from "@/lib/actions/crm-quote-acceptance";
+import { logSystemActivity } from "@/lib/crm/crm-activity";
 
 // PUBLIC quote acceptance, authorized by accept-token possession (the exact
 // pattern of the invoice payment portal: sendQuote mints Quote.acceptToken and
 // the customer opens /s/quote/[token]). Accepting drives the existing
 // acceptQuote flow — order + invoice + closed-won — with the acceptor's
 // name/email recorded on the timeline.
+//
+// Deliberately calls `acceptQuoteImpl`, not the `acceptQuote` server action:
+// that action carries the internal `operate_customer` capability guard, which a
+// signed-out customer clicking their own accept link will never hold. Token
+// possession IS the authority here, and it is checked below (token lookup +
+// status + expiry) before the commit runs.
 
 export async function getQuoteByAcceptToken(token: string) {
   if (!token || token.length < 16) return null;
@@ -45,7 +52,7 @@ export async function acceptQuoteByToken(input: {
     throw new Error("This quote has expired — please ask for a refreshed quote");
   }
 
-  await acceptQuote(quote.id);
+  await acceptQuoteImpl(quote.id, undefined, logSystemActivity);
 
   await prisma.activity
     .create({

--- a/apps/web/lib/actions/research-proposals.test.ts
+++ b/apps/web/lib/actions/research-proposals.test.ts
@@ -1,0 +1,81 @@
+// Regression test for BI-1017777D — the research proposal decision surface
+// checked only that SOMEONE was signed in. The product design for this gate is
+// explicit ("AI research is SCHEDULED, PROPOSED, and requests human APPROVAL
+// before any web/LLM execution"), so an authenticated-but-unprivileged user
+// being able to fire enqueueResearchExecution defeats the gate outright.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authMock, approveResearchMock, declineResearchMock, enqueueMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  approveResearchMock: vi.fn(),
+  declineResearchMock: vi.fn(),
+  enqueueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: authMock }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/wiki/research-proposal", () => ({
+  approveResearch: approveResearchMock,
+  declineResearch: declineResearchMock,
+  listPendingResearchProposals: vi.fn(async () => []),
+}));
+vi.mock("@/lib/wiki/research-execution", () => ({ enqueueResearchExecution: enqueueMock }));
+vi.mock("@dpf/db", () => ({
+  prisma: { organization: { findFirst: vi.fn(async () => ({ id: "org-1" })) } },
+}));
+
+import {
+  approveResearchProposalAction,
+  declineResearchProposalAction,
+} from "./research-proposals";
+
+/** manage_business_models is held by HR-000/HR-200/HR-300; HR-600 is the floor role. */
+const CAPABLE = { user: { id: "u-owner", platformRole: "HR-300", isSuperuser: false } };
+const FLOOR_ROLE = { user: { id: "u-floor", platformRole: "HR-600", isSuperuser: false } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  approveResearchMock.mockResolvedValue({ approved: true, proposal: {} });
+  declineResearchMock.mockResolvedValue({ declined: true });
+});
+
+describe("approveResearchProposalAction authorization", () => {
+  it("refuses an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    const res = await approveResearchProposalAction("RP-1");
+    expect(res.ok).toBe(false);
+    expect(approveResearchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a signed-in user without the capability — no research run is enqueued", async () => {
+    authMock.mockResolvedValue(FLOOR_ROLE);
+    const res = await approveResearchProposalAction("RP-1");
+    expect(res.ok).toBe(false);
+    expect(approveResearchMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a capable user", async () => {
+    authMock.mockResolvedValue(CAPABLE);
+    const res = await approveResearchProposalAction("RP-1");
+    expect(res.ok).toBe(true);
+    expect(approveResearchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("declineResearchProposalAction authorization", () => {
+  it("refuses a signed-in user without the capability", async () => {
+    authMock.mockResolvedValue(FLOOR_ROLE);
+    const res = await declineResearchProposalAction("RP-1");
+    expect(res.ok).toBe(false);
+    expect(declineResearchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a capable user", async () => {
+    authMock.mockResolvedValue(CAPABLE);
+    const res = await declineResearchProposalAction("RP-1");
+    expect(res.ok).toBe(true);
+    expect(declineResearchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/actions/research-proposals.ts
+++ b/apps/web/lib/actions/research-proposals.ts
@@ -14,11 +14,41 @@ import {
   type PendingResearchProposal,
 } from "@/lib/wiki/research-proposal";
 import { enqueueResearchExecution } from "@/lib/wiki/research-execution";
+import { can } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
 
 async function currentOrgId(): Promise<string | null> {
   const org = await prisma.organization.findFirst({ select: { id: true } });
   return org?.id ?? null;
+}
+
+/**
+ * Authority for a research DECISION (BI-1017777D).
+ *
+ * A signed-in session is not authority: approving spends web/LLM budget and lands a
+ * draft in the org's knowledge, and the whole point of this gate is that a *human with
+ * standing* releases it. Uses the shared `can()` primitive rather than a private rule —
+ * a per-surface copy is how two approval surfaces ended up with no rule at all — but
+ * keeps the `{ ok, error }` shape these actions contract for, which is exactly the case
+ * `shared/guards.ts` documents as not routing through `requireCapability`.
+ *
+ * `manage_business_models` is the capability: these proposals are scoped to a digital
+ * product / product line / business product, so product-direction authority is the right
+ * source — NOT the workforce org chart, which has no accountable manager for a market
+ * research question. Note the two host surfaces differ in audience (`/admin/research` is
+ * HR-000; the portfolio intelligence tab is view_portfolio), so portfolio VIEWERS
+ * without product-direction authority can still see a proposal they cannot release.
+ */
+async function authorizeResearchDecision(): Promise<
+  { ok: true; userId: string } | { ok: false; error: string }
+> {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id) return { ok: false, error: "Not authenticated" };
+  if (!can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "manage_business_models")) {
+    return { ok: false, error: "You do not have authority to decide research proposals." };
+  }
+  return { ok: true, userId: user.id };
 }
 
 export async function listPendingResearchProposalsAction(): Promise<PendingResearchProposal[]> {
@@ -32,8 +62,8 @@ export async function listPendingResearchProposalsAction(): Promise<PendingResea
 export async function approveResearchProposalAction(
   proposalId: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const session = await auth();
-  if (!session?.user?.id) return { ok: false, error: "Not authenticated" };
+  const authorized = await authorizeResearchDecision();
+  if (!authorized.ok) return { ok: false, error: authorized.error };
   const orgId = await currentOrgId();
   if (!orgId) return { ok: false, error: "No organization is configured." };
 
@@ -41,7 +71,7 @@ export async function approveResearchProposalAction(
     {
       proposalId,
       organizationId: orgId,
-      decidedByUserId: session.user.id,
+      decidedByUserId: authorized.userId,
     },
     // The gate: on approval, enqueue the actual research execution (slice C).
     { onApproved: (p) => enqueueResearchExecution(p) },
@@ -56,15 +86,15 @@ export async function approveResearchProposalAction(
 export async function declineResearchProposalAction(
   proposalId: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const session = await auth();
-  if (!session?.user?.id) return { ok: false, error: "Not authenticated" };
+  const authorized = await authorizeResearchDecision();
+  if (!authorized.ok) return { ok: false, error: authorized.error };
   const orgId = await currentOrgId();
   if (!orgId) return { ok: false, error: "No organization is configured." };
 
   const res = await declineResearch({
     proposalId,
     organizationId: orgId,
-    decidedByUserId: session.user.id,
+    decidedByUserId: authorized.userId,
   });
   if (!res.declined) {
     return { ok: false, error: "Proposal is no longer pending." };

--- a/apps/web/lib/crm/crm-activity.ts
+++ b/apps/web/lib/crm/crm-activity.ts
@@ -1,0 +1,61 @@
+// Shared CRM timeline writers.
+//
+// Extracted from lib/actions/crm.ts (BI-1017777D) so the PUBLIC accept-link flow
+// can log the same way without importing the capability-guarded crm.ts action
+// module — importing it from crm-quote-acceptance's caller would also close an
+// import cycle. Plain module, not "use server": crm.ts re-wraps `logActivity`
+// as its exported server action.
+
+import crypto from "crypto";
+import { prisma } from "@dpf/db";
+
+export type ActivityInput = {
+  type: string;
+  subject: string;
+  body?: string;
+  scheduledAt?: string;
+  completedAt?: string;
+  accountId?: string;
+  contactId?: string;
+  opportunityId?: string;
+  createdById?: string | null;
+};
+
+export async function logActivity(input: ActivityInput) {
+  return prisma.activity.create({
+    data: {
+      activityId: `ACT-${crypto.randomUUID()}`,
+      type: input.type,
+      subject: input.subject,
+      body: input.body || null,
+      scheduledAt: input.scheduledAt ? new Date(input.scheduledAt) : null,
+      completedAt: input.completedAt ? new Date(input.completedAt) : null,
+      accountId: input.accountId || null,
+      contactId: input.contactId || null,
+      opportunityId: input.opportunityId || null,
+      createdById: input.createdById || null,
+    },
+  });
+}
+
+/** Auto-log a system event (no user attribution). */
+export async function logSystemActivity(
+  subject: string,
+  opts: {
+    type?: string;
+    body?: string;
+    accountId?: string;
+    contactId?: string;
+    opportunityId?: string;
+  } = {},
+) {
+  return logActivity({
+    type: opts.type || "system",
+    subject,
+    body: opts.body,
+    accountId: opts.accountId,
+    contactId: opts.contactId,
+    opportunityId: opts.opportunityId,
+    createdById: null,
+  });
+}

--- a/docs/superpowers/specs/2026-08-01-approval-routing-design.md
+++ b/docs/superpowers/specs/2026-08-01-approval-routing-design.md
@@ -122,3 +122,62 @@ Counting authorization references across the action files that export `approve*`
 `leave` and `timesheet` were in the left column and are now fixed. **A zero count is a signal to
 look, not proof of a hole** — some surfaces may authorize by another route. The four remaining
 have not been read and are not claimed to be defective; they are the next place to look.
+
+## Addendum 2 — the four remaining surfaces, read (BI-1017777D)
+
+All four were read. **Two were clean, two were defective**, which is the point of the caveat
+above: the grep is a search heuristic, not a verdict.
+
+| Surface | Verdict | Authority |
+| --- | --- | --- |
+| `civic-governance` | **Clean** | Every action opens with `requireManageCompliance()` |
+| `compliance-proposals` | **Clean** | `requireViewCompliance()` to propose, `requireManageCompliance()` to approve/reject — the propose/approve split was already deliberate |
+| `crm` | **Defective — fixed** | `acceptQuote` / `rejectQuote` had *no* check at all, not even a session read |
+| `research-proposals` | **Defective — fixed** | `approve*`/`decline*` checked `session.user.id` and nothing else |
+
+### The regex was the weakest part of the sweep
+
+`requireManageCompliance` matches none of the alternatives in the original pattern, so both clean
+surfaces scored zero. Worse, **`leave` and `timesheet` still score zero after being fixed** —
+`authorizeApprovalDecision` doesn't match either. A zero is worth roughly one thing: read the file.
+Do not build a gate on this count.
+
+### Authority chosen per surface, and why not the org chart
+
+Neither fix uses `approval-authority.ts`. That helper resolves an *accountable manager* by walking
+the org chart, which is the right question for leave and timesheets and a meaningless one for a
+customer's quote or a market-research question — neither has an employee subject to walk up from.
+Both fixes instead use the shared capability primitive:
+
+- **`crm.acceptQuote` / `rejectQuote` → `requireCapability("operate_customer")`** (via the existing
+  `lib/actions/shared/guards.ts`). Accepting is not a draft edit: it creates a `SalesOrder`, closes
+  the opportunity WON, and auto-generates an invoice. `operate_customer` shares a role set with
+  `view_customer`, so no user who can see the button loses it.
+- **`research-proposals` → `can(..., "manage_business_models")`**, kept inline because these actions
+  contract for an `{ ok, error }` result rather than a throw — the case `shared/guards.ts` explicitly
+  documents as not routing through `requireCapability`. Proposals are scoped to a digital product /
+  product line / business product, so product-direction authority is the right source.
+
+### Every entry point carries its own authority
+
+`crm.ts` had three callers, and only guarding the action would have broken one of them:
+
+- `/api/v1/customer/quotes/[id]` — authenticates separately via `authenticateRequest`. Unchanged.
+- `QuoteLifecycleActions.tsx` — the internal portal button. Now guarded.
+- `quote-accept-public.ts` — the PUBLIC `/s/quote/[token]` flow, where a signed-out customer accepts
+  their own quote. Token possession *is* the authority. It now calls `acceptQuoteImpl` directly
+  rather than the guarded action, so the internal guard cannot lock out the customer it was never
+  aimed at. `logSystemActivity` moved to `lib/crm/crm-activity.ts` so both paths share one writer.
+
+There is **no Next.js middleware in `apps/web`**, so a page-level or layout-level guard does not
+protect a server action — the action body runs before any render-time redirect. Every exported
+`"use server"` function is its own endpoint and must carry its own check. That is the structural
+reason these holes keep appearing.
+
+### Still open
+
+- `crm.ts` and `customer-sites.ts` have **zero authorization across every action**, not just the
+  quote decisions — `createCustomerAccount`, `closeOpportunity`, `sendQuote` and ~15 others remain
+  unguarded. Out of scope here (this BI is the approval surfaces); worth its own item.
+- `listPendingResearchProposalsAction` still gates on session alone, leaking pending research topics
+  to any signed-in user. Lower severity than the decision actions, not fixed here.


### PR DESCRIPTION
Completes the approval-surface sweep started for leave (#3897) and timesheets (#3966). All four remaining zero-scoring action files were read. **Two were clean, two were genuinely defective** — which is the point of the BI's caveat that a zero grep count is a signal to look, not proof of a hole.

| Surface | Verdict | Authority |
| --- | --- | --- |
| `civic-governance.ts` | **Clean** | Every action opens with `requireManageCompliance()` |
| `compliance-proposals.ts` | **Clean** | `requireViewCompliance` to propose, `requireManageCompliance` to approve/reject — the split was already deliberate |
| `crm.ts` | **Defective — fixed** | `acceptQuote` / `rejectQuote` had *no* check at all, not even a session read |
| `research-proposals.ts` | **Defective — fixed** | `approve*` / `decline*` checked `session.user.id` and nothing else |

## The two holes

**`crm.acceptQuote` / `rejectQuote`** had zero authorization. Accepting is not a draft edit: it creates a `SalesOrder`, closes the opportunity WON, and auto-generates an invoice.

**`research-proposals` approve/decline** checked only that *someone* was signed in, so any authenticated user — including the HR-600 floor role — could fire a web+LLM research run. That defeats a gate whose stated design is "human approval before any execution".

## Authority chosen per surface — neither uses the org chart

`approval-authority.ts` resolves an accountable *manager* by walking the org chart. That is the right question for leave and timesheets and a meaningless one for a customer's quote or a market-research question — neither has an employee subject to walk up from. Both fixes use the shared capability primitive instead of a private per-surface rule:

- **crm** → `requireCapability("operate_customer")` via the existing `lib/actions/shared/guards.ts`. Same role set as `view_customer`, so no user who can see the button loses it.
- **research-proposals** → `can(..., "manage_business_models")`, kept inline because these actions contract for `{ ok, error }` rather than a throw — the case `guards.ts` explicitly documents as *not* routing through `requireCapability`.

## Every entry point carries its own authority

Guarding `acceptQuote` alone would have broken the public `/s/quote/[token]` flow, where a signed-out customer accepts their own quote on token possession. That path now calls `acceptQuoteImpl` directly; `logSystemActivity` moved to `lib/crm/crm-activity.ts` so both paths share one writer. The `/api/v1` route authenticates separately and is unchanged.

## Why this class keeps recurring

There is **no Next.js middleware in `apps/web`**. A page- or layout-level guard does not protect a server action — the action body runs before any render-time redirect. Every exported `"use server"` function is its own POST endpoint and must carry its own check.

Also worth recording: **the sweep regex is a weak signal.** `leave` and `timesheet` still score zero *after* being fixed, because `authorizeApprovalDecision` matches none of its alternatives; both clean surfaces scored zero because `requireManageCompliance` does not either. Do not build a gate on that count.

## Verification

- Regression tests written **first** and confirmed red before the fix (4 failures on crm, 2 on research), per `security-fix-needs-regression-test-first`.
- 35 tests green across the 5 affected suites; 1752 green in the broader sweep.
- Local-CI sandbox gate: **passed**, including `pnpm --filter web typecheck`.

## Follow-up filed

BI-EA5FA61C — `crm.ts` and `customer-sites.ts` have zero authorization across *every* action, not just the quote decisions. `sendQuote` is the notable one: it mints `Quote.acceptToken`, the bearer credential for the public accept portal. Out of scope here. The `listPendingResearchProposalsAction` read-leak is folded into that item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)