### PR TITLE
feat(local-ci): give the gate one readable verdict, and stop silent half-trees (BI-B1065D41, BI-1C1483C6)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/pregate-invocation-guard.mjs\""
           }
         ]
       },

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -299,6 +299,18 @@ run_typecheck() {
     echo ""
     cat /tmp/pre-commit-tc.log | tail -40
     echo ""
+    # BI-1C1483C6: "'next' is not recognized" and "Cannot find package 'react'"
+    # look exactly like real breakage. When the readiness probe corroborates that
+    # this worktree is unprovisioned, say so HERE rather than leaving the reader
+    # to lose a stash-and-re-run cycle discovering it. Silent otherwise; never
+    # changes the verdict.
+    if command -v node >/dev/null 2>&1 && [ -f scripts/lib/bootstrap-worktree-deps.mjs ]; then
+      diagnosis="$(node scripts/lib/bootstrap-worktree-deps.mjs . --diagnose-failure </tmp/pre-commit-tc.log 2>/dev/null || true)"
+      if [ -n "$diagnosis" ]; then
+        echo "$diagnosis"
+        echo ""
+      fi
+    fi
     FAILED="$FAILED $label"
   fi
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9529,7 +9529,7 @@
         "where-ci-runs-it",
         "run-locally-before-pushing",
         "the-pre-push-gate-pregate-default-on",
-        "reading-the-result-a-queued-run-can-exit-0",
+        "reading-the-result-ask-the-record-not-the-run",
         "agent-pretooluse-refuse-bi-563f6ab6-p2",
         "keep-internal-identifiers-out-of-the-pr-body",
         "identify-your-client-and-thread",

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -289,28 +289,52 @@ is available only as an explicit `scripts/gate-worktree.sh --push` (or
 `scripts/gate-worktree.mjs --push`) operation for recovery/transition cases
 that intentionally need it.
 
-### Reading the result — a queued run can exit 0
+### Reading the result — ask the record, not the run
 
-Admission is queued (one slot until BI-A4427AB8). While waiting, the run prints
-`local-CI admission queued at position N`. **A run that never reaches admission
-can still terminate with exit code 0**, so exit status alone does not
-distinguish "gate passed" from "gate never ran". Confirm by artifact:
+```bash
+pnpm run pregate:status
+```
 
-1. The run ends with the literal line `gate passed`.
-2. It wrote the metadata record (the path is echoed as
-   `[local-integration-ci] metadata …`), and in that record **`candidateSha` is
-   the commit you are about to push**, with `baseSha` the base it merged
-   against. Check `evidencePlan.evidenceTier` / `fullSuite` describe the
-   coverage you expected.
-3. `grep -v "admission queued"` over the log. If only queue polling remains,
-   nothing ran.
+That is the whole answer, and it is the only signal you should act on. It reads
+the SHA-bound gate record plus the schema-versioned metadata record, and prints
+one verdict — `PASS`, `FAIL`, `STALE`, `PENDING`, or `NO-RECORD` — with the
+bound SHA, how it compares to current HEAD, and how old it is. **It exits 0 only
+for a `PASS` bound to the current HEAD**, so `pnpm run pregate:status && git
+push` is a correct composition. Add `--json` for machine use. It never claims a
+lease and never runs a gate, so it is safe to call at any time, including while
+someone else's gate is mid-run.
 
-**Never wrap `pregate` in `timeout`.** Killing it mid-queue is what produces the
-false green above; run it unbounded. Queue contention is not a reason to reach
-for `DPF_SKIP_PREPUSH_GATE` — with a valid record for the head SHA the push is
-admitted normally. Cancelling a run can also leave a stale queued lease pinned
-to the **old** SHA; release it, or the next run queues behind your own
-abandoned entry.
+Everything else about a pregate run lies in a documented direction, which is why
+the reader exists (BI-B1065D41):
+
+| Signal | How it lies |
+| --- | --- |
+| The **exit code** | `pregate …; echo $?; tail …` reports *tail's* status. And a run that gave up while queued exits 0 having gated nothing (BI-2C7F51BA). |
+| The **log tail** | A *tolerated* `GuardRuntimeEnvironmentError` prints `Error:` and a red ✖ ~28,000 lines before a **passing** verdict. A watcher grepping `Error:` fabricates a failure. |
+| **`gate passed`** | True about the run you watched; silent about whether HEAD has moved since. `pregate:status` compares. |
+
+`gate passed` remains the last line of a passing run and is still a valid
+anchor *for that run* — it is what the closing summary block ends with. It is
+just not the thing to build automation on.
+
+**How to invoke it.** Run `pregate` in the **foreground**, unpiped, as the sole
+command. On timeout the harness migrates a foreground run to the background and
+it **continues** — that is the working path, and it is the opposite of the
+intuitive choice. Do not background it (`&` or `run_in_background`: the harness
+caps and kills it mid-install), do not chain another command after it with `;`
+or `||` (you get that command's exit code), and never wrap it in `timeout`
+(cutting it off mid-queue manufactures a false green and leaves a stale lease
+pinned to the **old** SHA). `pregate-invocation-guard.mjs` denies all four
+shapes at the tool edge on Claude, Codex, and Grok.
+
+Queue contention is not a reason to reach for `DPF_SKIP_PREPUSH_GATE` — with a
+valid record for the head SHA the push is admitted normally.
+
+**Output.** A run prints roughly 30 lines: admission, the full-log path, a
+periodic progress heartbeat, and a bounded closing summary. The complete
+~28,000-line transcript goes to the log file whose path is printed before the
+long stage begins. `DPF_PREGATE_VERBOSE=1` restores the full mirror for
+debugging the gate itself.
 
 **The gate command has a checked-in default (BI-157DC9B2, BI-4BE30454):**
 [`scripts/local-ci-runner.mjs`](../../scripts/local-ci-runner.mjs) runs the
@@ -637,8 +661,11 @@ Name them so you catch yourself.
 | Reaching for `DPF_SKIP_*` to get past a hook | Bypasses are for verified false positives only | Fix the underlying error; CI gates it anyway |
 | Verifying UX against worktree `next dev` | Not the production-bundled runtime | Use the canonical install or sandbox lease (AGENTS.md §13) |
 | Treating a local green as the merge gate | The binding gate is the CI **Unit Tests** check | Local pass = evidence; CI pass = the gate |
-| Reading a `pregate` exit code as the verdict | A run killed while queued exits 0 without running | Require `gate passed` + a metadata record whose `candidateSha` is yours |
-| Wrapping `pregate` in `timeout` | Cuts it off mid-queue and manufactures a false green | Run it unbounded; background it and wait |
+| Reading a `pregate` exit code as the verdict | A run killed while queued exits 0 without running | `pnpm run pregate:status` — it reads the SHA-bound record and exits 0 only for a PASS at HEAD |
+| Piping `pregate` to `head`/`grep` | The verdict is the LAST line, so a truncating reader removes exactly what you wanted (and it used to SIGPIPE-kill the run mid-install) | Let it print its ~30 lines; open the log path it prints for detail |
+| Backgrounding `pregate` (`&` / `run_in_background`) | The harness caps and kills a backgrounded run mid-install | Run it in the FOREGROUND — on timeout the harness migrates it and it continues |
+| Wrapping `pregate` in `timeout` | Cuts it off mid-queue and manufactures a false green | Run it unbounded in the foreground |
+| Trusting a worktree's typecheck/test failures | An unprovisioned worktree fails as `'next' is not recognized` / `Cannot find package 'react'`, which look like real breakage | `node scripts/lib/bootstrap-worktree-deps.mjs . --classify-only` before blaming your change |
 | Trusting a green test run without naming the tree | Sibling worktrees hold identical paths; shell cwd persists between calls | Check the runner's root banner; reconcile the test count against your file |
 
 ## What this gate is NOT

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -666,6 +666,7 @@ Name them so you catch yourself.
 | Backgrounding `pregate` (`&` / `run_in_background`) | The harness caps and kills a backgrounded run mid-install | Run it in the FOREGROUND — on timeout the harness migrates it and it continues |
 | Wrapping `pregate` in `timeout` | Cuts it off mid-queue and manufactures a false green | Run it unbounded in the foreground |
 | Trusting a worktree's typecheck/test failures | An unprovisioned worktree fails as `'next' is not recognized` / `Cannot find package 'react'`, which look like real breakage | `node scripts/lib/bootstrap-worktree-deps.mjs . --classify-only` before blaming your change |
+| Editing the PR body to satisfy a trailer gate, then re-running the job | `PR_BODY` / `PR_LABELS_JSON` come from `github.event.pull_request.*` — the **frozen webhook payload**. A rerun replays that same payload, so the edited body (or a new label) is invisible and the gate fails identically. `ci.yml` is triggered by bare `pull_request`, whose default types exclude `edited`. | Add the trailer, then **push a commit** — only a new `synchronize` event refreshes the payload. Budget for a re-gate: the new SHA makes your local-CI record `STALE`. |
 | Trusting a green test run without naming the tree | Sibling worktrees hold identical paths; shell cwd persists between calls | Check the runner's root banner; reconcile the test count against your file |
 
 ## What this gate is NOT

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:sandbox": "docker compose up -d sandbox",
     "pregate": "node scripts/pregate.mjs",
     "pregate:preflight": "node scripts/pregate-preflight.mjs",
+    "pregate:status": "node scripts/pregate-status.mjs",
     "review:semantic-gate": "node scripts/semantic-review-gate.mjs",
     "gate:context": "node scripts/gate-context.mjs",
     "build": "pnpm --filter web build",

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -23,6 +23,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-evidence-guard.mjs\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pregate-invocation-guard.mjs\""
           }
         ]
       },
@@ -93,6 +97,14 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-readiness-banner.mjs\""
           }
         ]
       }

--- a/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
+++ b/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
@@ -30,6 +30,7 @@ const GUARD_SCRIPTS = [
   "compose-guard.mjs",
   "lease-punt-guard.mjs",
   "pregate-evidence-guard.mjs",
+  "pregate-invocation-guard.mjs",
   "decision-routing-guard.mjs",
   "plan-backlog-coverage-guard.mjs",
   "ux-fit-precheck.mjs",

--- a/packages/dpf-skill-pack/hooks/pregate-invocation-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/pregate-invocation-guard.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/pregate-invocation-guard.mjs
+//
+// PreToolUse guard (BI-B1065D41 Phase 3): refuse a `pregate` invocation shaped
+// so it CANNOT succeed, or so its verdict cannot be read.
+//
+// Why a hook and not another paragraph. On 2026-08-04 roughly an hour was lost
+// to four failed pregate invocations. Not one was a knowledge gap — every
+// governing rule was already in the operator's context, in prose, and was
+// violated anyway. That is the signal: a rule that lives only in prose is
+// advisory at the moment of the tool call. Prose carries the WHY; hooks carry
+// the WHAT. If violating a rule costs an hour, it belongs in a hook.
+//
+// The four shapes, and what each actually does:
+//
+//   1. PIPED (`pregate | head`, `| grep`) — when the reader exits, the write
+//      fails and the run dies mid-install holding a shared lease. Killed three
+//      runs. Phase 1 makes the gate survive this AND removes the reason to pipe
+//      (~30 lines of stdout instead of ~28,000), so by the time you read this a
+//      pipe merely degrades. It is still denied: it truncates the verdict block
+//      whose LAST line is the verdict, so a piped run is unreadable by
+//      construction.
+//   2. BACKGROUNDED (`&`, or the harness's run_in_background) — the harness caps
+//      and kills a backgrounded command mid-install. The FOREGROUND form is the
+//      one that survives: on timeout the harness migrates it to background and
+//      it CONTINUES. This is the opposite of the intuitive choice for a
+//      long-running command, and nothing at the call site said so until now.
+//   3. CHAINED (`pregate; echo $?; tail ...`) — the reported status is the LAST
+//      command's. An operator read tail's exit 0 as the gate verdict.
+//   4. TIME-BOUNDED (`timeout 600 pregate`) — cuts the run off mid-queue and
+//      manufactures a false green; the record is left pinned to the old SHA.
+//
+// The denial always names the canonical form, because a guard that only says no
+// converts a wrong invocation into a stuck session.
+//
+// Structurally identical to compose-guard.mjs (the established pattern in this
+// directory, five guards over): pure `decide()` for tests, dual-envelope deny so
+// Claude/Codex/Grok all honor it, DPF-workspace scoped, and FAIL OPEN on any
+// parse/IO error — a guard must never wedge a session.
+
+import {
+  readHookPayload,
+  isShellTool,
+  emitDeny,
+  inDpfWorkspace,
+  shellCommandFromInput,
+} from "./lib/hook-io.mjs";
+import { executableCommandText } from "./command-text.mjs";
+
+/** `pnpm run pregate`, `pnpm pregate`, or the scripts it fronts. */
+const PREGATE_PATTERNS = [
+  /\bpnpm\s+(?:run\s+)?pregate\b/,
+  /\bnode\s+\S*scripts[/\\]pregate\.mjs\b/,
+  /\bscripts[/\\]gate-worktree\.(?:mjs|sh)\b/,
+];
+
+// The read-only sibling command is safe in every shape — it reads a record in
+// milliseconds and holds nothing. Denying `pregate:status | jq` would punish the
+// exact habit this BI wants to encourage.
+const STATUS_PATTERNS = [
+  /\bpnpm\s+(?:run\s+)?pregate:status\b/,
+  /\bnode\s+\S*scripts[/\\]pregate-status\.mjs\b/,
+];
+
+// Cheap, non-admitting pregate modes. `--dry-run` prints a plan and exits; the
+// contract tests and routing probes legitimately pipe them.
+const CHEAP_MODES = [/--dry-run\b/, /--help\b/, /\s-h\b/];
+
+const CANONICAL =
+  "Canonical form — run it as the SOLE command, in the FOREGROUND, unpiped:\n"
+  + "    pnpm run pregate\n"
+  + "On timeout the harness migrates a foreground run to the background and it CONTINUES; "
+  + "that is the working path. Read the verdict afterwards with `pnpm run pregate:status` "
+  + "(exit 0 only for a PASS bound to the current HEAD) — not the exit code, not the log tail. "
+  + "For the full transcript use the log path pregate prints, or DPF_PREGATE_VERBOSE=1. "
+  + "Deliberate exception: prefix the command with DPF_ALLOW_PREGATE_SHAPE=1.";
+
+/** Segment separators that let a later command's exit status surface. */
+function hasTrailingChain(text) {
+  // `&&` is fine: it short-circuits, so a failing pregate stops the chain and
+  // the shell's status is still pregate's. `;` and `||` are not — both run the
+  // next command REGARDLESS and hand you its status instead.
+  return /(?:;|\|\|)\s*\S/.test(text);
+}
+
+function hasPipe(text) {
+  // Match a real pipe, not the `||` operator.
+  return /\|(?!\|)/.test(text.replace(/\|\|/g, ""));
+}
+
+function isBackgrounded(text) {
+  // Trailing `&`, but not `&&`.
+  return /&\s*$/.test(text.replace(/&&/g, "")) || /&\s*(?:[;\n]|$)/.test(text.replace(/&&/g, ""));
+}
+
+function isTimeBounded(text) {
+  return /\b(?:timeout|gtimeout)\s+[\d.]+[smhd]?\b/.test(text);
+}
+
+/**
+ * Pure decision. Exported for tests.
+ * @param {{ command: string, env?: Record<string,string|undefined>, runInBackground?: boolean }} args
+ * @returns {{ block: boolean, reason?: string }}
+ */
+export function decide({ command, env = {}, runInBackground = false }) {
+  if (typeof command !== "string" || command.trim() === "") return { block: false };
+  if (env.DPF_ALLOW_PREGATE_SHAPE === "1" || /\bDPF_ALLOW_PREGATE_SHAPE=1\b/.test(command)) {
+    return { block: false };
+  }
+
+  const text = executableCommandText(command);
+  if (STATUS_PATTERNS.some((re) => re.test(text))) return { block: false };
+  if (!PREGATE_PATTERNS.some((re) => re.test(text))) return { block: false };
+  if (CHEAP_MODES.some((re) => re.test(text))) return { block: false };
+
+  const faults = [];
+  if (runInBackground === true) {
+    faults.push(
+      "run_in_background was set — the harness CAPS and KILLS a backgrounded run mid-install",
+    );
+  }
+  if (isBackgrounded(text)) {
+    faults.push("the command is backgrounded with `&` — the run is capped and killed mid-install");
+  }
+  if (hasPipe(text)) {
+    faults.push(
+      "the command is PIPED — the verdict is the LAST line of the closing block, so a truncating "
+      + "reader removes exactly the line you need (and before BI-B1065D41 the closing pipe "
+      + "SIGPIPE-killed the run outright)",
+    );
+  }
+  if (hasTrailingChain(text)) {
+    faults.push(
+      "another command is chained after pregate with `;` or `||` — the shell then reports THAT "
+      + "command's exit code, not the gate's",
+    );
+  }
+  if (isTimeBounded(text)) {
+    faults.push(
+      "the run is wrapped in `timeout` — it gets cut off mid-queue, which manufactures a false "
+      + "green and leaves a stale lease pinned to the old SHA",
+    );
+  }
+
+  if (faults.length === 0) return { block: false };
+  return {
+    block: true,
+    reason: `Local-CI gate invocation blocked (BI-B1065D41): ${faults.join("; ")}.\n${CANONICAL}`,
+  };
+}
+
+// ── runtime entry ────────────────────────────────────────────────────────────
+
+function main() {
+  const payload = readHookPayload();
+  if (payload === null) process.exit(0); // fail open on read/parse error
+  if (!inDpfWorkspace(payload.cwd)) process.exit(0);
+  if (!isShellTool(payload.toolName)) process.exit(0);
+
+  const command = shellCommandFromInput(payload.toolInput);
+  const runInBackground = payload.toolInput?.run_in_background === true
+    || payload.toolInput?.runInBackground === true;
+  const verdict = decide({ command, env: process.env, runInBackground });
+  if (!verdict.block) process.exit(0);
+
+  emitDeny(verdict.reason);
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("pregate-invocation-guard.mjs")) {
+  main();
+}

--- a/packages/dpf-skill-pack/hooks/pregate-invocation-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/pregate-invocation-guard.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { decide } from "./pregate-invocation-guard.mjs";
+
+const guard = fileURLToPath(new URL("./pregate-invocation-guard.mjs", import.meta.url));
+
+function runGuard(payload, env = {}) {
+  const r = spawnSync(process.execPath, [guard], {
+    input: JSON.stringify(payload),
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "1", ...env },
+  });
+  return { status: r.status, stdout: r.stdout.trim() };
+}
+
+// ── the four shapes that actually cost the hour ──────────────────────────────
+
+test("denies a PIPED pregate and names the canonical form", () => {
+  const v = decide({ command: "pnpm run pregate | head -5" });
+  assert.equal(v.block, true);
+  assert.match(v.reason, /PIPED/);
+  assert.match(v.reason, /pnpm run pregate/);
+  assert.match(v.reason, /pregate:status/);
+});
+
+test("denies a grep-piped pregate (the same shape, a different reader)", () => {
+  assert.equal(decide({ command: 'pnpm run pregate | grep -E "^gate passed"' }).block, true);
+});
+
+test("denies run_in_background even when the command text is clean", () => {
+  const v = decide({ command: "pnpm run pregate", runInBackground: true });
+  assert.equal(v.block, true);
+  assert.match(v.reason, /CAPS and KILLS/);
+});
+
+test("denies a `&`-backgrounded pregate", () => {
+  assert.equal(decide({ command: "pnpm run pregate &" }).block, true);
+});
+
+test("denies a chain whose exit code is somebody else's", () => {
+  const v = decide({ command: "pnpm run pregate; echo EXIT=$?; tail -50 out.log" });
+  assert.equal(v.block, true);
+  assert.match(v.reason, /exit code, not the gate/);
+});
+
+test("denies `||` chaining too — it also runs regardless and hands you its status", () => {
+  assert.equal(decide({ command: "pnpm run pregate || echo failed" }).block, true);
+});
+
+test("denies a timeout-wrapped pregate", () => {
+  const v = decide({ command: "timeout 900 pnpm run pregate" });
+  assert.equal(v.block, true);
+  assert.match(v.reason, /false\s+green/);
+});
+
+test("reports EVERY fault at once so a fix does not arrive one denial at a time", () => {
+  const v = decide({ command: "timeout 600 pnpm run pregate | head -5; echo done" });
+  assert.equal(v.block, true);
+  assert.match(v.reason, /PIPED/);
+  assert.match(v.reason, /timeout/);
+  assert.match(v.reason, /exit code/);
+});
+
+// ── the canonical form and its neighbours must stay allowed ──────────────────
+
+test("permits the canonical invocation", () => {
+  assert.equal(decide({ command: "pnpm run pregate" }).block, false);
+});
+
+test("permits the canonical invocation with gate arguments", () => {
+  assert.equal(
+    decide({ command: 'pnpm run pregate -- --branch "feat/x;y" --no-push' }).block,
+    false,
+    "quoted data must not be read as a chain",
+  );
+});
+
+test("permits `&&` — it short-circuits, so the shell still reports the gate's status", () => {
+  assert.equal(decide({ command: "pnpm run pregate && git push" }).block, false);
+});
+
+test("permits piping the read-only status command — that habit is the one being encouraged", () => {
+  assert.equal(decide({ command: "pnpm run pregate:status --json | jq .verdict" }).block, false);
+});
+
+test("permits piping the cheap non-admitting modes", () => {
+  assert.equal(decide({ command: "pnpm run pregate -- --dry-run | head -20" }).block, false);
+  assert.equal(decide({ command: "node scripts/pregate.mjs --help | head" }).block, false);
+});
+
+test("ignores commands that are not pregate at all", () => {
+  assert.equal(decide({ command: "pnpm test | head -20" }).block, false);
+  assert.equal(decide({ command: "git log --oneline | head -5" }).block, false);
+});
+
+test("does not fire on pregate merely MENTIONED inside quoted data", () => {
+  // Same class of false positive lease-punt-guard hit on 2026-07-06: filing a bug
+  // about a blocked command must not itself be blocked.
+  assert.equal(
+    decide({ command: 'gh issue comment 1 --body "we ran pnpm run pregate | head -5 and it died"' }).block,
+    false,
+  );
+});
+
+test("honors the deliberate escape hatch", () => {
+  assert.equal(decide({ command: "DPF_ALLOW_PREGATE_SHAPE=1 pnpm run pregate | head -5" }).block, false);
+  assert.equal(
+    decide({ command: "pnpm run pregate | head -5", env: { DPF_ALLOW_PREGATE_SHAPE: "1" } }).block,
+    false,
+  );
+});
+
+// ── runtime envelope + fail-open contract ────────────────────────────────────
+
+test("emits a dual-envelope deny that every surface honors", () => {
+  const r = runGuard({ tool_name: "Bash", tool_input: { command: "pnpm run pregate | head -5" }, cwd: process.cwd() });
+  assert.equal(r.status, 0, "a deny is delivered on stdout with exit 0");
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.decision, "deny", "Grok reads the top-level decision");
+  assert.equal(out.hookSpecificOutput.permissionDecision, "deny", "Claude/Codex read hookSpecificOutput");
+  assert.match(out.reason, /BI-B1065D41/);
+});
+
+test("reads Grok's camelCase envelope, not just Claude's snake_case", () => {
+  const r = runGuard({ toolName: "Shell", toolInput: { command: "pnpm run pregate | head -5" }, cwd: process.cwd() });
+  assert.equal(JSON.parse(r.stdout).decision, "deny");
+});
+
+test("denies run_in_background delivered through the tool input", () => {
+  const r = runGuard({
+    tool_name: "Bash",
+    tool_input: { command: "pnpm run pregate", run_in_background: true },
+    cwd: process.cwd(),
+  });
+  assert.match(JSON.parse(r.stdout).reason, /CAPS and KILLS/);
+});
+
+test("stays silent on the canonical form", () => {
+  const r = runGuard({ tool_name: "Bash", tool_input: { command: "pnpm run pregate" }, cwd: process.cwd() });
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout, "", "an allow emits nothing");
+});
+
+test("fails OPEN on an unparseable payload (a guard must never wedge a session)", () => {
+  const r = spawnSync(process.execPath, [guard], {
+    input: "{not json",
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "1" },
+  });
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout.trim(), "");
+});
+
+test("fails OPEN on a non-shell tool", () => {
+  const r = runGuard({ tool_name: "Read", tool_input: { file_path: "x" }, cwd: process.cwd() });
+  assert.equal(r.stdout, "");
+});
+
+test("stays out of non-DPF workspaces", () => {
+  const r = spawnSync(process.execPath, [guard], {
+    input: JSON.stringify({ tool_name: "Bash", tool_input: { command: "pnpm run pregate | head" }, cwd: "/nowhere-at-all" }),
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "" },
+  });
+  assert.equal(r.stdout.trim(), "");
+});

--- a/packages/dpf-skill-pack/hooks/root-clone-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-guard.mjs
@@ -51,6 +51,12 @@ const ROOT_GIT_STATE_GUIDANCE =
   "Root clone git state mutation blocked (BI-B6AF69E1). The install/root clone must stay on main and clean; active work belongs in a sibling worktree such as D:/DPF-worktrees/<topic>. Raw `git switch`, `git checkout`, `git reset`, `git pull`, `git merge`, or `git rebase` in the root clone moves the checkout before the pre-commit guard can help and is how sessions strand D:/DPF on feature branches with uncommitted work. " +
   "Use scripts/new-dev-worktree.sh (or the surface worktree command) for feature work. If this is verified root-clone maintenance, prefix the command with DPF_ALLOW_ROOT_CLONE_MUTATION=1.";
 
+const INSTALL_THROUGH_JUNCTION_GUIDANCE =
+  "Package install through a JUNCTIONED node_modules blocked (BI-1C1483C6). This worktree's node_modules is a link to the shared root clone, so an install here writes THROUGH it into D:/DPF — the mechanism that previously gutted the root clone (1198 deleted sources). " +
+  "To make this worktree compile-ready without touching the root, use the managed bootstrap: `node scripts/lib/bootstrap-worktree-deps.mjs .` (shared pnpm store, --frozen-lockfile, never junctions). " +
+  "To drop the junction first, remove the reparse point with `cmd /c rmdir node_modules` — NEVER `rm -rf`, which follows the link. " +
+  "If you genuinely intend to install into the shared root, do it from the root clone, or prefix this command with DPF_ALLOW_ROOT_CLONE_MUTATION=1.";
+
 // ── path helpers (forward-slash, drive-letter aware) ─────────────────────────
 
 function norm(p) {
@@ -171,6 +177,37 @@ export function recursiveDeleteTargets(seg) {
 }
 
 /**
+ * True when this segment is a package-manager command that WRITES into
+ * node_modules (BI-1C1483C6). Read-only queries (`pnpm ls`, `pnpm why`,
+ * `pnpm store status`) and script runners (`pnpm run x`, `pnpm test`) are not
+ * included — they do not materialize packages, so they cannot write through a
+ * junction. `pnpm install` is matched in both its bare and aliased forms.
+ * @param {string} seg
+ */
+export function isNodeModulesWritingInstall(seg) {
+  const tokens = tokenize(seg);
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i += 1; // leading VAR=val
+  if (tokens[i] === "sudo") i += 1;
+  const bin = tokens[i];
+  if (!bin) return false;
+  if (!/^(?:pnpm|npm|yarn|bun)(?:\.cmd|\.exe)?$/.test(bin)) return false;
+  // The first non-flag token after the binary is the subcommand — but several
+  // pnpm flags take a SEPARATE value (`pnpm --filter web add zod`), and reading
+  // that value as the subcommand would miss the install entirely.
+  const FLAGS_WITH_VALUES = new Set(["--filter", "-F", "--dir", "-C", "--workspace-concurrency", "--config"]);
+  let j = i + 1;
+  while (j < tokens.length && tokens[j].startsWith("-")) {
+    if (FLAGS_WITH_VALUES.has(tokens[j]) && !tokens[j].includes("=")) j += 1;
+    j += 1;
+  }
+  // A bare `yarn` / `bun` with no subcommand IS an install.
+  const sub = tokens[j] ?? (bin === "yarn" || bin === "bun" ? "install" : "");
+  return ["install", "i", "ci", "add", "update", "up", "upgrade", "dedupe", "rebuild", "prune", "link"]
+    .includes(sub);
+}
+
+/**
  * True when this segment is a `git clean` that removes ignored directories
  * (`-d` to recurse into dirs AND `-x`/`-X` to include ignored) — the form that
  * sweeps an ignored, junctioned node_modules and follows it into the shared root.
@@ -254,6 +291,21 @@ export function decide({ command, cwd = "", env = {}, isSymlink = () => false, i
   const cloneRoot = () => (cloneRootMemo !== undefined ? cloneRootMemo : (cloneRootMemo = deriveCloneRoot(cwd, isDir)));
 
   for (const seg of segments(command)) {
+    // BI-1C1483C6: the OTHER junction foot-gun. A recursive delete through a
+    // junctioned node_modules was already covered below; an INSTALL through the
+    // same junction was not, and it has its own history — the root clone was
+    // previously gutted (1198 deleted sources) by a package manager writing
+    // through a worktree's node_modules link into D:/DPF.
+    //
+    // The condition is runtime state, not command text: this fires only when
+    // <cwd>/node_modules is ACTUALLY a junction/symlink. So a normal install in
+    // the root clone (a real directory) and the managed worktree bootstrap
+    // (which installs only when node_modules does not exist yet) both stay
+    // allowed, and the guard cannot become a blanket ban on installing.
+    if (isNodeModulesWritingInstall(seg) && isSymlink(resolveAgainst(cwd, "node_modules"))) {
+      return { block: true, reason: INSTALL_THROUGH_JUNCTION_GUIDANCE };
+    }
+
     if (isRootCloneGitStateMutation(seg, cwd, isDir)) {
       return { block: true, reason: ROOT_GIT_STATE_GUIDANCE };
     }

--- a/packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
@@ -8,6 +8,7 @@ import {
   isUnderRootSharedArea,
   recursiveDeleteTargets,
   isDestructiveGitClean,
+  isNodeModulesWritingInstall,
 } from "./root-clone-guard.mjs";
 
 // A nested worktree (the dominant, dangerous layout: inside the root clone),
@@ -175,4 +176,73 @@ test("isDestructiveGitClean: true only when ignored dirs are swept", () => {
   assert.equal(isDestructiveGitClean("git clean -fdX"), true);
   assert.equal(isDestructiveGitClean("git clean -fd"), false);
   assert.equal(isDestructiveGitClean("git status"), false);
+});
+
+// ── BI-1C1483C6: install THROUGH a junctioned node_modules ───────────────────
+// The delete-through-junction case was already covered above. This is the other
+// half of the same foot-gun: a package manager writing through the link into the
+// shared root, which previously gutted the root clone (1198 deleted sources).
+
+const WT = "D:/DPF-worktrees/topic";
+const junctionedNodeModules = (p) => p === "D:/DPF-worktrees/topic/node_modules";
+
+test("isNodeModulesWritingInstall: matches the commands that materialize packages", () => {
+  for (const cmd of [
+    "pnpm install",
+    "pnpm i",
+    "pnpm install --frozen-lockfile",
+    "pnpm add zod",
+    "pnpm update",
+    "npm install",
+    "npm ci --no-audit",
+    "yarn",
+    "bun install",
+    "pnpm --filter web add zod",
+    "pnpm -C apps/web install",
+  ]) {
+    assert.equal(isNodeModulesWritingInstall(cmd), true, cmd);
+  }
+});
+
+test("isNodeModulesWritingInstall: does NOT match read-only queries or script runners", () => {
+  for (const cmd of [
+    "pnpm ls --depth -1",
+    "pnpm why react",
+    "pnpm store status",
+    "pnpm run pregate",
+    "pnpm test",
+    "pnpm --filter web typecheck",
+    "git install",
+  ]) {
+    assert.equal(isNodeModulesWritingInstall(cmd), false, cmd);
+  }
+});
+
+test("blocks a bare pnpm install when node_modules IS a junction", () => {
+  const v = decide({ command: "pnpm install", cwd: WT, isSymlink: junctionedNodeModules });
+  assert.equal(v.block, true);
+  assert.match(v.reason, /writes THROUGH it/);
+  assert.match(v.reason, /bootstrap-worktree-deps/, "the denial must name the managed alternative");
+  assert.match(v.reason, /cmd \/c rmdir/, "and the junction-safe way to drop the link");
+});
+
+test("ALLOWS the same install when node_modules is a real directory", () => {
+  // The root clone, and any worktree with its own real node_modules, install
+  // normally. The guard keys on runtime state, not on the command text — so it
+  // can never become a blanket ban on installing.
+  assert.equal(decide({ command: "pnpm install", cwd: WT, isSymlink: () => false }).block, false);
+});
+
+test("ALLOWS the managed bootstrap's own install (no node_modules yet, so no junction)", () => {
+  assert.equal(
+    decide({ command: "pnpm install --prefer-offline --frozen-lockfile", cwd: WT, isSymlink: () => false }).block,
+    false,
+  );
+});
+
+test("the junction install block honors the existing root-mutation escape hatch", () => {
+  assert.equal(
+    decide({ command: "DPF_ALLOW_ROOT_CLONE_MUTATION=1 pnpm install", cwd: WT, isSymlink: junctionedNodeModules }).block,
+    false,
+  );
 });

--- a/packages/dpf-skill-pack/hooks/worktree-readiness-banner.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-readiness-banner.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/worktree-readiness-banner.mjs
+//
+// SessionStart hook (BI-1C1483C6): announce whether this worktree can actually
+// run the gates an agent is about to promise.
+//
+// WHAT WAS OBSERVED (2026-08-04, worktree claude/approval-surfaces-auth-sweep-dd17fd)
+// `apps/web/node_modules` was an EMPTY directory and the worktree root had no
+// `node_modules` at all. The root clone was fine. NOTHING announced this. It
+// surfaced much later as `'next' is not recognized` from the pre-commit
+// typecheck gate and 14 vitest suites failing with "Cannot find package
+// 'react'" — which look exactly like real breakage. Confirming they were
+// environmental cost a `git stash` + re-run per suspicion, and an agent that
+// does not think to stash reports them as regressions its own change caused.
+//
+// WHY DETECTION, NOT PROVISIONING
+// The obvious reading is "worktree-create should install". It deliberately does
+// not: `worktree-create.mjs` only PLACES the worktree, and BI-3047C122 recorded
+// a principle_decide outcome that a multi-minute install must never gate the
+// blocking WorktreeCreate hook — bootstrap is opt-in (DPF_WORKTREE_BOOTSTRAP=1
+// via the seed script). That decision stands. What was wrong is not that the
+// half-tree is legal; it is that the hand-over was SILENT. This hook makes it
+// loud without reversing a ratified decision.
+//
+// The classification itself is not new either — `dpf-worktree-per-session`
+// documents a "compile-ready vs source-only" split and
+// scripts/lib/bootstrap-worktree-deps.mjs computes it. It was simply never
+// surfaced at runtime. This hook is the missing last hop.
+//
+// READ-ONLY. It probes with existsSync/readdirSync and nothing else. A
+// worktree's node_modules is normally a JUNCTION to the root clone: `rm -rf` on
+// it has gutted the root clone before (1198 deleted sources), and a bare
+// `pnpm install` writes THROUGH it. This hook must never grow a repair path.
+//
+// Fail-open in every direction — a banner that breaks session start is worse
+// than the silence it replaces.
+
+import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { inDpfWorkspace } from "./lib/hook-io.mjs";
+
+const hooksDir = dirname(fileURLToPath(import.meta.url));
+const repoRootGuess = resolve(hooksDir, "../../..");
+
+function readPayload() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    return raw.trim() ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function sessionCwd(payload) {
+  return payload.cwd || payload.workspaceRoot || payload.workspace_root || process.cwd();
+}
+
+/** The worktree root, so a session started in a subdirectory still classifies correctly. */
+function resolveWorktreeRoot(cwd) {
+  const r = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 10_000,
+  });
+  return r.status === 0 && r.stdout.trim() ? r.stdout.trim() : cwd;
+}
+
+async function loadProbe(worktreeRoot) {
+  // Prefer THIS worktree's copy so the probe matches the tree being classified.
+  for (const base of [worktreeRoot, repoRootGuess]) {
+    const candidate = join(base, "scripts/lib/bootstrap-worktree-deps.mjs");
+    if (existsSync(candidate)) {
+      try {
+        return await import(pathToFileURL(candidate).href);
+      } catch {
+        // Try the next candidate rather than failing the session.
+      }
+    }
+  }
+  return null;
+}
+
+function emitContext(text) {
+  process.stdout.write(
+    JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: text } }),
+  );
+}
+
+async function main() {
+  if (process.env.DPF_SKIP_WORKTREE_READINESS_BANNER === "1") process.exit(0);
+
+  const payload = readPayload();
+  const cwd = sessionCwd(payload);
+  if (!inDpfWorkspace(cwd)) process.exit(0);
+
+  const worktreeRoot = resolveWorktreeRoot(cwd);
+  const probe = await loadProbe(worktreeRoot);
+  if (!probe?.probeWorktreeReadiness || !probe?.formatReadinessBanner) process.exit(0);
+
+  const readiness = probe.probeWorktreeReadiness(worktreeRoot);
+  const lines = probe.formatReadinessBanner(readiness, worktreeRoot);
+  // A compile-ready worktree says nothing: the banner exists to correct a false
+  // belief, and there is no false belief to correct when the tree is ready.
+  if (lines.length > 0) emitContext(lines.join("\n"));
+  process.exit(0);
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("worktree-readiness-banner.mjs")) {
+  main().catch(() => process.exit(0));
+}

--- a/packages/dpf-skill-pack/hooks/worktree-readiness-banner.test.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-readiness-banner.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const hook = join(here, "worktree-readiness-banner.mjs");
+const repoRoot = join(here, "..", "..", "..");
+
+function runHook(cwd) {
+  const r = spawnSync(process.execPath, [hook], {
+    input: JSON.stringify({ hook_event_name: "SessionStart", cwd }),
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "1" },
+  });
+  return { status: r.status, stdout: r.stdout.trim() };
+}
+
+/**
+ * A worktree-shaped tree that is DPF-recognisable (packages/dpf-skill-pack) and
+ * carries the real probe, but has no node_modules — the observed condition.
+ */
+function makeSourceOnlyTree() {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-readiness-"));
+  mkdirSync(join(dir, "packages", "dpf-skill-pack"), { recursive: true });
+  mkdirSync(join(dir, "scripts", "lib"), { recursive: true });
+  writeFileSync(
+    join(dir, "scripts", "lib", "bootstrap-worktree-deps.mjs"),
+    readFileSync(join(repoRoot, "scripts", "lib", "bootstrap-worktree-deps.mjs"), "utf8"),
+  );
+  return dir;
+}
+
+test("announces SOURCE-ONLY and names the missing pieces and what they forbid", () => {
+  const dir = makeSourceOnlyTree();
+  const r = runHook(dir);
+  assert.equal(r.status, 0);
+  const context = JSON.parse(r.stdout).hookSpecificOutput.additionalContext;
+  assert.match(context, /SOURCE-ONLY/);
+  assert.match(context, /root node_modules/);
+  assert.match(context, /apps\/web\/node_modules/);
+  assert.match(context, /packages\/db\/generated/);
+  assert.match(context, /'next' is not recognized/, "must name the symptom the operator will actually see");
+  assert.match(context, /do not claim a gate you cannot run/i);
+});
+
+test("an EMPTY apps/web/node_modules still reports as missing", () => {
+  // The exact observed shape: the directory exists with zero entries.
+  const dir = makeSourceOnlyTree();
+  mkdirSync(join(dir, "apps", "web", "node_modules"), { recursive: true });
+  const context = JSON.parse(runHook(dir).stdout).hookSpecificOutput.additionalContext;
+  assert.match(context, /apps\/web\/node_modules \(empty\)/);
+});
+
+test("the banner is READ-ONLY — it creates nothing under node_modules", () => {
+  const dir = makeSourceOnlyTree();
+  runHook(dir);
+  assert.equal(existsSync(join(dir, "node_modules")), false, "the hook must never provision");
+  assert.equal(existsSync(join(dir, "apps", "web", "node_modules")), false);
+});
+
+test("the escape hatch silences it", () => {
+  const dir = makeSourceOnlyTree();
+  const r = spawnSync(process.execPath, [hook], {
+    input: JSON.stringify({ hook_event_name: "SessionStart", cwd: dir }),
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "1", DPF_SKIP_WORKTREE_READINESS_BANNER: "1" },
+  });
+  assert.equal(r.stdout.trim(), "");
+});
+
+test("stays out of non-DPF workspaces", () => {
+  const dir = mkdtempSync(join(tmpdir(), "not-dpf-"));
+  const r = spawnSync(process.execPath, [hook], {
+    input: JSON.stringify({ hook_event_name: "SessionStart", cwd: dir }),
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "" },
+  });
+  assert.equal(r.stdout.trim(), "");
+});
+
+test("fails open on an unreadable payload rather than breaking session start", () => {
+  const r = spawnSync(process.execPath, [hook], {
+    input: "{not json",
+    encoding: "utf8",
+    env: { ...process.env, DPF_GUARDS_WORKSPACE_ANY: "1" },
+  });
+  assert.equal(r.status, 0);
+});

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -1067,6 +1067,7 @@ GROK_HOOK_GUARDS = (
     "compose-guard.mjs",
     "plan-backlog-coverage-guard.mjs",
     "pregate-evidence-guard.mjs",
+    "pregate-invocation-guard.mjs",
 )
 # Matcher-scoped groups (BI-pretooluse): without matchers Grok runs EVERY PreToolUse
 # command on EVERY tool (6 serial node spawns per call), which looks like
@@ -1081,6 +1082,7 @@ GROK_PRETOOLUSE_GROUPS = (
             "root-clone-guard.mjs",
             "compose-guard.mjs",
             "pregate-evidence-guard.mjs",
+            "pregate-invocation-guard.mjs",
         ),
     ),
     (
@@ -1288,6 +1290,7 @@ CODEX_BASH_GUARDS = (
     "compose-guard.mjs",
     "lease-punt-guard.mjs",
     "pregate-evidence-guard.mjs",
+    "pregate-invocation-guard.mjs",
 )
 CODEX_ASK_GUARDS = ("decision-routing-guard.mjs",)
 CODEX_WRITE_GUARDS = ("plan-backlog-coverage-guard.mjs",)
@@ -1461,11 +1464,13 @@ HOOK_PURPOSES = {
     "decision-routing-guard.mjs": "blocks asking the operator a platform decision with no kernel consultation",
     "plan-backlog-coverage-guard.mjs": "blocks production source edits until xlarge and independently shippable plan work has live BI coverage",
     "pregate-evidence-guard.mjs": "blocks git push / gh pr create when HEAD has no unexpired local-CI sandbox evidence",
+    "pregate-invocation-guard.mjs": "blocks a pregate run shaped so it cannot succeed or cannot be read (piped, backgrounded, chained, timeout-wrapped)",
     "ux-fit-precheck.mjs": "reminds to run a UX-fit review when editing UI surfaces",
     "spec-plan-doc-precheck.mjs": "reminds to attach a spec/plan/doc when writing gated files",
     "design-grounding-precheck.mjs": "reminds to review specs and current code substrate before UX/workflow edits",
     "tool-economy-precheck.mjs": "reminds about tool-economy budget when adding tool surface",
     "worktree-create.mjs": "seeds a new worktree with MCP config on WorktreeCreate",
+    "worktree-readiness-banner.mjs": "SessionStart: announces a SOURCE-ONLY worktree and what it forbids, so agents never promise a typecheck they cannot run",
     "process-spine-health-check.mjs": "SessionStart: warns when DPF-native replacement skills are missing or hidden by retired generic skills",
     "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",
     "grok-session-start.mjs": "Grok SessionStart: process-spine exposure probe + governance-freshness (global hook plane)",

--- a/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
@@ -104,14 +104,15 @@ For normal feature/fix work: commit from the worktree, then route runtime-bound 
    git log origin/main..HEAD --oneline  # should be empty (no commits yet)
    ```
 
-7. **Classify verification readiness.** Read `.dpf-worktree-readiness.json` or re-check:
+7. **Classify verification readiness.** Run the probe — do **not** hand-check with `test -d node_modules`:
    ```
-   command -v pnpm >/dev/null || command -v corepack >/dev/null
-   test -d node_modules
+   node scripts/lib/bootstrap-worktree-deps.mjs . --classify-only
    ```
-   - `compile-ready`: package manager plus dependencies are present. Cheap source-local gates may run here.
-   - `source-only`: Git/MCP/Compose isolation is present, but local compile/test gates are not proven. Do code work here, but get verification from the shared local-CI convergence sandbox or canonical install.
-   - If a task requires cheap source-local gates and the worktree is source-only, try to make it compile-ready only when low-risk (`pnpm install --frozen-lockfile` with pinned pnpm available). If dependency bootstrap is unavailable or would distract from the task, record `source-only` and do not claim local gate passes.
+   A structural presence test is what let an **empty** `apps/web/node_modules` read as provisioned (BI-1C1483C6, 2026-08-04); the probe checks dependency resolution, `@dpf/*` workspace-link locality, and each named compile artifact for emptiness as well as absence.
+   - `compile-ready`: dependencies resolve and every compile artifact is populated. Cheap source-local gates may run here.
+   - `source-only`: Git/MCP/Compose isolation is present, but local compile/test gates are not proven. Do code work here, but get verification from the shared local-CI convergence sandbox or canonical install. The `missing` array names each gap and **what it forbids** — `apps/web/node_modules` forbids `pnpm --filter web typecheck` (it fails as `'next' is not recognized`); `packages/db/generated` forbids Prisma-touching tests (they fail as `Cannot find module '../generated/client/client'`). Those messages look exactly like real breakage; in a source-only worktree they are not.
+   - Since BI-1C1483C6 a SessionStart hook (`worktree-readiness-banner.mjs`) prints this automatically. Its silence means compile-ready.
+   - To become compile-ready, use the **managed** bootstrap — `node scripts/lib/bootstrap-worktree-deps.mjs .` — never a bare `pnpm install` in a worktree. A worktree's `node_modules` is normally a junction to the root clone, so a bare install writes **through** it into the root clone (which it has previously gutted); `root-clone-guard.mjs` now denies that shape. If bootstrap is unavailable or would distract from the task, stay `source-only` and do not claim local gate passes.
 
 ## Instructions for agents entering an existing worktree
 
@@ -119,7 +120,7 @@ Before editing or reviewing from an existing worktree:
 
 1. Run `git status --short --branch` and `git rev-parse --abbrev-ref HEAD`. Abort serious implementation on `main` or detached `HEAD` unless the user explicitly asked for inspection only.
 2. Confirm `.env` has a non-root `COMPOSE_PROJECT_NAME`. If it is missing or `dpf`, run `scripts/seed-worktree-mcp.{ps1,sh}` before any Compose command.
-3. Read `.dpf-worktree-readiness.json` if present. If absent, run `scripts/seed-worktree-mcp.{ps1,sh}` for this worktree or `scripts/sync-mcp-worktrees.{ps1,sh}` from the root to refresh all worktrees; treat the worktree as `source-only` until a marker proves otherwise.
+3. Classify readiness with `node scripts/lib/bootstrap-worktree-deps.mjs . --classify-only`. `.dpf-worktree-readiness.json` is a cached marker, not the authority — a worktree created by the `WorktreeCreate` hook has no marker at all (that hook only PLACES the worktree; provisioning is deliberately opt-in per BI-3047C122). Treat the worktree as `source-only` until the probe says otherwise, and run `scripts/seed-worktree-mcp.{ps1,sh}` if the marker is missing and you want one written.
 4. If `source-only`, you may edit and commit, but final answers and PR/evidence notes must say local worktree gates were not run and must point to canonical-runtime/local-CI evidence for any verification claim.
 5. Commit or capture dirty work frequently. A dirty active worker worktree blocks upgrade apply because uncommitted output cannot be safely rebased, promoted, or abandoned by automation.
 

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -44,6 +44,13 @@ import {
   summarizeLocalCiPressureSamples,
 } from "./lib/local-ci-host-pressure.mjs";
 import { buildAttributionEvidence, resolveAgentIdentity } from "./lib/agent-identity.mjs";
+import {
+  createGateOutputRelay,
+  createRepeatNotice,
+  formatGateSummary,
+  installBrokenPipeTolerance,
+  isVerboseGateConsole,
+} from "./lib/pregate-console.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
@@ -52,6 +59,17 @@ const LOCAL_CI_ACTIVE_LEASE_TTL_MS = 2 * 60_000;
 function die(message) {
   process.stderr.write(`gate-worktree: ${message}\n`);
   process.exit(1);
+}
+
+// BI-B1065D41: every "still waiting" line goes through ONE repeat notice. A
+// queued run polled admission ~40 times and printed 40 near-identical lines,
+// which is a large slice of a readable budget for a single bit of information.
+// The notice prints when the shape changes (the queue position moved, a
+// different blocker appeared) and otherwise re-prints periodically so a long
+// wait still proves liveness.
+const waitNotice = createRepeatNotice({ write: (text) => process.stdout.write(text) });
+function waiting(text) {
+  waitNotice.notice(text);
 }
 
 function sleep(ms) {
@@ -473,11 +491,21 @@ function createGateCommand(commandSpec, { cwd, env, allowStub, fullLogFile }) {
   let trackerTimer = null;
   let output = "";
   writeFileSync(fullLogFile, "");
-  const append = (chunk, stream) => {
+  // BI-B1065D41: the child's transcript is ~28,000 lines. It is persisted in
+  // full to fullLogFile (and its tail travels in the evidence record), so
+  // mirroring it to stdout bought nothing except unreadability — and the piping
+  // habit that unreadability provoked SIGPIPE-killed runs mid-install. stdout
+  // now gets a throttled heartbeat; DPF_PREGATE_VERBOSE=1 restores the mirror
+  // for anyone debugging the gate itself.
+  const relay = createGateOutputRelay({
+    write: (text) => process.stdout.write(text),
+    verbose: isVerboseGateConsole(),
+  });
+  const append = (chunk) => {
     const text = String(chunk);
     output = `${output}${text}`.slice(-12000);
     appendFileSync(fullLogFile, text);
-    stream.write(text);
+    relay.absorb(text);
   };
   return {
     run: () => new Promise((resolve, reject) => {
@@ -499,8 +527,8 @@ function createGateCommand(commandSpec, { cwd, env, allowStub, fullLogFile }) {
         () => tracker.sample(),
         Math.max(50, numberOrDefault(process.env.DPF_GATE_PROCESS_SCAN_MS, defaultProcessScanMs())),
       );
-      child.stdout.on("data", (chunk) => append(chunk, process.stdout));
-      child.stderr.on("data", (chunk) => append(chunk, process.stderr));
+      child.stdout.on("data", (chunk) => append(chunk));
+      child.stderr.on("data", (chunk) => append(chunk));
       child.once("error", reject);
       child.once("close", async (code, signal) => {
         if (trackerTimer) {
@@ -519,13 +547,15 @@ function createGateCommand(commandSpec, { cwd, env, allowStub, fullLogFile }) {
         if (terminated.length > 0) {
           append(
             `gate-worktree: terminated ${terminated.length} descendant process(es) before lease release: ${terminated.join(", ")}\n`,
-            process.stderr,
           );
         }
+        relay.finish();
         resolve({
           label: commandSpec.label,
           status: code ?? (signal ? 143 : 1),
           output,
+          logLines: relay.stats().lines,
+          elapsedMs: relay.stats().elapsedMs,
         });
       });
     }),
@@ -680,6 +710,10 @@ function writePendingEvidence(path, { branch, sha, expiresAt, reason, retryAfter
 }
 
 async function main() {
+  // BI-B1065D41: a stray `| head` must DEGRADE, not kill a 20-minute run that is
+  // holding a shared lease. Without this, the EPIPE raised when the reader exits
+  // is an unhandled stream error and the gate dies mid-install.
+  installBrokenPipeTolerance();
   const options = parseArgs(process.argv.slice(2));
   const gitBin = process.env.DPF_GATE_GIT_BIN || "git";
   const allowStub = process.env.DPF_ALLOW_LOCAL_CI_STUB === "1";
@@ -800,7 +834,7 @@ async function main() {
       retryAfterSeconds,
     });
     quiescenceAttempt += 1;
-    process.stdout.write(`portal is ${quiescence.level || "quiescing"}; retrying governed admission in ${(delayMs / 1000).toFixed(1)}s...\n`);
+    waiting(`portal is ${quiescence.level || "quiescing"}; retrying governed admission in ${(delayMs / 1000).toFixed(1)}s...`);
     await sleep(Math.min(delayMs, Math.max(10, deadline - Date.now())));
   }
 
@@ -963,7 +997,7 @@ async function main() {
       if (!isTransientMcpError(error) || Date.now() >= deadline) throw error;
       const delayMs = retryDelayMs({ attempt: claimAttempt, pollSeconds: options.pollSeconds });
       claimAttempt += 1;
-      process.stdout.write(`local-CI admission transport unavailable (${error.message}); retrying in ${(delayMs / 1000).toFixed(1)}s...\n`);
+      waiting(`local-CI admission transport unavailable (${error.message}); retrying in ${(delayMs / 1000).toFixed(1)}s...`);
       await sleep(Math.min(delayMs, Math.max(10, deadline - Date.now())));
       continue;
     }
@@ -1044,7 +1078,7 @@ async function main() {
       }
       const delayMs = retryDelayMs({ attempt: claimAttempt, pollSeconds: options.pollSeconds });
       claimAttempt += 1;
-      process.stdout.write(`local-CI admission queued at position ${admission.queuePosition}; observing again in ${(delayMs / 1000).toFixed(1)}s...\n`);
+      waiting(`local-CI admission queued at position ${admission.queuePosition}; observing again in ${(delayMs / 1000).toFixed(1)}s...`);
       await sleep(Math.min(delayMs, Math.max(10, deadline - Date.now())));
       continue;
     }
@@ -1061,7 +1095,7 @@ async function main() {
         pollSeconds: options.pollSeconds,
       });
       claimAttempt += 1;
-      process.stdout.write(`local-CI portal is on the legacy conflict contract; observing admission again in ${(delayMs / 1000).toFixed(1)}s...\n`);
+      waiting(`local-CI portal is on the legacy conflict contract; observing admission again in ${(delayMs / 1000).toFixed(1)}s...`);
       await sleep(Math.min(delayMs, Math.max(10, deadline - Date.now())));
       continue;
     }
@@ -1079,7 +1113,7 @@ async function main() {
         retryAfterSeconds,
       });
       claimAttempt += 1;
-      process.stdout.write(`portal is quiescing; preserving queue intent and retrying in ${(delayMs / 1000).toFixed(1)}s...\n`);
+      waiting(`portal is quiescing; preserving queue intent and retrying in ${(delayMs / 1000).toFixed(1)}s...`);
       await sleep(Math.min(delayMs, Math.max(10, deadline - Date.now())));
       continue;
     }
@@ -1259,11 +1293,11 @@ async function main() {
       expiresAt,
     });
     if (localFence.liveMutatorPids?.length > 0) {
-      process.stdout.write(
-        `local-CI sandbox still has live mutator processes (${localFence.liveMutatorPids.join(", ")}); retrying after admission...\n`,
+      waiting(
+        `local-CI sandbox still has live mutator processes (${localFence.liveMutatorPids.join(", ")}); retrying after admission...`,
       );
     } else {
-      process.stdout.write(`local-CI sandbox process fence held by ${localFence.active?.ownerSessionId || "unknown"}; retrying after admission...\n`);
+      waiting(`local-CI sandbox process fence held by ${localFence.active?.ownerSessionId || "unknown"}; retrying after admission...`);
     }
     await sleep(Math.min(options.pollSeconds * 1000, Math.max(10, deadline - Date.now())));
   }
@@ -1282,6 +1316,9 @@ async function main() {
   }
 
   process.stdout.write(`local-CI sandbox admitted: ${leaseId}\n`);
+  // BI-B1065D41: name the full log BEFORE the long stage, so the detail is one
+  // command away for the whole run rather than only after it finishes.
+  process.stdout.write(`full log: ${fullLogFile}\n`);
   if (commandSpec) process.stdout.write(`running local-CI command: ${commandSpec.label}\n`);
   else process.stdout.write("sandbox checkout/build stub: gate passed (explicit test-only mode)\n");
 
@@ -1596,10 +1633,30 @@ async function main() {
     evidencePending: false,
   });
 
+  // BI-B1065D41 Phase 1: one bounded, stable block closes every run. On a pass
+  // its LAST line is still the literal `gate passed` — the documented anchor,
+  // load-bearing because the exit code lies in two independent directions (a
+  // chained command surfaces someone else's status; a run that gave up while
+  // queued exits 0 without gating anything). Failure paths keep their own
+  // terminal wording, so the block carries only the supporting facts there.
+  const summaryInput = {
+    branch,
+    sha,
+    logFile: fullLogFile,
+    logLines: runResult.logLines,
+    elapsedMs: runResult.elapsedMs,
+    metadataFile: contentMetadata ? metadataFile : "",
+    candidateSha: contentMetadata?.candidateSha || "",
+    evidenceId,
+  };
+
   if (outcome.gatePassed) {
-    process.stdout.write("gate passed\n");
+    process.stdout.write(`${formatGateSummary({ ...summaryInput, verdictLine: "gate passed" }).join("\n")}\n`);
     process.exit(0);
   }
+  process.stderr.write(
+    `${formatGateSummary({ ...summaryInput, verdictLine: "", failureSummary }).join("\n")}\n`,
+  );
   if (outcome.status === "blocked_sandbox_drift") {
     process.stderr.write(`gate-worktree: BLOCKED (sandbox drift): ${outcome.summary}\n`);
     process.stderr.write("gate-worktree: this is a sandbox defect, not product build evidence; converge the sandbox and re-run the gate\n");

--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -17,7 +17,7 @@
 // explicitly (a `dpf worktree --bootstrap` CLI / the seed script / an opt-in env),
 // so worktree creation stays fast and convergence is a deliberate step.
 
-import { existsSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
 /**
@@ -28,6 +28,70 @@ import { execFileSync } from "node:child_process";
 export function classifyReadiness({ hasNodeModules, depProbeOk, gateOk }) {
   if (hasNodeModules && depProbeOk && gateOk) return "compile-ready";
   return "source-only";
+}
+
+// BI-1C1483C6: the three artifacts whose absence produces failures that look
+// exactly like real code breakage. Observed 2026-08-04: `apps/web/node_modules`
+// was an EMPTY directory (0 entries) and the worktree root had none at all,
+// which surfaced only much later as `'next' is not recognized` from the
+// pre-commit typecheck and 14 vitest suites failing with "Cannot find package
+// 'react'". Confirming those were environmental cost a `git stash` + re-run per
+// suspicion — and an agent that does not think to stash reports them as
+// regressions IT caused.
+//
+// `existsSync` alone is not the test: an EMPTY directory is the observed shape,
+// and it passes existsSync. Emptiness is the signal.
+export const WORKTREE_COMPILE_ARTIFACTS = Object.freeze([
+  Object.freeze({
+    path: "node_modules",
+    label: "root node_modules",
+    forbids: "any pnpm script, typecheck, or vitest run",
+  }),
+  Object.freeze({
+    path: "apps/web/node_modules",
+    label: "apps/web/node_modules",
+    forbids: "pnpm --filter web typecheck (fails as \"'next' is not recognized\") and component tests",
+  }),
+  Object.freeze({
+    path: "packages/db/generated",
+    label: "packages/db/generated (Prisma client)",
+    forbids: "any Prisma-touching test (fails as \"Cannot find module '../generated/client/client'\")",
+  }),
+]);
+
+/**
+ * Which of the named compile artifacts are absent or empty. READ-ONLY by
+ * construction — this module must never create, junction, or remove anything
+ * under node_modules. A worktree's node_modules is normally a JUNCTION to the
+ * root clone, and `rm -rf` on it has previously gutted the root clone (1198
+ * deleted sources); a bare `pnpm install` writes THROUGH the junction. Probing
+ * is safe precisely because it only reads.
+ *
+ * @param {string} worktreePath
+ * @param {{ readdir?: (dir: string) => string[], exists?: (p: string) => boolean }} [deps]
+ */
+export function missingCompileArtifacts(worktreePath, deps = {}) {
+  const exists = deps.exists ?? ((p) => existsSync(p));
+  const readdir = deps.readdir ?? ((dir) => {
+    try {
+      return readdirSync(dir);
+    } catch {
+      return [];
+    }
+  });
+  const wt = norm(worktreePath);
+  const missing = [];
+  for (const artifact of WORKTREE_COMPILE_ARTIFACTS) {
+    const full = `${wt}/${artifact.path}`;
+    if (!exists(full)) {
+      missing.push({ ...artifact, state: "absent" });
+      continue;
+    }
+    if (readdir(full).length === 0) {
+      missing.push({ ...artifact, state: "empty" });
+    }
+  }
+  return missing;
 }
 
 /** Operator-readable reason for the readiness outcome (written to the marker). */
@@ -106,17 +170,101 @@ export function checkWorkspaceLinksResolveLocally(worktreePath, deps = {}) {
  */
 export function probeWorktreeReadiness(worktreePath, opts = {}) {
   const pkgMgr = opts.packageManager ?? "pnpm";
-  const hasNodeModules = existsSync(`${worktreePath}/node_modules`);
+  // BI-1C1483C6: check every named artifact, not just the root. The observed
+  // failure had a root node_modules that was ABSENT and an apps/web one that
+  // existed but was EMPTY — so both the path set and the emptiness test matter.
+  const missing = missingCompileArtifacts(worktreePath, opts.artifactDeps);
+  const hasNodeModules = !missing.some((m) => m.path === "node_modules");
   const depProbeOk = hasNodeModules && run(pkgMgr, ["ls", "--depth", "-1"], worktreePath);
   const linkCheck = depProbeOk
     ? checkWorkspaceLinksResolveLocally(worktreePath, opts.linkCheckDeps)
     : { ok: true, stale: [] };
-  const gateOk = depProbeOk && linkCheck.ok;
+  const gateOk = depProbeOk && linkCheck.ok && missing.length === 0;
   return {
     status: classifyReadiness({ hasNodeModules, depProbeOk, gateOk }),
-    reason: readinessReason({ hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks: linkCheck.stale }),
+    reason: missing.length > 0 && hasNodeModules && depProbeOk && linkCheck.ok
+      ? `missing_compile_artifacts:${missing.map((m) => m.path).join(",")}`
+      : readinessReason({ hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks: linkCheck.stale }),
+    missing,
     checks: { hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks: linkCheck.stale },
   };
+}
+
+// BI-1C1483C6 (2): the exact strings an unprovisioned worktree produces. Every
+// one of them reads as a code defect at the point of use, which is why they cost
+// a `git stash` + re-run cycle per suspicion — and why an agent that skips the
+// stash reports them as regressions its own change caused.
+const UNPROVISIONED_SIGNATURES = Object.freeze([
+  { pattern: /'next' is not recognized|next: (?:command )?not found/i, artifact: "apps/web/node_modules" },
+  { pattern: /Cannot find package '(?:react|react-dom)/i, artifact: "node_modules" },
+  { pattern: /Cannot find module '.*generated[/\\]client/i, artifact: "packages/db/generated" },
+  { pattern: /Cannot find module '@dpf\//i, artifact: "node_modules" },
+  { pattern: /ERR_PNPM_NO_.*|command not found: pnpm/i, artifact: "node_modules" },
+]);
+
+/**
+ * Decide whether a command's output is the unprovisioned-worktree condition
+ * rather than a real defect. Pure — the caller supplies both the text and the
+ * readiness it already probed, because the text alone is ambiguous: `Cannot
+ * find package 'react'` in a COMPILE-READY tree really is a broken dependency
+ * and must keep reading as one.
+ *
+ * @param {string} outputText
+ * @param {{ status: string, missing?: Array<{path: string}> }} readiness
+ * @returns {{ unprovisioned: boolean, matched: string[], explanation: string }}
+ */
+export function diagnoseUnprovisionedFailure(outputText, readiness) {
+  const text = String(outputText ?? "");
+  const matched = UNPROVISIONED_SIGNATURES
+    .filter((sig) => sig.pattern.test(text))
+    .map((sig) => sig.artifact);
+  if (matched.length === 0 || readiness?.status === "compile-ready") {
+    return { unprovisioned: false, matched: [], explanation: "" };
+  }
+  const missingPaths = new Set((readiness?.missing ?? []).map((m) => m.path));
+  // Require the signature to CORROBORATE what was actually probed. Otherwise a
+  // genuinely broken dependency in a tree that merely lacks the Prisma client
+  // would be waved through as "environmental".
+  const corroborated = matched.filter((artifact) => missingPaths.has(artifact));
+  if (corroborated.length === 0) return { unprovisioned: false, matched, explanation: "" };
+  return {
+    unprovisioned: true,
+    matched: corroborated,
+    explanation:
+      "This is an UNPROVISIONED WORKTREE, not a code defect: "
+      + `${corroborated.join(", ")} ${corroborated.length === 1 ? "is" : "are"} missing or empty in this worktree. `
+      + "Do not attribute it to your change and do not stash to check. "
+      + "Provision with: node scripts/lib/bootstrap-worktree-deps.mjs . "
+      + "(never a bare `pnpm install` in a worktree — it writes THROUGH the junction into the root clone).",
+  };
+}
+
+/**
+ * The banner an agent needs BEFORE it promises a typecheck it cannot run.
+ *
+ * Naming what is missing is only half of it; naming what that FORBIDS is the
+ * half that changes behaviour. An agent that knows it is source-only does not
+ * report `Cannot find package 'react'` as a regression it caused.
+ *
+ * @param {{ status: string, reason: string, missing?: Array<{label: string, state: string, forbids: string}> }} readiness
+ * @param {string} worktreePath
+ * @returns {string[]} empty when the worktree is compile-ready (say nothing)
+ */
+export function formatReadinessBanner(readiness, worktreePath) {
+  if (readiness.status === "compile-ready") return [];
+  const lines = [
+    `Worktree verification-readiness: SOURCE-ONLY (${readiness.reason})`,
+    `  ${worktreePath}`,
+  ];
+  for (const item of readiness.missing ?? []) {
+    lines.push(`  missing  ${item.label} (${item.state}) — cannot run: ${item.forbids}`);
+  }
+  lines.push(
+    "  Do NOT report failures from those commands as code defects, and do not claim a gate you cannot run.",
+    "  Compile-ready costs one managed install: node scripts/lib/bootstrap-worktree-deps.mjs .",
+    "  (Never `pnpm install` bare in a worktree and never `rm -rf` node_modules — it is a junction to the root clone.)",
+  );
+  return lines;
 }
 
 /**
@@ -169,6 +317,24 @@ if (invokedDirectly) {
   const args = process.argv.slice(2);
   const classifyOnly = args.includes("--classify-only");
   const target = args.find((a) => !a.startsWith("--")) ?? process.cwd();
+
+  // BI-1C1483C6 (2): make the failure legible AT THE POINT OF USE. Callers that
+  // already captured a failing command's output pipe it in on stdin; if the
+  // output is the unprovisioned-worktree signature AND the probe corroborates
+  // it, print the relabelling. Silent (and exit 0) otherwise, so this can be
+  // dropped into any failure path without changing its behaviour.
+  if (args.includes("--diagnose-failure")) {
+    let text = "";
+    try {
+      text = readFileSync(0, "utf8");
+    } catch {
+      process.exit(0);
+    }
+    const diagnosis = diagnoseUnprovisionedFailure(text, probeWorktreeReadiness(target));
+    if (diagnosis.unprovisioned) process.stdout.write(`${diagnosis.explanation}\n`);
+    process.exit(0);
+  }
+
   const result = classifyOnly ? probeWorktreeReadiness(target) : bootstrapWorktreeDeps(target);
   process.stdout.write(JSON.stringify(result) + "\n");
   process.exit(0);

--- a/scripts/lib/bootstrap-worktree-deps.test.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.test.mjs
@@ -7,6 +7,9 @@ import {
   readinessReason,
   checkWorkspaceLinksResolveLocally,
   probeWorktreeReadiness,
+  missingCompileArtifacts,
+  formatReadinessBanner,
+  diagnoseUnprovisionedFailure,
 } from "./bootstrap-worktree-deps.mjs";
 
 test("compile-ready ONLY when deps resolved AND the cheap gate passes", () => {
@@ -72,4 +75,97 @@ test("probeWorktreeReadiness: no node_modules -> source-only / node_modules_miss
   assert.equal(result.status, "source-only");
   assert.equal(result.reason, "node_modules_missing");
   assert.equal(result.checks.hasNodeModules, false);
+});
+
+// ── BI-1C1483C6: verification-readiness must be SURFACED, not just computed ──
+
+test("missingCompileArtifacts treats an EMPTY directory as missing", () => {
+  // The observed 2026-08-04 shape: apps/web/node_modules EXISTED with 0 entries.
+  // existsSync alone would have called that provisioned.
+  const present = new Set(["/wt/apps/web/node_modules", "/wt/packages/db/generated"]);
+  const missing = missingCompileArtifacts("/wt", {
+    exists: (p) => present.has(p),
+    readdir: (p) => (p === "/wt/apps/web/node_modules" ? [] : ["client"]),
+  });
+  const byPath = Object.fromEntries(missing.map((m) => [m.path, m.state]));
+  assert.equal(byPath["node_modules"], "absent");
+  assert.equal(byPath["apps/web/node_modules"], "empty");
+  assert.equal(byPath["packages/db/generated"], undefined, "a populated artifact is not missing");
+});
+
+test("missingCompileArtifacts names what each absence FORBIDS", () => {
+  const missing = missingCompileArtifacts("/wt", { exists: () => false, readdir: () => [] });
+  assert.equal(missing.length, 3);
+  assert.ok(missing.every((m) => m.forbids && m.label), "every finding must name a label and a consequence");
+  assert.match(
+    missing.find((m) => m.path === "apps/web/node_modules").forbids,
+    /'next' is not recognized/,
+  );
+});
+
+test("the banner is silent for a compile-ready worktree", () => {
+  assert.deepEqual(formatReadinessBanner({ status: "compile-ready", reason: "managed_bootstrap_ok" }, "/wt"), []);
+});
+
+test("the banner names the tree, the gaps, and forbids claiming an unrun gate", () => {
+  const lines = formatReadinessBanner(
+    {
+      status: "source-only",
+      reason: "node_modules_missing",
+      missing: [{ label: "root node_modules", state: "absent", forbids: "any pnpm script" }],
+    },
+    "D:/DPF-worktrees/topic",
+  );
+  assert.match(lines[0], /SOURCE-ONLY/);
+  assert.ok(lines.some((l) => l.includes("D:/DPF-worktrees/topic")));
+  assert.ok(lines.some((l) => l.includes("root node_modules")));
+  assert.ok(lines.some((l) => /do not claim a gate you cannot run/i.test(l)));
+  assert.ok(lines.some((l) => /junction/i.test(l)), "the junction foot-gun must travel with the fix instruction");
+});
+
+test("an unprovisioned signature is relabelled only when the probe corroborates it", () => {
+  const sourceOnly = { status: "source-only", missing: [{ path: "node_modules" }] };
+  const hit = diagnoseUnprovisionedFailure("Error: Cannot find package 'react' imported from x", sourceOnly);
+  assert.equal(hit.unprovisioned, true);
+  assert.match(hit.explanation, /UNPROVISIONED WORKTREE, not a code defect/);
+  assert.match(hit.explanation, /never a bare `pnpm install`/);
+});
+
+test("the same text in a COMPILE-READY tree stays a real defect", () => {
+  const ready = { status: "compile-ready", missing: [] };
+  assert.equal(
+    diagnoseUnprovisionedFailure("Cannot find package 'react'", ready).unprovisioned,
+    false,
+    "a broken dependency in a provisioned tree must not be waved through as environmental",
+  );
+});
+
+test("a signature that does not match what is actually missing is NOT relabelled", () => {
+  // Only the Prisma client is missing, but the failure is about react: that is a
+  // real dependency problem, not this worktree's provisioning gap.
+  const partial = { status: "source-only", missing: [{ path: "packages/db/generated" }] };
+  assert.equal(diagnoseUnprovisionedFailure("Cannot find package 'react'", partial).unprovisioned, false);
+});
+
+test("the 'next' is not recognized signature maps to apps/web/node_modules", () => {
+  const readiness = { status: "source-only", missing: [{ path: "apps/web/node_modules" }] };
+  const d = diagnoseUnprovisionedFailure("'next' is not recognized as an internal or external command", readiness);
+  assert.equal(d.unprovisioned, true);
+  assert.deepEqual(d.matched, ["apps/web/node_modules"]);
+});
+
+test("the Prisma client signature maps to packages/db/generated", () => {
+  const readiness = { status: "source-only", missing: [{ path: "packages/db/generated" }] };
+  const d = diagnoseUnprovisionedFailure("Cannot find module '../generated/client/client'", readiness);
+  assert.equal(d.unprovisioned, true);
+  assert.deepEqual(d.matched, ["packages/db/generated"]);
+});
+
+test("ordinary type errors are never relabelled as environmental", () => {
+  const sourceOnly = { status: "source-only", missing: [{ path: "node_modules" }] };
+  assert.equal(
+    diagnoseUnprovisionedFailure("src/x.ts(4,2): error TS2339: Property 'y' does not exist on type 'Z'.", sourceOnly)
+      .unprovisioned,
+    false,
+  );
 });

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -216,6 +216,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/agent-identity.test.mjs",
         "tests/release/local-ci-gate-contract.test.mjs",
         "tests/release/pregate-node-gate-contract.test.mjs",
+        // BI-B1065D41: the gate's console policy (what reaches stdout, EPIPE
+        // tolerance, the bounded verdict block) and the pregate:status verdict
+        // reader. This inventory is hand-enumerated — there is no glob — so a
+        // test file omitted here simply never runs in CI, and a green PR says
+        // nothing about it.
+        "scripts/lib/pregate-console.test.mjs",
+        "scripts/lib/pregate-status.test.mjs",
       ),
       node("scripts/runtime-artifact-janitor.mjs", "--help"),
     ]),
@@ -275,6 +282,14 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs"),
       node("--test", "packages/dpf-skill-pack/hooks/compose-guard.test.mjs"),
       node("--test", "packages/dpf-skill-pack/hooks/worktree-create.test.mjs"),
+      // BI-B1065D41 / BI-1C1483C6: the sixth PreToolUse guard and the
+      // SessionStart readiness banner. Both are hand-added here for the same
+      // reason as every entry above — an unlisted test file never runs.
+      node(
+        "--test",
+        "packages/dpf-skill-pack/hooks/pregate-invocation-guard.test.mjs",
+        "packages/dpf-skill-pack/hooks/worktree-readiness-banner.test.mjs",
+      ),
       node(
         "--test",
         "packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs",

--- a/scripts/lib/pregate-console.mjs
+++ b/scripts/lib/pregate-console.mjs
@@ -1,0 +1,263 @@
+// scripts/lib/pregate-console.mjs
+//
+// BI-B1065D41 Phase 1 — make the local-CI gate READABLE.
+//
+// The gate used to mirror every byte its child produced onto pregate's stdout:
+// ~28,000 lines for one run. Nobody reads 28,000 lines, so operators piped the
+// gate to `head`/`grep` — and that pipe SIGPIPEs a 20-minute run dead mid-install.
+// The pipe was never the defect; unreadable output was. The full transcript has
+// always been persisted to the slot's `dpf-local-ci-output.log`, so mirroring it
+// bought nothing that the log path does not buy in one line.
+//
+// This module supplies the three pieces that fix the cause rather than the habit:
+//
+//   1. tolerateBrokenPipe   — a stray pipe DEGRADES instead of killing the run.
+//   2. createGateOutputRelay — the child's transcript goes to the log; stdout gets
+//      a throttled heartbeat so a long run still proves liveness in a few lines.
+//   3. createRepeatNotice / formatGateSummary — the gate's own waiting lines stop
+//      repeating verbatim, and the run ends in a bounded, stable verdict block.
+//
+// The final line of a passing run is still the literal `gate passed`. That anchor
+// is the documented verdict (docs/testing/pre-pr-gate.md) precisely because the
+// exit code lies in two directions, and Phase 2's `pnpm run pregate:status` reads
+// the record rather than this text. Nothing here may move that line.
+//
+// Everything is pure aside from injected `write`/`now`, so it unit-tests without
+// a gate run.
+
+/** Full mirroring is opt-in: the escape hatch for debugging the gate itself. */
+export function isVerboseGateConsole(env = process.env) {
+  return env.DPF_PREGATE_VERBOSE === "1";
+}
+
+/**
+ * Make a stream survive its reader going away.
+ *
+ * `pregate | head -5` closes the pipe once head has its five lines. Node then
+ * raises EPIPE as an 'error' event on the stream; unhandled, that is an uncaught
+ * exception and the gate dies mid-install holding a lease. Swallowing EPIPE turns
+ * the same situation into "the rest of the output goes nowhere", which is exactly
+ * what the operator asked for by piping to head.
+ *
+ * Non-EPIPE errors are still surfaced, so a genuinely broken stdout is not hidden.
+ * @param {NodeJS.WritableStream & { on: Function }} stream
+ * @param {(error: Error) => void} [onOther]
+ */
+export function tolerateBrokenPipe(stream, onOther = () => {}) {
+  if (!stream || typeof stream.on !== "function") return false;
+  stream.on("error", (error) => {
+    const code = error && typeof error === "object" ? error.code : "";
+    if (code === "EPIPE" || code === "ERR_STREAM_DESTROYED" || code === "ERR_STREAM_WRITE_AFTER_END") return;
+    onOther(error);
+  });
+  return true;
+}
+
+/** Apply broken-pipe tolerance to both standard streams of a process. */
+export function installBrokenPipeTolerance(proc = process) {
+  tolerateBrokenPipe(proc.stdout);
+  tolerateBrokenPipe(proc.stderr);
+}
+
+/**
+ * Collapse a status line to its invariant shape so re-prints of the same waiting
+ * state can be suppressed. `queued at position 3; observing again in 12.4s` and
+ * `... in 9.8s` share a key; `position 1` does not.
+ * @param {string} text
+ */
+export function noticeKey(text) {
+  return String(text)
+    // Every waiting line carries a jittered retry delay ("in 12.4s"). That is the
+    // one field guaranteed to differ between two otherwise identical polls, so it
+    // is normalized away; the queue position deliberately is NOT.
+    .replace(/\b\d+(?:\.\d+)?s\b/g, "<delay>")
+    .replace(/\d+\.\d+/g, "#")
+    .trim();
+}
+
+/**
+ * A printer for the gate's own "still waiting" lines.
+ *
+ * Admission polling emitted one line per poll — ~40 identical lines for a single
+ * queued run, which is a meaningful slice of the readable budget for no added
+ * information. This prints a line when its SHAPE changes (queue position moved,
+ * a different blocker appeared) and otherwise at most once per `minRepeatMs`, so
+ * liveness is still visible on a long wait.
+ *
+ * @param {{ write: (text: string) => void, now?: () => number, minRepeatMs?: number }} opts
+ */
+export function createRepeatNotice({ write, now = () => Date.now(), minRepeatMs = 120_000 }) {
+  let lastKey = null;
+  let lastAt = 0;
+  let suppressed = 0;
+  return {
+    notice(text) {
+      const key = noticeKey(text);
+      const at = now();
+      if (key === lastKey && at - lastAt < minRepeatMs) {
+        suppressed += 1;
+        return false;
+      }
+      const repeat = key === lastKey && suppressed > 0 ? ` (still; ${suppressed + 1} polls)` : "";
+      lastKey = key;
+      lastAt = at;
+      suppressed = 0;
+      write(`${String(text).replace(/\n+$/, "")}${repeat}\n`);
+      return true;
+    },
+    suppressedCount: () => suppressed,
+  };
+}
+
+function formatElapsed(ms) {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n) => String(n).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
+
+/** Last line with real content, trimmed to a single readable fragment. */
+export function lastMeaningfulLine(lines, maxChars = 110) {
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = String(lines[i]).replace(/\r/g, "").trim();
+    if (!line) continue;
+    // Progress bars and spinner frames carry no information once truncated.
+    if (/^[\s.\-=#>|/\\*]+$/.test(line)) continue;
+    return line.length > maxChars ? `${line.slice(0, maxChars - 1)}…` : line;
+  }
+  return "";
+}
+
+/**
+ * Route the gate child's transcript to the log, and a heartbeat to stdout.
+ *
+ * `absorb` is called with each raw chunk; the caller is responsible for writing
+ * the same chunk to the full log file (this relay never touches the filesystem).
+ * In verbose mode chunks pass straight through, preserving the pre-BI-B1065D41
+ * behaviour for anyone debugging the gate itself.
+ *
+ * @param {{
+ *   write: (text: string) => void,
+ *   now?: () => number,
+ *   heartbeatMs?: number,
+ *   verbose?: boolean,
+ *   label?: string,
+ * }} opts
+ */
+export function createGateOutputRelay({
+  write,
+  now = () => Date.now(),
+  heartbeatMs = 60_000,
+  verbose = false,
+  label = "local-CI",
+}) {
+  const startedAt = now();
+  let pending = "";
+  let lines = 0;
+  let bytes = 0;
+  let lastBeatAt = startedAt;
+  let recent = [];
+
+  function beat(force = false) {
+    const at = now();
+    if (!force && at - lastBeatAt < heartbeatMs) return false;
+    if (lines === 0) return false;
+    lastBeatAt = at;
+    // `recent` is a rolling window, not a drain: a heartbeat that arrives during
+    // a quiet stretch should still name the last thing that actually happened.
+    const tail = lastMeaningfulLine(recent);
+    write(
+      `  ${label} running · ${formatElapsed(at - startedAt)} · ${lines} log lines`
+      + (tail ? ` · ${tail}` : "")
+      + "\n",
+    );
+    return true;
+  }
+
+  return {
+    absorb(chunk) {
+      const text = String(chunk);
+      bytes += text.length;
+      if (verbose) {
+        write(text);
+        return;
+      }
+      pending += text;
+      const parts = pending.split(/\r?\n/);
+      pending = parts.pop() ?? "";
+      if (parts.length > 0) {
+        lines += parts.length;
+        // Only the tail can ever be shown, so only the tail is retained.
+        recent = recent.concat(parts).slice(-40);
+      }
+      beat();
+    },
+    /** Emit a final heartbeat if anything at all was absorbed. */
+    finish() {
+      if (verbose) return;
+      if (pending.trim()) {
+        lines += 1;
+        recent.push(pending);
+        pending = "";
+      }
+      if (lines > 0) beat(true);
+    },
+    stats: () => ({ lines, bytes, elapsedMs: now() - startedAt }),
+  };
+}
+
+/**
+ * The bounded verdict block that ends every run.
+ *
+ * Ordering is load-bearing: the verdict is the LAST line so `tail -1` and the
+ * documented `^gate passed` anchor agree, and every supporting fact sits above
+ * it. `verdictLine` is passed in verbatim rather than composed here because a
+ * passing run must emit exactly `gate passed` and nothing decorative.
+ *
+ * @param {{
+ *   verdictLine: string,
+ *   branch?: string,
+ *   sha?: string,
+ *   logFile?: string,
+ *   logLines?: number,
+ *   elapsedMs?: number,
+ *   metadataFile?: string,
+ *   candidateSha?: string,
+ *   evidenceId?: string,
+ *   failureSummary?: string,
+ *   maxLines?: number,
+ * }} input
+ * @returns {string[]}
+ */
+export function formatGateSummary(input) {
+  const maxLines = input.maxLines ?? 24;
+  const out = [];
+  out.push("──── local-CI gate ────");
+  if (input.branch || input.sha) {
+    out.push(`  branch      ${input.branch || "(unknown)"} @ ${(input.sha || "").slice(0, 12) || "(unknown)"}`);
+  }
+  if (Number.isFinite(input.elapsedMs)) {
+    out.push(`  ran for     ${formatElapsed(input.elapsedMs)}${
+      Number.isFinite(input.logLines) ? ` (${input.logLines} log lines)` : ""
+    }`);
+  }
+  if (input.candidateSha) {
+    out.push(`  gated sha   ${String(input.candidateSha).slice(0, 12)}`);
+  }
+  if (input.evidenceId) out.push(`  evidence    ${input.evidenceId}`);
+  if (input.metadataFile) out.push(`  record      ${input.metadataFile}`);
+  if (input.logFile) out.push(`  full log    ${input.logFile}`);
+  if (input.failureSummary) {
+    for (const line of String(input.failureSummary).split(/\r?\n/).filter(Boolean).slice(0, 8)) {
+      out.push(`  ! ${line.length > 110 ? `${line.slice(0, 109)}…` : line}`);
+    }
+  }
+  out.push("  verdict     pnpm run pregate:status  (reads the record, not this text)");
+  const trimmed = out.slice(0, Math.max(1, maxLines - 1));
+  // An empty verdictLine means the caller owns the terminal line itself (the
+  // failure paths keep their existing, separately-asserted wording).
+  if (input.verdictLine) trimmed.push(input.verdictLine);
+  return trimmed;
+}

--- a/scripts/lib/pregate-console.test.mjs
+++ b/scripts/lib/pregate-console.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { EventEmitter } from "node:events";
+
+import {
+  createGateOutputRelay,
+  createRepeatNotice,
+  formatGateSummary,
+  isVerboseGateConsole,
+  lastMeaningfulLine,
+  noticeKey,
+  tolerateBrokenPipe,
+} from "./pregate-console.mjs";
+
+function collector() {
+  const chunks = [];
+  return { write: (t) => chunks.push(t), text: () => chunks.join(""), lines: () => chunks.join("").split("\n").filter(Boolean) };
+}
+
+test("tolerateBrokenPipe swallows EPIPE and re-surfaces anything else", () => {
+  const stream = new EventEmitter();
+  const other = [];
+  assert.equal(tolerateBrokenPipe(stream, (e) => other.push(e)), true);
+  stream.emit("error", Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+  stream.emit("error", Object.assign(new Error("gone"), { code: "ERR_STREAM_DESTROYED" }));
+  assert.deepEqual(other, []);
+  stream.emit("error", Object.assign(new Error("disk"), { code: "ENOSPC" }));
+  assert.equal(other.length, 1);
+});
+
+test("isVerboseGateConsole is opt-in", () => {
+  assert.equal(isVerboseGateConsole({}), false);
+  assert.equal(isVerboseGateConsole({ DPF_PREGATE_VERBOSE: "0" }), false);
+  assert.equal(isVerboseGateConsole({ DPF_PREGATE_VERBOSE: "1" }), true);
+});
+
+test("noticeKey collapses the varying delay but not the queue position", () => {
+  assert.equal(
+    noticeKey("local-CI admission queued at position 3; observing again in 12.4s..."),
+    noticeKey("local-CI admission queued at position 3; observing again in 9.8s..."),
+  );
+  assert.notEqual(
+    noticeKey("local-CI admission queued at position 3; observing again in 12.4s..."),
+    noticeKey("local-CI admission queued at position 1; observing again in 12.4s..."),
+  );
+});
+
+test("repeat notice prints once per shape, then only after the repeat window", () => {
+  const out = collector();
+  let clock = 0;
+  const notice = createRepeatNotice({ write: out.write, now: () => clock, minRepeatMs: 100 });
+
+  for (let i = 0; i < 40; i += 1) {
+    clock += 1;
+    notice.notice(`local-CI admission queued at position 3; observing again in ${10 + i / 10}s...`);
+  }
+  assert.equal(out.lines().length, 1, "40 identical polls collapse to one line");
+
+  clock += 200;
+  notice.notice("local-CI admission queued at position 3; observing again in 11.0s...");
+  const lines = out.lines();
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /still; 40 polls/);
+
+  notice.notice("local-CI admission queued at position 1; observing again in 11.0s...");
+  assert.equal(out.lines().length, 3, "a changed position prints immediately");
+});
+
+test("lastMeaningfulLine skips blanks and pure progress noise", () => {
+  assert.equal(lastMeaningfulLine(["real line", "", "   ", "====="]), "real line");
+  assert.equal(lastMeaningfulLine([]), "");
+  assert.equal(lastMeaningfulLine(["x".repeat(400)]).length, 110);
+});
+
+test("relay keeps 28k child lines off stdout and heartbeats instead", () => {
+  const out = collector();
+  let clock = 0;
+  const relay = createGateOutputRelay({ write: out.write, now: () => clock, heartbeatMs: 1000 });
+
+  for (let i = 0; i < 28_000; i += 1) {
+    clock += 1; // 28s of wall clock over the whole run
+    relay.absorb(`webpack compiled module ${i}\n`);
+  }
+  relay.finish();
+
+  const lines = out.lines();
+  assert.equal(relay.stats().lines, 28_000);
+  assert.ok(lines.length <= 30, `expected a bounded heartbeat, got ${lines.length} lines`);
+  assert.ok(lines.length >= 2, "a long run must still prove liveness");
+  assert.match(lines.at(-1), /local-CI running · .* · 28000 log lines · webpack compiled module 27999/);
+  assert.ok(!out.text().includes("module 100\n"), "child transcript must not reach stdout");
+});
+
+test("relay reassembles lines split across chunk boundaries", () => {
+  const out = collector();
+  const relay = createGateOutputRelay({ write: out.write, now: () => 0, heartbeatMs: 60_000 });
+  relay.absorb("alpha be");
+  relay.absorb("ta\ngam");
+  relay.absorb("ma\n");
+  relay.finish();
+  assert.equal(relay.stats().lines, 2, "a line split across chunks counts once");
+  assert.equal(out.lines().length, 1, "only the closing heartbeat reaches stdout");
+  assert.match(out.text(), /gamma/, "the heartbeat names the newest line");
+});
+
+test("relay in verbose mode mirrors everything verbatim", () => {
+  const out = collector();
+  const relay = createGateOutputRelay({ write: out.write, now: () => 0, verbose: true });
+  relay.absorb("one\ntwo\n");
+  relay.finish();
+  assert.equal(out.text(), "one\ntwo\n");
+});
+
+test("relay stays silent when the child produced nothing", () => {
+  const out = collector();
+  const relay = createGateOutputRelay({ write: out.write, now: () => 0 });
+  relay.finish();
+  assert.equal(out.text(), "");
+});
+
+test("gate summary is bounded and ends in the verbatim verdict line", () => {
+  const lines = formatGateSummary({
+    verdictLine: "gate passed",
+    branch: "claude/topic",
+    sha: "0123456789abcdef0123456789abcdef01234567",
+    logFile: "D:/DPF/.git/worktrees/wt/dpf-local-ci-output.log",
+    logLines: 28_412,
+    elapsedMs: 22 * 60_000,
+    metadataFile: "D:/DPF/.git/worktrees/wt/dpf-local-ci-metadata.json",
+    candidateSha: "0123456789abcdef0123456789abcdef01234567",
+    evidenceId: "EV-1",
+  });
+  assert.ok(lines.length <= 24, `summary must stay bounded, got ${lines.length}`);
+  assert.equal(lines.at(-1), "gate passed", "the documented ^gate passed anchor must be the last line");
+  assert.ok(lines.some((l) => l.includes("dpf-local-ci-output.log")), "the log path must be one command away");
+  assert.ok(lines.some((l) => l.includes("pregate:status")), "the authoritative verdict command must be named");
+});
+
+test("gate summary truncates a runaway failure summary rather than replaying the log", () => {
+  const lines = formatGateSummary({
+    verdictLine: "gate failed",
+    failureSummary: Array.from({ length: 500 }, (_, i) => `failure line ${i}`).join("\n"),
+  });
+  assert.ok(lines.length <= 24, `summary must stay bounded, got ${lines.length}`);
+  assert.equal(lines.at(-1), "gate failed");
+});

--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -1,0 +1,209 @@
+// scripts/lib/pregate-status.mjs
+//
+// BI-B1065D41 Phase 2 — ONE authoritative verdict artifact, and one command
+// that reads it.
+//
+// Every convenient signal this gate exposes lies in a documented direction:
+//
+//   - the EXIT CODE lies twice over. `pnpm run pregate ...; echo EXIT=$?; tail`
+//     reports tail's status, and a run that gave up while queued exits 0 having
+//     gated nothing at all (BI-2C7F51BA Defect 3).
+//   - the LOG TAIL lies. A TOLERATED GuardRuntimeEnvironmentError prints
+//     `Error:` and a red cross roughly 28,000 lines before a PASSING verdict, so
+//     a watcher grepping for `Error:` fabricates a failure that never happened.
+//   - even `^gate passed` is only a claim about the run you happened to watch;
+//     it says nothing about whether HEAD has moved since.
+//
+// The records do not lie: `dpf-local-ci-gate.json` (the gate's own SHA-bound
+// state) and the schema-versioned `dpf-local-ci-metadata.json` written by
+// scripts/local-integration-ci.mjs. Both already existed. What was missing was a
+// command that reads them and states a verdict, so this module is deliberately
+// a READER — it computes nothing the gate did not already record.
+//
+// This is the first instance of a durable rule the BI generalizes: every gate
+// exposes ONE authoritative verdict artifact plus a command that reads it, and
+// the convenient-but-lying signals are made either correct or unavailable. The
+// other known instances (bare tsc printing "0 errors" after an OOM,
+// --test-force-exit masking late rejections, Policy Guards' tail vs its
+// --results JSON, `gh pr checks` never showing merge_group failures) are a
+// follow-on sweep, not this file's business.
+//
+// Pure aside from injected readers, so the verdict logic unit-tests without a
+// gate run or a filesystem.
+
+/** Terminal verdicts, ordered worst-to-best for slot reconciliation. */
+export const PREGATE_VERDICTS = Object.freeze([
+  "NO-RECORD",
+  "FAIL",
+  "STALE",
+  "PENDING",
+  "PASS",
+]);
+
+function rank(verdict) {
+  const index = PREGATE_VERDICTS.indexOf(verdict);
+  return index < 0 ? -1 : index;
+}
+
+/**
+ * Classify ONE slot's records against the current HEAD.
+ *
+ * `state` is the parsed dpf-local-ci-gate.json; `metadata` the parsed
+ * dpf-local-ci-metadata.json (either may be null when absent/unreadable).
+ *
+ * The SHA comparison is the point of the whole command. A record that passed for
+ * a commit you have since amended or rebased past is not evidence for what you
+ * are about to push, and that distinction is invisible in both the exit code and
+ * the log.
+ *
+ * @param {{
+ *   state: any, metadata: any, headSha: string, headBranch?: string, now?: number,
+ * }} input
+ * @returns {{ verdict: string, reason: string, boundSha: string, boundBranch: string,
+ *             candidateSha: string, staleness: string, evidenceId: string,
+ *             recordedAt: string, expiresAt: string }}
+ */
+export function classifySlotRecord({ state, metadata, headSha, headBranch = "", now = Date.now() }) {
+  const boundSha = String(state?.sha || "");
+  const boundBranch = String(state?.branch || "");
+  const candidateSha = String(metadata?.candidateSha || "");
+  const evidenceId = String(state?.evidenceRecordId || "");
+  const recordedAt = String(state?.recordedAt || "");
+  const expiresAt = String(state?.expiresAt || "");
+  const base = { boundSha, boundBranch, candidateSha, evidenceId, recordedAt, expiresAt, staleness: "" };
+
+  if (!state) {
+    return { ...base, verdict: "NO-RECORD", reason: "no gate record for this worktree — pregate has not run here" };
+  }
+
+  // A record for a DIFFERENT commit is not weaker evidence for HEAD; it is no
+  // evidence for HEAD. Report it as STALE and name both SHAs so the operator can
+  // see whether they amended, rebased, or simply committed since gating.
+  if (headSha && boundSha && boundSha !== headSha) {
+    return {
+      ...base,
+      verdict: "STALE",
+      reason: `gate record is bound to ${boundSha.slice(0, 12)} but HEAD is ${headSha.slice(0, 12)} — re-run pregate`,
+      staleness: "head-moved",
+    };
+  }
+  if (headBranch && boundBranch && boundBranch !== headBranch) {
+    return {
+      ...base,
+      verdict: "STALE",
+      reason: `gate record is bound to branch ${boundBranch} but HEAD is on ${headBranch} — re-run pregate`,
+      staleness: "branch-moved",
+    };
+  }
+
+  if (state.evidencePending === true) {
+    return {
+      ...base,
+      verdict: "PENDING",
+      reason: `gate passed but evidence publication is pending (${state.evidencePendingReason || "unknown"}) — finish with: pnpm run pregate -- --finalize-evidence`,
+    };
+  }
+
+  if (state.gatePassed !== true) {
+    return {
+      ...base,
+      verdict: "FAIL",
+      reason: `gate record status ${state.status || "unknown"} — this SHA has not passed`,
+    };
+  }
+
+  if (expiresAt) {
+    const expiry = Date.parse(expiresAt);
+    if (Number.isFinite(expiry) && expiry < now) {
+      return {
+        ...base,
+        verdict: "STALE",
+        reason: `gate record expired at ${expiresAt} — re-run pregate`,
+        staleness: "expired",
+      };
+    }
+  }
+
+  // The gate state says passed; cross-check the independent metadata record.
+  // These are written by different processes (the wrapper vs the sandbox run),
+  // so a disagreement means one of them is not describing this run.
+  if (candidateSha && headSha && candidateSha !== headSha) {
+    return {
+      ...base,
+      verdict: "STALE",
+      reason: `metadata record gated ${candidateSha.slice(0, 12)}, not HEAD ${headSha.slice(0, 12)} — re-run pregate`,
+      staleness: "metadata-mismatch",
+    };
+  }
+
+  return { ...base, verdict: "PASS", reason: "gate passed for this HEAD" };
+}
+
+/**
+ * Reconcile every slot into one verdict for the worktree.
+ *
+ * Two slots exist (BI-4BE30454) and only one of them ran your gate, so the other
+ * legitimately holds an older record. Taking the BEST verdict is correct: a PASS
+ * bound to this exact HEAD is proof regardless of which slot produced it, and a
+ * sibling slot's stale record must not be able to report a false FAIL.
+ *
+ * @param {Array<{ slotKey: string } & ReturnType<typeof classifySlotRecord>>} slots
+ */
+export function reconcileSlots(slots) {
+  const considered = slots.filter(Boolean);
+  if (considered.length === 0) {
+    return { verdict: "NO-RECORD", reason: "no local-CI slots were readable", slot: null };
+  }
+  let best = considered[0];
+  for (const slot of considered.slice(1)) {
+    if (rank(slot.verdict) > rank(best.verdict)) best = slot;
+  }
+  return { ...best, slot: best.slotKey ?? null };
+}
+
+/** Exit code contract: 0 ONLY for a PASS bound to the current HEAD. */
+export function exitCodeForVerdict(verdict) {
+  return verdict === "PASS" ? 0 : 1;
+}
+
+function ageText(iso, now) {
+  const at = Date.parse(iso || "");
+  if (!Number.isFinite(at)) return "";
+  const minutes = Math.max(0, Math.round((now - at) / 60_000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ${minutes % 60}m ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/**
+ * Render the verdict as the whole answer — short enough that nobody pipes it.
+ * @param {{ verdict: string, reason: string, slot?: string|null, boundBranch?: string,
+ *           boundSha?: string, candidateSha?: string, evidenceId?: string,
+ *           recordedAt?: string, logFile?: string }} result
+ * @param {{ headBranch: string, headSha: string, now?: number }} head
+ * @returns {string[]}
+ */
+export function formatStatusReport(result, { headBranch, headSha, now = Date.now() }) {
+  const lines = [];
+  lines.push(`local-CI gate: ${result.verdict}`);
+  lines.push(`  reason      ${result.reason}`);
+  lines.push(`  HEAD        ${headBranch || "(unknown)"} @ ${(headSha || "").slice(0, 12) || "(unknown)"}`);
+  if (result.boundSha) {
+    const age = ageText(result.recordedAt, now);
+    lines.push(
+      `  gated       ${result.boundBranch || "(unknown)"} @ ${result.boundSha.slice(0, 12)}`
+      + (age ? ` (${age})` : ""),
+    );
+  }
+  if (result.candidateSha && result.candidateSha !== result.boundSha) {
+    lines.push(`  metadata    candidateSha ${result.candidateSha.slice(0, 12)}`);
+  }
+  if (result.slot) lines.push(`  slot        ${result.slot}`);
+  if (result.evidenceId) lines.push(`  evidence    ${result.evidenceId}`);
+  if (result.logFile) lines.push(`  full log    ${result.logFile}`);
+  if (result.verdict !== "PASS") {
+    lines.push("  next        pnpm run pregate   (foreground, unpiped, as the sole command)");
+  }
+  return lines;
+}

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  classifySlotRecord,
+  exitCodeForVerdict,
+  formatStatusReport,
+  reconcileSlots,
+} from "./pregate-status.mjs";
+
+const HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OLD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const NOW = Date.parse("2026-08-04T12:00:00.000Z");
+
+function passingState(overrides = {}) {
+  return {
+    branch: "claude/topic",
+    sha: HEAD,
+    gatePassed: true,
+    status: "passed",
+    evidenceRecordId: "EXT-1",
+    evidencePending: false,
+    expiresAt: "2026-08-04T13:00:00.000Z",
+    recordedAt: "2026-08-04T11:40:00.000Z",
+    ...overrides,
+  };
+}
+
+test("PASS requires a passing record bound to THIS head", () => {
+  const r = classifySlotRecord({
+    state: passingState(),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    headBranch: "claude/topic",
+    now: NOW,
+  });
+  assert.equal(r.verdict, "PASS");
+  assert.equal(exitCodeForVerdict(r.verdict), 0);
+});
+
+test("NO-RECORD when pregate never ran here", () => {
+  const r = classifySlotRecord({ state: null, metadata: null, headSha: HEAD, now: NOW });
+  assert.equal(r.verdict, "NO-RECORD");
+  assert.equal(exitCodeForVerdict(r.verdict), 1);
+});
+
+test("STALE when HEAD has moved past the gated SHA", () => {
+  const r = classifySlotRecord({
+    state: passingState({ sha: OLD }),
+    metadata: { candidateSha: OLD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "STALE");
+  assert.equal(r.staleness, "head-moved");
+  assert.match(r.reason, /bbbbbbbbbbbb/);
+  assert.match(r.reason, /aaaaaaaaaaaa/);
+  assert.equal(exitCodeForVerdict(r.verdict), 1);
+});
+
+test("STALE when the branch moved under an otherwise-matching SHA", () => {
+  const r = classifySlotRecord({
+    state: passingState({ branch: "claude/other" }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    headBranch: "claude/topic",
+    now: NOW,
+  });
+  assert.equal(r.verdict, "STALE");
+  assert.equal(r.staleness, "branch-moved");
+});
+
+test("STALE when the record has expired", () => {
+  const r = classifySlotRecord({
+    state: passingState({ expiresAt: "2026-08-04T11:00:00.000Z" }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "STALE");
+  assert.equal(r.staleness, "expired");
+});
+
+test("STALE when the metadata record disagrees with the gate state", () => {
+  // The two records are written by different processes; a disagreement means one
+  // of them is not describing this run, which must never read as a PASS.
+  const r = classifySlotRecord({
+    state: passingState(),
+    metadata: { candidateSha: OLD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "STALE");
+  assert.equal(r.staleness, "metadata-mismatch");
+});
+
+test("FAIL when the record exists for this SHA but did not pass", () => {
+  const r = classifySlotRecord({
+    state: passingState({ gatePassed: false, status: "failed" }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "FAIL");
+  assert.equal(exitCodeForVerdict(r.verdict), 1);
+});
+
+test("a run that gave up while queued reads FAIL, not PASS", () => {
+  // BI-2C7F51BA Defect 3: that path exits 0 having gated nothing. The record is
+  // what makes the silent exit-0 detectable.
+  const r = classifySlotRecord({
+    state: passingState({ gatePassed: false, status: "blocked_quiescence", evidenceRecordId: "" }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "FAIL");
+  assert.match(r.reason, /blocked_quiescence/);
+});
+
+test("PENDING when the gate passed but evidence publication is unfinished", () => {
+  const r = classifySlotRecord({
+    state: passingState({ evidencePending: true, evidencePendingReason: "portal_quiescing" }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "PENDING");
+  assert.match(r.reason, /finalize-evidence/);
+  assert.equal(exitCodeForVerdict(r.verdict), 1, "pending evidence is not a green light to push");
+});
+
+test("reconcile takes the best slot so a sibling's stale record cannot fake a failure", () => {
+  const best = reconcileSlots([
+    { slotKey: "slot-0", verdict: "STALE", reason: "old" },
+    { slotKey: "slot-1", verdict: "PASS", reason: "gate passed for this HEAD" },
+  ]);
+  assert.equal(best.verdict, "PASS");
+  assert.equal(best.slot, "slot-1");
+});
+
+test("reconcile still reports the worst available when nothing passed", () => {
+  const best = reconcileSlots([
+    { slotKey: "slot-0", verdict: "FAIL", reason: "failed" },
+    { slotKey: "slot-1", verdict: "STALE", reason: "old" },
+  ]);
+  assert.equal(best.verdict, "STALE", "STALE outranks FAIL — it is the more actionable of the two");
+});
+
+test("reconcile of nothing is NO-RECORD, never a pass", () => {
+  assert.equal(reconcileSlots([]).verdict, "NO-RECORD");
+});
+
+test("the report is short enough that nobody pipes it, and names the next step", () => {
+  const lines = formatStatusReport(
+    { verdict: "STALE", reason: "head moved", boundSha: OLD, boundBranch: "claude/topic", recordedAt: "2026-08-04T11:00:00.000Z", slot: "slot-0", logFile: "D:/x.log" },
+    { headBranch: "claude/topic", headSha: HEAD, now: NOW },
+  );
+  assert.ok(lines.length <= 10, `got ${lines.length} lines`);
+  assert.equal(lines[0], "local-CI gate: STALE");
+  assert.ok(lines.some((l) => l.includes("pnpm run pregate")), "a non-PASS must name the next step");
+  assert.ok(lines.some((l) => l.includes("1h 0m ago")), "staleness must be human-readable");
+});
+
+test("a PASS report does not tell you to re-run", () => {
+  const lines = formatStatusReport(
+    { verdict: "PASS", reason: "gate passed for this HEAD", boundSha: HEAD, boundBranch: "claude/topic" },
+    { headBranch: "claude/topic", headSha: HEAD, now: NOW },
+  );
+  assert.ok(!lines.some((l) => l.includes("next")), "a PASS has no next step");
+});

--- a/scripts/pregate-status.mjs
+++ b/scripts/pregate-status.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// scripts/pregate-status.mjs — `pnpm run pregate:status` (BI-B1065D41 Phase 2).
+//
+// The one authoritative answer to "did the gate pass for what I am about to
+// push?". It reads the records the gate already wrote — it never runs a gate,
+// never claims a lease, and never talks to the portal, so it is safe to call at
+// any moment including while another session's gate is mid-run.
+//
+// Read scripts/lib/pregate-status.mjs for WHY a reader exists at all: the exit
+// code, the log tail, and even `^gate passed` each lie in a documented
+// direction, and each has been paid for at least once.
+//
+// Exit code: 0 only when the verdict is PASS for the current HEAD. That makes
+// `pnpm run pregate:status && git push` a correct composition — which the raw
+// pregate exit code never was.
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createLocalCiSlotManifest,
+  LOCAL_CI_SLOT_KEYS,
+} from "./lib/local-ci-slot-manifest.mjs";
+import {
+  classifySlotRecord,
+  exitCodeForVerdict,
+  formatStatusReport,
+  reconcileSlots,
+} from "./lib/pregate-status.mjs";
+import { installBrokenPipeTolerance } from "./lib/pregate-console.mjs";
+
+const THIS_FILE = fileURLToPath(import.meta.url);
+
+function gitText(args, cwd) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.error || result.status !== 0) return "";
+  return String(result.stdout || "").trim();
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function resolveWorktreeContext(cwd = process.cwd()) {
+  const worktreePath = gitText(["rev-parse", "--show-toplevel"], cwd);
+  if (!worktreePath) return null;
+  const gitCommonDirRaw = gitText(["rev-parse", "--git-common-dir"], worktreePath);
+  const statePathRaw = gitText(["rev-parse", "--git-path", "dpf-local-ci-gate.json"], worktreePath);
+  if (!gitCommonDirRaw || !statePathRaw) return null;
+  const gitCommonDir = resolvePath(worktreePath, gitCommonDirRaw);
+  return {
+    worktreePath,
+    gitCommonDir,
+    rootClone: dirname(gitCommonDir),
+    candidateGitDir: dirname(resolvePath(worktreePath, statePathRaw)),
+    headBranch: gitText(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath),
+    headSha: gitText(["rev-parse", "HEAD"], worktreePath),
+  };
+}
+
+/** Read and classify every slot's records for this worktree. */
+export function collectSlotVerdicts(context, { now = Date.now(), readJsonImpl = readJson } = {}) {
+  return LOCAL_CI_SLOT_KEYS.map((slotKey) => {
+    const manifest = createLocalCiSlotManifest({
+      slotKey,
+      rootClone: context.rootClone,
+      gitCommonDir: context.gitCommonDir,
+      candidateGitDir: context.candidateGitDir,
+    });
+    const state = readJsonImpl(manifest.evidence.state);
+    // No state at all means this slot never ran here — it is absent, not failing.
+    // Only slots with a record participate, so an unused slot cannot drag the
+    // reconciled verdict down to NO-RECORD while the other slot holds a PASS.
+    if (!state) return null;
+    return {
+      slotKey,
+      logFile: manifest.output.log,
+      ...classifySlotRecord({
+        state,
+        metadata: readJsonImpl(manifest.evidence.metadata),
+        headSha: context.headSha,
+        headBranch: context.headBranch,
+        now,
+      }),
+    };
+  }).filter(Boolean);
+}
+
+function main() {
+  installBrokenPipeTolerance();
+  const asJson = process.argv.slice(2).includes("--json");
+
+  const context = resolveWorktreeContext();
+  if (!context) {
+    process.stderr.write("pregate:status: not inside a git worktree (or git is unavailable).\n");
+    process.exit(1);
+  }
+
+  const slots = collectSlotVerdicts(context);
+  const result = slots.length > 0
+    ? reconcileSlots(slots)
+    : {
+      verdict: "NO-RECORD",
+      reason: "no gate record for this worktree — pregate has not run here",
+      slot: null,
+    };
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify({
+      verdict: result.verdict,
+      reason: result.reason,
+      headBranch: context.headBranch,
+      headSha: context.headSha,
+      boundSha: result.boundSha ?? "",
+      boundBranch: result.boundBranch ?? "",
+      candidateSha: result.candidateSha ?? "",
+      staleness: result.staleness ?? "",
+      evidenceId: result.evidenceId ?? "",
+      recordedAt: result.recordedAt ?? "",
+      slot: result.slot,
+      logFile: result.logFile ?? "",
+      worktreePath: context.worktreePath,
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatStatusReport(result, {
+      headBranch: context.headBranch,
+      headSha: context.headSha,
+    }).join("\n")}\n`);
+  }
+
+  process.exit(exitCodeForVerdict(result.verdict));
+}
+
+if (process.argv[1] === THIS_FILE) main();

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -32,6 +32,10 @@ import {
   releaseDeadLocalQueueObserversForGate,
   releaseLocalQueueObserver,
 } from "./lib/local-queue-observer.mjs";
+import {
+  installBrokenPipeTolerance,
+  isVerboseGateConsole,
+} from "./lib/pregate-console.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
@@ -468,6 +472,10 @@ export async function recoverInterruptedGate({
 }
 
 async function main() {
+  // BI-B1065D41: `pnpm run pregate | head -5` must survive head exiting. Both
+  // this wrapper and the gate it spawns need the tolerance — the gate inherits
+  // these very file descriptors.
+  installBrokenPipeTolerance();
   const args = process.argv.slice(2);
 
   const diskCheck = checkHostDiskSpace();
@@ -477,16 +485,29 @@ async function main() {
   }
 
   if (shouldRunPreflight(args)) {
+    // BI-B1065D41: the guard-parity preflight is loud and, on a passing run,
+    // uninteresting — including a TOLERATED GuardRuntimeEnvironmentError that
+    // prints `Error:` and a red cross on runs that PASS, which is exactly the
+    // text a log-tail reader mistakes for a failure. Capture it and replay it
+    // only when it actually fails.
+    const verbose = isVerboseGateConsole();
     const preflight = spawnSync(
       process.execPath,
       [join(SCRIPT_DIR, "pregate-preflight.mjs")],
-      { stdio: "inherit" },
+      verbose ? { stdio: "inherit" } : { encoding: "utf8" },
     );
     if (preflight.error || (preflight.status ?? 1) !== 0) {
+      if (!verbose) {
+        process.stderr.write(String(preflight.stdout || ""));
+        process.stderr.write(String(preflight.stderr || ""));
+      }
       process.stderr.write(
         "pregate: guard parity preflight failed — fix the deterministic guard failures above before the sandbox gate runs (no lease was claimed).\n",
       );
       process.exit(preflight.status ?? 1);
+    }
+    if (!verbose) {
+      process.stdout.write("pregate: guard parity preflight passed.\n");
     }
   } else if (process.env.DPF_SKIP_PREGATE_PREFLIGHT_REASON) {
     process.stderr.write(

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -209,6 +209,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "local-queue-observer.mjs"), join(temp, "scripts", "lib", "local-queue-observer.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-slot-manifest.mjs"), join(temp, "scripts", "lib", "local-ci-slot-manifest.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-gate-state.mjs"), join(temp, "scripts", "lib", "local-ci-gate-state.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "pregate-console.mjs"), join(temp, "scripts", "lib", "pregate-console.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-host-pressure.mjs"), join(temp, "scripts", "lib", "local-ci-host-pressure.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "agent-identity.mjs"), join(temp, "scripts", "lib", "agent-identity.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-base-freshness.mjs"), join(temp, "scripts", "lib", "local-ci-base-freshness.mjs"));
@@ -717,4 +718,164 @@ test("local-ci-runner.mjs refuses to gate main or a detached HEAD", () => {
   });
   assert.notEqual(onMain.status, 0);
   assert.match(onMain.stderr, /gate topic branches, not main/);
+});
+
+// ── BI-B1065D41 Phase 1: the gate must be READABLE and VERDICTABLE ───────────
+//
+// These are functional, not structural: they run the real gate against a real
+// (loud) child command and assert on what actually reaches stdout. The old
+// behaviour mirrored every child line, producing ~28,000 lines for one run —
+// which is what made piping to `head` the rational response, and that pipe is
+// what SIGPIPE-killed runs mid-install.
+
+/** Env for a gate run whose child command prints `lines` lines. */
+function loudGateEnv(mcpUrl, lines, extra = {}) {
+  return {
+    ...process.env,
+    DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+    DPF_GATE_OWNER_PROVIDER: "codex",
+    DPF_GATE_OWNER_SESSION_ID: "contract-thread",
+    DPF_LOCAL_CI_COMMAND: `${JSON.stringify(process.execPath)} -e "for(let i=0;i<${lines};i++)console.log('sandbox build step '+i)"`,
+    ...extra,
+  };
+}
+
+async function passingMcp() {
+  return startMockMcp({
+    claim_nonprod_environment_lease: () => ({ success: true, entityId: "NPEL-LOUD" }),
+    record_local_integration_result: () => ({ success: true, entityId: "EXT-LOUD" }),
+    release_nonprod_environment_lease: () => ({ success: true, entityId: "NPEL-LOUD" }),
+  });
+}
+
+test("gate stdout stays bounded while the full transcript lands in the log (BI-B1065D41)", async () => {
+  const { dir } = makeTempRepo();
+  const mcp = await passingMcp();
+  try {
+    const result = await runGateAsync(
+      ["--branch", "feat/loud", "--sha", "loud-sha", "--worktree", dir, "--no-push", "--mcp-url", mcp.url],
+      loudGateEnv(mcp.url, 20_000),
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const stdoutLines = result.stdout.split("\n").filter((l) => l.trim() !== "");
+    assert.ok(
+      stdoutLines.length <= 40,
+      `stdout must stay readable; got ${stdoutLines.length} lines:\n${result.stdout.slice(0, 2000)}`,
+    );
+    assert.equal(stdoutLines.at(-1), "gate passed", "the documented ^gate passed anchor must be the last line");
+    assert.ok(
+      !result.stdout.includes("sandbox build step 5000"),
+      "the child transcript must not be mirrored to stdout",
+    );
+
+    // …but it is not LOST: the full log holds every line, and stdout names it.
+    const logFile = join(dir, ".git", "dpf-local-ci-output.log");
+    assert.ok(result.stdout.includes(logFile), "stdout must name the full log path");
+    const logLines = readFileSync(logFile, "utf8").split("\n").filter((l) => l.trim() !== "");
+    assert.equal(logLines.length, 20_000, "the full transcript must be persisted");
+  } finally {
+    await mcp.close();
+  }
+});
+
+test("DPF_PREGATE_VERBOSE=1 restores the full mirror (BI-B1065D41)", async () => {
+  const { dir } = makeTempRepo();
+  const mcp = await passingMcp();
+  try {
+    const result = await runGateAsync(
+      ["--branch", "feat/verbose", "--sha", "verbose-sha", "--worktree", dir, "--no-push", "--mcp-url", mcp.url],
+      loudGateEnv(mcp.url, 200, { DPF_PREGATE_VERBOSE: "1" }),
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.ok(result.stdout.includes("sandbox build step 150"), "verbose mode must mirror the child");
+  } finally {
+    await mcp.close();
+  }
+});
+
+test("a piped gate completes and still records a gate record (BI-B1065D41)", async () => {
+  // The literal trap: three runs were SIGPIPE-killed mid-install by `| head`.
+  // A closed reader must degrade the OUTPUT, never terminate the run — the run
+  // holds a shared lease, so dying mid-flight wedges the queue for everyone.
+  const { dir } = makeTempRepo();
+  const mcp = await passingMcp();
+  try {
+    const status = await new Promise((resolve, reject) => {
+      const gate = spawn(process.execPath, [
+        gateScript,
+        "--branch", "feat/piped", "--sha", "piped-sha", "--worktree", dir, "--no-push", "--mcp-url", mcp.url,
+      ], { env: loudGateEnv(mcp.url, 20_000, { DPF_PREGATE_VERBOSE: "1" }), stdio: ["ignore", "pipe", "ignore"] });
+      gate.on("error", reject);
+      let seen = 0;
+      gate.stdout.on("data", (chunk) => {
+        seen += String(chunk).split("\n").length;
+        // Emulate `| head -5`: stop reading and destroy the pipe early.
+        if (seen >= 5 && !gate.stdout.destroyed) gate.stdout.destroy();
+      });
+      gate.on("close", resolve);
+    });
+
+    assert.equal(status, 0, "a closed stdout reader must not kill the gate");
+    const state = JSON.parse(readFileSync(join(dir, ".git", "dpf-local-ci-gate.json"), "utf8"));
+    assert.equal(state.gatePassed, true, "the gate record must still be written");
+    assert.equal(state.sha, "piped-sha");
+    assert.ok(
+      mcp.calls.some((c) => c.params.name === "record_local_integration_result"),
+      "evidence must still be recorded when the reader went away",
+    );
+  } finally {
+    await mcp.close();
+  }
+});
+
+// ── BI-B1065D41 Phase 2: pregate:status is the authoritative verdict ─────────
+
+const statusScript = join(repoRoot, "scripts", "pregate-status.mjs");
+
+function runStatus(cwd) {
+  const r = spawnSync(process.execPath, [statusScript, "--json"], { cwd, encoding: "utf8" });
+  return { status: r.status, report: r.stdout.trim() ? JSON.parse(r.stdout) : null, stderr: r.stderr };
+}
+
+test("pregate:status reports NO-RECORD (exit 1) for a worktree that never gated", () => {
+  const { dir } = makeTempRepo();
+  const out = runStatus(dir);
+  assert.equal(out.status, 1, "no record must never exit 0");
+  assert.equal(out.report.verdict, "NO-RECORD");
+});
+
+test("pregate:status reports PASS for the gated SHA, then STALE once HEAD moves", async () => {
+  const { dir, g } = makeTempRepo();
+  const headSha = g(["rev-parse", "HEAD"]);
+  const branch = g(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const mcp = await passingMcp();
+  try {
+    const gate = await runGateAsync(
+      ["--branch", branch, "--sha", headSha, "--worktree", dir, "--no-push", "--mcp-url", mcp.url],
+      loudGateEnv(mcp.url, 50),
+    );
+    assert.equal(gate.status, 0, `${gate.stdout}\n${gate.stderr}`);
+
+    const passed = runStatus(dir);
+    assert.equal(passed.status, 0, `expected exit 0 for a gated HEAD: ${passed.report?.reason}`);
+    assert.equal(passed.report.verdict, "PASS");
+    assert.equal(passed.report.boundSha, headSha);
+    assert.equal(passed.report.headSha, headSha);
+
+    // The whole point of the command: gate once, commit again, and the verdict
+    // flips WITHOUT re-reading a log or trusting the previous run's exit code.
+    writeFileSync(join(dir, "code.ts"), "export const x = 2;\n");
+    g(["add", "."]);
+    g(["commit", "-q", "-m", "second"]);
+
+    const stale = runStatus(dir);
+    assert.equal(stale.status, 1, "a moved HEAD must never exit 0");
+    assert.equal(stale.report.verdict, "STALE");
+    assert.equal(stale.report.staleness, "head-moved");
+    assert.equal(stale.report.boundSha, headSha);
+    assert.notEqual(stale.report.headSha, headSha);
+  } finally {
+    await mcp.close();
+  }
 });


### PR DESCRIPTION
Closes the two items filed after an hour was lost to four bad `pregate` invocations — none of which were knowledge gaps. Every governing rule was already in the operator's context, in prose, and was violated anyway. So the goal was not to document the rules better; it was to make the wrong invocation impossible or self-correcting, and to give the gate one verdict artifact that cannot lie.

## BI-B1065D41 — pregate is unreadable and unverdictable

**Phase 1 — cut stdout (the highest-value change in both items).** The gate mirrored its child's ~28,000-line transcript to stdout while *also* persisting it in full to the slot log. Piping to `head`/`grep` was the rational response to that, and the pipe SIGPIPE-killed three runs mid-install. Fixing the output removes the cause on every surface, including ones with no hook coverage.

- The child transcript now goes to the log only; stdout gets a throttled progress heartbeat.
- The ~40 identical admission polls collapse to one line plus a periodic "still" beat (the shape is the key, so a queue-position change still prints immediately).
- EPIPE is tolerated in both entry points, so a stray pipe **degrades** instead of killing a run that holds a shared lease.
- The guard-parity preflight is captured and replayed only on failure — it emits a *tolerated* `Error:` and a red ✖ on runs that **pass**, which is exactly the text a log-tail reader mistakes for a failure.
- `DPF_PREGATE_VERBOSE=1` restores the old mirror for debugging the gate itself.
- The last line of a passing run is still the literal `gate passed`.

**Phase 2 — one authoritative verdict command.** `pnpm run pregate:status` reads the SHA-bound gate record and the schema-versioned metadata record and prints `PASS` / `FAIL` / `STALE` / `PENDING` / `NO-RECORD`, with the bound SHA, its relation to HEAD, and staleness. It exits 0 **only** for a PASS at HEAD, so `pregate:status && git push` composes correctly — which the raw pregate exit code never did. `--json` for machine use. It never claims a lease and never runs a gate. Both records already existed; only the reader was missing.

**Phase 3 — invocation guard.** `pregate-invocation-guard.mjs`, PreToolUse on Bash, modelled on `compose-guard.mjs`. Denies the four shapes that cannot succeed or cannot be read — piped, backgrounded (including the harness's `run_in_background`), chained with `;`/`||`, wrapped in `timeout` — names the canonical foreground form, and **fails OPEN**. Wired on the plugin plane, the settings plane, and the Grok/Codex planes.

The existing guard layer missed all four because it is asymmetric: every hook protects the **output** side (that pregate ran before a push); nothing protected the **invocation** side.

## BI-1C1483C6 — worktree verification-readiness

**Established first, as the BI asked:** `worktree-create.mjs` does not fail to provision — it *never provisions at all*. It only places the worktree, because `BI-3047C122` ratified via `principle_decide` that a multi-minute install must not gate worktree creation. That decision stands and is not reopened here. What was wrong is that the half-tree hand-over was **silent**. So this is a detection fix.

- The readiness probe now checks root `node_modules`, `apps/web/node_modules`, and `packages/db/generated` for **emptiness as well as absence** — the observed `apps/web/node_modules` existed with zero entries and passed the old structural `test -d` check.
- Each gap names **what it forbids**, because that is the half that changes behaviour: an agent that knows it is source-only does not report `Cannot find package 'react'` as a regression it caused.
- A SessionStart hook prints the banner; it is silent when the tree is compile-ready.
- The pre-commit typecheck gate relabels `'next' is not recognized` and `Cannot find package 'react'` as an unprovisioned-worktree condition — but **only when the probe corroborates it**, so a real dependency failure in a provisioned tree still reads as one.

**Also closes the second junction foot-gun the BI names.** `root-clone-guard.mjs` already blocked a recursive *delete* through a junctioned `node_modules`, but not an *install* through it — which is how the root clone was previously gutted (1198 deleted sources). The new rule keys on runtime state (`node_modules` is actually a link), so a normal root-clone install and the managed worktree bootstrap both stay allowed; it can never become a blanket ban on installing.

## Verification — functional, not structural

Dogfooded on this very PR (the self-referential case):

- **Real gate run: 28,051 log lines → 32 lines of stdout**, ending in the bounded verdict block whose last line is `gate passed`. Each heartbeat named real progress.
- `pnpm run pregate:status` → `PASS`, exit 0, bound to HEAD `0361028`. The verdict was read from the record, not from the log text.
- The first attempt was killed after 45s of queueing; its lease was **revived, not leaked**, and the 4 identical queue polls had collapsed to 1 line.

Contract tests (real gate, mock control plane):

- 20,000-line child command → stdout ≤ 40 lines ending `gate passed`; the transcript absent from stdout; all 20,000 lines present in the log; the log path printed.
- A gate whose stdout reader is **destroyed after 5 lines** completes with exit 0 and still writes the gate record and records evidence.
- `pregate:status` → PASS for the gated SHA, then STALE (exit 1) after one more commit.
- Guard denies each malformed shape, permits the canonical one, and fails OPEN on parse/IO error.
- Banner reproduced on a synthetic tree with an **empty** `apps/web/node_modules`; asserted read-only (creates nothing).

**Root clone byte-identity:** verified intact — 1173 packages, **zero deletions** in `git -C D:\DPF status --porcelain`. No `node_modules` were written, junctioned, or removed; the probe is read-only by construction.

Totals: 119 unit tests + 23 gate contract tests green; guard-parity preflight 34/34 clean.

## Scope

Deliberately **not** touched: `BI-2C7F51BA` (queue wedges + drain deadlock) is owned by another session — Phase 2 is what makes its silent exit-0 give-up path detectable. The other lying-signal instances the BI generalizes (bare `tsc` printing "0 errors" after an OOM, `--test-force-exit` masking late rejections, Policy Guards' tail vs its `--results` JSON, `gh pr checks` never showing `merge_group` failures) are a follow-on sweep, not this PR.

## Design grounding

Extends existing contracts; no new design artifact. The sources of truth are `docs/testing/pre-pr-gate.md` (the gate's invocation and verdict contract) and the `dpf-worktree-per-session` skill (the compile-ready vs source-only classification) — both updated here. Both already *specified* this behaviour; neither was enforced or surfaced at runtime. The provisioning question was already decided under `BI-3047C122` and is not reopened.

Design-Grounding-Decision: Extends existing contracts, no new design artifact.

Docs-Impact-Decision: docs updated in this PR — `docs/testing/pre-pr-gate.md` (verdict command, invocation contract, drift table) and `dpf-worktree-per-session/SKILL.md` (probe replaces the structural `node_modules` test; managed bootstrap replaces bare `pnpm install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Seed fit

The changed seeded content is `packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md`. The edit corrects the readiness-classification procedure itself: it replaces a structural `test -d node_modules` check (which called an empty `apps/web/node_modules` compile-ready) with the real probe, and replaces "try `pnpm install --frozen-lockfile`" with the managed bootstrap (a bare install in a worktree writes through the junction into the root clone). Both corrections apply to every contributor on every install — the junction topology and the compile-ready/source-only split are platform substrate, not archetype-, vertical-, or install-specific — so this seeds globally rather than being parameterized or scoped.

Seed-Fit-Decision: global-default
