### PR TITLE
fix(federation): widen demand mirror version to BigInt — demand never crossed (BI-CC8021CE)

### DIFF
--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -70,7 +70,7 @@ export interface ChannelDemandDb extends FederationIdentityDb, DemandDeliveryDb 
     upsert(args: unknown): Promise<unknown>;
   };
   federatedRecordMirror: DemandDeliveryDb["federatedRecordMirror"] & {
-    findUnique(args: unknown): Promise<(ChannelMirror & { version: number }) | null>;
+    findUnique(args: unknown): Promise<(ChannelMirror & { version: bigint }) | null>;
   };
 }
 

--- a/apps/web/lib/federation/demand-delivery.ts
+++ b/apps/web/lib/federation/demand-delivery.ts
@@ -31,7 +31,7 @@ interface DemandOutboxRow {
   mirrorId: string;
   federationLinkId: string;
   canonicalSide?: string;
-  version: number;
+  version: bigint;
   syncStatus: string;
   deliveryAttempts: number;
   payload: unknown;
@@ -47,7 +47,7 @@ export interface DemandDeliveryDb {
     }>>;
   };
   federatedRecordMirror: {
-    findUnique(args: unknown): Promise<Partial<DemandOutboxRow> & { mirrorId: string; version: number; syncStatus: string; payload: unknown } | null>;
+    findUnique(args: unknown): Promise<Partial<DemandOutboxRow> & { mirrorId: string; version: bigint; syncStatus: string; payload: unknown } | null>;
     findMany(args: unknown): Promise<DemandOutboxRow[]>;
     create(args: unknown): Promise<unknown>;
     update(args: unknown): Promise<unknown>;
@@ -98,7 +98,7 @@ export async function queueDemandProjection(db: DemandDeliveryDb, input: {
   const existing = await db.federatedRecordMirror.findUnique({ where });
   const prior = decodeDemandOutboxPayload(existing?.payload);
   if (existing && prior?.envelope.payloadDigest === built.envelope.payloadDigest) {
-    return { action: "noop", mirrorId: existing.mirrorId, originVersion: existing.version };
+    return { action: "noop", mirrorId: existing.mirrorId, originVersion: Number(existing.version) };
   }
 
   const activity: OutboundDemandActivity = existing ? "dpf.demand.updated" : "dpf.demand.proposed";
@@ -147,7 +147,7 @@ export async function queueForwardedDemand(db: DemandDeliveryDb, input: {
   const existing = await db.federatedRecordMirror.findUnique({ where });
   const prior = decodeDemandOutboxPayload(existing?.payload);
   if (existing && prior?.envelope.payloadDigest === input.envelope.payloadDigest) {
-    return { action: "noop", mirrorId: existing.mirrorId, originVersion: existing.version };
+    return { action: "noop", mirrorId: existing.mirrorId, originVersion: Number(existing.version) };
   }
   const activity: OutboundDemandActivity = existing ? "dpf.demand.updated" : "dpf.demand.proposed";
   const payload: DemandOutboxPayload = {
@@ -197,7 +197,7 @@ export async function queueDemandWithdrawal(
   }
   const envelope: DemandEnvelopeV1 = {
     ...prior.envelope,
-    originVersion: Math.max(existing.version + 1, now.getTime()),
+    originVersion: Math.max(Number(existing.version) + 1, now.getTime()),
     updatedAt: now.toISOString(),
     payloadDigest: "sha256:pending",
   };
@@ -284,7 +284,7 @@ export async function dispatchDueDemand(db: DemandDeliveryDb, options: {
         ? (result.body as { noticeId?: unknown }).noticeId === noticeId
         : responseId
         ? (result.body as { responseId?: unknown }).responseId === responseId
-        : Number((result.body as { originVersion?: unknown }).originVersion) === row.version);
+        : Number((result.body as { originVersion?: unknown }).originVersion) === Number(row.version));
     if (acknowledged) {
       delivered++;
       await db.federatedRecordMirror.update({ where: { mirrorId: row.mirrorId }, data: {

--- a/apps/web/lib/federation/demand-digest.ts
+++ b/apps/web/lib/federation/demand-digest.ts
@@ -10,7 +10,7 @@ interface DigestMirrorRow {
   mirrorId?: string;
   federationLinkId?: string;
   peerRecordRef?: string | null;
-  version: number;
+  version: bigint;
   syncStatus: string;
   payload: unknown;
 }
@@ -52,13 +52,13 @@ export async function compareIncomingDemandDigest(
       needs.push({ originRecordRef: record.originRecordRef, reason: "missing" });
       continue;
     }
-    if (row.version < record.originVersion) {
-      needs.push({ originRecordRef: record.originRecordRef, reason: "stale", haveVersion: row.version });
+    if (Number(row.version) < record.originVersion) {
+      needs.push({ originRecordRef: record.originRecordRef, reason: "stale", haveVersion: Number(row.version) });
       continue;
     }
     const payload = decodeDemandMirrorPayload(row.payload);
-    if (row.version === record.originVersion && payload?.envelope.payloadDigest !== record.payloadDigest) {
-      needs.push({ originRecordRef: record.originRecordRef, reason: "digest-mismatch", haveVersion: row.version });
+    if (Number(row.version) === record.originVersion && payload?.envelope.payloadDigest !== record.payloadDigest) {
+      needs.push({ originRecordRef: record.originRecordRef, reason: "digest-mismatch", haveVersion: Number(row.version) });
     }
   }
   return { checked: digest.records.length, needs };

--- a/apps/web/lib/federation/demand-disposition.ts
+++ b/apps/web/lib/federation/demand-disposition.ts
@@ -76,8 +76,8 @@ export async function queueFounderDispositionNotices(
       localRecordRef,
     } };
     const existing = await db.federatedRecordMirror.findUnique({ where });
-    const version = existing ? existing.version + 1 : 1;
-    if (version > 2_147_483_647) throw new Error("Demand disposition version is exhausted.");
+    const version = existing ? Number(existing.version) + 1 : 1;
+    if (version > Number.MAX_SAFE_INTEGER) throw new Error("Demand disposition version is exhausted.");
     const data = {
       syncStatus: "pending",
       version,

--- a/apps/web/lib/federation/demand-exchange.test.ts
+++ b/apps/web/lib/federation/demand-exchange.test.ts
@@ -76,11 +76,33 @@ describe("handleIncomingDemand", () => {
     });
   });
 
+  it("passes a millisecond-epoch originVersion through without truncation (BigInt column — BI-CC8021CE)", async () => {
+    // originVersion derives from the source updatedAt epoch in ms (~1.7e12), which
+    // exceeds Int (int4, max 2,147,483,647). The mirror.version column is BigInt;
+    // create must receive the value unchanged. Before the fix this overflowed with
+    // P2020 and NO demand mirror was ever written across a link.
+    const msEpochVersion = 1_784_544_648_695;
+    expect(msEpochVersion).toBeGreaterThan(2_147_483_647);
+    const { db, create } = demandDb(null);
+
+    const result = await handleIncomingDemand(
+      db,
+      "link_1",
+      "dpf.demand.proposed",
+      envelope({ originVersion: msEpochVersion }),
+    );
+
+    expect(result).toMatchObject({ action: "created", originVersion: msEpochVersion });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ version: msEpochVersion }) }),
+    );
+  });
+
   it("noops an exact retry without writing again", async () => {
     const current = envelope();
     const { db, create, updateMany } = demandDb({
       mirrorId: "fdm_1",
-      version: 1,
+      version: 1n,
       syncStatus: "synced",
       payload: { envelope: current, activity: "dpf.demand.proposed", disposition: "observed" },
     });
@@ -97,7 +119,7 @@ describe("handleIncomingDemand", () => {
     const current = envelope();
     const { db, updateMany } = demandDb({
       mirrorId: "fdm_1",
-      version: 1,
+      version: 1n,
       syncStatus: "synced",
       payload: { envelope: current, activity: "dpf.demand.proposed", disposition: "observed" },
     });
@@ -117,7 +139,7 @@ describe("handleIncomingDemand", () => {
     const current = envelope({ originVersion: 3 });
     const { db, updateMany } = demandDb({
       mirrorId: "fdm_1",
-      version: 3,
+      version: 3n,
       syncStatus: "synced",
       payload: { envelope: current, activity: "dpf.demand.updated", disposition: "followed" },
     });
@@ -133,7 +155,7 @@ describe("handleIncomingDemand", () => {
     const current = envelope();
     const { db, updateMany } = demandDb({
       mirrorId: "fdm_1",
-      version: 1,
+      version: 1n,
       syncStatus: "synced",
       payload: { envelope: current, activity: "dpf.demand.proposed", disposition: "observed" },
     });
@@ -171,7 +193,7 @@ describe("received-demand decisions", () => {
       federationLinkId: "link_1",
       peerRecordRef: "inst_origin:ref_01",
       localRecordRef: null,
-      version: 1,
+      version: 1n,
       syncStatus: "synced",
       payload: {
         envelope: envelope(),

--- a/apps/web/lib/federation/demand-exchange.ts
+++ b/apps/web/lib/federation/demand-exchange.ts
@@ -28,7 +28,7 @@ export interface DemandMirrorRow {
   federationLinkId: string;
   peerRecordRef: string | null;
   localRecordRef: string | null;
-  version: number;
+  version: bigint;
   syncStatus: string;
   payload: unknown;
 }
@@ -143,22 +143,22 @@ export async function handleIncomingDemand(
 
   const current = decodeDemandMirrorPayload(existing.payload);
   if (
-    existing.version === envelope.originVersion
+    Number(existing.version) === envelope.originVersion
     && current?.envelope.payloadDigest === envelope.payloadDigest
     && current.activity === activity
   ) {
     return {
       action: "noop",
       mirrorId: existing.mirrorId,
-      originVersion: existing.version,
+      originVersion: Number(existing.version),
       disposition: current.disposition,
     };
   }
-  if (envelope.originVersion <= existing.version) {
+  if (envelope.originVersion <= Number(existing.version)) {
     return {
       action: "conflict",
       mirrorId: existing.mirrorId,
-      originVersion: existing.version,
+      originVersion: Number(existing.version),
       reason: "origin-version-not-advancing",
     };
   }
@@ -182,7 +182,7 @@ export async function handleIncomingDemand(
     return {
       action: "conflict",
       mirrorId: existing.mirrorId,
-      originVersion: existing.version,
+      originVersion: Number(existing.version),
       reason: "concurrent-update",
     };
   }

--- a/apps/web/lib/federation/demand-read-model.test.ts
+++ b/apps/web/lib/federation/demand-read-model.test.ts
@@ -41,7 +41,7 @@ describe("mapNetworkDemandRows", () => {
     const rows = mapNetworkDemandRows([{
       mirrorId: "fdm_1",
       syncStatus: "synced",
-      version: 2,
+      version: 2n,
       localRecordRef: null,
       lastSyncedAt: new Date("2026-07-20T05:10:00.000Z"),
       payload: {
@@ -93,7 +93,7 @@ describe("mapNetworkDemandRows", () => {
     expect(mapNetworkDemandRows([{
       mirrorId: "bad",
       syncStatus: "conflict",
-      version: 1,
+      version: 1n,
       localRecordRef: null,
       lastSyncedAt: null,
       payload: { nope: true },

--- a/apps/web/lib/federation/demand-read-model.ts
+++ b/apps/web/lib/federation/demand-read-model.ts
@@ -67,7 +67,7 @@ export interface DemandShareContext {
 interface DemandReadRow {
   mirrorId: string;
   syncStatus: string;
-  version: number;
+  version: bigint;
   localRecordRef: string | null;
   lastSyncedAt: Date | null;
   payload: unknown;
@@ -88,7 +88,7 @@ export function mapNetworkDemandRows(rows: DemandReadRow[]): NetworkDemandView[]
       affectedOrganizations: envelope.signal.affectedOrganizations ?? null,
       disposition: payload.disposition,
       syncStatus: row.syncStatus,
-      originVersion: row.version,
+      originVersion: Number(row.version),
       updatedAt: (row.lastSyncedAt ?? new Date(payload.receivedAt)).toISOString(),
       localItemId: row.localRecordRef,
       forwardingToFounderPermitted:

--- a/apps/web/lib/federation/demand-response.ts
+++ b/apps/web/lib/federation/demand-response.ts
@@ -22,7 +22,7 @@ interface ResponseMirrorRow {
   localRecordRef: string | null;
   peerRecordRef: string | null;
   syncStatus: string;
-  version: number;
+  version: bigint;
   payload: unknown;
 }
 

--- a/apps/web/lib/federation/exchange-handlers.ts
+++ b/apps/web/lib/federation/exchange-handlers.ts
@@ -41,7 +41,7 @@ export interface IncomingIncident {
 
 export interface IncidentExchangeDb {
   federatedRecordMirror: {
-    findFirst(args: unknown): Promise<{ version: number; syncStatus: string; payloadHash?: string | null } | null>;
+    findFirst(args: unknown): Promise<{ version: bigint; syncStatus: string; payloadHash?: string | null } | null>;
     upsert(args: unknown): Promise<unknown>;
   };
   serviceTicket: { upsert(args: unknown): Promise<unknown> };
@@ -70,7 +70,7 @@ export async function handleIncomingIncident(
   const decision = reconcileMirror(
     existing
       ? {
-          version: existing.version,
+          version: Number(existing.version),
           syncStatus: existing.syncStatus as MirrorSyncStatus,
           canonicalSide: "peer",
           payloadHash: existing.payloadHash ?? null,
@@ -78,7 +78,7 @@ export async function handleIncomingIncident(
       : null,
     {
       fromSide: "peer",
-      baseVersion: incident.baseVersion ?? existing?.version ?? 1,
+      baseVersion: incident.baseVersion ?? (existing ? Number(existing.version) : 1),
       payloadHash: incident.payloadHash,
     },
   );

--- a/changes/federated-record-mirror-version-bigint.data-impact.json
+++ b/changes/federated-record-mirror-version-bigint.data-impact.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-CC8021CE. Widen FederatedRecordMirror.version and acknowledgedVersion from Int (int4) to BigInt (int8). A demand envelope's originVersion is derived from the source record's updatedAt epoch in milliseconds (~1.7e12) so re-projecting an unchanged record is idempotent; that value overflows int4 (max 2,147,483,647), so every federatedRecordMirror.create() failed with P2020 and NO demand mirror was ever written across a federation link. This is a storage-type widening only: the fields are kept, no new persistent data is introduced, and existing rows are cast in place (int4->int8 is a safe non-destructive widening). Migration: 20260807220000_federated_record_mirror_version_bigint.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "FederatedRecordMirror",
+      "lifecycleDisposition": "retain-for-link-lifetime",
+      "fields": [
+        {
+          "name": "version",
+          "resolution": "not-applicable",
+          "reason": "Operational sync-versioning counter for a federated record mirror (monotonic per link/record for conflict resolution). Not personal data and not tied to a data subject; only its storage type widens Int->BigInt.",
+          "provenance": "Derived from the origin demand envelope's originVersion (source record updatedAt epoch, ms) on the receiving side, or existing.version+1 on event-driven counter paths. No new source of data.",
+          "flags": []
+        },
+        {
+          "name": "acknowledgedVersion",
+          "resolution": "not-applicable",
+          "reason": "Operational delivery-acknowledgement watermark (the peer-confirmed version of an outbox record). Not personal data; only its storage type widens Int->BigInt to match version.",
+          "provenance": "Set from the mirror's own version when a peer acknowledges delivery. No new source of data.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260807220000_federated_record_mirror_version_bigint/migration.sql
+++ b/packages/db/prisma/migrations/20260807220000_federated_record_mirror_version_bigint/migration.sql
@@ -1,0 +1,12 @@
+-- FederatedRecordMirror.version / acknowledgedVersion: Int -> BigInt. (BI-CC8021CE)
+--
+-- A demand envelope's originVersion is derived from the source record's updatedAt
+-- epoch in MILLISECONDS (~1.7e12) so that re-projecting an unchanged record is
+-- idempotent (same mtime -> same version -> same payload digest -> noop). That
+-- value overflows Int (int4, max 2,147,483,647), so federatedRecordMirror.create
+-- failed with P2020 "value out of range for type integer" and NO demand mirror was
+-- ever written across a federation link. Widening to BigInt (int8) fixes it.
+--
+-- Widening Int -> BigInt is a safe, non-destructive in-place cast in Postgres.
+ALTER TABLE "FederatedRecordMirror" ALTER COLUMN "version" SET DATA TYPE BIGINT;
+ALTER TABLE "FederatedRecordMirror" ALTER COLUMN "acknowledgedVersion" SET DATA TYPE BIGINT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15025,7 +15025,10 @@ model FederatedRecordMirror {
   peerRecordRef       String?
   // pending | synced | conflict | withdrawn | dead-letter | revoked
   syncStatus          String    @default("pending")
-  version             Int       @default(1)
+  // BigInt: demand originVersion is derived from the source record's updatedAt
+  // epoch (ms) so re-projecting an unchanged record is idempotent. A ms epoch
+  // (~1.7e12) overflows Int (int4, max ~2.1e9) — see BI-CC8021CE.
+  version             BigInt    @default(1)
   conflictReason      String?
   lastSyncedAt        DateTime?
   // Durable delivery state for local-canonical outbox records. Peer-canonical
@@ -15034,7 +15037,7 @@ model FederatedRecordMirror {
   nextDeliveryAt      DateTime?
   lastDeliveryAt      DateTime?
   lastDeliveryError   String?
-  acknowledgedVersion Int?
+  acknowledgedVersion BigInt?
   deadLetteredAt      DateTime?
   // Last projected (already minimized) payload that crossed — never raw data.
   payload             Json?

--- a/packages/db/scripts/schema-regression-guard.mjs
+++ b/packages/db/scripts/schema-regression-guard.mjs
@@ -192,6 +192,15 @@ export const INTENTIONAL_FIELD_REMOVALS = new Set([
   // every environment. (This guard keys the skip by field name; the field itself
   // is not dropped, so no other line for it can regress.)
   "InventoryRelationship.relationshipKey",
+  // 2026-08-07 BI-CC8021CE: FederatedRecordMirror.version / acknowledgedVersion
+  // WIDEN Int -> BigInt (the field is KEPT, only its storage type grows). A demand
+  // originVersion is a millisecond epoch (~1.7e12) that overflows int4, so demand
+  // mirrors never wrote (P2020). The guard keys removals by field name+type, so a
+  // type change reads as a removal of the Int-typed signature. Migration:
+  // 20260807220000_federated_record_mirror_version_bigint. Prune once shipped
+  // fleet-wide.
+  "FederatedRecordMirror.version",
+  "FederatedRecordMirror.acknowledgedVersion",
 ]);
 
 export function diffSchemas(base, head, allowlist = INTENTIONAL_FIELD_REMOVALS) {


### PR DESCRIPTION
## What

Widens `FederatedRecordMirror.version` and `acknowledgedVersion` from `Int` to `BigInt` (schema + migration), and adjusts the code that reads them.

## Why — the real reason demand never mirrored

A demand envelope's `originVersion` is derived from the source record's `updatedAt` epoch in **milliseconds** (~1.7e12) so that re-projecting an unchanged record is idempotent (same mtime → same version → same payload digest → noop). But the `version` column was `Int` (int4, max **2,147,483,647**), so **every** `federatedRecordMirror.create()` overflowed:

```
Invalid prisma.federatedRecordMirror.create() invocation:
value "1784544648695" is out of range for type integer   (P2020)
```

Result: on a **fully trusted, mutual-token** federation link, `mirrors=0` and no demand ever crossed — the write failed before a row could be created. Observed live on a same-org Mac↔Windows link.

## Fix

- `version` / `acknowledgedVersion` → `BigInt` (safe in-place int4→int8 widening; migration `20260807220000_federated_record_mirror_version_bigint`).
- Values stay within `Number.MAX_SAFE_INTEGER`, so reads convert back with `Number()` where a number is needed. All mirror reads funnel through `lib/federation`; **no raw BigInt is ever JSON-serialized** (verified — the read-model maps `version → Number(originVersion)`).
- Disposition/withdrawal counter-exhaustion guard raised from int4-max to `Number.MAX_SAFE_INTEGER` to match the widened column.
- Schema-regression guard: the two type-widened fields are allowlisted alongside the migration (the field is kept; only its storage type grows).

## Tests

- `demand-exchange.test.ts` (+1 regression): a ms-epoch `originVersion` (> int4 max) passes through `create` un-truncated.
- Full federation suite green (138); 0 type errors; local-CI gate passed.

## Deploy note

This is a code + DB-migration change: both federated installs need one self-upgrade to pick it up. No re-pairing needed — an already-trusted link will begin mirroring once deployed.

## Design grounding

Extends the mutual-token enrollment substrate (#4090); `originVersion` semantics unchanged (contract already types it as a safe integer). No contract/route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)