### PR TITLE
fix(ci): make the production build resilient to runner OOM/preemption SIGTERM (BI-6540EB2B)

### DIFF
--- a/apps/web/scripts/next-build.mjs
+++ b/apps/web/scripts/next-build.mjs
@@ -1,20 +1,100 @@
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
-const nextBin = require.resolve("next/dist/bin/next");
-const result = spawnSync(
-  process.execPath,
-  ["--max-old-space-size=8192", nextBin, "build", ...process.argv.slice(2)],
-  {
-    env: process.env,
-    stdio: "inherit",
-  },
-);
 
-if (result.error) {
-  console.error(result.error);
-  process.exit(1);
+// V8 old-space ceiling for the Next.js production build. Overridable via env so
+// the CI heap can be tuned from the workflow (per BI-6540EB2B) WITHOUT a code
+// change. Why it matters: on a 16 GB hosted runner an 8 GB old-space limit plus
+// RSS overhead plus Next's build workers can approach physical RAM. When the OS
+// reaps the process the job dies with a SIGTERM "runner received a shutdown
+// signal" and the PR is silently ejected from the merge queue while still
+// reporting mergeStateStatus: CLEAN. Lowering this ceiling makes an oversized
+// build fail as a clean V8 "heap out of memory" (attributable, re-run-safe)
+// instead of a runner death.
+const maxOldSpaceMb =
+  Number.parseInt(process.env.DPF_BUILD_MAX_OLD_SPACE_MB ?? "", 10) || 8192;
+
+// Retries are applied ONLY when the build child is killed by a signal (OOM /
+// runner preemption) — never on a real build error, which must fail fast so a
+// broken PR is not masked and the 45m job budget is not doubled. Default 1.
+const parsedRetries = Number.parseInt(process.env.DPF_BUILD_SIGNAL_RETRIES ?? "", 10);
+const maxSignalRetries =
+  Number.isFinite(parsedRetries) && parsedRetries >= 0 ? parsedRetries : 1;
+
+/**
+ * Decide what to do with a spawnSync result. Pure and exported so the
+ * retry/attribution policy is unit-testable without running a real build.
+ *
+ * @param {{error?: Error, status?: number|null, signal?: string|null}} result
+ * @param {{attempt: number, maxRetries: number}} ctx  attempt is 0-based.
+ * @returns {{action: "ok"|"retry"|"fail", code: number, signal?: string, reason?: string}}
+ */
+export function interpretBuildResult(result, { attempt, maxRetries }) {
+  if (result.error) {
+    return { action: "fail", code: 1, reason: `spawn error: ${result.error.message}` };
+  }
+  if (result.signal) {
+    // Signal death == the OS/runner killed the process (OOM or preemption),
+    // NOT a source-level build failure. Retry while attempts remain.
+    const canRetry = attempt < maxRetries;
+    return {
+      action: canRetry ? "retry" : "fail",
+      code: 137, // conventional 128+SIGKILL; marks an infra/OOM death, not exit 1
+      signal: result.signal,
+      reason: `child terminated by signal ${result.signal} (likely runner OOM/preemption, not a source error)`,
+    };
+  }
+  const status = result.status ?? 0;
+  return status === 0
+    ? { action: "ok", code: 0 }
+    : { action: "fail", code: status, reason: `build exited with status ${status}` };
 }
 
-process.exit(result.status ?? (result.signal ? 1 : 0));
+function runOnce() {
+  // Resolved lazily (not at import time) so tests can import the policy above
+  // without `next` being installed in the worktree.
+  const nextBin = require.resolve("next/dist/bin/next");
+  return spawnSync(
+    process.execPath,
+    [`--max-old-space-size=${maxOldSpaceMb}`, nextBin, "build", ...process.argv.slice(2)],
+    { env: process.env, stdio: "inherit" },
+  );
+}
+
+function main() {
+  for (let attempt = 0; ; attempt += 1) {
+    const decision = interpretBuildResult(runOnce(), {
+      attempt,
+      maxRetries: maxSignalRetries,
+    });
+
+    if (decision.action === "ok") process.exit(0);
+
+    if (decision.action === "retry") {
+      console.error(
+        `[production-build] ${decision.reason}; retrying (attempt ${attempt + 2}/${maxSignalRetries + 1})`,
+      );
+      continue;
+    }
+
+    // action === "fail"
+    if (decision.signal) {
+      console.error(
+        `[production-build] FATAL: ${decision.reason}; exhausted ${maxSignalRetries} ` +
+          `retr${maxSignalRetries === 1 ? "y" : "ies"}. This is infrastructure (memory/` +
+          `preemption), not a code failure — re-run the job, or lower DPF_BUILD_MAX_OLD_SPACE_MB ` +
+          `(currently ${maxOldSpaceMb}) / raise the runner size.`,
+      );
+    } else if (decision.reason) {
+      console.error(`[production-build] ${decision.reason}`);
+    }
+    process.exit(decision.code);
+  }
+}
+
+// Only drive the build when executed directly; importing for tests must not run it.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/apps/web/scripts/next-build.test.ts
+++ b/apps/web/scripts/next-build.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import { interpretBuildResult } from "./next-build.mjs";
+
+// BI-6540EB2B: the production build was killed mid-run by a runner SIGTERM and
+// exited 1 — indistinguishable from a real build error, so it silently ejected
+// PRs from the merge queue (they still reported mergeStateStatus: CLEAN). These
+// lock the retry/attribution policy that makes signal-death (OOM/preemption)
+// recoverable while a genuine build error still fails fast.
+describe("interpretBuildResult", () => {
+  test("status 0 -> ok, no retry", () => {
+    const d = interpretBuildResult({ status: 0, signal: null }, { attempt: 0, maxRetries: 1 });
+    expect(d.action).toBe("ok");
+    expect(d.code).toBe(0);
+  });
+
+  test("real build error (non-zero status) -> fail fast, preserves exit code, never retries", () => {
+    const d = interpretBuildResult({ status: 2, signal: null }, { attempt: 0, maxRetries: 1 });
+    expect(d.action).toBe("fail");
+    expect(d.code).toBe(2);
+  });
+
+  test("signal death with an attempt remaining -> retry", () => {
+    const d = interpretBuildResult({ status: null, signal: "SIGTERM" }, { attempt: 0, maxRetries: 1 });
+    expect(d.action).toBe("retry");
+    expect(d.signal).toBe("SIGTERM");
+  });
+
+  test("signal death with retries exhausted -> fail, marked infra (137)", () => {
+    const d = interpretBuildResult({ status: null, signal: "SIGKILL" }, { attempt: 1, maxRetries: 1 });
+    expect(d.action).toBe("fail");
+    expect(d.code).toBe(137);
+    expect(d.reason).toMatch(/OOM|preemption/);
+  });
+
+  test("maxRetries=0 -> signal death fails immediately (no retry)", () => {
+    const d = interpretBuildResult({ status: null, signal: "SIGTERM" }, { attempt: 0, maxRetries: 0 });
+    expect(d.action).toBe("fail");
+  });
+
+  test("spawn error -> fail with code 1", () => {
+    const d = interpretBuildResult({ error: new Error("boom") }, { attempt: 0, maxRetries: 1 });
+    expect(d.action).toBe("fail");
+    expect(d.code).toBe(1);
+  });
+});


### PR DESCRIPTION
Resolves **BI-6540EB2B** — *Production Build job killed by runner SIGTERM, ejecting PRs from the merge queue.*

## Problem
The `Production Build` job is killed mid-run by a runner SIGTERM (`The runner has received a shutdown signal` → `Command failed with signal "SIGTERM"`), most consistent with the Next.js build approaching the **16 GB hosted runner's physical memory** (8 GB V8 old-space + RSS overhead + build workers). `apps/web/scripts/next-build.mjs` exited `1` on that signal death — **indistinguishable from a real build error** — so `Merge Readiness` failed downstream and the PR was **silently ejected from the merge queue while still reporting `mergeStateStatus: CLEAN`**. (Observed again on this very session's PR #3987, which needed a manual re-run to land.)

## Fix (no workflow change; defaults preserve today's behavior)
- **Attribute the failure.** `next-build.mjs` now distinguishes a *signal-death* (OS/runner kill — OOM or preemption) from a *real build error*. A genuine non-zero build exit still fails fast with its own exit code — **no masking, no doubled 45m budget**. Only a signal-death is retried, **once**, with a loud greppable `[production-build] …` diagnostic naming it as infrastructure.
- **Make the heap tunable from the workflow.** `DPF_BUILD_MAX_OLD_SPACE_MB` (default `8192`) and `DPF_BUILD_SIGNAL_RETRIES` (default `1`) — the exact knobs the BI's investigation note asks for, so the ceiling can be dialed in from CI env once one instrumented run gives the real peak-memory number, without another code change.
- **Testable policy.** The retry/attribution decision is a pure `interpretBuildResult()` covered by vitest.

## Verification
`apps/web/scripts/next-build.test.ts` — **6/6 passing** (vitest v4.1.10): real error fails fast & preserves its code; signal-death retries then fails as infra (137); retry budget respected; spawn-error handled. Import is build-safe (lazy `require.resolve`, direct-run guard) so the policy is unit-testable without `next` installed.

## Follow-up (needs data, out of scope here)
The *definitive* choice between lowering the heap ceiling vs. a larger runner still needs one instrumented run's peak-RSS. This PR makes every remaining occurrence **loudly attributable and auto-retried**, and turns that final decision into an env change rather than a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)