### PR TITLE
fix(coworker): recover decision buttons from real-length prose closeouts (BI-AE7058FB)

### DIFF
--- a/apps/web/lib/tak/decision-block.test.ts
+++ b/apps/web/lib/tak/decision-block.test.ts
@@ -192,3 +192,50 @@ describe("deriveDecisionFromProse (fallback when the model emits no sentinel)", 
     expect(decision!.options[0]!.label).toBe("Go");
   });
 });
+
+describe("deriveDecisionFromProse — long real-world clauses (BI-AE7058FB)", () => {
+  // Verbatim closeout observed live on /customer during the EP-UX-AUDITOR portal
+  // survey (2026-08-04). The old 90-char clause cap rejected the first option
+  // (~117 chars), so a textbook two-option choice produced NO buttons at all.
+  const LIVE_CUSTOMER_CLOSEOUT =
+    "Based on the customer overview page, the highest-value next step is to review the onboarding journey for your top accounts. " +
+    "Would you like me to start by analyzing the onboarding journey for your highest-value accounts to surface the most critical friction points, " +
+    "or would you prefer to review the underlying customer data and engagement metrics first?";
+
+  it("recovers both options from the live /customer closeout", () => {
+    const decision = deriveDecisionFromProse(LIVE_CUSTOMER_CLOSEOUT);
+    expect(decision).not.toBeNull();
+    expect(decision!.options).toHaveLength(2);
+  });
+
+  it("marks the first option recommended so buttons render recommended-first", () => {
+    const decision = deriveDecisionFromProse(LIVE_CUSTOMER_CLOSEOUT)!;
+    expect(decision.options[0]!.recommended).toBe(true);
+    expect(decision.options[1]!.recommended).toBeUndefined();
+  });
+
+  it("strips the repeated lead-in so the second button reads as an imperative", () => {
+    const decision = deriveDecisionFromProse(LIVE_CUSTOMER_CLOSEOUT)!;
+    expect(decision.options[1]!.value).toMatch(/^Review the underlying customer data/);
+    expect(decision.options[1]!.value).not.toMatch(/would you prefer/i);
+  });
+
+  it("still truncates the visible label while keeping the full submitted value", () => {
+    const decision = deriveDecisionFromProse(LIVE_CUSTOMER_CLOSEOUT)!;
+    for (const option of decision.options) {
+      expect(option.label.length).toBeLessThanOrEqual(56);
+      expect(option.value.length).toBeGreaterThanOrEqual(option.label.length);
+    }
+  });
+
+  it("still refuses a paragraph-sized clause — the cap bounds runaway prose", () => {
+    const runaway = `Should I ${"a".repeat(200)}, or ${"b".repeat(200)}?`;
+    expect(deriveDecisionFromProse(runaway)).toBeNull();
+  });
+
+  it("still refuses a noun disjunction with no comma", () => {
+    expect(
+      deriveDecisionFromProse("Should this be tagged for reliability or incidents?"),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/tak/decision-block.ts
+++ b/apps/web/lib/tak/decision-block.ts
@@ -193,13 +193,37 @@ export function formatDecisionSentinel(decision: CoworkerDecision): string {
 // noun disjunction ("tagged for reliability or incidents?", which has no comma)
 // — a wrong button is worse than no button, so we only act on the strong signal.
 
-// Lead-in phrases that precede the actual options in a choice question.
+// Lead-in phrases that precede the actual options in a choice question. Applied
+// to the question head AND to each split clause: a coworker routinely repeats the
+// lead-in on the second option ("…, or would you prefer to review the data?"), and
+// without stripping it the button reads "Would you prefer to review the data"
+// instead of the imperative "Review the data".
 const PROSE_LEADIN_RE =
-  /^(?:what(?:'s| is) your call|what would you like(?: me to do)?|which would you prefer|would you like me to|do you want me to|want me to|should i|shall i|shall we|should we|do you want to|do you want)\b[\s,:—–-]*/i;
+  /^(?:what(?:'s| is) your call|what would you like(?: me to do)?|which would you prefer|would you (?:like me to|prefer(?: to)?|rather)|do you want me to|want me to|should i|shall i|shall we|should we|do you want to|do you want)\b[\s,:—–-]*/i;
 
 const PROSE_OPTION_PREFIX_RE = /^(?:perhaps|maybe|instead|else|or|either)\s+/i;
 
 const PROSE_LABEL_MAX = 56;
+
+/**
+ * Upper bound on a single option clause (BI-AE7058FB).
+ *
+ * This was 90, which rejected how coworkers actually phrase a substantive choice.
+ * Observed live on /customer during the EP-UX-AUDITOR portal survey: "…start by
+ * analyzing the onboarding journey for your highest-value accounts to surface the
+ * most critical friction points, or would you prefer to review the underlying
+ * customer data and engagement metrics first?" — a textbook two-option closeout
+ * whose first clause is ~117 characters. The 90-cap rejected it, so the whole
+ * decision returned null and the human got no buttons at all.
+ *
+ * The cap is not what protects against a wrong button — the STRUCTURAL guards do:
+ * the comma-or must sit inside the FINAL question, there must be 2-3 parts, no
+ * clause may contain sentence punctuation, and labels must be distinct. Display
+ * length is already handled separately by PROSE_LABEL_MAX truncation. So this
+ * bound exists only to reject runaway prose, and 160 leaves real closeouts room
+ * while still refusing anything paragraph-sized.
+ */
+const PROSE_CLAUSE_MAX = 160;
 
 /** Isolate the final sentence when the trimmed content ends with a question. */
 function finalQuestion(content: string): string | null {
@@ -239,11 +263,14 @@ export function deriveDecisionFromProse(content: string): CoworkerDecision | nul
   rawParts.forEach((part, index) => {
     const clause = part
       .replace(PROSE_OPTION_PREFIX_RE, "")
+      // A repeated lead-in on the second option ("or would you prefer to …")
+      // would otherwise become the button text verbatim.
+      .replace(PROSE_LEADIN_RE, "")
       .replace(/\s+/g, " ")
       .replace(/[.,;:\s]+$/, "")
       .trim();
     // Guardrails: each option must be a clean, sentence-free clause with letters.
-    if (clause.length < 4 || clause.length > 90) return;
+    if (clause.length < 4 || clause.length > PROSE_CLAUSE_MAX) return;
     if (!/[a-z]/i.test(clause)) return;
     if (/[.!?]/.test(clause)) return; // a period/bang means we split across sentences
     const value = clause.charAt(0).toUpperCase() + clause.slice(1);


### PR DESCRIPTION
Fixes **BI-AE7058FB**, found by the EP-UX-AUDITOR portal survey (BI-C3768478) on `/customer`.

## The defect

The coworker ended its turn on a textbook two-option choice and the human got **no buttons** — they had to retype the answer as free text:

> "Would you like me to start by analyzing the onboarding journey for your highest-value accounts to surface the most critical friction points, **or** would you prefer to review the underlying customer data and engagement metrics first?"

No sentinel was emitted, so recovery fell to `deriveDecisionFromProse`, which returned null. Trace: the comma-or split produced exactly 2 parts, but the first is ~117 characters and the `clause.length > 90` guard rejected it, so `options.length !== rawParts.length` discarded the whole decision.

## Why the cap was wrong, and why this isn't a blind loosening

The module's doctrine is *"a wrong button is worse than no button"*, so relaxing a guard deserves an argument rather than a bump:

- **The cap is not what protects against a wrong button.** The structural guards do: the comma-or must sit inside the FINAL question, there must be 2-3 parts, no clause may contain sentence punctuation, and labels must be distinct. All retained.
- **Long clauses were never a presentation problem.** `PROSE_LABEL_MAX` (56) already truncates the visible label while the full text rides in `value`. The 90-char rejection fired first and killed the decision before that solved display.
- So the bound exists only to reject runaway prose. Now `PROSE_CLAUSE_MAX = 160` — room for real closeouts, still refusing anything paragraph-sized.

Also strips a repeated lead-in from each split clause. A coworker routinely restates it on the second option, which previously became the button text verbatim. Result:

| # | Button | |
| --- | --- | --- |
| 1 | Start by analyzing the onboarding journey for your high… | recommended |
| 2 | Review the underlying customer data and engagement metr… | (was "Would you prefer to review…") |

## Tests

The verbatim live closeout is now a regression fixture. Alongside it: the cap still refuses a paragraph-sized clause, and a comma-less noun disjunction ("tagged for reliability or incidents?") still yields no buttons.

296 tests green across `decision-block`, `ux-audit`, and `components/agent`.

## Design grounding

- Source of truth: `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md` (BI-3237B5D6) and the P1.5 prose-fallback contract in `apps/web/lib/tak/decision-block.ts`.
- No contract change: the carrier vocabulary, `CoworkerDecision` shape, and the sentinel path are untouched. This recalibrates one guard constant and improves label phrasing within the existing fallback contract.
- Substrate reviewed: `decision-block.ts`, `AgentMessageBubble.tsx` (`DecisionButtons`), `apps/web/lib/ux-audit/button-decision-lens.ts`.

## Verification note

`deriveDecisionFromProse` runs **client-side at render time**, so this cannot reach the running portal until it merges and the install self-upgrades. Live re-verification on `:3000` is a post-merge step by contract; the unit evidence is the verbatim closeout that failed in production.

Verified via the governed local-CI gate (exact-tree, merged against main).
