### PR TITLE
feat(recruiting): get_recruiting_pipeline coworker tool — the Absorb surface (BI-E64D11AE)

### DIFF
--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -65,6 +65,7 @@ import { licensingPack } from "./packs/licensing-pack";
 import { marketingOpsPack } from "./packs/marketing-ops-pack";
 import { coworkerCapabilityPack } from "./packs/coworker-capability-pack";
 import { coworkerBacklogLensPack } from "./packs/coworker-backlog-lens-pack";
+import { recruitingPipelinePack } from "./packs/recruiting-pipeline-pack";
 import { publicWebDesignPack } from "./packs/public-web-design-pack";
 import { projectFilesPack } from "./packs/project-files-pack";
 import { sorReadPack } from "./packs/sor-read-pack";
@@ -146,6 +147,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   marketingOpsPack,
   coworkerCapabilityPack,
   coworkerBacklogLensPack,
+  recruitingPipelinePack,
   publicWebDesignPack,
   projectFilesPack,
   grokSigninPack,

--- a/apps/web/lib/mcp/packs/recruiting-pipeline-pack.test.ts
+++ b/apps/web/lib/mcp/packs/recruiting-pipeline-pack.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getRecruitingPipeline } = vi.hoisted(() => ({ getRecruitingPipeline: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/recruiting/pipeline-read-model", () => ({ getRecruitingPipeline }));
+
+import { recruitingPipelinePack } from "./recruiting-pipeline-pack";
+
+describe("recruitingPipelinePack", () => {
+  beforeEach(() => getRecruitingPipeline.mockReset());
+
+  it("declares one read-only get_recruiting_pipeline tool with the mirrored grant", () => {
+    expect(recruitingPipelinePack.packId).toBe("recruiting-pipeline");
+    expect(recruitingPipelinePack.definitions).toHaveLength(1);
+    const def = recruitingPipelinePack.definitions[0];
+    expect(def.name).toBe("get_recruiting_pipeline");
+    expect(def.sideEffect).toBe(false);
+    expect(def.annotations?.readOnlyHint).toBe(true);
+    expect(def.requiredCapability).toBe("view_employee");
+    expect(recruitingPipelinePack.grants?.get_recruiting_pipeline).toEqual([
+      "consumer_read",
+      "registry_read",
+    ]);
+  });
+
+  it("summarizes the funnel counts and returns the pipeline data", async () => {
+    getRecruitingPipeline.mockResolvedValue({
+      items: [
+        { id: "a1", source: "native", displayName: "N", status: "active", stage: null, externalId: null },
+        { id: "greenhouse:g1", source: "greenhouse", displayName: "G", status: null, stage: null, externalId: "g1" },
+      ],
+      counts: { native: 1, greenhouse: 1, total: 2 },
+    });
+
+    const handler = recruitingPipelinePack.handlers.get_recruiting_pipeline;
+    const result = await handler({ requisitionId: "req-1" }, "u1", {} as never);
+
+    expect(getRecruitingPipeline).toHaveBeenCalledWith({}, { requisitionId: "req-1" });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("2 in the funnel");
+    expect(result.message).toContain("1 native");
+    expect((result.data as { counts: { total: number } }).counts.total).toBe(2);
+  });
+
+  it("passes undefined requisitionId when the arg is absent", async () => {
+    getRecruitingPipeline.mockResolvedValue({ items: [], counts: { native: 0, greenhouse: 0, total: 0 } });
+    const handler = recruitingPipelinePack.handlers.get_recruiting_pipeline;
+    await handler({}, "u1", {} as never);
+    expect(getRecruitingPipeline).toHaveBeenCalledWith({}, { requisitionId: undefined });
+  });
+});

--- a/apps/web/lib/mcp/packs/recruiting-pipeline-pack.ts
+++ b/apps/web/lib/mcp/packs/recruiting-pipeline-pack.ts
@@ -1,0 +1,72 @@
+// Recruiting pipeline lens — BI-E64D11AE (Absorb surface).
+//
+// get_recruiting_pipeline: the unified recruiting funnel — native Applications
+// plus Greenhouse-sourced staged rows, deduped by crosswalk — so the HR
+// coworker (and any operator via the coworker) sees ONE pipeline across native
+// and integrated work without leaving to two systems. Read-only; the read model
+// is shared with the pipeline surface so the tool and any future UI never drift.
+
+import { prisma } from "@dpf/db";
+import {
+  getRecruitingPipeline,
+  type RecruitingPipelineClient,
+} from "@/lib/recruiting/pipeline-read-model";
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+
+import type { ToolPack, ToolPackHandler } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "get_recruiting_pipeline",
+    description:
+      "Show the unified recruiting pipeline — native applications plus Greenhouse-sourced candidates not yet promoted — as one funnel, deduped so a candidate imported from Greenhouse and its native row appear once. Optionally narrow to a single requisition. Read-only; no candidate PII beyond display name, status, and stage.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        requisitionId: {
+          type: "string",
+          description: "Only applications for this native requisition id.",
+        },
+      },
+    },
+    requiredCapability: "view_employee",
+    executionMode: "immediate",
+    sideEffect: false,
+    buildPhases: ["ideate", "plan", "build", "review", "ship"],
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+  },
+];
+
+async function getRecruitingPipelineHandler(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const requisitionId =
+    typeof params["requisitionId"] === "string" ? params["requisitionId"] : undefined;
+
+  // Prisma's generated client is structurally wider than the narrow read-model
+  // port; bridge it at this single call site.
+  const db = prisma as unknown as RecruitingPipelineClient;
+  const pipeline = await getRecruitingPipeline(db, { requisitionId });
+
+  return {
+    success: true,
+    message: `Recruiting pipeline: ${pipeline.counts.total} in the funnel (${pipeline.counts.native} native, ${pipeline.counts.greenhouse} from Greenhouse not yet promoted).`,
+    data: { ...pipeline },
+  };
+}
+
+const handlers: Record<string, ToolPackHandler> = {
+  get_recruiting_pipeline: (params) => getRecruitingPipelineHandler(params),
+};
+
+export const recruitingPipelinePack: ToolPack = {
+  packId: "recruiting-pipeline",
+  definitions,
+  handlers,
+  grants: {
+    get_recruiting_pipeline: ["consumer_read", "registry_read"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -715,6 +715,9 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // HR — query
   query_employees: ["consumer_read", "registry_read"],
 
+  // Recruiting pipeline lens (BI-E64D11AE) — unified native + Greenhouse funnel.
+  get_recruiting_pipeline: ["consumer_read", "registry_read"],
+
   // Workforce staffing (EP-WORKFORCE-OPS / BI-4AD09A35) read surface.
   list_staffing_demand: ["registry_read"],
   get_staffing_coverage: ["registry_read"],

--- a/docs/superpowers/plans/2026-08-06-recruiting-pipeline-coworker-surface.md
+++ b/docs/superpowers/plans/2026-08-06-recruiting-pipeline-coworker-surface.md
@@ -1,0 +1,35 @@
+# Recruiting pipeline coworker surface (BI-E64D11AE)
+
+- **BI:** BI-E64D11AE — *Absorb: surface the Greenhouse pipeline on the native recruiting surface*, epic EP-ECOSYSTEM-ABSORPTION-ARCH.
+- **Design:** [docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md](../specs/2026-08-05-greenhouse-ats-absorption-design.md) §4 Phase 2 (Absorb).
+- **Builds on:** the merged absorb read-model (`getRecruitingPipeline`, #4067).
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd`, `dpf-local-merge-ci-before-push` plus the completion gate before any success claim, and `dpf-pr-with-dco`.
+
+## Goal & boundary
+
+Surface the unified recruiting funnel to the **AI workforce**: an HR-coworker MCP tool `get_recruiting_pipeline` over the merged dual-read read-model, so the operator can ask a coworker to show the pipeline across native + Greenhouse-sourced work as one funnel. Deliberately a **coworker/MCP surface, not a UI route** — a bespoke page route carries a disproportionate ratified-page-purpose + ux-fit-sweep gauntlet for a read list; the visual page is a separate, heavier batch. Read-only; no candidate PII beyond display name / status / stage.
+
+## Design grounding
+
+Extends the Absorb spec (§4 Phase 2) — the read-model was #4067; this is its coworker surface. Reuses the tool-pack registry + `agent-grants` gating source (grants mirror `TOOL_TO_GRANTS`, enforced by the drift test). No new contract; the AI-workforce surface is the platform-native way to expose a read model.
+
+## Phases (atomic — one tool, one pack)
+
+1. **`recruiting-pipeline-pack.ts`** — `get_recruiting_pipeline` (read-only, `view_employee`, grants `consumer_read`+`registry_read`) calling `getRecruitingPipeline`. *Verify:* definition shape + grant mirror, funnel-count summary, requisition filter, absent-arg default.
+2. **Registration** — one import + one array entry in `pack-registry.ts`; the mirrored grant in `lib/tak/agent-grants.ts` (drift-test enforced).
+
+## Risks & rollback
+
+Read-only tool over a merged read-model; no schema/route/write. A new tool description may nudge the `/platform/audit/authority` route's word budget — re-baseline that one route via the `ux-route-sweep.yml -f update_baseline=true` workflow if the sweep flags it. Rollback = remove the pack + its registry/grant lines.
+
+## Completion gate
+
+`dpf-local-merge-ci-before-push` (or the recorded infra override) + `dpf-pr-with-dco`. 3 pack tests + the full 1339-test suite, tsc + all 24 guards clean locally.
+
+## Backlog coverage
+
+- **Decision:** `atomic` — one BI (BI-E64D11AE); the tool + its registration ship together.
+- **Receipt:** `cmshowshl0vhu01prmepb7pao` (recorded 2026-08-06 against BI-E64D11AE).
+- **Deliverables (none independently shippable):** recruiting-pipeline-pack → registration.
+- **Deferred (heavier separate batch):** the visual recruiting-pipeline UI page (ratified page-purpose contract + ux-fit sweep).

--- a/docs/superpowers/plans/2026-08-06-recruiting-pipeline-coworker-surface.md
+++ b/docs/superpowers/plans/2026-08-06-recruiting-pipeline-coworker-surface.md
@@ -14,6 +14,11 @@ Surface the unified recruiting funnel to the **AI workforce**: an HR-coworker MC
 
 Extends the Absorb spec (§4 Phase 2) — the read-model was #4067; this is its coworker surface. Reuses the tool-pack registry + `agent-grants` gating source (grants mirror `TOOL_TO_GRANTS`, enforced by the drift test). No new contract; the AI-workforce surface is the platform-native way to expose a read model.
 
+- **Existing specs/plans reviewed:** `docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md` §4 Phase 2 (Absorb) — the read-model + surfacing sequence this tool implements.
+- **Current code substrate reviewed:** `apps/web/lib/recruiting/pipeline-read-model.ts` (the `getRecruitingPipeline` port this tool calls), `apps/web/lib/mcp/pack-registry.ts` (the one-import-one-entry union-mergeable registry), and `apps/web/lib/tak/agent-grants.ts` (`TOOL_TO_GRANTS`, the drift-enforced gating source the pack's grant mirrors).
+- **Source of truth:** the shared read-model — the tool and any future UI read one `getRecruitingPipeline`, so they never drift.
+- **Decision:** coworker/MCP surface, not a UI route — a read-only lens earns the AI-workforce surface without the disproportionate ratified-page-purpose + ux-fit gauntlet a bespoke page carries.
+
 ## Phases (atomic — one tool, one pack)
 
 1. **`recruiting-pipeline-pack.ts`** — `get_recruiting_pipeline` (read-only, `view_employee`, grants `consumer_read`+`registry_read`) calling `getRecruitingPipeline`. *Verify:* definition shape + grant mirror, funnel-count summary, requisition filter, absent-arg default.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -53,7 +53,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
-apps/web/lib/tak/agent-grants.ts	915
+apps/web/lib/tak/agent-grants.ts	918
 apps/web/lib/tak/agent-routing.ts	1027
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,14 +3,14 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 361,
-      "reason": "Adds list_my_backlog (BI-474A1F55): a coworker's identity-scoped read lens over the backlog for its own surface + occupation. No existing tool carries it — query_backlog/list_backlog_items filter only by scopeKind/archetype/status and cannot scope by portfolio/occupation/owner, and get_next_recommended_work's forAgentId is grant-claimability, not surface. It is the missing read side of the coworker capability-evolution loop; open and file reuse get_backlog_item/create_backlog_item, so this is +1, under the 15-tool selection cliff.",
-      "recordedAt": "2026-08-05"
+      "value": 362,
+      "reason": "Adds get_recruiting_pipeline (BI-E64D11AE): the HR-coworker read lens over the unified recruiting funnel — native Applications plus Greenhouse-sourced staged rows, deduped by crosswalk — so a coworker sees one pipeline across native and absorbed work. No existing tool carries it: query_employees is People-Core directory, and the backlog/estate read lenses do not touch recruiting entities. It is the coworker surface of the merged dual-read read-model (getRecruitingPipeline, #4067); read-only, +1, under the 15-tool selection cliff.",
+      "recordedAt": "2026-08-06"
     },
     "registry.packFiles": {
-      "value": 86,
-      "reason": "Adds coworker-backlog-lens-pack.ts (the list_my_backlog pack) and coworker-scope.ts (shared identity-scope resolver, extracted from coworker-capability-pack so both packs share one requireCurrentCoworker + resolveCoworkerBacklogScope path). BI-474A1F55.",
-      "recordedAt": "2026-08-05"
+      "value": 87,
+      "reason": "Adds recruiting-pipeline-pack.ts (the get_recruiting_pipeline pack) — the Absorb coworker surface over the shared recruiting read-model. One pack, one tool; reuses lib/recruiting/pipeline-read-model.ts rather than adding read logic. BI-E64D11AE.",
+      "recordedAt": "2026-08-06"
     },
     "tier.coreToolNames": {
       "value": 29,


### PR DESCRIPTION
## What this is

The **coworker/MCP surface** for the recruiting funnel (BI-E64D11AE) — an HR-coworker tool over the merged dual-read read-model (`getRecruitingPipeline`, #4067). Backend/tool only; **no schema, route, or UI page**.

Plan: [docs/superpowers/plans/2026-08-06-recruiting-pipeline-coworker-surface.md](docs/superpowers/plans/2026-08-06-recruiting-pipeline-coworker-surface.md) · Design: [spec §4 Phase 2](docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md)

## Change

- **`recruiting-pipeline-pack.ts`** — `get_recruiting_pipeline` (read-only, `view_employee`, no PII beyond name/status/stage) returns the unified funnel: native applications + Greenhouse-sourced staged rows, deduped by crosswalk. One import + one array entry in `pack-registry.ts`; grant mirrored in `lib/tak/agent-grants.ts` `TOOL_TO_GRANTS` (drift-test enforced).

## Why a coworker tool, not a UI page

A bespoke page route carries a disproportionate ratified-page-purpose contract + ux-fit-sweep gauntlet for a read-only list. Surfacing the funnel to the AI workforce is the platform-native way to expose the read-model at low merge/sandbox stress. The visual page is a deliberate, heavier follow-up batch.

## Test evidence (local)

- 3 pack tests + the **full 1339-test suite** (incl. tool-budget, authority-extract, and agent-grants drift) — all green.
- `tsc --noEmit` clean; **all 24 guards + data-impact + docs-impact** clean.

## Local-CI override (recorded, PR-visible)

Local-CI sandbox is WinNAT-port-blocked on this host (infra); pushed with a recorded `operator-emergency` override. CI runs the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)