### PR TITLE
fix(local-ci): stop the shared gate queue from wedging (BI-2C7F51BA)

### DIFF
--- a/apps/web/lib/self-upgrade/activity-signal.test.ts
+++ b/apps/web/lib/self-upgrade/activity-signal.test.ts
@@ -1,0 +1,173 @@
+/**
+ * B-class activity signal — what counts as activity for the quiescence drain.
+ *
+ * Split from quiescence.test.ts: the exclusion set is a policy with its own
+ * module (activity-signal.ts) and its own failure history, and it deserves a
+ * suite that is read on its own.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  taskRunFindMany: vi.fn(),
+  taskRunUpdateMany: vi.fn(),
+  buildPhaseRunFindMany: vi.fn(),
+  buildPhaseRunUpdateMany: vi.fn(),
+  executeRaw: vi.fn(),
+  toolExecutionFindMany: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findMany: (...args: unknown[]) => prismaMock.taskRunFindMany(...args),
+      updateMany: (...args: unknown[]) => prismaMock.taskRunUpdateMany(...args),
+    },
+    buildPhaseRun: {
+      findMany: (...args: unknown[]) => prismaMock.buildPhaseRunFindMany(...args),
+      updateMany: (...args: unknown[]) => prismaMock.buildPhaseRunUpdateMany(...args),
+    },
+    $executeRaw: (...args: unknown[]) => prismaMock.executeRaw(...args),
+    toolExecution: {
+      findMany: (...args: unknown[]) => prismaMock.toolExecutionFindMany(...args),
+    },
+    quiescenceRun: { findUnique: vi.fn(), update: vi.fn(), findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/queue/inngest-client", () => ({ inngest: { send: vi.fn() } }));
+vi.mock("@/lib/tak/agent-event-bus", () => ({
+  agentEventBus: { broadcastSystem: vi.fn() },
+}));
+
+import { captureActiveSessionBlockers } from "./quiescence";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.taskRunFindMany.mockResolvedValue([]);
+  prismaMock.taskRunUpdateMany.mockResolvedValue({ count: 0 });
+  prismaMock.buildPhaseRunFindMany.mockResolvedValue([]);
+  prismaMock.buildPhaseRunUpdateMany.mockResolvedValue({ count: 0 });
+  prismaMock.executeRaw.mockResolvedValue(0);
+  prismaMock.toolExecutionFindMany.mockResolvedValue([]);
+});
+
+describe("B-class activity signal: a waiter must not count as activity (BI-2C7F51BA)", () => {
+  // The deadlock this fixes: a local-CI gate waits for the drain to clear, and
+  // the waiting is what keeps it armed. Every MCP call writes a ToolExecution
+  // row, INCLUDING read-only ones, so the gate's own get_quiescence_status poll
+  // — and the diagnostic call used to inspect the stall — re-armed the single
+  // soft blocker both were waiting on (observed: coordinator at ready-to-swap,
+  // one soft blocker, count 1).
+  //
+  // These drive the REAL where-clause through an in-memory row store, so the
+  // assertion is about which rows survive the filter, not about its shape.
+  type Row = {
+    toolName: string;
+    agentId: string;
+    auditClass: string | null;
+    createdAt: Date;
+  };
+
+  const NOW = new Date("2026-08-04T22:00:00.000Z");
+  const recently = (secondsAgo: number) => new Date(NOW.getTime() - secondsAgo * 1000);
+
+  /** A gate polling for admission, plus the diagnostic that inspects the stall.
+   *  All read-only: no side effect, no external access -> `metrics_only`. */
+  const WAITER_ROWS: Row[] = [
+    { toolName: "get_quiescence_status", agentId: "claude-thread", auditClass: "metrics_only", createdAt: recently(5) },
+    { toolName: "list_nonprod_environment_leases", agentId: "claude-thread", auditClass: "metrics_only", createdAt: recently(35) },
+    { toolName: "get_quiescence_status", agentId: "codex-thread", auditClass: "metrics_only", createdAt: recently(70) },
+  ];
+
+  function seedToolExecutions(rows: Row[]) {
+    prismaMock.toolExecutionFindMany.mockImplementation((args: unknown) => {
+      const where = (args as { where: Record<string, unknown> }).where;
+      const gte = (where.createdAt as { gte: Date }).gte;
+      const notPrefix = ((where.NOT as { agentId: { startsWith: string } }).agentId).startsWith;
+      const or = where.OR as Array<Record<string, unknown>> | undefined;
+      const matched = rows.filter((row) => {
+        if (row.createdAt < gte) return false;
+        if (row.agentId.startsWith(notPrefix)) return false;
+        if (!or) return true;
+        return or.some((clause) => {
+          if ("auditClass" in clause && clause.auditClass === null) return row.auditClass === null;
+          const nested = clause.auditClass as { not?: string } | undefined;
+          if (nested && typeof nested.not === "string") {
+            return row.auditClass !== null && row.auditClass !== nested.not;
+          }
+          return false;
+        });
+      });
+      matched.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      return Promise.resolve(matched.slice(0, 5));
+    });
+  }
+
+  it("a gate polling for admission raises no blocker, so the drain reaches swap", async () => {
+    seedToolExecutions(WAITER_ROWS);
+
+    const snapshot = await captureActiveSessionBlockers({ now: NOW });
+
+    expect(snapshot.surfaces.find((s) => s.surface === "request.recent-tool-execution"))
+      .toBeUndefined();
+    // Both gates the run has to pass are now clear. The conservative unattended
+    // path (self-upgrade.ts precheck) skips when ANY surface — soft included —
+    // is present, so an empty list is what lets it start the drain at all…
+    expect(snapshot.surfaces).toHaveLength(0);
+    // …and the drain loop itself breaks out on zero HARD blockers, i.e. it
+    // reaches ready-to-swap rather than sitting behind the waiter forever.
+    expect(snapshot.surfaces.filter((s) => s.kind === "hard")).toHaveLength(0);
+  });
+
+  it("still blocks on a MUTATING call — the scheduled path stays conservative (BI-F36E7510)", async () => {
+    seedToolExecutions([
+      ...WAITER_ROWS,
+      { toolName: "update_backlog_item", agentId: "claude-thread", auditClass: "ledger", createdAt: recently(20) },
+    ]);
+
+    const snapshot = await captureActiveSessionBlockers({ now: NOW });
+    const blocker = snapshot.surfaces.find((s) => s.surface === "request.recent-tool-execution");
+
+    expect(blocker).toBeDefined();
+    expect(blocker!.kind).toBe("soft");
+    // Only the real write is counted; the waiter's polls are not inflating it.
+    expect(blocker!.evidence).toEqual({ recentToolNames: ["update_backlog_item"] });
+  });
+
+  it("still blocks on an EXTERNAL-reaching read (journal), which is real activity", async () => {
+    seedToolExecutions([
+      ...WAITER_ROWS,
+      { toolName: "search_mcp_registry", agentId: "claude-thread", auditClass: "journal", createdAt: recently(15) },
+    ]);
+
+    const snapshot = await captureActiveSessionBlockers({ now: NOW });
+
+    expect(snapshot.surfaces.find((s) => s.surface === "request.recent-tool-execution")).toBeDefined();
+  });
+
+  it("fails closed on unclassified pre-Phase-3 rows", async () => {
+    // Rows written before auditClass existed carry null. A bare `NOT auditClass
+    // = 'metrics_only'` would evaluate to NULL for them in SQL and silently
+    // discard them; they must keep counting.
+    seedToolExecutions([
+      ...WAITER_ROWS,
+      { toolName: "legacy_tool", agentId: "claude-thread", auditClass: null, createdAt: recently(10) },
+    ]);
+
+    const snapshot = await captureActiveSessionBlockers({ now: NOW });
+    const blocker = snapshot.surfaces.find((s) => s.surface === "request.recent-tool-execution");
+
+    expect(blocker).toBeDefined();
+    expect(blocker!.evidence).toEqual({ recentToolNames: ["legacy_tool"] });
+  });
+
+  it("keeps excluding edge-node agents (the exclusion this one extends)", async () => {
+    seedToolExecutions([
+      { toolName: "record_agent_activity", agentId: "edge-node:tractor-7", auditClass: "ledger", createdAt: recently(5) },
+    ]);
+
+    const snapshot = await captureActiveSessionBlockers({ now: NOW });
+
+    expect(snapshot.surfaces.find((s) => s.surface === "request.recent-tool-execution")).toBeUndefined();
+  });
+});

--- a/apps/web/lib/self-upgrade/activity-signal.ts
+++ b/apps/web/lib/self-upgrade/activity-signal.ts
@@ -1,0 +1,53 @@
+/**
+ * The B-class "recent portal / MCP activity" signal used by the quiescence
+ * drain (`request.recent-tool-execution`).
+ *
+ * It lives in its own module because it is a POLICY about what counts as
+ * activity, not a query detail: what it excludes has twice been the difference
+ * between a self-upgrade that runs and one that cannot.
+ */
+import type { Prisma } from "@dpf/db";
+
+/** Edge-node agents heartbeat continuously and are not interactive work. */
+export const EDGE_AGENT_PREFIX = "edge-node:";
+
+/**
+ * The auditClass `deriveAuditClassForTool` assigns a tool with neither a side
+ * effect nor external access — a pure observation.
+ */
+export const OBSERVING_TOOL_AUDIT_CLASS = "metrics_only";
+
+/**
+ * Rows that count as activity in the window starting at `cutoff`.
+ *
+ * A WAITER MUST NOT COUNT AS ACTIVITY (BI-2C7F51BA). Every MCP call writes a
+ * ToolExecution row, INCLUDING read-only ones, so an agent asking "is it safe to
+ * proceed?" re-arms the very blocker it is asking about: a local-CI gate polling
+ * get_quiescence_status while it waited for the drain kept this surface armed at
+ * count 1 — its own poll — and the diagnostic call used to inspect the stall did
+ * the same. The signal was measuring observation, not work.
+ *
+ * Excluding observation extends the mechanism the edge-node clause already
+ * established, and reuses the argument BI-CC82B9A8 recorded one stage earlier at
+ * TRIGGER time (queue/functions/self-upgrade.ts): the soft
+ * `request.recent-tool-execution` surface fires on the very calls that drove the
+ * request. Narrowing the SIGNAL is deliberately preferred over discounting soft
+ * blockers at swap time — the unattended scheduled path must stay conservative
+ * and never drain while real work is in flight (BI-F36E7510), and it still does:
+ * only observation is excluded, while every mutating (`ledger`) and
+ * external-reaching (`journal`) call still arms the blocker.
+ *
+ * Null classes are pre-Phase-3 rows with no classification. They keep counting
+ * (fail closed) rather than being swept in by a bare `NOT auditClass =
+ * 'metrics_only'`, which SQL evaluates to NULL — and therefore drops — for them.
+ */
+export function recentActivityWhere(cutoff: Date): Prisma.ToolExecutionWhereInput {
+  return {
+    createdAt: { gte: cutoff },
+    NOT: { agentId: { startsWith: EDGE_AGENT_PREFIX } },
+    OR: [
+      { auditClass: null },
+      { auditClass: { not: OBSERVING_TOOL_AUDIT_CLASS } },
+    ],
+  };
+}

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -18,6 +18,7 @@
  * BI-QUIESCE-002.
  */
 import { prisma } from "@dpf/db";
+import { recentActivityWhere } from "@/lib/self-upgrade/activity-signal";
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { TASK_LIVE_STATES } from "@/lib/tak/task-states";
@@ -851,7 +852,6 @@ export type BlockerSignal =
   | { class: "G"; reason: string; mitigations: string[] };
 
 const TOOL_EXECUTION_RECENCY_MS = 5 * 60 * 1000;
-const EDGE_AGENT_PREFIX = "edge-node:";
 const TERMINAL_BUILD_PHASES = ["complete", "failed", "abandoned"] as const;
 
 /**
@@ -1163,11 +1163,10 @@ export async function captureActiveSessionBlockers(opts?: {
   // Acts as a proxy for "server actions / MCP tool calls were happening
   // recently"; not as authoritative as A/C/D-class direct signals.
   const cutoff = new Date(now.getTime() - thresholdMs);
+  // What counts as activity — and, critically, what does NOT (a waiter polling
+  // for permission to proceed) — is owned by activity-signal.ts (BI-2C7F51BA).
   const recentToolExecs = await prisma.toolExecution.findMany({
-    where: {
-      createdAt: { gte: cutoff },
-      NOT: { agentId: { startsWith: EDGE_AGENT_PREFIX } },
-    },
+    where: recentActivityWhere(cutoff),
     select: { toolName: true, createdAt: true },
     orderBy: { createdAt: "desc" },
     take: 5,

--- a/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md
@@ -567,6 +567,15 @@ Every existing Inngest function in `apps/web/lib/queue/functions/` is wrapped wi
 
 **Detection** — B-class proxy via `ToolExecution` recency (today's stopgap). Sharpened by Node-runtime mutation wrappers writing an `inFlightActions` gauge (new in-memory counter exposed through the same internal state route). Proxy itself should not own this gauge because it cannot reliably observe route completion.
 
+**Observation is not activity (BI-2C7F51BA).** The recency query counts rows that represent WORK, not rows that represent WATCHING. It excludes two classes, and the exclusion set is the contract — `apps/web/lib/self-upgrade/activity-signal.ts` owns it:
+
+- `agentId` starting with `edge-node:` — edge agents heartbeat continuously and are not interactive work.
+- `auditClass = metrics_only` — the class `deriveAuditClassForTool` assigns a tool with neither a side effect nor external access, i.e. a pure read.
+
+Without the second exclusion the signal is self-sustaining: every MCP call writes a `ToolExecution` row including read-only ones, so an agent asking whether it is safe to proceed re-arms the blocker it is asking about. Observed live — a local-CI gate polling `get_quiescence_status` while waiting for the drain held this surface armed at count 1, its own poll, and the diagnostic used to inspect the stall did the same.
+
+The remedy is deliberately applied to the SIGNAL, not to the coordinator's tolerance for soft blockers. Discounting soft blockers at swap time would regress the unattended scheduled path, which must never drain while real work is in flight (§6.5, BI-F36E7510). Rows classified `ledger` (mutating) or `journal` (external-reaching) still arm the blocker, as do unclassified pre-Phase-3 rows, which fail closed. This is the same argument BI-CC82B9A8 applied one stage earlier at trigger time.
+
 **Stop-accept** — extend the existing `apps/web/proxy.ts` (§2.4 gap). Next.js 16 renamed Middleware to Proxy; Proxy runs in the Edge runtime and cannot import Prisma, `@dpf/db`, filesystem APIs, or Node-only helpers. Therefore the gate has two layers:
 
 1. **Proxy path** — injects version headers on all matched responses and rejects mutation POSTs / new SSE handshakes when cached quiescence state is `draining` or `swapping`.

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -30,6 +30,7 @@ import {
   createGateObserverIdentity,
   findDeadLocalQueueObservers,
   registerLocalQueueObserver,
+  releaseDeadLocalQueueObserversForGate,
   releaseLocalQueueObserver,
 } from "./lib/local-queue-observer.mjs";
 import {
@@ -878,6 +879,40 @@ async function main() {
     },
   ]));
   for (const [signal, handler] of Object.entries(signalHandlers)) process.once(signal, handler);
+
+  // BI-2C7F51BA defect 1 — sweep the observer directory on STARTUP, before we
+  // add our own record to it.
+  //
+  // Every other reap site is conditional: a gate releases its OWN record on the
+  // release path, and pregate.mjs only reaps inside its interrupted/revival
+  // recovery paths — which sit behind `could not resolve worktree path` and so
+  // are skipped on exactly the failure the cleanup exists for. Nothing swept the
+  // directory unconditionally, so a hard-killed gate leaked a record forever:
+  // 192 records observed, 185 with dead pids, the oldest six days old, throttling
+  // admission for EVERY session on the host until swept by hand.
+  //
+  // The filters are DELIBERATELY EMPTY. This sweep must clear other branches',
+  // other shas', and other SESSIONS' dead records — a record leaked by a session
+  // that has since exited will otherwise never be reaped by anyone, because the
+  // only process that would scope a sweep to it is gone. Narrowing this to the
+  // current gate silently restores the leak. Liveness is proven per record
+  // (pid + process start time, TTL only when unverifiable), so a sweep can never
+  // take a slot from a gate that is genuinely running.
+  const sweptObservers = releaseDeadLocalQueueObserversForGate({
+    directory: queueObserverDirectory,
+  });
+  if (sweptObservers.length > 0) {
+    process.stdout.write(
+      `gate-worktree: swept ${sweptObservers.length} dead local-CI queue observer record(s) `
+        + `(pids ${sweptObservers.map((entry) => entry.pid).join(", ")})\n`,
+    );
+    leaseEvents.push({
+      type: "dead_queue_observers_swept",
+      count: sweptObservers.length,
+      observers: sweptObservers,
+      at: new Date().toISOString(),
+    });
+  }
 
   // Always register: the observer proves THIS PROCESS is alive, which is what
   // lets a dead waiter be reconciled out of the queue. It records the lease's

--- a/scripts/lib/local-queue-observer.mjs
+++ b/scripts/lib/local-queue-observer.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   mkdirSync,
@@ -7,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 
 const OBSERVER_SCHEMA = "dpf-local-ci-queue-observer/v1";
 const OWNER_PATTERN =
@@ -32,6 +34,178 @@ function isProcessAlive(pid) {
   } catch {
     return false;
   }
+}
+
+/**
+ * BI-2C7F51BA defect 2 — `process.kill(pid, 0)` alone is an UNSOUND liveness
+ * proof, and unsoundly in the direction that wedges the queue: Windows recycles
+ * pids aggressively, so a record whose gate died reads as alive FOREVER once the
+ * OS hands its pid to an unrelated process. Such a record can never be reaped and
+ * permanently leaks a queue slot. (Observed live: 6 surviving records, 4 of them
+ * registered days earlier, all "alive".)
+ *
+ * (pid, startTime) IS unique, so the record now carries the registering process's
+ * start time and liveness compares it against the host's real process table. Two
+ * independent guarantees follow:
+ *
+ *   - VERIFIED LIVE — pid present in the host table with a matching start time.
+ *     A genuinely running gate is never reaped, no matter how long it runs. The
+ *     TTL below deliberately does NOT apply to this case.
+ *   - UNVERIFIABLE — no start time on the record (pre-fix record), or the host
+ *     table could not be read. Falls back to pid-only liveness PLUS the TTL, so
+ *     no record can outlive a plausible gate run regardless of pid state.
+ *
+ * A pid whose start time does NOT match is proven reuse: dead, reaped now.
+ */
+const START_TIME_TOLERANCE_MS = 2_000;
+
+/**
+ * TTL backstop for records whose liveness cannot be positively verified. A local
+ * gate run is minutes-to-an-hour; 4h is far past any plausible run, and it only
+ * ever applies when the start-time proof is unavailable — so it cannot reap a
+ * gate we can see is still running.
+ */
+export const OBSERVER_TTL_MS = 4 * 60 * 60 * 1000;
+
+/** How long a host process-table snapshot may be reused (the reaper runs inside
+ *  the gate's claim-retry loop; re-shelling out every few seconds is waste). */
+const PROCESS_TABLE_CACHE_MS = 15_000;
+
+let processTableCache = null;
+
+function currentProcessStartedAtMs() {
+  // performance.timeOrigin is this process's start, as epoch ms.
+  return Math.round(performance.timeOrigin);
+}
+
+function parseProcessTable(stdout) {
+  const table = new Map();
+  for (const line of String(stdout).split(/\r?\n/)) {
+    const match = /^\s*(\d+)[\s,]+(-?\d+)\s*$/.exec(line);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1], 10);
+    const startedAtMs = Number.parseInt(match[2], 10);
+    if (!Number.isInteger(pid) || pid <= 0 || !Number.isFinite(startedAtMs)) continue;
+    table.set(pid, startedAtMs);
+  }
+  return table;
+}
+
+/**
+ * Snapshot every running pid with its start time as epoch ms, or null when the
+ * host cannot be queried. Null (not an empty map) is the failure signal, so an
+ * unreadable process table can never be mistaken for "nothing is running" and
+ * mass-reap live gates.
+ */
+export function readHostProcessStartTimes({
+  platform = process.platform,
+  run = spawnSync,
+  nowMs = Date.now(),
+} = {}) {
+  try {
+    let result;
+    if (platform === "win32") {
+      // Emit "<pid> <epochMs>" per line; computing the epoch inside PowerShell
+      // keeps the output locale-independent.
+      const script =
+        "Get-CimInstance Win32_Process | ForEach-Object { "
+        + "if ($_.CreationDate) { "
+        + "'{0} {1}' -f $_.ProcessId, "
+        + "[int64]($_.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds } }";
+      result = run(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", script],
+        { encoding: "utf8", windowsHide: true, timeout: 20_000 },
+      );
+    } else {
+      // etimes = elapsed seconds; start = now - elapsed. Second-granularity, which
+      // the tolerance above already accommodates.
+      result = run("ps", ["-Ao", "pid=,etimes="], { encoding: "utf8", timeout: 20_000 });
+    }
+    if (result?.status !== 0 || typeof result.stdout !== "string") return null;
+    const raw = parseProcessTable(result.stdout);
+    if (raw.size === 0) return null;
+    if (platform === "win32") return raw;
+    const table = new Map();
+    for (const [pid, elapsedSeconds] of raw) table.set(pid, nowMs - elapsedSeconds * 1000);
+    return table;
+  } catch {
+    return null;
+  }
+}
+
+function hostProcessStartTimes(nowMs = Date.now()) {
+  if (processTableCache && nowMs - processTableCache.at < PROCESS_TABLE_CACHE_MS) {
+    return processTableCache.table;
+  }
+  const table = readHostProcessStartTimes({ nowMs });
+  processTableCache = { at: nowMs, table };
+  return table;
+}
+
+/** Test seam: drop the memoized host process table. */
+export function resetHostProcessTableCache() {
+  processTableCache = null;
+}
+
+/**
+ * Decide whether one observer record still represents a running gate. See
+ * START_TIME_TOLERANCE_MS above for the two-guarantee argument.
+ */
+export function isObserverRecordLive(record, {
+  processAlive = isProcessAlive,
+  processStartTimes = null,
+  ttlMs = OBSERVER_TTL_MS,
+  nowMs = Date.now(),
+} = {}) {
+  if (!processAlive(record.pid)) return false;
+
+  const observedStartedAtMs = processStartTimes instanceof Map
+    ? processStartTimes.get(record.pid)
+    : undefined;
+  const recordedStartedAtMs = Number.isFinite(record.processStartedAtMs)
+    ? record.processStartedAtMs
+    : null;
+
+  if (observedStartedAtMs !== undefined && recordedStartedAtMs !== null) {
+    // Positive proof either way — no TTL needed in either direction.
+    return Math.abs(observedStartedAtMs - recordedStartedAtMs) <= START_TIME_TOLERANCE_MS;
+  }
+  if (processStartTimes instanceof Map && observedStartedAtMs === undefined) {
+    // We can see the whole host table and this pid is not in it: kill(0) lied.
+    return false;
+  }
+
+  // Unverifiable: pid-only liveness, bounded by the TTL so nothing leaks forever.
+  const registeredAtMs = Date.parse(record.registeredAt);
+  if (Number.isFinite(registeredAtMs) && nowMs - registeredAtMs > ttlMs) return false;
+  return true;
+}
+
+/**
+ * Build the liveness predicate the reapers use. An injected `processAlive`
+ * (tests, callers with their own oracle) is authoritative on its own: it is not
+ * second-guessed against the real host process table.
+ */
+function resolveObserverAlive({
+  observerAlive,
+  processAlive,
+  processStartTimes,
+  ttlMs = OBSERVER_TTL_MS,
+  nowMs = Date.now(),
+}) {
+  if (typeof observerAlive === "function") return observerAlive;
+  const startTimes = processStartTimes !== undefined
+    ? processStartTimes
+    : (processAlive ? null : hostProcessStartTimes(nowMs));
+  const alive = processAlive || isProcessAlive;
+  return (record) =>
+    isObserverRecordLive(record, {
+      processAlive: alive,
+      processStartTimes: startTimes,
+      ttlMs,
+      nowMs,
+    });
 }
 
 function readObserverRecords(directory) {
@@ -89,6 +263,10 @@ export function registerLocalQueueObserver({
   // observer's own id so pre-existing callers keep working unchanged.
   ownerSessionId = identity.ownerSessionId,
   now = () => new Date(),
+  // BI-2C7F51BA: (pid, startTime) is unique where pid alone is not. Defaults to
+  // THIS process's start time, which is the only one we can read without asking
+  // the OS; callers registering on behalf of another pid must pass it.
+  processStartedAtMs = identity.pid === process.pid ? currentProcessStartedAtMs() : null,
 }) {
   mkdirSync(directory, { recursive: true });
   const path = observerPath(directory, identity.token);
@@ -100,6 +278,7 @@ export function registerLocalQueueObserver({
     branch,
     sha,
     registeredAt: now().toISOString(),
+    ...(Number.isFinite(processStartedAtMs) ? { processStartedAtMs } : {}),
   };
   writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, {
     encoding: "utf8",
@@ -130,8 +309,19 @@ function readObserversBySession(directory) {
 export function findDeadLocalQueueObservers({
   directory,
   queuedLeases,
-  processAlive = isProcessAlive,
+  processAlive,
+  processStartTimes,
+  observerAlive: observerAliveOverride,
+  ttlMs,
+  nowMs,
 }) {
+  const observerAlive = resolveObserverAlive({
+    observerAlive: observerAliveOverride,
+    processAlive,
+    processStartTimes,
+    ttlMs,
+    nowMs,
+  });
   const dead = [];
   const bySession = readObserversBySession(directory);
   for (const lease of queuedLeases) {
@@ -144,7 +334,7 @@ export function findDeadLocalQueueObservers({
     }
     const records = bySession.get(lease.ownerSessionId);
     if (!Array.isArray(records) || records.length === 0) continue;
-    if (records.some((record) => processAlive(record.pid))) continue;
+    if (records.some((record) => observerAlive(record))) continue;
     const livenessProofs = records.map((record) => ({
       schema: OBSERVER_SCHEMA,
       observerToken: record.observerToken,
@@ -177,14 +367,25 @@ export function releaseDeadLocalQueueObserversForGate({
   branch,
   sha,
   ownerSessionId = "",
-  processAlive = isProcessAlive,
+  processAlive,
+  processStartTimes,
+  observerAlive: observerAliveOverride,
+  ttlMs,
+  nowMs,
 }) {
+  const observerAlive = resolveObserverAlive({
+    observerAlive: observerAliveOverride,
+    processAlive,
+    processStartTimes,
+    ttlMs,
+    nowMs,
+  });
   const released = [];
   for (const { path, record } of readObserverRecords(directory)) {
     if (branch && record.branch !== branch) continue;
     if (sha && record.sha !== sha) continue;
     if (ownerSessionId && record.ownerSessionId !== ownerSessionId) continue;
-    if (processAlive(record.pid)) continue;
+    if (observerAlive(record)) continue;
     const result = releaseLocalQueueObserver({
       path,
       token: record.observerToken,
@@ -197,6 +398,9 @@ export function releaseDeadLocalQueueObserversForGate({
       branch: record.branch,
       sha: record.sha,
       registeredAt: record.registeredAt,
+      ...(Number.isFinite(record.processStartedAtMs)
+        ? { processStartedAtMs: record.processStartedAtMs }
+        : {}),
       releaseStatus: result.status,
     });
   }

--- a/scripts/lib/local-queue-observer.test.mjs
+++ b/scripts/lib/local-queue-observer.test.mjs
@@ -1,15 +1,18 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import {
+  OBSERVER_TTL_MS,
   createGateObserverIdentity,
   findDeadLocalQueueObservers,
+  readHostProcessStartTimes,
   registerLocalQueueObserver,
   releaseDeadLocalQueueObserversForGate,
   releaseLocalQueueObserver,
+  resetHostProcessTableCache,
 } from "./local-queue-observer.mjs";
 
 function observerDirectory() {
@@ -334,4 +337,144 @@ test("duplicate observers fail closed when any recorded process is alive", () =>
   });
 
   assert.deepEqual(dead, []);
+});
+
+// ── BI-2C7F51BA defect 2: pid liveness must survive pid REUSE ───────────────
+//
+// These exercise the REAL host process-table probe (no injected oracle), which
+// is the half `process.kill(pid, 0)` could never do. `process.pid` stands in for
+// a recycled pid: it is unambiguously alive, so kill(0) says "live" — the whole
+// bug — and only the start-time comparison can tell the two apart.
+
+const hostStartTimes = readHostProcessStartTimes();
+const hostProbeSkip = hostStartTimes?.has(process.pid)
+  ? false
+  : "host process table is unreadable on this platform; start-time liveness degrades to pid + TTL";
+
+test("a RECYCLED pid is reaped even though the pid is alive", { skip: hostProbeSkip }, () => {
+  const directory = observerDirectory();
+  const identity = createGateObserverIdentity({
+    pid: process.pid,
+    token: "a1111111-1111-4111-8111-111111111111",
+  });
+  // The gate that wrote this record died long ago; the OS has since handed its
+  // pid to this test process.
+  const recycled = registerLocalQueueObserver({
+    directory,
+    identity,
+    branch: "fix/dead-gate",
+    sha: "a".repeat(40),
+    processStartedAtMs: Date.parse("2026-07-29T20:00:00.000Z"),
+  });
+  assert.equal(existsSync(recycled.path), true);
+
+  resetHostProcessTableCache();
+  const released = releaseDeadLocalQueueObserversForGate({ directory });
+
+  assert.equal(released.length, 1);
+  assert.equal(released[0].pid, process.pid);
+  assert.equal(released[0].releaseStatus, "released");
+  assert.equal(existsSync(recycled.path), false);
+});
+
+test("a genuinely running gate is never reaped, however long it has run", { skip: hostProbeSkip }, () => {
+  const directory = observerDirectory();
+  // registerLocalQueueObserver stamps THIS process's real start time.
+  const live = registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: process.pid,
+      token: "a2222222-2222-4222-8222-222222222222",
+    }),
+    branch: "fix/long-running",
+    sha: "b".repeat(40),
+    // Older than the TTL: a verified-live process outranks the TTL backstop, so
+    // the TTL can never take a slot from a gate we can see is still running.
+    now: () => new Date(Date.now() - OBSERVER_TTL_MS - 60_000),
+  });
+
+  resetHostProcessTableCache();
+  assert.deepEqual(releaseDeadLocalQueueObserversForGate({ directory }), []);
+  assert.equal(existsSync(live.path), true);
+});
+
+test("a pre-fix record with no start time is bounded by the TTL", () => {
+  const directory = observerDirectory();
+  // Shape written before this fix: live-looking pid, no start time, so reuse is
+  // undetectable. Without a TTL this record is immortal — the permanent
+  // queue-slot leak. The probe is forced unavailable to isolate the TTL path.
+  const legacy = registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: 909,
+      token: "a3333333-3333-4333-8333-333333333333",
+    }),
+    branch: "fix/legacy",
+    sha: "c".repeat(40),
+    processStartedAtMs: null,
+    now: () => new Date(Date.now() - OBSERVER_TTL_MS - 60_000),
+  });
+  assert.equal(JSON.parse(readFileSync(legacy.path, "utf8")).processStartedAtMs, undefined);
+
+  const released = releaseDeadLocalQueueObserversForGate({
+    directory,
+    processAlive: () => true,
+    processStartTimes: null,
+  });
+
+  assert.equal(released.length, 1);
+  assert.equal(existsSync(legacy.path), false);
+});
+
+test("a pre-fix record inside the TTL still holds its slot", () => {
+  const directory = observerDirectory();
+  const fresh = registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: 910,
+      token: "a4444444-4444-4444-8444-444444444444",
+    }),
+    branch: "fix/legacy-fresh",
+    sha: "d".repeat(40),
+    processStartedAtMs: null,
+  });
+
+  assert.deepEqual(
+    releaseDeadLocalQueueObserversForGate({
+      directory,
+      processAlive: () => true,
+      processStartTimes: null,
+    }),
+    [],
+  );
+  assert.equal(existsSync(fresh.path), true);
+});
+
+test("a recycled pid also stops holding its LEASE in the queue", { skip: hostProbeSkip }, () => {
+  const directory = observerDirectory();
+  registerLocalQueueObserver({
+    directory,
+    identity: createGateObserverIdentity({
+      pid: process.pid,
+      token: "a5555555-5555-4555-8555-555555555555",
+    }),
+    ownerSessionId: "thread-whose-gate-died",
+    branch: "fix/queued",
+    sha: "e".repeat(40),
+    processStartedAtMs: Date.parse("2026-07-29T20:00:00.000Z"),
+  });
+
+  resetHostProcessTableCache();
+  const dead = findDeadLocalQueueObservers({
+    directory,
+    queuedLeases: [{
+      leaseId: "NPEL-RECYCLED",
+      environmentKey: "local-integration-ci",
+      status: "queued",
+      ownerSessionId: "thread-whose-gate-died",
+    }],
+  });
+
+  assert.equal(dead.length, 1);
+  assert.equal(dead[0].leaseId, "NPEL-RECYCLED");
 });

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -8,13 +8,17 @@
 // tests/release/local-ci-gate-contract.test.mjs.
 
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, cpSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, cpSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
 import { spawn, spawnSync } from "node:child_process";
 import { test } from "node:test";
 import { detectWorkingShell } from "../../scripts/pregate.mjs";
+import {
+  createGateObserverIdentity,
+  registerLocalQueueObserver,
+} from "../../scripts/lib/local-queue-observer.mjs";
 
 const repoRoot = new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
 const pregateScript = join(repoRoot, "scripts", "pregate.mjs");
@@ -746,4 +750,61 @@ test("local-ci-runner.mjs refuses to gate main or a detached HEAD", () => {
   });
   assert.notEqual(onMain.status, 0);
   assert.match(onMain.stderr, /gate topic branches, not main/);
+});
+
+test("gate-worktree.mjs sweeps ANOTHER session's leaked observer record at startup (BI-2C7F51BA)", async () => {
+  // Defect 1 functionally: a gate that is hard-killed leaks its observer record,
+  // and the record keeps throttling admission for every session on the host.
+  // Nothing swept unconditionally — pregate.mjs only reaps inside recovery paths
+  // that sit behind `could not resolve worktree path`, i.e. they are skipped on
+  // exactly the failure they exist for. 192 records accumulated that way.
+  //
+  // Real dead process, real record, real gate launch. The leaked record belongs
+  // to a DIFFERENT branch, sha, and session than the gate being launched: the
+  // startup sweep is deliberately unfiltered, because the only process that
+  // would ever scope a sweep to that record has already exited.
+  const { dir } = makeTempRepo();
+  const observerDir = mkdtempSync(join(tmpdir(), "dpf-gate-observers-"));
+
+  const victim = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+  const victimPid = victim.pid;
+  const leaked = registerLocalQueueObserver({
+    directory: observerDir,
+    identity: createGateObserverIdentity({ pid: victimPid }),
+    ownerSessionId: "some-other-session-that-died",
+    branch: "feat/someone-elses-branch",
+    sha: "leaked-sha",
+  });
+  assert.equal(existsSync(leaked.path), true);
+
+  const exited = new Promise((resolve) => victim.once("exit", resolve));
+  victim.kill("SIGKILL");
+  await exited;
+
+  const mcp = await startMockMcp({
+    claim_nonprod_environment_lease: () => ({ success: true, entityId: "NPEL-SWEEP" }),
+    record_local_integration_result: () => ({ success: true, entityId: "EXT-SWEEP" }),
+    release_nonprod_environment_lease: () => ({ success: true, entityId: "NPEL-SWEEP" }),
+  });
+  try {
+    const result = await runGateAsync(
+      ["--branch", "feat/local-ci-sandbox", "--sha", "candidate-sha", "--worktree", dir, "--no-push", "--mcp-url", mcp.url],
+      {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+        DPF_GATE_OWNER_PROVIDER: "codex",
+        DPF_GATE_OWNER_SESSION_ID: "sweeping-thread",
+        DPF_ALLOW_LOCAL_CI_STUB: "1",
+        DPF_LOCAL_QUEUE_OBSERVER_DIR: observerDir,
+      },
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /swept 1 dead local-CI queue observer record/);
+    assert.equal(existsSync(leaked.path), false, "the leaked record must not survive a gate launch");
+    // The gate cleans up after itself too, so the directory ends empty.
+    assert.deepEqual(readdirSync(observerDir), []);
+  } finally {
+    await mcp.close();
+    rmSync(observerDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes BI-2C7F51BA.

Three compounding defects turned any interrupted local-CI gate into a persistent wedge of the shared admission queue — for every session on the host, not just the one that died. They compound: a killed gate leaks a record (1), the record can become unreapable (2), and a concurrent drain can stall admission indefinitely (3). Fixing one still leaves the queue able to wedge.

## 1 — the reaper never ran on the success path

`gate-worktree.mjs` registers a queue observer and releases only its **own**. `releaseDeadLocalQueueObserversForGate` was wired solely into `pregate.mjs`'s interrupted/revival recovery paths — which sit behind `pregate.mjs:88`'s `could not resolve worktree path` throw, so they are skipped on exactly the failure the cleanup exists for. The observed log was literally `queued gate revival skipped (could not resolve worktree path)`.

Nothing swept the directory unconditionally. 192 records had accumulated, 185 with dead pids, the oldest from 2026-07-29; a pregate sat at "position 3" for ~30 minutes and jumped to position 1 the moment they were swept by hand.

Gates now sweep on **startup**, immediately before registering, so every launch self-heals.

The sweep passes **no branch/sha/ownerSessionId filter, deliberately** — and says so in the code. A record leaked by a session that has since exited will otherwise never be reaped by anyone, because the only process that would scope a sweep to it is gone. Narrowing this to the current gate silently restores the leak.

## 2 — pid liveness was unsound (permanent wedge)

Liveness was `process.kill(pid, 0)`. Windows recycles pids aggressively, so a record whose gate died reads alive **forever** once the OS hands its pid to an unrelated process — a permanent queue-slot leak with no start time, no heartbeat, no TTL to bound it.

`(pid, startTime)` is unique where pid alone is not. Records now carry `processStartedAtMs`, and liveness compares it against the host's real process table (`Win32_Process` via PowerShell on Windows, `ps -Ao pid=,etimes=` elsewhere; memoized 15s because the reaper also runs inside the claim-retry loop). Two guarantees:

- **Verified live** — pid present with a matching start time. Never reaped, however long the gate runs. The TTL deliberately does not apply here.
- **Unverifiable** — no start time (pre-fix record) or the table could not be read. Falls back to pid-only liveness **plus** a 4h TTL, so nothing outlives a plausible gate run regardless of pid state.

A pid whose start time does not match is proven reuse: dead, reaped now. An unreadable process table returns `null`, not an empty map, so it can never be mistaken for "nothing is running".

## 3 — a waiter counted as itself as activity

`quiescence.ts` computed the soft `request.recent-tool-execution` blocker from a recency query over `ToolExecution`. Every MCP call writes a row **including read-only ones**, so a gate polling `get_quiescence_status` while waiting for the drain kept the blocker armed at count 1 — its own poll. The diagnostic used to inspect the stall did the same. The signal was measuring observation, not work.

The query now also excludes `auditClass = metrics_only` — the class `deriveAuditClassForTool` assigns a tool with neither a side effect nor external access. This extends the mechanism the `EDGE_AGENT_PREFIX` clause already established, and reuses the argument BI-CC82B9A8 recorded one stage earlier at trigger time (`queue/functions/self-upgrade.ts`) rather than inventing a new one.

**Soft blockers are not discounted at swap time.** BI-F36E7510 deliberately made the unattended scheduled path conservative — never drain while any work is in flight — and it stays that way. Only *observation* is excluded: every mutating (`ledger`) and external-reaching (`journal`) call still arms the blocker, and unclassified pre-Phase-3 rows (`auditClass IS NULL`) keep counting rather than being swept in by a bare `NOT` that SQL evaluates to NULL for them.

The policy lives in its own module (`activity-signal.ts`) rather than growing `quiescence.ts` past its size baseline, and the drain spec's B-class detection section (§6.4) now states the exclusion set as the contract.

## Verification — functional, not structural

- **(1)** A real child process is registered, `SIGKILL`ed, and a real `gate-worktree.mjs` launch against a mock MCP clears its record. The leaked record deliberately belongs to a different branch, sha, and session than the gate being launched.
- **(2)** A recycled pid — alive to `kill(0)` — is reaped via the **real** host process table, while a genuinely running gate survives past the TTL. A pre-fix record with no start time is bounded by the TTL; one inside the TTL still holds its slot.
- **(3)** The drain-blocker snapshot is empty while a gate polls, and still armed by a `ledger` row, a `journal` row, and an unclassified row. Driven through the real where-clause over an in-memory row store, so the assertion is about which rows survive the filter, not about its shape.

**Live evidence.** Over 24h on this install: of 105 five-minute windows that armed the blocker, **14 were armed by observation alone** and now clear; the other 91 still block.

**And it proved itself in production while gating this very PR.** The gate run recorded a `dead_queue_observers_swept` lease event clearing pid 50988 — a dead record belonging to *another session's* killed gate on `claude/local-ci-gate-readability-c32dac`. That session's live record, registered 30 seconds later, was untouched. Cross-session reach and the do-not-yank-a-live-slot property, both on the real shared queue.

## Notes for review

- Overlaps #4005 on `scripts/gate-worktree.mjs` (different concern — gate verdict readability; different region of the file). Whichever lands second rebases.
- The observer record gains one optional field; pre-fix records stay readable and are handled explicitly by the unverifiable path above.
- Not addressed here, tracked separately: the give-up path exiting 0, which is #4005's concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
