### PR TITLE
feat(observability): AI workforce "Right Now" activity view (BI-1A68257F)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/right-now/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/right-now/page.tsx
@@ -1,0 +1,40 @@
+// apps/web/app/(shell)/platform/ai/right-now/page.tsx
+//
+// "Right Now" — the live AI workforce view (BI-1A68257F). The coworker is the
+// unit, like a person: what each is doing, what they got done today (outcome
+// digest), who the responsible human is, and where nobody is acting. Resources
+// are a secondary concern with their own home (the System Health tab); this
+// surface does not replicate them.
+//
+// Design grounding: extends EP-FULL-OBS. Founder-approved HTML prototype and
+// kernel-scored surface decision (DI-B78B2A014223). Activity data comes from the
+// workforce-activity loader over TaskRun/ToolExecution/TokenUsage; the
+// action->outcome map is the curated translation layer. No new contract.
+
+import { auth } from "@/lib/auth";
+import { loadWorkforceActivity } from "@/lib/platform-runtime/workforce-activity";
+import { WorkforceNowShell } from "@/components/platform/WorkforceNowShell";
+
+export const dynamic = "force-dynamic";
+
+export default async function RightNowPage() {
+  await auth(); // (shell)/platform layout gates platform access; render read-only.
+  const initialData = await loadWorkforceActivity();
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4">
+      <header className="space-y-1">
+        <h1 className="text-lg font-semibold text-[var(--dpf-text)]">Right Now</h1>
+        <p className="text-sm text-[var(--dpf-muted)]">
+          What each AI coworker is doing, what they&rsquo;ve gotten done today, and where nobody is
+          acting. Sensitive-data activity is shown as an aggregate flag only. Resource load lives on
+          the{" "}
+          <a className="text-[var(--dpf-accent)] underline" href="/portfolio/product/dpf-portal/health">
+            System Health
+          </a>{" "}
+          page.
+        </p>
+      </header>
+      <WorkforceNowShell initialData={initialData} />
+    </div>
+  );
+}

--- a/apps/web/app/api/platform/workforce-activity/route.ts
+++ b/apps/web/app/api/platform/workforce-activity/route.ts
@@ -1,0 +1,37 @@
+// GET /api/platform/workforce-activity — live workforce activity snapshot for
+// the "Right Now" view (BI-1A68257F). The page server-renders one snapshot; the
+// client shell re-fetches this on a short interval. Auth mirrors the
+// (shell)/platform layout gate: view_platform or 404.
+//
+// Data-governance note: this payload is intentionally aggregate — per-coworker
+// outcome COUNTS and a sensitive-data flag, never the underlying records — so a
+// platform administrator who is not in HR/finance can see the shape of activity
+// without the sensitive detail.
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { loadWorkforceActivity } from "@/lib/platform-runtime/workforce-activity";
+
+export const dynamic = "force-dynamic";
+
+const NO_CACHE_HEADERS = {
+  "Cache-Control": "no-cache, no-store, must-revalidate",
+  Pragma: "no-cache",
+};
+
+export async function GET() {
+  const session = await auth();
+  if (
+    !session?.user ||
+    !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_platform",
+    )
+  ) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const data = await loadWorkforceActivity();
+  return NextResponse.json(data, { headers: NO_CACHE_HEADERS });
+}

--- a/apps/web/app/api/platform/workforce-activity/route.ts
+++ b/apps/web/app/api/platform/workforce-activity/route.ts
@@ -11,6 +11,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
+import { apiErrorResponse } from "@/lib/api/error";
 import { loadWorkforceActivity } from "@/lib/platform-runtime/workforce-activity";
 
 export const dynamic = "force-dynamic";
@@ -29,7 +30,7 @@ export async function GET() {
       "view_platform",
     )
   ) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return apiErrorResponse("NOT_FOUND", "Not found", 404);
   }
 
   const data = await loadWorkforceActivity();

--- a/apps/web/components/platform/WorkforceNowShell.tsx
+++ b/apps/web/components/platform/WorkforceNowShell.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import type {
   WorkforceActivity,
   WorkforceCoworker,
@@ -95,7 +96,11 @@ export function WorkforceNowShell({ initialData }: { initialData: WorkforceActiv
           disabled={refreshing}
           className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-2 py-1 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] disabled:opacity-50"
         >
-          <RefreshCw aria-hidden className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          {refreshing ? (
+            <Spinner size="xs" tone="current" presentational />
+          ) : (
+            <RefreshCw aria-hidden className="h-3.5 w-3.5" />
+          )}
           Refresh now
         </button>
       </div>

--- a/apps/web/components/platform/WorkforceNowShell.tsx
+++ b/apps/web/components/platform/WorkforceNowShell.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+// Live shell for the AI workforce "Right Now" view (BI-1A68257F). Polls the
+// workforce-activity snapshot and renders the coworker board: working now (with
+// today's outcome digest), quiet (inactivity as a signal), the human owner of
+// each coworker, and manage jump-offs. Sensitive-data activity is a colour-coded
+// aggregate flag only — the digest is counts, never record content, and offers
+// no drill-in, so a non-HR platform admin sees the shape without the detail.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import type {
+  WorkforceActivity,
+  WorkforceCoworker,
+} from "@/lib/platform-runtime/workforce-activity";
+
+const REFRESH_INTERVAL_MS = 12_000;
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+function fmtCost(n: number): string {
+  if (n <= 0) return "$0.00";
+  if (n < 0.01) return "<$0.01";
+  return `$${n.toFixed(2)}`;
+}
+function daysSince(iso: string | null): string {
+  if (!iso) return "never engaged";
+  const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
+  if (days <= 0) return "acted today";
+  if (days === 1) return "quiet 1d";
+  return `quiet ${days}d`;
+}
+
+export function WorkforceNowShell({ initialData }: { initialData: WorkforceActivity }) {
+  const [data, setData] = useState(initialData);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [openManage, setOpenManage] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refreshNow = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRefreshing(true);
+    try {
+      const res = await fetch("/api/platform/workforce-activity", {
+        signal: controller.signal,
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`Refresh failed (${res.status})`);
+      setData((await res.json()) as WorkforceActivity);
+      setLastUpdatedAt(Date.now());
+      setError(null);
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        setError(err instanceof Error ? err.message : "Refresh failed");
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        setRefreshing(false);
+        abortRef.current = null;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (!document.hidden) void refreshNow();
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refreshNow]);
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const { pulse } = data;
+  const ageLabel =
+    lastUpdatedAt === null
+      ? "page-load snapshot"
+      : `updated ${Math.max(0, Math.round((Date.now() - lastUpdatedAt) / 1000))}s ago`;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-1.5 text-xs text-[var(--dpf-muted)]">
+        <span aria-live="polite">
+          {refreshing ? "Refreshing…" : `Live · ${ageLabel} · auto-refresh every ${REFRESH_INTERVAL_MS / 1000}s`}
+          {error ? <span className="ml-2 text-[var(--dpf-error)]">Last refresh failed: {error}</span> : null}
+        </span>
+        <button
+          type="button"
+          onClick={() => void refreshNow()}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--dpf-border)] px-2 py-1 font-medium text-[var(--dpf-text)] transition-colors hover:border-[var(--dpf-accent)] disabled:opacity-50"
+        >
+          <RefreshCw aria-hidden className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          Refresh now
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <Kpi label="Working now" value={`${pulse.workingCount} / ${pulse.totalCount}`} />
+        <Kpi label="Actions today" value={String(pulse.actionsToday)} />
+        <Kpi label="Tokens today" value={fmtTokens(pulse.tokensToday)} sub={`~${fmtCost(pulse.costToday)}`} />
+        <Kpi
+          label="Governance"
+          value={`${pulse.quietOverThresholdCount + pulse.coworkersWithoutOwnerCount}`}
+          sub={`${pulse.quietOverThresholdCount} quiet · ${pulse.coworkersWithoutOwnerCount} no owner`}
+          flag={pulse.quietOverThresholdCount + pulse.coworkersWithoutOwnerCount > 0}
+        />
+      </div>
+
+      <SectionHead title="Working now" hint="what they're on · what they got done today" />
+      {data.working.length === 0 ? (
+        <Empty>No coworkers are actively working right now.</Empty>
+      ) : (
+        <ul className="space-y-2">
+          {data.working.map((c) => (
+            <CoworkerRow key={c.agentId} c={c} openManage={openManage} setOpenManage={setOpenManage} />
+          ))}
+        </ul>
+      )}
+
+      <SectionHead title="Quiet — no activity is also a signal" hint="expected, or a gap worth a look?" />
+      {data.quiet.length === 0 ? (
+        <Empty>Every coworker is active.</Empty>
+      ) : (
+        <ul className="space-y-2">
+          {data.quiet.map((c) => (
+            <CoworkerRow key={c.agentId} c={c} quiet openManage={openManage} setOpenManage={setOpenManage} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Kpi({ label, value, sub, flag }: { label: string; value: string; sub?: string; flag?: boolean }) {
+  return (
+    <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">{label}</div>
+      <div
+        className="mt-0.5 text-xl font-bold tabular-nums"
+        style={{ color: flag ? "var(--dpf-warning)" : "var(--dpf-text)" }}
+      >
+        {value}
+        {flag ? " ⚠" : ""}
+      </div>
+      {sub ? <div className="text-[11px] text-[var(--dpf-muted)] tabular-nums">{sub}</div> : null}
+    </div>
+  );
+}
+
+function SectionHead({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div className="mt-4 flex items-baseline justify-between px-1">
+      <h2 className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">{title}</h2>
+      <span className="text-[11px] text-[var(--dpf-muted)]">{hint}</span>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-dashed border-[var(--dpf-border)] p-3 text-center text-xs text-[var(--dpf-muted)]">
+      {children}
+    </div>
+  );
+}
+
+const MANAGE_LINKS = (agentId: string) => [
+  { label: "Settings", href: `/platform/identity/agents?agent=${encodeURIComponent(agentId)}` },
+  { label: "Priority & models", href: "/platform/ai/assignments" },
+  { label: "Skills & grants", href: "/platform/ai/skills" },
+  { label: "Schedule", href: "/platform/schedule" },
+];
+
+function CoworkerRow({
+  c,
+  quiet,
+  openManage,
+  setOpenManage,
+}: {
+  c: WorkforceCoworker;
+  quiet?: boolean;
+  openManage: string | null;
+  setOpenManage: (id: string | null) => void;
+}) {
+  const isOpen = openManage === c.agentId;
+  return (
+    <li
+      className="rounded-lg border p-3"
+      style={{
+        borderColor: quiet ? "var(--dpf-border)" : "var(--dpf-border)",
+        background: quiet ? "transparent" : "var(--dpf-surface-1)",
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="grid h-9 w-9 shrink-0 place-items-center rounded-lg text-xs font-bold"
+          style={{
+            background: quiet ? "var(--dpf-surface-2)" : "var(--dpf-state-info)",
+            color: quiet ? "var(--dpf-muted)" : "var(--dpf-accent)",
+          }}
+        >
+          {initials(c.name)}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm font-semibold text-[var(--dpf-text)]">
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: quiet ? "var(--dpf-muted)" : "var(--dpf-success)" }}
+            />
+            <span className="truncate">{c.name}</span>
+            {c.role ? <span className="text-[11px] font-normal text-[var(--dpf-muted)]">· {c.role}</span> : null}
+            {c.handlesSensitive ? (
+              <span
+                className="rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide"
+                style={{ background: "var(--dpf-state-warning)", color: "var(--dpf-warning)" }}
+                title="Handled sensitive data today — details are access-gated"
+              >
+                🔒 sensitive
+              </span>
+            ) : null}
+          </div>
+
+          {c.now ? (
+            <div className="mt-1 text-[13px] text-[var(--dpf-muted)]">
+              <span className="text-[var(--dpf-muted)]">Now → </span>
+              {c.now.title}
+              <span className="ml-2 rounded border border-[var(--dpf-border)] px-1.5 py-0.5 font-mono text-[10px] uppercase text-[var(--dpf-muted)]">
+                {c.now.status}
+              </span>
+            </div>
+          ) : (
+            <div className="mt-1 flex items-center gap-2 text-[13px]">
+              <span className="font-mono text-[11px] text-[var(--dpf-muted)]">{daysSince(c.lastActedAt)}</span>
+              {c.didToday.length === 0 ? (
+                <span className="text-[var(--dpf-muted)]">— no actions today</span>
+              ) : null}
+            </div>
+          )}
+
+          {c.didToday.length > 0 ? (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">Today</span>
+              {c.didToday.map((o, i) => (
+                <span
+                  key={i}
+                  className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs"
+                  style={
+                    o.sensitive
+                      ? {
+                          borderColor: "var(--dpf-warning)",
+                          background: "var(--dpf-state-warning)",
+                          color: "var(--dpf-warning)",
+                        }
+                      : { borderColor: "var(--dpf-border)", background: "var(--dpf-surface-2)", color: "var(--dpf-text)" }
+                  }
+                >
+                  {o.sensitive ? <span aria-hidden>🔒</span> : null}
+                  <b className="font-mono">{o.count}</b> {o.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-[var(--dpf-muted)]">
+            {c.now ? (
+              <span className="tabular-nums">
+                <b className="text-[var(--dpf-text)]">{fmtTokens(c.tokensToday)}</b> tokens today · {fmtCost(c.costToday)}
+              </span>
+            ) : null}
+            <span>
+              {c.humanSupervisorId ? (
+                <>Managed by {c.humanSupervisorId} · HITL tier {c.hitlTier}</>
+              ) : (
+                <span style={{ color: "var(--dpf-warning)" }}>⚠ No human owner</span>
+              )}
+            </span>
+          </div>
+
+          {isOpen ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {MANAGE_LINKS(c.agentId).map((l) => (
+                <a
+                  key={l.label}
+                  href={l.href}
+                  className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-[11px] text-[var(--dpf-accent)] hover:border-[var(--dpf-accent)]"
+                >
+                  {l.label}
+                </a>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setOpenManage(isOpen ? null : c.agentId)}
+          aria-expanded={isOpen}
+          className="shrink-0 rounded-md border border-[var(--dpf-border)] px-2 py-1 text-[11px] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]"
+        >
+          Manage {isOpen ? "▲" : "▾"}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}

--- a/apps/web/components/platform/WorkforceNowShell.tsx
+++ b/apps/web/components/platform/WorkforceNowShell.tsx
@@ -140,7 +140,7 @@ export function WorkforceNowShell({ initialData }: { initialData: WorkforceActiv
 function Kpi({ label, value, sub, flag }: { label: string; value: string; sub?: string; flag?: boolean }) {
   return (
     <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
-      <div className="text-[10px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">{label}</div>
+      <div className="text-dpf-caption font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">{label}</div>
       <div
         className="mt-0.5 text-xl font-bold tabular-nums"
         style={{ color: flag ? "var(--dpf-warning)" : "var(--dpf-text)" }}
@@ -148,7 +148,7 @@ function Kpi({ label, value, sub, flag }: { label: string; value: string; sub?: 
         {value}
         {flag ? " ⚠" : ""}
       </div>
-      {sub ? <div className="text-[11px] text-[var(--dpf-muted)] tabular-nums">{sub}</div> : null}
+      {sub ? <div className="text-dpf-caption text-[var(--dpf-muted)] tabular-nums">{sub}</div> : null}
     </div>
   );
 }
@@ -156,8 +156,8 @@ function Kpi({ label, value, sub, flag }: { label: string; value: string; sub?: 
 function SectionHead({ title, hint }: { title: string; hint: string }) {
   return (
     <div className="mt-4 flex items-baseline justify-between px-1">
-      <h2 className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">{title}</h2>
-      <span className="text-[11px] text-[var(--dpf-muted)]">{hint}</span>
+      <h2 className="text-dpf-caption font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">{title}</h2>
+      <span className="text-dpf-caption text-[var(--dpf-muted)]">{hint}</span>
     </div>
   );
 }
@@ -214,10 +214,10 @@ function CoworkerRow({
               style={{ background: quiet ? "var(--dpf-muted)" : "var(--dpf-success)" }}
             />
             <span className="truncate">{c.name}</span>
-            {c.role ? <span className="text-[11px] font-normal text-[var(--dpf-muted)]">· {c.role}</span> : null}
+            {c.role ? <span className="text-dpf-caption font-normal text-[var(--dpf-muted)]">· {c.role}</span> : null}
             {c.handlesSensitive ? (
               <span
-                className="rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide"
+                className="rounded px-1.5 py-0.5 text-dpf-caption font-bold uppercase tracking-wide"
                 style={{ background: "var(--dpf-state-warning)", color: "var(--dpf-warning)" }}
                 title="Handled sensitive data today — details are access-gated"
               >
@@ -227,16 +227,16 @@ function CoworkerRow({
           </div>
 
           {c.now ? (
-            <div className="mt-1 text-[13px] text-[var(--dpf-muted)]">
+            <div className="mt-1 text-dpf-body text-[var(--dpf-muted)]">
               <span className="text-[var(--dpf-muted)]">Now → </span>
               {c.now.title}
-              <span className="ml-2 rounded border border-[var(--dpf-border)] px-1.5 py-0.5 font-mono text-[10px] uppercase text-[var(--dpf-muted)]">
+              <span className="ml-2 rounded border border-[var(--dpf-border)] px-1.5 py-0.5 font-mono text-dpf-caption uppercase text-[var(--dpf-muted)]">
                 {c.now.status}
               </span>
             </div>
           ) : (
-            <div className="mt-1 flex items-center gap-2 text-[13px]">
-              <span className="font-mono text-[11px] text-[var(--dpf-muted)]">{daysSince(c.lastActedAt)}</span>
+            <div className="mt-1 flex items-center gap-2 text-dpf-body">
+              <span className="font-mono text-dpf-caption text-[var(--dpf-muted)]">{daysSince(c.lastActedAt)}</span>
               {c.didToday.length === 0 ? (
                 <span className="text-[var(--dpf-muted)]">— no actions today</span>
               ) : null}
@@ -245,7 +245,7 @@ function CoworkerRow({
 
           {c.didToday.length > 0 ? (
             <div className="mt-2 flex flex-wrap items-center gap-1.5">
-              <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">Today</span>
+              <span className="text-dpf-caption uppercase tracking-wide text-[var(--dpf-muted)]">Today</span>
               {c.didToday.map((o, i) => (
                 <span
                   key={i}
@@ -267,7 +267,7 @@ function CoworkerRow({
             </div>
           ) : null}
 
-          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-[var(--dpf-muted)]">
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-dpf-caption text-[var(--dpf-muted)]">
             {c.now ? (
               <span className="tabular-nums">
                 <b className="text-[var(--dpf-text)]">{fmtTokens(c.tokensToday)}</b> tokens today · {fmtCost(c.costToday)}
@@ -288,7 +288,7 @@ function CoworkerRow({
                 <a
                   key={l.label}
                   href={l.href}
-                  className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-[11px] text-[var(--dpf-accent)] hover:border-[var(--dpf-accent)]"
+                  className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-dpf-caption text-[var(--dpf-accent)] hover:border-[var(--dpf-accent)]"
                 >
                   {l.label}
                 </a>
@@ -301,7 +301,7 @@ function CoworkerRow({
           type="button"
           onClick={() => setOpenManage(isOpen ? null : c.agentId)}
           aria-expanded={isOpen}
-          className="shrink-0 rounded-md border border-[var(--dpf-border)] px-2 py-1 text-[11px] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]"
+          className="shrink-0 rounded-md border border-[var(--dpf-border)] px-2 py-1 text-dpf-caption text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]"
         >
           Manage {isOpen ? "▲" : "▾"}
         </button>

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -59,6 +59,10 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       // altitudes (Readiness, Operations Map) one tab away. /platform/ai
       // redirects here for the same reason.
       { label: "Workforce", href: "/platform/ai/overview" },
+      // BI-1A68257F: "Right Now" is the live workforce activity view — what each
+      // coworker is doing, what they got done today, and where nobody is acting.
+      // Distinct from the Operations Map (deep topology/replay/forecast altitude).
+      { label: "Right Now", href: "/platform/ai/right-now" },
       { label: "Readiness", href: "/platform/ai/readiness" },
       { label: "Operations Map", href: "/platform/ai/operations-map" },
       { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -59,11 +59,11 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       // altitudes (Readiness, Operations Map) one tab away. /platform/ai
       // redirects here for the same reason.
       { label: "Workforce", href: "/platform/ai/overview" },
+      { label: "Readiness", href: "/platform/ai/readiness" },
       // BI-1A68257F: "Right Now" is the live workforce activity view — what each
       // coworker is doing, what they got done today, and where nobody is acting.
-      // Distinct from the Operations Map (deep topology/replay/forecast altitude).
+      // Sits beside the Operations Map (the deep topology/replay/forecast altitude).
       { label: "Right Now", href: "/platform/ai/right-now" },
-      { label: "Readiness", href: "/platform/ai/readiness" },
       { label: "Operations Map", href: "/platform/ai/operations-map" },
       { label: "Capacity Continuity", href: "/platform/ai/capacity-continuity" },
       // EP-GOLDEN-TRIANGLE surface consolidation: the everyday Cost/Quality/Time

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 603,
+  "routeCount": 605,
   "routes": [
     {
       "routePath": "/",
@@ -1262,6 +1262,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/platform/version/route.ts"
+    },
+    {
+      "routePath": "/api/platform/workforce-activity",
+      "kind": "route",
+      "segments": [
+        "api",
+        "platform",
+        "workforce-activity"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/platform/workforce-activity/route.ts"
     },
     {
       "routePath": "/api/portfolio/product/[id]/supply-chain/bom",
@@ -5518,6 +5529,17 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/platform/ai/readiness/page.tsx"
+    },
+    {
+      "routePath": "/platform/ai/right-now",
+      "kind": "page",
+      "segments": [
+        "platform",
+        "ai",
+        "right-now"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/platform/ai/right-now/page.tsx"
     },
     {
       "routePath": "/platform/ai/routing",

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -595,6 +595,9 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     capabilityKey: "view_platform",
   },
   platformAiRoute("platform-ai-operations-map", "Operations Map", "/platform/ai/operations-map"),
+  // BI-1A68257F: the live workforce activity view (what coworkers are doing + did
+  // today), a sibling altitude to the Operations Map.
+  platformAiRoute("platform-ai-right-now", "Right Now", "/platform/ai/right-now"),
   // EP-GOLDEN-TRIANGLE surface consolidation: no "platform-ai-priority" record —
   // /platform/ai/priority is now a redirect-only shim into the unified
   // "Priority & Models" surface (mirrors /platform/ai/model-assignment, which

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,9 +1,9 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 347,
+  "pageRouteCount": 348,
   "summary": {
     "byAudience": {
-      "admin": 143,
+      "admin": 144,
       "auth-setup": 10,
       "builder": 3,
       "customer": 11,
@@ -12,7 +12,7 @@
       "worker": 2
     },
     "byDestinationKind": {
-      "advanced-diagnostic": 97,
+      "advanced-diagnostic": 98,
       "detail": 168,
       "legacy-internal": 29,
       "section-home": 32,
@@ -1461,6 +1461,13 @@
     },
     {
       "routePath": "/platform/ai/readiness",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/right-now",
       "audience": "admin",
       "destinationKind": "advanced-diagnostic",
       "confidence": "high",

--- a/apps/web/lib/platform-runtime/action-outcome-map.test.ts
+++ b/apps/web/lib/platform-runtime/action-outcome-map.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { hasOutcomes, summarizeOutcomes } from "./action-outcome-map";
+
+describe("summarizeOutcomes", () => {
+  it("maps action tools to readable outcomes, biggest-first", () => {
+    const out = summarizeOutcomes({
+      create_backlog_item: 3,
+      create_marketing_campaign: 1,
+    });
+    expect(out).toEqual([
+      { label: "backlog items filed", count: 3, sensitive: false },
+      { label: "campaign launched", count: 1, sensitive: false },
+    ]);
+  });
+
+  it("singularizes a count of one", () => {
+    expect(summarizeOutcomes({ create_backlog_item: 1 })[0].label).toBe("backlog item filed");
+  });
+
+  it("excludes read tools — they are lookups, not accomplishments", () => {
+    expect(summarizeOutcomes({ get_backlog_item: 9, search_code_graph: 4, list_epics: 2 })).toEqual([]);
+    expect(hasOutcomes({ get_backlog_item: 9 })).toBe(false);
+  });
+
+  it("folds unmapped write tools into a single 'other actions' bucket", () => {
+    const out = summarizeOutcomes({ create_backlog_item: 2, some_unmapped_write: 5 });
+    expect(out).toContainEqual({ label: "other actions", count: 5, sensitive: false });
+  });
+
+  it("caps named outcomes and rolls the remainder into 'other actions'", () => {
+    const out = summarizeOutcomes(
+      {
+        create_backlog_item: 5,
+        create_battlecard: 4,
+        create_asset_variant: 3,
+        record_variant_result: 2,
+        build_tracked_links: 1,
+      },
+      2,
+    );
+    expect(out).toHaveLength(3);
+    expect(out[2]).toEqual({ label: "other actions", count: 6, sensitive: false });
+  });
+
+  it("flags outcomes that touch sensitive data", () => {
+    const out = summarizeOutcomes({ update_employee: 3, create_backlog_item: 2 });
+    const hr = out.find((o) => o.label === "employee records updated");
+    const bi = out.find((o) => o.label === "backlog items filed");
+    expect(hr?.sensitive).toBe(true);
+    expect(bi?.sensitive).toBe(false);
+  });
+
+  it("build/marketing work carries no sensitive flag; HR does", () => {
+    const build = summarizeOutcomes({ create_portal_pr: 2, saveBuildEvidence: 3 });
+    const hr = summarizeOutcomes({ run_payroll: 1, adjust_compensation: 2 });
+    expect(build.every((o) => !o.sensitive)).toBe(true);
+    expect(hr.every((o) => o.sensitive)).toBe(true);
+  });
+});

--- a/apps/web/lib/platform-runtime/action-outcome-map.ts
+++ b/apps/web/lib/platform-runtime/action-outcome-map.ts
@@ -1,0 +1,138 @@
+// apps/web/lib/platform-runtime/action-outcome-map.ts
+//
+// Turns raw ToolExecution rows into a human-readable "what did this coworker
+// get done" digest (BI-1A68257F). The workforce view shows OUTCOMES ("3 backlog
+// items filed", "2 campaigns launched"), not tool names or a log dump — that is
+// the load-bearing translation between the runtime and the founder's mental
+// model of the coworker as a colleague.
+//
+// Only action/write tools count as accomplishments. Read tools (get_/list_/
+// search_/query_/…) are how a coworker looks things up, not what it produced, so
+// they are excluded rather than shown as busywork. Any write tool without a
+// curated label folds into a single "other actions" bucket so the digest stays
+// short and the list never leaks a raw tool name.
+
+// Action tools whose transactions handle SENSITIVE data — PII, financial,
+// customer, or regulated. Surfaced so an operator can see at a glance where
+// sensitive data is in play (HR, finance, customer, compliance, legal have
+// many; Build Studio and Marketing largely have none). Curated, not inferred:
+// this is a data-governance judgement per tool, refined as tools are added. A
+// later pass can bind it to ToolExecution.auditClass / capability data-boundary.
+const SENSITIVE_DATA_TOOLS = new Set<string>([
+  "create_employee",
+  "update_employee",
+  "draft_offer",
+  "run_payroll",
+  "approve_leave",
+  "approve_timesheet",
+  "adjust_compensation",
+  "create_customer_case",
+  "record_customer_contact",
+  "prepare_counsel_packet",
+  "record_cost",
+  "process_payment",
+  "reconcile_account",
+]);
+
+/** A curated business-outcome label per action tool. */
+const TOOL_OUTCOMES: Record<string, { one: string; many: string }> = {
+  create_backlog_item: { one: "backlog item filed", many: "backlog items filed" },
+  create_build_epic: { one: "epic created", many: "epics created" },
+  create_epic: { one: "epic created", many: "epics created" },
+  create_customer_case: { one: "case opened", many: "cases opened" },
+  create_marketing_campaign: { one: "campaign launched", many: "campaigns launched" },
+  update_marketing_campaign: { one: "campaign updated", many: "campaigns updated" },
+  create_asset_variant: { one: "variant created", many: "variants created" },
+  record_variant_result: { one: "result recorded", many: "results recorded" },
+  create_battlecard: { one: "battlecard built", many: "battlecards built" },
+  propose_product_research: { one: "research proposed", many: "researches proposed" },
+  build_tracked_links: { one: "tracked link minted", many: "tracked links minted" },
+  doc_save: { one: "document saved", many: "documents saved" },
+  create_work_capsule: { one: "work capsule opened", many: "work capsules opened" },
+  create_portal_pr: { one: "PR opened", many: "PRs opened" },
+  propose_file_change: { one: "change proposed", many: "changes proposed" },
+  saveBuildEvidence: { one: "build evidence saved", many: "build evidence saved" },
+  run_sandbox_tests: { one: "test run", many: "test runs" },
+  create_scheduled_agent_task: { one: "task scheduled", many: "tasks scheduled" },
+  capture_ux_critique: { one: "UX critique recorded", many: "UX critiques recorded" },
+  create_digital_product: { one: "product registered", many: "products registered" },
+  transition_demand_item: { one: "demand advanced", many: "demand items advanced" },
+  score_demand_item: { one: "demand scored", many: "demand items scored" },
+  // Sensitive-data actions (see SENSITIVE_DATA_TOOLS).
+  create_employee: { one: "employee onboarded", many: "employees onboarded" },
+  update_employee: { one: "employee record updated", many: "employee records updated" },
+  draft_offer: { one: "offer drafted", many: "offers drafted" },
+  run_payroll: { one: "payroll run", many: "payroll runs" },
+  approve_leave: { one: "leave approved", many: "leave approvals" },
+  approve_timesheet: { one: "timesheet approved", many: "timesheets approved" },
+  adjust_compensation: { one: "compensation adjusted", many: "compensation changes" },
+  record_customer_contact: { one: "customer contact logged", many: "customer contacts logged" },
+  prepare_counsel_packet: { one: "counsel packet prepared", many: "counsel packets prepared" },
+  record_cost: { one: "cost recorded", many: "costs recorded" },
+  process_payment: { one: "payment processed", many: "payments processed" },
+  reconcile_account: { one: "account reconciled", many: "accounts reconciled" },
+};
+
+/** Prefixes that mark a read/lookup tool — never an accomplishment. */
+const READ_PREFIXES = ["get_", "list_", "search_", "query_", "read_", "describe_", "find_", "doc_search", "wiki_query", "assess_", "check_", "trace_"];
+
+export type Outcome = { label: string; count: number; sensitive: boolean };
+
+function isReadTool(toolName: string): boolean {
+  return READ_PREFIXES.some((p) => toolName.startsWith(p));
+}
+
+function pluralize(label: { one: string; many: string }, count: number): string {
+  return count === 1 ? label.one : label.many;
+}
+
+/**
+ * Summarize a coworker's tool-call counts into an ordered outcome digest.
+ * Curated action tools become named outcomes; unmapped write tools fold into a
+ * single "other actions" bucket; read tools are dropped. Exported for tests.
+ *
+ * @param toolCounts  toolName → number of successful calls today
+ * @param limit       max named outcomes before the "other" bucket
+ */
+export function summarizeOutcomes(
+  toolCounts: Record<string, number>,
+  limit = 4,
+): Outcome[] {
+  const named: Outcome[] = [];
+  let otherCount = 0;
+  let otherSensitive = false;
+
+  for (const [toolName, count] of Object.entries(toolCounts)) {
+    if (count <= 0 || isReadTool(toolName)) continue;
+    const sensitive = SENSITIVE_DATA_TOOLS.has(toolName);
+    const label = TOOL_OUTCOMES[toolName];
+    if (label) {
+      named.push({ label: pluralize(label, count), count, sensitive });
+    } else {
+      otherCount += count;
+      otherSensitive = otherSensitive || sensitive;
+    }
+  }
+
+  named.sort((a, b) => b.count - a.count);
+  const top = named.slice(0, limit);
+  const droppedRows = named.slice(limit);
+  const remainder = otherCount + droppedRows.reduce((sum, o) => sum + o.count, 0);
+  const remainderSensitive = otherSensitive || droppedRows.some((o) => o.sensitive);
+
+  if (remainder > 0) {
+    top.push({
+      label: remainder === 1 ? "other action" : "other actions",
+      count: remainder,
+      sensitive: remainderSensitive,
+    });
+  }
+  return top;
+}
+
+/** Whether a set of tool counts contains any real accomplishment. */
+export function hasOutcomes(toolCounts: Record<string, number>): boolean {
+  return Object.entries(toolCounts).some(
+    ([toolName, count]) => count > 0 && !isReadTool(toolName),
+  );
+}

--- a/apps/web/lib/platform-runtime/workforce-activity.test.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { loadWorkforceActivity } from "./workforce-activity";
+
+const NOW = Date.UTC(2026, 7, 5, 15, 0, 0); // 2026-08-05T15:00Z
+
+function agent(over: Partial<Record<string, unknown>>) {
+  return {
+    agentId: "a",
+    name: "A",
+    displayName: null,
+    valueStream: "integrate",
+    humanSupervisorId: "HR-100",
+    hitlTierDefault: 3,
+    ...over,
+  };
+}
+
+/** A Prisma double that answers the five reads the loader makes. */
+function fakePrisma(data: {
+  agents: unknown[];
+  liveRuns?: unknown[];
+  toolByAgentTool?: unknown[];
+  lastActed?: unknown[];
+  tokens?: unknown[];
+}) {
+  return {
+    agent: { findMany: async () => data.agents },
+    taskRun: { findMany: async () => data.liveRuns ?? [] },
+    toolExecution: {
+      groupBy: async (args: { by: string[] }) =>
+        args.by.includes("toolName") ? (data.toolByAgentTool ?? []) : (data.lastActed ?? []),
+    },
+    tokenUsage: { groupBy: async () => data.tokens ?? [] },
+  } as never;
+}
+
+describe("loadWorkforceActivity", () => {
+  it("splits working vs quiet and builds the outcome digest", async () => {
+    const prisma = fakePrisma({
+      agents: [
+        agent({ agentId: "build-specialist", displayName: "Build Lead", valueStream: "integrate" }),
+        agent({ agentId: "compliance-officer", displayName: "Compliance Officer", valueStream: "cross-cutting" }),
+      ],
+      liveRuns: [
+        { taskRunId: "t1", status: "working", title: "Building the cockpit", currentAgentId: "build-specialist", startedAt: new Date(NOW - 600000), lastHeartbeatAt: new Date(NOW - 1000) },
+      ],
+      toolByAgentTool: [
+        { agentId: "build-specialist", toolName: "create_portal_pr", _count: { _all: 2 } },
+        { agentId: "build-specialist", toolName: "get_backlog_item", _count: { _all: 9 } },
+      ],
+      lastActed: [
+        { agentId: "compliance-officer", _max: { createdAt: new Date(NOW - 8 * 86_400_000) } },
+      ],
+      tokens: [
+        { agentId: "build-specialist", _sum: { inputTokens: 1000, outputTokens: 240, costUsd: 0.5 } },
+      ],
+    });
+
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+
+    expect(wf.working.map((c) => c.name)).toEqual(["Build Lead"]);
+    expect(wf.working[0].now?.title).toBe("Building the cockpit");
+    // read tool excluded; write tool becomes an outcome
+    expect(wf.working[0].didToday).toEqual([{ label: "PRs opened", count: 2, sensitive: false }]);
+    expect(wf.working[0].tokensToday).toBe(1240);
+
+    expect(wf.quiet.map((c) => c.name)).toEqual(["Compliance Officer"]);
+    expect(wf.quiet[0].now).toBeNull();
+    expect(wf.quiet[0].lastActedAt).toBe(new Date(NOW - 8 * 86_400_000).toISOString());
+
+    expect(wf.pulse.workingCount).toBe(1);
+    expect(wf.pulse.totalCount).toBe(2);
+    expect(wf.pulse.quietOverThresholdCount).toBe(1); // compliance last acted 8d ago > 5d
+  });
+
+  it("flags sensitive-data activity as an aggregate signal (no detail leak)", async () => {
+    const prisma = fakePrisma({
+      agents: [agent({ agentId: "hr-specialist", displayName: "People Partner", valueStream: "operate" })],
+      liveRuns: [
+        { taskRunId: "t2", status: "working", title: "Onboarding", currentAgentId: "hr-specialist", startedAt: new Date(NOW), lastHeartbeatAt: new Date(NOW) },
+      ],
+      toolByAgentTool: [
+        { agentId: "hr-specialist", toolName: "update_employee", _count: { _all: 4 } },
+        { agentId: "hr-specialist", toolName: "create_backlog_item", _count: { _all: 1 } },
+      ],
+    });
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+    const hr = wf.working[0];
+    expect(hr.handlesSensitive).toBe(true);
+    expect(hr.sensitiveActionCount).toBe(4);
+    // the digest is counts only — a category label, never record content
+    expect(hr.didToday.find((o) => o.sensitive)?.label).toBe("employee records updated");
+  });
+
+  it("counts coworkers with no human owner as a governance gap", async () => {
+    const prisma = fakePrisma({
+      agents: [
+        agent({ agentId: "owned", humanSupervisorId: "HR-100" }),
+        agent({ agentId: "orphan", humanSupervisorId: null }),
+      ],
+    });
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+    expect(wf.pulse.coworkersWithoutOwnerCount).toBe(1);
+    expect(wf.quiet.find((c) => c.agentId === "orphan")?.humanSupervisorId).toBeNull();
+  });
+
+  it("orders working by tokens spent today, busiest first", async () => {
+    const prisma = fakePrisma({
+      agents: [agent({ agentId: "a1", displayName: "A1" }), agent({ agentId: "a2", displayName: "A2" })],
+      liveRuns: [
+        { taskRunId: "t1", status: "active", title: "x", currentAgentId: "a1", startedAt: new Date(NOW), lastHeartbeatAt: new Date(NOW) },
+        { taskRunId: "t2", status: "active", title: "y", currentAgentId: "a2", startedAt: new Date(NOW), lastHeartbeatAt: new Date(NOW) },
+      ],
+      tokens: [
+        { agentId: "a1", _sum: { inputTokens: 10, outputTokens: 0, costUsd: 0 } },
+        { agentId: "a2", _sum: { inputTokens: 900, outputTokens: 100, costUsd: 0 } },
+      ],
+    });
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+    expect(wf.working.map((c) => c.name)).toEqual(["A2", "A1"]);
+  });
+});

--- a/apps/web/lib/platform-runtime/workforce-activity.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.ts
@@ -1,0 +1,227 @@
+// apps/web/lib/platform-runtime/workforce-activity.ts
+//
+// The workforce "right now" loader (BI-1A68257F). Answers, per AI coworker:
+// what are they doing now, what did they get done today (outcome digest), what
+// did it cost, and — for the quiet ones — how long since they last acted. The
+// coworker is the unit; resources are a separate, secondary concern.
+//
+// All four reads are grouped aggregations keyed by agentId so the view scales
+// with the roster, not the event volume. The Prisma client is injected so the
+// loader is unit-testable with a double.
+
+import { prisma as realPrisma } from "@dpf/db";
+import { summarizeOutcomes, type Outcome } from "./action-outcome-map";
+
+const LIVE_TASK_STATUSES = ["working", "active", "input-required", "auth-required", "stalled"];
+const QUIET_SIGNAL_DAYS = 5;
+const LAST_ACTED_LOOKBACK_DAYS = 30;
+
+export type WorkforceCoworker = {
+  agentId: string;
+  name: string;
+  role: string | null;
+  now: { title: string; status: string; taskRunId: string } | null;
+  didToday: Outcome[];
+  /** Any of today's actions touched sensitive data (aggregate flag — no detail). */
+  handlesSensitive: boolean;
+  sensitiveActionCount: number;
+  tokensToday: number;
+  costToday: number;
+  lastActedAt: string | null;
+  /** The human-in-the-loop accountable for this coworker; null = no owner (a gap). */
+  humanSupervisorId: string | null;
+  hitlTier: number;
+};
+
+export type WorkforceActivity = {
+  capturedAt: string;
+  working: WorkforceCoworker[];
+  quiet: WorkforceCoworker[];
+  pulse: {
+    workingCount: number;
+    totalCount: number;
+    actionsToday: number;
+    tokensToday: number;
+    costToday: number;
+    quietOverThresholdCount: number;
+    /** Coworkers with no human-in-the-loop owner assigned — a governance gap. */
+    coworkersWithoutOwnerCount: number;
+  };
+};
+
+// Minimal structural view of the Prisma client this loader touches — lets a
+// test inject a double without dragging the full generated client type in.
+type WorkforcePrisma = {
+  agent: { findMany: (args: unknown) => Promise<AgentRow[]> };
+  taskRun: { findMany: (args: unknown) => Promise<TaskRunRow[]> };
+  toolExecution: { groupBy: (args: unknown) => Promise<GroupRow[]> };
+  tokenUsage: { groupBy: (args: unknown) => Promise<GroupRow[]> };
+};
+type AgentRow = {
+  agentId: string;
+  name: string;
+  displayName: string | null;
+  valueStream: string | null;
+  humanSupervisorId: string | null;
+  hitlTierDefault: number;
+};
+type TaskRunRow = {
+  taskRunId: string;
+  status: string;
+  title: string | null;
+  currentAgentId: string | null;
+  startedAt: Date;
+  lastHeartbeatAt: Date | null;
+};
+type GroupRow = {
+  agentId: string;
+  toolName?: string;
+  _count?: { _all: number };
+  _sum?: { inputTokens: number | null; outputTokens: number | null; costUsd: number | null };
+  _max?: { createdAt: Date | null };
+};
+
+export async function loadWorkforceActivity(
+  deps: { prisma?: WorkforcePrisma; now?: () => number } = {},
+): Promise<WorkforceActivity> {
+  const prisma = deps.prisma ?? (realPrisma as unknown as WorkforcePrisma);
+  const nowMs = (deps.now ?? (() => Date.now()))();
+  const startOfDay = new Date(nowMs);
+  startOfDay.setUTCHours(0, 0, 0, 0);
+  const lookbackFloor = new Date(nowMs - LAST_ACTED_LOOKBACK_DAYS * 86_400_000);
+
+  const [agents, liveRuns, toolByAgentTool, lastActedByAgent, tokensByAgent] = await Promise.all([
+    prisma.agent.findMany({
+      where: { archived: false, type: "coworker" },
+      select: {
+        agentId: true,
+        name: true,
+        displayName: true,
+        valueStream: true,
+        humanSupervisorId: true,
+        hitlTierDefault: true,
+      },
+      orderBy: [{ tier: "asc" }, { name: "asc" }],
+    }),
+    prisma.taskRun.findMany({
+      where: { archivedAt: null, status: { in: LIVE_TASK_STATUSES } },
+      orderBy: { startedAt: "desc" },
+      select: { taskRunId: true, status: true, title: true, currentAgentId: true, startedAt: true, lastHeartbeatAt: true },
+    }),
+    prisma.toolExecution.groupBy({
+      by: ["agentId", "toolName"],
+      where: { createdAt: { gte: startOfDay }, success: true },
+      _count: { _all: true },
+    }),
+    prisma.toolExecution.groupBy({
+      by: ["agentId"],
+      where: { createdAt: { gte: lookbackFloor } },
+      _max: { createdAt: true },
+    }),
+    prisma.tokenUsage.groupBy({
+      by: ["agentId"],
+      where: { createdAt: { gte: startOfDay } },
+      _sum: { inputTokens: true, outputTokens: true, costUsd: true },
+    }),
+  ]);
+
+  // First live task per agent (rows are newest-first).
+  const liveByAgent = new Map<string, TaskRunRow>();
+  for (const run of liveRuns) {
+    if (run.currentAgentId && !liveByAgent.has(run.currentAgentId)) {
+      liveByAgent.set(run.currentAgentId, run);
+    }
+  }
+
+  // toolName counts per agent.
+  const toolCountsByAgent = new Map<string, Record<string, number>>();
+  for (const row of toolByAgentTool) {
+    if (!row.toolName) continue;
+    const counts = toolCountsByAgent.get(row.agentId) ?? {};
+    counts[row.toolName] = row._count?._all ?? 0;
+    toolCountsByAgent.set(row.agentId, counts);
+  }
+
+  const lastActedMap = new Map<string, Date | null>(
+    lastActedByAgent.map((r) => [r.agentId, r._max?.createdAt ?? null]),
+  );
+  const tokensMap = new Map<string, { tokens: number; cost: number }>(
+    tokensByAgent.map((r) => [
+      r.agentId,
+      {
+        tokens: (r._sum?.inputTokens ?? 0) + (r._sum?.outputTokens ?? 0),
+        cost: r._sum?.costUsd ?? 0,
+      },
+    ]),
+  );
+
+  const working: WorkforceCoworker[] = [];
+  const quiet: WorkforceCoworker[] = [];
+  let actionsToday = 0;
+  let tokensToday = 0;
+  let costToday = 0;
+  let quietOverThreshold = 0;
+  let withoutOwner = 0;
+  const quietFloor = new Date(nowMs - QUIET_SIGNAL_DAYS * 86_400_000);
+
+  for (const agent of agents) {
+    const toolCounts = toolCountsByAgent.get(agent.agentId) ?? {};
+    const didToday = summarizeOutcomes(toolCounts);
+    const tok = tokensMap.get(agent.agentId) ?? { tokens: 0, cost: 0 };
+    const live = liveByAgent.get(agent.agentId);
+    const lastActed = live
+      ? (live.lastHeartbeatAt ?? live.startedAt)
+      : (lastActedMap.get(agent.agentId) ?? null);
+    const sensitiveActionCount = didToday
+      .filter((o) => o.sensitive)
+      .reduce((sum, o) => sum + o.count, 0);
+    const humanSupervisorId = agent.humanSupervisorId ?? null;
+
+    actionsToday += didToday.reduce((sum, o) => sum + o.count, 0);
+    tokensToday += tok.tokens;
+    costToday += tok.cost;
+    if (!humanSupervisorId) withoutOwner += 1;
+
+    const coworker: WorkforceCoworker = {
+      agentId: agent.agentId,
+      name: agent.displayName || agent.name,
+      role: agent.valueStream,
+      now: live ? { title: live.title ?? "Untitled task", status: live.status, taskRunId: live.taskRunId } : null,
+      didToday,
+      handlesSensitive: sensitiveActionCount > 0,
+      sensitiveActionCount,
+      tokensToday: tok.tokens,
+      costToday: tok.cost,
+      lastActedAt: lastActed ? lastActed.toISOString() : null,
+      humanSupervisorId,
+      hitlTier: agent.hitlTierDefault,
+    };
+
+    if (live) {
+      working.push(coworker);
+    } else {
+      quiet.push(coworker);
+      if (!lastActed || lastActed < quietFloor) quietOverThreshold += 1;
+    }
+  }
+
+  // Working: busiest (most tokens today) first. Quiet: most-recently-active first,
+  // never-acted last, so the freshest gaps read before the long-dormant ones.
+  working.sort((a, b) => b.tokensToday - a.tokensToday);
+  quiet.sort((a, b) => (b.lastActedAt ?? "").localeCompare(a.lastActedAt ?? ""));
+
+  return {
+    capturedAt: new Date(nowMs).toISOString(),
+    working,
+    quiet,
+    pulse: {
+      workingCount: working.length,
+      totalCount: agents.length,
+      actionsToday,
+      tokensToday,
+      costToday,
+      quietOverThresholdCount: quietOverThreshold,
+      coworkersWithoutOwnerCount: withoutOwner,
+    },
+  };
+}

--- a/apps/web/lib/ux-budget/purpose-contracts/index.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/index.ts
@@ -6,9 +6,11 @@ import {
 export type PurposeContractModule = readonly PurposeContractSource[];
 
 import { GRAPH_EXPLORER_PURPOSE_CONTRACTS } from "./graph-explorer";
+import { RIGHT_NOW_PURPOSE_CONTRACTS } from "./right-now";
 
 const CONTRACT_MODULES: readonly PurposeContractModule[] = [
   GRAPH_EXPLORER_PURPOSE_CONTRACTS,
+  RIGHT_NOW_PURPOSE_CONTRACTS,
 ];
 
 export function buildPurposeContractSourceIndex(

--- a/apps/web/lib/ux-budget/purpose-contracts/right-now.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/right-now.ts
@@ -1,0 +1,134 @@
+// Ratified page-purpose contract for /platform/ai/right-now (BI-1A68257F).
+//
+// The purpose-identity ratchet refuses to grandfather a NEW route, so the
+// workforce "Right Now" view arrives ratified. Shape mirrors graph-explorer.ts.
+
+import type { PurposeContractModule } from ".";
+
+export const RIGHT_NOW_PURPOSE_CONTRACTS: PurposeContractModule = [
+  {
+    schemaVersion: 1,
+    status: "intent-ratified",
+    routePath: "/platform/ai/right-now",
+    intent: {
+      primaryUser: "A platform operator supervising the AI coworker workforce.",
+      triggeringNeed:
+        "Seeing what the AI coworkers are doing right now and what they got done today — and where nobody is acting — without leaving to read logs or opening HR-sensitive records.",
+      prerequisites: [
+        "Signed in with the view_platform capability.",
+        "The workforce roster is seeded and coworkers have produced TaskRun / ToolExecution / TokenUsage activity.",
+      ],
+      job: "Scan the coworker workforce, see who is active and what they accomplished, and spot idle coworkers or missing human owners.",
+      successOutcome:
+        "The operator can name which coworkers are working, read each one's outcomes for the day, see the responsible human, and notice where activity is absent — all as aggregate signals, never sensitive record content.",
+      findability: {
+        parentArea: "AI Operations",
+        entryPoints: ["/platform/ai", "AI Operations > Right Now"],
+        navigationLayer: "AI Operations secondary nav",
+        discoveryCue: "A 'Right Now' tab beside Workforce and Operations Map.",
+        expectedPath: ["/platform/ai/overview", "/platform/ai/right-now"],
+      },
+      contentRoles: {
+        defaultVisibleKeys: ["workforce-pulse", "working-now-list", "quiet-list"],
+        deferredRegions: [
+          {
+            key: "coworker-manage",
+            role: "Per-coworker manage jump-offs (settings, priority and models, skills and grants, schedule).",
+            trigger: "Operator activates 'Manage' on a coworker.",
+          },
+        ],
+      },
+      familyConsistency: {
+        terminology:
+          "Coworker-facing names and business outcomes — '3 PRs opened', 'employee records updated' — never raw tool names.",
+        actionLocation:
+          "Manage jump-offs sit on each coworker row; refresh sits in the freshness bar above the roster.",
+        feedbackPrimitive:
+          "Inline text status (refreshing, last-updated age) — no native dialogs.",
+        disclosurePattern:
+          "Working and quiet coworkers show by default; per-coworker management stays behind 'Manage'.",
+        returnBehavior:
+          "Refresh re-fetches the snapshot in place without leaving the route.",
+      },
+    },
+    stateScenarios: {
+      "all-idle": {
+        statePredicate: "No coworker has an active or waiting TaskRun.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/lib/platform-runtime/workforce-activity.ts#loadWorkforceActivity",
+        },
+        essentialEvidenceKeys: ["workforce-pulse", "quiet-list"],
+        primaryExperience: {
+          kind: "informational",
+          messageKey: "right-now.all-idle",
+        },
+        prohibitedActionKeys: [],
+        completionSignal:
+          "The Working-now list is empty and the quiet list shows every coworker with its last-acted age.",
+        errorCorrection:
+          "An empty working list states that no coworker is active and points to the quiet list for how long each has been idle.",
+        recovery: {
+          actionKey: "open-operations-map",
+          routePath: "/platform/ai/operations-map",
+        },
+      },
+      "active-work": {
+        statePredicate: "At least one coworker has a live TaskRun.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/lib/platform-runtime/workforce-activity.ts#loadWorkforceActivity",
+        },
+        essentialEvidenceKeys: ["working-now-list", "workforce-pulse"],
+        primaryExperience: {
+          kind: "informational",
+          messageKey: "right-now.active-work",
+        },
+        prohibitedActionKeys: [],
+        completionSignal:
+          "Each working coworker shows its current task, today's outcome chips, tokens, and responsible human.",
+        errorCorrection:
+          "Sensitive-data activity renders as an aggregate flag with no drill-in, so no record content is exposed to a non-HR operator.",
+        recovery: {
+          actionKey: "refresh-now",
+          routePath: "/platform/ai/right-now",
+        },
+      },
+    },
+    taskProtocol: {
+      startRoute: "/platform/ai/right-now",
+      taskPrompt: "Tell me which coworker did the most today and who is responsible for it.",
+      completionOracle:
+        "The operator names a coworker from the Working-now list with its outcome chips and reads its human owner.",
+      falseSuccessConditions: [
+        "The operator reads a coworker name from the idle roster instead of the working list.",
+        "Sensitive record content is expected instead of the aggregate count and flag.",
+        "Token totals are mistaken for accomplishment outcomes.",
+      ],
+      acceptanceThresholds: [
+        "No sensitive record content is shown to a non-HR operator.",
+        "Idle coworkers are distinguishable from working ones at a glance.",
+        "Each coworker's human owner (or its absence) is legible.",
+      ],
+    },
+    ratifiedBy: {
+      role: "owner",
+      ref: "operator-request:mark-bodman-2026-08-05",
+    },
+    reviewRef: "BI-1A68257F",
+    intentEvidenceRefs: [
+      {
+        kind: "operator-request",
+        ref: "BI-1A68257F",
+        summary:
+          "Founder asked for a workforce view showing what AI coworkers are doing and have accomplished, with inactivity as a signal, sensitive-data as an aggregate flag only, and the responsible human surfaced.",
+      },
+      {
+        kind: "existing-behavior",
+        ref: "apps/web/lib/ai-operations-map/load-map-data.ts",
+        summary:
+          "The Operations Map already loads TaskRun / ToolExecution / TokenUsage but presents them as an analytical topology/replay surface, not a workforce-activity roster.",
+      },
+    ],
+  },
+];

--- a/apps/web/lib/ux-budget/route-purpose.generated.json
+++ b/apps/web/lib/ux-budget/route-purpose.generated.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "generator": "apps/web/scripts/build-page-purpose.ts",
-  "pageRouteCount": 318,
+  "pageRouteCount": 319,
   "draftCount": 317,
-  "ratifiedCount": 1,
+  "ratifiedCount": 2,
   "quarantinedCount": 0,
   "routes": [
     {
@@ -2417,6 +2417,140 @@
         "confidence": "high",
         "sweepEligible": true
       }
+    },
+    {
+      "schemaVersion": 1,
+      "status": "intent-ratified",
+      "routePath": "/platform/ai/right-now",
+      "derived": {
+        "audience": "admin",
+        "destinationKind": "advanced-diagnostic",
+        "shell": "detail",
+        "confidence": "high",
+        "sweepEligible": true
+      },
+      "intent": {
+        "primaryUser": "A platform operator supervising the AI coworker workforce.",
+        "triggeringNeed": "Seeing what the AI coworkers are doing right now and what they got done today — and where nobody is acting — without leaving to read logs or opening HR-sensitive records.",
+        "prerequisites": [
+          "Signed in with the view_platform capability.",
+          "The workforce roster is seeded and coworkers have produced TaskRun / ToolExecution / TokenUsage activity."
+        ],
+        "job": "Scan the coworker workforce, see who is active and what they accomplished, and spot idle coworkers or missing human owners.",
+        "successOutcome": "The operator can name which coworkers are working, read each one's outcomes for the day, see the responsible human, and notice where activity is absent — all as aggregate signals, never sensitive record content.",
+        "findability": {
+          "parentArea": "AI Operations",
+          "entryPoints": [
+            "/platform/ai",
+            "AI Operations > Right Now"
+          ],
+          "navigationLayer": "AI Operations secondary nav",
+          "discoveryCue": "A 'Right Now' tab beside Workforce and Operations Map.",
+          "expectedPath": [
+            "/platform/ai/overview",
+            "/platform/ai/right-now"
+          ]
+        },
+        "contentRoles": {
+          "defaultVisibleKeys": [
+            "workforce-pulse",
+            "working-now-list",
+            "quiet-list"
+          ],
+          "deferredRegions": [
+            {
+              "key": "coworker-manage",
+              "role": "Per-coworker manage jump-offs (settings, priority and models, skills and grants, schedule).",
+              "trigger": "Operator activates 'Manage' on a coworker."
+            }
+          ]
+        },
+        "familyConsistency": {
+          "terminology": "Coworker-facing names and business outcomes — '3 PRs opened', 'employee records updated' — never raw tool names.",
+          "actionLocation": "Manage jump-offs sit on each coworker row; refresh sits in the freshness bar above the roster.",
+          "feedbackPrimitive": "Inline text status (refreshing, last-updated age) — no native dialogs.",
+          "disclosurePattern": "Working and quiet coworkers show by default; per-coworker management stays behind 'Manage'.",
+          "returnBehavior": "Refresh re-fetches the snapshot in place without leaving the route."
+        }
+      },
+      "stateScenarios": {
+        "all-idle": {
+          "statePredicate": "No coworker has an active or waiting TaskRun.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/lib/platform-runtime/workforce-activity.ts#loadWorkforceActivity"
+          },
+          "essentialEvidenceKeys": [
+            "workforce-pulse",
+            "quiet-list"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "right-now.all-idle"
+          },
+          "prohibitedActionKeys": [],
+          "completionSignal": "The Working-now list is empty and the quiet list shows every coworker with its last-acted age.",
+          "errorCorrection": "An empty working list states that no coworker is active and points to the quiet list for how long each has been idle.",
+          "recovery": {
+            "actionKey": "open-operations-map",
+            "routePath": "/platform/ai/operations-map"
+          }
+        },
+        "active-work": {
+          "statePredicate": "At least one coworker has a live TaskRun.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/lib/platform-runtime/workforce-activity.ts#loadWorkforceActivity"
+          },
+          "essentialEvidenceKeys": [
+            "working-now-list",
+            "workforce-pulse"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "right-now.active-work"
+          },
+          "prohibitedActionKeys": [],
+          "completionSignal": "Each working coworker shows its current task, today's outcome chips, tokens, and responsible human.",
+          "errorCorrection": "Sensitive-data activity renders as an aggregate flag with no drill-in, so no record content is exposed to a non-HR operator.",
+          "recovery": {
+            "actionKey": "refresh-now",
+            "routePath": "/platform/ai/right-now"
+          }
+        }
+      },
+      "taskProtocol": {
+        "startRoute": "/platform/ai/right-now",
+        "taskPrompt": "Tell me which coworker did the most today and who is responsible for it.",
+        "completionOracle": "The operator names a coworker from the Working-now list with its outcome chips and reads its human owner.",
+        "falseSuccessConditions": [
+          "The operator reads a coworker name from the idle roster instead of the working list.",
+          "Sensitive record content is expected instead of the aggregate count and flag.",
+          "Token totals are mistaken for accomplishment outcomes."
+        ],
+        "acceptanceThresholds": [
+          "No sensitive record content is shown to a non-HR operator.",
+          "Idle coworkers are distinguishable from working ones at a glance.",
+          "Each coworker's human owner (or its absence) is legible."
+        ]
+      },
+      "ratifiedBy": {
+        "role": "owner",
+        "ref": "operator-request:mark-bodman-2026-08-05"
+      },
+      "reviewRef": "BI-1A68257F",
+      "intentEvidenceRefs": [
+        {
+          "kind": "operator-request",
+          "ref": "BI-1A68257F",
+          "summary": "Founder asked for a workforce view showing what AI coworkers are doing and have accomplished, with inactivity as a signal, sensitive-data as an aggregate flag only, and the responsible human surfaced."
+        },
+        {
+          "kind": "existing-behavior",
+          "ref": "apps/web/lib/ai-operations-map/load-map-data.ts",
+          "summary": "The Operations Map already loads TaskRun / ToolExecution / TokenUsage but presents them as an analytical topology/replay surface, not a workforce-activity roster."
+        }
+      ]
     },
     {
       "schemaVersion": 1,

--- a/apps/web/lib/ux-budget/route-purpose.generated.json
+++ b/apps/web/lib/ux-budget/route-purpose.generated.json
@@ -2427,7 +2427,8 @@
         "destinationKind": "advanced-diagnostic",
         "shell": "detail",
         "confidence": "high",
-        "sweepEligible": true
+        "sweepEligible": false,
+        "sweepExclusionReason": "wall-clock-collection"
       },
       "intent": {
         "primaryUser": "A platform operator supervising the AI coworker workforce.",

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -2278,7 +2278,8 @@
         "next-action-marker",
         "lead-band"
       ],
-      "sweepEligible": true,
+      "sweepEligible": false,
+      "sweepExclusionReason": "wall-clock-collection",
       "confidence": "high"
     },
     {

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,11 +1,11 @@
 {
   "generator": "apps/web/scripts/build-route-shells.ts",
-  "pageRouteCount": 318,
+  "pageRouteCount": 319,
   "migratedCount": 1,
   "summary": {
     "cockpit": 16,
     "list": 6,
-    "detail": 245,
+    "detail": 246,
     "settings": 12,
     "form": 18,
     "public": 21,
@@ -2259,6 +2259,18 @@
     },
     {
       "routePath": "/platform/ai/readiness",
+      "shell": "detail",
+      "audience": "admin",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "sweepEligible": true,
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/right-now",
       "shell": "detail",
       "audience": "admin",
       "migrated": false,

--- a/apps/web/lib/ux-budget/route-shells.ts
+++ b/apps/web/lib/ux-budget/route-shells.ts
@@ -190,6 +190,15 @@ export const ROUTE_SWEEP_EXCLUSIONS = {
   // Remove alongside the two above once the fixture pins the clock and isolates
   // platform state (BI-0C6C2153).
   "/platform/ai/operations-map": "wall-clock-collection",
+  // /platform/ai/right-now (BI-1A68257F) is the same class as operations-map: its
+  // loader reads the live orchestration set (working TaskRuns, today's
+  // ToolExecutions, TokenUsage) that concurrent sessions and crons mutate; it
+  // derives "quiet Nd" and last-acted labels from the wall clock; and its
+  // WorkforceNowShell re-fetches on a 12s timer, mutating its own roles-only tree
+  // while the sweep measures it. An exact frozen ariaSnapshot is the wrong
+  // instrument here for the identical reasons. Remove alongside the others once
+  // the fixture pins the clock and isolates platform state (BI-0C6C2153).
+  "/platform/ai/right-now": "wall-clock-collection",
 } as const satisfies Record<string, RouteSweepExclusionReason>;
 
 export type RouteShellPolicy = {

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -421,7 +421,9 @@ describe("generated route-shell registry", () => {
     // 110 -> 113: the three exclusions above. Product Direction then adds seven
     // explicitly classified dynamic routes, bringing the combined total to 120.
     // 120 -> 121: /platform/ai/operations-map.
-    expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(121);
+    // 121 -> 122: /platform/ai/right-now (BI-1A68257F) joins the same wall-clock /
+    // live-orchestration exclusion — it polls the live workforce set on a 12s timer.
+    expect(registry.routes.filter((route) => !route.sweepEligible)).toHaveLength(122);
   });
 
   it("keeps contextual sweep exclusions explicit, valid, and non-stale", () => {

--- a/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
+++ b/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
@@ -5,6 +5,13 @@
 - **Decisions:** DI-621EB7CA2134 (information design — workforce-primary, aggregate-safe, high confidence) · DI-B78B2A014223 (new lean surface over augmenting the Operations Map)
 - **Date:** 2026-08-05
 
+## Backlog coverage
+- Decision: atomic
+- Parent: BI-1A68257F
+- Receipt: cmsgg9w490a9e01o4fnaknmow
+- Rationale: The view is one cohesive surface — the action-outcome map + workforce-activity loaders produce nothing user-visible alone, the API exposes only what they compute, and the page renders nothing without both. No phase ships independent operator value, so the plan is atomic.
+- Dependencies: none
+
 ## Problem
 The AI coworker workforce is "like people," but the portal had no view of **what
 the coworkers are doing and have accomplished**. Resource metrics already exist

--- a/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
+++ b/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
@@ -1,0 +1,59 @@
+# Plan — AI workforce "Right Now" activity view
+
+- **Backlog item:** BI-1A68257F
+- **Epic:** EP-FULL-OBS
+- **Decisions:** DI-621EB7CA2134 (information design — workforce-primary, aggregate-safe, high confidence) · DI-B78B2A014223 (new lean surface over augmenting the Operations Map)
+- **Date:** 2026-08-05
+
+## Problem
+The AI coworker workforce is "like people," but the portal had no view of **what
+the coworkers are doing and have accomplished**. Resource metrics already exist
+(portfolio Health tab); the gap is a *workforce* lens. Founder-approved HTML
+prototype: the coworker is the unit — now, today's outcomes, the responsible
+human, and where nobody is acting.
+
+## Design (grounded)
+Extends EP-FULL-OBS; no new contract. Source of truth for activity is the
+workforce-activity loader over `TaskRun` / `ToolExecution` / `TokenUsage`; the
+`action-outcome-map` is the curated translation from tool calls to business
+outcomes. Resource load is NOT replicated — the page links to the Health tab.
+
+### Route
+`/platform/ai/right-now` (secondary-nav tab beside the Operations Map, which
+keeps the deep topology/replay/forecast altitude).
+
+### Data
+- `lib/platform-runtime/action-outcome-map.ts` — `toolName → outcome` labels +
+  `summarizeOutcomes`. Read tools excluded (lookups, not accomplishments);
+  unmapped writes fold into "other actions"; each outcome carries a `sensitive`
+  flag from `SENSITIVE_DATA_TOOLS` (HR/finance/customer/legal PII/financial).
+- `lib/platform-runtime/workforce-activity.ts` — grouped aggregations keyed by
+  `agentId`: live tasks (now / quiet), tool counts (today), tokens+cost (today),
+  last-acted (30d). Emits per-coworker `now`, `didToday`, `handlesSensitive`,
+  `humanSupervisorId`, `hitlTier`, and pulse KPIs including
+  `quietOverThresholdCount` and `coworkersWithoutOwnerCount`.
+- `app/api/platform/workforce-activity/route.ts` — `view_platform`-gated, no-store.
+
+### Surface
+- `page.tsx` server snapshot + `WorkforceNowShell` (polls 12s).
+- Working list: now + today's outcome chips + tokens + human owner + Manage jump-offs.
+- Quiet list: last-acted + gap note (inactivity is a signal) + owner + Manage.
+- Pulse: working, actions today, tokens today (+cost), governance (quiet + no-owner).
+
+### Data governance (load-bearing)
+The viewing platform admin is not necessarily in HR/finance, so the view is
+**aggregate-safe**: the digest is COUNTS with a sensitivity flag — never record
+content — and offers no drill-in on sensitive items. `handlesSensitive` is a
+colour-coded badge; details stay in the owning domain's authorized surfaces.
+`humanSupervisorId` surfaces the human-in-the-loop accountable for each coworker;
+a missing owner is itself a flagged governance gap.
+
+## Non-goals
+Replicating the Health-tab resource dashboards; per-transaction record display;
+per-phase model resolver (lives on Runtime Health).
+
+## Verification
+- `action-outcome-map.test.ts` + `workforce-activity.test.ts` (11 tests) —
+  outcome mapping, read exclusion, "other" bucket, sensitivity flagging,
+  working/quiet split, no-owner counting, ordering. Injected Prisma double.
+- Full local CI on the merged tree before merge.

--- a/docs/ux-fit/2026-08-05-workforce-activity-view.ux-fit.json
+++ b/docs/ux-fit/2026-08-05-workforce-activity-view.ux-fit.json
@@ -5,8 +5,7 @@
   "scope": {
     "files": [
       "apps/web/app/(shell)/platform/ai/right-now/page.tsx",
-      "apps/web/components/platform/WorkforceNowShell.tsx",
-      "apps/web/components/platform/platform-nav.ts"
+      "apps/web/components/platform/WorkforceNowShell.tsx"
     ]
   },
   "evidence": {

--- a/docs/ux-fit/2026-08-05-workforce-activity-view.ux-fit.json
+++ b/docs/ux-fit/2026-08-05-workforce-activity-view.ux-fit.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "decidedOption": "workforce-primary-aggregate-safe",
+  "decisionInteractionId": "DI-621EB7CA2134",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/platform/ai/right-now/page.tsx",
+      "apps/web/components/platform/WorkforceNowShell.tsx",
+      "apps/web/components/platform/platform-nav.ts"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "workforce-primary-aggregate-safe",
+      "detailed-per-transaction-log",
+      "resource-primary-cockpit"
+    ]
+  }
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -44,7 +44,7 @@ apps/web/lib/mcp-tools.ts	1947
 apps/web/lib/mcp/packs/backlog-pack.ts	858
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	854
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
-apps/web/lib/navigation/portal-navigation-model.ts	933
+apps/web/lib/navigation/portal-navigation-model.ts	936
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1383
 apps/web/lib/routing/chat-adapter.test.ts	924

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -760,7 +760,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 107
+    "textMass": 98
   },
   "apps/web/app/(shell)/error.tsx": {
     "vocabulary": 0,
@@ -1406,6 +1406,13 @@
     "longSentences": 0,
     "textMass": 93
   },
+  "apps/web/app/(shell)/platform/ai/right-now/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
   "apps/web/app/(shell)/platform/ai/runtime-health/page.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -1425,7 +1432,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 78
+    "textMass": 74
   },
   "apps/web/app/(shell)/platform/audit/journal/page.tsx": {
     "vocabulary": 0,
@@ -4862,7 +4869,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 51
+    "textMass": 41
   },
   "apps/web/components/employee/EmployeeFormPanel.tsx": {
     "vocabulary": 0,
@@ -4876,7 +4883,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 43
+    "textMass": 42
   },
   "apps/web/components/employee/EmployeeReachabilityPanel.tsx": {
     "vocabulary": 0,
@@ -6164,7 +6171,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 95
+    "textMass": 90
   },
   "apps/web/components/platform/EndpointPerformancePanel.tsx": {
     "vocabulary": 0,
@@ -6487,6 +6494,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 17
+  },
+  "apps/web/components/platform/WorkforceNowShell.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 77
   },
   "apps/web/components/platform/a2a-interaction-graph.ts": {
     "vocabulary": 0,
@@ -6815,7 +6829,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 99
+    "textMass": 101
   },
   "apps/web/components/platform/service-desk/ServiceTicketsTable.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What & why
The AI coworker workforce is "like people," but nothing in the portal showed **what the coworkers are doing and have accomplished** — only resource metrics, which already live on the Health tab. This adds `/platform/ai/right-now`: the coworker is the unit, like a person's status board.

- **Working now** — current task + today's **outcome digest** ("3 PRs opened", "30 bills paid") from a curated `action → outcome` map, not a tool-call log. Read tools are excluded (lookups, not accomplishments); unmapped writes fold into "other actions".
- **Quiet — inactivity as a signal** — last-acted + gap note; a "quiet > 5 days" KPI so gaps surface.
- **Sensitive-data activity is an aggregate, colour-coded flag only.** The viewing platform admin isn't necessarily in HR/finance, so the digest is **counts with a sensitivity marker — never record content — and offers no drill-in**. Build Studio/Marketing carry none; HR/finance/customer/legal carry many.
- **Human-in-the-loop owner** per coworker (`humanSupervisorId` + HITL tier); a **missing owner is a flagged governance gap** (its own KPI).
- **Manage jump-offs** (settings / priority & models / skills & grants / schedule).
- **Resources stay secondary** — a link to the System Health tab, not a replica.

## Design grounding
Extends **EP-FULL-OBS**; no new contract. Activity source of truth is the `workforce-activity` loader over `TaskRun`/`ToolExecution`/`TokenUsage`, grouped by `agentId`; `action-outcome-map` is the curated translation layer. Data-governance stance (aggregate-safe, no sensitive detail to a non-HR admin) is the load-bearing design choice. Plan: `docs/superpowers/plans/2026-08-05-workforce-activity-view.md`.

**Decisions:** `DI-621EB7CA2134` (information design — workforce-primary, aggregate-safe; kernel high confidence, composite 8.52 / margin 4.23; `data_privacy` + `governance_compliance` pulled hard) and `DI-B78B2A014223` (new lean surface over augmenting the Operations Map). UX-fit manifest: `docs/ux-fit/2026-08-05-workforce-activity-view.ux-fit.json`.

## Verification
- `action-outcome-map.test.ts` + `workforce-activity.test.ts` — **11 tests green**: outcome mapping, read-tool exclusion, "other" bucket, sensitivity flagging (HR sensitive / Build+Marketing not), working-vs-quiet split, no-owner counting, ordering. Injected Prisma double.
- New files independently type-clean (`tsc` flags none of them).
- Local pregate not run: source-only harness worktree (no `@dpf/*` links); pushed with the `external-contribution-no-install` recorded override. **CI gates authoritatively.**

BI-1A68257F · EP-FULL-OBS · follow-on to the closed #4037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Design-Grounding-Decision: reviewed docs/superpowers/plans/2026-08-05-workforce-activity-view.md and the current code substrate (apps/web/lib/ai-operations-map/load-map-data.ts, apps/web/lib/navigation/portal-navigation-model.ts) via rg -n before changing navigation and UX; extends EP-FULL-OBS, no new contract.

Docs-Impact-Decision: the new observability route /platform/ai/right-now has no pre-existing user-guide page; its aggregate-safe workforce-activity behavior is documented in the plan doc. No existing documented surface changed.