### PR TITLE
feat(decision): add decision-domain routing axis to caller-context (BI-HDLEMP-01)

### DIFF
--- a/apps/web/lib/decision/caller-context.test.ts
+++ b/apps/web/lib/decision/caller-context.test.ts
@@ -64,4 +64,75 @@ describe("resolveDecisionCallerContext (BI-E1FB2307)", () => {
     expect(ctx.principalId).toBeNull();
     expect(ctx.governingProfileKind).toBe("organization");
   });
+
+  // BI-HDLEMP-01 — route on decision DOMAIN, not solely caller population.
+  // Kernel-ratified route-on-domain (WWMD, DI-58E1256CD8B4): a business-class
+  // decision resolves to the org WWWD profile regardless of who calls, and a
+  // platform-development decision resolves to WWMD. When decisionDomain is
+  // absent the legacy callingPopulation heuristic still governs (backward-compat).
+  describe("decisionDomain axis (BI-HDLEMP-01)", () => {
+    it("routes an external agent's business decision to the org (WWWD) profile", async () => {
+      const ctx = await resolveDecisionCallerContext(
+        {
+          callingPopulation: "external_coding_agent",
+          decisionDomain: "org-business",
+          userId: "user-42",
+        },
+        mockDb({ user: { "user-42": "PRIN-USER-42" } }),
+      );
+      expect(ctx.governingProfileId).toBe(WWWD_ORGANIZATION_PROFILE_ID);
+      expect(ctx.governingProfileKind).toBe("organization");
+      expect(ctx.resolvedVia).toBe("decision-domain");
+    });
+
+    it("routes an external agent's platform decision to the WWMD profile", async () => {
+      const ctx = await resolveDecisionCallerContext(
+        {
+          callingPopulation: "external_coding_agent",
+          decisionDomain: "platform-development",
+          userId: "user-42",
+        },
+        mockDb({ user: { "user-42": "PRIN-USER-42" } }),
+      );
+      expect(ctx.governingProfileId).toBe(WWMD_PLATFORM_PROFILE_ID);
+      expect(ctx.governingProfileKind).toBe("platform");
+      expect(ctx.resolvedVia).toBe("decision-domain");
+    });
+
+    it("lets domain override population: a coworker's platform decision routes to WWMD", async () => {
+      const ctx = await resolveDecisionCallerContext(
+        {
+          callingPopulation: "in_platform_coworker",
+          decisionDomain: "platform-development",
+          agentId: "build-specialist",
+        },
+        mockDb({ agent: { "build-specialist": "PRIN-AGENT-1" } }),
+      );
+      expect(ctx.governingProfileKind).toBe("platform");
+      expect(ctx.governingProfileId).toBe(WWMD_PLATFORM_PROFILE_ID);
+      expect(ctx.resolvedVia).toBe("decision-domain");
+    });
+
+    it("routes a human contributor's business decision to the org (WWWD) profile", async () => {
+      const ctx = await resolveDecisionCallerContext(
+        {
+          callingPopulation: "human",
+          decisionDomain: "org-business",
+          userId: "user-7",
+        },
+        mockDb({ user: { "user-7": "PRIN-7" } }),
+      );
+      expect(ctx.governingProfileKind).toBe("organization");
+      expect(ctx.governingProfileId).toBe(WWWD_ORGANIZATION_PROFILE_ID);
+    });
+
+    it("falls back to calling-population routing when decisionDomain is absent", async () => {
+      const ctx = await resolveDecisionCallerContext(
+        { callingPopulation: "external_coding_agent", userId: "user-42" },
+        mockDb({ user: { "user-42": "PRIN-USER-42" } }),
+      );
+      expect(ctx.governingProfileKind).toBe("platform");
+      expect(ctx.resolvedVia).toBe("calling-population");
+    });
+  });
 });

--- a/apps/web/lib/decision/caller-context.ts
+++ b/apps/web/lib/decision/caller-context.ts
@@ -2,15 +2,21 @@
 //
 // Maps a decision caller to (a) its Principal (for attribution/ledger) and
 // (b) the governing decision-perspective profile, enforcing the WWMD-vs-WWWD
-// boundary (AGENTS.md §16): an in-portal coworker's *business* decision is
-// governed by the organization's WWWD profile; platform-development work
-// (external coding agents, humans contributing to the platform) is governed by
-// the founder/platform WWMD profile.
+// boundary (AGENTS.md §16): a *business* decision is governed by the
+// organization's WWWD profile; platform-development work is governed by the
+// founder/platform WWMD profile.
 //
-// Resolution here is callingPopulation-based BY DESIGN. Richer
-// ownerPrincipalId/defaultResolver/fallback-chain selection and true
-// multi-tenant org scoping (no caller->org link exists today) are tracked by
-// BI-E1FB2307 (Gate routing) and BI-EF3F4A2D (multi-tenant identity).
+// Routing keys on the decision DOMAIN when the caller declares one
+// (BI-HDLEMP-01, kernel-ratified route-on-domain, WWMD ledger DI-58E1256CD8B4):
+// a business-class decision resolves to WWWD and a platform-development decision
+// to WWMD REGARDLESS of who calls — so an external agent operating an
+// organization's business is no longer scored against founder doctrine. When no
+// decisionDomain is declared, resolution falls back to the legacy
+// callingPopulation heuristic (in-portal coworker => business), which preserves
+// every prior caller's behaviour.
+//
+// True multi-tenant org scoping (no caller->org link exists today) remains
+// tracked by BI-E1FB2307 (Gate routing) and BI-EF3F4A2D (multi-tenant identity).
 
 import {
   resolvePrincipalIdForUser,
@@ -21,6 +27,16 @@ export type DecisionCallingPopulation =
   | "in_platform_coworker"
   | "external_coding_agent"
   | "human";
+
+/**
+ * The class of decision being made, which — when declared — governs WWMD-vs-WWWD
+ * routing independently of the calling population (BI-HDLEMP-01):
+ * - `org-business` — a decision about operating the organization's business
+ *   (pricing, staffing, customer stance, ...). Governed by the org WWWD profile.
+ * - `platform-development` — a decision about building/evolving the platform
+ *   itself. Governed by the founder WWMD profile.
+ */
+export type DecisionDomain = "org-business" | "platform-development";
 
 export type GoverningProfileKind = "platform" | "organization";
 
@@ -37,7 +53,7 @@ export type DecisionCallerContext = {
   governingProfileKind: GoverningProfileKind;
   callingPopulation: DecisionCallingPopulation;
   /** How the profile was chosen — for the response + audit trail. */
-  resolvedVia: "calling-population";
+  resolvedVia: "decision-domain" | "calling-population";
 };
 
 type PrincipalResolverDb = Parameters<typeof resolvePrincipalIdForUser>[1];
@@ -45,6 +61,12 @@ type PrincipalResolverDb = Parameters<typeof resolvePrincipalIdForUser>[1];
 export async function resolveDecisionCallerContext(
   input: {
     callingPopulation: DecisionCallingPopulation;
+    /**
+     * The decision's domain. When present it governs WWMD-vs-WWWD routing and
+     * overrides the callingPopulation heuristic (BI-HDLEMP-01). When absent,
+     * routing falls back to callingPopulation for backward compatibility.
+     */
+    decisionDomain?: DecisionDomain | null;
     userId?: string | null;
     agentId?: string | null;
   },
@@ -60,7 +82,17 @@ export async function resolveDecisionCallerContext(
     principalId = await resolvePrincipalIdForUser(input.userId, db);
   }
 
-  const isBusiness = input.callingPopulation === "in_platform_coworker";
+  // Route on the declared decision domain when present (BI-HDLEMP-01); else
+  // fall back to the legacy callingPopulation heuristic. A business decision is
+  // governed by the org WWWD profile and a platform decision by WWMD — so an
+  // external agent operating an organization's business reaches the org's own
+  // stance instead of founder doctrine.
+  const isBusiness = input.decisionDomain
+    ? input.decisionDomain === "org-business"
+    : input.callingPopulation === "in_platform_coworker";
+  const resolvedVia: DecisionCallerContext["resolvedVia"] = input.decisionDomain
+    ? "decision-domain"
+    : "calling-population";
 
   return {
     principalId,
@@ -69,6 +101,6 @@ export async function resolveDecisionCallerContext(
       : WWMD_PLATFORM_PROFILE_ID,
     governingProfileKind: isBusiness ? "organization" : "platform",
     callingPopulation: input.callingPopulation,
-    resolvedVia: "calling-population",
+    resolvedVia,
   };
 }


### PR DESCRIPTION
## What

Seam 1 of **EP-HEADLESS-EMPLOYEE** — the routing engine. `resolveDecisionCallerContext` (`apps/web/lib/decision/caller-context.ts`) chose the governing decision-perspective profile purely from `callingPopulation`, so an external coding agent (or human) was **always** governed by the founder **WWMD** kernel — even for a decision about operating an organization's business. Root cause of external AI interactions lacking the org's **archetype / locale / stance** context.

Add an optional **`decisionDomain`** axis (`org-business` → org WWWD profile; `platform-development` → founder WWMD). When declared it governs routing **regardless of caller population** (`resolvedVia: "decision-domain"`); when absent, the legacy `callingPopulation` heuristic still applies (`resolvedVia: "calling-population"`) — fully backward-compatible.

## Scope note

This PR delivers the **routing engine only**. I initially wired the `principle_decide` consumer too, but reverted it: `principle-decide-pack.ts` is already at the module-size ceiling (798/800), and growing it trips the substrate-complexity ratchet (`productionModuleHotspotCount 68→69`). Per `architecture-over-shortcuts` the maxed-out pack must not grow here — the consumer wires in **BI-HDLEMP-02**, alongside the org-context bundle that gives an agent its decision domain in the first place.

## Why

Kernel-ratified **route-on-domain** (`principle_decide`, WWMD `mark-dpf-platform`, high confidence, no commandment conflict; ledger `DI-58E1256CD8B4`).

## Design grounding

Source of truth: `caller-context.ts` + merged spec `docs/superpowers/specs/2026-08-05-headless-employee-external-agent-wwwd-exposure-design.md` (Seam 1, §6 BI-HDLEMP-01) + ledger `DI-58E1256CD8B4`. **Decision:** extends the existing spec/BI — additive optional `decisionDomain` axis, no new contract.

## Verification

- **Functional:** `vitest lib/decision/caller-context.test.ts` → **10/10 green**, incl. 5 new tests (external/human business decision → org WWWD; domain overrides population; absent-domain backward-compat).
- **Typecheck:** not runnable locally (source-only worktree can't resolve `next`/`@dpf/*` for `tsc`); pushed with `external-contribution-no-install` override. **CI runs the authoritative typecheck + guards.**

Backlog: `BI-HDLEMP-01` (epic `EP-HEADLESS-EMPLOYEE`). Spec merged in #4044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)