### PR TITLE
fix(federation): make exchange/edge dark-launch flags .env-durable (BI-8C1F0A2E)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,15 @@ services:
       # jobs are registered only when this flag is on. Library defaults stay
       # off for tests and ad-hoc imports; compose is the deployment contract.
       DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED: ${DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED:-1}
+      # Federation dark-launch flags (default OFF; founder enables per the
+      # federated-demand plan's two-instance verification gate). These MUST be
+      # base-compose passthroughs so an operator opt-in lives in the install's
+      # .env and survives the BASE-ONLY portal recreate that promote.sh falls
+      # back to when install-state composeFiles is empty (which otherwise drops
+      # docker-compose.override.yml and silently disables the exchange surface
+      # on every self-upgrade). See BI-8C1F0A2E.
+      DPF_FEDERATION_EXCHANGE_ENABLED: ${DPF_FEDERATION_EXCHANGE_ENABLED:-0}
+      DPF_EDGE_INCIDENT_CORRELATION_ENABLED: ${DPF_EDGE_INCIDENT_CORRELATION_ENABLED:-0}
       # Multi-client governance soak (BI-42FA7DD8): observe-only fleet
       # backstops for leftover worktrees and Build Studio sandbox builds.
       # Primary reaping stays session-lifecycle (worktree-session-hygiene on


### PR DESCRIPTION
## Summary

`DPF_FEDERATION_EXCHANGE_ENABLED` and `DPF_EDGE_INCIDENT_CORRELATION_ENABLED` were **absent** from the base `docker-compose.yml` portal `environment:` block, so `.env` could not set them — the only injection path was `docker-compose.override.yml`.

On an install whose `install-state.json` `composeFiles` is empty, `promote.sh:173` recreates the portal from the **BASE-ONLY** fallback (`docker-compose.yml` alone), which drops the override and **silently wipes the flag on every self-upgrade**. Observed live on the Windows Founder-Hub install (5 self-upgrades in 24h, empty `composeFiles`) while bringing it up for federation testing.

Fixes **BI-8C1F0A2E** (EP-DELIVERY-FLOW).

## Change

Add both dark-launch flags as base-compose passthroughs defaulting to `0` (off), matching the sibling `DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED` / janitor flags:

```yaml
DPF_FEDERATION_EXCHANGE_ENABLED: ${DPF_FEDERATION_EXCHANGE_ENABLED:-0}
DPF_EDGE_INCIDENT_CORRELATION_ENABLED: ${DPF_EDGE_INCIDENT_CORRELATION_ENABLED:-0}
```

An operator now sets the flag in the install-local `.env` (gitignored → survives self-upgrade, including the base-only recreate) with **no override and no install-state `composeFiles` surgery**. Default OFF preserves the federated-demand plan's founder two-instance verification gate.

## Verification

- `pnpm run pregate` (exact-tree local-integration-CI) **passed**; evidence `cmsfsa5c700yb01t3tku6ca0i`. Compose-only change; no TypeScript touched.
- Post-merge, on a self-upgrading install: `DPF_FEDERATION_EXCHANGE_ENABLED=1` in `.env` → `printenv` in the recreated portal returns `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: Compose-internal env passthrough only. Adds DPF_FEDERATION_EXCHANGE_ENABLED / DPF_EDGE_INCIDENT_CORRELATION_ENABLED to the base portal environment defaulting to 0 (off). No install's behavior changes and no user-guide page changes: both flags stay default-off behind the federated-demand plan's founder two-instance verification gate, and enabling is an operator opt-in already described there. The three flagged pages (platform-overview, disaster-recovery, long-running-agentic-process-architecture) are unaffected by an off-by-default passthrough.
