### PR TITLE
feat(graph): connect the corpus — project doc-impact into the mirror (BI-0E019B95)

### DIFF
--- a/apps/web/components/admin/GraphExplorer.tsx
+++ b/apps/web/components/admin/GraphExplorer.tsx
@@ -27,6 +27,7 @@ import type {
   GraphSubgraph,
 } from "@/lib/graph/explorer-queries";
 import {
+  ADDITIVE_MARKER_LABELS,
   GRAPH_DOMAINS,
   describeLabel,
   describeNodeLabels,
@@ -67,9 +68,11 @@ export function GraphExplorer({ census }: Props) {
     const counts = new Map<GraphDomainKey, number>();
     for (const row of census.labels) {
       const { domain } = describeLabel(row.label);
-      // `EaElement` and its concrete `ArchiMate__*` type both count the same node;
-      // the generic marker is the one that double-counts, so it is skipped.
-      if (row.label === "EaElement") continue;
+      // An additive marker shares a node with the projection that owns it — e.g.
+      // `EaElement` beside a concrete `ArchiMate__*` type, or `DocImpactSource`
+      // stamped on a `CodeFile`. Counting both inflates the tile, so markers are
+      // skipped (BI-0E019B95 generalised the former hard-coded EaElement check).
+      if (ADDITIVE_MARKER_LABELS.has(row.label)) continue;
       counts.set(domain, (counts.get(domain) ?? 0) + row.count);
     }
     return counts;

--- a/apps/web/lib/graph/__tests__/explorer-vocabulary.test.ts
+++ b/apps/web/lib/graph/__tests__/explorer-vocabulary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  ADDITIVE_MARKER_LABELS,
   GRAPH_DOMAINS,
   describeLabel,
   describeNodeLabels,
@@ -39,6 +40,37 @@ describe("describeLabel", () => {
     const descriptor = describeLabel("Wiki__Principle");
     expect(descriptor.label).toBe("Principle");
     expect(descriptor.domain).toBe("knowledge");
+  });
+
+  it("enumerates every additive marker so the census cannot double-count", () => {
+    // The census sums per-label counts, so a node carrying an additive marker plus
+    // the kind that owns it is counted twice and its tile overstates. Both known
+    // markers must be declared; a new one added without landing here silently
+    // inflates a domain (BI-0E019B95 generalised the hard-coded EaElement skip).
+    expect(ADDITIVE_MARKER_LABELS.has("EaElement")).toBe(true);
+    expect(ADDITIVE_MARKER_LABELS.has("DocImpactSource")).toBe(true);
+    // A concrete kind must never be treated as a marker, or its nodes vanish
+    // from the census entirely.
+    expect(ADDITIVE_MARKER_LABELS.has("CodeFile")).toBe(false);
+    expect(ADDITIVE_MARKER_LABELS.has("DocPage")).toBe(false);
+  });
+
+  it("groups repo documentation with the knowledge domain", () => {
+    const descriptor = describeLabel("DocPage");
+    expect(descriptor.label).toBe("Doc page");
+    expect(descriptor.domain).toBe("knowledge");
+  });
+
+  it("describes a shared doc-impact node by the kind that owns it, not the marker", () => {
+    // The doc-impact projection stamps DocImpactSource onto CodeFile nodes it shares
+    // with the code graph. The node must still read as a source file (BI-0E019B95).
+    const shared = describeNodeLabels(["DocImpactSource", "CodeFile"]);
+    expect(shared.key).toBe("CodeFile");
+
+    // A cited path the code graph does not index carries the marker alone, and must
+    // still land in `code` rather than the architecture-flavoured unknown bucket.
+    const leftover = describeNodeLabels(["DocImpactSource"]);
+    expect(leftover.domain).toBe("code");
   });
 
   it("keeps an uncurated wiki page kind inside the knowledge domain", () => {

--- a/apps/web/lib/graph/explorer-chart-colors.ts
+++ b/apps/web/lib/graph/explorer-chart-colors.ts
@@ -37,6 +37,10 @@ export const NODE_CATEGORY_COLORS = {
   Wiki__Summary: "#fecdd3",
   Wiki__Runbook: "#f5d0fe",
   Wiki__Index: "#c026d3",
+  // Repo documentation (BI-0E019B95). Same knowledge family as the wiki kinds, one
+  // step cooler so a doc page is separable from a wiki page at a glance without
+  // reading the label.
+  DocPage: "#ec4899",
 } as const satisfies Record<string, string>;
 
 /** Any ArchiMate type without a curated entry of its own. */
@@ -69,4 +73,5 @@ export const REL_TYPE_COLORS: Record<string, string> = {
   ROUTES_THROUGH: "#f472b6",
   LINKS_TO: "#f0abfc",
   OVERRIDES: "#d946ef",
+  IMPACTS: "#ec4899",
 };

--- a/apps/web/lib/graph/explorer-vocabulary.ts
+++ b/apps/web/lib/graph/explorer-vocabulary.ts
@@ -48,7 +48,7 @@ export const GRAPH_DOMAINS: GraphDomain[] = [
     key: "knowledge",
     label: "Knowledge",
     description:
-      "Wiki pages and the links between them: decision rules, organizational stances, profession corpora, and the founder kernel.",
+      "Two corpora the operator reads as one: wiki pages and the links between them (decision rules, organizational stances, profession corpora, the founder kernel), and the repository documentation that the code itself cites.",
   },
   {
     key: "architecture",
@@ -97,6 +97,18 @@ const LABEL_DESCRIPTORS: LabelDescriptor[] = [
     domain: "code",
     color: NODE_CATEGORY_COLORS.ExternalModule,
     size: 3,
+  },
+
+  // Listed AFTER the concrete code kinds on purpose: it is an additive marker, so a
+  // node that is also a `CodeFile` must describe as one. This entry only catches the
+  // honest leftover — a cited path the code graph does not index — which would
+  // otherwise degrade into the architecture-flavoured unknown bucket (BI-0E019B95).
+  {
+    key: "DocImpactSource",
+    label: "Cited source file",
+    domain: "code",
+    color: NODE_CATEGORY_COLORS.CodeFile,
+    size: 4,
   },
 
   // ── Data model ──────────────────────────────────────────────────────────────
@@ -153,6 +165,14 @@ const LABEL_DESCRIPTORS: LabelDescriptor[] = [
   { key: "Wiki__Summary", label: "Summary", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Summary, size: 4 },
   { key: "Wiki__Runbook", label: "Runbook", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Runbook, size: 5 },
   { key: "Wiki__Index", label: "Index page", domain: "knowledge", color: NODE_CATEGORY_COLORS.Wiki__Index, size: 7 },
+  //
+  // Repo documentation, projected from the committed doc-impact manifest
+  // (BI-0E019B95). Grouped with the wiki kinds because an operator asking "what
+  // explains this?" does not care which store it came from — but kept a distinct
+  // label and colour, because the substrates genuinely differ: wiki pages are rows,
+  // doc pages are files the code cites. This is also the only knowledge node that
+  // carries cross-domain edges today: `CodeFile`/`CodeRoute --IMPACTS--> DocPage`.
+  { key: "DocPage", label: "Doc page", domain: "knowledge", color: NODE_CATEGORY_COLORS.DocPage, size: 5 },
 
   // ── Portfolio ───────────────────────────────────────────────────────────────
   { key: "Portfolio", label: "Portfolio", domain: "portfolio", color: NODE_CATEGORY_COLORS.Portfolio, size: 8 },
@@ -173,6 +193,22 @@ const LABEL_DESCRIPTORS: LabelDescriptor[] = [
 ];
 
 const DESCRIPTOR_BY_KEY = new Map(LABEL_DESCRIPTORS.map((d) => [d.key, d]));
+
+/**
+ * Labels that are ADDITIVE markers on a node that another projection already owns,
+ * rather than a node's own kind.
+ *
+ * The corpus census sums per-label counts, so a node carrying two labels is counted
+ * twice and its domain tile overstates. `EaElement` (paired with a concrete
+ * `ArchiMate__*` type) needed a hard-coded skip for exactly this; `DocImpactSource`
+ * is the same shape — the doc-impact projection stamps it onto `CodeFile` nodes it
+ * shares with the code graph. Enumerating them here keeps the next additive marker
+ * from silently inflating a tile, which a second hard-coded string would not.
+ */
+export const ADDITIVE_MARKER_LABELS: ReadonlySet<string> = new Set([
+  "EaElement",
+  "DocImpactSource",
+]);
 
 /** The `ArchiMate__<Type>` family is open-ended — one rule covers every member. */
 const ARCHIMATE_PREFIX = "ArchiMate__";

--- a/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
+++ b/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
@@ -366,6 +366,66 @@ canvas was already a `default-visible` region in the ratified contract, so no ne
 region appears; the route keeps wide headroom against the `detail` shell's 450-word
 cap and the 300-word `deferred-detail` threshold.
 
+## Cross-domain edges: the doc-impact projection (BI-0E019B95, 2026-08-06)
+
+The corpus was in the mirror but disconnected. This closes the first real bridge, and
+the substrate audit that preceded it corrected three assumptions worth recording,
+because two of them were written into the backlog item by me and were wrong.
+
+### What the audit actually found
+
+The item proposed three "cheap" derivations. Measured against the live install:
+
+| Proposed | Reality |
+| --- | --- |
+| `principleConsumerContexts` → governed route | **Not a route link.** The values are open-ended *domain* slugs (`engineering-flow`, `data-model`, `ui`), and `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES` is an authoring vocabulary — "new contexts are added by authoring without a schema change". There is no slug→route registry to mirror. |
+| `WikiPageSource` → code | **Not code.** `RawSource` is external bibliographic provenance — `web-article`, `standard`, `framework`, with `url` / `doi` / `license`. Not repo paths. |
+| doc-impact derivation | **Real, and already committed.** |
+
+So the item's premise — that knowledge→code link data already exists and is merely
+unmirrored — is **false for the wiki corpus**. No structural link exists from `WikiPage`
+to code, and inventing one is a separate, genuinely-inferential piece of work.
+
+### What was real
+
+`apps/web/lib/docs/doc-impact.generated.json` is a committed, guard-regenerated manifest
+holding 529 doc→code and 87 doc→route links. `doc-impact-graph.ts`,
+`doc-impact-graph-sync.ts` and `rebuild-doc-impact-graph.ts` already project it into the
+mirror — and `graph:rebuild-doc-impact` had **exactly one reference in the repository: its
+own definition**. Nothing ever called it, so the mirror held zero `DocPage` nodes.
+
+That is the same failure mode BI-3045CC18 found in the portfolio spine: a complete writer
+with no caller. The fix is again a backfill, not a design.
+
+Projected on the live install: **183 `DocPage` nodes, 616 `IMPACTS` edges** —
+464 `CodeFile → DocPage` and 85 `CodeRoute → DocPage`.
+
+### The traversal now works
+
+Seeding `/admin/storefront/inbox` draws Route → Source file → Doc page across `Implements
+route` and `impacts`. "A route → the file that implements it → the documentation that
+governs it" is traversable in the UI.
+
+### Two vocabulary decisions
+
+**Doc pages join the `knowledge` domain rather than getting a seventh tile.** An operator
+asking "what explains this?" does not care which store it came from. They keep a distinct
+label and colour because the substrates genuinely differ — wiki pages are rows, doc pages
+are files the code cites.
+
+**`DocImpactSource` is an additive marker and must not be counted.** The projection stamps
+it onto `CodeFile` nodes it shares with the code graph, and the census sums per-label
+counts — the same double-count that forced a hard-coded `EaElement` skip. That skip is now
+`ADDITIVE_MARKER_LABELS`, enumerated and tested, so the next additive marker cannot
+silently inflate a tile. Verified live: Knowledge reads 542 (358 wiki + 183 doc) while Code
+stays 39,380, with the 504 markers excluded.
+
+### Still open
+
+`Wiki__*` nodes remain at **zero** cross-domain edges, and no route reaches a
+`PrismaModel` — `schema.prisma` still has no inbound edges. The route→file→**model** hop
+and the wiki→code hop are both unbuilt, and both need derivation rather than backfill.
+
 ## Follow-ups
 
 - Derive knowledge → code/data edges so the "decision that governed this route"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -77,6 +77,7 @@
     "seed": "tsx src/seed.ts",
     "graph:rebuild-doc-impact": "tsx src/rebuild-doc-impact-graph.ts",
     "graph:rebuild-knowledge-and-portfolio": "tsx src/rebuild-knowledge-and-portfolio-graph.ts",
+    "graph:rebuild-projections": "pnpm run graph:rebuild-doc-impact && pnpm run graph:rebuild-knowledge-and-portfolio",
     "index-integrity": "node scripts/index-integrity-guard.mjs",
     "skills:audit": "tsx src/skill-quality-audit.ts",
     "studio": "prisma studio",


### PR DESCRIPTION
The corpus was in the mirror but disconnected: knowledge nodes had **zero** cross-domain edges, so "which document governs this route?" could not be answered by traversal. This closes the first real bridge.

Advances BI-0E019B95 (stays open — see *Still open*).

## The traversal now works

Seeding `/admin/storefront/inbox` draws **Route → Source file → Doc page** across `Implements route` and `impacts`. A route, the file that implements it, and the documentation that governs it — traversable in the UI, on real data.

## The audit corrected the backlog item, including two things I wrote in it

The item proposed three "cheap" derivations. Measured first, as the kernel decision required (`DI-7CBA6260DB03`, *mirror-existing-links-first*, margin 6.63):

| Proposed | Reality |
| --- | --- |
| `principleConsumerContexts` → governed route | **Not a route link.** Values are open-ended *domain* slugs (`engineering-flow`, `data-model`, `ui`), and `PRINCIPLE_CONSUMER_CONTEXT_EXAMPLES` is an authoring vocabulary — *"new contexts are added by authoring without a schema change"*. No slug→route registry exists to mirror. |
| `WikiPageSource` → code | **Not code.** `RawSource` is external bibliographic provenance — `web-article`, `standard`, `framework`, with `url`/`doi`/`license`. Not repo paths. |
| doc-impact derivation | **Real, and already committed.** |

So the item's premise — that knowledge→code links already exist and are merely unmirrored — is **false for the wiki corpus**. Building on it would have meant inventing a mapping and calling it a mirror.

## What was real: a complete projection with no caller

`apps/web/lib/docs/doc-impact.generated.json` is committed and guard-regenerated, holding 529 doc→code and 87 doc→route links. `doc-impact-graph.ts`, `doc-impact-graph-sync.ts` and `rebuild-doc-impact-graph.ts` already project it.

`graph:rebuild-doc-impact` had **exactly one reference in the repository: its own definition.** Nothing ever called it, so the mirror held zero `DocPage` nodes — the same failure mode BI-3045CC18 found in the portfolio spine. The fix is a backfill, not a design.

Projected on the live install: **183 `DocPage` nodes, 616 `IMPACTS` edges** (464 `CodeFile→DocPage`, 85 `CodeRoute→DocPage`).

## Two vocabulary decisions

**Doc pages join the `knowledge` domain** rather than taking a seventh tile — an operator asking "what explains this?" doesn't care which store it came from. They keep a distinct label and colour because the substrates differ: wiki pages are rows, doc pages are files the code cites.

**`DocImpactSource` is an additive marker and must not be counted.** The projection stamps it onto `CodeFile` nodes it shares with the code graph, and the census sums per-label counts — the identical double-count that forced a hard-coded `EaElement` skip. That skip is now `ADDITIVE_MARKER_LABELS`: enumerated, exported and tested, so the next additive marker can't silently inflate a tile.

## Verification

Functional, on the running portal — the census reads **Knowledge 542** (358 wiki + 183 doc) while **Code stays 39,380**, with all 504 `DocImpactSource` markers correctly excluded. That verifies the marker fix live rather than asserting it.

Also green: web typecheck 0 errors, 241 tests across `lib/graph`, `lib/ux-budget`, `components/inventory`, 35 repo guards clean, local-CI gate **PASS** at `ef653d039143` (pushed on that record, no override code).

## Still open

`Wiki__*` nodes remain at **zero** cross-domain edges, and no route reaches a `PrismaModel` — `schema.prisma` still has no inbound edges. The route→file→**model** hop and the wiki→code hop are both unbuilt, and both need genuine derivation rather than backfill. BI-0E019B95 stays open for them rather than being closed by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
