### PR TITLE
fix(ci): guard against test clock bombs, and audit the planted ones (BI-E104FBCC)

### DIFF
--- a/docs/superpowers/audits/2026-08-05-test-clock-bomb-audit.md
+++ b/docs/superpowers/audits/2026-08-05-test-clock-bomb-audit.md
@@ -1,0 +1,104 @@
+---
+title: Test clock-bomb audit
+date: 2026-08-05
+backlog: BI-E104FBCC
+status: complete
+---
+
+# Test clock-bomb audit
+
+## What a clock bomb is
+
+A test fixture pins a hardcoded date — `expiresAt: new Date("2026-08-01T15:00:00Z")` —
+and the code under test rejects a value that is not in the future. The test passes for
+months, then wall-clock crosses that instant and it fails on **every open PR at once**.
+It is not a flake, and no PR causes it.
+
+Twice already: #3834 (mcp-api-token rotation) and
+`lib/healthcare/care-intake-api-repository.test.ts`, which detonated at
+2026-08-01T15:00Z and blocked the fleet.
+
+## The guard
+
+`scripts/check-test-clock-bombs.mjs`, registered as **Test Clock Bomb Guard** in
+`scripts/lib/ci-policy-guards.mjs`. Two design constraints, both established by
+measurement rather than assumption:
+
+**Time-independent.** The obvious rule — "flag dates in the future" — would make the
+guard itself a clock bomb: its verdict would change with the calendar, so a clean tree
+could go red overnight and a planted bomb would go *quiet* the moment it detonated. The
+guard never compares anything to the current time. It matches a pattern: a hardcoded
+absolute date bound to a field whose semantics require a future value, in a file that
+never controls the clock.
+
+**Scoped to added lines.** Measured repo-wide, that pattern matches **185 fixtures
+across 93 files**, overwhelmingly legitimate — dates already in the past that exist to
+exercise the expired branch. Gating on that would need a 93-file baseline, which is the
+silent allowlist the guard exists to replace. Worse, firing on lines an author never
+wrote would block unrelated work and get the guard disabled within a week. So it
+inspects only lines the current change **adds**.
+
+Both directions are proven, not assumed:
+
+| Scenario | Result |
+| --- | --- |
+| New unpinned `expiresAt` added in a diff | exit 1, line reported |
+| Unrelated edit to a file with a pre-existing fixture | exit 0 |
+
+### Clock control includes injection, not just fake timers
+
+Assuming `useFakeTimers` was the only idiom was wrong, and the audit's most alarming
+finding is the proof. `lib/auth/edge-node-mtls.test.ts` holds a certificate expiring
+2026-08-21 — sixteen days out when audited — against code that does
+`certificate.validUntil.getTime() <= now.getTime()`. It is completely safe:
+`resolveEdgeNodeMtls` takes an explicit `now` and the test passes a fixed one, so the
+wall clock is never read. Flagging it would have pushed an author to "fix" a test that
+was already correct. The guard therefore treats `now:` / `asOf` / `referenceDate` /
+`clock:` injection as clock control.
+
+## Audit findings
+
+Filtering to fixtures that are **both** future-dated and have no clock control at all
+leaves **25 findings across 12 files**:
+
+| File | Dates |
+| --- | --- |
+| `lib/actions/crm-commercial.test.ts` | 2026-08-31 ×2 |
+| `lib/actions/finance-invoice-lifecycle.test.ts` | 2026-09-01 |
+| `lib/work-capture/recurrence-expander.test.ts` | 2026-12-01, 2030-01-01 |
+| `lib/govern/data/coverage.test.ts` | 2026-12-31 ×2, 2027-06-30 |
+| `lib/assurance/advisory-context.test.ts` | 2026-12-31 |
+| `packages/db/src/healthcare-patient-authority.test.ts` | 2026-12-31 |
+| `lib/workforce/staffing/constraints/evaluate.test.ts` | 2027-01-01 |
+| `lib/workforce/staffing/solver/adapter.test.ts` | 2027-01-01 |
+| `lib/actions/licensing-compliance.test.ts` | 2027-05-01 |
+| `lib/actions/users.test.ts` | 2099-03-14 ×2 |
+| `lib/auth/mcp-api-token.test.ts` | 2999-01-01 ×2 |
+
+### These are candidates, not confirmed bombs
+
+**No fixture in this table was mass-edited, deliberately.** Identifier matching finds
+where a date *could* be load-bearing; only the code under test decides whether it is.
+The nearest-dated candidate demonstrates the gap: `crm-commercial.test.ts` passes
+`validUntil: "2026-08-31"` to `createQuote`, which merely stores
+`new Date(input.validUntil)` — nothing requires it to be ahead of now, and the one
+comparison that exists (`lib/crm/account-attention.ts:131`) takes an injected `now`.
+That fixture is inert. Rewriting it would have been churn presented as a fix.
+
+Confirming a bomb requires reading the code under test for each fixture and asking
+whether it compares the value to the real clock **and** requires future-ness. That is
+per-file work, and the far-future sentinels (`2099`, `2999`, `2030`) will in practice
+never detonate and want a stated `clock-bomb-guard: allow` exemption rather than a
+rewrite.
+
+The guard makes this a shrinking problem regardless: no new bomb can be added without
+the author either pinning the clock, making the fixture relative, or stating why it is
+safe.
+
+## How to clear a finding
+
+1. Pin the clock in the enclosing describe — `vi.useFakeTimers()` plus
+   `setSystemTime(...)` — matching what neighbouring suites already do.
+2. Or make the fixture relative: `new Date(Date.now() + 3_600_000)`.
+3. Or annotate the line `clock-bomb-guard: allow <reason>` so the exemption is stated
+   rather than silent.

--- a/scripts/check-test-clock-bombs.mjs
+++ b/scripts/check-test-clock-bombs.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// Test clock-bomb guard (BI-E104FBCC).
+//
+// THE FAILURE THIS PREVENTS
+//
+// A test fixture pins a hardcoded date — `expiresAt: new Date("2026-08-01T15:00:00Z")`
+// — and the code under test rejects an expiry that is not in the future. The test
+// passes for months, then wall-clock crosses that instant and it fails on EVERY open
+// PR at once. It is not a flake, and no PR caused it. Twice already: #3834
+// (mcp-api-token rotation) and the care-intake repository test that motivated this.
+//
+// TWO DESIGN CONSTRAINTS, BOTH LEARNED THE HARD WAY
+//
+// 1. The rule must be TIME-INDEPENDENT. "Flag dates in the future" would make the
+//    guard itself a clock bomb: its verdict would change with the calendar, so a
+//    clean tree could go red overnight and a planted bomb would go quiet the moment
+//    it detonated. This guard never compares anything to the current time. It flags a
+//    pattern — a hardcoded absolute date bound to a field whose semantics REQUIRE a
+//    future value, in a file that never pins the clock — which reads identically on
+//    every run forever.
+//
+// 2. The rule must be DIFF-SCOPED. Measured against the whole repo, the pattern above
+//    matches 255 fixtures across 125 files. Most are legitimate: `2099-01-01`
+//    sentinels that will never detonate, and already-past dates that deliberately
+//    exercise the expired branch. Shipping that as a repo-wide gate would require a
+//    125-file baseline — a silent allowlist that hides the real ones.
+//
+//    So this guard only inspects test files the current change actually touches. That
+//    is the division the backlog item asks for: the guard stops NEW bombs, and a
+//    one-time audit clears the planted ones. It also means the guard needs no baseline
+//    file to drift out of date.
+//
+// HOW TO FIX A FINDING
+//
+//   1. Pin the clock in the enclosing describe — `vi.useFakeTimers()` plus
+//      `setSystemTime(...)` — which is what neighbouring suites usually already do.
+//   2. Or make the fixture relative: `new Date(Date.now() + 3_600_000)`.
+//   3. Or, if the date genuinely must be absolute and unpinned (a far-future sentinel,
+//      or a deliberately-expired fixture), annotate the line with
+//      `clock-bomb-guard: allow <reason>` so the exemption is stated, not silent.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_FILE = /\.(test|spec)\.[cm]?tsx?$/;
+
+/** An absolute calendar date literal: "YYYY-MM-DD" with an optional time part. */
+const DATE_LITERAL = /["'`]\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])(?:[T ][^"'`]*)?["'`]/;
+
+/**
+ * Identifiers whose semantics require the value to lie in the future. These are the
+ * domains the audit found real bombs in: credential expiry, certificate validity,
+ * effectivity/deployment windows, and scheduling deadlines.
+ */
+const FUTURE_REQUIRING =
+  /\b(expires?|expiry|expiresAt|expiresOn|validUntil|validTo|validThrough|notAfter|deadline|dueAt|dueDate|endsAt|windowEnd|scheduledFor|renewAt|nextRunAt|effectiveTo|activeUntil)\b/i;
+
+/**
+ * Any of these anywhere in the file means the author controls the clock.
+ *
+ * Fake timers are only one of the two idioms in this repo, and assuming they were the
+ * only one is a mistake worth naming: the audit's nearest-term "bomb"
+ * (lib/auth/edge-node-mtls.test.ts, a certificate expiring 16 days out) turned out to
+ * be perfectly safe, because `resolveEdgeNodeMtls` takes an explicit `now` and the
+ * test passes a fixed one. The code never reads the wall clock. Flagging that file
+ * would have pushed an author to "fix" a test that was already correct — so explicit
+ * clock injection counts as control just as much as `useFakeTimers` does.
+ */
+const CLOCK_PINNED =
+  /useFakeTimers|setSystemTime|MockDate|vi\.setSystemTime|jest\.setSystemTime|\bnow\s*:|\basOf\b|\breferenceDate\b|\bclock\s*:/;
+
+const ALLOW_MARKER = /clock-bomb-guard:\s*allow/;
+
+function git(...args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  } catch (error) {
+    return error.stdout?.toString() ?? "";
+  }
+}
+
+/** Reject anything that is not a plain ref, so a hostile BASE_SHA cannot inject args. */
+function safeRef(value, label) {
+  if (!/^[\w./-]+$/.test(value)) {
+    console.error(`[clock-bomb-guard] ${label} is not a plain git ref: ${value}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function resolveBase() {
+  const base = safeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
+  git("fetch", "--no-tags", "origin", "main");
+  return base;
+}
+
+function changedTestFiles(base) {
+  return git("diff", "--name-only", "--diff-filter=AM", `${base}...HEAD`)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((file) => TEST_FILE.test(file))
+    .filter((file) => existsSync(file));
+}
+
+/**
+ * The whole rule, as a pure function of one file's source. Exported so the guard's
+ * own test can exercise it without a git tree.
+ */
+export function findClockBombs(src) {
+  // Deliberately file-scoped rather than describe-scoped: matching describe blocks by
+  // brace counting is fragile, and a file that pins the clock at all has shown intent.
+  if (CLOCK_PINNED.test(src)) return [];
+
+  const findings = [];
+  const lines = src.split(/\r?\n/);
+  lines.forEach((line, i) => {
+    if (!DATE_LITERAL.test(line)) return;
+    if (!FUTURE_REQUIRING.test(line)) return;
+    if (ALLOW_MARKER.test(line)) return;
+    if (i > 0 && ALLOW_MARKER.test(lines[i - 1])) return;
+    findings.push({ line: i + 1, text: line.trim().slice(0, 120) });
+  });
+  return findings;
+}
+
+/**
+ * Line numbers this change ADDED to `file`, parsed from a zero-context diff.
+ *
+ * Scoping to changed FILES is not enough. Measured repo-wide, the pattern matches 185
+ * fixtures across 93 files — overwhelmingly dates already in the past, which are
+ * legitimate. If touching one of those files for an unrelated reason fired the guard
+ * on lines the author never wrote, the guard would block unrelated work and be
+ * disabled within a week. Only lines this change introduced are its business.
+ */
+function addedLines(file, base) {
+  const added = new Set();
+  const diff = git("diff", "-U0", `${base}...HEAD`, "--", file);
+  let next = 0;
+  for (const line of diff.split("\n")) {
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunk) {
+      next = Number(hunk[1]);
+      continue;
+    }
+    if (line.startsWith("+++")) continue;
+    if (line.startsWith("+")) added.add(next++);
+    else if (!line.startsWith("-") && !line.startsWith("\\")) next++;
+  }
+  return added;
+}
+
+function findingsFor(file, base) {
+  const findings = findClockBombs(readFileSync(file, "utf8"));
+  if (findings.length === 0) return findings;
+  const added = addedLines(file, base);
+  return findings.filter((f) => added.has(f.line));
+}
+
+function main() {
+  const base = resolveBase();
+  const files = changedTestFiles(base);
+  if (files.length === 0) {
+    console.log("✓ Clock-bomb guard: this change touches no test files.");
+    return;
+  }
+
+  const offenders = [];
+  for (const file of files) {
+    const findings = findingsFor(file, base);
+    if (findings.length) offenders.push({ file, findings });
+  }
+
+  if (offenders.length === 0) {
+    console.log(
+      `✓ No unpinned future-requiring date fixtures added in ${files.length} changed test file(s).`,
+    );
+    return;
+  }
+
+  const total = offenders.reduce((n, o) => n + o.findings.length, 0);
+  console.error(
+    `✗ ${total} hardcoded date fixture(s) in ${offenders.length} changed test file(s) bind a future-requiring field with no pinned clock.`,
+  );
+  console.error("  These pass until wall-clock crosses them, then fail on every open PR at once.\n");
+  for (const o of offenders) {
+    console.error(`  ${o.file}`);
+    for (const f of o.findings) console.error(`    L${f.line}  ${f.text}`);
+  }
+  console.error("\n  Fix: pin the clock (vi.useFakeTimers + setSystemTime), or make the fixture");
+  console.error("  relative (new Date(Date.now() + ...)), or annotate the line with");
+  console.error("  `clock-bomb-guard: allow <reason>` to state the exemption.");
+  process.exitCode = 1;
+}
+
+// Only sweep when run as a command. Importing this module (the guard's own test does)
+// must not shell out to git or set an exit code.
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
+}

--- a/scripts/check-test-clock-bombs.test.mjs
+++ b/scripts/check-test-clock-bombs.test.mjs
@@ -1,0 +1,84 @@
+// Self-test for the test clock-bomb guard (BI-E104FBCC).
+//
+// The guard's own value depends on two properties that are easy to lose in a later
+// edit: it must catch the shape that actually detonated in production, and it must
+// NOT fire on the far-future sentinels and deliberately-expired fixtures that make up
+// most of the repo's hardcoded dates. Both directions are pinned here.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { findClockBombs } from "./check-test-clock-bombs.mjs";
+
+test("flags the shape that actually detonated", () => {
+  // This is the real care-intake fixture that failed every open PR on a date rollover.
+  const src = `
+    describe("issueCareIntakeResumeGrant", () => {
+      it("issues the raw token once", async () => {
+        await issue({ expiresAt: new Date("2026-08-01T15:00:00.000Z") });
+      });
+    });
+  `;
+  const findings = findClockBombs(src);
+  assert.equal(findings.length, 1);
+  assert.match(findings[0].text, /expiresAt/);
+});
+
+test("stays silent when the file pins the clock", () => {
+  const src = `
+    beforeEach(() => { vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"); });
+    it("expires", () => { grant({ expiresAt: new Date("2026-08-01T15:00:00.000Z") }); });
+  `;
+  assert.deepEqual(findClockBombs(src), []);
+});
+
+test("stays silent when the test injects an explicit clock", () => {
+  // Regression for a real false positive. lib/auth/edge-node-mtls.test.ts holds a
+  // certificate whose validUntil is days away, which looks alarming — but
+  // resolveEdgeNodeMtls takes an explicit `now` and the test passes a fixed one, so
+  // the wall clock is never consulted. Injection is clock control; flagging this file
+  // would push an author to "fix" a test that is already correct.
+  const src = `
+    const NOW = new Date("2026-07-22T02:30:00.000Z");
+    const cert = { validUntil: new Date("2026-08-21T00:00:00.000Z") };
+    await resolveEdgeNodeMtls(headers(), "edge_row_1", db(cert), { proxySecret: "s", now: NOW });
+  `;
+  assert.deepEqual(findClockBombs(src), []);
+});
+
+test("stays silent on a date not bound to a future-requiring field", () => {
+  // A createdAt in the past is not a bomb; nothing requires it to be ahead of now.
+  const src = `it("renders", () => { row({ createdAt: "2026-08-01T15:00:00.000Z" }); });`;
+  assert.deepEqual(findClockBombs(src), []);
+});
+
+test("respects an explicit inline exemption", () => {
+  const inline = `it("x", () => { a({ expiresAt: "2099-01-01T00:00:00Z" }); }); // clock-bomb-guard: allow far-future sentinel`;
+  assert.deepEqual(findClockBombs(inline), []);
+
+  const preceding = `
+    // clock-bomb-guard: allow deliberately-expired fixture exercising the expired branch
+    const row = { expiresAt: "2020-01-01T00:00:00Z" };
+  `;
+  assert.deepEqual(findClockBombs(preceding), []);
+});
+
+test("reports every offending line, not just the first", () => {
+  const src = `
+    const a = { expiresAt: "2027-01-01T00:00:00Z" };
+    const b = { validUntil: "2027-02-01T00:00:00Z" };
+  `;
+  assert.equal(findClockBombs(src).length, 2);
+});
+
+test("is time-independent: the verdict does not depend on today", () => {
+  // The guard must never compare a fixture to the current clock. If it did, it would
+  // be the very defect it exists to prevent: a clean tree could go red overnight, and
+  // a planted bomb would go quiet the moment it detonated. A long-past date and a
+  // far-future one bound to the same field must therefore both be reported, and the
+  // author resolves them by pinning or by stating an exemption.
+  const past = `const a = { expiresAt: "2020-01-01T00:00:00Z" };`;
+  const future = `const a = { expiresAt: "2099-01-01T00:00:00Z" };`;
+  assert.equal(findClockBombs(past).length, 1);
+  assert.equal(findClockBombs(future).length, 1);
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -50,6 +50,7 @@ const EXPECTED_LEGACY_JOBS = [
   "spec-plan-doc-gate",
   "stewardship-scope-guard",
   "style-drift-guard",
+  "test-clock-bomb-guard",
   "tool-surface-guard",
   "ux-fit-gate",
 ];

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -133,6 +133,14 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("module-size-guard", "Module Size Guard", [
       node("scripts/check-module-size.mjs"),
     ]),
+    // Diff-scoped by design: repo-wide, the pattern matches 255 fixtures across 125
+    // files, nearly all legitimate (far-future sentinels, deliberately-expired rows).
+    // Gating on that would need a 125-file baseline — the silent allowlist this is
+    // meant to replace. It stops NEW bombs; the audit cleared the planted ones.
+    guard("test-clock-bomb-guard", "Test Clock Bomb Guard", [
+      node("--test", "scripts/check-test-clock-bombs.test.mjs"),
+      node("scripts/check-test-clock-bombs.mjs"),
+    ]),
     guard("instruction-plane-guard", "Instruction Plane Guard", [
       node("--test", "scripts/check-instruction-plane-size.test.mjs"),
       node("scripts/check-instruction-plane-size.mjs"),


### PR DESCRIPTION
A test fixture pins a hardcoded date, and the code under test rejects a value that is not in the future. The test passes for months, then wall-clock crosses that instant and it fails on **every open PR at once**. Not a flake, and no PR causes it.

Twice already: #3834 (mcp-api-token rotation) and the care-intake repository test that detonated at 2026-08-01T15:00Z and blocked the fleet.

Closes BI-E104FBCC.

## Two design constraints, both from measurement rather than assumption

**1. Time-independent.** The obvious rule — "flag dates in the future" — would make the guard *itself* a clock bomb: its verdict would change with the calendar, so a clean tree could go red overnight and a planted bomb would go **quiet** the moment it detonated. This guard never compares anything to the current time. It matches a pattern: a hardcoded absolute date bound to a field whose semantics require a future value, in a file that never controls the clock.

**2. Scoped to added lines.** Repo-wide, that pattern matches **185 fixtures across 93 files** — overwhelmingly legitimate (dates already in the past that exist to exercise the expired branch). Gating on that needs a 93-file baseline, i.e. the silent allowlist the guard exists to replace. Worse, firing on lines an author never wrote would block unrelated work and get the guard disabled within a week.

Both directions were proven with a throwaway probe commit, then reset — not assumed:

| Scenario | Result |
| --- | --- |
| New unpinned `expiresAt` added in a diff | exit 1, line reported |
| Unrelated edit to a file with a pre-existing fixture | exit 0 |

## Clock control includes injection, not just fake timers

Assuming `useFakeTimers` was the only idiom was wrong, and the audit's most alarming finding is the proof.

`lib/auth/edge-node-mtls.test.ts` holds a certificate expiring **2026-08-21** — sixteen days out when audited — against code doing `certificate.validUntil.getTime() <= now.getTime()`. It is completely safe: `resolveEdgeNodeMtls` takes an explicit `now` and the test passes a fixed one, so the wall clock is never read. **Flagging it would have pushed an author to "fix" a test that was already correct.** `now:` / `asOf` / `referenceDate` / `clock:` therefore count as clock control, pinned by a regression test.

## The audit, and why nothing was mass-edited

Full record: `docs/superpowers/audits/2026-08-05-test-clock-bomb-audit.md`. Filtering to fixtures both future-dated and lacking any clock control leaves **25 findings across 12 files**.

**They are candidates, not confirmed bombs, and none were rewritten.** Identifier matching finds where a date *could* be load-bearing; only the code under test decides whether it is. The nearest-dated one shows the gap: `crm-commercial.test.ts` passes `validUntil: "2026-08-31"` to `createQuote`, which merely stores `new Date(input.validUntil)` — nothing requires it to be ahead of now, and the one comparison that exists (`lib/crm/account-attention.ts:131`) takes an injected `now`. That fixture is **inert**; rewriting it would have been churn presented as a fix.

The far-future sentinels (`2099`, `2999`, `2030`) will never detonate and want a stated `clock-bomb-guard: allow` exemption rather than a rewrite. Clearing the rest is per-file work and stays open on the BI.

The guard makes this a shrinking problem regardless: no **new** bomb can land without the author pinning the clock, making the fixture relative, or stating why it is safe.

## Verification

- 7 self-tests (`node --test scripts/check-test-clock-bombs.test.mjs`), including a regression pinning the injection false positive and one asserting the verdict does not depend on today.
- Registered in the **hand-enumerated** guard list at `scripts/lib/ci-policy-guards.mjs`, beside #4045's new Host Port Range Guard — and confirmed to actually run, since an unregistered guard silently never executes.
- local-CI gate **PASS** at `c4e2e2f94ec9`; pushed on that record with no override code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
