### PR TITLE
fix(federation): exempt remote peer callbacks from the PUBLIC_URL canonical redirect (BI-A5842B04)

### DIFF
--- a/apps/web/lib/canonical-host.test.ts
+++ b/apps/web/lib/canonical-host.test.ts
@@ -182,12 +182,26 @@ describe("isCanonicalRedirectExempt", () => {
   );
 
   it.each([
+    "/api/v1/federation",
+    "/api/v1/federation/enroll",
+    "/api/v1/federation/approval-relay",
+    "/api/v1/federation/demand",
+    "/api/v1/federation/demand/reconcile",
+    "/api/v1/federation/incident",
+    "/api/v1/federation/proposal",
+  ])("exempts remote federation peer callback %s", (p) =>
+    expect(isCanonicalRedirectExempt(p)).toBe(true),
+  );
+
+  it.each([
     "/",
     "/ops/demand",
-    "/api/v1/federation/demand",
     "/api/inngestx",
     "/api/mcpx",
     "/api/health/extra",
+    "/api/v1/federationx",
+    "/api/v1/federation-summary",
+    "/platform/federation-links",
   ])("does NOT exempt browser/other route %s", (p) =>
     expect(isCanonicalRedirectExempt(p)).toBe(false),
   );
@@ -317,4 +331,40 @@ describe("enforceCanonicalHost (Next.js wrapper)", () => {
       expect(enforceCanonicalHost(req)).toBeNull();
     },
   );
+
+  // Regression (extends BI-A5842B04): a remote federation peer dials us at a LAN
+  // address whose host form differs from PUBLIC_URL (here the operator set a
+  // hostname canonical, but the peer reaches us by IP). A 301 would turn the
+  // peer's signed Bearer POST into a GET — dropping the token + enrollment body
+  // and failing the pairing handshake. These machine callbacks must pass through.
+  it.each([
+    "/api/v1/federation/enroll",
+    "/api/v1/federation/approval-relay",
+    "/api/v1/federation/demand",
+  ])("never redirects federation peer callback %s even with PUBLIC_URL set", (peerPath) => {
+    process.env.PUBLIC_URL = "http://portal.example.com:3000";
+    delete process.env.PUBLIC_URL_ALIASES;
+    const req = buildRequest({
+      url: `http://192.168.0.200:3000${peerPath}`,
+      host: "192.168.0.200:3000",
+    });
+    expect(enforceCanonicalHost(req)).toBeNull();
+  });
+
+  // The browser pairing UI itself is NOT exempt — an operator landing on the
+  // federation-links admin page at a non-canonical host is still canonicalized.
+  it("still redirects the browser federation-links page at a non-canonical host", () => {
+    process.env.PUBLIC_URL = "https://portal.example.com";
+    delete process.env.PUBLIC_URL_ALIASES;
+    const req = buildRequest({
+      url: "http://192.168.0.200:3000/platform/federation-links",
+      host: "192.168.0.200:3000",
+    });
+    const res = enforceCanonicalHost(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(301);
+    expect(res!.headers.get("location")).toBe(
+      "https://portal.example.com/platform/federation-links",
+    );
+  });
 });

--- a/apps/web/lib/canonical-host.ts
+++ b/apps/web/lib/canonical-host.ts
@@ -106,13 +106,29 @@ const HEALTH_PROBE_PATHS = new Set(["/api/health", "/api/healthz", "/api/ready"]
 // canonicalization must not apply. See BI-A5842B04.
 const INTERNAL_SERVICE_CALLBACK_PREFIXES = ["/api/inngest", "/api/mcp"];
 
+// Remote federation peer-to-peer callbacks. Unlike the internal callbacks above
+// (loopback / Docker service host), these POSTs arrive from a *remote* sovereign
+// install over the LAN — enrollment, dual-approval relay, and the minimized
+// demand/incident/proposal exchange, each authenticated by an Authorization:
+// Bearer link token. A peer dials us at our PUBLIC_URL host, so normally the
+// Host already matches canonical and no redirect fires. But if the operator's
+// PUBLIC_URL host form differs from how the peer addresses us (IP vs hostname,
+// or a port/alias skew), the 301 turns the peer's POST into a GET: the token
+// authorization and JSON body are dropped and the pairing handshake fails with a
+// misleading 401/400. These are machine callbacks, never browser navigation —
+// canonicalization (and its Clear-Site-Data reset) must not apply. Same class as
+// the internal callbacks; kept as a distinct list to document the remote origin.
+// See BI-A5842B04 (the internal-callback fix this extends).
+const PEER_SERVICE_CALLBACK_PREFIXES = ["/api/v1/federation"];
+
 /** Paths exempt from canonical-host redirection: health probes that load
- *  balancers hit on the raw LAN IP, plus internal service callbacks that arrive
- *  on the Docker service hostname / loopback and must never be redirected. Pure
+ *  balancers hit on the raw LAN IP, internal service callbacks that arrive on
+ *  the Docker service hostname / loopback, and remote federation peer callbacks
+ *  — none of which may be redirected without corrupting a machine payload. Pure
  *  and exported for direct unit testing. */
 export function isCanonicalRedirectExempt(pathname: string): boolean {
   if (HEALTH_PROBE_PATHS.has(pathname)) return true;
-  return INTERNAL_SERVICE_CALLBACK_PREFIXES.some(
+  return [...INTERNAL_SERVICE_CALLBACK_PREFIXES, ...PEER_SERVICE_CALLBACK_PREFIXES].some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
 }


### PR DESCRIPTION
## What

Adds `PEER_SERVICE_CALLBACK_PREFIXES = ["/api/v1/federation"]` to the canonical-host redirect exemption in `apps/web/lib/canonical-host.ts`, so the six remote federation peer callbacks are never 301'd.

## Why

The routes `enroll`, `approval-relay`, `demand`, `demand/reconcile`, `incident`, `proposal` are **remote peer-to-peer machine POSTs** authenticated by an `Authorization: Bearer` link token. A peer normally dials us at our `PUBLIC_URL` host, so no redirect fires. But if the operator's `PUBLIC_URL` host form differs from how the peer addresses us — **IP vs hostname, or a port/alias skew** — the canonical-host 301 turns the peer's POST into a GET, dropping the token + JSON body and failing the pairing handshake with a misleading 401/400.

This is the **same machine-payload-corruption class** that #4062 fixed for the loopback Inngest/MCP callbacks, now applied to remote federation peers. It removes the last hidden failure mode in the LAN pairing path.

## Scope guard

The browser pairing UI (`/platform/federation-links`) stays canonicalized — only the machine API namespace (`/api/v1/federation`) is exempt. A test locks this in.

## Tests

`apps/web/lib/canonical-host.test.ts` — **52 pass** (13 new):
- exemption matrix over all six peer routes
- non-exemption of look-alikes (`/api/v1/federationx`, `/api/v1/federation-summary`, `/platform/federation-links`)
- middleware regression: a peer POST at a mismatched host passes through, while the admin page at a mismatched host still 301s

Local-CI gate: passed (evidence `cmsi699up0hkb01mv42840uqp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)