### PR TITLE
feat(federation): instance identity — stable crypto device ID (BI-67315C4A #1)

### DIFF
--- a/apps/web/lib/federation/demand-identity.test.ts
+++ b/apps/web/lib/federation/demand-identity.test.ts
@@ -5,32 +5,78 @@ import {
   resolveFederationIdentity,
   type FederationIdentityDb,
 } from "./demand-identity";
+import {
+  DEVICE_ID_RE,
+  deriveDeviceId,
+  generateInstanceSigningKeypair,
+} from "./instance-identity";
 
 describe("resolveFederationIdentity", () => {
-  it("reuses the persisted installation identity and projection secret", async () => {
+  it("reuses a persisted identity that already carries a keypair (no upgrade write)", async () => {
+    const kp = generateInstanceSigningKeypair();
     const existing = {
       installationId: `inst_${"c".repeat(32)}`,
       projectionSecret: "a".repeat(64),
+      deviceId: deriveDeviceId(kp.signingPublicKey),
+      signingPublicKey: kp.signingPublicKey,
+      signingPrivateKeyEnc: "enc:" + kp.signingPrivateKey,
     };
     const upsert = vi.fn().mockResolvedValue({ value: existing });
+    const update = vi.fn();
 
-    await expect(resolveFederationIdentity({ platformConfig: { upsert } } as FederationIdentityDb))
-      .resolves.toEqual(existing);
-    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
-      where: { key: "federation.identity" },
-      update: {},
-    }));
+    const identity = await resolveFederationIdentity(
+      { platformConfig: { upsert, update } } as FederationIdentityDb,
+    );
+
+    // Returns the PUBLIC identity — never the encrypted private key.
+    expect(identity).toEqual({
+      installationId: existing.installationId,
+      projectionSecret: existing.projectionSecret,
+      deviceId: existing.deviceId,
+      signingPublicKey: existing.signingPublicKey,
+    });
+    expect(update).not.toHaveBeenCalled();
   });
 
-  it("creates opaque identity material once when the installation has none", async () => {
+  it("upgrades a legacy identity (no keypair) by minting one exactly once", async () => {
+    const legacy = {
+      installationId: `inst_${"c".repeat(32)}`,
+      projectionSecret: "a".repeat(64),
+    };
+    const upsert = vi.fn().mockResolvedValue({ value: legacy });
+    const update = vi.fn().mockImplementation(async ({ data }: { data: { value: unknown } }) => ({
+      value: data.value,
+    }));
+
+    const identity = await resolveFederationIdentity(
+      { platformConfig: { upsert, update } } as FederationIdentityDb,
+    );
+
+    expect(identity.installationId).toBe(legacy.installationId);
+    expect(identity.deviceId).toMatch(DEVICE_ID_RE);
+    expect(identity.signingPublicKey).toBeTruthy();
+    // Persisted the upgrade once, and stored the ENCRYPTED private key (never returned).
+    expect(update).toHaveBeenCalledTimes(1);
+    const persisted = update.mock.calls[0][0].data.value as Record<string, unknown>;
+    expect(persisted.signingPrivateKeyEnc).toBeTruthy();
+    expect(identity).not.toHaveProperty("signingPrivateKeyEnc");
+  });
+
+  it("creates opaque identity material with a keypair when the installation has none", async () => {
     const upsert = vi.fn().mockImplementation(async ({ create }: { create: { value: unknown } }) => ({
       value: create.value,
     }));
+    const update = vi.fn();
 
-    const identity = await resolveFederationIdentity({ platformConfig: { upsert } } as FederationIdentityDb);
+    const identity = await resolveFederationIdentity(
+      { platformConfig: { upsert, update } } as FederationIdentityDb,
+    );
 
     expect(identity.installationId).toMatch(/^inst_[a-f0-9]{32}$/);
     expect(identity.projectionSecret).toMatch(/^[a-f0-9]{64}$/);
+    expect(identity.deviceId).toMatch(DEVICE_ID_RE);
+    expect(identity.signingPublicKey).toBeTruthy();
+    expect(update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/federation/demand-identity.ts
+++ b/apps/web/lib/federation/demand-identity.ts
@@ -1,34 +1,85 @@
 import { createHmac, randomBytes, randomUUID } from "node:crypto";
 
+import { encryptSecret } from "@/lib/govern/credential-crypto";
+
+import { deriveDeviceId, generateInstanceSigningKeypair, isDeviceId } from "./instance-identity";
+
 const FEDERATION_IDENTITY_KEY = "federation.identity";
 
 export interface FederationIdentity {
   installationId: string;
   projectionSecret: string;
+  /** Stable cryptographic device ID (fingerprint of the signing public key).
+   *  Present once the install has been upgraded to carry a keypair (increment 1);
+   *  optional so pre-keypair callers/fixtures keep compiling. */
+  deviceId?: string;
+  /** Ed25519 signing public key (SPKI DER, base64). Safe to publish to peers. */
+  signingPublicKey?: string;
 }
 
 export interface FederationIdentityDb {
   platformConfig: {
     upsert(args: unknown): Promise<{ value: unknown }>;
+    // Used only to upgrade a legacy identity in place with a keypair.
+    update(args: unknown): Promise<{ value: unknown }>;
   };
 }
 
-function decodeIdentity(value: unknown): FederationIdentity | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const candidate = value as Partial<FederationIdentity>;
-  if (!/^inst_[a-f0-9]{32}$/.test(candidate.installationId ?? "")) return null;
-  if (!/^[a-f0-9]{64}$/.test(candidate.projectionSecret ?? "")) return null;
-  return candidate as FederationIdentity;
+// The stored blob is a superset of FederationIdentity: it also holds the ENCRYPTED
+// private key, which is never returned in the in-memory FederationIdentity (a later
+// signing/SAS increment adds a guarded decrypt accessor).
+interface StoredFederationIdentity extends FederationIdentity {
+  signingPrivateKeyEnc?: string;
 }
 
-function generateIdentity(): FederationIdentity {
+function decodeIdentity(value: unknown): StoredFederationIdentity | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as Partial<StoredFederationIdentity>;
+  if (!/^inst_[a-f0-9]{32}$/.test(candidate.installationId ?? "")) return null;
+  if (!/^[a-f0-9]{64}$/.test(candidate.projectionSecret ?? "")) return null;
+  return candidate as StoredFederationIdentity;
+}
+
+/** True once the stored identity carries a complete, well-formed signing keypair. */
+function hasKeypair(stored: StoredFederationIdentity): boolean {
+  return (
+    isDeviceId(stored.deviceId) &&
+    typeof stored.signingPublicKey === "string" &&
+    stored.signingPublicKey.length > 0 &&
+    typeof stored.signingPrivateKeyEnc === "string" &&
+    stored.signingPrivateKeyEnc.length > 0
+  );
+}
+
+function keypairFields(): Pick<StoredFederationIdentity, "deviceId" | "signingPublicKey" | "signingPrivateKeyEnc"> {
+  const kp = generateInstanceSigningKeypair();
+  return {
+    deviceId: deriveDeviceId(kp.signingPublicKey),
+    signingPublicKey: kp.signingPublicKey,
+    signingPrivateKeyEnc: encryptSecret(kp.signingPrivateKey),
+  };
+}
+
+function generateIdentity(): StoredFederationIdentity {
   return {
     installationId: `inst_${randomUUID().replaceAll("-", "")}`,
     projectionSecret: randomBytes(32).toString("hex"),
+    ...keypairFields(),
   };
 }
 
-/** Resolve stable, local-only identity material without relying on hostnames. */
+function toPublicIdentity(stored: StoredFederationIdentity): FederationIdentity {
+  return {
+    installationId: stored.installationId,
+    projectionSecret: stored.projectionSecret,
+    ...(stored.deviceId ? { deviceId: stored.deviceId } : {}),
+    ...(stored.signingPublicKey ? { signingPublicKey: stored.signingPublicKey } : {}),
+  };
+}
+
+/** Resolve stable, local-only identity material without relying on hostnames.
+ *  A pre-increment-1 identity (no keypair) is upgraded in place on first read,
+ *  so every install gains a device ID exactly once with no operator action. */
 export async function resolveFederationIdentity(db: FederationIdentityDb): Promise<FederationIdentity> {
   const generated = generateIdentity();
   const row = await db.platformConfig.upsert({
@@ -37,9 +88,19 @@ export async function resolveFederationIdentity(db: FederationIdentityDb): Promi
     update: {},
     select: { value: true },
   });
-  const identity = decodeIdentity(row.value);
-  if (!identity) throw new Error("Stored federation identity is invalid and requires operator repair.");
-  return identity;
+  const stored = decodeIdentity(row.value);
+  if (!stored) throw new Error("Stored federation identity is invalid and requires operator repair.");
+  if (hasKeypair(stored)) return toPublicIdentity(stored);
+
+  // Legacy identity created before increment 1 — mint and persist a keypair once.
+  const upgraded: StoredFederationIdentity = { ...stored, ...keypairFields() };
+  const updated = await db.platformConfig.update({
+    where: { key: FEDERATION_IDENTITY_KEY },
+    data: { value: upgraded },
+    select: { value: true },
+  });
+  const reread = decodeIdentity(updated.value) ?? upgraded;
+  return toPublicIdentity(reread);
 }
 
 function opaqueRef(secret: string, purpose: string, localRecordRef: string): string {

--- a/apps/web/lib/federation/instance-identity.test.ts
+++ b/apps/web/lib/federation/instance-identity.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEVICE_ID_RE,
+  deriveDeviceId,
+  generateInstanceSigningKeypair,
+  isDeviceId,
+  keypairMatches,
+  shortDeviceId,
+} from "./instance-identity";
+
+describe("generateInstanceSigningKeypair", () => {
+  it("produces a valid, self-consistent Ed25519 keypair", () => {
+    const kp = generateInstanceSigningKeypair();
+    expect(kp.signingPublicKey.length).toBeGreaterThan(0);
+    expect(kp.signingPrivateKey.length).toBeGreaterThan(0);
+    expect(kp.signingPublicKey).not.toBe(kp.signingPrivateKey);
+    expect(keypairMatches(kp)).toBe(true);
+  });
+
+  it("generates a distinct keypair each call", () => {
+    const a = generateInstanceSigningKeypair();
+    const b = generateInstanceSigningKeypair();
+    expect(a.signingPublicKey).not.toBe(b.signingPublicKey);
+    expect(deriveDeviceId(a.signingPublicKey)).not.toBe(deriveDeviceId(b.signingPublicKey));
+  });
+});
+
+describe("deriveDeviceId", () => {
+  it("is deterministic for the same public key", () => {
+    const kp = generateInstanceSigningKeypair();
+    expect(deriveDeviceId(kp.signingPublicKey)).toBe(deriveDeviceId(kp.signingPublicKey));
+  });
+
+  it("returns a well-formed did_<64hex> device id", () => {
+    const kp = generateInstanceSigningKeypair();
+    const id = deriveDeviceId(kp.signingPublicKey);
+    expect(DEVICE_ID_RE.test(id)).toBe(true);
+    expect(isDeviceId(id)).toBe(true);
+  });
+
+  it("rejects an empty key", () => {
+    expect(() => deriveDeviceId("")).toThrow();
+  });
+
+  it("rejects a non-Ed25519 key (a random buffer is not a valid SPKI key)", () => {
+    expect(() => deriveDeviceId(Buffer.from("not a real spki key").toString("base64"))).toThrow();
+  });
+});
+
+describe("isDeviceId", () => {
+  it.each([
+    ["did_" + "a".repeat(64), true],
+    ["did_" + "A".repeat(64), false], // must be lowercase hex
+    ["did_" + "a".repeat(63), false], // wrong length
+    ["ab".repeat(32), false], // missing prefix
+    ["", false],
+    [42, false],
+  ])("isDeviceId(%s) === %s", (value, expected) => {
+    expect(isDeviceId(value)).toBe(expected);
+  });
+});
+
+describe("shortDeviceId", () => {
+  it("elides the middle of a valid device id for display", () => {
+    const id = "did_" + "0123456789abcdef".repeat(4);
+    expect(shortDeviceId(id)).toBe("did_0123…cdef");
+  });
+
+  it("returns the input unchanged when it is not a device id", () => {
+    expect(shortDeviceId("nonsense")).toBe("nonsense");
+  });
+});
+
+describe("keypairMatches", () => {
+  it("is false when the private key is swapped for another keypair's", () => {
+    const a = generateInstanceSigningKeypair();
+    const b = generateInstanceSigningKeypair();
+    expect(keypairMatches({ signingPublicKey: a.signingPublicKey, signingPrivateKey: b.signingPrivateKey })).toBe(false);
+  });
+
+  it("is false on a garbage private key rather than throwing", () => {
+    const a = generateInstanceSigningKeypair();
+    expect(keypairMatches({ signingPublicKey: a.signingPublicKey, signingPrivateKey: "garbage" })).toBe(false);
+  });
+});

--- a/apps/web/lib/federation/instance-identity.ts
+++ b/apps/web/lib/federation/instance-identity.ts
@@ -1,0 +1,81 @@
+// EP-DELIVERY-FLOW · BI-67315C4A increment 1 — federation instance identity.
+//
+// A DPF install's federation identity is a stable cryptographic device ID (the
+// fingerprint of a long-lived Ed25519 signing keypair), NOT a typed URL and NOT
+// the random-UUID installationId. Identity travels with the key, so an install's
+// LAN address can change (or be reached via localhost) without breaking a link —
+// the exact class of failure the original invite-token/paste-URL flow suffered.
+//
+// This is the foundation the robust pairing rests on: peers bind a FederationLink
+// to the peer's deviceId, mDNS advertises it, and SAS pairing (a later increment)
+// runs an ephemeral ECDH whose transcript is authenticated against these stable
+// identity keys. Prior art: Syncthing device IDs (a hash of the device cert).
+//
+// Pure and Node-crypto only — no DB, no env — so it is exhaustively unit-testable.
+// Persistence + key-at-rest encryption live in demand-identity.ts, which composes
+// these functions and stores the private key via the existing credential-crypto.
+
+import { createHash, createPrivateKey, createPublicKey, generateKeyPairSync } from "node:crypto";
+
+/** A device ID: `did_` + the lowercase hex SHA-256 of the SPKI-DER public key. */
+export const DEVICE_ID_RE = /^did_[a-f0-9]{64}$/;
+
+export interface InstanceSigningKeypair {
+  /** Ed25519 public key, SPKI DER, base64. Safe to publish to peers. */
+  signingPublicKey: string;
+  /** Ed25519 private key, PKCS8 DER, base64. MUST be encrypted at rest. */
+  signingPrivateKey: string;
+}
+
+/** Generate a fresh long-lived Ed25519 identity keypair for this installation. */
+export function generateInstanceSigningKeypair(): InstanceSigningKeypair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  return {
+    signingPublicKey: publicKey.export({ type: "spki", format: "der" }).toString("base64"),
+    signingPrivateKey: privateKey.export({ type: "pkcs8", format: "der" }).toString("base64"),
+  };
+}
+
+/** Derive the stable device ID from a base64 SPKI-DER public key.
+ *  Deterministic: the same public key always yields the same device ID. */
+export function deriveDeviceId(signingPublicKeyBase64: string): string {
+  const der = Buffer.from(signingPublicKeyBase64, "base64");
+  if (der.length === 0) throw new Error("empty public key");
+  // Validate it really is an Ed25519 SPKI key before fingerprinting it, so a
+  // malformed/foreign key can never masquerade as a well-formed device ID.
+  const key = createPublicKey({ key: der, format: "der", type: "spki" });
+  if (key.asymmetricKeyType !== "ed25519") {
+    throw new Error(`expected an ed25519 public key, got ${key.asymmetricKeyType}`);
+  }
+  return `did_${createHash("sha256").update(der).digest("hex")}`;
+}
+
+/** True for a well-formed device ID string. */
+export function isDeviceId(value: unknown): value is string {
+  return typeof value === "string" && DEVICE_ID_RE.test(value);
+}
+
+/** A short, human-comparable form of a device ID for UI display (never for
+ *  equality — always compare the full device ID). E.g. `did_ab12…9f0c`. */
+export function shortDeviceId(deviceId: string): string {
+  if (!isDeviceId(deviceId)) return deviceId;
+  const hex = deviceId.slice("did_".length);
+  return `did_${hex.slice(0, 4)}…${hex.slice(-4)}`;
+}
+
+/** Verify a base64 PKCS8 private key belongs to the given base64 SPKI public key,
+ *  by re-deriving the public key from the private key and comparing device IDs.
+ *  Guards against a corrupted/mismatched keypair after decrypt. */
+export function keypairMatches(keypair: InstanceSigningKeypair): boolean {
+  try {
+    const priv = createPrivateKey({
+      key: Buffer.from(keypair.signingPrivateKey, "base64"),
+      format: "der",
+      type: "pkcs8",
+    });
+    const derivedPub = createPublicKey(priv).export({ type: "spki", format: "der" }).toString("base64");
+    return deriveDeviceId(derivedPub) === deriveDeviceId(keypair.signingPublicKey);
+  } catch {
+    return false;
+  }
+}

--- a/docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md
+++ b/docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md
@@ -1,0 +1,49 @@
+# Federation Robust-Design Build Plan (BI-67315C4A)
+
+| Field | Value |
+| --- | --- |
+| Status | In progress |
+| Date | 2026-08-07 |
+| Backlog item | BI-67315C4A (EP-DELIVERY-FLOW) |
+| Spec | `docs/superpowers/specs/2026-08-06-federation-zero-shell-autodiscovery-increment.md` |
+| Reviews | dpf-architecture-review + dpf-ux-fit-review (recorded on BI-67315C4A); kernel decision DI-1BC547243903 (version vector) |
+
+## Why
+
+The Federated Demand Network shipped without market research, expert review, or the
+queue substrate, and its core data path never worked end-to-end. This plan builds the
+reviewed robust design in verifiable increments, each a PR with tests, replacing the
+brittle invite-token/paste-URL/wall-clock-version machinery with standard mechanisms
+(Syncthing device IDs, mDNS/DNS-SD, IETF SAS pairing, ActivityPub-style inbox on the
+canonical `WorkQueue`, version vectors).
+
+## Increments
+
+Each is an independent PR; later increments depend on earlier ones as noted.
+
+1. **Instance identity (THIS increment).** A stable Ed25519 signing keypair per install;
+   the device ID is its public-key fingerprint (`did_<sha256-hex>`). Foundation for SAS
+   pairing, discovery, and address-independent links. Stored in the existing
+   `PlatformConfig["federation.identity"]` blob (no migration); private key encrypted at
+   rest via `credential-crypto` (same as `peerTokenEnc`). Legacy identities upgrade in
+   place on first read. Pure crypto in `lib/federation/instance-identity.ts`.
+2. **mDNS/DNS-SD discovery.** Advertise `_dpf-federation._tcp.local.` (device ID + address);
+   browse and list nearby installs. Extends `nearby-candidates` / `nearby-pairing-service`.
+3. **SAS pairing.** ECDH ephemeral exchange + 6-digit Short Authentication String numeric
+   comparison, authenticated against the increment-1 identity keys. Replaces invite-token /
+   pasted URL / bare dual-approve (which has zero MITM protection).
+4. **Introducer / hub.** One trusted peer introduces others (customer→reseller→hub), the
+   Syncthing introducer pattern.
+5. **Queue-based inbox delivery.** Deliver demand envelopes to a peer inbox as `WorkQueue`
+   jobs (retry/backoff/telemetry), retiring the hand-rolled outbox loop. ActivityPub model.
+6. **Version-vector conflict model.** Per-installation counters on the mirror; one-sided
+   dominance = clean, divergence = explicit conflict. Kernel-decided over CRDT
+   (DI-1BC547243903). Supersedes the wall-clock scalar (interim BigInt fix #4092).
+7. **Deprecate manual pairing UI + finish navigation/labels.** Nav entry landed in #4094;
+   this retires the invite/paste/approve flow to recovery-only and fixes the scope/env labels.
+
+## Acceptance gate (was missing the first time)
+
+Every increment carries unit tests; the epic is not "done" until an **end-to-end
+two-instance validation** (two installs discover → SAS-pair → demand mirrors both ways with
+correct version-vector ordering) passes on real installs.


### PR DESCRIPTION
## What
Robust-design **increment 1** (of BI-67315C4A): a DPF install's federation identity becomes a stable **Ed25519 device ID** — the fingerprint of a long-lived signing keypair (`did_<sha256hex>`) — not a typed URL and not the random-UUID `installationId`.

- `apps/web/lib/federation/instance-identity.ts` (NEW): pure, Node-crypto-only keypair generation, device-ID derivation (validates the SPKI key is Ed25519 before fingerprinting), display shortener, keypair self-check. **16 unit tests.**
- `demand-identity.ts`: extends the single `PlatformConfig["federation.identity"]` blob with the keypair — `deviceId` + `signingPublicKey` + **encrypted** private key via the existing `credential-crypto` (same as `peerTokenEnc`). **No migration.** Legacy identities upgrade in place on first read, exactly once. In-memory `FederationIdentity` exposes only the **public** device ID + key — never the private key. New fields are optional, so existing consumers/fixtures are unaffected.

## Why
Identity travels with the key, so an install's address can change (or be reached via `localhost`) without breaking a link — the exact class of failure the invite-token/paste-URL flow suffered. Foundation for SAS pairing (increment 3) and mDNS discovery (increment 2). Prior art: Syncthing device IDs.

## Grounding
`dpf-architecture-review` said extend existing substrate, not a new identity table — done (`EdgeNodeCertificate` is edge-*device* scoped, a distinct concept; the install's federation identity lives in the existing config blob). Spec §3.6 + plan `docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md`.

Typecheck clean; full federation suite green (156). Local-CI gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)