### PR TITLE
docs(spec): fold architecture review into federation redesign spec (BI-67315C4A)

### DIFF
--- a/docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md
+++ b/docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md
@@ -40,7 +40,9 @@ Behind that single Connect tap, the platform — not the operator — is respons
 2. **Internal-service safety (closes the incident class):** configuring an authority/public URL must **never** subject internal service callbacks to the canonical-host redirect. `/api/inngest` (and every internal service route) is exempt like `/api/health` already is, and/or the internal service host is auto-aliased. Enabling federation must be incapable of killing background jobs.
 3. **Feature enablement:** the federation flag is set by the guided action, not by hand-editing an env file.
 4. **Transport trust:** secure auto-pairing needs certificate-valid HTTPS, but the operator must not manage certificates. The platform auto-provisions org HTTPS (embedded Step CA / org-PKI) as part of the guided join, or uses a reviewed certificate-free PAKE. No cert files, no CA passwords, no shell.
-5. **Discovery capability provisioned everywhere:** every install's Edge Node must carry `federation.discovery` by default (observed gap: the Windows install's edge had only `discovery.network`, so it could not participate in nearby discovery at all).
+5. **Pairing authentication (added by architecture review — closes the MITM gap):** the happy-path "Yes, mine → Approve" dual-tap is, on its own, the **"just works"** pairing method, which the pairing literature is explicit gives **zero MITM protection**. The confirm step MUST be a **Short Authentication String (SAS) numeric comparison**: both installs run an ECDH key exchange, then each screen shows the **same 6-digit code** and the operator confirms they match before trust is granted. This is the IETF `draft-ietf-dnssd-pairing` standard (SAS pairing over DNS-SD — DPF's exact same-LAN case) and Bluetooth LE Secure Connections numeric comparison. The 6-digit compare replaces the invite-token/paste-URL dance entirely.
+6. **Instance identity (added by architecture review):** the install's federation identity is a **cryptographic device ID** — the fingerprint of its instance keypair — NOT the current random-UUID `installationId` and NOT a typed URL. Extend the existing `EdgeNodeCertificate` substrate for the keypair rather than adding a parallel identity table (`schema-audit-before-features`). Identity travels with the key, which is what makes address changes (and the `localhost` trap) irrelevant.
+7. **Discovery capability provisioned everywhere:** every install's Edge Node must carry `federation.discovery` by default (observed gap: the Windows install's edge had only `discovery.network`, so it could not participate in nearby discovery at all).
 
 ## 4. Explicit non-goals (removed from the operator path)
 
@@ -76,5 +78,36 @@ An operator-facing `PUBLIC_URL_ALIASES` band-aid is both insufficient (it did no
 1. **P1 platform:** exempt `/api/inngest` and internal service callbacks from the `PUBLIC_URL` canonical-host redirect (fleet hazard; kills background jobs on any public-domain install).
 2. Auto-derive and wire the LAN Authority URL into the federation enroll path (no operator `PUBLIC_URL`).
 3. Provision `federation.discovery` on every install's Edge Node by default.
-4. Zero-shell guided Connect: discovery candidate → Connect → same-org confirm → dual approve, with platform auto-config of flag/URL/alias/HTTPS (ties into `BI-87B0DBD7`).
+4. Zero-shell guided Connect: discovery candidate → Connect → **SAS 6-digit numeric compare** → dual approve, with platform auto-config of flag/URL/alias/HTTPS (ties into `BI-87B0DBD7`).
 5. Retire manual URL/`.env` entry from the customer path; keep as documented recovery only.
+
+_The redesign that supersedes ad-hoc federation patching is tracked as **BI-67315C4A** (EP-DELIVERY-FLOW); the missing standards reference doc as **IP-43ED5 / BI-IMP-38549108**._
+
+## 9. Conflict & versioning model (added by architecture review — critical)
+
+The shipped design carried **no conflict model**: `DemandEnvelope.originVersion` was set to the source record's `updatedAt` epoch in **milliseconds** (`Date.now()`) and written into an `Int` (int4) column. That value (~1.7e12) overflows int4 (max 2,147,483,647), so **every** `federatedRecordMirror.create()` failed with Postgres `P2020` and demand **never once mirrored across a link** — the defect that let a non-functional feature ship. A wall-clock scalar is the single worst choice: no causality, clock-skew-dependent, and unbounded.
+
+**Requirement:** adopt a **version vector** — a per-`installationId` counter map. Comparison is one-sided dominance (every entry of A ≥ B → A is newer; mixed dominance → a real concurrent-edit conflict surfaced explicitly, not silently lost). Store it as typed JSON keyed by installation, never a scalar clock. A CRDT (e.g. Automerge / last-writer-wins register per field) is the stronger alternative where field-level convergence is wanted.
+
+**Escalation:** version-vector vs CRDT is a genuine architectural trade-off (operational simplicity + explicit-conflict UX vs conflict-free convergence at higher storage/complexity) — route it through `dpf-decision-via-kernel` before implementation, don't assert one here.
+
+_Interim: `#4092` widens the column to `BigInt` so the current link mirrors at all — a stopgap, not this model._
+
+## 10. Substrate fit (added by architecture review)
+
+- **Delivery on the canonical queue.** The hand-rolled `FederatedRecordMirror` outbox + retry + reconcile loop re-implements `WorkQueue` / `QueueTelemetryEvent` / `QueueMetricSnapshot` (EP-056D2A5E). Adopt the **ActivityPub inbox model** — deliver each demand envelope as a job to the peer's inbox — riding `WorkQueue` for retry/backoff/telemetry. `FederatedRecordMirror` retains only mirror + version-vector state, not transport machinery (`single-source-of-truth`).
+- **Discovery + pairing extend existing scaffolding.** Build on `lib/federation/nearby-candidates` + `nearby-pairing-service` + `nearby-pairing-rate-limit`; the SAS layer is an addition to that flow, not a new module (`verify-substrate-first`).
+- **Identity extends `EdgeNodeCertificate`** (see §3.6), not a new identity table.
+
+## 11. Standards & prior art (market research — the step originally skipped)
+
+| Concern | Standard adopted | Source |
+| --- | --- | --- |
+| Identity | Crypto device ID = cert fingerprint | Syncthing device IDs |
+| Discovery | mDNS / DNS-SD LAN broadcast | Syncthing; `_dpf-federation._tcp.local.` |
+| Pairing auth | ECDH + 6-digit SAS (numeric comparison) | IETF `draft-ietf-dnssd-pairing`; BLE Secure Connections |
+| Scaling topology | Introducer nodes (== customer→reseller→hub) | Syncthing introducer |
+| Delivery | Server-to-server inbox (JSON/HTTP) on a queue | W3C ActivityPub |
+| Conflict/versioning | Version vector / CRDT | version-vector & CRDT literature |
+
+Sources: docs.syncthing.net/dev/device-ids, docs.syncthing.net/users/introducer, w3.org/TR/activitypub, datatracker.ietf.org/doc/html/draft-ietf-dnssd-pairing-00.


### PR DESCRIPTION
## What

Applies the `dpf-architecture-review` findings (market-research-grounded) to the zero-shell federation pairing spec `docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md`.

## Reviewed additions

- **§3.5 Pairing authentication** — ECDH + 6-digit **SAS numeric comparison** (IETF `draft-ietf-dnssd-pairing`; BLE Secure Connections). The bare dual-tap approve is the "just works" method = **zero MITM protection**.
- **§3.6 Instance identity** — crypto device-ID (cert fingerprint) **extending `EdgeNodeCertificate`**, not the random-UUID `installationId` or a typed URL.
- **§9 Conflict & versioning** — **version vector / CRDT** replacing the wall-clock ms-epoch `Int` that overflowed (P2020) so demand never mirrored. Vector-vs-CRDT escalated to the kernel.
- **§10 Substrate fit** — ActivityPub inbox delivery on the canonical **`WorkQueue`** (not the hand-rolled mirror outbox); discovery/pairing extend `nearby-pairing-service`; identity extends `EdgeNodeCertificate`.
- **§11 Standards & prior art** table (Syncthing, ActivityPub, IETF SAS, CRDT).

## Governance

Redesign tracked as **BI-67315C4A** (EP-DELIVERY-FLOW); missing standards reference doc as **IP-43ED5 / BI-IMP-38549108**. This is the spec output of the architecture-review step that was skipped when the feature first shipped. Spec-only; no code/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)