### PR TITLE
feat(coworker): roster opens the Coworker Identity 360 as the front door (EP-COWORKER-IDENTITY-360)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/overview/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/overview/page.test.tsx
@@ -102,7 +102,10 @@ describe("PlatformAiOverviewPage", () => {
     expect(html).toContain("Your team");
     expect(html).toContain("Supports the employee lifecycle.");
     expect(html).toContain("Acts with review");
-    expect(html).toContain("/platform/ai/agent/hr-specialist");
+    // EP-COWORKER-IDENTITY-360: a roster row now opens the coworker IDENTITY
+    // (/workforce/[agentId]) as its front door; the admin record is reached from
+    // there via "Manage".
+    expect(html).toContain("/workforce/hr-specialist");
   });
 
   it("describes an empty selectable roster honestly and offers a recovery path", async () => {

--- a/apps/web/components/platform/coworker-record/RosterView.test.tsx
+++ b/apps/web/components/platform/coworker-record/RosterView.test.tsx
@@ -187,7 +187,8 @@ describe("RosterView", () => {
     );
     document.removeEventListener("open-agent-panel", handler);
     expect(events[0]?.detail).toEqual({
-      routeContext: "/platform/ai/agent/marketing-specialist",
+      // EP-COWORKER-IDENTITY-360: Ask context is the coworker's identity route.
+      routeContext: "/workforce/marketing-specialist",
     });
   });
 

--- a/apps/web/components/platform/coworker-record/RosterView.tsx
+++ b/apps/web/components/platform/coworker-record/RosterView.tsx
@@ -408,8 +408,14 @@ function RosterRowCard({
   returnHref: string;
   grantedCapabilities: ReadonlySet<CapabilityKey>;
 }) {
-  const detailRoute = `/platform/ai/agent/${encodeURIComponent(row.agentId)}`;
-  const detailHref = `${detailRoute}?returnTo=${encodeURIComponent(returnHref)}`;
+  // EP-COWORKER-IDENTITY-360: the roster is the directory; a row opens the
+  // coworker's IDENTITY (peer to People/Customers), which deep-links to the admin
+  // record via "Manage". Setup/recovery still targets the admin record, where the
+  // configuration affordances live.
+  const identityRoute = `/workforce/${encodeURIComponent(row.agentId)}`;
+  const adminRoute = `/platform/ai/agent/${encodeURIComponent(row.agentId)}`;
+  const identityHref = `${identityRoute}?returnTo=${encodeURIComponent(returnHref)}`;
+  const adminHref = `${adminRoute}?returnTo=${encodeURIComponent(returnHref)}`;
   const canStartConversation = row.canStartConversation;
   const attention = needsAttention(row);
   const availabilityOwnsAttention =
@@ -417,7 +423,7 @@ function RosterRowCard({
     row.availability.state === "needs-attention";
   const recovery = availabilityRecoveryTarget(
     row.availability,
-    detailHref,
+    adminHref,
     grantedCapabilities,
   );
 
@@ -471,7 +477,7 @@ function RosterRowCard({
       <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
         {canStartConversation && (
           <AskCoworkerButton
-            routeContext={detailRoute}
+            routeContext={identityRoute}
             label={`Ask ${row.displayName}`}
             className="inline-flex min-h-11 items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 text-sm font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] hover:opacity-90"
           >
@@ -489,7 +495,7 @@ function RosterRowCard({
           </Link>
         )}
         <Link
-          href={detailHref}
+          href={identityHref}
           className="inline-flex min-h-11 items-center gap-1 rounded-md px-2 text-sm font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
         >
           View coworker


### PR DESCRIPTION
## What & why

Finish-Phase-1 wiring for `EP-COWORKER-IDENTITY-360`: an **AI Workforce Directory** row now opens the coworker's **identity** (`/workforce/[agentId]`) — the peer-to-People/Customers surface shipped in #4085 — instead of the platform-admin record. The admin record is still reached from the identity via **Manage**, and setup/recovery on a not-ready coworker still targets the admin record (where configuration lives).

- `RosterView` row **View coworker** link + Ask context → `/workforce/[agentId]`
- recovery/setup link → `/platform/ai/agent/[agentId]` (unchanged)
- overview page test asserts the new identity front-door href

## Verification

- `apps/web/app/(shell)/platform/ai/overview/page.test.tsx` — 2/2 pass.
- UX-Fit: `check-ux-fit-decision.mjs` → **nothing to gate** (changes link targets on existing controls; no new control/route).
- Style-drift + prose-lint: clean.

## Design grounding

Extends `docs/superpowers/specs/2026-08-06-coworker-identity-360-hub-design.md` §4.2 (roster is the directory; the identity is the front door). **No nav-model re-domiciling here** — the AI Workforce directory is already a top-level nav area; moving it into the *business* domain beside People/Customers is a deliberate IA decision left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)