### PR TITLE
feat(work-capsules): lease-based liveness contract + governed reaper (WS9, BI-CBAAEA94)

### DIFF
--- a/apps/web/lib/actions/work-capsules.ts
+++ b/apps/web/lib/actions/work-capsules.ts
@@ -112,11 +112,31 @@ export async function getWorkControlData() {
       headBranch: true,
       worktreePath: true,
       pullRequestUrl: true,
+      pullRequestNumber: true,
       leaseExpiresAt: true,
       lastSyncedAt: true,
       updatedAt: true,
+      featureBuildId: true,
     },
   });
+
+  // WS9 (BI-CBAAEA94): join the linked Build Studio build so a null-lease
+  // capsule's liveness on the board reads from real build progress, not its
+  // frozen-at-14:00 updatedAt. A terminal build now surfaces the capsule as
+  // abandoned-build instead of a healthy-looking "working" row.
+  const buildIds = capsules
+    .map((capsule) => capsule.featureBuildId)
+    .filter((id): id is string => Boolean(id));
+  const buildsById = new Map<string, { phase: string | null; lastActivityAt: Date | null }>();
+  if (buildIds.length > 0) {
+    const builds = await prisma.featureBuild.findMany({
+      where: { id: { in: [...new Set(buildIds)] } },
+      select: { id: true, phase: true, updatedAt: true },
+    });
+    for (const build of builds) {
+      buildsById.set(build.id, { phase: build.phase ?? null, lastActivityAt: build.updatedAt ?? null });
+    }
+  }
 
   const adoptedBranches = new Set(
     capsules.map((capsule) => capsule.headBranch).filter((branch): branch is string => Boolean(branch)),
@@ -124,7 +144,12 @@ export async function getWorkControlData() {
   const adoptable = await loadAdoptableRows(resolveRepoRoot(), adoptedBranches);
 
   return {
-    capsules: capsules.map((row) => presentCapsuleRow(row)),
+    capsules: capsules.map(({ featureBuildId, ...row }) =>
+      presentCapsuleRow({
+        ...row,
+        featureBuild: featureBuildId ? buildsById.get(featureBuildId) ?? null : null,
+      }),
+    ),
     adoptable,
   };
 }

--- a/apps/web/lib/build/inert-build-reaper.ts
+++ b/apps/web/lib/build/inert-build-reaper.ts
@@ -231,6 +231,17 @@ export async function reapInertStuckBuilds(
         "@/lib/integrate/sandbox/sandbox-build-gc"
       );
       await releaseSandboxForTerminalBuild(c.buildId, { deleteBranch: false }).catch(() => {});
+      // WS9 (BI-CBAAEA94): a terminal build must not leave a zombie "working"
+      // WorkCapsule behind — that is the surface that reads as active and gets
+      // silently duplicated. Transition the attached capsule in the same tick.
+      const { transitionCapsuleForTerminalBuild } = await import(
+        "@/lib/work-capsules/work-capsule-reaper"
+      );
+      await transitionCapsuleForTerminalBuild(
+        c.buildId,
+        inert ? `inert — no activity in ${c.phase}.` : `stalled — no activity in ${c.phase}.`,
+        now,
+      ).catch(() => {});
     } catch (err) {
       console.warn(`[inert-build-reaper] failed to reap build ${c.buildId}:`, err);
     }

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -46,13 +46,15 @@ const scopeProperties = {
 const definitions: ToolDefinition[] = [
   {
     name: "list_work_capsules",
-    description: "List Work Capsule coordination records for active portal, Build Studio, and external agent work. Read-only.",
+    description:
+      "List Work Capsule coordination records for active portal, Build Studio, and external agent work, each annotated with its TRUE liveness (live | lease-expired | build-terminal | idle-stale | no-signal). Liveness is derived from lease expiry, the linked build's phase, an open PR, and last sync — NOT from updatedAt, which a daily heartbeat freezes for Build Studio capsules, so a `working` status is not proof of life. Includes a livenessSummary (live vs reap-candidate counts). Pass staleOnly=true for just the not-live reap candidates. Read-only.",
     inputSchema: {
       type: "object",
       properties: {
         status: { type: "string", enum: ENUMS.statuses, description: "Filter by Work Capsule status." },
         decisionScope: { type: "string", enum: ENUMS.decisionScopes, description: "Filter by WWMD, WWWD, or WSID scope." },
         portfolioRole: { type: "string", enum: ENUMS.portfolioRoles, description: "Filter by primary portfolio role." },
+        staleOnly: { type: "boolean", description: "Return only capsules that are NOT truly live (reap candidates). Default false." },
         limit: { type: "number", description: "Max results (default 50, max 100)." },
       },
       required: [],

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -268,6 +268,39 @@ export const taskrunWatchdog = inngest.createFunction(
       console.warn("[taskrun-watchdog] inert-build reaper failed:", err);
     }
 
+    // WS9 (BI-CBAAEA94): governed WorkCapsule reaper — transition capsules whose
+    // TRUE liveness is dead (lease expired, linked build terminal, or idle past
+    // the floor) out of "working" so abandoned work stops reading as active and
+    // jamming the WIP cap. GOVERNED: observe-only (dry-run) unless
+    // DPF_WORKCAPSULE_REAPER_ENABLED=1, and live actuation only when additionally
+    // DPF_WORKCAPSULE_REAPER_AUTO_REAP=1 (mirrors the runtime-artifact / worktree
+    // janitors). Best-effort. DB-only (junction-safe: never touches worktrees).
+    let workCapsulesReapCandidates = 0;
+    let workCapsulesReaped = 0;
+    try {
+      const reaperEnabled = process.env.DPF_WORKCAPSULE_REAPER_ENABLED === "1";
+      if (reaperEnabled) {
+        const autoReap = process.env.DPF_WORKCAPSULE_REAPER_AUTO_REAP === "1";
+        const { reapStaleWorkCapsules } = await import("@/lib/work-capsules/work-capsule-reaper");
+        const { prisma: capsuleDb } = await import("@dpf/db");
+        const result = await reapStaleWorkCapsules({
+          db: capsuleDb as never,
+          now: new Date(),
+          dryRun: !autoReap,
+        });
+        workCapsulesReapCandidates = result.candidates.length;
+        workCapsulesReaped = result.reaped;
+        if (!autoReap && result.candidates.length > 0) {
+          console.warn(
+            `[work-capsule-reaper] observe-only: ${result.candidates.length} reap candidate(s) — ` +
+              "set DPF_WORKCAPSULE_REAPER_AUTO_REAP=1 to actuate.",
+          );
+        }
+      }
+    } catch (err) {
+      console.warn("[taskrun-watchdog] work-capsule reaper failed:", err);
+    }
+
     // BI-B62B9F1E: release stale BacklogItem claims (dead sessions) so they do
     // not linger as "active" operator noise. Complements the atomic reclaim path.
     let staleBacklogClaimsReaped = 0;
@@ -280,14 +313,14 @@ export const taskrunWatchdog = inngest.createFunction(
     }
 
     if (!(await isStallWatchdogEnabled())) {
-      return { skipped: true, reason: "flag-off", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, staleBacklogClaimsReaped };
+      return { skipped: true, reason: "flag-off", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, staleBacklogClaimsReaped };
     }
 
     const { prisma } = await import("@dpf/db");
 
     const thresholds = await prisma.buildStudioStallThreshold.findMany();
     if (thresholds.length === 0) {
-      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, staleBacklogClaimsReaped };
+      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped, staleBacklogClaimsReaped };
     }
 
     // Coarse SQL filter using the smallest applicable thresholds across all
@@ -339,7 +372,7 @@ export const taskrunWatchdog = inngest.createFunction(
     }
 
     if (decisions.length === 0) {
-      return { processed: 0, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped };
+      return { processed: 0, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped };
     }
 
     // Batch id-resolution: business taskRunId → cuid id for FK writes.
@@ -499,6 +532,6 @@ export const taskrunWatchdog = inngest.createFunction(
       processed += 1;
     }
 
-    return { processed, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped };
+    return { processed, quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, workCapsulesReapCandidates, workCapsulesReaped };
   },
 );

--- a/apps/web/lib/work-capsules.ts
+++ b/apps/web/lib/work-capsules.ts
@@ -160,6 +160,16 @@ export const LEASE_TTL_MS = 30 * 60 * 1000;
 export const STALE_CACHE_MS = 30 * 60 * 1000;
 export const STATUS_OVERRIDE_TTL_MS = 24 * 60 * 60 * 1000;
 
+// WS9 (BI-CBAAEA94): how long a NON-lease-backed capsule (e.g. a Build Studio
+// capsule, whose leaseExpiresAt is null by construction) may sit with no fresh
+// liveness signal — no open PR, no live linked build, no recent sync — before it
+// is treated as idle/stale rather than "working". This is the liveness floor for
+// the surface a null lease cannot cover; lease-backed capsules use their exact
+// leaseExpiresAt, not this. Deliberately generous (6h) so a genuinely-long build
+// phase is never mistaken for abandonment. Override with WORK_CAPSULE_IDLE_MS.
+export const WORK_CAPSULE_IDLE_STALE_MS =
+  Number(process.env.WORK_CAPSULE_IDLE_MS) || 6 * 60 * 60 * 1000;
+
 export const RELEASE_WORKTREE_DEFAULTS = {
   win32: "D:\\DPF",
   darwin: "{home}/dpf",

--- a/apps/web/lib/work-capsules/liveness-inventory.ts
+++ b/apps/web/lib/work-capsules/liveness-inventory.ts
@@ -1,0 +1,101 @@
+// apps/web/lib/work-capsules/liveness-inventory.ts
+//
+// WS9 (BI-CBAAEA94): the read-side of the liveness contract. Loads a page of
+// WorkCapsules, joins each build-studio capsule's linked FeatureBuild (its only
+// real liveness signal — phase + activity, never the frozen-at-14:00 updatedAt),
+// and annotates every row with its true-liveness verdict plus a summary. Shared
+// by the `list_work_capsules` MCP tool so the handler stays thin.
+
+import { classifyWorkCapsuleLiveness } from "./liveness";
+
+const INVENTORY_SELECT = {
+  capsuleId: true,
+  title: true,
+  status: true,
+  source: true,
+  executorKind: true,
+  decisionScope: true,
+  portfolioRole: true,
+  servedPersona: true,
+  activityKind: true,
+  outcomeAnchor: true,
+  servesPortfolioRoles: true,
+  dependsOnPortfolioRoles: true,
+  headBranch: true,
+  worktreePath: true,
+  pullRequestUrl: true,
+  pullRequestNumber: true,
+  leaseExpiresAt: true,
+  lastSyncedAt: true,
+  updatedAt: true,
+  featureBuildId: true,
+} as const;
+
+type InventoryDb = {
+  workCapsule: { findMany(args: unknown): Promise<any[]> };
+  featureBuild: { findMany(args: unknown): Promise<any[]> };
+};
+
+export type CapsuleLivenessSummary = {
+  scanned: number;
+  live: number;
+  reapable: number;
+  byLiveness: Record<string, number>;
+};
+
+/**
+ * Load and liveness-annotate a page of capsules. Orders by updatedAt for a
+ * stable page (updatedAt is a sort key only — liveness is derived, never read
+ * from it). Returns every row annotated plus a live/reap-candidate summary.
+ */
+export async function loadCapsuleLivenessInventory(
+  db: InventoryDb,
+  args: { where: Record<string, unknown>; take: number },
+  now: Date = new Date(),
+): Promise<{ capsulesAll: Array<Record<string, unknown>>; livenessSummary: CapsuleLivenessSummary }> {
+  const rows = await db.workCapsule.findMany({
+    where: args.where,
+    orderBy: { updatedAt: "desc" },
+    take: args.take,
+    select: INVENTORY_SELECT,
+  });
+
+  const buildIds = rows.map((r) => r.featureBuildId).filter((id): id is string => Boolean(id));
+  const buildsById = new Map<string, { phase: string | null; lastActivityAt: Date | null }>();
+  if (buildIds.length > 0) {
+    const builds = await db.featureBuild.findMany({
+      where: { id: { in: [...new Set(buildIds)] } },
+      select: { id: true, phase: true, updatedAt: true },
+    });
+    for (const b of builds) {
+      buildsById.set(b.id, { phase: b.phase ?? null, lastActivityAt: b.updatedAt ?? null });
+    }
+  }
+
+  const capsulesAll = rows.map((row) => {
+    const featureBuild = row.featureBuildId ? buildsById.get(row.featureBuildId) ?? null : null;
+    const verdict = classifyWorkCapsuleLiveness({ ...row, featureBuild }, now);
+    const { featureBuildId: _omit, ...rest } = row;
+    return {
+      ...rest,
+      liveness: verdict.liveness,
+      isLive: verdict.isLive,
+      isReapable: verdict.isReapable,
+      livenessReason: verdict.reason,
+      trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
+    };
+  });
+
+  const byLiveness: Record<string, number> = {};
+  for (const c of capsulesAll) byLiveness[c.liveness as string] = (byLiveness[c.liveness as string] ?? 0) + 1;
+
+  return {
+    capsulesAll,
+    livenessSummary: {
+      scanned: capsulesAll.length,
+      live: capsulesAll.filter((c) => c.isLive).length,
+      reapable: capsulesAll.filter((c) => c.isReapable).length,
+      byLiveness,
+    },
+  };
+}

--- a/apps/web/lib/work-capsules/liveness.test.ts
+++ b/apps/web/lib/work-capsules/liveness.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyWorkCapsuleLiveness, type CapsuleLivenessInput } from "./liveness";
+
+const NOW = new Date("2026-08-05T15:00:00.000Z");
+
+function row(overrides: Partial<CapsuleLivenessInput> = {}): CapsuleLivenessInput {
+  return {
+    status: "working",
+    executorKind: "build-studio",
+    leaseExpiresAt: null,
+    lastSyncedAt: null,
+    updatedAt: NOW,
+    pullRequestUrl: null,
+    pullRequestNumber: null,
+    featureBuild: null,
+    ...overrides,
+  };
+}
+
+describe("classifyWorkCapsuleLiveness", () => {
+  it("REGRESSION (BI-CBAAEA94): a null-lease build-studio capsule frozen at 14:00 is NOT live", () => {
+    // The exact sprawl shape: born at the daily tee-up, build stalled, never
+    // written again. updatedAt == createdAt == 14:00 on a prior day.
+    const v = classifyWorkCapsuleLiveness(
+      row({ status: "working", updatedAt: new Date("2026-08-02T14:00:01.000Z") }),
+      NOW,
+    );
+    expect(v.isLive).toBe(false);
+    expect(v.isReapable).toBe(true);
+    expect(v.liveness).toBe("idle-stale");
+    // Crucially, updatedAt is NOT treated as the liveness timestamp.
+    expect(v.trueLivenessAt).toBeNull();
+  });
+
+  it("treats an expired lease as dead regardless of updatedAt", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "codex-desktop",
+        leaseExpiresAt: new Date("2026-08-05T14:00:00.000Z"), // 1h ago
+        lastSyncedAt: new Date("2026-08-05T13:00:00.000Z"),
+        updatedAt: NOW, // freshly bumped, but must not read as live
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("lease-expired");
+    expect(v.isLive).toBe(false);
+    expect(v.isReapable).toBe(true);
+    expect(v.trueLivenessAt).toEqual(new Date("2026-08-05T14:00:00.000Z"));
+  });
+
+  it("treats a valid lease as live", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({ executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-05T15:20:00.000Z") }),
+      NOW,
+    );
+    expect(v.liveness).toBe("live");
+    expect(v.isLive).toBe(true);
+    expect(v.isReapable).toBe(false);
+  });
+
+  it("treats an open PR as live even after the authoring lease lapsed", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "codex-desktop",
+        leaseExpiresAt: new Date("2026-08-04T00:00:00.000Z"), // long expired
+        pullRequestNumber: 4055,
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("live");
+    expect(v.isReapable).toBe(false);
+    expect(v.reason).toContain("#4055");
+  });
+
+  it("marks a capsule dead when its linked build is terminal (zombie BS capsule)", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        status: "working",
+        featureBuild: { phase: "abandoned", lastActivityAt: new Date("2026-08-02T09:00:00.000Z") },
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("build-terminal");
+    expect(v.isLive).toBe(false);
+    expect(v.isReapable).toBe(true);
+  });
+
+  it("keeps a null-lease capsule live while its build is recently active", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        featureBuild: { phase: "build", lastActivityAt: new Date("2026-08-05T14:50:00.000Z") }, // 10m ago
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("live");
+    expect(v.isReapable).toBe(false);
+    expect(v.trueLivenessAt).toEqual(new Date("2026-08-05T14:50:00.000Z"));
+  });
+
+  it("flags a null-lease capsule idle-stale when its build went silent past the floor", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        featureBuild: { phase: "build", lastActivityAt: new Date("2026-08-05T05:00:00.000Z") }, // 10h ago
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("idle-stale");
+    expect(v.isReapable).toBe(true);
+  });
+
+  it("withholds judgment on a brand-new null-lease capsule (no-signal, still live-ish)", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({ updatedAt: new Date("2026-08-05T14:40:00.000Z") }), // born 20m ago
+      NOW,
+    );
+    expect(v.liveness).toBe("no-signal");
+    expect(v.isLive).toBe(true); // recent — never shown as dead
+    expect(v.isReapable).toBe(false); // but never reaped either
+  });
+
+  it("never reaps a capsule that is already terminal", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({ status: "abandoned", updatedAt: new Date("2026-06-01T14:00:00.000Z") }),
+      NOW,
+    );
+    expect(v.liveness).toBe("terminal");
+    expect(v.isReapable).toBe(false);
+    expect(v.isLive).toBe(false);
+  });
+
+  it("prefers a still-fresh sync over the idle floor for adopted worktrees", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: null,
+        lastSyncedAt: new Date("2026-08-05T14:30:00.000Z"), // 30m ago
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("live");
+    expect(v.trueLivenessAt).toEqual(new Date("2026-08-05T14:30:00.000Z"));
+  });
+});

--- a/apps/web/lib/work-capsules/liveness.ts
+++ b/apps/web/lib/work-capsules/liveness.ts
@@ -1,0 +1,188 @@
+// apps/web/lib/work-capsules/liveness.ts
+//
+// WS9 (BI-CBAAEA94 / EP-PROCESS-SPINE) — the WorkCapsule liveness contract.
+//
+// Why this exists:
+//   A WorkCapsule's `updatedAt` is NOT a liveness signal. Build Studio capsules
+//   are born at the daily 14:00 governed-backlog tee-up and, if their build
+//   stalls immediately, are never written again — so `updatedAt` freezes at
+//   `...T14:00:00` forever while the row still says status="working". Dozens of
+//   dead capsules therefore DISPLAY as active, jam the WIP cap, and become the
+//   mechanism by which work is silently duplicated (the sprawl this WS fixes).
+//
+//   Real liveness comes from signals that only advance when work actually
+//   advances:
+//     - an OPEN PR (work parked in review / the merge queue),
+//     - a lease-backed executor's `leaseExpiresAt` (external Claude/Codex/Grok;
+//       auto-renewed on every capsule write — expiry == the session died),
+//     - the linked Build Studio FeatureBuild's phase + last activity (a null-lease
+//       BS capsule's only real signal), and
+//     - `lastSyncedAt` (adopted-worktree cache sync).
+//
+//   This module is the ONE place those signals are combined into a verdict, so
+//   the board, the `list_work_capsules` tool, and the governed reaper all agree.
+//   It is intentionally PURE (no DB, no clock of its own — `now` is injected) so
+//   it is exhaustively unit-testable.
+
+import { WORK_CAPSULE_IDLE_STALE_MS } from "@/lib/work-capsules";
+
+/** Capsule statuses that mean the work is already closed out. */
+const TERMINAL_STATUSES = new Set(["complete", "abandoned", "archived"]);
+
+/** Linked FeatureBuild phases that mean the build is closed out. */
+const TERMINAL_BUILD_PHASES = new Set(["complete", "failed", "abandoned"]);
+
+export type WorkCapsuleLiveness =
+  /** Demonstrably live: valid lease, open PR, or recent real activity. */
+  | "live"
+  /** Lease-backed executor whose lease has elapsed — the session died. */
+  | "lease-expired"
+  /** Linked Build Studio build is complete/failed/abandoned — nothing to do. */
+  | "build-terminal"
+  /** No live signal and older than the idle floor (the frozen-14:00 case). */
+  | "idle-stale"
+  /** Capsule status is already terminal (complete/abandoned/archived). */
+  | "terminal"
+  /** Null lease, no build/sync signal, but recent enough to withhold judgment. */
+  | "no-signal";
+
+/** The dead states a governed reaper may act on. Excludes `terminal` (already
+ *  closed) and `no-signal`/`live` (benefit of the doubt). */
+const REAPABLE_LIVENESS = new Set<WorkCapsuleLiveness>([
+  "lease-expired",
+  "build-terminal",
+  "idle-stale",
+]);
+
+export type CapsuleLivenessInput = {
+  status: string;
+  executorKind: string | null;
+  leaseExpiresAt: Date | null;
+  lastSyncedAt: Date | null;
+  updatedAt: Date;
+  pullRequestUrl: string | null;
+  pullRequestNumber?: number | null;
+  /**
+   * Snapshot of the linked Build Studio FeatureBuild, when this capsule is a
+   * build-studio capsule and the caller has loaded it. `phase` drives the
+   * build-terminal verdict; `lastActivityAt` is the freshest real signal a
+   * null-lease capsule has. Absent/null for non-BS capsules or when not loaded.
+   */
+  featureBuild?: { phase: string | null; lastActivityAt: Date | null } | null;
+};
+
+export type CapsuleLivenessVerdict = {
+  liveness: WorkCapsuleLiveness;
+  /** True when this should read as ACTIVE on a board. `no-signal` (recent but
+   *  unproven) counts as live so a brand-new capsule is never shown as dead. */
+  isLive: boolean;
+  /** True when a governed reaper may transition this capsule to abandoned. */
+  isReapable: boolean;
+  reason: string;
+  /**
+   * The timestamp that actually governs liveness — lease expiry, last build
+   * activity, or last sync. Deliberately NEVER `updatedAt` (which the 14:00
+   * heartbeat masks). Null when the only available signal was `updatedAt`.
+   */
+  trueLivenessAt: Date | null;
+};
+
+function hasOpenPr(input: CapsuleLivenessInput): boolean {
+  return Boolean(input.pullRequestUrl) || (input.pullRequestNumber ?? 0) > 0;
+}
+
+function humanAge(ms: number): string {
+  const mins = Math.round(ms / 60000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.round(ms / 3_600_000);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(ms / 86_400_000)}d`;
+}
+
+/**
+ * Classify a capsule's TRUE liveness from signals that only advance with real
+ * work. Pure: `now` is injected. Precedence, most authoritative first:
+ *   1. terminal capsule status,
+ *   2. open PR (parked in review),
+ *   3. terminal linked build,
+ *   4. lease-backed executor: lease valid → live, elapsed → dead,
+ *   5. null lease: freshest of (build activity, sync) vs the idle floor,
+ *   6. no signal at all: recent → withhold judgment, old → idle-stale.
+ */
+export function classifyWorkCapsuleLiveness(
+  input: CapsuleLivenessInput,
+  now: Date = new Date(),
+  idleMs: number = WORK_CAPSULE_IDLE_STALE_MS,
+): CapsuleLivenessVerdict {
+  const verdict = (
+    liveness: WorkCapsuleLiveness,
+    reason: string,
+    trueLivenessAt: Date | null,
+  ): CapsuleLivenessVerdict => ({
+    liveness,
+    isLive: liveness === "live" || liveness === "no-signal",
+    isReapable: REAPABLE_LIVENESS.has(liveness),
+    reason,
+    trueLivenessAt,
+  });
+
+  if (TERMINAL_STATUSES.has(input.status)) {
+    return verdict("terminal", `Capsule already ${input.status}.`, null);
+  }
+
+  // An open PR is the live artifact even if the authoring session's lease has
+  // since lapsed — the work is in review / the merge queue, not abandoned.
+  if (hasOpenPr(input)) {
+    const label = input.pullRequestNumber ? `PR #${input.pullRequestNumber}` : "an open PR";
+    return verdict("live", `Parked in review as ${label}.`, input.lastSyncedAt ?? null);
+  }
+
+  const build = input.featureBuild ?? null;
+  if (build && build.phase && TERMINAL_BUILD_PHASES.has(build.phase)) {
+    return verdict(
+      "build-terminal",
+      `Linked build is ${build.phase} — capsule should be closed out.`,
+      build.lastActivityAt ?? null,
+    );
+  }
+
+  // Lease-backed executor: the lease IS the liveness contract.
+  if (input.leaseExpiresAt != null) {
+    const expired = input.leaseExpiresAt.getTime() <= now.getTime();
+    if (expired) {
+      const age = humanAge(now.getTime() - input.leaseExpiresAt.getTime());
+      return verdict("lease-expired", `Lease expired ${age} ago — session died.`, input.leaseExpiresAt);
+    }
+    const remaining = humanAge(input.leaseExpiresAt.getTime() - now.getTime());
+    return verdict("live", `Lease valid for ${remaining}.`, input.leaseExpiresAt);
+  }
+
+  // Null lease (e.g. a Build Studio capsule): use the freshest REAL signal.
+  const buildActivityAt = build?.lastActivityAt ?? null;
+  const signalAt =
+    buildActivityAt && input.lastSyncedAt
+      ? new Date(Math.max(buildActivityAt.getTime(), input.lastSyncedAt.getTime()))
+      : buildActivityAt ?? input.lastSyncedAt ?? null;
+
+  if (signalAt) {
+    const age = now.getTime() - signalAt.getTime();
+    if (age <= idleMs) {
+      const which = signalAt === input.lastSyncedAt ? "Synced" : "Build activity";
+      return verdict("live", `${which} ${humanAge(age)} ago.`, signalAt);
+    }
+    return verdict("idle-stale", `No live signal for ${humanAge(age)} (past the ${humanAge(idleMs)} idle floor).`, signalAt);
+  }
+
+  // No lease, no build activity, no sync — `updatedAt` is the only marker, and it
+  // is NOT a liveness signal (frozen at 14:00 birth). Withhold judgment while
+  // recent; flip to idle-stale once past the floor.
+  const updatedAge = now.getTime() - input.updatedAt.getTime();
+  if (updatedAge <= idleMs) {
+    return verdict("no-signal", `No lease or activity signal yet (created ${humanAge(updatedAge)} ago).`, null);
+  }
+  return verdict(
+    "idle-stale",
+    `No lease, sync, or build activity — last touched ${humanAge(updatedAge)} ago (updatedAt is not liveness).`,
+    null,
+  );
+}

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -211,12 +211,16 @@ export async function listWorkCapsulesTool(params: Record<string, unknown>): Pro
   }
 
   const limit = numberParam(params, "limit");
+  // WS9 (BI-CBAAEA94): `staleOnly` returns only capsules that are NOT truly live
+  // — the reap-candidate lens a sprawl triage needs. Defaults to false so the
+  // tool stays a full inventory.
+  const staleOnly = params["staleOnly"] === true;
   const where = {
     ...(status ? { status } : {}),
     ...(decisionScope ? { decisionScope } : {}),
     ...(portfolioRole ? { portfolioRole } : {}),
   };
-  const capsules = await prisma.workCapsule.findMany({
+  const rows = await prisma.workCapsule.findMany({
     where,
     orderBy: { updatedAt: "desc" },
     take: limit === null ? 50 : Math.min(Math.max(Math.trunc(limit), 1), 100),
@@ -236,16 +240,64 @@ export async function listWorkCapsulesTool(params: Record<string, unknown>): Pro
       headBranch: true,
       worktreePath: true,
       pullRequestUrl: true,
+      pullRequestNumber: true,
       leaseExpiresAt: true,
       lastSyncedAt: true,
       updatedAt: true,
+      featureBuildId: true,
     },
   });
 
+  // Join the linked Build Studio build so a null-lease capsule's liveness reads
+  // from real build progress (phase + updatedAt), not its frozen-at-14:00
+  // updatedAt. FeatureBuild.updatedAt advances only on genuine phase progress.
+  const { classifyWorkCapsuleLiveness } = await import("@/lib/work-capsules/liveness");
+  const buildIds = rows
+    .map((r) => r.featureBuildId)
+    .filter((id): id is string => Boolean(id));
+  const buildsById = new Map<string, { phase: string | null; lastActivityAt: Date | null }>();
+  if (buildIds.length > 0) {
+    const builds = await prisma.featureBuild.findMany({
+      where: { id: { in: [...new Set(buildIds)] } },
+      select: { id: true, phase: true, updatedAt: true },
+    });
+    for (const b of builds) {
+      buildsById.set(b.id, { phase: b.phase ?? null, lastActivityAt: b.updatedAt ?? null });
+    }
+  }
+
+  const now = new Date();
+  const capsulesAll = rows.map((row) => {
+    const featureBuild = row.featureBuildId ? buildsById.get(row.featureBuildId) ?? null : null;
+    const verdict = classifyWorkCapsuleLiveness({ ...row, featureBuild }, now);
+    const { featureBuildId: _omit, ...rest } = row;
+    return {
+      ...rest,
+      liveness: verdict.liveness,
+      isLive: verdict.isLive,
+      isReapable: verdict.isReapable,
+      livenessReason: verdict.reason,
+      // The timestamp that PROVES liveness (lease / build activity / sync) — not
+      // updatedAt, which is a daily-heartbeat artifact for Build Studio capsules.
+      trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
+    };
+  });
+  const capsules = staleOnly ? capsulesAll.filter((c) => !c.isLive) : capsulesAll;
+
+  const liveCount = capsulesAll.filter((c) => c.isLive).length;
+  const reapableCount = capsulesAll.filter((c) => c.isReapable).length;
+  const byLiveness: Record<string, number> = {};
+  for (const c of capsulesAll) byLiveness[c.liveness] = (byLiveness[c.liveness] ?? 0) + 1;
+
   return {
     success: true,
-    message: `Listed ${capsules.length} work capsule(s).`,
-    data: { capsules },
+    message:
+      `Listed ${capsules.length} work capsule(s). True liveness (updatedAt is NOT a liveness signal): ` +
+      `${liveCount} live, ${reapableCount} reap-candidate of ${capsulesAll.length} scanned.`,
+    data: {
+      capsules,
+      livenessSummary: { scanned: capsulesAll.length, live: liveCount, reapable: reapableCount, byLiveness },
+    },
   };
 }
 

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -211,93 +211,26 @@ export async function listWorkCapsulesTool(params: Record<string, unknown>): Pro
   }
 
   const limit = numberParam(params, "limit");
-  // WS9 (BI-CBAAEA94): `staleOnly` returns only capsules that are NOT truly live
-  // — the reap-candidate lens a sprawl triage needs. Defaults to false so the
-  // tool stays a full inventory.
+  // WS9 (BI-CBAAEA94): `staleOnly` returns only NOT-truly-live capsules (the reap
+  // lens); default false keeps the tool a full inventory. Liveness is derived
+  // from lease/build/sync — never updatedAt (a daily-heartbeat artifact).
   const staleOnly = params["staleOnly"] === true;
   const where = {
     ...(status ? { status } : {}),
     ...(decisionScope ? { decisionScope } : {}),
     ...(portfolioRole ? { portfolioRole } : {}),
   };
-  const rows = await prisma.workCapsule.findMany({
-    where,
-    orderBy: { updatedAt: "desc" },
-    take: limit === null ? 50 : Math.min(Math.max(Math.trunc(limit), 1), 100),
-    select: {
-      capsuleId: true,
-      title: true,
-      status: true,
-      source: true,
-      executorKind: true,
-      decisionScope: true,
-      portfolioRole: true,
-      servedPersona: true,
-      activityKind: true,
-      outcomeAnchor: true,
-      servesPortfolioRoles: true,
-      dependsOnPortfolioRoles: true,
-      headBranch: true,
-      worktreePath: true,
-      pullRequestUrl: true,
-      pullRequestNumber: true,
-      leaseExpiresAt: true,
-      lastSyncedAt: true,
-      updatedAt: true,
-      featureBuildId: true,
-    },
-  });
-
-  // Join the linked Build Studio build so a null-lease capsule's liveness reads
-  // from real build progress (phase + updatedAt), not its frozen-at-14:00
-  // updatedAt. FeatureBuild.updatedAt advances only on genuine phase progress.
-  const { classifyWorkCapsuleLiveness } = await import("@/lib/work-capsules/liveness");
-  const buildIds = rows
-    .map((r) => r.featureBuildId)
-    .filter((id): id is string => Boolean(id));
-  const buildsById = new Map<string, { phase: string | null; lastActivityAt: Date | null }>();
-  if (buildIds.length > 0) {
-    const builds = await prisma.featureBuild.findMany({
-      where: { id: { in: [...new Set(buildIds)] } },
-      select: { id: true, phase: true, updatedAt: true },
-    });
-    for (const b of builds) {
-      buildsById.set(b.id, { phase: b.phase ?? null, lastActivityAt: b.updatedAt ?? null });
-    }
-  }
-
-  const now = new Date();
-  const capsulesAll = rows.map((row) => {
-    const featureBuild = row.featureBuildId ? buildsById.get(row.featureBuildId) ?? null : null;
-    const verdict = classifyWorkCapsuleLiveness({ ...row, featureBuild }, now);
-    const { featureBuildId: _omit, ...rest } = row;
-    return {
-      ...rest,
-      liveness: verdict.liveness,
-      isLive: verdict.isLive,
-      isReapable: verdict.isReapable,
-      livenessReason: verdict.reason,
-      // The timestamp that PROVES liveness (lease / build activity / sync) — not
-      // updatedAt, which is a daily-heartbeat artifact for Build Studio capsules.
-      trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
-    };
-  });
+  const take = limit === null ? 50 : Math.min(Math.max(Math.trunc(limit), 1), 100);
+  const { loadCapsuleLivenessInventory } = await import("@/lib/work-capsules/liveness-inventory");
+  const { capsulesAll, livenessSummary } = await loadCapsuleLivenessInventory(prisma as never, { where, take });
   const capsules = staleOnly ? capsulesAll.filter((c) => !c.isLive) : capsulesAll;
-
-  const liveCount = capsulesAll.filter((c) => c.isLive).length;
-  const reapableCount = capsulesAll.filter((c) => c.isReapable).length;
-  const byLiveness: Record<string, number> = {};
-  for (const c of capsulesAll) byLiveness[c.liveness] = (byLiveness[c.liveness] ?? 0) + 1;
 
   return {
     success: true,
     message:
-      `Listed ${capsules.length} work capsule(s). True liveness (updatedAt is NOT a liveness signal): ` +
-      `${liveCount} live, ${reapableCount} reap-candidate of ${capsulesAll.length} scanned.`,
-    data: {
-      capsules,
-      livenessSummary: { scanned: capsulesAll.length, live: liveCount, reapable: reapableCount, byLiveness },
-    },
+      `Listed ${capsules.length} work capsule(s). Liveness (updatedAt is NOT a liveness signal): ` +
+      `${livenessSummary.live} live, ${livenessSummary.reapable} reap-candidate of ${livenessSummary.scanned} scanned.`,
+    data: { capsules, livenessSummary },
   };
 }
 

--- a/apps/web/lib/work-capsules/work-capsule-presenter.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.test.ts
@@ -41,22 +41,68 @@ describe("presentCapsuleRow", () => {
     expect(row.branch).toBe("no branch");
   });
 
-  it("marks a working capsule that has not advanced as stalled, not ok", () => {
+  it("WS9: a null-lease capsule idle past the floor reads stalled, not ok", () => {
+    // The frozen-14:00 Build Studio shape: no lease, no sync, no build signal,
+    // updatedAt stuck at birth. Liveness must come from that idle age, not the
+    // presence of a recent updatedAt.
     const row = presentCapsuleRow({
       capsuleId: "WC-STALL",
-      title: "Add timestamps",
+      title: "Frozen build-studio capsule",
       status: "working",
-      source: "manual",
+      source: "build-studio",
       executorKind: "build-studio",
       headBranch: null,
       worktreePath: null,
       pullRequestUrl: null,
-      leaseExpiresAt: new Date("2026-05-14T05:00:00.000Z"), // lease still valid
-      lastSyncedAt: new Date("2026-05-14T01:00:00.000Z"), // freshly synced (not stale-cache)
-      updatedAt: new Date("2026-05-14T00:30:00.000Z"), // no progress for 30 min
+      leaseExpiresAt: null,
+      lastSyncedAt: null,
+      updatedAt: new Date("2026-05-12T14:00:00.000Z"), // born two days ago at 14:00
     }, new Date("2026-05-14T01:00:00.000Z"));
 
     expect(row.health).toBe("stalled");
+    expect(row.isLive).toBe(false);
+    expect(row.liveness).toBe("idle-stale");
+  });
+
+  it("WS9: a valid lease reads live even when updatedAt is old (updatedAt is not liveness)", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-LIVE-LEASE",
+      title: "Actively leased work",
+      status: "working",
+      source: "external-adoption",
+      executorKind: "codex-desktop",
+      headBranch: "feat/x",
+      worktreePath: "D:/DPF-x",
+      pullRequestUrl: null,
+      leaseExpiresAt: new Date("2026-05-14T05:00:00.000Z"), // lease still valid
+      lastSyncedAt: new Date("2026-05-14T01:00:00.000Z"),
+      updatedAt: new Date("2026-05-14T00:30:00.000Z"), // old — must NOT flag stalled
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("ok");
+    expect(row.isLive).toBe(true);
+    expect(row.liveness).toBe("live");
+  });
+
+  it("WS9: a capsule whose linked build is abandoned reads abandoned-build, not working-healthy", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-ZOMBIE",
+      title: "Build died, capsule stuck working",
+      status: "working",
+      source: "build-studio",
+      executorKind: "build-studio",
+      headBranch: null,
+      worktreePath: null,
+      pullRequestUrl: null,
+      leaseExpiresAt: null,
+      lastSyncedAt: null,
+      updatedAt: new Date("2026-05-14T00:50:00.000Z"), // recently born — updatedAt looks fresh
+      featureBuild: { phase: "abandoned", lastActivityAt: new Date("2026-05-13T09:00:00.000Z") },
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("abandoned-build");
+    expect(row.isLive).toBe(false);
+    expect(row.liveness).toBe("build-terminal");
   });
 
   it("keeps a freshly-advanced working capsule healthy", () => {

--- a/apps/web/lib/work-capsules/work-capsule-presenter.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.ts
@@ -1,10 +1,5 @@
 import { STALE_CACHE_MS } from "@/lib/work-capsules";
-
-// A capsule that claims to be "working" but has not changed in this long is
-// almost certainly stalled (e.g. its build died in ideate). Surface that as a
-// degraded health signal instead of a misleading "ok" — Work Control must not
-// report a dead capsule as healthy.
-const WORKING_STALL_MS = 15 * 60 * 1000;
+import { classifyWorkCapsuleLiveness } from "./liveness";
 
 type CapsuleRowInput = {
   capsuleId: string;
@@ -22,9 +17,14 @@ type CapsuleRowInput = {
   headBranch: string | null;
   worktreePath: string | null;
   pullRequestUrl: string | null;
+  pullRequestNumber?: number | null;
   leaseExpiresAt: Date | null;
   lastSyncedAt: Date | null;
   updatedAt: Date;
+  // WS9 (BI-CBAAEA94): the linked Build Studio build snapshot, when loaded, so a
+  // null-lease capsule's liveness reads from real build progress instead of its
+  // frozen-at-14:00 updatedAt. Optional — absent falls back to lease/sync/idle.
+  featureBuild?: { phase: string | null; lastActivityAt: Date | null } | null;
 };
 
 export type PresentedCapsuleRow = ReturnType<typeof presentCapsuleRow>;
@@ -72,10 +72,25 @@ function outcomeAnchorLabel(value: unknown): string | null {
 }
 
 export function presentCapsuleRow(row: CapsuleRowInput, now = new Date()) {
-  const leaseExpired = row.leaseExpiresAt != null && row.leaseExpiresAt.getTime() < now.getTime();
+  // WS9: liveness is derived from lease / linked-build / sync — NOT updatedAt,
+  // which the 14:00 governed-backlog tee-up freezes at capsule birth. The
+  // classifier is the single source of truth shared with the tool and reaper.
+  const verdict = classifyWorkCapsuleLiveness(row, now);
+  // Stale scanner cache is an orthogonal, still-useful nuance: the lease is live
+  // but the cached worktree data is old. Only surfaced when the capsule is not
+  // already dead by a stronger signal.
   const staleCache = row.lastSyncedAt != null && now.getTime() - row.lastSyncedAt.getTime() > STALE_CACHE_MS;
-  const stalledWorking =
-    row.status === "working" && now.getTime() - row.updatedAt.getTime() > WORKING_STALL_MS;
+
+  const health =
+    verdict.liveness === "lease-expired"
+      ? "lease-expired"
+      : verdict.liveness === "build-terminal"
+        ? "abandoned-build"
+        : verdict.liveness === "idle-stale"
+          ? "stalled"
+          : staleCache
+            ? "stale-cache"
+            : "ok";
 
   return {
     capsuleId: row.capsuleId,
@@ -98,13 +113,16 @@ export function presentCapsuleRow(row: CapsuleRowInput, now = new Date()) {
     },
     worktreePath: row.worktreePath,
     pullRequestUrl: row.pullRequestUrl,
-    health: leaseExpired
-      ? "lease-expired"
-      : stalledWorking
-        ? "stalled"
-        : staleCache
-          ? "stale-cache"
-          : "ok",
+    health,
+    // WS9 true-liveness surface: `liveness`/`isLive`/`livenessReason` say whether
+    // the work is actually alive, and `trueLivenessAt` is the timestamp that
+    // proves it (lease expiry / build activity / sync) — never the frozen
+    // updatedAt. `updatedAt` is retained for continuity but is not a liveness
+    // signal.
+    liveness: verdict.liveness,
+    isLive: verdict.isLive,
+    livenessReason: verdict.reason,
+    trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
     updatedAt: row.updatedAt.toISOString(),
   };
 }

--- a/apps/web/lib/work-capsules/work-capsule-reaper.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-reaper.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/portal-context/invalidation", () => ({
+  revalidatePortalContext: vi.fn(),
+}));
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    workCapsule: { findFirst: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+    workCapsuleActivity: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+vi.mock("@dpf/db", () => ({ prisma: prismaMock }));
+
+import {
+  reapStaleWorkCapsules,
+  selectReapCandidates,
+  transitionCapsuleForTerminalBuild,
+  type ReaperBuildSnapshot,
+} from "./work-capsule-reaper";
+import type { CapsuleDb } from "./work-capsule-store";
+
+const NOW = new Date("2026-08-05T15:00:00.000Z");
+
+function capsule(overrides: Record<string, unknown> = {}) {
+  return {
+    capsuleId: "WC-X",
+    title: "Something",
+    status: "working",
+    source: "build-studio",
+    executorKind: "build-studio",
+    leaseExpiresAt: null,
+    lastSyncedAt: null,
+    updatedAt: NOW,
+    pullRequestUrl: null,
+    pullRequestNumber: null,
+    headBranch: null,
+    worktreePath: null,
+    featureBuildId: null,
+    ...overrides,
+  };
+}
+
+describe("selectReapCandidates", () => {
+  it("selects lease-expired, build-terminal, and idle-stale — never live/terminal", () => {
+    const builds = new Map<string, ReaperBuildSnapshot>([
+      ["fb-abandoned", { phase: "abandoned", lastActivityAt: new Date("2026-08-02T09:00:00.000Z") }],
+      ["fb-building", { phase: "build", lastActivityAt: new Date("2026-08-05T14:55:00.000Z") }],
+    ]);
+    const rows = [
+      capsule({ capsuleId: "WC-LEASE-DEAD", executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z") }),
+      capsule({ capsuleId: "WC-LEASE-LIVE", executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-05T15:20:00.000Z") }),
+      capsule({ capsuleId: "WC-ZOMBIE", featureBuildId: "fb-abandoned" }),
+      capsule({ capsuleId: "WC-BUILDING", featureBuildId: "fb-building" }),
+      capsule({ capsuleId: "WC-FROZEN14", updatedAt: new Date("2026-08-02T14:00:00.000Z") }),
+      capsule({ capsuleId: "WC-PR", pullRequestNumber: 4055, leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z") }),
+      capsule({ capsuleId: "WC-DONE", status: "complete", updatedAt: new Date("2026-06-01T00:00:00.000Z") }),
+      capsule({ capsuleId: "WC-NEW", updatedAt: new Date("2026-08-05T14:45:00.000Z") }),
+    ];
+
+    const picked = selectReapCandidates(rows, builds, NOW).map((c) => c.capsuleId);
+
+    expect(picked).toEqual(["WC-LEASE-DEAD", "WC-ZOMBIE", "WC-FROZEN14"]);
+    expect(picked).not.toContain("WC-LEASE-LIVE");
+    expect(picked).not.toContain("WC-BUILDING");
+    expect(picked).not.toContain("WC-PR");
+    expect(picked).not.toContain("WC-DONE");
+    expect(picked).not.toContain("WC-NEW");
+  });
+});
+
+function makeDb() {
+  const db = {
+    workCapsule: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    workCapsuleActivity: { create: vi.fn() },
+    featureBuild: { findMany: vi.fn() },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(db)),
+  };
+  return db;
+}
+
+describe("reapStaleWorkCapsules", () => {
+  let db: ReturnType<typeof makeDb>;
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  const deadRows = () => [
+    capsule({ capsuleId: "WC-LEASE-DEAD", executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z") }),
+    capsule({ capsuleId: "WC-LIVE", executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-05T15:30:00.000Z") }),
+  ];
+
+  it("DEFAULTS to dry-run: returns candidates but writes nothing", async () => {
+    db.workCapsule.findMany.mockResolvedValueOnce(deadRows());
+    db.featureBuild.findMany.mockResolvedValueOnce([]);
+
+    const result = await reapStaleWorkCapsules({ db: db as unknown as CapsuleDb, now: NOW });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.reaped).toBe(0);
+    expect(result.candidates.map((c) => c.capsuleId)).toEqual(["WC-LEASE-DEAD"]);
+    // No mutation on the default path.
+    expect(db.workCapsule.update).not.toHaveBeenCalled();
+    expect(db.workCapsuleActivity.create).not.toHaveBeenCalled();
+  });
+
+  it("transitions dead capsules to abandoned only when dryRun=false", async () => {
+    db.workCapsule.findMany.mockResolvedValueOnce(deadRows());
+    db.featureBuild.findMany.mockResolvedValueOnce([]);
+    db.workCapsule.findUnique.mockResolvedValue({ id: "row-lease-dead", capsuleId: "WC-LEASE-DEAD", workspaceState: {} });
+    db.workCapsule.update.mockResolvedValue({ id: "row-lease-dead", capsuleId: "WC-LEASE-DEAD" });
+
+    const result = await reapStaleWorkCapsules({ db: db as unknown as CapsuleDb, now: NOW, dryRun: false });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.reaped).toBe(1);
+    expect(db.workCapsule.update).toHaveBeenCalledTimes(1);
+    expect(db.workCapsule.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { capsuleId: "WC-LEASE-DEAD" },
+        data: expect.objectContaining({ status: "abandoned" }),
+      }),
+    );
+    // The live capsule is never touched.
+    expect(db.workCapsule.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ where: { capsuleId: "WC-LIVE" } }),
+    );
+  });
+
+  it("classifies zombie build-studio capsules via the linked build snapshot", async () => {
+    db.workCapsule.findMany.mockResolvedValueOnce([
+      capsule({ capsuleId: "WC-ZOMBIE", featureBuildId: "fb-1" }),
+    ]);
+    db.featureBuild.findMany.mockResolvedValueOnce([
+      { id: "fb-1", phase: "abandoned", updatedAt: new Date("2026-08-02T09:00:00.000Z") },
+    ]);
+
+    const result = await reapStaleWorkCapsules({ db: db as unknown as CapsuleDb, now: NOW });
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]!.liveness).toBe("build-terminal");
+  });
+});
+
+describe("transitionCapsuleForTerminalBuild (build-reap coupling)", () => {
+  beforeEach(() => {
+    prismaMock.workCapsule.findFirst.mockReset();
+    prismaMock.workCapsule.findUnique.mockReset();
+    prismaMock.workCapsule.update.mockReset();
+    prismaMock.workCapsuleActivity.create.mockReset();
+    prismaMock.$transaction.mockReset();
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => fn(prismaMock));
+  });
+
+  it("abandons the non-terminal capsule attached to a reaped build", async () => {
+    prismaMock.workCapsule.findFirst.mockResolvedValueOnce({ capsuleId: "WC-ZOMBIE" });
+    prismaMock.workCapsule.findUnique.mockResolvedValueOnce({ id: "row-z", capsuleId: "WC-ZOMBIE", workspaceState: {} });
+    prismaMock.workCapsule.update.mockResolvedValueOnce({ id: "row-z", capsuleId: "WC-ZOMBIE" });
+
+    const did = await transitionCapsuleForTerminalBuild("FB-123", "inert — no activity in ideate.");
+
+    expect(did).toBe(true);
+    // Looks up by the build-studio idempotency key and only when non-terminal.
+    expect(prismaMock.workCapsule.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ idempotencyKey: "build-studio:FB-123" }),
+      }),
+    );
+    expect(prismaMock.workCapsule.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "abandoned" }) }),
+    );
+  });
+
+  it("is a no-op when no attached non-terminal capsule exists", async () => {
+    prismaMock.workCapsule.findFirst.mockResolvedValueOnce(null);
+
+    const did = await transitionCapsuleForTerminalBuild("FB-404", "stalled.");
+
+    expect(did).toBe(false);
+    expect(prismaMock.workCapsule.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/work-capsules/work-capsule-reaper.ts
+++ b/apps/web/lib/work-capsules/work-capsule-reaper.ts
@@ -1,0 +1,242 @@
+// apps/web/lib/work-capsules/work-capsule-reaper.ts
+//
+// WS9 (BI-CBAAEA94 / EP-PROCESS-SPINE) — the governed WorkCapsule reaper.
+//
+// The liveness contract (liveness.ts) makes a dead capsule READ as dead on every
+// surface. This reaper makes the STORED status catch up: a capsule whose lease
+// expired without renewal (or whose linked build is terminal, or that has sat
+// idle past the floor) is transitioned working/blocked → abandoned instead of
+// lingering as "working" and jamming the WIP cap.
+//
+// Governance (kernel: destructive-actions-require-explicit-go):
+//   - DRY-RUN IS THE DEFAULT. `reapStaleWorkCapsules` returns the candidate set
+//     and writes NOTHING unless the caller passes `dryRun: false`.
+//   - The scheduled caller (taskrun-watchdog) gates live actuation behind
+//     DPF_WORKCAPSULE_REAPER_AUTO_REAP=1 (observe-only otherwise), mirroring the
+//     runtime-artifact / worktree janitors.
+//   - Abandon is REVERSIBLE: re-promoting the backlog item (or re-adopting the
+//     branch) restarts the work cleanly. No data is deleted.
+//
+// Junction-safety: this module writes DB rows ONLY. It never touches the
+// filesystem, so it cannot damage a worktree junction or the root clone.
+// Worktree removal is a separate, explicitly-gated step (dpf-worktree-hygiene).
+
+import { WORK_CAPSULE_IDLE_STALE_MS } from "@/lib/work-capsules";
+import {
+  classifyWorkCapsuleLiveness,
+  type CapsuleLivenessInput,
+  type WorkCapsuleLiveness,
+} from "./liveness";
+import { updateWorkCapsuleStatus, type CapsuleDb, type WorkCapsuleActor } from "./work-capsule-store";
+
+/** Capsule statuses the reaper will never touch — already closed out. */
+const TERMINAL_STATUSES = new Set(["complete", "abandoned", "archived"]);
+
+const SYSTEM_ACTOR: WorkCapsuleActor = {
+  userId: "system:workcapsule-reaper",
+  agentId: null,
+  principalId: null,
+};
+
+export type ReapCandidate = {
+  capsuleId: string;
+  title: string;
+  status: string;
+  source: string;
+  executorKind: string | null;
+  headBranch: string | null;
+  worktreePath: string | null;
+  liveness: WorkCapsuleLiveness;
+  reason: string;
+  trueLivenessAt: string | null;
+};
+
+/** The linked-build snapshot the reaper joins onto build-studio capsules. */
+export type ReaperBuildSnapshot = { phase: string | null; lastActivityAt: Date | null };
+
+type ReaperCapsuleRow = CapsuleLivenessInput & {
+  capsuleId: string;
+  title: string;
+  source: string;
+  headBranch: string | null;
+  worktreePath: string | null;
+  featureBuildId: string | null;
+};
+
+/**
+ * Pure core: pick the reapable capsules. A capsule is a candidate when its
+ * status is non-terminal AND {@link classifyWorkCapsuleLiveness} says it is
+ * reapable (lease-expired, build-terminal, or idle-stale). `buildsById` supplies
+ * the linked FeatureBuild snapshot keyed by `featureBuildId`. No DB, fully tested.
+ */
+export function selectReapCandidates(
+  capsules: readonly ReaperCapsuleRow[],
+  buildsById: ReadonlyMap<string, ReaperBuildSnapshot>,
+  now: Date = new Date(),
+  idleMs: number = WORK_CAPSULE_IDLE_STALE_MS,
+): ReapCandidate[] {
+  const candidates: ReapCandidate[] = [];
+  for (const row of capsules) {
+    if (TERMINAL_STATUSES.has(row.status)) continue;
+    const featureBuild = row.featureBuildId ? buildsById.get(row.featureBuildId) ?? null : null;
+    const verdict = classifyWorkCapsuleLiveness({ ...row, featureBuild }, now, idleMs);
+    if (!verdict.isReapable) continue;
+    candidates.push({
+      capsuleId: row.capsuleId,
+      title: row.title,
+      status: row.status,
+      source: row.source,
+      executorKind: row.executorKind,
+      headBranch: row.headBranch,
+      worktreePath: row.worktreePath,
+      liveness: verdict.liveness,
+      reason: verdict.reason,
+      trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
+    });
+  }
+  return candidates;
+}
+
+export type ReapResult = {
+  dryRun: boolean;
+  scanned: number;
+  candidates: ReapCandidate[];
+  reaped: number;
+};
+
+type ReaperDb = CapsuleDb & {
+  featureBuild?: { findMany(args: unknown): Promise<any[]> };
+};
+
+const NON_TERMINAL_STATUSES = [
+  "draft",
+  "ready",
+  "working",
+  "blocked",
+  "verifying",
+  "ready-for-review",
+  "ready-for-promotion",
+];
+
+/**
+ * DB wrapper: scan non-terminal capsules, classify each against its true
+ * liveness signals, and (when `dryRun` is false) transition the dead ones to
+ * `abandoned`. DRY-RUN by default — a caller must pass `dryRun: false` to write.
+ * Best-effort per row: one failed transition never aborts the sweep. The reap
+ * SET is always returned so an operator can review before acting.
+ */
+export async function reapStaleWorkCapsules(args: {
+  db: ReaperDb;
+  now?: Date;
+  /** DEFAULT true. Pass false to actually transition dead capsules. */
+  dryRun?: boolean;
+  idleMs?: number;
+  actor?: WorkCapsuleActor;
+}): Promise<ReapResult> {
+  const now = args.now ?? new Date();
+  const idleMs = args.idleMs ?? WORK_CAPSULE_IDLE_STALE_MS;
+  const dryRun = args.dryRun ?? true;
+
+  const capsules: ReaperCapsuleRow[] = await args.db.workCapsule.findMany({
+    where: { status: { in: NON_TERMINAL_STATUSES }, archivedAt: null },
+    select: {
+      capsuleId: true,
+      title: true,
+      status: true,
+      source: true,
+      executorKind: true,
+      leaseExpiresAt: true,
+      lastSyncedAt: true,
+      updatedAt: true,
+      pullRequestUrl: true,
+      pullRequestNumber: true,
+      headBranch: true,
+      worktreePath: true,
+      featureBuildId: true,
+    },
+    take: 500,
+  });
+
+  // Batch-load the linked FeatureBuild snapshot for the build-studio capsules
+  // (their only real liveness signal). FeatureBuild.updatedAt advances on genuine
+  // phase progress — unlike the capsule's own updatedAt, which the 14:00 tee-up
+  // freezes at birth.
+  const buildIds = capsules
+    .map((c) => c.featureBuildId)
+    .filter((id): id is string => Boolean(id));
+  const buildsById = new Map<string, ReaperBuildSnapshot>();
+  if (buildIds.length > 0 && args.db.featureBuild) {
+    const builds = await args.db.featureBuild.findMany({
+      where: { id: { in: [...new Set(buildIds)] } },
+      select: { id: true, phase: true, updatedAt: true },
+    });
+    for (const b of builds) {
+      buildsById.set(b.id, { phase: b.phase ?? null, lastActivityAt: b.updatedAt ?? null });
+    }
+  }
+
+  const candidates = selectReapCandidates(capsules, buildsById, now, idleMs);
+
+  if (dryRun) {
+    return { dryRun: true, scanned: capsules.length, candidates, reaped: 0 };
+  }
+
+  let reaped = 0;
+  const actor = args.actor ?? SYSTEM_ACTOR;
+  for (const candidate of candidates) {
+    try {
+      await updateWorkCapsuleStatus({
+        db: args.db,
+        capsuleId: candidate.capsuleId,
+        status: "abandoned",
+        reason:
+          `Auto-abandoned by the governed WorkCapsule reaper (WS9/BI-CBAAEA94): ${candidate.reason} ` +
+          "Re-promote the backlog item or re-adopt the branch to resume. Worktree left untouched.",
+        actor,
+        now,
+      });
+      reaped += 1;
+      console.warn(
+        `[work-capsule-reaper] abandoned ${candidate.capsuleId} (${candidate.liveness}): ${candidate.reason}`,
+      );
+    } catch (err) {
+      console.warn(`[work-capsule-reaper] failed to abandon ${candidate.capsuleId}:`, err);
+    }
+  }
+  return { dryRun: false, scanned: capsules.length, candidates, reaped };
+}
+
+/**
+ * Close the loop when a Build Studio build is abandoned/completed: transition its
+ * attached WorkCapsule out of `working` so a terminal build never leaves a zombie
+ * "working" capsule behind (the largest slice of the WS9 sprawl). Best-effort and
+ * idempotent — a missing or already-terminal capsule is a no-op. Called from the
+ * inert-build reaper inside the same watchdog tick that abandons the build, so
+ * the capsule dies with its build without waiting for the periodic reaper. Since
+ * the build reaper is itself the governed actor here, this needs no extra flag.
+ */
+export async function transitionCapsuleForTerminalBuild(
+  buildId: string,
+  reason: string,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const { prisma } = await import("@dpf/db");
+  const db = prisma as unknown as CapsuleDb;
+  const capsule = await db.workCapsule.findFirst({
+    where: {
+      idempotencyKey: `build-studio:${buildId}`,
+      status: { notIn: [...TERMINAL_STATUSES] },
+    },
+    select: { capsuleId: true },
+  });
+  if (!capsule) return false;
+  await updateWorkCapsuleStatus({
+    db,
+    capsuleId: capsule.capsuleId,
+    status: "abandoned",
+    reason: `Linked build ${buildId} was abandoned: ${reason} Re-promote the backlog item to resume.`,
+    actor: SYSTEM_ACTOR,
+    now,
+  });
+  return true;
+}

--- a/docs/superpowers/plans/2026-08-05-workcapsule-liveness-and-reaper-ws9.md
+++ b/docs/superpowers/plans/2026-08-05-workcapsule-liveness-and-reaper-ws9.md
@@ -1,0 +1,74 @@
+# WS9 — WorkCapsule liveness contract + governed reaper
+
+**Backlog item:** BI-CBAAEA94 (WS9) · **Epic:** EP-PROCESS-SPINE
+**Date:** 2026-08-05 · **Type:** chore / observability + prevention
+
+## Problem
+
+A `list_work_capsules` sweep during the 2026-08-05 sprawl triage found ~100 `working` +
+~14 `blocked` capsules whose apparent liveness is **false**. Two root shapes:
+
+1. **Build Studio capsules** are born at the daily 14:00 `governed-backlog-tee-up`
+   (`build/governed-backlog-tee-up-scheduled`, cron `0 14 * * *`). If the build stalls
+   immediately, the capsule is never written again, so `updatedAt` freezes at
+   `...T14:00:00` while `status` stays `working`. They carry a **null lease**
+   (`isExternalLeaseExecutor("build-studio") === false`), so lease/sync say nothing.
+2. **External (codex/claude) capsules** get a 30-min lease (`LEASE_TTL_MS`) auto-renewed on
+   every capsule write. Their leases are overwhelmingly **expired** (oldest 2026-06-20), but
+   nothing transitions an expired-lease capsule out of `working`/`blocked`.
+
+Abandoned work therefore **displays as active**, jams the Build Studio WIP cap
+(`promote_to_build_studio` → `wip_cap_reached`, "15 builds vs 3"), and is the mechanism by
+which work is silently duplicated. This is root-cause E (no observability) made physical.
+
+## Design grounding
+
+- **Source of truth:** the WorkCapsule harness spec (`docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md` §21) already defines `leaseExpiresAt` / `lastSyncedAt` as the freshness witnesses and `LEASE_TTL_MS` as the lease contract. This WS **uses** that substrate; it does not invent new machinery.
+- **Existing substrate reused:** `presentCapsuleRow` (already lease/sync-aware), `heartbeatWorkCapsule` (lease renewal on every write via `runAutoRenewedCapsuleWrite`), `inert-build-reaper.ts` (the FeatureBuild WIP-cap reaper) and its `taskrun-watchdog` host, and the janitor flag pattern (`DPF_*_ENABLED` / `DPF_*_AUTO_REAP`).
+- **Decision:** extend, not create. The one net-new artifact is a shared pure classifier (`liveness.ts`) so board + tool + reaper agree, plus a capsule-level reaper mirroring the build reaper. No schema change (all fields already exist).
+
+## Approach (one coherent PR)
+
+1. **Liveness contract — `apps/web/lib/work-capsules/liveness.ts` (new, pure).**
+   `classifyWorkCapsuleLiveness(row, now)` → `{ liveness, isLive, isReapable, reason, trueLivenessAt }`.
+   Precedence: terminal status → open PR → terminal linked build → lease valid/expired →
+   null-lease freshest-of(build activity, sync) vs a 6h idle floor (`WORK_CAPSULE_IDLE_STALE_MS`,
+   override `WORK_CAPSULE_IDLE_MS`) → no-signal (recent, benefit of the doubt). **Never** uses
+   `updatedAt` as a liveness signal.
+
+2. **Observability (read-only).**
+   - `list_work_capsules` annotates each row with `liveness` / `isLive` / `isReapable` /
+     `livenessReason` / `trueLivenessAt`, adds a `livenessSummary`, and a `staleOnly=true`
+     reap-candidate lens. It joins the linked `FeatureBuild` phase for null-lease capsules.
+   - `presentCapsuleRow` (Work Control board) derives `health` from the classifier and exposes
+     the same liveness fields; `getWorkControlData` joins the linked build.
+
+3. **Prevention (reaper).**
+   - `work-capsule-reaper.ts` (new): `selectReapCandidates` (pure) + `reapStaleWorkCapsules`
+     (**dry-run by default**; live transition `working`→`abandoned` only when `dryRun:false`).
+   - Wired into the `taskrun-watchdog` tick: observe-only under `DPF_WORKCAPSULE_REAPER_ENABLED=1`,
+     live only with `DPF_WORKCAPSULE_REAPER_AUTO_REAP=1`.
+   - `transitionCapsuleForTerminalBuild` closes the zombie loop: the inert-build reaper abandons
+     a build → its attached capsule is abandoned in the same tick.
+   - **DB-only ⇒ junction-safe:** the reaper never touches the filesystem; worktree removal stays
+     with `worktree-janitor` / `dpf-worktree-hygiene` behind its own explicit go. Abandon is
+     reversible (re-promote / re-adopt).
+
+## Governance
+
+- `destructive-actions-require-explicit-go`: reaper dry-run default; live actuation flag-gated; the
+  reap SET is surfaced for human review (`staleOnly`), never auto-executed on the existing sprawl.
+- No auto-abandon of the current backlog of ~100 stale capsules — that is a **recommend-only** list
+  presented for explicit operator go.
+
+## Tests (TDD)
+
+- `liveness.test.ts` — incl. the regression: a null-lease BS capsule frozen at 14:00 is **not** live.
+- `work-capsule-reaper.test.ts` — candidate selection; dry-run writes nothing; live transitions only
+  the dead; build-terminal via the linked snapshot; the terminal-build → capsule coupling.
+- `work-capsule-presenter.test.ts` — dead lease still `lease-expired`; valid lease reads live despite
+  old `updatedAt`; abandoned linked build reads `abandoned-build`.
+
+## Backlog coverage
+
+- **BI-CBAAEA94 (WS9)** — Task 9.1 (reap-by-lease candidate set, recommend-only) → `list_work_capsules staleOnly` + reaper dry-run. Task 9.2 (board tells the truth; stop the 14:00 heartbeat masking) → classifier + presenter/tool + reaper.

--- a/docs/superpowers/plans/2026-08-05-workcapsule-liveness-and-reaper-ws9.md
+++ b/docs/superpowers/plans/2026-08-05-workcapsule-liveness-and-reaper-ws9.md
@@ -71,4 +71,10 @@ which work is silently duplicated. This is root-cause E (no observability) made 
 
 ## Backlog coverage
 
-- **BI-CBAAEA94 (WS9)** — Task 9.1 (reap-by-lease candidate set, recommend-only) → `list_work_capsules staleOnly` + reaper dry-run. Task 9.2 (board tells the truth; stop the 14:00 heartbeat masking) → classifier + presenter/tool + reaper.
+- Decision: atomic
+- Parent: BI-CBAAEA94
+- Receipt: cmsgy9bof045t01nviamzpgje
+- Rationale: One coherent PR by explicit design — WS10 (BI-71991853) names the 1-BI-per-PR-per-lease pattern as the cause of this sprawl. The classifier, the tool/board surfacing that consumes it, the governed reaper, and the build-reap-to-capsule coupling are mutually dependent; no phase ships independently, and tests land with the code.
+- Dependencies: none
+
+Covers BI-CBAAEA94 (WS9): Task 9.1 (recommend-only reap set via list_work_capsules staleOnly + reaper dry-run) and Task 9.2 (board tells the truth; stop the 14:00 heartbeat masking).

--- a/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
@@ -38,6 +38,7 @@ Creates are covered by [`dpf-worktree-per-session`](../dpf-worktree-per-session/
 |------|--------|------------------|
 | **Primary reaper** — this session's worktree on **SessionEnd** when Tier-A (merged + clean). Never on `Stop`: that fires every turn, and a live tree becomes Tier-A the moment its own PR merges (BI-E5D810B8) | Client hooks (`worktree-session-hygiene.mjs`) | No — automatic when dpf-platform / global hooks are installed |
 | **Fleet soak** — scheduled observe / optional Tier-A, sandbox leftover GC | Portal Inngest (`ops/worktree-janitor`, `ops/sandbox-build-gc`) + env flags | No — enable flags; do not hand-cron |
+| **WorkCapsule reaper** — transition dead capsule *records* (lease expired / build terminal / idle) `working`→`abandoned`; the DB half of hygiene (WS9) | Portal Inngest (`ops/taskrun-watchdog` tick) + `DPF_WORKCAPSULE_REAPER_*` flags | No — enable flags; observe via `list_work_capsules staleOnly=true` |
 | **Exceptional reclaim** — live Tier-A bulk prune, force-delete locked dirs, kill locking shells | Operator + explicit "go" | Only after dry-run report + operator approval |
 
 Primary design: multi-client governance parity (BI-42FA7DD8, BI-8BD61C30, BI-A4BEFE99). Spec/plan under `docs/superpowers/*2026-07-26-multi-client-governance-parity*`.
@@ -50,6 +51,8 @@ Primary design: multi-client governance parity (BI-42FA7DD8, BI-8BD61C30, BI-A4B
 | `DPF_WORKTREE_JANITOR_AUTO_REAP` | off | When `1` **and** ENABLED, live **Tier A only** |
 | `DPF_SANDBOX_BUILD_GC_ENABLED` | off | When `1`, daily GC for terminal/orphan `.builds/*` |
 | `DPF_SANDBOX_BUILD_GC_DELETE_BRANCHES` | off | When `1` **and** ENABLED, also age-delete `build/*` past grace |
+| `DPF_WORKCAPSULE_REAPER_ENABLED` | off | When `1`, the taskrun-watchdog tick **scans** for dead WorkCapsules (observe-only unless AUTO_REAP) |
+| `DPF_WORKCAPSULE_REAPER_AUTO_REAP` | off | When `1` **and** ENABLED, live-transition dead capsules `working`→`abandoned` (reversible; DB-only) |
 
 Wire via host `.env` and/or gitignored `docker-compose.override.yml` on the **portal** service, then recreate portal so `printenv` shows the flags. Do not set AUTO_REAP or BRANCH delete until observe-only soak looks clean.
 
@@ -148,6 +151,17 @@ Prefer flag-enabled scheduled GC. Manual one-shot only with go:
 - Remove **orphan** `.builds/FB-*` (no FeatureBuild row) or **terminal** phases.
 - Keep currently checked-out / non-terminal (`review`, `building`, …) branches.
 - `git worktree prune` inside sandbox if a dir was deleted out from under git.
+
+### F. Stale WorkCapsule records (the DB half of the sprawl — WS9 / BI-CBAAEA94)
+
+Disk hygiene reaps *worktrees and sandboxes*; this reaps the **WorkCapsule row** — the coordination record that shows on the Work Control board and in `list_work_capsules`. They drift apart: a Build Studio capsule is born at the daily 14:00 governed-backlog tee-up and, if its build stalls, is never written again, so `updatedAt` freezes at `...T14:00:00` while `status` still says `working`. Dozens of dead capsules then **read as active**, jam the Build Studio WIP cap, and become the mechanism by which work is silently duplicated.
+
+**`updatedAt` is not liveness.** True liveness (`apps/web/lib/work-capsules/liveness.ts`) is derived from signals that only advance with real work: an open PR, a lease-backed executor's `leaseExpiresAt` (external Claude/Codex/Grok), the linked build's phase + activity (a null-lease BS capsule's only real signal), and `lastSyncedAt`. The board, `list_work_capsules` (see its `livenessSummary` and `staleOnly=true`), and the reaper all share that one classifier.
+
+- **Observe (always safe):** `list_work_capsules staleOnly=true` — the reap-candidate set, each with a `liveness` verdict and the `trueLivenessAt` that proves it. No writes.
+- **Governed reaper** (`apps/web/lib/work-capsules/work-capsule-reaper.ts`) runs on the taskrun-watchdog tick: observe-only when `DPF_WORKCAPSULE_REAPER_ENABLED=1`, live only with `DPF_WORKCAPSULE_REAPER_AUTO_REAP=1`. It transitions dead capsules `working`→`abandoned`.
+- **DB-only, so junction-safe:** the reaper never touches the filesystem. Reaping the capsule record does **not** delete the worktree — that stays for `worktree-janitor` / section C after its own explicit go. Abandon is reversible: re-promote the backlog item or re-adopt the branch.
+- A terminal build now abandons its attached capsule in the same watchdog tick (no zombie `working` capsule left behind).
 
 ## Per-worktree caches and links that make a fresh worktree look broken
 


### PR DESCRIPTION
## What & why

WS9 of **EP-PROCESS-SPINE** (BI-CBAAEA94). Abandoned Work Capsules were displaying as **active**. Build Studio capsules are born at the daily 14:00 `governed-backlog-tee-up` and, if the build stalls, never written again — so `updatedAt` freezes at `...T14:00:00` while `status` stays `working`. They carry a **null lease**, so ~80 dead capsules read as live, jam the Build Studio WIP cap (`wip_cap_reached`, "15 vs 3"), and become the mechanism of silent work duplication. External codex/claude capsules similarly linger with long-expired leases. Root-cause **E** (no observability) made physical.

**`updatedAt` is not a liveness signal.** This makes the lease the liveness contract.

## Changes (one coherent PR)

1. **Liveness contract** — `apps/web/lib/work-capsules/liveness.ts` (new, pure). `classifyWorkCapsuleLiveness` derives true liveness from open PR, lease expiry, linked-build phase/activity, and `lastSyncedAt` — never `updatedAt`. Single source of truth shared by board, tool, and reaper.
2. **Observability (read-only)** — `list_work_capsules` annotates each row with `liveness`/`isLive`/`isReapable`/`trueLivenessAt` + a `livenessSummary`, and a `staleOnly=true` reap-candidate lens; joins the linked build. `presentCapsuleRow` (Work Control board) derives `health` from the classifier and joins the build so a terminal build reads `abandoned-build`, not healthy-`working`.
3. **Prevention (governed reaper)** — `work-capsule-reaper.ts` (new) transitions dead capsules `working`→`abandoned`. **Dry-run by default**; wired into the `taskrun-watchdog` tick, observe-only under `DPF_WORKCAPSULE_REAPER_ENABLED=1`, live only with `DPF_WORKCAPSULE_REAPER_AUTO_REAP=1`. The inert-build reaper now abandons a build's attached capsule in the same tick (no zombie). **DB-only ⇒ junction-safe**: worktree removal stays with `worktree-janitor` behind its own explicit go. Abandon is reversible (re-promote / re-adopt).

No schema change — all fields already existed.

## Governance

- `destructive-actions-require-explicit-go`: reaper dry-run default; live actuation flag-gated. **No auto-abandon of the existing ~100-capsule backlog** — that is a recommend-only reap set surfaced for explicit operator go (see the work-item report).

## Design grounding

Extends the existing WorkCapsule harness substrate (spec `2026-05-14…control-harness-design.md` §21 lease/sync witnesses; `LEASE_TTL_MS`). One net-new shared classifier + a capsule reaper mirroring `inert-build-reaper.ts`. Plan: `docs/superpowers/plans/2026-08-05-workcapsule-liveness-and-reaper-ws9.md`.

## Tests (TDD)

`liveness.test.ts`, `work-capsule-reaper.test.ts`, `work-capsule-presenter.test.ts` — **24 passing locally**. Includes the regression: a null-lease Build Studio capsule frozen at 14:00 no longer reads as live; a dead lease and a terminal linked build read dead.

## Verification note

Source-only worktree (`node_modules_missing`; `@dpf/db` types unbuilt), so the full local typecheck/pregate cannot run here — pushed with the allowlisted `external-contribution-no-install` override (records an override, not a pass). Unit tests for the changed code are green; **CI runs the full four gates** on this PR.

Backlog coverage: BI-CBAAEA94 (WS9) Task 9.1 (recommend-only reap set → `list_work_capsules staleOnly` + reaper dry-run) and Task 9.2 (board tells the truth; stop the 14:00 heartbeat masking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Docs-Impact-Decision: internal changes only — work-capsules-pack.ts adds a staleOnly param + a liveness note to an existing tool description, and taskrun-watchdog.ts adds a governed reaper hook; neither changes a user-guide page.
Seed-Fit-Decision: global-default
