### PR TITLE
test(release): prove runGateAsync's child 'error' handler actually fires (BI-58B02382)

### DIFF
--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -104,9 +104,11 @@ function runGate(args, env) {
 // MUST spawn asynchronously: spawnSync blocks this process's event loop for
 // its entire duration, which would starve the very http.Server the child
 // needs to reach (self-deadlock — the child would hang until it times out).
-function runGateAsync(args, env) {
+// `execPath` is injectable so the spawn-failure contract below can force an
+// 'error' event deterministically; every production caller uses the default.
+function runGateAsync(args, env, { execPath = process.execPath } = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [gateScript, ...args], { env });
+    const child = spawn(execPath, [gateScript, ...args], { env });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => { stdout += chunk; });
@@ -119,6 +121,33 @@ function runGateAsync(args, env) {
     child.on("close", (status) => resolve({ status, stdout, stderr }));
   });
 }
+
+// ── test-harness contract: runGateAsync spawn failure (BI-58B02382) ─────────
+
+// Guards the child 'error' listener added in #3910. A ChildProcess that emits
+// 'error' with no listener does not fail the awaiting test — Node re-throws it
+// as an uncaughtException that kills this whole test file, while the
+// 'close'-based Promise stays forever pending. Deleting the listener must break
+// a test rather than silently reopen that crash surface, so assert on the
+// rejection directly instead of trusting the other cases to notice.
+test("runGateAsync rejects (not crashes) when the child cannot be spawned (BI-58B02382)", async () => {
+  const missingInterpreter = join(tmpdir(), "dpf-58b02382-no-such-interpreter");
+  assert.equal(existsSync(missingInterpreter), false, "fixture path must not exist");
+
+  await assert.rejects(
+    runGateAsync(
+      ["--dry-run", "--branch", "feat/x", "--worktree", repoRoot],
+      { ...process.env },
+      { execPath: missingInterpreter },
+    ),
+    (error) => {
+      assert.ok(error instanceof Error, "spawn failure must reject with an Error");
+      assert.equal(error.code, "ENOENT");
+      assert.equal(error.path, missingInterpreter);
+      return true;
+    },
+  );
+});
 
 // ── scripts/pregate.mjs: shell detection + routing ──────────────────────────
 


### PR DESCRIPTION
## What

Closes **BI-58B02382**.

The BI asks for a `child.on("error", ...)` listener on `runGateAsync` in `tests/release/pregate-node-gate-contract.test.mjs`. **That one-line fix is already on main** — it landed 2026-08-01 in [#3910](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3910) (`f8a82c2134c`). The BI was filed 08-04 by automated detection from a stale snapshot, so re-applying it would have been a duplicate.

What #3910 did *not* ship is a test that exercises the listener. The BI itself lists that as optional ("Optional: a targeted test that injects a bad interpreter path"); this PR delivers it, because without it the guarantee was asserted in a comment and enforced by nothing — **deleting `child.on("error", reject)` left all 19 cases green**, silently reopening the crash surface the fix closed.

## Why the gap mattered

This is not a defect a normal test would have caught. A `ChildProcess` that emits `'error'` with no listener does not fail the awaiting test — Node re-throws it as an `uncaughtException` that kills the whole test-file subprocess, while the `'close'`-based Promise stays **forever pending**. Under CI parallelism the trigger is real: `EAGAIN`/`EMFILE` from fd/process pressure, `ENOENT`/`EACCES` on an unresolvable interpreter path.

## Change

- New contract test that injects a nonexistent interpreter path to force a deterministic spawn `'error'`, and asserts the Promise **rejects** with that `ENOENT` instead of the process crashing.
- `runGateAsync` gains an optional `{ execPath }` override purely as the injection seam. All nine production callers use the default `process.execPath`.

Test-harness robustness only — **no runtime or gate behavior changes**, and nothing touching the `ci-policy-guards` tail-summary work from #3903.

## Verification

Red/green proven against the real file, not a mock (dpf-tdd):

- **Red** — with `child.on("error", reject)` removed, the new test fails with a raw `ENOENT` thrown from `ChildProcess._handle.onexit` (an uncaught error, not an assertion) — exactly the pathology described.
- **Green** — with the listener restored, `node --test tests/release/pregate-node-gate-contract.test.mjs` → **20/20 pass**.
- **Pregate preflight** — `OK — 34 guards clean (3 environment-skipped)`, including the **`Janitor Tests`** guard (source profile) that owns this file.

### Local-CI pregate did NOT reach a green terminal state

Stating this plainly rather than implying a gate that did not pass. Three attempts, failing in two different places, neither attributable to this change:

| # | Outcome |
|---|---|
| 1 | Preflight `OK — 34 guards clean`; lease queued at position 2 for 10 min, then the wrapper was killed |
| 2 | Admitted (`NPEL-A77C19230F`), ran the sandbox gate, killed mid-vitest — `childStatus: 4294967295`, `reason: gate-wrapper-exited-before-terminal-state`. Log streams green and simply stops: no summary, **no failing test** |
| 3 | Preflight *failed* on the **identical** guard set attempt 1 tolerated as "3 environment-skipped" |

The environmental cause: this worktree was never bootstrapped (no `node_modules`/`.env`), so guards resolve TypeScript through to the root clone and trip `GuardRuntimeEnvironmentError`, while `FPAW Standard` / `Prose Lint` die on `'tsx' is not recognized`. `packages/repo-guard-runtime/node_modules` is absent from the root clone. Host is healthy (20.6 GB RAM free, 1.4 TB free on D) — not OOM or disk.

Per the BLOCKED stop-rule this was not converted into a build-infra fix: repairing it means mutating dependency state shared with other live sessions. Filed separately as an infrastructure BI. **CI on this PR is therefore the gate evidence** — please don't merge on a red or unrun required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: external-contribution-no-install: worktree has no node_modules (never bootstrapped); pregate preflight cannot run FPAW Standard / Prose Lint (tsx absent) and packages/repo-guard-runtime/node_modules is missing from the root clone, so the sandbox gate cannot reach a terminal state. Test-harness-only change, suite verified 20/20 locally, Janitor Tests guard clean. Infra BI filed separately.
