### PR TITLE
fix(local-ci): report a killed guard spawn as a runner failure, not a violation (BI-AA2EE621)

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1327,7 +1327,8 @@
       "docs/architecture/enforced-ci-gates.md"
     ],
     "scripts/check-guards.mjs": [
-      "docs/architecture/theme-aware-styling-runbook.md"
+      "docs/architecture/theme-aware-styling-runbook.md",
+      "docs/testing/pre-pr-gate.md"
     ],
     "scripts/check-host-port-range.test.mjs": [
       "docs/operations/local-ci-sandbox-slots.md"
@@ -2518,6 +2519,7 @@
       ".github/workflows/policy-guards-recheck.yml",
       "docker-compose.local-ci.yml",
       "packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs",
+      "scripts/check-guards.mjs",
       "scripts/check-mobile-jest-pin.mjs",
       "scripts/ci-policy-guards.test.mjs",
       "scripts/gate-worktree.mjs",

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -216,7 +216,16 @@ aborts in well under a minute **before any lease is claimed**, so a doomed run
 never occupies the contended sandbox slot. A guard this host cannot execute
 (missing isolated or workspace runtime) is reported as
 `environment-skipped` with its remedy — a warning, never a false red; CI
-remains the enforcer. Run it standalone with `pnpm run pregate:preflight`
+remains the enforcer. A guard the host *killed or refused to spawn* — an
+OS-refused launch, or a signal/`taskkill /T` during a local-CI eviction, which
+leaves `spawnSync` `status: null` — is reported as a **runner failure**, not a
+guard violation (BI-AA2EE621): a transient host-pressure condition, retried
+before it is believed, warned rather than mislabelled "deterministic", and left
+to CI/the sandbox to enforce. The Repo Guard Loop runner
+(`scripts/check-guards.mjs`) applies the same distinction to its own child
+guards and exits with a dedicated runner-failure code so a killed spawn never
+prints `N/24 guard(s) FAILED` naming an innocent guard that had, in fact, run.
+Run it standalone with `pnpm run pregate:preflight`
 (`--plan` prints the guard plan without running it). Emergency skip:
 `DPF_SKIP_PREGATE_PREFLIGHT_REASON="<why>"` — printed on the gate run, and CI
 still enforces every guard. Routing probes (`--dry-run`) and evidence replays

--- a/scripts/check-guards.mjs
+++ b/scripts/check-guards.mjs
@@ -53,10 +53,19 @@ export const SPAWN_OUTCOME = Object.freeze({
   RUNNER_FAILURE: "runner-failure",
 });
 
+// Coerce a retry count to a safe non-negative integer. A non-numeric env value
+// (e.g. DPF_GUARD_SPAWN_RETRIES=off) must NOT yield NaN — `attempt >= NaN` is
+// always false, which would loop forever under a persistent runner failure,
+// exactly the host-pressure condition this path exists for.
+export function coerceRetryCount(value, fallback = 2) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
+}
+
 // How many times to re-spawn a guard whose spawn was killed/refused before
 // believing the host genuinely cannot run it. A runner failure is transient by
 // definition; a real violation is deterministic and never reaches this path.
-export const DEFAULT_SPAWN_RETRIES = Number(process.env.DPF_GUARD_SPAWN_RETRIES ?? 2);
+export const DEFAULT_SPAWN_RETRIES = coerceRetryCount(process.env.DPF_GUARD_SPAWN_RETRIES, 2);
 
 // Classify a spawnSync result WITHOUT collapsing "the spawn never ran / was
 // killed" into "the guard found a violation". The order matters:
@@ -85,10 +94,11 @@ export function classifySpawnResult(result) {
 // Spawn `argv`, retrying only while the outcome is a RUNNER failure. `spawn` is
 // injectable so the loop is unit-testable without touching the OS.
 export function spawnWithRunnerRetry(argv, { spawn, maxRetries = DEFAULT_SPAWN_RETRIES } = {}) {
+  const cap = coerceRetryCount(maxRetries, DEFAULT_SPAWN_RETRIES);
   let classified;
   for (let attempt = 0; ; attempt += 1) {
     classified = classifySpawnResult(spawn(argv, attempt));
-    if (classified.outcome !== SPAWN_OUTCOME.RUNNER_FAILURE || attempt >= maxRetries) {
+    if (classified.outcome !== SPAWN_OUTCOME.RUNNER_FAILURE || attempt >= cap) {
       return { ...classified, attempts: attempt + 1 };
     }
   }

--- a/scripts/check-guards.mjs
+++ b/scripts/check-guards.mjs
@@ -21,6 +21,17 @@
 //
 //   node scripts/check-guards.mjs        # run all guards (CI)
 //   pnpm check:guards                    # same, from anywhere in the repo
+//
+// KILLED-SPAWN HONESTY (BI-AA2EE621): a guard child the OS refused to launch
+// (spawn ENOMEM/EAGAIN) or that was killed by a signal — on Windows a local-CI
+// eviction issues `taskkill /T /F`, which leaves spawnSync `status: null` — is a
+// RUNNER failure, not a guard violation. Conflating the two once reported
+// `1/24 guard(s) FAILED: check-no-native-dialogs.mjs` for a guard that had run
+// and PASSED, sending readers to audit an innocent guard for ~2h. classifySpawn-
+// Result() keeps the two distinct; runner failures are retried (transient by
+// definition) and, if still failing, reported under a separate heading with a
+// distinct exit code so callers (pregate, local-CI) can tell "the host could not
+// run the guards" apart from "a guard found a violation".
 
 import { readdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -31,6 +42,58 @@ import { pathToFileURL } from "node:url";
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPTS_DIR, "..");
 
+// Exit code for "this host could not RUN the guards" — deliberately distinct
+// from 1 ("a guard found a violation") and from 0, so a caller can tell a
+// transient host failure apart from a deterministic tree failure.
+export const RUNNER_FAILURE_EXIT_CODE = 3;
+
+export const SPAWN_OUTCOME = Object.freeze({
+  OK: "ok",
+  VIOLATION: "violation",
+  RUNNER_FAILURE: "runner-failure",
+});
+
+// How many times to re-spawn a guard whose spawn was killed/refused before
+// believing the host genuinely cannot run it. A runner failure is transient by
+// definition; a real violation is deterministic and never reaches this path.
+export const DEFAULT_SPAWN_RETRIES = Number(process.env.DPF_GUARD_SPAWN_RETRIES ?? 2);
+
+// Classify a spawnSync result WITHOUT collapsing "the spawn never ran / was
+// killed" into "the guard found a violation". The order matters:
+//   - result.error set     -> the child never launched (ENOMEM/EAGAIN/ENOENT)
+//   - result.status null    -> launched, then terminated by a signal / taskkill
+//   - result.status === 0   -> clean
+//   - result.status > 0     -> a genuine guard violation, as before
+export function classifySpawnResult(result) {
+  if (!result || typeof result !== "object") {
+    return { outcome: SPAWN_OUTCOME.RUNNER_FAILURE, detail: "no spawn result" };
+  }
+  if (result.error) {
+    const code = result.error.code ?? result.error.message ?? "spawn failed";
+    return { outcome: SPAWN_OUTCOME.RUNNER_FAILURE, detail: `spawn ${code}` };
+  }
+  if (typeof result.status !== "number") {
+    const detail = result.signal
+      ? `killed by ${result.signal}`
+      : "no exit status (killed)";
+    return { outcome: SPAWN_OUTCOME.RUNNER_FAILURE, detail };
+  }
+  if (result.status === 0) return { outcome: SPAWN_OUTCOME.OK, detail: "exit 0" };
+  return { outcome: SPAWN_OUTCOME.VIOLATION, detail: `exit ${result.status}` };
+}
+
+// Spawn `argv`, retrying only while the outcome is a RUNNER failure. `spawn` is
+// injectable so the loop is unit-testable without touching the OS.
+export function spawnWithRunnerRetry(argv, { spawn, maxRetries = DEFAULT_SPAWN_RETRIES } = {}) {
+  let classified;
+  for (let attempt = 0; ; attempt += 1) {
+    classified = classifySpawnResult(spawn(argv, attempt));
+    if (classified.outcome !== SPAWN_OUTCOME.RUNNER_FAILURE || attempt >= maxRetries) {
+      return { ...classified, attempts: attempt + 1 };
+    }
+  }
+}
+
 export function discoverGuardFiles(entries) {
   const sorted=[...entries].sort();
   return {
@@ -39,42 +102,81 @@ export function discoverGuardFiles(entries) {
   };
 }
 
-export function main() {
-const { guards, tests } = discoverGuardFiles(readdirSync(SCRIPTS_DIR));
+// Pure orchestrator: run every guard (and its self-test) through the injected
+// `spawn`, sorting outcomes into genuine violations vs runner failures. No
+// process I/O, so tests can inject killed/errored/violating spawn results.
+export function runGuards({ guards, tests, spawn, maxRetries = DEFAULT_SPAWN_RETRIES }) {
+  const violations = [];
+  const runnerFailures = [];
+  const run = (argv) => spawnWithRunnerRetry(argv, { spawn, maxRetries });
 
-if (guards.length === 0) {
-  console.error("No scripts/check-no-*.mjs guards found — that is itself a failure.");
-  process.exit(1);
-}
-
-const failed = [];
-
-for (const guard of guards) {
-  const testFile = guard.replace(/\.mjs$/, ".test.mjs");
-  if (tests.has(testFile)) {
-    const t = spawnSync(process.execPath, ["--test", join(SCRIPTS_DIR, testFile)], {
-      cwd: REPO_ROOT,
-      stdio: "inherit",
-    });
-    if (t.status !== 0) {
-      failed.push(`${testFile} (guard self-test)`);
-      continue; // don't run a guard whose own logic is broken
+  for (const guard of guards) {
+    const testFile = guard.replace(/\.mjs$/, ".test.mjs");
+    if (tests.has(testFile)) {
+      const t = run(["--test", join(SCRIPTS_DIR, testFile)]);
+      if (t.outcome === SPAWN_OUTCOME.RUNNER_FAILURE) {
+        runnerFailures.push(`${testFile} (guard self-test) — ${t.detail}`);
+        continue; // couldn't run the self-test; don't run the guard on this pass
+      }
+      if (t.outcome === SPAWN_OUTCOME.VIOLATION) {
+        violations.push(`${testFile} (guard self-test)`);
+        continue; // don't run a guard whose own logic is broken
+      }
     }
+    const r = run([join(SCRIPTS_DIR, guard)]);
+    if (r.outcome === SPAWN_OUTCOME.RUNNER_FAILURE) runnerFailures.push(`${guard} — ${r.detail}`);
+    else if (r.outcome === SPAWN_OUTCOME.VIOLATION) violations.push(guard);
   }
-  const r = spawnSync(process.execPath, [join(SCRIPTS_DIR, guard)], {
-    cwd: REPO_ROOT,
-    stdio: "inherit",
-  });
-  if (r.status !== 0) failed.push(guard);
+
+  return { violations, runnerFailures };
 }
 
-console.log("");
-if (failed.length > 0) {
-  console.error(`Guard loop: ${failed.length}/${guards.length} guard(s) FAILED:`);
-  for (const f of failed) console.error(`  - ${f}`);
-  process.exit(1);
+// Pure summary: decide the exit code and the exact operator lines from a run.
+// A genuine violation dominates (exit 1); a runner-only failure is honest about
+// being a host problem (exit RUNNER_FAILURE_EXIT_CODE), never "deterministic".
+export function summarizeGuardRun({ guards, tests, violations, runnerFailures }) {
+  const lines = [];
+  const guardCount = guards.length;
+
+  if (violations.length > 0) {
+    lines.push(`Guard loop: ${violations.length}/${guardCount} guard(s) FAILED (found violations):`);
+    for (const f of violations) lines.push(`  - ${f}`);
+  }
+  if (runnerFailures.length > 0) {
+    lines.push(
+      `Guard loop: could not RUN ${runnerFailures.length}/${guardCount} guard(s) — the host failed to spawn them or killed them mid-run; this is NOT a guard violation:`,
+    );
+    for (const f of runnerFailures) lines.push(`  - ${f}`);
+    lines.push(
+      "These are RUNNER failures (transient host pressure / OS refused the spawn / local-CI eviction), not deterministic guard failures — retry on a quieter host.",
+    );
+  }
+
+  if (violations.length > 0) return { exitCode: 1, lines };
+  if (runnerFailures.length > 0) return { exitCode: RUNNER_FAILURE_EXIT_CODE, lines };
+
+  lines.push(`Guard loop OK — ${guardCount} guards passed (${tests.size} self-tests).`);
+  return { exitCode: 0, lines };
 }
-console.log(`Guard loop OK — ${guards.length} guards passed (${tests.size} self-tests).`);
+
+export function main() {
+  const { guards, tests } = discoverGuardFiles(readdirSync(SCRIPTS_DIR));
+
+  if (guards.length === 0) {
+    console.error("No scripts/check-no-*.mjs guards found — that is itself a failure.");
+    process.exit(1);
+  }
+
+  const spawn = (argv) =>
+    spawnSync(process.execPath, argv, { cwd: REPO_ROOT, stdio: "inherit" });
+
+  const { violations, runnerFailures } = runGuards({ guards, tests, spawn });
+  const { exitCode, lines } = summarizeGuardRun({ guards, tests, violations, runnerFailures });
+
+  console.log("");
+  const sink = exitCode === 0 ? console.log : console.error;
+  for (const line of lines) sink(line);
+  process.exit(exitCode);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) main();

--- a/scripts/check-guards.test.mjs
+++ b/scripts/check-guards.test.mjs
@@ -12,6 +12,7 @@ import {
   RUNNER_FAILURE_EXIT_CODE,
   SPAWN_OUTCOME,
   classifySpawnResult,
+  coerceRetryCount,
   spawnWithRunnerRetry,
   runGuards,
   summarizeGuardRun,
@@ -81,6 +82,24 @@ test("spawnWithRunnerRetry never retries a real violation", () => {
   });
   assert.equal(result.outcome, SPAWN_OUTCOME.VIOLATION);
   assert.equal(attempts, 1);
+});
+
+test("coerceRetryCount rejects NaN so a persistent runner failure cannot loop forever", () => {
+  assert.equal(coerceRetryCount("off"), 2); // non-numeric env → fallback, not NaN
+  assert.equal(coerceRetryCount(undefined), 2);
+  assert.equal(coerceRetryCount(-1), 2); // negative → fallback
+  assert.equal(coerceRetryCount(0), 0);
+  assert.equal(coerceRetryCount("3"), 3);
+});
+
+test("spawnWithRunnerRetry with a NaN maxRetries terminates (uses the safe default)", () => {
+  let attempts = 0;
+  const result = spawnWithRunnerRetry(["x"], {
+    maxRetries: Number("off"), // NaN — must not loop forever
+    spawn: () => (attempts++, { status: null, signal: "SIGKILL" }),
+  });
+  assert.equal(result.outcome, SPAWN_OUTCOME.RUNNER_FAILURE);
+  assert.equal(attempts, 3); // initial + default 2 retries
 });
 
 // ── runGuards — killed guards land in runnerFailures, not violations ─────────

--- a/scripts/check-guards.test.mjs
+++ b/scripts/check-guards.test.mjs
@@ -1,0 +1,165 @@
+// scripts/check-guards.test.mjs
+// node --test (no vitest). Pins the killed-spawn honesty contract of the Repo
+// Guard Loop runner (BI-AA2EE621): a guard child the OS refused to launch or
+// killed mid-run must be reported as a RUNNER failure, never conflated with a
+// guard that found a real violation, and the two must be distinguishable in
+// BOTH the exit code and the printed message.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  RUNNER_FAILURE_EXIT_CODE,
+  SPAWN_OUTCOME,
+  classifySpawnResult,
+  spawnWithRunnerRetry,
+  runGuards,
+  summarizeGuardRun,
+} from "./check-guards.mjs";
+
+// ── classifySpawnResult — the exact injections the BI requires ───────────────
+
+test("a SIGKILL'd spawn (status:null) is a runner failure, not a violation", () => {
+  const c = classifySpawnResult({ status: null, signal: "SIGKILL" });
+  assert.equal(c.outcome, SPAWN_OUTCOME.RUNNER_FAILURE);
+  assert.match(c.detail, /SIGKILL/);
+});
+
+test("a Windows taskkill /T /F (status 4294967295 surfaces as null) is a runner failure", () => {
+  // spawnSync reports a signal-terminated child as status:null; the tree-kill
+  // the local-CI supervisor issues on eviction lands exactly here.
+  const c = classifySpawnResult({ status: null, signal: "SIGTERM" });
+  assert.equal(c.outcome, SPAWN_OUTCOME.RUNNER_FAILURE);
+});
+
+test("a spawn that never launched (error ENOMEM) is a runner failure, not a violation", () => {
+  const c = classifySpawnResult({
+    error: Object.assign(new Error("spawn ENOMEM"), { code: "ENOMEM" }),
+    status: null,
+  });
+  assert.equal(c.outcome, SPAWN_OUTCOME.RUNNER_FAILURE);
+  assert.match(c.detail, /ENOMEM/);
+});
+
+test("a positive exit status is a genuine guard violation", () => {
+  const c = classifySpawnResult({ status: 1 });
+  assert.equal(c.outcome, SPAWN_OUTCOME.VIOLATION);
+  assert.match(c.detail, /exit 1/);
+});
+
+test("exit 0 is clean", () => {
+  assert.equal(classifySpawnResult({ status: 0 }).outcome, SPAWN_OUTCOME.OK);
+});
+
+// ── retry — a runner failure is transient, a violation is not ────────────────
+
+test("spawnWithRunnerRetry re-spawns a killed guard and accepts a later clean exit", () => {
+  let attempts = 0;
+  const result = spawnWithRunnerRetry(["x"], {
+    maxRetries: 2,
+    spawn: () => (++attempts < 2 ? { status: null, signal: "SIGKILL" } : { status: 0 }),
+  });
+  assert.equal(result.outcome, SPAWN_OUTCOME.OK);
+  assert.equal(result.attempts, 2);
+});
+
+test("spawnWithRunnerRetry gives up after maxRetries and reports a runner failure", () => {
+  let attempts = 0;
+  const result = spawnWithRunnerRetry(["x"], {
+    maxRetries: 2,
+    spawn: () => (attempts++, { status: null, signal: "SIGKILL" }),
+  });
+  assert.equal(result.outcome, SPAWN_OUTCOME.RUNNER_FAILURE);
+  assert.equal(result.attempts, 3); // initial + 2 retries
+});
+
+test("spawnWithRunnerRetry never retries a real violation", () => {
+  let attempts = 0;
+  const result = spawnWithRunnerRetry(["x"], {
+    maxRetries: 5,
+    spawn: () => (attempts++, { status: 1 }),
+  });
+  assert.equal(result.outcome, SPAWN_OUTCOME.VIOLATION);
+  assert.equal(attempts, 1);
+});
+
+// ── runGuards — killed guards land in runnerFailures, not violations ─────────
+
+test("runGuards separates a killed guard from a violating guard", () => {
+  const guards = ["check-no-alpha.mjs", "check-no-beta.mjs", "check-no-gamma.mjs"];
+  const tests = new Set();
+  const spawn = (argv) => {
+    const file = String(argv[argv.length - 1]);
+    if (file.includes("check-no-alpha")) return { status: null, signal: "SIGKILL" }; // killed
+    if (file.includes("check-no-beta")) return { status: 1 }; // real violation
+    return { status: 0 }; // clean
+  };
+  const { violations, runnerFailures } = runGuards({ guards, tests, spawn, maxRetries: 0 });
+
+  assert.deepEqual(violations, ["check-no-beta.mjs"]);
+  assert.equal(runnerFailures.length, 1);
+  assert.match(runnerFailures[0], /check-no-alpha\.mjs/);
+  // The killed guard must NOT be reported as a violation.
+  assert.ok(!violations.some((v) => v.includes("check-no-alpha")));
+});
+
+test("runGuards treats a killed guard SELF-TEST as a runner failure, not a broken guard", () => {
+  const guards = ["check-no-alpha.mjs"];
+  const tests = new Set(["check-no-alpha.test.mjs"]);
+  const spawn = (argv) => (argv.includes("--test") ? { status: null, signal: "SIGKILL" } : { status: 0 });
+  const { violations, runnerFailures } = runGuards({ guards, tests, spawn, maxRetries: 0 });
+  assert.deepEqual(violations, []);
+  assert.equal(runnerFailures.length, 1);
+  assert.match(runnerFailures[0], /self-test/);
+});
+
+// ── summarizeGuardRun — distinguishable in exit code AND message ─────────────
+
+test("a violation exits 1 and names it a violation", () => {
+  const s = summarizeGuardRun({
+    guards: ["check-no-a.mjs"],
+    tests: new Set(),
+    violations: ["check-no-a.mjs"],
+    runnerFailures: [],
+  });
+  assert.equal(s.exitCode, 1);
+  assert.ok(s.lines.some((l) => /FAILED \(found violations\)/.test(l)));
+});
+
+test("a runner-only failure exits with the distinct runner code and never says 'deterministic'", () => {
+  const s = summarizeGuardRun({
+    guards: ["check-no-a.mjs"],
+    tests: new Set(),
+    violations: [],
+    runnerFailures: ["check-no-a.mjs — killed by SIGKILL"],
+  });
+  assert.equal(s.exitCode, RUNNER_FAILURE_EXIT_CODE);
+  assert.notEqual(s.exitCode, 1); // distinguishable from a violation by exit code
+  assert.ok(s.lines.some((l) => /could not RUN/.test(l)));
+  assert.ok(s.lines.some((l) => /not deterministic guard failures/.test(l)));
+  // distinguishable from a violation by message
+  assert.ok(!s.lines.some((l) => /found violations/.test(l)));
+});
+
+test("a clean run exits 0", () => {
+  const s = summarizeGuardRun({
+    guards: ["check-no-a.mjs", "check-no-b.mjs"],
+    tests: new Set(["check-no-a.test.mjs"]),
+    violations: [],
+    runnerFailures: [],
+  });
+  assert.equal(s.exitCode, 0);
+  assert.ok(s.lines.some((l) => /Guard loop OK/.test(l)));
+});
+
+test("a violation and a runner failure together still exit 1 but report both", () => {
+  const s = summarizeGuardRun({
+    guards: ["check-no-a.mjs", "check-no-b.mjs"],
+    tests: new Set(),
+    violations: ["check-no-a.mjs"],
+    runnerFailures: ["check-no-b.mjs — killed by SIGKILL"],
+  });
+  assert.equal(s.exitCode, 1); // a real violation dominates
+  assert.ok(s.lines.some((l) => /found violations/.test(l)));
+  assert.ok(s.lines.some((l) => /could not RUN/.test(l))); // but the runner failure is not lost
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -52,6 +52,7 @@ export function resolvePolicyGuardInvocation(
 export const POLICY_GUARD_PROFILES = Object.freeze({
   source: Object.freeze([
     guard("repo-guard-loop", "Repo Guard Loop", [
+      node("--test", "scripts/check-guards.test.mjs"),
       node("scripts/check-guards.mjs"),
       node("--test", "scripts/check-capability-compose-profiles.test.mjs"),
       node("scripts/check-capability-compose-profiles.mjs"),

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -39,6 +39,7 @@ import {
   runPolicyProfile,
 } from "./ci-policy-guards.mjs";
 import { GUARD_RUNTIME_ENVIRONMENT_ERROR_NAME } from "./load-pinned-guard-typescript.mjs";
+import { RUNNER_FAILURE_EXIT_CODE } from "../check-guards.mjs";
 
 export const PREFLIGHT_SKIP_ENV = "DPF_SKIP_PREGATE_PREFLIGHT_REASON";
 
@@ -68,17 +69,21 @@ export function isEnvironmentFailureOutput(output) {
     || ENVIRONMENT_FAILURE_RE.test(text);
 }
 
-// Output signatures that mean "the host could not RUN the guard" — an OS-refused
-// or signal-killed spawn (a local-CI eviction issues `taskkill /T /F`), NOT a
-// deterministic tree violation (BI-AA2EE621). Distinct from an ENVIRONMENT
-// failure, which is a stable missing-runtime condition rather than transient
-// host pressure. The first alternate is the marker the Repo Guard Loop runner
-// prints when it exits with its distinct runner code (scripts/check-guards.mjs).
-export const RUNNER_FAILURE_RE =
-  /could not RUN \d+\/\d+ guard\(s\)|RUNNER failures|spawn (?:ENOMEM|EAGAIN|ENOENT)|killed by SIG/i;
-
-export function isRunnerFailureOutput(output) {
-  return RUNNER_FAILURE_RE.test(String(output ?? ""));
+// A guard command is a RUNNER failure — "the host could not run the guard", NOT
+// a deterministic tree violation (BI-AA2EE621) — when the host refused or killed
+// its spawn (`error`, or a signal/`taskkill /T` that leaves spawnSync
+// `status: null`), or when the Repo Guard Loop runner itself exits with its
+// reserved runner-failure code. Keyed on the EXIT CODE and spawn signals, never
+// on guard OUTPUT text: a real violation (exit 1) whose output happens to
+// mention a killed sub-guard must never be downgraded to a non-blocking warning.
+// `check-guards.mjs` emits RUNNER_FAILURE_EXIT_CODE only when it found zero
+// violations, so honouring that code (for the guard-loop runner alone) cannot
+// mask a violation; every guard's own contract stays exit 1 = violation.
+export function isRunnerFailureResult({ args = [], status, error } = {}) {
+  if (error) return true;
+  if (status === null || status === undefined) return true;
+  const isGuardLoopRunner = args.some((a) => String(a).includes("check-guards.mjs"));
+  return isGuardLoopRunner && status === RUNNER_FAILURE_EXIT_CODE;
 }
 
 function stripSelfTests(entries) {
@@ -113,10 +118,11 @@ function defaultExecute(command, args) {
   });
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`;
   if (result.status !== 0) process.stderr.write(output);
-  // A guard command the host refused to launch (result.error) or killed by a
-  // signal (result.status === null) is a runner failure, not a violation —
-  // surfaced so runPreflight never mislabels an evicted spawn as deterministic.
-  const runnerFailure = Boolean(result.error) || result.status === null;
+  // A guard command the host refused to launch, killed by a signal, or the
+  // guard-loop runner's reserved runner-failure exit code — keyed on exit code,
+  // never on output text — so runPreflight never mislabels an evicted spawn as
+  // deterministic, nor downgrades a real violation that merely mentions one.
+  const runnerFailure = isRunnerFailureResult({ args, status: result.status, error: result.error });
   return { exitCode: result.status ?? 1, output, runnerFailure };
 }
 
@@ -124,8 +130,9 @@ function defaultExecute(command, args) {
  * Runs the preflight plan. Unlike runPolicyProfile, the executor returns
  * `{ exitCode, output, runnerFailure }` so a non-zero exit can be reclassified:
  * output matching ENVIRONMENT_FAILURE_RE becomes `skipped_environment`, and a
- * spawn the host refused or killed (runnerFailure, or RUNNER_FAILURE_RE output)
- * becomes `runner_failed` (BI-AA2EE621). Both mean "this host could not run the
+ * spawn the host refused or killed (the `runnerFailure` flag, keyed on exit code
+ * and spawn signals) becomes `runner_failed` (BI-AA2EE621). Both mean "this host
+ * could not run the
  * guard", so — like the environment skip this file already documents — they
  * WARN and let CI/the sandbox enforce rather than mislabelling an evicted spawn
  * as a deterministic violation. `ok` is false only for genuine guard failures.
@@ -150,9 +157,11 @@ export async function runPreflight({
       if (exitCode !== 0) {
         // Precedence: a stable missing-runtime signal (environment) wins over a
         // transient host-pressure signal (runner) wins over a real violation.
+        // `runnerFailure` is keyed on exit code / spawn signals, not output
+        // text, so a real violation is never downgraded to a warning.
         const kind = isEnvironmentFailureOutput(output)
           ? "environment"
-          : (runnerFailure || isRunnerFailureOutput(output))
+          : runnerFailure
             ? "runner"
             : "violation";
         wrapped.set([command, ...args].join(" "), kind);

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -68,6 +68,19 @@ export function isEnvironmentFailureOutput(output) {
     || ENVIRONMENT_FAILURE_RE.test(text);
 }
 
+// Output signatures that mean "the host could not RUN the guard" — an OS-refused
+// or signal-killed spawn (a local-CI eviction issues `taskkill /T /F`), NOT a
+// deterministic tree violation (BI-AA2EE621). Distinct from an ENVIRONMENT
+// failure, which is a stable missing-runtime condition rather than transient
+// host pressure. The first alternate is the marker the Repo Guard Loop runner
+// prints when it exits with its distinct runner code (scripts/check-guards.mjs).
+export const RUNNER_FAILURE_RE =
+  /could not RUN \d+\/\d+ guard\(s\)|RUNNER failures|spawn (?:ENOMEM|EAGAIN|ENOENT)|killed by SIG/i;
+
+export function isRunnerFailureOutput(output) {
+  return RUNNER_FAILURE_RE.test(String(output ?? ""));
+}
+
 function stripSelfTests(entries) {
   return entries
     .map((entry) => ({
@@ -100,14 +113,22 @@ function defaultExecute(command, args) {
   });
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`;
   if (result.status !== 0) process.stderr.write(output);
-  return { exitCode: result.status ?? 1, output };
+  // A guard command the host refused to launch (result.error) or killed by a
+  // signal (result.status === null) is a runner failure, not a violation —
+  // surfaced so runPreflight never mislabels an evicted spawn as deterministic.
+  const runnerFailure = Boolean(result.error) || result.status === null;
+  return { exitCode: result.status ?? 1, output, runnerFailure };
 }
 
 /**
  * Runs the preflight plan. Unlike runPolicyProfile, the executor returns
- * `{ exitCode, output }` so a non-zero exit whose output matches
- * ENVIRONMENT_FAILURE_RE can be reclassified as `skipped_environment` instead
- * of `failed`. `ok` is false only for genuine guard failures.
+ * `{ exitCode, output, runnerFailure }` so a non-zero exit can be reclassified:
+ * output matching ENVIRONMENT_FAILURE_RE becomes `skipped_environment`, and a
+ * spawn the host refused or killed (runnerFailure, or RUNNER_FAILURE_RE output)
+ * becomes `runner_failed` (BI-AA2EE621). Both mean "this host could not run the
+ * guard", so — like the environment skip this file already documents — they
+ * WARN and let CI/the sandbox enforce rather than mislabelling an evicted spawn
+ * as a deterministic violation. `ok` is false only for genuine guard failures.
  */
 export async function runPreflight({
   plan = buildPreflightPlan(),
@@ -125,12 +146,16 @@ export async function runPreflight({
   const result = await runPolicyProfile({
     entries: plan,
     execute: (command, args) => {
-      const { exitCode, output } = execute(command, args);
+      const { exitCode, output, runnerFailure } = execute(command, args);
       if (exitCode !== 0) {
-        wrapped.set(
-          [command, ...args].join(" "),
-          isEnvironmentFailureOutput(output) ? "environment" : "violation",
-        );
+        // Precedence: a stable missing-runtime signal (environment) wins over a
+        // transient host-pressure signal (runner) wins over a real violation.
+        const kind = isEnvironmentFailureOutput(output)
+          ? "environment"
+          : (runnerFailure || isRunnerFailureOutput(output))
+            ? "runner"
+            : "violation";
+        wrapped.set([command, ...args].join(" "), kind);
       }
       return exitCode;
     },
@@ -141,9 +166,9 @@ export async function runPreflight({
   const entries = result.entries.map((entry) => {
     if (entry.status !== "failed") return entry;
     const kind = wrapped.get(entry.failedCommand);
-    return kind === "environment"
-      ? { ...entry, status: "skipped_environment" }
-      : entry;
+    if (kind === "environment") return { ...entry, status: "skipped_environment" };
+    if (kind === "runner") return { ...entry, status: "runner_failed" };
+    return entry;
   });
 
   return {

--- a/scripts/pregate-preflight.mjs
+++ b/scripts/pregate-preflight.mjs
@@ -67,11 +67,23 @@ export async function main() {
   const environmentSkipped = result.entries.filter(
     (entry) => entry.status === "skipped_environment",
   );
+  const runnerFailed = result.entries.filter(
+    (entry) => entry.status === "runner_failed",
+  );
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
 
   for (const entry of environmentSkipped) {
     process.stderr.write(
       `[pregate-preflight] WARN ${entry.name} could not run on this host (missing runtime) — CI will still enforce it. Remedy: pnpm install --frozen-lockfile --ignore-scripts --filter @dpf/repo-guard-runtime\n`,
+    );
+  }
+
+  // BI-AA2EE621: a spawn the host killed or refused is NOT a deterministic guard
+  // violation. Report it honestly (host contention, retry) and let CI/the
+  // sandbox enforce — never send the reader to audit an innocent guard.
+  for (const entry of runnerFailed) {
+    process.stderr.write(
+      `[pregate-preflight] WARN ${entry.name} could not RUN on this host (spawn killed or refused — host under pressure, not a guard violation) — retry on a quieter host; CI will still enforce it.\n`,
     );
   }
 
@@ -90,11 +102,13 @@ export async function main() {
     return;
   }
 
+  const caveats = [
+    environmentSkipped.length > 0 ? `${environmentSkipped.length} environment-skipped` : null,
+    runnerFailed.length > 0 ? `${runnerFailed.length} host-could-not-run` : null,
+  ].filter(Boolean);
   process.stdout.write(
     `[pregate-preflight] OK — ${result.entries.length} guards clean in ${elapsed}s` +
-      (environmentSkipped.length > 0
-        ? ` (${environmentSkipped.length} environment-skipped, see warnings)`
-        : "") +
+      (caveats.length > 0 ? ` (${caveats.join(", ")}, see warnings)` : "") +
       "\n",
   );
 }

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -15,12 +15,12 @@ import {
   ENVIRONMENT_FAILURE_RE,
   LOCAL_SAFE_PR_GUARD_IDS,
   PREFLIGHT_SKIP_ENV,
-  RUNNER_FAILURE_RE,
   buildPreflightPlan,
   isEnvironmentFailureOutput,
-  isRunnerFailureOutput,
+  isRunnerFailureResult,
   runPreflight,
 } from "./lib/pregate-preflight.mjs";
+import { RUNNER_FAILURE_EXIT_CODE } from "./check-guards.mjs";
 import { loadPinnedGuardTypeScript } from "./lib/load-pinned-guard-typescript.mjs";
 import { shouldRunPreflight } from "./pregate.mjs";
 
@@ -226,15 +226,17 @@ test("runPreflight reclassifies a killed spawn as runner_failed, not a violation
   assert.equal(entry.status, "runner_failed");
 });
 
-test("runPreflight reclassifies the guard-loop runner marker in output as runner_failed", async () => {
+test("runPreflight reclassifies the guard-loop runner's reserved exit code as runner_failed", async () => {
+  // defaultExecute maps check-guards' RUNNER_FAILURE_EXIT_CODE to runnerFailure;
+  // this simulates that executor output for the guard-loop command.
   const result = await runPreflight({
     plan: PLAN.filter((entry) => entry.id === "clean" || entry.id === "violating"),
     execute: (command, args) => {
       const script = args[args.length - 1];
       if (script.includes("violating")) {
-        return { exitCode: 3, output: "Guard loop: could not RUN 1/24 guard(s) — RUNNER failures" };
+        return { exitCode: RUNNER_FAILURE_EXIT_CODE, output: "could not RUN 1/24 guard(s)", runnerFailure: true };
       }
-      return { exitCode: 0, output: "" };
+      return { exitCode: 0, output: "", runnerFailure: false };
     },
     env: {},
   });
@@ -248,16 +250,44 @@ test("a genuine violation is still failed even though the runner path exists", a
   assert.equal(result.entries.find((e) => e.id === "violating").status, "failed");
 });
 
-test("runner-failure classification uses transient host signals, not guard verdicts", () => {
-  assert.ok(isRunnerFailureOutput("Guard loop: could not RUN 2/24 guard(s) — the host killed them"));
-  assert.ok(isRunnerFailureOutput("child process error: spawn ENOMEM"));
-  assert.ok(isRunnerFailureOutput("check-no-native-dialogs.mjs — killed by SIGKILL"));
-  assert.ok(RUNNER_FAILURE_RE.test("These are RUNNER failures (transient host pressure)"));
-  // A real ratchet violation must NOT read as a runner failure.
-  assert.ok(!isRunnerFailureOutput("module exceeds ratchet baseline: 1050 > 1047 lines"));
-  assert.ok(!isRunnerFailureOutput("Missing UX-Fit-Decision trailer"));
-  // An environment failure is its own class, not a runner failure.
-  assert.ok(!isRunnerFailureOutput("GuardRuntimeEnvironmentError: runtime unavailable"));
+test("REGRESSION (BI-AA2EE621): exit 1 whose output mentions a killed sub-guard stays a violation", async () => {
+  // The dangerous case: check-guards found a REAL violation (exit 1) while a
+  // DIFFERENT sub-guard was evicted, so its output contains both blocks. Keying
+  // on output text would downgrade this to a warning and let a doomed tree pass.
+  const result = await runPreflight({
+    plan: PLAN.filter((entry) => entry.id === "clean" || entry.id === "violating"),
+    execute: (command, args) => {
+      const script = args[args.length - 1];
+      if (script.includes("violating")) {
+        return {
+          exitCode: 1,
+          output:
+            "1/24 guard(s) FAILED (found violations)\n" +
+            "could not RUN 1/24 guard(s) — RUNNER failures — killed by SIGKILL",
+          runnerFailure: false,
+        };
+      }
+      return { exitCode: 0, output: "", runnerFailure: false };
+    },
+    env: {},
+  });
+  assert.equal(result.ok, false, "a real violation must hard-fail even when a sibling spawn was killed");
+  assert.equal(result.entries.find((e) => e.id === "violating").status, "failed");
+});
+
+test("isRunnerFailureResult keys on exit code and spawn signals, never on guard output", () => {
+  // Killed / refused spawns → runner, for any command.
+  assert.ok(isRunnerFailureResult({ args: ["scripts/check-module-size.mjs"], status: null, error: null }));
+  assert.ok(isRunnerFailureResult({ args: ["scripts/x.mjs"], error: Object.assign(new Error("spawn ENOMEM"), { code: "ENOMEM" }) }));
+  // The guard-loop runner's reserved runner code → runner.
+  assert.ok(isRunnerFailureResult({ args: ["scripts/check-guards.mjs"], status: RUNNER_FAILURE_EXIT_CODE }));
+  // The SAME reserved code from a DIFFERENT command is NOT a runner failure.
+  assert.ok(!isRunnerFailureResult({ args: ["scripts/check-module-size.mjs"], status: RUNNER_FAILURE_EXIT_CODE }));
+  // A real violation (exit 1) is NEVER a runner failure — the load-bearing property.
+  assert.ok(!isRunnerFailureResult({ args: ["scripts/check-guards.mjs"], status: 1 }));
+  assert.ok(!isRunnerFailureResult({ args: ["scripts/check-module-size.mjs"], status: 1 }));
+  // Clean is not a runner failure.
+  assert.ok(!isRunnerFailureResult({ args: ["scripts/check-guards.mjs"], status: 0 }));
 });
 
 test("runPreflight honors the recorded emergency skip", async () => {

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -15,8 +15,10 @@ import {
   ENVIRONMENT_FAILURE_RE,
   LOCAL_SAFE_PR_GUARD_IDS,
   PREFLIGHT_SKIP_ENV,
+  RUNNER_FAILURE_RE,
   buildPreflightPlan,
   isEnvironmentFailureOutput,
+  isRunnerFailureOutput,
   runPreflight,
 } from "./lib/pregate-preflight.mjs";
 import { loadPinnedGuardTypeScript } from "./lib/load-pinned-guard-typescript.mjs";
@@ -204,6 +206,58 @@ test("wrong-graph guard runtime resolution carries the same stable environment s
   });
   assert.match(output, /GuardRuntimeEnvironmentError/);
   assert.ok(isEnvironmentFailureOutput(output));
+});
+
+test("runPreflight reclassifies a killed spawn as runner_failed, not a violation (BI-AA2EE621)", async () => {
+  // The executor signals a spawn the host killed/refused via runnerFailure.
+  const result = await runPreflight({
+    plan: PLAN.filter((entry) => entry.id === "clean" || entry.id === "violating"),
+    execute: (command, args) => {
+      const script = args[args.length - 1];
+      if (script.includes("violating")) return { exitCode: 1, output: "", runnerFailure: true };
+      return { exitCode: 0, output: "", runnerFailure: false };
+    },
+    env: {},
+  });
+  // A host that could not run a guard must not hard-fail the preflight...
+  assert.equal(result.ok, true);
+  const entry = result.entries.find((e) => e.id === "violating");
+  // ...and must be distinguishable from both a real violation and an env skip.
+  assert.equal(entry.status, "runner_failed");
+});
+
+test("runPreflight reclassifies the guard-loop runner marker in output as runner_failed", async () => {
+  const result = await runPreflight({
+    plan: PLAN.filter((entry) => entry.id === "clean" || entry.id === "violating"),
+    execute: (command, args) => {
+      const script = args[args.length - 1];
+      if (script.includes("violating")) {
+        return { exitCode: 3, output: "Guard loop: could not RUN 1/24 guard(s) — RUNNER failures" };
+      }
+      return { exitCode: 0, output: "" };
+    },
+    env: {},
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.entries.find((e) => e.id === "violating").status, "runner_failed");
+});
+
+test("a genuine violation is still failed even though the runner path exists", async () => {
+  const result = await runPreflight({ plan: PLAN, execute: fakeExecute, env: {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.entries.find((e) => e.id === "violating").status, "failed");
+});
+
+test("runner-failure classification uses transient host signals, not guard verdicts", () => {
+  assert.ok(isRunnerFailureOutput("Guard loop: could not RUN 2/24 guard(s) — the host killed them"));
+  assert.ok(isRunnerFailureOutput("child process error: spawn ENOMEM"));
+  assert.ok(isRunnerFailureOutput("check-no-native-dialogs.mjs — killed by SIGKILL"));
+  assert.ok(RUNNER_FAILURE_RE.test("These are RUNNER failures (transient host pressure)"));
+  // A real ratchet violation must NOT read as a runner failure.
+  assert.ok(!isRunnerFailureOutput("module exceeds ratchet baseline: 1050 > 1047 lines"));
+  assert.ok(!isRunnerFailureOutput("Missing UX-Fit-Decision trailer"));
+  // An environment failure is its own class, not a runner failure.
+  assert.ok(!isRunnerFailureOutput("GuardRuntimeEnvironmentError: runtime unavailable"));
 });
 
 test("runPreflight honors the recorded emergency skip", async () => {

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -501,8 +501,15 @@ async function main() {
         process.stderr.write(String(preflight.stdout || ""));
         process.stderr.write(String(preflight.stderr || ""));
       }
+      // BI-AA2EE621: the preflight process itself being killed or failing to
+      // spawn (taskkill /T during an eviction leaves status === null) is a
+      // runner failure, not a deterministic guard violation — say so, or the
+      // reader audits an innocent guard the loop never even reported on.
+      const preflightKilled = Boolean(preflight.error) || preflight.status === null;
       process.stderr.write(
-        "pregate: guard parity preflight failed — fix the deterministic guard failures above before the sandbox gate runs (no lease was claimed).\n",
+        preflightKilled
+          ? "pregate: guard parity preflight could not RUN on this host (killed or failed to spawn — host under pressure, not a guard violation) — retry on a quieter host (no lease was claimed).\n"
+          : "pregate: guard parity preflight failed — fix the deterministic guard failures above before the sandbox gate runs (no lease was claimed).\n",
       );
       process.exit(preflight.status ?? 1);
     }


### PR DESCRIPTION
## Problem (BI-AA2EE621)

`scripts/check-guards.mjs` (the Repo Guard Loop) and the pregate guard-parity preflight conflated a guard child the OS **refused to launch** (`spawnSync` `error`, e.g. ENOMEM) or that a signal / `taskkill /T` **killed mid-run** (`status: null` — what a local-CI eviction leaves) with a guard that found a **real violation**. Under host pressure the loop printed a factual-looking `1/24 guard(s) FAILED: check-no-native-dialogs.mjs` for a guard that had actually run and **passed**, and the preflight labelled it a "deterministic CI failure" — sending readers to audit an innocent guard (~2h each across several sessions) and pushing toward false attestations. `r.error` was never inspected and `r.status === null` was indistinguishable from `r.status === 1`.

## Fix

- **`classifySpawnResult`** splits a runner failure (`error` / `status === null`) from a genuine violation (positive exit). Runner failures are **retried** (transient by definition) and, if persistent, reported under a distinct heading with a dedicated exit code (**3**), so callers can tell "the host could not run the guards" from "a guard found a violation".
- **Preflight** (`pregate-preflight.mjs`) reclassifies a killed/refused guard spawn as `runner_failed` — an honest WARN, consistent with the existing `environment-skipped` contract; CI and the sandbox still enforce. Classification is keyed on the **exit code and spawn signals, never on guard output text**, so a real violation (exit 1) whose output merely mentions a killed sibling guard is never downgraded to a warning.
- **`pregate.mjs`** no longer calls a killed preflight process a "deterministic guard failure".
- Hardened `DPF_GUARD_SPAWN_RETRIES` against a non-numeric value (would otherwise loop forever under persistent runner failure).

## Verification

- 16 `check-guards` + 19 `pregate-preflight` unit tests (node:test), incl. the exact injections the item requires (`status:null`/SIGKILL, `error` ENOMEM, `status:1`) and a **load-bearing regression test** pinning "exit 1 + runner-looking output stays a violation".
- Full guard loop runs **24/24** clean on a provisioned tree.
- **Independent adversarial semantic review** caught a real masking regression in an interim revision (output-text classification); fixed by keying on the deterministic exit-code contract; re-review verdict **SHIP**.
- Full local-CI gate: **PASS** at this HEAD (evidence `cmsh1mry202et01pranevmjip`).

## Docs

`docs/testing/pre-pr-gate.md` documents the runner-failure classification alongside the existing environment-skip contract; `doc-impact.generated.json` regenerated.

Resolves BI-AA2EE621. Sibling BI-184D4DBD (the contention that does the killing) is separately diagnosed — its eviction is a `taskkill /T` from the lease authority-deadline or a foreign-occupant cross-kill; this PR removes the phantom-guard-failure tax that sits on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)