### PR TITLE
fix(ci): fail the production build fast instead of burning the job cap (BI-F75AADB7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,9 @@ jobs:
     # hang or exceed 20–30m when Turbopack FS cache is enabled with an exact-key
     # miss (overnight 2026-08-04: #3958 / #3963). Cap at 45m and disable the
     # experimental Turbopack cache on merge_group (see build step env).
+    #
+    # BI-F75AADB7: this is the OUTER backstop only. The compile step carries its
+    # own inner bound — see `timeout-minutes` on "Build web (Next.js production)".
     timeout-minutes: 45
     needs: [changes, exact-tree-evidence-shadow]
     if: >-
@@ -502,6 +505,23 @@ jobs:
 
       - name: Build web (Next.js production)
         if: needs.changes.outputs.heavy == 'true'
+        # BI-F75AADB7 — inner, fail-fast bound on the compile itself.
+        #
+        # Without it a hung compile runs until the 45m JOB cap, and the job then
+        # ends `cancelled` rather than `failure`. Three things follow from that,
+        # all measured on #3984 job 92139777135 (twice, deterministically): ~53
+        # minutes burned in this one step (55m1s wall); NO retrievable log,
+        # because `gh run view --job <id> --log` returns "log not found" for a
+        # cancelled job, so the hang is undiagnosable after the fact; and Merge
+        # Readiness reports "build concluded cancelled" even though every other
+        # dependency succeeded, which reads as a second, unrelated failure.
+        #
+        # 15m sits near the healthy ceiling — pull_request builds on the same
+        # config that day all finished in 3–4m against the 8–10m expectation
+        # documented on the job above — so a hang trips it while a merely slow
+        # cold compile does not. Timing out the STEP fails the job for real and
+        # RETAINS this step's log.
+        timeout-minutes: 15
         # Experimental Turbopack FS cache on pull_request only. On merge_group
         # exact-key misses have produced multi-tens-of-minutes hangs that eject
         # otherwise-green PRs from the merge queue; webpack/default build is
@@ -509,7 +529,7 @@ jobs:
         env:
           DPF_TURBOPACK_BUILD_CACHE: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
-          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} event=${{ github.event_name }} turbopack_cache=${{ github.event_name == 'pull_request' && '1' || '0' }} timeout=45m command=pnpm --filter web build"
+          echo "[production-build] run=${{ github.run_id }} attempt=${{ github.run_attempt }} tree=${{ github.sha }} event=${{ github.event_name }} turbopack_cache=${{ github.event_name == 'pull_request' && '1' || '0' }} timeout=15m/step 45m/job command=pnpm --filter web build"
           pnpm --filter web build
 
       # BI-959F4F38. PR and merge-group UX runs consume this exact-tree output

--- a/scripts/check-ci-build-cache.test.mjs
+++ b/scripts/check-ci-build-cache.test.mjs
@@ -41,9 +41,27 @@ test("Production Build is bounded and identifies timed-out evidence", () => {
   assert.match(block, /\n\s{4}timeout-minutes:\s*45\s*\n/);
   assert.match(buildStep, /production-build.*run=\$\{\{ github\.run_id \}\}/);
   assert.match(buildStep, /tree=\$\{\{ github\.sha \}\}/);
-  assert.match(buildStep, /timeout=45m/);
+  assert.match(buildStep, /timeout=15m\/step 45m\/job/);
   // Turbopack FS cache only on pull_request — merge_group must not hard-pin "1".
   assert.match(buildStep, /DPF_TURBOPACK_BUILD_CACHE:\s*\$\{\{\s*github\.event_name\s*==\s*'pull_request'/);
   assert.match(buildStep, /pnpm --filter web build/);
   assert.doesNotMatch(buildStep, /continue-on-error:\s*true/);
+});
+
+test("the production compile fails fast on its own step timeout (BI-F75AADB7)", () => {
+  // Without a STEP bound a hung compile runs to the 45m job cap and the job ends
+  // `cancelled`, not `failure`. Measured on #3984 job 92139777135: ~53 minutes in
+  // this single step, and `gh run view --job <id> --log` returns "log not found"
+  // for a cancelled job — so the occurrence costs ~55 minutes of hosted-runner
+  // time AND leaves nothing to diagnose. The inner bound makes it a real failure
+  // with a retained log; the 45m job cap stays as the outer backstop.
+  const buildStep = stepBlock("Build web (Next.js production)");
+  const stepTimeout = /\n\s{8}timeout-minutes:\s*(\d+)\s*\n/.exec(buildStep);
+
+  assert.ok(stepTimeout, "Build web (Next.js production) must carry a step-level timeout-minutes");
+  const minutes = Number(stepTimeout[1]);
+  // Healthy PR builds run 3-4m against a documented 8-10m expectation. Below that
+  // ceiling the bound would fail honest cold compiles; far above it, it stops
+  // being fail-fast and the job cap does the work again.
+  assert.ok(minutes >= 12 && minutes < 45, `step timeout ${minutes}m must sit between the healthy ceiling and the 45m job cap`);
 });

--- a/scripts/merge-readiness-policy.mjs
+++ b/scripts/merge-readiness-policy.mjs
@@ -9,11 +9,29 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 export const DEFAULT_MANIFEST = resolve(ROOT, "config/merge-readiness-policy.json");
 const TERMINAL_SUCCESS = new Set(["success", "skipped"]);
 
+/**
+ * BI-F75AADB7: `cancelled` is the least self-explanatory conclusion GitHub
+ * reports here, and it is also the one that reads as a second, unrelated
+ * failure — a hung Production Build that burns its job cap surfaces to the
+ * operator only as "build concluded cancelled" while every other dependency
+ * succeeded. The conclusion alone does not distinguish a timeout from a queue
+ * eviction or a human cancel, and a cancelled job keeps no retrievable log, so
+ * name the likely causes in the annotation rather than leaving the reader to
+ * rediscover them.
+ */
+function failureHint(result) {
+  return result === "cancelled"
+    ? " — a cancelled job is a timeout (the job cap, not a step bound), a queue eviction, or a manual cancel; its log is not retrievable, so check the job's step durations for the step that never completed"
+    : "";
+}
+
 export function evaluateDependencyResults(needs) {
   const failures = [];
   for (const [jobId, value] of Object.entries(needs ?? {})) {
     const result = typeof value === "string" ? value : value?.result;
-    if (!TERMINAL_SUCCESS.has(result)) failures.push({ jobId, result: result ?? "missing" });
+    if (!TERMINAL_SUCCESS.has(result)) {
+      failures.push({ jobId, result: result ?? "missing", hint: failureHint(result) });
+    }
   }
   return { ok: failures.length === 0, failures };
 }
@@ -160,7 +178,9 @@ function main() {
   if (command === "evaluate-needs") {
     const result = evaluateDependencyResults(JSON.parse(process.env.NEEDS_JSON ?? "{}"));
     if (!result.ok) {
-      for (const failure of result.failures) console.error(`::error::${failure.jobId} concluded ${failure.result}`);
+      for (const failure of result.failures) {
+        console.error(`::error::${failure.jobId} concluded ${failure.result}${failure.hint ?? ""}`);
+      }
       process.exitCode = 1;
     }
     return;

--- a/scripts/merge-readiness-policy.test.mjs
+++ b/scripts/merge-readiness-policy.test.mjs
@@ -8,6 +8,8 @@ import {
   validateWorkflowConformance,
 } from "./merge-readiness-policy.mjs";
 
+const CANCELLED_HINT = evaluateDependencyResults({ j: { result: "cancelled" } }).failures[0].hint;
+
 const manifest = {
   requiredContexts: ["Merge Readiness", "UX Route Budget Sweep", "DCO"],
   strict: false,
@@ -31,10 +33,22 @@ test("dependency evaluator accepts only success and intentional skips", () => {
   }), {
     ok: false,
     failures: [
-      { jobId: "build", result: "failure" },
-      { jobId: "cancelled", result: "cancelled" },
+      { jobId: "build", result: "failure", hint: "" },
+      { jobId: "cancelled", result: "cancelled", hint: CANCELLED_HINT },
     ],
   });
+});
+
+test("a cancelled dependency names its likely causes (BI-F75AADB7)", () => {
+  // "build concluded cancelled" alone reads as a second, unrelated failure and
+  // gives no hint that the cause was a timeout rather than a queue eviction or a
+  // user cancel — and a cancelled job keeps no retrievable log to check.
+  const { failures } = evaluateDependencyResults({ build: { result: "cancelled" } });
+  assert.match(failures[0].hint, /timeout/);
+  assert.match(failures[0].hint, /queue eviction/);
+  assert.match(failures[0].hint, /log is not retrievable/);
+  // Ordinary failures carry their own log, so they get no extra prose.
+  assert.equal(evaluateDependencyResults({ build: { result: "failure" } }).failures[0].hint, "");
 });
 
 test("workflow conformance requires complete aggregate coverage and merge-group triggers", () => {


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` caps the Production Build **job** at 45 minutes but leaves the `Build web (Next.js production)` **step** unbounded. When that step hangs, the job burns the full budget.

Measured on #3984, job 92139777135 — twice, deterministically:

```
Set up job ............. 21:37:32 -> 21:37:33
Setup pnpm with cache .. 21:37:38 -> 21:39:12
Generate Prisma client . 21:39:12 -> 21:39:23
Cache Turbopack ........ 21:39:23 -> 21:39:26
Build web (Next.js) .... 21:39:26 -> (never completed)
job cancelled .......... 22:32:32     conclusion=cancelled
```

~53 minutes in one step; `gh pr checks` reported 55m1s wall. For contrast, every healthy `pull_request` Production Build that day on the same config finished in 3–4 minutes (jobs 92150247299, 92149543816, 92146646376, 92146173170, 92143330556, 92142557645), against the 8–10m expectation the workflow comment itself documents.

The cost is not only runner time:

- the job ends `conclusion=cancelled` rather than `failure`, and `gh run view --job <id> --log` returns "log not found" for a cancelled job — so the hang is **undiagnosable after the fact**;
- it cascades: Merge Readiness fails with `build concluded cancelled` even though every other dependency succeeded, which reads as a second, unrelated failure.

## Change

**Inner bound on the compile step.** `timeout-minutes: 15` on `Build web (Next.js production)` — near the healthy ceiling, so a hang trips it while an honest cold compile does not. The step fails fast, the job ends in a real `failure`, and the step log is **retained**. The 45m job cap stays as the outer backstop; this is an inner bound, not a replacement. The step's own `[production-build]` echo now reports `timeout=15m/step 45m/job`.

**Cancellation cause in Merge Readiness.** `evaluateDependencyResults` attaches a hint to a `cancelled` dependency naming the candidates (job-cap timeout / queue eviction / manual cancel) and noting its log is not retrievable, instead of printing the bare conclusion. Ordinary `failure` results keep their own log and get no extra prose.

## Verification

Functional, not structural — the new guard in `scripts/check-ci-build-cache.test.mjs` asserts the step carries a `timeout-minutes` between the healthy ceiling and the job cap. Verified it **fails** with the timeout removed:

```
✖ the production compile fails fast on its own step timeout (BI-F75AADB7)
  AssertionError: Build web (Next.js production) must carry a step-level timeout-minutes
```

and passes with it. Local-CI pregate: `gate passed`. 34 preflight guards clean.

Refs: BI-57582F89 (the 45m job cap + merge_group Turbopack cache disable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)