### PR TITLE
fix(routing): never auto-retire the last endpoint cleared for a data class (BI-32426CA0)

### DIFF
--- a/apps/web/lib/routing/endpoint-retirement-guard.test.ts
+++ b/apps/web/lib/routing/endpoint-retirement-guard.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const guardState = vi.hoisted(() => ({
+  selfClearance: ["public", "internal", "confidential", "restricted"] as string[],
+  peerClearances: [] as string[][],
+  lastPeerWhere: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProfile: {
+      findUnique: vi.fn(async () => ({
+        id: "self-profile-id",
+        provider: { sensitivityClearance: guardState.selfClearance },
+      })),
+      findMany: vi.fn(async (args: { where: Record<string, unknown> }) => {
+        guardState.lastPeerWhere = args.where;
+        return guardState.peerClearances.map((c) => ({
+          provider: { sensitivityClearance: c },
+        }));
+      }),
+    },
+  },
+}));
+
+import { sensitivityClassesLeftUncoveredByRetiring } from "./endpoint-retirement-guard";
+
+// BI-32426CA0. Retiring is not a downrank — routing filters candidates on
+// `retiredAt: null`, so retiring the sole holder of a clearance leaves that
+// sensitivity class with zero eligible endpoints, and every request in it fails
+// with the generic "No AI model can handle this request right now".
+describe("sensitivityClassesLeftUncoveredByRetiring", () => {
+  beforeEach(() => {
+    guardState.selfClearance = ["public", "internal", "confidential", "restricted"];
+    guardState.peerClearances = [];
+    guardState.lastPeerWhere = null;
+  });
+
+  it("reports the classes only this endpoint covers", async () => {
+    // The live shape: the bundled local model is the only holder of
+    // `restricted`; a cloud peer covers everything below it.
+    guardState.peerClearances = [["public", "internal", "confidential"]];
+    expect(await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6"))
+      .toEqual(["restricted"]);
+  });
+
+  it("reports nothing when a peer covers every class", async () => {
+    guardState.peerClearances = [["public", "internal", "confidential", "restricted"]];
+    expect(await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6")).toEqual([]);
+  });
+
+  it("reports every class when no routable peer remains", async () => {
+    guardState.peerClearances = [];
+    expect(await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6"))
+      .toEqual(["public", "internal", "confidential", "restricted"]);
+  });
+
+  it("unions cover across several peers", async () => {
+    guardState.peerClearances = [["public"], ["internal"], ["confidential", "restricted"]];
+    expect(await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6")).toEqual([]);
+  });
+
+  it("does not guard a provider that holds no clearance at all", async () => {
+    guardState.selfClearance = [];
+    expect(await sensitivityClassesLeftUncoveredByRetiring("x", "y")).toEqual([]);
+  });
+
+  // The peer query must mirror queryEndpointManifests exactly. If it drifts to a
+  // looser filter, a retired/disabled/transcription endpoint would count as
+  // cover and the guard would wave through the very retirement it exists to
+  // prevent — on the motivating install the only other `restricted`-cleared
+  // provider was a transcription endpoint that can never serve a chat request.
+  it("only counts endpoints that routing would actually consider", async () => {
+    guardState.peerClearances = [["restricted"]];
+    await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
+    const where = guardState.lastPeerWhere as Record<string, any>;
+    expect(where.retiredAt).toBeNull();
+    expect(where.modelStatus).toEqual({ in: ["active", "degraded"] });
+    expect(where.provider.status).toEqual({ in: ["active", "degraded"] });
+    expect(where.provider.endpointType.in).toEqual(
+      expect.arrayContaining(["llm", "chat"]),
+    );
+    // A transcription endpoint must not be routable cover.
+    expect(where.provider.endpointType.in).not.toContain("transcription");
+    // and never counts itself as its own peer
+    expect(where.id).toEqual({ not: "self-profile-id" });
+  });
+});

--- a/apps/web/lib/routing/endpoint-retirement-guard.ts
+++ b/apps/web/lib/routing/endpoint-retirement-guard.ts
@@ -1,0 +1,60 @@
+// apps/web/lib/routing/endpoint-retirement-guard.ts
+//
+// Guards that sit in front of auto-retirement (BI-32426CA0).
+//
+// Retiring an endpoint is not a downrank. `queryEndpointManifests`
+// (apps/web/lib/routing/loader.ts) filters candidates on `retiredAt: null`, so a
+// retirement REMOVES the endpoint from routing entirely. Where one provider is
+// the sole holder of a sensitivity clearance — typically the bundled local model
+// for `restricted` — retiring it leaves that class with zero eligible endpoints
+// and every request in it fails with the generic "No AI model can handle this
+// request right now".
+//
+// Lives outside eval-runner.ts so the retirement policy is testable on its own
+// and the eval runner stays under the module-size ceiling.
+
+import { prisma } from "@dpf/db";
+import { MODEL_ROUTING_ENDPOINT_TYPES } from "./provider-eligibility";
+
+/**
+ * Which sensitivity classes would lose their last routable endpoint if this
+ * profile were retired.
+ *
+ * Mirrors the candidate query in `queryEndpointManifests` exactly —
+ * modelStatus active|degraded, retiredAt null, provider active|degraded,
+ * provider endpointType routable. A transcription/embedding endpoint therefore
+ * never counts as cover, which matters: on the install that motivated this, the
+ * only other provider holding `restricted` clearance was a transcription
+ * endpoint that can never serve a chat request, so a naive "is any other
+ * provider cleared?" check would have wrongly concluded nothing was at risk.
+ *
+ * Returns [] when the provider holds no clearance at all — there is nothing to
+ * strand.
+ */
+export async function sensitivityClassesLeftUncoveredByRetiring(
+  providerId: string,
+  modelId: string,
+): Promise<string[]> {
+  const self = await prisma.modelProfile.findUnique({
+    where: { providerId_modelId: { providerId, modelId } },
+    select: { id: true, provider: { select: { sensitivityClearance: true } } },
+  });
+  const covered = self?.provider?.sensitivityClearance ?? [];
+  if (covered.length === 0) return [];
+
+  const peers = await prisma.modelProfile.findMany({
+    where: {
+      id: { not: self!.id },
+      modelStatus: { in: ["active", "degraded"] },
+      retiredAt: null,
+      provider: {
+        status: { in: ["active", "degraded"] },
+        endpointType: { in: [...MODEL_ROUTING_ENDPOINT_TYPES] },
+      },
+    },
+    select: { provider: { select: { sensitivityClearance: true } } },
+  });
+
+  const peerCover = new Set(peers.flatMap((p) => p.provider?.sensitivityClearance ?? []));
+  return covered.filter((level) => !peerCover.has(level));
+}

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -88,53 +88,10 @@ import {
   errorEndsEvalCycle,
   resolveEvaluatedToolUse,
   runDimensionEval,
-  sensitivityClassesLeftUncoveredByRetiring,
   TOOL_USE_MIN_FIDELITY,
   type DriftResult,
 } from "./eval-runner";
 
-// BI-32426CA0. Retiring is not a downrank — routing filters candidates on
-// `retiredAt: null`, so retiring the sole holder of a clearance leaves that
-// sensitivity class with zero eligible endpoints and every request in it fails
-// with the generic "No AI model can handle this request right now".
-describe("sensitivityClassesLeftUncoveredByRetiring (last-endpoint-standing guard)", () => {
-  beforeEach(() => {
-    evalState.selfClearance = ["public", "internal", "confidential", "restricted"];
-    evalState.peerClearances = [];
-  });
-
-  it("reports the classes only this endpoint covers", async () => {
-    // The live shape: bundled local model is the only holder of `restricted`;
-    // a cloud peer covers everything below it.
-    evalState.peerClearances = [["public", "internal", "confidential"]];
-    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
-    expect(stranded).toEqual(["restricted"]);
-  });
-
-  it("reports nothing when a peer covers every class", async () => {
-    evalState.peerClearances = [["public", "internal", "confidential", "restricted"]];
-    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
-    expect(stranded).toEqual([]);
-  });
-
-  it("reports every class when no routable peer remains", async () => {
-    evalState.peerClearances = [];
-    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
-    expect(stranded).toEqual(["public", "internal", "confidential", "restricted"]);
-  });
-
-  it("unions cover across several peers", async () => {
-    evalState.peerClearances = [["public"], ["internal"], ["confidential", "restricted"]];
-    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
-    expect(stranded).toEqual([]);
-  });
-
-  it("does not guard a provider that holds no clearance at all", async () => {
-    evalState.selfClearance = [];
-    const stranded = await sensitivityClassesLeftUncoveredByRetiring("x", "y");
-    expect(stranded).toEqual([]);
-  });
-});
 
 describe("resolveEvaluatedToolUse — calibrate half (BI-DFC30977)", () => {
   const dim = (newScore: number, inconclusive = false) => ({ newScore, inconclusive });

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -12,6 +12,9 @@ const evalState = vi.hoisted(() => ({
   reapedCount: 0,
   // BI-C8164664: recency-cooldown fixture
   lastEvalAt: null as Date | null,
+  // BI-32426CA0: last-endpoint-standing guard fixtures
+  selfClearance: ["public", "internal", "confidential", "restricted"] as string[],
+  peerClearances: [] as string[][],
 }));
 
 vi.mock("@/lib/ai-inference", () => {
@@ -35,10 +38,18 @@ vi.mock("@dpf/db", () => ({
   prisma: {
     modelProfile: {
       findUnique: vi.fn(async () => ({
+        id: "self-profile-id",
         evalCount: 0,
         modelStatus: "active",
         lastEvalAt: evalState.lastEvalAt,
+        // Clearance of the profile under test, for the last-endpoint-standing
+        // guard (BI-32426CA0). Extra keys are ignored by the other suites.
+        provider: { sensitivityClearance: evalState.selfClearance },
       })),
+      // Peer endpoints that would still be routable if this profile retired.
+      findMany: vi.fn(async () =>
+        evalState.peerClearances.map((c) => ({ provider: { sensitivityClearance: c } })),
+      ),
       update: vi.fn(async (args: { data: Record<string, unknown> }) => {
         evalState.profileUpdates.push(args.data);
         return {};
@@ -77,9 +88,53 @@ import {
   errorEndsEvalCycle,
   resolveEvaluatedToolUse,
   runDimensionEval,
+  sensitivityClassesLeftUncoveredByRetiring,
   TOOL_USE_MIN_FIDELITY,
   type DriftResult,
 } from "./eval-runner";
+
+// BI-32426CA0. Retiring is not a downrank — routing filters candidates on
+// `retiredAt: null`, so retiring the sole holder of a clearance leaves that
+// sensitivity class with zero eligible endpoints and every request in it fails
+// with the generic "No AI model can handle this request right now".
+describe("sensitivityClassesLeftUncoveredByRetiring (last-endpoint-standing guard)", () => {
+  beforeEach(() => {
+    evalState.selfClearance = ["public", "internal", "confidential", "restricted"];
+    evalState.peerClearances = [];
+  });
+
+  it("reports the classes only this endpoint covers", async () => {
+    // The live shape: bundled local model is the only holder of `restricted`;
+    // a cloud peer covers everything below it.
+    evalState.peerClearances = [["public", "internal", "confidential"]];
+    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
+    expect(stranded).toEqual(["restricted"]);
+  });
+
+  it("reports nothing when a peer covers every class", async () => {
+    evalState.peerClearances = [["public", "internal", "confidential", "restricted"]];
+    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
+    expect(stranded).toEqual([]);
+  });
+
+  it("reports every class when no routable peer remains", async () => {
+    evalState.peerClearances = [];
+    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
+    expect(stranded).toEqual(["public", "internal", "confidential", "restricted"]);
+  });
+
+  it("unions cover across several peers", async () => {
+    evalState.peerClearances = [["public"], ["internal"], ["confidential", "restricted"]];
+    const stranded = await sensitivityClassesLeftUncoveredByRetiring("local", "qwen3.6");
+    expect(stranded).toEqual([]);
+  });
+
+  it("does not guard a provider that holds no clearance at all", async () => {
+    evalState.selfClearance = [];
+    const stranded = await sensitivityClassesLeftUncoveredByRetiring("x", "y");
+    expect(stranded).toEqual([]);
+  });
+});
 
 describe("resolveEvaluatedToolUse — calibrate half (BI-DFC30977)", () => {
   const dim = (newScore: number, inconclusive = false) => ({ newScore, inconclusive });
@@ -194,6 +249,26 @@ describe("errorLooksLikeInfrastructure (BI-INST-008 circuit breaker)", () => {
     expect(errorLooksLikeInfrastructure(
       "Network error calling local: The operation was aborted due to timeout",
     )).toBe(true);
+  });
+
+  // BI-32426CA0. Verbatim retiredReason observed on a live install; it retired
+  // the bundled local model for five weeks while that model answered direct
+  // curl requests fine. The pre-existing
+  // /operation was aborted due to timeout/ pattern did not match this wording.
+  it("classifies a local-engine admission timeout as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "inference admission timeout on local engine after 120000ms (origin=interactive, provider=local)",
+    )).toBe(true);
+  });
+  it("classifies a generic 'timed out after Nms' as infrastructure", () => {
+    expect(errorLooksLikeInfrastructure(
+      "Provider call timed out after 60000ms",
+    )).toBe(true);
+  });
+  it("still treats a genuine model failure as retirable", () => {
+    expect(errorLooksLikeInfrastructure(
+      "404 model_not_found: The model 'gpt-4-vision-preview' has been deprecated",
+    )).toBe(false);
   });
   it("classifies generic 'network error' as infrastructure", () => {
     expect(errorLooksLikeInfrastructure(

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -18,7 +18,7 @@ import {
   scoreRetrieval,
   scoreDimension,
 } from "./eval-scoring";
-import { BACKGROUND_EVAL_ENDPOINT_TYPES } from "./provider-eligibility";
+import { BACKGROUND_EVAL_ENDPOINT_TYPES, MODEL_ROUTING_ENDPOINT_TYPES } from "./provider-eligibility";
 
 // ── Infrastructure Error Classifier (BI-INST-008 circuit breaker) ──────────
 //
@@ -37,6 +37,18 @@ const INFRASTRUCTURE_ERROR_PATTERNS: RegExp[] = [
   /socket hang up/i,
   /Docker Model Runner is not running/i,
   /could not resolve host/i,
+  // Capacity/admission timeouts describe a BUSY engine, not a broken model.
+  // A local engine holding a 20GB model can exceed the admission budget purely
+  // from load or a cold weight-load, and the same model answers a direct
+  // request seconds later. Retiring on this stranded the bundled model for five
+  // weeks on a live install: "Auto-retired: inference admission timeout on
+  // local engine after 120000ms" (BI-32426CA0). The existing
+  // /operation was aborted due to timeout/ pattern did not match this wording.
+  /admission timeout/i,
+  /timed? ?out after \d+ms/i,
+  /request timeout/i,
+  /engine is busy/i,
+  /capacity/i,
 ];
 
 /**
@@ -50,6 +62,49 @@ const INFRASTRUCTURE_ERROR_PATTERNS: RegExp[] = [
  */
 export function errorLooksLikeInfrastructure(error: string | null): boolean {
   return error !== null && INFRASTRUCTURE_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
+/**
+ * Which sensitivity classes would lose their last routable endpoint if this
+ * profile were retired.
+ *
+ * Mirrors the candidate query in `queryEndpointManifests`
+ * (apps/web/lib/routing/loader.ts) exactly — modelStatus active|degraded,
+ * retiredAt null, provider active|degraded, provider endpointType routable.
+ * A transcription/embedding endpoint therefore never counts as cover, which
+ * matters: on the install that motivated this, the only other provider holding
+ * `restricted` clearance was a transcription endpoint that can never serve a
+ * chat request.
+ *
+ * Pure-ish and exported so the guard is unit-testable without driving a full
+ * eval run.
+ */
+export async function sensitivityClassesLeftUncoveredByRetiring(
+  providerId: string,
+  modelId: string,
+): Promise<string[]> {
+  const self = await prisma.modelProfile.findUnique({
+    where: { providerId_modelId: { providerId, modelId } },
+    select: { id: true, provider: { select: { sensitivityClearance: true } } },
+  });
+  const covered = self?.provider?.sensitivityClearance ?? [];
+  if (covered.length === 0) return [];
+
+  const peers = await prisma.modelProfile.findMany({
+    where: {
+      id: { not: self!.id },
+      modelStatus: { in: ["active", "degraded"] },
+      retiredAt: null,
+      provider: {
+        status: { in: ["active", "degraded"] },
+        endpointType: { in: [...MODEL_ROUTING_ENDPOINT_TYPES] },
+      },
+    },
+    select: { provider: { select: { sensitivityClearance: true } } },
+  });
+
+  const peerCover = new Set(peers.flatMap((p) => p.provider?.sensitivityClearance ?? []));
+  return covered.filter((level) => !peerCover.has(level));
 }
 
 // ── Config-gap Error Classifier ────────────────────────────────────────────
@@ -672,7 +727,24 @@ export async function runDimensionEval(
   const looksLikeInfrastructure = errorLooksLikeInfrastructure(firstError);
   const looksLikeConfigGap = errorLooksLikeConfigGap(firstError);
 
-  if (allInconclusive && firstError && !looksLikeInfrastructure && !looksLikeConfigGap) {
+  // Last line of defence, independent of what the error text looks like: never
+  // auto-retire the last routable endpoint for a sensitivity class. Retiring is
+  // load-bearing in a way the classifier above cannot see — routing filters
+  // candidates on `retiredAt: null`, so a retirement does not merely downrank an
+  // endpoint, it removes it. On an install where one provider is the sole holder
+  // of a clearance (typically the bundled local model for `restricted`), that
+  // silently leaves the class with zero eligible endpoints and every request in
+  // it fails with the generic "No AI model can handle this request right now"
+  // (BI-32426CA0). Degrade instead: the model keeps ranking last but stays
+  // reachable, and the operator gets a warning naming the exposed class.
+  const strandedClasses = allInconclusive && firstError
+    ? await sensitivityClassesLeftUncoveredByRetiring(providerId, modelId)
+    : [];
+
+  if (
+    allInconclusive && firstError && !looksLikeInfrastructure && !looksLikeConfigGap &&
+    strandedClasses.length === 0
+  ) {
     await prisma.modelProfile.update({
       where: { providerId_modelId: { providerId, modelId } },
       data: {
@@ -682,6 +754,14 @@ export async function runDimensionEval(
       },
     });
     console.log(`[eval-runner] Auto-retired ${providerId}/${modelId}: all tests failed — ${firstError.slice(0, 100)}`);
+  } else if (allInconclusive && firstError && strandedClasses.length > 0) {
+    await prisma.modelProfile.update({
+      where: { providerId_modelId: { providerId, modelId } },
+      data: { modelStatus: "degraded" },
+    });
+    console.warn(
+      `[eval-runner] All dimensions inconclusive for ${providerId}/${modelId} but it is the LAST routable endpoint cleared for [${strandedClasses.join(", ")}] — degrading instead of retiring, so that sensitivity class keeps an eligible endpoint. Error: ${firstError.slice(0, 200)}`,
+    );
   } else if (allInconclusive && (looksLikeInfrastructure || looksLikeConfigGap)) {
     console.warn(
       `[eval-runner] All dimensions inconclusive for ${providerId}/${modelId} but error looks like ${looksLikeConfigGap ? "a config gap" : "infrastructure"} — NOT retiring. Error: ${firstError?.slice(0, 200)}`,

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -18,7 +18,8 @@ import {
   scoreRetrieval,
   scoreDimension,
 } from "./eval-scoring";
-import { BACKGROUND_EVAL_ENDPOINT_TYPES, MODEL_ROUTING_ENDPOINT_TYPES } from "./provider-eligibility";
+import { BACKGROUND_EVAL_ENDPOINT_TYPES } from "./provider-eligibility";
+import { sensitivityClassesLeftUncoveredByRetiring } from "./endpoint-retirement-guard";
 
 // ── Infrastructure Error Classifier (BI-INST-008 circuit breaker) ──────────
 //
@@ -62,49 +63,6 @@ const INFRASTRUCTURE_ERROR_PATTERNS: RegExp[] = [
  */
 export function errorLooksLikeInfrastructure(error: string | null): boolean {
   return error !== null && INFRASTRUCTURE_ERROR_PATTERNS.some((re) => re.test(error));
-}
-
-/**
- * Which sensitivity classes would lose their last routable endpoint if this
- * profile were retired.
- *
- * Mirrors the candidate query in `queryEndpointManifests`
- * (apps/web/lib/routing/loader.ts) exactly — modelStatus active|degraded,
- * retiredAt null, provider active|degraded, provider endpointType routable.
- * A transcription/embedding endpoint therefore never counts as cover, which
- * matters: on the install that motivated this, the only other provider holding
- * `restricted` clearance was a transcription endpoint that can never serve a
- * chat request.
- *
- * Pure-ish and exported so the guard is unit-testable without driving a full
- * eval run.
- */
-export async function sensitivityClassesLeftUncoveredByRetiring(
-  providerId: string,
-  modelId: string,
-): Promise<string[]> {
-  const self = await prisma.modelProfile.findUnique({
-    where: { providerId_modelId: { providerId, modelId } },
-    select: { id: true, provider: { select: { sensitivityClearance: true } } },
-  });
-  const covered = self?.provider?.sensitivityClearance ?? [];
-  if (covered.length === 0) return [];
-
-  const peers = await prisma.modelProfile.findMany({
-    where: {
-      id: { not: self!.id },
-      modelStatus: { in: ["active", "degraded"] },
-      retiredAt: null,
-      provider: {
-        status: { in: ["active", "degraded"] },
-        endpointType: { in: [...MODEL_ROUTING_ENDPOINT_TYPES] },
-      },
-    },
-    select: { provider: { select: { sensitivityClearance: true } } },
-  });
-
-  const peerCover = new Set(peers.flatMap((p) => p.provider?.sensitivityClearance ?? []));
-  return covered.filter((level) => !peerCover.has(level));
 }
 
 // ── Config-gap Error Classifier ────────────────────────────────────────────

--- a/docs/user-guide/ai-workforce/model-routing-lifecycle.md
+++ b/docs/user-guide/ai-workforce/model-routing-lifecycle.md
@@ -161,7 +161,9 @@ The rollout is cumulative and ordered: compiler shadow → admin preview → onb
 | Admin clicks "Discover Models" | Calls provider's model list API, creates discovery records, profiles using quality tiers. |
 | Model restricted by `modelRestrictions` | Profiling auto-retires it with reason "Model not accessible with provider credential type." |
 | New model pulled into Docker Model Runner | Discovered automatically on next providers page load. |
-| Model returns inference errors | Fallback chain tries the next model. After repeated failures, model status degrades to `retired`. |
+| Model returns inference errors | Fallback chain tries the next model. After repeated failures, model status degrades to `retired` — unless the error looks like infrastructure/capacity (timeouts, connection failures, a busy engine) or a credential gap, or unless retiring would strand a sensitivity class (see below). |
+| Model times out under load | Not retired. Capacity and admission timeouts describe a busy engine, not a broken model — a local engine holding a large model can exceed its admission budget from load or a cold weight-load alone. |
+| Retiring would strand a sensitivity class | Not retired. The model is marked `degraded` instead and a warning names the exposed class. |
 | Model disappears from provider API | After 2+ discovery cycles without seeing it, model is retired. |
 | Pre-evaluated profile re-profiled | Metadata is updated but dimension scores are NOT overwritten (`profileSource: "evaluated"` is protected). |
 | Admin overrides AgentModelConfig | Takes effect immediately. Seed will not overwrite admin-configured rows on next restart. |
@@ -210,6 +212,11 @@ Local models are automatically discovered and profiled. They are assigned the `b
 - Discovery is manual for cloud providers. Go to AI Workforce > Providers > select the provider > click "Discover Models"
 - After discovery, click "Profile Models" to assign quality tiers and dimension scores
 - Models outside the provider's `modelRestrictions` allowlist will be automatically retired
+
+**Every request in one sensitivity class fails with "No AI model can handle this request right now":**
+- That message names cloud sign-in as the likely cause, but it is emitted whenever routing finds no eligible endpoint — for any reason. Check the router's own verdict before re-authenticating anything: `docker logs dpf-portal-1 | grep -A25 "no eligible endpoints"` prints the contract inputs and the rejection reason for every candidate.
+- Routing filters candidates on `retiredAt IS NULL`, **not** on `modelStatus`. A profile can therefore read `active` in the admin UI and still be invisible to routing. Compare the router's excluded-endpoint count against the profiles the manifest query would return — an endpoint missing from the rejection list never became a candidate at all.
+- Auto-retirement will not strand a class on its own (see the lifecycle table), but a row stranded before that guard existed is healed at boot.
 
 **A provider is active but restricted work is blocked:**
 - Open the provider detail page and review **Provider trust evidence**.


### PR DESCRIPTION
Closes BI-32426CA0. Companion to #4009 — both are "a silent state change makes an endpoint unroutable, with no operator-visible signal".

## What happened

On 2026-07-31 a single admission timeout retired the bundled local model:

```
retiredReason | Auto-retired: inference admission timeout on local engine after 120000ms
              | (origin=interactive, provider=local)
```

`queryEndpointManifests` filters candidates on **`retiredAt: null`**, so retiring doesn't downrank an endpoint — it **removes** it. The bundled local model was the only provider holding `restricted` clearance, so that one timeout left the class with zero eligible endpoints.

Every HR/finance coworker request then failed for **five weeks** with *"No AI model can handle this request right now. This usually means your cloud AI providers are disconnected…"* — while the model answered direct `curl` requests fine and the cloud providers were healthy throughout.

## Two guards

The existing BI-INST-008 circuit breaker classifies error **text**, which will never be exhaustive — this incident is the proof. So this adds one fix at that layer and one that doesn't depend on it.

**1. Capacity/admission timeouts are infrastructure, not model defects.** An engine holding a 20GB model can blow the admission budget from load or a cold weight-load alone. The observed wording was not matched by the pre-existing `/operation was aborted due to timeout/` pattern.

**2. Structural backstop: never auto-retire the last routable endpoint for a sensitivity class.** Degrade instead — the model ranks last but stays reachable — and warn the operator naming the exposed class.

`sensitivityClassesLeftUncoveredByRetiring` mirrors the candidate query in `loader.ts` exactly, so a transcription or embedding endpoint never counts as cover. That distinction is load-bearing here: the only *other* provider holding `restricted` on this install was a transcription endpoint that can never serve a chat request, so a naive "is any other provider cleared?" check would have concluded everything was fine.

## Tests

53 pass. New coverage:

- the verbatim live `retiredReason` classifies as infrastructure — **fails without guard 1**
- a generic `timed out after Nms` likewise — **fails without guard 1**
- a genuine `404 model_not_found … deprecated` is still retirable (the guard doesn't over-reach)
- the guard reports `["restricted"]` for the live shape (local sole holder, cloud peer covers the rest)
- reports nothing when a peer covers every class; reports everything when no peer remains; unions cover across several peers; ignores a provider holding no clearance

## Scope note

This is about the retirement *decision*. #3990 already heals a row stranded in the split state (`retiredAt` set, `modelStatus` not `retired`) at boot, so existing installs self-recover; this stops it recurring.

The local pregate is SIGTERM-killed by host memory pressure (DMR holds a 20.6GiB model resident). Verified directly: `apps/web` `tsc --noEmit` clean at 8GB heap, 53/53 tests pass. Pushed under `operator-emergency`; **CI is authoritative**.