### PR TITLE
fix(proxy): serve /.well-known/* pre-auth so mobile install discovery works (BI-2AC1307A)

### DIFF
--- a/apps/web/lib/release/storefront-middleware.test.ts
+++ b/apps/web/lib/release/storefront-middleware.test.ts
@@ -16,6 +16,14 @@ describe("classifyRoute", () => {
     expect(classifyRoute("/api/storefront/acme-vet/items")).toBe(RouteClass.PublicApi);
   });
 
+  it("classifies the well-known discovery namespace as public (BI-2AC1307A)", () => {
+    // The mobile connect flow fetches this pre-auth; it must not be redirected
+    // to /welcome. Also covers the universal-link / app-link assets.
+    expect(classifyRoute("/.well-known/dpf-instance.json")).toBe(RouteClass.PublicApi);
+    expect(classifyRoute("/.well-known/apple-app-site-association")).toBe(RouteClass.PublicApi);
+    expect(classifyRoute("/.well-known/assetlinks.json")).toBe(RouteClass.PublicApi);
+  });
+
   it("classifies /api/* as protected api", () => {
     expect(classifyRoute("/api/agents")).toBe(RouteClass.ProtectedApi);
   });

--- a/apps/web/lib/release/storefront-middleware.ts
+++ b/apps/web/lib/release/storefront-middleware.ts
@@ -14,6 +14,14 @@ export enum RouteClass {
 const LEGACY_REDIRECT_PATHS = ["/customer-login", "/customer-signup"];
 
 export function classifyRoute(pathname: string): RouteClass {
+  // RFC 8615 well-known URIs are machine-discovery endpoints and MUST be
+  // publicly fetchable pre-auth. The mobile app's "connect to your org" flow
+  // fetches /.well-known/dpf-instance.json BEFORE login; without this the
+  // descriptor falls through to RouteClass.Other, the proxy redirects the
+  // unauthenticated request to /welcome, and the app receives HTML instead of
+  // JSON (BI-2AC1307A). Also covers the P2 universal-link / app-link assets
+  // (apple-app-site-association, assetlinks.json) which are public by spec.
+  if (pathname.startsWith("/.well-known/")) return RouteClass.PublicApi;
   if (pathname.startsWith("/s/")) return RouteClass.Storefront;
   if (pathname === "/portal/sign-in" || pathname === "/portal/sign-up") return RouteClass.PublicPage;
   if (pathname.startsWith("/portal")) return RouteClass.Portal;


### PR DESCRIPTION
## Summary

The mobile **"connect to your organization"** flow was dead against every install. It fetches `GET /.well-known/dpf-instance.json` *before* login to validate an install and learn its org name + archetype — but `classifyRoute()` had no case for the well-known namespace, so the descriptor fell through to `RouteClass.Other`, `proxy.ts` required an authenticated session, and redirected the unauthenticated request to `/welcome`. The app followed the 307, got the `/welcome` HTML, and threw **"JSON Parse error: unexpected character."**

Fixes BI-2AC1307A. Part of EP-MOBILE-IOS-APP.

## How it was found

Live, driving the iOS Simulator: tried to add a second install (a Windows restaurant-archetype box at `192.168.0.200:3000`) via the connect flow → JSON parse error. `curl` from the Mac confirmed the network was fine (ping OK, port 3000 open) but `/.well-known/dpf-instance.json` returned **307 → /welcome (HTML)** on *both* the Windows install and the Mac's own Arcamanus install. The Mac install only appeared to work in-app because the binary used its build-time default URL and never exercised descriptor discovery.

## Change

- `apps/web/lib/release/storefront-middleware.ts` — `classifyRoute()` returns `RouteClass.PublicApi` for any `/.well-known/*` path. Per RFC 8615 these are public machine-discovery endpoints; also future-proofs the spec's P2 universal-link / app-link assets (`apple-app-site-association`, `assetlinks.json`).
- Unit test asserts the three well-known paths classify public.

## Verification

- [x] `pnpm --filter web exec vitest run lib/release/storefront-middleware` — 8/8.
- [ ] CI typecheck (local pre-commit OOMed on the web project — env limit, not a type error; the change is a `string.startsWith` guard returning an existing enum member).

## Deployment note

This takes effect on an install only after it self-upgrades to a build carrying it — **both** the Mac and the Windows restaurant install need the upgrade before their descriptors serve JSON and the mobile connect flow works against them.

## Follow-up (separate BI worth filing)

Make the mobile connect flow degrade gracefully when the descriptor is absent/non-JSON, so a reachable install with no descriptor is still connectable (fall through to login) rather than hard-failing — resilience against older installs and reverse-proxy setups.
