### PR TITLE
feat(federation): resolve self Authority URL from the request host (BI-CC8021CE)

### DIFF
--- a/apps/web/lib/actions/federation-links.ts
+++ b/apps/web/lib/actions/federation-links.ts
@@ -21,7 +21,7 @@ import {
 } from "@dpf/db/federation-link-types";
 import { isPartnerStanding, type PartnerStanding } from "@dpf/db/federated-channel";
 
-import { resolveAppBaseUrl } from "@/lib/app-url";
+import { resolveLocalFederationAuthorityUrl } from "@/lib/federation/self-authority";
 import { auth } from "@/lib/auth";
 import { resolveFederationIdentity } from "@/lib/federation/demand-identity";
 import {
@@ -359,9 +359,9 @@ export async function enrollWithPeerAction(input: {
   if (!input.peerAuthorityUrl?.trim() || !input.bootstrapToken?.trim() || !input.displayName?.trim()) {
     return { ok: false, error: "invalid_input", message: "peer URL, invitation token, and a name are required" };
   }
-  const localAuthorityUrl = resolveAppBaseUrl();
+  const localAuthorityUrl = await resolveLocalFederationAuthorityUrl();
   if (!localAuthorityUrl) {
-    return { ok: false, error: "internal_error", message: "this deployment's base URL is not configured (set APP_URL)" };
+    return { ok: false, error: "internal_error", message: "could not determine this installation's address to advertise to the peer" };
   }
   try {
     const result = await enrollWithPeer({
@@ -410,9 +410,9 @@ export async function startNearbyPairingAction(input: {
   if (candidate.automaticPairing === "blocked-insecure-transport") {
     return { ok: false, error: "invalid_input", message: "Automatic pairing requires HTTPS. Use a manual invitation until this installation has a trusted certificate." };
   }
-  const localAuthorityUrl = resolveAppBaseUrl();
+  const localAuthorityUrl = await resolveLocalFederationAuthorityUrl();
   if (!localAuthorityUrl) {
-    return { ok: false, error: "internal_error", message: "This installation's base URL is not configured." };
+    return { ok: false, error: "internal_error", message: "could not determine this installation's address to advertise to the peer" };
   }
   try {
     await assertEncryptionReadyForCredentialWrite();
@@ -541,7 +541,7 @@ export async function pollNearbyPairingAction(pairingId: string): Promise<Nearby
     return { ok: true, ...baseResult, status: peer.status };
   }
   const [localAuthorityUrl, organization] = await Promise.all([
-    Promise.resolve(resolveAppBaseUrl()),
+    resolveLocalFederationAuthorityUrl(),
     prisma.organization.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true, name: true } }),
   ]);
   if (!localAuthorityUrl) {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4877,6 +4877,7 @@
       "publishedPortal": false,
       "anchors": [
         "federated-demand-channels",
+        "how-an-installation-advertises-its-own-address",
         "same-company-installations",
         "customer-and-reseller-operation",
         "founder-hub-business-management",

--- a/apps/web/lib/federation/self-authority.test.ts
+++ b/apps/web/lib/federation/self-authority.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveFederationAuthorityUrl } from "./self-authority";
+
+describe("deriveFederationAuthorityUrl", () => {
+  it("explicit configured base URL wins over the request host", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: "https://portal.example.com",
+        host: "192.168.0.152:3000",
+        forwardedProto: "http",
+      }),
+    ).toBe("https://portal.example.com");
+  });
+
+  it("falls back to the request Host header when nothing is configured (the LAN case)", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: null,
+        host: "192.168.0.152:3000",
+        forwardedProto: null,
+      }),
+    ).toBe("http://192.168.0.152:3000");
+  });
+
+  it("honors x-forwarded-proto when present (reverse proxy terminating TLS)", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: null,
+        host: "portal.example.com",
+        forwardedProto: "https",
+      }),
+    ).toBe("https://portal.example.com");
+  });
+
+  it("takes the first hop of a comma-listed x-forwarded-proto", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: null,
+        host: "portal.example.com",
+        forwardedProto: "https, http",
+      }),
+    ).toBe("https://portal.example.com");
+  });
+
+  it("trims a trailing slash from the configured URL", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: "https://portal.example.com/",
+        host: null,
+        forwardedProto: null,
+      }),
+    ).toBe("https://portal.example.com");
+  });
+
+  it("returns null when neither config nor host is available", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: null,
+        host: null,
+        forwardedProto: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores an empty configured URL and uses the host", () => {
+    expect(
+      deriveFederationAuthorityUrl({
+        configuredBaseUrl: "",
+        host: "10.0.0.5:3000",
+        forwardedProto: null,
+      }),
+    ).toBe("http://10.0.0.5:3000");
+  });
+});

--- a/apps/web/lib/federation/self-authority.ts
+++ b/apps/web/lib/federation/self-authority.ts
@@ -1,0 +1,67 @@
+// Resolve THIS installation's federation Authority URL — the address a peer is
+// told to reach us at during enroll — WITHOUT requiring the operator to type it.
+//
+// Before this, the pairing actions called resolveAppBaseUrl(), which returns null
+// in production unless PUBLIC_URL (or NEXT_PUBLIC_*) is set. A same-organization
+// LAN operator then hit "base URL is not configured (set APP_URL)" and pairing
+// failed — the manual-typing step this design eliminates.
+//
+// The reliable zero-typing source is the REQUEST HOST: the operator reached the
+// portal at (e.g.) http://192.168.0.152:3000/platform/federation-links, so that
+// Host header IS the LAN address a same-org peer can reach. We cannot derive it
+// from os.networkInterfaces() — inside the portal container that returns the
+// Docker bridge IP (172.x), not the host's reachable LAN IP.
+//
+// Precedence: explicit config wins (PUBLIC_URL / NEXT_PUBLIC_* via
+// resolveAppBaseUrl — correct for reverse-proxy / public deployments), then the
+// request Host header (correct for same-org LAN), then null (caller errors).
+
+import { headers } from "next/headers";
+
+import { resolveAppBaseUrl } from "@/lib/app-url";
+
+/** Pure core: pick the self-authority URL from configured value or request host.
+ *  Exported for direct unit testing (no next/headers dependency). */
+export function deriveFederationAuthorityUrl(args: {
+  /** resolveAppBaseUrl() result — explicit PUBLIC_URL / NEXT_PUBLIC_* config. */
+  configuredBaseUrl: string | null;
+  /** x-forwarded-host ?? host from the incoming request. */
+  host: string | null | undefined;
+  /** x-forwarded-proto from the incoming request, if any. */
+  forwardedProto: string | null | undefined;
+}): string | null {
+  const { configuredBaseUrl, host, forwardedProto } = args;
+
+  if (configuredBaseUrl && configuredBaseUrl.trim()) {
+    return configuredBaseUrl.trim().replace(/\/+$/, "");
+  }
+
+  if (host && host.trim()) {
+    // x-forwarded-proto may be a comma list (proxy chain); take the first hop.
+    const proto = forwardedProto?.split(",")[0]?.trim() || "http";
+    return `${proto}://${host.trim()}`.replace(/\/+$/, "");
+  }
+
+  return null;
+}
+
+/** Resolve this install's federation Authority URL for enroll/invite/connect.
+ *  Must be called from a request scope (server action / route) so the Host
+ *  header is available. Returns null only when neither config nor a Host header
+ *  is present. */
+export async function resolveLocalFederationAuthorityUrl(): Promise<string | null> {
+  const configuredBaseUrl = resolveAppBaseUrl();
+  let host: string | null = null;
+  let forwardedProto: string | null = null;
+  try {
+    const h = await headers();
+    host = h.get("x-forwarded-host") ?? h.get("host");
+    forwardedProto = h.get("x-forwarded-proto");
+  } catch {
+    // headers() throws outside a request scope (background job / unit test).
+    // There is no Host header to read, so fall back to explicit config only —
+    // the pre-existing behavior. The Host fallback applies only to the
+    // request-scoped pairing actions, which is exactly where it is needed.
+  }
+  return deriveFederationAuthorityUrl({ configuredBaseUrl, host, forwardedProto });
+}

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -5,6 +5,24 @@ shares a deliberately minimized demand envelope; it never exposes or co-writes
 the source backlog. The source installation decides which item can travel over
 which connection and may withdraw that projection independently.
 
+## How an installation advertises its own address
+
+When you invite or connect to a peer, this installation tells the peer the
+address to reach it at. That address is resolved automatically — the operator
+does not type it:
+
+1. If `PUBLIC_URL` (or `NEXT_PUBLIC_*`) is configured it is used — the correct
+   choice for a reverse-proxy or public deployment.
+2. Otherwise the address is taken from the **request host** — the address you
+   used to open the Connections page. Opening
+   `http://192.168.0.152:3000/platform/federation-links` advertises
+   `http://192.168.0.152:3000`, which is exactly what a same-network peer can
+   reach. (The container's own network address cannot be used: inside the portal
+   container it is the Docker bridge address, not the reachable LAN address.)
+
+So a same-organization LAN pairing needs no typed URL — open the Connections
+page at the installation's LAN address and pair.
+
 ## Same-company installations
 
 Approved `same-organization` connections synchronize share-safe platform demand


### PR DESCRIPTION
## What

The three federation pairing actions (invite / connect / enroll) no longer require `PUBLIC_URL` to be typed. A new `resolveLocalFederationAuthorityUrl()` derives the address this installation advertises to a peer:

1. explicit `PUBLIC_URL` / `NEXT_PUBLIC_*` (reverse-proxy / public deployment) wins, else
2. the **request Host header** — the address the operator opened the Connections page at, which for a same-org LAN is the reachable LAN address, else
3. `null` (clear error).

## Why

Previously these actions called `resolveAppBaseUrl()`, which returns `null` in production unless `PUBLIC_URL` is set — so a same-organization LAN operator hit *"base URL is not configured (set APP_URL)"* and pairing failed. Requiring a hand-typed URL is exactly the manual step the zero-shell pairing work is removing.

`os.networkInterfaces()` can't be used: inside the portal container it yields the Docker bridge IP (172.x), not the host's reachable LAN IP. The **request host is the address the browser actually reached us on**, so it is correct by construction and needs no typing.

## Scope

First of three zero-typing pairing increments (self-address). Follow-ups: (2) scoped same-org/private-LAN outbound allowance so the http peer POST isn't SSRF-blocked without the flag — carefully scoped + regression-tested; (3) pairing enables exchange.

## Safety

`headers()` throws outside a request scope (background jobs / unit tests); `resolveLocalFederationAuthorityUrl()` catches that and falls back to explicit config only, preserving prior behavior. The Host fallback applies solely inside the request-scoped pairing actions.

## Tests

- `self-authority.test.ts` — 7 cases for the pure `deriveFederationAuthorityUrl` (config precedence, Host fallback, x-forwarded-proto, comma-list proto, trailing slash, null, empty-config).
- Full `lib/actions` suite green (1338 passed) including the pairing actions that call these outside a request scope.
- Local-CI gate: passed.

## Design grounding

Source of truth: `docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md` + EP-MSP-FEDERATION enroll self-advertisement. Changes only how the self URL is resolved; no schema, contract, or route change. Operator doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)