### PR TITLE
feat(graph): put the knowledge corpus and the portfolio spine in the mirror (BI-3045CC18)

### DIFF
--- a/apps/web/lib/graph/__tests__/explorer-vocabulary.test.ts
+++ b/apps/web/lib/graph/__tests__/explorer-vocabulary.test.ts
@@ -16,6 +16,10 @@ describe("humanizeLabel", () => {
   it("strips the ArchiMate namespace prefix", () => {
     expect(humanizeLabel("ArchiMate__DataObject")).toBe("Data Object");
   });
+
+  it("strips the Wiki namespace prefix", () => {
+    expect(humanizeLabel("Wiki__Principle")).toBe("Principle");
+  });
 });
 
 describe("describeLabel", () => {
@@ -29,6 +33,20 @@ describe("describeLabel", () => {
     const descriptor = describeLabel("ArchiMate__ApplicationService");
     expect(descriptor.label).toBe("Application Service");
     expect(descriptor.domain).toBe("architecture");
+  });
+
+  it("returns the curated descriptor for a knowledge page kind", () => {
+    const descriptor = describeLabel("Wiki__Principle");
+    expect(descriptor.label).toBe("Principle");
+    expect(descriptor.domain).toBe("knowledge");
+  });
+
+  it("keeps an uncurated wiki page kind inside the knowledge domain", () => {
+    // `WikiPage.pageKind` is a plain string, so a kind added later must not fall
+    // through to the architecture-flavoured unknown bucket (BI-3045CC18).
+    const descriptor = describeLabel("Wiki__FieldGuide");
+    expect(descriptor.domain).toBe("knowledge");
+    expect(descriptor.label).toBe("Field Guide");
   });
 
   it("degrades rather than throwing on an unknown label", () => {

--- a/apps/web/lib/graph/explorer-chart-colors.ts
+++ b/apps/web/lib/graph/explorer-chart-colors.ts
@@ -25,10 +25,27 @@ export const NODE_CATEGORY_COLORS = {
   Portfolio: "#818cf8",
   DigitalProduct: "#4ade80",
   TaxonomyNode: "#fb923c",
+  // Knowledge corpus (BI-3045CC18). A rose/fuchsia family, deliberately coherent:
+  // the other domains already own blues (code), ambers (data model), greens (EA),
+  // cyan (infrastructure) and indigo/orange (portfolio), so the whole knowledge
+  // corpus reads as one body at a glance while the page kinds stay separable.
+  Wiki__Principle: "#fb7185",
+  Wiki__Stance: "#f0abfc",
+  Wiki__Heuristic: "#e879f9",
+  Wiki__Decision: "#d946ef",
+  Wiki__Entity: "#fda4af",
+  Wiki__Summary: "#fecdd3",
+  Wiki__Runbook: "#f5d0fe",
+  Wiki__Index: "#c026d3",
 } as const satisfies Record<string, string>;
 
 /** Any ArchiMate type without a curated entry of its own. */
 export const ARCHIMATE_DEFAULT_COLOR = "#86efac";
+
+/** Any wiki page kind without a curated entry of its own. `pageKind` is an open
+ *  string in the schema, so a new kind degrades to the family colour rather than
+ *  to the unknown-neutral, keeping it inside the knowledge domain visually. */
+export const WIKI_DEFAULT_COLOR = "#fbcfe8";
 
 /** Unknown node label or relationship type — deliberately the muted neutral. */
 export const UNKNOWN_CATEGORY_COLOR = "#8888a0";
@@ -50,4 +67,6 @@ export const REL_TYPE_COLORS: Record<string, string> = {
   HOSTS: "#22d3ee",
   RUNS_ON: "#34d399",
   ROUTES_THROUGH: "#f472b6",
+  LINKS_TO: "#f0abfc",
+  OVERRIDES: "#d946ef",
 };

--- a/apps/web/lib/graph/explorer-vocabulary.ts
+++ b/apps/web/lib/graph/explorer-vocabulary.ts
@@ -16,9 +16,16 @@ import {
   NODE_CATEGORY_COLORS,
   REL_TYPE_COLORS,
   UNKNOWN_CATEGORY_COLOR,
+  WIKI_DEFAULT_COLOR,
 } from "./explorer-chart-colors";
 
-export type GraphDomainKey = "code" | "data" | "architecture" | "infrastructure" | "portfolio";
+export type GraphDomainKey =
+  | "code"
+  | "data"
+  | "knowledge"
+  | "architecture"
+  | "infrastructure"
+  | "portfolio";
 
 export type GraphDomain = {
   key: GraphDomainKey;
@@ -36,6 +43,12 @@ export const GRAPH_DOMAINS: GraphDomain[] = [
     key: "data",
     label: "Data model",
     description: "Prisma models and their fields.",
+  },
+  {
+    key: "knowledge",
+    label: "Knowledge",
+    description:
+      "Wiki pages and the links between them: decision rules, organizational stances, profession corpora, and the founder kernel.",
   },
   {
     key: "architecture",
@@ -108,6 +121,39 @@ const LABEL_DESCRIPTORS: LabelDescriptor[] = [
     size: 5,
   },
 
+  // ── Knowledge ───────────────────────────────────────────────────────────────
+  //
+  // One label per node, not a generic `WikiPage` marker plus a specific kind. The
+  // census sums per-label counts, so a node carrying two labels is counted twice —
+  // which is exactly why `EaElement` needs a hard-coded skip there. A single
+  // specific label keeps the knowledge domain out of that trap (BI-3045CC18).
+  {
+    key: "Wiki__Principle",
+    label: "Principle",
+    domain: "knowledge",
+    color: NODE_CATEGORY_COLORS.Wiki__Principle,
+    size: 6,
+  },
+  { key: "Wiki__Stance", label: "Stance", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Stance, size: 6 },
+  {
+    key: "Wiki__Heuristic",
+    label: "Heuristic",
+    domain: "knowledge",
+    color: NODE_CATEGORY_COLORS.Wiki__Heuristic,
+    size: 5,
+  },
+  {
+    key: "Wiki__Decision",
+    label: "Decision rule",
+    domain: "knowledge",
+    color: NODE_CATEGORY_COLORS.Wiki__Decision,
+    size: 6,
+  },
+  { key: "Wiki__Entity", label: "Entity page", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Entity, size: 5 },
+  { key: "Wiki__Summary", label: "Summary", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Summary, size: 4 },
+  { key: "Wiki__Runbook", label: "Runbook", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Runbook, size: 5 },
+  { key: "Wiki__Index", label: "Index page", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Index, size: 7 },
+
   // ── Portfolio ───────────────────────────────────────────────────────────────
   { key: "Portfolio", label: "Portfolio", domain: "portfolio", color: NODE_CATEGORY_COLORS.Portfolio, size: 8 },
   {
@@ -131,6 +177,11 @@ const DESCRIPTOR_BY_KEY = new Map(LABEL_DESCRIPTORS.map((d) => [d.key, d]));
 /** The `ArchiMate__<Type>` family is open-ended — one rule covers every member. */
 const ARCHIMATE_PREFIX = "ArchiMate__";
 
+/** `Wiki__<PageKind>`. `WikiPage.pageKind` is a plain string in the schema, so a
+ *  kind added later must still land in the knowledge domain rather than in the
+ *  architecture-flavoured unknown bucket (BI-3045CC18). */
+const WIKI_PREFIX = "Wiki__";
+
 const UNKNOWN_DESCRIPTOR: Omit<LabelDescriptor, "key" | "label"> = {
   domain: "architecture",
   color: UNKNOWN_CATEGORY_COLOR,
@@ -139,7 +190,11 @@ const UNKNOWN_DESCRIPTOR: Omit<LabelDescriptor, "key" | "label"> = {
 
 /** Split a PascalCase / prefixed storage label into readable words. */
 export function humanizeLabel(raw: string): string {
-  const stripped = raw.startsWith(ARCHIMATE_PREFIX) ? raw.slice(ARCHIMATE_PREFIX.length) : raw;
+  const stripped = raw.startsWith(ARCHIMATE_PREFIX)
+    ? raw.slice(ARCHIMATE_PREFIX.length)
+    : raw.startsWith(WIKI_PREFIX)
+      ? raw.slice(WIKI_PREFIX.length)
+      : raw;
   return stripped
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .replace(/_+/g, " ")
@@ -158,6 +213,16 @@ export function describeLabel(raw: string): LabelDescriptor {
       domain: "architecture",
       color: ARCHIMATE_DEFAULT_COLOR,
       size: 4,
+    };
+  }
+
+  if (raw.startsWith(WIKI_PREFIX)) {
+    return {
+      key: raw,
+      label: humanizeLabel(raw),
+      domain: "knowledge",
+      color: WIKI_DEFAULT_COLOR,
+      size: 5,
     };
   }
 

--- a/apps/web/lib/ux-budget/purpose-contracts/graph-explorer.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/graph-explorer.ts
@@ -16,10 +16,10 @@ export const GRAPH_EXPLORER_PURPOSE_CONTRACTS: PurposeContractModule = [
       primaryUser:
         "A platform operator or architect who wants to see how the platform is wired together.",
       triggeringNeed:
-        "Understanding or demonstrating the breadth of what the platform knows about itself — source code, data model, architecture, and infrastructure — which was only possible through the Neo4j browser before BET-5 retired it.",
+        "Understanding or demonstrating the breadth of what the platform knows about itself — source code, data model, knowledge corpus, architecture, infrastructure, and business portfolio — which was only possible through the Neo4j browser before BET-5 retired it.",
       prerequisites: [
         "Signed in with the view_admin capability.",
-        "The graph mirror has been populated by the code-graph indexer and the EA/discovery sync.",
+        "The graph mirror has been populated by the code-graph indexer, the EA/discovery sync, and the knowledge/portfolio backfill.",
       ],
       job: "Find a starting point in the corpus and follow its relationships outward to see what it connects to.",
       successOutcome:

--- a/apps/web/lib/ux-budget/route-purpose.generated.json
+++ b/apps/web/lib/ux-budget/route-purpose.generated.json
@@ -128,10 +128,10 @@
       },
       "intent": {
         "primaryUser": "A platform operator or architect who wants to see how the platform is wired together.",
-        "triggeringNeed": "Understanding or demonstrating the breadth of what the platform knows about itself — source code, data model, architecture, and infrastructure — which was only possible through the Neo4j browser before BET-5 retired it.",
+        "triggeringNeed": "Understanding or demonstrating the breadth of what the platform knows about itself — source code, data model, knowledge corpus, architecture, infrastructure, and business portfolio — which was only possible through the Neo4j browser before BET-5 retired it.",
         "prerequisites": [
           "Signed in with the view_admin capability.",
-          "The graph mirror has been populated by the code-graph indexer and the EA/discovery sync."
+          "The graph mirror has been populated by the code-graph indexer, the EA/discovery sync, and the knowledge/portfolio backfill."
         ],
         "job": "Find a starting point in the corpus and follow its relationships outward to see what it connects to.",
         "successOutcome": "The operator can name a thing (a file, a data model, a route, a tool, an EA element), see its neighbourhood drawn, and read its properties and degree.",

--- a/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
+++ b/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
@@ -172,9 +172,94 @@ SQL. There is no write path and no free-form query surface.
 4. **This rulebook** — no rule is re-homed. AGENTS.md is unchanged; the operator
    documentation lives in `docs/user-guide/admin/index.md`.
 
+## Knowledge and portfolio domains (BI-3045CC18, 2026-08-04)
+
+The first cut demonstrated the *technical* substrate only. Two of the things a
+demonstration most wants were effectively absent: the knowledge corpus was not in
+the mirror at all, and Portfolio was a single node.
+
+### The scope question was already answered by the substrate
+
+The open question recorded against this work was whether the mirror is a *code and
+architecture* graph or a *whole-platform* graph. Measured before building, the
+substrate had already answered it:
+
+- `explorer-vocabulary.ts` already declared a `portfolio` domain with `Portfolio`,
+  `DigitalProduct` and `TaxonomyNode` descriptors.
+- `graph-sync.ts` already exported `syncPortfolio`, `syncTaxonomyNode` and
+  `syncDigitalProduct`.
+- The mirror already carried 569 customer-scoped `InfraCI` nodes with
+  `customerAccountId` / `customerSiteId` — business data, not code.
+
+So the mirror was already a whole-platform graph by declaration. What was missing
+was not a decision but a **backfill**: `syncPortfolio` and `syncTaxonomyNode` had
+zero callers, and `syncDigitalProduct` fired only on create/update, so nothing
+predating the explorer was ever mirrored. The governing pattern is that a domain is
+only as complete as its rebuild script — every populated domain had one
+(`neo4j-rebuild-ea.ts`, `neo4j-rebuild-documents.ts`) and every empty one did not.
+
+Scored through the kernel (`principle_decide`, high confidence, no commandment
+conflict), with *Ground New Work In Existing Platform* and *Audit Existing Schema
+Before Adding Large Features* the strongest contributors.
+
+### What landed
+
+`packages/db/src/rebuild-knowledge-and-portfolio-graph.ts`, run against the live
+install:
+
+| Domain | Before | After |
+| --- | --- | --- |
+| Knowledge | 0 | 359 nodes, 640 `LINKS_TO` edges |
+| Portfolio | 1 | 818 nodes (4 Portfolio, 323 DigitalProduct, 491 TaxonomyNode) |
+
+Totals moved from 24,225 / 32,597 to 25,397 / 34,220.
+
+### One label per wiki node, not two
+
+An EA node carries both `EaElement` and its concrete `ArchiMate__*` type, and the
+census sums per-label counts — which is why the read side needs a hard-coded skip
+for `EaElement` to avoid double-counting. Wiki pages therefore carry exactly **one**
+label, `Wiki__<PageKind>`, so the knowledge domain needs no such special case. A
+`Wiki__` prefix rule keeps an uncurated page kind inside the knowledge domain
+rather than in the architecture-flavoured unknown bucket.
+
+Nodes are keyed by `WikiPage.id`, not `slug`: the model is unique on
+`(organizationId, slug)`, so a slug is ambiguous between a kernel page and each
+organization's overlay of it. This matches `EaElement`, also keyed by its cuid.
+
+### Backfill upserts and prunes; it does not clear
+
+`clearGraphByLabel` deletes every edge touching a label before reinserting. For the
+portfolio spine that is actively unsafe: EA elements carry edges onto
+`DigitalProduct` nodes and only the EA rebuild recreates them, so clearing here
+would silently drop cross-domain edges this script cannot restore. The writers are
+idempotent UPSERTs, so re-sync suffices; the prune is scoped to the `Wiki__` label
+prefix and to the `LINKS_TO` / `OVERRIDES` relationship types this script owns.
+
+### Known limits
+
+- **No structural edge from knowledge to code or data.** `WikiPage` has FKs only to
+  its organization, its kernel page, its links, revisions and sources. The
+  "route → file → model → the decision that governed it" path is therefore still
+  broken at the last hop; closing it needs derived links, not a backfill, and is a
+  separate piece of work.
+- **`OVERRIDES` is implemented but unexercised** — no page currently sets
+  `kernelPageId`, so the backfill wrote 0 override edges.
+- 127 of 359 pages are isolated (no `LINKS_TO`); the connected 232 average 3.57
+  links, with `Founder Kernel` the largest hub at 27.
+
+### UX budget, re-measured
+
+Adding a sixth census tile adds visible words on arrival, so the budget was
+re-measured rather than assumed. The tile renders label + count only — the domain
+description is a `title` tooltip, exactly as the five existing tiles already do, so
+it contributes no visible text. Against the `detail` shell's caps the route has
+wide headroom: 174 baseline default-visible words versus a 450 cap, and
+`deferred-detail` is only required above 300. The ratified purpose contract's
+`triggeringNeed` and `prerequisites` were updated to name the corpus accurately.
+
 ## Follow-ups
 
-- `WikiPageLink` already models the knowledge-corpus link graph but is not in the
-  mirror, so the WWMD / WWWD / WSID corpus is not yet explorable here. Mirroring
-  it is the natural next domain.
+- Derive knowledge → code/data edges so the "decision that governed this route"
+  path closes. No FK exists for it today (see Known limits above).
 - Saved views ("perspectives") are deliberately out of scope for the first cut.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -76,6 +76,7 @@
     "migrate:deploy": "prisma migrate deploy",
     "seed": "tsx src/seed.ts",
     "graph:rebuild-doc-impact": "tsx src/rebuild-doc-impact-graph.ts",
+    "graph:rebuild-knowledge-and-portfolio": "tsx src/rebuild-knowledge-and-portfolio-graph.ts",
     "index-integrity": "node scripts/index-integrity-guard.mjs",
     "skills:audit": "tsx src/skill-quality-audit.ts",
     "studio": "prisma studio",

--- a/packages/db/src/graph-sync.ts
+++ b/packages/db/src/graph-sync.ts
@@ -180,6 +180,71 @@ export async function syncPortfolio(p: {
   });
 }
 
+/**
+ * Storage label for a wiki page, derived from its `pageKind` (BI-3045CC18).
+ *
+ * One label per node rather than a generic `WikiPage` marker plus a specific kind:
+ * the explorer census sums per-label counts, so a dual-labelled node is counted
+ * twice — the reason `EaElement` needs a hard-coded skip on the read side.
+ *
+ * `pageKind` is a plain string in the schema, so an unrecognised kind still yields
+ * a well-formed `Wiki__*` label and lands in the knowledge domain via the prefix
+ * rule in explorer-vocabulary.ts.
+ */
+export function wikiPageLabel(pageKind: string): string {
+  const pascal = pageKind
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+  return `Wiki__${pascal || "Page"}`;
+}
+
+/** Upsert a WikiPage node and its OVERRIDES edge onto the kernel page it refines.
+ *
+ *  Keyed by `id`, not `slug`: `WikiPage` is unique on (organizationId, slug), so a
+ *  slug is ambiguous across the kernel page and each organization's overlay of it.
+ *  This matches EaElement, which is also keyed by its cuid. */
+export async function syncWikiPage(page: {
+  id: string;
+  slug: string;
+  title: string;
+  pageKind: string;
+  status: string;
+  isKernel: boolean;
+  organizationId?: string | null;
+  kernelPageId?: string | null;
+}): Promise<void> {
+  await upsertGraphNode(page.id, [wikiPageLabel(page.pageKind)], {
+    pageId: page.id,
+    slug: page.slug,
+    // `name` is the property the explorer's search and canvas labels read across
+    // every domain; carrying the title under it keeps wiki pages findable without
+    // special-casing the read side.
+    name: page.title,
+    title: page.title,
+    pageKind: page.pageKind,
+    status: page.status,
+    isKernel: page.isKernel,
+    organizationId: page.organizationId ?? null,
+    syncedAt: nowIso(),
+  });
+
+  // An organization's overlay page refines a kernel page. This is the edge that
+  // makes the WWWD-over-kernel relationship visible rather than implied.
+  if (page.kernelPageId) {
+    await upsertGraphEdge(page.id, page.kernelPageId, "OVERRIDES");
+  }
+}
+
+/** Upsert the page-to-page link edge (`WikiPageLink`). */
+export async function syncWikiPageLink(link: {
+  fromPageId: string;
+  toPageId: string;
+}): Promise<void> {
+  await upsertGraphEdge(link.fromPageId, link.toPageId, "LINKS_TO");
+}
+
 export async function syncDocumentNode(doc: {
   documentId: string;
   title: string;

--- a/packages/db/src/rebuild-knowledge-and-portfolio-graph.ts
+++ b/packages/db/src/rebuild-knowledge-and-portfolio-graph.ts
@@ -1,0 +1,169 @@
+// packages/db/src/rebuild-knowledge-and-portfolio-graph.ts
+//
+// Backfill of the knowledge corpus and the portfolio spine into the unified
+// `graph_node` / `graph_edge` mirror (BI-3045CC18).
+// Usage: pnpm --filter @dpf/db graph:rebuild-knowledge-and-portfolio
+//
+// WHY THIS EXISTS
+//
+// The mirror already declared both domains and already had writers for the
+// portfolio spine — `syncPortfolio` and `syncTaxonomyNode` simply had no callers,
+// and `syncDigitalProduct` fired only on create/update, so nothing that existed
+// before the explorer shipped was ever mirrored. The measured result was a
+// "Portfolio: 1" tile next to 16,147 code nodes. The knowledge corpus had no
+// vocabulary and no writer at all.
+//
+// The pattern this follows is the one the populated domains already use: a domain
+// is only as complete as its rebuild script (neo4j-rebuild-ea.ts,
+// neo4j-rebuild-documents.ts). Domains without one stayed empty.
+//
+// WHY IT UPSERTS AND PRUNES RATHER THAN CLEARING
+//
+// `clearGraphByLabel` deletes every edge touching a label before reinserting. For
+// the portfolio spine that is actively unsafe: EA elements carry edges onto
+// DigitalProduct nodes, and only the EA rebuild recreates them, so clearing
+// DigitalProduct here would silently drop cross-domain edges this script cannot
+// restore. The writers are idempotent UPSERTs, so a plain re-sync is sufficient,
+// and the prune below is scoped to keys this script owns.
+
+import "./load-env.js";
+import { prisma } from "./client.js";
+import {
+  syncDigitalProduct,
+  syncPortfolio,
+  syncTaxonomyNode,
+  syncWikiPage,
+  syncWikiPageLink,
+  wikiPageLabel,
+} from "./graph-sync.js";
+
+/** Remove mirrored wiki nodes whose source page is gone, and the derived edges
+ *  that no longer exist. Scoped by the `Wiki__` label prefix and by the two
+ *  relationship types this script owns, so it cannot reach another domain. */
+async function pruneKnowledge(livePageIds: string[]): Promise<number> {
+  const removedEdges = await prisma.$executeRawUnsafe(
+    `DELETE FROM graph_edge
+      WHERE rel_type IN ('LINKS_TO', 'OVERRIDES')
+        AND (NOT (src_key = ANY($1::text[])) OR NOT (dst_key = ANY($1::text[])))`,
+    livePageIds,
+  );
+  const removedNodes = await prisma.$executeRawUnsafe(
+    `DELETE FROM graph_node
+      WHERE EXISTS (SELECT 1 FROM unnest(labels) l WHERE l LIKE 'Wiki\\_\\_%')
+        AND NOT (key = ANY($1::text[]))`,
+    livePageIds,
+  );
+  return Number(removedEdges) + Number(removedNodes);
+}
+
+async function rebuildKnowledge(): Promise<void> {
+  console.log("Backfilling knowledge corpus...");
+
+  const pages = await prisma.wikiPage.findMany({
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      pageKind: true,
+      status: true,
+      isKernel: true,
+      organizationId: true,
+      kernelPageId: true,
+    },
+  });
+
+  for (const page of pages) {
+    await syncWikiPage(page);
+  }
+
+  const byKind = new Map<string, number>();
+  for (const page of pages) {
+    const label = wikiPageLabel(page.pageKind);
+    byKind.set(label, (byKind.get(label) ?? 0) + 1);
+  }
+  console.log(
+    `Synced ${pages.length} WikiPages (${[...byKind.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([label, n]) => `${label}=${n}`)
+      .join(", ")})`,
+  );
+
+  // Page-to-page links. `WikiPageLink` is a pure join table, so both endpoints are
+  // guaranteed present by the loop above.
+  const links = await prisma.wikiPageLink.findMany({
+    select: { fromPageId: true, toPageId: true },
+  });
+  for (const link of links) {
+    await syncWikiPageLink(link);
+  }
+  console.log(`Synced ${links.length} WikiPageLinks`);
+
+  const overrides = pages.filter((p) => p.kernelPageId).length;
+  console.log(`Synced ${overrides} kernel-override edges`);
+
+  const pruned = await pruneKnowledge(pages.map((p) => p.id));
+  if (pruned > 0) console.log(`Pruned ${pruned} stale knowledge rows`);
+}
+
+async function rebuildPortfolio(): Promise<void> {
+  console.log("Backfilling portfolio spine...");
+
+  const portfolios = await prisma.portfolio.findMany({ select: { slug: true, name: true } });
+  for (const p of portfolios) {
+    await syncPortfolio(p);
+  }
+  console.log(`Synced ${portfolios.length} Portfolios`);
+
+  // Taxonomy before products: `syncDigitalProduct` resolves its CATEGORIZED_AS
+  // target through the taxonomy row, and the edge is only written once the
+  // taxonomy node it points at exists.
+  const taxonomy = await prisma.taxonomyNode.findMany({
+    select: { nodeId: true, name: true, id: true, parent: { select: { nodeId: true } } },
+  });
+  for (const tn of taxonomy) {
+    await syncTaxonomyNode({
+      nodeId: tn.nodeId,
+      name: tn.name,
+      pgId: tn.id,
+      parentNodeId: tn.parent?.nodeId ?? null,
+    });
+  }
+  console.log(`Synced ${taxonomy.length} TaxonomyNodes`);
+
+  const products = await prisma.digitalProduct.findMany({
+    select: {
+      productId: true,
+      name: true,
+      lifecycleStage: true,
+      lifecycleStatus: true,
+      taxonomyNodeId: true,
+      portfolio: { select: { slug: true } },
+    },
+  });
+  for (const dp of products) {
+    await syncDigitalProduct({
+      productId: dp.productId,
+      name: dp.name,
+      lifecycleStage: dp.lifecycleStage,
+      lifecycleStatus: dp.lifecycleStatus,
+      portfolioSlug: dp.portfolio?.slug ?? null,
+      taxonomyNodeId: dp.taxonomyNodeId,
+    });
+  }
+  console.log(`Synced ${products.length} DigitalProducts`);
+}
+
+async function main(): Promise<void> {
+  await rebuildKnowledge();
+  await rebuildPortfolio();
+  console.log("Done.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/packages/db/test/graph-sync-wiki.test.ts
+++ b/packages/db/test/graph-sync-wiki.test.ts
@@ -1,0 +1,132 @@
+// BI-3045CC18: the knowledge corpus reaches the graph mirror through syncWikiPage
+// / syncWikiPageLink. Mock the client seam and assert on the SQL that lands.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execMock } = vi.hoisted(() => ({ execMock: vi.fn() }));
+
+vi.mock("../src/client", () => ({
+  prisma: {
+    $executeRawUnsafe: execMock,
+    $queryRawUnsafe: vi.fn().mockResolvedValue([]),
+    taxonomyNode: { findUnique: vi.fn().mockResolvedValue(null) },
+  },
+}));
+
+import { syncWikiPage, syncWikiPageLink, wikiPageLabel } from "../src/graph-sync";
+
+beforeEach(() => {
+  execMock.mockReset();
+  execMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function findNodeUpsert() {
+  const call = execMock.mock.calls.find(
+    ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO graph_node"),
+  );
+  expect(call).toBeDefined();
+  const [, key, labels, propsJson] = call as [string, string, string[], string];
+  return { key, labels, props: JSON.parse(propsJson) as Record<string, unknown> };
+}
+
+function findEdgeUpserts() {
+  return execMock.mock.calls
+    .filter(([sql]) => typeof sql === "string" && sql.includes("INSERT INTO graph_edge"))
+    .map((call) => {
+      const [, srcKey, dstKey, relType] = call as [string, string, string, string];
+      return { srcKey, dstKey, relType };
+    });
+}
+
+const BASE_PAGE = {
+  id: "wp_principle_1",
+  slug: "never-wipe-db",
+  title: "Never wipe the DB to fix code",
+  pageKind: "principle",
+  status: "published",
+  isKernel: true,
+  organizationId: null,
+  kernelPageId: null,
+};
+
+describe("wikiPageLabel", () => {
+  it("maps a page kind to its namespaced storage label", () => {
+    expect(wikiPageLabel("principle")).toBe("Wiki__Principle");
+    expect(wikiPageLabel("stance")).toBe("Wiki__Stance");
+  });
+
+  it("normalises a multi-word or oddly-cased kind", () => {
+    expect(wikiPageLabel("field guide")).toBe("Wiki__FieldGuide");
+    expect(wikiPageLabel("RUNBOOK")).toBe("Wiki__Runbook");
+  });
+
+  it("still yields a well-formed label for an empty kind", () => {
+    // pageKind is a plain string in the schema, so this must not produce the
+    // bare prefix "Wiki__", which would humanize to an empty display name.
+    expect(wikiPageLabel("")).toBe("Wiki__Page");
+  });
+});
+
+describe("syncWikiPage", () => {
+  it("keys the node by id, not slug", async () => {
+    // WikiPage is unique on (organizationId, slug), so a slug is ambiguous between
+    // the kernel page and each organization's overlay of it.
+    await syncWikiPage(BASE_PAGE);
+    expect(findNodeUpsert().key).toBe("wp_principle_1");
+  });
+
+  it("writes exactly ONE label per node", async () => {
+    // Load-bearing: the explorer census sums per-label counts, so a node carrying
+    // both a generic marker and a specific kind is counted twice — the reason
+    // EaElement needs a hard-coded skip on the read side. One label keeps the
+    // knowledge domain out of that trap.
+    await syncWikiPage(BASE_PAGE);
+    expect(findNodeUpsert().labels).toEqual(["Wiki__Principle"]);
+  });
+
+  it("carries the title under `name` so cross-domain search finds it", async () => {
+    await syncWikiPage(BASE_PAGE);
+    const { props } = findNodeUpsert();
+    expect(props).toMatchObject({
+      name: "Never wipe the DB to fix code",
+      title: "Never wipe the DB to fix code",
+      slug: "never-wipe-db",
+      pageKind: "principle",
+      status: "published",
+      isKernel: true,
+    });
+  });
+
+  it("writes an OVERRIDES edge when the page refines a kernel page", async () => {
+    await syncWikiPage({
+      ...BASE_PAGE,
+      id: "wp_org_override",
+      isKernel: false,
+      organizationId: "org_1",
+      kernelPageId: "wp_principle_1",
+    });
+    expect(findEdgeUpserts()).toContainEqual({
+      srcKey: "wp_org_override",
+      dstKey: "wp_principle_1",
+      relType: "OVERRIDES",
+    });
+  });
+
+  it("writes no edge when the page is not an override", async () => {
+    await syncWikiPage(BASE_PAGE);
+    expect(findEdgeUpserts()).toHaveLength(0);
+  });
+});
+
+describe("syncWikiPageLink", () => {
+  it("writes a directed LINKS_TO edge", async () => {
+    await syncWikiPageLink({ fromPageId: "wp_a", toPageId: "wp_b" });
+    expect(findEdgeUpserts()).toEqual([
+      { srcKey: "wp_a", dstKey: "wp_b", relType: "LINKS_TO" },
+    ]);
+  });
+});


### PR DESCRIPTION
The admin graph explorer shipped able to demonstrate the *technical* substrate only. The two things a demonstration most wants were effectively absent: the knowledge corpus was not mirrored at all, and Portfolio was a single node next to 16,147 code nodes.

Closes BI-3045CC18.

## The scope question was already answered by the substrate

The BI recorded an open design question — is the mirror a *code and architecture* graph or a *whole-platform* graph — and asked for it to be settled before building. Measured first, the substrate had already settled it:

- `explorer-vocabulary.ts` **already declared** a `portfolio` domain with `Portfolio`, `DigitalProduct`, `TaxonomyNode`.
- `graph-sync.ts` **already exported** `syncPortfolio`, `syncTaxonomyNode`, `syncDigitalProduct`.
- The mirror **already carried** 569 customer-scoped `InfraCI` nodes with `customerAccountId` / `customerSiteId` — business data, not code.

What was missing was not a decision but a **backfill**. `syncPortfolio` and `syncTaxonomyNode` had **zero callers**, and `syncDigitalProduct` fired only on create/update, so nothing predating the explorer was ever mirrored. The governing pattern: a domain is only as complete as its rebuild script — every populated domain had one (`neo4j-rebuild-ea.ts`, `neo4j-rebuild-documents.ts`), every empty one did not.

Scored through the kernel (`principle_decide`: high confidence, margin 4.2, no commandment conflict), with *Ground New Work In Existing Platform* and *Audit Existing Schema Before Adding Large Features* the strongest contributors.

## What landed, measured on the live install

| Domain | Before | After |
| --- | --- | --- |
| Knowledge | 0 | **359 nodes, 640 `LINKS_TO` edges** |
| Portfolio | 1 | **818 nodes** (4 Portfolio, 323 DigitalProduct, 491 TaxonomyNode) |
| Totals | 24,225 / 32,597 | **25,397 / 34,220** |

## One label per wiki node, not two

An EA node carries both `EaElement` and its concrete `ArchiMate__*` type, and the census sums per-label counts — which is exactly why the read side needs a hard-coded skip for `EaElement` to avoid double-counting. Copying that shape would have imported the same bug, so wiki pages carry exactly **one** label, `Wiki__<PageKind>`. The census tile reads 359 against 359 source rows. A `Wiki__` prefix rule keeps an uncurated page kind inside the knowledge domain rather than in the architecture-flavoured unknown bucket.

Nodes are keyed by `WikiPage.id`, not `slug`: the model is unique on `(organizationId, slug)`, so a slug is ambiguous between a kernel page and each organization's overlay of it. This matches `EaElement`, also keyed by its cuid.

## The backfill upserts and prunes; it does not clear

`clearGraphByLabel` deletes every edge touching a label before reinserting. For the portfolio spine that is **actively unsafe**: EA elements carry edges onto `DigitalProduct` nodes and only the EA rebuild recreates them, so clearing here would silently drop cross-domain edges this script cannot restore. The writers are idempotent UPSERTs, so re-sync suffices; the prune is scoped to the `Wiki__` label prefix and the `LINKS_TO` / `OVERRIDES` rel types this script owns. Verified before running that neither rel type existed anywhere in `graph_edge`.

## Verification

Functional, on the running portal — not just structural:

- Census renders **Knowledge 359** and **Portfolio 818**; totals match the database exactly.
- Searching "Never wipe the DB to fix code" finds the kernel principle, typed as **Principle**.
- Expanding the **Founder Kernel** hub two hops draws **34 nodes / 166 links** across five page kinds (Entity page, Heuristic, Index page, Principle, Stance).

Also green: `web` and `@dpf/db` typecheck 0 errors, 190 web tests across `lib/graph` + `lib/ux-budget`, 33 db graph-sync tests, 34 repo guards clean, local-CI gate PASS at `43fdf243a514`.

### UX budget, re-measured rather than assumed

A sixth census tile adds visible words on arrival. The tile renders label + count only — the domain description is a `title` tooltip, exactly as the five existing tiles already do — leaving the 174 baseline default-visible words against the `detail` shell's **450** cap, with `deferred-detail` only required above **300**. The ratified purpose contract's `triggeringNeed` and `prerequisites` were updated to name the corpus accurately, and the generated registry regenerated.

## Known limits, stated rather than implied

- **No structural edge from knowledge to code or data.** `WikiPage` has FKs only to its organization, kernel page, links, revisions and sources, so the BI's "route → file → model → the decision that governed it" path is **still broken at the last hop**. Closing it needs *derived* links, not a backfill, and is recorded as the spec's follow-up rather than left looking closed.
- **`OVERRIDES` is implemented but unexercised** — no page sets `kernelPageId` today, so the backfill wrote 0 override edges.
- 127 of 359 pages are isolated; the connected 232 average 3.57 links, with `Founder Kernel` the largest hub at 27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
