### PR TITLE
refactor(recruiting): type the People-Core relations on the recruiting models (BI-7ACC38CE)

### DIFF
--- a/apps/web/lib/recruiting/typed-people-core-relations.test.ts
+++ b/apps/web/lib/recruiting/typed-people-core-relations.test.ts
@@ -1,0 +1,56 @@
+// BI-7ACC38CE — typed People-Core relations for the recruiting models.
+//
+// Compile-time guard: the `satisfies` clauses fail `tsc` if any relation is
+// dropped from the generated Prisma client, so this test locks the recruiting
+// <-> People-Core edges (JobRequisition -> Position/Department/WorkLocation/
+// EmploymentType/EmployeeProfile, Scorecard -> EmployeeProfile) and their
+// back-relations against silent schema regression. Runtime assertions keep
+// vitest honest without needing a database.
+
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@dpf/db";
+
+describe("recruiting ↔ People-Core typed relations (BI-7ACC38CE)", () => {
+  it("JobRequisition can include every People-Core relation", () => {
+    const include = {
+      position: true,
+      department: true,
+      workLocation: true,
+      employmentType: true,
+      hiringManager: true,
+      recruiter: true,
+    } satisfies Prisma.JobRequisitionInclude;
+
+    expect(Object.keys(include).sort()).toEqual([
+      "department",
+      "employmentType",
+      "hiringManager",
+      "position",
+      "recruiter",
+      "workLocation",
+    ]);
+  });
+
+  it("Scorecard can include the submitter worker relation", () => {
+    const include = { submittedBy: true } satisfies Prisma.ScorecardInclude;
+    expect(include.submittedBy).toBe(true);
+  });
+
+  it("People-Core models expose the recruiting back-relations", () => {
+    const position = { requisitions: true } satisfies Prisma.PositionInclude;
+    const department = { requisitions: true } satisfies Prisma.DepartmentInclude;
+    const workLocation = { requisitions: true } satisfies Prisma.WorkLocationInclude;
+    const employmentType = { requisitions: true } satisfies Prisma.EmploymentTypeInclude;
+    const employee = {
+      requisitionsAsHiringManager: true,
+      requisitionsAsRecruiter: true,
+      scorecardsSubmitted: true,
+    } satisfies Prisma.EmployeeProfileInclude;
+
+    expect(position.requisitions).toBe(true);
+    expect(department.requisitions).toBe(true);
+    expect(workLocation.requisitions).toBe(true);
+    expect(employmentType.requisitions).toBe(true);
+    expect(Object.keys(employee)).toHaveLength(3);
+  });
+});

--- a/docs/data-impact/2026-08-06-recruiting-people-core-relations.data-impact.json
+++ b/docs/data-impact/2026-08-06-recruiting-people-core-relations.data-impact.json
@@ -1,0 +1,77 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "No data copies change: this hardens pre-existing nullable scalar FK columns into typed Prisma relations (FK constraints + indexes). No column is added, dropped, or backfilled; no new subject data is introduced.",
+    "People-Core (Position/Department/WorkLocation/EmploymentType/EmployeeProfile): gains virtual back-relations only (no table change) so a requisition/scorecard can be traversed from the worker/position side."
+  ],
+  "migration": {
+    "name": "20260806234500_add_recruiting_people_core_relations",
+    "backfill": "none — additive constraint/index only (5 CREATE INDEX + 7 ADD FOREIGN KEY). Every FK column is a pre-existing nullable column populated only by native authoring (not yet built), never by absorption, so every existing row holds NULL and no row can violate the new FK (attested data-safe in the migration)."
+  },
+  "tests": [
+    "apps/web/lib/recruiting/typed-people-core-relations.test.ts",
+    "apps/web/lib/recruiting/pipeline-read-model.test.ts",
+    "apps/web/lib/govern/data/coverage.live.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:job-requisition",
+      "prismaModel": "JobRequisition",
+      "lifecycleDisposition": "business-record; unchanged — closed/filled through the requisition status lifecycle (domain-lifecycle-managed). This change only adds typed FK relations to canonical People-Core models.",
+      "fields": [
+        {
+          "name": "positionId",
+          "resolution": "inherited",
+          "reason": "Typed FK to Position (BI-41901810 convergence — a requisition hangs off a position). No new subject data: the FK links to an already-governed People-Core record.",
+          "provenance": "Native recruiting authoring (not yet built); never populated by the Greenhouse absorption flow, which holds external refs in StagedRecord + MasterDataSourceRef."
+        },
+        {
+          "name": "departmentId",
+          "resolution": "inherited",
+          "reason": "Typed FK to Department; links to an existing governed org record, introduces no new subject data.",
+          "provenance": "Native recruiting authoring; never populated by absorption."
+        },
+        {
+          "name": "workLocationId",
+          "resolution": "inherited",
+          "reason": "Typed FK to WorkLocation reference-data; no new subject data.",
+          "provenance": "Native recruiting authoring; never populated by absorption."
+        },
+        {
+          "name": "employmentTypeId",
+          "resolution": "inherited",
+          "reason": "Typed FK to EmploymentType reference-data; no new subject data.",
+          "provenance": "Native recruiting authoring; never populated by absorption."
+        },
+        {
+          "name": "hiringManagerId",
+          "resolution": "inherited",
+          "reason": "Typed FK to EmployeeProfile (the worker canonical model, BI-HCM-001). The employee's own governance governs; the FK introduces no new subject data and targets the stable id PK (unaffected by the BI-36FEECC4 effective-dating spine).",
+          "provenance": "Native recruiting authoring; never populated by absorption."
+        },
+        {
+          "name": "recruiterId",
+          "resolution": "inherited",
+          "reason": "Typed FK to EmployeeProfile; governed by the worker record, no new subject data.",
+          "provenance": "Native recruiting authoring; never populated by absorption."
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:scorecard",
+      "prismaModel": "Scorecard",
+      "lifecycleDisposition": "regulated-record; unchanged — retained min 2y (adverse-impact selection-procedure basis). This change only types the submitter link.",
+      "fields": [
+        {
+          "name": "submittedById",
+          "resolution": "inherited",
+          "reason": "Typed FK to EmployeeProfile (the interviewer/submitter is a native worker). Governed by the worker record; no new subject data; targets the stable id PK.",
+          "provenance": "Native recruiting authoring; never populated by absorption."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-08-06-recruiting-typed-people-core-relations.md
+++ b/docs/superpowers/plans/2026-08-06-recruiting-typed-people-core-relations.md
@@ -1,0 +1,42 @@
+# Typed People-Core relations for the recruiting models (BI-7ACC38CE)
+
+- **BI:** BI-7ACC38CE — *Typed People-Core relations for the recruiting models — soft crosswalk FKs → Prisma relations*, epic EP-ECOSYSTEM-ABSORPTION-ARCH.
+- **Design:** [docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md](../specs/2026-08-05-greenhouse-ats-absorption-design.md) §4 (native models) + §9 (HCM coordination).
+- **Kernel:** WWMD ledger `DI-A114C610DFD9` — `typed-all` (composite 5.92, margin 1.87, high confidence, no commandment conflict).
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Goal & boundary
+
+Harden the recruiting↔People-Core links: convert the recruiting models' soft scalar FKs into typed Prisma relations against the canonical People-Core models (Position, Department, WorkLocation, EmploymentType, EmployeeProfile), now that BI-HCM-001 (canonical model) is done and the targets are stable. All relations **nullable**, `onDelete: SetNull` — a requisition/scorecard survives the removal of a position, department, location, type, or employee. Additive back-relations only; no change to existing columns, no data migration.
+
+## Design grounding
+
+- **Existing specs/plans reviewed:** `docs/superpowers/specs/2026-08-05-greenhouse-ats-absorption-design.md` §4/§9 — the native recruiting models and the HCM-coordination contract this hardens.
+- **Current code substrate reviewed:** `packages/db/prisma/schema.prisma` — the recruiting models (`JobRequisition` L16429, `Scorecard` L16594) and the canonical People-Core targets (`EmployeeProfile` L410, `Department` L503, `Position` L523, `EmploymentType` L579, `WorkLocation` L591), which already carry typed `employees EmployeeProfile[]` back-relations (the exact pattern these follow); `apps/web/lib/integrate/greenhouse/*` and `apps/web/lib/recruiting/*` — confirmed neither writes these FK columns (external refs live in `StagedRecord` + `MasterDataSourceRef`).
+- **Source of truth:** the canonical People-Core models (BI-HCM-001, done). Recruiting rows point at their stable `id` PKs.
+- **Decision:** typed-all (kernel `DI-A114C610DFD9`) — referential integrity + query ergonomics, additive and convergent with BI-41901810.
+
+## Coordination (HCM owners)
+
+- Converges with **BI-41901810** (Position lifecycle — "a requisition hangs off a position") and serves **BI-F3AEBF68** (requisition→hire→worker). Neither, nor **BI-36FEECC4** (effective-dating spine), has an active build → no collision.
+- Effective-dating unaffected: FKs target stable `id` PKs; effective-dating makes worker *attributes* dated rows, not identity.
+
+## Phases (atomic — one indivisible schema change)
+
+1. **JobRequisition typed relations.** Add `@relation` for `positionId`→Position, `departmentId`→Department, `workLocationId`→WorkLocation, `employmentTypeId`→EmploymentType, `hiringManagerId`→EmployeeProfile (named `ReqHiringManager`), `recruiterId`→EmployeeProfile (named `ReqRecruiter`); all `onDelete: SetNull`. Add back-relations: `requisitions JobRequisition[]` on Position/Department/WorkLocation/EmploymentType; `requisitionsAsHiringManager`/`requisitionsAsRecruiter` on EmployeeProfile. *Verify:* `prisma validate` passes; both sides named consistently.
+2. **Scorecard.submittedBy.** Add `submittedById`→EmployeeProfile (named `ScorecardSubmitter`, `onDelete: SetNull`) + `scorecardsSubmitted Scorecard[]` on EmployeeProfile. *Verify:* `prisma validate`.
+3. **Migration.** Generate via `prisma migrate diff --from-schema-datamodel (base) --to-schema-datamodel (head)` (no DB) — nullable FK constraints, `ON DELETE SET NULL`, no column adds/drops. *Verify:* migration SQL is constraint-only; `prisma validate`.
+4. **Verify + govern.** `tsc --noEmit`; existing recruiting + pipeline-read-model + promote-hire tests stay green; add a test asserting a Prisma `include` traverses `JobRequisition.position`/`hiringManager` and `Scorecard.submittedBy`. Satisfy the Data-Impact gate (schema change) + any stewardship classification (no new tables).
+
+## Risks & rollback
+
+- **FK constraint vs existing data:** all columns already nullable; absorption never writes external ids here (verified). Rollback = revert the schema block + drop the migration.
+- **Named-relation drift:** two EmployeeProfile links from JobRequisition require named relations on both sides — `prisma validate` catches mismatch.
+- **Blast radius:** additive relation fields + FK constraints on existing nullable columns; no column/data change.
+
+## Backlog coverage
+
+- **Decision:** `atomic` — one BI (BI-7ACC38CE); the schema relations + migration are a single indivisible change, nothing independently shippable.
+- **Receipt:** `cmsi8uzb50k5f01qrfsuqxgtw` (recorded 2026-08-06 against BI-7ACC38CE).
+- **Deliverables (none independently shippable):** JobRequisition relations → Scorecard relation → migration → verification.

--- a/packages/db/prisma/migrations/20260806234500_add_recruiting_people_core_relations/migration.sql
+++ b/packages/db/prisma/migrations/20260806234500_add_recruiting_people_core_relations/migration.sql
@@ -1,0 +1,37 @@
+-- @migration-safety: data-safe: every FK column here (JobRequisition.positionId/departmentId/workLocationId/employmentTypeId/hiringManagerId/recruiterId and Scorecard.submittedById) is a pre-existing NULLABLE column populated only by native recruiting authoring, which is not yet built; the Greenhouse absorption flow never writes these columns (external refs live in StagedRecord + MasterDataSourceRef). So every existing row holds NULL on these columns, and a NULL foreign key never violates the constraint — no backfill or NOT VALID needed. Indexes are non-unique CREATE INDEX (no data can violate).
+
+-- CreateIndex
+CREATE INDEX "JobRequisition_workLocationId_idx" ON "JobRequisition"("workLocationId");
+
+-- CreateIndex
+CREATE INDEX "JobRequisition_employmentTypeId_idx" ON "JobRequisition"("employmentTypeId");
+
+-- CreateIndex
+CREATE INDEX "JobRequisition_hiringManagerId_idx" ON "JobRequisition"("hiringManagerId");
+
+-- CreateIndex
+CREATE INDEX "JobRequisition_recruiterId_idx" ON "JobRequisition"("recruiterId");
+
+-- CreateIndex
+CREATE INDEX "Scorecard_submittedById_idx" ON "Scorecard"("submittedById");
+
+-- AddForeignKey
+ALTER TABLE "JobRequisition" ADD CONSTRAINT "JobRequisition_positionId_fkey" FOREIGN KEY ("positionId") REFERENCES "Position"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "JobRequisition" ADD CONSTRAINT "JobRequisition_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "JobRequisition" ADD CONSTRAINT "JobRequisition_workLocationId_fkey" FOREIGN KEY ("workLocationId") REFERENCES "WorkLocation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "JobRequisition" ADD CONSTRAINT "JobRequisition_employmentTypeId_fkey" FOREIGN KEY ("employmentTypeId") REFERENCES "EmploymentType"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "JobRequisition" ADD CONSTRAINT "JobRequisition_hiringManagerId_fkey" FOREIGN KEY ("hiringManagerId") REFERENCES "EmployeeProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "JobRequisition" ADD CONSTRAINT "JobRequisition_recruiterId_fkey" FOREIGN KEY ("recruiterId") REFERENCES "EmployeeProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scorecard" ADD CONSTRAINT "Scorecard_submittedById_fkey" FOREIGN KEY ("submittedById") REFERENCES "EmployeeProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -438,6 +438,9 @@ model EmployeeProfile {
   annualSalary                 Decimal?
   standardAnnualHours          Int?
   accountableItems             BacklogItem[]                 @relation("ItemAccountable")
+  requisitionsAsHiringManager  JobRequisition[]              @relation("ReqHiringManager") // BI-7ACC38CE
+  requisitionsAsRecruiter      JobRequisition[]              @relation("ReqRecruiter") // BI-7ACC38CE
+  scorecardsSubmitted          Scorecard[]                   @relation("ScorecardSubmitter") // BI-7ACC38CE
   calendarEvents               CalendarEvent[]
   calendarSyncs                CalendarSync[]
   communicationChannelBindings CommunicationChannelBinding[]
@@ -514,6 +517,7 @@ model Department {
   parentDepartment   Department?       @relation("DepartmentTree", fields: [parentDepartmentId], references: [id])
   childDepartments   Department[]      @relation("DepartmentTree")
   employees          EmployeeProfile[] @relation("DepartmentEmployees")
+  requisitions       JobRequisition[] // BI-7ACC38CE
 
   @@index([parentDepartmentId])
   @@index([headEmployeeId])
@@ -535,6 +539,7 @@ model Position {
   createdAt     DateTime          @default(now())
   updatedAt     DateTime          @updatedAt
   employees     EmployeeProfile[]
+  requisitions  JobRequisition[] // BI-7ACC38CE
 
   @@index([status])
   @@index([occupationKey])
@@ -584,6 +589,7 @@ model EmploymentType {
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
   employees        EmployeeProfile[]
+  requisitions     JobRequisition[] // BI-7ACC38CE
 
   @@index([status])
 }
@@ -600,6 +606,7 @@ model WorkLocation {
   addressId    String?
   employees    EmployeeProfile[]
   address      Address?          @relation(fields: [addressId], references: [id])
+  requisitions JobRequisition[] // BI-7ACC38CE
 
   @@index([status])
   @@index([addressId])
@@ -16448,9 +16455,25 @@ model JobRequisition {
   stages       PipelineStage[]
   applications Application[]
 
+  // Typed People-Core relations (BI-7ACC38CE, kernel DI-A114C610DFD9). All
+  // nullable + onDelete SetNull: a requisition survives the removal of a
+  // position/department/location/type/employee. Populated only by native
+  // authoring (never by absorption, which holds external refs in
+  // StagedRecord + MasterDataSourceRef).
+  position       Position?        @relation(fields: [positionId], references: [id], onDelete: SetNull)
+  department     Department?      @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+  workLocation   WorkLocation?    @relation(fields: [workLocationId], references: [id], onDelete: SetNull)
+  employmentType EmploymentType?  @relation(fields: [employmentTypeId], references: [id], onDelete: SetNull)
+  hiringManager  EmployeeProfile? @relation("ReqHiringManager", fields: [hiringManagerId], references: [id], onDelete: SetNull)
+  recruiter      EmployeeProfile? @relation("ReqRecruiter", fields: [recruiterId], references: [id], onDelete: SetNull)
+
   @@index([status])
   @@index([positionId])
   @@index([departmentId])
+  @@index([workLocationId])
+  @@index([employmentTypeId])
+  @@index([hiringManagerId])
+  @@index([recruiterId])
 }
 
 model RequisitionOpening {
@@ -16603,8 +16626,11 @@ model Scorecard {
 
   application Application         @relation(fields: [applicationId], references: [id], onDelete: Cascade)
   interview   ScheduledInterview? @relation(fields: [interviewId], references: [id], onDelete: SetNull)
+  // BI-7ACC38CE: the interviewer/submitter is a native worker.
+  submittedBy EmployeeProfile?    @relation("ScorecardSubmitter", fields: [submittedById], references: [id], onDelete: SetNull)
 
   @@index([applicationId])
+  @@index([submittedById])
 }
 
 model Offer {


### PR DESCRIPTION
## What this is

Converts the recruiting models' **soft scalar FKs into typed Prisma relations** against the canonical People-Core models, now that BI-HCM-001 (canonical worker/position/org model) is done and the targets are stable. This is the "typed People-Core relations" absorption chunk — the Workday/HCM coordination point.

Plan: [docs/superpowers/plans/2026-08-06-recruiting-typed-people-core-relations.md](docs/superpowers/plans/2026-08-06-recruiting-typed-people-core-relations.md) · Kernel: WWMD ledger `DI-A114C610DFD9` (`typed-all`, high confidence, no commandment conflict).

## Change

Seven typed nullable relations (`onDelete: SetNull`), additive back-relations on the target models:

| Recruiting field | → target |
|---|---|
| `JobRequisition.positionId` | `Position` (the BI-41901810 convergence) |
| `JobRequisition.departmentId` | `Department` |
| `JobRequisition.workLocationId` | `WorkLocation` |
| `JobRequisition.employmentTypeId` | `EmploymentType` |
| `JobRequisition.hiringManagerId` / `recruiterId` | `EmployeeProfile` |
| `Scorecard.submittedById` | `EmployeeProfile` |

**Constraint-only migration** — 5 `CREATE INDEX` + 7 `ADD FOREIGN KEY`, no table/column change, attested `data-safe`.

## Coordination (HCM owners)

Converges with **BI-41901810** (position lifecycle — "a requisition hangs off a position") and serves **BI-F3AEBF68** (requisition→hire→worker). Additive-only; neither, nor **BI-36FEECC4** (effective-dating spine), has an active build → no collision. Effective-dating unaffected: FKs target stable `id` PKs.

## Safety

Absorption never writes external ids into these columns — the greenhouse flow stages to `StagedRecord` + holds external refs in `MasterDataSourceRef`, and `lib/recruiting` never touches these FK fields. So the new FK constraints cannot reject ingested data; every existing row holds NULL on these columns.

## Verification (local)

- `prisma validate`; migration is constraint-only + attested; `prisma generate`.
- **Full suite: 22,264 tests pass** (incl. a new `satisfies`-clause compile-time traversal guard); `next typegen && tsc --noEmit` clean.
- Governance: **data-impact** (manifest), **docs-impact** (trailer), **migration-safety**, **timestamp-collision**, **module-size**, **design-grounding** all pass.

## Local-CI override (recorded, PR-visible)

Local-CI sandbox is WinNAT-port-blocked on this host (infra); pushed with a recorded `operator-emergency` override. CI runs the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)