### PR TITLE
fix(inference): capture inferenceMs on routed metering so compute cost can price (BI-105E8A1E)

### DIFF
--- a/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
+++ b/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
@@ -158,6 +158,7 @@ describe("routeAndCall activity harness overrides", () => {
       content: "ok",
       toolCalls: [],
       tokenUsage: { inputTokens: 12, outputTokens: 4 },
+      inferenceMs: 1234,
       downgraded: false,
       downgradeMessage: null,
     });
@@ -265,6 +266,11 @@ describe("routeAndCall activity harness overrides", () => {
           }),
         ],
       }),
+    );
+    // BI-105E8A1E: the adapter's measured latency must reach the metering row so
+    // the `compute` cost model can price local inference; it was dropped before.
+    expect(mocks.logTokenUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ inferenceMs: 1234 }),
     );
   });
 

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -629,6 +629,7 @@ export async function routeAndCall(
       contextKey: options?.threadId ?? options?.taskType ?? "routed-call",
       inputTokens: result.tokenUsage?.inputTokens ?? 0,
       outputTokens: result.tokenUsage?.outputTokens ?? 0,
+      inferenceMs: result.inferenceMs,
     });
 
     return {
@@ -709,6 +710,7 @@ export async function routeAndCall(
     contextKey: options?.threadId ?? options?.taskType ?? "routed-call",
     inputTokens: result.tokenUsage?.inputTokens ?? 0,
     outputTokens: result.tokenUsage?.outputTokens ?? 0,
+    inferenceMs: result.inferenceMs,
   });
 
   // 7. Normalize result to RoutedInferenceResult
@@ -757,6 +759,10 @@ async function persistRoutedTokenUsage(input: {
   contextKey: string;
   inputTokens: number;
   outputTokens: number;
+  // BI-105E8A1E: carry the adapter's measured latency so logTokenUsage's
+  // `compute` cost model can fire — it is the cost signal for a fully-local
+  // install, and was previously dropped here, leaving inferenceMs ~99% empty.
+  inferenceMs?: number;
 }): Promise<void> {
   // Skip rows with zero tokens both ways. A successful call always reports at
   // least the input prompt tokens; zero/zero usually means the adapter

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -101,6 +101,10 @@ export interface FallbackResult {
   content: string;
   toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
   tokenUsage?: { inputTokens: number; outputTokens: number };
+  // BI-105E8A1E: the adapter's measured wall-clock latency, carried through to
+  // metering so the `compute` cost model (watts × time) can price local
+  // inference. Optional because a screened/stub path may not measure it.
+  inferenceMs?: number;
   downgraded: boolean;
   downgradeMessage: string | null;
   responseId?: string;
@@ -363,6 +367,7 @@ export async function callWithFallbackChain(
           result.inputTokens !== undefined || result.outputTokens !== undefined
             ? { inputTokens: result.inputTokens, outputTokens: result.outputTokens }
             : undefined,
+        inferenceMs: result.inferenceMs,
         downgraded,
         downgradeMessage: downgraded
           ? preferenceMiss


### PR DESCRIPTION
## Problem (BI-105E8A1E, Slice A)

`TokenUsage.inferenceMs` was populated on only **235 of 34,398 rows (0.7%)**, so `logTokenUsage`'s `compute` cost model (watts × time × electricity) — the real cost signal for a fully-local install — never fired. It prices compute only when `inferenceMs` is present.

The gap: the routed metering wrapper `persistRoutedTokenUsage` dropped the field, and the `FallbackResult` it reads from never carried it — even though the adapter result (`callProvider`) measures the latency and already uses it elsewhere (`latencyMs`).

## Fix — thread `inferenceMs` end-to-end

- `FallbackResult` gains an optional `inferenceMs`, populated at construction from `result.inferenceMs` (already available at that site).
- Both `persistRoutedTokenUsage` call sites pass `result.inferenceMs`.
- The wrapper's input type carries it through to `logTokenUsage`, which already prices and persists it.

Optional throughout, so a screened/stub path that doesn't measure latency is unaffected.

## Verification

- `routed-inference.activity-overrides.test.ts` asserts `logTokenUsage` receives `inferenceMs` from a routed call — **load-bearing** (the assertion fails without the thread).
- Local-CI sandbox gate: **PASS** at this HEAD, incl. `[local-ci-typecheck] classification=passed` (the sandbox resolves `@dpf/db`, which a source-only worktree cannot — so the local skip was pure harness friction, and the authoritative typecheck is green).

## Scope

Slice A only (capacity/time visibility — the resource that matters for a local platform, and which the gate-contention work BI-184D4DBD needs made visible). Deliberately **not** in scope, recorded as separate slices on BI-105E8A1E:
- Defect #2: making "unpriced" distinguishable from "free" (needs a schema change).
- Defect #3: chatgpt `agentId='unknown'` attribution.

No fabricated spend for subscription/local providers — explicit `0` prices stay `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)