### PR TITLE
fix(graph): scale the canvas layout to occupancy and stop the idle loop (BI-C2B6396B)

### DIFF
--- a/apps/web/components/inventory/RelationshipGraph.focus-label.test.tsx
+++ b/apps/web/components/inventory/RelationshipGraph.focus-label.test.tsx
@@ -21,7 +21,9 @@ import type { GraphData } from "@/lib/actions/graph";
 // Reset per test: the budget is consumed by each render, and a later test that
 // starts at zero never lays out its nodes, so the click would silently miss.
 let framesLeft = 60;
+let lastArc: { x: number; y: number } | null = null;
 beforeEach(() => {
+  lastArc = null;
   // Auto-cleanup is not configured for this file, so renders would otherwise
   // accumulate and every query would match the previous test's DOM too.
   cleanup();
@@ -32,8 +34,12 @@ beforeAll(() => {
   const noop = () => {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (HTMLCanvasElement.prototype as any).getContext = () => ({
-    clearRect: noop, beginPath: noop, arc: noop, fill: noop, stroke: noop,
+    clearRect: noop, beginPath: noop, fill: noop, stroke: noop,
     moveTo: noop, lineTo: noop, fillText: noop,
+    measureText: (text: string) => ({ width: text.length * 5 }),
+    // Record where the node is actually painted so the click below can land on
+    // it, rather than assuming a position.
+    arc: (x: number, y: number) => { lastArc = { x, y }; },
     set fillStyle(_v: string) {}, set strokeStyle(_v: string) {},
     set lineWidth(_v: number) {}, set globalAlpha(_v: number) {},
     set font(_v: string) {}, set textAlign(_v: string) {},
@@ -49,11 +55,6 @@ beforeAll(() => {
   globalThis.ResizeObserver = class {
     observe() {} unobserve() {} disconnect() {}
   } as never;
-
-  // Seed positions are `centre + (Math.random() - 0.5) * 300`. Pinning random to
-  // 0.5 puts the node exactly at the canvas centre, so the click below is a
-  // deterministic hit rather than a race with force-layout convergence.
-  Math.random = () => 0.5;
 });
 
 const DATA: GraphData = {
@@ -63,13 +64,20 @@ const DATA: GraphData = {
   links: [],
 };
 
-/** Click the canvas at the node's simulated position to focus it. */
+/**
+ * Click the canvas where the node was actually painted.
+ *
+ * Seed positions are derived from the node id (BI-C2B6396B), so there is no fixed
+ * coordinate to aim at — and pinning Math.random no longer moves them. Reading
+ * the position back from the last drawn arc keeps this independent of the
+ * layout's internals.
+ */
 function focusTheNode(container: HTMLElement) {
   const canvas = container.querySelector("canvas");
   if (!canvas) throw new Error("canvas did not render");
+  if (!lastArc) throw new Error("no node was painted — cannot locate it to click");
   canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 500 }) as DOMRect;
-  // The single node settles at the centre of the default 800x500 canvas.
-  fireEvent.click(canvas, { clientX: 400, clientY: 250 });
+  fireEvent.click(canvas, { clientX: lastArc.x, clientY: lastArc.y });
 }
 
 describe("focus chip type name (BI-AB7FE57B)", () => {

--- a/apps/web/components/inventory/RelationshipGraph.layout.test.tsx
+++ b/apps/web/components/inventory/RelationshipGraph.layout.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+//
+// BI-C2B6396B — the canvas must stay readable at the node counts the graph
+// explorer spec sanctions, and must stop animating once the layout is at rest.
+//
+// Both defects were found by driving the live install, and neither is visible to
+// a DOM assertion: the graph is painted to a <canvas>. So these tests record the
+// 2D context calls and assert on the geometry that reaches it.
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { RelationshipGraph } from "./RelationshipGraph";
+import type { GraphData } from "@/lib/actions/graph";
+
+type Arc = { x: number; y: number; r: number };
+type Label = { text: string; x: number; y: number; size: number };
+
+let arcs: Arc[] = [];
+let labels: Label[] = [];
+let rafCalls = 0;
+let framesLeft = 0;
+
+/** Roughly proportional to the real thing; enough for overlap geometry. */
+const CHAR_WIDTH = 5;
+
+beforeAll(() => {
+  const noop = () => {};
+  let currentFontSize = 9;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLCanvasElement.prototype as any).getContext = () => ({
+    clearRect: noop, beginPath: noop, moveTo: noop, lineTo: noop, stroke: noop,
+    arc: (x: number, y: number, r: number) => arcs.push({ x, y, r }),
+    fill: noop,
+    fillText: (text: string, x: number, y: number) =>
+      labels.push({ text, x, y, size: currentFontSize }),
+    measureText: (text: string) => ({ width: text.length * CHAR_WIDTH }),
+    set font(v: string) { currentFontSize = Number.parseFloat(v) || 9; },
+    get font() { return `${currentFontSize}px`; },
+    set fillStyle(_v: string) {}, set strokeStyle(_v: string) {},
+    set lineWidth(_v: number) {}, set globalAlpha(_v: number) {},
+    set textAlign(_v: string) {},
+  });
+
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    rafCalls += 1;
+    if (framesLeft-- > 0) cb(0);
+    return rafCalls;
+  }) as never;
+  globalThis.cancelAnimationFrame = noop as never;
+  globalThis.ResizeObserver = class {
+    observe() {} unobserve() {} disconnect() {}
+  } as never;
+  // No Math.random pinning needed: seed positions are derived from node ids, so
+  // the layout is already deterministic (BI-C2B6396B).
+});
+
+beforeEach(() => {
+  cleanup();
+  arcs = [];
+  labels = [];
+  rafCalls = 0;
+  framesLeft = 0;
+});
+
+function crowdedGraph(nodeCount: number): GraphData {
+  // A hub-and-spoke shape: every node linked to the first. This is the shape a
+  // one-hop expansion produces in the explorer, and the one the old fixed spring
+  // collapsed hardest — every edge pulled toward the same 100px of the centre.
+  return {
+    nodes: Array.from({ length: nodeCount }, (_, i) => ({
+      id: `n${i}`,
+      name: `Node${i}`,
+      label: "PrismaModel",
+      color: "#fbbf24",
+      size: 7,
+    })),
+    links: Array.from({ length: nodeCount - 1 }, (_, i) => ({
+      source: "n0",
+      target: `n${i + 1}`,
+      type: "HAS_FIELD",
+    })),
+  };
+}
+
+/** Positions from the final painted frame — one arc per node, in node order. */
+function finalPositions(nodeCount: number): Arc[] {
+  return arcs.slice(-nodeCount);
+}
+
+function meanNearestNeighbour(points: Arc[]): number {
+  let total = 0;
+  for (const a of points) {
+    let best = Infinity;
+    for (const b of points) {
+      if (a === b) continue;
+      const d = Math.hypot(a.x - b.x, a.y - b.y);
+      if (d < best) best = d;
+    }
+    total += best;
+  }
+  return total / points.length;
+}
+
+describe("layout spreads to fill the canvas (BI-C2B6396B)", () => {
+  it("keeps ~120 nodes legibly separated rather than knotting in the centre", () => {
+    const nodeCount = 120;
+    framesLeft = 400; // more than enough for the temperature to reach rest
+    render(<RelationshipGraph data={crowdedGraph(nodeCount)} />);
+
+    const points = finalPositions(nodeCount);
+    expect(points).toHaveLength(nodeCount);
+
+    // Ideal separation for 120 nodes in 800x500 is sqrt(400000/120) ~= 58px.
+    // The old fixed constants settled far below this; anything above ~20px means
+    // the nodes are distinguishable rather than a single blob.
+    expect(meanNearestNeighbour(points)).toBeGreaterThan(20);
+
+    // And the graph should occupy the canvas, not a puddle in the middle.
+    const xs = points.map((p) => p.x);
+    const ys = points.map((p) => p.y);
+    const spanX = Math.max(...xs) - Math.min(...xs);
+    const spanY = Math.max(...ys) - Math.min(...ys);
+    expect(spanX).toBeGreaterThan(800 * 0.5);
+    expect(spanY).toBeGreaterThan(500 * 0.5);
+  });
+
+  it("does not scatter a tiny graph to the edges", () => {
+    // The clamp on ideal separation earns its keep here: unbounded k for 3 nodes
+    // in 800x500 would be ~365px and push them into the corners.
+    framesLeft = 400;
+    render(
+      <RelationshipGraph
+        data={{
+          nodes: ["a", "b", "c"].map((id) => ({
+            id, name: id, label: "PrismaModel", color: "#fbbf24", size: 7,
+          })),
+          links: [{ source: "a", target: "b", type: "HAS_FIELD" }],
+        }}
+      />,
+    );
+
+    const points = finalPositions(3);
+    const xs = points.map((p) => p.x);
+    expect(Math.max(...xs) - Math.min(...xs)).toBeLessThan(800 * 0.75);
+  });
+});
+
+describe("labels do not overlap (BI-C2B6396B)", () => {
+  it("skips a label rather than painting it over one already placed", () => {
+    // Deliberately over-crowded: 240 nodes puts the ideal separation at ~41px
+    // while these names measure ~95px wide, so without the overlap pass the
+    // labels are guaranteed to collide. Verified: removing the guard from the
+    // component makes this test fail.
+    const nodeCount = 240;
+    const data: GraphData = {
+      nodes: Array.from({ length: nodeCount }, (_, i) => ({
+        id: `n${i}`,
+        name: `VeryLongNodeLabel${i}`,
+        label: "PrismaModel",
+        color: "#fbbf24",
+        size: 7,
+      })),
+      links: Array.from({ length: nodeCount - 1 }, (_, i) => ({
+        source: "n0", target: `n${i + 1}`, type: "HAS_FIELD",
+      })),
+    };
+
+    framesLeft = 260;
+    render(<RelationshipGraph data={data} />);
+
+    // Labels from the final frame only.
+    const lastFrame: Label[] = [];
+    for (let i = labels.length - 1; i >= 0; i--) {
+      const l = labels[i]!;
+      if (lastFrame.some((seen) => seen.text === l.text)) break;
+      lastFrame.unshift(l);
+    }
+    expect(lastFrame.length).toBeGreaterThan(1);
+
+    const boxes = lastFrame.map((l) => ({
+      x0: l.x - (l.text.length * CHAR_WIDTH) / 2,
+      x1: l.x + (l.text.length * CHAR_WIDTH) / 2,
+      y1: l.y,
+      y0: l.y - l.size,
+    }));
+
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i]!;
+        const b = boxes[j]!;
+        const overlaps = !(a.x1 < b.x0 || a.x0 > b.x1 || a.y1 < b.y0 || a.y0 > b.y1);
+        expect(overlaps, `"${lastFrame[i]!.text}" overlaps "${lastFrame[j]!.text}"`).toBe(false);
+      }
+    }
+  });
+});
+
+describe("animation stops when the layout is at rest (BI-C2B6396B)", () => {
+  it("stops re-arming requestAnimationFrame once cooled", () => {
+    framesLeft = 2000; // never the limiting factor — the component must stop itself
+    render(<RelationshipGraph data={crowdedGraph(30)} />);
+
+    // Temperature decays 1.0 * 0.98^n, reaching 0.01 after ~228 frames. Well
+    // under the 2000 the harness would allow, so a plateau proves the component
+    // stopped rather than the harness running out.
+    expect(rafCalls).toBeGreaterThan(0);
+    expect(rafCalls).toBeLessThan(400);
+
+    const settled = rafCalls;
+    // Nothing further should be scheduled without an input change.
+    expect(rafCalls).toBe(settled);
+  });
+
+  it("still paints a frame after cooling so a repaint-only restart renders", () => {
+    framesLeft = 2000;
+    const { rerender } = render(<RelationshipGraph data={crowdedGraph(10)} />);
+    const afterSettle = arcs.length;
+
+    // A prop change that affects painting but not physics.
+    rerender(<RelationshipGraph data={crowdedGraph(10)} title="Renamed" />);
+
+    expect(arcs.length).toBeGreaterThan(afterSettle);
+  });
+});

--- a/apps/web/components/inventory/RelationshipGraph.layout.test.tsx
+++ b/apps/web/components/inventory/RelationshipGraph.layout.test.tsx
@@ -127,7 +127,13 @@ describe("layout spreads to fill the canvas (BI-C2B6396B)", () => {
 
   it("does not scatter a tiny graph to the edges", () => {
     // The clamp on ideal separation earns its keep here: unbounded k for 3 nodes
-    // in 800x500 would be ~365px and push them into the corners.
+    // in 800x500 is ~365px, which spreads them far wider than the canvas wants.
+    //
+    // The threshold below is calibrated against both branches rather than guessed.
+    // Measured x-span for this fixture: 266px with the clamp, 483px with
+    // MAX_IDEAL_SEPARATION raised out of the way. An earlier version asserted
+    // < 800 * 0.75 (600px), which both branches satisfy — it would have passed
+    // with the clamp deleted and so proved nothing. 320px sits clear of both.
     framesLeft = 400;
     render(
       <RelationshipGraph
@@ -142,7 +148,7 @@ describe("layout spreads to fill the canvas (BI-C2B6396B)", () => {
 
     const points = finalPositions(3);
     const xs = points.map((p) => p.x);
-    expect(Math.max(...xs) - Math.min(...xs)).toBeLessThan(800 * 0.75);
+    expect(Math.max(...xs) - Math.min(...xs)).toBeLessThan(800 * 0.4);
   });
 });
 

--- a/apps/web/components/inventory/RelationshipGraph.tsx
+++ b/apps/web/components/inventory/RelationshipGraph.tsx
@@ -5,6 +5,46 @@ import type { GraphData } from "@/lib/actions/graph";
 
 export type GraphLegendEntry = { label: string; key: string; color: string };
 
+// ── Layout tuning (BI-C2B6396B) ──────────────────────────────────────────────
+//
+// The forces are expressed relative to `k`, the ideal node separation, which is
+// derived per frame from canvas area over node count (Fruchterman-Reingold).
+// Fixed constants collapsed the graph into a knot once the canvas carried ~100
+// nodes — well inside the 400-node cap the graph-explorer spec sanctions.
+
+/** Below this temperature the layout is at rest and the loop stops. */
+const COOLED_TEMPERATURE = 0.01;
+/** Ideal separation is clamped: unbounded k scatters a 3-node graph to the edges. */
+const MIN_IDEAL_SEPARATION = 34;
+const MAX_IDEAL_SEPARATION = 130;
+/** Repulsion at exactly the ideal separation. */
+const REPULSION_GAIN = 0.6;
+/** Ceiling for near-coincident nodes, which would otherwise be flung off-canvas. */
+const REPULSION_CAP = 6;
+const SPRING_GAIN = 0.0035;
+/** Padding around a label's box when testing it against already-placed labels. */
+const LABEL_PADDING = 2;
+
+/**
+ * Deterministic seed position for a node, derived from its id.
+ *
+ * Replaces `Math.random()` so a given graph always lays out identically. The
+ * golden-angle step spreads consecutive hashes around the circle instead of
+ * clustering them, and the radius varies so nodes do not land on one ring.
+ */
+function hashToUnitAngle(id: string): { angle: number; radius: number } {
+  let h = 2166136261;
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const unit = ((h >>> 0) % 100000) / 100000;
+  return {
+    angle: unit * Math.PI * 2 * 1.618033988749895,
+    radius: 30 + unit * 140,
+  };
+}
+
 const DEFAULT_LABEL_LEGEND: GraphLegendEntry[] = [
   { label: "Portfolio", color: "var(--dpf-accent)", key: "Portfolio" },
   { label: "Product", color: "#4ade80", key: "DigitalProduct" },
@@ -124,11 +164,36 @@ export function RelationshipGraph({
     const cy = dimensions.height / 2;
     const temp = temperatureRef.current;
 
-    if (temp <= 0.01) return;
+    if (temp <= COOLED_TEMPERATURE) return;
     temperatureRef.current *= 0.98;
 
+    // Ideal node separation, Fruchterman-Reingold style: k = sqrt(area / n).
+    // The forces below are expressed relative to k so the layout self-scales with
+    // how crowded the canvas is (BI-C2B6396B). The previous constants were fixed —
+    // repulsion of 80/d² and a spring pulling every edge to a flat 100px — which
+    // meant repulsion was already negligible at ~30px apart while the spring kept
+    // pulling inward. Past roughly a hundred nodes (a two-hop expansion in the
+    // graph explorer reaches that easily) the whole graph collapsed into an
+    // unreadable knot in the middle of the canvas.
+    const k = Math.max(
+      MIN_IDEAL_SEPARATION,
+      Math.min(
+        MAX_IDEAL_SEPARATION,
+        Math.sqrt((dimensions.width * dimensions.height) / Math.max(1, nodes.length)),
+      ),
+    );
+
     for (const node of nodes) {
-      if (node.x === undefined) { node.x = cx + (Math.random() - 0.5) * 300; node.y = cy + (Math.random() - 0.5) * 200; }
+      if (node.x === undefined) {
+        // Seeded from the node id rather than Math.random (BI-C2B6396B). Two
+        // benefits: the same graph lays out the same way every time, so the
+        // picture is stable across reloads and reproducible in tests; and no two
+        // nodes can start exactly coincident, where dx and dy are both zero, the
+        // repulsion direction is undefined, and the pair stays fused forever.
+        const seed = hashToUnitAngle(node.id);
+        node.x = cx + Math.cos(seed.angle) * seed.radius;
+        node.y = cy + Math.sin(seed.angle) * seed.radius * 0.7;
+      }
       node.vx = (node.vx ?? 0) * 0.6;
       node.vy = (node.vy ?? 0) * 0.6;
       node.vx! += (cx - node.x!) * 0.002 * temp;
@@ -141,8 +206,11 @@ export function RelationshipGraph({
         const b = nodes[j]!;
         const dx = (a.x ?? 0) - (b.x ?? 0);
         const dy = (a.y ?? 0) - (b.y ?? 0);
-        const dist = Math.max(10, Math.sqrt(dx * dx + dy * dy));
-        const force = Math.min(3, 80 / (dist * dist)) * temp;
+        const dist = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+        // Coulomb term relative to the ideal separation: at dist == k this is
+        // REPULSION_GAIN, and it falls off as 1/d². Capped so two nodes that spawn
+        // almost on top of each other cannot fling themselves off the canvas.
+        const force = Math.min(REPULSION_CAP, REPULSION_GAIN * ((k * k) / (dist * dist))) * temp;
         const fx = (dx / dist) * force;
         const fy = (dy / dist) * force;
         a.vx! += fx; a.vy! += fy;
@@ -158,7 +226,9 @@ export function RelationshipGraph({
       const dx = (target.x ?? 0) - (source.x ?? 0);
       const dy = (target.y ?? 0) - (source.y ?? 0);
       const dist = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-      const force = (dist - 100) * 0.003 * temp;
+      // Spring toward the same ideal separation the repulsion is scaled to, so
+      // the two forces balance at k rather than fighting to a fixed 100px.
+      const force = (dist - k) * SPRING_GAIN * temp;
       const fx = (dx / dist) * force;
       const fy = (dy / dist) * force;
       source.vx! += fx; source.vy! += fy;
@@ -225,13 +295,44 @@ export function RelationshipGraph({
       }
 
       ctx.globalAlpha = 1;
+    }
 
-      if (isHovered || isFocus || node.size >= 6) {
-        ctx.font = `${isHovered || isFocus ? 11 : 9}px -apple-system, sans-serif`;
-        ctx.fillStyle = isHovered || isFocus ? "#fff" : "rgba(224,224,255,0.6)";
-        ctx.textAlign = "center";
-        ctx.fillText(node.name, node.x, node.y - radius - 4);
-      }
+    // Labels last, as their own pass with greedy overlap rejection (BI-C2B6396B).
+    // Drawing them inside the node loop meant every eligible label was painted
+    // unconditionally and in arbitrary order, so a crowded centre became a pile of
+    // overlapping text. Hovered and focused labels are drawn first and always win
+    // their space; the rest take what is left and are skipped when they would
+    // collide. A skipped label is not lost — hovering the node reveals it.
+    const placed: Array<{ x0: number; y0: number; x1: number; y1: number }> = [];
+    const labelled = nodes
+      .filter((n) => n.x !== undefined && n.y !== undefined)
+      .filter((n) => hoveredNode === n.id || focusNodeId === n.id || (n.size ?? 4) >= 6)
+      .sort((a, b) => {
+        const rank = (n: SimNode) =>
+          (hoveredNode === n.id || focusNodeId === n.id ? 1000 : 0) + (n.size ?? 4);
+        return rank(b) - rank(a);
+      });
+
+    ctx.textAlign = "center";
+    for (const node of labelled) {
+      const important = hoveredNode === node.id || focusNodeId === node.id;
+      const fontSize = important ? 11 : 9;
+      ctx.font = `${fontSize}px -apple-system, sans-serif`;
+      const width = ctx.measureText(node.name).width;
+      const radius = (node.size ?? 4) * (important ? 1.5 : 1);
+      const x0 = node.x! - width / 2 - LABEL_PADDING;
+      const x1 = node.x! + width / 2 + LABEL_PADDING;
+      const y1 = node.y! - radius - 4;
+      const y0 = y1 - fontSize - LABEL_PADDING;
+
+      if (
+        !important
+        && placed.some((r) => !(x1 < r.x0 || x0 > r.x1 || y1 < r.y0 || y0 > r.y1))
+      ) continue;
+
+      placed.push({ x0, y0, x1, y1 });
+      ctx.fillStyle = important ? "#fff" : "rgba(224,224,255,0.6)";
+      ctx.fillText(node.name, node.x!, y1);
     }
   }, [dimensions, hoveredNode, focusNodeId, linkLegend]);
 
@@ -256,18 +357,43 @@ export function RelationshipGraph({
     return () => ro.disconnect();
   }, []);
 
-  // Animation loop
+  // A resize moves the centre and changes the ideal separation, so let the layout
+  // settle again rather than leaving nodes where the old geometry put them. Partial
+  // re-heat: enough to rearrange, not so much that the graph jumps on every drag of
+  // a window edge. Declared before the animation effect so the temperature is
+  // already raised when that effect re-runs.
+  useEffect(() => {
+    temperatureRef.current = Math.max(temperatureRef.current, 0.4);
+  }, [dimensions]);
+
+  // Animation loop — runs only while the layout is still settling (BI-C2B6396B).
+  //
+  // This used to re-arm requestAnimationFrame unconditionally. Once cooled,
+  // `simulate()` returned immediately but `draw()` kept repainting an unchanged
+  // canvas at ~60fps for as long as the page was open — pinning a renderer thread
+  // on both /inventory and /admin/graph-explorer, and timing out CDP screenshots
+  // against the page, which is how it was noticed.
+  //
+  // Stopping is safe because every input that changes the picture re-runs this
+  // effect: `filteredData` covers data and filter changes, and `draw`'s identity
+  // changes with hover, focus, dimensions, and the link legend. The cooled branch
+  // still paints one final frame, so a restart triggered purely by a repaint
+  // concern (a hover, say) renders correctly without restarting the physics.
   useEffect(() => {
     let running = true;
     function tick() {
       if (!running) return;
+      if (temperatureRef.current <= COOLED_TEMPERATURE) {
+        draw();
+        return;
+      }
       simulate();
       draw();
       animRef.current = requestAnimationFrame(tick);
     }
     tick();
     return () => { running = false; cancelAnimationFrame(animRef.current); };
-  }, [simulate, draw]);
+  }, [simulate, draw, filteredData]);
 
   // Click to focus
   function handleClick(e: React.MouseEvent<HTMLCanvasElement>) {

--- a/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
+++ b/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
@@ -155,6 +155,53 @@ the repo is a grandfathered draft — so this route ships the registry's first
 | `MAX_SUBGRAPH_EDGES` | 2000 | Bounds the payload to the canvas |
 | `MAX_EXPAND_DEPTH` | 3 | Beyond three hops the picture stops being legible |
 
+## Canvas legibility and idle cost (added 2026-08-01, BI-C2B6396B)
+
+The caps above assume the canvas stays readable up to `MAX_SUBGRAPH_NODES`. Live
+verification after this route shipped showed it did not: a single one-hop
+expansion reached **111 nodes / 230 links** and collapsed into a knot in the middle
+of the canvas with labels stacked on top of one another. Two causes, both in
+`RelationshipGraph`:
+
+**Fixed force constants.** Repulsion was `min(3, 80 / d²)` — already negligible at
+30px and effectively zero at 60px — while the link spring pulled every edge toward
+a flat 100px regardless of how many nodes shared the canvas. For ~110 nodes in
+800×500 the ideal separation is about 60px, where repulsion contributed ~0.02 per
+frame against a spring an order of magnitude stronger. The knot was the
+equilibrium those constants described.
+
+The forces are now expressed relative to `k = sqrt(area / n)`, the
+Fruchterman-Reingold ideal separation, so the layout self-scales with occupancy.
+`k` is clamped to [34, 130]: unclamped, a three-node graph would compute a ~365px
+ideal and fling its nodes into the corners.
+
+**Unconditional label drawing.** Every node with `size >= 6` painted its name, in
+node order, with no overlap test. Labels are now a separate pass with greedy
+overlap rejection, ordered hovered/focused first and then by size, so the
+important labels always win their space. A skipped label is not lost — hovering
+its node reveals it.
+
+**Seeding is deterministic.** Start positions derive from a hash of the node id
+rather than `Math.random()`. The same graph now lays out the same way every time,
+which makes the picture stable across reloads and reproducible in tests, and it
+removes a latent trap: two nodes seeded to exactly the same point have no defined
+repulsion direction and stay fused forever.
+
+### The animation loop stops
+
+`tick()` re-armed `requestAnimationFrame` unconditionally. Once the simulation
+cooled, `simulate()` returned immediately but `draw()` kept repainting an unchanged
+canvas at ~60fps for as long as the page was open. That pinned a renderer thread on
+both `/inventory` and `/admin/graph-explorer`, and it is why CDP
+`Page.captureScreenshot` timed out against this route — any agent driving this
+surface had to fall back to `get_page_text`.
+
+The loop now stops at rest and paints one final frame. Restarting is safe and
+automatic because every input that changes the picture re-runs the effect:
+`filteredData` covers data and filter changes, and `draw`'s identity changes with
+hover, focus, dimensions, and the link legend. A resize additionally re-heats the
+layout part-way, because it moves the centre and changes `k`.
+
 ## Security
 
 Every server action asserts `view_admin`. Operator text is bound as a positional


### PR DESCRIPTION
Two defects in `apps/web/components/inventory/RelationshipGraph.tsx`, both found by driving `/admin/graph-explorer` on the live install, and both affecting every surface that embeds this canvas (`/admin/graph-explorer` and `/inventory`).

Closes BI-C2B6396B.

## 1. The layout collapsed under its own sanctioned load

One hop from `DigitalProduct` grew the canvas to 111 nodes / 230 links and it knotted in the middle with labels stacked on one another. That is a defect against this surface's own spec, not a wish: `docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md` sets `MAX_SUBGRAPH_NODES = 400` and treats legibility as first-class.

The force constants were fixed rather than scaled. Repulsion was `min(3, 80 / dist²)` — negligible at 30px and effectively zero at 60px — while the spring pulled every edge toward a flat 100px however crowded the canvas was. At ~110 nodes in 800×500 the ideal separation is ~60px, where repulsion contributed ~0.02 per frame against a spring an order of magnitude stronger. The knot was the equilibrium those numbers described.

Forces are now relative to `k = sqrt(area / n)` (Fruchterman-Reingold), so the layout self-scales with occupancy. `k` is clamped to [34, 130] — unclamped, three nodes compute a ~365px ideal and fly to the corners.

Labels moved into their own pass with greedy overlap rejection, hovered/focused first then by size, so the important ones win the space. A skipped label is not lost; hovering reveals it.

Seed positions derive from a hash of the node id instead of `Math.random`. Beyond determinism, this closes a latent trap: two nodes seeded to the same point have no defined repulsion direction and stay fused forever.

## 2. The animation loop never stopped

`tick()` re-armed `requestAnimationFrame` unconditionally. Once cooled, `simulate()` returned immediately but `draw()` kept repainting an unchanged canvas at ~60fps for as long as the page was open — pinning a renderer thread and timing out CDP `Page.captureScreenshot` against the route, which is how it was noticed.

The loop now stops at rest after one final frame. Restart is automatic: every input that changes the picture re-runs the effect, and a resize additionally re-heats part-way.

## Verification

Functional, on the running portal with real data at the spec's 400-node ceiling — not just structural:

| Claim | Measured |
| --- | --- |
| Layout stays legible | 400 nodes, mean nearest-neighbour 31.1px, 0 nodes off-canvas |
| Loop terminates | self-terminated at 228 frames, the predicted cooling length |
| Labels don't collide | 22 labels drawn, 0 overlapping pairs |

`Page.captureScreenshot` now succeeds against this route, where it previously timed out.

Also green: `pnpm --filter web typecheck` 0 errors, 21 test files / 107 tests across `components/inventory` and `lib/graph`, 34 repo guards clean, and a local-CI gate PASS at `55319f617a85`.

## A second vacuous test, caught the same way

Each new test was verified to fail against the unfixed component by reverting that specific change. That discipline had already caught one inert test on this branch; re-running it caught another.

`does not scatter a tiny graph to the edges` passed with `MAX_IDEAL_SEPARATION` raised out of the way — it proved nothing about the clamp its own comment said it guarded, because `REPULSION_CAP` already bounds how far three nodes can push apart. Measured x-span is 266px clamped and 483px unclamped; the assertion allowed 600px, so both branches satisfied it.

The threshold is now 320px, calibrated against both branches rather than guessed, and verified to fail with the clamp removed. That is the second commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
