### PR TITLE
fix(hooks): stop the worktree reaper from deleting the live worktree it runs in (BI-E5D810B8)

### DIFF
--- a/docs/superpowers/specs/2026-08-04-governance-hook-portability-design.md
+++ b/docs/superpowers/specs/2026-08-04-governance-hook-portability-design.md
@@ -29,7 +29,16 @@ That unknown is larger than it looks, and it already produced a live doctrine de
 | `PreToolUse` | `Write\|Edit\|MultiEdit` | `plan-backlog-coverage-guard`, `ux-fit-precheck`, `spec-plan-doc-precheck`, `design-grounding-precheck`, `tool-economy-precheck` |
 | `WorktreeCreate` | `*` | `worktree-create` |
 | `SessionStart` | `*` | `process-spine-health-check`, `governance-freshness-check`, `worktree-session-hygiene` |
-| `SessionEnd` / `Stop` | `*` | `uncommitted-work-guard`, `worktree-session-hygiene` |
+| `SessionEnd` | `*` | `uncommitted-work-guard`, `worktree-session-hygiene` |
+| `Stop` | `*` | `uncommitted-work-guard` |
+
+> `Stop` and `SessionEnd` are **not** interchangeable. `Stop` fires after every
+> assistant turn, so it carries only non-destructive guards. The Tier-A worktree
+> reaper is SessionEnd-only: wired to `Stop` it removed the worktree the session
+> was still working in, starting the turn its own PR merged — that is exactly when
+> a live tree first satisfies Tier A (merged + clean + no open PR). See BI-E5D810B8
+> and §D4 of `2026-07-26-multi-client-governance-parity-design.md`, which assigns
+> the reaper to SessionEnd.
 
 **Portability is worse than "does the host support hooks".** The matchers are Claude Code's *tool names* (`Bash`, `AskUserQuestion`, `MultiEdit`) and the events are its *session lifecycle*. A host would need not merely a hook plane but the same tool vocabulary and session model. Full parity is not a realistic onboarding gate for any surface that is not Claude-derived.
 

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -135,14 +135,6 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\""
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
-          }
-        ]
       }
     ]
   }

--- a/packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
@@ -4,8 +4,20 @@
 // Session-lifecycle worktree hygiene (operator concern: transactional, not cron).
 //
 // SessionStart — OBSERVE: report worktree count / non-canonical cwd; never delete.
-// SessionEnd / Stop — TRANSACTIONAL REAP of THIS session's worktree only when it
-//   is Tier A (merged + clean + no open PR + not pinned). Fail-open always.
+// SessionEnd — TRANSACTIONAL REAP of THIS session's worktree only when it is
+//   Tier A (merged + clean + no open PR + not pinned). Fail-open always.
+//
+// NOT on Stop (BI-E5D810B8). `Stop` fires after EVERY assistant turn, not at the
+// end of a session. Wired there, this hook force-removed the worktree the session
+// was still working in — from the turn its PR merged (which is exactly when a live
+// tree first satisfies Tier A) onward, every turn. The removal could not complete
+// against a live cwd, so it gutted the tree instead: 59 tracked files deleted,
+// `.git` intact, presenting as a pile of "uncommitted deletions".
+//
+// Per the governing spec (2026-07-26-multi-client-governance-parity-design.md),
+// §D4 assigns the reaper to SessionEnd; G4 gives `Stop` only uncommitted-artifact
+// warnings and lease release. The uncommitted-work-guard remains on Stop; this
+// hook must not. Destructive reaping belongs to a session-lifecycle event only.
 //
 // Why not cron-first: client CLIs do not run fleets of crons; portal Inngest may
 // not see host worktrees; schedules get disabled or go dark. Session hooks fire
@@ -167,6 +179,32 @@ function gatherThisWorktreeFacts(cwd, mainRoot) {
   };
 }
 
+/**
+ * Undo a PARTIAL reap (BI-E5D810B8).
+ *
+ * `git worktree remove --force` deletes files as it walks and can then fail —
+ * e.g. the tree is a live cwd, or a file is held open. What it leaves behind is
+ * worse than either outcome: a directory with an intact `.git` and dozens of
+ * tracked files missing, which reads as "N uncommitted deletions" rather than
+ * "a reap failed". Observed 2026-08-04: 59 files gone, including pnpm-lock.yaml,
+ * tsconfig.base.json and .githooks/* — so the tree also silently lost its
+ * pre-commit and pre-push gates.
+ *
+ * Restoring is safe precisely BECAUSE we only get here on a Tier-A candidate,
+ * and Tier A requires `dirty === false`: the tree had no uncommitted work, so
+ * every difference from HEAD is damage this reap caused. Nothing of the
+ * operator's can be clobbered.
+ */
+function restorePartialReap(wtPath) {
+  if (!existsSync(join(wtPath, ".git"))) return null; // fully removed — nothing to undo
+  const before = runGit(["status", "--porcelain"], wtPath);
+  if (!before.ok || !before.stdout) return null; // intact, or not readable
+  const r = runGit(["restore", "--", "."], wtPath);
+  const after = runGit(["status", "--porcelain"], wtPath);
+  const remaining = after.ok ? after.stdout.split("\n").filter(Boolean).length : -1;
+  return { attempted: true, ok: r.ok && remaining === 0, remaining };
+}
+
 function removeThisWorktree(mainRoot, wtPath) {
   const helper = join(repoRootGuess, "scripts/lib/junction-safe-worktree-remove.mjs");
   if (!existsSync(helper)) {
@@ -177,10 +215,17 @@ function removeThisWorktree(mainRoot, wtPath) {
     windowsHide: true,
     timeout: 120_000,
   });
-  return {
-    ok: r.status === 0,
-    detail: (r.stdout || r.stderr || "").trim().slice(0, 400),
-  };
+  const ok = r.status === 0;
+  let detail = (r.stdout || r.stderr || "").trim().slice(0, 400);
+  if (!ok) {
+    const undo = restorePartialReap(wtPath);
+    if (undo?.attempted) {
+      detail += undo.ok
+        ? " — partial delete reverted (worktree left intact)."
+        : ` — partial delete only PARTIALLY reverted, ${undo.remaining} path(s) still differ from HEAD; run \`git restore -- .\` in ${wtPath}.`;
+    }
+  }
+  return { ok, detail };
 }
 
 function emitContext(hookEventName, text) {

--- a/packages/dpf-skill-pack/hooks/worktree-session-hygiene.test.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-hygiene.test.mjs
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const script = join(here, "worktree-session-hygiene.mjs");
+
+function hookCommandsFor(eventName) {
+  const wiring = JSON.parse(readFileSync(join(here, "hooks.json"), "utf8"));
+  const events = wiring.hooks ?? wiring;
+  return (events[eventName] ?? []).flatMap((entry) =>
+    (entry.hooks ?? []).map((h) => String(h.command ?? "")),
+  );
+}
 
 describe("worktree-session-hygiene", () => {
   it("no-ops outside DPF workspace and with skip env", () => {
@@ -38,5 +47,59 @@ describe("worktree-session-hygiene", () => {
       timeout: 60_000,
     });
     assert.equal(r.status, 0);
+  });
+
+  // BI-E5D810B8 — the regression that cost a day of worktrees.
+  //
+  // Wired on `Stop`, this hook force-removed the worktree the session was STILL
+  // WORKING IN: `Stop` fires after every assistant turn, and a live tree first
+  // satisfies Tier A (merged + clean + no open PR) the moment its own PR merges.
+  // The removal could not complete against a live cwd, so it gutted the tree —
+  // 59 tracked files deleted (pnpm-lock.yaml, tsconfig.base.json, .githooks/*)
+  // with `.git` left intact, presenting as "uncommitted deletions".
+  //
+  // Spec 2026-07-26-multi-client-governance-parity-design.md §D4 puts the reaper
+  // on SessionEnd; G4 gives Stop only uncommitted-artifact warning + lease release.
+  it("is NOT wired to Stop — a per-turn event must never trigger a destructive reap", () => {
+    const stopCommands = hookCommandsFor("Stop");
+    assert.ok(
+      !stopCommands.some((c) => c.includes("worktree-session-hygiene")),
+      `worktree-session-hygiene must not run on Stop (fires every turn); found: ${JSON.stringify(stopCommands)}`,
+    );
+  });
+
+  it("still reaps on SessionEnd, and still observes on SessionStart", () => {
+    for (const event of ["SessionStart", "SessionEnd"]) {
+      assert.ok(
+        hookCommandsFor(event).some((c) => c.includes("worktree-session-hygiene")),
+        `worktree-session-hygiene must stay wired to ${event}`,
+      );
+    }
+  });
+
+  it("keeps the uncommitted-work guard on Stop — that one is non-destructive and belongs there", () => {
+    assert.ok(
+      hookCommandsFor("Stop").some((c) => c.includes("uncommitted-work-guard")),
+      "removing the reaper from Stop must not strip the uncommitted-work guard",
+    );
+  });
+
+  it("a Stop payload never removes anything, even for a Tier-A cwd", () => {
+    // Belt-and-braces: even if the wiring regressed, the handler must not reap
+    // on a per-turn event. Exercised against the repo root, which exits early.
+    const root = join(here, "../../..");
+    const r = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      cwd: root,
+      env: { ...process.env, DPF_SKIP_WORKTREE_SESSION_HYGIENE: "0" },
+      input: JSON.stringify({ hookEventName: "Stop", cwd: root }),
+      windowsHide: true,
+      timeout: 60_000,
+    });
+    assert.equal(r.status, 0);
+    assert.ok(
+      !/reaped Tier-A worktree/.test(r.stdout || ""),
+      `Stop must not report a reap; got: ${r.stdout}`,
+    );
   });
 });

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -1108,6 +1108,12 @@ GROK_SESSION_END_SCRIPTS = (
     "uncommitted-work-guard.mjs",
     "worktree-session-hygiene.mjs",
 )
+# Stop is NOT SessionEnd (BI-E5D810B8). Grok fires `Stop` after every turn, so a
+# destructive reap wired here removes the worktree the session is still working
+# in — from the turn its PR merges (when a live tree first satisfies Tier A)
+# onward. Stop carries the non-destructive uncommitted-work warning only; the
+# reaper stays on SessionEnd. Mirrors hooks.json for the Claude plane.
+GROK_STOP_SCRIPTS = ("uncommitted-work-guard.mjs",)
 # Back-compat single names (older docs / tests may reference these).
 GROK_SESSION_START_SCRIPT = GROK_SESSION_START_SCRIPTS[0]
 GROK_SESSION_END_SCRIPT = GROK_SESSION_END_SCRIPTS[0]
@@ -1173,7 +1179,13 @@ def build_grok_hooks_payload(managed: Path, dry_run: bool = False) -> dict[str, 
     ]
     if end:
         payload["hooks"]["SessionEnd"] = end
-        payload["hooks"]["Stop"] = end
+    stop = [
+        _grok_command_entry(hooks_dir, script, timeout=60)
+        for script in GROK_STOP_SCRIPTS
+        if dry_run or (hooks_dir / script).exists()
+    ]
+    if stop:
+        payload["hooks"]["Stop"] = stop
     return payload
 
 

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -97,8 +97,16 @@ class InstallGrokHooksTest(unittest.TestCase):
             self.assertTrue(any("worktree-session-hygiene.mjs" in c for c in session_cmds))
             stop_cmds = [h["command"] for e in data["hooks"]["Stop"] for h in e["hooks"]]
             self.assertTrue(any("uncommitted-work-guard.mjs" in c for c in stop_cmds))
-            self.assertTrue(any("worktree-session-hygiene.mjs" in c for c in stop_cmds))
+            # BI-E5D810B8: Stop fires every turn, so it must never carry the
+            # destructive reaper — that removed the worktree the session was
+            # still working in, the moment its own PR merged.
+            self.assertFalse(
+                any("worktree-session-hygiene.mjs" in c for c in stop_cmds),
+                f"worktree-session-hygiene must not run on Grok Stop: {stop_cmds}",
+            )
             self.assertIn("SessionEnd", data["hooks"])
+            end_cmds = [h["command"] for e in data["hooks"]["SessionEnd"] for h in e["hooks"]]
+            self.assertTrue(any("worktree-session-hygiene.mjs" in c for c in end_cmds))
 
     def test_dry_run_writes_nothing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
@@ -36,7 +36,7 @@ Creates are covered by [`dpf-worktree-per-session`](../dpf-worktree-per-session/
 
 | Path | Owner | Agent freestyle? |
 |------|--------|------------------|
-| **Primary reaper** — this session's worktree on SessionEnd/Stop when Tier-A (merged + clean) | Client hooks (`worktree-session-hygiene.mjs`) | No — automatic when dpf-platform / global hooks are installed |
+| **Primary reaper** — this session's worktree on **SessionEnd** when Tier-A (merged + clean). Never on `Stop`: that fires every turn, and a live tree becomes Tier-A the moment its own PR merges (BI-E5D810B8) | Client hooks (`worktree-session-hygiene.mjs`) | No — automatic when dpf-platform / global hooks are installed |
 | **Fleet soak** — scheduled observe / optional Tier-A, sandbox leftover GC | Portal Inngest (`ops/worktree-janitor`, `ops/sandbox-build-gc`) + env flags | No — enable flags; do not hand-cron |
 | **Exceptional reclaim** — live Tier-A bulk prune, force-delete locked dirs, kill locking shells | Operator + explicit "go" | Only after dry-run report + operator approval |
 


### PR DESCRIPTION
Fixes **BI-E5D810B8**.

## What was happening

`worktree-session-hygiene.mjs` was registered on **`Stop`** as well as SessionStart/SessionEnd. `Stop` fires after **every assistant turn**, not at the end of a session. On each one the hook classified the current worktree and, when the verdict was `PRUNE_TIER_A`, called:

```
junction-safe-worktree-remove.mjs <root> <worktree> --force
```

— a forced removal of the tree **the session was still working in**.

The timing is what made it vicious. Tier A is *merged + clean + no open PR + not pinned*, so a live worktree first qualifies **the moment its own PR merges** — i.e. mid-session. From that turn onward, every turn attempted a delete.

The removal can't complete against a live cwd, so it gutted the tree instead: **59 tracked files unlinked with `.git` left intact**, including `pnpm-lock.yaml`, `tsconfig.base.json` and `.githooks/*` — so the tree also silently lost its pre-commit and pre-push gates. `git status` then reports a pile of "uncommitted deletions", which reads as *work to save* rather than *a failed reap*, and invites committing away the repo's install surface.

Verified against the live classifier on an affected worktree:

```
UNPINNED -> {"verdict":"PRUNE_TIER_A","reason":"...merged to origin/main, clean, no open PR/lease","tier":"A"}
PINNED   -> {"verdict":"PINNED", ...}
```

Corroborating evidence: the deleted set was byte-identical across two independent worktrees; not sparse-checkout (`fatal: this worktree is not sparse`, 0 skip-worktree bits); no git op in the worktree reflog, no stash, no crontab; the root clone was never touched (`facts.isRoot` early-exit); and pinning the tree stopped the recurrence outright.

## Fix — two separable defects

**1. Wrong trigger.** Removed `worktree-session-hygiene` from `Stop` in `hooks.json` (Claude plane). The **Grok plane had the same bug by aliasing** — `payload["hooks"]["Stop"] = end` reused the SessionEnd script list verbatim — so `update_agent_toolchain.py` now has a separate `GROK_STOP_SCRIPTS` carrying only the non-destructive `uncommitted-work-guard`. The reaper stays on SessionEnd on **both** planes; `uncommitted-work-guard` stays on `Stop`, where it belongs.

**2. Non-atomic removal.** A failed reap now self-reverts: `restorePartialReap()` runs `git restore -- .` in the target and reports whether the tree was left intact. This is safe *precisely because* we only reach it for a Tier-A candidate, and Tier A requires `dirty === false` — the tree had no uncommitted work, so every difference from HEAD is damage the reap itself caused. Nothing of the operator's can be clobbered.

## Tests

The wiring assertion is the regression guard, and it's **proven load-bearing**: re-adding the `Stop` entry fails it, removing it passes. Also asserts SessionEnd/SessionStart stay wired, that `Stop` keeps `uncommitted-work-guard`, and that a `Stop` payload never reports a reap.

`update_agent_toolchain_test.py` previously **enforced the bug** (asserted the reaper *was* in `stop_cmds`) — inverted, plus a new assertion that SessionEnd still carries it.

Verified locally:
- hooks suite **245/245** green
- `process-spine-conformance` + `gate-worktree-lease` **29/29**
- `update_agent_toolchain_test` **56 tests OK**
- design-grounding gate and ux-fit gate pass

## Design grounding

- **Existing specs/plans reviewed:**
  - `docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md` — §D4 *"End | SessionEnd reaper"*; G4 gives `Stop` only uncommitted durable artifacts + lease release; G7 Tier-A auto-reap; risk row *"Auto-reap deletes wanted worktree"* mitigated by strict predicates + `.worktree-pinned` + soak.
  - `docs/superpowers/specs/2026-08-04-governance-hook-portability-design.md` — its guard/event table had copied a combined `SessionEnd / Stop` row; split and annotated here.
- **Current code substrate reviewed:** `hooks.json`; `worktree-session-hygiene.mjs`; `scripts/lib/worktree-janitor-core.mjs` (Tier-A predicate); `scripts/lib/junction-safe-worktree-remove.mjs`; `update_agent_toolchain.py` (Grok plane); `apps/web/lib/queue/functions/worktree-janitor.ts` (fleet backstop — confirmed **not** the cause: cron 05:40, whole-worktree, flag-gated default OFF).
- **Source of truth:** the 2026-07-26 spec §D4/G4/G7 for which lifecycle event owns destructive reaping.
- **Decision:** conformance fix, **not** a contract change. The spec already assigns the reaper to SessionEnd and gives `Stop` only non-destructive guards; the `Stop` registration never had spec authority.

## Mitigation for anyone hit before this lands

`touch .worktree-pinned` in the worktree (verified to flip the verdict to `PINNED`), or `DPF_WORKTREE_SESSION_REAP=0`, or `DPF_SKIP_WORKTREE_SESSION_HYGIENE=1`. To repair a gutted tree: `git restore -- .` (lossless — all 59 are tracked and unmodified in HEAD). Check `git status --porcelain | grep -v '^??' | grep -vc '^ D'` is 0 first so real edits aren't clobbered.

## Local-CI note

Guard-parity preflight **passed**. The sandbox gate could not complete on this host: swap exhausted (55.0G of 56.3G used) and the gate's 16GB-heap stage was SIGTERM'd by the OS at 0:26 — the same OOM that killed three runs earlier today, unrelated to this change.

Local-CI-Override: operator-emergency: host swap exhausted, sandbox gate SIGTERM'd; guard preflight passed and 330 tests green locally

Docs-Impact-Decision: spec table + `dpf-worktree-hygiene` SKILL.md ownership row updated in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default
