### PR TITLE
feat(federation): version-vector causal-ordering core (BI-67315C4A #6)

### DIFF
--- a/apps/web/lib/federation/version-vector.test.ts
+++ b/apps/web/lib/federation/version-vector.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareVersionVectors,
+  dominatesOrEqual,
+  incrementVersionVector,
+  isVersionVector,
+  mergeVersionVectors,
+} from "./version-vector";
+
+describe("isVersionVector", () => {
+  it.each([
+    [{ inst_a: 0, inst_b: 3 }, true],
+    [{}, true],
+    [{ inst_a: -1 }, false],
+    [{ inst_a: 1.5 }, false],
+    [{ inst_a: "3" }, false],
+    [{ "": 1 }, false],
+    [null, false],
+    [[1, 2], false],
+  ])("isVersionVector(%o) === %s", (value, expected) => {
+    expect(isVersionVector(value)).toBe(expected);
+  });
+});
+
+describe("compareVersionVectors", () => {
+  it("equal for identical vectors (missing key ≡ 0)", () => {
+    expect(compareVersionVectors({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe("equal");
+    expect(compareVersionVectors({ a: 0 }, {})).toBe("equal");
+  });
+
+  it("dominates when strictly newer in every dimension", () => {
+    expect(compareVersionVectors({ a: 2, b: 2 }, { a: 1, b: 2 })).toBe("dominates");
+    expect(compareVersionVectors({ a: 1 }, {})).toBe("dominates");
+  });
+
+  it("dominated is the mirror of dominates", () => {
+    expect(compareVersionVectors({ a: 1, b: 2 }, { a: 2, b: 2 })).toBe("dominated");
+  });
+
+  it("concurrent when each leads in a different dimension (a real conflict)", () => {
+    expect(compareVersionVectors({ a: 2, b: 1 }, { a: 1, b: 2 })).toBe("concurrent");
+    // customer closed (bumps its own counter) while reseller updated concurrently
+    expect(compareVersionVectors({ customer: 1 }, { reseller: 1 })).toBe("concurrent");
+  });
+});
+
+describe("dominatesOrEqual", () => {
+  it("accepts an equal or strictly-newer incoming vector, rejects older/concurrent", () => {
+    expect(dominatesOrEqual({ a: 2 }, { a: 1 })).toBe(true);
+    expect(dominatesOrEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(dominatesOrEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(dominatesOrEqual({ a: 2, b: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+});
+
+describe("mergeVersionVectors", () => {
+  it("is the entrywise max (least upper bound)", () => {
+    expect(mergeVersionVectors({ a: 2, b: 1 }, { a: 1, b: 3, c: 5 })).toEqual({ a: 2, b: 3, c: 5 });
+  });
+
+  it("a merged vector dominates (or equals) both inputs", () => {
+    const a = { a: 2, b: 1 };
+    const b = { a: 1, b: 2 };
+    const m = mergeVersionVectors(a, b);
+    expect(dominatesOrEqual(m, a)).toBe(true);
+    expect(dominatesOrEqual(m, b)).toBe(true);
+  });
+});
+
+describe("incrementVersionVector", () => {
+  it("advances only the local installation's counter and returns a new object", () => {
+    const v = { peer: 5 };
+    const next = incrementVersionVector(v, "self");
+    expect(next).toEqual({ peer: 5, self: 1 });
+    expect(v).toEqual({ peer: 5 }); // input unchanged
+    expect(incrementVersionVector(next, "self")).toEqual({ peer: 5, self: 2 });
+  });
+
+  it("makes the local edit strictly newer than what it was based on", () => {
+    const base = { self: 1, peer: 3 };
+    expect(compareVersionVectors(incrementVersionVector(base, "self"), base)).toBe("dominates");
+  });
+
+  it("requires an installation id", () => {
+    expect(() => incrementVersionVector({}, "")).toThrow();
+  });
+});

--- a/apps/web/lib/federation/version-vector.ts
+++ b/apps/web/lib/federation/version-vector.ts
@@ -1,0 +1,81 @@
+// EP-DELIVERY-FLOW · BI-67315C4A increment 6 — version-vector causal ordering.
+//
+// Kernel-decided over CRDT (DI-1BC547243903) as the federated-demand conflict model.
+// A version vector is a per-installation counter map. It gives causal ordering for
+// updates and status/closure changes that can originate from different points in a
+// customer→reseller→hub chain: two vectors compare by one-sided dominance (a clean
+// newer-than) or reveal a genuine CONCURRENT edit that must surface as a conflict
+// rather than be silently lost (the failure mode a wall-clock scalar hides).
+//
+// Supersedes the ms-epoch scalar (interim BigInt fix #4092) for conflict detection;
+// the scalar remains only as a coarse back-compat ordering hint during migration.
+//
+// Pure and dependency-free — exhaustively unit-testable. Wiring it onto the demand
+// envelope + FederatedRecordMirror (schema + exchange) is the following increment.
+
+/** installationId → monotonic counter. Missing key ≡ 0. */
+export type VersionVector = Record<string, number>;
+
+export type VectorOrder = "equal" | "dominates" | "dominated" | "concurrent";
+
+/** True for a well-formed version vector (non-negative safe-integer counters). */
+export function isVersionVector(value: unknown): value is VersionVector {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.entries(value as Record<string, unknown>).every(
+    ([k, v]) =>
+      k.length > 0 &&
+      typeof v === "number" &&
+      Number.isSafeInteger(v) &&
+      v >= 0,
+  );
+}
+
+function keysOf(a: VersionVector, b: VersionVector): string[] {
+  return [...new Set([...Object.keys(a), ...Object.keys(b)])];
+}
+
+/** Compare two version vectors:
+ *  - `equal`      — identical causal history.
+ *  - `dominates`  — `a` is strictly newer (every entry ≥ b, at least one >).
+ *  - `dominated`  — `b` is strictly newer.
+ *  - `concurrent` — each has an entry the other lacks/exceeds → a real conflict. */
+export function compareVersionVectors(a: VersionVector, b: VersionVector): VectorOrder {
+  let aAhead = false;
+  let bAhead = false;
+  for (const k of keysOf(a, b)) {
+    const av = a[k] ?? 0;
+    const bv = b[k] ?? 0;
+    if (av > bv) aAhead = true;
+    else if (bv > av) bAhead = true;
+    if (aAhead && bAhead) return "concurrent";
+  }
+  if (aAhead) return "dominates";
+  if (bAhead) return "dominated";
+  return "equal";
+}
+
+/** True when `a` is at least as new as `b` in every dimension (equal or dominates).
+ *  The safe "accept without conflict" predicate for an incoming update. */
+export function dominatesOrEqual(a: VersionVector, b: VersionVector): boolean {
+  const order = compareVersionVectors(a, b);
+  return order === "dominates" || order === "equal";
+}
+
+/** Entrywise max — the least upper bound after reconciling a concurrent conflict. */
+export function mergeVersionVectors(a: VersionVector, b: VersionVector): VersionVector {
+  const merged: VersionVector = {};
+  for (const k of keysOf(a, b)) merged[k] = Math.max(a[k] ?? 0, b[k] ?? 0);
+  return merged;
+}
+
+/** Return a NEW vector with this installation's counter advanced by one. Called
+ *  whenever the local install authors a change (create / update / close). */
+export function incrementVersionVector(
+  vector: VersionVector,
+  installationId: string,
+): VersionVector {
+  if (!installationId) throw new Error("installationId is required to advance a version vector");
+  const current = vector[installationId] ?? 0;
+  if (current >= Number.MAX_SAFE_INTEGER) throw new Error("version vector counter exhausted");
+  return { ...vector, [installationId]: current + 1 };
+}


### PR DESCRIPTION
## What
Robust-design **increment 6**: the conflict model the kernel decided over CRDT (**DI-1BC547243903**). A **version vector** (per-installation counter map) gives causal ordering for updates and status/closure changes originating from different points in a customer→reseller→hub chain.

`apps/web/lib/federation/version-vector.ts` (NEW, pure):
- `compareVersionVectors` → `equal | dominates | dominated | concurrent`
- `dominatesOrEqual` — the safe "accept without conflict" predicate
- `mergeVersionVectors` — entrywise max (least upper bound after reconciling)
- `incrementVersionVector` — advance the local counter on each authored change
- **18 unit tests** incl. concurrent-conflict detection and merge-dominates-both.

## Why
Supersedes the wall-clock ms-epoch scalar (interim BigInt #4092) for conflict detection: a scalar can't distinguish "strictly newer" from a genuine **concurrent** edit, so a concurrent close/update along the chain would be silently lost. The vector surfaces it explicitly. Wiring onto the demand envelope + `FederatedRecordMirror` is the next increment. Spec §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)