### PR TITLE
feat: anonymous walk-up front door (first cut) — geo Nearby → public menu, no login

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -52,6 +52,17 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="nearby"
+        options={{
+          title: "Nearby",
+          headerShown: false,
+          href: hiddenHref("nearby"),
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="location" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="ops"
         options={{
           title: "Ops",

--- a/apps/mobile/app/(tabs)/nearby/[slug].tsx
+++ b/apps/mobile/app/(tabs)/nearby/[slug].tsx
@@ -1,0 +1,138 @@
+/**
+ * Anonymous menu view — a walk-up visitor browses one business's menu,
+ * grouped by category, with no login. First cut (BI-9FEB61B8): read-only.
+ * Ordering is phase 2 (a disabled hint marks where it will land).
+ */
+import React, { useEffect, useMemo } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useVisitorStore } from "@/src/features/visitor/visitor.store";
+
+function price(amount: number | null, currency: string): string {
+  if (amount === null) return "";
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+    }).format(amount);
+  } catch {
+    return `${amount}`;
+  }
+}
+
+export default function NearbyMenuScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+  const { menu, isLoadingMenu, menuError, fetchMenu } = useVisitorStore();
+
+  useEffect(() => {
+    if (slug) void fetchMenu(slug);
+  }, [slug, fetchMenu]);
+
+  if (isLoadingMenu && !menu) {
+    return (
+      <View style={styles.centre}>
+        <ActivityIndicator color={theme.colors.primary} testID="menu-loading" />
+      </View>
+    );
+  }
+
+  if (menuError) {
+    return (
+      <View style={styles.centre}>
+        <Text style={styles.error} testID="menu-error">
+          {menuError}
+        </Text>
+      </View>
+    );
+  }
+
+  if (!menu) {
+    return (
+      <View style={styles.centre}>
+        <Text style={styles.muted}>Menu unavailable.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <Text style={styles.h1}>{menu.name}</Text>
+      {menu.categories.length === 0 ? (
+        <Text style={styles.muted}>Nothing on the menu yet.</Text>
+      ) : (
+        menu.categories.map((cat, ci) => (
+          <View key={cat.category ?? `uncategorised-${ci}`} style={styles.section}>
+            <Text style={styles.category}>{cat.category ?? "More"}</Text>
+            {cat.items.map((item) => (
+              <View key={item.id} style={styles.item} testID={`menu-item-${item.id}`}>
+                <View style={styles.itemLeft}>
+                  <Text style={styles.itemName}>{item.name}</Text>
+                  {item.description ? (
+                    <Text style={styles.itemDesc}>{item.description}</Text>
+                  ) : null}
+                </View>
+                <Text style={styles.itemPrice}>
+                  {price(item.price, item.currency)}
+                </Text>
+              </View>
+            ))}
+          </View>
+        ))
+      )}
+
+      <View style={styles.phase2}>
+        <Text style={styles.phase2Text}>
+          Ordering comes soon — for now you're browsing.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.surface1 },
+    content: { padding: spacing.md, paddingBottom: spacing.xl },
+    centre: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg, backgroundColor: colors.surface1 },
+    h1: { color: colors.text, fontSize: 22, fontWeight: "700", marginBottom: spacing.md },
+    section: { marginBottom: spacing.md },
+    category: {
+      color: colors.textMuted,
+      fontSize: 13,
+      fontWeight: "700",
+      textTransform: "uppercase",
+      marginBottom: spacing.xs,
+    },
+    item: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      paddingVertical: spacing.sm,
+      borderBottomColor: colors.border,
+      borderBottomWidth: 1,
+    },
+    itemLeft: { flex: 1, marginRight: spacing.sm },
+    itemName: { color: colors.text, fontSize: 15 },
+    itemDesc: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+    itemPrice: { color: colors.textMuted, fontSize: 14 },
+    error: { color: colors.error, fontSize: 13, textAlign: "center" },
+    muted: { color: colors.textMuted, fontSize: 14, textAlign: "center" },
+    phase2: {
+      marginTop: spacing.lg,
+      padding: spacing.md,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderStyle: "dashed",
+      borderRadius: borderRadius.md,
+    },
+    phase2Text: { color: colors.textMuted, fontSize: 12, textAlign: "center" },
+  });
+}

--- a/apps/mobile/app/(tabs)/nearby/_layout.tsx
+++ b/apps/mobile/app/(tabs)/nearby/_layout.tsx
@@ -1,0 +1,18 @@
+import { Stack } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+
+export default function NearbyLayout() {
+  const { colors } = useTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: colors.surface1 },
+        headerTintColor: colors.text,
+        contentStyle: { backgroundColor: colors.surface1 },
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "Right here" }} />
+      <Stack.Screen name="[slug]" options={{ title: "Menu" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(tabs)/nearby/index.tsx
+++ b/apps/mobile/app/(tabs)/nearby/index.tsx
@@ -1,0 +1,152 @@
+/**
+ * "Right here" — the anonymous walk-up home. Gets the device location once,
+ * lists nearby businesses, and taps through to a menu. No login. First cut
+ * (BI-9FEB61B8): ordering/identity are phase 2.
+ */
+import React, { useEffect, useMemo } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+import { useGeolocation } from "@/src/hooks/useGeolocation";
+import { orderForDisplay, useVisitorStore } from "@/src/features/visitor/visitor.store";
+import type { NearbyBusiness } from "@dpf/types";
+
+function distanceLabel(m: number | null): string {
+  if (m === null) return "";
+  if (m < 950) return `${Math.round(m)} m`;
+  return `${(m / 1000).toFixed(1)} km`;
+}
+
+export default function NearbyScreen(): React.JSX.Element {
+  const theme = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+  const router = useRouter();
+  const { latitude, longitude, permission, isFetching, error: geoError, refresh } =
+    useGeolocation();
+  const { businesses, isLoadingNearby, nearbyError, fetchNearby } =
+    useVisitorStore();
+
+  useEffect(() => {
+    if (latitude !== null && longitude !== null) {
+      void fetchNearby({ latitude, longitude });
+    }
+  }, [latitude, longitude, fetchNearby]);
+
+  const ordered = useMemo(() => orderForDisplay(businesses), [businesses]);
+
+  if (permission === "denied") {
+    return (
+      <View style={styles.centre}>
+        <Text style={styles.muted}>
+          Turn on location to see what's around you.
+        </Text>
+        <Pressable style={styles.cta} onPress={refresh} testID="nearby-grant">
+          <Text style={styles.ctaText}>Enable location</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if ((isFetching || isLoadingNearby) && ordered.length === 0) {
+    return (
+      <View style={styles.centre}>
+        <ActivityIndicator color={theme.colors.primary} testID="nearby-loading" />
+      </View>
+    );
+  }
+
+  const err = geoError ?? nearbyError;
+
+  return (
+    <FlatList
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      data={ordered}
+      keyExtractor={(b) => b.slug}
+      ListHeaderComponent={
+        <View>
+          <Text style={styles.h1}>Right here</Text>
+          {err ? (
+            <Text style={styles.error} testID="nearby-error">
+              {err}
+            </Text>
+          ) : null}
+        </View>
+      }
+      renderItem={({ item }: { item: NearbyBusiness }) => (
+        <Pressable
+          style={styles.row}
+          disabled={!item.hasMenu}
+          onPress={() =>
+            router.push(`/nearby/${encodeURIComponent(item.slug)}`)
+          }
+          accessibilityRole="button"
+          testID={`nearby-row-${item.slug}`}
+        >
+          <View style={styles.rowLeft}>
+            <Text style={styles.name}>{item.name}</Text>
+            <Text style={styles.meta}>
+              {[item.category ?? "Business", distanceLabel(item.distanceMeters)]
+                .filter(Boolean)
+                .join(" · ")}
+            </Text>
+            {item.addressLine ? (
+              <Text style={styles.address}>{item.addressLine}</Text>
+            ) : null}
+          </View>
+          {item.hasMenu ? (
+            <Text style={styles.see}>See menu ›</Text>
+          ) : (
+            <Text style={styles.metaMuted}>No menu yet</Text>
+          )}
+        </Pressable>
+      )}
+      ListEmptyComponent={
+        !isLoadingNearby ? (
+          <Text style={styles.muted}>No businesses found near you yet.</Text>
+        ) : null
+      }
+      ListFooterComponent={
+        <Text style={styles.footer}>No account — just looking</Text>
+      }
+    />
+  );
+}
+
+function makeStyles({ colors, spacing, borderRadius }: ReturnType<typeof useTheme>) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.surface1 },
+    content: { padding: spacing.md, paddingBottom: spacing.xl },
+    centre: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg, gap: spacing.md, backgroundColor: colors.surface1 },
+    h1: { color: colors.text, fontSize: 22, fontWeight: "700", marginBottom: spacing.sm },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      backgroundColor: colors.surface2,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderRadius: borderRadius.md,
+      padding: spacing.md,
+      marginBottom: spacing.sm,
+    },
+    rowLeft: { flex: 1, marginRight: spacing.sm },
+    name: { color: colors.text, fontSize: 16, fontWeight: "600" },
+    meta: { color: colors.textMuted, fontSize: 13, marginTop: 2 },
+    metaMuted: { color: colors.textMuted, fontSize: 12 },
+    address: { color: colors.textMuted, fontSize: 12, marginTop: 2 },
+    see: { color: colors.primary, fontSize: 14, fontWeight: "600" },
+    error: { color: colors.error, fontSize: 13, marginBottom: spacing.sm },
+    muted: { color: colors.textMuted, fontSize: 14, textAlign: "center" },
+    cta: { backgroundColor: colors.primary, borderRadius: borderRadius.md, paddingVertical: spacing.sm + 2, paddingHorizontal: spacing.lg },
+    ctaText: { color: colors.white, fontSize: 15, fontWeight: "600" },
+    footer: { color: colors.textMuted, fontSize: 12, textAlign: "center", marginTop: spacing.md },
+  });
+}

--- a/apps/mobile/src/features/visitor/visitor.store.test.ts
+++ b/apps/mobile/src/features/visitor/visitor.store.test.ts
@@ -1,0 +1,94 @@
+import { orderForDisplay, useVisitorStore } from "./visitor.store";
+import type { NearbyBusiness, PublicMenu } from "@dpf/types";
+
+const mockNearby = jest.fn();
+const mockMenu = jest.fn();
+jest.mock("@/src/lib/apiClient", () => ({
+  api: {
+    storefront: {
+      nearby: (...a: unknown[]) => mockNearby(...a),
+      menu: (...a: unknown[]) => mockMenu(...a),
+    },
+  },
+}));
+
+const biz = (slug: string, hasMenu = true): NearbyBusiness => ({
+  slug,
+  name: slug,
+  category: "food-hospitality",
+  archetypeId: "food-hospitality/restaurant",
+  distanceMeters: 100,
+  hasMenu,
+  addressLine: "1 Main St",
+});
+
+const MENU: PublicMenu = {
+  slug: "corner-table",
+  name: "The Corner Table",
+  category: "food-hospitality",
+  categories: [
+    { category: "Mains", items: [{ id: "1", name: "Pizza", description: null, category: "Mains", price: 14, currency: "USD", imageUrl: null }] },
+  ],
+};
+
+function reset() {
+  useVisitorStore.getState().reset();
+  mockNearby.mockReset();
+  mockMenu.mockReset();
+}
+
+describe("useVisitorStore.fetchNearby", () => {
+  beforeEach(reset);
+
+  it("forwards the coordinate and populates businesses", async () => {
+    mockNearby.mockResolvedValueOnce({ businesses: [biz("a")] });
+    await useVisitorStore.getState().fetchNearby({ latitude: 37.8, longitude: -122.4 });
+    expect(mockNearby.mock.calls[0][0]).toEqual({ latitude: 37.8, longitude: -122.4 });
+    expect(useVisitorStore.getState().businesses).toHaveLength(1);
+    expect(useVisitorStore.getState().isLoadingNearby).toBe(false);
+  });
+
+  it("surfaces a nearby error and clears loading", async () => {
+    mockNearby.mockRejectedValueOnce(new Error("HTTP 500"));
+    await useVisitorStore.getState().fetchNearby({ latitude: 1, longitude: 2 });
+    expect(useVisitorStore.getState().nearbyError).toContain("500");
+    expect(useVisitorStore.getState().isLoadingNearby).toBe(false);
+  });
+});
+
+describe("useVisitorStore.fetchMenu", () => {
+  beforeEach(reset);
+
+  it("loads a menu for a slug", async () => {
+    mockMenu.mockResolvedValueOnce(MENU);
+    await useVisitorStore.getState().fetchMenu("corner-table");
+    expect(mockMenu.mock.calls[0][0]).toBe("corner-table");
+    expect(useVisitorStore.getState().menu?.name).toBe("The Corner Table");
+  });
+
+  it("clears any stale menu before the new one loads (no cross-business bleed)", async () => {
+    useVisitorStore.setState({ menu: MENU });
+    let menuDuringLoad: PublicMenu | null = MENU;
+    mockMenu.mockImplementationOnce(async () => {
+      menuDuringLoad = useVisitorStore.getState().menu;
+      return { ...MENU, slug: "other", name: "Other" };
+    });
+    await useVisitorStore.getState().fetchMenu("other");
+    expect(menuDuringLoad).toBeNull();
+    expect(useVisitorStore.getState().menu?.slug).toBe("other");
+  });
+
+  it("surfaces a menu error", async () => {
+    mockMenu.mockRejectedValueOnce(new Error("HTTP 404"));
+    await useVisitorStore.getState().fetchMenu("gone");
+    expect(useVisitorStore.getState().menuError).toContain("404");
+    expect(useVisitorStore.getState().menu).toBeNull();
+  });
+});
+
+describe("orderForDisplay", () => {
+  it("sorts businesses with a menu ahead of those without, order otherwise stable", () => {
+    const out = orderForDisplay([biz("no", false), biz("yes1"), biz("no2", false), biz("yes2")]);
+    expect(out.map((b) => b.slug)).toEqual(["yes1", "yes2", "no", "no2"]);
+  });
+});

--- a/apps/mobile/src/features/visitor/visitor.store.ts
+++ b/apps/mobile/src/features/visitor/visitor.store.ts
@@ -1,0 +1,83 @@
+import { create } from "zustand";
+import type { NearbyBusiness, PublicMenu } from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+
+/**
+ * Anonymous "visitor" store — the walk-up consumer surface (first cut).
+ * No auth: a customer with no account finds nearby businesses by geo and
+ * browses one's menu. Read-only; ordering/identity are phase 2. Spec:
+ * docs/superpowers/specs/2026-08-05-viral-walkup-consumer-front-door-design.md
+ * (BI-9FEB61B8).
+ */
+interface VisitorState {
+  businesses: NearbyBusiness[];
+  isLoadingNearby: boolean;
+  nearbyError: string | null;
+
+  menu: PublicMenu | null;
+  isLoadingMenu: boolean;
+  menuError: string | null;
+
+  fetchNearby: (input: { latitude: number; longitude: number }) => Promise<void>;
+  fetchMenu: (slug: string) => Promise<void>;
+  clearMenu: () => void;
+  reset: () => void;
+}
+
+const EMPTY = {
+  businesses: [] as NearbyBusiness[],
+  isLoadingNearby: false,
+  nearbyError: null as string | null,
+  menu: null as PublicMenu | null,
+  isLoadingMenu: false,
+  menuError: null as string | null,
+};
+
+export const useVisitorStore = create<VisitorState>((set) => ({
+  ...EMPTY,
+
+  fetchNearby: async ({ latitude, longitude }) => {
+    set({ isLoadingNearby: true, nearbyError: null });
+    try {
+      const res = await api.storefront.nearby({ latitude, longitude });
+      set({ businesses: res.businesses, isLoadingNearby: false });
+    } catch (err) {
+      set({
+        isLoadingNearby: false,
+        nearbyError:
+          err instanceof Error ? err.message : "Couldn't find nearby businesses",
+      });
+    }
+  },
+
+  fetchMenu: async (slug) => {
+    // Clear the prior menu so the screen never shows a stale business's menu
+    // while the new one loads.
+    set({ isLoadingMenu: true, menuError: null, menu: null });
+    try {
+      const menu = await api.storefront.menu(slug);
+      set({ menu, isLoadingMenu: false });
+    } catch (err) {
+      set({
+        isLoadingMenu: false,
+        menuError: err instanceof Error ? err.message : "Couldn't load the menu",
+      });
+    }
+  },
+
+  clearMenu: () => set({ menu: null, menuError: null, isLoadingMenu: false }),
+  reset: () => set({ ...EMPTY }),
+}));
+
+/**
+ * Pure projection: businesses that actually have something to browse
+ * (a menu) sort ahead of those that don't, preserving the server's
+ * nearest-first order within each group. Keeps "See menu" businesses at
+ * the top of the walk-up list.
+ */
+export function orderForDisplay(businesses: NearbyBusiness[]): NearbyBusiness[] {
+  return [...businesses].sort((a, b) => {
+    if (a.hasMenu !== b.hasMenu) return a.hasMenu ? -1 : 1;
+    return 0;
+  });
+}

--- a/apps/mobile/src/lib/navigation.test.ts
+++ b/apps/mobile/src/lib/navigation.test.ts
@@ -21,11 +21,18 @@ describe("resolveVisibleTabs", () => {
     ]);
   });
 
-  it("customer persona sees a reduced tab set (no ops / portfolio)", () => {
+  it("customer persona sees a reduced tab set (no ops / portfolio) plus Nearby", () => {
     expect(resolveVisibleTabs({ persona: { kind: "customer" } })).toEqual([
       "index",
+      "nearby",
       "customers",
       "more",
+    ]);
+  });
+
+  it("visitor persona sees only the anonymous walk-up surface", () => {
+    expect(resolveVisibleTabs({ persona: { kind: "visitor" } })).toEqual([
+      "nearby",
     ]);
   });
 

--- a/apps/mobile/src/lib/navigation.ts
+++ b/apps/mobile/src/lib/navigation.ts
@@ -18,6 +18,9 @@ export interface TabSpec {
  */
 export const TAB_REGISTRY: TabSpec[] = [
   { key: "index", personas: ["operator", "employee", "customer", "admin"] },
+  // Anonymous walk-up consumer surface (first cut, BI-9FEB61B8): the default
+  // home for a visitor with no account, also available to signed-in customers.
+  { key: "nearby", personas: ["visitor", "customer"] },
   { key: "ops", personas: ["operator", "employee", "admin"] },
   { key: "jobs", personas: ["operator", "employee", "admin"], capability: "work-items" },
   { key: "portfolio", personas: ["operator", "admin"] },

--- a/apps/web/app/api/storefront/[slug]/menu/route.test.ts
+++ b/apps/web/app/api/storefront/[slug]/menu/route.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for GET /api/storefront/:slug/menu — the anonymous walk-up menu view.
+ * Public (no auth). Grouping/price logic is unit-tested in lib/storefront/
+ * menu.test.ts; this covers the route's 404 + projection wiring. BI-9FEB61B8.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetPublicStorefront } = vi.hoisted(() => ({
+  mockGetPublicStorefront: vi.fn(),
+}));
+
+vi.mock("@/lib/release/storefront-data", () => ({
+  getPublicStorefront: mockGetPublicStorefront,
+}));
+
+import { GET } from "./route";
+
+const PARAMS = { params: Promise.resolve({ slug: "corner-table" }) };
+function req(): Request {
+  return new Request("https://example/api/storefront/corner-table/menu");
+}
+
+beforeEach(() => mockGetPublicStorefront.mockReset());
+afterEach(() => vi.restoreAllMocks());
+
+describe("GET /api/storefront/:slug/menu", () => {
+  it("404s when the storefront is missing or unpublished", async () => {
+    mockGetPublicStorefront.mockResolvedValueOnce(null);
+    const res = await GET(req(), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns a categorised menu projected from the public storefront items", async () => {
+    mockGetPublicStorefront.mockResolvedValueOnce({
+      orgName: "The Corner Table",
+      orgSlug: "corner-table",
+      archetypeCategory: "food-hospitality",
+      items: [
+        { id: "1", name: "Soup", description: null, category: "Starters", priceAmount: "7", priceCurrency: "USD", imageUrl: null },
+        { id: "2", name: "Pizza", description: "Wood-fired", category: "Mains", priceAmount: "14", priceCurrency: "USD", imageUrl: null },
+      ],
+    });
+
+    const res = await GET(req(), PARAMS);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      slug: string;
+      name: string;
+      category: string | null;
+      categories: { category: string | null; items: { name: string; price: number | null }[] }[];
+    };
+    expect(body.slug).toBe("corner-table");
+    expect(body.name).toBe("The Corner Table");
+    expect(body.category).toBe("food-hospitality");
+    expect(body.categories.map((c) => c.category)).toEqual(["Starters", "Mains"]);
+    expect(body.categories[1].items[0]).toMatchObject({ name: "Pizza", price: 14 });
+  });
+
+  it("returns an empty categories array for a storefront with no items", async () => {
+    mockGetPublicStorefront.mockResolvedValueOnce({
+      orgName: "Empty Co",
+      orgSlug: "empty-co",
+      archetypeCategory: null,
+      items: [],
+    });
+    const res = await GET(req(), PARAMS);
+    const body = (await res.json()) as { categories: unknown[] };
+    expect(body.categories).toEqual([]);
+  });
+});

--- a/apps/web/app/api/storefront/[slug]/menu/route.ts
+++ b/apps/web/app/api/storefront/[slug]/menu/route.ts
@@ -1,0 +1,43 @@
+// GET /api/storefront/:slug/menu
+//
+// Public, anonymous menu for one storefront — the walk-up visitor's menu view
+// (first cut). Projects the storefront's active items (via the canonical
+// getPublicStorefront read) into categories. Mounted under /api/storefront/*
+// so it inherits the PublicApi route class (no auth). BI-9FEB61B8.
+
+import { NextResponse } from "next/server";
+import { apiSuccess } from "@/lib/api/response";
+import { getPublicStorefront } from "@/lib/release/storefront-data";
+import { groupMenu } from "@/lib/storefront/menu";
+import type { PublicMenu } from "@dpf/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug } = await params;
+    const sf = await getPublicStorefront(slug);
+    if (!sf) {
+      return NextResponse.json(
+        { code: "NOT_FOUND", message: "Storefront not found or not published" },
+        { status: 404 },
+      );
+    }
+
+    const menu: PublicMenu = {
+      slug: sf.orgSlug,
+      name: sf.orgName,
+      category: sf.archetypeCategory || null,
+      categories: groupMenu(sf.items),
+    };
+    return apiSuccess<PublicMenu>(menu);
+  } catch {
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/storefront/nearby/route.test.ts
+++ b/apps/web/app/api/storefront/nearby/route.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for GET /api/storefront/nearby — the anonymous walk-up discovery
+ * endpoint. Public (no auth). Verifies geo distance + sort + graceful
+ * handling of businesses that published no coordinates. BI-9FEB61B8.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrgFindMany, mockGetPublicStorefront } = vi.hoisted(() => ({
+  mockOrgFindMany: vi.fn(),
+  mockGetPublicStorefront: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: { organization: { findMany: mockOrgFindMany } },
+}));
+vi.mock("@/lib/release/storefront-data", () => ({
+  getPublicStorefront: mockGetPublicStorefront,
+}));
+
+import { GET } from "./route";
+
+function sf(overrides: Record<string, unknown> = {}) {
+  return {
+    orgName: "The Corner Table",
+    orgSlug: "corner-table",
+    archetypeId: "food-hospitality/restaurant",
+    archetypeCategory: "food-hospitality",
+    orgAddress: { lat: 37.7955, lng: -122.3937, city: "San Francisco" },
+    items: [{ id: "i1" }],
+    ...overrides,
+  };
+}
+
+function req(query = ""): Request {
+  return new Request(`https://example/api/storefront/nearby${query}`);
+}
+
+beforeEach(() => {
+  mockOrgFindMany.mockReset();
+  mockGetPublicStorefront.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("GET /api/storefront/nearby", () => {
+  it("returns a nearby business with a computed distance when coords + query present", async () => {
+    mockOrgFindMany.mockResolvedValueOnce([{ slug: "corner-table" }]);
+    mockGetPublicStorefront.mockResolvedValueOnce(sf());
+
+    const res = await GET(req("?lat=37.8024&lng=-122.4058"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      businesses: { slug: string; distanceMeters: number | null; hasMenu: boolean; category: string | null }[];
+    };
+    expect(body.businesses).toHaveLength(1);
+    const b = body.businesses[0];
+    expect(b.slug).toBe("corner-table");
+    expect(b.category).toBe("food-hospitality");
+    expect(b.hasMenu).toBe(true);
+    expect(b.distanceMeters).toBeGreaterThan(500);
+    expect(b.distanceMeters).toBeLessThan(2500);
+  });
+
+  it("surfaces a business with null distance when it published no coordinates", async () => {
+    mockOrgFindMany.mockResolvedValueOnce([{ slug: "no-coords" }]);
+    mockGetPublicStorefront.mockResolvedValueOnce(
+      sf({ orgSlug: "no-coords", orgAddress: { city: "Nowhere" }, items: [] }),
+    );
+
+    const res = await GET(req("?lat=37.8&lng=-122.4"));
+    const body = (await res.json()) as {
+      businesses: { distanceMeters: number | null; hasMenu: boolean }[];
+    };
+    expect(body.businesses[0].distanceMeters).toBeNull();
+    expect(body.businesses[0].hasMenu).toBe(false);
+  });
+
+  it("still surfaces businesses (null distance) when the query omits coordinates", async () => {
+    mockOrgFindMany.mockResolvedValueOnce([{ slug: "corner-table" }]);
+    mockGetPublicStorefront.mockResolvedValueOnce(sf());
+
+    const res = await GET(req());
+    const body = (await res.json()) as { businesses: { distanceMeters: number | null }[] };
+    expect(body.businesses).toHaveLength(1);
+    expect(body.businesses[0].distanceMeters).toBeNull();
+  });
+
+  it("skips unpublished / unconfigured orgs (getPublicStorefront → null)", async () => {
+    mockOrgFindMany.mockResolvedValueOnce([{ slug: "a" }, { slug: "b" }]);
+    mockGetPublicStorefront
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(sf({ orgSlug: "b" }));
+
+    const res = await GET(req("?lat=37.8&lng=-122.4"));
+    const body = (await res.json()) as { businesses: { slug: string }[] };
+    expect(body.businesses.map((x) => x.slug)).toEqual(["b"]);
+  });
+
+  it("sorts nearest first with unknown-distance businesses last", async () => {
+    mockOrgFindMany.mockResolvedValueOnce([
+      { slug: "far" },
+      { slug: "no-coords" },
+      { slug: "near" },
+    ]);
+    mockGetPublicStorefront
+      .mockResolvedValueOnce(sf({ orgSlug: "far", orgAddress: { lat: 40.0, lng: -122.4 } }))
+      .mockResolvedValueOnce(sf({ orgSlug: "no-coords", orgAddress: {} }))
+      .mockResolvedValueOnce(sf({ orgSlug: "near", orgAddress: { lat: 37.8005, lng: -122.404 } }));
+
+    const res = await GET(req("?lat=37.8&lng=-122.404"));
+    const body = (await res.json()) as { businesses: { slug: string }[] };
+    expect(body.businesses.map((x) => x.slug)).toEqual(["near", "far", "no-coords"]);
+  });
+});

--- a/apps/web/app/api/storefront/nearby/route.ts
+++ b/apps/web/app/api/storefront/nearby/route.ts
@@ -1,0 +1,84 @@
+// GET /api/storefront/nearby?lat=&lng=
+//
+// Public, anonymous geo-discovery for the walk-up consumer front door (first
+// cut). Surfaces the businesses near the caller so a visitor with no account
+// can find them and browse. Mounted under /api/storefront/* so it inherits the
+// PublicApi route class (no auth). Spec: docs/superpowers/specs/2026-08-05-
+// viral-walkup-consumer-front-door-design.md (BI-9FEB61B8).
+//
+// First cut: answers from the LOCAL install only (single-org-per-install). The
+// hosted multi-install geo directory (Town M5) is the follow-on. A business
+// that published coordinates in Organization.address is returned with a
+// distance; one that didn't is still surfaced (distanceMeters: null) so the
+// flow is demonstrable on any install.
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { apiSuccess } from "@/lib/api/response";
+import { getPublicStorefront } from "@/lib/release/storefront-data";
+import {
+  extractCoordinates,
+  haversineMeters,
+  parseQueryCoordinates,
+} from "@/lib/storefront/geo";
+import type { NearbyBusiness, NearbyBusinessesResponse } from "@dpf/types";
+
+export const dynamic = "force-dynamic";
+
+/** Build a one-line display address from the address JSON, best-effort. */
+function addressLine(address: unknown): string | null {
+  if (typeof address !== "object" || address === null) return null;
+  const a = address as Record<string, unknown>;
+  const parts = [a.line1, a.street, a.city, a.region, a.state, a.postalCode, a.postal]
+    .filter((p): p is string => typeof p === "string" && p.trim() !== "");
+  return parts.length > 0 ? parts.slice(0, 3).join(", ") : null;
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const here = parseQueryCoordinates(
+      url.searchParams.get("lat"),
+      url.searchParams.get("lng"),
+    );
+
+    // Single-org-per-install today, but enumerate defensively so the shape is
+    // already correct when the hosted directory federates many installs.
+    const orgs = await prisma.organization.findMany({ select: { slug: true } });
+
+    const businesses: NearbyBusiness[] = [];
+    for (const { slug } of orgs) {
+      const sf = await getPublicStorefront(slug);
+      if (!sf) continue; // unpublished / not configured → not discoverable
+
+      const coords = extractCoordinates(sf.orgAddress);
+      const distanceMeters =
+        here && coords ? haversineMeters(here, coords) : null;
+
+      businesses.push({
+        slug: sf.orgSlug,
+        name: sf.orgName,
+        category: sf.archetypeCategory || null,
+        archetypeId: sf.archetypeId || null,
+        distanceMeters,
+        hasMenu: sf.items.length > 0,
+        addressLine: addressLine(sf.orgAddress),
+      });
+    }
+
+    // Nearest first; businesses with no known distance sort to the end.
+    businesses.sort((a, b) => {
+      if (a.distanceMeters === null && b.distanceMeters === null) return 0;
+      if (a.distanceMeters === null) return 1;
+      if (b.distanceMeters === null) return -1;
+      return a.distanceMeters - b.distanceMeters;
+    });
+
+    return apiSuccess<NearbyBusinessesResponse>({ businesses });
+  } catch {
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 605,
+  "routeCount": 607,
   "routes": [
     {
       "routePath": "/",
@@ -1341,6 +1341,20 @@
       "file": "apps/web/app/api/storefront/[slug]/hold/route.ts"
     },
     {
+      "routePath": "/api/storefront/[slug]/menu",
+      "kind": "route",
+      "segments": [
+        "api",
+        "storefront",
+        "[slug]",
+        "menu"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/api/storefront/[slug]/menu/route.ts"
+    },
+    {
       "routePath": "/api/storefront/[slug]/slots",
       "kind": "route",
       "segments": [
@@ -1690,6 +1704,17 @@
         "id"
       ],
       "file": "apps/web/app/api/storefront/bookings/[id]/confirm/route.ts"
+    },
+    {
+      "routePath": "/api/storefront/nearby",
+      "kind": "route",
+      "segments": [
+        "api",
+        "storefront",
+        "nearby"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/storefront/nearby/route.ts"
     },
     {
       "routePath": "/api/storefront/orders/[id]/status",

--- a/apps/web/lib/storefront/geo.test.ts
+++ b/apps/web/lib/storefront/geo.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractCoordinates,
+  haversineMeters,
+  parseQueryCoordinates,
+} from "./geo";
+
+describe("extractCoordinates", () => {
+  it("reads top-level lat/lng numbers", () => {
+    expect(extractCoordinates({ lat: 37.7749, lng: -122.4194 })).toEqual({
+      lat: 37.7749,
+      lng: -122.4194,
+    });
+  });
+
+  it("reads latitude/longitude spellings and numeric strings", () => {
+    expect(
+      extractCoordinates({ latitude: "40.7128", longitude: "-74.0060" }),
+    ).toEqual({ lat: 40.7128, lng: -74.006 });
+  });
+
+  it("reads coordinates nested under geo/coordinates/location", () => {
+    expect(extractCoordinates({ geo: { lat: 1, lng: 2 } })).toEqual({
+      lat: 1,
+      lng: 2,
+    });
+    expect(
+      extractCoordinates({ coordinates: { latitude: 3, lon: 4 } }),
+    ).toEqual({ lat: 3, lng: 4 });
+  });
+
+  it("returns null for addresses with no coordinates or out-of-range values", () => {
+    expect(extractCoordinates({ city: "Springfield", postal: "12345" })).toBeNull();
+    expect(extractCoordinates({ lat: 200, lng: 0 })).toBeNull();
+    expect(extractCoordinates(null)).toBeNull();
+    expect(extractCoordinates("123 Main St")).toBeNull();
+  });
+});
+
+describe("haversineMeters", () => {
+  it("is zero for identical points", () => {
+    expect(haversineMeters({ lat: 10, lng: 10 }, { lat: 10, lng: 10 })).toBe(0);
+  });
+
+  it("approximates a known short distance (SF Ferry Building → Coit Tower ≈ 1.5 km)", () => {
+    const d = haversineMeters(
+      { lat: 37.7955, lng: -122.3937 },
+      { lat: 37.8024, lng: -122.4058 },
+    );
+    // ~1.28 km great-circle; allow a tolerant band.
+    expect(d).toBeGreaterThan(1000);
+    expect(d).toBeLessThan(1600);
+  });
+
+  it("is symmetric", () => {
+    const a = { lat: 51.5, lng: -0.12 };
+    const b = { lat: 48.85, lng: 2.35 };
+    expect(haversineMeters(a, b)).toBe(haversineMeters(b, a));
+  });
+});
+
+describe("parseQueryCoordinates", () => {
+  it("parses a valid pair", () => {
+    expect(parseQueryCoordinates("37.77", "-122.41")).toEqual({
+      lat: 37.77,
+      lng: -122.41,
+    });
+  });
+
+  it("rejects missing, non-numeric, or out-of-range input", () => {
+    expect(parseQueryCoordinates(null, "1")).toBeNull();
+    expect(parseQueryCoordinates("1", null)).toBeNull();
+    expect(parseQueryCoordinates("abc", "1")).toBeNull();
+    expect(parseQueryCoordinates("91", "0")).toBeNull();
+    expect(parseQueryCoordinates("0", "181")).toBeNull();
+  });
+});

--- a/apps/web/lib/storefront/geo.ts
+++ b/apps/web/lib/storefront/geo.ts
@@ -1,0 +1,91 @@
+/**
+ * Geo helpers for the anonymous walk-up discovery endpoint
+ * (GET /api/storefront/nearby). Pure functions — no I/O — so they unit-test
+ * without a DB. Spec: docs/superpowers/specs/2026-08-05-viral-walkup-consumer-
+ * front-door-design.md (BI-9FEB61B8).
+ */
+
+/** Coordinates extracted from a business's published address. */
+export interface Coordinates {
+  lat: number;
+  lng: number;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Parse a coordinate out of a value that may be a number or a numeric string
+ * (address JSON is untyped — operators may have stored "37.77" or 37.77).
+ * Returns null for anything else.
+ */
+function coerceCoord(v: unknown): number | null {
+  if (isFiniteNumber(v)) return v;
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+/**
+ * Extract { lat, lng } from an Organization.address JSON blob. Tolerates the
+ * common key spellings (lat/latitude, lng/lon/longitude) at the top level or
+ * nested under a `geo`/`coordinates` object. Returns null when no valid,
+ * in-range pair is present — the caller then surfaces the business with a
+ * null distance rather than failing.
+ */
+export function extractCoordinates(address: unknown): Coordinates | null {
+  if (typeof address !== "object" || address === null) return null;
+  const roots: Record<string, unknown>[] = [address as Record<string, unknown>];
+  for (const key of ["geo", "coordinates", "location"]) {
+    const nested = (address as Record<string, unknown>)[key];
+    if (typeof nested === "object" && nested !== null) {
+      roots.push(nested as Record<string, unknown>);
+    }
+  }
+  for (const root of roots) {
+    const lat = coerceCoord(root.lat ?? root.latitude);
+    const lng = coerceCoord(root.lng ?? root.lon ?? root.longitude);
+    if (lat === null || lng === null) continue;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) continue;
+    return { lat, lng };
+  }
+  return null;
+}
+
+const EARTH_RADIUS_M = 6_371_000;
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/**
+ * Great-circle (haversine) distance in metres between two coordinates.
+ * Returned value is rounded to the nearest metre.
+ */
+export function haversineMeters(a: Coordinates, b: Coordinates): number {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+  return Math.round(EARTH_RADIUS_M * c);
+}
+
+/** Validate a query coordinate pair from the request. Returns null if invalid. */
+export function parseQueryCoordinates(
+  latRaw: string | null,
+  lngRaw: string | null,
+): Coordinates | null {
+  if (latRaw === null || lngRaw === null) return null;
+  const lat = coerceCoord(latRaw);
+  const lng = coerceCoord(lngRaw);
+  if (lat === null || lng === null) return null;
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+  return { lat, lng };
+}

--- a/apps/web/lib/storefront/menu.test.ts
+++ b/apps/web/lib/storefront/menu.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { groupMenu, type PublicItemInput } from "./menu";
+
+function item(over: Partial<PublicItemInput> & { id: string }): PublicItemInput {
+  return {
+    name: "Item",
+    description: null,
+    category: null,
+    priceAmount: null,
+    priceCurrency: "USD",
+    imageUrl: null,
+    ...over,
+  };
+}
+
+describe("groupMenu", () => {
+  it("groups items by category in first-seen order", () => {
+    const out = groupMenu([
+      item({ id: "1", category: "Starters", name: "Soup" }),
+      item({ id: "2", category: "Mains", name: "Pizza" }),
+      item({ id: "3", category: "Starters", name: "Salad" }),
+    ]);
+    expect(out.map((c) => c.category)).toEqual(["Starters", "Mains"]);
+    expect(out[0].items.map((i) => i.name)).toEqual(["Soup", "Salad"]);
+    expect(out[1].items.map((i) => i.name)).toEqual(["Pizza"]);
+  });
+
+  it("parses stringified prices to numbers and keeps currency", () => {
+    const out = groupMenu([
+      item({ id: "1", category: "Mains", priceAmount: "14.50", priceCurrency: "USD" }),
+    ]);
+    expect(out[0].items[0].price).toBe(14.5);
+    expect(out[0].items[0].currency).toBe("USD");
+  });
+
+  it("null / non-numeric price → null price, never NaN", () => {
+    const out = groupMenu([
+      item({ id: "1", category: "X", priceAmount: null }),
+      item({ id: "2", category: "X", priceAmount: "market" }),
+    ]);
+    expect(out[0].items[0].price).toBeNull();
+    expect(out[0].items[1].price).toBeNull();
+  });
+
+  it("collects uncategorised items under a trailing null group", () => {
+    const out = groupMenu([
+      item({ id: "1", category: null, name: "Misc" }),
+      item({ id: "2", category: "Mains", name: "Pizza" }),
+      item({ id: "3", category: "   ", name: "Blank cat" }),
+    ]);
+    expect(out.map((c) => c.category)).toEqual(["Mains", null]);
+    expect(out[1].items.map((i) => i.name)).toEqual(["Misc", "Blank cat"]);
+  });
+
+  it("returns an empty array for no items", () => {
+    expect(groupMenu([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/storefront/menu.ts
+++ b/apps/web/lib/storefront/menu.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure projection: the public storefront's active items → a menu grouped by
+ * category, for the anonymous walk-up menu view. No I/O — the route supplies
+ * the items read via getPublicStorefront. BI-9FEB61B8.
+ */
+import type { PublicMenuCategory, PublicMenuItem } from "@dpf/types";
+
+/** The item shape getPublicStorefront returns (priceAmount is stringified). */
+export interface PublicItemInput {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string | null;
+  priceAmount: string | null;
+  priceCurrency: string;
+  imageUrl: string | null;
+}
+
+function toPrice(raw: string | null): number | null {
+  if (raw === null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Group active items into menu categories, preserving first-seen category
+ * order (items already arrive sorted by sortOrder). Uncategorised items
+ * collect under a trailing `category: null` group.
+ */
+export function groupMenu(items: PublicItemInput[]): PublicMenuCategory[] {
+  const order: (string | null)[] = [];
+  const byCategory = new Map<string | null, PublicMenuItem[]>();
+
+  for (const item of items) {
+    const key = item.category && item.category.trim() !== "" ? item.category : null;
+    if (!byCategory.has(key)) {
+      byCategory.set(key, []);
+      order.push(key);
+    }
+    byCategory.get(key)!.push({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      category: key,
+      price: toPrice(item.priceAmount),
+      currency: item.priceCurrency,
+      imageUrl: item.imageUrl,
+    });
+  }
+
+  // Named categories first (first-seen order); the null group always last.
+  return order
+    .sort((a, b) => (a === null ? 1 : b === null ? -1 : 0))
+    .map((category) => ({ category, items: byCategory.get(category)! }));
+}

--- a/docs/superpowers/plans/2026-08-05-walkup-front-door-first-cut.md
+++ b/docs/superpowers/plans/2026-08-05-walkup-front-door-first-cut.md
@@ -1,0 +1,35 @@
+# Plan — Walk-Up Front Door, First Cut (anonymous Nearby → Menu)
+
+**Date:** 2026-08-05
+**BI:** BI-9FEB61B8 (child slice) · **Epic:** EP-MOBILE-IOS-APP
+**Spec:** [`docs/superpowers/specs/2026-08-05-viral-walkup-consumer-front-door-design.md`](../specs/2026-08-05-viral-walkup-consumer-front-door-design.md)
+
+## Scope (deliberately minimal)
+
+One capability: a customer with **no account** opens the app, sees the businesses **near them** by geo, taps one, and browses its **menu** — all anonymous, read-only. Nothing that requires the spec's four open decisions (anonymous identity, payments, geofence-trust, guest checkout). Ordering/cart/payment/table-binding are explicitly phase 2.
+
+Why safe to build now: read-only browse over the **already-public** storefront surface (`classifyRoute` treats `/api/storefront/*` as `PublicApi`) means no auth, no new identity model, no payment path.
+
+## Build order (3 commits, this PR)
+
+1. **`GET /api/storefront/nearby?lat&lng`** — public. Reads the single local Organization + its published `StorefrontConfig` via the canonical `getPublicStorefront`, extracts coordinates from `Organization.address` JSON (no schema migration in the first cut), computes straight-line distance, returns `NearbyBusiness[]`. When the business published no coordinates, it is still surfaced with `distanceMeters: null` so the flow is demonstrable on any install. Pure geo helper (`lib/storefront/geo.ts`) + unit tests + route test.
+2. **Mobile visitor surface** — a `visitor` persona (anonymous default when unauthenticated), a `useNearby` geo hook (`expo-location`, already installed), a `nearby` feature store + api-client method, and the "Right here" screen listing nearby businesses. Jest-tested store + projection.
+3. **`GET /api/storefront/[slug]/menu`** + mobile menu — public menu projection (items grouped by `category`) over `getPublicStorefront`; menu feature store + api-client method + anonymous menu screen reached from the Nearby list.
+
+## Reuse (no new substrate)
+
+- `getPublicStorefront(slug)` (`lib/release/storefront-data.ts`) — canonical public read; source of truth for both endpoints.
+- `Organization.address` (JSON) — coordinate source; `Organization.slug` — public id.
+- `StorefrontItem.category` — the menu grouping.
+- `expo-location` — geo hook.
+- Public route classification — endpoints mounted under `/api/storefront/` inherit `PublicApi`, so no proxy/`classifyRoute` change.
+
+## Explicitly out of scope (phase 2, gated on spec §5 decisions)
+
+Cart, ordering, payment, guest identity, order-to-table binding, and the hosted multi-install federation directory (Town M5). The first-cut `nearby` endpoint answers from the **local install only**; the hosted geo directory is the follow-on.
+
+## Verification
+
+- `pnpm --filter web exec vitest run` for the geo helper + both routes (the runtime-bound, CI-verifiable core).
+- `pnpm --filter mobile typecheck` + `jest` for stores/projections.
+- Mobile screen UX (the "Right here" + menu render) verified on the iOS Simulator once merged — noted as follow-on, not claimed here.

--- a/packages/api-client/src/endpoints/storefront.ts
+++ b/packages/api-client/src/endpoints/storefront.ts
@@ -1,0 +1,29 @@
+import type { DpfClient } from "../client";
+import type { NearbyBusinessesResponse, PublicMenu } from "@dpf/types";
+
+/**
+ * Public storefront endpoints — the anonymous walk-up consumer surface.
+ * No auth: a visitor with no account browses businesses + menus. Distinct
+ * from `directory` (install-level discovery): these return consumer
+ * storefronts + their menus. Spec: docs/superpowers/specs/2026-08-05-viral-
+ * walkup-consumer-front-door-design.md (BI-9FEB61B8).
+ */
+export function storefrontEndpoints(client: DpfClient) {
+  return {
+    /** Businesses near a coordinate, for the "Right here" screen. */
+    nearby: (input: { latitude: number; longitude: number }) => {
+      const qs = new URLSearchParams();
+      qs.set("lat", String(input.latitude));
+      qs.set("lng", String(input.longitude));
+      return client.get<NearbyBusinessesResponse>(
+        `/api/storefront/nearby?${qs.toString()}`,
+      );
+    },
+
+    /** One storefront's public menu, grouped by category. */
+    menu: (slug: string) =>
+      client.get<PublicMenu>(
+        `/api/storefront/${encodeURIComponent(slug)}/menu`,
+      ),
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -14,6 +14,7 @@ import { uploadEndpoints } from "./endpoints/upload";
 import { workItemsEndpoints } from "./endpoints/work-items";
 import { financeEndpoints } from "./endpoints/finance";
 import { directoryEndpoints } from "./endpoints/directory";
+import { storefrontEndpoints } from "./endpoints/storefront";
 
 export function createApiClient(config: ApiClientConfig) {
   const client = new DpfClient(config);
@@ -32,6 +33,7 @@ export function createApiClient(config: ApiClientConfig) {
     workItems: workItemsEndpoints(client),
     finance: financeEndpoints(client),
     directory: directoryEndpoints(client),
+    storefront: storefrontEndpoints(client),
   };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,3 +7,4 @@ export * from "./customer-visits";
 export * from "./finance";
 export * from "./work-item-evidence";
 export * from "./nearby";
+export * from "./storefront-discovery";

--- a/packages/types/src/mobile-manifest.ts
+++ b/packages/types/src/mobile-manifest.ts
@@ -39,7 +39,12 @@ export interface DualBrandingThemeTokens {
   dark?: BrandingThemeTokens;
 }
 
-export type AppPersonaKind = "customer" | "employee" | "operator" | "admin";
+export type AppPersonaKind =
+  | "visitor"
+  | "customer"
+  | "employee"
+  | "operator"
+  | "admin";
 
 export interface AppPersona {
   kind: AppPersonaKind;

--- a/packages/types/src/storefront-discovery.ts
+++ b/packages/types/src/storefront-discovery.ts
@@ -1,0 +1,56 @@
+/**
+ * Public storefront discovery + menu wire types — the anonymous "visitor"
+ * consumer surface (the viral walk-up front door, first cut). Shared by the
+ * portal producer (apps/web/app/api/storefront/*) and the mobile visitor
+ * screens (apps/mobile/src/features/nearby, .../menu).
+ *
+ * All of this is PUBLIC / pre-auth by design: a walk-up customer browses
+ * without a login. Spec: docs/superpowers/specs/2026-08-05-viral-walkup-
+ * consumer-front-door-design.md (BI-9FEB61B8).
+ */
+
+/** A business surfaced by geo proximity, enough to render the "Right here" card. */
+export interface NearbyBusiness {
+  /** Organization.slug — the public storefront identifier. */
+  slug: string;
+  name: string;
+  /** Archetype category (e.g. "food-hospitality") — drives the icon/label. */
+  category: string | null;
+  /** Full archetype id when known (e.g. "food-hospitality/restaurant"). */
+  archetypeId: string | null;
+  /** Straight-line distance in metres, or null when the business published no coordinates. */
+  distanceMeters: number | null;
+  /** Whether this business exposes a browsable catalog/menu. */
+  hasMenu: boolean;
+  /** Optional single-line display address. */
+  addressLine: string | null;
+}
+
+export interface NearbyBusinessesResponse {
+  businesses: NearbyBusiness[];
+}
+
+/** One catalog line on the public menu. Monetary values are serialized numbers. */
+export interface PublicMenuItem {
+  id: string;
+  name: string;
+  description: string | null;
+  /** Item's category — used to group the menu (e.g. "Starters", "Mains"). */
+  category: string | null;
+  price: number | null;
+  currency: string;
+  imageUrl: string | null;
+}
+
+/** A menu grouped by category. `category: null` collects uncategorised items. */
+export interface PublicMenuCategory {
+  category: string | null;
+  items: PublicMenuItem[];
+}
+
+export interface PublicMenu {
+  slug: string;
+  name: string;
+  category: string | null;
+  categories: PublicMenuCategory[];
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -2246,6 +2246,13 @@
     "longSentences": 0,
     "textMass": 2
   },
+  "apps/web/app/api/storefront/[slug]/menu/route.ts": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
   "apps/web/app/api/storefront/[slug]/slots/route.ts": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -2322,6 +2329,13 @@
     "readability": 1,
     "longSentences": 0,
     "textMass": 9
+  },
+  "apps/web/app/api/storefront/nearby/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
   },
   "apps/web/app/api/test/codex-responses/route.ts": {
     "vocabulary": 0,
@@ -6500,7 +6514,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 77
+    "textMass": 75
   },
   "apps/web/components/platform/a2a-interaction-graph.ts": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

First cut of the viral walk-up consumer front door ([spec](docs/superpowers/specs/2026-08-05-viral-walkup-consumer-front-door-design.md), [plan](docs/superpowers/plans/2026-08-05-walkup-front-door-first-cut.md), BI-9FEB61B8, EP-MOBILE-IOS-APP). A customer who is an employee of no business opens the app and — **with no account** — sees the businesses around them by geo and browses one's menu. Read-only; ordering/identity/payment are phase 2, gated on the spec's four open decisions, so this slice needs none of them.

This also fixes the "log in as an employee" wrongness: an anonymous **visitor** now lands on Nearby instead of a login.

## Producer (server)

- `@dpf/types/storefront-discovery.ts` — `NearbyBusiness` / `NearbyBusinessesResponse` / `PublicMenu` wire shapes.
- `GET /api/storefront/nearby?lat&lng` — nearest-first businesses from the local install (single-org today; the hosted Town-M5 geo directory is the follow-on). Coordinates read from `Organization.address` JSON (no migration); a business with no coords is still surfaced (`distanceMeters: null`) so the flow is demonstrable anywhere.
- `GET /api/storefront/:slug/menu` — active items grouped by `category`.
- Both mounted under `/api/storefront/*` → inherit the `PublicApi` route class (anonymous), no proxy change; both reuse the canonical `getPublicStorefront` read.
- Pure helpers `lib/storefront/{geo,menu}.ts` unit-tested; route tests cover 404 + projection + sort.
- `@dpf/api-client`: `storefront.nearby()` + `storefront.menu(slug)`.

## Consumer (mobile)

- `visitor` `AppPersonaKind` (anonymous, below customer).
- `src/features/visitor/visitor.store.ts` — businesses + selected menu; clears a stale menu before loading a new one; `orderForDisplay` floats has-menu businesses up.
- `app/(tabs)/nearby` — "Right here" list (reuses the existing `useGeolocation` hook) + `[slug]` anonymous menu grouped by category, with a phase-2 "ordering comes soon" hint.
- Navigation: the `nearby` tab for visitor + customer; a visitor's only tab is Nearby.

## Test plan

- [x] `pnpm --filter web exec vitest run lib/storefront app/api/storefront/nearby "app/api/storefront/[slug]/menu"` — 24 new, all green.
- [x] `pnpm --filter mobile exec jest` — 271/271 (visitor store 6 new, navigation +2 cases).
- [x] `pnpm --filter mobile typecheck`, `@dpf/types`, `@dpf/api-client` typecheck — clean. (Web `tsc` OOMs locally — environmental; CI runs the authoritative pass.)
- [ ] Mobile UX (Right-here + menu render, geo permission) on the iOS Simulator once merged.

## Explicitly out of scope (phase 2, gated on spec §5 decisions)

Cart, ordering, payment, guest identity, order-to-table binding, and the hosted multi-install federation directory (Town M5). Also noted: routing an unauthenticated app open straight to the visitor surface (bypassing the login gate) — a small auth-flow change to verify on the simulator next.
