### PR TITLE
fix(federation): resolve self Authority URL from PUBLIC_URL for HTTP installs (BI-9D2E4F17)

### DIFF
--- a/apps/web/lib/app-url.test.ts
+++ b/apps/web/lib/app-url.test.ts
@@ -18,9 +18,24 @@ describe("resolveAppBaseUrl", () => {
     expect(resolveAppBaseUrl()).toBe("https://portal.example.com");
   });
 
+  it("falls back to the compose-plumbed PUBLIC_URL when NEXT_PUBLIC_* are unset (production)", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("PUBLIC_URL", "http://192.168.0.152:3000/");
+    vi.stubEnv("NODE_ENV", "production");
+    expect(resolveAppBaseUrl()).toBe("http://192.168.0.152:3000");
+  });
+
+  it("prefers NEXT_PUBLIC_* over PUBLIC_URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://portal.example.com");
+    vi.stubEnv("PUBLIC_URL", "http://192.168.0.152:3000");
+    expect(resolveAppBaseUrl()).toBe("https://portal.example.com");
+  });
+
   it("uses localhost outside production when nothing is configured", () => {
     vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("PUBLIC_URL", "");
     vi.stubEnv("NODE_ENV", "development");
     expect(resolveAppBaseUrl()).toBe("http://localhost:3000");
   });
@@ -28,6 +43,7 @@ describe("resolveAppBaseUrl", () => {
   it("returns null in production when nothing is configured (no broken localhost link)", () => {
     vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("PUBLIC_URL", "");
     vi.stubEnv("NODE_ENV", "production");
     expect(resolveAppBaseUrl()).toBeNull();
   });

--- a/apps/web/lib/app-url.ts
+++ b/apps/web/lib/app-url.ts
@@ -1,11 +1,20 @@
-// Resolve the install's public base URL for links embedded in outbound emails.
+// Resolve the install's public base URL for links embedded in outbound emails
+// and for federation enrollment (advertising a reachable Authority URL to a peer).
 //
-// Prefers explicit configuration (NEXT_PUBLIC_BASE_URL / NEXT_PUBLIC_APP_URL).
+// Prefers explicit build-time configuration (NEXT_PUBLIC_BASE_URL /
+// NEXT_PUBLIC_APP_URL), then the runtime, compose-plumbed PUBLIC_URL — the
+// install's public base URL, settable via .env. PUBLIC_URL is what a production
+// HTTP/LAN install (no NEXT_PUBLIC_* baked in) uses to resolve its own URL; without
+// this fallback resolveAppBaseUrl returned null in production and federation
+// invitation/enroll failed with "base URL is not configured" (BI-9D2E4F17).
 // In non-production it falls back to localhost (correct for local dev). In
 // production with nothing configured it returns null — callers must NOT emit a
 // knowingly-broken "http://localhost:3000" link in a real customer email.
 export function resolveAppBaseUrl(): string | null {
-  const configured = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_APP_URL;
+  const configured =
+    process.env.NEXT_PUBLIC_BASE_URL
+    || process.env.NEXT_PUBLIC_APP_URL
+    || process.env.PUBLIC_URL;
   if (configured && configured.trim()) return configured.trim().replace(/\/+$/, "");
   if (process.env.NODE_ENV !== "production") return "http://localhost:3000";
   return null;


### PR DESCRIPTION
## Summary

Federation invitation/enroll actions resolve the install's own Authority URL via `resolveAppBaseUrl()`, which read only `NEXT_PUBLIC_BASE_URL` / `NEXT_PUBLIC_APP_URL` and **returned `null` in production** when neither was set — then bailed with "this deployment's base URL is not configured". Those NEXT_PUBLIC_* vars are build-time and not compose-settable, so a production HTTP/LAN install can't pair. Base compose already plumbs `PUBLIC_URL`, which the resolver ignored.

Fixes **BI-9D2E4F17**. Unblocks two-host pairing (**BI-52D34506**). Found on the Arcamanus Mac↔Windows verification: both boxes had `NEXT_PUBLIC_*` unset and `PUBLIC_URL` empty, so enrollment couldn't resolve a reachable URL.

## Change

`resolveAppBaseUrl()` falls back to `PUBLIC_URL` after the `NEXT_PUBLIC_*` vars. Operators set `PUBLIC_URL=http://<lan-ip>:3000` in the install `.env` (already passthrough'd, survives self-upgrade) and enrollment resolves a reachable Authority URL. Precedence: `NEXT_PUBLIC_BASE_URL` > `NEXT_PUBLIC_APP_URL` > `PUBLIC_URL` > dev-localhost > null. No change for existing configs; still null in production when nothing is set.

## Verification

- 6/6 `app-url` tests pass (adds PUBLIC_URL-fallback and precedence cases).
- `pnpm run pregate` (exact-tree local CI) passed; evidence `cmsfujeun00za01pb3yfe5vba`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)