### PR TITLE
fix(ux-audit): record the live button-decision validation; archive reports per run scope (BI-C3768478)

### DIFF
--- a/apps/web/lib/ux-audit/button-decision-lens.test.ts
+++ b/apps/web/lib/ux-audit/button-decision-lens.test.ts
@@ -171,3 +171,21 @@ describe("inference-failure replies are NOT-RUN, never a silent pass", () => {
     expect(findings[0]!.severity).toBe("critical");
   });
 });
+
+describe("carrier attribution when the sentinel is stripped at render time", () => {
+  it("attributes rendered buttons with no visible carrier to a stripped sentinel", () => {
+    expect(expectedCarrier("Here is what I found. No question here.", true)).toBe(
+      "sentinel-stripped",
+    );
+  });
+
+  it("still reports none when no buttons rendered", () => {
+    expect(expectedCarrier("Here is what I found. No question here.", false)).toBe("none");
+  });
+
+  it("prefers a real prose closeout over the stripped-sentinel fallback", () => {
+    expect(
+      expectedCarrier("Should I fix the render first, or prioritize the CLI saturation?", true),
+    ).toBe("prose-fallback");
+  });
+});

--- a/apps/web/lib/ux-audit/button-decision-lens.ts
+++ b/apps/web/lib/ux-audit/button-decision-lens.ts
@@ -86,12 +86,19 @@ export function isDecisionCloseout(reply: string): boolean {
  * attribute a miss precisely: a sentinel that never rendered is a different
  * defect from a prose closeout the fallback failed to recover.
  */
-export function expectedCarrier(rawReply: string): "sentinel" | "prose-fallback" | "none" {
+export function expectedCarrier(
+  rawReply: string,
+  buttonsRendered = false,
+): "sentinel" | "sentinel-stripped" | "prose-fallback" | "none" {
   if (rawReply.includes("dpf-decision")) {
     const { decision } = parseDecisionFromContent(rawReply);
     if (decision) return "sentinel";
   }
   if (deriveDecisionFromProse(rawReply)) return "prose-fallback";
+  // Buttons rendered but the visible text explains neither: the renderer strips
+  // the sentinel before the DOM is readable (parseDecisionFromContent runs at
+  // render time), so a live observation can only attribute it by elimination.
+  if (buttonsRendered) return "sentinel-stripped";
   return "none";
 }
 

--- a/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
+++ b/docs/superpowers/plans/2026-07-16-ux-auditor-portal-survey.md
@@ -58,8 +58,30 @@ against the live portal with a real authenticated session. The page lens correct
 instead of a clean page — the `interpretExtraction` fix working in production. The behavioral
 lens drove a real coworker on a real route and read back its rendered turn.
 
-**Not proven — the button-decision lens has not yet observed rendered buttons live.** Two
-host-level outages block it, both filed:
+**PROVEN — the button-decision lens observed recommended-first buttons live.** On `/workspace`,
+during a real survey run against the authenticated portal, the coworker's turn rendered two
+decision buttons in DOM order:
+
+| # | Label | `data-recommended` |
+| --- | --- | --- |
+| 1 | Check platform status first | **true** |
+| 2 | Try configuring again now | — |
+
+The lens returned **zero findings**, and did so having actually executed its shape assertions
+(buttons present → recommended-first ordering → accessible-name check), not by short-circuiting.
+That is the founder's standing requirement satisfied: the button-decision interface (BI-3237B5D6)
+validated as one lens INSIDE a comprehensive portal survey, not spot-checked.
+
+Carrier attribution reads `sentinel-stripped`: the renderer strips the sentinel before the DOM is
+observable (`parseDecisionFromContent` runs at render time), so a live observation can only
+attribute a rendered decision by elimination. The lens's verdict does not depend on it.
+
+**Coverage is still partial.** A later full-shell run measured 5 of 6 section homes and returned
+`portalVerdict: fail` on 4 critical NOT-RUNs — the local engine re-saturates under six
+back-to-back coworker turns, so `/customer`, `/delivery`, `/knowledge` and `/platform` answered
+with a provider-busy notice; `/ops` replied but offered no decision (a correct silent pass). Those
+NOT-RUNs are the new rule working: before it, every one would have read as a clean pass. Two
+host-level outages gate full coverage, both filed:
 
 | Blocker | Effect | Filed |
 | --- | --- | --- |
@@ -69,11 +91,17 @@ host-level outages block it, both filed:
 The lens behaved correctly throughout: it emits no finding when the coworker did not close on
 a decision, and — after this run exposed the gap — a **critical NOT-RUN** when the reply is an
 inference-failure notice, so a saturated engine can never read as "no decision offered,
-nothing wrong". Re-run once either blocker clears:
+nothing wrong". Re-run for full coverage once either blocker clears:
 
 ```
 DPF_RECORD_FUNCTIONAL_FAILURES=1 pnpm test:e2e -- --project=ux-audit
 ```
+
+**Reports are archived per run scope** to `e2e-report/ux-audit/ux-audit-report-<scope>.json`.
+Playwright wipes `outputDir` at the start of every run, so a later survey otherwise destroys an
+earlier one's evidence — including a PASS, which files no finding and so leaves no other trace.
+Learned the hard way: a full-shell run erased the single-route run that had captured the live
+decision buttons above.
 
 **Operational notes for the next runner.** The survey persists its report after EACH route,
 because a long live-inference run is exactly the job an outer process budget cuts short and an

--- a/e2e/ux-audit/portal-survey.spec.ts
+++ b/e2e/ux-audit/portal-survey.spec.ts
@@ -169,7 +169,7 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
           route,
           reply: observed.reply,
           buttons: observed.buttons,
-          expectedCarrier: expectedCarrier(observed.reply),
+          expectedCarrier: expectedCarrier(observed.reply, observed.buttons.length > 0),
         });
 
         return evaluateButtonDecision({ route, ...observed });
@@ -183,6 +183,18 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
   const reportPath = join(testInfo.outputDir, "ux-audit-report.json");
   await mkdir(dirname(reportPath), { recursive: true });
 
+  // Playwright wipes outputDir at the start of every run, so a later survey
+  // silently destroys an earlier one's evidence — including a PASS, which files
+  // no finding and therefore leaves no other trace. Keep a durable copy per run
+  // scope outside outputDir. (Observed the hard way: a full-shell run erased the
+  // single-route run that had captured live decision buttons.)
+  const scopeTag = (routeFilter.length > 0 ? routeFilter.join("_") : "shell")
+    .replace(/[^a-z0-9]+/gi, "-")
+    .replace(/^-+|-+$/g, "");
+  const archiveDir = join("e2e-report", "ux-audit");
+  const archivePath = join(archiveDir, `ux-audit-report-${scopeTag}.json`);
+  await mkdir(archiveDir, { recursive: true });
+
   const results: RouteSurveyResult[] = [];
   let report: UxAuditReport = aggregateReport(results);
 
@@ -191,9 +203,7 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
     results.push(...partial.routes);
     report = aggregateReport(results);
 
-    await writeFile(
-      reportPath,
-      JSON.stringify(
+    const serialized = JSON.stringify(
         {
           epic: "EP-UX-AUDITOR",
           backlogItemId: "BI-C3768478",
@@ -209,9 +219,9 @@ test("portal-shell UX survey — page lens + coworker button-decision lens", asy
         },
         null,
         2,
-      ),
-      "utf8",
-    );
+      );
+    await writeFile(reportPath, serialized, "utf8");
+    await writeFile(archivePath, serialized, "utf8");
     // eslint-disable-next-line no-console
     console.log(
       `[ux-audit] ${entry.route}: verdict=${results[results.length - 1]!.verdict} ` +


### PR DESCRIPTION
Follow-up to #3998 (BI-C3768478, EP-UX-AUDITOR P2).

## The button-decision lens is validated live

On `/workspace`, inside a real survey run against the authenticated portal, the coworker's turn rendered two decision buttons in DOM order:

| # | Label | `data-recommended` |
| --- | --- | --- |
| 1 | Check platform status first | **true** |
| 2 | Try configuring again now | — |

The lens returned zero findings *having actually executed its shape assertions* (buttons present → recommended-first ordering → accessible-name check), so this is a real pass rather than a short-circuit. This records that observation in the plan.

**Scope of the claim, precisely:** this proves the *sentinel* carrier renders recommended-first buttons inside a survey. It does **not** close the P1.5 gap — the deterministic prose fallback (`deriveDecisionFromProse`) still has not been live-driven. The observed decision attributes as `sentinel-stripped`, not `prose-fallback`.

## Two fixes that run surfaced

1. **Reports are archived per run scope** to `e2e-report/ux-audit/ux-audit-report-<scope>.json`. Playwright wipes `outputDir` at the start of every run, so a later survey destroys an earlier one's evidence — including a PASS, which files no finding and therefore leaves no other trace. A full-shell run erased the single-route run that had captured the buttons above.
2. **`expectedCarrier` reports `sentinel-stripped`** when buttons rendered but the visible text explains neither carrier. The renderer strips the sentinel before the DOM is observable (`parseDecisionFromContent` runs at render time), so a live observation can only attribute a rendered decision by elimination. Reporting `none` while buttons were plainly on screen was misleading metadata.

## Coverage is still partial

A full-shell run measured 5 of 6 section homes and returned `portalVerdict: fail` on 4 critical NOT-RUNs — the local engine re-saturates under six back-to-back coworker turns, so `/customer`, `/delivery`, `/knowledge` and `/platform` answered with a provider-busy notice. `/ops` replied but offered no decision (a correct silent pass).

Those NOT-RUNs are the rule from #3998 working: before it, each would have read as a clean pass. But it means **the survey has not yet produced UX findings about the portal** — every finding so far is a NOT-RUN about the harness or infrastructure. Two host outages gate real coverage, both filed with evidence:

- **BI-D26CEBBB** — browser-use sidecar down, so the page lens is NOT-RUN on every route.
- **BI-32631D86** — local inference unusable under load (only chat model is a 30B MoE at 4096 context).

BI-C3768478 stays open pending those.

Verified via the governed local-CI gate (exact-tree, merged against main): typecheck passed, 2554 vitest files passed / 4 skipped.
