### PR TITLE
fix(platform): add Connections to nav; disambiguate Identity Federation (SSO) (BI-67315C4A)

### DIFF
--- a/apps/web/components/platform/platform-nav.test.ts
+++ b/apps/web/components/platform/platform-nav.test.ts
@@ -47,6 +47,19 @@ describe("platform-nav", () => {
     expect(getPlatformFamily("/platform/services").key).toBe("tools");
   });
 
+  it("routes the peer-deployment Connections page (federation-links) to Tools & Services", () => {
+    const family = getPlatformFamily("/platform/federation-links");
+    expect(family.key).toBe("tools");
+    expect(family.subItems.some((item) => item.href === "/platform/federation-links")).toBe(true);
+    expect(family.subItems.some((item) => item.label === "Connections")).toBe(true);
+  });
+
+  it("disambiguates Identity Federation (SSO) from peer-deployment Connections", () => {
+    const identity = getPlatformFamily("/platform/identity");
+    expect(identity.subItems.some((item) => item.label === "Identity Federation (SSO)")).toBe(true);
+    expect(identity.subItems.some((item) => item.label === "Federation")).toBe(false);
+  });
+
   it("renames discovery operations to estate discovery in the tools family", () => {
     const toolsFamily = getPlatformFamily("/platform/tools/discovery");
 

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -40,7 +40,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       { label: "Principals", href: "/platform/identity/principals" },
       { label: "Groups", href: "/platform/identity/groups" },
       { label: "Directory", href: "/platform/identity/directory" },
-      { label: "Federation", href: "/platform/identity/federation" },
+      { label: "Identity Federation (SSO)", href: "/platform/identity/federation" },
       { label: "Applications", href: "/platform/identity/applications" },
       { label: "Authorization", href: "/platform/identity/authorization" },
       { label: "AI Coworkers", href: "/platform/identity/agents" },
@@ -93,6 +93,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       "/platform/tools",
       "/platform/integrations",
       "/platform/services",
+      "/platform/federation-links",
     ],
     subItems: [
       { label: "Hub", href: "/platform/tools" },
@@ -102,6 +103,9 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       { label: "Built-in Tools", href: "/platform/tools/built-ins" },
       { label: "Estate Discovery", href: "/platform/tools/discovery" },
       { label: "Capability Inventory", href: "/platform/tools/inventory" },
+      // Peer-deployment federation ("Connections" page). Distinct from Identity
+      // Federation (SSO); lives here because it is connection-lifecycle work.
+      { label: "Connections", href: "/platform/federation-links" },
     ],
   },
   {

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -630,6 +630,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
       "/platform/tools/built-ins",
       "/platform/tools/discovery",
       "/platform/tools/inventory",
+      "/platform/federation-links",
     ],
   },
   {
@@ -686,6 +687,18 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     key: "platform-tools-inventory",
     label: "Capability Inventory",
     path: "/platform/tools/inventory",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    // Peer-deployment federation ("Connections" page). Distinct from Identity
+    // Federation (SSO) under /platform/identity/federation.
+    key: "platform-federation-links",
+    label: "Connections",
+    path: "/platform/federation-links",
     parentPath: "/platform/tools",
     domain: "platform",
     audienceModes: ["operator"],

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -44,7 +44,7 @@ apps/web/lib/mcp-tools.ts	1947
 apps/web/lib/mcp/packs/backlog-pack.ts	858
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	854
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
-apps/web/lib/navigation/portal-navigation-model.ts	936
+apps/web/lib/navigation/portal-navigation-model.ts	949
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1383
 apps/web/lib/routing/chat-adapter.test.ts	924

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -6878,7 +6878,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 101
+    "textMass": 104
   },
   "apps/web/components/platform/service-desk/ServiceTicketsTable.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What
`/platform/federation-links` (titled **"Connections"** — peer-deployment federation) had **no nav entry**; the Platform nav's "Federation" pointed at a **different** feature (`/platform/identity/federation` = SSO/Entra). The menu both hid the page and misled.

- Add **"Connections" → /platform/federation-links** to Tools & Services in **both** nav registries (`platform-nav.ts` + `portal-navigation-model.ts`, kept in sync by a coverage test) + matchPrefix.
- Rename Identity's **"Federation" → "Identity Federation (SSO)"**.
- Tests: route resolution, SSO relabel, nav-model coverage.

## Why
CRITICAL finding from the `dpf-ux-fit-review` on **BI-67315C4A** — first shippable slice of the federation redesign, fixing "I can't even navigate to it." One subitem + one relabel; no new nav substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)