### PR TITLE
feat(docs): derive doc-impact edges from backtick-cited paths, and say what is left

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -267,26 +267,61 @@
     ".githooks/lib/pre-push-chained.sh": [
       "docs/testing/pre-pr-gate.md"
     ],
+    ".github/codeql/codeql-config.yml": [
+      "docs/security/codeql-advanced-setup.md"
+    ],
+    ".github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml": [
+      "docs/security/codeql-advanced-setup.md"
+    ],
+    ".github/codeql/dpf-sanitizers/qlpack.yml": [
+      "docs/security/codeql-advanced-setup.md"
+    ],
+    ".github/dependabot.yml": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    ".github/workflows/ci-calibration.yml": [
+      "docs/testing/ci-evidence.md"
+    ],
     ".github/workflows/ci.yml": [
       "docs/security/2026-05-24-shift-left-rollout.md",
       "docs/testing/pre-pr-gate.md"
     ],
     ".github/workflows/codeql.yml": [
       "docs/security/2026-05-24-shift-left-rollout.md",
+      "docs/security/codeql-advanced-setup.md",
       "docs/security/secrets-scan.md",
       "docs/testing/pre-pr-gate.md"
     ],
     ".github/workflows/install-verification.yml": [
       "docs/install/linux.md"
     ],
+    ".github/workflows/migration-safety-guard.yml": [
+      "docs/architecture/orientation.md"
+    ],
     ".github/workflows/policy-guards-recheck.yml": [
       "docs/testing/pre-pr-gate.md"
     ],
+    ".github/workflows/refresh-docs-staleness.yml": [
+      "docs/maintenance/README.md"
+    ],
+    ".github/workflows/release-gates.yml": [
+      "docs/install/verification-runbook.md"
+    ],
     ".github/workflows/secrets-scan.yml": [
-      "docs/security/2026-05-24-shift-left-rollout.md"
+      "docs/security/2026-05-24-shift-left-rollout.md",
+      "docs/security/secrets-scan.md"
     ],
     ".github/workflows/security-inflow-gate.yml": [
+      "docs/security/2026-05-24-shift-left-rollout.md",
+      "docs/security/README.md",
       "docs/security/secrets-scan.md"
+    ],
+    ".github/workflows/ux-route-sweep.yml": [
+      "docs/platform-usability-standards.md",
+      "docs/testing/ci-evidence.md"
+    ],
+    "apps/mobile/dynamic/fields/SignatureField.tsx": [
+      "docs/testing/handoff-invoice-gaps.md"
     ],
     "apps/mobile/eas.json": [
       "docs/operations/mobile-store-launch-runbook.md"
@@ -309,8 +344,36 @@
     "apps/web/app/api/integrations/email-postmark/inbound/route.ts": [
       "docs/architecture/2026-06-14-odysseus-review-depth-pass.md"
     ],
+    "apps/web/app/api/mcp/v1/route.ts": [
+      "docs/architecture/ai-agent-meta-model.md",
+      "docs/architecture/mcp-tool-authorization-runbook.md"
+    ],
+    "apps/web/app/api/v1/auth/provider-oauth/callback/route.ts": [
+      "docs/user-guide/ai-workforce/provider-developer-notes.md"
+    ],
     "apps/web/app/api/v1/edge/adapters/route.ts": [
       "docs/edge-node/unifi-adapter.md"
+    ],
+    "apps/web/app/api/v1/edge/discovery-runs/route.ts": [
+      "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md"
+    ],
+    "apps/web/app/api/v1/edge/enroll/route.ts": [
+      "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md"
+    ],
+    "apps/web/app/api/v1/ops/backlog/route.ts": [
+      "docs/architecture/backlog-archetype-scope.md"
+    ],
+    "apps/web/app/api/v1/ops/epics/route.ts": [
+      "docs/architecture/backlog-archetype-scope.md"
+    ],
+    "apps/web/app/auth/callback/route.ts": [
+      "docs/user-guide/ai-workforce/provider-developer-notes.md"
+    ],
+    "apps/web/app/callback/route.ts": [
+      "docs/user-guide/ai-workforce/provider-developer-notes.md"
+    ],
+    "apps/web/components/admin/OperatingHoursEditor.tsx": [
+      "docs/platform-usability-standards.md"
     ],
     "apps/web/components/attention/AttentionInbox.tsx": [
       "docs/user-guide/workspace/attention-inbox.md"
@@ -339,8 +402,20 @@
     "apps/web/components/build/WorkflowStageInspector.tsx": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
+    "apps/web/components/finance/CreateBillForm.tsx": [
+      "docs/testing/handoff-invoice-gaps.md"
+    ],
+    "apps/web/components/finance/InvoiceSendButton.tsx": [
+      "docs/testing/pending-backlog-items.md"
+    ],
     "apps/web/components/monitoring/health-summary.ts": [
       "docs/install/platform-support-watchlist.md"
+    ],
+    "apps/web/components/monitoring/prometheus-config.test.ts": [
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "apps/web/components/platform/AgentCardSupervisorPanel.tsx": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
     ],
     "apps/web/components/platform/ProviderSuitabilityGuide.tsx": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
@@ -354,6 +429,27 @@
     "apps/web/components/shell/SectionNav.tsx": [
       "docs/architecture/section-navigation.md"
     ],
+    "apps/web/components/shell/shell-action-result-contract.test.tsx": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/components/storefront-admin/ItemFormDialog.tsx": [
+      "docs/testing/findings/run-10-equipment-rental-findings.md"
+    ],
+    "apps/web/components/storefront-admin/ItemsManager.tsx": [
+      "docs/architecture/theme-aware-styling-runbook.md"
+    ],
+    "apps/web/components/storefront-admin/ServiceLinesPanel.tsx": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/components/ui/SaveStateIndicator.tsx": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/components/ui/form/SelectField.tsx": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/components/ui/report-kit/statusColors.ts": [
+      "docs/platform-usability-standards.md"
+    ],
     "apps/web/components/workspace/WorkCaseAttentionLens.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
@@ -366,26 +462,99 @@
     "apps/web/components/workspace/work-room/WorkRoomParticipants.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
+    "apps/web/design/tokens-utilities.test.ts": [
+      "docs/platform-usability-standards.md"
+    ],
     "apps/web/instrumentation.ts": [
-      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/testing/ci-evidence.md"
+    ],
+    "apps/web/lib/actions/agent-task-scheduler.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
     ],
     "apps/web/lib/actions/build.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
+    "apps/web/lib/actions/compliance.ts": [
+      "docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md"
+    ],
+    "apps/web/lib/actions/coworker-tool-budget.ts": [
+      "docs/architecture/context-engineering-standards.md"
+    ],
+    "apps/web/lib/actions/coworker-tool-filter.ts": [
+      "docs/architecture/contributor-procedure-runbook.md",
+      "docs/specs/routing-resilience-and-failure-observability-spec.md"
+    ],
+    "apps/web/lib/actions/finance.ts": [
+      "docs/testing/handoff-invoice-gaps.md"
+    ],
+    "apps/web/lib/actions/golden-triangle.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
+    ],
+    "apps/web/lib/actions/invite-actions.ts": [
+      "docs/testing/archetype-job-validation.md"
+    ],
+    "apps/web/lib/actions/provider-oauth.ts": [
+      "docs/user-guide/ai-workforce/provider-developer-notes.md"
+    ],
+    "apps/web/lib/actions/skill-discovery.ts": [
+      "docs/prompts/a2a-coworker-substrate-prompt.md"
+    ],
     "apps/web/lib/actions/sovereignty.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "apps/web/lib/agent-grants.ts": [
+      "docs/architecture/ai-agent-meta-model.md",
+      "docs/architecture/mcp-tool-authorization-runbook.md"
+    ],
     "apps/web/lib/ai-inference.ts": [
+      "docs/architecture/ai-agent-meta-model.md",
+      "docs/architecture/orientation.md",
       "docs/user-guide/ai-workforce/connecting-providers.md"
+    ],
+    "apps/web/lib/ai-operations-map/project-routing-topology.ts": [
+      "docs/specs/routing-resilience-and-failure-observability-spec.md"
+    ],
+    "apps/web/lib/assurance/cyclonedx-generator.ts": [
+      "docs/architecture/dependency-reduction-routine.md"
     ],
     "apps/web/lib/attention/owner-projection.ts": [
       "docs/user-guide/workspace/attention-inbox.md"
     ],
+    "apps/web/lib/autonomy/regulatory-ceiling.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
+    ],
+    "apps/web/lib/autonomy/trust-graduation.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
+    ],
+    "apps/web/lib/backlog.ts": [
+      "docs/architecture/contributor-procedure-runbook.md",
+      "docs/professions/data-architect/wiki/strongly-typed-string-enums.md"
+    ],
     "apps/web/lib/build-pipeline.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
+    "apps/web/lib/build/ideate-build-resolution.ts": [
+      "docs/dogfood/2026-05-23-dale-hvac-build-studio.md"
+    ],
     "apps/web/lib/build/progress-visibility.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/build/unified-wip-query.ts": [
+      "docs/architecture/agent-client-capability-parity.md"
+    ],
+    "apps/web/lib/build/unified-wip.ts": [
+      "docs/architecture/agent-client-capability-parity.md",
+      "docs/architecture/delivery-surfaces-runbook.md"
+    ],
+    "apps/web/lib/build/wip-cap.ts": [
+      "docs/architecture/delivery-surfaces-runbook.md"
+    ],
+    "apps/web/lib/change-management/register-change.ts": [
+      "docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md"
+    ],
+    "apps/web/lib/change-review/semantic-change-review.ts": [
+      "docs/architecture/agent-client-governance.md"
     ],
     "apps/web/lib/contracts/entity-contract-drift.ts": [
       "docs/architecture/package-boundaries.md"
@@ -393,8 +562,28 @@
     "apps/web/lib/contracts/package-boundaries.test.ts": [
       "docs/architecture/package-boundaries.md"
     ],
+    "apps/web/lib/coworker-lifecycle/lifecycle-gate.ts": [
+      "docs/architecture/mcp-tool-authorization-runbook.md"
+    ],
     "apps/web/lib/decision-perspective/build-studio-gate.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/decision-perspective/evaluator.ts": [
+      "docs/architecture/vector-decisioning-and-jsi.md"
+    ],
+    "apps/web/lib/decision-perspective/material.ts": [
+      "docs/architecture/decision-vectors.md",
+      "docs/architecture/vector-decisioning-and-jsi.md"
+    ],
+    "apps/web/lib/decision-perspective/stance-promotion.ts": [
+      "docs/architecture/vector-decisioning-and-jsi.md"
+    ],
+    "apps/web/lib/decision-perspective/weight-inference.ts": [
+      "docs/architecture/customer-zero-and-use-case-zero.md",
+      "docs/architecture/vector-decisioning-and-jsi.md"
+    ],
+    "apps/web/lib/decision/dimension-catalog.ts": [
+      "docs/architecture/skill-surfaces-runbook.md"
     ],
     "apps/web/lib/decision/golden-decisions.baseline.json": [
       "docs/founder-kernel/AUTHORING.md"
@@ -402,14 +591,73 @@
     "apps/web/lib/decision/golden-decisions.test.ts": [
       "docs/founder-kernel/AUTHORING.md"
     ],
+    "apps/web/lib/decision/option-scoring.ts": [
+      "docs/architecture/decision-vectors.md",
+      "docs/architecture/vector-decisioning-and-jsi.md",
+      "docs/user-guide/ai-workforce/decision-perspective-in-practice.md"
+    ],
+    "apps/web/lib/deliberation/external-review-activation.ts": [
+      "docs/architecture/agent-client-capability-parity.md"
+    ],
+    "apps/web/lib/design-intelligence.ts": [
+      "docs/architecture/operational-precedent-corpus.md"
+    ],
+    "apps/web/lib/docs-route-map.ts": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "apps/web/lib/docs/doc-link-resolver.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
     "apps/web/lib/ea/ai-routing-architecture-extract.ts": [
-      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md",
+      "docs/architecture/ai-routing-document-map.md"
     ],
     "apps/web/lib/ea/ai-routing-architecture-registry.ts": [
-      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md",
+      "docs/architecture/ai-routing-document-map.md"
+    ],
+    "apps/web/lib/ea/reconcile-ai-routing-architecture.ts": [
+      "docs/architecture/ai-routing-document-map.md"
+    ],
+    "apps/web/lib/explore/backlog.ts": [
+      "docs/architecture/backlog-archetype-scope.md"
     ],
     "apps/web/lib/explore/feature-build-types.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/finance/finance-validation.ts": [
+      "docs/testing/handoff-invoice-gaps.md"
+    ],
+    "apps/web/lib/founder-review/queue.ts": [
+      "docs/user-guide/ai-workforce/decision-perspective.md"
+    ],
+    "apps/web/lib/golden-triangle/compile.ts": [
+      "docs/design/golden-triangle-vector-reference.md"
+    ],
+    "apps/web/lib/govern/auth-redirect.ts": [
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "apps/web/lib/govern/data/field-classification.ts": [
+      "docs/architecture/backlog-and-planning-runbook.md"
+    ],
+    "apps/web/lib/govern/data/legacy-coverage-baseline.ts": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "apps/web/lib/govern/data/policy-decision.ts": [
+      "docs/architecture/ai-routing-document-map.md"
+    ],
+    "apps/web/lib/govern/data/policy-enforcement.ts": [
+      "docs/architecture/ai-routing-document-map.md"
+    ],
+    "apps/web/lib/govern/permissions.ts": [
+      "docs/architecture/delivery-ia.md"
+    ],
+    "apps/web/lib/identity/aidoc-resolver.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/ai-agent-meta-model.md"
+    ],
+    "apps/web/lib/identity/principal-linking.ts": [
+      "docs/architecture/ai-agent-meta-model.md"
     ],
     "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
@@ -417,30 +665,64 @@
     "apps/web/lib/inference/data-screening/vertical-policy-packs.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
     ],
+    "apps/web/lib/inference/jit-retrieval-discipline.test.ts": [
+      "docs/architecture/context-engineering-standards.md"
+    ],
     "apps/web/lib/inference/local-only.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
     "apps/web/lib/inference/routed-inference.ts": [
-      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md"
+      "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
+      "docs/architecture/ai-routing-document-map.md"
     ],
     "apps/web/lib/integrate/build-orchestrator.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/architecture/build-gate-runbook.md",
       "docs/user-guide/build-studio/index.md"
     ],
     "apps/web/lib/integrate/build-pipeline.ts": [
-      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/triage/2026-05-20-handoff-prompt-next-session.md"
+    ],
+    "apps/web/lib/integrate/build-plan-paths.ts": [
+      "docs/architecture/build-studio-namespace.md"
     ],
     "apps/web/lib/integrate/build-studio-config.ts": [
-      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/operations/build-cost-flags-activation-runbook.md"
     ],
     "apps/web/lib/integrate/claude-dispatch.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
+    "apps/web/lib/integrate/coding-agent.ts": [
+      "docs/architecture/build-gate-runbook.md",
+      "docs/triage/2026-05-20-handoff-prompt-next-session.md"
+    ],
+    "apps/web/lib/integrate/sandbox/sandbox.ts": [
+      "docs/triage/2026-05-20-handoff-prompt-next-session.md"
+    ],
+    "apps/web/lib/integrations/connectors/index.ts": [
+      "docs/architecture/unified-connector-kernel.md"
+    ],
+    "apps/web/lib/kernel/runtime-gate.ts": [
+      "docs/founder-kernel/wiki/principles/outbound-actions-require-explicit-go.md"
+    ],
+    "apps/web/lib/marketing/archetype-fit.ts": [
+      "docs/platform-usability-standards.md"
+    ],
     "apps/web/lib/marketing/channels/email-postmark/responder.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md",
       "docs/architecture/2026-06-14-odysseus-review-depth-pass.md"
     ],
     "apps/web/lib/marketing/scheduler.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/mcp-governed-execute.ts": [
+      "docs/architecture/ai-agent-meta-model.md",
+      "docs/architecture/mcp-tool-surface-ergonomics-audit.md"
+    ],
+    "apps/web/lib/mcp/packs/backlog-pack.ts": [
+      "docs/architecture/backlog-archetype-scope.md"
     ],
     "apps/web/lib/mcp/packs/deliberation-siem-pack.ts": [
       "docs/architecture/mcp-tool-packs.md"
@@ -458,13 +740,27 @@
       "docs/architecture/mcp-tool-packs.md"
     ],
     "apps/web/lib/mcp/tool-pack.ts": [
-      "docs/architecture/mcp-tool-packs.md"
+      "docs/architecture/mcp-tool-packs.md",
+      "docs/architecture/mcp-tool-surface-ergonomics-audit.md"
     ],
     "apps/web/lib/mcp/tool-registry.ts": [
       "docs/architecture/mcp-tool-packs.md"
     ],
+    "apps/web/lib/mcp/tool-tier.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/context-engineering-standards.md"
+    ],
+    "apps/web/lib/mdm/domain-registry.ts": [
+      "docs/professions/data-architect/wiki/mdm-what-it-does-and-does-not-do.md"
+    ],
     "apps/web/lib/navigation/section-nav-model.ts": [
       "docs/architecture/section-navigation.md"
+    ],
+    "apps/web/lib/operate/db-continuity.ts": [
+      "docs/architecture/delivery-surfaces-runbook.md"
+    ],
+    "apps/web/lib/operate/retention/policies.ts": [
+      "docs/architecture/enforced-ci-gates.md"
     ],
     "apps/web/lib/platform-runtime/capability-service-projection.ts": [
       "docs/architecture/capability-driven-runtime-profiles.md"
@@ -475,9 +771,36 @@
     "apps/web/lib/proactivity/proactivity-roster.ts": [
       "docs/user-guide/ai-workforce/coworker-proactivity.md"
     ],
+    "apps/web/lib/product-management/product-direction-view.ts": [
+      "docs/architecture/business-commercial-catalog.md"
+    ],
+    "apps/web/lib/product-management/product-operating-context-query.ts": [
+      "docs/architecture/business-commercial-catalog.md"
+    ],
+    "apps/web/lib/product-management/product-route-authority.ts": [
+      "docs/architecture/business-commercial-catalog.md"
+    ],
+    "apps/web/lib/products/product-sold-query.ts": [
+      "docs/architecture/business-commercial-catalog.md"
+    ],
+    "apps/web/lib/provider-oauth.ts": [
+      "docs/user-guide/ai-workforce/provider-developer-notes.md"
+    ],
+    "apps/web/lib/queue/functions/agent-task-dispatch.ts": [
+      "docs/prompts/a2a-coworker-substrate-prompt.md"
+    ],
+    "apps/web/lib/queue/functions/alert-delivery-bridge.ts": [
+      "docs/operations/observability-coverage.md"
+    ],
+    "apps/web/lib/queue/functions/build-review-verification.ts": [
+      "docs/architecture/build-gate-runbook.md"
+    ],
     "apps/web/lib/queue/functions/deliberation-run.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
       "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/queue/functions/hive-scout-ingest.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
     ],
     "apps/web/lib/queue/functions/index.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
@@ -488,20 +811,42 @@
     "apps/web/lib/queue/functions/taskrun-watchdog.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
+    "apps/web/lib/queue/functions/wiki-lint.ts": [
+      "docs/founder-kernel/SCHEMA.md"
+    ],
     "apps/web/lib/queue/inngest-client.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
     "apps/web/lib/queue/notification-adapter.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
     ],
+    "apps/web/lib/readability/policy.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/reporting-types.ts": [
+      "docs/specs/reporting-ux-primitives-spec.md"
+    ],
     "apps/web/lib/routes.ts": [
       "docs/architecture/data-model-stewardship-runbook.md"
+    ],
+    "apps/web/lib/routing/anthropic-cache.ts": [
+      "docs/architecture/agent-client-capability-parity.md"
     ],
     "apps/web/lib/routing/chat-adapter.ts": [
       "docs/design/golden-triangle-design.md"
     ],
+    "apps/web/lib/routing/cli-adapter.ts": [
+      "docs/dogfood/2026-05-23-dale-hvac-build-studio.md"
+    ],
     "apps/web/lib/routing/cost-ranking.ts": [
       "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/routing/fallback.ts": [
+      "docs/architecture/context-engineering-standards.md",
+      "docs/specs/routing-resilience-and-failure-observability-spec.md"
+    ],
+    "apps/web/lib/routing/pipeline-v2.test.ts": [
+      "docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md"
     ],
     "apps/web/lib/routing/pipeline-v2.ts": [
       "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
@@ -510,12 +855,35 @@
     "apps/web/lib/routing/provider-suitability/workload-profile.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
     ],
+    "apps/web/lib/routing/rate-tracker.ts": [
+      "docs/specs/routing-resilience-and-failure-observability-spec.md"
+    ],
+    "apps/web/lib/routing/request-contract.email.test.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+    ],
     "apps/web/lib/routing/request-contract.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md",
       "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
+      "docs/architecture/ai-routing-document-map.md",
       "docs/design/golden-triangle-design.md"
+    ],
+    "apps/web/lib/routing/task-requirements.email.test.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+    ],
+    "apps/web/lib/routing/task-requirements.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+    ],
+    "apps/web/lib/runtime/measurement-runtime.ts": [
+      "docs/testing/ci-evidence.md"
+    ],
+    "apps/web/lib/security/safe-log.ts": [
+      "docs/security/codeql-advanced-setup.md"
     ],
     "apps/web/lib/self-upgrade/local-changes-ledger.ts": [
       "docs/architecture/branch-and-worktree-runbook.md"
+    ],
+    "apps/web/lib/self-upgrade/prepare-source.ts": [
+      "docs/dev/collision-free-dev-workflow.md"
     ],
     "apps/web/lib/shared/action-result.ts": [
       "docs/architecture/data-model-stewardship-runbook.md"
@@ -523,17 +891,90 @@
     "apps/web/lib/shared/coerce.ts": [
       "docs/architecture/data-model-stewardship-runbook.md"
     ],
+    "apps/web/lib/shared/email.ts": [
+      "docs/testing/handoff-invoice-gaps.md"
+    ],
     "apps/web/lib/shared/org-address.ts": [
       "docs/architecture/data-model-stewardship-runbook.md"
     ],
+    "apps/web/lib/shared/use-save-state.test.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/shared/use-save-state.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/shell/shell-action-contract.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/storefront/archetype-reset.ts": [
+      "docs/testing/findings/run-1-swap-findings.md"
+    ],
+    "apps/web/lib/storefront/archetype-vocabulary.ts": [
+      "docs/personas/linda-clinic.md",
+      "docs/personas/marisol-retail.md"
+    ],
+    "apps/web/lib/tak/agent-card-service.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
+    ],
+    "apps/web/lib/tak/agent-event-bus.ts": [
+      "docs/prompts/a2a-coworker-substrate-prompt.md"
+    ],
     "apps/web/lib/tak/agent-grants.ts": [
-      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+      "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/contributor-procedure-runbook.md"
+    ],
+    "apps/web/lib/tak/agent-routing.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
     ],
     "apps/web/lib/tak/agentic-loop.ts": [
       "docs/design/golden-triangle-design.md"
     ],
     "apps/web/lib/tak/autonomous-work-run.ts": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md"
+    ],
+    "apps/web/lib/tak/compaction-digest.ts": [
+      "docs/architecture/context-engineering-standards.md"
+    ],
+    "apps/web/lib/tak/context-arbitrator.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
+    ],
+    "apps/web/lib/tak/context-economy-metrics.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/context-engineering-standards.md"
+    ],
+    "apps/web/lib/tak/delegation-authority.ts": [
+      "docs/prompts/a2a-coworker-substrate-prompt.md"
+    ],
+    "apps/web/lib/tak/prompt-assembler.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/tak/route-context.ts": [
+      "docs/user-guide/ai-workforce/decision-perspective.md"
+    ],
+    "apps/web/lib/tak/tool-result-budget.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/context-engineering-standards.md",
+      "docs/architecture/mcp-tool-authorization-runbook.md"
+    ],
+    "apps/web/lib/tak/tool-script.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/context-engineering-standards.md"
+    ],
+    "apps/web/lib/tool-description-hygiene.test.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md",
+      "docs/architecture/context-engineering-standards.md",
+      "docs/architecture/mcp-tool-authorization-runbook.md"
+    ],
+    "apps/web/lib/ux-budget/measure.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/voice-synthesis/tts-health-contract.test.ts": [
+      "docs/operations/observability-coverage.md"
+    ],
+    "apps/web/lib/wiki/principle-lint-detectors.ts": [
+      "docs/operations/runtime-kernel-commandments.md"
     ],
     "apps/web/lib/work-management/room-channel-continuity.ts": [
       "docs/user-guide/workspace/work-rooms.md"
@@ -550,14 +991,39 @@
     "apps/web/lib/work-management/workspace-room-access.ts": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
+    "apps/web/lib/workbooks/backlog-adapter-mapping.ts": [
+      "docs/architecture/backlog-archetype-scope.md"
+    ],
+    "apps/web/lib/workbooks/people-supplier-configs.ts": [
+      "docs/testing/findings/run-1-phase-w-retest.md"
+    ],
+    "apps/web/lib/workforce/oversight-copy.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "apps/web/lib/workspace-home/profiles.ts": [
+      "docs/testing/archetype-job-validation.md"
+    ],
+    "apps/web/scripts/issue-edge-bootstrap-token.ts": [
+      "docs/install/verification-runbook.md"
+    ],
     "config/merge-readiness-policy.json": [
       "docs/testing/pr-health.md"
     ],
+    "docker-compose.dev-against-live-db.yml": [
+      "docs/operations/disaster-recovery.md",
+      "docs/operations/runtime-glossary.md"
+    ],
+    "docker-compose.edge-actions.yml": [
+      "docs/install/platform-support-watchlist.md",
+      "docs/operations/remote-action-edge-dispatch.md"
+    ],
     "docker-compose.edge-snmp.yml": [
-      "docs/edge-node/deployment-topology.md"
+      "docs/edge-node/deployment-topology.md",
+      "docs/install/edge-node-multi-host.md"
     ],
     "docker-compose.edge-standalone-tls.yml": [
       "docs/edge-node/deployment-topology.md",
+      "docs/edge-node/security-and-sovereignty.md",
       "docs/install/edge-node-air-gapped.md",
       "docs/install/edge-node-multi-host.md"
     ],
@@ -569,25 +1035,51 @@
     ],
     "docker-compose.edge.macvlan.yml": [
       "docs/edge-node/deployment-topology.md",
-      "docs/edge-node/macvlan-deployment.md"
+      "docs/edge-node/macvlan-deployment.md",
+      "docs/user-guide/platform/edge-nodes.md"
     ],
     "docker-compose.edge.yml": [
       "docs/edge-node/deployment-topology.md",
       "docs/install/edge-node-multi-host.md"
     ],
+    "docker-compose.linux.yml": [
+      "docs/install/linux.md",
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "docker-compose.local-ci.yml": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "docker-compose.macos.yml": [
+      "docs/install/macos.md",
+      "docs/operations/observability-coverage.md"
+    ],
     "docker-compose.tls.yml": [
-      "docs/install/edge-node-multi-host.md"
+      "docs/install/edge-node-multi-host.md",
+      "docs/install/verification-runbook.md",
+      "docs/security/tool-evaluations/2026-07-20-step-ca.md"
     ],
     "docker-compose.yml": [
       "docs/architecture/2026-06-09-long-running-agentic-process-architecture.md",
       "docs/architecture/platform-overview.md",
       "docs/operations/disaster-recovery.md"
     ],
+    "docker-entrypoint.sh": [
+      "docs/install/platform-support-watchlist.md",
+      "docs/user-guide/ai-workforce/model-routing-lifecycle.md",
+      "docs/user-guide/ai-workforce/provider-codex.md"
+    ],
+    "docs/_config.yml": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
     "docs/testing/ci-observation-baseline.json": [
       "docs/testing/ci-evidence.md"
     ],
+    "e2e/fixtures/evidence.ts": [
+      "docs/architecture/agent-client-capability-parity.md"
+    ],
     "monitoring/prometheus/prometheus.yml": [
-      "docs/architecture/platform-overview.md"
+      "docs/architecture/platform-overview.md",
+      "docs/operations/observability-coverage.md"
     ],
     "packages/db/data/platform-runtime-capabilities.json": [
       "docs/architecture/capability-driven-runtime-profiles.md",
@@ -601,19 +1093,72 @@
     "packages/db/scripts/check-cada-readiness.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "packages/db/scripts/dev-preview-migrate-deploy.mjs": [
+      "docs/user-guide/contributing/dev-container.md"
+    ],
+    "packages/db/scripts/generate-taxonomy-v3-json.ts": [
+      "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md"
+    ],
+    "packages/db/scripts/index-integrity-guard.mjs": [
+      "docs/professions/data-architect/wiki/index-and-collation-integrity.md",
+      "docs/runbooks/2026-07-20-collation-drift-index-corruption.md"
+    ],
     "packages/db/scripts/seed-cada-regulation.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
+    ],
+    "packages/db/scripts/seed-dora-regulation.ts": [
+      "docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md"
+    ],
+    "packages/db/src/agent-identity.test.ts": [
+      "docs/architecture/contributor-procedure-runbook.md"
+    ],
+    "packages/db/src/agent-identity.ts": [
+      "docs/architecture/contributor-procedure-runbook.md"
     ],
     "packages/db/src/cada-readiness.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "packages/db/src/capability-maturity.ts": [
+      "docs/architecture/customer-zero-and-use-case-zero.md"
+    ],
+    "packages/db/src/dimension-scope.ts": [
+      "docs/architecture/decision-vectors.md"
+    ],
     "packages/db/src/discovery-collectors/network.ts": [
       "docs/install/platform-support-watchlist.md"
     ],
+    "packages/db/src/discovery-fingerprint-redaction.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
+    ],
+    "packages/db/src/discovery-fingerprint-rules.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
+    ],
+    "packages/db/src/discovery-fingerprint-types.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
+    ],
+    "packages/db/src/discovery-promotion-policy.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
+    ],
+    "packages/db/src/discovery-triage.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
+    ],
+    "packages/db/src/edge-node-types.ts": [
+      "docs/edge-node/event-envelope.md",
+      "docs/install/edge-node-air-gapped.md"
+    ],
+    "packages/db/src/eu-jurisdictions.test.ts": [
+      "docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md"
+    ],
     "packages/db/src/eu-jurisdictions.ts": [
+      "docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md",
+      "docs/professions/legal-compliance/wiki/eu-cada-cloud-sovereignty.md",
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "packages/db/src/hive-scout-config.ts": [
+      "docs/specs/device-identification-and-portfolio-placement-spec.md"
+    ],
     "packages/db/src/migrations/exact-key-repair.ts": [
+      "docs/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong.md",
       "docs/runbooks/2026-07-20-collation-drift-index-corruption.md"
     ],
     "packages/db/src/pg-graph.ts": [
@@ -622,11 +1167,38 @@
     "packages/db/src/pgvector-store.ts": [
       "docs/architecture/platform-overview.md"
     ],
+    "packages/db/src/portfolio-sources/vertical-incumbents-manifest.ts": [
+      "docs/architecture/operational-precedent-corpus.md"
+    ],
+    "packages/db/src/profession-local-axes.ts": [
+      "docs/architecture/decision-vectors.md"
+    ],
     "packages/db/src/regulation-applicability.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "packages/db/src/seed-decision-perspective.ts": [
+      "docs/architecture/agent-standards-dpf-conformance.md"
+    ],
+    "packages/db/src/seed-ea-reference-models.ts": [
+      "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md"
+    ],
+    "packages/db/src/seed-ea-sysml-agent-authority.ts": [
+      "docs/architecture/ai-agent-meta-model.md"
+    ],
+    "packages/db/src/seed-ea-sysml-cada.ts": [
+      "docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md"
+    ],
+    "packages/db/src/seed-ea-sysml2.test.ts": [
+      "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md"
+    ],
     "packages/db/src/seed-platform-backup.ts": [
       "docs/operations/disaster-recovery.md"
+    ],
+    "packages/db/src/seed-skills.ts": [
+      "docs/architecture/skill-surfaces-runbook.md"
+    ],
+    "packages/db/src/seed-wiki-kernel.ts": [
+      "docs/founder-kernel/AUTHORING.md"
     ],
     "packages/db/src/seed.ts": [
       "docs/dogfood/2026-05-23-dale-hvac-build-studio.md"
@@ -634,27 +1206,131 @@
     "packages/db/src/sovereignty-assessment.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "packages/db/src/table-classification.ts": [
+      "docs/architecture/backlog-and-planning-runbook.md",
+      "docs/architecture/enforced-ci-gates.md"
+    ],
     "packages/db/src/wiki-taxonomy.ts": [
       "docs/founder-kernel/AUTHORING.md",
       "docs/founder-kernel/SCHEMA.md"
     ],
+    "packages/dpf-skill-pack/hooks/design-grounding-precheck.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs": [
+      "docs/architecture/agent-client-capability-parity.md"
+    ],
+    "packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "packages/dpf-skill-pack/hooks/process-spine-health-check.mjs": [
+      "docs/architecture/skill-surfaces-runbook.md"
+    ],
+    "packages/dpf-skill-pack/hooks/tool-economy-precheck.mjs": [
+      "docs/architecture/context-engineering-standards.md"
+    ],
+    "packages/dpf-skill-pack/hooks/worktree-create.mjs": [
+      "docs/architecture/delivery-surfaces-runbook.md"
+    ],
+    "packages/dpf-skill-pack/scripts/update-agent-toolchain.ps1": [
+      "docs/operations/install.md"
+    ],
+    "packages/dpf-skill-pack/scripts/update-agent-toolchain.sh": [
+      "docs/operations/install.md"
+    ],
+    "packages/integration-shared/src/credential-crypto.ts": [
+      "docs/architecture/2026-06-22-platform-adequacy-architecture-review.md"
+    ],
+    "packages/storefront-templates/src/archetype-readiness.ts": [
+      "docs/architecture/2026-07-27-platform-adequacy-roadmap-backlog-map.md"
+    ],
+    "packages/storefront-templates/src/archetypes/fitness-recreation.ts": [
+      "docs/testing/findings/run-4-fresh-findings.md"
+    ],
+    "packages/storefront-templates/src/archetypes/healthcare-wellness.ts": [
+      "docs/personas/linda-clinic.md"
+    ],
     "packages/storefront-templates/src/archetypes/index.ts": [
+      "docs/architecture/four-portfolio-archetype-standard-profile-catalog.md",
       "docs/testing/archetype-audit-plan.md"
+    ],
+    "packages/storefront-templates/src/archetypes/retail-goods.ts": [
+      "docs/personas/marisol-retail.md"
+    ],
+    "packages/storefront-templates/src/archetypes/trades-maintenance.ts": [
+      "docs/personas/dale-hvac.md"
+    ],
+    "packages/storefront-templates/src/twin-profile.ts": [
+      "docs/architecture/operational-precedent-corpus.md"
+    ],
+    "packages/storefront-templates/src/types.ts": [
+      "docs/architecture/archetype-business-value-streams.md"
+    ],
+    "packages/types/src/entities.ts": [
+      "docs/architecture/package-boundaries.md"
     ],
     "packages/validators/src/field-dispatch.ts": [
       "docs/architecture/field-service-work-item.md"
     ],
+    "packages/validators/src/readability.ts": [
+      "docs/platform-usability-standards.md"
+    ],
+    "pnpm-lock.yaml": [
+      "docs/architecture/build-gate-runbook.md",
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
     "scripts/backup-postgres.sh": [
       "docs/operations/disaster-recovery.md"
     ],
+    "scripts/build-docs-staleness.mjs": [
+      "docs/maintenance/README.md",
+      "docs/maintenance/staleness-report.md"
+    ],
+    "scripts/build-images.ps1": [
+      "docs/testing/findings/run-1-phase-w-retest.md",
+      "docs/testing/handoff-invoice-gaps.md"
+    ],
+    "scripts/build-images.sh": [
+      "docs/testing/findings/run-1-findings.md"
+    ],
+    "scripts/build-kernel-embeddings.ts": [
+      "docs/founder-kernel/AUTHORING.md"
+    ],
     "scripts/capability-service-catalog.generated.json": [
       "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "scripts/check-application-boundaries.mjs": [
+      "docs/architecture/application-boundaries.md"
     ],
     "scripts/check-build-namespace.mjs": [
       "docs/architecture/build-studio-namespace.md"
     ],
     "scripts/check-capability-compose-profiles.mjs": [
       "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
+    "scripts/check-compose-env-contract.mjs": [
+      "docs/runbooks/2026-07-18-self-upgrade-mounts-denied-state-dir.md"
+    ],
+    "scripts/check-data-impact.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-design-grounding-decision.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-doc-links.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-doc-reference-integrity.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-docs-impact.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-guards.mjs": [
+      "docs/architecture/theme-aware-styling-runbook.md"
+    ],
+    "scripts/check-instruction-plane-size.mjs": [
+      "docs/architecture/context-engineering-standards.md"
     ],
     "scripts/check-mcp-tool-pack.mjs": [
       "docs/architecture/mcp-tool-packs.md"
@@ -666,32 +1342,98 @@
     "scripts/check-module-size.mjs": [
       "docs/architecture/mcp-tool-packs.md"
     ],
+    "scripts/check-no-dialog-in-transition.mjs": [
+      "docs/architecture/theme-aware-styling-runbook.md"
+    ],
+    "scripts/check-no-hand-rolled-loading.mjs": [
+      "docs/platform-usability-standards.md"
+    ],
+    "scripts/check-no-local-isrecord.mjs": [
+      "docs/architecture/data-model-stewardship-runbook.md"
+    ],
+    "scripts/check-no-native-dialogs.mjs": [
+      "docs/architecture/theme-aware-styling-runbook.md",
+      "docs/founder-kernel/wiki/principles/no-native-browser-dialogs.md"
+    ],
     "scripts/check-no-private-identity.mjs": [
       "docs/operations/oss-repo-identity-hygiene.md"
+    ],
+    "scripts/check-no-provider-local-connector-lifecycle.mjs": [
+      "docs/architecture/unified-connector-kernel.md"
+    ],
+    "scripts/check-override-comments.mjs": [
+      "docs/architecture/contributor-procedure-runbook.md"
     ],
     "scripts/check-package-boundaries.mjs": [
       "docs/architecture/package-boundaries.md"
     ],
+    "scripts/check-retired-substrate.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-spec-plan-doc.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
+    "scripts/check-stewardship-scope.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
     "scripts/check-style-drift.mjs": [
-      "docs/architecture/ui-token-styling.md"
+      "docs/architecture/ui-token-styling.md",
+      "docs/platform-usability-standards.md"
+    ],
+    "scripts/check-tool-surface.mjs": [
+      "docs/architecture/mcp-tool-surface-ergonomics-audit.md"
+    ],
+    "scripts/check-ux-fit-decision.mjs": [
+      "docs/architecture/theme-aware-styling-runbook.md",
+      "docs/design/golden-triangle-design.md"
+    ],
+    "scripts/ci-evidence-plan.mjs": [
+      "docs/testing/ci-evidence.md"
+    ],
+    "scripts/ci-policy-guards.test.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/ci-shadow-selection.mjs": [
+      "docs/testing/ci-evidence.md"
     ],
     "scripts/compile-capability-service-catalog.mjs": [
       "docs/architecture/capability-driven-runtime-profiles.md"
     ],
+    "scripts/detect-hardware-host.ts": [
+      "docs/install/linux.md",
+      "docs/install/macos.md"
+    ],
     "scripts/dpf-bootstrap-agent-toolchain.ps1": [
+      "docs/architecture/branch-and-worktree-runbook.md",
       "docs/user-guide/contributing/agent-dev-environments.md"
     ],
     "scripts/dpf-bootstrap-agent-toolchain.sh": [
       "docs/user-guide/contributing/agent-dev-environments.md"
     ],
     "scripts/dpf-compose.mjs": [
-      "docs/architecture/capability-driven-runtime-profiles.md"
+      "docs/architecture/capability-driven-runtime-profiles.md",
+      "docs/operations/install.md"
     ],
     "scripts/fresh-install.ps1": [
+      "docs/install/scratch-install-rehearsal.md",
       "docs/testing/archetype-audit-plan.md"
     ],
+    "scripts/gate-worktree.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/gate-worktree.sh": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/harness/archetype-exercise.mjs": [
+      "docs/testing/archetype-exercise-harness.md"
+    ],
+    "scripts/harness/scenarios/restaurant.mjs": [
+      "docs/testing/archetype-exercise-harness.md",
+      "docs/testing/archetype-exercise-playbook.md"
+    ],
     "scripts/hooks/run-hook.mjs": [
-      "docs/install/platform-support-watchlist.md"
+      "docs/install/platform-support-watchlist.md",
+      "docs/operations/session-transcript-recovery.md"
     ],
     "scripts/installer/install-state.schema.json": [
       "docs/operations/install.md"
@@ -700,14 +1442,49 @@
       "docs/install/platform-support-watchlist.md"
     ],
     "scripts/issue-authority-tls-cert.sh": [
+      "docs/edge-node/security-and-sovereignty.md",
       "docs/install/edge-node-air-gapped.md",
       "docs/install/edge-node-multi-host.md"
     ],
+    "scripts/lib/bootstrap-worktree-deps.mjs": [
+      "docs/architecture/mcp-tool-authorization-runbook.md"
+    ],
     "scripts/lib/ci-policy-guards.mjs": [
+      "docs/architecture/context-engineering-standards.md",
+      "docs/maintenance/staleness-report.md",
       "docs/testing/pre-pr-gate.md"
     ],
+    "scripts/lib/compose-safety.mjs": [
+      "docs/architecture/delivery-surfaces-runbook.md"
+    ],
+    "scripts/lib/dockerfile-portal-build.test.mjs": [
+      "docs/install/platform-support-watchlist.md"
+    ],
+    "scripts/lib/ensure-pre-push-hook.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/lib/gate-context.mjs": [
+      "docs/testing/pr-health.md"
+    ],
+    "scripts/lib/junction-safe-worktree-remove.mjs": [
+      "docs/architecture/delivery-surfaces-runbook.md"
+    ],
+    "scripts/lib/local-ci-slot-manifest.mjs": [
+      "docs/operations/local-ci-sandbox-slots.md",
+      "docs/operations/runtime-glossary.md"
+    ],
+    "scripts/lib/local-integration-ci.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/lib/published-doc-roots.mjs": [
+      "docs/architecture/enforced-ci-gates.md"
+    ],
     "scripts/lib/resolve-capability-compose-profiles.mjs": [
-      "docs/architecture/capability-driven-runtime-profiles.md"
+      "docs/architecture/capability-driven-runtime-profiles.md",
+      "docs/operations/install.md"
+    ],
+    "scripts/local-ci-pilot-report.mjs": [
+      "docs/operations/local-ci-sandbox-slots.md"
     ],
     "scripts/local-ci-runner.mjs": [
       "docs/testing/pre-pr-gate.md"
@@ -715,11 +1492,18 @@
     "scripts/mcp-tool-pack-baseline.json": [
       "docs/architecture/mcp-tool-packs.md"
     ],
+    "scripts/measure-doc-staleness-coverage.mjs": [
+      "docs/maintenance/staleness-coverage.md"
+    ],
     "scripts/measure-platform-substrate-runtime.mjs": [
       "docs/architecture/platform-substrate-boundaries.md"
     ],
     "scripts/measure-platform-substrate.mjs": [
       "docs/architecture/platform-substrate-boundaries.md"
+    ],
+    "scripts/new-dev-worktree.sh": [
+      "docs/architecture/delivery-surfaces-runbook.md",
+      "docs/install/macos.md"
     ],
     "scripts/platform-substrate-baseline.json": [
       "docs/architecture/platform-substrate-boundaries.md"
@@ -741,22 +1525,94 @@
     "scripts/probes/marketing-media/local-render-receipt.json": [
       "docs/security/tool-evaluations/2026-08-01-marketing-media-stack.md"
     ],
+    "scripts/promote.sh": [
+      "docs/runbooks/bet5-windows-self-upgrade.md"
+    ],
+    "scripts/regen-lockfile.mjs": [
+      "docs/architecture/agent-skill-index.md",
+      "docs/architecture/contributor-procedure-runbook.md"
+    ],
     "scripts/restore-postgres.sh": [
       "docs/operations/disaster-recovery.md"
     ],
+    "scripts/safety/transcript-snapshot.ps1": [
+      "docs/operations/session-transcript-recovery.md"
+    ],
+    "scripts/sbom/audit-provenance.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/check-lockfile-release-age.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/check-new-dependencies.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/check-sbom-drift.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/check-singleton-safety.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/internalization-candidates.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/runtime-surface.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/sbom/scan-dependencies.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
+    "scripts/seed-worktree-mcp.ps1": [
+      "docs/founder-kernel/wiki/principles/worktree-per-session.md",
+      "docs/user-guide/contributing/developer-setup.md"
+    ],
+    "scripts/seed-worktree-mcp.sh": [
+      "docs/founder-kernel/wiki/principles/worktree-per-session.md",
+      "docs/user-guide/contributing/developer-setup.md"
+    ],
+    "scripts/set-hooks-path.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "scripts/setup.sh": [
+      "docs/install/macos.md"
+    ],
     "scripts/style-drift-baseline.json": [
       "docs/architecture/ui-token-styling.md"
+    ],
+    "scripts/tts/setup-chatterbox-tts-macos.sh": [
+      "docs/install/macos.md"
     ],
     "scripts/verify-edge-node-air-gap.sh": [
       "docs/edge-node/security-and-sovereignty.md",
       "docs/install/edge-node-air-gapped-verification-report.md",
       "docs/install/edge-node-air-gapped.md"
     ],
+    "scripts/verify-install-edge.sh": [
+      "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md",
+      "docs/edge-node/deployment-topology.md"
+    ],
     "services/edge-node/scripts/verify-lifecycle.ts": [
+      "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md",
+      "docs/install/edge-node-multi-host.md",
       "docs/install/verification-runbook.md"
+    ],
+    "services/edge-node/src/__tests__/state.test.ts": [
+      "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md"
+    ],
+    "services/edge-node/src/__tests__/sweep.test.ts": [
+      "docs/install/edge-node-air-gapped.md"
     ],
     "services/edge-node/src/collectors/unifi.ts": [
       "docs/edge-node/unifi-adapter.md"
+    ],
+    "services/edge-node/src/metrics-loop.ts": [
+      "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md"
+    ],
+    "services/edge-node/src/sweep.ts": [
+      "docs/install/edge-node-air-gapped.md"
+    ],
+    "tests/release/local-ci-gate-contract.test.mjs": [
+      "docs/testing/pre-pr-gate.md"
     ]
   },
   "docToRoutes": {
@@ -976,7 +1832,13 @@
     ],
     "docs/architecture/2026-06-14-ai-cockpit-sysml-architecture-note.md": [
       "apps/web/lib/ea/ai-routing-architecture-extract.ts",
-      "apps/web/lib/ea/ai-routing-architecture-registry.ts"
+      "apps/web/lib/ea/ai-routing-architecture-registry.ts",
+      "apps/web/lib/marketing/channels/email-postmark/responder.ts",
+      "apps/web/lib/routing/request-contract.email.test.ts",
+      "apps/web/lib/routing/request-contract.ts",
+      "apps/web/lib/routing/task-requirements.email.test.ts",
+      "apps/web/lib/routing/task-requirements.ts",
+      "packages/db/src/seed-ea-sysml2.test.ts"
     ],
     "docs/architecture/2026-06-14-odysseus-review-depth-pass.md": [
       "apps/web/app/api/integrations/email-postmark/inbound/route.ts",
@@ -986,11 +1848,113 @@
       "apps/web/lib/routing/request-contract.ts",
       "packages/db/prisma/schema.prisma"
     ],
+    "docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md": [
+      "apps/web/lib/routing/pipeline-v2.test.ts",
+      "packages/db/src/eu-jurisdictions.test.ts",
+      "packages/db/src/eu-jurisdictions.ts",
+      "packages/db/src/seed-ea-sysml-cada.ts"
+    ],
+    "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md": [
+      "apps/web/app/api/v1/edge/discovery-runs/route.ts",
+      "apps/web/app/api/v1/edge/enroll/route.ts",
+      "scripts/verify-install-edge.sh",
+      "services/edge-node/scripts/verify-lifecycle.ts",
+      "services/edge-node/src/__tests__/state.test.ts",
+      "services/edge-node/src/metrics-loop.ts"
+    ],
+    "docs/architecture/2026-06-22-platform-adequacy-architecture-review.md": [
+      "packages/integration-shared/src/credential-crypto.ts"
+    ],
+    "docs/architecture/2026-07-27-platform-adequacy-roadmap-backlog-map.md": [
+      "packages/storefront-templates/src/archetype-readiness.ts"
+    ],
+    "docs/architecture/agent-client-capability-parity.md": [
+      "apps/web/lib/build/unified-wip-query.ts",
+      "apps/web/lib/build/unified-wip.ts",
+      "apps/web/lib/deliberation/external-review-activation.ts",
+      "apps/web/lib/routing/anthropic-cache.ts",
+      "e2e/fixtures/evidence.ts",
+      "packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs"
+    ],
+    "docs/architecture/agent-client-governance.md": [
+      "apps/web/lib/change-review/semantic-change-review.ts"
+    ],
+    "docs/architecture/agent-skill-index.md": [
+      "scripts/regen-lockfile.mjs"
+    ],
+    "docs/architecture/agent-standards-dpf-conformance.md": [
+      "apps/web/components/platform/AgentCardSupervisorPanel.tsx",
+      "apps/web/lib/actions/agent-task-scheduler.ts",
+      "apps/web/lib/actions/golden-triangle.ts",
+      "apps/web/lib/autonomy/regulatory-ceiling.ts",
+      "apps/web/lib/autonomy/trust-graduation.ts",
+      "apps/web/lib/identity/aidoc-resolver.ts",
+      "apps/web/lib/mcp/tool-tier.ts",
+      "apps/web/lib/tak/agent-card-service.ts",
+      "apps/web/lib/tak/agent-grants.ts",
+      "apps/web/lib/tak/agent-routing.ts",
+      "apps/web/lib/tak/context-arbitrator.ts",
+      "apps/web/lib/tak/context-economy-metrics.ts",
+      "apps/web/lib/tak/prompt-assembler.ts",
+      "apps/web/lib/tak/tool-result-budget.ts",
+      "apps/web/lib/tak/tool-script.ts",
+      "apps/web/lib/tool-description-hygiene.test.ts",
+      "packages/db/src/seed-decision-perspective.ts"
+    ],
+    "docs/architecture/ai-agent-meta-model.md": [
+      "apps/web/app/api/mcp/v1/route.ts",
+      "apps/web/lib/agent-grants.ts",
+      "apps/web/lib/ai-inference.ts",
+      "apps/web/lib/identity/aidoc-resolver.ts",
+      "apps/web/lib/identity/principal-linking.ts",
+      "apps/web/lib/mcp-governed-execute.ts",
+      "packages/db/src/seed-ea-sysml-agent-authority.ts"
+    ],
+    "docs/architecture/ai-routing-document-map.md": [
+      "apps/web/lib/ea/ai-routing-architecture-extract.ts",
+      "apps/web/lib/ea/ai-routing-architecture-registry.ts",
+      "apps/web/lib/ea/reconcile-ai-routing-architecture.ts",
+      "apps/web/lib/govern/data/policy-decision.ts",
+      "apps/web/lib/govern/data/policy-enforcement.ts",
+      "apps/web/lib/inference/routed-inference.ts",
+      "apps/web/lib/routing/request-contract.ts"
+    ],
+    "docs/architecture/application-boundaries.md": [
+      "scripts/check-application-boundaries.mjs"
+    ],
+    "docs/architecture/archetype-business-value-streams.md": [
+      "packages/storefront-templates/src/types.ts"
+    ],
+    "docs/architecture/backlog-and-planning-runbook.md": [
+      "apps/web/lib/govern/data/field-classification.ts",
+      "packages/db/src/table-classification.ts"
+    ],
+    "docs/architecture/backlog-archetype-scope.md": [
+      "apps/web/app/api/v1/ops/backlog/route.ts",
+      "apps/web/app/api/v1/ops/epics/route.ts",
+      "apps/web/lib/explore/backlog.ts",
+      "apps/web/lib/mcp/packs/backlog-pack.ts",
+      "apps/web/lib/workbooks/backlog-adapter-mapping.ts"
+    ],
     "docs/architecture/branch-and-worktree-runbook.md": [
-      "apps/web/lib/self-upgrade/local-changes-ledger.ts"
+      "apps/web/lib/self-upgrade/local-changes-ledger.ts",
+      "scripts/dpf-bootstrap-agent-toolchain.ps1"
+    ],
+    "docs/architecture/build-gate-runbook.md": [
+      "apps/web/lib/integrate/build-orchestrator.ts",
+      "apps/web/lib/integrate/coding-agent.ts",
+      "apps/web/lib/queue/functions/build-review-verification.ts",
+      "pnpm-lock.yaml"
     ],
     "docs/architecture/build-studio-namespace.md": [
+      "apps/web/lib/integrate/build-plan-paths.ts",
       "scripts/check-build-namespace.mjs"
+    ],
+    "docs/architecture/business-commercial-catalog.md": [
+      "apps/web/lib/product-management/product-direction-view.ts",
+      "apps/web/lib/product-management/product-operating-context-query.ts",
+      "apps/web/lib/product-management/product-route-authority.ts",
+      "apps/web/lib/products/product-sold-query.ts"
     ],
     "docs/architecture/capability-driven-runtime-profiles.md": [
       "apps/web/lib/platform-runtime/capability-service-projection.ts",
@@ -1003,17 +1967,107 @@
       "scripts/lib/resolve-capability-compose-profiles.mjs",
       "scripts/platform-substrate-manifest.json"
     ],
+    "docs/architecture/context-engineering-standards.md": [
+      "apps/web/lib/actions/coworker-tool-budget.ts",
+      "apps/web/lib/inference/jit-retrieval-discipline.test.ts",
+      "apps/web/lib/mcp/tool-tier.ts",
+      "apps/web/lib/routing/fallback.ts",
+      "apps/web/lib/tak/compaction-digest.ts",
+      "apps/web/lib/tak/context-economy-metrics.ts",
+      "apps/web/lib/tak/tool-result-budget.ts",
+      "apps/web/lib/tak/tool-script.ts",
+      "apps/web/lib/tool-description-hygiene.test.ts",
+      "packages/dpf-skill-pack/hooks/tool-economy-precheck.mjs",
+      "scripts/check-instruction-plane-size.mjs",
+      "scripts/lib/ci-policy-guards.mjs"
+    ],
+    "docs/architecture/contributor-procedure-runbook.md": [
+      "apps/web/lib/actions/coworker-tool-filter.ts",
+      "apps/web/lib/backlog.ts",
+      "apps/web/lib/tak/agent-grants.ts",
+      "packages/db/src/agent-identity.test.ts",
+      "packages/db/src/agent-identity.ts",
+      "scripts/check-override-comments.mjs",
+      "scripts/regen-lockfile.mjs"
+    ],
+    "docs/architecture/customer-zero-and-use-case-zero.md": [
+      "apps/web/lib/decision-perspective/weight-inference.ts",
+      "packages/db/src/capability-maturity.ts"
+    ],
     "docs/architecture/data-model-stewardship-runbook.md": [
       "apps/web/lib/routes.ts",
       "apps/web/lib/shared/action-result.ts",
       "apps/web/lib/shared/coerce.ts",
-      "apps/web/lib/shared/org-address.ts"
+      "apps/web/lib/shared/org-address.ts",
+      "scripts/check-no-local-isrecord.mjs"
+    ],
+    "docs/architecture/decision-vectors.md": [
+      "apps/web/lib/decision-perspective/material.ts",
+      "apps/web/lib/decision/option-scoring.ts",
+      "packages/db/src/dimension-scope.ts",
+      "packages/db/src/profession-local-axes.ts"
     ],
     "docs/architecture/delivery-ia.md": [
-      "apps/web/app/(shell)/delivery/page.tsx"
+      "apps/web/app/(shell)/delivery/page.tsx",
+      "apps/web/lib/govern/permissions.ts"
+    ],
+    "docs/architecture/delivery-surfaces-runbook.md": [
+      "apps/web/lib/build/unified-wip.ts",
+      "apps/web/lib/build/wip-cap.ts",
+      "apps/web/lib/operate/db-continuity.ts",
+      "packages/dpf-skill-pack/hooks/worktree-create.mjs",
+      "scripts/lib/compose-safety.mjs",
+      "scripts/lib/junction-safe-worktree-remove.mjs",
+      "scripts/new-dev-worktree.sh"
+    ],
+    "docs/architecture/dependency-reduction-routine.md": [
+      ".github/dependabot.yml",
+      "apps/web/lib/assurance/cyclonedx-generator.ts",
+      "pnpm-lock.yaml",
+      "scripts/sbom/audit-provenance.mjs",
+      "scripts/sbom/check-lockfile-release-age.mjs",
+      "scripts/sbom/check-new-dependencies.mjs",
+      "scripts/sbom/check-sbom-drift.mjs",
+      "scripts/sbom/check-singleton-safety.mjs",
+      "scripts/sbom/internalization-candidates.mjs",
+      "scripts/sbom/runtime-surface.mjs",
+      "scripts/sbom/scan-dependencies.mjs"
+    ],
+    "docs/architecture/enforced-ci-gates.md": [
+      "apps/web/lib/docs-route-map.ts",
+      "apps/web/lib/docs/doc-link-resolver.mjs",
+      "apps/web/lib/govern/data/legacy-coverage-baseline.ts",
+      "apps/web/lib/operate/retention/policies.ts",
+      "docs/_config.yml",
+      "packages/db/src/table-classification.ts",
+      "packages/dpf-skill-pack/hooks/design-grounding-precheck.mjs",
+      "scripts/check-data-impact.mjs",
+      "scripts/check-design-grounding-decision.mjs",
+      "scripts/check-doc-links.mjs",
+      "scripts/check-doc-reference-integrity.mjs",
+      "scripts/check-docs-impact.mjs",
+      "scripts/check-retired-substrate.mjs",
+      "scripts/check-spec-plan-doc.mjs",
+      "scripts/check-stewardship-scope.mjs",
+      "scripts/lib/published-doc-roots.mjs"
     ],
     "docs/architecture/field-service-work-item.md": [
       "packages/validators/src/field-dispatch.ts"
+    ],
+    "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md": [
+      "packages/db/scripts/generate-taxonomy-v3-json.ts",
+      "packages/db/src/seed-ea-reference-models.ts"
+    ],
+    "docs/architecture/four-portfolio-archetype-standard-profile-catalog.md": [
+      "packages/storefront-templates/src/archetypes/index.ts"
+    ],
+    "docs/architecture/mcp-tool-authorization-runbook.md": [
+      "apps/web/app/api/mcp/v1/route.ts",
+      "apps/web/lib/agent-grants.ts",
+      "apps/web/lib/coworker-lifecycle/lifecycle-gate.ts",
+      "apps/web/lib/tak/tool-result-budget.ts",
+      "apps/web/lib/tool-description-hygiene.test.ts",
+      "scripts/lib/bootstrap-worktree-deps.mjs"
     ],
     "docs/architecture/mcp-tool-packs.md": [
       "apps/web/lib/mcp/packs/deliberation-siem-pack.ts",
@@ -1027,9 +2081,24 @@
       "scripts/check-module-size.mjs",
       "scripts/mcp-tool-pack-baseline.json"
     ],
+    "docs/architecture/mcp-tool-surface-ergonomics-audit.md": [
+      "apps/web/lib/mcp-governed-execute.ts",
+      "apps/web/lib/mcp/tool-pack.ts",
+      "scripts/check-tool-surface.mjs"
+    ],
+    "docs/architecture/operational-precedent-corpus.md": [
+      "apps/web/lib/design-intelligence.ts",
+      "packages/db/src/portfolio-sources/vertical-incumbents-manifest.ts",
+      "packages/storefront-templates/src/twin-profile.ts"
+    ],
+    "docs/architecture/orientation.md": [
+      ".github/workflows/migration-safety-guard.yml",
+      "apps/web/lib/ai-inference.ts"
+    ],
     "docs/architecture/package-boundaries.md": [
       "apps/web/lib/contracts/entity-contract-drift.ts",
       "apps/web/lib/contracts/package-boundaries.test.ts",
+      "packages/types/src/entities.ts",
       "scripts/check-package-boundaries.mjs"
     ],
     "docs/architecture/platform-overview.md": [
@@ -1051,18 +2120,50 @@
       "apps/web/components/shell/SectionNav.tsx",
       "apps/web/lib/navigation/section-nav-model.ts"
     ],
+    "docs/architecture/skill-surfaces-runbook.md": [
+      "apps/web/lib/decision/dimension-catalog.ts",
+      "packages/db/src/seed-skills.ts",
+      "packages/dpf-skill-pack/hooks/process-spine-health-check.mjs"
+    ],
+    "docs/architecture/theme-aware-styling-runbook.md": [
+      "apps/web/components/storefront-admin/ItemsManager.tsx",
+      "scripts/check-guards.mjs",
+      "scripts/check-no-dialog-in-transition.mjs",
+      "scripts/check-no-native-dialogs.mjs",
+      "scripts/check-ux-fit-decision.mjs"
+    ],
     "docs/architecture/ui-token-styling.md": [
       "scripts/check-style-drift.mjs",
       "scripts/style-drift-baseline.json"
+    ],
+    "docs/architecture/unified-connector-kernel.md": [
+      "apps/web/lib/integrations/connectors/index.ts",
+      "scripts/check-no-provider-local-connector-lifecycle.mjs"
+    ],
+    "docs/architecture/vector-decisioning-and-jsi.md": [
+      "apps/web/lib/decision-perspective/evaluator.ts",
+      "apps/web/lib/decision-perspective/material.ts",
+      "apps/web/lib/decision-perspective/stance-promotion.ts",
+      "apps/web/lib/decision-perspective/weight-inference.ts",
+      "apps/web/lib/decision/option-scoring.ts"
     ],
     "docs/design/golden-triangle-design.md": [
       "apps/web/lib/queue/functions/deliberation-run.ts",
       "apps/web/lib/routing/chat-adapter.ts",
       "apps/web/lib/routing/cost-ranking.ts",
       "apps/web/lib/routing/request-contract.ts",
-      "apps/web/lib/tak/agentic-loop.ts"
+      "apps/web/lib/tak/agentic-loop.ts",
+      "scripts/check-ux-fit-decision.mjs"
+    ],
+    "docs/design/golden-triangle-vector-reference.md": [
+      "apps/web/lib/golden-triangle/compile.ts"
+    ],
+    "docs/dev/collision-free-dev-workflow.md": [
+      "apps/web/lib/self-upgrade/prepare-source.ts"
     ],
     "docs/dogfood/2026-05-23-dale-hvac-build-studio.md": [
+      "apps/web/lib/build/ideate-build-resolution.ts",
+      "apps/web/lib/routing/cli-adapter.ts",
       "packages/db/src/seed.ts"
     ],
     "docs/edge-node/deployment-topology.md": [
@@ -1070,12 +2171,18 @@
       "docker-compose.edge-standalone-tls.yml",
       "docker-compose.edge-standalone.yml",
       "docker-compose.edge.macvlan.yml",
-      "docker-compose.edge.yml"
+      "docker-compose.edge.yml",
+      "scripts/verify-install-edge.sh"
+    ],
+    "docs/edge-node/event-envelope.md": [
+      "packages/db/src/edge-node-types.ts"
     ],
     "docs/edge-node/macvlan-deployment.md": [
       "docker-compose.edge.macvlan.yml"
     ],
     "docs/edge-node/security-and-sovereignty.md": [
+      "docker-compose.edge-standalone-tls.yml",
+      "scripts/issue-authority-tls-cert.sh",
       "scripts/verify-edge-node-air-gap.sh"
     ],
     "docs/edge-node/unifi-adapter.md": [
@@ -1085,10 +2192,23 @@
     "docs/founder-kernel/AUTHORING.md": [
       "apps/web/lib/decision/golden-decisions.baseline.json",
       "apps/web/lib/decision/golden-decisions.test.ts",
-      "packages/db/src/wiki-taxonomy.ts"
+      "packages/db/src/seed-wiki-kernel.ts",
+      "packages/db/src/wiki-taxonomy.ts",
+      "scripts/build-kernel-embeddings.ts"
     ],
     "docs/founder-kernel/SCHEMA.md": [
+      "apps/web/lib/queue/functions/wiki-lint.ts",
       "packages/db/src/wiki-taxonomy.ts"
+    ],
+    "docs/founder-kernel/wiki/principles/no-native-browser-dialogs.md": [
+      "scripts/check-no-native-dialogs.mjs"
+    ],
+    "docs/founder-kernel/wiki/principles/outbound-actions-require-explicit-go.md": [
+      "apps/web/lib/kernel/runtime-gate.ts"
+    ],
+    "docs/founder-kernel/wiki/principles/worktree-per-session.md": [
+      "scripts/seed-worktree-mcp.ps1",
+      "scripts/seed-worktree-mcp.sh"
     ],
     "docs/install/cloud-single-vm.md": [
       "docker-compose.edge-standalone.yml"
@@ -1099,58 +2219,220 @@
     "docs/install/edge-node-air-gapped.md": [
       "docker-compose.edge-standalone-tls.yml",
       "docker-compose.edge-standalone.yml",
+      "packages/db/src/edge-node-types.ts",
       "scripts/issue-authority-tls-cert.sh",
-      "scripts/verify-edge-node-air-gap.sh"
+      "scripts/verify-edge-node-air-gap.sh",
+      "services/edge-node/src/__tests__/sweep.test.ts",
+      "services/edge-node/src/sweep.ts"
     ],
     "docs/install/edge-node-multi-host.md": [
+      "docker-compose.edge-snmp.yml",
       "docker-compose.edge-standalone-tls.yml",
       "docker-compose.edge-standalone.yml",
       "docker-compose.edge.yml",
       "docker-compose.tls.yml",
-      "scripts/issue-authority-tls-cert.sh"
+      "scripts/issue-authority-tls-cert.sh",
+      "services/edge-node/scripts/verify-lifecycle.ts"
     ],
     "docs/install/linux.md": [
-      ".github/workflows/install-verification.yml"
+      ".github/workflows/install-verification.yml",
+      "docker-compose.linux.yml",
+      "scripts/detect-hardware-host.ts"
+    ],
+    "docs/install/macos.md": [
+      "docker-compose.macos.yml",
+      "scripts/detect-hardware-host.ts",
+      "scripts/new-dev-worktree.sh",
+      "scripts/setup.sh",
+      "scripts/tts/setup-chatterbox-tts-macos.sh"
     ],
     "docs/install/platform-support-watchlist.md": [
       "apps/web/components/monitoring/health-summary.ts",
+      "apps/web/components/monitoring/prometheus-config.test.ts",
+      "apps/web/lib/govern/auth-redirect.ts",
+      "docker-compose.edge-actions.yml",
+      "docker-compose.linux.yml",
+      "docker-entrypoint.sh",
       "packages/db/src/discovery-collectors/network.ts",
       "scripts/hooks/run-hook.mjs",
-      "scripts/installer/lib/platform.sh"
+      "scripts/installer/lib/platform.sh",
+      "scripts/lib/dockerfile-portal-build.test.mjs"
+    ],
+    "docs/install/scratch-install-rehearsal.md": [
+      "scripts/fresh-install.ps1"
     ],
     "docs/install/verification-runbook.md": [
+      ".github/workflows/release-gates.yml",
+      "apps/web/scripts/issue-edge-bootstrap-token.ts",
+      "docker-compose.tls.yml",
       "services/edge-node/scripts/verify-lifecycle.ts"
     ],
+    "docs/maintenance/README.md": [
+      ".github/workflows/refresh-docs-staleness.yml",
+      "scripts/build-docs-staleness.mjs"
+    ],
+    "docs/maintenance/staleness-coverage.md": [
+      "scripts/measure-doc-staleness-coverage.mjs"
+    ],
+    "docs/maintenance/staleness-report.md": [
+      "scripts/build-docs-staleness.mjs",
+      "scripts/lib/ci-policy-guards.mjs"
+    ],
+    "docs/operations/build-cost-flags-activation-runbook.md": [
+      "apps/web/lib/integrate/build-studio-config.ts"
+    ],
     "docs/operations/disaster-recovery.md": [
+      "docker-compose.dev-against-live-db.yml",
       "docker-compose.yml",
       "packages/db/src/seed-platform-backup.ts",
       "scripts/backup-postgres.sh",
       "scripts/restore-postgres.sh"
     ],
     "docs/operations/install.md": [
-      "scripts/installer/install-state.schema.json"
+      "packages/dpf-skill-pack/scripts/update-agent-toolchain.ps1",
+      "packages/dpf-skill-pack/scripts/update-agent-toolchain.sh",
+      "scripts/dpf-compose.mjs",
+      "scripts/installer/install-state.schema.json",
+      "scripts/lib/resolve-capability-compose-profiles.mjs"
+    ],
+    "docs/operations/local-ci-sandbox-slots.md": [
+      "scripts/lib/local-ci-slot-manifest.mjs",
+      "scripts/local-ci-pilot-report.mjs"
     ],
     "docs/operations/mobile-store-launch-runbook.md": [
       "apps/mobile/eas.json"
     ],
+    "docs/operations/observability-coverage.md": [
+      "apps/web/lib/queue/functions/alert-delivery-bridge.ts",
+      "apps/web/lib/voice-synthesis/tts-health-contract.test.ts",
+      "docker-compose.macos.yml",
+      "monitoring/prometheus/prometheus.yml"
+    ],
     "docs/operations/oss-repo-identity-hygiene.md": [
       "scripts/check-no-private-identity.mjs"
     ],
-    "docs/runbooks/2026-07-20-collation-drift-index-corruption.md": [
+    "docs/operations/remote-action-edge-dispatch.md": [
+      "docker-compose.edge-actions.yml"
+    ],
+    "docs/operations/runtime-glossary.md": [
+      "docker-compose.dev-against-live-db.yml",
+      "scripts/lib/local-ci-slot-manifest.mjs"
+    ],
+    "docs/operations/runtime-kernel-commandments.md": [
+      "apps/web/lib/wiki/principle-lint-detectors.ts"
+    ],
+    "docs/operations/session-transcript-recovery.md": [
+      "scripts/hooks/run-hook.mjs",
+      "scripts/safety/transcript-snapshot.ps1"
+    ],
+    "docs/personas/dale-hvac.md": [
+      "packages/storefront-templates/src/archetypes/trades-maintenance.ts"
+    ],
+    "docs/personas/linda-clinic.md": [
+      "apps/web/lib/storefront/archetype-vocabulary.ts",
+      "packages/storefront-templates/src/archetypes/healthcare-wellness.ts"
+    ],
+    "docs/personas/marisol-retail.md": [
+      "apps/web/lib/storefront/archetype-vocabulary.ts",
+      "packages/storefront-templates/src/archetypes/retail-goods.ts"
+    ],
+    "docs/platform-usability-standards.md": [
+      ".github/workflows/ux-route-sweep.yml",
+      "apps/web/components/admin/OperatingHoursEditor.tsx",
+      "apps/web/components/shell/shell-action-result-contract.test.tsx",
+      "apps/web/components/storefront-admin/ServiceLinesPanel.tsx",
+      "apps/web/components/ui/SaveStateIndicator.tsx",
+      "apps/web/components/ui/form/SelectField.tsx",
+      "apps/web/components/ui/report-kit/statusColors.ts",
+      "apps/web/design/tokens-utilities.test.ts",
+      "apps/web/lib/marketing/archetype-fit.ts",
+      "apps/web/lib/readability/policy.ts",
+      "apps/web/lib/shared/use-save-state.test.ts",
+      "apps/web/lib/shared/use-save-state.ts",
+      "apps/web/lib/shell/shell-action-contract.ts",
+      "apps/web/lib/tak/prompt-assembler.ts",
+      "apps/web/lib/ux-budget/measure.ts",
+      "apps/web/lib/workforce/oversight-copy.ts",
+      "packages/validators/src/readability.ts",
+      "scripts/check-no-hand-rolled-loading.mjs",
+      "scripts/check-style-drift.mjs"
+    ],
+    "docs/professions/data-architect/wiki/dedupe-migration-means-the-constraint-is-wrong.md": [
       "packages/db/src/migrations/exact-key-repair.ts"
+    ],
+    "docs/professions/data-architect/wiki/index-and-collation-integrity.md": [
+      "packages/db/scripts/index-integrity-guard.mjs"
+    ],
+    "docs/professions/data-architect/wiki/mdm-what-it-does-and-does-not-do.md": [
+      "apps/web/lib/mdm/domain-registry.ts"
+    ],
+    "docs/professions/data-architect/wiki/strongly-typed-string-enums.md": [
+      "apps/web/lib/backlog.ts"
+    ],
+    "docs/professions/legal-compliance/wiki/eu-cada-cloud-sovereignty.md": [
+      "packages/db/src/eu-jurisdictions.ts"
+    ],
+    "docs/prompts/a2a-coworker-substrate-prompt.md": [
+      "apps/web/lib/actions/skill-discovery.ts",
+      "apps/web/lib/queue/functions/agent-task-dispatch.ts",
+      "apps/web/lib/tak/agent-event-bus.ts",
+      "apps/web/lib/tak/delegation-authority.ts"
+    ],
+    "docs/runbooks/2026-07-18-self-upgrade-mounts-denied-state-dir.md": [
+      "scripts/check-compose-env-contract.mjs"
+    ],
+    "docs/runbooks/2026-07-20-collation-drift-index-corruption.md": [
+      "packages/db/scripts/index-integrity-guard.mjs",
+      "packages/db/src/migrations/exact-key-repair.ts"
+    ],
+    "docs/runbooks/bet5-windows-self-upgrade.md": [
+      "scripts/promote.sh"
     ],
     "docs/security/2026-05-24-shift-left-rollout.md": [
       ".github/workflows/ci.yml",
       ".github/workflows/codeql.yml",
       ".github/workflows/secrets-scan.yml",
+      ".github/workflows/security-inflow-gate.yml",
       "scripts/check-mobile-jest-pin.mjs"
+    ],
+    "docs/security/README.md": [
+      ".github/workflows/security-inflow-gate.yml"
+    ],
+    "docs/security/codeql-advanced-setup.md": [
+      ".github/codeql/codeql-config.yml",
+      ".github/codeql/dpf-sanitizers/dpf-sanitizers.model.yml",
+      ".github/codeql/dpf-sanitizers/qlpack.yml",
+      ".github/workflows/codeql.yml",
+      "apps/web/lib/security/safe-log.ts"
     ],
     "docs/security/secrets-scan.md": [
       ".github/workflows/codeql.yml",
+      ".github/workflows/secrets-scan.yml",
       ".github/workflows/security-inflow-gate.yml"
+    ],
+    "docs/security/tool-evaluations/2026-07-20-step-ca.md": [
+      "docker-compose.tls.yml"
     ],
     "docs/security/tool-evaluations/2026-08-01-marketing-media-stack.md": [
       "scripts/probes/marketing-media/local-render-receipt.json"
+    ],
+    "docs/specs/device-identification-and-portfolio-placement-spec.md": [
+      "apps/web/lib/queue/functions/hive-scout-ingest.ts",
+      "packages/db/src/discovery-fingerprint-redaction.ts",
+      "packages/db/src/discovery-fingerprint-rules.ts",
+      "packages/db/src/discovery-fingerprint-types.ts",
+      "packages/db/src/discovery-promotion-policy.ts",
+      "packages/db/src/discovery-triage.ts",
+      "packages/db/src/hive-scout-config.ts"
+    ],
+    "docs/specs/reporting-ux-primitives-spec.md": [
+      "apps/web/lib/reporting-types.ts"
+    ],
+    "docs/specs/routing-resilience-and-failure-observability-spec.md": [
+      "apps/web/lib/actions/coworker-tool-filter.ts",
+      "apps/web/lib/ai-operations-map/project-routing-topology.ts",
+      "apps/web/lib/routing/fallback.ts",
+      "apps/web/lib/routing/rate-tracker.ts"
     ],
     "docs/strategy/2026-09-cada-architects-forum-deck.md": [
       "apps/web/lib/actions/sovereignty.ts",
@@ -1163,15 +2445,65 @@
       "packages/db/src/regulation-applicability.ts",
       "packages/db/src/sovereignty-assessment.ts"
     ],
+    "docs/strategy/2026-09-cada-cloud-sovereignty-architects-forum.md": [
+      "apps/web/lib/actions/compliance.ts",
+      "apps/web/lib/change-management/register-change.ts",
+      "packages/db/scripts/seed-dora-regulation.ts"
+    ],
     "docs/testing/archetype-audit-plan.md": [
       "packages/storefront-templates/src/archetypes/index.ts",
       "scripts/fresh-install.ps1"
     ],
+    "docs/testing/archetype-exercise-harness.md": [
+      "scripts/harness/archetype-exercise.mjs",
+      "scripts/harness/scenarios/restaurant.mjs"
+    ],
+    "docs/testing/archetype-exercise-playbook.md": [
+      "scripts/harness/scenarios/restaurant.mjs"
+    ],
+    "docs/testing/archetype-job-validation.md": [
+      "apps/web/lib/actions/invite-actions.ts",
+      "apps/web/lib/workspace-home/profiles.ts"
+    ],
     "docs/testing/ci-evidence.md": [
-      "docs/testing/ci-observation-baseline.json"
+      ".github/workflows/ci-calibration.yml",
+      ".github/workflows/ux-route-sweep.yml",
+      "apps/web/instrumentation.ts",
+      "apps/web/lib/runtime/measurement-runtime.ts",
+      "docs/testing/ci-observation-baseline.json",
+      "scripts/ci-evidence-plan.mjs",
+      "scripts/ci-shadow-selection.mjs"
+    ],
+    "docs/testing/findings/run-1-findings.md": [
+      "scripts/build-images.sh"
+    ],
+    "docs/testing/findings/run-1-phase-w-retest.md": [
+      "apps/web/lib/workbooks/people-supplier-configs.ts",
+      "scripts/build-images.ps1"
+    ],
+    "docs/testing/findings/run-1-swap-findings.md": [
+      "apps/web/lib/storefront/archetype-reset.ts"
+    ],
+    "docs/testing/findings/run-10-equipment-rental-findings.md": [
+      "apps/web/components/storefront-admin/ItemFormDialog.tsx"
+    ],
+    "docs/testing/findings/run-4-fresh-findings.md": [
+      "packages/storefront-templates/src/archetypes/fitness-recreation.ts"
+    ],
+    "docs/testing/handoff-invoice-gaps.md": [
+      "apps/mobile/dynamic/fields/SignatureField.tsx",
+      "apps/web/components/finance/CreateBillForm.tsx",
+      "apps/web/lib/actions/finance.ts",
+      "apps/web/lib/finance/finance-validation.ts",
+      "apps/web/lib/shared/email.ts",
+      "scripts/build-images.ps1"
+    ],
+    "docs/testing/pending-backlog-items.md": [
+      "apps/web/components/finance/InvoiceSendButton.tsx"
     ],
     "docs/testing/pr-health.md": [
       "config/merge-readiness-policy.json",
+      "scripts/lib/gate-context.mjs",
       "scripts/pr-health.mjs",
       "scripts/pr-health.test.mjs"
     ],
@@ -1180,10 +2512,24 @@
       ".github/workflows/ci.yml",
       ".github/workflows/codeql.yml",
       ".github/workflows/policy-guards-recheck.yml",
+      "docker-compose.local-ci.yml",
+      "packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs",
       "scripts/check-mobile-jest-pin.mjs",
+      "scripts/ci-policy-guards.test.mjs",
+      "scripts/gate-worktree.mjs",
+      "scripts/gate-worktree.sh",
       "scripts/lib/ci-policy-guards.mjs",
+      "scripts/lib/ensure-pre-push-hook.mjs",
+      "scripts/lib/local-integration-ci.mjs",
       "scripts/local-ci-runner.mjs",
-      "scripts/pr-health.mjs"
+      "scripts/pr-health.mjs",
+      "scripts/set-hooks-path.mjs",
+      "tests/release/local-ci-gate-contract.test.mjs"
+    ],
+    "docs/triage/2026-05-20-handoff-prompt-next-session.md": [
+      "apps/web/lib/integrate/build-pipeline.ts",
+      "apps/web/lib/integrate/coding-agent.ts",
+      "apps/web/lib/integrate/sandbox/sandbox.ts"
     ],
     "docs/user-guide/ai-workforce/connecting-providers.md": [
       "apps/web/app/(shell)/platform/ai/providers/page.tsx",
@@ -1194,6 +2540,26 @@
       "apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx",
       "apps/web/components/proactivity/ProactivityRosterList.tsx",
       "apps/web/lib/proactivity/proactivity-roster.ts"
+    ],
+    "docs/user-guide/ai-workforce/decision-perspective-in-practice.md": [
+      "apps/web/lib/decision/option-scoring.ts"
+    ],
+    "docs/user-guide/ai-workforce/decision-perspective.md": [
+      "apps/web/lib/founder-review/queue.ts",
+      "apps/web/lib/tak/route-context.ts"
+    ],
+    "docs/user-guide/ai-workforce/model-routing-lifecycle.md": [
+      "docker-entrypoint.sh"
+    ],
+    "docs/user-guide/ai-workforce/provider-codex.md": [
+      "docker-entrypoint.sh"
+    ],
+    "docs/user-guide/ai-workforce/provider-developer-notes.md": [
+      "apps/web/app/api/v1/auth/provider-oauth/callback/route.ts",
+      "apps/web/app/auth/callback/route.ts",
+      "apps/web/app/callback/route.ts",
+      "apps/web/lib/actions/provider-oauth.ts",
+      "apps/web/lib/provider-oauth.ts"
     ],
     "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md": [
       "apps/web/lib/inference/data-screening/evaluate-inference-policy.ts",
@@ -1206,6 +2572,16 @@
     "docs/user-guide/contributing/agent-dev-environments.md": [
       "scripts/dpf-bootstrap-agent-toolchain.ps1",
       "scripts/dpf-bootstrap-agent-toolchain.sh"
+    ],
+    "docs/user-guide/contributing/dev-container.md": [
+      "packages/db/scripts/dev-preview-migrate-deploy.mjs"
+    ],
+    "docs/user-guide/contributing/developer-setup.md": [
+      "scripts/seed-worktree-mcp.ps1",
+      "scripts/seed-worktree-mcp.sh"
+    ],
+    "docs/user-guide/platform/edge-nodes.md": [
+      "docker-compose.edge.macvlan.yml"
     ],
     "docs/user-guide/workspace/attention-inbox.md": [
       "apps/web/components/attention/AttentionInbox.tsx",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4646,6 +4646,7 @@
         "doc-staleness-signal-coverage-measurement",
         "why-this-exists",
         "the-finding",
+        "the-uncovered-remainder-is-not-all-a-gap",
         "coverage-by-area",
         "what-this-implies-for-bi-3e5969df"
       ]

--- a/docs/maintenance/staleness-coverage.md
+++ b/docs/maintenance/staleness-coverage.md
@@ -19,17 +19,28 @@ page it has no edge to, at any precision.
 
 ## The finding
 
-**95 of 612 published doc pages (15.5%) carry a doc-impact edge.**
-The other **517** (84.5%) carry none, and are invisible to
+**180 of 612 published doc pages (29.4%) carry a doc-impact edge.**
+The other **432** (70.6%) carry none, and are invisible to
 the doc-impact gate by construction — not because the gate is imprecise, but
 because there is no edge along which it could ever be told to look.
 
 | Signal | Pages |
 | ------ | ----- |
-| Code edges only | 48 |
-| Route edges only | 45 |
-| Both | 2 |
-| **No edge at all** | **517** |
+| Code edges only | 133 |
+| Route edges only | 43 |
+| Both | 4 |
+| **No edge at all** | **432** |
+
+### The uncovered remainder is not all a gap
+
+Of those 432, **416 reference no repo file anywhere in their text** — no link, no
+backticked path. They are WSID profession doctrine and founder-kernel principle
+pages: they describe how to decide, not what the code does. **No code-edge
+derivation will ever reach them**, and counting them as a shortfall argues
+forever for widening that has already run out.
+
+The genuinely recoverable set is **16** page(s) — those that cite a repo file but
+whose citation the current derivations do not turn into an edge.
 
 The timestamp detector (`build-docs-staleness.mjs`, BI-AA5DFEA2) currently reports **3** stale
 candidate(s). That number is small because its reach is small, not because the
@@ -41,40 +52,42 @@ Darkest first. These are the areas where a semantic gate would be blind today.
 
 | Area | Pages | Covered | Coverage |
 | ---- | ----- | ------- | -------- |
-| `professions` | 204 | 0 | 0% |
-| `triage` | 7 | 0 | 0% |
 | `marketing` | 4 | 0 | 0% |
-| `personas` | 4 | 0 | 0% |
-| `(root)` | 3 | 0 | 0% |
-| `specs` | 3 | 0 | 0% |
-| `dev` | 1 | 0 | 0% |
-| `maintenance` | 1 | 0 | 0% |
-| `prompts` | 1 | 0 | 0% |
-| `founder-kernel` | 125 | 2 | 1.6% |
-| `testing` | 40 | 4 | 10% |
-| `architecture` | 83 | 15 | 18.1% |
-| `operations` | 20 | 4 | 20% |
-| `runbooks` | 5 | 1 | 20% |
-| `design` | 4 | 1 | 25% |
-| `security` | 6 | 3 | 50% |
+| `professions` | 204 | 5 | 2.5% |
+| `founder-kernel` | 125 | 5 | 4% |
+| `triage` | 7 | 1 | 14.3% |
+| `(root)` | 3 | 1 | 33.3% |
+| `testing` | 40 | 14 | 35% |
+| `design` | 4 | 2 | 50% |
 | `dogfood` | 2 | 1 | 50% |
-| `strategy` | 2 | 1 | 50% |
-| `edge-node` | 7 | 4 | 57.1% |
-| `user-guide` | 80 | 52 | 65% |
-| `install` | 10 | 7 | 70% |
+| `operations` | 20 | 11 | 55% |
+| `architecture` | 83 | 48 | 57.8% |
+| `runbooks` | 5 | 3 | 60% |
+| `edge-node` | 7 | 5 | 71.4% |
+| `user-guide` | 80 | 58 | 72.5% |
+| `personas` | 4 | 3 | 75% |
+| `install` | 10 | 9 | 90% |
+| `security` | 6 | 6 | 100% |
+| `specs` | 3 | 3 | 100% |
+| `strategy` | 2 | 2 | 100% |
+| `dev` | 1 | 1 | 100% |
+| `maintenance` | 1 | 1 | 100% |
+| `prompts` | 1 | 1 | 100% |
 
 ## What this implies for BI-3E5969DF
 
-1. **Coverage is the binding constraint, not precision.** Tuning a semantic
-   detector against the covered minority would leave the uncovered majority
-   exactly as dark as it is now, while producing a green check that reads as
-   "docs are fine" — the failure mode the
+1. **Widening is close to exhausted.** Of the pages any code-edge derivation could
+   reach, 180 of 196 (91.8%) now carry an edge. The headline 29.4% understates
+   the gate because most of what it excludes is doctrine, not undocumented code.
+   Further widening buys single-digit page counts; the cheap direction is spent.
+2. **Reach is no longer the binding constraint — precision is.** That inverts
+   this report's earlier recommendation, and it is the change that makes a
+   semantic detector worth designing rather than deferring.
+3. **Gate on the addressable corpus, never on the whole.** A gate whose
+   denominator includes principle pages will always look broken, and one that
+   silently ignores them reports a coverage it does not have — the failure the
    [`gate-coverage-matches-blast-radius`](../founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md)
-   principle names.
-2. **Widening edges beats sharpening signal, for now.** PR #4004 already showed
-   the cheap direction: derive edges from references docs already contain rather
-   than ask authors to declare them (27 → 155 code edges, no annotation).
-3. **Do not gate yet.** On this corpus a semantic detector cannot be honestly
-   described as covering the docs. Advisory reporting first; binding later, and
-   only against a measured over-report rate on a corpus it can actually see.
+   principle names. Say which population is in scope, and measure against it.
+4. **Still measure over-report before binding.** Nothing here says the semantic
+   signal is accurate — only that it would now have something to look at.
 

--- a/scripts/gen-doc-impact.mjs
+++ b/scripts/gen-doc-impact.mjs
@@ -104,6 +104,38 @@ const isExternalHref = (h) => /^(https?:|mailto:|tel:|data:|#)/i.test(h);
  *  documentation-graph concern, not a code-change blast radius. */
 const CODE_EXT_RE = /\.(ts|tsx|mts|mjs|js|jsx|prisma|sql|ya?ml|sh|ps1|json|toml)$/i;
 
+/** EDGE SOURCE 4 — a repo path cited in backticks, e.g. `apps/web/lib/foo.ts`.
+ *  Same premise as source 3 (the author already wrote the reference) applied to
+ *  the form DPF docs actually use most: prose citing a path inline rather than
+ *  linking it. Measured on this corpus, it is what the link-only walk was missing. */
+const TICK_PATH_RE = /`([A-Za-z0-9_.\-/]+\.(?:ts|tsx|mts|mjs|js|jsx|prisma|sql|ya?ml|sh|ps1))`/g;
+
+/**
+ * Fan-out ceiling for DERIVED tick edges.
+ *
+ * A path cited by more than this many published pages is a LANDMARK, not a
+ * dependency — `packages/db/src/seed.ts` is named by 14 pages because it is the
+ * canonical example of a seed file, not because those 14 pages document it.
+ * Without a ceiling, touching seed.ts would flag all 14 and the gate becomes the
+ * noise it was built to avoid.
+ *
+ * 3 is measured, not guessed — and measured against the COMBINED fan-out, which
+ * is the number that matters. Capping tick edges alone is misleading: a file also
+ * carries frontmatter and link edges, so a tick cap of 6 still produced a combined
+ * worst case of 7. Sweeping the cap and re-measuring the whole manifest each time:
+ *
+ *   tick cap 2 → combined max fan-out 4, 178 pages covered
+ *   tick cap 3 → combined max fan-out 4, 182 pages covered   ← chosen
+ *   tick cap 4 → combined max fan-out 5, 183 pages covered
+ *   tick cap 6 → combined max fan-out 7, 186 pages covered
+ *
+ * Cap 3 buys all but four pages of the available coverage while holding the
+ * ceiling at 4 — exactly what PR #4004 reported for the link-derived source. The
+ * four extra pages are not worth raising the worst case by 75%: BI-22207E9A is
+ * explicit that edges which make the gate noisy are a regression, not progress.
+ */
+const TICK_FANOUT_CAP = 3;
+
 /**
  * Repo-relative source files that `markdown` links to, resolved relative to the
  * doc's own directory.
@@ -129,6 +161,43 @@ export function linkedCodePaths(markdown, docPath, repoRoot) {
   return [...out].sort();
 }
 
+/**
+ * Repo-relative source files this markdown cites in BACKTICKS.
+ *
+ * Resolved from the repo root rather than the doc's directory: a prose citation
+ * is written as the repo path (`apps/web/lib/x.ts`), not as a relative link.
+ * Explicitly relative forms are skipped — those are link syntax, and source 3
+ * already owns them.
+ *
+ * @returns {string[]} sorted, de-duplicated repo-relative POSIX paths
+ */
+export function tickedCodePaths(markdown, repoRoot) {
+  const body = markdown.replace(FENCE_RE, "");
+  const out = new Set();
+  for (const m of body.matchAll(TICK_PATH_RE)) {
+    const rel = m[1];
+    if (rel.startsWith("./") || rel.startsWith("../") || rel.startsWith("/")) continue;
+    const abs = path.join(repoRoot, rel);
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) continue;
+    out.add(rel);
+  }
+  return [...out].sort();
+}
+
+/**
+ * Drop tick-derived edges whose source file is cited by more than `cap` pages.
+ *
+ * Pure and exported so the ceiling is testable without a corpus.
+ *
+ * @param {Array<{code: string, doc: string}>} candidates
+ * @returns {Array<{code: string, doc: string}>} kept edges
+ */
+export function applyFanoutCap(candidates, cap = TICK_FANOUT_CAP) {
+  const fanout = new Map();
+  for (const { code } of candidates) fanout.set(code, (fanout.get(code) ?? 0) + 1);
+  return candidates.filter(({ code }) => fanout.get(code) <= cap);
+}
+
 export function buildManifest() {
   const entries = parseRouteMap(fs.readFileSync(ROUTE_MAP_TS, "utf-8"));
   const routeToDocs = {};
@@ -136,6 +205,8 @@ export function buildManifest() {
   const docToRoutes = {};
   const docToCode = {};
   const problems = [];
+  /** @type {Array<{code: string, doc: string}>} tick edges, capped after the walk. */
+  const tickCandidates = [];
 
   // 1. Route -> doc, inverted from DOCS_ROUTE_MAP.
   for (const { routePrefix, docsPath } of entries) {
@@ -169,6 +240,18 @@ export function buildManifest() {
       addEdge(codeToDocs, code, sourcePath);
       addEdge(docToCode, sourcePath, code);
     }
+
+    // 4. DERIVED edges from BACKTICK citations. Collected rather than added, so
+    //    the fan-out ceiling can be applied across the whole corpus below — a
+    //    per-page decision cannot see that a path is cited by fifteen pages.
+    for (const code of tickedCodePaths(raw, REPO_ROOT)) {
+      tickCandidates.push({ code, doc: sourcePath });
+    }
+  }
+
+  for (const { code, doc } of applyFanoutCap(tickCandidates)) {
+    addEdge(codeToDocs, code, doc);
+    addEdge(docToCode, doc, code);
   }
 
   const sortObj = (o) => Object.fromEntries(Object.keys(o).sort().map((k) => [k, o[k].sort()]));

--- a/scripts/gen-doc-impact.test.mjs
+++ b/scripts/gen-doc-impact.test.mjs
@@ -5,7 +5,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { frontmatterList, linkedCodePaths } from "./gen-doc-impact.mjs";
+import {
+  applyFanoutCap,
+  frontmatterList,
+  linkedCodePaths,
+  tickedCodePaths,
+} from "./gen-doc-impact.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -76,4 +81,71 @@ test("linkedCodePaths de-duplicates and sorts for a byte-stable manifest", () =>
   const md = "[a](../../packages/db/src/pg-graph.ts)\n[a2](../../packages/db/src/pg-graph.ts)\n[b](../../packages/db/src/graph-sync.ts)\n";
   assert.deepEqual(linkedCodePaths(md, DOC, REPO_ROOT),
     ["packages/db/src/graph-sync.ts", "packages/db/src/pg-graph.ts"]);
+});
+
+// ─── EDGE SOURCE 4: backtick-cited repo paths (BI-22207E9A) ──────────────────
+// The link-only walk missed the form DPF docs actually use most — prose citing a
+// path inline. Measured: this took published-page coverage from 15.5% to 29.4%.
+
+test("tickedCodePaths derives an edge from a backtick-cited repo path", () => {
+  const md = "See `scripts/gen-doc-impact.mjs` for the generator.";
+  assert.deepEqual(tickedCodePaths(md, REPO_ROOT), ["scripts/gen-doc-impact.mjs"]);
+});
+
+test("tickedCodePaths ignores paths that do not exist", () => {
+  // A citation is only an edge if it resolves; a typo is the Doc Reference
+  // Integrity gate's finding to report, not a phantom edge here.
+  assert.deepEqual(tickedCodePaths("`apps/web/lib/does-not-exist.ts`", REPO_ROOT), []);
+});
+
+test("tickedCodePaths ignores non-source extensions and prose in backticks", () => {
+  assert.deepEqual(tickedCodePaths("`README.md` and `some phrase`", REPO_ROOT), []);
+});
+
+test("tickedCodePaths ignores citations inside fenced blocks", () => {
+  // Fenced blocks hold EXAMPLES; same rule the link-derived source already obeys.
+  const fence = "`".repeat(3);
+  const md = [fence, "see `scripts/gen-doc-impact.mjs`", fence].join("\n");
+  assert.deepEqual(tickedCodePaths(md, REPO_ROOT), []);
+});
+
+test("tickedCodePaths skips relative forms — those belong to the link source", () => {
+  assert.deepEqual(tickedCodePaths("`./gen-doc-impact.mjs` `../x.ts`", REPO_ROOT), []);
+});
+
+test("tickedCodePaths de-duplicates repeat citations of one file", () => {
+  const md = "`scripts/gen-doc-impact.mjs` again `scripts/gen-doc-impact.mjs`";
+  assert.deepEqual(tickedCodePaths(md, REPO_ROOT), ["scripts/gen-doc-impact.mjs"]);
+});
+
+test("applyFanoutCap drops landmark files cited by too many pages", () => {
+  // packages/db/src/seed.ts is named by 14 pages because it is the canonical
+  // example of a seed file, not because 14 pages document it. Without the cap,
+  // touching it would flag all 14 and the gate becomes the noise it exists to avoid.
+  const candidates = [
+    { code: "seed.ts", doc: "a.md" },
+    { code: "seed.ts", doc: "b.md" },
+    { code: "seed.ts", doc: "c.md" },
+    { code: "narrow.ts", doc: "a.md" },
+  ];
+  assert.deepEqual(applyFanoutCap(candidates, 2), [{ code: "narrow.ts", doc: "a.md" }]);
+});
+
+test("applyFanoutCap keeps a file sitting exactly on the cap", () => {
+  const candidates = [
+    { code: "x.ts", doc: "a.md" },
+    { code: "x.ts", doc: "b.md" },
+  ];
+  assert.equal(applyFanoutCap(candidates, 2).length, 2);
+});
+
+test("applyFanoutCap counts fan-out globally, not per document", () => {
+  // A per-page decision cannot see that a path is cited by many pages — which is
+  // exactly why the tick edges are collected first and capped after the walk.
+  const candidates = [
+    { code: "x.ts", doc: "a.md" },
+    { code: "x.ts", doc: "b.md" },
+    { code: "x.ts", doc: "c.md" },
+  ];
+  assert.deepEqual(applyFanoutCap(candidates, 2), []);
 });

--- a/scripts/measure-doc-staleness-coverage.mjs
+++ b/scripts/measure-doc-staleness-coverage.mjs
@@ -74,7 +74,7 @@ export function docArea(docPath) {
  *            byCodeOnly:number, byRouteOnly:number, byBoth:number,
  *            areas: Array<{area:string,total:number,covered:number,coveredPct:number}>}}
  */
-export function computeCoverage(corpus, manifest) {
+export function computeCoverage(corpus, manifest, mentionsCode = null) {
   const withCode = new Set(Object.keys(manifest.docToCode ?? {}));
   const withRoute = new Set(Object.keys(manifest.docToRoutes ?? {}));
 
@@ -101,11 +101,30 @@ export function computeCoverage(corpus, manifest) {
   const total = corpus.length;
   const pct = (n, d) => (d === 0 ? 0 : Math.round((n / d) * 1000) / 10);
 
+  // Split the uncovered remainder (BI-22207E9A). Without this, "N% covered"
+  // reads as N% of a population that could all be covered — and it cannot. A
+  // WSID profession doctrine page or a founder-kernel principle names no source
+  // file, so no code-edge derivation will ever reach it. Those are not a gap;
+  // they are a different kind of document, and counting them as a shortfall
+  // argues forever for widening that has already run out.
+  let inert = 0;
+  if (mentionsCode) {
+    for (const doc of corpus) {
+      const c = withCode.has(doc);
+      const r = withRoute.has(doc);
+      if (!c && !r && !mentionsCode.has(doc)) inert++;
+    }
+  }
+
   return {
     total,
     covered,
     uncovered: total - covered,
     coveredPct: pct(covered, total),
+    /** Uncovered pages that reference no repo file at all — unreachable by design. */
+    inert: mentionsCode ? inert : null,
+    /** Uncovered pages that DO cite a repo file — the genuinely recoverable set. */
+    recoverable: mentionsCode ? total - covered - inert : null,
     byCodeOnly,
     byRouteOnly,
     byBoth,
@@ -161,6 +180,23 @@ export function renderReport(cov, candidates) {
   L.push(`| Route edges only | ${cov.byRouteOnly} |`);
   L.push(`| Both | ${cov.byBoth} |`);
   L.push(`| **No edge at all** | **${cov.uncovered}** |`);
+  if (cov.inert !== null) {
+    L.push("");
+    L.push("### The uncovered remainder is not all a gap");
+    L.push("");
+    L.push(
+      `Of those ${cov.uncovered}, **${cov.inert} reference no repo file anywhere in their text** — no link, no`,
+    );
+    L.push("backticked path. They are WSID profession doctrine and founder-kernel principle");
+    L.push("pages: they describe how to decide, not what the code does. **No code-edge");
+    L.push("derivation will ever reach them**, and counting them as a shortfall argues");
+    L.push("forever for widening that has already run out.");
+    L.push("");
+    L.push(
+      `The genuinely recoverable set is **${cov.recoverable}** page(s) — those that cite a repo file but`,
+    );
+    L.push("whose citation the current derivations do not turn into an edge.");
+  }
   if (candidates !== null) {
     L.push("");
     L.push(
@@ -182,20 +218,64 @@ export function renderReport(cov, candidates) {
   L.push("");
   L.push("## What this implies for BI-3E5969DF");
   L.push("");
-  L.push("1. **Coverage is the binding constraint, not precision.** Tuning a semantic");
-  L.push("   detector against the covered minority would leave the uncovered majority");
-  L.push("   exactly as dark as it is now, while producing a green check that reads as");
-  L.push("   \"docs are fine\" — the failure mode the");
-  L.push("   [`gate-coverage-matches-blast-radius`](../founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md)");
-  L.push("   principle names.");
-  L.push("2. **Widening edges beats sharpening signal, for now.** PR #4004 already showed");
-  L.push("   the cheap direction: derive edges from references docs already contain rather");
-  L.push("   than ask authors to declare them (27 → 155 code edges, no annotation).");
-  L.push("3. **Do not gate yet.** On this corpus a semantic detector cannot be honestly");
-  L.push("   described as covering the docs. Advisory reporting first; binding later, and");
-  L.push("   only against a measured over-report rate on a corpus it can actually see.");
+  if (cov.inert !== null && cov.recoverable !== null) {
+    const addressable = cov.covered + cov.recoverable;
+    const addressablePct =
+      addressable === 0 ? 0 : Math.round((cov.covered / addressable) * 1000) / 10;
+    L.push(
+      `1. **Widening is close to exhausted.** Of the pages any code-edge derivation could`,
+    );
+    L.push(
+      `   reach, ${cov.covered} of ${addressable} (${addressablePct}%) now carry an edge. The headline ${cov.coveredPct}% understates`,
+    );
+    L.push("   the gate because most of what it excludes is doctrine, not undocumented code.");
+    L.push("   Further widening buys single-digit page counts; the cheap direction is spent.");
+    L.push("2. **Reach is no longer the binding constraint — precision is.** That inverts");
+    L.push("   this report's earlier recommendation, and it is the change that makes a");
+    L.push("   semantic detector worth designing rather than deferring.");
+    L.push("3. **Gate on the addressable corpus, never on the whole.** A gate whose");
+    L.push("   denominator includes principle pages will always look broken, and one that");
+    L.push("   silently ignores them reports a coverage it does not have — the failure the");
+    L.push("   [`gate-coverage-matches-blast-radius`](../founder-kernel/wiki/principles/gate-coverage-matches-blast-radius.md)");
+    L.push("   principle names. Say which population is in scope, and measure against it.");
+    L.push("4. **Still measure over-report before binding.** Nothing here says the semantic");
+    L.push("   signal is accurate — only that it would now have something to look at.");
+  } else {
+    L.push("Coverage split unavailable — re-run with the corpus scan enabled.");
+  }
   L.push("");
   return L.join("\n") + "\n";
+}
+
+/** Any citation of a real repo source file — markdown link OR backticked path. */
+const ANY_CODE_REF =
+  /(?:\]\(\s*|`)([A-Za-z0-9_.\-/]+\.(?:ts|tsx|mts|mjs|js|jsx|prisma|sql|ya?ml|sh|ps1))(?:`|[)\s#])/g;
+
+/**
+ * Docs that mention at least one real repo source file.
+ *
+ * Deliberately LOOSER than the generator's derivations: the question here is
+ * "could any edge derivation ever reach this page?", not "does one today". A
+ * page that cites a file the generator skipped is recoverable; a page that cites
+ * nothing is not.
+ */
+function docsMentioningCode(corpus) {
+  const out = new Set();
+  for (const doc of corpus) {
+    const text = fs.readFileSync(path.join(REPO_ROOT, doc), "utf-8");
+    for (const m of text.matchAll(ANY_CODE_REF)) {
+      const rel = m[1];
+      if (rel.startsWith("./") || rel.startsWith("../")) {
+        out.add(doc);
+        break;
+      }
+      if (fs.existsSync(path.join(REPO_ROOT, rel))) {
+        out.add(doc);
+        break;
+      }
+    }
+  }
+  return out;
 }
 
 function build() {
@@ -204,7 +284,8 @@ function build() {
   const candidates = fs.existsSync(STALENESS_REPORT_PATH)
     ? parseStalenessCandidates(fs.readFileSync(STALENESS_REPORT_PATH, "utf-8"))
     : null;
-  return renderReport(computeCoverage(corpus, manifest), candidates);
+  const cov = computeCoverage(corpus, manifest, docsMentioningCode(corpus));
+  return renderReport(cov, candidates);
 }
 
 function main() {

--- a/scripts/measure-doc-staleness-coverage.test.mjs
+++ b/scripts/measure-doc-staleness-coverage.test.mjs
@@ -99,6 +99,50 @@ test("renders deterministically — same input, byte-identical report", () => {
   assert.equal(renderReport(cov, 3), renderReport(cov, 3));
 });
 
+// ─── Inert vs recoverable split (BI-22207E9A) ───────────────────────────────
+// Without this split, "N% covered" reads as N% of a population that could all be
+// covered — and it cannot. A profession doctrine page names no source file, so no
+// code-edge derivation will ever reach it.
+
+test("splits the uncovered remainder into recoverable and inert", () => {
+  const corpus = ["docs/a.md", "docs/b.md", "docs/c.md", "docs/d.md"];
+  const manifest = { docToCode: { "docs/a.md": ["x.ts"] } };
+  // b cites code but has no edge yet; c and d cite nothing at all.
+  const mentions = new Set(["docs/a.md", "docs/b.md"]);
+
+  const cov = computeCoverage(corpus, manifest, mentions);
+
+  assert.equal(cov.covered, 1);
+  assert.equal(cov.uncovered, 3);
+  assert.equal(cov.recoverable, 1); // b
+  assert.equal(cov.inert, 2); // c, d
+});
+
+test("recoverable + inert always accounts for the whole uncovered set", () => {
+  const corpus = ["docs/a.md", "docs/b.md", "docs/c.md"];
+  const cov = computeCoverage(corpus, {}, new Set(["docs/a.md"]));
+  assert.equal(cov.recoverable + cov.inert, cov.uncovered);
+});
+
+test("reports nulls rather than guessing when no corpus scan is supplied", () => {
+  // Silently reporting inert=0 would overstate the remaining opportunity.
+  const cov = computeCoverage(["docs/a.md"], {});
+  assert.equal(cov.inert, null);
+  assert.equal(cov.recoverable, null);
+});
+
+test("report states the addressable-corpus percentage, not just the headline", () => {
+  // The headline understates the gate: most of what it excludes is doctrine.
+  const cov = computeCoverage(
+    ["docs/a.md", "docs/b.md", "docs/c.md"],
+    { docToCode: { "docs/a.md": ["x.ts"] } },
+    new Set(["docs/a.md"]),
+  );
+  const out = renderReport(cov, 0);
+  assert.match(out, /reference no repo file anywhere in their text/);
+  assert.match(out, /1 of 1 \(100%\) now carry an edge/);
+});
+
 test("excludes its own output from the corpus it measures", () => {
   // Without this the report is part of the corpus the moment it is written, the
   // total grows by one, and `--check` reports the just-written file as stale.


### PR DESCRIPTION
Delivers **BI-22207E9A**. Published-corpus coverage goes **15.5% → 29.4%** (95 → 180 of 612 pages), code sources 156 → 413. More usefully, the report now says what the remaining 70.6% actually *is*.

## Edge source 4: backtick-cited paths

PR #4004 derived edges from markdown **links** into source. DPF docs mostly cite paths the other way — inline, in backticks: `` `apps/web/lib/x.ts` ``. Same premise (the author already wrote the reference, so nothing needs annotating), applied to the form the corpus actually uses.

## Fan-out ceiling — and a measurement I got wrong first

A path cited by many pages is a **landmark, not a dependency**: `packages/db/src/seed.ts` is named by 14 pages because it's the canonical example of a seed file, not because 14 pages document it. Uncapped, touching it would flag all 14.

**My first cap was measured against tick edges alone, which is the wrong quantity.** A file also carries frontmatter and link edges, so a tick cap of 6 still produced a *combined* worst case of 7 — worse than #4004's ceiling of 4, which is exactly what the BI says not to do. Re-swept against combined fan-out by regenerating the whole manifest per cap:

| tick cap | combined max fan-out | pages covered |
| --- | --- | --- |
| 2 | 4 | 178 |
| **3** | **4** | **182** ← chosen |
| 4 | 5 | 183 |
| 6 | 7 | 186 |

Cap 3 buys all but four pages of the available coverage while holding the ceiling at **4** — exactly #4004's precedent. Four pages aren't worth raising the worst case by 75%.

## The remainder is mostly not a gap

This is the part that changes decisions. Of the 432 uncovered pages, **416 reference no repo file anywhere in their text** — no link, no backticked path. They're WSID profession doctrine (196 pages) and founder-kernel principles (113): they describe how to *decide*, not what the code does. **No code-edge derivation will ever reach them.**

Only **16 pages** are genuinely recoverable. So of the *addressable* corpus, **180 of 196 (91.8%)** now carry an edge.

Counting doctrine as a shortfall argues forever for widening that has already run out, so the report now splits the remainder explicitly.

## This inverts the report's own standing recommendation

The previous version said *"widening edges beats sharpening signal"* and *"do not gate yet."* That was right when reach was 15.5% of an unknown denominator. It isn't now, and the report says so:

1. **Widening is close to exhausted** — further widening buys single-digit page counts.
2. **Reach is no longer the binding constraint; precision is** — which is what makes BI-3E5969DF's semantic detector worth *designing* rather than deferring.
3. **Gate on the addressable corpus, never the whole.** A denominator including principle pages will always look broken; one that silently drops them reports coverage it doesn't have — the `gate-coverage-matches-blast-radius` failure. Declare the population.
4. **Still measure over-report before binding.** Nothing here says the semantic signal is *accurate*, only that it would now have something to look at.

## Verification

- 22 `gen-doc-impact` tests, 14 coverage tests — both **exit 0** (captured, not piped)
- Full `pull-request` policy-guard profile **7/7**
- Manifest and coverage report both `--check` fresh; doc-index regenerated
- Fan-out ceiling asserted in tests, including that the cap counts globally rather than per-document

**Pregate:** not run — fresh worktree with no `node_modules`. Pushed under the allowlisted `external-contribution-no-install` code with the above recorded. CI is the binding gate.

Refs BI-22207E9A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
