### PR TITLE
doc(mcp): phased plan + ready-to-file BI graph for MCP 2025-11-25 + A2A adoption

### DIFF
--- a/docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md
+++ b/docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md
@@ -1,0 +1,55 @@
+# Plan — MCP `2025-11-25` + A2A feature adoption
+
+| Field | Value |
+|-------|-------|
+| **Status** | **DRAFT — pre-filing design addendum.** NOT a governed plan yet: no umbrella BI is filed and no live coverage receipt exists (see below). |
+| **Date** | 2026-08-06 |
+| **Author** | Claude Code for Mark Bodman |
+| **Implements** | [MCP `2025-11-25` + A2A feature adoption assessment](../specs/2026-08-06-mcp-2025-11-25-and-a2a-feature-adoption-design.md) (merged in `main`) |
+| **Backlog** | **Unfiled.** Authored in a web session with no reachable DPF backlog MCP / running portal, so BIs could not be filed and `record_plan_backlog_coverage` could not be called. Per the `dpf-writing-plans` guardrail, Markdown checkboxes are **not** a backlog substitute — the governed filing step below must run in a runtime-capable session before this becomes a live plan. |
+| **Blast radius** | Mixed — Slices 1/2/3/5 are low (transport presentation, isolated); Slice 4 is HIGH (coordination plane); Slice 6 is a separate A2A/GAID track. |
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Why this is a plan, not a same-session patch
+
+The MCP transport (`apps/web/app/api/mcp/v1/route.ts`) is the coordination plane (AGENTS.md §12). The version is already at `2025-11-25`; the remaining work is *feature adoption* and conformance, split so each piece ships and verifies on its own. Slice 4 (standard MCP Tasks) is high blast radius on the same path and carries unresolved design decisions — it must be kernel-routed and given its own sub-plan before code, exactly as the A1 A2A build-path convergence was.
+
+## Deliverable → BI graph (ready to file)
+
+Each row is an independently shippable deliverable. Sizes/epics are proposals for the governed filing step to confirm against live state.
+
+| # | Deliverable (proposed BI title) | Epic (link) | Size | Blast radius | Depends on |
+|---|---|---|---|---|---|
+| 1 | MCP protocol-negotiation completeness — `MCP-Protocol-Version` request-header handling + `serverInfo.description` | Platform Infrastructure | S | Low | — |
+| 2 | MCP tool metadata enrichment — top-level `title`, `icons`, `outputSchema` (JSON Schema 2020-12) | Platform Infrastructure | M | Low–Med | — |
+| 3 | MCP input-validation error conformance — schema failures → `isError` content (SEP-1303) + new-tool naming lint (SEP-986) | Platform Infrastructure | S–M | Low (error path) | — |
+| 4 | Standard MCP **Tasks** lifecycle — converge bespoke `tasks/submit` onto `tasks` capability + `tasks/list\|get\|result\|cancel` over `TaskRun` | Platform Infrastructure | L/XL | **HIGH** | kernel decision + own sub-plan |
+| 5 | ADP service `initialize` handler — conformant handshake in `services/adp/src/server.ts` | Platform Infrastructure | S | Low (isolated) | — |
+| 6 | A2A signed **agent-card export** — read-only projection of coworker `Agent` rows to `.well-known/agent-card.json` (realizes inventory P3) | EP-A2A / GAID | M–L | Med | A2A inventory owner |
+
+## Phases (each independently shippable + verifiable)
+
+- **Phase 1 — BI-1 (protocol-negotiation completeness).** In `route.ts` `POST`, read `MCP-Protocol-Version` on non-`initialize` requests: default to the negotiated version when absent (per spec), return `400` on an unsupported explicit value; add `description` to `serverInfo` (`:399-402`). *Verify:* extend `route.test.ts` — header present/absent/unsupported; `serverInfo` shape. Source-only unit + build gate.
+- **Phase 2 — BI-2 (tool metadata).** Add optional `title`/`icons`/`outputSchema` to `ToolDefinition` (`mcp-tools.ts:98`); surface them in `annotateTool` (`route.ts:353`); backfill `outputSchema` (2020-12) for the highest-traffic tools first. *Verify:* unit test that emitted tools carry the fields and the schema dialect; grant/tier filtering unchanged.
+- **Phase 3 — BI-3 (validation-error conformance).** Confirm `governedExecuteTool` schema-validation failures return `isError` content, not JSON-RPC protocol errors (model self-correction, SEP-1303); add a naming-guidance lint for *new* tools that exempts the frozen existing names. *Verify:* unit tests over the error path; lint runs clean on current tools.
+- **Phase 4 — BI-4 (standard MCP Tasks) — own sub-plan.** Route decisions through `dpf-decision-via-kernel` first: durable-result retention, cancellation authority, and back-compat for current `tasks/submit` callers. Then advertise the `tasks` capability and map `tasks/list|get|result|cancel` onto the `TaskRun` substrate behind a flag, converging the bespoke method. *Verify:* real remote-coworker task submitted, polled, and retrieved through the standard lifecycle; existing `tasks/submit` callers unbroken.
+- **Phase 5 — BI-5 (ADP `initialize`).** Add a conformant `initialize` handler to `services/adp/src/server.ts` (currently only `tools/list`/`tools/call`). *Verify:* a client completes the handshake against the ADP server; ADP integration tests green.
+- **Phase 6 — BI-6 (A2A agent-card export).** Coordinate with the A2A inventory owner. Project coworker `Agent` identity (name, description, skills via `AgentSkillAssignment`, tool grants → capabilities) into the A2A Agent Card schema at `/.well-known/agent-card.json` + a per-agent variant; signed; **read-only, no inbound task execution**. *Verify:* card validates against the A2A card schema; export is governance-gated and read-only; ops-map/user-guide doc updated.
+
+## Risks & rollback
+
+- **Slice 1/2/3:** touch the transport's presentation/negotiation layer only, not `governedExecuteTool`. Risk is a stricter header check rejecting a lenient client → mitigate by defaulting on absence and only rejecting explicit unsupported values; each is a small revertable PR.
+- **Slice 4 (HIGH):** changes long-running task semantics on the coordination plane. Mitigate with a capability flag + parallel back-compat path for `tasks/submit`; do not retire the bespoke method until callers are migrated. Rollback = disable the flag.
+- **Slice 5:** isolated to the ADP service; rollback = revert the handler.
+- **Slice 6:** read-only export; the risk is over-exposing agent metadata externally → governance gate + explicit allowlist of exported fields; rollback = unpublish the route.
+
+## Backlog coverage (pending — file in a runtime session)
+
+This design is **not** yet represented in the live backlog. Before implementation, in a runtime-capable session with the DPF backlog MCP reachable:
+
+1. File the umbrella BI and the six child BIs above via the governed `dpf-file-backlog-item` path, confirming size/epic against live state and reusing any existing covering BI (`search_backlog` first — do not duplicate).
+2. Call `record_plan_backlog_coverage` with the umbrella BI, this plan's path, the deliverable graph, the BI mappings, and `decision: decomposed`.
+3. Replace this section with the canonical `## Backlog coverage` block (Parent / Decision / Receipt / Dependencies / deliverable→BI mappings) carrying the returned live receipt, and add the umbrella-BI marker line the coverage gate keys on (the bolded `Backlog item:` field pointing at the filed umbrella id) so the gate validates it.
+
+Until step 3 lands, this file is a pre-filing design addendum, not a governed plan.


### PR DESCRIPTION
## Summary

Companion **plan** to the merged [MCP `2025-11-25` + A2A adoption assessment](``https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-08-06-mcp-2025-11-25-and-a2a-feature-adoption-design.md)`` (#4069). It breaks the adoption work into six independently shippable deliverables with per-phase verification, risks/rollback, and a proposed deliverable→BI graph.

It is filed as a **pre-filing DRAFT**: this was authored in a Claude Code web session with no reachable DPF backlog MCP / running portal, so BIs could not be filed and `record_plan_backlog_coverage` could not be called. Per the `dpf-writing-plans` guardrail, Markdown checkboxes are **not** a backlog substitute — the plan's "Backlog coverage (pending)" section records the exact governed filing steps to run in a runtime session before this becomes a live plan.

## Changes

- Adds `docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md`:
  - Canonical DPF agent-execution preamble (one BI / one branch / one PR; `dpf-tdd`, `dpf-local-merge-ci-before-push`, `dpf-pr-with-dco`).
  - Deliverable→BI graph (6 rows): protocol-negotiation completeness; tool metadata (`title`/`icons`/`outputSchema`); validation-error conformance; standard MCP **Tasks** lifecycle (HIGH blast radius, own sub-plan, kernel-routed); ADP `initialize`; A2A signed agent-card export (realizes inventory P3).
  - Per-phase verification, risks & rollback.
  - "Backlog coverage (pending)" section documenting the governed filing steps — deliberately **not** a fake receipt.

## Test plan

- [x] **Source-only change** (doc)
- [x] **Verification-harness limitation acknowledged** — web session, no canonical runtime (`node_modules` absent). Guards reasoned about statically:
  - `check-plan-backlog-coverage`: out of scope — the plan carries no `Backlog item: BI-…` marker (it is not yet tied to a filed BI), so the gate returns OK by design (`scripts/check-plan-backlog-coverage.mjs:11-12`).
  - `check-no-retired-superpowers-skills`: no `superpowers:<slug>` invocation tokens introduced (verified `grep` = 0); only DPF-native skill names and the `docs/superpowers/` path are referenced.
  - `check:prose-lint` scans only `apps/web/app` + `components`, so this `docs/` file is out of its scope.

## Pre-PR readiness

Docs-only change; no runtime surface. Context/preflight/local-CI gates require the canonical runtime this session lacks.

- Local-CI-Override: docs-only change authored without canonical runtime; no code/UX/migration surface touched.

## Related issues / Epic

- Implements the merged assessment spec (#4069). Proposed epic linkage: Platform Infrastructure, EP-A2A, EP-COWORKER-INTERACTIVITY (to confirm at filing time against live state).

## Notes for the reviewer

- This is intentionally a **pre-filing** artifact. The BIs and coverage receipt will be filed through the governed `dpf-file-backlog-item` + `record_plan_backlog_coverage` path in a runtime-capable session, at which point the "Backlog coverage (pending)" section is replaced with the canonical block carrying a live receipt and the umbrella-BI marker.
- Slice 4 (standard MCP Tasks) is flagged HIGH blast radius and gated on `dpf-decision-via-kernel` before code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtVJp2ouxgkYvxxFVxDzkN)_