### PR TITLE
fix(test): defuse three real wall-clock time bombs, found by measurement not grep

### DIFF
--- a/apps/web/lib/actions/finance.test.ts
+++ b/apps/web/lib/actions/finance.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/permissions", () => ({ can: vi.fn() }));
@@ -180,6 +180,13 @@ describe("createInvoice total calculation", () => {
 // ─── Sequential ref generation ───────────────────────────────────────────────
 
 describe("createInvoice sequential ref generation", () => {
+  // Pinned because `createInvoice` stamps the ref with `new Date().getFullYear()`
+  // (finance.ts:38) while the case below hardcodes INV-2026-…. Unpinned, it would
+  // pass until 2027-01-01 and then fail forever on a required unit shard — the
+  // same shape as the 2026-08-01T15:00Z outage fixed in #3883/#3885.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-06-15T12:00:00.000Z"));
+  afterEach(() => vi.useRealTimers());
+
   it("generates INV-2026-0042 when invoice count is 41", async () => {
     mockPrisma.invoice.count.mockResolvedValue(41);
     mockPrisma.invoice.create.mockResolvedValue({ id: "inv-42", invoiceRef: "INV-2026-0042" });

--- a/apps/web/lib/actions/voice-consent.test.ts
+++ b/apps/web/lib/actions/voice-consent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest"
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest"
 
 const mockCreate = vi.hoisted(() => vi.fn().mockResolvedValue({ id: "vcr-1" }))
 const mockUpsert = vi.hoisted(() => vi.fn().mockResolvedValue({ id: "vp-1" }))
@@ -20,6 +20,13 @@ vi.mock("@dpf/db", () => ({
 import { createVoiceConsentRecord } from "./voice-consent"
 
 describe("createVoiceConsentRecord", () => {
+  // Pinned because the fixture below carries `expiresAt: 2027-01-01` while the
+  // guard in voice-consent.ts:31 compares it to `new Date()`. Unpinned, this
+  // passes until 2027-01-01 and then fails forever — the same shape as the
+  // 2026-08-01T15:00Z outage fixed in #3883/#3885.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-06-15T12:00:00.000Z"))
+  afterEach(() => vi.useRealTimers())
+
   it("creates a VoiceConsentRecord and upserts VoiceProfile in a transaction", async () => {
     const result = await createVoiceConsentRecord({
       profileId: "mark-dpf-platform",

--- a/apps/web/lib/integrate/adp/cert-parse.test.ts
+++ b/apps/web/lib/integrate/adp/cert-parse.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseCertExpiry } from "./cert-parse";
@@ -7,6 +7,15 @@ const validPem = readFileSync(resolve(__dirname, "fixtures/valid-cert.pem"), "ut
 const malformedPem = readFileSync(resolve(__dirname, "fixtures/malformed-cert.pem"), "utf8");
 
 describe("parseCertExpiry", () => {
+  // Pinned so the "genuinely in the future" sanity check below keeps a fixed
+  // reference point. The fixture cert expires 2027-05-24; against the real clock
+  // that assertion is the last remaining wall-clock dependency in this test and
+  // would fail permanently on that date. This is the third round of the same
+  // fight — see the comment below on the >350 -> >340 day-count loosening — and
+  // pinning ends it rather than moving the threshold again.
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-06-15T12:00:00.000Z"));
+  afterEach(() => vi.useRealTimers());
+
   it("extracts a future expiry date from a valid PEM (cert is openssl -days 365)", () => {
     const result = parseCertExpiry(validPem);
     expect(result).toBeInstanceOf(Date);

--- a/apps/web/vitest.clock-shift-setup.ts
+++ b/apps/web/vitest.clock-shift-setup.ts
@@ -15,11 +15,19 @@
 // would mean churn across several teams' tests, would prevent nothing, and
 // would manufacture confidence that the class was handled.
 //
-// WHAT ACTUALLY WORKS. Run the suite twice — once normally, once with the clock
-// shifted forward — and take the set difference. A test that passes now and
-// fails at now+90d IS a bomb, by definition, with no heuristic and no judgement.
-// Benign fixtures stay green and produce no noise. `scripts/detect-time-bombs.mjs`
-// drives that comparison; this file is the shift half.
+// WHAT ACTUALLY WORKS BETTER. Run the suite twice — once normally, once with the
+// clock shifted forward — and take the set difference. Benign fixtures mostly stay
+// green. `scripts/detect-time-bombs.mjs` drives that comparison; this file is the
+// shift half.
+//
+// BUT NOT PERFECTLY. This comment used to claim the difference was a bomb "with no
+// heuristic and no judgement". A +365d sweep on 2026-08-04 measured otherwise: 17
+// findings, 5 real, 12 artifacts of one class — subprocess boundaries. Because the
+// shim patches `Date` in the vitest process ONLY (see the note below), a test that
+// spawns a child hands it parent-built timestamps the child then checks against the
+// real clock. Those fixtures can be perfectly drift-proof and still fail here. So
+// this catches real bombs the static grep misses, at ~2.4:1 rather than ~6:1 — a
+// shortlist worth investigating, not a verdict. Tracked as BI-F8808EDA.
 //
 // DESIGN NOTES.
 //   * Off unless `DPF_CLOCK_SHIFT_DAYS` is set to a non-zero finite number, so

--- a/scripts/detect-time-bombs.mjs
+++ b/scripts/detect-time-bombs.mjs
@@ -77,23 +77,38 @@ async function runSuite({ shiftDays, filter, outFile }) {
   const label = shiftDays ? `+${shiftDays}d` : "baseline";
   process.stdout.write(`[time-bombs] running suite (${label})…\n`);
 
-  const exitCode = await new Promise((resolve) => {
+  const { exitCode, signal, spawnError } = await new Promise((resolve) => {
     const child = spawn(process.execPath, args, {
       cwd: WEB_DIR,
       env,
       stdio: ["ignore", "ignore", "inherit"],
     });
-    child.on("close", (code) => resolve(code ?? 1));
-    child.on("error", () => resolve(1));
+    child.on("close", (code, receivedSignal) =>
+      resolve({ exitCode: code ?? 1, signal: receivedSignal, spawnError: null }),
+    );
+    child.on("error", (error) => resolve({ exitCode: 1, signal: null, spawnError: error }));
   });
 
   let report;
   try {
     report = JSON.parse(await readFile(outFile, "utf8"));
   } catch (error) {
+    // Report HOW the child died, not just that no report showed up. The two
+    // causes look identical from the missing file alone and need opposite
+    // responses: `signal` set (usually SIGKILL/SIGTERM) means the run was killed
+    // from outside — a job timeout or the OOM killer under memory pressure, so
+    // the suite is fine and the harness needs more room; a non-zero `exitCode`
+    // with no signal means vitest itself failed and the suite is the problem.
+    // Without this distinction the message reads "the run produced no parseable
+    // output" for both, which is where the diagnosis stalls.
+    const cause = spawnError
+      ? `could not spawn vitest: ${spawnError.message}`
+      : signal
+        ? `vitest was KILLED by ${signal} — an external timeout or the OOM killer, not a test failure`
+        : `vitest exited ${exitCode} without writing the report`;
     throw new Error(
-      `could not read the ${label} JSON report — the run produced no parseable ` +
-        `output, so its result cannot be trusted (${String(error)})`,
+      `could not read the ${label} JSON report — ${cause}, so its result cannot ` +
+        `be trusted (${String(error)})`,
     );
   }
 

--- a/scripts/detect-time-bombs.mjs
+++ b/scripts/detect-time-bombs.mjs
@@ -3,14 +3,23 @@
 //
 // Runs the web unit suite twice — once normally, once with the clock shifted
 // forward — and reports the SET DIFFERENCE: tests that pass now and fail later.
-// That difference is the definition of a time bomb, so there is no heuristic to
-// tune and no false-positive class to triage.
 //
 // Context: on 2026-08-01 a single test with a hardcoded `expiresAt` went red at
 // the instant it encoded and blocked every PR in the repo (a required shard).
 // The obvious static sweep was measured on this repo and over-reports ~6:1 — 29
 // files matched, the 5 most imminent all passed — because a future date is inert
 // unless something compares it to now. Hence this dynamic check.
+//
+// THIS IS NOT JUDGEMENT-FREE — the original version of this comment claimed
+// "no false-positive class to triage", and a +365d sweep on 2026-08-04 falsified
+// that: 17 findings, 5 real, 12 (71%) one artifact class. The shim patches `Date`
+// in THIS process only, so a test that spawns a subprocess straddles two clocks —
+// parent-built fixtures carry shifted timestamps that the child validates against
+// the real one. See promote-script-functional.test.ts, where a relative (and
+// therefore drift-proof) `expiresAt` makes promote.sh exit 78 under shift alone.
+// Treat a finding whose test shells out as suspect until you have read it.
+// Tracked as BI-F8808EDA. Still far better than the static grep — 2.4:1 beats
+// 6:1 — but the output is a shortlist to investigate, not a verdict.
 //
 // Usage:
 //   node scripts/detect-time-bombs.mjs                  # +90d (default)


### PR DESCRIPTION
Defuses three test-suite time bombs — tests that pass today and fail permanently on a
known future date. The 2026-08-01T15:00Z outage (fixed in #3883/#3885) was one of these:
it blocked every PR in the repo, was not flaky, and rerunning could not help.

## The sweep that motivated this pointed at the wrong files

A static sweep ("fixed future date in a fixture, no `useFakeTimers` in scope") named
`capacity-allocation-repository.server.test.ts` and `product-sold.test.ts`. Both were
measured and **neither is a bomb** — they pass at +90d, +365d and +3650d. Their pinned
dates are inert because nothing compares them to now: capacity-allocation's real-clock
`new Date()` is a `releasedAt` fed to a mocked `updateMany` that no assertion inspects,
and product-sold's `validTo` is only ever compared against `validFrom`
(`product-sold.ts:338`). The whole 29-file `2026-08-01` cohort was run shifted: **283/283
pass.** That matches what #3899 measured about this heuristic — it over-reports ~6:1 — so
no fixture was rewritten on its say-so.

## Running the dynamic check found the real ones

Using the clock-shift shim from #3899 against the full suite: **21,775 tests, 0 failures
unshifted, 17 failures at +365d.** Three are fixed here, each pinned the way #3885 pinned
the care-intake suite:

| File | Detonates | Cause |
| --- | --- | --- |
| `finance.test.ts` | **2027-01-01** | asserts a hardcoded `INV-2026-0042` while `createInvoice` stamps the ref from `new Date().getFullYear()` (`finance.ts:38`) |
| `voice-consent.test.ts` | **2027-01-01** | `expiresAt: 2027-01-01` against a `<= new Date()` guard (`voice-consent.ts:31`) — the exact shape of the original outage |
| `cert-parse.test.ts` | **2027-05-24** | asserts its fixture cert's expiry is still in the future; the cert expires 2027-05-24 |

`cert-parse` deserves a note: its own comment records two earlier rounds of this fight (a
`>350` -> `>340` day-count loosening that then failed at 339.78). This pins the clock
rather than moving the threshold a third time.

Each verified **failing at +365d before, passing at +365d and +3650d after.**

## The other 14 findings, dispositioned so nobody re-derives them

- **2 are a product defect, not a test defect** — filed as **BI-68D44727**.
  `provider-compliance-source-registry.ts` pins every governed source to
  `retrievedAt: "2026-07-20"` with a per-source `maxAgeDays`; past that,
  `provider-compliance-advisory.ts:135` emits `stale-source`, grounding validation fails,
  and advisories degrade from `local-model` to deterministic non-approval. **Three
  vendor-policy sources expire 2026-09-18** — six weeks out — and `grep -rln retrievedAt
  scripts/ .github/` returns nothing, so nothing refreshes them and nothing warns first.
  Fail-closed is correct; silent and unowned is not.
- **12 are detector false positives** — filed as **BI-F8808EDA**, and the second commit
  here corrects the misleading comments. The shim patches `Date` in the vitest process
  only, so a test that spawns a subprocess straddles two clocks.
  `promote-script-functional.test.ts` is all 12: its `expiresAt: new Date(Date.now() +
  60_000)` is relative and genuinely drift-proof, yet under shift the migration envelope
  looks issued a year ahead, `promoter-migration-envelope.mjs` rejects it against the
  child's real clock, and `promote.sh` exits 78.

Both files previously claimed the two-run difference yields bombs "with no heuristic and
no judgement" and has "no false-positive class to triage". Measured: 71% were one artifact
class. The tool is still far better than the static grep it replaced (~2.4:1 vs ~6:1); the
problem was the promise attached to it, which is what sends the next investigator hunting a
bomb that isn't there.

## Verification

- Touched tests: 46 passing, unshifted and at +365d (and +3650d for the three fixes)
- Clock-shift shim self-tests: 8/8
- Detector end-to-end: clean on a filtered run
- Full suite baseline: 21,775 tests, 0 failures

Local-CI-Override: external-contribution-no-install — the local-CI gate was SIGTERM-killed
on six attempts in this sandbox (at ~20m, 54s and 38s, including run foreground/unpiped as
`pregate:status` prescribes). It never went red: across attempts it cleared 34 preflight
guards, 24 guard-loop guards, a clean merge with current main, the authoritative 16GB
typecheck, and thousands of unit tests with zero failures before each kill. Operator Mark
Bodman authorized this override in-session. CI on this PR is the gate.

Backlog-Item: BI-F8808EDA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
