### PR TITLE
fix(deps): floor js-yaml and mermaid to patched releases (Dependabot #141-147)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   ws@>=8.0.0 <8.20.1: ^8.20.1
   fast-uri: ^3.1.4
   hono: ^4.12.34
-  mermaid: 11.15.0
+  mermaid: 11.16.1
   '@mermaid-js/mermaid-zenuml': 0.2.2
   '@zenuml/core': 3.47.8
   '@floating-ui/core': 1.7.5
@@ -30,6 +30,8 @@ overrides:
   '@floating-ui/react-dom': 2.1.8
   '@floating-ui/react': 0.27.19
   '@floating-ui/utils': 0.2.11
+  js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   ip-address: ^10.3.1
   sharp: ^0.35.3
   body-parser: ^2.3.0
@@ -2112,12 +2114,12 @@ packages:
   '@mermaid-js/layout-elk@0.2.2':
     resolution: {integrity: sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==}
     peerDependencies:
-      mermaid: 11.15.0
+      mermaid: 11.16.1
 
   '@mermaid-js/layout-tidy-tree@0.2.2':
     resolution: {integrity: sha512-8RmjDXjKJBxqTS1mICStm8zWRM45fSzs0SOrkp28+KsOGS2YEMFMVTwwRU8CsC6M1L+pDYZVjf1m9AC1c9Wndg==}
     peerDependencies:
-      mermaid: 11.15.0
+      mermaid: 11.16.1
 
   '@mermaid-js/mermaid-cli@11.15.0':
     resolution: {integrity: sha512-rmz9ELKtmKQvRcYJGI2e509FK9yCBvmEVfHeRSYkleGqo6qqh8LFooxRPCqq04uVx3JHMp9g/vmM85gi/QFFlQ==}
@@ -2129,7 +2131,7 @@ packages:
   '@mermaid-js/mermaid-zenuml@0.2.2':
     resolution: {integrity: sha512-sUjwk4NWUpy9uaHypYSIGJDks10ZaZo5CHH9lx9xcmyqv9w7yvd4vecUmlUQxmlHStYO+aqSkYKX5/gFjDfypw==}
     peerDependencies:
-      mermaid: 11.15.0
+      mermaid: 11.16.1
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
@@ -6613,12 +6615,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -7166,8 +7168,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   metro-babel-transformer@0.84.4:
     resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
@@ -10902,7 +10904,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@faker-js/faker@10.5.0': {}
 
@@ -11162,7 +11164,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -11398,32 +11400,32 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@mermaid-js/layout-elk@0.2.2(mermaid@11.15.0)':
+  '@mermaid-js/layout-elk@0.2.2(mermaid@11.16.1)':
     dependencies:
       d3: 7.9.0
       elkjs: 0.9.3
-      mermaid: 11.15.0
+      mermaid: 11.16.1
 
-  '@mermaid-js/layout-tidy-tree@0.2.2(mermaid@11.15.0)':
+  '@mermaid-js/layout-tidy-tree@0.2.2(mermaid@11.16.1)':
     dependencies:
       d3: 7.9.0
-      mermaid: 11.15.0
+      mermaid: 11.16.1
     optional: true
 
   '@mermaid-js/mermaid-cli@11.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(puppeteer@23.11.1(typescript@6.0.3))':
     dependencies:
       '@fortawesome/fontawesome-free': 7.3.1
-      '@mermaid-js/layout-elk': 0.2.2(mermaid@11.15.0)
-      '@mermaid-js/mermaid-zenuml': 0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.15.0)
+      '@mermaid-js/layout-elk': 0.2.2(mermaid@11.16.1)
+      '@mermaid-js/mermaid-zenuml': 0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.16.1)
       chalk: 5.6.2
       commander: 13.1.0
       import-meta-resolve: 4.2.0
       katex: 0.16.47
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       p-limit: 6.2.0
       puppeteer: 23.11.1(typescript@6.0.3)
     optionalDependencies:
-      '@mermaid-js/layout-tidy-tree': 0.2.2(mermaid@11.15.0)
+      '@mermaid-js/layout-tidy-tree': 0.2.2(mermaid@11.16.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11431,10 +11433,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@mermaid-js/mermaid-zenuml@0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.15.0)':
+  '@mermaid-js/mermaid-zenuml@0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.16.1)':
     dependencies:
       '@zenuml/core': 3.47.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)
-      mermaid: 11.15.0
+      mermaid: 11.16.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -14737,7 +14739,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -15888,7 +15890,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -16640,12 +16642,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -16741,7 +16743,7 @@ snapshots:
   json-schema-ref-parser@6.1.0:
     dependencies:
       call-me-maybe: 1.0.2
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       ono: 4.0.11
 
   json-schema-traverse@1.0.0: {}
@@ -17228,7 +17230,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.15.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,13 @@ overrides:
   # Keep the CLI's diagram stack on the last policy-vetted releases. Floating
   # transitive ranges let lockfile regeneration pull a same-day ZenUML/Floating
   # UI graph even after the CLI itself was rolled back (BI-72E0A27B).
-  mermaid: '11.15.0'
+  # mermaid < 11.16.1: GHSA-rhh3-jpg6-66xh (Dependabot #145, medium),
+  # GHSA-6x64-9x62-f2gx (Dependabot #143, medium), GHSA-3rrr-jr9j-h3q3
+  # (Dependabot #142, medium), GHSA-2v8p-3f2j-5mp7 (Dependabot #141, medium),
+  # and GHSA-c4c3-pg64-4m4v (Dependabot #144, low). Raise the policy pin from
+  # the vulnerable 11.15.0 to the patched 11.16.1 (deps diff is minor-range
+  # only; no ZenUML/Floating-UI companion move needed).
+  mermaid: '11.16.1'
   '@mermaid-js/mermaid-zenuml': '0.2.2'
   '@zenuml/core': '3.47.8'
   '@floating-ui/core': '1.7.5'
@@ -71,6 +77,13 @@ overrides:
   '@floating-ui/react-dom': '2.1.8'
   '@floating-ui/react': '0.27.19'
   '@floating-ui/utils': '0.2.11'
+  # js-yaml GHSA-5p4m-2wfm-xmqj (high): special-character handling flaw. Both
+  # supported major lines resolve to a vulnerable transitive copy, so each is
+  # floored to its patched release independently.
+  # js-yaml < 3.15.1: GHSA-5p4m-2wfm-xmqj (Dependabot #147, high).
+  'js-yaml@>=3.0.0 <3.15.1': '^3.15.1'
+  # js-yaml >= 4.0.0 < 4.3.1: GHSA-5p4m-2wfm-xmqj (Dependabot #146, high).
+  'js-yaml@>=4.0.0 <4.3.1': '^4.3.1'
   # ip-address < 10.3.1: GHSA-mwp4-54f8-5fhr / CVE-2026-69192, high severity —
   # Address4 decodes leading-zero octets as decimal while resolvers decode
   # them as octal, an SSRF-adjacent parser confusion (found on PR #3893's

--- a/scripts/check-diagram-dependency-pins.mjs
+++ b/scripts/check-diagram-dependency-pins.mjs
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const expectedRootDependency = '"@mermaid-js/mermaid-cli": "11.15.0"';
 const expectedOverrides = [
-  "mermaid: '11.15.0'",
+  "mermaid: '11.16.1'",
   "'@mermaid-js/mermaid-zenuml': '0.2.2'",
   "'@zenuml/core': '3.47.8'",
   "'@floating-ui/core': '1.7.5'",


### PR DESCRIPTION
## What

Clears **seven open Dependabot alerts** (#141–#147), all transitive, by flooring two packages to their patched releases in the `pnpm-workspace.yaml` `overrides:` block.

| Package | Alert(s) | Severity | Vulnerable → Patched |
|---|---|---|---|
| `js-yaml` (3.x line) | #147 (GHSA-5p4m-2wfm-xmqj) | high | 3.15.0 → 3.15.1 |
| `js-yaml` (4.x line) | #146 (GHSA-5p4m-2wfm-xmqj) | high | 4.3.0 → 4.3.1 |
| `mermaid` | #145 (GHSA-rhh3-jpg6-66xh), #143 (GHSA-6x64-9x62-f2gx), #142 (GHSA-3rrr-jr9j-h3q3), #141 (GHSA-2v8p-3f2j-5mp7), #144 (GHSA-c4c3-pg64-4m4v) | medium ×4 / low ×1 | 11.15.0 → 11.16.1 |

## How

- **js-yaml** — both supported major lines resolved to a vulnerable transitive copy, so each is floored independently: `js-yaml@>=3.0.0 <3.15.1` → `^3.15.1` and `js-yaml@>=4.0.0 <4.3.1` → `^4.3.1`. Every floor carries its GHSA + Dependabot tag for the Override Provenance Guard.
- **mermaid** — raised the existing **BI-72E0A27B** policy pin from the now-vulnerable `11.15.0` to the patched `11.16.1`. The `mermaid@11.15.0`→`11.16.1` deps diff is minor-range only (dayjs/katex/cytoscape/dompurify/@mermaid-js/parser), so no ZenUML/Floating-UI companion pin moves. The `@mermaid-js/mermaid-cli` devDep stays at `11.15.0` (it is not the vulnerable package; it declares `mermaid ^11.14.0`, which the override satisfies — the CLI has no 11.16.1 release). The **Diagram Dependency Pin Guard** expectation was updated in lockstep to the new vetted core version.

Lockfile regenerated via `scripts/regen-lockfile.mjs` against a fresh empty store — reported **SCOPED** (only `js-yaml`, `mermaid` changed) and **STABLE** (second resolve a no-op, so frozen-lockfile CI passes).

## Verification

- `grep js-yaml@` in the lockfile → only `3.15.1`, `4.3.1` resolve; `grep mermaid@` → only `11.16.1`. No vulnerable version remains.
- `pnpm scan:deps` → **OK — no blocking vulnerabilities**.
- `node scripts/check-override-comments.mjs` → passed (73 overrides, all security floors advisory-tagged).
- `node scripts/check-diagram-dependency-pins.mjs` → **policy-safe**.
- `pnpm check:sbom-drift` → OK, no new first-party version splits (component/dup counts decreased).
- `pnpm run pregate:preflight` → 0 (35 guards clean; 3 tsx-runtime guards env-skipped, CI enforces).

One concern per PR: security dependency floors only.

Local-CI-Evidence: cmsjjc15o064s01rs64cdaxdf (fix/dependabot-jsyaml-mermaid-floors@25ff215f2)
Docs-Impact-Decision: security version floor of js-yaml/mermaid in pnpm-lock.yaml — no change to the build-gate runbook or dependency-reduction routine content, and no user-facing behavior change.
