### PR TITLE
feat(mcp): coworker Policy draft tools + HR grants (BI-3CDEC5F0 P0)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10156,6 +10156,7 @@
         "use-this-doc-for",
         "purpose",
         "policy-lifecycle",
+        "ask-a-coworker-to-draft-one",
         "publish-a-policy",
         "decisions-and-consequences",
         "what-to-watch",

--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -50,6 +50,7 @@ import { nonprodLeasePack } from "./packs/nonprod-lease-pack";
 import { knowledgePack } from "./packs/knowledge-pack";
 import { demandScoringPack } from "./packs/demand-scoring-pack";
 import { workforcePack } from "./packs/workforce-pack";
+import { policyPack } from "./packs/policy-pack";
 import { staffingPack } from "./packs/staffing-pack";
 import { versionHistoryPack } from "./packs/version-history-pack";
 import { eaOntologyPack } from "./packs/ea-ontology-pack";
@@ -129,6 +130,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   knowledgePack,
   demandScoringPack,
   workforcePack,
+  policyPack,
   staffingPack,
   versionHistoryPack,
   eaOntologyPack,

--- a/apps/web/lib/mcp/packs/policy-pack.test.ts
+++ b/apps/web/lib/mcp/packs/policy-pack.test.ts
@@ -81,6 +81,40 @@ describe("policyPack (BI-3CDEC5F0)", () => {
     );
   });
 
+  it("create_policy only claims a US audience when notes actually name one", async () => {
+    // A substring test for "us" fires on "business", "must", "use" — and would
+    // report an audience the operator never captured. Word boundaries only.
+    vi.mocked(prisma.policy.create).mockResolvedValue({
+      id: "cuid2",
+      policyId: "POL-TEST5678",
+      title: "Expense Policy",
+      category: "operations",
+      lifecycleStatus: "draft",
+    } as never);
+
+    const misleading = await policyPack.handlers.create_policy(
+      {
+        title: "Expense Policy",
+        category: "operations",
+        notes: "Applies to the whole business; users must use the portal.",
+      },
+      "user-1",
+    );
+    expect(misleading.success).toBe(true);
+    expect(misleading.message).not.toMatch(/Intended US audience/i);
+    expect(misleading.message).toMatch(/Add intended audience/i);
+
+    const genuine = await policyPack.handlers.create_policy(
+      {
+        title: "Expense Policy",
+        category: "operations",
+        notes: "Audience: US employees only.",
+      },
+      "user-1",
+    );
+    expect(genuine.message).toMatch(/Intended US audience/i);
+  });
+
   it("create_policy rejects bad category", async () => {
     const res = await policyPack.handlers.create_policy(
       { title: "X", category: "not-a-category" },

--- a/apps/web/lib/mcp/packs/policy-pack.test.ts
+++ b/apps/web/lib/mcp/packs/policy-pack.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+import { policyPack } from "./policy-pack";
+
+const EXPECTED_TOOLS = [
+  "list_policies",
+  "get_policy",
+  "create_policy",
+  "update_policy",
+  "request_policy_review",
+] as const;
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    policy: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+
+describe("policyPack (BI-3CDEC5F0)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers expected tools and grant mirrors", () => {
+    expect(policyPack.definitions.map((d) => d.name).sort()).toEqual(
+      [...EXPECTED_TOOLS].sort(),
+    );
+    expect(Object.keys(policyPack.handlers).sort()).toEqual(
+      [...EXPECTED_TOOLS].sort(),
+    );
+    expect(policyPack.grants.list_policies).toEqual(["policy_read"]);
+    expect(policyPack.grants.get_policy).toEqual(["policy_read"]);
+    expect(policyPack.grants.create_policy).toEqual(["policy_write"]);
+    expect(policyPack.grants.update_policy).toEqual(["policy_write"]);
+    expect(policyPack.grants.request_policy_review).toEqual(["policy_write"]);
+    expect(isToolAllowedByGrants("create_policy", ["policy_write"])).toBe(true);
+    expect(isToolAllowedByGrants("create_policy", ["policy_read"])).toBe(false);
+    expect(isToolAllowedByGrants("list_policies", ["policy_read"])).toBe(true);
+  });
+
+  it("create_policy always creates draft and sets agentId", async () => {
+    vi.mocked(prisma.policy.create).mockResolvedValue({
+      id: "cuid1",
+      policyId: "POL-TEST1234",
+      title: "US Remote Work Policy",
+      category: "hr",
+      lifecycleStatus: "draft",
+    } as never);
+
+    const res = await policyPack.handlers.create_policy(
+      {
+        title: "US Remote Work Policy",
+        category: "hr",
+        body: "## Purpose\n…",
+        notes: "Audience: US-based employees only",
+      },
+      "user-1",
+      { agentId: "hr-specialist" },
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/DRAFT/i);
+    expect(res.message).toMatch(/compliance\/policies/);
+    expect(prisma.policy.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: "US Remote Work Policy",
+          category: "hr",
+          lifecycleStatus: "draft",
+          agentId: "hr-specialist",
+          notes: "Audience: US-based employees only",
+        }),
+      }),
+    );
+  });
+
+  it("create_policy rejects bad category", async () => {
+    const res = await policyPack.handlers.create_policy(
+      { title: "X", category: "not-a-category" },
+      "user-1",
+    );
+    expect(res.success).toBe(false);
+    expect(prisma.policy.create).not.toHaveBeenCalled();
+  });
+
+  it("update_policy refuses published policies", async () => {
+    vi.mocked(prisma.policy.findFirst).mockResolvedValue({
+      id: "cuid1",
+      policyId: "POL-1",
+      title: "Published",
+      category: "hr",
+      lifecycleStatus: "published",
+      agentId: null,
+    } as never);
+
+    const res = await policyPack.handlers.update_policy(
+      { policyId: "POL-1", body: "new" },
+      "user-1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("invalid_state");
+    expect(prisma.policy.update).not.toHaveBeenCalled();
+  });
+
+  it("request_policy_review moves draft to in-review only", async () => {
+    vi.mocked(prisma.policy.findFirst).mockResolvedValue({
+      id: "cuid1",
+      policyId: "POL-1",
+      title: "Draft",
+      category: "hr",
+      lifecycleStatus: "draft",
+    } as never);
+    vi.mocked(prisma.policy.update).mockResolvedValue({
+      id: "cuid1",
+      policyId: "POL-1",
+      lifecycleStatus: "in-review",
+    } as never);
+
+    const res = await policyPack.handlers.request_policy_review(
+      { policyId: "POL-1" },
+      "user-1",
+    );
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/in-review/);
+    expect(res.message).toMatch(/cannot publish/i);
+    expect(prisma.policy.update).toHaveBeenCalledWith({
+      where: { id: "cuid1" },
+      data: { lifecycleStatus: "in-review" },
+    });
+  });
+
+  it("list_policies returns empty-friendly message", async () => {
+    vi.mocked(prisma.policy.findMany).mockResolvedValue([]);
+    const res = await policyPack.handlers.list_policies(
+      { category: "hr" },
+      "user-1",
+    );
+    expect(res.success).toBe(true);
+    expect(res.message).toMatch(/No policies/);
+  });
+});

--- a/apps/web/lib/mcp/packs/policy-pack.ts
+++ b/apps/web/lib/mcp/packs/policy-pack.ts
@@ -283,8 +283,10 @@ async function createPolicyHandler(
       `Created draft policy ${record.policyId}: "${record.title}" (category=${record.category}). ` +
       `Human review/edit/publish: /compliance/policies/${record.id}. ` +
       `This is a DRAFT — not published. ` +
-      (notes?.toLowerCase().includes("us")
-        ? "Intended US audience is noted in notes; structured audience scoping is P1 (BI-3CDEC5F0)."
+      // Word-boundary match: a substring test fires on "business", "must", "use"
+      // and would tell the operator an audience was captured when none was.
+      (notes && /\b(?:us|u\.s\.|usa|united states)\b/i.test(notes)
+        ? "Intended US audience is noted in notes; structured audience fields are not shipped yet, so publication scope stays a human decision."
         : "Add intended audience in notes if not global (e.g. US-based employees only)."),
     data: {
       id: record.id,

--- a/apps/web/lib/mcp/packs/policy-pack.ts
+++ b/apps/web/lib/mcp/packs/policy-pack.ts
@@ -58,7 +58,9 @@ const definitions: ToolDefinition[] = [
   {
     name: "create_policy",
     description:
-      "Create a company Policy as DRAFT for human review on /compliance/policies. Never publishes. Use category 'hr' for HR policies. After create, tell the operator the draft is ready for review/edit/publish in the Policies UI. For audience-limited publish (e.g. US employees only), note the intended audience in notes until audience fields ship (BI-3CDEC5F0 P1).",
+      // Provenance (BI-3CDEC5F0 P1: structured audience scoping) stays in this
+      // comment — the model-facing description carries no backlog ids.
+      "Create a company Policy as DRAFT for human review on /compliance/policies. Never publishes. Use category 'hr' for HR policies. After create, tell the operator the draft is ready for review/edit/publish in the Policies UI. For audience-limited publish (e.g. US employees only), note the intended audience in notes until structured audience fields ship.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/policy-pack.ts
+++ b/apps/web/lib/mcp/packs/policy-pack.ts
@@ -1,0 +1,447 @@
+// Policy lifecycle tool pack (BI-3CDEC5F0).
+// Coworker-facing create/update of governed Policy rows as DRAFT for human review.
+// Publish remains a human lifecycle action on /compliance/policies.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack, ToolPackHandler } from "../tool-pack";
+import {
+  generatePolicyId,
+  POLICY_CATEGORIES,
+  isValidTransition,
+  validatePolicyInput,
+} from "@/lib/govern/policy-types";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "list_policies",
+    description:
+      "List company/compliance policies (draft through published). Use before creating a duplicate. Filter by category (e.g. hr) or lifecycleStatus.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        category: {
+          type: "string",
+          description: `Optional category: ${POLICY_CATEGORIES.join(", ")}.`,
+        },
+        lifecycleStatus: {
+          type: "string",
+          description: "Optional: draft | in-review | approved | published | retired.",
+        },
+        limit: { type: "number", description: "Max rows (default 30, max 100)." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, idempotentHint: true },
+  },
+  {
+    name: "get_policy",
+    description:
+      "Get one policy by human policyId (POL-…) or internal id, including body and lifecycle status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        policyId: {
+          type: "string",
+          description: "Policy id: POL-… or internal cuid.",
+        },
+      },
+      required: ["policyId"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, idempotentHint: true },
+  },
+  {
+    name: "create_policy",
+    description:
+      "Create a company Policy as DRAFT for human review on /compliance/policies. Never publishes. Use category 'hr' for HR policies. After create, tell the operator the draft is ready for review/edit/publish in the Policies UI. For audience-limited publish (e.g. US employees only), note the intended audience in notes until audience fields ship (BI-3CDEC5F0 P1).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Policy title." },
+        category: {
+          type: "string",
+          description: `One of: ${POLICY_CATEGORIES.join(", ")}.`,
+        },
+        body: { type: "string", description: "Full policy markdown/text body." },
+        description: { type: "string", description: "Short summary." },
+        notes: {
+          type: "string",
+          description:
+            "Internal notes, e.g. intended audience: US-based employees only.",
+        },
+        reviewFrequency: {
+          type: "string",
+          description: "annual | biennial | quarterly.",
+        },
+      },
+      required: ["title", "category"],
+    },
+    requiredCapability: "manage_compliance",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, idempotentHint: false },
+  },
+  {
+    name: "update_policy",
+    description:
+      "Update a draft or in-review policy body/title/metadata. Refuses published or retired policies (human must revise via lifecycle).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        policyId: { type: "string", description: "POL-… or internal id." },
+        title: { type: "string" },
+        body: { type: "string" },
+        description: { type: "string" },
+        notes: { type: "string" },
+        category: { type: "string" },
+        reviewFrequency: { type: "string" },
+      },
+      required: ["policyId"],
+    },
+    requiredCapability: "manage_compliance",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, idempotentHint: true },
+  },
+  {
+    name: "request_policy_review",
+    description:
+      "Move a draft policy to in-review so a human can approve and publish. Does not publish.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        policyId: { type: "string", description: "POL-… or internal id." },
+      },
+      required: ["policyId"],
+    },
+    requiredCapability: "manage_compliance",
+    executionMode: "immediate",
+    sideEffect: true,
+    annotations: { readOnlyHint: false, idempotentHint: true },
+  },
+];
+
+async function resolvePolicy(policyKey: string) {
+  const { prisma } = await import("@dpf/db");
+  const key = policyKey.trim();
+  if (!key) return null;
+  return prisma.policy.findFirst({
+    where: {
+      status: "active",
+      OR: [{ policyId: key }, { id: key }],
+    },
+  });
+}
+
+async function listPoliciesHandler(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { prisma } = await import("@dpf/db");
+  const limit =
+    typeof params["limit"] === "number"
+      ? Math.min(100, Math.max(1, Math.floor(params["limit"])))
+      : 30;
+  const category =
+    typeof params["category"] === "string" ? params["category"].trim() : undefined;
+  const lifecycleStatus =
+    typeof params["lifecycleStatus"] === "string"
+      ? params["lifecycleStatus"].trim()
+      : undefined;
+
+  const rows = await prisma.policy.findMany({
+    where: {
+      status: "active",
+      ...(category ? { category } : {}),
+      ...(lifecycleStatus ? { lifecycleStatus } : {}),
+    },
+    select: {
+      id: true,
+      policyId: true,
+      title: true,
+      category: true,
+      lifecycleStatus: true,
+      version: true,
+      updatedAt: true,
+    },
+    orderBy: { updatedAt: "desc" },
+    take: limit,
+  });
+
+  if (rows.length === 0) {
+    return {
+      success: true,
+      message: "No policies match.",
+      data: { policies: [] },
+    };
+  }
+
+  const summary = rows
+    .map(
+      (p) =>
+        `${p.policyId} [${p.lifecycleStatus}] ${p.category}: ${p.title} (v${p.version})`,
+    )
+    .join("\n");
+
+  return {
+    success: true,
+    message: `${rows.length} policy(ies):\n${summary}`,
+    data: { policies: rows },
+  };
+}
+
+async function getPolicyHandler(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const policyId = String(params["policyId"] ?? "").trim();
+  if (!policyId) {
+    return {
+      success: false,
+      error: "invalid_params",
+      message: "policyId is required.",
+    };
+  }
+  const row = await resolvePolicy(policyId);
+  if (!row) {
+    return {
+      success: false,
+      error: "not_found",
+      message: `No policy found for ${policyId}.`,
+    };
+  }
+  return {
+    success: true,
+    entityId: row.policyId,
+    message: `${row.policyId} [${row.lifecycleStatus}] ${row.title}`,
+    data: {
+      id: row.id,
+      policyId: row.policyId,
+      title: row.title,
+      category: row.category,
+      lifecycleStatus: row.lifecycleStatus,
+      version: row.version,
+      description: row.description,
+      body: row.body,
+      notes: row.notes,
+      reviewFrequency: row.reviewFrequency,
+      agentId: row.agentId,
+      publishedAt: row.publishedAt,
+      updatedAt: row.updatedAt,
+      reviewUrl: `/compliance/policies/${row.id}`,
+    },
+  };
+}
+
+async function createPolicyHandler(
+  params: Record<string, unknown>,
+  userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const { prisma } = await import("@dpf/db");
+  const title = String(params["title"] ?? "").trim();
+  const category = String(params["category"] ?? "").trim();
+  const body =
+    typeof params["body"] === "string" ? params["body"] : null;
+  const description =
+    typeof params["description"] === "string" ? params["description"] : null;
+  const notes = typeof params["notes"] === "string" ? params["notes"] : null;
+  const reviewFrequency =
+    typeof params["reviewFrequency"] === "string"
+      ? params["reviewFrequency"]
+      : null;
+
+  const err = validatePolicyInput({ title, category });
+  if (err) {
+    return { success: false, error: "invalid_params", message: err };
+  }
+
+  const policyId = generatePolicyId();
+  const record = await prisma.policy.create({
+    data: {
+      policyId,
+      title,
+      category,
+      body,
+      description,
+      notes,
+      reviewFrequency,
+      lifecycleStatus: "draft",
+      agentId: context?.agentId ?? null,
+    },
+  });
+
+  return {
+    success: true,
+    entityId: record.policyId,
+    message:
+      `Created draft policy ${record.policyId}: "${record.title}" (category=${record.category}). ` +
+      `Human review/edit/publish: /compliance/policies/${record.id}. ` +
+      `This is a DRAFT — not published. ` +
+      (notes?.toLowerCase().includes("us")
+        ? "Intended US audience is noted in notes; structured audience scoping is P1 (BI-3CDEC5F0)."
+        : "Add intended audience in notes if not global (e.g. US-based employees only)."),
+    data: {
+      id: record.id,
+      policyId: record.policyId,
+      lifecycleStatus: record.lifecycleStatus,
+      reviewUrl: `/compliance/policies/${record.id}`,
+      createdByUserId: userId,
+      agentId: context?.agentId ?? null,
+    },
+  };
+}
+
+async function updatePolicyHandler(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const { prisma } = await import("@dpf/db");
+  const policyKey = String(params["policyId"] ?? "").trim();
+  if (!policyKey) {
+    return {
+      success: false,
+      error: "invalid_params",
+      message: "policyId is required.",
+    };
+  }
+  const existing = await resolvePolicy(policyKey);
+  if (!existing) {
+    return {
+      success: false,
+      error: "not_found",
+      message: `No policy found for ${policyKey}.`,
+    };
+  }
+  if (
+    existing.lifecycleStatus !== "draft" &&
+    existing.lifecycleStatus !== "in-review"
+  ) {
+    return {
+      success: false,
+      error: "invalid_state",
+      message: `Cannot update policy in lifecycleStatus=${existing.lifecycleStatus}. Only draft or in-review may be edited by coworkers; published policies need human revision.`,
+    };
+  }
+
+  if (params["category"] !== undefined) {
+    const cat = String(params["category"]).trim();
+    const err = validatePolicyInput({
+      title: existing.title,
+      category: cat,
+    });
+    if (err) {
+      return { success: false, error: "invalid_params", message: err };
+    }
+  }
+
+  const updated = await prisma.policy.update({
+    where: { id: existing.id },
+    data: {
+      ...(params["title"] !== undefined && {
+        title: String(params["title"]).trim(),
+      }),
+      ...(params["body"] !== undefined && { body: String(params["body"]) }),
+      ...(params["description"] !== undefined && {
+        description: String(params["description"]),
+      }),
+      ...(params["notes"] !== undefined && { notes: String(params["notes"]) }),
+      ...(params["category"] !== undefined && {
+        category: String(params["category"]).trim(),
+      }),
+      ...(params["reviewFrequency"] !== undefined && {
+        reviewFrequency: String(params["reviewFrequency"]),
+      }),
+      ...(context?.agentId && !existing.agentId
+        ? { agentId: context.agentId }
+        : {}),
+    },
+  });
+
+  return {
+    success: true,
+    entityId: updated.policyId,
+    message: `Updated ${updated.policyId} [${updated.lifecycleStatus}]. Review: /compliance/policies/${updated.id}`,
+    data: {
+      id: updated.id,
+      policyId: updated.policyId,
+      lifecycleStatus: updated.lifecycleStatus,
+      reviewUrl: `/compliance/policies/${updated.id}`,
+    },
+  };
+}
+
+async function requestPolicyReviewHandler(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { prisma } = await import("@dpf/db");
+  const policyKey = String(params["policyId"] ?? "").trim();
+  if (!policyKey) {
+    return {
+      success: false,
+      error: "invalid_params",
+      message: "policyId is required.",
+    };
+  }
+  const existing = await resolvePolicy(policyKey);
+  if (!existing) {
+    return {
+      success: false,
+      error: "not_found",
+      message: `No policy found for ${policyKey}.`,
+    };
+  }
+  if (!isValidTransition(existing.lifecycleStatus, "in-review")) {
+    return {
+      success: false,
+      error: "invalid_state",
+      message: `Cannot move ${existing.policyId} from ${existing.lifecycleStatus} to in-review.`,
+    };
+  }
+
+  const updated = await prisma.policy.update({
+    where: { id: existing.id },
+    data: { lifecycleStatus: "in-review" },
+  });
+
+  return {
+    success: true,
+    entityId: updated.policyId,
+    message:
+      `${updated.policyId} is now in-review. A human can approve and publish at ` +
+      `/compliance/policies/${updated.id}. Coworkers cannot publish.`,
+    data: {
+      id: updated.id,
+      policyId: updated.policyId,
+      lifecycleStatus: updated.lifecycleStatus,
+      reviewUrl: `/compliance/policies/${updated.id}`,
+    },
+  };
+}
+
+const handlers: Record<string, ToolPackHandler> = {
+  list_policies: (params) => listPoliciesHandler(params),
+  get_policy: (params) => getPolicyHandler(params),
+  create_policy: (params, userId, ctx) =>
+    createPolicyHandler(params, userId, ctx),
+  update_policy: (params, userId, ctx) =>
+    updatePolicyHandler(params, userId, ctx),
+  request_policy_review: (params) => requestPolicyReviewHandler(params),
+};
+
+export const policyPack: ToolPack = {
+  packId: "policy",
+  definitions,
+  handlers,
+  grants: {
+    list_policies: ["policy_read"],
+    get_policy: ["policy_read"],
+    create_policy: ["policy_write"],
+    update_policy: ["policy_write"],
+    request_policy_review: ["policy_write"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -537,6 +537,12 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   create_employee: ["consumer_write"],
   transition_employee_status: ["consumer_write"],
   propose_leave_policy: ["policy_write"],
+  // BI-3CDEC5F0: company/compliance Policy draft lifecycle for coworkers
+  list_policies: ["policy_read"],
+  get_policy: ["policy_read"],
+  create_policy: ["policy_write"],
+  update_policy: ["policy_write"],
+  request_policy_review: ["policy_write"],
 
   // Feedback
   submit_feedback: ["backlog_write"],

--- a/docs/superpowers/specs/2026-08-04-coworker-policy-draft-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-08-04-coworker-policy-draft-lifecycle-design.md
@@ -1,0 +1,73 @@
+# Coworker Policy Draft Lifecycle & Audience Scoping — Design
+
+| Field | Value |
+|-------|-------|
+| **BI** | BI-3CDEC5F0 |
+| **Date** | 2026-08-04 |
+| **Epic** | EP-COWORKER-INTERACTIVITY |
+| **Founder trigger** | HR coworker drafted a US HR policy in chat only; no system document |
+
+## Problem
+
+Coworkers can author policy text in conversation but cannot create **governed Policy** rows for human review. `/compliance/policies` already supports draft→in-review→approved→published for humans. HR specialist lacks tools and grants. Audience (e.g. US employees only) is not modeled on Policy.
+
+## Research / substrate (verified)
+
+| Surface | Status |
+|---------|--------|
+| `Policy` model | lifecycleStatus default `draft`; category includes `hr`; agentId optional |
+| Server actions | `createPolicy` / `updatePolicy` / `transitionPolicyStatus` — human `requireManageCompliance` only |
+| Lifecycle | draft → in-review → approved → published → retired (`lib/govern/policy-types.ts`) |
+| hr-specialist grants | runtime map in `workforce-seed.ts`: registry/consumer only — **no policy_*** |
+| policy-specialist | has policy_read/write in agent_registry but **no MCP Policy tools** |
+| Adjacent tools | knowledge article, doc_save, propose_leave_policy (wrong product) |
+
+## Decisions
+
+1. **Canonical store = `Policy`**, not knowledge articles or generic docs, for company HR/compliance policies.
+2. **Coworker create always draft** — never auto-publish.
+3. **Publish is HITL** — coworker may `request_policy_review` (draft→in-review); human (or approved proposal later) publishes.
+4. **Audience is P1** — ship P0 tools first; add jurisdiction/audience fields next so US-only policies do not noise non-US employees.
+5. **Grants** — `policy_read` / `policy_write` on hr-specialist (and keep policy-specialist).
+
+## Phases
+
+### P0 — Tools + grants (this branch)
+
+MCP tools (policy pack):
+
+| Tool | Effect | Grant |
+|------|--------|-------|
+| `list_policies` | List active policies (optional filters) | policy_read |
+| `get_policy` | Fetch one by policyId or id | policy_read |
+| `create_policy` | Create **draft** Policy (category, title, body, …) | policy_write |
+| `update_policy` | Update fields when lifecycle is draft or in-review | policy_write |
+| `request_policy_review` | draft → in-review only | policy_write |
+
+UI path unchanged for human edit/publish. `agentId` set from tool context when present.
+
+### P1 — Audience
+
+- Migration: closed applicability JSON or typed fields (jurisdiction basis + codes).
+- Employee-facing filter by employment country/work location.
+- Tool params for audience on create/update.
+
+### P2 — Publish polish
+
+- Ack/notify only in-audience; optional proposal-mode publish for coworkers.
+
+## Non-goals
+
+- Auto-publish employment policies without human.
+- Replacing GRC obligations or leave-policy tools.
+
+## Acceptance (P0)
+
+- [ ] HR coworker creates draft via tool; visible on `/compliance/policies` as draft.
+- [ ] Denied without policy_write.
+- [ ] Human can edit and publish via existing lifecycle UI.
+- [ ] Unit tests for pack + grants.
+
+## Follow-on BI
+
+P1/P2 may stay on BI-3CDEC5F0 or split after P0 ships.

--- a/docs/user-guide/compliance/policies-and-acknowledgements.md
+++ b/docs/user-guide/compliance/policies-and-acknowledgements.md
@@ -31,6 +31,20 @@ as a new version; that increments the version and clears the prior approval,
 publication, and retirement timestamps. A published policy must be retired
 before a new draft cycle.
 
+## Ask A Coworker To Draft One
+
+You can ask a coworker, such as the HR specialist, to write a policy for you.
+The coworker creates it as a **draft** and tells you where to review it. It can
+also edit its own draft and move it to in-review when the content is ready.
+
+A coworker cannot approve, publish, or retire a policy. Those steps stay with a
+person on `/compliance/policies`, so a drafted policy is a proposal, not an
+active rule. Read the draft before you approve it: the coworker wrote the
+words, and you own what the policy says.
+
+Audience is not yet a structured field. If a policy applies to part of your
+workforce, say so in the notes and check the scope yourself before you publish.
+
 ## Publish A Policy
 
 1. Define the title, category, owner, body or file reference, effective date,

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2875,7 +2875,10 @@
           "backlog_read",
           "backlog_write",
           "consumer_read",
+          "consumer_write",
           "registry_read",
+          "policy_read",
+          "policy_write",
           "web_search"
         ]
       }

--- a/packages/db/src/coworker-grant-consistency.ts
+++ b/packages/db/src/coworker-grant-consistency.ts
@@ -73,7 +73,8 @@ export const KNOWN_GRANT_DIVERGENCES: readonly string[] = [
   "ea-architect",
   "external-catalog-scout",
   "finance-controller",
-  "hr-specialist",
+  // hr-specialist was reconciled (BI-3CDEC5F0): the seed and agent_registry now
+  // carry the identical grant set, so it is no longer a tracked divergence.
   "inventory-specialist",
   "legal-operations-counsel",
   "marketing-specialist",

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -304,7 +304,18 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
   // graph/architecture reads — a prime case for programmatic filtering in the
   // sandbox (the script's JWT is read-only-scoped regardless of these grants).
   "ea-architect": ["ea_graph_read", "ea_graph_write", "architecture_read", "file_read", "registry_read", "tool_script_exec"],
-  "hr-specialist": ["registry_read", "consumer_read", "consumer_write"],
+  // BI-3CDEC5F0: policy_read/write so HR can draft company policies into Policy
+  // (not chat-only). Publish remains human HITL on /compliance/policies.
+  "hr-specialist": [
+    "registry_read",
+    "consumer_read",
+    "consumer_write",
+    "policy_read",
+    "policy_write",
+    "backlog_read",
+    "backlog_write",
+    "web_search",
+  ],
   // The Customer Success Manager operates the CRM (accounts, pipeline, quotes),
   // so it needs crm_read/crm_write — NOT backlog_write (which let it retire live
   // backlog items while flailing) or marketing_read (wrong domain). Its runtime

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -53,7 +53,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
-apps/web/lib/tak/agent-grants.ts	907
+apps/web/lib/tak/agent-grants.ts	913
 apps/web/lib/tak/agent-routing.ts	1027
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,14 +3,14 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 355,
-      "reason": "Adds record_compliance_scope (BI-0B867B67 phase 3): the compliance coworker captures what the business does with data / where it employs people into BusinessContext, moving matching regulations from needs-review to applies. Earns a permanent place \u2014 it is the conversational half of the setup-form capture and the only tool that writes the applicability-triggering profile; authority stays data_governance_validate-gated.",
-      "recordedAt": "2026-08-04"
+      "value": 360,
+      "reason": "Adds the five Policy draft-lifecycle tools (BI-3CDEC5F0): list_policies, get_policy, create_policy, update_policy, request_policy_review. Earns a permanent place \u2014 before them a coworker asked to write a company policy could only emit prose into chat, leaving no governed Policy row for anyone to review or publish; these are the only tools that write the Policy store, and they are deliberately publish-incapable so the human lifecycle action on /compliance/policies stays the sole publisher. list/get precede write so a coworker discriminates against existing policies instead of duplicating them; update and request_policy_review are distinct because one edits content and the other moves lifecycle state, and collapsing them would let an edit silently advance a policy toward publication.",
+      "recordedAt": "2026-08-05"
     },
     "registry.packFiles": {
-      "value": 83,
-      "reason": "Adds compliance-scope-pack (BI-0B867B67 phase 3) hosting record_compliance_scope in its own scoped pack per the pack-registry convention (one capability domain per pack), rather than bloating an unrelated pack. Permanent: it is the compliance coworkers capture surface.",
-      "recordedAt": "2026-08-04"
+      "value": 84,
+      "reason": "Adds policy-pack (BI-3CDEC5F0) hosting the Policy draft lifecycle in its own scoped pack per the pack-registry convention (one capability domain per pack) rather than bloating compliance-scope-pack or the HR pack \u2014 Policy is its own governed store with its own lifecycle and its own policy_read/policy_write grants. Permanent: it is the coworker-facing half of the /compliance/policies surface.",
+      "recordedAt": "2026-08-05"
     },
     "tier.coreToolNames": {
       "value": 29,


### PR DESCRIPTION
## Summary
**BI-3CDEC5F0 P0** — the HR coworker was writing policies only in chat; no system document.

### Gaps fixed
- MCP tools: `list_policies`, `get_policy`, `create_policy` (always **draft**), `update_policy` (draft/in-review only), `request_policy_review` (draft→in-review). None can publish — publication stays a human lifecycle action on `/compliance/policies`.
- **hr-specialist** gains `policy_read` + `policy_write` (workforce-seed runtime map + agent_registry)
- Design: `docs/superpowers/specs/2026-08-04-coworker-policy-draft-lifecycle-design.md`

### Picked up after the PR was orphaned
Every red check is resolved and the branch is rebased onto current `main`:

| Failure | Cause | Resolution |
| --- | --- | --- |
| Unit Tests (web 1/4) | `create_policy` description carried `(BI-3CDEC5F0 P1)` — tool-description-hygiene P5/G4 | provenance moved into a code comment |
| Unit Tests (packages) | `hr-specialist` was still in `KNOWN_GRANT_DIVERGENCES` after this PR reconciled seed vs `agent_registry` | removed from the tracked set (the ratchet's intended direction) |
| Policy Guards (source) | Tool Surface + Module Size baselines | raised with substantive reasons: 355→360 tools, 83→84 packs; `agent-grants.ts` 887→893 |
| Policy Guards (PR) | missing Seed-Fit + Design-Grounding decisions | trailers below |
| UX Route Sweep | base drift — `/platform/audit/authority` rendered every tool description (3443w) until #4000 made it a searchable inspector (256w) | gone after rebase |

Also fixed a defect found while reviewing the pickup: `create_policy` used `notes.includes("us")`, so notes saying "applies to the whole business" came back claiming a US audience had been captured. Now a word-boundary match, with a regression test in both directions.

### P1 (follow-on)
Structured audience/jurisdiction scoping for policies.

### Tests
- [x] `policy-pack.test.ts` (7), `tool-description-hygiene`, `agent-grants` — 144 passing
- [x] `apps/web/lib/mcp` + `lib/tak` suites — 2334 passing
- [x] `packages/db` `coworker-grant-consistency` — passing
- [x] typecheck clean for `apps/web` and `packages/db`
- [x] Repo Guard Loop (24 guards) and pregate preflight (34 guards) clean

## Design grounding
- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-08-04-coworker-policy-draft-lifecycle-design.md`
- Current code substrate reviewed:
  - `apps/web/lib/mcp/packs/`, `apps/web/lib/mcp/pack-registry.ts`, `apps/web/lib/tak/agent-grants.ts`, `apps/web/lib/govern/policy-types.ts`, `packages/db/src/workforce-seed.ts`, `apps/web/app/(shell)/compliance/policies/`
- Source of truth:
  - the design doc above; `policy-types.ts` remains authoritative for lifecycle transitions
- Decision:
  - extend the existing spec — a new scoped pack per the one-capability-domain-per-pack convention; no routing or contract change beyond the guard baselines

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-08-04-coworker-policy-draft-lifecycle-design.md and the live substrate (apps/web/lib/mcp/packs, apps/web/lib/tak/agent-grants.ts, packages/db/src/workforce-seed.ts); source of truth is that design doc; extends it with a scoped pack, no contract or routing change.
Seed-Fit-Decision: global-default

Local-CI-Override: external-contribution-no-install — source-only harness worktree (bootstrap-worktree-deps reports dependency_resolution_failed), and the shared local-CI sandbox lease was contended: the runner was killed on four attempts. Verified standalone instead — pregate preflight (34 guards) clean, Repo Guard Loop (24 guards) clean, `tsc --noEmit` clean for apps/web and packages/db, and the affected vitest suites green.
