### PR TITLE
fix(federation): refuse advertising a loopback self-address to a remote peer (BI-CC8021CE)

### DIFF
--- a/apps/web/lib/actions/federation-links.ts
+++ b/apps/web/lib/actions/federation-links.ts
@@ -21,7 +21,10 @@ import {
 } from "@dpf/db/federation-link-types";
 import { isPartnerStanding, type PartnerStanding } from "@dpf/db/federated-channel";
 
-import { resolveLocalFederationAuthorityUrl } from "@/lib/federation/self-authority";
+import {
+  resolveLocalFederationAuthorityUrl,
+  selfAuthorityUnreachableReason,
+} from "@/lib/federation/self-authority";
 import { auth } from "@/lib/auth";
 import { resolveFederationIdentity } from "@/lib/federation/demand-identity";
 import {
@@ -363,6 +366,13 @@ export async function enrollWithPeerAction(input: {
   if (!localAuthorityUrl) {
     return { ok: false, error: "internal_error", message: "could not determine this installation's address to advertise to the peer" };
   }
+  const unreachable = selfAuthorityUnreachableReason({
+    selfAuthorityUrl: localAuthorityUrl,
+    peerAuthorityUrl: input.peerAuthorityUrl.trim(),
+  });
+  if (unreachable) {
+    return { ok: false, error: "invalid_input", message: unreachable };
+  }
   try {
     const result = await enrollWithPeer({
       peerAuthorityUrl: input.peerAuthorityUrl.trim(),
@@ -413,6 +423,13 @@ export async function startNearbyPairingAction(input: {
   const localAuthorityUrl = await resolveLocalFederationAuthorityUrl();
   if (!localAuthorityUrl) {
     return { ok: false, error: "internal_error", message: "could not determine this installation's address to advertise to the peer" };
+  }
+  const unreachable = selfAuthorityUnreachableReason({
+    selfAuthorityUrl: localAuthorityUrl,
+    peerAuthorityUrl: candidate.endpoint,
+  });
+  if (unreachable) {
+    return { ok: false, error: "invalid_input", message: unreachable };
   }
   try {
     await assertEncryptionReadyForCredentialWrite();

--- a/apps/web/lib/federation/self-authority.test.ts
+++ b/apps/web/lib/federation/self-authority.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { deriveFederationAuthorityUrl } from "./self-authority";
+import { deriveFederationAuthorityUrl, isLoopbackAuthorityHost, selfAuthorityUnreachableReason } from "./self-authority";
 
 describe("deriveFederationAuthorityUrl", () => {
   it("explicit configured base URL wins over the request host", () => {
@@ -71,5 +71,50 @@ describe("deriveFederationAuthorityUrl", () => {
         forwardedProto: null,
       }),
     ).toBe("http://10.0.0.5:3000");
+  });
+});
+
+describe("isLoopbackAuthorityHost", () => {
+  it.each(["http://localhost:3000", "http://127.0.0.1:3000", "http://127.5.5.5", "http://[::1]:3000"])(
+    "is true for loopback host %s",
+    (u) => expect(isLoopbackAuthorityHost(u)).toBe(true),
+  );
+  it.each([
+    "http://192.168.0.152:3000",
+    "http://10.0.0.4:3000",
+    "http://172.16.0.9:3000",
+    "https://peer.example.com",
+    "not a url",
+  ])("is false for LAN/public/invalid host %s", (u) =>
+    expect(isLoopbackAuthorityHost(u)).toBe(false),
+  );
+});
+
+describe("selfAuthorityUnreachableReason", () => {
+  it("refuses a loopback self-URL advertised to a remote LAN peer", () => {
+    const reason = selfAuthorityUnreachableReason({
+      selfAuthorityUrl: "http://localhost:3000",
+      peerAuthorityUrl: "http://192.168.0.152:3000",
+    });
+    expect(reason).toContain("http://localhost:3000");
+    expect(reason).toContain("LAN address");
+  });
+
+  it("allows a loopback self-URL when the peer is also loopback (same-host dev)", () => {
+    expect(
+      selfAuthorityUnreachableReason({
+        selfAuthorityUrl: "http://localhost:3000",
+        peerAuthorityUrl: "http://127.0.0.1:4000",
+      }),
+    ).toBeNull();
+  });
+
+  it("allows a LAN self-URL advertised to a remote peer (the good case)", () => {
+    expect(
+      selfAuthorityUnreachableReason({
+        selfAuthorityUrl: "http://192.168.0.200:3000",
+        peerAuthorityUrl: "http://192.168.0.152:3000",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/lib/federation/self-authority.ts
+++ b/apps/web/lib/federation/self-authority.ts
@@ -45,6 +45,42 @@ export function deriveFederationAuthorityUrl(args: {
   return null;
 }
 
+/** True for a loopback host — localhost, 127.0.0.0/8, or ::1. A private LAN
+ *  address (192.168.x, 10.x, 172.16-31.x) is NOT loopback: it is reachable by a
+ *  peer on the same network, so it is a valid self-address to advertise. */
+export function isLoopbackAuthorityHost(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === "localhost") return true;
+  if (host.replace(/^\[|\]$/g, "") === "::1") return true;
+  return host.startsWith("127.");
+}
+
+/** Guard the self-address we are about to advertise to a peer. A loopback
+ *  self-URL is unreachable from any OTHER host, so advertising it to a remote
+ *  (non-loopback) peer silently breaks the link — the peer records our address
+ *  as its own localhost. We allow a loopback self-URL only when the peer is also
+ *  loopback (both instances on one host — legitimate dev). Returns an operator-
+ *  facing reason string when the pairing must be refused, else null. */
+export function selfAuthorityUnreachableReason(args: {
+  selfAuthorityUrl: string;
+  peerAuthorityUrl: string;
+}): string | null {
+  const { selfAuthorityUrl, peerAuthorityUrl } = args;
+  if (!isLoopbackAuthorityHost(selfAuthorityUrl)) return null;
+  if (isLoopbackAuthorityHost(peerAuthorityUrl)) return null; // both on one host
+  return (
+    `This installation resolved its own address as ${selfAuthorityUrl}, which the ` +
+    `peer at ${peerAuthorityUrl} cannot reach. Open this page at this installation's ` +
+    `LAN address (for example http://192.168.x.x:3000) — the address you view it at ` +
+    `is what the peer is told to use — or set PUBLIC_URL, then reconnect.`
+  );
+}
+
 /** Resolve this install's federation Authority URL for enroll/invite/connect.
  *  Must be called from a request scope (server action / route) so the Host
  *  header is available. Returns null only when neither config nor a Host header

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -23,6 +23,13 @@ does not type it:
 So a same-organization LAN pairing needs no typed URL — open the Connections
 page at the installation's LAN address and pair.
 
+Because the address is taken from how you reached the page, **open it at the LAN
+address, not `localhost`** — the address you view it at is exactly what the peer
+is told to use. As a safety net, connecting is refused with a clear message if
+this installation would advertise a loopback address (`localhost` / `127.x` /
+`::1`) to a peer on a different host, since the peer could never reach it. Two
+instances on one host may still pair over loopback.
+
 ## Local-network peers over http
 
 Outbound calls to a peer default to HTTPS-only with private/loopback networks


### PR DESCRIPTION
## What

`enrollWithPeerAction` and the nearby-pairing action now refuse to pair when this installation's auto-derived self-address is a loopback host (`localhost` / `127.x` / `::1`) **and** the peer is on a different host, with an operator-facing message to open the page at the LAN address (or set `PUBLIC_URL`) and retry.

## Why

The self-address is derived from the request Host (PR #4086). If the operator opens the Connections page at `http://localhost:3000` instead of the LAN address, the box silently advertises `localhost` — and the peer records **its own** localhost as our address, so approval-relay and demand delivery dial the wrong host and the link never functions.

**Observed live:** a real pairing produced `peerAuthorityUrl = http://localhost:3000` on the inviter, from the connector advertising localhost. No error surfaced — the link just sat dead. This turns that silent misconfiguration into a clear, actionable refusal.

## Scope

- Loopback → **loopback** peer is still allowed (two instances on one host — legitimate same-host dev).
- A LAN self-address (`192.168.x` / `10.x` / `172.16-31.x`) is reachable by a same-network peer and is always allowed — only true loopback is refused.

## Tests

`self-authority.test.ts` (+7): `isLoopbackAuthorityHost` matrix (loopback true; LAN/public/invalid false) and `selfAuthorityUnreachableReason` (refuses loopback→remote; allows loopback→loopback and LAN→remote). Full self-authority + pairing-action suites green; 0 type errors; local-CI gate passed.

## Design grounding

Source of truth: `docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md`. Hardens the #4086 auto-address resolution; no schema/route change. Operator doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)