### PR TITLE
docs(spec): federation enablement must be zero-shell, auto-discovery-first (design increment)

### DIFF
--- a/docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md
+++ b/docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md
@@ -1,0 +1,80 @@
+# Federation Enablement & Pairing — Zero-Shell, Auto-Discovery-First (design increment)
+
+| Field | Value |
+| --- | --- |
+| Status | Draft for founder review |
+| Date | 2026-08-06 |
+| Amends | `docs/superpowers/specs/2026-07-19-federated-demand-network-design.md` (§5, R-FDN-09) |
+| Trigger | Founder two-instance verification — two same-organization installs (a Mac host and a Windows host) on one LAN |
+
+## 1. Why this increment exists
+
+The founder end-to-end verification proved the federation *machinery* works, but it also proved the *enablement and pairing experience is unshippable to the actual DPF customer*. To connect two installs a developer had to: edit `.env` (`DPF_FEDERATION_EXCHANGE_ENABLED`, `PUBLIC_URL`, `PUBLIC_URL_ALIASES`), `docker compose --force-recreate` the portal, hand-type each peer's LAN IP, and force self-upgrades past the release-batch valve. One of those env changes (`PUBLIC_URL`) silently broke the Inngest executor fleet-wide-style (all background jobs dead) until another manual override.
+
+**None of that is possible for the target user** — a plumber, an HVAC/AC tech, a shop owner who does not open terminals. It also directly violates the design's own ratified requirement:
+
+> **R-FDN-09:** require no IP address, GitHub credential, shell command, certificate management, or database expertise from normal operators.
+> **§5:** "A non-technical operator can connect the right DPF installations in a few guided actions."
+
+And it regressed from the design's intended entry point — **automatic nearby discovery (§5.1, mDNS/DNS-SD `_dpf-federation._tcp.local.`)** — to **manual URL entry**, which is the opposite of the vision.
+
+This increment resets the enablement + pairing contract to zero-shell, auto-discovery-first, and makes the platform responsible for all configuration.
+
+## 2. Target experience (the "plumber test")
+
+Two DPF installs on the same shop network. Neither operator types anything but a tap:
+
+1. Each install **auto-advertises and auto-browses** on the LAN (mDNS). No IP, no config.
+2. In the portal, the operator sees **"We found another DPF on your network — <friendly name>."** (Discovery is a candidate only; it grants no trust.)
+3. Operator taps **Connect** → answers one plain question: **"Is this another DPF you own?" [Yes]**.
+4. The other install's operator sees **"<name> wants to connect" → [Approve]** (dual approval).
+5. Done. Demand syncs. No IP typed, no `.env`, no Docker, no certificate handling, no forced upgrade.
+
+Manual invitation / URL entry survives **only** as an out-of-band recovery path for routed/off-LAN cases — never the primary flow, and never required on a same-LAN same-org pairing.
+
+## 3. What the platform MUST do automatically (no operator action)
+
+Behind that single Connect tap, the platform — not the operator — is responsible for:
+
+1. **Self Authority URL:** auto-derive the install's LAN-reachable URL (private IPv4). The operator never types `PUBLIC_URL` or an IP. (The design already called for this — "derive a LAN-reachable private IPv4 Authority URL when no explicit `DPF_LAN_AUTHORITY_URL` is configured" — it must actually be wired into the enroll path, not left to `resolveAppBaseUrl` returning null.)
+2. **Internal-service safety (closes the incident class):** configuring an authority/public URL must **never** subject internal service callbacks to the canonical-host redirect. `/api/inngest` (and every internal service route) is exempt like `/api/health` already is, and/or the internal service host is auto-aliased. Enabling federation must be incapable of killing background jobs.
+3. **Feature enablement:** the federation flag is set by the guided action, not by hand-editing an env file.
+4. **Transport trust:** secure auto-pairing needs certificate-valid HTTPS, but the operator must not manage certificates. The platform auto-provisions org HTTPS (embedded Step CA / org-PKI) as part of the guided join, or uses a reviewed certificate-free PAKE. No cert files, no CA passwords, no shell.
+5. **Discovery capability provisioned everywhere:** every install's Edge Node must carry `federation.discovery` by default (observed gap: the Windows install's edge had only `discovery.network`, so it could not participate in nearby discovery at all).
+
+## 4. Explicit non-goals (removed from the operator path)
+
+The following must **not** appear in any customer-facing enablement or pairing flow (recovery-only, at most, and never on the same-LAN same-org happy path):
+
+- Editing `.env` or any file (`DPF_FEDERATION_EXCHANGE_ENABLED`, `PUBLIC_URL`, `PUBLIC_URL_ALIASES`, …).
+- `docker` / `docker compose` commands or container recreation.
+- Typing a peer's IP address or URL.
+- Certificate / CA management.
+- Forcing or sequencing self-upgrades by hand.
+
+## 5. Fleet-protecting platform fix (independent of federation)
+
+The `PUBLIC_URL` canonical-host redirect currently 301s **every internal API consumer whose Host is not the canonical URL** — observed tonight breaking at least:
+- `/api/inngest` (internal `portal:3000` callback) → Inngest signature validation fails → **all** Inngest-driven work (self-upgrade, backups, watchdogs, evals, the federation reconciliation job) silently dies;
+- `/api/mcp/v1` (`127.0.0.1:3000`) → the `dpf` MCP tool surface disconnects **and** the local-CI/pregate `gate-worktree` reconciliation fails closed (`invalid JSON response … (status 301)`), so the platform can no longer verify its own changes.
+
+An operator-facing `PUBLIC_URL_ALIASES` band-aid is both insufficient (it did not cover every internal host/path) and off-limits (it requires typing config). This is **pre-existing** (canonical-URL middleware, #822) and hits **any** install that sets `PUBLIC_URL` for a public domain — federation or not. It must be fixed at the platform level (exempt internal service routes — `/api/inngest`, `/api/mcp/*`, and the internal-callback family — from the canonical redirect, the way `/api/health` already is) as a **P1 fleet hazard**, separate from and ahead of the federation UX work.
+
+## 6. Dependencies & sequencing
+
+- The zero-shell secure auto-pairing depends on auto-provisioned HTTPS, which depends on the machine-bound signed Edge action channel (`BI-F12A8D0D`, unstarted) → governed org-join host actions (`BI-A8399604`) → the no-shell Connections workflow (`BI-87B0DBD7`). These were always the gating items; this increment makes them the critical path for customer-facing federation.
+- Until they land, federation stays **founder-test-only** (the manual path is acceptable for founder verification, never for a customer).
+
+## 7. Verification — the plumber test
+
+- A non-technical operator connects two same-org installs on one LAN using **taps only**: discover → Connect → "Yes, mine" → peer Approves. No shell, no `.env`, no IP, no certificate, no forced upgrade at any step.
+- Turning federation on **never** degrades background processing: Inngest executes throughout; `/api/inngest` is never redirected; the "background jobs need attention" alert never fires as a side effect of enablement.
+- Every install ships with `federation.discovery` on its Edge Node and appears as a nearby candidate to same-LAN peers.
+
+## 8. Backlog items to file (governed MCP was offline at authoring)
+
+1. **P1 platform:** exempt `/api/inngest` and internal service callbacks from the `PUBLIC_URL` canonical-host redirect (fleet hazard; kills background jobs on any public-domain install).
+2. Auto-derive and wire the LAN Authority URL into the federation enroll path (no operator `PUBLIC_URL`).
+3. Provision `federation.discovery` on every install's Edge Node by default.
+4. Zero-shell guided Connect: discovery candidate → Connect → same-org confirm → dual approve, with platform auto-config of flag/URL/alias/HTTPS (ties into `BI-87B0DBD7`).
+5. Retire manual URL/`.env` entry from the customer path; keep as documented recovery only.


### PR DESCRIPTION
## Summary

A design increment amending the Federated Demand Network spec (§5, R-FDN-09), written from the founder two-instance verification. That exercise proved the federation *machinery* works — and proved the *enablement/pairing experience is unshippable to the field-service customer*: connecting two installs required `.env` edits, `docker compose --force-recreate`, hand-typed peer IPs, and forced upgrades, and one of those env settings (`PUBLIC_URL`) silently broke internal services.

## What it locks in

- **Zero-shell, auto-discovery-first.** The operator taps to connect; the platform (not the operator) auto-derives the LAN URL, sets the flag, exempts internal callbacks, and provisions HTTPS. Manual URL/`.env`/Docker/cert steps are explicit non-goals (recovery-only). This restores §5.1 nearby discovery (mDNS) as the entry point instead of manual IP entry, and honors R-FDN-09.
- **P1 fleet fix (independent of federation).** The `PUBLIC_URL` canonical-host redirect 301s internal API consumers — observed tonight breaking `/api/inngest` (all background jobs), `/api/mcp/v1` (the MCP tool surface **and** the local-CI gate). It must be fixed at the platform level (exempt internal service routes like `/api/health` already is). This is pre-existing (canonical-URL middleware, #822) and hits any public-domain install.
- **The plumber test** as the verification bar; §8 lists the BIs to file (P1 canonical-redirect fix first) once the governed MCP is reachable.

## Verification / gate note

Docs-only (1 file). The private-identity guard was verified passing standalone after scrubbing install-specific identifiers. Local-CI (`pregate`) was blocked by local GPU eval-runner timeouts and an unserializable gate verdict — infrastructure flake, not content — so this relies on **GitHub CI as the merge gate** (`DPF_SKIP_PREPUSH_GATE` with recorded reason). No code, route, or runtime changed.

Docs-Impact-Decision: New design-increment spec under docs/superpowers/specs/; no user-guide page exists for this unbuilt capability yet and no runtime/route changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)