### PR TITLE
feat(federation): version vector live in the demand path (BI-67315C4A #6 slice B)

### DIFF
--- a/apps/web/lib/federation/demand-delivery.ts
+++ b/apps/web/lib/federation/demand-delivery.ts
@@ -15,6 +15,12 @@ import { sendDemandToPeer, type PeerPostResult } from "./client";
 import { buildDemandEnvelope, type ProjectableDemandSource } from "./demand-projection";
 import type { FederationIdentity } from "./demand-identity";
 import { decryptPeerToken } from "./outbound";
+import { incrementVersionVector, isVersionVector, type VersionVector } from "./version-vector";
+
+/** Parse a stored JSON version vector, defaulting to empty when absent/legacy. */
+function readStoredVector(value: unknown): VersionVector {
+  return isVersionVector(value) ? value : {};
+}
 
 type OutboundDemandActivity = Extract<DemandActivity, "dpf.demand.proposed" | "dpf.demand.updated" | "dpf.demand.withdrawn">;
 type OutboundResponseActivity = Extract<DemandActivity, "dpf.demand.interest-recorded" | "dpf.demand.help-offered">;
@@ -47,7 +53,7 @@ export interface DemandDeliveryDb {
     }>>;
   };
   federatedRecordMirror: {
-    findUnique(args: unknown): Promise<Partial<DemandOutboxRow> & { mirrorId: string; version: bigint; syncStatus: string; payload: unknown } | null>;
+    findUnique(args: unknown): Promise<Partial<DemandOutboxRow> & { mirrorId: string; version: bigint; syncStatus: string; payload: unknown; versionVector?: unknown } | null>;
     findMany(args: unknown): Promise<DemandOutboxRow[]>;
     create(args: unknown): Promise<unknown>;
     update(args: unknown): Promise<unknown>;
@@ -101,6 +107,15 @@ export async function queueDemandProjection(db: DemandDeliveryDb, input: {
     return { action: "noop", mirrorId: existing.mirrorId, originVersion: Number(existing.version) };
   }
 
+  // Real content change → advance THIS installation's counter in the causal vector,
+  // carried forward from the record's prior vector. Set after the noop check and
+  // (harmlessly) after digest computation, since the vector is digest-excluded.
+  const versionVector = incrementVersionVector(
+    readStoredVector(existing?.versionVector),
+    input.identity.installationId,
+  );
+  built.envelope.versionVector = versionVector;
+
   const activity: OutboundDemandActivity = existing ? "dpf.demand.updated" : "dpf.demand.proposed";
   const payload: DemandOutboxPayload = {
     envelope: built.envelope,
@@ -111,6 +126,7 @@ export async function queueDemandProjection(db: DemandDeliveryDb, input: {
   const data = {
     syncStatus: "pending",
     version: built.envelope.originVersion,
+    versionVector,
     payload,
     deliveryAttempts: 0,
     nextDeliveryAt: input.now ?? new Date(),

--- a/apps/web/lib/federation/demand-exchange.test.ts
+++ b/apps/web/lib/federation/demand-exchange.test.ts
@@ -284,3 +284,38 @@ describe("received-demand decisions", () => {
     expect(ingest).not.toHaveBeenCalled();
   });
 });
+
+describe("handleIncomingDemand — version-vector conflict (BI-67315C4A)", () => {
+  it("flags a genuinely concurrent version-vector edit as a conflict (the scalar can't)", async () => {
+    const current = envelope({ versionVector: { origin: 1, peerY: 1 } });
+    const { db, updateMany } = demandDb({
+      mirrorId: "fdm_1",
+      version: 1n,
+      versionVector: { origin: 1, peerY: 1 },
+      syncStatus: "synced",
+      payload: { envelope: current, activity: "dpf.demand.proposed", disposition: "observed" },
+    });
+    // Incoming leads on origin+peerX; stored leads on peerY → concurrent.
+    const incoming = envelope({ originVersion: 2, versionVector: { origin: 2, peerX: 1 } });
+    await expect(handleIncomingDemand(db, "link_1", "dpf.demand.updated", incoming)).resolves.toMatchObject({
+      action: "conflict",
+      reason: "concurrent-update",
+    });
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it("accepts a cleanly-newer version vector (dominates) — no false conflict", async () => {
+    const current = envelope({ versionVector: { origin: 1 } });
+    const { db } = demandDb({
+      mirrorId: "fdm_1",
+      version: 1n,
+      versionVector: { origin: 1 },
+      syncStatus: "synced",
+      payload: { envelope: current, activity: "dpf.demand.proposed", disposition: "observed" },
+    });
+    const incoming = envelope({ originVersion: 2, versionVector: { origin: 2 } });
+    await expect(handleIncomingDemand(db, "link_1", "dpf.demand.updated", incoming)).resolves.toMatchObject({
+      action: "updated",
+    });
+  });
+});

--- a/apps/web/lib/federation/demand-exchange.ts
+++ b/apps/web/lib/federation/demand-exchange.ts
@@ -8,6 +8,7 @@ import {
 
 import type { BacklogIngestInput, BacklogIngestResult } from "@/lib/operate/backlog-ingest";
 import { BACKLOG_WORK_TYPE_VALUES, type BacklogWorkType } from "@/lib/explore/backlog";
+import { compareVersionVectors, isVersionVector } from "./version-vector";
 
 export type InboundDemandActivity = Extract<
   DemandActivity,
@@ -31,6 +32,7 @@ export interface DemandMirrorRow {
   version: bigint;
   syncStatus: string;
   payload: unknown;
+  versionVector?: unknown;
 }
 
 export interface DemandExchangeDb {
@@ -124,6 +126,7 @@ export async function handleIncomingDemand(
           peerRecordRef: peerRef,
           syncStatus,
           version: envelope.originVersion,
+          ...(isVersionVector(envelope.versionVector) ? { versionVector: envelope.versionVector } : {}),
           payload,
           lastSyncedAt: new Date(receivedAt),
         },
@@ -142,6 +145,25 @@ export async function handleIncomingDemand(
   }
 
   const current = decodeDemandMirrorPayload(existing.payload);
+
+  // Causal-vector conflict detection (BI-67315C4A): when BOTH sides carry a version
+  // vector, a "concurrent" comparison is a genuine concurrent edit that the scalar
+  // `version` cannot see — surface it as a conflict rather than let one side's write
+  // silently clobber the other. Ordering otherwise still flows through the scalar
+  // below (back-compat with peers that send no vector).
+  if (
+    isVersionVector(envelope.versionVector)
+    && isVersionVector(existing.versionVector)
+    && compareVersionVectors(envelope.versionVector, existing.versionVector) === "concurrent"
+  ) {
+    return {
+      action: "conflict",
+      mirrorId: existing.mirrorId,
+      originVersion: Number(existing.version),
+      reason: "concurrent-update",
+    };
+  }
+
   if (
     Number(existing.version) === envelope.originVersion
     && current?.envelope.payloadDigest === envelope.payloadDigest
@@ -173,6 +195,7 @@ export async function handleIncomingDemand(
     data: {
       syncStatus,
       version: envelope.originVersion,
+      ...(isVersionVector(envelope.versionVector) ? { versionVector: envelope.versionVector } : {}),
       payload,
       conflictReason: null,
       lastSyncedAt: new Date(receivedAt),

--- a/changes/federated-record-mirror-version-vector.data-impact.json
+++ b/changes/federated-record-mirror-version-vector.data-impact.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-67315C4A. Add FederatedRecordMirror.versionVector (nullable JSONB): a per-installation causal-ordering vector for federated demand records. When present on both peer + local mirrors, the demand exchange uses it to distinguish a clean newer-than from a genuine concurrent conflict (which the scalar version cannot see); null on legacy rows / peers that predate it, where the exchange falls back to the scalar. Additive, non-destructive: no existing row is rewritten. No personal data — the vector holds only opaque installation ids mapped to monotonic integers. Migration: 20260807230000_federated_record_mirror_version_vector.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "FederatedRecordMirror",
+      "lifecycleDisposition": "retain-for-link-lifetime",
+      "fields": [
+        {
+          "name": "versionVector",
+          "resolution": "not-applicable",
+          "reason": "Operational causal-ordering metadata (installationId -> monotonic counter) for conflict detection between federated mirrors. Not personal data and not tied to a data subject.",
+          "provenance": "Authored locally by queueDemandProjection (advances this installation's counter on each real change) and carried on the demand envelope; stored on the receiving mirror by the exchange. No new source of data.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260807230000_federated_record_mirror_version_vector/migration.sql
+++ b/packages/db/prisma/migrations/20260807230000_federated_record_mirror_version_vector/migration.sql
@@ -1,0 +1,7 @@
+-- FederatedRecordMirror.versionVector — per-installation causal-ordering vector. (BI-67315C4A)
+--
+-- Additive, nullable JSONB. When present on both peer + local mirrors, the demand
+-- exchange uses it to tell a clean newer-than from a genuine concurrent conflict;
+-- null on legacy rows / peers that predate it, where the exchange falls back to the
+-- scalar `version`. Non-destructive: no existing row is rewritten.
+ALTER TABLE "FederatedRecordMirror" ADD COLUMN "versionVector" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15029,6 +15029,11 @@ model FederatedRecordMirror {
   // epoch (ms) so re-projecting an unchanged record is idempotent. A ms epoch
   // (~1.7e12) overflows Int (int4, max ~2.1e9) — see BI-CC8021CE.
   version             BigInt    @default(1)
+  // Per-installation causal-ordering vector (BI-67315C4A). When present on both
+  // sides, the exchange uses it (not the scalar `version`) to distinguish a clean
+  // newer-than from a genuine concurrent conflict. Null on legacy rows / peers
+  // that predate the vector — the exchange falls back to the scalar then.
+  versionVector       Json?
   conflictReason      String?
   lastSyncedAt        DateTime?
   // Durable delivery state for local-canonical outbox records. Peer-canonical


### PR DESCRIPTION
Runtime wiring of the version-vector: FederatedRecordMirror.versionVector column + migration, projection populates the vector on real changes, receiver surfaces concurrent conflicts the scalar can't see. Back-compat/guarded. Spec §9; kernel DI-1BC547243903. End-to-end two-instance validation is the deploy-time acceptance gate. Data-impact manifest included. 🤖 Generated with [Claude Code](https://claude.com/claude-code)