### PR TITLE
feat(observability): AI "Right Now" cockpit — live resource pressure + local-model visibility (BI-1A68257F)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/right-now/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/right-now/page.tsx
@@ -1,0 +1,98 @@
+// apps/web/app/(shell)/platform/ai/right-now/page.tsx
+//
+// "Right Now" — the lean live cockpit for what's happening on this install this
+// moment (BI-1A68257F / EP-FULL-OBS). It answers the founder-observed gap: the
+// AI workforce surfaces had NO realtime resource visibility, so "why is memory
+// at 90%, and did the local model just kick in?" could only be answered from
+// Windows Task Manager. The Operations Map remains the deep analytical/planning
+// view (topology, replay, scheduled-job forecasts); this page is deliberately
+// "right now" only — resource pressure + who's working, nothing scheduled.
+//
+// Design grounding: extends EP-FULL-OBS. Source of truth for resource signals is
+// the Docker socket + /proc/meminfo (see resource-pressure.ts); for active work,
+// the operations-map TaskRun read model (reused, not re-projected). No new
+// contract — a new read-only observability surface over existing substrate.
+
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { loadResourcePressure } from "@/lib/platform-runtime/resource-pressure";
+import { loadActiveWork } from "@/lib/platform-runtime/right-now-activity";
+import { RightNowLiveShell } from "@/components/platform/RightNowLiveShell";
+
+export const dynamic = "force-dynamic";
+
+export default async function RightNowPage() {
+  await auth(); // (shell)/platform layout gates platform access; render read-only.
+
+  const [snapshot, activeWork] = await Promise.all([
+    loadResourcePressure(),
+    loadActiveWork(),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4">
+      <header className="space-y-1">
+        <h1 className="text-lg font-semibold text-[var(--dpf-text)]">Right Now</h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Live resource pressure and active work on this install. For the routing
+          topology, replay, and scheduled-job forecasts, see the{" "}
+          <Link className="text-[var(--dpf-accent)] underline" href="/platform/ai/operations-map">
+            Operations Map
+          </Link>
+          ; for which model runs each build phase, see{" "}
+          <Link className="text-[var(--dpf-accent)] underline" href="/platform/ai/runtime-health">
+            Runtime Health
+          </Link>
+          .
+        </p>
+      </header>
+
+      <RightNowLiveShell initialData={snapshot} />
+
+      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <div className="flex items-baseline justify-between gap-2">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Working now</h2>
+          <span className="text-xs text-[var(--dpf-muted)]">
+            {activeWork.length === 0 ? "idle" : `${activeWork.length} active`} · page-load snapshot
+          </span>
+        </div>
+        {activeWork.length === 0 ? (
+          <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+            No active or waiting task runs right now.
+          </p>
+        ) : (
+          <ul className="mt-3 divide-y divide-[var(--dpf-border)]">
+            {activeWork.map((item) => (
+              <li key={item.taskRunId} className="flex items-center justify-between gap-3 py-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm text-[var(--dpf-text)]" title={item.title ?? undefined}>
+                    {item.title ?? "Untitled task"}
+                  </div>
+                  <div className="text-[11px] text-[var(--dpf-muted)]">
+                    {item.agentId ?? "unassigned"}
+                    {item.startedAt ? (
+                      <>
+                        {" · started "}
+                        <LocalTime value={item.startedAt} mode="time" />
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase"
+                  style={{
+                    background: "var(--dpf-surface-2)",
+                    color: item.needsAttention ? "var(--dpf-warning)" : "var(--dpf-accent)",
+                  }}
+                >
+                  {item.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/api/platform/resource-pressure/route.ts
+++ b/apps/web/app/api/platform/resource-pressure/route.ts
@@ -1,0 +1,33 @@
+// GET /api/platform/resource-pressure — live resource snapshot for the
+// "Right Now" cockpit (BI-1A68257F / EP-FULL-OBS). The page server-renders one
+// snapshot; the client shell re-fetches this on a short interval so the memory
+// pressure / local-model bucket stay honest. Auth mirrors the (shell)/platform
+// layout gate: view_platform or 404 (don't reveal the surface).
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { loadResourcePressure } from "@/lib/platform-runtime/resource-pressure";
+
+export const dynamic = "force-dynamic";
+
+const NO_CACHE_HEADERS = {
+  "Cache-Control": "no-cache, no-store, must-revalidate",
+  Pragma: "no-cache",
+};
+
+export async function GET() {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_platform",
+    )
+  ) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const data = await loadResourcePressure();
+  return NextResponse.json(data, { headers: NO_CACHE_HEADERS });
+}

--- a/apps/web/components/platform/RightNowLiveShell.tsx
+++ b/apps/web/components/platform/RightNowLiveShell.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+// Live-refresh shell for the "Right Now" cockpit (BI-1A68257F / EP-FULL-OBS).
+//
+// Polls /api/platform/resource-pressure on a short interval (paused while the
+// tab is hidden) and renders the volatile resource picture: Docker-VM memory
+// pressure, where that memory is going (top containers + the model-runner /
+// overhead bucket), and the local inference engine state. This is the "right
+// now" lens the operator was missing — no scheduled/forecast rows, no topology.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import type { ResourcePressureSnapshot } from "@/lib/platform-runtime/resource-pressure";
+
+const REFRESH_INTERVAL_MS = 12_000;
+
+/** Bytes → compact GiB/MiB. Exported for unit tests. */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+  if (bytes >= 1024 ** 2) return `${Math.round(bytes / 1024 ** 2)} MiB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KiB`;
+  return `${bytes} B`;
+}
+
+/** Human age label for the freshness bar. Exported for unit tests. */
+export function formatRefreshAge(ageMs: number): string {
+  if (ageMs < 15_000) return "just now";
+  if (ageMs < 60_000) return `${Math.round(ageMs / 1000)}s ago`;
+  if (ageMs < 60 * 60_000) return `${Math.round(ageMs / 60_000)}m ago`;
+  return `${Math.round(ageMs / (60 * 60_000))}h ago`;
+}
+
+type PressureTone = "ok" | "warn" | "high";
+
+/** Pressure banding. Exported for unit tests. */
+export function pressureTone(pct: number): PressureTone {
+  if (pct >= 85) return "high";
+  if (pct >= 65) return "warn";
+  return "ok";
+}
+
+const TONE_COLOR: Record<PressureTone, string> = {
+  ok: "var(--dpf-success)",
+  warn: "var(--dpf-warning)",
+  high: "var(--dpf-error)",
+};
+
+export function RightNowLiveShell({
+  initialData,
+}: {
+  initialData: ResourcePressureSnapshot;
+}) {
+  const [data, setData] = useState(initialData);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refreshNow = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRefreshing(true);
+    try {
+      const res = await fetch("/api/platform/resource-pressure", {
+        signal: controller.signal,
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`Refresh failed (${res.status})`);
+      setData((await res.json()) as ResourcePressureSnapshot);
+      setLastUpdatedAt(Date.now());
+      setError(null);
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        setError(err instanceof Error ? err.message : "Refresh failed");
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        setRefreshing(false);
+        abortRef.current = null;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (document.hidden) return;
+      void refreshNow();
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refreshNow]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return (
+    <div className="space-y-3">
+      <FreshnessBar
+        lastUpdatedAt={lastUpdatedAt}
+        refreshing={refreshing}
+        error={error}
+        onRefresh={() => void refreshNow()}
+      />
+      <MemoryHero memory={data.memory} />
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <MemoryBreakdown data={data} />
+        <LocalInferenceCard data={data} />
+      </div>
+    </div>
+  );
+}
+
+function FreshnessBar({
+  lastUpdatedAt,
+  refreshing,
+  error,
+  onRefresh,
+}: {
+  lastUpdatedAt: number | null;
+  refreshing: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((v) => v + 1), 5_000);
+    return () => clearInterval(id);
+  }, []);
+  const ageLabel =
+    lastUpdatedAt === null
+      ? "showing the page-load snapshot"
+      : `refreshed ${formatRefreshAge(Date.now() - lastUpdatedAt)}`;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs text-[var(--dpf-muted)]">
+      <span aria-live="polite">
+        {refreshing
+          ? "Refreshing…"
+          : `Live · ${ageLabel} · auto-refresh every ${Math.round(REFRESH_INTERVAL_MS / 1000)}s`}
+        {error ? <span className="ml-2 text-[var(--dpf-error)]">Last refresh failed: {error}</span> : null}
+      </span>
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={refreshing}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-2 py-1 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)] disabled:opacity-50"
+      >
+        <RefreshCw aria-hidden className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+        Refresh now
+      </button>
+    </div>
+  );
+}
+
+function MemoryHero({ memory }: { memory: ResourcePressureSnapshot["memory"] }) {
+  if (!memory.available) {
+    return (
+      <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm text-[var(--dpf-muted)]">
+        Docker-VM memory telemetry is unavailable on this install (the portal
+        could not read <code>/proc/meminfo</code>). Container-level figures below
+        stand alone where present.
+      </div>
+    );
+  }
+  const tone = pressureTone(memory.pressurePct);
+  const color = TONE_COLOR[tone];
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+            Docker VM memory
+          </div>
+          <div className="mt-1 flex items-baseline gap-2">
+            <span className="text-3xl font-bold" style={{ color }}>
+              {memory.pressurePct}%
+            </span>
+            <span className="text-sm text-[var(--dpf-muted)]">
+              {formatBytes(memory.vmUsedBytes)} used of {formatBytes(memory.vmTotalBytes)} ·{" "}
+              {formatBytes(memory.vmAvailableBytes)} free
+            </span>
+          </div>
+        </div>
+        <span
+          className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase"
+          style={{ background: "var(--dpf-surface-2)", color }}
+        >
+          {tone === "high" ? "High pressure" : tone === "warn" ? "Elevated" : "Healthy"}
+        </span>
+      </div>
+      <div className="mt-3 h-2.5 w-full overflow-hidden rounded-full bg-[var(--dpf-surface-2)]">
+        <div
+          className="h-full rounded-full transition-all"
+          style={{ width: `${Math.min(100, memory.pressurePct)}%`, background: color }}
+        />
+      </div>
+      <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+        This is the WSL/Docker VM ceiling, not your Windows host total — the VM is
+        capped well below physical RAM, so a high Windows figure is mostly other
+        apps, not this stack.
+      </p>
+    </div>
+  );
+}
+
+function MemoryBreakdown({ data }: { data: ResourcePressureSnapshot }) {
+  const vmTotal = data.memory.available ? data.memory.vmTotalBytes : null;
+  const other = data.memory.available ? data.memory.otherBytes : null;
+  const top = data.containers.slice(0, 6);
+  const maxBar = Math.max(
+    ...top.map((c) => c.memBytes),
+    other ?? 0,
+    1,
+  );
+
+  return (
+    <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Where the memory is</h2>
+      <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
+        Top containers by working set{data.containersTruncated ? " (list truncated)" : ""}.
+      </p>
+      <ul className="mt-3 space-y-2">
+        {top.map((c) => (
+          <li key={c.id}>
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="truncate font-medium text-[var(--dpf-text)]" title={c.name}>
+                {c.name}
+              </span>
+              <span className="shrink-0 text-[var(--dpf-muted)]">
+                {formatBytes(c.memBytes)}
+                {c.cpuPct !== null ? ` · ${c.cpuPct}% CPU` : ""}
+              </span>
+            </div>
+            <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-[var(--dpf-surface-2)]">
+              <div
+                className="h-full rounded-full bg-[var(--dpf-accent)]"
+                style={{ width: `${(c.memBytes / maxBar) * 100}%` }}
+              />
+            </div>
+          </li>
+        ))}
+        {other !== null && other > 0 ? (
+          <li>
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="font-medium text-[var(--dpf-text)]">
+                Model runner + VM overhead
+              </span>
+              <span className="shrink-0 text-[var(--dpf-muted)]">{formatBytes(other)}</span>
+            </div>
+            <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-[var(--dpf-surface-2)]">
+              <div
+                className="h-full rounded-full bg-[var(--dpf-warning)]"
+                style={{ width: `${(other / maxBar) * 100}%` }}
+              />
+            </div>
+            <p className="mt-1 text-[11px] text-[var(--dpf-muted)]">
+              Not attributable to a container — this is where a loaded local model
+              shows up (it runs outside the container set).
+            </p>
+          </li>
+        ) : null}
+        {top.length === 0 ? (
+          <li className="text-xs text-[var(--dpf-muted)]">
+            No container stats available (Docker socket not reachable).
+          </li>
+        ) : null}
+      </ul>
+      {vmTotal ? null : (
+        <p className="mt-2 text-[11px] text-[var(--dpf-muted)]">
+          VM total unknown, so shares are shown as absolute bytes.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function LocalInferenceCard({ data }: { data: ResourcePressureSnapshot }) {
+  const { localModel } = data;
+  return (
+    <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Local inference engine</h2>
+      {!localModel.reachable ? (
+        <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+          No Docker Model Runner detected on this install — inference is cloud-routed.
+        </p>
+      ) : (
+        <>
+          <div className="mt-2 flex items-center gap-2">
+            <span
+              className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase"
+              style={{
+                background: "var(--dpf-surface-2)",
+                color: localModel.engineRunning ? "var(--dpf-success)" : "var(--dpf-muted)",
+              }}
+            >
+              {localModel.engineRunning ? "● Engine running" : "Engine idle"}
+            </span>
+            <span className="text-xs text-[var(--dpf-muted)]">llama.cpp backend</span>
+          </div>
+          <div className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+            Models available locally
+          </div>
+          <ul className="mt-1 space-y-1">
+            {localModel.models.length === 0 ? (
+              <li className="text-xs text-[var(--dpf-muted)]">None pulled.</li>
+            ) : (
+              localModel.models.map((m) => (
+                <li key={m.id} className="flex items-center justify-between gap-2 text-xs">
+                  <span className="truncate font-medium text-[var(--dpf-text)]" title={m.id}>
+                    {m.label}
+                  </span>
+                  <span className="shrink-0 text-[var(--dpf-muted)]">
+                    {m.sizeBytes !== null ? `${formatBytes(m.sizeBytes)} when loaded` : "size unknown"}
+                  </span>
+                </li>
+              ))
+            )}
+          </ul>
+          <p className="mt-2 text-[11px] text-[var(--dpf-muted)]">
+            A model loads on demand and self-unloads when idle — watch the “model
+            runner + VM overhead” bucket rise and fall as it does.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -59,6 +59,10 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       // altitudes (Readiness, Operations Map) one tab away. /platform/ai
       // redirects here for the same reason.
       { label: "Workforce", href: "/platform/ai/overview" },
+      // BI-1A68257F: "Right Now" is the lean live cockpit — resource pressure +
+      // active work this moment. It sits beside the Operations Map, which keeps
+      // the deep analytical/planning altitude (topology, replay, forecasts).
+      { label: "Right Now", href: "/platform/ai/right-now" },
       { label: "Readiness", href: "/platform/ai/readiness" },
       { label: "Operations Map", href: "/platform/ai/operations-map" },
       { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },

--- a/apps/web/lib/platform-runtime/resource-pressure.test.ts
+++ b/apps/web/lib/platform-runtime/resource-pressure.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCpuPct,
+  loadResourcePressure,
+  parseBinarySize,
+  parseEngineRunning,
+  parseMemInfoKb,
+  parseModelList,
+} from "./resource-pressure";
+
+const MEMINFO = [
+  "MemTotal:       24610000 kB",
+  "MemFree:          518124 kB",
+  "MemAvailable:   15992988 kB",
+  "Buffers:         4354960 kB",
+].join("\n");
+
+/** A minimal /containers/{id}/stats payload. */
+function stats({ usage, inactiveFile = 0 }: { usage: number; inactiveFile?: number }) {
+  return {
+    memory_stats: { usage, stats: { inactive_file: inactiveFile } },
+    cpu_stats: {
+      cpu_usage: { total_usage: 200 },
+      system_cpu_usage: 2000,
+      online_cpus: 4,
+    },
+    precpu_stats: {
+      cpu_usage: { total_usage: 100 },
+      system_cpu_usage: 1000,
+    },
+  };
+}
+
+function makeDockerGet(
+  containers: Array<{ Id: string; Names: string[]; Image: string }>,
+  statsById: Record<string, unknown>,
+  info: unknown = { NCPU: 12 },
+) {
+  return async (path: string): Promise<unknown> => {
+    if (path === "/containers/json") return containers;
+    if (path === "/info") return info;
+    const m = /^\/containers\/([^/]+)\/stats/.exec(path);
+    if (m) {
+      const s = statsById[m[1]];
+      if (s === undefined) throw new Error("no stats");
+      return s;
+    }
+    throw new Error(`unexpected path ${path}`);
+  };
+}
+
+describe("parseMemInfoKb", () => {
+  it("extracts the kB value for a key", () => {
+    expect(parseMemInfoKb(MEMINFO, "MemTotal")).toBe(24610000);
+    expect(parseMemInfoKb(MEMINFO, "MemAvailable")).toBe(15992988);
+  });
+  it("returns null for a missing key", () => {
+    expect(parseMemInfoKb(MEMINFO, "SwapTotal")).toBeNull();
+  });
+});
+
+describe("parseBinarySize", () => {
+  it("parses binary units", () => {
+    expect(parseBinarySize("16.45GiB")).toBe(Math.round(16.45 * 1024 ** 3));
+    expect(parseBinarySize("260.86MiB")).toBe(Math.round(260.86 * 1024 ** 2));
+  });
+  it("tolerates spacing and decimal GB", () => {
+    expect(parseBinarySize("23.47 GB")).toBe(Math.round(23.47 * 1024 ** 3));
+  });
+  it("returns null for junk", () => {
+    expect(parseBinarySize("not a size")).toBeNull();
+  });
+});
+
+describe("computeCpuPct", () => {
+  it("applies the docker stats formula", () => {
+    // cpuDelta=100, sysDelta=1000, online=4 → 0.1 * 4 * 100 = 40
+    expect(
+      computeCpuPct(
+        { cpu_usage: { total_usage: 200 }, system_cpu_usage: 2000, online_cpus: 4 },
+        { cpu_usage: { total_usage: 100 }, system_cpu_usage: 1000 },
+      ),
+    ).toBe(40);
+  });
+  it("returns null when the system delta is non-positive (single-shot sample)", () => {
+    expect(
+      computeCpuPct(
+        { cpu_usage: { total_usage: 200 }, system_cpu_usage: 1000, online_cpus: 4 },
+        { cpu_usage: { total_usage: 100 }, system_cpu_usage: 1000 },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseEngineRunning", () => {
+  it("detects a running backend", () => {
+    expect(
+      parseEngineRunning({
+        status: 200,
+        body: JSON.stringify({ "llama.cpp": "Running: llama.cpp latest-cuda", vllm: "Not Installed" }),
+      }),
+    ).toBe(true);
+  });
+  it("reports false when no backend is running", () => {
+    expect(
+      parseEngineRunning({ status: 200, body: JSON.stringify({ "llama.cpp": "Not Installed" }) }),
+    ).toBe(false);
+  });
+  it("returns null when unreachable", () => {
+    expect(parseEngineRunning(null)).toBeNull();
+  });
+});
+
+describe("parseModelList", () => {
+  it("sizes and sorts models biggest-first", () => {
+    const models = parseModelList({
+      status: 200,
+      body: JSON.stringify({
+        data: [
+          { id: "docker.io/ai/nomic-embed-text-v1.5:latest", dmr: { size: "260.86MiB" } },
+          { id: "docker.io/ai/qwen3-coder:latest", dmr: { size: "16.45GiB" } },
+        ],
+      }),
+    });
+    expect(models.map((m) => m.label)).toEqual(["qwen3-coder", "nomic-embed-text-v1.5"]);
+    expect(models[0].sizeBytes).toBe(Math.round(16.45 * 1024 ** 3));
+  });
+});
+
+describe("loadResourcePressure", () => {
+  const containers = [
+    { Id: "aaa", Names: ["/dpf-sandbox-1"], Image: "dpf-sandbox" },
+    { Id: "bbb", Names: ["/dpf-portal-1"], Image: "dpf-portal" },
+  ];
+
+  it("computes VM pressure, container attribution, and the model-runner gap", async () => {
+    // VM: total 24610000kB, available 15992988kB → used ≈ 8617012kB ≈ 8.82e9 B
+    // sandbox usage 3GiB (no cache) + portal usage 1GiB → attributed 4GiB
+    const statsById = {
+      aaa: stats({ usage: 3 * 1024 ** 3 }),
+      bbb: stats({ usage: 1 * 1024 ** 3 }),
+    };
+    const snap = await loadResourcePressure({
+      readProcFile: async () => MEMINFO,
+      dockerGet: makeDockerGet(containers, statsById),
+      modelRunnerGet: async () => null,
+      now: () => 1_000_000,
+    });
+
+    expect(snap.memory.available).toBe(true);
+    if (!snap.memory.available) throw new Error("expected available memory");
+    expect(snap.memory.vmTotalBytes).toBe(24610000 * 1024);
+    expect(snap.memory.vmUsedBytes).toBe((24610000 - 15992988) * 1024);
+    expect(snap.memory.containerAttributedBytes).toBe(4 * 1024 ** 3);
+    // otherBytes = vmUsed - attributed (the model runner + overhead bucket)
+    expect(snap.memory.otherBytes).toBe(
+      (24610000 - 15992988) * 1024 - 4 * 1024 ** 3,
+    );
+    // sorted biggest-first
+    expect(snap.containers.map((c) => c.name)).toEqual(["dpf-sandbox-1", "dpf-portal-1"]);
+    expect(snap.containers[0].memPctOfVm).not.toBeNull();
+    expect(snap.cpuCount).toBe(12);
+    expect(snap.capturedAt).toBe(new Date(1_000_000).toISOString());
+  });
+
+  it("subtracts page cache like docker stats does", async () => {
+    const statsById = {
+      aaa: stats({ usage: 3 * 1024 ** 3, inactiveFile: 1 * 1024 ** 3 }),
+    };
+    const snap = await loadResourcePressure({
+      readProcFile: async () => MEMINFO,
+      dockerGet: makeDockerGet([containers[0]], statsById),
+      modelRunnerGet: async () => null,
+    });
+    expect(snap.containers[0].memBytes).toBe(2 * 1024 ** 3);
+  });
+
+  it("degrades gracefully when /proc/meminfo is unavailable", async () => {
+    const snap = await loadResourcePressure({
+      readProcFile: async () => {
+        throw new Error("ENOENT");
+      },
+      dockerGet: makeDockerGet(containers, {
+        aaa: stats({ usage: 1 * 1024 ** 3 }),
+        bbb: stats({ usage: 1 * 1024 ** 3 }),
+      }),
+      modelRunnerGet: async () => null,
+    });
+    expect(snap.memory.available).toBe(false);
+    if (snap.memory.available) throw new Error("expected unavailable");
+    expect(snap.memory.reason).toBe("meminfo_unavailable");
+    // container view still works; %-of-VM is null without a VM total
+    expect(snap.containers).toHaveLength(2);
+    expect(snap.containers[0].memPctOfVm).toBeNull();
+  });
+
+  it("degrades gracefully when the docker socket is unavailable", async () => {
+    const snap = await loadResourcePressure({
+      readProcFile: async () => MEMINFO,
+      dockerGet: async () => {
+        throw new Error("EACCES");
+      },
+      modelRunnerGet: async () => null,
+    });
+    expect(snap.containers).toEqual([]);
+    expect(snap.memory.available).toBe(true);
+    if (!snap.memory.available) throw new Error("expected available");
+    // With no containers, the whole VM-used figure lands in the "other" bucket.
+    expect(snap.memory.otherBytes).toBe(snap.memory.vmUsedBytes);
+  });
+
+  it("drops containers whose stats vanish mid-snapshot without failing", async () => {
+    const snap = await loadResourcePressure({
+      readProcFile: async () => MEMINFO,
+      dockerGet: makeDockerGet(containers, { aaa: stats({ usage: 2 * 1024 ** 3 }) }),
+      modelRunnerGet: async () => null,
+    });
+    expect(snap.containers.map((c) => c.name)).toEqual(["dpf-sandbox-1"]);
+  });
+
+  it("surfaces local-model state when the model runner answers", async () => {
+    const snap = await loadResourcePressure({
+      readProcFile: async () => MEMINFO,
+      dockerGet: makeDockerGet(containers, {
+        aaa: stats({ usage: 1 * 1024 ** 3 }),
+        bbb: stats({ usage: 1 * 1024 ** 3 }),
+      }),
+      modelRunnerGet: async (path) => {
+        if (path === "/engines/status") {
+          return { status: 200, body: JSON.stringify({ "llama.cpp": "Running: cuda" }) };
+        }
+        return {
+          status: 200,
+          body: JSON.stringify({ data: [{ id: "docker.io/ai/qwen3-coder:latest", dmr: { size: "16.45GiB" } }] }),
+        };
+      },
+    });
+    expect(snap.localModel.reachable).toBe(true);
+    expect(snap.localModel.engineRunning).toBe(true);
+    expect(snap.localModel.models[0].label).toBe("qwen3-coder");
+  });
+});

--- a/apps/web/lib/platform-runtime/resource-pressure.ts
+++ b/apps/web/lib/platform-runtime/resource-pressure.ts
@@ -1,0 +1,434 @@
+// apps/web/lib/platform-runtime/resource-pressure.ts
+//
+// "Right Now" cockpit data source — the live resource-pressure snapshot the
+// portal never used to surface (BI-1A68257F / EP-FULL-OBS). It answers the
+// founder-observed question "why is memory at 90%, and did the local model just
+// kick in?" from INSIDE the portal container, with three verified signals:
+//
+//   1. VM memory (the headline).  /proc/meminfo as seen from the portal is
+//      VM-WIDE on Docker Desktop / WSL2 (verified: MemTotal ≈ the 23.47GiB WSL
+//      cap, not a cgroup slice), so MemTotal-MemAvailable is the true Docker-VM
+//      memory pressure — and it captures the Docker Model Runner even though the
+//      model is NOT a container (`docker ps` never lists it).
+//   2. Container attribution.  The Docker socket (already bind-mounted into the
+//      portal, see docker-compose.yml) gives per-container memory via the same
+//      formula `docker stats` uses (usage - inactive_file), so the operator can
+//      see WHICH container to act on. Reuses the bounded, timeout-guarded
+//      `dockerSocketGet` helper.
+//   3. The gap.  vmUsed - sum(containers) = "model runner + VM overhead". This
+//      bucket balloons ~16GiB when qwen3-coder loads — it is the local-model
+//      pressure signal, derived without any model-runner API dependency.
+//
+// Local inference engine state is a best-effort fourth signal from the Docker
+// Model Runner's own endpoints (/engines/status, /engines/v1/models). It
+// degrades to "unavailable" on installs without a model runner; the memory and
+// container views stand alone.
+//
+// Every external reader is injectable so the loader is unit-testable with no
+// socket, no /proc, and no model runner.
+
+import { readFile } from "node:fs/promises";
+import { dockerSocketGet } from "./docker-socket.mjs";
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+export type ContainerConsumer = {
+  id: string;
+  name: string;
+  image: string;
+  memBytes: number;
+  /** Share of VM total memory, 0-100, or null when VM total is unknown. */
+  memPctOfVm: number | null;
+  /** Instantaneous CPU%, or null when the single-shot sample can't compute it. */
+  cpuPct: number | null;
+};
+
+export type MemorySignal =
+  | {
+      available: true;
+      vmTotalBytes: number;
+      vmUsedBytes: number;
+      vmAvailableBytes: number;
+      /** vmUsed / vmTotal * 100. The headline "we're at N%" number. */
+      pressurePct: number;
+      /** Sum of per-container working sets. */
+      containerAttributedBytes: number;
+      /** vmUsed - containerAttributed: model runner + VM/kernel overhead. */
+      otherBytes: number;
+    }
+  | { available: false; reason: string };
+
+export type LocalModelSignal = {
+  /** Whether the model-runner endpoints were reachable at all. */
+  reachable: boolean;
+  /** llama.cpp backend serving state, when the engines endpoint answered. */
+  engineRunning: boolean | null;
+  /** Locally-available models with parsed byte sizes (biggest first). */
+  models: Array<{ id: string; label: string; sizeBytes: number | null }>;
+};
+
+export type ResourcePressureSnapshot = {
+  capturedAt: string;
+  cpuCount: number | null;
+  memory: MemorySignal;
+  containers: ContainerConsumer[];
+  /** True when more running containers exist than the per-snapshot cap. */
+  containersTruncated: boolean;
+  localModel: LocalModelSignal;
+};
+
+export type ResourcePressureDeps = {
+  /** Reads a path like "/proc/meminfo". Defaults to fs. */
+  readProcFile?: (path: string) => Promise<string>;
+  /** Docker Engine GET over the socket. Defaults to dockerSocketGet. */
+  dockerGet?: (path: string) => Promise<unknown>;
+  /** Best-effort model-runner GET; returns null on any failure. */
+  modelRunnerGet?: (
+    path: string,
+  ) => Promise<{ status: number; body: string } | null>;
+  now?: () => number;
+};
+
+// Cap the number of containers we pull stats for in one snapshot. 40 is far
+// above a normal DPF stack (~19); the excess is flagged, never silently hidden.
+const CONTAINER_CAP = 40;
+const STATS_CONCURRENCY = 6;
+
+// ─── Loader ─────────────────────────────────────────────────────────────────
+
+export async function loadResourcePressure(
+  deps: ResourcePressureDeps = {},
+): Promise<ResourcePressureSnapshot> {
+  const readProcFile = deps.readProcFile ?? ((p: string) => readFile(p, "utf8"));
+  const dockerGet = deps.dockerGet ?? dockerSocketGet;
+  const modelRunnerGet = deps.modelRunnerGet ?? defaultModelRunnerGet;
+  const now = deps.now ?? (() => Date.now());
+
+  const [meminfo, containersResult, localModel, cpuCount] = await Promise.all([
+    readMemInfo(readProcFile),
+    readContainers(dockerGet),
+    readLocalModel(modelRunnerGet),
+    readCpuCount(dockerGet),
+  ]);
+
+  const containerAttributedBytes = containersResult.containers.reduce(
+    (sum, c) => sum + c.memBytes,
+    0,
+  );
+
+  const memory: MemorySignal = meminfo
+    ? (() => {
+        const vmUsedBytes = Math.max(0, meminfo.totalBytes - meminfo.availableBytes);
+        return {
+          available: true as const,
+          vmTotalBytes: meminfo.totalBytes,
+          vmUsedBytes,
+          vmAvailableBytes: meminfo.availableBytes,
+          pressurePct: meminfo.totalBytes > 0
+            ? round1((vmUsedBytes / meminfo.totalBytes) * 100)
+            : 0,
+          containerAttributedBytes,
+          otherBytes: Math.max(0, vmUsedBytes - containerAttributedBytes),
+        };
+      })()
+    : {
+        available: false as const,
+        reason: "meminfo_unavailable",
+      };
+
+  // Backfill each container's %-of-VM now that VM total is known.
+  const vmTotal = memory.available ? memory.vmTotalBytes : null;
+  const containers = containersResult.containers
+    .map((c) => ({
+      ...c,
+      memPctOfVm: vmTotal && vmTotal > 0 ? round1((c.memBytes / vmTotal) * 100) : null,
+    }))
+    .sort((a, b) => b.memBytes - a.memBytes);
+
+  return {
+    capturedAt: new Date(now()).toISOString(),
+    cpuCount,
+    memory,
+    containers,
+    containersTruncated: containersResult.truncated,
+    localModel,
+  };
+}
+
+// ─── /proc/meminfo ──────────────────────────────────────────────────────────
+
+async function readMemInfo(
+  readProcFile: (path: string) => Promise<string>,
+): Promise<{ totalBytes: number; availableBytes: number } | null> {
+  try {
+    const raw = await readProcFile("/proc/meminfo");
+    const total = parseMemInfoKb(raw, "MemTotal");
+    const available = parseMemInfoKb(raw, "MemAvailable");
+    if (total === null || available === null) return null;
+    return { totalBytes: total * 1024, availableBytes: available * 1024 };
+  } catch {
+    return null;
+  }
+}
+
+/** Parse a "<Key>: <n> kB" line from /proc/meminfo. Exported for tests. */
+export function parseMemInfoKb(raw: string, key: string): number | null {
+  const match = new RegExp(`^${key}:\\s+(\\d+)\\s*kB`, "m").exec(raw);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+// ─── Docker socket: containers + stats ──────────────────────────────────────
+
+type ContainerListEntry = {
+  Id?: unknown;
+  Names?: unknown;
+  Image?: unknown;
+};
+
+async function readContainers(
+  dockerGet: (path: string) => Promise<unknown>,
+): Promise<{ containers: ContainerConsumer[]; truncated: boolean }> {
+  let list: ContainerListEntry[];
+  try {
+    const raw = await dockerGet("/containers/json");
+    list = Array.isArray(raw) ? (raw as ContainerListEntry[]) : [];
+  } catch {
+    return { containers: [], truncated: false };
+  }
+
+  const truncated = list.length > CONTAINER_CAP;
+  const capped = list.slice(0, CONTAINER_CAP);
+
+  const consumers = await mapWithConcurrency(
+    capped,
+    STATS_CONCURRENCY,
+    async (entry) => {
+      const id = typeof entry.Id === "string" ? entry.Id : null;
+      if (!id) return null;
+      try {
+        const stats = await dockerGet(`/containers/${id}/stats?stream=false`);
+        return toConsumer(id, entry, stats);
+      } catch {
+        // A container that vanished mid-snapshot (ephemeral build/test box) or a
+        // stats timeout drops out rather than failing the whole view.
+        return null;
+      }
+    },
+  );
+
+  return {
+    containers: consumers.filter((c): c is ContainerConsumer => c !== null),
+    truncated,
+  };
+}
+
+function toConsumer(
+  id: string,
+  entry: ContainerListEntry,
+  stats: unknown,
+): ContainerConsumer | null {
+  const s = stats as {
+    memory_stats?: {
+      usage?: number;
+      stats?: {
+        inactive_file?: number;
+        total_inactive_file?: number;
+        cache?: number;
+      };
+    };
+    cpu_stats?: DockerCpuStats;
+    precpu_stats?: DockerCpuStats;
+  };
+  const mem = s.memory_stats;
+  if (!mem || typeof mem.usage !== "number") return null;
+
+  // Match `docker stats`: subtract page cache from usage.
+  const cache =
+    mem.stats?.inactive_file ??
+    mem.stats?.total_inactive_file ??
+    mem.stats?.cache ??
+    0;
+  const memBytes = Math.max(0, mem.usage - cache);
+
+  const names = Array.isArray(entry.Names) ? (entry.Names as unknown[]) : [];
+  const rawName = typeof names[0] === "string" ? (names[0] as string) : id.slice(0, 12);
+  const name = rawName.replace(/^\//, "");
+  const image = typeof entry.Image === "string" ? entry.Image : "";
+
+  return {
+    id,
+    name,
+    image,
+    memBytes,
+    memPctOfVm: null, // backfilled once VM total is known
+    cpuPct: computeCpuPct(s.cpu_stats, s.precpu_stats),
+  };
+}
+
+type DockerCpuStats = {
+  cpu_usage?: { total_usage?: number; percpu_usage?: number[] };
+  system_cpu_usage?: number;
+  online_cpus?: number;
+};
+
+/** The `docker stats` CPU% formula. Exported for tests. */
+export function computeCpuPct(
+  cpu: DockerCpuStats | undefined,
+  precpu: DockerCpuStats | undefined,
+): number | null {
+  const cpuTotal = cpu?.cpu_usage?.total_usage;
+  const preTotal = precpu?.cpu_usage?.total_usage;
+  const sys = cpu?.system_cpu_usage;
+  const preSys = precpu?.system_cpu_usage;
+  if (
+    typeof cpuTotal !== "number" ||
+    typeof preTotal !== "number" ||
+    typeof sys !== "number" ||
+    typeof preSys !== "number"
+  ) {
+    return null;
+  }
+  const cpuDelta = cpuTotal - preTotal;
+  const sysDelta = sys - preSys;
+  const online =
+    cpu?.online_cpus ?? cpu?.cpu_usage?.percpu_usage?.length ?? 0;
+  if (cpuDelta <= 0 || sysDelta <= 0 || online <= 0) return null;
+  return round1((cpuDelta / sysDelta) * online * 100);
+}
+
+async function readCpuCount(
+  dockerGet: (path: string) => Promise<unknown>,
+): Promise<number | null> {
+  try {
+    const info = (await dockerGet("/info")) as { NCPU?: unknown };
+    return typeof info.NCPU === "number" ? info.NCPU : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Docker Model Runner (best-effort) ──────────────────────────────────────
+
+async function readLocalModel(
+  modelRunnerGet: (
+    path: string,
+  ) => Promise<{ status: number; body: string } | null>,
+): Promise<LocalModelSignal> {
+  const [engines, models] = await Promise.all([
+    modelRunnerGet("/engines/status"),
+    modelRunnerGet("/engines/v1/models"),
+  ]);
+
+  const reachable = engines !== null || models !== null;
+  return {
+    reachable,
+    engineRunning: parseEngineRunning(engines),
+    models: parseModelList(models),
+  };
+}
+
+/** `{ "llama.cpp": "Running: ...", "vllm": "Not Installed..." }` → true. Exported for tests. */
+export function parseEngineRunning(
+  res: { status: number; body: string } | null,
+): boolean | null {
+  if (!res || res.status !== 200) return null;
+  try {
+    const parsed = JSON.parse(res.body) as Record<string, unknown>;
+    return Object.values(parsed).some(
+      (v) => typeof v === "string" && /^running\b/i.test(v.trim()),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** OpenAI-style `{ data: [{ id, dmr: { size } }] }` → sized model list. Exported for tests. */
+export function parseModelList(
+  res: { status: number; body: string } | null,
+): Array<{ id: string; label: string; sizeBytes: number | null }> {
+  if (!res || res.status !== 200) return [];
+  try {
+    const parsed = JSON.parse(res.body) as {
+      data?: Array<{ id?: unknown; dmr?: { size?: unknown; parameters?: unknown } }>;
+    };
+    const rows = Array.isArray(parsed.data) ? parsed.data : [];
+    return rows
+      .map((row) => {
+        const id = typeof row.id === "string" ? row.id : null;
+        if (!id) return null;
+        const sizeBytes =
+          typeof row.dmr?.size === "string" ? parseBinarySize(row.dmr.size) : null;
+        return { id, label: shortModelLabel(id), sizeBytes };
+      })
+      .filter((m): m is { id: string; label: string; sizeBytes: number | null } => m !== null)
+      .sort((a, b) => (b.sizeBytes ?? 0) - (a.sizeBytes ?? 0));
+  } catch {
+    return [];
+  }
+}
+
+/** "docker.io/ai/qwen3-coder:latest" → "qwen3-coder". */
+function shortModelLabel(id: string): string {
+  const noTag = id.split(":")[0] ?? id;
+  const last = noTag.split("/").pop() ?? noTag;
+  return last;
+}
+
+/** "16.45GiB" / "260.86MiB" / "23.47 GB" → bytes. Exported for tests. */
+export function parseBinarySize(text: string): number | null {
+  const match = /([\d.]+)\s*([KMGT]?)i?B/i.exec(text.trim());
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const unit = match[2].toUpperCase();
+  const factor: Record<string, number> = {
+    "": 1,
+    K: 1024,
+    M: 1024 ** 2,
+    G: 1024 ** 3,
+    T: 1024 ** 4,
+  };
+  return Math.round(value * (factor[unit] ?? 1));
+}
+
+async function defaultModelRunnerGet(
+  path: string,
+): Promise<{ status: number; body: string } | null> {
+  try {
+    const res = await fetch(`http://model-runner.docker.internal${path}`, {
+      signal: AbortSignal.timeout(2500),
+    });
+    return { status: res.status, body: await res.text() };
+  } catch {
+    return null;
+  }
+}
+
+// ─── small utilities ────────────────────────────────────────────────────────
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await fn(items[index]);
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/apps/web/lib/platform-runtime/right-now-activity.ts
+++ b/apps/web/lib/platform-runtime/right-now-activity.ts
@@ -1,0 +1,53 @@
+// apps/web/lib/platform-runtime/right-now-activity.ts
+//
+// The "who's working now" half of the Right Now cockpit (BI-1A68257F). A
+// deliberately lean read: the active/attention TaskRuns only, reusing the
+// operations-map read model so the shape matches the deep view. This is NOT the
+// operations-map projection — no scheduled/forecast rows, no topology; the
+// cockpit's job is "right now", not planning.
+
+import { prisma } from "@dpf/db";
+import {
+  OPERATIONS_RUN_SELECT,
+  type OperationsRunRow,
+} from "@/lib/ai-operations-map/operations-run-read-model";
+
+/** TaskRun statuses that mean "in flight or waiting on a human, right now". */
+const LIVE_STATUSES = ["active", "input-required", "auth-required", "stalled"] as const;
+
+const ACTIVE_WORK_LIMIT = 12;
+
+export type ActiveWorkItem = {
+  taskRunId: string;
+  title: string | null;
+  status: string;
+  agentId: string | null;
+  startedAt: string | null;
+  needsAttention: boolean;
+};
+
+export async function loadActiveWork(): Promise<ActiveWorkItem[]> {
+  let rows: OperationsRunRow[];
+  try {
+    rows = await prisma.taskRun.findMany({
+      where: { archivedAt: null, status: { in: [...LIVE_STATUSES] } },
+      orderBy: { startedAt: "desc" },
+      take: ACTIVE_WORK_LIMIT,
+      select: OPERATIONS_RUN_SELECT,
+    });
+  } catch {
+    return [];
+  }
+
+  return rows.map((row) => ({
+    taskRunId: row.taskRunId,
+    title: row.title,
+    status: row.status,
+    agentId: row.currentAgentId,
+    startedAt: row.startedAt ? row.startedAt.toISOString() : null,
+    needsAttention:
+      row.status === "input-required" ||
+      row.status === "auth-required" ||
+      row.status === "stalled",
+  }));
+}

--- a/docs/superpowers/plans/2026-08-05-right-now-cockpit.md
+++ b/docs/superpowers/plans/2026-08-05-right-now-cockpit.md
@@ -1,0 +1,88 @@
+# Plan — AI "Right Now" cockpit: live resource pressure + active work
+
+- **Backlog item:** BI-1A68257F
+- **Epic:** EP-FULL-OBS (Full Observability)
+- **Decision:** DI-B78B2A014223 (kernel-scored, high confidence — new lean cockpit over stripping/augmenting the Operations Map)
+- **Date:** 2026-08-05
+
+## Problem
+
+When Docker starts, host memory reads high (~90%) then drops to ~70% seconds
+later. Evidence shows this is expected mechanics, not a leak:
+
+- WSL2 is capped at 24 GB with `autoMemoryReclaim=gradual` (`.wslconfig`, set
+  2026-08-04); the reclaim hands idle VM pages back to Windows.
+- The Docker Model Runner llama-server loads a model on demand (qwen3-coder is
+  16.45 GiB) and self-unloads when idle. The 90%→70% drop is that unload / the
+  gradual reclaim, not a fault.
+- Container steady-state working set is only ~7.7 GiB across 19 containers.
+
+The real gap: **the portal surfaces none of this.** The operator infers "the
+local model kicked in" and "resources are all used" from Windows Task Manager,
+not from any portal view. The AI Operations Map (the "subway map") fuses a
+station map, topology canvas, replay timeline, deliberation lens, routing
+diagnostics, and **future scheduled markers** onto one replay axis — "what's
+happening now" is diluted by "what's planned," and there is no resource-pressure
+signal anywhere.
+
+## Decision (founder + kernel)
+
+1. Build a **new lean `/platform/ai/right-now` cockpit**. Leave the Operations
+   Map intact as the deep analytical/planning altitude. (Kernel: DI-B78B2A014223
+   — lowest human_cognitive_load, lowest blast_radius, high reversibility.)
+2. Add **real resource telemetry** — currently missing because cAdvisor /
+   node-exporter are Linux-only and gated off on this Windows Docker Desktop
+   host, so Prometheus scrapes no memory metrics.
+
+## Substrate (verified before building)
+
+- The portal container already bind-mounts `/var/run/docker.sock`
+  (`docker-compose.yml`), and `lib/platform-runtime/docker-socket.mjs`
+  (`boundedDockerSocketGet`, timeout + max-bytes guarded) is the proven reader —
+  used by `local-ci-capacity-broker.ts` (`/info`) and `operational-state.ts`.
+- `/proc/meminfo` as seen **inside** the portal is VM-wide on Docker Desktop /
+  WSL2 (verified: MemTotal ≈ the 23.47 GiB cap, not a cgroup slice). This is the
+  signal that captures the Model Runner even though the model is **not** a
+  container (`docker ps` never lists it).
+- The Docker Model Runner exposes `/engines/status` (backend running state) and
+  `/engines/v1/models` (available models + sizes) at `model-runner.docker.internal`.
+
+## Design
+
+### Data
+- `lib/platform-runtime/resource-pressure.ts` — one snapshot loader, every reader
+  injectable for tests:
+  - **VM memory** from `/proc/meminfo`: `MemTotal - MemAvailable` = the headline
+    "we're at N%".
+  - **Container attribution** from the Docker socket (`/containers/json` +
+    per-container `/stats?stream=false`), using the `docker stats` memory formula
+    (`usage - inactive_file`) and CPU formula.
+  - **The gap** `vmUsed - Σcontainers` = "model runner + VM overhead" — the
+    bucket that balloons ~16 GiB when a local model loads. This is the
+    local-model pressure signal, derived with no model-runner API dependency.
+  - **Local inference** (best-effort) from the two model-runner endpoints.
+  - Degrades gracefully: no `/proc/meminfo` → memory `available:false`; no socket
+    → empty container list; no model runner → `reachable:false`.
+- `lib/platform-runtime/right-now-activity.ts` — the lean "who's working now"
+  read: active/attention `TaskRun`s only, reusing `OPERATIONS_RUN_SELECT`. No
+  scheduled/forecast rows (that is the Operations Map's job).
+
+### Surface
+- `app/api/platform/resource-pressure/route.ts` — `view_platform`-gated (404
+  otherwise), `no-store`. Mirrors the operations-map route.
+- `app/(shell)/platform/ai/right-now/page.tsx` — server snapshot + `RightNowLiveShell`.
+- `components/platform/RightNowLiveShell.tsx` — polls the endpoint every 12 s
+  (paused while hidden). Renders memory hero + "where the memory is" + local
+  inference. Working-now list is server-rendered (page-load snapshot).
+- `components/platform/platform-nav.ts` — "Right Now" tab beside Operations Map.
+
+## Non-goals
+Redesigning/stripping the Operations Map; adding cAdvisor/node-exporter; a new
+Prometheus scrape; naming the exact loaded model (no reachable endpoint — the
+overhead bucket carries the signal instead); per-phase model detail (already on
+Runtime Health, linked, not duplicated).
+
+## Verification
+- Unit tests (`resource-pressure.test.ts`): parsing, the docker-stats memory
+  formula, the CPU formula, the gap computation, and all three degradation paths.
+- Full local CI on the exact merged tree before PR.

--- a/docs/ux-fit/2026-08-05-right-now-cockpit.ux-fit.json
+++ b/docs/ux-fit/2026-08-05-right-now-cockpit.ux-fit.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "decidedOption": "new-lean-right-now-cockpit",
+  "decisionInteractionId": "DI-B78B2A014223",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/platform/ai/right-now/page.tsx",
+      "apps/web/components/platform/RightNowLiveShell.tsx",
+      "apps/web/components/platform/platform-nav.ts"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "new-lean-right-now-cockpit",
+      "strip-operations-map-in-place",
+      "add-now-panel-to-map"
+    ]
+  }
+}


### PR DESCRIPTION
## What & why

The AI workforce surfaces had **no realtime resource visibility**. An operator inferred "memory is at 90%" and "the local model just kicked in" from Windows Task Manager, never from the portal. The AI Operations Map ("subway map") fuses a station map, topology, replay, and **future scheduled markers** onto one axis — "right now" is diluted by "what's planned" — and nothing surfaced resource pressure at all (cAdvisor/node-exporter are Linux-only and gated off on this Windows Docker Desktop host, so Prometheus scrapes no memory).

This adds a lean, dedicated **`/platform/ai/right-now`** cockpit. The Operations Map is unchanged and remains the deep analytical/planning altitude.

### The memory reality this makes visible
- WSL2 is capped at 24 GB with `autoMemoryReclaim=gradual`; the local model (qwen3-coder, 16.45 GiB) loads on demand and self-unloads. The observed **90%→70% drop is that reclaim/unload working**, not a leak. Container steady-state is only ~7.7 GiB.

### Signals (all read from inside the portal container)
- **VM memory pressure** from `/proc/meminfo` (VM-wide on WSL2/Docker Desktop) — the headline "we're at N%".
- **Per-container attribution** via the already-mounted Docker socket, using the `docker stats` memory/CPU formulas.
- **The gap** (`vmUsed − Σcontainers`) = "model runner + VM overhead" — balloons ~16 GiB when a local model loads, since the Docker Model Runner is **not** a container. This is the "local model kicked in" signal.
- **Local inference** engine state + available models (best-effort, from the model runner `/engines` endpoints).
- A lean **"working now"** list (active/attention `TaskRun`s), reusing the operations-map read model. No scheduled/forecast rows.

## Design grounding
Extends **EP-FULL-OBS**. Source of truth for resource signals is the Docker socket + `/proc/meminfo` (`resource-pressure.ts`); active work reuses the operations-map `TaskRun` read model (`OPERATIONS_RUN_SELECT`), not re-projected. No new contract — a read-only observability surface over existing substrate. Plan: `docs/superpowers/plans/2026-08-05-right-now-cockpit.md`.

**Design decision `DI-B78B2A014223`** (kernel-scored via `principle_decide`, high confidence, composite 5.08 / margin 2.73): new lean cockpit chosen over stripping or augmenting the Operations Map — lowest human_cognitive_load, lowest blast_radius, highest reversibility. UX-fit manifest: `docs/ux-fit/2026-08-05-right-now-cockpit.ux-fit.json` (propose-n-pick).

## Verification
- **17 unit tests** green (`resource-pressure.test.ts`): meminfo/size/CPU parsing, docker-stats memory formula, the model-runner-gap computation, and all three graceful-degradation paths (no `/proc`, no socket, no model runner).
- **Data path functionally verified against live infrastructure**: VM 34.8% (8.2/23.5 GiB), container-attributed 7.8 GiB across 19 (matches `docker stats`), engine running, models endpoint 200.
- **Local pregate not run**: this harness worktree is source-only (`dependency_resolution_failed`, no `@dpf/*` workspace links) so it cannot run the gate; pushed with the `external-contribution-no-install` recorded override. **CI runs the authoritative typecheck/tests/gates against a full build.**

BI-1A68257F · EP-FULL-OBS

🤖 Generated with [Claude Code](https://claude.com/claude-code)