### PR TITLE
fix(janitor): reclaim orphaned compose-project volumes, not just containers (BI-DBF3F426)

### DIFF
--- a/scripts/lib/runtime-artifact-janitor.mjs
+++ b/scripts/lib/runtime-artifact-janitor.mjs
@@ -34,6 +34,38 @@ export const ROOT_COMPOSE_PROJECT = "dpf";
 export const DEFAULT_STALENESS_DAYS = 7;
 export const MS_PER_DAY = 86_400_000;
 
+/**
+ * May the reaper delete the named Docker volumes of `projectName`?
+ *
+ * A compose `down --remove-orphans` reaps a stray project's containers + networks
+ * but never its named volumes (the `pgdata` / `node_modules` volumes), so a
+ * reaped project's storage lingers forever — the observed volume bloat: dead
+ * `dpf-<topic>` dev stacks whose worktree is long gone still holding ~1GB pgdata +
+ * node_modules each. Volume storage is only reclaimed when we ALSO remove those.
+ *
+ * This is the decision the "never-wipe-db rule" governs, so it is deliberately its
+ * own gate rather than an inline `--volumes` flag on `down`:
+ *   - A project only reaches here after decideComposeProject() already ruled it
+ *     REAP — not root, no live worktree, idle past the staleness threshold. Its
+ *     pgdata belongs to a branch that no longer exists on disk.
+ *   - The root `dpf` project is refused here too, as defense-in-depth independent
+ *     of the caller — deleting `dpf_pgdata` is the 2026-06-23 live-data revert
+ *     (BI-B61779DB), which the compose-safety guard also blocks.
+ *
+ * @param {string} projectName
+ * @returns {{ok:boolean, reason:string}}
+ */
+export function decideVolumeReclaim(projectName) {
+  const name = String(projectName ?? "").trim();
+  if (!name) {
+    return { ok: false, reason: "empty project name — refusing volume reclaim" };
+  }
+  if (name.toLowerCase() === ROOT_COMPOSE_PROJECT) {
+    return { ok: false, reason: "root dpf project — its volumes are never reclaimed" };
+  }
+  return { ok: true, reason: `stray project ${name} — its named volumes are orphaned and reclaimable` };
+}
+
 // `dpf-local-integration-<slug>-build` — the per-branch CI build image tag produced by
 // scripts/lib/local-integration-ci.mjs `dockerBuildTag()`.
 const CI_BUILD_IMAGE_RE = /^dpf-local-integration-[a-z0-9-]+-build$/i;
@@ -103,9 +135,12 @@ export function decideBuildImage(image, opts) {
  *   1. It is NOT the root `dpf` project (commandment: never touch root).
  *   2. It has no live worktree backing it. A `dpf-<topic>` project whose worktree is
  *      still present is active infrastructure — KEEP regardless of age.
- *   3. Its newest container is older than the staleness threshold.
+ *   3. It has no running container. A stack that is still `Up` is in use right now,
+ *      even if it was created long ago (a long-lived dev stack is created once and
+ *      runs for weeks) — KEEP regardless of age, independent of worktree naming.
+ *   4. Its newest container/volume is older than the staleness threshold.
  *
- * @param {{projectName:string, newestContainerCreatedMs:number}} project
+ * @param {{projectName:string, newestContainerCreatedMs:number, hasRunningContainer?:boolean}} project
  * @param {{
  *   nowMs:number,
  *   stalenessDays?:number,
@@ -131,6 +166,10 @@ export function decideComposeProject(project, opts) {
 
   if (live.has(name)) {
     return { verdict: "KEEP", reason: `backed by a live worktree (${name})`, ageDays: 0 };
+  }
+
+  if (project?.hasRunningContainer) {
+    return { verdict: "KEEP", reason: `has a running container (${name}) — in use`, ageDays: 0 };
   }
 
   const ageDays = ageInDays(project.newestContainerCreatedMs, opts.nowMs);

--- a/scripts/lib/runtime-artifact-janitor.test.mjs
+++ b/scripts/lib/runtime-artifact-janitor.test.mjs
@@ -8,6 +8,7 @@ import {
   ageInDays,
   decideBuildImage,
   decideComposeProject,
+  decideVolumeReclaim,
   isLocalCiBuildImage,
   planReap,
 } from "./runtime-artifact-janitor.mjs";
@@ -132,6 +133,15 @@ test("an orphaned dpf-<topic> project (no live worktree) past threshold is REAPE
   assert.match(d.reason, /orphaned worktree compose project/);
 });
 
+test("a project with a running container is NEVER reaped, even when ancient (in use now)", () => {
+  const d = decideComposeProject(
+    { projectName: "dpf-long-lived-devstack", newestContainerCreatedMs: daysAgo(99), hasRunningContainer: true },
+    { nowMs: NOW, liveWorktreeProjectNames: [] },
+  );
+  assert.equal(d.verdict, "KEEP");
+  assert.match(d.reason, /running container/);
+});
+
 test("a foreign (non-dpf) project past threshold is REAPED and labeled foreign", () => {
   const d = decideComposeProject(
     { projectName: "some-other-stack", newestContainerCreatedMs: daysAgo(10) },
@@ -198,4 +208,30 @@ test("planReap tolerates empty/missing inputs", () => {
   assert.deepEqual(plan.projectDecisions, []);
   assert.deepEqual(plan.imagesToReap, []);
   assert.deepEqual(plan.projectsToReap, []);
+});
+
+// ── decideVolumeReclaim ───────────────────────────────────────────────────────
+
+test("reclaims volumes for a stray dpf-<topic> project", () => {
+  const r = decideVolumeReclaim("dpf-provider-openrouter-policy");
+  assert.equal(r.ok, true);
+  assert.match(r.reason, /orphaned and reclaimable/);
+});
+
+test("reclaims volumes for a foreign compose project", () => {
+  assert.equal(decideVolumeReclaim("some-foreign-project").ok, true);
+});
+
+test("NEVER reclaims the root dpf project's volumes (never-wipe-db, case-insensitive)", () => {
+  for (const name of [ROOT_COMPOSE_PROJECT, "dpf", "DPF", " Dpf "]) {
+    const r = decideVolumeReclaim(name);
+    assert.equal(r.ok, false, `expected ${JSON.stringify(name)} refused`);
+    assert.match(r.reason, /root dpf project/);
+  }
+});
+
+test("refuses an empty/nullish project name rather than reclaiming broadly", () => {
+  for (const name of ["", "   ", null, undefined]) {
+    assert.equal(decideVolumeReclaim(name).ok, false);
+  }
 });

--- a/scripts/runtime-artifact-janitor.mjs
+++ b/scripts/runtime-artifact-janitor.mjs
@@ -44,7 +44,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { DEFAULT_STALENESS_DAYS, planReap } from "./lib/runtime-artifact-janitor.mjs";
+import { DEFAULT_STALENESS_DAYS, decideVolumeReclaim, planReap } from "./lib/runtime-artifact-janitor.mjs";
 import { deriveWorktreeComposeProjectName } from "./lib/compose-safety.mjs";
 
 // ── Arg parse ────────────────────────────────────────────────────────────────
@@ -128,30 +128,72 @@ function discoverBuildImages() {
 }
 
 /**
- * Discover compose projects and the creation time of their newest container.
- * Uses `docker ps -a` with the compose project label so we see stopped projects too.
+ * Discover compose projects and the newest activity timestamp of each.
+ *
+ * Two sources are unioned, because a stray project can outlive its containers:
+ *   1. `docker ps -a` container labels — sees running AND stopped projects.
+ *   2. `docker volume ls` volume labels + each volume's CreatedAt — sees projects
+ *      whose containers are already gone (e.g. `docker container prune` ran) but
+ *      whose named volumes still hold disk. Container-only discovery is blind to
+ *      these, which is exactly how the observed volume bloat became invisible:
+ *      dead dev stacks with no container but a lingering pgdata + node_modules.
+ *
+ * The staleness signal is the NEWEST timestamp seen across a project's containers
+ * and volumes (so a project stays "fresh" while any part of it is recent).
  */
 function discoverComposeProjects() {
-  const out = runCapture("docker", [
+  const newestByProject = new Map();
+  const runningProjects = new Set();
+  // NB: never `line.trim()` before splitting — when the project label is empty the
+  // line begins with a tab, and trimming would shift the NEXT field into the project
+  // slot (a container with no compose label would masquerade as a project named after
+  // its CreatedAt). Split the raw line; trim individual fields.
+  const bump = (projectName, ms) => {
+    const key = (projectName ?? "").trim();
+    if (!key) return;
+    const value = Number.isFinite(ms) ? ms : 0;
+    const prev = newestByProject.get(key);
+    if (prev === undefined || value > prev) newestByProject.set(key, value);
+  };
+
+  const containers = runCapture("docker", [
     "ps",
     "-a",
     "--format",
-    "{{.Label \"com.docker.compose.project\"}}\t{{.CreatedAt}}",
+    "{{.Label \"com.docker.compose.project\"}}\t{{.CreatedAt}}\t{{.State}}",
   ]);
-  const newestByProject = new Map();
-  for (const line of out.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const [projectName, createdAt] = trimmed.split("\t");
-    if (!projectName) continue; // containers not part of a compose project
-    const createdMs = Date.parse(createdAt);
-    const ms = Number.isFinite(createdMs) ? createdMs : 0;
-    const prev = newestByProject.get(projectName);
-    if (prev === undefined || ms > prev) newestByProject.set(projectName, ms);
+  for (const line of containers.split("\n")) {
+    if (!line) continue;
+    const [projectName, createdAt, state] = line.split("\t");
+    bump(projectName, Date.parse((createdAt || "").trim()));
+    if ((state || "").trim() === "running") {
+      const key = (projectName || "").trim();
+      if (key) runningProjects.add(key);
+    }
   }
+
+  // Volume-labelled projects (may include ones with no surviving container).
+  const volumes = runCapture("docker", [
+    "volume",
+    "ls",
+    "--format",
+    "{{.Name}}\t{{.Label \"com.docker.compose.project\"}}",
+  ]);
+  for (const line of volumes.split("\n")) {
+    if (!line) continue;
+    const [name, projectName] = line.split("\t");
+    if (!(projectName || "").trim()) continue; // anonymous / non-compose volumes are out of scope
+    // Fetch this volume's creation time so a volume-only project has a staleness signal.
+    const inspect = spawnSync("docker", ["volume", "inspect", name, "--format", "{{.CreatedAt}}"], {
+      encoding: "utf8",
+    });
+    bump(projectName, inspect.status === 0 ? Date.parse((inspect.stdout || "").trim()) : 0);
+  }
+
   return [...newestByProject.entries()].map(([projectName, newestContainerCreatedMs]) => ({
     projectName,
     newestContainerCreatedMs,
+    hasRunningContainer: runningProjects.has(projectName),
   }));
 }
 
@@ -174,15 +216,52 @@ function reapImage(repository) {
   return { ok: res.status === 0, detail: (res.status === 0 ? res.stdout : res.stderr || "").trim() };
 }
 
+/** List the named volumes Docker labelled as belonging to `projectName`. */
+function discoverProjectVolumes(projectName) {
+  const res = spawnSync(
+    "docker",
+    ["volume", "ls", "-q", "--filter", `label=com.docker.compose.project=${projectName}`],
+    { encoding: "utf8" },
+  );
+  if (res.status !== 0) return [];
+  return (res.stdout ?? "")
+    .split("\n")
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
 function reapComposeProject(projectName) {
-  // `down` removes containers + networks for the project. We do NOT pass --volumes:
-  // volumes are explicitly out of scope (never-wipe-db rule). COMPOSE_PROJECT_NAME
-  // scopes the teardown to exactly this stray project.
+  // `down` removes containers + networks for the project. We deliberately do NOT
+  // pass --volumes here: a bare `docker compose -p <name> down` runs without the
+  // project's compose file in context, so `--volumes` would not know its named
+  // volumes anyway. Volume reclaim is a separate, label-scoped step below, gated
+  // by decideVolumeReclaim() (the never-wipe-db rule). COMPOSE_PROJECT_NAME scopes
+  // the teardown to exactly this stray project.
   const res = spawnSync("docker", ["compose", "-p", projectName, "down", "--remove-orphans"], {
     encoding: "utf8",
     env: { ...process.env, COMPOSE_PROJECT_NAME: projectName },
   });
-  return { ok: res.status === 0, detail: (res.status === 0 ? res.stdout : res.stderr || "").trim() };
+  const down = { ok: res.status === 0, detail: (res.status === 0 ? res.stdout : res.stderr || "").trim() };
+
+  // Reclaim the stray project's orphaned named volumes (pgdata / node_modules /
+  // per-package caches). Without this the project's storage lingers after its
+  // worktree is gone — the observed volume bloat. decideVolumeReclaim() refuses
+  // the root `dpf` project as defense-in-depth; the project reached here only
+  // because planReap already classified it a stray REAP candidate.
+  const volumes = [];
+  const gate = decideVolumeReclaim(projectName);
+  if (gate.ok) {
+    for (const name of discoverProjectVolumes(projectName)) {
+      const rm = spawnSync("docker", ["volume", "rm", name], { encoding: "utf8" });
+      volumes.push({
+        name,
+        ok: rm.status === 0,
+        detail: (rm.status === 0 ? rm.stdout : rm.stderr || "").trim(),
+      });
+    }
+  }
+
+  return { ...down, volumesSkippedReason: gate.ok ? undefined : gate.reason, volumes };
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -278,6 +357,12 @@ function renderText(plan, opts, applied) {
     }
     for (const r of applied.projects) {
       console.log(`  ${r.ok ? "tore down project " : "FAILED project "}${r.projectName}  ${r.detail}`);
+      for (const v of r.volumes ?? []) {
+        console.log(`    ${v.ok ? "reclaimed volume " : "FAILED volume "}${v.name}  ${v.detail}`);
+      }
+      if (r.volumesSkippedReason) {
+        console.log(`    volumes kept — ${r.volumesSkippedReason}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Why

On a well-used install the dominant local-disk leak is **orphaned Docker volumes from dead per-worktree dev stacks**. When a `dpf-<topic>` dev stack's worktree merges and is reaped, ~1GB+ of `pgdata` + `node_modules` + package-cache volumes are left behind forever.

Root cause: neither the worktree reaper nor the worktree janitor touches Docker at all (grep-confirmed). The runtime-artifact janitor is the only thing that can reclaim it — and it tore down stray-project **containers/networks only** (`down --remove-orphans`), deliberately never `--volumes`. So volumes accumulated with no reaper anywhere.

Observed on the current install before this change: 3 orphaned `dpf-provider-*` dev stacks (48 volumes, ~25GB reclaimable) whose branches no longer exist.

## What

1. **Volume reclaim, label-scoped and gated.** After `down`, reap volumes selected by `com.docker.compose.project=<name>`. Done as a separate label-scoped step, not a `--volumes` flag — a bare `-p <name> down` runs without the project's compose file in context, so `--volumes` wouldn't know the named volumes. New pure `decideVolumeReclaim()` refuses the root `dpf` project as defense-in-depth (deleting `dpf_pgdata` is the 2026-06-23 revert, BI-B61779DB).
2. **Volume-based project discovery.** A stray project can outlive its containers (`docker container prune`), leaving volumes with no container — invisible to container-label discovery. Discovery now unions `docker ps -a` with volume labels, using volume CreatedAt as the staleness signal.
3. **Running-container liveness guard + parse fix.** KEEP any project with a running container regardless of age (a long-lived dev stack runs for weeks; staleness alone would reap it while in use). Also stop `line.trim()` before the field split — an empty project label begins the line with a tab, which shifted CreatedAt into the project slot (a non-compose container masqueraded as a project named after its timestamp).

## Scope / safety

This fixes the reaping **primitive**. The scheduled home stays **observe-only and founder-gated** (`DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED`); arming real `--apply` remains a separate governed operator action, unchanged here. The `destructive-actions-require-explicit-go` contract is preserved.

## Verification

- 22 unit tests pass (new `decideVolumeReclaim` cases + running-container guard).
- Dry-run against the live install correctly classifies the 3 orphaned `dpf-provider-*` stacks + a stale `dpf-local-ci` as REAP, while keeping root `dpf` and every running stack.
- End-to-end reclaim proven on a synthetic labeled volume (discover → gate → `volume rm`); root-`dpf` guard confirmed to refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)