### PR TITLE
Watch for PRs that received no CI dispatch at all

### DIFF
--- a/.github/workflows/watch-missing-ci-dispatch.yml
+++ b/.github/workflows/watch-missing-ci-dispatch.yml
@@ -1,0 +1,50 @@
+name: Missing CI Dispatch Watch
+
+# Every other CI failure mode in this repo turns a check RED. This one makes
+# checks ABSENT, which is indistinguishable from "still pending" — nothing
+# alerts, auto-merge waits forever, and the PR never moves.
+#
+# On 2026-08-01 the installation's GitHub API rate limit was exhausted (the same
+# exhaustion that reported "CodeQL job status was configuration error"). PR #3907
+# was opened inside that window and got FIVE checks instead of the usual ~36 —
+# the CI workflow never dispatched. Auto-merge was armed and would have waited
+# indefinitely on required contexts that were never created. A human noticed by
+# eyeballing the check count, which is not a control.
+#
+# Detection is shape-based, not cause-based: an open non-draft PR whose head has
+# been pushed a while and has ZERO check runs. Rate limiting is only the cause we
+# have seen; a disabled workflow, an over-broad `paths` filter, or a dropped
+# webhook present identically and are equally worth catching. Pairs with
+# merge-queue-churn-watch.yml, which covers the other silent PR-level stall.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # every 30 minutes
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write # post the one-time flag comment
+
+concurrency:
+  group: watch-missing-ci-dispatch
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Watch for PRs with no dispatched CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+      - name: Flag PRs whose head received no check runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Single `gh pr list` call for the whole sweep — statusCheckRollup
+        # answers "any checks?" per PR, so there is no per-PR follow-up. This
+        # watch exists because API budget ran out; a detector that is itself
+        # expensive would be part of the problem it reports.
+        run: node scripts/check-missing-ci-dispatch.mjs

--- a/scripts/check-missing-ci-dispatch.mjs
+++ b/scripts/check-missing-ci-dispatch.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// scripts/check-missing-ci-dispatch.mjs
+//
+// Missing-CI-dispatch watch. Every other CI failure mode in this repo turns a
+// check RED. This one makes checks ABSENT, which is indistinguishable from
+// "still pending" — so nothing alerts, auto-merge waits forever, and the PR
+// simply never moves.
+//
+// Observed 2026-08-01: the installation's GitHub API rate limit was exhausted
+// (the same exhaustion that reported "CodeQL job status was configuration
+// error" on three Analyze jobs). PR #3907 was opened inside that window and
+// received FIVE checks instead of the usual ~36 — the CI workflow never
+// dispatched at all. Auto-merge was armed and would have waited indefinitely on
+// required contexts that were never coming. It was found by a human eyeballing
+// the check count, which is not a control.
+//
+// Detection is deliberately shape-based, not cause-based: an open, non-draft PR
+// whose head commit is older than the threshold and has ZERO check runs of any
+// kind. Rate limiting is only the cause we have seen; a bad `paths` filter, a
+// disabled workflow, or a webhook drop present identically and are equally worth
+// catching.
+//
+// Pure `findMissingDispatch()` (unit-tested) + a thin gh CLI wrapper, matching
+// scripts/check-merge-queue-churn.mjs. Run on a schedule by
+// .github/workflows/watch-missing-ci-dispatch.yml. `--dry-run` prints the
+// analysis without commenting.
+
+import { execFileSync } from "node:child_process";
+
+const COMMENT_MARKER = "<!-- missing-ci-dispatch-watch -->";
+
+/** Default grace period. Dispatch normally happens in seconds; 20 minutes is
+ *  generous enough that a merely slow queue is never flagged. */
+const DEFAULT_MIN_AGE_MINUTES = 20;
+
+/**
+ * Timestamp of the PR's head commit, in ms. Uses the newest `committedDate`
+ * across the PR's commits rather than the PR's own `updatedAt`, because
+ * `updatedAt` also moves on comments and label changes — a PR that was pushed
+ * three days ago but commented on a minute ago must not read as "just pushed"
+ * and escape the age check.
+ *
+ * @param {{commits?: Array<{committedDate?: string}>}} pr
+ * @returns {number|null} ms since epoch, or null when unknowable
+ */
+export function headCommitTime(pr) {
+  const commits = Array.isArray(pr?.commits) ? pr.commits : [];
+  let newest = null;
+  for (const c of commits) {
+    const t = Date.parse(c?.committedDate ?? "");
+    if (Number.isNaN(t)) continue;
+    if (newest === null || t > newest) newest = t;
+  }
+  return newest;
+}
+
+/**
+ * Flag open PRs whose head has received NO check runs at all.
+ *
+ * Skips, and why each skip is deliberate:
+ *   - drafts            — not expected to be gated yet
+ *   - any checks present — dispatch worked; a RED check is a different problem
+ *                          with its own alerting, not this one
+ *   - head younger than minAgeMinutes — dispatch may legitimately be in flight
+ *   - unknowable head time — we do not guess; a missing timestamp is not
+ *                          evidence of a missing run
+ *
+ * Pure.
+ *
+ * @param {Array<{number?:number, isDraft?:boolean, headRefOid?:string,
+ *                statusCheckRollup?:Array<unknown>, commits?:Array<{committedDate?:string}>}>} prs
+ * @param {{minAgeMinutes?:number, now?:number}} [opts]
+ * @returns {Array<{pr:number, headSha:string, ageMinutes:number}>}
+ */
+export function findMissingDispatch(prs, opts = {}) {
+  const minAgeMinutes = opts.minAgeMinutes ?? DEFAULT_MIN_AGE_MINUTES;
+  const now = opts.now ?? Date.now();
+  const flagged = [];
+
+  for (const pr of Array.isArray(prs) ? prs : []) {
+    if (!pr || typeof pr.number !== "number") continue;
+    if (pr.isDraft) continue;
+    const checks = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
+    if (checks.length > 0) continue;
+
+    const headAt = headCommitTime(pr);
+    if (headAt === null) continue;
+
+    const ageMinutes = (now - headAt) / 60000;
+    if (ageMinutes < minAgeMinutes) continue;
+
+    flagged.push({
+      pr: pr.number,
+      headSha: String(pr.headRefOid ?? "").slice(0, 8),
+      ageMinutes: Math.round(ageMinutes),
+    });
+  }
+  return flagged;
+}
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+}
+
+export function commentBody(f) {
+  return (
+    `${COMMENT_MARKER}\n` +
+    `⚠️ **No CI was dispatched for this PR.** Head \`${f.headSha}\` has been pushed for ` +
+    `**${f.ageMinutes} minutes** with **zero check runs** — not red, simply absent.\n\n` +
+    `This is not the same as CI being slow. Nothing is queued, so nothing will arrive: if ` +
+    `auto-merge is enabled it will wait forever on required contexts that were never created.\n\n` +
+    `The cause we have seen is the installation's GitHub API rate limit silently dropping ` +
+    `workflow dispatch (2026-08-01, PR #3907 got 5 checks instead of ~36). A disabled workflow, ` +
+    `an over-broad \`paths\` filter, or a dropped webhook look identical from here.\n\n` +
+    `**To recover:** re-trigger the \`pull_request\` event — push a commit, or close and reopen ` +
+    `the PR. "Re-run jobs" will not help, because there are no jobs to re-run.`
+  );
+}
+
+function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  let prs;
+  try {
+    // One call for everything: statusCheckRollup tells us whether ANY check
+    // exists on the head, so we never need a per-PR follow-up. That matters
+    // here more than usual — this watch exists because API budget ran out, and
+    // a detector that is itself expensive would be part of the problem.
+    prs = JSON.parse(
+      gh([
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "100",
+        "--json",
+        "number,isDraft,headRefOid,statusCheckRollup,commits",
+      ]),
+    );
+  } catch (err) {
+    console.error("[missing-ci-dispatch] could not list open PRs:", err.message);
+    process.exit(0); // never fail the scheduled job on a transient gh/API error
+  }
+
+  const flagged = findMissingDispatch(prs);
+  if (flagged.length === 0) {
+    console.log(`[missing-ci-dispatch] all ${prs.length} open PR(s) have dispatched CI.`);
+    return;
+  }
+
+  if (dryRun) {
+    for (const f of flagged) {
+      console.log(`[missing-ci-dispatch] (dry-run) PR #${f.pr}: head ${f.headSha}, ${f.ageMinutes}m, 0 checks`);
+    }
+    return;
+  }
+
+  for (const f of flagged) {
+    let view;
+    try {
+      view = JSON.parse(gh(["pr", "view", String(f.pr), "--json", "state,comments"]));
+    } catch {
+      console.log(`[missing-ci-dispatch] PR #${f.pr}: could not read — skip`);
+      continue;
+    }
+    if (view.state !== "OPEN") {
+      console.log(`[missing-ci-dispatch] PR #${f.pr} is ${view.state} — skip`);
+      continue;
+    }
+    if ((view.comments ?? []).some((c) => (c.body ?? "").includes(COMMENT_MARKER))) {
+      console.log(`[missing-ci-dispatch] PR #${f.pr} already flagged — skip`);
+      continue;
+    }
+    gh(["pr", "comment", String(f.pr), "--body", commentBody(f)]);
+    console.log(`[missing-ci-dispatch] flagged PR #${f.pr} (head ${f.headSha}, ${f.ageMinutes}m, 0 checks).`);
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("check-missing-ci-dispatch.mjs");
+if (invokedDirectly) main();

--- a/scripts/check-missing-ci-dispatch.test.mjs
+++ b/scripts/check-missing-ci-dispatch.test.mjs
@@ -1,0 +1,116 @@
+// Tests for the missing-CI-dispatch watch.
+//
+// The bar matches the other guard tests: prove the watch FIRES on the failure it
+// exists for, and — just as important here — prove it STAYS QUIET on the four
+// look-alikes. A watch that cries wolf on drafts or fresh pushes gets muted, and
+// a muted watch is worse than none, because the silent stall it was built for
+// then looks exactly like its own noise.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findMissingDispatch, headCommitTime, commentBody } from "./check-missing-ci-dispatch.mjs";
+
+const NOW = Date.parse("2026-08-04T20:00:00.000Z");
+const minsAgo = (m) => new Date(NOW - m * 60000).toISOString();
+
+const pr = (over = {}) => ({
+  number: 1,
+  isDraft: false,
+  headRefOid: "abcdef1234567890",
+  statusCheckRollup: [],
+  commits: [{ committedDate: minsAgo(60) }],
+  ...over,
+});
+
+test("fires on an open PR whose head has zero checks — the whole point", () => {
+  const found = findMissingDispatch([pr()], { now: NOW });
+  assert.equal(found.length, 1);
+  assert.equal(found[0].pr, 1);
+  assert.equal(found[0].headSha, "abcdef12");
+  assert.equal(found[0].ageMinutes, 60);
+});
+
+test("stays quiet when ANY check exists — a red check is a different problem", () => {
+  // Dispatch worked. Whether those checks passed is not this watch's business;
+  // failures already alert loudly on their own.
+  const found = findMissingDispatch([pr({ statusCheckRollup: [{ name: "DCO", conclusion: "FAILURE" }] })], {
+    now: NOW,
+  });
+  assert.deepEqual(found, []);
+});
+
+test("stays quiet on a freshly pushed head — dispatch may be in flight", () => {
+  const found = findMissingDispatch([pr({ commits: [{ committedDate: minsAgo(3) }] })], { now: NOW });
+  assert.deepEqual(found, []);
+});
+
+test("stays quiet on drafts", () => {
+  const found = findMissingDispatch([pr({ isDraft: true })], { now: NOW });
+  assert.deepEqual(found, []);
+});
+
+test("ages on the head COMMIT, not on PR updatedAt", () => {
+  // Regression guard for the tempting shortcut. A PR pushed days ago but
+  // commented on a minute ago must still be flagged — using updatedAt would
+  // make it look freshly pushed and let a genuinely stalled PR escape.
+  const old = pr({ commits: [{ committedDate: minsAgo(4320) }], updatedAt: minsAgo(1) });
+  const found = findMissingDispatch([old], { now: NOW });
+  assert.equal(found.length, 1);
+  assert.equal(found[0].ageMinutes, 4320);
+});
+
+test("uses the NEWEST commit when a PR has several", () => {
+  const multi = pr({
+    commits: [{ committedDate: minsAgo(500) }, { committedDate: minsAgo(30) }, { committedDate: minsAgo(200) }],
+  });
+  assert.equal(headCommitTime(multi), NOW - 30 * 60000);
+  assert.equal(findMissingDispatch([multi], { now: NOW })[0].ageMinutes, 30);
+});
+
+test("does not guess when the head timestamp is unknowable", () => {
+  // A missing or unparseable date is not evidence of a missing run. Flagging
+  // here would be inventing a failure out of absent metadata.
+  for (const commits of [[], [{}], [{ committedDate: "not-a-date" }], undefined]) {
+    assert.deepEqual(findMissingDispatch([pr({ commits })], { now: NOW }), [], JSON.stringify(commits));
+  }
+});
+
+test("threshold is configurable and is a strict floor", () => {
+  const p = pr({ commits: [{ committedDate: minsAgo(20) }] });
+  assert.equal(findMissingDispatch([p], { now: NOW, minAgeMinutes: 20 }).length, 1, "20m meets a 20m floor");
+  assert.deepEqual(findMissingDispatch([p], { now: NOW, minAgeMinutes: 21 }), [], "20m is under a 21m floor");
+});
+
+test("survives malformed input without throwing", () => {
+  // The scheduled job must never fail on odd API output — a crashed watch is a
+  // silent watch, which is the exact failure it is meant to prevent.
+  assert.deepEqual(findMissingDispatch(null), []);
+  assert.deepEqual(findMissingDispatch(undefined), []);
+  assert.deepEqual(findMissingDispatch([null, {}, { number: "x" }], { now: NOW }), []);
+});
+
+test("only the flagged PRs come back from a mixed set", () => {
+  const found = findMissingDispatch(
+    [
+      pr({ number: 10 }),
+      pr({ number: 11, statusCheckRollup: [{ name: "CI" }] }),
+      pr({ number: 12, isDraft: true }),
+      pr({ number: 13, commits: [{ committedDate: minsAgo(1) }] }),
+      pr({ number: 14 }),
+    ],
+    { now: NOW },
+  );
+  assert.deepEqual(
+    found.map((f) => f.pr),
+    [10, 14],
+  );
+});
+
+test("the comment names the recovery that actually works", () => {
+  // "Re-run failed jobs" is the reflex and it is useless here: there are no jobs
+  // to re-run. The comment must say so or it sends the reader down a dead end.
+  const body = commentBody({ pr: 1, headSha: "abcdef12", ageMinutes: 60 });
+  assert.match(body, /re-trigger the `pull_request` event/);
+  assert.match(body, /will not help/);
+  assert.match(body, /<!-- missing-ci-dispatch-watch -->/, "marker enables comment-once");
+});


### PR DESCRIPTION
## Summary

Every other CI failure mode in this repo turns a check **red**. This one makes checks **absent** — indistinguishable from "still pending". Nothing alerts, auto-merge waits forever, and the PR never moves.

On 2026-08-01 the installation's GitHub API rate limit was exhausted — the same exhaustion that reported `CodeQL job status was configuration error` on three Analyze jobs. **PR #3907 was opened inside that window and received 5 checks instead of the usual ~36.** The CI workflow never dispatched. Auto-merge was armed and would have waited indefinitely on required contexts that were never created.

It was caught by a human eyeballing the check count. That is not a control.

## Changes

A scheduled watch that flags an open, non-draft PR whose head commit is older than 20 minutes and carries **zero check runs of any kind**, then comments once.

Detection is **shape-based, not cause-based**. Rate limiting is only the cause observed so far; a disabled workflow, an over-broad `paths` filter, and a dropped webhook present identically and are equally worth catching.

Mirrors `check-merge-queue-churn.mjs`, which covers the other silent PR-level stall — pure unit-tested analysis + thin `gh` wrapper, comment marker for post-once idempotency, `--dry-run`, and `exit(0)` on any gh/API error.

That last property is load-bearing: **a crashed watch is a silent watch**, which is precisely the failure it exists to prevent. Verified by invoking it where `gh` is unavailable — it exits 0 with a clear message rather than going red.

## Two design choices worth stating

**Age is measured from the newest head commit, not from `updatedAt`.** `updatedAt` also moves on comments and labels, so a PR pushed days ago but commented on a minute ago would read as freshly pushed and escape detection entirely. There's a regression test pinning this.

**The whole sweep is a single `gh pr list` call**, using `statusCheckRollup` to answer "any checks?" per PR with no follow-up. This watch exists *because* API budget ran out — a detector that is itself expensive would be part of the problem it reports.

## Test plan

- [x] **Source-only change** (one scheduled workflow + one script + its tests; no server route, MCP tool, runtime wiring, migration, or UX surface)

### Verification evidence

```
$ node --test scripts/check-missing-ci-dispatch.test.mjs      # 11/11
$ node scripts/security/check-actions-injection.mjs
    ✓ Actions injection audit PASSED
$ node scripts/check-guards.mjs        → Guard loop OK — 24 guards passed.
$ node scripts/check-module-size.mjs   → Module-size OK.
$ python3 -c "yaml.safe_load(...)"
    YAML OK | triggers: {"schedule":[{"cron":"*/30 * * * *"}],"workflow_dispatch":{}}
    permissions: {"contents":"read","pull-requests":"write"}

$ node scripts/check-missing-ci-dispatch.mjs --dry-run   # gh absent here
    [missing-ci-dispatch] could not list open PRs: spawnSync gh ENOENT
    EXIT CODE: 0        ← the never-self-fail guarantee, exercised
```

The 11 tests cover the fire case and — more importantly — the **four look-alikes that must stay quiet**: checks present, fresh push, draft, and an unknowable timestamp. A watch that cries wolf gets muted, and a muted watch is worse than none, because the silent stall then looks exactly like its own noise.

- [x] **Verification-harness limitation acknowledged** — the scheduled trigger and live `gh` path can only be exercised on `main`. Analysis logic is unit-tested; the wrapper is deliberately thin for that reason, and `workflow_dispatch` is enabled so it can be run on demand after merge.

## Pre-PR readiness

Local-CI-Override: scheduled workflow + script + tests; no application runtime code in the diff, all applicable source-local gates captured above.

## Related issues / Epic

Closes the last unaddressed face of the API rate-limit problem tracked through #3982 and #3992. Related: BI-A08EBAEC.

## Overlap sweep

`scripts/check-missing-ci-dispatch.{mjs,test.mjs}` (new), `.github/workflows/watch-missing-ci-dispatch.yml` (new). No application code, no changes to existing workflows, guards, or doctrine.

## Notes for the reviewer

**Why a 20-minute threshold.** Dispatch normally happens in seconds. 20 minutes is generous enough that a merely congested Actions queue is never flagged, while still catching a stall long before a human would. It's a parameter on the pure function, so it's trivial to tune — the test pins it as a strict floor in both directions.

**What this does not do.** It does not re-dispatch. There is no reliable way to re-fire a `pull_request` event from a scheduled job, so the comment names the recovery that actually works — push a commit, or close and reopen — and says explicitly that **"Re-run failed jobs" will not help, because there are no jobs to re-run.** That reflex sends the reader down a dead end, and the comment is tested for saying so.

**Where the remaining rate-limit work sits.** This is the detection half. The prevention half is the duplicate CodeQL run reported in #3992 — the signature suggests Code Scanning **default setup** is enabled alongside the advanced workflow, which would double the repo's most API-expensive job class. That's a repository-settings change at Settings → Code security → Code scanning, and it's inference from run shape rather than something I can read directly, so it still needs a human to confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX2tk9whhQLGawaEYKRF13)_