### PR TITLE
feat(federation): carry version vector on the demand envelope (BI-67315C4A #6 slice A)

### DIFF
--- a/packages/db/src/federated-demand-contract.test.ts
+++ b/packages/db/src/federated-demand-contract.test.ts
@@ -205,3 +205,32 @@ describe("validateDemandResponseV1", () => {
     ]));
   });
 });
+
+describe("versionVector (BI-67315C4A)", () => {
+  it("accepts an envelope carrying a valid version vector", () => {
+    expect(validateDemandEnvelopeV1(envelope({ versionVector: { inst_a: 2, inst_b: 0 } }))).toEqual([]);
+  });
+
+  it("treats versionVector as an allowed field", () => {
+    expect(validateDemandEnvelopeV1(envelope({ versionVector: { inst_a: 1 } }))).not.toContain(
+      "field:not-allowed:versionVector",
+    );
+  });
+
+  it.each([
+    { inst_a: -1 },
+    { inst_a: 1.5 },
+    { "": 1 },
+    { inst_a: "3" },
+  ])("rejects a malformed version vector %o", (bad) => {
+    expect(
+      validateDemandEnvelopeV1(envelope({ versionVector: bad as unknown as Record<string, number> })),
+    ).toEqual(expect.arrayContaining(["versionVector:invalid"]));
+  });
+
+  it("EXCLUDES the version vector from the payload digest (idempotent re-projection)", () => {
+    const base = envelope({ versionVector: { inst_a: 1 } });
+    const reprojected = { ...base, versionVector: { inst_a: 2, inst_b: 5 } };
+    expect(computeDemandPayloadDigest(reprojected)).toBe(computeDemandPayloadDigest(base));
+  });
+});

--- a/packages/db/src/federated-demand-contract.ts
+++ b/packages/db/src/federated-demand-contract.ts
@@ -37,6 +37,12 @@ export interface DemandEnvelopeV1 {
   originInstallationId: string;
   originRecordRef: string;
   originVersion: number;
+  /** Per-installation causal-ordering vector (BI-67315C4A). Optional for
+   *  back-compat; when present, the receiver uses it (not the scalar
+   *  originVersion) to detect clean-newer vs a concurrent conflict. Deliberately
+   *  EXCLUDED from payloadDigest so re-projecting an unchanged record stays
+   *  idempotent while the vector still advances on real changes. */
+  versionVector?: Record<string, number>;
   route: DemandRouteHopV1[];
   audience: DemandAudience;
   title: string;
@@ -131,6 +137,7 @@ const COLLABORATIVE_FIELDS = [
   "applicability",
   "evidence",
   "forwarding",
+  "versionVector",
 ];
 
 const PARTNER_FIELDS = [
@@ -194,6 +201,10 @@ function stableJson(value: unknown): string {
 export function computeDemandPayloadDigest(value: Omit<DemandEnvelopeV1, "payloadDigest"> | DemandEnvelopeV1): string {
   const content = { ...(value as DemandEnvelopeV1) } as Record<string, unknown>;
   delete content.payloadDigest;
+  // The version vector is causal-ordering metadata, not content: excluding it
+  // keeps an unchanged re-projection digest-identical (idempotent noop) while the
+  // vector still advances on real content changes. See DemandEnvelopeV1.
+  delete content.versionVector;
   return `sha256:${createHash("sha256").update(stableJson(content)).digest("hex")}`;
 }
 
@@ -299,6 +310,24 @@ export function validateDemandEnvelopeV1(
     && Number(value.originVersion) <= context.previousOriginVersion
   ) {
     violations.push("originVersion:not-advancing");
+  }
+  if (value.versionVector !== undefined) {
+    if (!isRecord(value.versionVector)) {
+      violations.push("versionVector:invalid");
+    } else {
+      for (const [installationId, counter] of Object.entries(value.versionVector)) {
+        if (
+          installationId.length === 0 ||
+          installationId.length > 160 ||
+          typeof counter !== "number" ||
+          !Number.isSafeInteger(counter) ||
+          counter < 0
+        ) {
+          violations.push("versionVector:invalid");
+          break;
+        }
+      }
+    }
   }
   if (!(DEMAND_AUDIENCES as readonly unknown[]).includes(value.audience)) violations.push("audience:unsupported");
   if (!isNonEmptyString(value.title, 240)) {


### PR DESCRIPTION
## What
First slice of wiring the version-vector core (#4099) into the demand path — the **contract** level only. Pure contract; **no schema, no runtime behavior change** (field is optional and current logic ignores it).

- `DemandEnvelopeV1` gains optional `versionVector: Record<string, number>`.
- `computeDemandPayloadDigest` **excludes** it (like `payloadDigest`) — the **idempotency fix**: a re-projection of an unchanged record stays digest-identical (noop) while the vector still advances on real changes. Locked in by a test.
- Allowed field + shape validation (non-empty install ids → non-negative safe-integer counters).

## Why / next
Sets up the receiver to use causal ordering instead of the wall-clock scalar. Follow-up slices: mirror column + migration → projection populates the vector → exchange uses clean-newer-vs-concurrent detection. Spec §9; kernel DI-1BC547243903.

Typecheck clean (apps/web + packages/db); 179 federation tests green; contract test +6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)