### PR TITLE
feat(compose): forward runtime-artifact janitor flags to the portal (BI-A55BE432)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,6 +226,16 @@ services:
       # explicit per-install operator opt-in after a clean observe soak.
       DPF_WORKTREE_JANITOR_ENABLED: ${DPF_WORKTREE_JANITOR_ENABLED:-1}
       DPF_SANDBOX_BUILD_GC_ENABLED: ${DPF_SANDBOX_BUILD_GC_ENABLED:-1}
+      # Runtime-artifact janitor (BI-DBF3F426 / BI-A55BE432): reaps orphaned
+      # per-branch CI images + stray compose projects INCLUDING their named
+      # volumes — the dominant local-disk leak (dead dpf-<topic> dev stacks
+      # still holding pgdata/node_modules). Same soak model as the worktree
+      # janitor: observe defaults ON so operators get the daily would-reap log;
+      # AUTO_REAP is live/destructive and stays OFF until a per-install opt-in
+      # after a clean observe soak. The portal mounts the docker socket, so the
+      # daily 05:20 job can actually see Docker on a compose install.
+      DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED: ${DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED:-1}
+      DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP: ${DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP:-0}
       # Register ScheduledJob heartbeat rows and other low-risk boot hygiene
       # for installed runtimes. Without this, first-run installs have no
       # code-graph job row and status surfaces report missing background work.


### PR DESCRIPTION
## Why

Follow-up to [#4030](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4030). That PR added the founder-gated auto-reap **code**; this wires it so it can actually be turned on.

The portal `environment:` block never forwarded `DPF_RUNTIME_ARTIFACT_JANITOR_*`, so the janitor could not be enabled on any real compose install regardless of `.env` — the missing half of "reclaim in perpetuity".

## What

Mirror the worktree-janitor precedent exactly (adjacent lines in the same block):
- `DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED: ${...:-1}` — observe **on by default**, so every compose install gets the daily 05:20 would-reap log without asking.
- `DPF_RUNTIME_ARTIFACT_JANITOR_AUTO_REAP: ${...:-0}` — live reap **off**, a per-install operator opt-in after a clean observe soak.

The portal already mounts the docker socket (`/var/run/docker.sock`), so the scheduled job can actually see Docker on a compose install — verified present in the running `dpf-portal-1`.

## Safety

Observe is non-destructive (logs only). Auto-reap stays off by default; arming it is the explicit-go. No image/pin changes.

## Verification

Local-CI pregate passed (evidence `cmsfqmera00nd01o54a0mzbo2`).

Docs-Impact-Decision recorded (operator env-flag wiring only, no user-facing page change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)