### PR TITLE
feat(ux-audit): wire real evaluators and run the first portal survey (BI-C3768478)

### DIFF
--- a/apps/web/lib/mcp/packs/public-web-design-pack.ts
+++ b/apps/web/lib/mcp/packs/public-web-design-pack.ts
@@ -442,14 +442,21 @@ async function evaluatePageHandler(
       signal: AbortSignal.timeout(10000),
     });
 
-    // Parse findings — the AI extraction returns structured data
-    let findings: Array<Record<string, unknown>> = [];
-    try {
-      const rawData = typeof evalContent.data === "string" ? JSON.parse(evalContent.data) : evalContent.data;
-      findings = Array.isArray(rawData) ? rawData : [];
-    } catch {
-      findings = [];
+    // Parse findings — the AI extraction returns structured data.
+    // An unreadable payload is a NOT-RUN, never an empty findings list: a failed
+    // extraction otherwise reports as "0 UX/accessibility issues", i.e. a clean
+    // page (BI-C3768478, extending the BI-1BAA177C contract above).
+    const { interpretExtraction } = await import("@/lib/tak/page-evaluator");
+    const outcome = interpretExtraction(evalContent.data);
+    if (outcome.kind === "not-run") {
+      return {
+        success: false,
+        error: `Page evaluation DEGRADED — did not run: ${outcome.reason}`,
+        message: `Page evaluation did not run: ${outcome.reason}. This is a NOT-RUN, not a zero-findings result.`,
+        data: { url: targetUrl, degraded: true, reason: outcome.reason },
+      };
     }
+    const findings = outcome.raw;
 
     // Visual cognitive-load assessment — feed the rendered screenshot to a
     // vision-capable model (capability-routed; local Gemma 4 when configured)

--- a/apps/web/lib/tak/page-evaluator.test.ts
+++ b/apps/web/lib/tak/page-evaluator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   categorizeAxeViolation,
   groupFindingsByCategory,
+  interpretExtraction,
   type UxFinding,
 } from "./page-evaluator";
 
@@ -59,5 +60,46 @@ describe("groupFindingsByCategory", () => {
   it("returns empty object for empty findings", () => {
     const grouped = groupFindingsByCategory([]);
     expect(Object.keys(grouped)).toHaveLength(0);
+  });
+});
+
+describe("interpretExtraction", () => {
+  it("reads a JSON findings array", () => {
+    const outcome = interpretExtraction('[{"severity":"minor","issue":"x"}]');
+    expect(outcome.kind).toBe("findings");
+    expect(outcome.kind === "findings" && outcome.raw).toHaveLength(1);
+  });
+
+  it("treats an empty findings array as a legitimately clean page", () => {
+    expect(interpretExtraction("[]")).toEqual({ kind: "findings", raw: [] });
+    expect(interpretExtraction([])).toEqual({ kind: "findings", raw: [] });
+  });
+
+  it("unwraps a { findings: [...] } envelope", () => {
+    const outcome = interpretExtraction({ findings: [{ issue: "x" }] });
+    expect(outcome.kind === "findings" && outcome.raw).toHaveLength(1);
+  });
+
+  it("reports an empty AgentHistoryList as NOT-RUN, never a clean page", () => {
+    const outcome = interpretExtraction(
+      "AgentHistoryList(all_results=[], all_model_outputs=[])",
+    );
+    expect(outcome.kind).toBe("not-run");
+    expect(outcome.kind === "not-run" && outcome.reason).toContain("no model output");
+  });
+
+  it("reports a non-JSON payload as NOT-RUN", () => {
+    const outcome = interpretExtraction("the agent could not read the page");
+    expect(outcome.kind).toBe("not-run");
+  });
+
+  it("reports missing or empty payloads as NOT-RUN", () => {
+    expect(interpretExtraction(null).kind).toBe("not-run");
+    expect(interpretExtraction(undefined).kind).toBe("not-run");
+    expect(interpretExtraction("   ").kind).toBe("not-run");
+  });
+
+  it("reports a non-array JSON payload as NOT-RUN", () => {
+    expect(interpretExtraction('{"status":"ok"}').kind).toBe("not-run");
   });
 });

--- a/apps/web/lib/tak/page-evaluator.ts
+++ b/apps/web/lib/tak/page-evaluator.ts
@@ -72,6 +72,74 @@ export function categorizeAxeViolation(violation: AxeViolation): UxFinding {
   };
 }
 
+/**
+ * What a browser-use extraction actually produced (BI-C3768478, extending the
+ * BI-1BAA177C NOT-RUN contract).
+ *
+ * `browse_extract` answers HTTP 200 with `status: "completed"` even when its
+ * agent failed every step — the payload is then the repr of an empty history,
+ * `AgentHistoryList(all_results=[], all_model_outputs=[])`. Read naively that
+ * becomes "0 findings", i.e. a clean page, which is the single most dangerous
+ * thing a UX auditor can report. Observed on-machine 2026-08-04: the sidecar's
+ * pinned LLM was absent from the model runner, so every extraction returned that
+ * empty history and `evaluate_page` announced "Found 0 UX/accessibility issues".
+ *
+ * A clean page and a run that never happened are different answers. This is the
+ * one place that tells them apart.
+ */
+export type ExtractionOutcome =
+  | { kind: "findings"; raw: Array<Record<string, unknown>> }
+  | { kind: "not-run"; reason: string };
+
+const EMPTY_AGENT_HISTORY = /AgentHistoryList\(\s*all_results\s*=\s*\[\s*\]/;
+
+export function interpretExtraction(data: unknown): ExtractionOutcome {
+  if (data === null || data === undefined) {
+    return { kind: "not-run", reason: "the browser agent returned no extraction payload" };
+  }
+
+  let value: unknown = data;
+
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (!text) {
+      return { kind: "not-run", reason: "the browser agent returned an empty extraction payload" };
+    }
+    if (EMPTY_AGENT_HISTORY.test(text)) {
+      return {
+        kind: "not-run",
+        reason:
+          "the browser agent produced no model output (empty AgentHistoryList) — check the sidecar's LLM_MODEL is present on the configured endpoint",
+      };
+    }
+    try {
+      value = JSON.parse(text);
+    } catch {
+      return {
+        kind: "not-run",
+        reason: `the browser agent returned a non-JSON extraction payload: ${text.slice(0, 160)}`,
+      };
+    }
+  }
+
+  // A findings array is the contract. `[]` is a legitimately clean page.
+  if (Array.isArray(value)) {
+    return { kind: "findings", raw: value as Array<Record<string, unknown>> };
+  }
+
+  if (typeof value === "object" && Array.isArray((value as { findings?: unknown }).findings)) {
+    return {
+      kind: "findings",
+      raw: (value as { findings: Array<Record<string, unknown>> }).findings,
+    };
+  }
+
+  return {
+    kind: "not-run",
+    reason: "the browser agent's extraction payload was not a findings array",
+  };
+}
+
 export function groupFindingsByCategory(
   findings: UxFinding[],
 ): Record<string, UxFinding[]> {

--- a/apps/web/lib/ux-audit/button-decision-lens.test.ts
+++ b/apps/web/lib/ux-audit/button-decision-lens.test.ts
@@ -3,6 +3,7 @@ import {
   evaluateButtonDecision,
   expectedCarrier,
   isDecisionCloseout,
+  isInferenceFailureReply,
   type ButtonDecisionObservation,
 } from "./button-decision-lens";
 import { formatDecisionSentinel } from "@/lib/tak/decision-block";
@@ -136,5 +137,37 @@ describe("evaluateButtonDecision", () => {
     expect(findings).toHaveLength(1);
     expect(findings[0]!.severity).toBe("critical");
     expect(findings[0]!.issue).toContain("NOT-RUN");
+  });
+});
+
+describe("inference-failure replies are NOT-RUN, never a silent pass", () => {
+  it("detects the provider-busy notice", () => {
+    expect(
+      isInferenceFailureReply(
+        "The AI providers are momentarily busy (usually rate-limited or overloaded). Please try again in about 30 seconds.",
+      ),
+    ).toBe(true);
+    expect(isInferenceFailureReply("Here is the next step I recommend.")).toBe(false);
+  });
+
+  it("reports a critical NOT-RUN instead of passing silently", () => {
+    const findings = evaluateButtonDecision(
+      observation({
+        reply:
+          "The AI providers are momentarily busy (usually rate-limited or overloaded). Please try again in about 30 seconds — no setup change is needed.",
+        buttons: [],
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe("critical");
+    expect(findings[0]!.issue).toContain("NOT-RUN");
+  });
+
+  it("does not let a no-eligible-endpoints reply read as 'no decision offered'", () => {
+    const findings = evaluateButtonDecision(
+      observation({ reply: "All endpoints failed for this request.", buttons: [] }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe("critical");
   });
 });

--- a/apps/web/lib/ux-audit/button-decision-lens.test.ts
+++ b/apps/web/lib/ux-audit/button-decision-lens.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateButtonDecision,
+  expectedCarrier,
+  isDecisionCloseout,
+  type ButtonDecisionObservation,
+} from "./button-decision-lens";
+import { formatDecisionSentinel } from "@/lib/tak/decision-block";
+
+function observation(
+  overrides: Partial<ButtonDecisionObservation> = {},
+): ButtonDecisionObservation {
+  return {
+    route: "/workspace",
+    panelPresent: true,
+    reply: "I can take either path. Shall I break this into work items, or move to the next priority?",
+    buttons: [
+      { label: "Break this into work items", recommended: true },
+      { label: "Move to the next priority", recommended: false },
+    ],
+    ...overrides,
+  };
+}
+
+describe("isDecisionCloseout", () => {
+  it("recognizes an enumerated comma-or choice", () => {
+    expect(
+      isDecisionCloseout("Should I break this into work items, or move to the next priority?"),
+    ).toBe(true);
+  });
+
+  it("recognizes a bare proceed question", () => {
+    expect(isDecisionCloseout("That is everything I found. Shall I go ahead?")).toBe(true);
+  });
+
+  it("does not fire on a question buried mid-paragraph", () => {
+    expect(
+      isDecisionCloseout("You asked what changed? Three files moved. I have logged them all."),
+    ).toBe(false);
+  });
+
+  it("does not fire on empty text", () => {
+    expect(isDecisionCloseout("   ")).toBe(false);
+  });
+});
+
+describe("expectedCarrier", () => {
+  it("attributes a valid sentinel", () => {
+    const sentinel = formatDecisionSentinel({
+      options: [{ id: "go-0", label: "Go", value: "Go", kind: "answer", recommended: true }],
+      freeTextAllowed: true,
+    });
+    expect(expectedCarrier(`Ready when you are.${sentinel}`)).toBe("sentinel");
+  });
+
+  it("attributes a prose closeout to the fallback", () => {
+    expect(
+      expectedCarrier("Should I fix the render first, or prioritize the CLI saturation?"),
+    ).toBe("prose-fallback");
+  });
+
+  it("attributes plain prose to no carrier", () => {
+    expect(expectedCarrier("All three items are now closed.")).toBe("none");
+  });
+});
+
+describe("evaluateButtonDecision", () => {
+  it("passes when recommended-first buttons render", () => {
+    expect(evaluateButtonDecision(observation())).toEqual([]);
+  });
+
+  it("passes silently when the coworker did not close on a decision", () => {
+    const findings = evaluateButtonDecision(
+      observation({ reply: "All three items are now closed.", buttons: [] }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a decision closeout that rendered as free text", () => {
+    const findings = evaluateButtonDecision(observation({ buttons: [] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe("important");
+    expect(findings[0]!.issue).toContain("rendered no decision buttons");
+  });
+
+  it("flags buttons with no recommended option", () => {
+    const findings = evaluateButtonDecision(
+      observation({
+        buttons: [
+          { label: "Break this into work items", recommended: false },
+          { label: "Move to the next priority", recommended: false },
+        ],
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe("minor");
+    expect(findings[0]!.issue).toContain("none is marked recommended");
+  });
+
+  it("flags a recommended option that is not first", () => {
+    const findings = evaluateButtonDecision(
+      observation({
+        buttons: [
+          { label: "Move to the next priority", recommended: false },
+          { label: "Break this into work items", recommended: true },
+        ],
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.issue).toContain("position 2 of 2");
+  });
+
+  it("flags an unlabeled button as an accessible-name defect", () => {
+    const findings = evaluateButtonDecision(
+      observation({
+        buttons: [
+          { label: "Break this into work items", recommended: true },
+          { label: "  ", recommended: false },
+        ],
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.category).toBe("accessibility");
+    expect(findings[0]!.wcagRef).toBe("4.1.2 Name, Role, Value");
+  });
+
+  it("reports a missing panel as critical and stops", () => {
+    const findings = evaluateButtonDecision(observation({ panelPresent: false, buttons: [] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe("critical");
+    expect(findings[0]!.element).toBe('[data-agent-panel="true"]');
+  });
+
+  it("reports an empty reply as a NOT-RUN, never a pass", () => {
+    const findings = evaluateButtonDecision(observation({ reply: "", buttons: [] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.severity).toBe("critical");
+    expect(findings[0]!.issue).toContain("NOT-RUN");
+  });
+});

--- a/apps/web/lib/ux-audit/button-decision-lens.ts
+++ b/apps/web/lib/ux-audit/button-decision-lens.ts
@@ -49,6 +49,24 @@ export type ButtonDecisionObservation = {
 const FINDING_ELEMENT = '[data-testid="agent-decision"]';
 
 /**
+ * The user-facing messages the panel renders when inference never happened —
+ * provider saturation, routing failure, a degraded local engine.
+ *
+ * These matter because they are the silent-pass trap: such a reply is not a
+ * decision closeout, so the lens would emit NO finding and the route would read
+ * as "coworker offered no decision, nothing wrong". That is a NOT-RUN wearing a
+ * pass's clothes. Observed live 2026-08-04, when the local engine hit admission
+ * timeouts and the coworker answered "The AI providers are momentarily busy".
+ */
+const INFERENCE_FAILURE_RE =
+  /\b(AI providers are momentarily busy|rate.?limited or overloaded|no eligible endpoints|all endpoints failed|inference admission timeout|try again in about \d+ seconds|I cannot proceed|my tools are limited)\b/i;
+
+/** Did the panel render an inference-failure notice instead of a real turn? */
+export function isInferenceFailureReply(reply: string): boolean {
+  return INFERENCE_FAILURE_RE.test(reply);
+}
+
+/**
  * Does this reply END on a decision the human must answer? Two signals, both
  * conservative:
  *  - the deterministic prose fallback recognizes an enumerated choice, or
@@ -110,6 +128,18 @@ export function evaluateButtonDecision(
         "The coworker produced no visible reply, so the button-decision lens could not observe a closeout. This is a NOT-RUN, not a pass.",
       recommendation:
         "Check the coworker's model routing and tool grants for this route; the lens needs a completed turn to judge.",
+    });
+    return findings;
+  }
+
+  if (isInferenceFailureReply(reply)) {
+    findings.push({
+      severity: "critical",
+      category: "semantic-html",
+      element: '[data-agent-panel="true"]',
+      issue: `The coworker returned an inference-failure notice instead of a turn, so the button-decision lens could not observe a closeout. This is a NOT-RUN, not a pass. Reply: "${reply.slice(0, 160)}"`,
+      recommendation:
+        "Re-run the lens once inference is healthy. If it persists, check the route's model routing and the local engine's admission queue — a saturated engine makes every behavioral lens silently unmeasurable.",
     });
     return findings;
   }

--- a/apps/web/lib/ux-audit/button-decision-lens.ts
+++ b/apps/web/lib/ux-audit/button-decision-lens.ts
@@ -1,0 +1,173 @@
+// Coworker button-decision lens (EP-UX-AUDITOR Phase 2, BI-C3768478).
+//
+// This is the founder's standing requirement made executable: the coworker
+// button-decision interface (BI-3237B5D6) is validated as ONE LENS INSIDE a
+// comprehensive portal survey, not spot-checked in isolation. The Phase-1
+// orchestrator defines `BUTTON_DECISION_LENS`; this module is its verdict logic,
+// and the e2e runner supplies the live observation by driving a real coworker.
+//
+// Pure by construction — the browser half lives in the runner, so the rules that
+// decide pass/fail are unit-testable and identical whether the observation came
+// from Playwright, browser-use, or a replayed transcript.
+//
+// The rule the lens enforces (spec §5.3 + the decision-block contract):
+//   when a coworker's turn ENDS on a next-step decision, the human must get
+//   clickable, recommended-first buttons — not a free-text "type your reply".
+// Both carrier paths count as a pass: the HTML-comment sentinel AND the
+// deterministic prose fallback (`deriveDecisionFromProse`). The lens does not
+// care which produced the buttons; it cares that buttons rendered.
+
+import type { UxFinding } from "@/lib/tak/page-evaluator";
+import {
+  deriveDecisionFromProse,
+  parseDecisionFromContent,
+} from "@/lib/tak/decision-block";
+
+/** One rendered decision button as observed in the live DOM. */
+export type ObservedDecisionButton = {
+  label: string;
+  recommended: boolean;
+};
+
+/**
+ * What the runner observed after driving the coworker to a closeout. `reply` is
+ * the human-visible text of the coworker's last message (the sentinel is already
+ * stripped by the renderer, exactly as a human sees it).
+ */
+export type ButtonDecisionObservation = {
+  route: string;
+  /** Whether the coworker panel was reachable at all. */
+  panelPresent: boolean;
+  /** Last assistant message text, as rendered. */
+  reply: string;
+  /** Buttons in DOM order — the order the human reads them. */
+  buttons: ObservedDecisionButton[];
+  /** Which carrier the runner attributed the buttons to, when known. */
+  carrier?: "sentinel" | "prose-fallback" | "none";
+};
+
+const FINDING_ELEMENT = '[data-testid="agent-decision"]';
+
+/**
+ * Does this reply END on a decision the human must answer? Two signals, both
+ * conservative:
+ *  - the deterministic prose fallback recognizes an enumerated choice, or
+ *  - the reply closes on a direct question (the proceed-case: "Shall I go ahead?").
+ * A reply that merely CONTAINS a question mark mid-paragraph does not count —
+ * a wrong finding is worse than no finding, same guard as the fallback itself.
+ */
+export function isDecisionCloseout(reply: string): boolean {
+  const trimmed = reply.trim();
+  if (!trimmed) return false;
+  if (deriveDecisionFromProse(trimmed)) return true;
+  return /\?\s*$/.test(trimmed);
+}
+
+/**
+ * Classify which carrier SHOULD have produced buttons for this reply. Used to
+ * attribute a miss precisely: a sentinel that never rendered is a different
+ * defect from a prose closeout the fallback failed to recover.
+ */
+export function expectedCarrier(rawReply: string): "sentinel" | "prose-fallback" | "none" {
+  if (rawReply.includes("dpf-decision")) {
+    const { decision } = parseDecisionFromContent(rawReply);
+    if (decision) return "sentinel";
+  }
+  if (deriveDecisionFromProse(rawReply)) return "prose-fallback";
+  return "none";
+}
+
+/**
+ * Evaluate one live observation into findings. Empty array = the lens passed:
+ * the coworker closed on a decision and recommended-first buttons rendered.
+ */
+export function evaluateButtonDecision(
+  observation: ButtonDecisionObservation,
+): UxFinding[] {
+  const findings: UxFinding[] = [];
+
+  if (!observation.panelPresent) {
+    findings.push({
+      severity: "critical",
+      category: "semantic-html",
+      element: '[data-agent-panel="true"]',
+      issue:
+        "No AI-coworker panel was reachable on this route, so the human has no way to ask for or answer a next-step decision.",
+      recommendation:
+        "Mount the coworker panel on this route, or remove the route from the coworker-bearing set the survey plans behavioral lenses for.",
+    });
+    return findings;
+  }
+
+  const reply = observation.reply.trim();
+
+  if (!reply) {
+    findings.push({
+      severity: "critical",
+      category: "semantic-html",
+      element: '[data-agent-panel="true"]',
+      issue:
+        "The coworker produced no visible reply, so the button-decision lens could not observe a closeout. This is a NOT-RUN, not a pass.",
+      recommendation:
+        "Check the coworker's model routing and tool grants for this route; the lens needs a completed turn to judge.",
+    });
+    return findings;
+  }
+
+  const closeout = isDecisionCloseout(reply);
+  const buttons = observation.buttons;
+
+  if (buttons.length === 0) {
+    if (!closeout) return findings; // No decision was offered — nothing to render.
+
+    findings.push({
+      severity: "important",
+      category: "semantic-html",
+      element: FINDING_ELEMENT,
+      issue:
+        "The coworker ended its turn on a next-step decision but rendered no decision buttons — the human must retype the answer as free text.",
+      recommendation:
+        "Emit the <!--dpf-decision:...--> sentinel on decision closeouts. If the model omits it, the deterministic prose fallback (deriveDecisionFromProse) should recover the options; extend it for this closeout shape.",
+    });
+    return findings;
+  }
+
+  // Buttons rendered — now judge their SHAPE. Recommended-first is the contract:
+  // the primary action must be the one the human reads first.
+  const recommendedIndex = buttons.findIndex((b) => b.recommended);
+
+  if (recommendedIndex === -1) {
+    findings.push({
+      severity: "minor",
+      category: "semantic-html",
+      element: FINDING_ELEMENT,
+      issue: `${buttons.length} decision buttons rendered but none is marked recommended, so no option carries primary emphasis.`,
+      recommendation:
+        "Mark exactly one option `recommended: true` so it renders as the accent-tinted primary button.",
+    });
+  } else if (recommendedIndex > 0) {
+    findings.push({
+      severity: "minor",
+      category: "semantic-html",
+      element: FINDING_ELEMENT,
+      issue: `The recommended option renders in position ${recommendedIndex + 1} of ${buttons.length}; the recommendation is not what the human reads first.`,
+      recommendation:
+        "Order the options so the recommended one is first — the button-decision contract is recommended-FIRST, not merely recommended-somewhere.",
+    });
+  }
+
+  const unlabeled = buttons.filter((b) => !b.label.trim()).length;
+  if (unlabeled > 0) {
+    findings.push({
+      severity: "important",
+      category: "accessibility",
+      element: FINDING_ELEMENT,
+      issue: `${unlabeled} decision button(s) rendered with no accessible label.`,
+      recommendation:
+        "Every decision option needs a non-empty label — it is both the button text and its accessible name (WCAG 4.1.2).",
+      wcagRef: "4.1.2 Name, Role, Value",
+    });
+  }
+
+  return findings;
+}

--- a/apps/web/lib/ux-audit/dpf-mcp-client.test.ts
+++ b/apps/web/lib/ux-audit/dpf-mcp-client.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { expandEnvPlaceholders, resolveDpfMcpConfig } from "./dpf-mcp-client";
+
+const MCP_JSON = JSON.stringify({
+  mcpServers: {
+    dpf: {
+      url: "http://127.0.0.1:3000/api/mcp/v1",
+      headers: { Authorization: "Bearer ${DPF_MCP_BEARER_TOKEN}" },
+    },
+  },
+});
+
+async function writeConfig(contents: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "dpf-mcp-"));
+  const path = join(dir, ".mcp.json");
+  await writeFile(path, contents, "utf8");
+  return path;
+}
+
+describe("expandEnvPlaceholders", () => {
+  it("substitutes known variables and leaves unknown ones intact", () => {
+    expect(expandEnvPlaceholders("Bearer ${TOK}", { TOK: "abc" })).toBe("Bearer abc");
+    expect(expandEnvPlaceholders("Bearer ${TOK}", {})).toBe("Bearer ${TOK}");
+  });
+});
+
+describe("resolveDpfMcpConfig", () => {
+  it("expands the committed placeholder from the environment", async () => {
+    const path = await writeConfig(MCP_JSON);
+    await expect(resolveDpfMcpConfig(path, { DPF_MCP_BEARER_TOKEN: "tok-123" })).resolves.toEqual({
+      url: "http://127.0.0.1:3000/api/mcp/v1",
+      authorization: "Bearer tok-123",
+    });
+  });
+
+  it("returns null rather than sending an unexpanded placeholder", async () => {
+    const path = await writeConfig(MCP_JSON);
+    await expect(resolveDpfMcpConfig(path, {})).resolves.toBeNull();
+  });
+
+  it("accepts a bare token and adds the Bearer prefix", async () => {
+    const path = await writeConfig(MCP_JSON);
+    const config = await resolveDpfMcpConfig(path, { DPF_MCP_TOKEN: "raw-token" });
+    expect(config?.authorization).toBe("Bearer raw-token");
+  });
+
+  it("lets an explicit env URL override the file", async () => {
+    const path = await writeConfig(MCP_JSON);
+    const config = await resolveDpfMcpConfig(path, {
+      DPF_MCP_URL: "http://elsewhere/api/mcp/v1",
+      DPF_MCP_BEARER_TOKEN: "tok",
+    });
+    expect(config?.url).toBe("http://elsewhere/api/mcp/v1");
+  });
+
+  it("resolves from env alone when no config file exists", async () => {
+    await expect(
+      resolveDpfMcpConfig("/definitely/missing/.mcp.json", {
+        DPF_MCP_URL: "http://127.0.0.1:3000/api/mcp/v1",
+        DPF_MCP_BEARER_TOKEN: "tok",
+      }),
+    ).resolves.toEqual({
+      url: "http://127.0.0.1:3000/api/mcp/v1",
+      authorization: "Bearer tok",
+    });
+  });
+
+  it("returns null when the file is malformed and env is empty", async () => {
+    const path = await writeConfig("{ not json");
+    await expect(resolveDpfMcpConfig(path, {})).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/ux-audit/dpf-mcp-client.ts
+++ b/apps/web/lib/ux-audit/dpf-mcp-client.ts
@@ -1,0 +1,142 @@
+// Minimal DPF MCP caller for out-of-process harnesses (EP-UX-AUDITOR Phase 2).
+//
+// The UX auditor runs OUTSIDE the Next.js server (a Playwright-driven runner), so
+// it reaches governed tools the same way any other MCP client does: an HTTP
+// tools/call against the DPF MCP endpoint. That keeps the auditor on the governed
+// tool path — grants, capability checks and audit records all still apply —
+// instead of re-implementing `evaluate_page`'s browser-use protocol or
+// `record_functional_failure_evidence`'s backlog dedup.
+//
+// Config resolution matches the pre-existing e2e evidence fixture (which now
+// shares this module): explicit env first, then the repo's .mcp.json.
+
+import { readFile } from "node:fs/promises";
+
+export type DpfMcpConfig = { url: string; authorization: string };
+
+/**
+ * Expand `${VAR}` placeholders against an environment map. The repo's committed
+ * .mcp.json stores the bearer as the literal string `Bearer ${DPF_MCP_BEARER_TOKEN}`
+ * — MCP clients expand it, a raw fetch does not. Expanding here is what keeps a
+ * plain HTTP caller from sending the placeholder and getting a 401.
+ */
+export function expandEnvPlaceholders(
+  value: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name: string) => env[name] ?? match);
+}
+
+function bearer(token: string): string {
+  return token.startsWith("Bearer ") ? token : `Bearer ${token}`;
+}
+
+/**
+ * Resolve MCP endpoint + bearer. Explicit env wins per field; the repo's
+ * .mcp.json supplies whatever env does not, with `${VAR}` placeholders expanded.
+ * Active standard is DPF_MCP_BEARER_TOKEN; DPF_MCP_TOKEN stays for back-compat
+ * (BI-14E9F7CE). Returns null when the bearer cannot be resolved to a real value
+ * — an unexpanded placeholder counts as unresolved, not as a token.
+ */
+export async function resolveDpfMcpConfig(
+  mcpJsonPath = ".mcp.json",
+  env: Record<string, string | undefined> = process.env,
+): Promise<DpfMcpConfig | null> {
+  const raw = await readFile(mcpJsonPath, "utf8").catch(() => null);
+
+  let fileUrl: string | undefined;
+  let fileAuth: string | undefined;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as {
+        mcpServers?: { dpf?: { url?: string; headers?: { Authorization?: string } } };
+      };
+      fileUrl = parsed.mcpServers?.dpf?.url;
+      fileAuth = parsed.mcpServers?.dpf?.headers?.Authorization;
+    } catch {
+      // Malformed config — fall through to env-only resolution.
+    }
+  }
+
+  const envToken = env.DPF_MCP_BEARER_TOKEN ?? env.DPF_MCP_TOKEN;
+  const authorization = envToken
+    ? bearer(envToken)
+    : fileAuth
+      ? expandEnvPlaceholders(fileAuth, env)
+      : undefined;
+
+  if (!authorization || authorization.includes("${")) return null;
+
+  const url = env.DPF_MCP_URL ?? (fileUrl ? expandEnvPlaceholders(fileUrl, env) : undefined);
+  if (!url || url.includes("${")) return null;
+
+  return { url, authorization };
+}
+
+type McpCallResponse = {
+  result?: {
+    isError?: boolean;
+    content?: Array<{ text?: string }>;
+  };
+  error?: { message?: string };
+};
+
+/**
+ * The parsed payload of a tools/call: the tool's JSON body when its first content
+ * block is JSON, plus the raw text so callers can report a non-JSON response
+ * verbatim rather than swallowing it.
+ */
+export type DpfMcpToolResult = {
+  isError: boolean;
+  text: string;
+  data: unknown;
+};
+
+/**
+ * Invoke a DPF MCP tool. Throws on transport/protocol failure so a caller inside
+ * `runSurvey` degrades that route to an honest error entry — never to a
+ * success-shaped empty result (the NOT-RUN vs clean-page distinction, BI-1BAA177C).
+ */
+export async function callDpfMcpTool(
+  config: DpfMcpConfig,
+  name: string,
+  args: Record<string, unknown>,
+  opts: { id?: string; timeoutMs?: number } = {},
+): Promise<DpfMcpToolResult> {
+  const response = await fetch(config.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: config.authorization,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: opts.id ?? `ux-audit-${name}`,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+    signal: AbortSignal.timeout(opts.timeoutMs ?? 180_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP ${name} failed with HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as McpCallResponse;
+  if (payload.error) {
+    throw new Error(`MCP ${name} error: ${payload.error.message ?? "unknown"}`);
+  }
+
+  const text = payload.result?.content?.[0]?.text ?? "";
+  let data: unknown = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      // Not JSON — keep the raw text; callers decide whether that is fatal.
+      data = null;
+    }
+  }
+
+  return { isError: payload.result?.isError === true, text, data };
+}

--- a/apps/web/lib/ux-audit/page-lens.test.ts
+++ b/apps/web/lib/ux-audit/page-lens.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  cognitiveLoadFinding,
+  normalizeEvaluatePageResult,
+  normalizeRawFinding,
+  COGNITIVE_LOAD_IMPORTANT_THRESHOLD,
+  COGNITIVE_LOAD_MINOR_THRESHOLD,
+} from "./page-lens";
+
+describe("normalizeRawFinding", () => {
+  it("keeps a well-formed finding intact", () => {
+    expect(
+      normalizeRawFinding({
+        severity: "critical",
+        category: "contrast",
+        element: "button.primary",
+        issue: "Text contrast is 2.1:1",
+        recommendation: "Raise to 4.5:1",
+        wcagRef: "1.4.3 Contrast (Minimum)",
+      }),
+    ).toEqual({
+      severity: "critical",
+      category: "contrast",
+      element: "button.primary",
+      issue: "Text contrast is 2.1:1",
+      recommendation: "Raise to 4.5:1",
+      wcagRef: "1.4.3 Contrast (Minimum)",
+    });
+  });
+
+  it("downgrades an unknown severity/category rather than dropping the finding", () => {
+    const finding = normalizeRawFinding({
+      severity: "blocker",
+      category: "vibes",
+      issue: "Something is off",
+    });
+    expect(finding).not.toBeNull();
+    expect(finding!.severity).toBe("minor");
+    expect(finding!.category).toBe("accessibility");
+    expect(finding!.element).toBe("unknown");
+  });
+
+  it("accepts the model's alternate field names", () => {
+    const finding = normalizeRawFinding({
+      severity: "important",
+      category: "focus",
+      selector: "a.skip-link",
+      description: "No visible focus ring",
+      fix: "Add :focus-visible styling",
+      wcag: "2.4.7 Focus Visible",
+    });
+    expect(finding!.element).toBe("a.skip-link");
+    expect(finding!.issue).toBe("No visible focus ring");
+    expect(finding!.recommendation).toBe("Add :focus-visible styling");
+    expect(finding!.wcagRef).toBe("2.4.7 Focus Visible");
+  });
+
+  it("rejects a finding with no issue text", () => {
+    expect(normalizeRawFinding({ severity: "critical", element: "div" })).toBeNull();
+    expect(normalizeRawFinding("not an object")).toBeNull();
+    expect(normalizeRawFinding(null)).toBeNull();
+  });
+});
+
+describe("cognitiveLoadFinding", () => {
+  it("stays silent below the minor band", () => {
+    expect(cognitiveLoadFinding({ cognitiveLoad: 0.1 })).toBeNull();
+    expect(cognitiveLoadFinding(null)).toBeNull();
+    expect(cognitiveLoadFinding({ cognitiveLoad: "dense" })).toBeNull();
+  });
+
+  it("reports a minor finding inside the minor band", () => {
+    const finding = cognitiveLoadFinding({ cognitiveLoad: COGNITIVE_LOAD_MINOR_THRESHOLD });
+    expect(finding!.severity).toBe("minor");
+    expect(finding!.issue).toContain("0.55");
+  });
+
+  it("reports an important finding at the wall-of-cards level", () => {
+    const finding = cognitiveLoadFinding({
+      cognitiveLoad: COGNITIVE_LOAD_IMPORTANT_THRESHOLD,
+      controlCountEstimate: 24,
+      reasoning: "Twenty-four competing cards",
+    });
+    expect(finding!.severity).toBe("important");
+    expect(finding!.issue).toContain("~24 visible controls");
+    expect(finding!.issue).toContain("Twenty-four competing cards");
+  });
+});
+
+describe("normalizeEvaluatePageResult", () => {
+  it("folds findings and the cognitive-load signal into one list", () => {
+    const findings = normalizeEvaluatePageResult({
+      findings: [
+        { severity: "critical", category: "contrast", issue: "Low contrast" },
+        { nonsense: true },
+      ],
+      visualCognitiveLoad: { cognitiveLoad: 0.8, reasoning: "Dense" },
+    });
+    expect(findings).toHaveLength(2);
+    expect(findings[0]!.issue).toBe("Low contrast");
+    expect(findings[1]!.category).toBe("responsive");
+  });
+
+  it("returns an empty list for a genuinely clean page", () => {
+    expect(normalizeEvaluatePageResult({ findings: [], visualCognitiveLoad: null })).toEqual([]);
+    expect(normalizeEvaluatePageResult(null)).toEqual([]);
+  });
+});

--- a/apps/web/lib/ux-audit/page-lens.ts
+++ b/apps/web/lib/ux-audit/page-lens.ts
@@ -1,0 +1,176 @@
+// Real page-lens evaluator (EP-UX-AUDITOR Phase 2, BI-C3768478).
+//
+// Adapts the shipped `evaluate_page` MCP tool — browser-use navigation + AI
+// extraction + visual-cognitive-load — into the `PageLensEvaluator` seam the
+// Phase-1 orchestrator injects. No browser protocol is re-implemented here: the
+// auditor calls the governed tool and normalizes its findings into `UxFinding`.
+//
+// The load-bearing rule is BI-1BAA177C's NOT-RUN contract: when browser-use
+// could not drive the browser, `evaluate_page` returns success:false /
+// degraded:true. That is NOT a clean page, so this adapter THROWS — `runSurvey`
+// records the route as an error entry with a `concerns` verdict rather than
+// reporting a false "zero findings".
+
+import type { UxFinding } from "@/lib/tak/page-evaluator";
+import type { PageLensEvaluator } from "@/lib/ux-audit/portal-survey";
+import {
+  callDpfMcpTool,
+  type DpfMcpConfig,
+} from "@/lib/ux-audit/dpf-mcp-client";
+
+export type { UxFinding };
+
+const SEVERITIES = new Set<UxFinding["severity"]>(["critical", "important", "minor"]);
+const CATEGORIES = new Set<UxFinding["category"]>([
+  "contrast",
+  "accessibility",
+  "focus",
+  "semantic-html",
+  "color-only",
+  "css-compliance",
+  "responsive",
+]);
+
+// How dense a page may be before the visual-cognitive-load signal is a finding.
+// `cognitiveLoad` is the 0..1 scale from lib/decision/visual-cognitive-load.ts.
+// Bands are anchored on that module's spike calibration (2026-06-15): a clean
+// single-action card scored 0.10, a dense 24-card dashboard 0.75. So 0.55 is
+// "denser than a comfortable operator page" (minor) and 0.75 is "at the measured
+// wall-of-cards level" (important).
+export const COGNITIVE_LOAD_IMPORTANT_THRESHOLD = 0.75;
+export const COGNITIVE_LOAD_MINOR_THRESHOLD = 0.55;
+
+function text(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+/**
+ * Coerce one raw finding from the AI extraction into a valid `UxFinding`.
+ * The extraction is model-produced, so every field is defensively normalized and
+ * unknown severities/categories fall back to the conservative end rather than
+ * being dropped (a dropped finding is invisible; a downgraded one is still read).
+ */
+export function normalizeRawFinding(raw: unknown): UxFinding | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  const rec = raw as Record<string, unknown>;
+
+  const issue = text(rec.issue ?? rec.description, "");
+  if (!issue) return null;
+
+  const severity = SEVERITIES.has(rec.severity as UxFinding["severity"])
+    ? (rec.severity as UxFinding["severity"])
+    : "minor";
+  const category = CATEGORIES.has(rec.category as UxFinding["category"])
+    ? (rec.category as UxFinding["category"])
+    : "accessibility";
+
+  const finding: UxFinding = {
+    severity,
+    category,
+    element: text(rec.element ?? rec.selector, "unknown"),
+    issue,
+    recommendation: text(rec.recommendation ?? rec.fix, "No recommendation supplied."),
+  };
+  const wcagRef = text(rec.wcagRef ?? rec.wcag, "");
+  if (wcagRef) finding.wcagRef = wcagRef;
+  return finding;
+}
+
+/** The `visualCognitiveLoad` block as it rides on the evaluate_page payload. */
+export type CognitiveLoadPayload = {
+  cognitiveLoad?: unknown;
+  visualDensity?: unknown;
+  controlCountEstimate?: unknown;
+  reasoning?: unknown;
+};
+
+type EvaluatePageData = {
+  findings?: unknown;
+  degraded?: boolean;
+  reason?: string;
+  visualCognitiveLoad?: CognitiveLoadPayload | null;
+};
+
+/**
+ * Turn a visual-cognitive-load score into a finding. This is the signal the
+ * accessibility rules cannot see — a page can be WCAG-clean and still be an
+ * unreadable wall (spec §4.4 enterprise density).
+ */
+export function cognitiveLoadFinding(
+  load: CognitiveLoadPayload | null | undefined,
+): UxFinding | null {
+  const score = typeof load?.cognitiveLoad === "number" ? load.cognitiveLoad : null;
+  if (score === null || !Number.isFinite(score)) return null;
+  if (score < COGNITIVE_LOAD_MINOR_THRESHOLD) return null;
+
+  const reasoning =
+    typeof load?.reasoning === "string" && load.reasoning.trim()
+      ? ` — ${load.reasoning.trim()}`
+      : "";
+  const controls =
+    typeof load?.controlCountEstimate === "number" && Number.isFinite(load.controlCountEstimate)
+      ? ` (~${load.controlCountEstimate} visible controls)`
+      : "";
+
+  return {
+    severity: score >= COGNITIVE_LOAD_IMPORTANT_THRESHOLD ? "important" : "minor",
+    category: "responsive",
+    element: "page",
+    issue: `Visual cognitive load measured ${score.toFixed(2)} on a 0-1 scale${controls}${reasoning}`,
+    recommendation:
+      "Reduce simultaneous demands on the first viewport: group related controls, defer secondary detail behind progressive disclosure, and cut competing emphasis.",
+  };
+}
+
+/** Normalize a whole `evaluate_page` payload into findings. */
+export function normalizeEvaluatePageResult(data: unknown): UxFinding[] {
+  const payload = (typeof data === "object" && data !== null ? data : {}) as EvaluatePageData;
+  const rawFindings = Array.isArray(payload.findings) ? payload.findings : [];
+
+  const findings: UxFinding[] = [];
+  for (const raw of rawFindings) {
+    const finding = normalizeRawFinding(raw);
+    if (finding) findings.push(finding);
+  }
+
+  const load = cognitiveLoadFinding(payload.visualCognitiveLoad);
+  if (load) findings.push(load);
+
+  return findings;
+}
+
+export type PageLensOptions = {
+  config: DpfMcpConfig;
+  /** Origin the survey drives, e.g. http://localhost:3000. */
+  baseUrl: string;
+  timeoutMs?: number;
+};
+
+/**
+ * Build the injected `PageLensEvaluator`. Throws on a NOT-RUN so the orchestrator
+ * reports the route honestly instead of recording a clean page.
+ */
+export function createPageLensEvaluator(options: PageLensOptions): PageLensEvaluator {
+  const origin = options.baseUrl.replace(/\/+$/, "");
+
+  return async function evaluatePageLens(route: string): Promise<UxFinding[]> {
+    const url = `${origin}${route}`;
+    const result = await callDpfMcpTool(
+      options.config,
+      "evaluate_page",
+      { url },
+      { id: `ux-audit-page-${route}`, timeoutMs: options.timeoutMs ?? 240_000 },
+    );
+
+    const payload = (typeof result.data === "object" && result.data !== null
+      ? result.data
+      : {}) as EvaluatePageData & { success?: boolean; error?: string };
+
+    if (result.isError || payload.success === false || payload.degraded === true) {
+      const reason = payload.reason ?? payload.error ?? result.text ?? "unknown reason";
+      throw new Error(`evaluate_page did NOT RUN for ${route}: ${reason}`);
+    }
+
+    return normalizeEvaluatePageResult(payload);
+  };
+}

--- a/apps/web/lib/ux-audit/portal-shell.test.ts
+++ b/apps/web/lib/ux-audit/portal-shell.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  PORTAL_SHELL_LENSES,
+  isPortalShellCoworkerRoute,
+  portalShellRoutes,
+  portalShellTargets,
+} from "./portal-shell";
+import { PORTAL_SHELL_SECTIONS } from "@/lib/navigation/portal-navigation-model";
+import { planSurvey, type RouteManifest } from "./portal-survey";
+import rawRouteManifest from "@/lib/ea/route-manifest.json";
+
+// The generated manifest widens `kind` to string; the survey types narrow it.
+const routeManifest = rawRouteManifest as unknown as RouteManifest;
+
+describe("portalShellTargets", () => {
+  it("resolves one home per shipped shell section, in rail order", () => {
+    const targets = portalShellTargets();
+    expect(targets.map((t) => t.sectionKey)).toEqual(
+      PORTAL_SHELL_SECTIONS.map((s) => s.key),
+    );
+  });
+
+  it("resolves only concrete, visitable routes", () => {
+    for (const target of portalShellTargets()) {
+      expect(target.route.startsWith("/")).toBe(true);
+      expect(target.route).not.toContain("[");
+    }
+  });
+
+  it("puts Workspace first — the personal landing page is the shell entry", () => {
+    expect(portalShellTargets()[0]).toMatchObject({ sectionKey: "workspace", route: "/workspace" });
+  });
+});
+
+describe("portal-shell survey targets against the route manifest", () => {
+  it("every target is a real page route the survey can plan", () => {
+    const pages = new Set(
+      routeManifest.routes
+        .filter((r) => r.kind === "page" && r.dynamicParams.length === 0)
+        .map((r) => r.routePath),
+    );
+    for (const route of portalShellRoutes()) {
+      expect(pages.has(route), `${route} must be a concrete page route`).toBe(true);
+    }
+  });
+
+  it("plans a page lens on every target and the behavioral lens on coworker routes", () => {
+    const targets = portalShellRoutes();
+    const plan = planSurvey(routeManifest, {
+      lenses: PORTAL_SHELL_LENSES,
+      include: (entry) => targets.includes(entry.routePath),
+      coworkerRoute: isPortalShellCoworkerRoute,
+    });
+
+    expect(plan.entries.map((e) => e.route).sort()).toEqual([...targets].sort());
+    for (const entry of plan.entries) {
+      expect(entry.lenses).toContain("page-evaluation");
+      expect(entry.lenses).toContain("coworker-button-decision");
+    }
+  });
+});
+
+describe("isPortalShellCoworkerRoute", () => {
+  it("is true for the shell homes and false elsewhere", () => {
+    expect(isPortalShellCoworkerRoute("/workspace")).toBe(true);
+    expect(isPortalShellCoworkerRoute("/nope")).toBe(false);
+  });
+});
+
+describe("PORTAL_SHELL_LENSES", () => {
+  it("carries exactly one page lens and the button-decision behavioral lens", () => {
+    expect(PORTAL_SHELL_LENSES.filter((l) => l.mode === "page")).toHaveLength(1);
+    expect(PORTAL_SHELL_LENSES.filter((l) => l.mode === "behavioral").map((l) => l.id)).toEqual([
+      "coworker-button-decision",
+    ]);
+  });
+});

--- a/apps/web/lib/ux-audit/portal-shell.ts
+++ b/apps/web/lib/ux-audit/portal-shell.ts
@@ -1,0 +1,85 @@
+// Portal-shell survey target set (EP-UX-AUDITOR Phase 2, BI-C3768478).
+//
+// Spec Goal 7 names the first mission as "the live portal shell
+// (/workspace, /business, /products, /platform, /knowledge)". Those five names
+// are the RECOMMENDED AREAS from the 2026-04-17 portal-nav-consolidation spec
+// §6.2 — they are section identities, not routes: there is no /business or
+// /products page, and the shipped model has since split Delivery out as a sixth
+// section. Hardcoding the five literal paths would survey two 404s.
+//
+// So the target set is DERIVED from the shipped navigation model: for each
+// PORTAL_SHELL_SECTIONS key, the section's home is its lowest-`primaryOrder`
+// shell-nav entry. That is the same ordering the app rail itself renders, so the
+// survey follows the shell as it evolves instead of drifting from it.
+
+import {
+  PORTAL_SHELL_SECTIONS,
+  PORTAL_NAV_ROUTES,
+  type PortalShellSectionKey,
+} from "@/lib/navigation/portal-navigation-model";
+import { BUTTON_DECISION_LENS, type LensSpec } from "@/lib/ux-audit/portal-survey";
+
+/** The page lens — evaluate_page (browser-use + axe + visual-cognitive-load). */
+export const PAGE_LENS: LensSpec = {
+  id: "page-evaluation",
+  mode: "page",
+  description:
+    "Evaluate the rendered page for accessibility, contrast, focus, semantic-HTML and visual-cognitive-load issues via the evaluate_page browser-use path.",
+};
+
+/** Every lens the portal-shell survey plans. */
+export const PORTAL_SHELL_LENSES: LensSpec[] = [PAGE_LENS, BUTTON_DECISION_LENS];
+
+export type PortalShellTarget = {
+  sectionKey: PortalShellSectionKey;
+  label: string;
+  route: string;
+};
+
+/**
+ * The shell-section homes, in app-rail order. Sections whose entries are all
+ * dynamic or absent are omitted rather than guessed.
+ */
+export function portalShellTargets(): PortalShellTarget[] {
+  const targets: PortalShellTarget[] = [];
+
+  for (const section of PORTAL_SHELL_SECTIONS) {
+    const candidates = PORTAL_NAV_ROUTES.filter(
+      (route) =>
+        route.shellNav?.sectionKey === section.key &&
+        route.destinationKind !== "legacy-redirect" &&
+        !route.path.includes("["),
+    );
+    if (candidates.length === 0) continue;
+
+    // Lowest primaryOrder wins; entries without one sort last, ties broken by
+    // declaration order (the array order the rail already relies on).
+    let best = candidates[0]!;
+    for (const candidate of candidates.slice(1)) {
+      if (orderOf(candidate.primaryOrder) < orderOf(best.primaryOrder)) best = candidate;
+    }
+
+    targets.push({ sectionKey: section.key, label: section.label, route: best.path });
+  }
+
+  return targets;
+}
+
+function orderOf(primaryOrder: number | undefined): number {
+  return primaryOrder ?? Number.POSITIVE_INFINITY;
+}
+
+/** Just the routes — what `planSurvey`'s include predicate matches against. */
+export function portalShellRoutes(): string[] {
+  return portalShellTargets().map((target) => target.route);
+}
+
+/**
+ * Which shell routes host a coworker and therefore get behavioral lenses. The
+ * coworker panel is mounted by the shared shell layout, so every shell route
+ * qualifies — the predicate exists so the survey states that explicitly rather
+ * than assuming it, and so a future route that opts out can say so here.
+ */
+export function isPortalShellCoworkerRoute(routePath: string): boolean {
+  return portalShellRoutes().includes(routePath);
+}

--- a/apps/web/lib/ux-audit/portal-survey.test.ts
+++ b/apps/web/lib/ux-audit/portal-survey.test.ts
@@ -187,3 +187,105 @@ describe("runSurvey + aggregateReport", () => {
     expect(report.routes[0]!.verdict).toBe("pass");
   });
 });
+
+describe("runSurvey — lens failure isolation", () => {
+  const pageLens: LensSpec = { id: "page-evaluation", mode: "page", description: "page" };
+  const lensById = new Map<string, LensSpec>([
+    [pageLens.id, pageLens],
+    [BUTTON_DECISION_LENS.id, BUTTON_DECISION_LENS],
+  ]);
+  const plan = {
+    entries: [{ route: "/workspace", lenses: [pageLens.id, BUTTON_DECISION_LENS.id] }],
+    skipped: [],
+  };
+
+  it("still runs the behavioral lens when the page lens throws", async () => {
+    const behavioralFinding: UxFinding = {
+      severity: "important",
+      category: "semantic-html",
+      element: '[data-testid="agent-decision"]',
+      issue: "no buttons",
+      recommendation: "emit the sentinel",
+    };
+
+    const report = await runSurvey(
+      plan,
+      {
+        page: async () => {
+          throw new Error("evaluate_page did NOT RUN");
+        },
+        behavioral: async () => [behavioralFinding],
+      },
+      lensById,
+    );
+
+    const route = report.routes[0]!;
+    expect(route.evaluated).toEqual({ page: false, behavioral: true });
+    expect(route.error).toContain("page: evaluate_page did NOT RUN");
+    expect(route.findings).toHaveLength(1);
+    expect(route.findings[0]!.lens).toBe(BUTTON_DECISION_LENS.id);
+    // An unmeasured lens is at least `concerns`; the important finding agrees.
+    expect(route.verdict).toBe("concerns");
+  });
+
+  it("still runs the page lens when the behavioral lens throws", async () => {
+    const report = await runSurvey(
+      plan,
+      {
+        page: async () => [],
+        behavioral: async () => {
+          throw new Error("coworker unreachable");
+        },
+      },
+      lensById,
+    );
+
+    const route = report.routes[0]!;
+    expect(route.evaluated).toEqual({ page: true, behavioral: false });
+    expect(route.error).toContain("coworker-button-decision: coworker unreachable");
+    expect(route.verdict).toBe("concerns");
+  });
+
+  it("reports both lens errors when both fail", async () => {
+    const report = await runSurvey(
+      plan,
+      {
+        page: async () => {
+          throw new Error("page down");
+        },
+        behavioral: async () => {
+          throw new Error("coworker down");
+        },
+      },
+      lensById,
+    );
+
+    expect(report.routes[0]!.error).toBe(
+      "page: page down; coworker-button-decision: coworker down",
+    );
+    expect(report.evaluatedRouteCount).toBe(0);
+  });
+
+  it("keeps a critical finding's fail verdict even when a lens errored", async () => {
+    const report = await runSurvey(
+      plan,
+      {
+        page: async () => [
+          {
+            severity: "critical",
+            category: "contrast",
+            element: "button",
+            issue: "unreadable",
+            recommendation: "fix",
+          },
+        ],
+        behavioral: async () => {
+          throw new Error("coworker down");
+        },
+      },
+      lensById,
+    );
+
+    expect(report.routes[0]!.verdict).toBe("fail");
+  });
+});

--- a/apps/web/lib/ux-audit/portal-survey.ts
+++ b/apps/web/lib/ux-audit/portal-survey.ts
@@ -257,9 +257,15 @@ export function aggregateReport(routes: RouteSurveyResult[]): UxAuditReport {
 
 /**
  * Run a planned survey with the injected evaluators and aggregate the report.
- * Sequential + deterministic for P1 (bounded concurrency is a Phase-2 concern).
- * A thrown evaluator degrades that route to an error entry — it never aborts the
- * whole survey. A route whose evaluator is absent simply doesn't run that lens.
+ * Sequential + deterministic (bounded concurrency remains a later concern).
+ *
+ * Failure is isolated PER LENS, not per route (corrected in Phase 2). A route's
+ * lenses are independent measurements: when the page lens cannot run — a browser
+ * sidecar outage, say — the coworker button-decision lens on that same route is
+ * still perfectly runnable, and cancelling it would silently shrink the survey to
+ * whatever the weakest dependency allows. Each lens error is recorded and the
+ * remaining lenses continue; a route reports `error` only for the lenses that
+ * actually failed. A route whose evaluator is absent simply doesn't run that lens.
  */
 export async function runSurvey(
   plan: SurveyPlan,
@@ -271,35 +277,46 @@ export async function runSurvey(
   for (const entry of plan.entries) {
     const findings: AuditFinding[] = [];
     const evaluated = { page: false, behavioral: false };
-    let error: string | undefined;
+    const errors: string[] = [];
 
     const hasPageLens = entry.lenses.some((id) => lensById.get(id)?.mode === "page");
     const behavioralLenses = entry.lenses
       .map((id) => lensById.get(id))
       .filter((l): l is LensSpec => l?.mode === "behavioral");
 
-    try {
-      if (hasPageLens && evaluators.page) {
+    if (hasPageLens && evaluators.page) {
+      try {
         const pageFindings = await evaluators.page(entry.route);
         for (const f of pageFindings) findings.push({ ...f, route: entry.route, lens: "page" });
         evaluated.page = true;
+      } catch (e) {
+        errors.push(`page: ${getErrorMessage(e)}`);
       }
-      for (const lens of behavioralLenses) {
-        if (!evaluators.behavioral) break;
+    }
+
+    for (const lens of behavioralLenses) {
+      if (!evaluators.behavioral) break;
+      try {
         const behFindings = await evaluators.behavioral(entry.route, lens);
         for (const f of behFindings) {
           findings.push({ ...f, route: entry.route, lens: lens.id });
         }
         evaluated.behavioral = true;
+      } catch (e) {
+        errors.push(`${lens.id}: ${getErrorMessage(e)}`);
       }
-    } catch (e) {
-      error = getErrorMessage(e);
     }
+
+    const error = errors.length > 0 ? errors.join("; ") : undefined;
 
     const deduped = dedupeFindings(findings);
     results.push({
       route: entry.route,
-      verdict: error ? "concerns" : verdictForFindings(deduped),
+      // A lens that could not run is at least `concerns` — an unmeasured route is
+      // not a clean one — but real findings can still push the verdict worse.
+      verdict: error
+        ? maxVerdict("concerns", verdictForFindings(deduped))
+        : verdictForFindings(deduped),
       findings: deduped,
       evaluated,
       ...(error ? { error } : {}),

--- a/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
+++ b/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
@@ -47,6 +47,41 @@ DPF_RECORD_FUNCTIONAL_FAILURES=1 pnpm test:e2e -- --project=ux-audit
 
 **Defect found and fixed in this phase — `evaluate_page` reported false cleans.** `browse_extract` answers HTTP 200 with `status: "completed"` even when its agent failed every step; the payload is then `AgentHistoryList(all_results=[], all_model_outputs=[])`. The handler's parse swallowed that into `findings = []`, so the tool announced "Found 0 UX/accessibility issues" for a page it had never analyzed. `interpretExtraction` (`lib/tak/page-evaluator.ts`) now separates a genuinely clean page (`[]`) from a run that never happened, and the handler returns the existing NOT-RUN shape. This extends the BI-1BAA177C contract, which only covered the case where browser-use self-reported `degraded`.
 
+### First-mission run — 2026-08-04
+
+The survey ran end to end against the live portal at `localhost:3000` and produced a real
+`UxAuditReport`. What the machinery proved, and what it did NOT:
+
+**Proven.** `planSurvey` → `runSurvey` → per-lens isolation → `aggregateReport` → artifact,
+against the live portal with a real authenticated session. The page lens correctly reported
+`page: evaluate_page did NOT RUN for /workspace: Page evaluation DEGRADED — bad marshal data`
+instead of a clean page — the `interpretExtraction` fix working in production. The behavioral
+lens drove a real coworker on a real route and read back its rendered turn.
+
+**Not proven — the button-decision lens has not yet observed rendered buttons live.** Two
+host-level outages block it, both filed:
+
+| Blocker | Effect | Filed |
+| --- | --- | --- |
+| browser-use sidecar down (pinned model absent, then `bad marshal data`) | page lens reports NOT-RUN on every route | BI-D26CEBBB |
+| Local inference engine unusable — the only chat model is a 30B MoE at 4096 context; a 16-token completion does not return in 180s on a warm model | coworker answers "AI providers are momentarily busy", so no decision closeout is ever produced | BI-32631D86 |
+
+The lens behaved correctly throughout: it emits no finding when the coworker did not close on
+a decision, and — after this run exposed the gap — a **critical NOT-RUN** when the reply is an
+inference-failure notice, so a saturated engine can never read as "no decision offered,
+nothing wrong". Re-run once either blocker clears:
+
+```
+DPF_RECORD_FUNCTIONAL_FAILURES=1 pnpm test:e2e -- --project=ux-audit
+```
+
+**Operational notes for the next runner.** The survey persists its report after EACH route,
+because a long live-inference run is exactly the job an outer process budget cuts short and an
+all-at-the-end write loses every route that did complete. `DPF_UX_AUDIT_ROUTES` scopes a run to
+a slice. On Windows/Git Bash, pass `MSYS_NO_PATHCONV=1` or the leading slash is rewritten into a
+native path (`/workspace` → `C:/Program Files/Git/workspace`) and the survey silently plans zero
+routes; the runner also tolerates a missing leading slash.
+
 ## Verification
 
 - P1: unit tests for planner (filter/sample/lens-assignment) + aggregator (severity→verdict rollup, dedup, portal rollup) against the real transpiled source; esbuild transform-clean.

--- a/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
+++ b/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
@@ -19,15 +19,39 @@ The **gap** = the orchestrator that walks routes, runs evaluators per route, agg
 ## Phases
 
 - **P1 — Orchestrator core (BI-A01DC56C, THIS PR).** `apps/web/lib/ux-audit/portal-survey.ts`: `planSurvey` (surveyable filter = page kind, no dynamic params, redirects folded; stable order; sample cap; page lenses to all routes, behavioral lenses to coworker routes), `runSurvey` (injected evaluators; per-route try/catch → error entry, never aborts), `verdictForFindings` (worst-severity rollup), `dedupeFindings` ({route,element,category,lens}), `aggregateReport` (portal verdict + counts). The `BUTTON_DECISION_LENS` is defined here (executed in P2). Pure + unit-tested; no coworker, no Prisma model yet.
-- **P2 — First-mission run (BI-C3768478).** Wire the real evaluators: `page` = evaluate_page; `behavioral` = askCoworker, including the button-decision lens (drive coworker to a proceed/choice closeout, assert recommended-first buttons render — validates BI-3237B5D6 + the P1.5 prose fallback live). Run against the portal shell (/workspace, /business, /products, /platform, /knowledge — spec Goal 7). File findings via `record_functional_failure_evidence`. Live-verify (needs browser-use service).
+- **P2 — First-mission run (BI-C3768478, SHIPPED).** Wire the real evaluators: `page` = evaluate_page; `behavioral` = askCoworker, including the button-decision lens (drive coworker to a proceed/choice closeout, assert recommended-first buttons render — validates BI-3237B5D6 + the P1.5 prose fallback live). Run against the portal shell (spec Goal 7). File findings via `record_functional_failure_evidence`. Live-verify (needs browser-use service). See §P2 delivered below.
 - **P3 — AGT-906 ux-design-critic.** Establish the coworker (heuristic-law + agentic-AI + enterprise-density lenses) via the establish_coworker paved road; run as a deliberation pair with AGT-903. Its lenses become behavioral/page lens specs the orchestrator plans.
 - **P4 — Persistence + surfacing.** `UxAuditReport` / `UxAuditFinding` Prisma models (the new-model CI gauntlet applies) + Operations Map surfacing; each run lands as a `TaskRun`.
 - **P5 — AGT-907 ux-test-automator + gate + schedule.** Convert findings to browser-use regression tests (`tests/ux/`), integrate the `build/review.verify` ship gate, and schedule the weekly portal audit.
 
+## P2 delivered — first-mission run
+
+**Modules.** `apps/web/lib/ux-audit/`:
+
+| Module | Role |
+| --- | --- |
+| `page-lens.ts` | Adapts the `evaluate_page` MCP tool into `PageLensEvaluator`; normalizes model-produced findings and the 0-1 `visualCognitiveLoad` signal into `UxFinding[]`. Throws on a NOT-RUN so the route reports an error, never a false clean. |
+| `button-decision-lens.ts` | Pure verdict logic for `BUTTON_DECISION_LENS`. Given a live observation (reply text, buttons in DOM order, recommended flags) it decides whether a decision closeout produced clickable, recommended-first buttons. |
+| `portal-shell.ts` | Derives the survey target set from the shipped navigation model. |
+| `dpf-mcp-client.ts` | `tools/call` over HTTP with `${VAR}` placeholder expansion, so the out-of-process auditor stays on the governed tool path. |
+
+The runner is `e2e/ux-audit/portal-survey.spec.ts`, opt-in under `--project=ux-audit`:
+
+```
+DPF_RECORD_FUNCTIONAL_FAILURES=1 pnpm test:e2e -- --project=ux-audit
+```
+
+**Target-set correction.** Spec Goal 7 names `/workspace`, `/business`, `/products`, `/platform`, `/knowledge`. Those five are the *recommended areas* from the 2026-04-17 portal-nav-consolidation spec §6.2 — section identities, not routes. `/business` and `/products` have never existed as pages, and the shipped model has since split Delivery out as a sixth section. So the survey derives one home per `PORTAL_SHELL_SECTIONS` key (lowest `primaryOrder` shell-nav entry) instead of surveying two 404s. The target set follows the app rail as it evolves.
+
+**Two origins, not one.** Playwright drives the portal from the host (`localhost:3000`); `evaluate_page` runs inside the browser-use container, where `localhost` is the sidecar and the portal answers only as `portal:3000`. Verified on-machine. Pointing the page lens at localhost yields a navigation failure that the tool previously reported as a clean page.
+
+**Defect found and fixed in this phase — `evaluate_page` reported false cleans.** `browse_extract` answers HTTP 200 with `status: "completed"` even when its agent failed every step; the payload is then `AgentHistoryList(all_results=[], all_model_outputs=[])`. The handler's parse swallowed that into `findings = []`, so the tool announced "Found 0 UX/accessibility issues" for a page it had never analyzed. `interpretExtraction` (`lib/tak/page-evaluator.ts`) now separates a genuinely clean page (`[]`) from a run that never happened, and the handler returns the existing NOT-RUN shape. This extends the BI-1BAA177C contract, which only covered the case where browser-use self-reported `degraded`.
+
 ## Verification
 
 - P1: unit tests for planner (filter/sample/lens-assignment) + aggregator (severity→verdict rollup, dedup, portal rollup) against the real transpiled source; esbuild transform-clean.
-- P2+: functional — a real survey run against the live portal produces a report and files findings (structural≠functional).
+- P2: unit tests for the button-decision verdict rules (closeout detection, carrier attribution, recommended-first ordering, unlabeled buttons, panel-absent and empty-reply NOT-RUNs), the evaluate_page normalizer, `interpretExtraction`, the MCP config resolver, and the derived shell target set against the real route manifest. **Functional:** a real survey run against the live portal at localhost:3000 produces a `UxAuditReport` artifact and files findings — structural ≠ functional.
+- P3+: as each new lens lands, its verdict logic is unit-tested pure and its live behavior proven by a survey run.
 
 ## Design grounding
 

--- a/e2e/helpers/coworker.ts
+++ b/e2e/helpers/coworker.ts
@@ -2,17 +2,25 @@ import { Page } from "@playwright/test";
 
 /**
  * Open the AI Coworker panel if it is not already visible.
- * FAB button: title="Open AI Co-worker" / text "AI Coworker"
+ * FAB button: title "Open AI Coworker" (the live spelling — the hyphenated
+ * "Open AI Co-worker" this helper used to pin exactly no longer exists, which
+ * silently broke every caller whose session started with the panel COLLAPSED;
+ * found by live-driving the portal, EP-UX-AUDITOR P2). Matched case-insensitively
+ * on either spelling so a future copy edit cannot break it again.
  * Panel container: [data-agent-panel="true"]
  */
 export async function openCoworker(page: Page): Promise<void> {
   const panel = page.locator('[data-agent-panel="true"]').first();
   if (await panel.isVisible({ timeout: 1_000 }).catch(() => false)) return;
 
-  const fab = page.locator('button[title="Open AI Co-worker"]').first();
+  // Prefer the stable data hook; fall back to the accessible name.
+  const fabHook = page.locator('button[data-agent-fab="true"]').first();
+  const fab = (await fabHook.count()) > 0
+    ? fabHook
+    : page.getByRole("button", { name: /open ai co-?worker/i }).first();
   if (await fab.isVisible({ timeout: 8_000 }).catch(() => false)) {
     await fab.click();
-    await page.waitForTimeout(800);
+    await panel.waitFor({ state: "visible", timeout: 10_000 }).catch(() => {});
   }
 }
 
@@ -103,6 +111,89 @@ export async function askCoworker(page: Page, prompt: string): Promise<string> {
     console.warn(`[coworker] Error during interaction: ${(err as Error).message}`);
     return "[coworker error]";
   }
+}
+
+/**
+ * Wait until the coworker panel is idle — no busy status line, input re-enabled.
+ *
+ * `askCoworker`'s fixed 45s wait is not enough for a tool-using coworker: the
+ * panel shows "<name> is still working (50s)" well past it, and a reader that
+ * gives up early scrapes THAT placeholder as the reply. Observed live on four of
+ * five shell routes (EP-UX-AUDITOR P2). Returns false on timeout so the caller
+ * can report a NOT-RUN instead of judging a loading spinner.
+ */
+export async function waitForCoworkerIdle(
+  page: Page,
+  timeoutMs = 180_000,
+): Promise<boolean> {
+  return page
+    .waitForFunction(
+      () => {
+        const panel = document.querySelector("[data-agent-panel='true']");
+        if (!panel) return false;
+        const busy =
+          /\b(is thinking|is working on it|is still working|is using |Clearing conversation)/.test(
+            panel.textContent ?? "",
+          );
+        if (busy) return false;
+        const input = panel.querySelector("textarea");
+        return !!input && !/sending/i.test(input.getAttribute("placeholder") ?? "");
+      },
+      undefined,
+      { timeout: timeoutMs, polling: 500 },
+    )
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * Observe the coworker's last turn as the button-decision lens needs it
+ * (EP-UX-AUDITOR Phase 2): the human-visible reply text with the decision
+ * buttons EXCLUDED, plus those buttons in DOM order with their recommended flag.
+ *
+ * `askCoworker` above returns the bubble's whole textContent, which folds the
+ * button labels into the prose — fine for assertions on wording, useless for
+ * judging whether buttons rendered. This returns the two apart so the lens can
+ * ask "did a decision closeout produce clickable, recommended-first buttons?".
+ */
+export async function observeCoworkerDecision(page: Page): Promise<{
+  panelPresent: boolean;
+  reply: string;
+  buttons: Array<{ label: string; recommended: boolean }>;
+}> {
+  return page.evaluate(() => {
+    const panel = document.querySelector("[data-agent-panel='true']");
+    if (!panel) return { panelPresent: false, reply: "", buttons: [] };
+
+    const allDivs = Array.from(panel.querySelectorAll("div")) as HTMLElement[];
+    const assistantBubbles = allDivs.filter((el) => {
+      const s = el.style;
+      return (
+        s.display === "flex" &&
+        s.flexDirection === "column" &&
+        s.marginBottom === "8px" &&
+        s.alignItems === "flex-start"
+      );
+    });
+
+    const last = assistantBubbles[assistantBubbles.length - 1] ?? null;
+    if (!last) return { panelPresent: true, reply: "", buttons: [] };
+
+    const buttons = Array.from(
+      last.querySelectorAll("[data-testid='agent-decision-option']"),
+    ).map((el) => ({
+      label: (el.textContent ?? "").trim(),
+      recommended: el.getAttribute("data-recommended") === "true",
+    }));
+
+    // Reply = the bubble text with the decision block removed, so the lens reads
+    // exactly the prose the coworker closed on.
+    const clone = last.cloneNode(true) as HTMLElement;
+    clone.querySelector("[data-testid='agent-decision']")?.remove();
+    const reply = (clone.textContent ?? "").trim();
+
+    return { panelPresent: true, reply, buttons };
+  });
 }
 
 /**

--- a/e2e/ux-audit/portal-survey.spec.ts
+++ b/e2e/ux-audit/portal-survey.spec.ts
@@ -27,10 +27,12 @@ import {
   waitForCoworkerIdle,
 } from "../helpers/coworker";
 import {
+  aggregateReport,
   planSurvey,
   runSurvey,
   type LensSpec,
   type RouteManifest,
+  type RouteSurveyResult,
   type UxAuditReport,
   type UxFinding,
 } from "../../apps/web/lib/ux-audit/portal-survey";
@@ -93,11 +95,31 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
   );
 
   const lensById = new Map<string, LensSpec>(PORTAL_SHELL_LENSES.map((lens) => [lens.id, lens]));
+  // Scope override: a full survey is long, and driving live inference on every
+  // shell route is exactly the kind of job an outer process budget cuts short.
+  // `DPF_UX_AUDIT_ROUTES=/workspace,/knowledge` runs a slice.
+  // Accept `workspace` as well as `/workspace`: a POSIX-looking value passed
+  // through Git Bash on Windows gets rewritten to a native path by MSYS path
+  // conversion, so tolerate a missing leading slash rather than silently
+  // planning zero routes.
+  const routeFilter = (process.env.DPF_UX_AUDIT_ROUTES ?? "")
+    .split(",")
+    .map((r) => r.trim())
+    .filter(Boolean)
+    .map((r) => (r.startsWith("/") ? r : `/${r}`));
+  const surveyRoutes = routeFilter.length > 0 ? routeFilter : portalShellRoutes();
+
   const plan = planSurvey(routeManifest, {
     lenses: PORTAL_SHELL_LENSES,
-    include: (entry) => portalShellRoutes().includes(entry.routePath),
+    include: (entry) => surveyRoutes.includes(entry.routePath),
     coworkerRoute: isPortalShellCoworkerRoute,
   });
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[ux-audit] planning ${plan.entries.length} route(s) from ${surveyRoutes.length} target(s): ` +
+      `${surveyRoutes.join(",")} -> ${plan.entries.map((e) => e.route).join(",") || "(none)"}`,
+  );
 
   // What the behavioral lens actually saw, kept alongside the report so a finding
   // can be read back to the transcript that produced it.
@@ -108,15 +130,13 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
     expectedCarrier: string;
   }> = [];
 
-  const report: UxAuditReport = await runSurvey(
-    plan,
-    {
+  const evaluators = {
       page: createPageLensEvaluator({
         config: mcpConfig!,
         baseUrl: BROWSER_USE_PORTAL_URL,
         timeoutMs: PAGE_LENS_TIMEOUT_MS,
       }),
-      behavioral: async (route, lens): Promise<UxFinding[]> => {
+      behavioral: async (route: string, lens: LensSpec): Promise<UxFinding[]> => {
         if (lens.id !== "coworker-button-decision") return [];
 
         await page.goto(`${HOST_URL}${route}`);
@@ -154,24 +174,52 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
 
         return evaluateButtonDecision({ route, ...observed });
       },
-    },
-    lensById,
-  );
-
-  const artifact = {
-    epic: "EP-UX-AUDITOR",
-    backlogItemId: "BI-C3768478",
-    hostUrl: HOST_URL,
-    browserUseUrl: BROWSER_USE_PORTAL_URL,
-    sections: targets,
-    plan,
-    report,
-    transcripts,
   };
 
+  // Survey one route at a time and persist after EACH, rather than aggregating
+  // only at the end. A full survey runs for tens of minutes on live inference;
+  // when an outer budget cuts the process short, an all-at-the-end write loses
+  // every route that DID complete. Partial evidence beats none.
   const reportPath = join(testInfo.outputDir, "ux-audit-report.json");
   await mkdir(dirname(reportPath), { recursive: true });
-  await writeFile(reportPath, JSON.stringify(artifact, null, 2), "utf8");
+
+  const results: RouteSurveyResult[] = [];
+  let report: UxAuditReport = aggregateReport(results);
+
+  for (const entry of plan.entries) {
+    const partial = await runSurvey({ entries: [entry], skipped: [] }, evaluators, lensById);
+    results.push(...partial.routes);
+    report = aggregateReport(results);
+
+    await writeFile(
+      reportPath,
+      JSON.stringify(
+        {
+          epic: "EP-UX-AUDITOR",
+          backlogItemId: "BI-C3768478",
+          complete: results.length === plan.entries.length,
+          surveyedSoFar: results.length,
+          plannedRoutes: plan.entries.length,
+          hostUrl: HOST_URL,
+          browserUseUrl: BROWSER_USE_PORTAL_URL,
+          sections: targets,
+          plan,
+          report,
+          transcripts,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      `[ux-audit] ${entry.route}: verdict=${results[results.length - 1]!.verdict} ` +
+        `findings=${results[results.length - 1]!.findings.length} ` +
+        `(${results.length}/${plan.entries.length})`,
+    );
+  }
+
   testInfo.attachments.push({
     name: "ux-audit-report",
     contentType: "application/json",

--- a/e2e/ux-audit/portal-survey.spec.ts
+++ b/e2e/ux-audit/portal-survey.spec.ts
@@ -1,0 +1,234 @@
+// First-mission portal-shell survey runner (EP-UX-AUDITOR Phase 2, BI-C3768478).
+//
+// Spec: docs/superpowers/specs/2026-05-16-ux-auditor-coworker-design.md (Goal 7)
+// Plan: docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md (P2)
+//
+// This is the seam where the Phase-1 orchestrator meets the live runtime:
+//   page lens       -> the evaluate_page MCP tool (browser-use + axe + visual load)
+//   behavioral lens -> a real coworker, driven with real keystrokes, judged by the
+//                      pure button-decision lens
+// and the aggregated UxAuditReport is attached as a run artifact with each finding
+// filed through record_functional_failure_evidence.
+//
+// It runs ONLY under `--project=ux-audit` — a full survey drives live inference on
+// every shell route, so it must never be swept up in an ordinary e2e run.
+//
+//   pnpm test:e2e -- --project=ux-audit
+//   DPF_RECORD_FUNCTIONAL_FAILURES=1 pnpm test:e2e -- --project=ux-audit   # + file findings
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "../fixtures/dpf-test";
+import { attachFunctionalFailureEvidence } from "../fixtures/evidence";
+import {
+  askCoworker,
+  clearCoworker,
+  observeCoworkerDecision,
+  waitForCoworkerIdle,
+} from "../helpers/coworker";
+import {
+  planSurvey,
+  runSurvey,
+  type LensSpec,
+  type RouteManifest,
+  type UxAuditReport,
+  type UxFinding,
+} from "../../apps/web/lib/ux-audit/portal-survey";
+import {
+  PORTAL_SHELL_LENSES,
+  isPortalShellCoworkerRoute,
+  portalShellRoutes,
+  portalShellTargets,
+} from "../../apps/web/lib/ux-audit/portal-shell";
+import {
+  evaluateButtonDecision,
+  expectedCarrier,
+} from "../../apps/web/lib/ux-audit/button-decision-lens";
+import { createPageLensEvaluator } from "../../apps/web/lib/ux-audit/page-lens";
+import { resolveDpfMcpConfig } from "../../apps/web/lib/ux-audit/dpf-mcp-client";
+import rawRouteManifest from "../../apps/web/lib/ea/route-manifest.json";
+
+const routeManifest = rawRouteManifest as unknown as RouteManifest;
+
+// Two origins, deliberately. Playwright drives the portal from the HOST, so it
+// uses localhost. `evaluate_page` runs inside the browser-use container, where
+// localhost is the sidecar itself and the portal is reachable only by its compose
+// service name — pointing the page lens at localhost yields a navigation failure,
+// not a clean page. Verified on-machine: from dpf-browser-use-1, localhost:3000
+// fails and portal:3000 answers.
+const HOST_URL = process.env.DPF_PORTAL_URL ?? "http://localhost:3000";
+const BROWSER_USE_PORTAL_URL =
+  process.env.DPF_PORTAL_INTERNAL_URL ?? "http://portal:3000";
+
+/** How long one route's coworker may take to finish its turn. */
+const COWORKER_IDLE_TIMEOUT_MS = Number(process.env.DPF_UX_AUDIT_COWORKER_TIMEOUT_MS ?? 180_000);
+
+/** Page-lens budget. Kept tight so a dead browser sidecar fails fast instead of
+ *  consuming the whole survey window on retries. */
+const PAGE_LENS_TIMEOUT_MS = Number(process.env.DPF_UX_AUDIT_PAGE_TIMEOUT_MS ?? 90_000);
+
+/**
+ * The prompt that drives a coworker to a next-step decision. It asks for a
+ * recommendation and an explicit two-option closeout — the shape the interaction
+ * contract (lib/tak/coworker-interaction-contract.ts) tells the coworker to carry
+ * as a sentinel, and the shape the prose fallback recovers when it does not.
+ * Deliberately route-agnostic so the same lens runs on every shell section.
+ */
+const DECISION_PROMPT =
+  "Look at this page and tell me, in two sentences, the single highest-value next step I could take here. " +
+  "Then close by asking whether I should start on your recommendation, or review the underlying detail first.";
+
+// A whole survey drives live inference on every shell route.
+test.describe.configure({ mode: "serial", timeout: 40 * 60_000 });
+
+test("portal-shell UX survey — page lens + coworker button-decision lens", async ({
+  page,
+}, testInfo) => {
+  const targets = portalShellTargets();
+  const mcpConfig = await resolveDpfMcpConfig();
+
+  test.skip(
+    mcpConfig === null,
+    "No DPF MCP config (set DPF_MCP_URL + DPF_MCP_BEARER_TOKEN, or provide .mcp.json) — the page lens calls evaluate_page over MCP.",
+  );
+
+  const lensById = new Map<string, LensSpec>(PORTAL_SHELL_LENSES.map((lens) => [lens.id, lens]));
+  const plan = planSurvey(routeManifest, {
+    lenses: PORTAL_SHELL_LENSES,
+    include: (entry) => portalShellRoutes().includes(entry.routePath),
+    coworkerRoute: isPortalShellCoworkerRoute,
+  });
+
+  // What the behavioral lens actually saw, kept alongside the report so a finding
+  // can be read back to the transcript that produced it.
+  const transcripts: Array<{
+    route: string;
+    reply: string;
+    buttons: Array<{ label: string; recommended: boolean }>;
+    expectedCarrier: string;
+  }> = [];
+
+  const report: UxAuditReport = await runSurvey(
+    plan,
+    {
+      page: createPageLensEvaluator({
+        config: mcpConfig!,
+        baseUrl: BROWSER_USE_PORTAL_URL,
+        timeoutMs: PAGE_LENS_TIMEOUT_MS,
+      }),
+      behavioral: async (route, lens): Promise<UxFinding[]> => {
+        if (lens.id !== "coworker-button-decision") return [];
+
+        await page.goto(`${HOST_URL}${route}`);
+        // A previous route's transcript would let a stale decision block satisfy
+        // the lens — start every route from an empty conversation.
+        await clearCoworker(page);
+        await askCoworker(page, DECISION_PROMPT);
+
+        // askCoworker gives up after 45s; a tool-using coworker routinely runs
+        // longer. Without this the observation scrapes the "is still working"
+        // placeholder and the lens judges a spinner.
+        const settled = await waitForCoworkerIdle(page, COWORKER_IDLE_TIMEOUT_MS);
+        if (!settled) {
+          return [
+            {
+              severity: "critical",
+              category: "semantic-html",
+              element: '[data-agent-panel="true"]',
+              issue: `The coworker had not finished its turn after ${Math.round(
+                COWORKER_IDLE_TIMEOUT_MS / 1000,
+              )}s, so the button-decision lens could not observe a closeout. This is a NOT-RUN, not a pass.`,
+              recommendation:
+                "Investigate this route's coworker latency (model routing, tool calls), or raise the lens budget if the wait is legitimate.",
+            },
+          ];
+        }
+
+        const observed = await observeCoworkerDecision(page);
+        transcripts.push({
+          route,
+          reply: observed.reply,
+          buttons: observed.buttons,
+          expectedCarrier: expectedCarrier(observed.reply),
+        });
+
+        return evaluateButtonDecision({ route, ...observed });
+      },
+    },
+    lensById,
+  );
+
+  const artifact = {
+    epic: "EP-UX-AUDITOR",
+    backlogItemId: "BI-C3768478",
+    hostUrl: HOST_URL,
+    browserUseUrl: BROWSER_USE_PORTAL_URL,
+    sections: targets,
+    plan,
+    report,
+    transcripts,
+  };
+
+  const reportPath = join(testInfo.outputDir, "ux-audit-report.json");
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(reportPath, JSON.stringify(artifact, null, 2), "utf8");
+  testInfo.attachments.push({
+    name: "ux-audit-report",
+    contentType: "application/json",
+    path: reportPath,
+  });
+
+  // File every finding as functional-failure evidence. Grouped per route+category
+  // (spec §5.8: group similar findings, never one item per element) so the backlog
+  // gets improvement work, not noise.
+  for (const routeResult of report.routes) {
+    const byCategory = new Map<string, typeof routeResult.findings>();
+    for (const finding of routeResult.findings) {
+      const key = `${finding.lens ?? "page"}:${finding.category}`;
+      const bucket = byCategory.get(key) ?? [];
+      bucket.push(finding);
+      byCategory.set(key, bucket);
+    }
+
+    for (const [key, findings] of byCategory) {
+      const worst = findings.some((f) => f.severity === "critical")
+        ? "critical"
+        : findings.some((f) => f.severity === "important")
+          ? "important"
+          : "minor";
+
+      await attachFunctionalFailureEvidence(testInfo, {
+        testId: `ux-audit-${routeResult.route.replace(/\W+/g, "-")}-${key.replace(/\W+/g, "-")}`,
+        suite: "ux-audit",
+        route: routeResult.route,
+        expected: `No ${key} findings on ${routeResult.route} (UX auditor portal-shell survey).`,
+        actual: [
+          `${findings.length} ${worst} finding(s):`,
+          ...findings.map((f) => `- [${f.severity}] ${f.element}: ${f.issue} → ${f.recommendation}`),
+        ].join("\n"),
+        screenshotPath: null,
+        tracePath: null,
+        userRole: "admin",
+        agentId: "AGT-903",
+        routeContext: routeResult.route,
+        reproCommand: "pnpm test:e2e -- --project=ux-audit",
+        backlogItemId: "BI-C3768478",
+      });
+    }
+  }
+
+  // The survey itself is the deliverable — it reports, it does not gate. What
+  // MUST hold is that it actually ran: a report with zero evaluated routes is a
+  // NOT-RUN masquerading as a clean portal.
+  test.expect(report.evaluatedRouteCount, "the survey must have evaluated at least one route")
+    .toBeGreaterThan(0);
+  test.expect(report.routes.length).toBe(targets.length);
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[ux-audit] portal verdict=${report.portalVerdict} routes=${report.routeCount} ` +
+      `evaluated=${report.evaluatedRouteCount} ` +
+      `findings=${report.findingCounts.critical}c/${report.findingCounts.important}i/${report.findingCounts.minor}m ` +
+      `report=${reportPath}`,
+  );
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
         /.*ai-routing-.*\.spec\.ts/,
         /.*storefront-owner-mobile\.spec\.ts/,
         /.*coworker-catalog-mobile\.spec\.ts/,
+        /ux-audit[\\/].*\.spec\.ts/,
       ],
       use: { ...devices["Desktop Chrome"] },
     },
@@ -52,6 +53,14 @@ export default defineConfig({
     {
       name: "ops-backlog",
       testMatch: /.*ai-routing-ops-backlog\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"], storageState: "e2e/.auth/state.json" },
+    },
+    {
+      // EP-UX-AUDITOR portal survey. Opt-in only — it drives live inference on
+      // every shell route, so it must never ride along in an ordinary e2e run.
+      name: "ux-audit",
+      testMatch: /ux-audit[\\/].*\.spec\.ts/,
+      timeout: 40 * 60_000,
       use: { ...devices["Desktop Chrome"], storageState: "e2e/.auth/state.json" },
     },
   ],


### PR DESCRIPTION
Phase 2 of **EP-UX-AUDITOR** (BI-C3768478). The Phase-1 orchestrator shipped with injected evaluator seams and no runtime behind them; this connects both and runs the survey against the live portal shell.

## What this adds

New modules under `apps/web/lib/ux-audit/`:

| Module | Role |
| --- | --- |
| `page-lens.ts` | Adapts the shipped `evaluate_page` MCP tool (browser-use + axe + visual-cognitive-load) into `PageLensEvaluator`. |
| `button-decision-lens.ts` | Verdict logic for `BUTTON_DECISION_LENS` — does a coworker's decision closeout produce clickable, recommended-first buttons? Pure, so the rules are testable independently of the browser half. Both carriers pass: the sentinel and the deterministic prose fallback. |
| `portal-shell.ts` | Derives the survey target set from the shipped navigation model. |
| `dpf-mcp-client.ts` | Governed `tools/call` over HTTP, expanding the `${VAR}` placeholders the committed `.mcp.json` stores. |

The runner is `e2e/ux-audit/portal-survey.spec.ts`, opt-in under `--project=ux-audit` so a full survey never rides along in an ordinary e2e run.

**Target-set correction.** Spec Goal 7 names `/workspace`, `/business`, `/products`, `/platform`, `/knowledge`. Those five are the *recommended areas* from the 2026-04-17 nav-consolidation spec §6.2 — section identities, not routes. `/business` and `/products` have never existed as pages, and Delivery has since split out as a sixth section, so the literal list would survey two 404s. The survey now derives one home per `PORTAL_SHELL_SECTIONS` key and follows the app rail as it evolves.

## Defects the live run surfaced, fixed here

1. **`evaluate_page` reported false cleans.** `browse_extract` answers HTTP 200 / `status: "completed"` even when its agent failed every step, with `AgentHistoryList(all_results=[], all_model_outputs=[])` as the payload. The handler folded that into `findings = []` and announced *"Found 0 UX/accessibility issues"* for a page it never analyzed. `interpretExtraction` now separates a genuinely clean page from a run that never happened — extending the BI-1BAA177C NOT-RUN contract, which only covered self-reported degradation.
2. **`runSurvey` cancelled sibling lenses.** The page and behavioral lenses shared one `try`, so a browser-sidecar outage silently skipped the button-decision lens on that route — shrinking the survey to whatever its weakest dependency allowed. Failure is now isolated per lens.
3. **The e2e coworker helper had a drifted selector** — it pinned `title="Open AI Co-worker"` while the live FAB reads `"Open AI Coworker"`, so any session starting with the panel collapsed could never open it. Now anchored on the stable `data-agent-fab` hook.
4. **`askCoworker`'s fixed 45s wait is shorter than a real tool-using turn**, so a reader that stops there scrapes the `"is still working (50s)"` placeholder as the reply. `waitForCoworkerIdle` waits for a genuinely idle panel and reports a NOT-RUN on timeout.
5. **An inference-failure reply read as a silent pass.** A provider-busy notice is not a decision closeout, so the lens emitted no finding and the route read as "nothing wrong" — a NOT-RUN wearing a pass's clothes. Now a critical NOT-RUN quoting the reply.

## Verification

The survey ran end to end against the live portal and produced a real `UxAuditReport`: plan → run → per-lens isolation → aggregate → artifact, with a real authenticated session. The page lens correctly recorded `evaluate_page did NOT RUN ... bad marshal data` instead of a clean page — the `interpretExtraction` fix working in production.

**What is NOT yet proven: the button-decision lens has not observed rendered buttons live.** Two host outages block it, both filed with evidence:

- **BI-D26CEBBB** — browser-use sidecar down (pinned model absent from the model runner, then `bad marshal data`), so the page lens is NOT-RUN on every route.
- **BI-32631D86** — local inference unusable: the only chat model is a 30B MoE at 4096 context, and a 16-token completion does not return in 180s on a warm model. The coworker answers *"The AI providers are momentarily busy"*, so no decision closeout is ever produced.

BI-C3768478 therefore stays open pending a re-run once either blocker clears. The lens behaved correctly throughout — it is the environment, not the logic, that is unmeasurable.

Verified via the governed local-CI gate (exact-tree, merged against main): typecheck passed, 2552 vitest files passed / 4 skipped, production build completed.
