### PR TITLE
feat(recruiting): Greenhouse Absorb backend — crosswalk, dual-read pipeline, hire→native (BI-E64D11AE)

### DIFF
--- a/apps/web/lib/recruiting/pipeline-read-model.test.ts
+++ b/apps/web/lib/recruiting/pipeline-read-model.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { getRecruitingPipeline, type RecruitingPipelineClient } from "./pipeline-read-model";
+
+function fakeDb(opts: {
+  nativeApps?: Array<{
+    id: string;
+    status: string | null;
+    candidate: { displayName: string } | null;
+    currentStage: { name: string } | null;
+  }>;
+  staged?: Array<{ externalId: string; displayFields: unknown }>;
+  promoted?: Array<{ sourceEntityId: string }>;
+}) {
+  const appFindMany = vi.fn().mockResolvedValue(opts.nativeApps ?? []);
+  const stagedFindMany = vi.fn().mockResolvedValue(opts.staged ?? []);
+  const refFindMany = vi.fn().mockResolvedValue(opts.promoted ?? []);
+  const db: RecruitingPipelineClient = {
+    application: { findMany: appFindMany },
+    integrationImportStagedRecord: { findMany: stagedFindMany },
+    masterDataSourceRef: { findMany: refFindMany },
+  };
+  return { db, appFindMany };
+}
+
+describe("getRecruitingPipeline", () => {
+  it("unions native applications and Greenhouse-staged records into one funnel", async () => {
+    const { db } = fakeDb({
+      nativeApps: [
+        {
+          id: "app-native-1",
+          status: "active",
+          candidate: { displayName: "Nadia Native" },
+          currentStage: { name: "Onsite" },
+        },
+      ],
+      staged: [
+        {
+          externalId: "gh-app-1",
+          displayFields: [
+            { label: "Name", value: "Greta Greenhouse" },
+            { label: "Status", value: "active" },
+            { label: "Stage", value: "Screen" },
+          ],
+        },
+      ],
+    });
+
+    const result = await getRecruitingPipeline(db);
+
+    expect(result.counts).toEqual({ native: 1, greenhouse: 1, total: 2 });
+    expect(result.items[0]).toMatchObject({
+      id: "app-native-1",
+      source: "native",
+      displayName: "Nadia Native",
+      stage: "Onsite",
+    });
+    expect(result.items[1]).toMatchObject({
+      id: "greenhouse:gh-app-1",
+      source: "greenhouse",
+      displayName: "Greta Greenhouse",
+      status: "active",
+      stage: "Screen",
+      externalId: "gh-app-1",
+    });
+  });
+
+  it("dedupes a staged record already crosswalked to a native row", async () => {
+    const { db } = fakeDb({
+      nativeApps: [
+        { id: "app-native-1", status: "hired", candidate: { displayName: "Promoted Pat" }, currentStage: null },
+      ],
+      staged: [
+        { externalId: "gh-app-1", displayFields: [{ label: "Name", value: "Promoted Pat" }] },
+        { externalId: "gh-app-2", displayFields: [{ label: "Name", value: "Still Staged" }] },
+      ],
+      // gh-app-1 is already promoted → excluded from the Greenhouse side.
+      promoted: [{ sourceEntityId: "gh-app-1" }],
+    });
+
+    const result = await getRecruitingPipeline(db);
+
+    expect(result.counts).toEqual({ native: 1, greenhouse: 1, total: 2 });
+    const ghItems = result.items.filter((i) => i.source === "greenhouse");
+    expect(ghItems).toHaveLength(1);
+    expect(ghItems[0].externalId).toBe("gh-app-2");
+  });
+
+  it("passes a requisitionId filter through to the native query", async () => {
+    const { db, appFindMany } = fakeDb({});
+    await getRecruitingPipeline(db, { requisitionId: "req-7" });
+    expect(appFindMany.mock.calls[0][0].where).toEqual({ requisitionId: "req-7" });
+  });
+
+  it("falls back to a placeholder name when a staged row has no Name field", async () => {
+    const { db } = fakeDb({ staged: [{ externalId: "gh-9", displayFields: [] }] });
+    const result = await getRecruitingPipeline(db);
+    expect(result.items[0].displayName).toBe("Greenhouse application gh-9");
+  });
+});

--- a/apps/web/lib/recruiting/pipeline-read-model.ts
+++ b/apps/web/lib/recruiting/pipeline-read-model.ts
@@ -1,0 +1,125 @@
+// BI-E64D11AE (Absorb) — the "one funnel" read model. Unions native recruiting
+// Applications with Greenhouse-staged application records (dual-read), deduping
+// staged records that have already been crosswalked to a native row. This lets
+// the operator see one pipeline across native + Greenhouse-sourced work without
+// a lossy promotion step (design §4 Phase 2).
+
+const GREENHOUSE = "greenhouse";
+const RECRUITING_APPLICATION_DOMAIN = "recruiting-application";
+
+export interface PipelineItem {
+  /** Native application id, or `greenhouse:<externalId>` for a staged row. */
+  id: string;
+  source: "native" | "greenhouse";
+  displayName: string;
+  status: string | null;
+  stage: string | null;
+  externalId: string | null;
+}
+
+export interface RecruitingPipeline {
+  items: PipelineItem[];
+  counts: { native: number; greenhouse: number; total: number };
+}
+
+type StagedDisplayField = { label?: string; value?: string };
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type RecruitingPipelineClient = {
+  application: {
+    findMany: (args: unknown) => Promise<
+      Array<{
+        id: string;
+        status: string | null;
+        candidate: { displayName: string } | null;
+        currentStage: { name: string } | null;
+      }>
+    >;
+  };
+  integrationImportStagedRecord: {
+    findMany: (args: unknown) => Promise<
+      Array<{ externalId: string; displayFields: unknown }>
+    >;
+  };
+  masterDataSourceRef: {
+    findMany: (args: unknown) => Promise<Array<{ sourceEntityId: string }>>;
+  };
+};
+
+function fieldValue(displayFields: unknown, label: string): string | null {
+  if (!Array.isArray(displayFields)) return null;
+  const match = (displayFields as StagedDisplayField[]).find(
+    (f) => f && typeof f.label === "string" && f.label.toLowerCase() === label.toLowerCase(),
+  );
+  return match?.value ?? null;
+}
+
+export interface GetRecruitingPipelineArgs {
+  requisitionId?: string;
+}
+
+/**
+ * Read the unified recruiting pipeline. Native applications first, then any
+ * Greenhouse-staged applications not yet promoted to a native row.
+ */
+export async function getRecruitingPipeline(
+  db: RecruitingPipelineClient,
+  args: GetRecruitingPipelineArgs = {},
+): Promise<RecruitingPipeline> {
+  const nativeApps = await db.application.findMany({
+    where: args.requisitionId ? { requisitionId: args.requisitionId } : {},
+    select: {
+      id: true,
+      status: true,
+      candidate: { select: { displayName: true } },
+      currentStage: { select: { name: true } },
+    },
+  });
+
+  const nativeItems: PipelineItem[] = nativeApps.map((a) => ({
+    id: a.id,
+    source: "native",
+    displayName: a.candidate?.displayName ?? "(unknown candidate)",
+    status: a.status,
+    stage: a.currentStage?.name ?? null,
+    externalId: null,
+  }));
+
+  // Dedupe: staged rows already crosswalked to a native row are represented by
+  // the native item above, so drop them from the Greenhouse side.
+  const promotedRefs = await db.masterDataSourceRef.findMany({
+    where: { domain: RECRUITING_APPLICATION_DOMAIN, sourceSystem: GREENHOUSE, status: "active" },
+    select: { sourceEntityId: true },
+  });
+  const promoted = new Set(promotedRefs.map((r) => r.sourceEntityId));
+
+  const staged = await db.integrationImportStagedRecord.findMany({
+    where: {
+      sourceProvider: GREENHOUSE,
+      entityFamily: RECRUITING_APPLICATION_DOMAIN,
+      reviewStatus: { in: ["candidate", "linked"] },
+    },
+    select: { externalId: true, displayFields: true },
+  });
+
+  const greenhouseItems: PipelineItem[] = staged
+    .filter((r) => !promoted.has(r.externalId))
+    .map((r) => ({
+      id: `greenhouse:${r.externalId}`,
+      source: "greenhouse",
+      displayName: fieldValue(r.displayFields, "Name") ?? `Greenhouse application ${r.externalId}`,
+      status: fieldValue(r.displayFields, "Status"),
+      stage: fieldValue(r.displayFields, "Stage"),
+      externalId: r.externalId,
+    }));
+
+  const items = [...nativeItems, ...greenhouseItems];
+  return {
+    items,
+    counts: {
+      native: nativeItems.length,
+      greenhouse: greenhouseItems.length,
+      total: items.length,
+    },
+  };
+}

--- a/apps/web/lib/recruiting/promote-hire.test.ts
+++ b/apps/web/lib/recruiting/promote-hire.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { promoteGreenhouseHireToNative, type PromoteHireClient } from "./promote-hire";
+import type { GreenhouseHire } from "@/lib/integrate/greenhouse/land-hire";
+
+function hire(overrides: Partial<GreenhouseHire> = {}): GreenhouseHire {
+  return {
+    candidateId: "cand-1",
+    applicationId: "app-1",
+    firstName: "Ana",
+    lastName: "López",
+    displayName: "Ana López",
+    workEmail: "ana@example.com",
+    phoneWork: null,
+    startDate: "2026-09-01",
+    ...overrides,
+  };
+}
+
+function fakeDb(opts: { crosswalks?: Record<string, string> } = {}) {
+  const map = opts.crosswalks ?? {};
+  const key = (a: { where: { domain_sourceSystem_sourceEntityId: { domain: string; sourceEntityId: string } } }) =>
+    `${a.where.domain_sourceSystem_sourceEntityId.domain}:${a.where.domain_sourceSystem_sourceEntityId.sourceEntityId}`;
+  const findUnique = vi.fn().mockImplementation(async (a) => {
+    const id = map[key(a)];
+    return id ? { canonicalId: id } : null;
+  });
+  const findMany = vi.fn().mockResolvedValue([]);
+  const upsert = vi.fn().mockResolvedValue({});
+  const candidateCreate = vi.fn().mockResolvedValue({ id: "native-candidate-1" });
+  const applicationCreate = vi.fn().mockResolvedValue({ id: "native-application-1" });
+  const db: PromoteHireClient = {
+    masterDataSourceRef: { findUnique, findMany, upsert },
+    candidate: { create: candidateCreate },
+    application: { create: applicationCreate },
+  };
+  return { db, candidateCreate, applicationCreate, upsert };
+}
+
+describe("promoteGreenhouseHireToNative", () => {
+  it("creates a native Candidate + hired Application + crosswalks on a new hire", async () => {
+    const { db, candidateCreate, applicationCreate, upsert } = fakeDb();
+
+    const result = await promoteGreenhouseHireToNative(db, hire());
+
+    expect(result).toEqual({
+      candidateId: "native-candidate-1",
+      applicationId: "native-application-1",
+      promoted: true,
+    });
+    expect(candidateCreate.mock.calls[0][0].data).toMatchObject({
+      candidateId: "gh-cand-1",
+      kind: "candidate",
+      displayName: "Ana López",
+      email: "ana@example.com",
+    });
+    expect(applicationCreate.mock.calls[0][0].data).toMatchObject({
+      applicationId: "gh-app-1",
+      candidateId: "native-candidate-1",
+      status: "hired",
+    });
+    // Two crosswalks registered: candidate + application.
+    expect(upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("is idempotent — an existing application crosswalk creates nothing", async () => {
+    const { db, candidateCreate, applicationCreate } = fakeDb({
+      crosswalks: {
+        "recruiting-application:app-1": "existing-app",
+        "recruiting-candidate:cand-1": "existing-candidate",
+      },
+    });
+
+    const result = await promoteGreenhouseHireToNative(db, hire());
+
+    expect(result).toEqual({
+      candidateId: "existing-candidate",
+      applicationId: "existing-app",
+      promoted: false,
+    });
+    expect(candidateCreate).not.toHaveBeenCalled();
+    expect(applicationCreate).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing candidate crosswalk but still creates the application", async () => {
+    const { db, candidateCreate, applicationCreate } = fakeDb({
+      crosswalks: { "recruiting-candidate:cand-1": "existing-candidate" },
+    });
+
+    const result = await promoteGreenhouseHireToNative(db, hire());
+
+    expect(candidateCreate).not.toHaveBeenCalled();
+    expect(applicationCreate.mock.calls[0][0].data.candidateId).toBe("existing-candidate");
+    expect(result).toMatchObject({ candidateId: "existing-candidate", promoted: true });
+  });
+
+  it("falls back to the candidate id when the hire carries no application id", async () => {
+    const { db, applicationCreate } = fakeDb();
+    await promoteGreenhouseHireToNative(db, hire({ applicationId: null }));
+    expect(applicationCreate.mock.calls[0][0].data.applicationId).toBe("gh-cand-1");
+  });
+});

--- a/apps/web/lib/recruiting/promote-hire.ts
+++ b/apps/web/lib/recruiting/promote-hire.ts
@@ -1,0 +1,104 @@
+// BI-E64D11AE (Absorb) — promote a Greenhouse hire into native recruiting rows.
+// A hired candidate becomes a native Candidate + a hired Application, crosswalked
+// to their Greenhouse source ids so the native pipeline shows the hire as one
+// funnel item (deduped against the staged row by the pipeline read-model).
+// Idempotent via the recruiting crosswalk. Complements the batch-1 hire->worker
+// landing (which creates the EmployeeProfile); this creates the recruiting record.
+
+import type { GreenhouseHire } from "@/lib/integrate/greenhouse/land-hire";
+import {
+  RECRUITING_DOMAINS,
+  registerRecruitingCrosswalk,
+  resolveNativeRecruitingId,
+  type RecruitingCrosswalkClient,
+} from "./recruiting-crosswalk";
+
+const SOURCE = "greenhouse";
+
+/** Structural client — the real PrismaClient and test fakes satisfy it. */
+export type PromoteHireClient = RecruitingCrosswalkClient & {
+  candidate: { create: (args: unknown) => Promise<{ id: string }> };
+  application: { create: (args: unknown) => Promise<{ id: string }> };
+};
+
+export interface PromoteHireResult {
+  candidateId: string;
+  applicationId: string;
+  promoted: boolean;
+}
+
+/** Greenhouse application id, or the candidate id when the hire carries none. */
+function applicationKey(hire: GreenhouseHire): string {
+  return hire.applicationId ?? hire.candidateId;
+}
+
+export async function promoteGreenhouseHireToNative(
+  db: PromoteHireClient,
+  hire: GreenhouseHire,
+): Promise<PromoteHireResult> {
+  const appKey = applicationKey(hire);
+
+  // Idempotent: an existing application crosswalk means this hire is already
+  // represented natively.
+  const existingApp = await resolveNativeRecruitingId(db, {
+    domain: RECRUITING_DOMAINS.application,
+    sourceSystem: SOURCE,
+    sourceEntityId: appKey,
+  });
+  if (existingApp) {
+    const existingCandidate = await resolveNativeRecruitingId(db, {
+      domain: RECRUITING_DOMAINS.candidate,
+      sourceSystem: SOURCE,
+      sourceEntityId: hire.candidateId,
+    });
+    return {
+      candidateId: existingCandidate ?? "",
+      applicationId: existingApp,
+      promoted: false,
+    };
+  }
+
+  // Resolve or create the native Candidate.
+  let candidateId = await resolveNativeRecruitingId(db, {
+    domain: RECRUITING_DOMAINS.candidate,
+    sourceSystem: SOURCE,
+    sourceEntityId: hire.candidateId,
+  });
+  if (!candidateId) {
+    const created = await db.candidate.create({
+      data: {
+        candidateId: `gh-${hire.candidateId}`,
+        kind: "candidate",
+        displayName: hire.displayName || `candidate-${hire.candidateId}`,
+        ...(hire.firstName ? { firstName: hire.firstName } : {}),
+        ...(hire.lastName ? { lastName: hire.lastName } : {}),
+        ...(hire.workEmail ? { email: hire.workEmail } : {}),
+        ...(hire.phoneWork ? { phone: hire.phoneWork } : {}),
+      },
+    });
+    candidateId = created.id;
+    await registerRecruitingCrosswalk(db, {
+      domain: RECRUITING_DOMAINS.candidate,
+      sourceSystem: SOURCE,
+      sourceEntityId: hire.candidateId,
+      canonicalId: candidateId,
+    });
+  }
+
+  // Create the hired native Application and crosswalk it.
+  const application = await db.application.create({
+    data: {
+      applicationId: `gh-${appKey}`,
+      candidateId,
+      status: "hired",
+    },
+  });
+  await registerRecruitingCrosswalk(db, {
+    domain: RECRUITING_DOMAINS.application,
+    sourceSystem: SOURCE,
+    sourceEntityId: appKey,
+    canonicalId: application.id,
+  });
+
+  return { candidateId, applicationId: application.id, promoted: true };
+}

--- a/apps/web/lib/recruiting/recruiting-crosswalk.test.ts
+++ b/apps/web/lib/recruiting/recruiting-crosswalk.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  loadRecruitingCrosswalk,
+  registerRecruitingCrosswalk,
+  resolveNativeRecruitingId,
+  type RecruitingCrosswalkClient,
+} from "./recruiting-crosswalk";
+
+function fakeDb(opts: { findUnique?: unknown; findMany?: unknown[] } = {}) {
+  const findUnique = vi.fn().mockResolvedValue(opts.findUnique ?? null);
+  const findMany = vi.fn().mockResolvedValue(opts.findMany ?? []);
+  const upsert = vi.fn().mockResolvedValue({});
+  const db: RecruitingCrosswalkClient = {
+    masterDataSourceRef: { findUnique, findMany, upsert },
+  };
+  return { db, findUnique, findMany, upsert };
+}
+
+describe("registerRecruitingCrosswalk", () => {
+  it("upserts on the (domain, sourceSystem, sourceEntityId) unique key", async () => {
+    const { db, upsert } = fakeDb();
+    await registerRecruitingCrosswalk(db, {
+      domain: "recruiting-candidate",
+      sourceSystem: "greenhouse",
+      sourceEntityId: "cand-1",
+      canonicalId: "dpf-candidate-1",
+    });
+    const call = upsert.mock.calls[0][0];
+    expect(call.where.domain_sourceSystem_sourceEntityId).toEqual({
+      domain: "recruiting-candidate",
+      sourceSystem: "greenhouse",
+      sourceEntityId: "cand-1",
+    });
+    expect(call.create).toMatchObject({
+      domain: "recruiting-candidate",
+      sourceSystem: "greenhouse",
+      sourceEntityId: "cand-1",
+      canonicalId: "dpf-candidate-1",
+      trustTier: "connector",
+    });
+    expect(call.update).toMatchObject({ canonicalId: "dpf-candidate-1" });
+  });
+});
+
+describe("resolveNativeRecruitingId", () => {
+  it("returns the canonicalId when a crosswalk exists", async () => {
+    const { db } = fakeDb({ findUnique: { canonicalId: "dpf-app-9" } });
+    const id = await resolveNativeRecruitingId(db, {
+      domain: "recruiting-application",
+      sourceSystem: "greenhouse",
+      sourceEntityId: "app-9",
+    });
+    expect(id).toBe("dpf-app-9");
+  });
+
+  it("returns null when there is no crosswalk", async () => {
+    const { db } = fakeDb();
+    expect(
+      await resolveNativeRecruitingId(db, {
+        domain: "recruiting-candidate",
+        sourceSystem: "greenhouse",
+        sourceEntityId: "missing",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("loadRecruitingCrosswalk", () => {
+  it("builds a sourceEntityId -> canonicalId map for a domain+source", async () => {
+    const { db } = fakeDb({
+      findMany: [
+        { sourceEntityId: "cand-1", canonicalId: "dpf-1" },
+        { sourceEntityId: "cand-2", canonicalId: "dpf-2" },
+      ],
+    });
+    const map = await loadRecruitingCrosswalk(db, {
+      domain: "recruiting-candidate",
+      sourceSystem: "greenhouse",
+    });
+    expect(map.get("cand-1")).toBe("dpf-1");
+    expect(map.get("cand-2")).toBe("dpf-2");
+    expect(map.size).toBe(2);
+  });
+});

--- a/apps/web/lib/recruiting/recruiting-crosswalk.ts
+++ b/apps/web/lib/recruiting/recruiting-crosswalk.ts
@@ -1,0 +1,100 @@
+// BI-E64D11AE (Absorb, Seam A generalized) — the recruiting external-source
+// crosswalk. Maps an external ATS record (Greenhouse candidate/application/etc.)
+// to a canonical DPF recruiting entity via MasterDataSourceRef's soft-ref
+// (domain, sourceSystem, sourceEntityId) -> canonicalId, with no schema change.
+// Connector-agnostic: Greenhouse now, Fountain/Workday later reuse it verbatim.
+
+export const RECRUITING_DOMAINS = {
+  candidate: "recruiting-candidate",
+  application: "recruiting-application",
+  job: "recruiting-job",
+  offer: "recruiting-offer",
+  scorecard: "recruiting-scorecard",
+} as const;
+
+export type RecruitingCrosswalkDomain =
+  (typeof RECRUITING_DOMAINS)[keyof typeof RECRUITING_DOMAINS];
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type RecruitingCrosswalkClient = {
+  masterDataSourceRef: {
+    findUnique: (args: unknown) => Promise<{ canonicalId: string } | null>;
+    findMany: (args: unknown) => Promise<Array<{ sourceEntityId: string; canonicalId: string }>>;
+    upsert: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export interface RegisterCrosswalkInput {
+  domain: RecruitingCrosswalkDomain;
+  sourceSystem: string;
+  sourceEntityId: string;
+  canonicalId: string;
+  trustTier?: string;
+}
+
+/**
+ * Idempotently record (or refresh) the crosswalk for one external record. The
+ * @@unique(domain, sourceSystem, sourceEntityId) makes re-registration a no-op
+ * update; the canonicalId can be corrected but the key is stable.
+ */
+export async function registerRecruitingCrosswalk(
+  db: RecruitingCrosswalkClient,
+  input: RegisterCrosswalkInput,
+): Promise<void> {
+  const now = new Date();
+  await db.masterDataSourceRef.upsert({
+    where: {
+      domain_sourceSystem_sourceEntityId: {
+        domain: input.domain,
+        sourceSystem: input.sourceSystem,
+        sourceEntityId: input.sourceEntityId,
+      },
+    },
+    create: {
+      domain: input.domain,
+      canonicalId: input.canonicalId,
+      sourceSystem: input.sourceSystem,
+      sourceEntityId: input.sourceEntityId,
+      observedAt: now,
+      lastSeenAt: now,
+      trustTier: input.trustTier ?? "connector",
+    },
+    update: {
+      canonicalId: input.canonicalId,
+      lastSeenAt: now,
+    },
+  });
+}
+
+/** Resolve one external record to its canonical recruiting entity id, or null. */
+export async function resolveNativeRecruitingId(
+  db: RecruitingCrosswalkClient,
+  args: { domain: RecruitingCrosswalkDomain; sourceSystem: string; sourceEntityId: string },
+): Promise<string | null> {
+  const ref = await db.masterDataSourceRef.findUnique({
+    where: {
+      domain_sourceSystem_sourceEntityId: {
+        domain: args.domain,
+        sourceSystem: args.sourceSystem,
+        sourceEntityId: args.sourceEntityId,
+      },
+    },
+  });
+  return ref?.canonicalId ?? null;
+}
+
+/**
+ * Bulk map of sourceEntityId -> canonicalId for a domain+source. Used by the
+ * dual-read pipeline to dedupe already-crosswalked (promoted) external records
+ * against native rows so the operator sees one funnel, not two.
+ */
+export async function loadRecruitingCrosswalk(
+  db: RecruitingCrosswalkClient,
+  args: { domain: RecruitingCrosswalkDomain; sourceSystem: string },
+): Promise<Map<string, string>> {
+  const refs = await db.masterDataSourceRef.findMany({
+    where: { domain: args.domain, sourceSystem: args.sourceSystem, status: "active" },
+    select: { sourceEntityId: true, canonicalId: true },
+  });
+  return new Map(refs.map((r) => [r.sourceEntityId, r.canonicalId]));
+}

--- a/docs/superpowers/plans/2026-08-06-greenhouse-absorb-native-recruiting-b2.md
+++ b/docs/superpowers/plans/2026-08-06-greenhouse-absorb-native-recruiting-b2.md
@@ -1,0 +1,33 @@
+# Greenhouse Absorb — native recruiting backend (BI-E64D11AE), batch 2
+
+- **BI:** BI-E64D11AE — *Absorb: surface the Greenhouse pipeline on the native recruiting surface*, epic EP-ECOSYSTEM-ABSORPTION-ARCH.
+- **Design:** [docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md](../specs/2026-08-05-greenhouse-ats-absorption-design.md) §4 Phase 2 (Absorb), §2.1 (Seam A).
+- **Builds on:** the merged native recruiting models (BI-F3AEBF68, PR #4053) + the import-review staging store + `MasterDataSourceRef`.
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Goal & boundary
+
+The **backend of Absorb**: make the Greenhouse pipeline native-visible as one funnel, with no lossy promotion. Pure lib modules — no schema change, no new route, no UI (the pipeline UI page + connect page are batch 3, sequenced to keep the UX-Fit/route gauntlet out of this PR). Typed relations from the recruiting models to People-Core (Position/Department/EmployeeProfile) are deferred to coordinate with the HCM owners (design §9: BI-41901810, BI-HCM-003).
+
+## Phases (all shipped together — atomic)
+
+1. **Recruiting crosswalk** (`apps/web/lib/recruiting/recruiting-crosswalk.ts`) — generalizes Seam A: register/resolve/bulk-load `MasterDataSourceRef` soft-refs for `recruiting-*` domains (connector-agnostic; Fountain/Workday reuse it). *Verify:* upsert on the unique key, resolve hit/miss, bulk map.
+2. **Dual-read pipeline read-model** (`apps/web/lib/recruiting/pipeline-read-model.ts`) — `getRecruitingPipeline` unions native `Application`s with Greenhouse-staged application records, deduping staged rows already crosswalked to a native row (one funnel; design §4 Phase 2 dual-read). *Verify:* union + counts, dedupe by crosswalk, displayFields projection, requisition filter.
+3. **Hire → native promotion** (`apps/web/lib/recruiting/promote-hire.ts`) — `promoteGreenhouseHireToNative` turns a Greenhouse hire into a native `Candidate` + hired `Application`, crosswalked and idempotent; complements the batch-1 hire→worker `EmployeeProfile` landing. *Verify:* create + 2 crosswalks, idempotent re-run, candidate reuse, null-application fallback.
+
+## Risks & rollback
+
+- Read-model reads only; promotion writes native rows idempotently (crosswalk unique key). No existing table touched, no migration. Rollback = delete the three lib files; the crosswalk rows are inert `MasterDataSourceRef` soft-refs.
+- Staged records carry only redacted `displayFields`, so the Greenhouse side of the funnel is low-fidelity by design (full-fidelity durable promotion via Harvest re-fetch is a follow-up).
+
+## Completion gate
+
+`dpf-local-merge-ci-before-push` (or the recorded infra override) + `dpf-pr-with-dco`. 12 unit tests, tsc + all 24 guards clean locally.
+
+## Backlog coverage
+
+- **Decision:** `atomic` — one BI (BI-E64D11AE); the three modules ship together as the absorb backend.
+- **Receipt:** `cmsh1937t01g501pra63r66sj` (recorded 2026-08-06 against BI-E64D11AE).
+- **Deliverables (none independently shippable):** recruiting-crosswalk → pipeline-read-model + promote-hire.
+- **Deferred (separate batch):** pipeline UI page + connect UI page (UX-Fit/route gauntlet); typed People-Core relations (coordinate with HCM owners BI-41901810 / BI-HCM-003).


### PR DESCRIPTION
## What this is

The **backend of Absorb** (BI-E64D11AE) — makes the Greenhouse pipeline native-visible as one funnel, on the native recruiting models merged in #4053. Pure lib modules; **no schema, route, or UI change**.

Plan: [docs/superpowers/plans/2026-08-06-greenhouse-absorb-native-recruiting-b2.md](docs/superpowers/plans/2026-08-06-greenhouse-absorb-native-recruiting-b2.md) · Design: [spec §4 Phase 2](docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md)

## Modules

- **`recruiting-crosswalk.ts`** — Seam A generalized: register/resolve/bulk-load `MasterDataSourceRef` soft-refs for `recruiting-*` domains. Connector-agnostic (Fountain/Workday reuse it), no schema change.
- **`pipeline-read-model.ts`** — `getRecruitingPipeline` unions native `Application`s with Greenhouse-staged application rows, **deduping** staged rows already crosswalked to a native row (design §4 Phase 2 dual-read).
- **`promote-hire.ts`** — `promoteGreenhouseHireToNative` turns a Greenhouse hire into a native `Candidate` + hired `Application`, crosswalked and idempotent (complements the batch-1 hire→worker `EmployeeProfile` landing).

## Scope discipline (deferred, own batches)

- **Pipeline UI page + connect UI page** — deferred to keep the UX-Fit/route gauntlet out of this PR.
- **Typed People-Core relations** (recruiting models → Position/Department/EmployeeProfile) — deferred to coordinate with the HCM owners (design §9: BI-41901810, BI-HCM-003).
- Full-fidelity durable promotion (Harvest re-fetch) — follow-up; staged rows carry only redacted `displayFields` by design.

## Test evidence (local)

- **12 unit tests** (crosswalk, pipeline union/dedupe/projection/filter, promotion create/idempotent/reuse/fallback) — all green.
- `tsc --noEmit` clean; **all 24 guards + stewardship + data-impact + docs-impact** clean. Atomic backlog-coverage receipt `cmsh1937t01g501pra63r66sj`.

## Local-CI override (recorded, PR-visible)

Local-CI sandbox is WinNAT-port-blocked on this host (infra); pushed with a recorded `operator-emergency` override. Backend-only change (no schema/route) — CI runs the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)