### PR TITLE
feat(compliance): warn before AI-provider compliance evidence lapses (BI-68D44727)

### DIFF
--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -17,6 +17,7 @@ import {
   type CoworkerMemoryAttentionDb,
 } from "./sources/coworker-memory";
 import { loadProviderCredentialItems, loadProviderSuitabilityDriftItems } from "./sources/provider-credential";
+import { loadComplianceSourceFreshnessItems } from "./sources/compliance-source-freshness";
 import { loadReservationExceptionItems } from "./sources/reservation-exception";
 import { loadHospitalityCapacityAttentionItems } from "./sources/hospitality-capacity";
 import { loadStorefrontInquiryItems } from "./sources/storefront-inquiry";
@@ -106,6 +107,11 @@ export async function loadAttentionItems(
       load: () => loadHospitalityCapacityAttentionItems(db),
     },
     { source: "storefront-inquiry", load: () => loadStorefrontInquiryItems(db) },
+    {
+      // Pure registry arithmetic — no query, so it costs nothing per load.
+      source: "compliance-source-freshness",
+      load: async () => loadComplianceSourceFreshnessItems(),
+    },
     {
       source: "provider-credential",
       load: async () => [

--- a/apps/web/lib/attention/outside-in.ts
+++ b/apps/web/lib/attention/outside-in.ts
@@ -87,6 +87,7 @@ const SOURCE_PORTFOLIO: Record<AttentionSource, AttentionPortfolio> = {
   "ai-readiness-blocker": "foundational", // platform readiness gap
   "platform-health": "foundational", // platform health alert — infra posture
   "provider-credential": "foundational", // an AI provider's saved sign-in expired
+  "compliance-source-freshness": "foundational", // governed compliance evidence lapsing — platform posture
 };
 
 /** The default portfolio for a source (outside-in classification). Pure. */

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -19,6 +19,7 @@ const HEADLINE: Record<AttentionSource, string> = {
   "hospitality-capacity": "Resolve this capacity issue?",
   "storefront-inquiry": "Reply to this enquiry?",
   "business-journey": "Choose how to fix this for customers?",
+  "compliance-source-freshness": "Renew this compliance evidence?",
 };
 
 const SPECIALIST: Record<AttentionSource, string> = {
@@ -40,6 +41,7 @@ const SPECIALIST: Record<AttentionSource, string> = {
   "hospitality-capacity": "Hospitality operations",
   "storefront-inquiry": "Front of house",
   "business-journey": "Front of house",
+  "compliance-source-freshness": "Legal and compliance",
 };
 
 export function specialistFor(source: AttentionSource): string {

--- a/apps/web/lib/attention/reach-message.ts
+++ b/apps/web/lib/attention/reach-message.ts
@@ -53,6 +53,7 @@ const OUTCOME_CLASS: Record<AttentionSource, string> = {
   "ai-readiness-blocker": "Your AI setup is not finished",
   "platform-health": "A platform service is having trouble",
   "provider-credential": "A connection needs reconnecting",
+  "compliance-source-freshness": "Compliance evidence is going out of date",
 };
 
 const URGENCY_LINE: Record<ReachDecision["urgency"], string> = {

--- a/apps/web/lib/attention/sources/compliance-source-freshness.test.ts
+++ b/apps/web/lib/attention/sources/compliance-source-freshness.test.ts
@@ -1,0 +1,61 @@
+// BI-68D44727 — the compliance-source freshness attention projection.
+//
+// Every case passes an explicit `now`. This projector is about expiry dates, so
+// a test that read the real clock would be the very defect it warns about.
+import { describe, expect, it } from "vitest";
+
+import { loadComplianceSourceFreshnessItems } from "./compliance-source-freshness";
+
+const BEFORE_ANY_EXPIRY = new Date("2026-08-05T12:00:00.000Z");
+const INSIDE_WARNING_WINDOW = new Date("2026-09-01T12:00:00.000Z");
+const AFTER_60D_EXPIRY = new Date("2026-09-19T12:00:00.000Z");
+
+describe("loadComplianceSourceFreshnessItems", () => {
+  it("stays silent while every source is fresh", () => {
+    // A healthy source is not news. An inbox that lists fine things teaches
+    // people to skim past it, which is how the real item gets missed.
+    expect(loadComplianceSourceFreshnessItems({ now: BEFORE_ANY_EXPIRY })).toEqual([]);
+  });
+
+  it("warns before anything breaks, not after", () => {
+    const items = loadComplianceSourceFreshnessItems({ now: INSIDE_WARNING_WINDOW });
+    expect(items.length).toBe(3);
+    for (const item of items) {
+      expect(item.source).toBe("compliance-source-freshness");
+      expect(item.triage.timeToAct).toBe("due-soon");
+      expect(item.riskClass).toBe("bounded-write");
+      expect(item.title).toContain("expiring");
+      // The lead time is the whole point — say how long they have.
+      expect(item.context).toMatch(/lapses in \d+ days/);
+      // Do not imply a self-service button that does not exist.
+      expect(item.context).toContain("re-reading the source");
+    }
+  });
+
+  it("escalates to overdue once the evidence has actually lapsed", () => {
+    const items = loadComplianceSourceFreshnessItems({ now: AFTER_60D_EXPIRY });
+    expect(items.length).toBe(3);
+    for (const item of items) {
+      expect(item.triage.timeToAct).toBe("overdue");
+      expect(item.riskClass).toBe("high-risk");
+      expect(item.title).toContain("out of date");
+      // Name the user-visible consequence, not the internal failure mode.
+      expect(item.context).toContain("a human needs to review this");
+    }
+  });
+
+  it("routes to a person, because re-attesting vendor terms is judgement", () => {
+    const [item] = loadComplianceSourceFreshnessItems({ now: AFTER_60D_EXPIRY });
+    expect(item.triage.decideEffort).toBe("judgment");
+    expect(item.triage.residueReason).toBe("no-self-heal");
+    expect(item.audience?.operator).toBe(true);
+  });
+
+  it("gives each source a stable id so repeat loads do not duplicate cards", () => {
+    const first = loadComplianceSourceFreshnessItems({ now: AFTER_60D_EXPIRY });
+    const second = loadComplianceSourceFreshnessItems({ now: AFTER_60D_EXPIRY });
+    expect(first.map((i) => i.id)).toEqual(second.map((i) => i.id));
+    expect(new Set(first.map((i) => i.id)).size).toBe(first.length);
+    expect(first[0]?.id.startsWith("compliance-source-freshness:")).toBe(true);
+  });
+});

--- a/apps/web/lib/attention/sources/compliance-source-freshness.ts
+++ b/apps/web/lib/attention/sources/compliance-source-freshness.ts
@@ -1,0 +1,98 @@
+// Compliance-source freshness source (BI-68D44727) — the governed evidence
+// behind AI-provider compliance advice is about to lapse, or already has.
+//
+// WHY THIS EXISTS. The provider-compliance registry stamps each source with when
+// it was retrieved and how long that copy stays trustworthy. Past the window the
+// advisory guard emits `stale-source`, grounding validation fails, and advice
+// that would have said "conditional" degrades to a deterministic non-approval.
+// Failing closed is right. Failing closed SILENTLY is the defect: nothing
+// refreshed the corpus and nothing warned, so on a known date the compliance
+// coworker quietly got less useful on every install, with no error to read. The
+// operator experiences that as "the AI got worse", and they experience it
+// whenever they next try to onboard a provider — which is precisely the moment
+// they can least afford to debug it.
+//
+// This is the same shape as the sibling provider-credential source (BI-282C39D5):
+// an asset that was valid, lapsed on a schedule, and had no proactive signal. The
+// fix is the same too — fire BEFORE the lapse, while a human can still act.
+//
+// SCOPED ON PURPOSE. Only "expiring soon" and "already stale" project. A fresh
+// source is not news, and an inbox that lists healthy things trains people to
+// ignore it. Read-only projection over the registry — pure arithmetic, no DB, no
+// network — so it costs nothing to include on every inbox load.
+
+import {
+  summarizeComplianceSourceFreshness,
+  type ComplianceSourceFreshness,
+} from "@/lib/routing/provider-suitability/source-freshness";
+import type { AttentionItem } from "../types";
+
+/** Renewal is a compliance review, not a scrape: someone opens the vendor's
+ *  current policy page and confirms the specific claims DPF cites still hold.
+ *  The copy says so plainly, because "refresh the source" reads like a button
+ *  that exists, and no such button does. */
+function describe(source: ComplianceSourceFreshness): { title: string; context: string } {
+  const lapsed = source.daysUntilStale < 0;
+  const when = lapsed
+    ? `lapsed ${Math.abs(source.daysUntilStale)} day${Math.abs(source.daysUntilStale) === 1 ? "" : "s"} ago`
+    : source.daysUntilStale === 0
+      ? "lapses after today"
+      : `lapses in ${source.daysUntilStale} days`;
+
+  return {
+    title: lapsed
+      ? `Compliance evidence out of date: ${source.title}`
+      : `Compliance evidence expiring: ${source.title}`,
+    context: lapsed
+      ? `DPF's copy of this ${source.publisher} source ${when} (retrieved ${source.retrievedAt}, trusted for ${source.maxAgeDays} days). ` +
+        `AI-provider advice that cites it can no longer be substantiated, so it now answers "a human needs to review this" instead of giving a recommendation. ` +
+        `To restore it, someone re-reads the source and confirms the claims DPF cites still hold, then updates the retrieval date.`
+      : `DPF's copy of this ${source.publisher} source ${when} (retrieved ${source.retrievedAt}, trusted for ${source.maxAgeDays} days). ` +
+        `Nothing is broken yet. When it lapses, AI-provider advice citing it stops giving recommendations and defers to a human instead. ` +
+        `Renewing means re-reading the source and confirming the claims DPF cites still hold.`,
+  };
+}
+
+/** Pure projection of one at-risk source into an attention item. */
+export function complianceSourceToAttentionItem(source: ComplianceSourceFreshness): AttentionItem {
+  const lapsed = source.daysUntilStale < 0;
+  const { title, context } = describe(source);
+
+  return {
+    id: `compliance-source-freshness:${source.sourceKey}`,
+    source: "compliance-source-freshness",
+    title,
+    context,
+    // An expiry date is a fact, not a judgement call — the same reasoning that
+    // makes a platform-health outage unscorable.
+    decisionClass: { scorability: "unscorable" },
+    riskClass: lapsed ? "high-risk" : "bounded-write",
+    triage: {
+      // Deadline-bearing on purpose: the whole point is that this has a date on
+      // it. Once lapsed it is overdue; inside the warning window it is due-soon.
+      timeToAct: lapsed ? "overdue" : "due-soon",
+      residueReason: "no-self-heal",
+      blastRadius: "AI provider compliance advice",
+      // Re-attesting a vendor's data-handling terms is a judgement a person owns.
+      decideEffort: "judgment",
+      irreversible: false,
+    },
+    createdAtIso: new Date().toISOString(),
+    actions: [
+      { kind: "open-in-context", label: "Review AI provider compliance", href: "/platform/ai/providers" },
+    ],
+    deepLink: "/platform/ai/providers",
+    audience: { operator: true },
+  };
+}
+
+/** Project every source that is lapsed or inside the warning window.
+ *
+ *  `now` is injectable purely so tests need not touch the real clock — a module
+ *  about expiry dates must never depend on today's date to pass. */
+export function loadComplianceSourceFreshnessItems(
+  options: { now?: Date } = {},
+): AttentionItem[] {
+  const summary = summarizeComplianceSourceFreshness({ now: options.now });
+  return [...summary.stale, ...summary.expiringSoon].map(complianceSourceToAttentionItem);
+}

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -27,7 +27,8 @@ export type AttentionSource =
   | "reservation-exception" // a public StorefrontBooking awaiting owner action — confirm / reschedule / overlap (BI-3DA1DFDC)
   | "hospitality-capacity" // blocked, quarantined, over-capacity, or idle Food & Hospitality capacity
   | "storefront-inquiry" // a new public StorefrontInquiry awaiting the owner's first response (BI-348766E5)
-  | "business-journey"; // PortfolioQualityIssue issueType=journey_failure — a critical business journey failed its watchdog run (BI-E105303D)
+  | "business-journey" // PortfolioQualityIssue issueType=journey_failure — a critical business journey failed its watchdog run (BI-E105303D)
+  | "compliance-source-freshness"; // governed AI-provider compliance evidence lapsing or lapsed (BI-68D44727)
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -852,6 +852,12 @@
       "docs/architecture/2026-06-14-odysseus-review-depth-pass.md",
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
     ],
+    "apps/web/lib/routing/provider-suitability/provider-compliance-advisory.ts": [
+      "docs/operations/ai-provider-compliance-source-renewal-runbook.md"
+    ],
+    "apps/web/lib/routing/provider-suitability/source-freshness.ts": [
+      "docs/operations/ai-provider-compliance-source-renewal-runbook.md"
+    ],
     "apps/web/lib/routing/provider-suitability/workload-profile.ts": [
       "docs/user-guide/ai-workforce/sensitive-data-policy-packs.md"
     ],
@@ -1172,6 +1178,9 @@
     ],
     "packages/db/src/profession-local-axes.ts": [
       "docs/architecture/decision-vectors.md"
+    ],
+    "packages/db/src/provider-compliance-source-registry.ts": [
+      "docs/operations/ai-provider-compliance-source-renewal-runbook.md"
     ],
     "packages/db/src/regulation-applicability.ts": [
       "docs/strategy/2026-09-cada-architects-forum-deck.md"
@@ -2280,6 +2289,11 @@
     "docs/maintenance/staleness-report.md": [
       "scripts/build-docs-staleness.mjs",
       "scripts/lib/ci-policy-guards.mjs"
+    ],
+    "docs/operations/ai-provider-compliance-source-renewal-runbook.md": [
+      "apps/web/lib/routing/provider-suitability/provider-compliance-advisory.ts",
+      "apps/web/lib/routing/provider-suitability/source-freshness.ts",
+      "packages/db/src/provider-compliance-source-registry.ts"
     ],
     "docs/operations/build-cost-flags-activation-runbook.md": [
       "apps/web/lib/integrate/build-studio-config.ts"

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 625,
+  "pageCount": 626,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -4742,6 +4742,26 @@
         "8-message-house",
         "9-backlog-anchors",
         "10-sources-and-market-signals"
+      ]
+    },
+    "docs/operations/ai-provider-compliance-source-renewal-runbook.md": {
+      "publicHref": "/operations/ai-provider-compliance-source-renewal-runbook/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "runbook-renewing-the-ai-provider-compliance-sources",
+        "why-this-exists",
+        "this-is-a-review-not-a-scrape",
+        "procedure",
+        "1-identify-what-is-lapsing",
+        "2-read-the-current-source",
+        "3-re-attest-each-claim",
+        "4-update-the-registry",
+        "5-verify",
+        "6-ship-it",
+        "deliberately-not-a-ci-gate",
+        "if-it-has-already-lapsed"
       ]
     },
     "docs/operations/antigravity-cli-onboarding.md": {

--- a/apps/web/lib/routing/provider-suitability/source-freshness.test.ts
+++ b/apps/web/lib/routing/provider-suitability/source-freshness.test.ts
@@ -1,0 +1,110 @@
+// BI-68D44727 — tests for the compliance-source freshness horizon.
+//
+// EVERY case here pins the clock. This module is ABOUT expiry dates, so an
+// unpinned assertion would be precisely the defect the module exists to warn
+// about — a test that passes today and fails on a date nobody wrote down.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  COMPLIANCE_SOURCE_EXPIRY_WARNING_DAYS,
+  summarizeComplianceSourceFreshness,
+} from "./source-freshness";
+
+// The shipped registry retrieved every source on 2026-07-20. The three
+// provider-terms sources carry maxAgeDays 60 → stale from 2026-09-18.
+const BEFORE_ANY_EXPIRY = "2026-08-05T12:00:00.000Z";
+const INSIDE_WARNING_WINDOW = "2026-09-01T12:00:00.000Z"; // 17 days before the 60d cliff
+const AFTER_60D_EXPIRY = "2026-09-19T12:00:00.000Z";
+
+function pin(instant: string) {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(instant));
+  afterEach(() => vi.useRealTimers());
+}
+
+describe("summarizeComplianceSourceFreshness", () => {
+  describe("well before any expiry", () => {
+    pin(BEFORE_ANY_EXPIRY);
+
+    it("reports every source fresh and warns about nothing", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      expect(summary.stale).toEqual([]);
+      expect(summary.expiringSoon).toEqual([]);
+      expect(summary.worst).toBe("fresh");
+      expect(summary.sources.length).toBeGreaterThan(0);
+      expect(summary.sources.every((s) => s.status === "fresh")).toBe(true);
+    });
+
+    it("counts days remaining from the source's own window, not a global default", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      const short = summary.sources.find((s) => s.maxAgeDays === 60);
+      const long = summary.sources.find((s) => s.maxAgeDays === 365);
+      // 2026-07-20 + 60d = 2026-09-18; from 2026-08-05 that is 44 days out.
+      expect(short?.daysUntilStale).toBe(44);
+      expect(long?.daysUntilStale).toBe(349);
+    });
+  });
+
+  describe("inside the warning window", () => {
+    pin(INSIDE_WARNING_WINDOW);
+
+    it("flags the 60-day provider terms as expiring soon while they are still valid", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      expect(summary.stale).toEqual([]);
+      expect(summary.worst).toBe("expiring-soon");
+      expect(summary.expiringSoon.length).toBe(3);
+      // Still usable — the point of warning early is that nothing has broken yet.
+      expect(summary.expiringSoon.every((s) => s.daysUntilStale > 0)).toBe(true);
+      expect(summary.expiringSoon.every((s) => s.sourceType === "provider-terms")).toBe(true);
+    });
+
+    it("leaves the long-window regulatory sources alone", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      expect(summary.expiringSoon.some((s) => s.maxAgeDays === 365)).toBe(false);
+    });
+  });
+
+  describe("after the 60-day sources lapse", () => {
+    pin(AFTER_60D_EXPIRY);
+
+    it("reports them stale, which is when advisories stop substantiating", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      expect(summary.worst).toBe("stale");
+      expect(summary.stale.length).toBe(3);
+      expect(summary.stale.every((s) => s.daysUntilStale < 0)).toBe(true);
+    });
+
+    it("does not double-report a stale source as also expiring soon", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      const staleKeys = new Set(summary.stale.map((s) => s.sourceKey));
+      expect(summary.expiringSoon.some((s) => staleKeys.has(s.sourceKey))).toBe(false);
+    });
+  });
+
+  describe("boundary — the exact instant a window closes", () => {
+    // maxAgeDays is a whole-day allowance, so a source is still valid THROUGH
+    // its final day. Asserting the boundary explicitly stops an off-by-one from
+    // silently moving the alert a day early or a day late.
+    pin("2026-09-18T12:00:00.000Z");
+
+    it("treats the final day of the window as still valid", () => {
+      const summary = summarizeComplianceSourceFreshness();
+      expect(summary.stale).toEqual([]);
+      expect(summary.sources.find((s) => s.maxAgeDays === 60)?.daysUntilStale).toBe(0);
+    });
+  });
+
+  describe("caller-supplied instant", () => {
+    pin(BEFORE_ANY_EXPIRY);
+
+    it("honours an explicit `now`, so callers can project a future horizon", () => {
+      const summary = summarizeComplianceSourceFreshness({ now: new Date(AFTER_60D_EXPIRY) });
+      expect(summary.worst).toBe("stale");
+    });
+  });
+
+  it("exports a warning window long enough to act on a compliance review", () => {
+    // The renewal is a human re-reading vendor policy pages, not a scrape, so
+    // the lead time has to be weeks rather than days.
+    expect(COMPLIANCE_SOURCE_EXPIRY_WARNING_DAYS).toBeGreaterThanOrEqual(14);
+  });
+});

--- a/apps/web/lib/routing/provider-suitability/source-freshness.ts
+++ b/apps/web/lib/routing/provider-suitability/source-freshness.ts
@@ -1,0 +1,130 @@
+// Compliance-source freshness horizon (BI-68D44727).
+//
+// WHY THIS EXISTS. Every governed source in the provider-compliance registry
+// carries a `retrievedAt` stamp and its own `maxAgeDays`. Past that window
+// provider-compliance-advisory.ts emits `stale-source:<ref>`, grounding
+// validation fails, and an advisory that would have said "conditional" degrades
+// to the deterministic non-approval instead. That direction is correct — DPF must
+// not vouch for a vendor's data-handling terms from a stale copy.
+//
+// What was missing is the other half. Nothing refreshed the corpus and nothing
+// warned before the cliff, so the degradation was silent, product-wide, and
+// dated: the three provider-terms sources were retrieved 2026-07-20 with a
+// 60-day window, making 2026-09-18 the day the compliance coworker quietly got
+// less useful on every install. To an operator that reads as "the AI got worse",
+// not "an evidence copy expired" — and it lands whenever someone happens to be
+// onboarding a provider, which is exactly when they can least afford it.
+//
+// This module is the arithmetic behind the warning. It is deliberately PURE and
+// registry-only — no database, no network — so the attention projector, a
+// health surface, or a scheduled audit can all ask the same question cheaply and
+// get the same answer.
+//
+// DELIBERATELY NOT A REQUIRED CI CHECK. A per-PR gate that fails once a source
+// lapses would be a fleet-blocking time bomb with a known detonation date — the
+// precise failure this warning exists to prevent (see #3883/#3885, and the
+// 2026-08-01T15:00Z outage). Warn early, in-product, where a human can act; do
+// not wire expiry into anything that can block a merge.
+
+import {
+  PROVIDER_COMPLIANCE_SOURCE_REGISTRY,
+  type ProviderComplianceSourceEntry,
+} from "@dpf/db/provider-compliance-source-registry";
+
+const MS_PER_DAY = 86_400_000;
+
+/** How much notice the warning gives before a source lapses.
+ *
+ *  Renewal is a person re-reading the vendor's current policy page and
+ *  confirming the specific claims DPF cites still hold — a compliance review,
+ *  not a scrape. Three weeks is enough to schedule that around other work
+ *  without the alert becoming background noise it outlives. */
+export const COMPLIANCE_SOURCE_EXPIRY_WARNING_DAYS = 21;
+
+export type ComplianceSourceFreshnessStatus = "fresh" | "expiring-soon" | "stale";
+
+export type ComplianceSourceFreshness = {
+  sourceKey: string;
+  title: string;
+  publisher: string;
+  url: string;
+  sourceType: ProviderComplianceSourceEntry["sourceType"];
+  retrievedAt: string;
+  maxAgeDays: number;
+  /** ISO date (YYYY-MM-DD) the copy stops being trusted. */
+  staleFrom: string;
+  /** Whole days remaining. 0 = final valid day; negative = already lapsed. */
+  daysUntilStale: number;
+  status: ComplianceSourceFreshnessStatus;
+};
+
+export type ComplianceSourceFreshnessSummary = {
+  sources: ComplianceSourceFreshness[];
+  expiringSoon: ComplianceSourceFreshness[];
+  stale: ComplianceSourceFreshness[];
+  /** The worst status present — what a single badge should show. */
+  worst: ComplianceSourceFreshnessStatus;
+};
+
+/** Whole days from `now` until the source's window closes.
+ *
+ *  `maxAgeDays` is a whole-day allowance, so a source stays valid THROUGH its
+ *  final day: the advisory guard rejects only when `ageDays > maxAgeDays`. Both
+ *  sides are floored to UTC midnight so the answer does not swing with the time
+ *  of day a page happens to be rendered. */
+function daysUntilStale(source: ProviderComplianceSourceEntry, now: Date): number {
+  const retrievedAtUtcMidnight = Date.parse(`${source.retrievedAt.slice(0, 10)}T00:00:00.000Z`);
+  const staleFromMs = retrievedAtUtcMidnight + (source.maxAgeDays + 1) * MS_PER_DAY;
+  const nowUtcMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return Math.round((staleFromMs - nowUtcMidnight) / MS_PER_DAY) - 1;
+}
+
+function classify(remaining: number): ComplianceSourceFreshnessStatus {
+  if (remaining < 0) return "stale";
+  if (remaining <= COMPLIANCE_SOURCE_EXPIRY_WARNING_DAYS) return "expiring-soon";
+  return "fresh";
+}
+
+function isoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** Freshness of every governed compliance source, worst first.
+ *
+ *  `now` is injectable so callers can project a future horizon ("what lapses
+ *  before the end of the quarter?") and so tests never depend on the real clock. */
+export function summarizeComplianceSourceFreshness(
+  options: { now?: Date } = {},
+): ComplianceSourceFreshnessSummary {
+  const now = options.now ?? new Date();
+
+  const sources = Object.values(PROVIDER_COMPLIANCE_SOURCE_REGISTRY)
+    .map((entry): ComplianceSourceFreshness => {
+      const source = entry as ProviderComplianceSourceEntry;
+      const remaining = daysUntilStale(source, now);
+      const retrievedAtUtcMidnight = Date.parse(`${source.retrievedAt.slice(0, 10)}T00:00:00.000Z`);
+      return {
+        sourceKey: source.sourceKey,
+        title: source.title,
+        publisher: source.publisher,
+        url: source.url,
+        sourceType: source.sourceType,
+        retrievedAt: source.retrievedAt,
+        maxAgeDays: source.maxAgeDays,
+        staleFrom: isoDate(retrievedAtUtcMidnight + (source.maxAgeDays + 1) * MS_PER_DAY),
+        daysUntilStale: remaining,
+        status: classify(remaining),
+      };
+    })
+    .sort((a, b) => a.daysUntilStale - b.daysUntilStale);
+
+  const stale = sources.filter((s) => s.status === "stale");
+  const expiringSoon = sources.filter((s) => s.status === "expiring-soon");
+
+  return {
+    sources,
+    expiringSoon,
+    stale,
+    worst: stale.length > 0 ? "stale" : expiringSoon.length > 0 ? "expiring-soon" : "fresh",
+  };
+}

--- a/docs/operations/ai-provider-compliance-source-renewal-runbook.md
+++ b/docs/operations/ai-provider-compliance-source-renewal-runbook.md
@@ -1,0 +1,130 @@
+# Runbook — Renewing the AI-provider compliance sources
+
+- **Owner:** Platform operator, with whoever owns compliance judgement for the install
+- **BI:** BI-68D44727
+- **Cadence:** driven by the alert, not the calendar — the shortest window is 60 days
+- **Registry:** [`packages/db/src/provider-compliance-source-registry.ts`](../../packages/db/src/provider-compliance-source-registry.ts)
+- **Freshness arithmetic:** [`apps/web/lib/routing/provider-suitability/source-freshness.ts`](../../apps/web/lib/routing/provider-suitability/source-freshness.ts)
+
+## Why this exists
+
+When someone connects an AI provider, DPF advises whether it is suitable for company
+data, and cites governed sources for that advice: the vendors' own data-privacy and
+model-training policies, plus GDPR/ICO guidance. Each source carries the date DPF
+retrieved it and how long that copy stays trustworthy (`maxAgeDays`).
+
+Past that window, [`provider-compliance-advisory.ts`](../../apps/web/lib/routing/provider-suitability/provider-compliance-advisory.ts)
+emits `stale-source`, grounding validation fails, and advice that would have said
+"conditional" degrades to a deterministic non-approval. **That direction is correct.**
+DPF must not vouch for a vendor's data-handling terms from a stale copy.
+
+What was missing was the other half: nothing refreshed the corpus and nothing warned
+first. The degradation was silent, product-wide, and dated. To an operator it reads as
+"the AI got worse", not "an evidence copy expired" — and it lands whenever they next try
+to onboard a provider, which is exactly when they can least afford to debug it.
+
+The warning now fires in the attention inbox 21 days ahead. This runbook is what to do
+when it does.
+
+## This is a review, not a scrape
+
+The renewal is **not** "re-download the page and bump the date". The registry does not
+merely cite a document; it cites specific *claims* from it, each scoped to particular
+providers, services, account classes, jurisdictions and workloads. A vendor can rewrite a
+policy without changing what DPF relies on — or leave the page looking similar while
+narrowing exactly the entitlement a claim depends on.
+
+So the question at renewal is never "is the URL still live?" It is **"does this source
+still support this claim, for this scope?"** That is a judgement a person owns. Automating
+the fetch is possible; automating the attestation is not, and should not be.
+
+## Procedure
+
+### 1. Identify what is lapsing
+
+The attention item names the source, the publisher, and the days remaining. For the full
+picture across every source:
+
+```bash
+node -e "import('./apps/web/lib/routing/provider-suitability/source-freshness.ts').then(m=>console.table(m.summarizeComplianceSourceFreshness().sources))"
+```
+
+The three `provider-terms` sources (OpenAI and Anthropic) carry the short 60-day window —
+deliberately, because vendor data-handling terms change far more often than statute. The
+GDPR/ICO sources sit at 180–365 days.
+
+### 2. Read the current source
+
+Open the `url` from the registry entry. Read the **current** published policy, not a
+cached copy and not a summary of it.
+
+### 3. Re-attest each claim
+
+For every entry in that source's `claims[]`, confirm the `summary` still holds **and** that
+`appliesTo` is still correctly scoped. Watch for the failure that matters most: a claim
+that is still broadly true but no longer true *for the account class or region DPF applies
+it to*. That is the change most likely to slip through, because the page still "says the
+right thing".
+
+Outcomes:
+
+- **Claim unchanged** → nothing to edit but the retrieval date.
+- **Claim narrowed or reworded** → update `summary` and/or `appliesTo` to match reality.
+  Narrow rather than broaden when the new wording is ambiguous; the fail-closed direction
+  is the safe one.
+- **Claim withdrawn** → remove it. Do not leave a claim DPF can no longer substantiate.
+  Removing a claim may change advice from "conditional" to "insufficient evidence" — that
+  is the system working, not a regression to paper over.
+
+### 4. Update the registry
+
+Edit the entry in `provider-compliance-source-registry.ts`:
+
+- Set `retrievedAt` to the date you actually read the page (`YYYY-MM-DD`).
+- Apply any claim edits from step 3.
+- Reconsider `maxAgeDays` if the vendor's revision pace has visibly changed. Shorten it
+  freely; lengthen it only with a reason you would be willing to defend in an audit.
+
+Only bump `retrievedAt` for sources you genuinely re-read. Touching every date to silence
+the alert converts a working control into decoration, and the next person will trust it.
+
+### 5. Verify
+
+```bash
+cd apps/web && pnpm vitest run lib/routing/provider-suitability
+```
+
+```bash
+pnpm --filter @dpf/db exec vitest run src/provider-compliance-source-registry.test.ts
+```
+
+`validateProviderComplianceSourceRegistry` enforces the structural rules (HTTPS URLs,
+unique claim ids, non-empty applicability axes, no `secondary` authority). The freshness
+tests assert the warning arithmetic against pinned clocks.
+
+Then confirm the attention item has cleared — it disappears once every source is outside
+the 21-day warning window.
+
+### 6. Ship it
+
+A normal DCO PR. Record in the body which sources you re-read and what changed in the
+claims, so the next renewal can see whether a given vendor's terms are stable or churning.
+
+## Deliberately not a CI gate
+
+There is no per-PR check that fails when a source lapses, and there should not be. A
+required check with a date in it is a fleet-blocking time bomb with a known detonation
+date — precisely the failure this work exists to prevent (see the 2026-08-01T15:00Z
+outage, fixed in #3883/#3885, and the detector added in #3899).
+
+The warning belongs where a human can act on it and nowhere that can block a merge.
+
+## If it has already lapsed
+
+Nothing is broken and nothing is unsafe — the platform is refusing to substantiate advice
+it can no longer ground, which is the designed behaviour. Users will see "a human needs to
+review this" instead of a recommendation.
+
+Work the procedure above. If an answer is needed before the review can be completed, that
+answer is a human compliance decision, made and recorded as such — not a temporary widening
+of `maxAgeDays` to make the warning go away.

--- a/docs/superpowers/plans/2026-08-06-compliance-source-staleness-warning-plan.md
+++ b/docs/superpowers/plans/2026-08-06-compliance-source-staleness-warning-plan.md
@@ -1,0 +1,83 @@
+# Plan — Warn before AI-provider compliance evidence lapses (BI-68D44727)
+
+- **BI:** BI-68D44727
+- **Governing spec:** [`2026-06-23-human-attention-surface-design.md`](../specs/2026-06-23-human-attention-surface-design.md) §4.1 (pure projector, no materialized table)
+- **Runbook produced:** [`ai-provider-compliance-source-renewal-runbook.md`](../../operations/ai-provider-compliance-source-renewal-runbook.md)
+
+## Problem
+
+Each governed source in the provider-compliance registry carries `retrievedAt` and its own
+`maxAgeDays`. Past that window `provider-compliance-advisory.ts:135` emits `stale-source`,
+grounding validation fails, and AI-provider advice degrades from a real recommendation to a
+deterministic non-approval.
+
+Failing closed is correct. Failing closed **silently** is the defect: nothing refreshed the
+corpus, nothing warned first, and the three `provider-terms` sources (retrieved 2026-07-20,
+60-day window) are valid only through **2026-09-18**, going stale on the 19th. On that day
+the compliance coworker quietly becomes less useful on every install, with no error to read
+and no owner. It surfaces as "the AI got worse", at whatever moment someone next tries to
+onboard a provider.
+
+Found by the time-bomb detector (#3899) at +365d; two failing tests were the symptom, the
+registry was the cause.
+
+## Scope
+
+Warning plus a renewal procedure. Explicitly **not** automated re-attestation: confirming a
+vendor's data-handling claims still hold, for the scope DPF applies them to, is a compliance
+judgement a person owns. Automating the fetch would be possible; automating the attestation
+would move a judgement into code that cannot make it.
+
+## Phases
+
+### 1. Freshness arithmetic (done)
+
+`apps/web/lib/routing/provider-suitability/source-freshness.ts` — pure, registry-only, no DB
+or network, injectable `now`. Returns per-source `daysUntilStale`, `staleFrom`, and a
+`fresh | expiring-soon | stale` status, plus the worst status for a single badge.
+
+`maxAgeDays` is a whole-day allowance and the guard rejects only on `ageDays > maxAgeDays`, so
+a source stays valid **through** its final day. Both sides floor to UTC midnight so the answer
+does not swing with render time. The boundary is asserted explicitly in tests.
+
+Warning window: 21 days. The renewal is a scheduled human review, so the lead time has to be
+weeks; much longer and the alert outlives its own urgency.
+
+### 2. Attention projection (done)
+
+`apps/web/lib/attention/sources/compliance-source-freshness.ts` — projects only `stale` and
+`expiring-soon`. A healthy source is not news, and an inbox listing fine things trains people
+to skim past it.
+
+Same shape as the sibling `provider-credential` source (BI-282C39D5): an asset that was valid,
+lapsed on a schedule, and had no proactive signal. `decideEffort: "judgment"` routes it to
+"needs-you-now" through the existing `owner-routing` rules with no change there — the
+re-attestation is owner/specialist work, not technical custodian work.
+
+New `AttentionSource` key wired through the four exhaustive maps (`outside-in`,
+`owner-decision-copy` ×2, `reach-message`).
+
+### 3. Runbook (done)
+
+The procedure: identify what is lapsing, read the current source, re-attest each claim against
+its `appliesTo` scope, update the registry, verify, ship. Names the failure mode that matters
+most — a claim still broadly true but no longer true for the account class or region DPF
+applies it to — because that is the one a quick skim of the page misses.
+
+## Deliberately out of scope
+
+**No CI gate on expiry.** A required check that fails once a source lapses is a fleet-blocking
+time bomb with a known detonation date — the exact failure this work exists to prevent. The
+warning goes where a human can act and nowhere that can block a merge.
+
+**A scheduled audit** (weekly cron that files a BI, mirroring `audit-time-bombs.yml`) is a
+reasonable follow-up if the in-product warning proves too easy to miss. Left out here to keep
+the change small and because the attention inbox is the surface the operator already watches.
+
+## Verification
+
+- `source-freshness.test.ts` — 9 cases, every one clock-pinned, including the exact boundary day
+- `compliance-source-freshness.test.ts` — 5 cases, explicit `now`, covering silence-while-fresh,
+  warn-before-break, escalate-once-lapsed, routing, and id stability
+- Full `lib/attention` + `lib/proactivity` suites green (294 tests)
+- Both new suites verified at +365d and +3650d — a module about expiry must not itself expire


### PR DESCRIPTION
Closes the silent half of a fail-closed control. Found by the time-bomb detector (#3899)
while sweeping for #4017; two failing tests were the symptom, the registry was the cause.

## The problem

Every governed source in the provider-compliance registry carries a `retrievedAt` stamp
and its own `maxAgeDays`. Past that window `provider-compliance-advisory.ts:135` emits
`stale-source`, grounding validation fails, and AI-provider advice that would have said
"conditional" degrades to a deterministic non-approval.

**That direction is correct.** DPF must not vouch for a vendor's data-handling terms from
a stale copy. Failing closed *silently* is the defect. Nothing refreshed the corpus and
nothing warned first:

| maxAgeDays | Valid through | Sources |
| --- | --- | --- |
| 60 | **2026-09-18** (stale from the 19th) | `openai/business-data-privacy`, `anthropic/commercial-training`, `anthropic/consumer-training` |
| 180 | 2027-01-16 | `ico/international-transfers` |
| 365 | 2027-07-20 | the two GDPR/ICO contract sources |

On 19 September the compliance coworker quietly becomes less useful on every install, with
no error to read and no owner. An operator experiences that as "the AI got worse" — and
experiences it at whatever moment they next try to onboard a provider, which is exactly
when they can least afford to debug it. `grep -rln retrievedAt scripts/ .github/` returned
nothing: no refresh job, no alert, no CI awareness.

## What this adds

**`source-freshness.ts`** — pure registry arithmetic, no DB or network, injectable `now`.
`maxAgeDays` is a whole-day allowance and the guard rejects only on `ageDays > maxAgeDays`,
so a source stays valid *through* its final day; both sides floor to UTC midnight so the
answer does not swing with render time. The boundary day is asserted explicitly rather than
left to an off-by-one.

**`compliance-source-freshness.ts`** — attention projection with 21 days of notice. Only
`stale` and `expiring-soon` project: a healthy source is not news, and an inbox that lists
fine things teaches people to skim past it. The copy names the user-visible consequence
("a human needs to review this") rather than the internal failure mode, and deliberately
does not imply a refresh button that does not exist.

**The renewal runbook** — the half that was actually missing. Renewal is a compliance
review, not a scrape: the registry cites specific *claims*, each scoped to providers,
services, account classes, jurisdictions and regions. The question is never "is the URL
still live?" but *"does this source still support this claim, for this scope?"* The runbook
names the failure most likely to slip past a skim — a claim still broadly true but no
longer true for the account class DPF applies it to.

## Two deliberate omissions

**No CI gate on expiry.** A required check that fails once a source lapses would be a
fleet-blocking time bomb with a known detonation date — precisely the failure this warning
exists to prevent (see #3883/#3885 and the 2026-08-01T15:00Z outage). The warning goes
where a human can act and nowhere that can block a merge.

**No automated re-attestation.** Automating the *fetch* would be possible; automating the
*attestation* would move a compliance judgement into code that cannot make it.

Relatedly, the two cold-start tests that exposed this are left failing-under-clock-shift
rather than pinned. Pinning them would hide the defect this PR exists to surface; they go
green when the sources are renewed.

## Design grounding

Extends the existing Attention Surface spec
([`2026-06-23-human-attention-surface-design.md`](docs/superpowers/specs/2026-06-23-human-attention-surface-design.md)
§4.1) — a new `AttentionSource` projected purely over its owning model, no materialized
`AttentionItem` table, exactly as §4.1 requires. The new key is wired through all four
exhaustive `Record<AttentionSource, …>` maps. `decideEffort: "judgment"` routes the item to
"needs-you-now" through the *existing* `owner-routing` rules with no change there —
re-attesting vendor terms is owner/specialist work, not technical custodian work. Plan at
[`2026-08-06-compliance-source-staleness-warning-plan.md`](docs/superpowers/plans/2026-08-06-compliance-source-staleness-warning-plan.md).

## Verification

- 14 new tests, every one clock-pinned or given an explicit `now` — a module about expiry
  dates must not itself expire. Both new suites verified green at +365d and +3650d.
- `lib/attention` + `lib/proactivity` + `lib/routing/provider-suitability`: **433 passing**
  unshifted. The sole +365d failure is the pre-existing cold-start test that *is* this BI.
- 34/34 pregate preflight guards clean; **local-CI gate PASS** (evidence
  `cmsh1a1lg02m201pl41209dee`).

Backlog-Item: BI-68D44727

🤖 Generated with [Claude Code](https://claude.com/claude-code)
