### PR TITLE
refactor(workforce): keep system-noise out of the "did today" digest (BI-A1B4BE05)

### DIFF
--- a/apps/web/lib/platform-runtime/action-outcome-map.test.ts
+++ b/apps/web/lib/platform-runtime/action-outcome-map.test.ts
@@ -22,6 +22,13 @@ describe("summarizeOutcomes", () => {
     expect(hasOutcomes({ get_backlog_item: 9 })).toBe(false);
   });
 
+  it("excludes synthetic access-audit executions — not accomplishments (BI-A1B4BE05)", () => {
+    expect(
+      summarizeOutcomes({ external_access_permission_approval: 5, external_access_permission_request: 3 }),
+    ).toEqual([]);
+    expect(hasOutcomes({ external_access_permission_request: 3 })).toBe(false);
+  });
+
   it("folds unmapped write tools into a single 'other actions' bucket", () => {
     const out = summarizeOutcomes({ create_backlog_item: 2, some_unmapped_write: 5 });
     expect(out).toContainEqual({ label: "other actions", count: 5, sensitive: false });

--- a/apps/web/lib/platform-runtime/action-outcome-map.ts
+++ b/apps/web/lib/platform-runtime/action-outcome-map.ts
@@ -76,10 +76,19 @@ const TOOL_OUTCOMES: Record<string, { one: string; many: string }> = {
 /** Prefixes that mark a read/lookup tool — never an accomplishment. */
 const READ_PREFIXES = ["get_", "list_", "search_", "query_", "read_", "describe_", "find_", "doc_search", "wiki_query", "assess_", "check_", "trace_"];
 
+// Synthetic / system-audit tool executions that are not accomplishments even
+// though they are not reads — belt-and-suspenders alongside the loader's
+// executionMode filter, in case such a row reaches this map (BI-A1B4BE05).
+const NON_OUTCOME_TOOLS = new Set<string>([
+  "external_access_permission_approval",
+  "external_access_permission_request",
+]);
+
 export type Outcome = { label: string; count: number; sensitive: boolean };
 
-function isReadTool(toolName: string): boolean {
-  return READ_PREFIXES.some((p) => toolName.startsWith(p));
+/** A tool call that never counts as an accomplishment (a lookup or a system/audit event). */
+function isNonOutcomeTool(toolName: string): boolean {
+  return NON_OUTCOME_TOOLS.has(toolName) || READ_PREFIXES.some((p) => toolName.startsWith(p));
 }
 
 function pluralize(label: { one: string; many: string }, count: number): string {
@@ -103,7 +112,7 @@ export function summarizeOutcomes(
   let otherSensitive = false;
 
   for (const [toolName, count] of Object.entries(toolCounts)) {
-    if (count <= 0 || isReadTool(toolName)) continue;
+    if (count <= 0 || isNonOutcomeTool(toolName)) continue;
     const sensitive = SENSITIVE_DATA_TOOLS.has(toolName);
     const label = TOOL_OUTCOMES[toolName];
     if (label) {
@@ -133,6 +142,6 @@ export function summarizeOutcomes(
 /** Whether a set of tool counts contains any real accomplishment. */
 export function hasOutcomes(toolCounts: Record<string, number>): boolean {
   return Object.entries(toolCounts).some(
-    ([toolName, count]) => count > 0 && !isReadTool(toolName),
+    ([toolName, count]) => count > 0 && !isNonOutcomeTool(toolName),
   );
 }

--- a/apps/web/lib/platform-runtime/workforce-activity.test.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.test.ts
@@ -104,6 +104,25 @@ describe("loadWorkforceActivity", () => {
     expect(wf.quiet.find((c) => c.agentId === "orphan")?.humanSupervisorId).toBeNull();
   });
 
+  it("excludes background/permission executionModes from the outcome query (BI-A1B4BE05)", async () => {
+    const wheres: Array<Record<string, unknown>> = [];
+    const prisma = {
+      agent: { findMany: async () => [agent({ agentId: "a" })] },
+      taskRun: { findMany: async () => [] },
+      toolExecution: {
+        groupBy: async (args: { where: Record<string, unknown> }) => {
+          wheres.push(args.where);
+          return [];
+        },
+      },
+      tokenUsage: { groupBy: async () => [] },
+    } as never;
+    await loadWorkforceActivity({ prisma, now: () => NOW });
+    // the tool-by-tool outcome query is the one filtered to success:true
+    const outcomeWhere = wheres.find((w) => w.success === true);
+    expect(outcomeWhere?.executionMode).toEqual({ notIn: ["background", "permission"] });
+  });
+
   it("orders working by tokens spent today, busiest first", async () => {
     const prisma = fakePrisma({
       agents: [agent({ agentId: "a1", displayName: "A1" }), agent({ agentId: "a2", displayName: "A2" })],

--- a/apps/web/lib/platform-runtime/workforce-activity.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.ts
@@ -110,7 +110,15 @@ export async function loadWorkforceActivity(
     }),
     prisma.toolExecution.groupBy({
       by: ["agentId", "toolName"],
-      where: { createdAt: { gte: startOfDay }, success: true },
+      // ToolExecution is a general governed-tool ledger: it also records background
+      // system jobs (executionMode "background") and permission/access AUDIT events
+      // (executionMode "permission"). Those are not coworker accomplishments, so
+      // they never count toward "did today" / "actions today" (BI-A1B4BE05).
+      where: {
+        createdAt: { gte: startOfDay },
+        success: true,
+        executionMode: { notIn: ["background", "permission"] },
+      },
       _count: { _all: true },
     }),
     prisma.toolExecution.groupBy({


### PR DESCRIPTION
## What & why
Follow-up to the merged workforce view (BI-1A68257F, #4040). The "did today" outcome digest is built from `ToolExecution`, which is a general **governed-tool ledger** — it also records background system jobs (`executionMode: "background"`) and permission/access **audit** events (`executionMode: "permission"`, synthetic toolNames like `external_access_permission_approval`). Those aren't coworker accomplishments, and they were inflating both the per-coworker digest and the "actions today" pulse.

This keeps the digest to genuine agent-initiated actions — which is what the founder asked the view to show (accomplishments, not noise).

- `workforce-activity.ts`: the outcome `groupBy` excludes `executionMode in {background, permission}`.
- `action-outcome-map.ts`: `isReadTool` → `isNonOutcomeTool`, which also drops the synthetic access-audit toolNames (belt-and-suspenders in case such a row reaches the map).

## Verification (done before first push, per the #4040 lesson)
- `action-outcome-map.test.ts` + `workforce-activity.test.ts` — **13 pass**: new audit-exclusion unit test + a loader test asserting the query carries the `executionMode notIn` filter. Existing outcome/sensitivity/read-exclusion behavior unchanged.
- `check-guards` (source), `module-size`, `style-drift` all pass locally. Lib-only change — no route/nav/UI, so no route-manifest / page-purpose / ux-fit / ux-budget surface touched.

## Grounding
Process-Spine-Decision: edits existing observability loaders under `apps/web/lib/platform-runtime`; no new capability/contract, no route, no user-facing doc surface to update.

BI-A1B4BE05 · EP-FULL-OBS · follow-up to #4040

🤖 Generated with [Claude Code](https://claude.com/claude-code)