### PR TITLE
fix(db): stop catalog reconcile trusting a source hash to vouch for row state (BI-E552BB73)

### DIFF
--- a/packages/db/scripts/reconcile-catalog-capabilities.test.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.test.ts
@@ -59,6 +59,51 @@ describe("diffExcludingOverrides", () => {
     const diff = diffExcludingOverrides(profile as any, entry as any, null);
     expect(diff).toEqual({});
   });
+
+  // BI-E552BB73. A nulled capability inside the blob must register as drift.
+  // The routing hard filter drops any endpoint whose capabilities.streaming is
+  // not exactly `true` on a sync call, so this specific divergence silently made
+  // all 8 zai-coding models unroutable and left the Build Studio plan phase with
+  // no eligible provider.
+  it("detects a nulled capability inside the capabilities blob", () => {
+    const profile = {
+      capabilities: { ...EMPTY_CAPABILITIES, toolUse: true, streaming: null },
+    };
+    const entry = {
+      capabilities: { ...EMPTY_CAPABILITIES, toolUse: true, streaming: true },
+    };
+    const diff = diffExcludingOverrides(profile as any, entry as any, null);
+    expect(diff).toHaveProperty("capabilities");
+    expect((diff.capabilities as Record<string, unknown>).streaming).toBe(true);
+  });
+
+  // Postgres jsonb re-orders object keys on write (by length, then bytewise), so
+  // the stored blob never comes back in the source order of the catalog literal.
+  // Comparing raw JSON.stringify would therefore report `capabilities` as changed
+  // on EVERY run and write a changelog entry at every boot. Compare canonically.
+  it("does not report drift when only key order differs (jsonb round-trip)", () => {
+    const profile = {
+      capabilities: { streaming: true, toolUse: true, thinking: false },
+    };
+    const entry = {
+      capabilities: { toolUse: true, thinking: false, streaming: true },
+    };
+    const diff = diffExcludingOverrides(profile as any, entry as any, null);
+    expect(diff).toEqual({});
+  });
+
+  it("still honours capabilityOverrides for a drifted capabilities blob", () => {
+    const profile = {
+      capabilities: { ...EMPTY_CAPABILITIES, streaming: null },
+    };
+    const entry = {
+      capabilities: { ...EMPTY_CAPABILITIES, streaming: true },
+    };
+    const diff = diffExcludingOverrides(profile as any, entry as any, {
+      capabilities: true,
+    });
+    expect(diff).toEqual({});
+  });
 });
 
 describe("catalogEntryToProfileFields", () => {

--- a/packages/db/scripts/reconcile-catalog-capabilities.ts
+++ b/packages/db/scripts/reconcile-catalog-capabilities.ts
@@ -135,8 +135,13 @@ export function diffExcludingOverrides(
   const diff: Record<string, unknown> = {};
   for (const key of Object.keys(incoming)) {
     if (overrides && key in overrides) continue; // admin-pinned field
-    const currentVal = JSON.stringify(current[key] ?? null);
-    const incomingVal = JSON.stringify(incoming[key] ?? null);
+    // Compare canonically. `capabilities` round-trips through Postgres jsonb,
+    // which re-orders keys (by length, then bytewise), so a plain
+    // JSON.stringify of the stored blob never matches the source order of the
+    // catalog literal. Without sorting, that field would report as changed on
+    // every single run and write a changelog entry each boot.
+    const currentVal = JSON.stringify(sortedJson(current[key] ?? null));
+    const incomingVal = JSON.stringify(sortedJson(incoming[key] ?? null));
     if (currentVal !== incomingVal) {
       diff[key] = incoming[key];
     }
@@ -292,11 +297,26 @@ async function reconcile(): Promise<void> {
         continue;
       }
 
-      // Hash match — no change needed
-      if (profile.catalogHash === hash) {
-        noChange++;
-        continue;
-      }
+      // NOTE: catalogHash is deliberately NOT used to skip the comparison below.
+      // It hashes the catalog ENTRY (the source), so a match only proves the
+      // catalog has not changed since we last wrote — it says nothing about
+      // whether the profile ROW still matches it. Anything that mutates the row
+      // afterwards (metadata-sync, an activation eval, an admin edit, a manual
+      // repair) leaves the hash matching while the row has drifted, and the old
+      // short-circuit then reported "unchanged" forever without ever comparing a
+      // field.
+      //
+      // That is not hypothetical: every zai-coding profile sat with
+      // capabilities.streaming = null while the catalog declared `true`. The
+      // routing hard filter drops any endpoint without streaming === true on a
+      // sync call, so all 8 models were silently unroutable and the Build Studio
+      // plan phase had no eligible provider at all — while reconcile logged
+      // "12 unchanged, 0 updated" at every boot (BI-E552BB73).
+      //
+      // The row is already fetched with every managed field selected, so the
+      // diff below costs no extra query. The hash is still written, and is still
+      // useful as a provenance marker, but it can no longer vouch for state it
+      // does not describe.
 
       // Compute what changed, excluding admin-pinned fields
       const overrides = profile.capabilityOverrides as Record<string, unknown> | null;


### PR DESCRIPTION
Closes BI-E552BB73.

## The bug

`catalogHash` hashes the catalog **entry**. The reconcile loop used it as a short-circuit:

```js
// Hash match — no change needed
if (profile.catalogHash === hash) { noChange++; continue; }
```

A hash match only proves *the catalog* hasn't changed since we last wrote. It says nothing about whether the profile **row** still matches it. Anything that mutates the row afterwards — metadata-sync, an activation eval, an admin edit, a manual repair — leaves the hash matching while the row has drifted. Reconcile then reports `unchanged` forever, without ever comparing a single field. A cache key on the *source*, used to skip verifying the *destination*.

## What it cost

Every `zai-coding` profile sat with `capabilities.streaming = null` while `ZAI_GLM_CORE_CAPABILITIES` declares `streaming: true`.

`getExclusionReasonV2` drops any endpoint whose `capabilities.streaming !== true` on a sync call. So all 8 models were silently unroutable, and the Build Studio **`plan` phase had no eligible provider at all** — while boot logged `Catalog reconciliation: 0 created, 0 updated, 0 skipped, 12 unchanged, 0 failed` every single time.

`glm-5.2` scores 90/94/88 and clears the `frontier` floor comfortably. It was excluded purely on the null flag. Correcting that one field took `resolve_model_selection` from a hard `no-eligible-endpoint` error to selecting `zai-coding/glm-5.2`, and the install from **5/5 build phases dead → 5/5 resolving, zero flags**.

Same failure shape as the nomic-embed `modelClass` defect (#3977): an unset capability produces a silent routing exclusion with no operator-visible signal.

## Fix

**1. Always compute the diff.** The row is already fetched with every managed field selected, so this costs no extra query — the hash was only saving an in-memory comparison, at the cost of correctness. The hash is still written and still useful as a provenance marker; it just can no longer vouch for state it doesn't describe.

**2. Compare canonically** via the existing `sortedJson` helper. `capabilities` round-trips through Postgres jsonb, which re-orders keys (by length, then bytewise), so the stored blob never returns in the source order of the catalog literal. Without sorting, fix 1 would report `capabilities` as changed on *every* run and write a changelog entry at every boot — trading a silent false negative for noisy false positives.

## Tests

26 pass. Three new cases:

- a nulled capability inside the blob registers as drift
- key-order-only differences do **not** (the jsonb round-trip case) — **verified failing without fix 2**
- `capabilityOverrides` still protects a drifted blob

## Noted, not fixed here

`has_hash` is 0 for most providers, so only rows that had ever been hashed were affected — `zai-coding` had exactly 1 (glm-5.2), which is precisely the model the short-circuit silenced.

Separately: reconcile only iterates `KNOWN_PROVIDER_MODELS`, so profiles present in the DB but absent from the catalog are never visited and keep seed defaults (55/55/55, `streaming: null`) indefinitely. That's how the other 7 zai-coding models ended up null. Out of scope here — say the word and I'll file it.

The local pregate is SIGTERM-killed by host memory pressure (DMR holds a 20.6GiB model resident). Verified directly: `packages/db` `tsc --noEmit` clean, 26/26 tests pass. Pushed under `operator-emergency`; **CI is authoritative**.