### PR TITLE
fix(security): authorize applyBrandDesignSystem (BI-6197FFE3)

### DIFF
--- a/apps/web/lib/actions/apply-brand-design-system.test.ts
+++ b/apps/web/lib/actions/apply-brand-design-system.test.ts
@@ -6,7 +6,14 @@ const mocks = vi.hoisted(() => ({
   organizationUpdate: vi.fn(),
   brandingConfigUpsert: vi.fn(),
   designSystemToThemeTokens: vi.fn(),
+  auth: vi.fn(),
 }));
+
+// applyBrandDesignSystem is capability-guarded (BI-6197FFE3), which pulls
+// next-auth into this module graph. The cases below cover the mapping
+// behaviour behind the guard, so they sign in as a role holding
+// manage_branding; authorization itself has its own describe block.
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -76,13 +83,79 @@ function sampleSystem(overrides?: Partial<BrandDesignSystem>): BrandDesignSystem
   };
 }
 
+/** manage_branding is held by HR-000 only; HR-300 is a capable-but-not-branding role. */
+const BRAND_ADMIN = { user: { id: "u-admin", platformRole: "HR-000", isSuperuser: false } };
+const NON_BRAND_ROLE = { user: { id: "u-arch", platformRole: "HR-300", isSuperuser: false } };
+
+// Regression test for BI-6197FFE3. applyBrandDesignSystem shipped as a "use server"
+// export with NO authorization of any kind — no capability check, no session read, no
+// auth import — while writing Organization.designSystem and BrandingConfig.tokens, the
+// visual identity rendered across the whole portal.
+//
+// The /admin layout enforces view_admin, but a LAYOUT GUARD DOES NOT PROTECT A SERVER
+// ACTION: there is no middleware in apps/web, so the action body runs before any
+// render-time redirect. These cases pin the action's own check.
+//
+// Note the transport asymmetry this closes: manage_branding was already enforced on the
+// equivalent MCP tool path (lib/mcp/packs/public-web-design-pack.ts), so a coworker
+// calling the tool was checked while a direct POST to this action was not.
+describe("applyBrandDesignSystem authorization", () => {
+  beforeEach(() => {
+    mocks.organizationFindUnique.mockReset();
+    mocks.organizationUpdate.mockReset();
+    mocks.brandingConfigUpsert.mockReset();
+    mocks.designSystemToThemeTokens.mockReset();
+    mocks.auth.mockReset();
+    mocks.organizationFindUnique.mockResolvedValue({ designSystem: sampleSystem() });
+    mocks.organizationUpdate.mockResolvedValue({});
+    mocks.brandingConfigUpsert.mockResolvedValue({});
+    mocks.designSystemToThemeTokens.mockReturnValue({ dark: {}, light: {} });
+  });
+
+  // Refusal is REPORTED, not thrown: this action's contract is ApplyResult and its sole
+  // caller checks `result.success` without a try/catch. What matters for the defect is
+  // that neither write happens.
+  it("refuses an unauthenticated caller and writes nothing", async () => {
+    mocks.auth.mockResolvedValue(null);
+
+    const result = await applyBrandDesignSystem("org-1");
+
+    expect(result.success).toBe(false);
+    expect(mocks.organizationUpdate).not.toHaveBeenCalled();
+    expect(mocks.brandingConfigUpsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses a signed-in user who lacks manage_branding and writes nothing", async () => {
+    mocks.auth.mockResolvedValue(NON_BRAND_ROLE);
+
+    const result = await applyBrandDesignSystem("org-1", {
+      palette: { primary: "#000000" },
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(mocks.organizationUpdate).not.toHaveBeenCalled();
+    expect(mocks.brandingConfigUpsert).not.toHaveBeenCalled();
+  });
+
+  it("allows a user holding manage_branding", async () => {
+    mocks.auth.mockResolvedValue(BRAND_ADMIN);
+
+    const result = await applyBrandDesignSystem("org-1");
+
+    expect(result.success).toBe(true);
+    expect(mocks.organizationUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("applyBrandDesignSystem", () => {
   beforeEach(() => {
     mocks.organizationFindUnique.mockReset();
     mocks.organizationUpdate.mockReset();
     mocks.brandingConfigUpsert.mockReset();
     mocks.designSystemToThemeTokens.mockReset();
+    mocks.auth.mockReset();
 
+    mocks.auth.mockResolvedValue(BRAND_ADMIN);
     mocks.organizationUpdate.mockResolvedValue({});
     mocks.brandingConfigUpsert.mockResolvedValue({});
     mocks.designSystemToThemeTokens.mockReturnValue({ dark: { tag: "dark-tokens" }, light: { tag: "light-tokens" } });

--- a/apps/web/lib/actions/apply-brand-design-system.ts
+++ b/apps/web/lib/actions/apply-brand-design-system.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@dpf/db";
 import { isBrandDesignSystem, type BrandDesignSystem } from "@/lib/brand/types";
 import { designSystemToThemeTokens } from "@/lib/brand/apply";
+import { requireCapability } from "@/lib/actions/shared/guards";
 
 export type ApplyResult =
   | { success: true }
@@ -50,6 +51,32 @@ export async function applyBrandDesignSystem(
   organizationId: string,
   overrides?: Partial<Omit<BrandDesignSystem, "version" | "overrides">>,
 ): Promise<ApplyResult> {
+  // Authority check FIRST — this writes the organization's visual identity across the
+  // whole portal (BI-6197FFE3). `manage_branding` is the capability the MCP brand tools
+  // already require (lib/mcp/packs/public-web-design-pack.ts), so this closes a
+  // per-transport gap rather than inventing a new rule: the coworker calling the tool
+  // was checked, a direct POST to this action was not.
+  //
+  // The /admin layout enforces view_admin, but a layout guard does NOT protect a server
+  // action — there is no middleware in apps/web, so the body runs before any
+  // render-time redirect. manage_branding and view_admin are both ["HR-000"], so no
+  // user who can reach the branding page loses the ability to apply.
+  //
+  // `organizationId` stays caller-supplied: every caller passes the single install org
+  // resolved server-side, and with authority now restricted to HR-000 — who can rebrand
+  // the install regardless — narrowing it further buys nothing. Revisit if this action
+  // is ever exposed to a broader role or a multi-org install.
+  //
+  // Returned rather than thrown: every other failure here returns ApplyResult, and the
+  // sole caller (BrandExtractionSection) checks `result.success` without a try/catch, so
+  // throwing would break this module's contract and surface as an unhandled rejection.
+  // The refusal is identical either way — nothing below runs.
+  try {
+    await requireCapability("manage_branding");
+  } catch {
+    return { success: false, error: "You do not have permission to change branding." };
+  }
+
   const org = await prisma.organization.findUnique({
     where: { id: organizationId },
     select: { designSystem: true },


### PR DESCRIPTION
`applyBrandDesignSystem` shipped as a `"use server"` export with **no authorization of any kind** — no capability check, no session read, no auth import at all — while writing `Organization.designSystem` and `BrandingConfig.tokens`, the visual identity rendered across the entire portal. It also accepts `organizationId` as a caller-supplied parameter.

Found by widening the BI-1017777D approval sweep past `approve*`/`reject*` to the full decision-verb set (publish, confirm, authorize, grant, deny, sign, commit, promote, release).

## The transport asymmetry this closes

This is **not** the same defect as the three fixed in #3995. `manage_branding` already existed and was **already enforced on the equivalent MCP tool path**:

- `lib/mcp/packs/public-web-design-pack.ts` declares `requiredCapability: "manage_branding"` on the brand tools (lines 72, 88, 156)
- `lib/tak/agent-routing.ts` gates the branding launchers on it

So an AI coworker invoking the tool was checked, while a direct POST to the server action exposing the same operation was not. The capability wasn't missing — it was applied to one door out of two. That's a new variant worth naming: **a capability enforced on one transport and absent on another.**

The `/admin` layout does enforce `view_admin`, but a layout guard does not protect a server action — there is no middleware in `apps/web`, so the action body runs before any render-time redirect.

## No access regression

`manage_branding` and `view_admin` are both `["HR-000"]`, so every user who can reach `/admin/branding` can still apply.

## Two deliberate calls

**Refusal is returned, not thrown.** Every other failure in this action returns `ApplyResult`, and the sole caller (`BrandExtractionSection`) checks `result.success` without a try/catch — throwing would break the module's contract and surface as an unhandled rejection in a transition. Nothing below the guard runs either way. Same reasoning applied to `research-proposals` in #3995.

**`organizationId` stays caller-supplied.** It is a real smell, but with authority now restricted to HR-000 — who can rebrand the install regardless — narrowing it buys nothing today. Documented in-code with the condition that would change the answer: a broader role, or a multi-org install.

## Verification

- Regression tests written **first** and confirmed red with the **source fix reverted and the tests present** (my first attempt stashed both and proved nothing). Exactly the two authorization cases failed; both assert neither write occurs.
- 7/7 in the affected suite; 1326 passing across `lib/actions` + `lib/brand` with zero test-level failures. The 4 failing suites are pre-existing environmental import errors in this worktree (`react`, `react-dom`, prisma generated client), verified identical before the change — tracked as BI-1C1483C6.
- Local-CI sandbox gate **passed** for `4eeb995fa46`, including `pnpm --filter web typecheck`.

## Still open under BI-6197FFE3

Two candidates deliberately **not** fixed here, because both need the wiki-overlay authorization model read first and may intend an author-not-approver split:

- `wiki-publish.ts` `publishWikiOverlayPages` — `requireUser()` only, then publishes org doctrine and runs `promoteCraftOverrideOnPublish`
- `business-stance.ts` `publishBusinessStance` — authorizes via wrapper at authentication grade, then promotes a confirmed-tier `PerspectiveMaterial` that changes what `evaluate_org_business_decision` allows

🤖 Generated with [Claude Code](https://claude.com/claude-code)