### PR TITLE
fix(federation): mutual-token enrollment — both sides reach trusted + demand flows both ways (BI-CC8021CE)

### DIFF
--- a/apps/web/app/api/v1/federation/enroll/route.ts
+++ b/apps/web/app/api/v1/federation/enroll/route.ts
@@ -56,6 +56,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ...(parsed.data.localOrganizationId !== undefined
       ? { localOrganizationId: parsed.data.localOrganizationId }
       : {}),
+    ...(parsed.data.callbackToken !== undefined
+      ? { callbackToken: parsed.data.callbackToken }
+      : {}),
     ...(parsed.data.metadata !== undefined ? { metadata: parsed.data.metadata } : {}),
   });
 

--- a/apps/web/lib/federation/enrollment-mutual-token.test.ts
+++ b/apps/web/lib/federation/enrollment-mutual-token.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mutual-token half of the enroll handshake: when the connecting peer supplies a
+// callbackToken, the inviter stores it as ITS outbound token (peerTokenEnc) so it
+// can relay approval + push demand back. Absent → one-directional (peerTokenEnc null).
+
+const captured: { data?: Record<string, unknown> } = {};
+
+const mockTx = {
+  federationBootstrapToken: { update: vi.fn().mockResolvedValue({}) },
+  principal: { create: vi.fn().mockResolvedValue({ id: "principal-row-1" }) },
+  principalAlias: { create: vi.fn().mockResolvedValue({}) },
+  federationLink: {
+    create: vi.fn().mockImplementation((args: { data: Record<string, unknown> }) => {
+      captured.data = args.data;
+      return Promise.resolve({ id: "link-row-1" });
+    }),
+  },
+};
+
+const findUnique = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    federationBootstrapToken: { findUnique: (...a: unknown[]) => findUnique(...a) },
+    $transaction: (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx),
+  },
+}));
+
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  encryptSecret: (plain: string) => `enc(${plain})`,
+}));
+
+import { generateFederationBootstrapToken, hashToken } from "./tokens";
+import { enrollFederationLink } from "./enrollment";
+
+const bootstrap = generateFederationBootstrapToken();
+
+function validTokenRow() {
+  return {
+    id: "bt-1",
+    tokenHash: hashToken(bootstrap.plaintext),
+    consumedAt: null,
+    revokedAt: null,
+    expiresAt: new Date(Date.now() + 60_000),
+    offeredRole: "same-org-peer",
+    proposedProjection: null,
+    proposedAuthorityBand: null,
+  };
+}
+
+describe("enrollFederationLink — mutual callback token", () => {
+  beforeEach(() => {
+    captured.data = undefined;
+    findUnique.mockReset().mockResolvedValue(validTokenRow());
+    mockTx.federationLink.create.mockClear();
+  });
+
+  it("stores the connector's callbackToken as the inviter's outbound token", async () => {
+    const res = await enrollFederationLink({
+      bootstrapToken: bootstrap.plaintext,
+      peerAuthorityUrl: "http://192.168.0.152:3000",
+      displayName: "Mac",
+      callbackToken: "dpflink_callback_from_connector",
+    });
+    expect(res.ok).toBe(true);
+    // The inviter can now call the connector back.
+    expect(captured.data?.peerTokenEnc).toBe("enc(dpflink_callback_from_connector)");
+    // And it still issues its own inbound token for the connector to use.
+    expect(typeof captured.data?.tokenHash).toBe("string");
+  });
+
+  it("leaves peerTokenEnc null when no callbackToken is supplied (older connector)", async () => {
+    const res = await enrollFederationLink({
+      bootstrapToken: bootstrap.plaintext,
+      peerAuthorityUrl: "http://192.168.0.152:3000",
+      displayName: "Mac",
+    });
+    expect(res.ok).toBe(true);
+    expect(captured.data?.peerTokenEnc).toBeNull();
+  });
+});

--- a/apps/web/lib/federation/enrollment.ts
+++ b/apps/web/lib/federation/enrollment.ts
@@ -24,6 +24,8 @@ import {
   type FederationRole,
 } from "@dpf/db/federation-link-types";
 
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+
 import {
   classifyFederationToken,
   computeFederationBootstrapExpiry,
@@ -77,6 +79,10 @@ export interface EnrollFederationInput {
   peerOrganizationRef?: string | null;
   localOrganizationId?: string | null;
   displayName: string;
+  /** The connecting peer's inbound link token. When present we store it as our
+   *  outbound token (peerTokenEnc) so we can relay our approval and push demand
+   *  back to them — the mutual half of the handshake. */
+  callbackToken?: string | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -165,6 +171,10 @@ export async function enrollFederationLink(
         tokenHash: linkToken.hash,
         tokenPrefix: linkToken.prefix,
         tokenRotatedAt: now,
+        // Mutual handshake: the connector's inbound token becomes OUR outbound
+        // token, so the inviter can relay its approval and push demand back.
+        // Absent (older connector) → one-directional link, as before.
+        peerTokenEnc: input.callbackToken ? encryptSecret(input.callbackToken) : null,
         enrolledAt: now,
         metadata: {
           ...(input.metadata ?? {}),

--- a/apps/web/lib/federation/federation-outbound.test.ts
+++ b/apps/web/lib/federation/federation-outbound.test.ts
@@ -104,4 +104,14 @@ describe("enrollWithPeer (error paths, no prisma)", () => {
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toBe("invalid_peer_response");
   });
+
+  it("sends its own callbackToken in the enroll body (mutual handshake)", async () => {
+    // Peer rejects → returns before prisma, but the body was still sent.
+    const f = mockFetch({ ok: false, status: 401, json: { ok: false } });
+    await enrollWithPeer({ ...base, fetchImpl: f });
+    const [, init] = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    const sent = JSON.parse(init.body as string) as { callbackToken?: string };
+    expect(typeof sent.callbackToken).toBe("string");
+    expect(sent.callbackToken!.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/lib/federation/outbound.ts
+++ b/apps/web/lib/federation/outbound.ts
@@ -22,6 +22,7 @@ import {
 import { decryptSecret, encryptSecret } from "@/lib/govern/credential-crypto";
 
 import { postToPeer } from "./client";
+import { generateLinkToken } from "./tokens";
 
 export interface EnrollWithPeerInput {
   /** The peer Authority Core base URL. */
@@ -52,6 +53,12 @@ interface PeerEnrollResponse {
 }
 
 export async function enrollWithPeer(input: EnrollWithPeerInput): Promise<EnrollWithPeerResult> {
+  // Our own inbound token, minted here and sent to the inviter as the callback
+  // token. The inviter stores it as ITS outbound token, so it can relay approval
+  // and push demand back to us — the mutual half of the handshake. We keep its
+  // hash to authenticate the inviter's inbound calls.
+  const callback = generateLinkToken();
+
   // Reuse the generic peer-POST. The enroll body fields are from the RECEIVER's
   // POV, so we send OUR url/org as the "peer" the receiver records.
   const res = await postToPeer({
@@ -61,6 +68,7 @@ export async function enrollWithPeer(input: EnrollWithPeerInput): Promise<Enroll
     cloudEvent: {
       peerAuthorityUrl: input.localAuthorityUrl,
       displayName: input.displayName,
+      callbackToken: callback.plaintext,
       ...(input.localOrganizationId ? { peerOrganizationRef: input.localOrganizationId } : {}),
     },
     // Operator-initiated connect: allow a private-LAN peer over http without the
@@ -104,8 +112,13 @@ export async function enrollWithPeer(input: EnrollWithPeerInput): Promise<Enroll
         peerOrganizationRef: input.peerOrganizationRef ?? null,
         localOrganizationId: input.localOrganizationId ?? null,
         linkState: "pending",
-        // Outbound token (peer-issued) encrypted at rest; no inbound token here.
+        // Outbound token (peer-issued) encrypted at rest, so we can call them.
         peerTokenEnc: encryptSecret(body.linkToken!),
+        // Our inbound token (the callback we sent): authenticates the inviter's
+        // calls back to us (approval relay + demand push).
+        tokenHash: callback.hash,
+        tokenPrefix: callback.prefix,
+        tokenRotatedAt: now,
         enrolledAt: now,
       },
     });

--- a/apps/web/lib/federation/wire-contract.ts
+++ b/apps/web/lib/federation/wire-contract.ts
@@ -12,6 +12,10 @@ export const FederationEnrollBody = z.object({
   localOrganizationId: z.string().min(1).max(200).optional(),
   /** Operator-set display name for the peer (shown in the links admin). */
   displayName: z.string().min(1).max(200),
+  /** The connecting peer's OWN inbound link token, so the inviter can call it
+   *  back (approval relay + demand push). Optional for backward compatibility:
+   *  an older connector omits it and the link stays one-directional. */
+  callbackToken: z.string().min(1).max(400).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -53,6 +53,12 @@ new eligible work and later source updates become visible to the other internal
 installations without another sharing click. This is the normal pattern for a
 company operating separate Mac, Windows, development, or test installations.
 
+Both directions work because enrollment is a **mutual** exchange: each side issues
+the other an inbound link token, so either box can relay its approval and push
+demand to the other. This is what lets a link reach `trusted` on **both** sides
+(not just the inviter) and demand flow each way — a one-directional token exchange
+would leave the connecting side stuck at `pending`.
+
 This is not multi-master backlog replication. Each source backlog item remains
 single-writer authoritative. A peer receives a versioned mirror that it can
 follow, respond to, or adopt as separately owned local work. Status, priority,


### PR DESCRIPTION
## What

Enrollment is now a **mutual** token exchange. The connecting box mints its own inbound link token and sends it in the enroll body (`callbackToken`); the inviter stores it as its outbound token. Both links end up with **both** an inbound token (`tokenHash`) and an outbound token (`peerTokenEnc`), so each side can call the other.

## Why — a real bug, seen live

Same-org bidirectional pairing could **never complete on the connecting side**. The old handshake was one-directional: the inviter issued the connector a token (connector→inviter works), but got nothing back. So the inviter had no token to (a) relay its approval to the connector or (b) push demand to it.

Observed on two real boxes: inviter shows `trusted`, **connector stuck `pending` forever** (its `approvedAtPeer` can only be set by an inbound relay the inviter can't make), and **no demand crosses either way**.

## How the fix completes trust

- Connector mints token → sends as `callbackToken` → stores its hash as the connector link's `tokenHash`.
- Inviter stores `callbackToken` as `peerTokenEnc`.
- The existing approval-relay and demand-delivery paths already fire whenever `peerTokenEnc` is present — which the inviter now has — so **no change** to those paths. Both approvals relay → link `trusted` on both sides; demand delivers both ways.

## Backward compatible

An older connector omits `callbackToken` → the inviter leaves `peerTokenEnc` null and the link degrades to the prior one-directional behavior. New↔old and old↔new both keep working.

## Tests

`enrollment-mutual-token.test.ts` (inviter stores callbackToken as peerTokenEnc; null when absent), `federation-outbound.test.ts` (connector sends callbackToken in the body). Full federation suite green (138); 0 type errors; local-CI gate passed.

## Follow-up (not this PR)

This is the bilateral-trust **substrate**. A discovery-based front end (LAN short-code / hub-mediated) that retires the manual invite/paste/approve flow sits on top and is tracked separately.

## Design grounding

Source of truth: `docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md` + EP-MSP-FEDERATION dual-approval handshake. Operator doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)