### PR TITLE
fix(proxy): exempt internal service callbacks from the PUBLIC_URL canonical redirect (BI-A5842B04)

### DIFF
--- a/apps/web/lib/canonical-host.test.ts
+++ b/apps/web/lib/canonical-host.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
-import { decideHostMatch, enforceCanonicalHost } from "./canonical-host";
+import { decideHostMatch, enforceCanonicalHost, isCanonicalRedirectExempt } from "./canonical-host";
 
 const path = "/foo";
 const search = "?bar=1";
@@ -165,6 +165,34 @@ describe("decideHostMatch", () => {
   });
 });
 
+describe("isCanonicalRedirectExempt", () => {
+  it.each(["/api/health", "/api/healthz", "/api/ready"])(
+    "exempts health-probe path %s",
+    (p) => expect(isCanonicalRedirectExempt(p)).toBe(true),
+  );
+
+  it.each([
+    "/api/inngest",
+    "/api/inngest/",
+    "/api/mcp",
+    "/api/mcp/v1",
+    "/api/mcp/v1/anything",
+  ])("exempts internal service callback %s", (p) =>
+    expect(isCanonicalRedirectExempt(p)).toBe(true),
+  );
+
+  it.each([
+    "/",
+    "/ops/demand",
+    "/api/v1/federation/demand",
+    "/api/inngestx",
+    "/api/mcpx",
+    "/api/health/extra",
+  ])("does NOT exempt browser/other route %s", (p) =>
+    expect(isCanonicalRedirectExempt(p)).toBe(false),
+  );
+});
+
 // Helper: build a NextRequest with optional host / x-forwarded-host headers.
 function buildRequest(opts: {
   url: string;
@@ -268,6 +296,23 @@ describe("enforceCanonicalHost (Next.js wrapper)", () => {
       const req = buildRequest({
         url: `http://192.168.1.10:3000${probePath}`,
         host: "192.168.1.10:3000",
+      });
+      expect(enforceCanonicalHost(req)).toBeNull();
+    },
+  );
+
+  // Regression (BI-A5842B04): setting PUBLIC_URL must never 301 the internal
+  // service callbacks that arrive on the Docker service host / loopback — a
+  // redirect there corrupts Inngest's signed POSTs (background jobs die) and the
+  // MCP/CI JSON. Even with PUBLIC_URL set and a non-canonical host, pass through.
+  it.each(["/api/inngest", "/api/mcp/v1"])(
+    "never redirects internal service callback %s even with PUBLIC_URL set",
+    (internalPath) => {
+      process.env.PUBLIC_URL = "https://portal.example.com";
+      delete process.env.PUBLIC_URL_ALIASES;
+      const req = buildRequest({
+        url: `http://portal:3000${internalPath}`,
+        host: "portal:3000",
       });
       expect(enforceCanonicalHost(req)).toBeNull();
     },

--- a/apps/web/lib/canonical-host.ts
+++ b/apps/web/lib/canonical-host.ts
@@ -96,15 +96,36 @@ import { NextResponse, type NextRequest } from "next/server";
 
 const HEALTH_PROBE_PATHS = new Set(["/api/health", "/api/healthz", "/api/ready"]);
 
+// Internal service-to-service callbacks arrive on the internal Docker hostname
+// (INNGEST_SERVE_ORIGIN=http://portal:3000) or loopback — hosts that never match
+// a public PUBLIC_URL. A 301 corrupts these machine payloads: the Inngest
+// executor's signed function-run POSTs then fail signature validation, killing
+// ALL background jobs (self-upgrade, backups, watchdogs, evals, the federation
+// reconciliation), and the MCP tool surface / local-CI gate get a redirect
+// instead of JSON. These are machine callbacks, not browser navigation, so
+// canonicalization must not apply. See BI-A5842B04.
+const INTERNAL_SERVICE_CALLBACK_PREFIXES = ["/api/inngest", "/api/mcp"];
+
+/** Paths exempt from canonical-host redirection: health probes that load
+ *  balancers hit on the raw LAN IP, plus internal service callbacks that arrive
+ *  on the Docker service hostname / loopback and must never be redirected. Pure
+ *  and exported for direct unit testing. */
+export function isCanonicalRedirectExempt(pathname: string): boolean {
+  if (HEALTH_PROBE_PATHS.has(pathname)) return true;
+  return INTERNAL_SERVICE_CALLBACK_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
 /** Enforce canonical-host policy on an incoming Next request.
  *
  *  Returns a 301 redirect response (with `Clear-Site-Data: "storage"`) when
  *  the request host does not match PUBLIC_URL or PUBLIC_URL_ALIASES, and
  *  `null` when the request should pass through unchanged.
  *
- *  Health-probe paths (`/api/health`, `/api/healthz`, `/api/ready`) are
- *  always excluded — load balancers hit these on the LAN IP and a redirect
- *  would fail the probe.
+ *  Exempt paths (`isCanonicalRedirectExempt`) always pass through: health probes
+ *  (a redirect would fail the LAN-IP probe) and internal service callbacks
+ *  (`/api/inngest`, `/api/mcp/*`) whose signed/JSON payloads a 301 would corrupt.
  *
  *  Header is set on the response object after construction (not via init
  *  options) — Next can strip headers during redirect normalization, and
@@ -115,7 +136,7 @@ export function enforceCanonicalHost(
 ): NextResponse | null {
   const { pathname, search } = req.nextUrl;
 
-  if (HEALTH_PROBE_PATHS.has(pathname)) return null;
+  if (isCanonicalRedirectExempt(pathname)) return null;
 
   const host =
     req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? null;


### PR DESCRIPTION
## Summary (P1 fleet hazard)

`enforceCanonicalHost` 301-redirects any request whose Host doesn't match `PUBLIC_URL`, exempting only health probes. Internal service-to-service callbacks arrive on the Docker service host (`INNGEST_SERVE_ORIGIN=http://portal:3000`) or loopback — hosts that never match a public `PUBLIC_URL` — so **setting `PUBLIC_URL` 301s them**, corrupting machine payloads:
- `/api/inngest`: the Inngest executor's signed POSTs fail signature validation → **all** background jobs die (self-upgrade, backups, watchdogs, evals, federation reconciliation).
- `/api/mcp/*`: the MCP tool surface disconnects and the local-CI gate gets a redirect instead of JSON.

Observed live: setting `PUBLIC_URL` took down Inngest, MCP, and CI until it was removed. Pre-existing since the canonical-URL middleware (#822); hits **any** public-domain install, federation or not. Fixes **BI-A5842B04**.

## Change

Extend the redirect exemption beyond health probes to internal service-callback routes (`/api/inngest`, `/api/mcp/*`) via a pure, exported `isCanonicalRedirectExempt()`. Browser routes still canonicalize. Also unblocks HTTP-LAN federation: with this + merged #4036, `PUBLIC_URL` is safe to set, so an install resolves its own Authority URL from `.env` without breaking internal services.

## Verification
- `canonical-host.test.ts`: **39/39** — exemption matrix + regression that `/api/inngest` and `/api/mcp/v1` are never redirected even with `PUBLIC_URL` set on a non-canonical host.
- Exact-tree local-CI (`pregate`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)