### PR TITLE
fix(federation): sync only open backlog items; closed leave scope (BI-8A8C1D3A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ __pycache__/
 # `.git/hooks/`. Multiple Windows worktrees in this repo have observed it.
 # Without this entry, a `git add -A` would happily commit the stray hooks.
 dev/null/
+
+# Local-integration-CI runner verdict artifacts (never committed)
+.dpf-local-ci-*.json
+.dpf-sandbox-freshness.json

--- a/apps/web/lib/explore/backlog.test.ts
+++ b/apps/web/lib/explore/backlog.test.ts
@@ -5,6 +5,8 @@ import {
   BACKLOG_STATUS_COLOURS,
   EPIC_STATUS_COLOURS,
   EPIC_STATUSES,
+  FEDERATION_SYNCABLE_BACKLOG_STATUSES,
+  isFederationSyncableBacklogStatus,
   LIFECYCLE_STAGE_LABELS,
   initialDemandStageForInput,
   type BacklogItemInput,
@@ -113,6 +115,24 @@ describe("LIFECYCLE_STAGE_LABELS", () => {
     for (const stage of ["plan", "design", "build", "production", "retirement"]) {
       expect(LIFECYCLE_STAGE_LABELS[stage]).toBeDefined();
     }
+  });
+});
+
+describe("isFederationSyncableBacklogStatus()", () => {
+  it("treats open work (triaging/open/in-progress) as syncable", () => {
+    expect(FEDERATION_SYNCABLE_BACKLOG_STATUSES).toEqual(["triaging", "open", "in-progress"]);
+    for (const status of FEDERATION_SYNCABLE_BACKLOG_STATUSES) {
+      expect(isFederationSyncableBacklogStatus(status)).toBe(true);
+    }
+  });
+
+  it("treats closed work (done) and paused work (deferred) as not syncable", () => {
+    expect(isFederationSyncableBacklogStatus("done")).toBe(false);
+    expect(isFederationSyncableBacklogStatus("deferred")).toBe(false);
+  });
+
+  it("returns false for an unknown status rather than defaulting to syncable", () => {
+    expect(isFederationSyncableBacklogStatus("bogus")).toBe(false);
   });
 });
 

--- a/apps/web/lib/explore/backlog.ts
+++ b/apps/web/lib/explore/backlog.ts
@@ -194,6 +194,24 @@ export const BACKLOG_STATUS_VALUES = [
 ] as const;
 export type BacklogStatus = (typeof BACKLOG_STATUS_VALUES)[number];
 
+// Federation demand sharing operates on OPEN work only — "closed is closed."
+// Closed items are never projected to a peer; an item that transitions out of
+// this set leaves projection scope and is withdrawn from peers on the next
+// reconciliation. `deferred` is treated as not-currently-syncable per the
+// live-work convention (paused work resumes syncing when it reopens); `done`
+// is terminal. This is the single source of truth for that grouping — the same
+// federation lanes (demand-reconciliation, channel-demand) must import it rather
+// than re-listing statuses. See BI-8A8C1D3A.
+export const FEDERATION_SYNCABLE_BACKLOG_STATUSES = [
+  "triaging",
+  "open",
+  "in-progress",
+] as const satisfies readonly BacklogStatus[];
+
+export function isFederationSyncableBacklogStatus(status: string): boolean {
+  return (FEDERATION_SYNCABLE_BACKLOG_STATUSES as readonly string[]).includes(status);
+}
+
 export const BACKLOG_TRIAGE_OUTCOMES = [
   "build",
   "runbook",

--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -47,6 +47,7 @@ describe("selectLocalDemandForLink direction", () => {
           itemId: "BI-LOCAL",
           title: "Local need",
           body: null,
+          status: "open",
           workType: "feature",
           occurrenceCount: 1,
           createdAt: new Date(),
@@ -60,6 +61,42 @@ describe("selectLocalDemandForLink direction", () => {
         linkId: "FL-REVERSE",
         itemId: "BI-LOCAL",
       })).rejects.toThrow("Local demand can only be shared toward your distributor or Founder Hub.");
+    },
+  );
+
+  it.each(["done", "deferred"])(
+    "rejects sharing a closed (%s) backlog item — only open demand is projected",
+    async (status) => {
+      const db = {
+        federationLink: { findUnique: vi.fn().mockResolvedValue({
+          linkId: "FL-FOUNDER",
+          role: "channel-downstream",
+          linkState: "trusted",
+          peerAuthorityUrl: "https://founder-hub.example",
+          peerTokenEnc: "token",
+          peerInstallationId: "inst_founder",
+          projectionContractId: null,
+          revokedAt: null,
+          quarantinedAt: null,
+        }) },
+        backlogItem: { findUnique: vi.fn().mockResolvedValue({
+          itemId: "BI-CLOSED",
+          title: "Resolved need",
+          body: null,
+          status,
+          workType: "feature",
+          occurrenceCount: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          digitalProduct: null,
+        }) },
+        projectionContract: { findFirst: vi.fn().mockResolvedValue(null) },
+      };
+
+      await expect(selectLocalDemandForLink(db as never, {
+        linkId: "FL-FOUNDER",
+        itemId: "BI-CLOSED",
+      })).rejects.toThrow("Closed backlog items cannot be shared; only open demand is projected to a connection.");
     },
   );
 
@@ -80,6 +117,7 @@ describe("selectLocalDemandForLink direction", () => {
         itemId: "BI-LOCAL",
         title: "Distributor need",
         body: null,
+        status: "open",
         workType: "feature",
         occurrenceCount: 1,
         createdAt: new Date(),

--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -13,6 +13,8 @@ import {
   type FederationRole,
 } from "@dpf/db/federation-link-types";
 
+import { isFederationSyncableBacklogStatus } from "@/lib/explore/backlog";
+
 import {
   queueDemandProjection,
   queueDemandWithdrawal,
@@ -39,6 +41,7 @@ interface ChannelBacklogItem {
   itemId: string;
   title: string;
   body: string | null;
+  status: string;
   workType: string | null;
   occurrenceCount: number;
   createdAt: Date;
@@ -228,6 +231,7 @@ export async function selectLocalDemandForLink(
         itemId: true,
         title: true,
         body: true,
+        status: true,
         workType: true,
         occurrenceCount: true,
         createdAt: true,
@@ -247,6 +251,9 @@ export async function selectLocalDemandForLink(
     );
   }
   if (!item) throw new Error("Local demand item was not found.");
+  if (!isFederationSyncableBacklogStatus(item.status)) {
+    throw new Error("Closed backlog items cannot be shared; only open demand is projected to a connection.");
+  }
   if ((item.body ?? "").includes("[origin:federatedDemand:")) {
     throw new Error("Adopted demand must use governed forwarding so original provenance is preserved.");
   }

--- a/apps/web/lib/federation/demand-reconciliation.test.ts
+++ b/apps/web/lib/federation/demand-reconciliation.test.ts
@@ -57,6 +57,28 @@ describe("runDemandReconciliation", () => {
     });
   });
 
+  it("projects only open backlog items — closed work is excluded from the query", async () => {
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue(links) },
+      backlogItem: { findMany: vi.fn().mockResolvedValue([]) },
+      federatedRecordMirror: { findMany: vi.fn().mockResolvedValue([]) },
+    } as unknown as DemandReconciliationDb;
+
+    await runDemandReconciliation(db, {
+      resolveIdentity: vi.fn().mockResolvedValue({ installationId: `inst_${"a".repeat(32)}`, projectionSecret: "b".repeat(64) }),
+      queueProjection: vi.fn(),
+      queueWithdrawal: vi.fn(),
+      reconcileDigests: vi.fn().mockResolvedValue({ linksChecked: 0, requeued: 0, confirmed: 0, failedLinks: 0 }),
+      dispatch: vi.fn().mockResolvedValue({ attempted: 0, delivered: 0, deferred: 0, deadLettered: 0 }),
+    });
+
+    expect(db.backlogItem.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        status: { in: ["triaging", "open", "in-progress"] },
+      }),
+    }));
+  });
+
   it("never re-egresses a locally adopted peer envelope", async () => {
     const queueProjection = vi.fn();
     const db = {

--- a/apps/web/lib/federation/demand-reconciliation.ts
+++ b/apps/web/lib/federation/demand-reconciliation.ts
@@ -2,6 +2,8 @@ import { prisma } from "@dpf/db";
 import { DEMAND_PROJECTION_TEMPLATES } from "@dpf/db/federated-demand-contract";
 import type { FederationRelationshipPreset } from "@dpf/db/federation-link-types";
 
+import { FEDERATION_SYNCABLE_BACKLOG_STATUSES } from "@/lib/explore/backlog";
+
 import {
   dispatchDueDemand,
   queueDemandProjection,
@@ -92,6 +94,9 @@ export async function runDemandReconciliation(
     const items = await db.backlogItem.findMany({
       where: {
         digitalProduct: { productId: "dpf-portal" },
+        // Open work only. A closed item is excluded here, drops out of
+        // eligibleIds below, and is withdrawn from the peer. See BI-8A8C1D3A.
+        status: { in: [...FEDERATION_SYNCABLE_BACKLOG_STATUSES] },
         NOT: { body: { contains: "[origin:federatedDemand:" } },
       },
       select: {


### PR DESCRIPTION
## Summary

Founder-directed: the federated demand network must sync **open** work only — "closed are closed." Today the same-org demand reconciliation projects **every** `dpf-portal` backlog item regardless of status, so `done`/`deferred` (closed) work is synced to peers; the explicit channel-sharing path has no status check either.

Fixes **BI-8A8C1D3A** (EP-DELIVERY-FLOW).

## Change

- **Single source of truth** for the federation-syncable status set in `apps/web/lib/explore/backlog.ts`: `FEDERATION_SYNCABLE_BACKLOG_STATUSES = [triaging, open, in-progress]` + `isFederationSyncableBacklogStatus()`. `done` is terminal; `deferred` is treated as not-currently-syncable per the existing live-work convention (`backlog-ingest.ts:307`) — paused work resumes syncing when reopened.
- **Same-org reconciliation** (`demand-reconciliation.ts`): the projection query now filters to the syncable set. Because the loop already withdraws items that leave `eligibleIds`, an item that transitions **closed automatically emits `dpf.demand.withdrawn`** to the peer — no new transport.
- **Channel/partner sharing** (`channel-demand.ts`): `selectLocalDemandForLink` now rejects sharing a closed item.
- `.gitignore`: ignore local-integration-CI runner verdict artifacts (`.dpf-local-ci-*.json`, `.dpf-sandbox-freshness.json`) so they can't be swept into a commit.

## Deliberately out of scope

Cascade-closing a peer's **adopted** local `BacklogItem` when the origin closes — that mutates a locally-owned BI and touches the ratified "no remote party changes a local backlog item's status" principle. Filed as **BI-D571FB82**; governed kernel decision **DI-7A14B2C9B479** selected **signal-and-confirm** (never silent auto-close, even same-org) over auto-close. That work also needs a distinct resolved-signal on the envelope + chain auto-forward, so it is its own slice.

## Verification

- Targeted vitest: `backlog.test.ts` + `channel-demand.test.ts` + `demand-reconciliation.test.ts` — 35/35 pass (adds status-filter, closed-share-rejection, and helper-boundary tests).
- Exact-tree local-integration-CI (`pnpm run pregate`) **passed** on the committed tree: full `pnpm --filter web typecheck` (16GB heap) passed, exhaustive web vitest passed, production Next build completed. Evidence `cmsfkjbxy068u01monbcm0r51`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)