### PR TITLE
feat(workforce): fold delegations, handoffs, and backlog evidence into "did today" (BI-3D37CE9D)

### DIFF
--- a/apps/web/lib/platform-runtime/action-outcome-map.test.ts
+++ b/apps/web/lib/platform-runtime/action-outcome-map.test.ts
@@ -49,6 +49,17 @@ describe("summarizeOutcomes", () => {
     expect(out[2]).toEqual({ label: "other actions", count: 6, sensitive: false });
   });
 
+  it("folds pre-labeled extra (non-tool) outcomes into the ranking (BI-3D37CE9D)", () => {
+    const out = summarizeOutcomes(
+      { create_backlog_item: 2 },
+      4,
+      [{ label: "handoffs", count: 5, sensitive: false }],
+    );
+    // the extra outcome ranks by count alongside the tool-derived ones
+    expect(out[0]).toEqual({ label: "handoffs", count: 5, sensitive: false });
+    expect(out.map((o) => o.label)).toContain("backlog items filed");
+  });
+
   it("flags outcomes that touch sensitive data", () => {
     const out = summarizeOutcomes({ update_employee: 3, create_backlog_item: 2 });
     const hr = out.find((o) => o.label === "employee records updated");

--- a/apps/web/lib/platform-runtime/action-outcome-map.ts
+++ b/apps/web/lib/platform-runtime/action-outcome-map.ts
@@ -100,14 +100,19 @@ function pluralize(label: { one: string; many: string }, count: number): string 
  * Curated action tools become named outcomes; unmapped write tools fold into a
  * single "other actions" bucket; read tools are dropped. Exported for tests.
  *
- * @param toolCounts  toolName → number of successful calls today
- * @param limit       max named outcomes before the "other" bucket
+ * @param toolCounts     toolName → number of successful calls today
+ * @param limit          max named outcomes before the "other" bucket
+ * @param extraOutcomes  pre-labeled non-tool outcomes (A2A delegations/handoffs,
+ *                       backlog/build evidence) — ranked and capped alongside the
+ *                       tool-derived ones so a coworker's delegated/lifecycle work
+ *                       shows too, not just its tool calls (BI-3D37CE9D).
  */
 export function summarizeOutcomes(
   toolCounts: Record<string, number>,
   limit = 4,
+  extraOutcomes: readonly Outcome[] = [],
 ): Outcome[] {
-  const named: Outcome[] = [];
+  const named: Outcome[] = extraOutcomes.filter((o) => o.count > 0).map((o) => ({ ...o }));
   let otherCount = 0;
   let otherSensitive = false;
 

--- a/apps/web/lib/platform-runtime/workforce-activity.test.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.test.ts
@@ -15,13 +15,16 @@ function agent(over: Partial<Record<string, unknown>>) {
   };
 }
 
-/** A Prisma double that answers the five reads the loader makes. */
+/** A Prisma double that answers the reads the loader makes. */
 function fakePrisma(data: {
   agents: unknown[];
   liveRuns?: unknown[];
   toolByAgentTool?: unknown[];
   lastActed?: unknown[];
   tokens?: unknown[];
+  delegated?: unknown[];
+  handoffs?: unknown[];
+  evidence?: unknown[];
 }) {
   return {
     agent: { findMany: async () => data.agents },
@@ -31,6 +34,9 @@ function fakePrisma(data: {
         args.by.includes("toolName") ? (data.toolByAgentTool ?? []) : (data.lastActed ?? []),
     },
     tokenUsage: { groupBy: async () => data.tokens ?? [] },
+    delegationChain: { groupBy: async () => data.delegated ?? [] },
+    phaseHandoff: { groupBy: async () => data.handoffs ?? [] },
+    backlogItemActivity: { groupBy: async () => data.evidence ?? [] },
   } as never;
 }
 
@@ -116,11 +122,36 @@ describe("loadWorkforceActivity", () => {
         },
       },
       tokenUsage: { groupBy: async () => [] },
+      delegationChain: { groupBy: async () => [] },
+      phaseHandoff: { groupBy: async () => [] },
+      backlogItemActivity: { groupBy: async () => [] },
     } as never;
     await loadWorkforceActivity({ prisma, now: () => NOW });
     // the tool-by-tool outcome query is the one filtered to success:true
     const outcomeWhere = wheres.find((w) => w.success === true);
     expect(outcomeWhere?.executionMode).toEqual({ notIn: ["background", "permission"] });
+  });
+
+  it("folds A2A delegations, handoffs, and backlog evidence into 'did today' (BI-3D37CE9D)", async () => {
+    const prisma = fakePrisma({
+      agents: [agent({ agentId: "orch", displayName: "Orchestrator" })],
+      liveRuns: [
+        { taskRunId: "t", status: "active", title: "coordinating", currentAgentId: "orch", startedAt: new Date(NOW), lastHeartbeatAt: new Date(NOW) },
+      ],
+      toolByAgentTool: [{ agentId: "orch", toolName: "create_backlog_item", _count: { _all: 1 } }],
+      delegated: [{ fromAgentId: "orch", _count: { _all: 3 } }],
+      handoffs: [{ fromAgentId: "orch", _count: { _all: 2 } }],
+      evidence: [{ recordedByAgentId: "orch", _count: { _all: 4 } }],
+    });
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+    const labels = wf.working[0].didToday.map((o) => o.label);
+    expect(labels).toContain("delegations");
+    expect(labels).toContain("handoffs");
+    expect(labels).toContain("evidence logged");
+    // the tool-derived outcome is still present alongside the folded-in ones
+    expect(labels).toContain("backlog item filed");
+    // and the non-tool outcomes are ranked in (evidence:4 is the top count)
+    expect(wf.working[0].didToday[0].label).toBe("evidence logged");
   });
 
   it("orders working by tokens spent today, busiest first", async () => {

--- a/apps/web/lib/platform-runtime/workforce-activity.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.ts
@@ -56,6 +56,15 @@ type WorkforcePrisma = {
   taskRun: { findMany: (args: unknown) => Promise<TaskRunRow[]> };
   toolExecution: { groupBy: (args: unknown) => Promise<GroupRow[]> };
   tokenUsage: { groupBy: (args: unknown) => Promise<GroupRow[]> };
+  delegationChain: { groupBy: (args: unknown) => Promise<ActorCountRow[]> };
+  phaseHandoff: { groupBy: (args: unknown) => Promise<ActorCountRow[]> };
+  backlogItemActivity: { groupBy: (args: unknown) => Promise<ActorCountRow[]> };
+};
+/** A groupBy row keyed on the ACTING coworker for a non-tool source. */
+type ActorCountRow = {
+  fromAgentId?: string | null;
+  recordedByAgentId?: string | null;
+  _count?: { _all: number };
 };
 type AgentRow = {
   agentId: string;
@@ -90,7 +99,16 @@ export async function loadWorkforceActivity(
   startOfDay.setUTCHours(0, 0, 0, 0);
   const lookbackFloor = new Date(nowMs - LAST_ACTED_LOOKBACK_DAYS * 86_400_000);
 
-  const [agents, liveRuns, toolByAgentTool, lastActedByAgent, tokensByAgent] = await Promise.all([
+  const [
+    agents,
+    liveRuns,
+    toolByAgentTool,
+    lastActedByAgent,
+    tokensByAgent,
+    delegatedRows,
+    handoffRows,
+    evidenceRows,
+  ] = await Promise.all([
     prisma.agent.findMany({
       where: { archived: false, type: "coworker" },
       select: {
@@ -131,6 +149,25 @@ export async function loadWorkforceActivity(
       where: { createdAt: { gte: startOfDay } },
       _sum: { inputTokens: true, outputTokens: true, costUsd: true },
     }),
+    // Non-tool accomplishments so a coworker deep in delegation/lifecycle work
+    // doesn't read as under-busy (BI-3D37CE9D): A2A delegations it initiated,
+    // phase handoffs it made, and backlog evidence it logged — all keyed on the
+    // ACTING coworker (fromAgentId / recordedByAgentId), today.
+    prisma.delegationChain.groupBy({
+      by: ["fromAgentId"],
+      where: { startedAt: { gte: startOfDay } },
+      _count: { _all: true },
+    }),
+    prisma.phaseHandoff.groupBy({
+      by: ["fromAgentId"],
+      where: { createdAt: { gte: startOfDay } },
+      _count: { _all: true },
+    }),
+    prisma.backlogItemActivity.groupBy({
+      by: ["recordedByAgentId"],
+      where: { kind: "evidence", recordedAt: { gte: startOfDay } },
+      _count: { _all: true },
+    }),
   ]);
 
   // First live task per agent (rows are newest-first).
@@ -163,6 +200,10 @@ export async function loadWorkforceActivity(
     ]),
   );
 
+  const delegatedByAgent = countByActor(delegatedRows, "fromAgentId");
+  const handoffsByAgent = countByActor(handoffRows, "fromAgentId");
+  const evidenceByAgent = countByActor(evidenceRows, "recordedByAgentId");
+
   const working: WorkforceCoworker[] = [];
   const quiet: WorkforceCoworker[] = [];
   let actionsToday = 0;
@@ -174,7 +215,11 @@ export async function loadWorkforceActivity(
 
   for (const agent of agents) {
     const toolCounts = toolCountsByAgent.get(agent.agentId) ?? {};
-    const didToday = summarizeOutcomes(toolCounts);
+    const didToday = summarizeOutcomes(
+      toolCounts,
+      4,
+      activityOutcomes(agent.agentId, delegatedByAgent, handoffsByAgent, evidenceByAgent),
+    );
     const tok = tokensMap.get(agent.agentId) ?? { tokens: 0, cost: 0 };
     const live = liveByAgent.get(agent.agentId);
     const lastActed = live
@@ -232,4 +277,40 @@ export async function loadWorkforceActivity(
       coworkersWithoutOwnerCount: withoutOwner,
     },
   };
+}
+
+/** Count grouped rows by the acting-coworker field into a per-agent map. */
+function countByActor(
+  rows: ActorCountRow[],
+  key: "fromAgentId" | "recordedByAgentId",
+): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    const id = row[key];
+    if (id) map.set(id, row._count?._all ?? 0);
+  }
+  return map;
+}
+
+/** A coworker's non-tool accomplishments today, as ranked-in outcome chips. */
+function activityOutcomes(
+  agentId: string,
+  delegatedByAgent: Map<string, number>,
+  handoffsByAgent: Map<string, number>,
+  evidenceByAgent: Map<string, number>,
+): Outcome[] {
+  const out: Outcome[] = [];
+  const delegated = delegatedByAgent.get(agentId) ?? 0;
+  const handoffs = handoffsByAgent.get(agentId) ?? 0;
+  const evidence = evidenceByAgent.get(agentId) ?? 0;
+  if (delegated > 0) {
+    out.push({ label: delegated === 1 ? "delegation" : "delegations", count: delegated, sensitive: false });
+  }
+  if (handoffs > 0) {
+    out.push({ label: handoffs === 1 ? "handoff" : "handoffs", count: handoffs, sensitive: false });
+  }
+  if (evidence > 0) {
+    out.push({ label: "evidence logged", count: evidence, sensitive: false });
+  }
+  return out;
 }


### PR DESCRIPTION
## What & why
Follow-up to the merged workforce view (#4040). The "did today" digest was built **only** from `ToolExecution`, so a coworker deep in delegation or lifecycle work read as under-busy. This folds in three non-tool accomplishment sources, keyed on the **acting** coworker, for today:
- `delegationChain.fromAgentId` → "N delegations"
- `phaseHandoff.fromAgentId` → "N handoffs"
- `backlogItemActivity.recordedByAgentId` (kind=`evidence`) → "N evidence logged"

`summarizeOutcomes` gains an optional `extraOutcomes` list that ranks + caps alongside the tool-derived outcomes, so the biggest-count work leads whatever its source. Non-tool outcomes are non-sensitive; the aggregate-safe posture is unchanged.

## Verification (before first push)
- `action-outcome-map.test.ts` + `workforce-activity.test.ts` — **15 pass**: extra-outcome ranking, the folded delegations/handoffs/evidence appearing in `didToday`, existing behavior unchanged.
- `check-guards` / `module-size` / `style-drift` pass; both files type-clean. Lib-only — no route/UI/nav.

Process-Spine-Decision: extends the workforce-activity loader with read sources reused from the operations-map read model; no new contract or route.

BI-3D37CE9D · EP-FULL-OBS · follow-up to #4040

🤖 Generated with [Claude Code](https://claude.com/claude-code)