### PR TITLE
feat(docs): derive doc-impact edges from the references docs already contain

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -264,8 +264,35 @@
     ]
   },
   "codeToDocs": {
+    ".githooks/lib/pre-push-chained.sh": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    ".github/workflows/ci.yml": [
+      "docs/security/2026-05-24-shift-left-rollout.md",
+      "docs/testing/pre-pr-gate.md"
+    ],
+    ".github/workflows/codeql.yml": [
+      "docs/security/2026-05-24-shift-left-rollout.md",
+      "docs/security/secrets-scan.md",
+      "docs/testing/pre-pr-gate.md"
+    ],
+    ".github/workflows/install-verification.yml": [
+      "docs/install/linux.md"
+    ],
+    ".github/workflows/secrets-scan.yml": [
+      "docs/security/2026-05-24-shift-left-rollout.md"
+    ],
+    ".github/workflows/security-inflow-gate.yml": [
+      "docs/security/secrets-scan.md"
+    ],
+    "apps/mobile/eas.json": [
+      "docs/operations/mobile-store-launch-runbook.md"
+    ],
     "apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx": [
       "docs/user-guide/ai-workforce/coworker-proactivity.md"
+    ],
+    "apps/web/app/(shell)/delivery/page.tsx": [
+      "docs/architecture/delivery-ia.md"
     ],
     "apps/web/app/(shell)/platform/ai/providers/page.tsx": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
@@ -276,17 +303,53 @@
     "apps/web/app/(shell)/workspace/my-queue/page.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
+    "apps/web/app/api/integrations/email-postmark/inbound/route.ts": [
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md"
+    ],
+    "apps/web/app/api/v1/edge/adapters/route.ts": [
+      "docs/edge-node/unifi-adapter.md"
+    ],
     "apps/web/components/attention/AttentionInbox.tsx": [
       "docs/user-guide/workspace/attention-inbox.md"
     ],
     "apps/web/components/attention/OwnerDecisionCards.tsx": [
       "docs/user-guide/workspace/attention-inbox.md"
     ],
+    "apps/web/components/build/BuildDispatchHistoryCard.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/build/BuildProgressOperationalPanel.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/build/DecisionPerspectiveGatePanel.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/build/ProcessGraph.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/build/StallEventHistoryStrip.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/build/UnifiedEvidenceTimeline.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/build/WorkflowStageInspector.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/components/monitoring/health-summary.ts": [
+      "docs/install/platform-support-watchlist.md"
+    ],
     "apps/web/components/platform/ProviderSuitabilityGuide.tsx": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
     ],
+    "apps/web/components/platform/StalledTaskRecoveryActions.tsx": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
     "apps/web/components/proactivity/ProactivityRosterList.tsx": [
       "docs/user-guide/ai-workforce/coworker-proactivity.md"
+    ],
+    "apps/web/components/shell/SectionNav.tsx": [
+      "docs/architecture/section-navigation.md"
     ],
     "apps/web/components/workspace/WorkCaseAttentionLens.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
@@ -300,11 +363,50 @@
     "apps/web/components/workspace/work-room/WorkRoomParticipants.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
+    "apps/web/instrumentation.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/actions/build.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/actions/sovereignty.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
     "apps/web/lib/ai-inference.ts": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
     ],
     "apps/web/lib/attention/owner-projection.ts": [
       "docs/user-guide/workspace/attention-inbox.md"
+    ],
+    "apps/web/lib/build-pipeline.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/build/progress-visibility.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/contracts/entity-contract-drift.ts": [
+      "docs/architecture/package-boundaries.md"
+    ],
+    "apps/web/lib/contracts/package-boundaries.test.ts": [
+      "docs/architecture/package-boundaries.md"
+    ],
+    "apps/web/lib/decision-perspective/build-studio-gate.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/decision/golden-decisions.baseline.json": [
+      "docs/founder-kernel/AUTHORING.md"
+    ],
+    "apps/web/lib/decision/golden-decisions.test.ts": [
+      "docs/founder-kernel/AUTHORING.md"
+    ],
+    "apps/web/lib/ea/ai-routing-architecture-extract.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+    ],
+    "apps/web/lib/ea/ai-routing-architecture-registry.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+    ],
+    "apps/web/lib/explore/feature-build-types.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
     "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
@@ -312,14 +414,123 @@
     "apps/web/lib/inference/data-screening/vertical-policy-packs.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
     ],
+    "apps/web/lib/inference/local-only.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "apps/web/lib/inference/routed-inference.ts": [
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md"
+    ],
     "apps/web/lib/integrate/build-orchestrator.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
       "docs/user-guide/build-studio/index.md"
+    ],
+    "apps/web/lib/integrate/build-pipeline.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/integrate/build-studio-config.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/integrate/claude-dispatch.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/marketing/channels/email-postmark/responder.ts": [
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md"
+    ],
+    "apps/web/lib/marketing/scheduler.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/mcp/packs/deliberation-siem-pack.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/mcp/packs/feedback-pack.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/mcp/packs/runtime-coordination-pack.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/mcp/packs/work-capsules-pack.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/mcp/packs/workbooks-pack.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/mcp/tool-pack.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/mcp/tool-registry.ts": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "apps/web/lib/navigation/section-nav-model.ts": [
+      "docs/architecture/section-navigation.md"
+    ],
+    "apps/web/lib/platform-runtime/capability-service-projection.ts": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "apps/web/lib/platform-runtime/operational-state.ts": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
     ],
     "apps/web/lib/proactivity/proactivity-roster.ts": [
       "docs/user-guide/ai-workforce/coworker-proactivity.md"
     ],
+    "apps/web/lib/queue/functions/deliberation-run.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/queue/functions/index.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/queue/functions/quiescence-run.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/queue/functions/taskrun-watchdog.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/queue/inngest-client.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/queue/notification-adapter.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/routes.ts": [
+      "docs/architecture/data-model-stewardship-runbook.md"
+    ],
+    "apps/web/lib/routing/chat-adapter.ts": [
+      "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/routing/cost-ranking.ts": [
+      "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/routing/pipeline-v2.ts": [
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
     "apps/web/lib/routing/provider-suitability/workload-profile.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
+    ],
+    "apps/web/lib/routing/request-contract.ts": [
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
+      "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/self-upgrade/local-changes-ledger.ts": [
+      "docs/architecture/branch-and-worktree-runbook.md"
+    ],
+    "apps/web/lib/shared/action-result.ts": [
+      "docs/architecture/data-model-stewardship-runbook.md"
+    ],
+    "apps/web/lib/shared/coerce.ts": [
+      "docs/architecture/data-model-stewardship-runbook.md"
+    ],
+    "apps/web/lib/shared/org-address.ts": [
+      "docs/architecture/data-model-stewardship-runbook.md"
+    ],
+    "apps/web/lib/tak/agent-grants.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/tak/agentic-loop.ts": [
+      "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/tak/autonomous-work-run.ts": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
     "apps/web/lib/work-management/room-channel-continuity.ts": [
       "docs/user-guide/workspace/work-rooms.md"
@@ -336,15 +547,71 @@
     "apps/web/lib/work-management/workspace-room-access.ts": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
+    "config/merge-readiness-policy.json": [
+      "docs/testing/pr-health.md"
+    ],
+    "docker-compose.edge-snmp.yml": [
+      "docs/edge-node/deployment-topology.md"
+    ],
+    "docker-compose.edge-standalone-tls.yml": [
+      "docs/edge-node/deployment-topology.md",
+      "docs/install/edge-node-air-gapped.md",
+      "docs/install/edge-node-multi-host.md"
+    ],
+    "docker-compose.edge-standalone.yml": [
+      "docs/edge-node/deployment-topology.md",
+      "docs/install/cloud-single-vm.md",
+      "docs/install/edge-node-air-gapped.md",
+      "docs/install/edge-node-multi-host.md"
+    ],
+    "docker-compose.edge.macvlan.yml": [
+      "docs/edge-node/deployment-topology.md",
+      "docs/edge-node/macvlan-deployment.md"
+    ],
+    "docker-compose.edge.yml": [
+      "docs/edge-node/deployment-topology.md",
+      "docs/install/edge-node-multi-host.md"
+    ],
+    "docker-compose.tls.yml": [
+      "docs/install/edge-node-multi-host.md"
+    ],
     "docker-compose.yml": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
       "docs/architecture/platform-overview.md",
       "docs/operations/disaster-recovery.md"
+    ],
+    "docs/testing/ci-observation-baseline.json": [
+      "docs/testing/ci-evidence.md"
     ],
     "monitoring/prometheus/prometheus.yml": [
       "docs/architecture/platform-overview.md"
     ],
+    "packages/db/data/platform-runtime-capabilities.json": [
+      "docs/architecture/capability-driven-runtime-profiles.md",
+      "docs/architecture/platform-substrate-boundaries.md"
+    ],
     "packages/db/prisma/schema.prisma": [
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
       "docs/architecture/platform-overview.md"
+    ],
+    "packages/db/scripts/check-cada-readiness.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "packages/db/scripts/seed-cada-regulation.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "packages/db/src/cada-readiness.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "packages/db/src/discovery-collectors/network.ts": [
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "packages/db/src/eu-jurisdictions.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "packages/db/src/migrations/exact-key-repair.ts": [
+      "docs/runbooks/2026-07-20-collation-drift-index-corruption.md"
     ],
     "packages/db/src/pg-graph.ts": [
       "docs/architecture/platform-overview.md"
@@ -352,11 +619,61 @@
     "packages/db/src/pgvector-store.ts": [
       "docs/architecture/platform-overview.md"
     ],
+    "packages/db/src/regulation-applicability.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
     "packages/db/src/seed-platform-backup.ts": [
       "docs/operations/disaster-recovery.md"
     ],
+    "packages/db/src/seed.ts": [
+      "docs/dogfood/2026-05-23-dale-hvac-build-studio.md"
+    ],
+    "packages/db/src/sovereignty-assessment.ts": [
+      "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "packages/db/src/wiki-taxonomy.ts": [
+      "docs/founder-kernel/AUTHORING.md",
+      "docs/founder-kernel/SCHEMA.md"
+    ],
+    "packages/storefront-templates/src/archetypes/index.ts": [
+      "docs/testing/archetype-audit-plan.md"
+    ],
+    "packages/validators/src/field-dispatch.ts": [
+      "docs/architecture/field-service-work-item.md"
+    ],
     "scripts/backup-postgres.sh": [
       "docs/operations/disaster-recovery.md"
+    ],
+    "scripts/capability-service-catalog.generated.json": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "scripts/check-build-namespace.mjs": [
+      "docs/architecture/build-studio-namespace.md"
+    ],
+    "scripts/check-capability-compose-profiles.mjs": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "scripts/check-mcp-tool-pack.mjs": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "scripts/check-mobile-jest-pin.mjs": [
+      "docs/security/2026-05-24-shift-left-rollout.md",
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/check-module-size.mjs": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "scripts/check-no-private-identity.mjs": [
+      "docs/operations/oss-repo-identity-hygiene.md"
+    ],
+    "scripts/check-package-boundaries.mjs": [
+      "docs/architecture/package-boundaries.md"
+    ],
+    "scripts/check-style-drift.mjs": [
+      "docs/architecture/ui-token-styling.md"
+    ],
+    "scripts/compile-capability-service-catalog.mjs": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
     ],
     "scripts/dpf-bootstrap-agent-toolchain.ps1": [
       "docs/user-guide/contributing/agent-dev-environments.md"
@@ -364,8 +681,79 @@
     "scripts/dpf-bootstrap-agent-toolchain.sh": [
       "docs/user-guide/contributing/agent-dev-environments.md"
     ],
+    "scripts/dpf-compose.mjs": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "scripts/fresh-install.ps1": [
+      "docs/testing/archetype-audit-plan.md"
+    ],
+    "scripts/hooks/run-hook.mjs": [
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "scripts/installer/install-state.schema.json": [
+      "docs/operations/install.md"
+    ],
+    "scripts/installer/lib/platform.sh": [
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "scripts/issue-authority-tls-cert.sh": [
+      "docs/install/edge-node-air-gapped.md",
+      "docs/install/edge-node-multi-host.md"
+    ],
+    "scripts/lib/ci-policy-guards.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/lib/resolve-capability-compose-profiles.mjs": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "scripts/local-ci-runner.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/mcp-tool-pack-baseline.json": [
+      "docs/architecture/mcp-tool-packs.md"
+    ],
+    "scripts/measure-platform-substrate-runtime.mjs": [
+      "docs/architecture/platform-substrate-boundaries.md"
+    ],
+    "scripts/measure-platform-substrate.mjs": [
+      "docs/architecture/platform-substrate-boundaries.md"
+    ],
+    "scripts/platform-substrate-baseline.json": [
+      "docs/architecture/platform-substrate-boundaries.md"
+    ],
+    "scripts/platform-substrate-manifest.json": [
+      "docs/architecture/capability-driven-runtime-profiles.md",
+      "docs/architecture/platform-substrate-boundaries.md"
+    ],
+    "scripts/platform-substrate-runtime-baseline.json": [
+      "docs/architecture/platform-substrate-boundaries.md"
+    ],
+    "scripts/pr-health.mjs": [
+      "docs/testing/pr-health.md",
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/pr-health.test.mjs": [
+      "docs/testing/pr-health.md"
+    ],
+    "scripts/probes/marketing-media/local-render-receipt.json": [
+      "docs/security/tool-evaluations/2026-08-01-marketing-media-stack.md"
+    ],
     "scripts/restore-postgres.sh": [
       "docs/operations/disaster-recovery.md"
+    ],
+    "scripts/style-drift-baseline.json": [
+      "docs/architecture/ui-token-styling.md"
+    ],
+    "scripts/verify-edge-node-air-gap.sh": [
+      "docs/edge-node/security-and-sovereignty.md",
+      "docs/install/edge-node-air-gapped-verification-report.md",
+      "docs/install/edge-node-air-gapped.md"
+    ],
+    "services/edge-node/scripts/verify-lifecycle.ts": [
+      "docs/install/verification-runbook.md"
+    ],
+    "services/edge-node/src/collectors/unifi.ts": [
+      "docs/edge-node/unifi-adapter.md"
     ]
   },
   "docToRoutes": {
@@ -552,6 +940,95 @@
     ]
   },
   "docToCode": {
+    "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md": [
+      "apps/web/components/build/BuildDispatchHistoryCard.tsx",
+      "apps/web/components/build/BuildProgressOperationalPanel.tsx",
+      "apps/web/components/build/DecisionPerspectiveGatePanel.tsx",
+      "apps/web/components/build/ProcessGraph.tsx",
+      "apps/web/components/build/StallEventHistoryStrip.tsx",
+      "apps/web/components/build/UnifiedEvidenceTimeline.tsx",
+      "apps/web/components/build/WorkflowStageInspector.tsx",
+      "apps/web/components/platform/StalledTaskRecoveryActions.tsx",
+      "apps/web/instrumentation.ts",
+      "apps/web/lib/actions/build.ts",
+      "apps/web/lib/build-pipeline.ts",
+      "apps/web/lib/build/progress-visibility.ts",
+      "apps/web/lib/decision-perspective/build-studio-gate.ts",
+      "apps/web/lib/explore/feature-build-types.ts",
+      "apps/web/lib/integrate/build-orchestrator.ts",
+      "apps/web/lib/integrate/build-pipeline.ts",
+      "apps/web/lib/integrate/build-studio-config.ts",
+      "apps/web/lib/integrate/claude-dispatch.ts",
+      "apps/web/lib/marketing/scheduler.ts",
+      "apps/web/lib/queue/functions/deliberation-run.ts",
+      "apps/web/lib/queue/functions/index.ts",
+      "apps/web/lib/queue/functions/quiescence-run.ts",
+      "apps/web/lib/queue/functions/taskrun-watchdog.ts",
+      "apps/web/lib/queue/inngest-client.ts",
+      "apps/web/lib/queue/notification-adapter.ts",
+      "apps/web/lib/tak/agent-grants.ts",
+      "apps/web/lib/tak/autonomous-work-run.ts",
+      "docker-compose.yml",
+      "packages/db/prisma/schema.prisma"
+    ],
+    "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md": [
+      "apps/web/lib/ea/ai-routing-architecture-extract.ts",
+      "apps/web/lib/ea/ai-routing-architecture-registry.ts"
+    ],
+    "docs/architecture/2026-06-14-odysseus-review-depth-pass.md": [
+      "apps/web/app/api/integrations/email-postmark/inbound/route.ts",
+      "apps/web/lib/inference/routed-inference.ts",
+      "apps/web/lib/marketing/channels/email-postmark/responder.ts",
+      "apps/web/lib/routing/pipeline-v2.ts",
+      "apps/web/lib/routing/request-contract.ts",
+      "packages/db/prisma/schema.prisma"
+    ],
+    "docs/architecture/branch-and-worktree-runbook.md": [
+      "apps/web/lib/self-upgrade/local-changes-ledger.ts"
+    ],
+    "docs/architecture/build-studio-namespace.md": [
+      "scripts/check-build-namespace.mjs"
+    ],
+    "docs/architecture/capability-driven-runtime-profiles.md": [
+      "apps/web/lib/platform-runtime/capability-service-projection.ts",
+      "apps/web/lib/platform-runtime/operational-state.ts",
+      "packages/db/data/platform-runtime-capabilities.json",
+      "scripts/capability-service-catalog.generated.json",
+      "scripts/check-capability-compose-profiles.mjs",
+      "scripts/compile-capability-service-catalog.mjs",
+      "scripts/dpf-compose.mjs",
+      "scripts/lib/resolve-capability-compose-profiles.mjs",
+      "scripts/platform-substrate-manifest.json"
+    ],
+    "docs/architecture/data-model-stewardship-runbook.md": [
+      "apps/web/lib/routes.ts",
+      "apps/web/lib/shared/action-result.ts",
+      "apps/web/lib/shared/coerce.ts",
+      "apps/web/lib/shared/org-address.ts"
+    ],
+    "docs/architecture/delivery-ia.md": [
+      "apps/web/app/(shell)/delivery/page.tsx"
+    ],
+    "docs/architecture/field-service-work-item.md": [
+      "packages/validators/src/field-dispatch.ts"
+    ],
+    "docs/architecture/mcp-tool-packs.md": [
+      "apps/web/lib/mcp/packs/deliberation-siem-pack.ts",
+      "apps/web/lib/mcp/packs/feedback-pack.ts",
+      "apps/web/lib/mcp/packs/runtime-coordination-pack.ts",
+      "apps/web/lib/mcp/packs/work-capsules-pack.ts",
+      "apps/web/lib/mcp/packs/workbooks-pack.ts",
+      "apps/web/lib/mcp/tool-pack.ts",
+      "apps/web/lib/mcp/tool-registry.ts",
+      "scripts/check-mcp-tool-pack.mjs",
+      "scripts/check-module-size.mjs",
+      "scripts/mcp-tool-pack-baseline.json"
+    ],
+    "docs/architecture/package-boundaries.md": [
+      "apps/web/lib/contracts/entity-contract-drift.ts",
+      "apps/web/lib/contracts/package-boundaries.test.ts",
+      "scripts/check-package-boundaries.mjs"
+    ],
     "docs/architecture/platform-overview.md": [
       "docker-compose.yml",
       "monitoring/prometheus/prometheus.yml",
@@ -559,11 +1036,150 @@
       "packages/db/src/pg-graph.ts",
       "packages/db/src/pgvector-store.ts"
     ],
+    "docs/architecture/platform-substrate-boundaries.md": [
+      "packages/db/data/platform-runtime-capabilities.json",
+      "scripts/measure-platform-substrate-runtime.mjs",
+      "scripts/measure-platform-substrate.mjs",
+      "scripts/platform-substrate-baseline.json",
+      "scripts/platform-substrate-manifest.json",
+      "scripts/platform-substrate-runtime-baseline.json"
+    ],
+    "docs/architecture/section-navigation.md": [
+      "apps/web/components/shell/SectionNav.tsx",
+      "apps/web/lib/navigation/section-nav-model.ts"
+    ],
+    "docs/architecture/ui-token-styling.md": [
+      "scripts/check-style-drift.mjs",
+      "scripts/style-drift-baseline.json"
+    ],
+    "docs/design/golden-triangle-design.md": [
+      "apps/web/lib/queue/functions/deliberation-run.ts",
+      "apps/web/lib/routing/chat-adapter.ts",
+      "apps/web/lib/routing/cost-ranking.ts",
+      "apps/web/lib/routing/request-contract.ts",
+      "apps/web/lib/tak/agentic-loop.ts"
+    ],
+    "docs/dogfood/2026-05-23-dale-hvac-build-studio.md": [
+      "packages/db/src/seed.ts"
+    ],
+    "docs/edge-node/deployment-topology.md": [
+      "docker-compose.edge-snmp.yml",
+      "docker-compose.edge-standalone-tls.yml",
+      "docker-compose.edge-standalone.yml",
+      "docker-compose.edge.macvlan.yml",
+      "docker-compose.edge.yml"
+    ],
+    "docs/edge-node/macvlan-deployment.md": [
+      "docker-compose.edge.macvlan.yml"
+    ],
+    "docs/edge-node/security-and-sovereignty.md": [
+      "scripts/verify-edge-node-air-gap.sh"
+    ],
+    "docs/edge-node/unifi-adapter.md": [
+      "apps/web/app/api/v1/edge/adapters/route.ts",
+      "services/edge-node/src/collectors/unifi.ts"
+    ],
+    "docs/founder-kernel/AUTHORING.md": [
+      "apps/web/lib/decision/golden-decisions.baseline.json",
+      "apps/web/lib/decision/golden-decisions.test.ts",
+      "packages/db/src/wiki-taxonomy.ts"
+    ],
+    "docs/founder-kernel/SCHEMA.md": [
+      "packages/db/src/wiki-taxonomy.ts"
+    ],
+    "docs/install/cloud-single-vm.md": [
+      "docker-compose.edge-standalone.yml"
+    ],
+    "docs/install/edge-node-air-gapped-verification-report.md": [
+      "scripts/verify-edge-node-air-gap.sh"
+    ],
+    "docs/install/edge-node-air-gapped.md": [
+      "docker-compose.edge-standalone-tls.yml",
+      "docker-compose.edge-standalone.yml",
+      "scripts/issue-authority-tls-cert.sh",
+      "scripts/verify-edge-node-air-gap.sh"
+    ],
+    "docs/install/edge-node-multi-host.md": [
+      "docker-compose.edge-standalone-tls.yml",
+      "docker-compose.edge-standalone.yml",
+      "docker-compose.edge.yml",
+      "docker-compose.tls.yml",
+      "scripts/issue-authority-tls-cert.sh"
+    ],
+    "docs/install/linux.md": [
+      ".github/workflows/install-verification.yml"
+    ],
+    "docs/install/platform-support-watchlist.md": [
+      "apps/web/components/monitoring/health-summary.ts",
+      "packages/db/src/discovery-collectors/network.ts",
+      "scripts/hooks/run-hook.mjs",
+      "scripts/installer/lib/platform.sh"
+    ],
+    "docs/install/verification-runbook.md": [
+      "services/edge-node/scripts/verify-lifecycle.ts"
+    ],
     "docs/operations/disaster-recovery.md": [
       "docker-compose.yml",
       "packages/db/src/seed-platform-backup.ts",
       "scripts/backup-postgres.sh",
       "scripts/restore-postgres.sh"
+    ],
+    "docs/operations/install.md": [
+      "scripts/installer/install-state.schema.json"
+    ],
+    "docs/operations/mobile-store-launch-runbook.md": [
+      "apps/mobile/eas.json"
+    ],
+    "docs/operations/oss-repo-identity-hygiene.md": [
+      "scripts/check-no-private-identity.mjs"
+    ],
+    "docs/runbooks/2026-07-20-collation-drift-index-corruption.md": [
+      "packages/db/src/migrations/exact-key-repair.ts"
+    ],
+    "docs/security/2026-05-24-shift-left-rollout.md": [
+      ".github/workflows/ci.yml",
+      ".github/workflows/codeql.yml",
+      ".github/workflows/secrets-scan.yml",
+      "scripts/check-mobile-jest-pin.mjs"
+    ],
+    "docs/security/secrets-scan.md": [
+      ".github/workflows/codeql.yml",
+      ".github/workflows/security-inflow-gate.yml"
+    ],
+    "docs/security/tool-evaluations/2026-08-01-marketing-media-stack.md": [
+      "scripts/probes/marketing-media/local-render-receipt.json"
+    ],
+    "docs/strategy/2026-09-cada-architects-forum-deck.md": [
+      "apps/web/lib/actions/sovereignty.ts",
+      "apps/web/lib/inference/local-only.ts",
+      "apps/web/lib/routing/pipeline-v2.ts",
+      "packages/db/scripts/check-cada-readiness.ts",
+      "packages/db/scripts/seed-cada-regulation.ts",
+      "packages/db/src/cada-readiness.ts",
+      "packages/db/src/eu-jurisdictions.ts",
+      "packages/db/src/regulation-applicability.ts",
+      "packages/db/src/sovereignty-assessment.ts"
+    ],
+    "docs/testing/archetype-audit-plan.md": [
+      "packages/storefront-templates/src/archetypes/index.ts",
+      "scripts/fresh-install.ps1"
+    ],
+    "docs/testing/ci-evidence.md": [
+      "docs/testing/ci-observation-baseline.json"
+    ],
+    "docs/testing/pr-health.md": [
+      "config/merge-readiness-policy.json",
+      "scripts/pr-health.mjs",
+      "scripts/pr-health.test.mjs"
+    ],
+    "docs/testing/pre-pr-gate.md": [
+      ".githooks/lib/pre-push-chained.sh",
+      ".github/workflows/ci.yml",
+      ".github/workflows/codeql.yml",
+      "scripts/check-mobile-jest-pin.mjs",
+      "scripts/lib/ci-policy-guards.mjs",
+      "scripts/local-ci-runner.mjs",
+      "scripts/pr-health.mjs"
     ],
     "docs/user-guide/ai-workforce/connecting-providers.md": [
       "apps/web/app/(shell)/platform/ai/providers/page.tsx",

--- a/scripts/gen-doc-impact.mjs
+++ b/scripts/gen-doc-impact.mjs
@@ -23,8 +23,16 @@
 // /architecture/platform-overview/ — a published page whose entire "three data
 // layers" section described Neo4j — went unflagged. `docs/architecture/**` is
 // as customer-visible as `docs/user-guide/**`; the site publishes both.
-// Widening is safe because edges are OPT-IN: a page contributes nothing until
-// it declares `relatedCode:` / `relatedRoutes:`.
+// Widening was safe because frontmatter edges are OPT-IN: a page contributed
+// nothing until it declared `relatedCode:` / `relatedRoutes:`.
+//
+// EDGE SOURCE 3 closes that opt-in gap. Frontmatter protects only pages someone
+// remembered to annotate, which is not the population that goes stale. A
+// markdown link from a doc INTO a source file is an edge the author already
+// wrote, so it is derived rather than declared — no annotation, no second place
+// to keep in sync. Measured on this corpus: 27 declared code edges -> 155, with
+// a maximum fan-out of 4 docs per file, so coverage rises without the gate
+// becoming noise.
 //
 //   node scripts/gen-doc-impact.mjs           # write the manifest
 //   node scripts/gen-doc-impact.mjs --check    # fail if stale, or edges are invalid
@@ -79,6 +87,48 @@ function addEdge(map, key, val) {
   if (!map[key].includes(val)) map[key].push(val);
 }
 
+// ─── Derived doc → code edges ────────────────────────────────────────────────
+// The link/fence patterns are kept deliberately identical to
+// scripts/check-doc-reference-integrity.mjs, which already parses these links to
+// validate them. Same corpus, same syntax, same nesting rule for Next.js route
+// groups — if one gate can see a reference, so should the other.
+
+/** Inline markdown links and images, allowing ONE level of nested parens so
+ *  `apps/web/app/(shell)/…` is captured whole rather than truncated at the "(". */
+const LINK_RE = /!?\[[^\]]*\]\(\s*((?:[^()\s]|\([^()]*\))+)(?:\s+"[^"]*")?\s*\)/g;
+/** Fenced blocks hold EXAMPLE links; stripped before extraction. */
+const FENCE_RE = /^([`~]{3,})[^\n]*\n[\s\S]*?^\1[^\n]*$/gm;
+const isExternalHref = (h) => /^(https?:|mailto:|tel:|data:|#)/i.test(h);
+
+/** Source-ish extensions. `.md` is excluded on purpose: a doc linking a doc is a
+ *  documentation-graph concern, not a code-change blast radius. */
+const CODE_EXT_RE = /\.(ts|tsx|mts|mjs|js|jsx|prisma|sql|ya?ml|sh|ps1|json|toml)$/i;
+
+/**
+ * Repo-relative source files that `markdown` links to, resolved relative to the
+ * doc's own directory.
+ *
+ * Silently skips links that do not resolve or escape the repo — a dead reference
+ * is the Doc Reference Integrity gate's finding to report, and duplicating it
+ * here would give the same defect two owners and two error messages.
+ *
+ * @returns {string[]} sorted, de-duplicated repo-relative POSIX paths
+ */
+export function linkedCodePaths(markdown, docPath, repoRoot) {
+  const body = markdown.replace(FENCE_RE, "");
+  const out = new Set();
+  for (const m of body.matchAll(LINK_RE)) {
+    const href = m[1].split("#")[0].trim();
+    if (!href || isExternalHref(href) || !CODE_EXT_RE.test(href)) continue;
+    const abs = path.resolve(path.dirname(path.join(repoRoot, docPath)), href);
+    const rel = path.relative(repoRoot, abs).split(path.sep).join("/");
+    if (rel.startsWith("..") || path.isAbsolute(rel)) continue;
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) continue;
+    out.add(rel);
+  }
+  return [...out].sort();
+}
+
 export function buildManifest() {
   const entries = parseRouteMap(fs.readFileSync(ROUTE_MAP_TS, "utf-8"));
   const routeToDocs = {};
@@ -105,6 +155,17 @@ export function buildManifest() {
     for (const code of frontmatterList(raw, "relatedCode")) {
       const abs = path.join(REPO_ROOT, code);
       if (!fs.existsSync(abs)) problems.push(`${sourcePath}: relatedCode "${code}" does not exist`);
+      addEdge(codeToDocs, code, sourcePath);
+      addEdge(docToCode, sourcePath, code);
+    }
+
+    // 3. DERIVED edges: source files the page already links to. Declared
+    //    `relatedCode:` edges are opt-in, so they protect only pages somebody
+    //    remembered to annotate — the same "someone must remember" failure the
+    //    graph exists to remove. A markdown link from a doc INTO a source file
+    //    is an edge the author already wrote; deriving it needs no annotation
+    //    and no second place to keep in sync.
+    for (const code of linkedCodePaths(raw, sourcePath, REPO_ROOT)) {
       addEdge(codeToDocs, code, sourcePath);
       addEdge(docToCode, sourcePath, code);
     }

--- a/scripts/gen-doc-impact.test.mjs
+++ b/scripts/gen-doc-impact.test.mjs
@@ -3,7 +3,11 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { frontmatterList } from "./gen-doc-impact.mjs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { frontmatterList, linkedCodePaths } from "./gen-doc-impact.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 test("frontmatterList parses a YAML block list", () => {
   const md = ["---", "title: X", "relatedCode:", "  - apps/web/lib/a.ts", "  - scripts/b.sh", "order: 1", "---", "body"].join("\n");
@@ -28,4 +32,48 @@ test("frontmatterList stops at the next top-level key", () => {
 test("frontmatterList only reads the frontmatter block, not the body", () => {
   const md = ["---", "title: X", "---", "relatedCode:", "  - body/not/frontmatter.ts"].join("\n");
   assert.deepEqual(frontmatterList(md, "relatedCode"), []);
+});
+
+// ── Derived doc → code edges ────────────────────────────────────────────────
+// These close the opt-in gap: a page is covered because it already links to the
+// source file, not because someone remembered to add `relatedCode:`.
+
+const DOC = "docs/architecture/platform-overview.md";
+
+test("linkedCodePaths derives an edge from a relative link into source", () => {
+  const md = "See [the sync writer](../../packages/db/src/graph-sync.ts) for detail.\n";
+  assert.deepEqual(linkedCodePaths(md, DOC, REPO_ROOT), ["packages/db/src/graph-sync.ts"]);
+});
+
+test("linkedCodePaths ignores .md links — doc->doc is a different concern", () => {
+  assert.deepEqual(linkedCodePaths("[rb](../operations/disaster-recovery.md)\n", DOC, REPO_ROOT), []);
+});
+
+test("linkedCodePaths ignores external links and pure anchors", () => {
+  const md = "[gh](https://github.com/x/y/a.ts)\n[m](mailto:x@y.z)\n[a](#s)\n";
+  assert.deepEqual(linkedCodePaths(md, DOC, REPO_ROOT), []);
+});
+
+test("linkedCodePaths ignores links inside fenced blocks (examples, not references)", () => {
+  const md = ["```md", "[ex](../../packages/db/src/graph-sync.ts)", "```", ""].join("\n");
+  assert.deepEqual(linkedCodePaths(md, DOC, REPO_ROOT), []);
+});
+
+test("linkedCodePaths skips a link that does not resolve — the reference gate owns that", () => {
+  assert.deepEqual(linkedCodePaths("[x](../../packages/db/src/not-here.ts)\n", DOC, REPO_ROOT), []);
+});
+
+test("linkedCodePaths refuses to escape the repo root", () => {
+  assert.deepEqual(linkedCodePaths("[o](../../../../../../etc/passwd.sh)\n", DOC, REPO_ROOT), []);
+});
+
+test("linkedCodePaths captures Next.js route-group parens whole", () => {
+  const md = "[r](../../apps/web/app/(shell)/docs/[[...slug]]/page.tsx)\n";
+  assert.deepEqual(linkedCodePaths(md, DOC, REPO_ROOT), ["apps/web/app/(shell)/docs/[[...slug]]/page.tsx"]);
+});
+
+test("linkedCodePaths de-duplicates and sorts for a byte-stable manifest", () => {
+  const md = "[a](../../packages/db/src/pg-graph.ts)\n[a2](../../packages/db/src/pg-graph.ts)\n[b](../../packages/db/src/graph-sync.ts)\n";
+  assert.deepEqual(linkedCodePaths(md, DOC, REPO_ROOT),
+    ["packages/db/src/graph-sync.ts", "packages/db/src/pg-graph.ts"]);
 });


### PR DESCRIPTION
## Summary

Closes the opt-in gap left by the BET-5 doc-staleness fix (#3871). Frontmatter `relatedCode:` edges protect only pages somebody remembered to annotate — which is not the population that goes stale. **Two pages in the entire corpus declared edges.**

A markdown link from a doc *into* a source file is an edge the author already wrote. Deriving it needs no annotation and creates no second place to keep in sync — the same "derive, don't restate" move that fixed the corpus scope.

## Measured on this corpus

| | before | after |
|---|---|---|
| Code files with edges | 27 | **155** |
| Docs with code edges | 7 | **50** |
| Max fan-out (one file change → docs flagged) | — | **4** |
| Files referenced by exactly one doc | — | 107 / 155 |

~5× the coverage while staying quiet enough to be believed. Fan-out was measured before building, precisely because a noisy gate is worse than none — it trains people to ignore it.

## Verified firing, not just wired

Changing `packages/db/prisma/schema.prisma` now flags:

```
docs/architecture/platform-overview.md
docs/architecture/2026-06-09-long-running-agentic-process-architecture.md
docs/architecture/2026-06-14-odysseus-review-depth-pass.md
```

The last two **never declared anything**. They are covered purely because they link to the schema. That is the opt-in gap closing.

## Design notes

**The link/fence patterns are deliberately identical to `check-doc-reference-integrity.mjs`**, which already parses these same links to validate them — same corpus, same syntax, same nested-paren rule so `apps/web/app/(shell)/…` is captured whole. If one gate can see a reference, so should the other.

**Dead or repo-escaping links are skipped, not reported.** A dead reference is the Doc Reference Integrity gate's finding; duplicating it would give one defect two owners and two error messages.

**`.md` links are excluded.** A doc linking a doc is a documentation-graph concern, not a code-change blast radius — including them would have added ~1000 edges of a different kind.

## Deliberately NOT done: querying the graph mirror

The original proposal was to have the gate query `graph_node` / `graph_edge` directly. **The Policy Guards (PR) job has no database** — no services block — so a DB-backed gate cannot run there. That is precisely why the source-controlled manifest exists.

Projecting these edges *into* the graph mirror remains the later step the generator header already describes (spec §5.5). This change makes the edges worth projecting: 155 derived code→doc edges instead of 27 hand-declared ones.

## Test plan

- [x] **Source-only change** (doc tooling + regenerated manifest)
  - [x] 8 new unit tests for `linkedCodePaths`: relative resolution, `.md` exclusion, external/anchor links, fenced-block examples, unresolvable links, repo-escape refusal, Next.js route-group parens, dedup/sort stability
  - [x] Full `pull-request` policy-guard profile: **7/7 pass**

### Verification evidence

```
gen-doc-impact.mjs --check            PASS   (155 code edges, 87 route edges)
gen-doc-index.mjs --check             PASS
check-doc-links.mjs                   PASS
check-doc-reference-integrity.mjs     PASS
check-retired-substrate.mjs           PASS
derived-artifacts-gate.mjs check-all  PASS
unit tests                            # pass 30  # fail 0
policy-guards --profile pull-request  7 of 7 passed
```

## Notes for the reviewer

- **No backlog coverage.** Authored in a cloud session with no DPF MCP connector and no database, so `Epic`/`BacklogItem` could not be read or written. This is the fifth item now needing a BI attached retrospectively, alongside #3871, the Retired Substrate Guard, #3980, and the seed-fit re-trigger papercut below.
- **The branch was force-pushed.** It previously carried #3980, which squash-merged — so its commits diverged from `main` while their content landed. Left as-is, the seed-fit gate fired on a principle page already in `main`. Restarted from `main` and replayed this change alone; verified the remote head was exactly the merged content before forcing (`--force-with-lease` kept reporting stale info through the git proxy despite a matching expected SHA).
- **Known papercut, unchanged:** the Seed Fit gate tells contributors to fix a finding via the PR body or a label, and neither re-triggers CI. Escaping it requires an unrelated push. A narrow re-trigger for just `policy-guards-pr` would be the cheaper fix than adding `edited` to the whole pipeline — a CI-spend decision rather than a tweak.

---
_Generated by [Claude Code](https://claude.ai/code/session_019DMsBGkTvAF2sbjSzvKtsk)_