### PR TITLE
feat(federation): cross-org demand deny-by-default gate (BI-DC4E526E)

### DIFF
--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -46,6 +46,7 @@ describe("selectLocalDemandForLink direction", () => {
         backlogItem: { findUnique: vi.fn().mockResolvedValue({
           itemId: "BI-LOCAL",
           title: "Local need",
+          sensitivity: "public",
           body: null,
           status: "open",
           workType: "feature",
@@ -82,6 +83,7 @@ describe("selectLocalDemandForLink direction", () => {
         backlogItem: { findUnique: vi.fn().mockResolvedValue({
           itemId: "BI-CLOSED",
           title: "Resolved need",
+          sensitivity: "public",
           body: null,
           status,
           workType: "feature",
@@ -116,6 +118,7 @@ describe("selectLocalDemandForLink direction", () => {
       backlogItem: { findUnique: vi.fn().mockResolvedValue({
         itemId: "BI-LOCAL",
         title: "Distributor need",
+        sensitivity: "public",
         body: null,
         status: "open",
         workType: "feature",
@@ -132,6 +135,40 @@ describe("selectLocalDemandForLink direction", () => {
       itemId: "BI-LOCAL",
       allowForwardToFounder: true,
     })).rejects.toThrow("Founder forwarding consent applies only when sharing with a distributor.");
+  });
+
+  it("denies cross-org sharing of an item that is not marked public (BI-DC4E526E deny-by-default)", async () => {
+    const db = {
+      federationLink: { findUnique: vi.fn().mockResolvedValue({
+        linkId: "FL-CHANNEL",
+        role: "channel-downstream",
+        linkState: "trusted",
+        peerAuthorityUrl: "https://distributor.example",
+        peerTokenEnc: "token",
+        peerInstallationId: "inst_dist",
+        projectionContractId: null,
+        revokedAt: null,
+        quarantinedAt: null,
+      }) },
+      backlogItem: { findUnique: vi.fn().mockResolvedValue({
+        itemId: "BI-PROPRIETARY",
+        title: "Proprietary need",
+        sensitivity: "internal", // the default — not cleared to leave the org
+        body: null,
+        status: "open",
+        workType: "feature",
+        occurrenceCount: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        digitalProduct: null,
+      }) },
+      projectionContract: { findFirst: vi.fn().mockResolvedValue(null) },
+    };
+
+    await expect(selectLocalDemandForLink(db as never, {
+      linkId: "FL-CHANNEL",
+      itemId: "BI-PROPRIETARY",
+    })).rejects.toThrow(/does not permit cross-organization sharing/);
   });
 });
 

--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -21,6 +21,7 @@ import {
   queueForwardedDemand,
   type DemandDeliveryDb,
 } from "./demand-delivery";
+import { assertMayCrossOrgBoundary } from "./cross-org-sharing";
 import { decodeDemandMirrorPayload } from "./demand-exchange";
 import { resolveFederationIdentity, type FederationIdentityDb } from "./demand-identity";
 import { relationshipPresetForRole } from "./demand-reconciliation";
@@ -42,6 +43,7 @@ interface ChannelBacklogItem {
   title: string;
   body: string | null;
   status: string;
+  sensitivity: string;
   workType: string | null;
   occurrenceCount: number;
   createdAt: Date;
@@ -232,6 +234,7 @@ export async function selectLocalDemandForLink(
         title: true,
         body: true,
         status: true,
+        sensitivity: true,
         workType: true,
         occurrenceCount: true,
         createdAt: true,
@@ -257,6 +260,11 @@ export async function selectLocalDemandForLink(
   if ((item.body ?? "").includes("[origin:federatedDemand:")) {
     throw new Error("Adopted demand must use governed forwarding so original provenance is preserved.");
   }
+  // Cross-org deny-by-default (BI-DC4E526E, kernel DI-3E77E48D5710): this link
+  // crosses an organization boundary (channel / service-provider), so the item may
+  // leave only if its sensitivity explicitly permits it. Unclassified ("internal")
+  // proprietary demand never leaks upstream.
+  assertMayCrossOrgBoundary(item.sensitivity);
   const preset = relationshipPresetForRole(link.role);
   if (preset !== "channel" && preset !== "service-provider") {
     throw new Error("This relationship cannot receive explicitly shared demand.");

--- a/apps/web/lib/federation/cross-org-sharing.test.ts
+++ b/apps/web/lib/federation/cross-org-sharing.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertMayCrossOrgBoundary,
+  DEFAULT_BACKLOG_SENSITIVITY,
+  isBacklogSensitivity,
+  mayCrossOrgBoundary,
+  normalizeSensitivity,
+} from "./cross-org-sharing";
+
+describe("normalizeSensitivity", () => {
+  it("keeps valid values and defaults everything else to the safe internal", () => {
+    expect(normalizeSensitivity("public")).toBe("public");
+    expect(normalizeSensitivity("confidential")).toBe("confidential");
+    expect(normalizeSensitivity(undefined)).toBe("internal");
+    expect(normalizeSensitivity(null)).toBe("internal");
+    expect(normalizeSensitivity("bogus")).toBe("internal");
+    expect(DEFAULT_BACKLOG_SENSITIVITY).toBe("internal");
+  });
+});
+
+describe("mayCrossOrgBoundary — deny-by-default (DI-3E77E48D5710)", () => {
+  it("permits ONLY explicitly public items across an org boundary", () => {
+    expect(mayCrossOrgBoundary("public")).toBe(true);
+  });
+
+  it.each(["internal", "confidential", "restricted", undefined, null, "bogus"])(
+    "denies %s (unclassified/proprietary never leaks upstream)",
+    (value) => {
+      expect(mayCrossOrgBoundary(value)).toBe(false);
+    },
+  );
+});
+
+describe("assertMayCrossOrgBoundary", () => {
+  it("passes for public and throws an operator-facing refusal otherwise", () => {
+    expect(() => assertMayCrossOrgBoundary("public")).not.toThrow();
+    expect(() => assertMayCrossOrgBoundary("internal")).toThrow(/does not permit cross-organization sharing/);
+    expect(() => assertMayCrossOrgBoundary(undefined)).toThrow(/Mark it "public"/);
+  });
+});
+
+describe("isBacklogSensitivity", () => {
+  it.each([
+    ["public", true],
+    ["restricted", true],
+    ["", false],
+    ["Public", false],
+    [3, false],
+  ])("isBacklogSensitivity(%s) === %s", (value, expected) => {
+    expect(isBacklogSensitivity(value)).toBe(expected);
+  });
+});

--- a/apps/web/lib/federation/cross-org-sharing.ts
+++ b/apps/web/lib/federation/cross-org-sharing.ts
@@ -1,0 +1,59 @@
+// EP-DELIVERY-FLOW · BI-DC4E526E — cross-organization demand-sharing gate.
+//
+// Same-org federation is trust-by-default. Crossing an ORG boundary (customer →
+// reseller → upstream vendor hub) is DENY-BY-DEFAULT: a backlog item may be proprietary
+// and not meant for others. Kernel decision DI-3E77E48D5710 (high confidence,
+// "least privilege, deny by default") governs this: an item crosses an org
+// boundary only if its sensitivity explicitly permits it.
+//
+// Sensitivity reuses the platform's existing classification vocabulary
+// (public | internal | confidential | restricted). Only `public` — the operator's
+// explicit "safe to share beyond our organization" mark — is cross-org eligible.
+// The DEFAULT is `internal`, so an unclassified item never leaks upstream.
+//
+// Pure and dependency-free — exhaustively unit-testable. The egress chokepoints
+// (channel-demand selection, and any future cross-org auto-projection) call
+// assertMayCrossOrgBoundary before an item is projected onto a cross-org link.
+
+export const BACKLOG_SENSITIVITY_VALUES = [
+  "public",
+  "internal",
+  "confidential",
+  "restricted",
+] as const;
+export type BacklogSensitivity = (typeof BACKLOG_SENSITIVITY_VALUES)[number];
+
+/** The safe default for an unclassified item: within-org only. */
+export const DEFAULT_BACKLOG_SENSITIVITY: BacklogSensitivity = "internal";
+
+/** The ONLY sensitivity that may cross an organization boundary. */
+const CROSS_ORG_ELIGIBLE: ReadonlySet<BacklogSensitivity> = new Set(["public"]);
+
+export function isBacklogSensitivity(value: unknown): value is BacklogSensitivity {
+  return (
+    typeof value === "string" &&
+    (BACKLOG_SENSITIVITY_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/** Coerce a stored/nullable value to a valid sensitivity, defaulting to the safe
+ *  `internal` — an unknown or missing classification is treated as NOT shareable. */
+export function normalizeSensitivity(value: unknown): BacklogSensitivity {
+  return isBacklogSensitivity(value) ? value : DEFAULT_BACKLOG_SENSITIVITY;
+}
+
+/** Deny-by-default: true only when the item is explicitly cleared to leave the org. */
+export function mayCrossOrgBoundary(sensitivity: unknown): boolean {
+  return CROSS_ORG_ELIGIBLE.has(normalizeSensitivity(sensitivity));
+}
+
+/** Throw a clear, operator-facing refusal when an item may not cross an org
+ *  boundary. Called at every cross-org egress chokepoint. */
+export function assertMayCrossOrgBoundary(sensitivity: unknown): void {
+  if (!mayCrossOrgBoundary(sensitivity)) {
+    throw new Error(
+      `This item's sensitivity ("${normalizeSensitivity(sensitivity)}") does not permit ` +
+        `cross-organization sharing. Mark it "public" to share it beyond your organization.`,
+    );
+  }
+}

--- a/changes/backlog-item-sensitivity.data-impact.json
+++ b/changes/backlog-item-sensitivity.data-impact.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-DC4E526E. Add BacklogItem.sensitivity (public|internal|confidential|restricted, default internal) to gate cross-organization federated-demand sharing deny-by-default (kernel DI-3E77E48D5710). Only `public` items may cross an org boundary; unclassified items default to internal and never leak upstream. Additive, non-destructive; existing rows default to the safe `internal`. Migration: 20260807234500_backlog_item_sensitivity.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "BacklogItem",
+      "lifecycleDisposition": "retain-with-item",
+      "fields": [
+        {
+          "name": "sensitivity",
+          "resolution": "governed",
+          "reason": "Governs whether the item's demand projection may cross an organization boundary. Not itself personal data; it is the operator's confidentiality classification of the work item, enforced at the cross-org egress chokepoint.",
+          "provenance": "Operator-set (default internal). Read by assertMayCrossOrgBoundary at the channel/service-provider egress point; no external source.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260807234500_backlog_item_sensitivity/migration.sql
+++ b/packages/db/prisma/migrations/20260807234500_backlog_item_sensitivity/migration.sql
@@ -1,0 +1,8 @@
+-- BacklogItem.sensitivity — cross-org sharing classification. (BI-DC4E526E)
+--
+-- public | internal | confidential | restricted. Deny-by-default: only `public`
+-- may cross an organization boundary in federated demand (kernel DI-3E77E48D5710).
+-- Defaults to `internal` so every existing/unclassified item is treated as NOT
+-- cross-org-shareable — proprietary demand never leaks upstream. Additive,
+-- non-destructive.
+ALTER TABLE "BacklogItem" ADD COLUMN "sensitivity" TEXT NOT NULL DEFAULT 'internal';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2101,6 +2101,11 @@ model BacklogItem {
   title                   String
   status                  String
   type                    String
+  // Cross-org sharing classification (BI-DC4E526E): public | internal |
+  // confidential | restricted. Deny-by-default — only `public` may cross an
+  // organization boundary in federated demand (kernel DI-3E77E48D5710). Default
+  // `internal` so unclassified proprietary demand never leaks upstream.
+  sensitivity             String                        @default("internal")
   body                    String?
   createdAt               DateTime                      @default(now())
   updatedAt               DateTime                      @updatedAt


### PR DESCRIPTION
## What
Makes cross-organization demand sharing **deny-by-default** — the proprietary-data concern, enforced.

- **`BacklogItem.sensitivity`** (`public|internal|confidential|restricted`, default `internal`), reusing the platform's existing classification vocabulary. Additive migration + data-impact manifest; existing rows default to the safe `internal`.
- **`cross-org-sharing.ts`** (NEW, pure): `mayCrossOrgBoundary` permits **only** `public`; unknown/missing → `internal` (denied). 9 tests.
- **Wired at the cross-org egress chokepoint** (`selectLocalDemandForLink`): an item leaves the org only if its sensitivity permits; internal/unclassified is refused with an operator-facing message. +1 enforcement test.

## Why
Same-org = trust-by-default; **cross-org = deny-by-default** (kernel **DI-3E77E48D5710**, high confidence). Unclassified proprietary demand can't leak upstream. Same-org path unaffected. Follow-ups: content redaction for cross-org summaries, egress audit.

Typecheck clean; 194 federation tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)