### PR TITLE
fix(mcp): make capture_ux_critique reachable from the surface it exists for

### DIFF
--- a/apps/web/lib/mcp-token-scopes.ts
+++ b/apps/web/lib/mcp-token-scopes.ts
@@ -191,6 +191,14 @@ const DEVELOPMENT_TEMPLATE_GRANTS = [
   "document_read",
   "coworker_catalog_read",
   // Writes / actions for the build-studio + ship loop
+  // `critique_capture` lets an external review session DRAFT a UX critique into
+  // the design corpus (BI-52839DEA). Narrow on purpose: capture originally
+  // required `registry_write`, which this template does not hold, so the tool
+  // was unreachable from the surface it exists for. Granting registry_write
+  // here would have come with eleven other registry tools; this grants exactly
+  // the one capability, and the entry is still only ever agent-proposed —
+  // never calibration-eligible until a founder attaches a verdict in the portal.
+  "critique_capture",
   "backlog_write",
   "backlog_triage",
   "build_promote",

--- a/apps/web/lib/mcp/packs/ux-critique-pack.test.ts
+++ b/apps/web/lib/mcp/packs/ux-critique-pack.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { uxCritiquePack } from "./ux-critique-pack";
+import { TOOL_TO_GRANTS, expandGrants } from "@/lib/tak/agent-grants";
+import { MCP_TOKEN_TEMPLATES } from "@/lib/mcp-token-scopes";
+
+// BI-52839DEA follow-up. The corpus door shipped UNREACHABLE: capture required
+// `registry_write`, which the `development` template — the coding-agent token —
+// does not hold. So an external review session could read the corpus and never
+// feed it, which is the entire capability the pack exists to provide. The tool
+// was present, granted, registered, and dead.
+//
+// These tests pin REACHABILITY, not just registration. A grant entry existing
+// proves nothing if no token a real caller holds can satisfy it.
+
+const developmentGrants = expandGrants([
+  ...(MCP_TOKEN_TEMPLATES.find((t) => t.id === "development")?.grants ?? []),
+]);
+
+describe("ux-critique pack — reachable from the surface it exists for", () => {
+  it("lets a development-template token actually call capture", () => {
+    const required = TOOL_TO_GRANTS.capture_ux_critique;
+    expect(required, "capture_ux_critique must have a gating entry").toBeTruthy();
+    // ANY-of semantics, matching getAvailableTools.
+    expect(
+      required.some((g) => developmentGrants.includes(g)),
+      `capture_ux_critique requires ${JSON.stringify(required)} but the development ` +
+        `token holds none of them — the tool would be silently denied to every ` +
+        `Claude Code / Codex / Grok session, which is the only surface it is for`,
+    ).toBe(true);
+  });
+
+  it("lets a development-template token read the corpus", () => {
+    const required = TOOL_TO_GRANTS.search_ux_critique_corpus;
+    expect(required.some((g) => developmentGrants.includes(g))).toBe(true);
+  });
+
+  it("does not hand coding agents blanket registry write to get there", () => {
+    // The naive fix. `registry_write` would also unlock wiki_ingest,
+    // publish_wiki_overlay_pages, create_knowledge_article, doc_save, doc_link,
+    // doc_state_change, run_discovery_triage, attribute_entity_to_product,
+    // dismiss_entity and resolve_portfolio_quality_issue — eleven tools of
+    // authority to enable one.
+    expect(developmentGrants).not.toContain("registry_write");
+  });
+
+  it("keeps existing broad-authority holders working via one-way implication", () => {
+    // An employee_ea / admin token already holds registry_write and could write
+    // the craft overlay directly, so narrowing must not revoke it.
+    expect(expandGrants(["registry_write"])).toContain("critique_capture");
+    // One-way: the narrow grant never widens back.
+    expect(expandGrants(["critique_capture"])).not.toContain("registry_write");
+  });
+
+  it("mirrors TOOL_TO_GRANTS exactly — the pack must not advertise a grant the gate lacks", () => {
+    for (const [tool, grants] of Object.entries(uxCritiquePack.grants ?? {})) {
+      expect(TOOL_TO_GRANTS[tool], `${tool} missing from TOOL_TO_GRANTS`).toEqual(grants);
+    }
+  });
+});
+
+describe("ux-critique pack — the authority boundary", () => {
+  it("declares capture as side-effecting and search as not", () => {
+    const byName = Object.fromEntries(uxCritiquePack.definitions.map((d) => [d.name, d]));
+    expect(byName.capture_ux_critique.sideEffect).toBe(true);
+    expect(byName.search_ux_critique_corpus.sideEffect).toBe(false);
+  });
+
+  it("never exposes callerKind or verdictAuthority as caller-supplied input", () => {
+    // The correctness boundary: an MCP caller is ALWAYS an agent, so a captured
+    // entry can only ever be agent-proposed. If either became an input, a caller
+    // could author a founder verdict and the judge would be calibrated against
+    // its own output.
+    const capture = uxCritiquePack.definitions.find((d) => d.name === "capture_ux_critique");
+    const props = Object.keys(
+      (capture?.inputSchema as { properties?: Record<string, unknown> })?.properties ?? {},
+    );
+    expect(props).not.toContain("callerKind");
+    expect(props).not.toContain("verdictAuthority");
+    // A verdict may only ever be PROPOSED.
+    expect(props).toContain("proposedVerdict");
+  });
+});

--- a/apps/web/lib/mcp/packs/ux-critique-pack.ts
+++ b/apps/web/lib/mcp/packs/ux-critique-pack.ts
@@ -219,6 +219,16 @@ async function searchUxCritiqueCorpus(
     message,
     data: {
       total: entries.length,
+      // The fail-loud signal lives in DATA, not only in `message`. Verified
+      // 2026-08-04 against the deployed tool: an empty corpus came back as a
+      // bare `{total: 0, entries: []}` because this client surfaces `data` and
+      // drops `message` — so the one sentence that stops a caller treating
+      // silence as "nothing relevant" never arrived. A warning a client can
+      // discard is not a warning.
+      grounding:
+        entries.length > 0
+          ? "grounded"
+          : "UNGROUNDED — no matching critique entries. Any design judgement offered here is not backed by this product's design authority. Say so explicitly rather than asserting a verdict, and capture what you observe so the corpus starts accruing.",
       entries: entries.map(({ page, entry }) => ({
         slug: page.slug,
         title: page.title,
@@ -248,11 +258,13 @@ export const uxCritiquePack: ToolPack = {
   // does not carry is DENIED for every coworker while looking authoritative —
   // the BI-88B77204 failure.
   //
-  // Capture writes a draft WikiPage into the craft overlay, so it takes
-  // `registry_write`, the same scope `record_org_business_answer` uses for the
-  // org corpus. Search is read-only and advisory, like the WWMD/WSID gates.
+  // Capture takes its OWN narrow grant rather than `registry_write`: the
+  // coding-agent (`development`) token holds registry_read but not
+  // registry_write, so shipping on the broad grant made this tool unreachable
+  // from the external review sessions it exists for. Search is read-only and
+  // advisory, like the WWMD/WSID gates.
   grants: {
-    capture_ux_critique: ["registry_write"],
+    capture_ux_critique: ["critique_capture"],
     search_ux_critique_corpus: ["registry_read"],
   },
 };

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -42,6 +42,11 @@ export const GRANT_IMPLICATIONS: Readonly<Record<string, readonly string[]>> = {
   siem_investigate: ["siem_read"],
   siem_tune: ["siem_read"],
   incident_respond: ["siem_read"],
+  // A holder of broad registry write authority can already write the craft
+  // overlay directly, so it implies the narrow critique-capture grant. One-way:
+  // `critique_capture` never implies `registry_write` — that narrowing is the
+  // entire point of splitting it out.
+  registry_write: ["critique_capture"],
 };
 
 /** Expand a list of held grants by applying GRANT_IMPLICATIONS one-way.
@@ -252,14 +257,29 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
 
   // UX critique corpus (BI-52839DEA). Reading past design findings is advisory
   // and read-only, so it matches the decision gates. Capture writes a DRAFT
-  // WikiPage under the craft overlay — the same shape and scope as
-  // `record_org_business_answer` writing into the org corpus.
+  // WikiPage under the craft overlay.
   //
-  // `registry_write` is not authority over the corpus: the pack pins every MCP
+  // `critique_capture` is DELIBERATELY ITS OWN GRANT rather than `registry_write`
+  // (BI-52839DEA follow-up). Capture shipped on `registry_write`, which the
+  // `development` template — the coding-agent token — does not hold, so the tool
+  // was unreachable from the exact surface it was built for: a review happening
+  // in Claude Code / Codex / Grok could read the corpus but never feed it.
+  //
+  // Widening the development template to `registry_write` would have fixed that
+  // by also handing coding agents wiki_ingest, publish_wiki_overlay_pages,
+  // create_knowledge_article, doc_save/doc_link/doc_state_change,
+  // run_discovery_triage, attribute_entity_to_product, dismiss_entity and
+  // resolve_portfolio_quality_issue — eleven tools of authority to enable one.
+  // A narrow per-capability grant is the platform's own pattern here
+  // (browser_read/browser_drive, siem_read/siem_investigate), and it keeps the
+  // authority story honest: a coding agent may draft critique entries, and
+  // nothing else in the registry.
+  //
+  // The grant is not authority over the corpus either: the pack pins every MCP
   // caller to `callerKind: "agent"`, so a captured entry can only ever carry an
   // agent-proposed verdict and is never calibration-eligible. Attaching a
   // founder/designer verdict stays a human act in the portal.
-  capture_ux_critique: ["registry_write"],
+  capture_ux_critique: ["critique_capture"],
   search_ux_critique_corpus: ["registry_read"],
 
   // Org/WWWD qa elicitation feeder (BI-44526F3E Phase C): capture a CONFIRMED

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_at": "2026-04-28",
-  "notes": "Catalog of grant keys referenced by packages/db/data/agent_registry.json. honored_by_tools is empty when no tool in apps/web/lib/mcp-tools.ts (via apps/web/lib/tak/agent-grants.ts TOOL_TO_GRANTS) checks the grant \u2014 those are aspirational grants that do not yet authorize any platform action. The tool-grant audit's GRANT-002 surfaces them as findings; backfill PRs either implement the tool or remove the grant from the registry. Descriptions are heuristic placeholders generated from the grant key \u2014 refine by hand during reconciliation.",
+  "notes": "Catalog of grant keys referenced by packages/db/data/agent_registry.json. honored_by_tools is empty when no tool in apps/web/lib/mcp-tools.ts (via apps/web/lib/tak/agent-grants.ts TOOL_TO_GRANTS) checks the grant — those are aspirational grants that do not yet authorize any platform action. The tool-grant audit's GRANT-002 surfaces them as findings; backfill PRs either implement the tool or remove the grant from the registry. Descriptions are heuristic placeholders generated from the grant key — refine by hand during reconciliation.",
   "grants": [
     {
       "key": "acceptance_package_write",
@@ -39,33 +39,6 @@
       "implies": [
         "admin_read"
       ]
-    },
-    {
-      "key": "browser_drive",
-      "description": "Drive an authenticated browser session through the governed browser-use substrate. Side-effecting browser actions require this grant and remain bounded by approval, target-domain, and audit policies. Honors the coworker-facing drive_browser_task orchestrator and the namespaced browse_act sidecar tool.",
-      "category": "platform",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "drive_browser_task",
-        "mcp-browser-use__browse_act"
-      ],
-      "implies": [
-        "browser_read"
-      ]
-    },
-    {
-      "key": "browser_read",
-      "description": "Open, read, screenshot, and close governed browser-use sessions without authorizing side-effecting browser actions.",
-      "category": "platform",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "mcp-browser-use__browse_close",
-        "mcp-browser-use__browse_extract",
-        "mcp-browser-use__browse_open",
-        "mcp-browser-use__browse_run_tests",
-        "mcp-browser-use__browse_screenshot"
-      ],
-      "implies": []
     },
     {
       "key": "adr_create",
@@ -186,6 +159,33 @@
       ]
     },
     {
+      "key": "browser_drive",
+      "description": "Drive an authenticated browser session through the governed browser-use substrate. Side-effecting browser actions require this grant and remain bounded by approval, target-domain, and audit policies. Honors the coworker-facing drive_browser_task orchestrator and the namespaced browse_act sidecar tool.",
+      "category": "platform",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "drive_browser_task",
+        "mcp-browser-use__browse_act"
+      ],
+      "implies": [
+        "browser_read"
+      ]
+    },
+    {
+      "key": "browser_read",
+      "description": "Open, read, screenshot, and close governed browser-use sessions without authorizing side-effecting browser actions.",
+      "category": "platform",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "mcp-browser-use__browse_close",
+        "mcp-browser-use__browse_extract",
+        "mcp-browser-use__browse_open",
+        "mcp-browser-use__browse_run_tests",
+        "mcp-browser-use__browse_screenshot"
+      ],
+      "implies": []
+    },
+    {
       "key": "budget_read",
       "description": "Read budget.",
       "category": "governance",
@@ -194,32 +194,8 @@
       "implies": []
     },
     {
-      "key": "coworker_catalog_read",
-      "description": "Read coworker service and offer catalog entries for governed AI workforce discovery.",
-      "category": "platform",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "get_coworker_offer",
-        "list_coworker_offers",
-        "list_coworker_services"
-      ],
-      "implies": []
-    },
-    {
-      "key": "coworker_engagement_write",
-      "description": "Create governed coworker engagement requests against catalog offers.",
-      "category": "platform",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "request_coworker_engagement"
-      ],
-      "implies": [
-        "coworker_catalog_read"
-      ]
-    },
-    {
       "key": "build_evidence",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5): record evidence against a FeatureBuild \u2014 execution outcome, notes, persisted artifacts. Finer-grained successor to the build-evidence-related slice of backlog_write; lets scoped coworker tokens record build progress without authority to mutate the broader backlog. Implied by backlog_write (one-way).",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5): record evidence against a FeatureBuild — execution outcome, notes, persisted artifacts. Finer-grained successor to the build-evidence-related slice of backlog_write; lets scoped coworker tokens record build progress without authority to mutate the broader backlog. Implied by backlog_write (one-way).",
       "category": "integrate",
       "sensitivity": "internal",
       "honored_by_tools": [
@@ -231,7 +207,7 @@
     },
     {
       "key": "build_lifecycle",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5): advance a FeatureBuild's lifecycle state \u2014 promote into Build Studio, process backlog batches into builds, and (when BI-0B3B0232 lands) reopen abandoned builds. Successor to build_promote; covers the full lifecycle surface required by the Pseudo-User Contract envelope flow. Implied by build_promote (one-way) for backwards compat.",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5): advance a FeatureBuild's lifecycle state — promote into Build Studio, process backlog batches into builds, and (when BI-0B3B0232 lands) reopen abandoned builds. Successor to build_promote; covers the full lifecycle surface required by the Pseudo-User Contract envelope flow. Implied by build_promote (one-way) for backwards compat.",
       "category": "integrate",
       "sensitivity": "internal",
       "honored_by_tools": [
@@ -242,7 +218,7 @@
     },
     {
       "key": "build_phase_advance",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5): advance a FeatureBuild's phase \u2014 approve or override a decomposition, propose a downstream decomposition. Finer-grained successor to the phase-advancing slice of backlog_write; gates the Ideate\u2192Plan handoff. Implied by backlog_write (one-way).",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5): advance a FeatureBuild's phase — approve or override a decomposition, propose a downstream decomposition. Finer-grained successor to the phase-advancing slice of backlog_write; gates the Ideate→Plan handoff. Implied by backlog_write (one-way).",
       "category": "integrate",
       "sensitivity": "internal",
       "honored_by_tools": [
@@ -270,52 +246,6 @@
       "honored_by_tools": [],
       "implies": [
         "build_lifecycle"
-      ]
-    },
-    {
-      "key": "work_capsule_read",
-      "description": "Read Work Capsule coordination records.",
-      "category": "integrate",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "get_runtime_coordination_map",
-        "get_work_capsule",
-        "list_work_capsules"
-      ],
-      "implies": []
-    },
-    {
-      "key": "work_capsule_write",
-      "description": "Create and update Work Capsule coordination records.",
-      "category": "integrate",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "claim_capsule_scope",
-        "create_work_capsule",
-        "heartbeat_capsule",
-        "heartbeat_runtime_target",
-        "plan_capsule_worktree",
-        "record_capsule_evidence",
-        "record_runtime_verification",
-        "register_runtime_target",
-        "release_runtime_target",
-        "release_capsule_scope",
-        "update_work_capsule_status"
-      ],
-      "implies": [
-        "work_capsule_read"
-      ]
-    },
-    {
-      "key": "work_capsule_adopt",
-      "description": "Adopt external branches and worktrees into Work Capsules.",
-      "category": "integrate",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "adopt_worktree"
-      ],
-      "implies": [
-        "work_capsule_read"
       ]
     },
     {
@@ -402,6 +332,118 @@
       "implies": []
     },
     {
+      "key": "contract_read",
+      "description": "Read contract.",
+      "category": "explore",
+      "sensitivity": "internal",
+      "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "contract_write",
+      "description": "Create or update contract.",
+      "category": "explore",
+      "sensitivity": "internal",
+      "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "conway_validate",
+      "description": "Validate conway.",
+      "category": "governance",
+      "sensitivity": "internal",
+      "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "coworker_catalog_read",
+      "description": "Read coworker service and offer catalog entries for governed AI workforce discovery.",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "get_coworker_offer",
+        "list_coworker_offers",
+        "list_coworker_services"
+      ],
+      "implies": []
+    },
+    {
+      "key": "coworker_engagement_write",
+      "description": "Create governed coworker engagement requests against catalog offers.",
+      "category": "platform",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "request_coworker_engagement"
+      ],
+      "implies": [
+        "coworker_catalog_read"
+      ]
+    },
+    {
+      "key": "coworker_screen_drive",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): drive the screen the user is on — select entities, navigate routes, open/close panels, focus fields. Read-only for the user (the coworker drives).",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "screen_close_panel",
+        "screen_dispatch_action",
+        "screen_focus_field",
+        "screen_navigate",
+        "screen_open_panel",
+        "screen_propose_action",
+        "screen_select_entity"
+      ],
+      "implies": []
+    },
+    {
+      "key": "coworker_screen_fill",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): pre-fill form fields on behalf of the user. Higher tier than coworker_screen_drive — the user can still override before submit, but the coworker is setting input without explicit user keystrokes.",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "screen_set_input"
+      ],
+      "implies": []
+    },
+    {
+      "key": "coworker_screen_read",
+      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): read the current screen's state — selected entities, focused field, open panels, route, scroll anchor. Read-only side of the coworker view-command surface (POLA-aligned per chief-architect review of PR #1361 — screen_scroll_to is read-class).",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "screen_describe",
+        "screen_get_state",
+        "screen_scroll_to"
+      ],
+      "implies": []
+    },
+    {
+      "key": "credential_scan",
+      "description": "Scan credential.",
+      "category": "governance",
+      "sensitivity": "internal",
+      "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "criteria_read",
+      "description": "Read criteria.",
+      "category": "evaluate",
+      "sensitivity": "internal",
+      "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "critique_capture",
+      "description": "Draft a UX critique entry into the design-critique corpus. Narrower than registry_write on purpose: a coding agent may record what it observed on a screen and nothing else in the registry. Entries are always agent-proposed and never calibration-eligible; attaching a founder/designer verdict stays a human act in the portal.",
+      "category": "registry",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "capture_ux_critique"
+      ],
+      "implies": []
+    },
+    {
       "key": "crm_read",
       "description": "Read CRM records: customer accounts, sales-pipeline opportunities, and quotes.",
       "category": "consume",
@@ -427,133 +469,6 @@
       "implies": [
         "crm_read"
       ]
-    },
-    {
-      "key": "siem_read",
-      "description": "Read security telemetry: OCSF security events, detections, and security cases.",
-      "category": "operate",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "query_security_events",
-        "query_detections",
-        "get_security_case"
-      ],
-      "implies": []
-    },
-    {
-      "key": "siem_investigate",
-      "description": "Open and update security cases: timeline, evidence-based verdict, detection links. Does not execute response.",
-      "category": "operate",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "open_security_case",
-        "update_security_case"
-      ],
-      "implies": [
-        "siem_read"
-      ]
-    },
-    {
-      "key": "siem_tune",
-      "description": "Propose detection-rule tuning or suppression for operator review. Does not change rule behavior.",
-      "category": "operate",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "propose_detection_tuning"
-      ],
-      "implies": [
-        "siem_read"
-      ]
-    },
-    {
-      "key": "incident_respond",
-      "description": "Propose a containment/remediation action for a security case. Recorded for human approval; never executed directly.",
-      "category": "operate",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "propose_response"
-      ],
-      "implies": [
-        "siem_read"
-      ]
-    },
-    {
-      "key": "contract_read",
-      "description": "Read contract.",
-      "category": "explore",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
-    },
-    {
-      "key": "contract_write",
-      "description": "Create or update contract.",
-      "category": "explore",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
-    },
-    {
-      "key": "conway_validate",
-      "description": "Validate conway.",
-      "category": "governance",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
-    },
-    {
-      "key": "coworker_screen_drive",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): drive the screen the user is on \u2014 select entities, navigate routes, open/close panels, focus fields. Read-only for the user (the coworker drives).",
-      "category": "platform",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "screen_close_panel",
-        "screen_dispatch_action",
-        "screen_focus_field",
-        "screen_navigate",
-        "screen_open_panel",
-        "screen_propose_action",
-        "screen_select_entity"
-      ],
-      "implies": []
-    },
-    {
-      "key": "coworker_screen_fill",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): pre-fill form fields on behalf of the user. Higher tier than coworker_screen_drive \u2014 the user can still override before submit, but the coworker is setting input without explicit user keystrokes.",
-      "category": "platform",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "screen_set_input"
-      ],
-      "implies": []
-    },
-    {
-      "key": "coworker_screen_read",
-      "description": "Pseudo-User Contract (BI-B2F7ABF5/BI-DF6079E9): read the current screen's state \u2014 selected entities, focused field, open panels, route, scroll anchor. Read-only side of the coworker view-command surface (POLA-aligned per chief-architect review of PR #1361 \u2014 screen_scroll_to is read-class).",
-      "category": "platform",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "screen_describe",
-        "screen_get_state",
-        "screen_scroll_to"
-      ],
-      "implies": []
-    },
-    {
-      "key": "credential_scan",
-      "description": "Scan credential.",
-      "category": "governance",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
-    },
-    {
-      "key": "criteria_read",
-      "description": "Read criteria.",
-      "category": "evaluate",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
     },
     {
       "key": "data_governance_validate",
@@ -598,26 +513,29 @@
       "implies": []
     },
     {
-      "key": "thread_read",
-      "description": "Read child thread status and results for specialist subtask delegation.",
-      "category": "platform",
+      "key": "dependency_audit",
+      "description": "dependency audit.",
+      "category": "governance",
       "sensitivity": "internal",
-      "honored_by_tools": [
-        "get_thread_result",
-        "get_child_threads"
-      ],
+      "honored_by_tools": [],
       "implies": []
     },
     {
-      "key": "thread_write",
-      "description": "Spawn or cancel specialist subtask child threads, and hand off / summon a named coworker.",
-      "category": "platform",
+      "key": "dependency_graph_read",
+      "description": "Read dependency graph.",
+      "category": "governance",
+      "sensitivity": "internal",
+      "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "deployment_plan_create",
+      "description": "Create deployment plan.",
+      "category": "deploy",
       "sensitivity": "internal",
       "honored_by_tools": [
-        "spawn_work_thread",
-        "cancel_thread",
-        "request_coworker",
-        "summon_coworker"
+        "check_deployment_windows",
+        "schedule_promotion"
       ],
       "implies": []
     },
@@ -660,54 +578,6 @@
       ]
     },
     {
-      "key": "dependency_audit",
-      "description": "dependency audit.",
-      "category": "governance",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
-    },
-    {
-      "key": "dependency_graph_read",
-      "description": "Read dependency graph.",
-      "category": "governance",
-      "sensitivity": "internal",
-      "honored_by_tools": [],
-      "implies": []
-    },
-    {
-      "key": "deployment_plan_create",
-      "description": "Create deployment plan.",
-      "category": "deploy",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "check_deployment_windows",
-        "schedule_promotion"
-      ],
-      "implies": []
-    },
-    {
-      "key": "enrichment_write",
-      "description": "Run software/asset enrichment on demand \u2014 resolve a product's CatalogIdentity CPE + endoflife.date support-lifecycle and flag items for re-enrichment (EP-ASSET-INTELLIGENCE). Scoped finer than registry_write so enrichment mutation is separately auditable.",
-      "category": "explore",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "enrich_digital_product",
-        "request_re_enrichment"
-      ],
-      "implies": []
-    },
-    {
-      "key": "email_config",
-      "description": "Configure the organization's OWN outbound email (SMTP) \u2014 detect provider, save settings, send a test. Operator-gated (manage_provider_connections); DPF never relays mail on the operator's behalf.",
-      "category": "integrate",
-      "sensitivity": "confidential",
-      "honored_by_tools": [
-        "setup_email"
-      ],
-      "implies": []
-    },
-    {
       "key": "ea_graph_read",
       "description": "Read ea graph.",
       "category": "explore",
@@ -729,6 +599,27 @@
         "create_ea_element",
         "create_ea_relationship",
         "import_archimate"
+      ],
+      "implies": []
+    },
+    {
+      "key": "email_config",
+      "description": "Configure the organization's OWN outbound email (SMTP) — detect provider, save settings, send a test. Operator-gated (manage_provider_connections); DPF never relays mail on the operator's behalf.",
+      "category": "integrate",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "setup_email"
+      ],
+      "implies": []
+    },
+    {
+      "key": "enrichment_write",
+      "description": "Run software/asset enrichment on demand — resolve a product's CatalogIdentity CPE + endoflife.date support-lifecycle and flag items for re-enrichment (EP-ASSET-INTELLIGENCE). Scoped finer than registry_write so enrichment mutation is separately auditable.",
+      "category": "explore",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "enrich_digital_product",
+        "request_re_enrichment"
       ],
       "implies": []
     },
@@ -888,6 +779,18 @@
       "implies": []
     },
     {
+      "key": "incident_respond",
+      "description": "Propose a containment/remediation action for a security case. Recorded for human approval; never executed directly.",
+      "category": "operate",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "propose_response"
+      ],
+      "implies": [
+        "siem_read"
+      ]
+    },
+    {
       "key": "incident_write",
       "description": "Create or update incident.",
       "category": "operate",
@@ -944,26 +847,6 @@
       "implies": [
         "marketing_read"
       ]
-    },
-    {
-      "key": "storefront_read",
-      "description": "Read guest-facing storefront activity: orders (with item-quantity rollups), reservations, and inquiries.",
-      "category": "consume",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "list_storefront_activity"
-      ],
-      "implies": []
-    },
-    {
-      "key": "stock_read",
-      "description": "Read stocked-supply levels and derived coverage: on-hand quantity, consumption from sales, days of cover, and suggested reorder quantity.",
-      "category": "consume",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "list_stock_coverage"
-      ],
-      "implies": []
     },
     {
       "key": "order_create",
@@ -1098,6 +981,7 @@
         "run_discovery_triage"
       ],
       "implies": [
+        "critique_capture",
         "registry_read"
       ]
     },
@@ -1205,16 +1089,6 @@
       "implies": []
     },
     {
-      "key": "tool_script_exec",
-      "description": "Run governed read-only programmatic tool-calling scripts in the sandbox (run_tool_script). Default-deny; also gated by the programmatic_tool_calling flag.",
-      "category": "integrate",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "run_tool_script"
-      ],
-      "implies": []
-    },
-    {
       "key": "sandbox_execute",
       "description": "Execute code in the build sandbox: read, write, edit, run tests and commands.",
       "category": "integrate",
@@ -1298,6 +1172,43 @@
       "implies": []
     },
     {
+      "key": "siem_investigate",
+      "description": "Open and update security cases: timeline, evidence-based verdict, detection links. Does not execute response.",
+      "category": "operate",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "open_security_case",
+        "update_security_case"
+      ],
+      "implies": [
+        "siem_read"
+      ]
+    },
+    {
+      "key": "siem_read",
+      "description": "Read security telemetry: OCSF security events, detections, and security cases.",
+      "category": "operate",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "query_security_events",
+        "query_detections",
+        "get_security_case"
+      ],
+      "implies": []
+    },
+    {
+      "key": "siem_tune",
+      "description": "Propose detection-rule tuning or suppression for operator review. Does not change rule behavior.",
+      "category": "operate",
+      "sensitivity": "confidential",
+      "honored_by_tools": [
+        "propose_detection_tuning"
+      ],
+      "implies": [
+        "siem_read"
+      ]
+    },
+    {
       "key": "sla_compliance_write",
       "description": "Create or update sla compliance.",
       "category": "operate",
@@ -1312,6 +1223,26 @@
       "sensitivity": "internal",
       "honored_by_tools": [
         "search_specs_and_plans"
+      ],
+      "implies": []
+    },
+    {
+      "key": "stock_read",
+      "description": "Read stocked-supply levels and derived coverage: on-hand quantity, consumption from sales, days of cover, and suggested reorder quantity.",
+      "category": "consume",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "list_stock_coverage"
+      ],
+      "implies": []
+    },
+    {
+      "key": "storefront_read",
+      "description": "Read guest-facing storefront activity: orders (with item-quantity rollups), reservations, and inquiries.",
+      "category": "consume",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "list_storefront_activity"
       ],
       "implies": []
     },
@@ -1366,6 +1297,30 @@
       "implies": []
     },
     {
+      "key": "thread_read",
+      "description": "Read child thread status and results for specialist subtask delegation.",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "get_thread_result",
+        "get_child_threads"
+      ],
+      "implies": []
+    },
+    {
+      "key": "thread_write",
+      "description": "Spawn or cancel specialist subtask child threads, and hand off / summon a named coworker.",
+      "category": "platform",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "spawn_work_thread",
+        "cancel_thread",
+        "request_coworker",
+        "summon_coworker"
+      ],
+      "implies": []
+    },
+    {
       "key": "tool_evaluation_create",
       "description": "Create tool evaluation.",
       "category": "platform",
@@ -1389,6 +1344,16 @@
       "category": "platform",
       "sensitivity": "internal",
       "honored_by_tools": [],
+      "implies": []
+    },
+    {
+      "key": "tool_script_exec",
+      "description": "Run governed read-only programmatic tool-calling scripts in the sandbox (run_tool_script). Default-deny; also gated by the programmatic_tool_calling flag.",
+      "category": "integrate",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "run_tool_script"
+      ],
       "implies": []
     },
     {
@@ -1438,6 +1403,83 @@
       "implies": []
     },
     {
+      "key": "work_capsule_adopt",
+      "description": "Adopt external branches and worktrees into Work Capsules.",
+      "category": "integrate",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "adopt_worktree"
+      ],
+      "implies": [
+        "work_capsule_read"
+      ]
+    },
+    {
+      "key": "work_capsule_read",
+      "description": "Read Work Capsule coordination records.",
+      "category": "integrate",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "get_runtime_coordination_map",
+        "get_work_capsule",
+        "list_work_capsules"
+      ],
+      "implies": []
+    },
+    {
+      "key": "work_capsule_write",
+      "description": "Create and update Work Capsule coordination records.",
+      "category": "integrate",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "claim_capsule_scope",
+        "create_work_capsule",
+        "heartbeat_capsule",
+        "heartbeat_runtime_target",
+        "plan_capsule_worktree",
+        "record_capsule_evidence",
+        "record_runtime_verification",
+        "register_runtime_target",
+        "release_runtime_target",
+        "release_capsule_scope",
+        "update_work_capsule_status"
+      ],
+      "implies": [
+        "work_capsule_read"
+      ]
+    },
+    {
+      "key": "work_engagement_read",
+      "description": "Read work engagements and their materialized recurring instances.",
+      "category": "work_engagement",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "get_work_engagement_instances"
+      ],
+      "implies": []
+    },
+    {
+      "key": "work_engagement_transition",
+      "description": "Advance a work engagement's status lifecycle including cancel and complete; higher-privilege than create.",
+      "category": "work_engagement",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "transition_work_engagement"
+      ],
+      "implies": []
+    },
+    {
+      "key": "work_engagement_write",
+      "description": "Create work engagements (including recurring) and append activity-timeline entries.",
+      "category": "work_engagement",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "create_recurring_work_engagement",
+        "record_work_engagement_activity"
+      ],
+      "implies": []
+    },
+    {
       "key": "workbook_read",
       "description": "Read user-defined Workbook / Universal Grid tables: list tables, read schema, and query rows (EP-GRID-WORKBOOKS).",
       "category": "platform",
@@ -1457,37 +1499,6 @@
       "honored_by_tools": [
         "workbook_create_row",
         "workbook_update_cells"
-      ],
-      "implies": []
-    },
-    {
-      "key": "work_engagement_read",
-      "description": "Read work engagements and their materialized recurring instances.",
-      "category": "work_engagement",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "get_work_engagement_instances"
-      ],
-      "implies": []
-    },
-    {
-      "key": "work_engagement_write",
-      "description": "Create work engagements (including recurring) and append activity-timeline entries.",
-      "category": "work_engagement",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "create_recurring_work_engagement",
-        "record_work_engagement_activity"
-      ],
-      "implies": []
-    },
-    {
-      "key": "work_engagement_transition",
-      "description": "Advance a work engagement's status lifecycle including cancel and complete; higher-privilege than create.",
-      "category": "work_engagement",
-      "sensitivity": "internal",
-      "honored_by_tools": [
-        "transition_work_engagement"
       ],
       "implies": []
     }

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -55,6 +55,8 @@ apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
 apps/web/lib/tak/agent-grants.ts	887
 apps/web/lib/tak/agent-routing.ts	1027
+apps/web/lib/tak/agent-grants.ts	900
+apps/web/lib/tak/agent-routing.ts	991
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737
 apps/web/lib/tak/route-context-map.ts	1212

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -53,10 +53,8 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
-apps/web/lib/tak/agent-grants.ts	887
+apps/web/lib/tak/agent-grants.ts	907
 apps/web/lib/tak/agent-routing.ts	1027
-apps/web/lib/tak/agent-grants.ts	900
-apps/web/lib/tak/agent-routing.ts	991
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737
 apps/web/lib/tak/route-context-map.ts	1212


### PR DESCRIPTION
The corpus door shipped **dead**. `capture_ux_critique` required `registry_write`, which the `development` template — the coding-agent token — does not hold. An external review session could read the critique corpus and never feed it, which is the entire capability the pack exists to provide.

Verified against the deployed tool, not inferred: only `search_ux_critique_corpus` resolved into this session's tool surface. `capture_ux_critique` was absent.

## Why it mattered

This stalled the founder's "capture as we go" decision. The corpus is the gating asset of the UX-quality programme — an ungrounded design judge is the UICrit zero-shot case at 13.1% valid comments, and **accrual rate, not start date, decides when the critic may gate**. It currently holds zero entries, with no reachable way to add one from an external session.

## The fix, and the fix I didn't take

A narrow **`critique_capture`** grant, added to the development template.

The naive alternative — granting `registry_write` to coding agents — would also have unlocked `wiki_ingest`, `publish_wiki_overlay_pages`, `create_knowledge_article`, `doc_save`, `doc_link`, `doc_state_change`, `run_discovery_triage`, `attribute_entity_to_product`, `dismiss_entity` and `resolve_portfolio_quality_issue`. Eleven tools of authority to enable one.

Narrow per-capability grants are this platform's own pattern (`browser_read`/`browser_drive`, `siem_read`/`siem_investigate`). `registry_write` implies `critique_capture` **one-way**, so `employee_ea` and `admin` tokens that already hold broad registry authority keep working, and the narrow grant never widens back.

The authority boundary is unchanged: the pack still pins `callerKind` to `"agent"`, so a captured entry can only ever be agent-proposed and never calibration-eligible. Founder verdicts stay a human act in the portal.

## Second defect: a warning the client could discard

The empty-corpus response came back as a bare `{total: 0, entries: []}`. The sentence I wrote to stop a caller reading silence as "nothing relevant" lived in `message`, and this client surfaces `data` and drops `message` — so it never arrived.

Moved into `data.grounding`. A warning a client can discard is not a warning.

## Tests pin reachability, not registration

The original pack had a grant entry, a registry entry, and a passing grant-parity test. All of that was true while the tool was uncallable. The new tests assert that a token a **real caller actually holds** satisfies the requirement, and that the naive widening did not happen:

- a `development` token can call capture
- a `development` token can read the corpus
- `development` does **not** hold blanket `registry_write`
- `registry_write` still implies `critique_capture`, one-way
- pack grants mirror `TOOL_TO_GRANTS` exactly
- `callerKind` / `verdictAuthority` are never caller-supplied inputs

54 tests pass across `ux-critique-pack`, `tool-registry`, `pack-registry`.

**Local-CI-Override:** `install-bootstrap-recovery` — the `@dpf` workspace links are absent from `node_modules`, so `pregate`'s guard preflight and local `tsc` are unusable. Local evidence above; CI is the binding check.

Backlog: BI-52839DEA

## Seeded content

`packages/db/data/grant_catalog.json` gains one entry, so this carries a seeded-content decision.

A grant key is platform authority infrastructure: the same MCP tools, the same gating map, and the same catalog ship to every install. It is not archetype- or vertical-specific, has nothing to parameterize, and an install-local variant would mean one install could authorize a tool another could not — which is the opposite of what a catalog the audit holds in parity is for.

Seed-Fit-Decision: global-default
