### PR TITLE
doc(mcp): fold context-economy / progressive-disclosure slices into adoption plan

### DIFF
--- a/docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md
+++ b/docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md
@@ -6,8 +6,9 @@
 | **Date** | 2026-08-06 |
 | **Author** | Claude Code for Mark Bodman |
 | **Implements** | [MCP `2025-11-25` + A2A feature adoption assessment](../specs/2026-08-06-mcp-2025-11-25-and-a2a-feature-adoption-design.md) (merged in `main`) |
+| **Grounds in (extend, do not duplicate)** | [context-engineering & tool-efficiency design](../specs/2026-06-20-context-engineering-tool-efficiency-design.md) (R1/R3/R4/R6, §10 decisions resolved) · [MCP tool-tier deferred-loading design](../specs/2026-06-20-mcp-tool-tier-deferred-loading-design.md) (Phase 1 shipped, Phase 2 staged) · `docs/architecture/context-engineering-standards.md` |
 | **Backlog** | **Unfiled.** Authored in a web session with no reachable DPF backlog MCP / running portal, so BIs could not be filed and `record_plan_backlog_coverage` could not be called. Per the `dpf-writing-plans` guardrail, Markdown checkboxes are **not** a backlog substitute — the governed filing step below must run in a runtime-capable session before this becomes a live plan. |
-| **Blast radius** | Mixed — Slices 1/2/3/5 are low (transport presentation, isolated); Slice 4 is HIGH (coordination plane); Slice 6 is a separate A2A/GAID track. |
+| **Blast radius** | Mixed — Slices 1/2/3/5 low (transport presentation, isolated); Slice 4 HIGH (coordination plane); Slice 6 a separate A2A/GAID track. Context-economy: Slice 7 low, Slice 8 medium (stateful transport + schema migration, discovery-only), Slice 9 HIGH (sandbox boundary), Slice 10 medium. |
 
 > **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
 
@@ -27,6 +28,27 @@ Each row is an independently shippable deliverable. Sizes/epics are proposals fo
 | 4 | Standard MCP **Tasks** lifecycle — converge bespoke `tasks/submit` onto `tasks` capability + `tasks/list\|get\|result\|cancel` over `TaskRun` | Platform Infrastructure | L/XL | **HIGH** | kernel decision + own sub-plan |
 | 5 | ADP service `initialize` handler — conformant handshake in `services/adp/src/server.ts` | Platform Infrastructure | S | Low (isolated) | — |
 | 6 | A2A signed **agent-card export** — read-only projection of coworker `Agent` rows to `.well-known/agent-card.json` (realizes inventory P3) | EP-A2A / GAID | M–L | Med | A2A inventory owner |
+| 7 | Prompt-cache TTL + local prefix-cache hardening — set 1h TTL on long agentic loops; verify DMR/llama.cpp prefix-KV reuse (context-engineering R6/P8) | Platform Infrastructure | S | Low | — |
+| 8 | Phase-2 deferred tool loading on the external-CLI MCP path — `load_tools` + `notifications/tools/list_changed` + per-token `McpToolSession`, **append-not-swap** (cache-preserving) | Platform Infrastructure | M | Med (schema migration + stateful transport; discovery-only) | builds on shipped core tier |
+| 9 | Programmatic tool calling / code execution in the native loop (context-engineering R4) — model filters tool results in-sandbox before they reach context | Platform Infrastructure | L | **HIGH** (sandbox security boundary) | kernel decision + own sub-plan |
+| 10 | Coworker-discovery meta-tool — A2A-plane twin of `load_tools`; disclose coworkers on demand (verify vs existing `requestCoworker` first) | EP-A2A / EP-COWORKER-INTERACTIVITY | M–L | Med | Slice 8 pattern; A2A owner |
+
+## Sequencing — now vs later (recommended)
+
+The progressive-disclosure shift (front-load → disclose-on-demand) is architecturally significant, but the substrate already exists — the **core tier** (R3 Phase 1), the **result-size cap** (R1), the **tool-description lint** (R2), and the **static/dynamic prompt-cache boundary** (P8) all shipped per the context-engineering work — so the *now* slices are contained. The one genuinely high-blast-radius piece (code execution) is correctly *later*. This split is a WWMD work-scope recommendation; route it through `dpf-decision-via-kernel` at filing time (guard-off in this web session).
+
+**NOW — this pass. Highest ROI on the token-cost pain, contained blast radius:**
+- **Slice 7 (cache-TTL hardening)** — near-free. Set `ttl: "1h"` on the stable prefix for long iterative loops (the default silently regressed 1h→5m), and verify the local served model reuses prefix-KV. Directly attacks "iterative calls are expensive".
+- **Slice 8 (Phase-2 deferred tool loading)** — the headline refactor. ~85% up-front tool-surface cut (Anthropic Tool Search figure, cited in the context-engineering design), and **cache-preserving because it appends rather than swaps**. Needs a small `McpToolSession` schema migration and runtime verification, but stays discovery-only and additive on the shipped core tier.
+
+**LATER — sequence after, or gate on a decision:**
+- **Slice 9 (code execution / PTC)** — the biggest iterative-cost lever (Anthropic reports 37–98% cuts) but it touches the sandbox security boundary → kernel-gated spike, own sub-plan.
+- **Slice 10 (coworker-discovery meta-tool)** — after Slice 8 proves the pattern; coordinate with the A2A owner.
+- **Slice 4 (standard MCP Tasks)** — stays later, kernel-gated as before.
+
+**Opportunistic — independent quick wins, any time:** Slices 1/2/3/5 (MCP conformance), Slice 6 (A2A card).
+
+**Already shipped — foundation, do not re-file:** core tier, result-size cap, tool-description lint, static/dynamic cache boundary.
 
 ## Phases (each independently shippable + verifiable)
 
@@ -36,6 +58,10 @@ Each row is an independently shippable deliverable. Sizes/epics are proposals fo
 - **Phase 4 — BI-4 (standard MCP Tasks) — own sub-plan.** Route decisions through `dpf-decision-via-kernel` first: durable-result retention, cancellation authority, and back-compat for current `tasks/submit` callers. Then advertise the `tasks` capability and map `tasks/list|get|result|cancel` onto the `TaskRun` substrate behind a flag, converging the bespoke method. *Verify:* real remote-coworker task submitted, polled, and retrieved through the standard lifecycle; existing `tasks/submit` callers unbroken.
 - **Phase 5 — BI-5 (ADP `initialize`).** Add a conformant `initialize` handler to `services/adp/src/server.ts` (currently only `tools/list`/`tools/call`). *Verify:* a client completes the handshake against the ADP server; ADP integration tests green.
 - **Phase 6 — BI-6 (A2A agent-card export).** Coordinate with the A2A inventory owner. Project coworker `Agent` identity (name, description, skills via `AgentSkillAssignment`, tool grants → capabilities) into the A2A Agent Card schema at `/.well-known/agent-card.json` + a per-agent variant; signed; **read-only, no inbound task execution**. *Verify:* card validates against the A2A card schema; export is governance-gated and read-only; ops-map/user-guide doc updated.
+- **Phase 7 — BI-7 (cache-TTL hardening) [NOW].** Audit the assembled request path (`apps/web/lib/routing/anthropic-cache.ts`, `prompt-assembler.ts`); set `ttl: "1h"` on the stable prefix for long iterative loops whose gaps exceed 5 min; verify the local served model (DMR/llama.cpp) reuses prefix-KV across turns and reorder cache-first if not. *Verify:* `usage.cache_read_input_tokens` non-zero across repeated turns; local cache-hit measured.
+- **Phase 8 — BI-8 (Phase-2 deferred loading) [NOW].** Implement the tool-tier deferred-loading design §4: `tools/list` returns core ∪ session-loaded ∪ a `load_tools` tool; `load_tools({query?,names?})` marks tools loaded for the token session and fires `notifications/tools/list_changed`; add a per-token `McpToolSession` short-TTL store (schema migration). Append, never swap, so the cached prefix survives. *Verify:* a `list_changed`-aware client (Claude Code/Codex) starts on the lean core, loads on demand, and `cache_read_input_tokens` stays non-zero across the expansion; core tier remains the floor for non-aware clients.
+- **Phase 9 — BI-9 (code execution / PTC) [LATER — own sub-plan].** Route through `dpf-decision-via-kernel` first (sandbox authority; kernel-gate-inside-code). Behind a flag, let the build model (then coworkers) emit code that calls tools and filters results in the existing sandbox before results re-enter context. *Verify:* a real build path with tool-result token volume cut and the kernel gate enforced inside the code path.
+- **Phase 10 — BI-10 (coworker-discovery meta-tool) [LATER].** After Slice 8. Verify `requestCoworker`/agent-registry doesn't already cover intent-based discovery; if not, add a `find_coworker`/discover-by-intent tool mirroring `load_tools` so coworkers disclose incrementally. *Verify:* a coworker surfaced on demand; ops-map/registry model unchanged.
 
 ## Risks & rollback
 
@@ -43,12 +69,16 @@ Each row is an independently shippable deliverable. Sizes/epics are proposals fo
 - **Slice 4 (HIGH):** changes long-running task semantics on the coordination plane. Mitigate with a capability flag + parallel back-compat path for `tasks/submit`; do not retire the bespoke method until callers are migrated. Rollback = disable the flag.
 - **Slice 5:** isolated to the ADP service; rollback = revert the handler.
 - **Slice 6:** read-only export; the risk is over-exposing agent metadata externally → governance gate + explicit allowlist of exported fields; rollback = unpublish the route.
+- **Slice 7:** config-level. Risk is a 1h TTL on a not-actually-stable prefix wasting cache writes → scope the 1h TTL to genuinely stable prefixes; rollback = revert the TTL setting.
+- **Slice 8 (Med):** stateful transport + schema migration, and client-dependent (only `list_changed`-aware clients benefit). Mitigate: keep the static core tier as the universal floor; append-not-swap preserves the cache (naive top-level `tools`-array edits would bust it — do not do that); rollback = stop advertising `load_tools` and disable the session store, and clients fall back to core tier.
+- **Slice 9 (HIGH):** sandbox security boundary. Kernel-gated, flag-guarded; the kernel gate must run *inside* the code path. Rollback = disable the flag.
+- **Slice 10:** discovery/read only; rollback = unregister the tool.
 
 ## Backlog coverage (pending — file in a runtime session)
 
 This design is **not** yet represented in the live backlog. Before implementation, in a runtime-capable session with the DPF backlog MCP reachable:
 
-1. File the umbrella BI and the six child BIs above via the governed `dpf-file-backlog-item` path, confirming size/epic against live state and reusing any existing covering BI (`search_backlog` first — do not duplicate).
+1. File the umbrella BI and the child BIs listed above via the governed `dpf-file-backlog-item` path, confirming size/epic against live state and reusing any existing covering BI (`search_backlog` first — do not duplicate). Note Slices 7–10 extend the context-engineering work (R1/R3/R4/R6) — reuse those BIs/epic where they already exist rather than filing parallel ones.
 2. Call `record_plan_backlog_coverage` with the umbrella BI, this plan's path, the deliverable graph, the BI mappings, and `decision: decomposed`.
 3. Replace this section with the canonical `## Backlog coverage` block (Parent / Decision / Receipt / Dependencies / deliverable→BI mappings) carrying the returned live receipt, and add the umbrella-BI marker line the coverage gate keys on (the bolded `Backlog item:` field pointing at the filed umbrella id) so the gate validates it.
 


### PR DESCRIPTION
## Summary

Extends the merged [MCP `2025-11-25` + A2A adoption plan](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md) with the **context-economy / progressive-disclosure** workstream and an explicit **now-vs-later** sequencing call, in response to high per-transaction token cost and expensive iterative calls. It is grounded in DPF's existing context-engineering research (`2026-06-20-context-engineering-tool-efficiency-design.md` R1/R3/R4/R6 and the tool-tier deferred-loading design), so it **extends rather than duplicates** — and it records what already shipped so nothing is re-filed. No code changed.

## Changes

- Edits `docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md`:
  - **Four new deliverables (7–10):** cache-TTL + local prefix-cache hardening; Phase-2 deferred tool loading on the external-CLI MCP path (`load_tools` + `notifications/tools/list_changed` + `McpToolSession`, **append-not-swap so the prompt cache survives**); programmatic tool calling / code execution in the native loop; a coworker-discovery meta-tool (A2A-plane twin of `load_tools`).
  - **A "Sequencing — now vs later" section:** NOW = Slice 7 (near-free TTL win) + Slice 8 (the headline ~85% up-front cut, cache-preserving, contained); LATER = Slice 9 (code execution — biggest lever, sandbox boundary, kernel-gated) + Slice 10 (coworker discovery) + Slice 4 (standard Tasks). Opportunistic: MCP conformance + A2A card. Already-shipped foundation listed so it is not re-filed.
  - Per-slice **blast radius, phases, and risks/rollback**, including the explicit caveat that naive top-level `tools`-array edits bust the cache while the append-not-swap mechanisms preserve it.
  - Grounding cross-links to the context-engineering + tool-tier deferred-loading specs.

## Test plan

- [x] **Source-only change** (doc)
- [x] **Verification-harness limitation acknowledged** — web session, no canonical runtime. Guards reasoned statically: no `superpowers:<slug>` tokens (grep = 0); no `Backlog item: BI-…` marker, so `check-plan-backlog-coverage` stays out of scope; cross-linked specs confirmed present; `check:prose-lint` scans only `apps/web/app` + `components`.

## Pre-PR readiness

Docs-only change; no runtime surface.

- Local-CI-Override: docs-only change authored without canonical runtime; no code/UX/migration surface touched.

## Related issues / Epic

- Extends the merged adoption plan (#4072) / assessment spec (#4069) and grounds in the context-engineering work (R1/R3/R4/R6). Proposed epics: Platform Infrastructure, EP-A2A, EP-COWORKER-INTERACTIVITY — to confirm at filing time, reusing existing context-engineering BIs/epic where present.

## Notes for the reviewer

- The now-vs-later split is a WWMD work-scope **recommendation** — flagged in the doc to route through `dpf-decision-via-kernel` at filing time (guard-off in this web session).
- Right-sizing note: the progressive-disclosure *pattern* is architecturally significant, but the *now* slices are contained because the substrate (core tier, result cap, cache boundary) already shipped; the one high-blast-radius piece (code execution) is deliberately *later*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtVJp2ouxgkYvxxFVxDzkN)_