### PR TITLE
feat(coworker): /ops/self-upgrade domain context (injector #2) + route-context inheritance guard (BI-5457E216)

### DIFF
--- a/apps/web/lib/tak/route-context-inheritance.conformance.test.ts
+++ b/apps/web/lib/tak/route-context-inheritance.conformance.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { resolveRouteContext } from "./route-context-map";
+import routeManifest from "@/lib/ea/route-manifest.json";
+
+/**
+ * Coworker page-perception inheritance guard.
+ *
+ * Source of truth: docs/superpowers/specs/2026-08-05-coworker-page-perception-
+ * context-contract-design.md §6.2 (exact-route resolution, NO data inheritance)
+ * and §8 (a child route must never inherit a sibling's page context). Tracked by
+ * BI-5457E216 under EP-8C706944. This is the mechanical guard slice, buildable
+ * now against the central registry before the full page-owned-contract rebuild
+ * (Option B) lands.
+ *
+ * THE BUG CLASS THIS PREVENTS (BI-FD7E4D72, and 3 recurrences to date):
+ * both coworker context injectors resolve "what page am I on" by LONGEST-PREFIX
+ * match. Some entries assert a *specific page identity* — the "/ops" entry's
+ * domainContext says the page "shows the delivery backlog". A new child route
+ * under such a parent that has no entry of its own silently inherits that
+ * identity, so the coworker on /ops/self-upgrade confidently described the
+ * delivery backlog. The default fallback never fires because a (wrong) match was
+ * found — nothing looks broken at runtime.
+ *
+ * This anchors on resolveRouteContext (route-context-map.ts, the domain-context
+ * injector) — its ROUTE_CONTEXT_MAP + resolveRouteContext are already exported,
+ * and the same longest-prefix mislabel exists in the PAGE DATA provider registry
+ * (route-context.ts). The guard scopes to IDENTITY-ASSERTING parents (whose
+ * domainContext names a specific page that would be wrong for a sibling), NOT
+ * all inheritance: broad-domain entries (finance) or sub-route-aware providers
+ * (compliance) legitimately serve their children and are out of scope. Adding a
+ * newly-identified greedy parent is a one-line change below.
+ */
+
+// Entries whose domainContext asserts a specific page identity, so a child that
+// inherits it is actively MISLABELED (not merely under-briefed). Keep this tight
+// — only add a prefix once its entry is confirmed to assert an identity that
+// contradicts its sub-routes.
+const IDENTITY_ASSERTING_PARENTS: readonly string[] = [
+  // ROUTE_CONTEXT_MAP["/ops"].domainContext → "shows the delivery backlog"
+  // (proven 3× offender via longest-prefix fallthrough).
+  "/ops",
+];
+
+// Children that inherit an identity-asserting parent and have been reviewed.
+//   OK             — inheriting the parent's identity is genuinely correct here.
+//   NEEDS-PROVIDER — known mislabel debt: this route should get its own entry.
+//                    Tracked under BI-5457E216 / the page-perception epic. Listed
+//                    here so the guard stays green while blocking NEW drift, and
+//                    so the debt is counted and visible rather than silent.
+const ACKNOWLEDGED_IDENTITY_INHERITORS: Record<string, string> = {
+  // NEEDS-PROVIDER: the /ops/* orphans that inherit the "delivery backlog"
+  // identity today. Design doc §3 / §7 Phase 1 calls for carving each out like
+  // /ops/dev-loop and /ops/self-upgrade already were. Until then, known debt.
+  "/ops/changes": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/demand": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/health": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/improvements": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/journeys": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/patches": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/promotions": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+  "/ops/security": "NEEDS-PROVIDER: inherits Operations/backlog identity; needs own entry (BI-5457E216)",
+};
+
+type ManifestRow = {
+  routePath: string;
+  kind: string;
+  file?: string;
+  dynamicParams?: string[];
+};
+
+/**
+ * Static shell page routes: the pages a coworker panel renders on. Dynamic
+ * detail routes ([id]) are excluded — they legitimately share their parent
+ * entity's context, so they are not the mislabel class this guard targets.
+ */
+function shellStaticPageRoutes(): string[] {
+  const rows = (routeManifest as { routes: ManifestRow[] }).routes;
+  return rows
+    .filter(
+      (r) =>
+        r.kind === "page" &&
+        (r.file ?? "").includes("app/(shell)/") &&
+        (r.dynamicParams ?? []).length === 0,
+    )
+    .map((r) => r.routePath);
+}
+
+/** The route-context entry a route resolves to (longest-prefix match). */
+function resolvedPrefix(route: string): string {
+  return resolveRouteContext(route).routePrefix;
+}
+
+describe("coworker route-context inheritance guard", () => {
+  const routes = shellStaticPageRoutes();
+
+  it("has a non-empty route manifest to check against", () => {
+    // Guards the guard: if the manifest ever fails to load, the coverage checks
+    // below would vacuously pass. Fail loudly instead.
+    expect(routes.length).toBeGreaterThan(50);
+  });
+
+  it("every child of an identity-asserting parent is enrolled or explicitly acknowledged", () => {
+    const violations: string[] = [];
+
+    for (const route of routes) {
+      const prefix = resolvedPrefix(route);
+      if (route === prefix) continue; // has its own entry — exact match, fine
+      if (!IDENTITY_ASSERTING_PARENTS.includes(prefix)) continue; // broad/sub-route-aware or the default fallback — out of scope
+      if (route in ACKNOWLEDGED_IDENTITY_INHERITORS) continue; // reviewed
+      violations.push(
+        `${route} silently inherits ${prefix}'s page identity (a mislabel). ` +
+          `Give it its own entry in ROUTE_CONTEXT_MAP (route-context-map.ts) — ` +
+          `and, for the PAGE DATA injector, a provider in ROUTE_CONTEXT_PROVIDERS ` +
+          `(route-context.ts) — or add it to ACKNOWLEDGED_IDENTITY_INHERITORS with a reason.`,
+      );
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("has no stale acknowledgements (every acknowledged route still exists and still inherits)", () => {
+    const routeSet = new Set(routes);
+    const stale: string[] = [];
+
+    for (const route of Object.keys(ACKNOWLEDGED_IDENTITY_INHERITORS)) {
+      if (!routeSet.has(route)) {
+        stale.push(`${route}: no longer a static shell route — remove from ACKNOWLEDGED_IDENTITY_INHERITORS`);
+        continue;
+      }
+      const prefix = resolvedPrefix(route);
+      if (route === prefix) {
+        stale.push(`${route}: now has its own entry — remove from ACKNOWLEDGED_IDENTITY_INHERITORS`);
+        continue;
+      }
+      if (!IDENTITY_ASSERTING_PARENTS.includes(prefix)) {
+        stale.push(`${route}: no longer inherits an identity-asserting parent — remove from ACKNOWLEDGED_IDENTITY_INHERITORS`);
+      }
+    }
+
+    expect(stale, stale.join("\n")).toEqual([]);
+  });
+
+  it("surfaces the current mislabel debt (visible, non-blocking blast-radius record)", () => {
+    const needsProvider = Object.entries(ACKNOWLEDGED_IDENTITY_INHERITORS)
+      .filter(([, reason]) => reason.startsWith("NEEDS-PROVIDER"))
+      .map(([route]) => route);
+    if (needsProvider.length > 0) {
+      // Intentional visibility — the blast-radius record the design doc asks
+      // planning to be able to see. Not a failure; it's tracked debt.
+      console.warn(
+        `[coworker-perception] ${needsProvider.length} route(s) still inherit an identity-asserting ` +
+          `entry's page identity and need their own entry:\n  ${needsProvider.join("\n  ")}`,
+      );
+    }
+    // The count is expected to only ever go DOWN. Pinning the known ceiling makes
+    // adding a new NEEDS-PROVIDER a conscious, reviewed act rather than silent
+    // accretion.
+    expect(needsProvider.length).toBeLessThanOrEqual(8);
+  });
+});

--- a/apps/web/lib/tak/route-context-map.ts
+++ b/apps/web/lib/tak/route-context-map.ts
@@ -518,6 +518,54 @@ export const ROUTE_CONTEXT_MAP: Record<string, RouteContextDef> = {
     ],
   },
 
+  // /ops/self-upgrade governs how the portal updates ITSELF (image/source
+  // deploy), not the delivery backlog. Same class of bug as /ops/dev-loop
+  // (BI-FD7E4D72): without its own entry, longest-prefix match falls to "/ops"
+  // and the coworker describes the delivery backlog on an upgrade page. This is
+  // the DOMAIN-CONTEXT map (injector #2); PR #4048 fixes the PAGE DATA provider
+  // (injector #1) for the same route. Guarded by
+  // route-context-inheritance.conformance.test.ts (BI-5457E216).
+  "/ops/self-upgrade": {
+    routePrefix: "/ops/self-upgrade",
+    domain: "Self-Upgrade — Portal Release Status",
+    sensitivity: "internal",
+    domainContext:
+      "This page is the governed portal self-upgrade console: whether upgrade automation is enabled and on which channel, the running platform version, the latest and last-successful upgrade runs, whether an update is available, whether it is safe to apply now (maintenance window / quiescence blockers), whether the operator can keep working during it, and whether it can be rolled back. It is NOT the delivery backlog — do not answer questions here with backlog items or epics. Use the PAGE DATA block as ground truth for the running version and run history. In merge mode the deployed identity is a local merge commit that CONTAINS but never equals the upstream target, so a raw SHA comparison can read 'update available' forever — the build is fresh when the upstream lineage it already absorbed equals the target. For the live 'is a batch pending / is an upgrade eligible' answer prefer get_self_upgrade_queue_status; for what is holding an in-flight upgrade use get_quiescence_status.",
+    domainTools: [
+      "get_self_upgrade_queue_status",
+      "get_quiescence_status",
+      "request_self_upgrade",
+      "repair_promoter_image",
+      "search_code_graph",
+      "trace_code_surface",
+      "doc_search",
+      "search_knowledge",
+    ],
+    docsPath: "/docs/operations/index",
+    skills: [
+      {
+        label: "Is an update available?",
+        description: "Explain the current upgrade status and whether one is pending",
+        capability: "view_operations",
+        taskType: "analysis",
+        prompt: "Look at the PAGE DATA for this Self-Upgrade page. In plain language tell me: is upgrade automation on, what version is running, and whether an update is available or a release batch is still accumulating. If the page data doesn't settle it, call get_self_upgrade_queue_status for the live batch/eligibility tally. Don't describe the delivery backlog — this page is about portal updates.",
+      },
+      {
+        label: "What's holding the upgrade?",
+        description: "Explain blockers on an in-flight or pending upgrade",
+        capability: "view_operations",
+        taskType: "analysis",
+        prompt: "Explain what, if anything, is blocking a self-upgrade right now — maintenance window, quiescence drain, cooldown, or job-engine health. Use get_quiescence_status and get_self_upgrade_queue_status for live state, then summarize whether it's safe to keep working and what would let the upgrade proceed.",
+      },
+      {
+        label: "Report an issue",
+        description: "Report a bug or give feedback",
+        capability: null,
+        prompt: "I'd like to report an issue or give feedback about this page.",
+      },
+    ],
+  },
+
   "/ops": {
     routePrefix: "/ops",
     domain: "Operations",

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -57,7 +57,7 @@ apps/web/lib/tak/agent-grants.ts	915
 apps/web/lib/tak/agent-routing.ts	1027
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737
-apps/web/lib/tak/route-context-map.ts	1212
+apps/web/lib/tak/route-context-map.ts	1260
 apps/web/lib/tak/route-context.ts	1105
 apps/web/lib/work-capsules/mcp-handlers.ts	884
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1103


### PR DESCRIPTION
## What & why

The AI coworker on `/ops/self-upgrade` answered page questions with the **Operations Backlog** because both route-context injectors resolve the page by longest-prefix match and `/ops/self-upgrade` had no entry of its own — it inherited `/ops`, whose `domainContext` asserts "shows the delivery backlog". Same class as `/ops/dev-loop` (BI-FD7E4D72); third recurrence.

This PR is **deliberately additive and non-overlapping** with #4048 (which fixes the PAGE DATA provider, injector #1, in its own file). Together they fully fix `/ops/self-upgrade` across both injectors, plus this adds the systemic guard so the class stops recurring.

## Changes

- **`route-context-map.ts`** — add a `/ops/self-upgrade` domain-context entry (injector #2: domain blurb + skills + upgrade tools). #4048 does not touch this file.
- **`route-context-inheritance.conformance.test.ts`** — a systemic guard that enumerates static shell routes from `route-manifest.json` and **fails CI when a new child of an identity-asserting parent (seed: `/ops`) silently inherits its page identity**, unless the route is enrolled or explicitly acknowledged. Blocks new drift by construction and prints the current mislabel debt (8 `/ops/*` orphans) as a blast-radius record. Anchored on the already-exported `resolveRouteContext`, so it shares **no files** with #4048.
- **`scripts/module-size-baseline.txt`** — re-baseline `route-context-map.ts` (different line from #4048's; auto-merges).

Guard verified both ways (green when correct; precise failure when an orphan drifts in). Scoped to identity-asserting parents so broad-domain (finance) and sub-route-aware (compliance) providers are not falsely flagged.

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-05-coworker-page-perception-context-contract-design.md` (Option B, §6.2 exact-route / no-data-inheritance guard); memory `coworker-page-perception-agency-gap`.
- Current code substrate reviewed: `apps/web/lib/tak/route-context-map.ts` (resolveRouteContext longest-prefix match + ROUTE_CONTEXT_MAP), `apps/web/lib/tak/route-context.ts` (ROUTE_CONTEXT_PROVIDERS + getOpsContext identity assertion), `apps/web/lib/ea/route-manifest.json`.
- Source of truth: the §6.2 design doc; complements #4048 which owns injector #1.
- Decision: additive injector-#2 entry + systemic guard; no new contract or routing change. Tracked by BI-5457E216 under EP-8C706944.

## Testing
- `route-context-map` suite + new guard: **39 tests pass** locally.
- 34/34 deterministic pregate preflight guards pass.

## Local-CI note
Local-CI-Override: operator-emergency: local sandbox gate cannot bind — deployed portal (f3e90191b) predates #4045's local-CI slot-port change (slot-0 now 3010/15432), causing nonprod_slot_resource_binding_mismatch. Deterministic guards + tak tests pass; GitHub CI runs the authoritative gate before merge.

Related: #4048 (injector #1 provider), BI-5457E216, BI-FD7E4D72, EP-8C706944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
