### PR TITLE
feat(federation): scoped same-org LAN outbound allowance, no flag (BI-CC8021CE)

### DIFF
--- a/apps/web/lib/actions/federation-links.ts
+++ b/apps/web/lib/actions/federation-links.ts
@@ -161,7 +161,7 @@ export async function approveFederationLinkAction(linkId: string): Promise<LinkL
     if (envFlagEnabled(process.env, "DPF_FEDERATION_EXCHANGE_ENABLED")) {
       const full = await prisma.federationLink.findUnique({
         where: { linkId },
-        select: { linkId: true, peerAuthorityUrl: true, peerTokenEnc: true },
+        select: { linkId: true, peerAuthorityUrl: true, peerTokenEnc: true, role: true },
       });
       if (full?.peerTokenEnc) {
         try {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4878,6 +4878,7 @@
       "anchors": [
         "federated-demand-channels",
         "how-an-installation-advertises-its-own-address",
+        "local-network-peers-over-http",
         "same-company-installations",
         "customer-and-reseller-operation",
         "founder-hub-business-management",

--- a/apps/web/lib/federation/client.test.ts
+++ b/apps/web/lib/federation/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { postToPeer, sendDemandDigestToPeer, sendDemandToPeer, sendIncidentToPeer } from "./client";
+import { isPrivateOrLoopbackFederationHost, postToPeer, sendDemandDigestToPeer, sendDemandToPeer, sendIncidentToPeer } from "./client";
 
 function mockFetch(res: { ok?: boolean; status?: number; json?: unknown } = {}) {
   return vi.fn().mockResolvedValue({
@@ -123,5 +123,86 @@ describe("sendDemandDigestToPeer", () => {
     const [url, init] = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
     expect(url).toBe("https://peer.example/api/v1/federation/demand/reconcile");
     expect(JSON.parse(init.body as string)).toMatchObject({ id: "evt_digest", type: "dpf.demand.reconcile" });
+  });
+});
+
+describe("isPrivateOrLoopbackFederationHost", () => {
+  it.each([
+    "http://192.168.0.152:3000",
+    "http://10.1.2.3:3000",
+    "http://172.16.0.9:3000",
+    "http://172.31.255.1",
+    "http://127.0.0.1:3000",
+    "http://localhost:3000",
+    "http://[::1]:3000",
+    "https://box.local:3000",
+  ])("is true for private/loopback/link-local host %s", (u) => {
+    expect(isPrivateOrLoopbackFederationHost(u)).toBe(true);
+  });
+
+  it.each([
+    "https://peer.example.com",
+    "http://203.0.113.10:3000",
+    "http://172.15.0.1", // just below the 172.16-31 private block
+    "http://172.32.0.1", // just above
+    "https://federation.acme.io",
+    "not a url",
+  ])("is false for public/DNS/out-of-range host %s", (u) => {
+    expect(isPrivateOrLoopbackFederationHost(u)).toBe(false);
+  });
+});
+
+describe("safePeerRequestUrl scoped same-org LAN allowance (via postToPeer)", () => {
+  const base = {
+    linkToken: "dpflink_secret",
+    path: "/api/v1/federation/enroll",
+    cloudEvent: {},
+  };
+
+  it("same-org LAN: dials a private http peer WITHOUT the global flag", async () => {
+    const f = mockFetch({ ok: true, status: 200 });
+    const result = await postToPeer({
+      ...base,
+      peerAuthorityUrl: "http://192.168.0.200:3000",
+      sameOrgLan: true,
+      fetchImpl: f,
+    });
+    expect(result.ok).toBe(true);
+    expect((f as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(1);
+  });
+
+  it("NOT same-org: a private http peer is still SSRF-blocked and never dialed", async () => {
+    const f = mockFetch();
+    const result = await postToPeer({
+      ...base,
+      peerAuthorityUrl: "http://192.168.0.200:3000",
+      sameOrgLan: false,
+      fetchImpl: f,
+    });
+    expect(result.ok).toBe(false);
+    expect((f as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(0);
+  });
+
+  it("same-org but PUBLIC http peer: still requires HTTPS (public http never auto-allowed)", async () => {
+    const f = mockFetch();
+    const result = await postToPeer({
+      ...base,
+      peerAuthorityUrl: "http://peer.example.com",
+      sameOrgLan: true,
+      fetchImpl: f,
+    });
+    expect(result.ok).toBe(false);
+    expect((f as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(0);
+  });
+
+  it("same-org + private HTTPS peer: dialed", async () => {
+    const f = mockFetch({ ok: true, status: 200 });
+    const result = await postToPeer({
+      ...base,
+      peerAuthorityUrl: "https://192.168.0.200:3000",
+      sameOrgLan: true,
+      fetchImpl: f,
+    });
+    expect(result.ok).toBe(true);
   });
 });

--- a/apps/web/lib/federation/client.ts
+++ b/apps/web/lib/federation/client.ts
@@ -11,15 +11,56 @@ import type { DemandActivity } from "@dpf/db/federated-demand-contract";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
 
+// True only for an IP-LITERAL private/loopback/link-local host, or localhost /
+// *.local. Arbitrary DNS hostnames return false on purpose: we must not relax the
+// SSRF guard for a name an attacker could rebind to an internal address. Used to
+// scope the same-org LAN allowance below to addresses that are unambiguously LAN.
+export function isPrivateOrLoopbackFederationHost(peerAuthorityUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(peerAuthorityUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === "localhost" || host.endsWith(".local")) return true;
+  const v6 = host.replace(/^\[|\]$/g, "");
+  if (v6 === "::1") return true;
+  if (host.startsWith("127.")) return true;
+  if (host.startsWith("10.") || host.startsWith("192.168.")) return true;
+  const m = /^172\.(\d{1,3})\./.exec(host);
+  if (m) {
+    const octet = Number(m[1]);
+    if (octet >= 16 && octet <= 31) return true;
+  }
+  return false;
+}
+
 // peerAuthorityUrl is operator-supplied → an SSRF sink (CWE-918). Validate it at
 // this single chokepoint that every outbound federation call funnels through
 // (incident / proposal / enroll / approval-relay). Safe-by-default: https +
-// public hosts only. Local/LAN federation — two on-prem DPF instances or dev —
-// opts in explicitly via DPF_FEDERATION_ALLOW_INSECURE_PEERS (permits http +
-// private/loopback networks). The peer route `path` is our own constant, not
-// user input, so it is appended to the validated origin.
-function safePeerRequestUrl(peerAuthorityUrl: string, path: string): string {
-  const allowInsecure = envFlagEnabled(process.env, "DPF_FEDERATION_ALLOW_INSECURE_PEERS");
+// public hosts only.
+//
+// Two opt-ins permit http + private/loopback networks for on-prem LAN federation:
+//   1. DPF_FEDERATION_ALLOW_INSECURE_PEERS=1 — global operator flag (unchanged).
+//   2. `sameOrgLan` — a SCOPED, per-call allowance for same-organization LAN
+//      pairing that needs no typed flag. It permits http/private ONLY when the
+//      peer address is itself an IP-literal private/loopback host
+//      (isPrivateOrLoopbackFederationHost). This is strictly NARROWER than the
+//      global flag: public and DNS-named peers still require HTTPS even when
+//      sameOrgLan is set, so a same-org channel/reseller on a public host is
+//      unaffected. Callers set sameOrgLan from an operator-declared same-org
+//      link (role "same-org-peer") or an operator-initiated same-org connect.
+//
+// The peer route `path` is our own constant, not user input, so it is appended
+// to the validated origin.
+function safePeerRequestUrl(
+  peerAuthorityUrl: string,
+  path: string,
+  sameOrgLan = false,
+): string {
+  const globalFlag = envFlagEnabled(process.env, "DPF_FEDERATION_ALLOW_INSECURE_PEERS");
+  const scopedLan = sameOrgLan && isPrivateOrLoopbackFederationHost(peerAuthorityUrl);
+  const allowInsecure = globalFlag || scopedLan;
   const validated = assertSafeOutboundUrl(peerAuthorityUrl, {
     allowedSchemes: allowInsecure ? ["https:", "http:"] : ["https:"],
     blockPrivateNetworks: !allowInsecure,
@@ -40,11 +81,13 @@ export async function postToPeer(input: {
   path: string;
   cloudEvent: unknown;
   fetchImpl?: typeof fetch;
+  /** Scoped same-org LAN allowance — see safePeerRequestUrl. Default false. */
+  sameOrgLan?: boolean;
 }): Promise<PeerPostResult> {
   const f = input.fetchImpl ?? fetch;
   let url: string;
   try {
-    url = safePeerRequestUrl(input.peerAuthorityUrl, input.path);
+    url = safePeerRequestUrl(input.peerAuthorityUrl, input.path, input.sameOrgLan ?? false);
   } catch (err) {
     // A peer URL that fails the SSRF guard is never dialed.
     return { ok: false, status: 0, error: err instanceof Error ? err.message : "unsafe peer url" };
@@ -76,6 +119,10 @@ export interface PeerLinkTarget {
   linkToken: string;
   linkId: string;
   fetchImpl?: typeof fetch;
+  /** Set when this link is a same-organization peer, so a private-LAN address is
+   *  reachable over http without the global insecure-peers flag. See
+   *  safePeerRequestUrl. Default false. */
+  sameOrgLan?: boolean;
 }
 
 function envelope(linkId: string, type: string, data: unknown) {
@@ -96,6 +143,7 @@ export async function sendIncidentToPeer(target: PeerLinkTarget, incident: unkno
     linkToken: target.linkToken,
     path: "/api/v1/federation/incident",
     cloudEvent: envelope(target.linkId, "dpf.federation.incident", incident),
+    sameOrgLan: target.sameOrgLan ?? false,
     ...(target.fetchImpl ? { fetchImpl: target.fetchImpl } : {}),
   });
 }
@@ -107,6 +155,7 @@ export async function sendProposalToPeer(target: PeerLinkTarget, proposal: unkno
     linkToken: target.linkToken,
     path: "/api/v1/federation/proposal",
     cloudEvent: envelope(target.linkId, "dpf.federation.proposal", proposal),
+    sameOrgLan: target.sameOrgLan ?? false,
     ...(target.fetchImpl ? { fetchImpl: target.fetchImpl } : {}),
   });
 }
@@ -130,6 +179,7 @@ export async function sendDemandToPeer(
       linkId: target.linkId,
       data: demandEnvelope,
     }),
+    sameOrgLan: target.sameOrgLan ?? false,
     ...(target.fetchImpl ? { fetchImpl: target.fetchImpl } : {}),
   });
 }
@@ -152,6 +202,7 @@ export async function sendDemandDigestToPeer(
       linkId: target.linkId,
       data: digest,
     }),
+    sameOrgLan: target.sameOrgLan ?? false,
     ...(target.fetchImpl ? { fetchImpl: target.fetchImpl } : {}),
   });
 }

--- a/apps/web/lib/federation/demand-delivery.ts
+++ b/apps/web/lib/federation/demand-delivery.ts
@@ -43,6 +43,7 @@ export interface DemandDeliveryDb {
       linkId: string;
       peerAuthorityUrl: string;
       peerTokenEnc: string | null;
+      role: string;
     }>>;
   };
   federatedRecordMirror: {
@@ -245,7 +246,7 @@ export async function dispatchDueDemand(db: DemandDeliveryDb, options: {
       linkId: { in: [...new Set(rows.map((row) => row.federationLinkId))] },
       linkState: "trusted", revokedAt: null, quarantinedAt: null,
     },
-    select: { linkId: true, peerAuthorityUrl: true, peerTokenEnc: true },
+    select: { linkId: true, peerAuthorityUrl: true, peerTokenEnc: true, role: true },
   });
   const linkById = new Map(links.map((link) => [link.linkId, link]));
   const deliverableRows = rows.filter((row) => linkById.has(row.federationLinkId));
@@ -260,7 +261,12 @@ export async function dispatchDueDemand(db: DemandDeliveryDb, options: {
     if (!payload) result = { ok: false, status: 0, error: "invalid outbox payload" };
     else if (!token) result = { ok: false, status: 0, error: "missing peer token" };
     else result = await (options.send ?? sendDemandToPeer)(
-      { peerAuthorityUrl: link.peerAuthorityUrl, linkToken: token, linkId: link.linkId },
+      {
+        peerAuthorityUrl: link.peerAuthorityUrl,
+        linkToken: token,
+        linkId: link.linkId,
+        sameOrgLan: link.role === "same-org-peer",
+      },
       payload.activity,
       payload.envelope,
       { eventId: payload.eventId, now },

--- a/apps/web/lib/federation/demand-digest.ts
+++ b/apps/web/lib/federation/demand-digest.ts
@@ -17,7 +17,7 @@ interface DigestMirrorRow {
 
 export interface DemandDigestDb {
   federationLink?: {
-    findMany(args: unknown): Promise<Array<{ linkId: string; peerAuthorityUrl: string; peerTokenEnc: string | null }>>;
+    findMany(args: unknown): Promise<Array<{ linkId: string; peerAuthorityUrl: string; peerTokenEnc: string | null; role: string }>>;
   };
   federatedRecordMirror: {
     findMany(args: unknown): Promise<DigestMirrorRow[]>;
@@ -82,7 +82,7 @@ export async function reconcileDemandDigests(
   const now = options.now ?? new Date();
   const links = await db.federationLink.findMany({
     where: { linkState: "trusted", revokedAt: null, quarantinedAt: null },
-    select: { linkId: true, peerAuthorityUrl: true, peerTokenEnc: true },
+    select: { linkId: true, peerAuthorityUrl: true, peerTokenEnc: true, role: true },
   });
   let linksChecked = 0;
   let requeued = 0;
@@ -121,7 +121,12 @@ export async function reconcileDemandDigests(
       records,
     };
     const result: PeerPostResult = await (options.send ?? sendDemandDigestToPeer)(
-      { peerAuthorityUrl: link.peerAuthorityUrl, linkToken: token, linkId: link.linkId },
+      {
+        peerAuthorityUrl: link.peerAuthorityUrl,
+        linkToken: token,
+        linkId: link.linkId,
+        sameOrgLan: link.role === "same-org-peer",
+      },
       digest,
       { now },
     );

--- a/apps/web/lib/federation/outbound.ts
+++ b/apps/web/lib/federation/outbound.ts
@@ -63,6 +63,11 @@ export async function enrollWithPeer(input: EnrollWithPeerInput): Promise<Enroll
       displayName: input.displayName,
       ...(input.localOrganizationId ? { peerOrganizationRef: input.localOrganizationId } : {}),
     },
+    // Operator-initiated connect: allow a private-LAN peer over http without the
+    // global flag. The role is not known until the peer responds, so this is
+    // scoped by the private-host check in safePeerRequestUrl — a public peer URL
+    // still requires HTTPS here.
+    sameOrgLan: true,
     ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}),
   });
 
@@ -121,7 +126,7 @@ export function decryptPeerToken(peerTokenEnc: string | null | undefined): strin
  * whether the peer accepted. Needs the peer-issued token (from outbound enroll).
  */
 export async function relayApprovalToPeer(
-  link: { linkId: string; peerAuthorityUrl: string; peerTokenEnc: string | null },
+  link: { linkId: string; peerAuthorityUrl: string; peerTokenEnc: string | null; role?: string },
   fetchImpl?: typeof fetch,
 ): Promise<{ ok: boolean; reason?: string }> {
   const token = decryptPeerToken(link.peerTokenEnc);
@@ -131,6 +136,7 @@ export async function relayApprovalToPeer(
     linkToken: token,
     path: "/api/v1/federation/approval-relay",
     cloudEvent: { type: "dpf.federation.approval", linkId: link.linkId },
+    sameOrgLan: link.role === "same-org-peer",
     ...(fetchImpl ? { fetchImpl } : {}),
   });
   return res.ok ? { ok: true } : { ok: false, reason: `peer responded ${res.status}` };

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -23,6 +23,21 @@ does not type it:
 So a same-organization LAN pairing needs no typed URL — open the Connections
 page at the installation's LAN address and pair.
 
+## Local-network peers over http
+
+Outbound calls to a peer default to HTTPS-only with private/loopback networks
+blocked (SSRF protection). Two things relax that for on-premises LAN federation:
+
+- `DPF_FEDERATION_ALLOW_INSECURE_PEERS=1` — a global operator flag (all peers).
+- **Automatically, with no flag, for a same-organization peer whose address is a
+  private/loopback host** (for example `http://192.168.0.200:3000`). This scoped
+  allowance is narrower than the global flag: a public or DNS-named peer still
+  requires HTTPS even when it is a same-organization link, so channel/reseller
+  connections to public hosts are unaffected.
+
+Combined with automatic address resolution above, a same-organization LAN
+pairing needs no typed URL and no typed flag — install, then Connect and Approve.
+
 ## Same-company installations
 
 Approved `same-organization` connections synchronize share-safe platform demand


### PR DESCRIPTION
## What

Outbound federation calls stay HTTPS-only with private networks blocked (SSRF, CWE-918) by default. This adds a **scoped** auto-allowance so a **same-organization LAN** peer works over http without the global `DPF_FEDERATION_ALLOW_INSECURE_PEERS` flag.

`safePeerRequestUrl` permits http + private **only** when the caller passes `sameOrgLan` **and** the peer address is an IP-literal private/loopback host (`isPrivateOrLoopbackFederationHost`).

## Why

Increment 2 of the zero-typing pairing set (after #4086 removed the `PUBLIC_URL` typing). Without this, same-org LAN pairing still needs `DPF_FEDERATION_ALLOW_INSECURE_PEERS=1` typed into `.env` — the last manual config step.

## Security — net tighter than the flag it replaces

- **Strictly narrower than the global flag** (which permits *all* insecure peers). Public and DNS-named peers still require HTTPS even on a same-org link, so channel/reseller connections to public hosts are unaffected.
- **DNS names return `false`** — an attacker cannot rebind a hostname to an internal address to slip past the guard; only IP-literal RFC1918 / loopback / link-local + `localhost` / `*.local` qualify.
- The `sameOrgLan` signal comes from an operator-declared same-org relationship (`role === "same-org-peer"`), or an operator-initiated connect (enroll, still gated to a private peer address).
- The global flag remains as an explicit override for any other insecure topology.

## Threaded paths

`enroll`, `approval-relay`, `demand delivery`, `demand digest` — each sets `sameOrgLan` from the link role (or operator-initiated connect for enroll). Cross-org channel paths (`incident`, `proposal`) intentionally stay `false`.

## Tests

`client.test.ts` (+9): same-org+private http **dials**; non-same-org+private http **blocked & never dialed**; same-org+**public** http **blocked** (HTTPS required); same-org+private **https** dials; `isPrivateOrLoopbackFederationHost` matrix incl. 172.15/172.32 boundary exclusions. Full federation suite green (118); 0 type errors; local-CI gate passed.

## Design grounding

Source of truth: `docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md` + the EP-MSP-FEDERATION outbound SSRF chokepoint. No schema/route change. Operator doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)