### PR TITLE
feat(mobile): connect flow degrades gracefully when an install has no descriptor

### DIFF
--- a/apps/mobile/app/connect.tsx
+++ b/apps/mobile/app/connect.tsx
@@ -23,7 +23,7 @@ import {
 import { useRouter } from "expo-router";
 import { useTheme } from "@/src/lib/theme";
 import {
-  fetchInstanceDescriptor,
+  resolveInstall,
   setServerUrl,
 } from "@/src/lib/serverConfig";
 import { useSpacesStore } from "@/src/stores/spaces";
@@ -44,7 +44,10 @@ export default function ConnectScreen(): React.JSX.Element {
     setError(null);
     setSubmitting(true);
     try {
-      const descriptor = await fetchInstanceDescriptor(url.trim());
+      // Resilient resolve: a reachable install with no (or a not-yet-served)
+      // discovery descriptor still connects — we synthesize a minimal one and
+      // proceed to sign-in rather than dying on a /welcome HTML redirect.
+      const { descriptor } = await resolveInstall(url.trim());
       const persisted = await setServerUrl(url.trim());
       addSpace({ url: persisted, descriptor });
       router.replace("/login");

--- a/apps/mobile/src/lib/serverConfig.test.ts
+++ b/apps/mobile/src/lib/serverConfig.test.ts
@@ -6,6 +6,7 @@ import {
   setServerUrl,
   clearServerUrl,
   fetchInstanceDescriptor,
+  resolveInstall,
 } from "./serverConfig";
 
 /* ------------------------------------------------------------------ */
@@ -182,5 +183,78 @@ describe("fetchInstanceDescriptor", () => {
     const result = await fetchInstanceDescriptor("acme.io");
     expect(result.orgName).toBe("DPF");
     expect(result.authModes).toEqual(["password"]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  resolveInstall — resilient connect probe (BI graceful-degrade)     */
+/* ------------------------------------------------------------------ */
+
+describe("resolveInstall", () => {
+  afterEach(() => {
+    // @ts-expect-error test cleanup
+    delete global.fetch;
+  });
+
+  it("uses a valid descriptor (degraded=false)", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            instanceId: "inst_1",
+            orgName: "Acme HVAC",
+            archetype: "trades-maintenance/hvac-contractor",
+            apiVersion: "v1",
+          }),
+        ),
+    }) as unknown as typeof fetch;
+
+    const { descriptor, degraded } = await resolveInstall("acme.io");
+    expect(degraded).toBe(false);
+    expect(descriptor.orgName).toBe("Acme HVAC");
+    expect(descriptor.archetype).toBe("trades-maintenance/hvac-contractor");
+  });
+
+  it("degrades when the descriptor endpoint returns HTML (login redirect landed on /welcome)", async () => {
+    // 1st call: descriptor → 200 with HTML body (auth redirect). 2nd call:
+    // origin probe → reachable. Must NOT throw a JSON parse error.
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve("<!DOCTYPE html><html>welcome</html>"),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { descriptor, degraded } = await resolveInstall("192.168.0.200:3000");
+    expect(degraded).toBe(true);
+    expect(descriptor.instanceId).toBe("192.168.0.200:3000");
+    expect(descriptor.orgName).toBe("192.168.0.200:3000");
+    expect(descriptor.apiVersion).toBe("v1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("degrades when the descriptor endpoint 404s but the origin is reachable", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve("") })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { degraded } = await resolveInstall("https://acme.io");
+    expect(degraded).toBe(true);
+  });
+
+  it("throws only when the origin itself is unreachable (network error)", async () => {
+    // descriptor fetch throws AND origin probe throws → fatal.
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("Network request failed")) as unknown as typeof fetch;
+
+    await expect(resolveInstall("http://192.168.0.99:3000")).rejects.toThrow(
+      /could not reach/i,
+    );
   });
 });

--- a/apps/mobile/src/lib/serverConfig.ts
+++ b/apps/mobile/src/lib/serverConfig.ts
@@ -152,3 +152,103 @@ export async function fetchInstanceDescriptor(
     branding: data.branding,
   };
 }
+
+/** Result of the resilient connect probe. */
+export interface ResolvedInstall {
+  descriptor: InstanceDescriptor;
+  /**
+   * True when the discovery descriptor could not be read and a minimal
+   * descriptor was synthesized from the URL. The install is still connectable
+   * (sign-in works); we just don't have its org name / archetype / branding
+   * until it serves /.well-known/dpf-instance.json.
+   */
+  degraded: boolean;
+}
+
+/** Minimal descriptor built from the URL alone when discovery is unavailable. */
+function synthesizeDescriptor(baseUrl: string): InstanceDescriptor {
+  let host = baseUrl;
+  try {
+    host = new URL(baseUrl).host;
+  } catch {
+    // keep baseUrl as-is; normalizeServerUrl already validated it upstream
+  }
+  return {
+    instanceId: host,
+    orgName: host,
+    apiVersion: "v1",
+    authModes: ["password"],
+  };
+}
+
+/**
+ * Resolve an install for the connect flow, degrading gracefully rather than
+ * hard-failing when discovery is unavailable. Preference order:
+ *
+ *   1. A valid /.well-known/dpf-instance.json descriptor  → degraded=false.
+ *   2. Descriptor missing / non-JSON / redirected to a login page, BUT the
+ *      origin still answers HTTP at all → synthesize a minimal descriptor
+ *      from the URL so the user can still connect and sign in → degraded=true.
+ *      Real installs behind reverse proxies, on older versions, or not yet
+ *      upgraded past the descriptor-auth-gate fix (BI-2AC1307A) land here.
+ *   3. Genuine network failure (connection refused / DNS / timeout) → throw.
+ *
+ * This is why the connect flow no longer dies on "JSON Parse error: unexpected
+ * character": a /welcome HTML redirect is treated as "reachable but not yet
+ * describable", not a fatal error.
+ */
+export async function resolveInstall(rawUrl: string): Promise<ResolvedInstall> {
+  const baseUrl = normalizeServerUrl(rawUrl);
+
+  // (1) Preferred path: a real descriptor.
+  try {
+    const res = await fetch(`${baseUrl}/.well-known/dpf-instance.json`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+    if (res.ok) {
+      // Parse defensively: a 200 with an HTML body (auth redirect landed on a
+      // login page) must NOT throw — it falls through to the degraded probe.
+      const body = await res.text();
+      try {
+        const data = JSON.parse(body) as Partial<InstanceDescriptor> | null;
+        if (
+          data &&
+          typeof data.instanceId === "string" &&
+          typeof data.apiVersion === "string"
+        ) {
+          return {
+            degraded: false,
+            descriptor: {
+              instanceId: data.instanceId,
+              orgName: typeof data.orgName === "string" ? data.orgName : "DPF",
+              archetype: data.archetype,
+              apiVersion: data.apiVersion,
+              authModes: Array.isArray(data.authModes)
+                ? data.authModes
+                : ["password"],
+              capabilities: data.capabilities,
+              branding: data.branding,
+            },
+          };
+        }
+      } catch {
+        // non-JSON body → fall through to the reachability probe
+      }
+    }
+  } catch {
+    // descriptor request itself threw → fall through to the reachability probe
+  }
+
+  // (2)/(3) Descriptor unusable. Confirm the origin is reachable before
+  // degrading; any HTTP response (even a redirect / 4xx / 5xx) proves the host
+  // is there. Only a thrown fetch (refused / DNS / timeout) is fatal.
+  try {
+    await fetch(baseUrl, { method: "GET" });
+    return { degraded: true, descriptor: synthesizeDescriptor(baseUrl) };
+  } catch {
+    throw new Error(
+      `Could not reach ${baseUrl} — check the URL and that your device is on the same network.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

The mobile "connect to your organization" flow hard-failed whenever an install's `GET /.well-known/dpf-instance.json` didn't return valid JSON — it threw **"JSON Parse error: unexpected character"** on any HTML redirect (e.g. a `/welcome` login page) and blocked the whole connect. This is the app-side complement to the server fix in opendigitalproductfactory#4022 (BI-2AC1307A): it unblocks connecting to installs **today**, without waiting for each install to self-upgrade.

Part of EP-MOBILE-IOS-APP.

## How it was found

Driving the iOS Simulator, trying to add a second install (a Windows restaurant-archetype box at `192.168.0.200:3000`) via the connect flow → JSON parse error. The install was reachable (ping OK, port open) but its descriptor was redirecting to `/welcome` (the BI-2AC1307A server bug), and the app treated a reachable-but-undescribed install as a hard failure.

## Change

- **`resolveInstall(rawUrl) → { descriptor, degraded }`** in `serverConfig.ts`:
  1. valid descriptor → `degraded: false`
  2. descriptor missing / non-JSON / redirected **but origin answers HTTP** → synthesize a minimal descriptor (`instanceId`/`orgName` = host, `apiVersion: "v1"`, `authModes: ["password"]`) → `degraded: true`, still connectable
  3. genuine network failure (refused / DNS / timeout) → throw
  The 200-with-HTML body is parsed defensively (`res.text()` + `try/catch JSON.parse`), so a `/welcome` redirect is "reachable, not yet describable," not fatal.
- **`connect.tsx`** uses `resolveInstall` and proceeds to `/login` on degraded.
- `fetchInstanceDescriptor` kept for the strict path (NearbyPanel still uses it).

## Verification

- [x] `pnpm --filter mobile exec jest src/lib/serverConfig.test.ts` — 19/19 (4 new `resolveInstall` cases: valid, HTML-redirect-degrade, 404-degrade, unreachable-throws).
- [x] `pnpm --filter mobile typecheck` — clean.

## Why it matters beyond the one bug

Real installs behind reverse proxies, on older versions, or not-yet-upgraded also won't serve the descriptor. The app should connect to any reachable install and let sign-in gate access — the descriptor is a discovery *nicety*, not a precondition.
