### PR TITLE
feat(federation): context-derived cross-org gate — platform auto-flows, customer-domain private (BI-DC4E526E)

### DIFF
--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -47,6 +47,7 @@ describe("selectLocalDemandForLink direction", () => {
           itemId: "BI-LOCAL",
           title: "Local need",
           sensitivity: "public",
+          scopeKind: null,
           body: null,
           status: "open",
           workType: "feature",
@@ -84,6 +85,7 @@ describe("selectLocalDemandForLink direction", () => {
           itemId: "BI-CLOSED",
           title: "Resolved need",
           sensitivity: "public",
+          scopeKind: null,
           body: null,
           status,
           workType: "feature",
@@ -118,14 +120,15 @@ describe("selectLocalDemandForLink direction", () => {
       backlogItem: { findUnique: vi.fn().mockResolvedValue({
         itemId: "BI-LOCAL",
         title: "Distributor need",
-        sensitivity: "public",
+        sensitivity: "internal",
+        scopeKind: "platform",
         body: null,
         status: "open",
         workType: "feature",
         occurrenceCount: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
-        digitalProduct: null,
+        digitalProduct: { productId: "dpf-portal" },
       }) },
       projectionContract: { findFirst: vi.fn().mockResolvedValue(null) },
     };
@@ -153,7 +156,8 @@ describe("selectLocalDemandForLink direction", () => {
       backlogItem: { findUnique: vi.fn().mockResolvedValue({
         itemId: "BI-PROPRIETARY",
         title: "Proprietary need",
-        sensitivity: "internal", // the default — not cleared to leave the org
+        sensitivity: "internal",
+        scopeKind: null, // the default — not cleared to leave the org
         body: null,
         status: "open",
         workType: "feature",
@@ -168,7 +172,7 @@ describe("selectLocalDemandForLink direction", () => {
     await expect(selectLocalDemandForLink(db as never, {
       linkId: "FL-CHANNEL",
       itemId: "BI-PROPRIETARY",
-    })).rejects.toThrow(/does not permit cross-organization sharing/);
+    })).rejects.toThrow(/cannot be shared across an organization boundary/);
   });
 });
 

--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -21,7 +21,7 @@ import {
   queueForwardedDemand,
   type DemandDeliveryDb,
 } from "./demand-delivery";
-import { assertMayCrossOrgBoundary } from "./cross-org-sharing";
+import { assertMayShareDemandCrossOrg } from "./cross-org-sharing";
 import { decodeDemandMirrorPayload } from "./demand-exchange";
 import { resolveFederationIdentity, type FederationIdentityDb } from "./demand-identity";
 import { relationshipPresetForRole } from "./demand-reconciliation";
@@ -44,6 +44,7 @@ interface ChannelBacklogItem {
   body: string | null;
   status: string;
   sensitivity: string;
+  scopeKind: string | null;
   workType: string | null;
   occurrenceCount: number;
   createdAt: Date;
@@ -235,6 +236,7 @@ export async function selectLocalDemandForLink(
         body: true,
         status: true,
         sensitivity: true,
+        scopeKind: true,
         workType: true,
         occurrenceCount: true,
         createdAt: true,
@@ -260,11 +262,16 @@ export async function selectLocalDemandForLink(
   if ((item.body ?? "").includes("[origin:federatedDemand:")) {
     throw new Error("Adopted demand must use governed forwarding so original provenance is preserved.");
   }
-  // Cross-org deny-by-default (BI-DC4E526E, kernel DI-3E77E48D5710): this link
-  // crosses an organization boundary (channel / service-provider), so the item may
-  // leave only if its sensitivity explicitly permits it. Unclassified ("internal")
-  // proprietary demand never leaks upstream.
-  assertMayCrossOrgBoundary(item.sensitivity);
+  // Cross-org gate (BI-DC4E526E, kernel DI-3E77E48D5710) — CONTEXT-DERIVED, so no
+  // manual per-item classification is required for correct behavior (cognitive-load
+  // aversion): PLATFORM demand (dpf-portal / scopeKind=platform) auto-flows upstream
+  // to the vendor; a customer's OWN domain work (their internal infrastructure /
+  // operations) never leaves by default. Sensitivity is only a rare override.
+  assertMayShareDemandCrossOrg({
+    sensitivity: item.sensitivity,
+    digitalProductId: item.digitalProduct?.productId ?? null,
+    scopeKind: item.scopeKind,
+  });
   const preset = relationshipPresetForRole(link.role);
   if (preset !== "channel" && preset !== "service-provider") {
     throw new Error("This relationship cannot receive explicitly shared demand.");

--- a/apps/web/lib/federation/cross-org-sharing.test.ts
+++ b/apps/web/lib/federation/cross-org-sharing.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertMayCrossOrgBoundary,
+  isPlatformScopedDemand,
+  mayShareDemandCrossOrg,
   DEFAULT_BACKLOG_SENSITIVITY,
   isBacklogSensitivity,
   mayCrossOrgBoundary,
@@ -49,5 +51,34 @@ describe("isBacklogSensitivity", () => {
     [3, false],
   ])("isBacklogSensitivity(%s) === %s", (value, expected) => {
     expect(isBacklogSensitivity(value)).toBe(expected);
+  });
+});
+
+describe("isPlatformScopedDemand", () => {
+  it("is true for dpf-portal digitalProduct or scopeKind platform", () => {
+    expect(isPlatformScopedDemand({ digitalProductId: "dpf-portal" })).toBe(true);
+    expect(isPlatformScopedDemand({ scopeKind: "platform" })).toBe(true);
+  });
+  it("is false for a customer's own business domain", () => {
+    expect(isPlatformScopedDemand({ digitalProductId: "acme-widgets", scopeKind: "archetype-leaf" })).toBe(false);
+    expect(isPlatformScopedDemand({})).toBe(false);
+  });
+});
+
+describe("mayShareDemandCrossOrg — context-derived, automatic (BI-DC4E526E)", () => {
+  it("auto-permits PLATFORM demand upstream with no manual flag (default internal)", () => {
+    expect(mayShareDemandCrossOrg({ digitalProductId: "dpf-portal" })).toBe(true);
+    expect(mayShareDemandCrossOrg({ scopeKind: "platform", sensitivity: "internal" })).toBe(true);
+  });
+  it("auto-denies customer-domain demand by default (no manual step to stay private)", () => {
+    expect(mayShareDemandCrossOrg({ digitalProductId: "acme-widgets", sensitivity: "internal" })).toBe(false);
+    expect(mayShareDemandCrossOrg({})).toBe(false);
+  });
+  it("lets an explicit public release a customer-domain item (rare override)", () => {
+    expect(mayShareDemandCrossOrg({ digitalProductId: "acme-widgets", sensitivity: "public" })).toBe(true);
+  });
+  it("hard-blocks confidential/restricted even for platform demand", () => {
+    expect(mayShareDemandCrossOrg({ digitalProductId: "dpf-portal", sensitivity: "confidential" })).toBe(false);
+    expect(mayShareDemandCrossOrg({ scopeKind: "platform", sensitivity: "restricted" })).toBe(false);
   });
 });

--- a/apps/web/lib/federation/cross-org-sharing.ts
+++ b/apps/web/lib/federation/cross-org-sharing.ts
@@ -57,3 +57,56 @@ export function assertMayCrossOrgBoundary(sensitivity: unknown): void {
     );
   }
 }
+
+// ─── Context-derived eligibility (BI-DC4E526E) ──────────────────────────────
+//
+// The PRIMARY cross-org gate is the BI's context, not a hand-set flag: demand for
+// the DPF PLATFORM ITSELF legitimately flows upstream to the vendor (that IS the
+// federated-demand network's purpose), while a customer's OWN business/domain work
+// — their internal infrastructure, operations, proprietary product backlog — must
+// never auto-leave. Sensitivity is only an override on top of that context.
+
+/** The DigitalProduct id that denotes the DPF platform itself. */
+export const PLATFORM_DIGITAL_PRODUCT_ID = "dpf-portal";
+
+export interface DemandShareContext {
+  /** BacklogItem.sensitivity (public|internal|confidential|restricted). */
+  sensitivity?: unknown;
+  /** The item's DigitalProduct productId, if any (dpf-portal ⇒ platform demand). */
+  digitalProductId?: string | null;
+  /** The item's planning scope (scopeKind="platform" ⇒ platform demand). */
+  scopeKind?: string | null;
+}
+
+/** True when the item is demand for the DPF platform itself (vs. a customer's own
+ *  business domain). Platform demand is what may flow upstream to the vendor. */
+export function isPlatformScopedDemand(ctx: DemandShareContext): boolean {
+  return ctx.digitalProductId === PLATFORM_DIGITAL_PRODUCT_ID || ctx.scopeKind === "platform";
+}
+
+/** Context-derived cross-org eligibility (deny-by-default):
+ *   - `confidential` / `restricted` sensitivity is a HARD block, even for platform demand.
+ *   - otherwise PLATFORM-scoped demand is eligible (auto-flows upstream to the vendor).
+ *   - otherwise (customer-domain) it is denied unless explicitly marked `public`.
+ *  So a customer's internal infrastructure BI never leaves by default; a platform
+ *  feature/bug BI does; and either can be overridden by an explicit sensitivity. */
+export function mayShareDemandCrossOrg(ctx: DemandShareContext): boolean {
+  const s = normalizeSensitivity(ctx.sensitivity);
+  if (s === "confidential" || s === "restricted") return false;
+  if (isPlatformScopedDemand(ctx)) return true;
+  return s === "public";
+}
+
+/** Operator-facing refusal for a context-gated cross-org share. */
+export function assertMayShareDemandCrossOrg(ctx: DemandShareContext): void {
+  if (mayShareDemandCrossOrg(ctx)) return;
+  const s = normalizeSensitivity(ctx.sensitivity);
+  const reason =
+    s === "confidential" || s === "restricted"
+      ? `it is classified "${s}"`
+      : `it is customer-domain demand (not platform demand) and is not marked "public"`;
+  throw new Error(
+    `This item cannot be shared across an organization boundary: ${reason}. ` +
+      `Platform demand flows upstream automatically; customer-domain demand must be marked "public" to share.`,
+  );
+}


### PR DESCRIPTION
## What
Makes the cross-org gate **automatic** — derived from the BI's context, so no operator hand-classifies anything (cognitive-load aversion; kernel `human_cognitive_load` cost axis). Builds on #4104 (the `sensitivity` field + deny-by-default gate, now merged).

- **Platform demand** (`digitalProduct=dpf-portal` or `scopeKind=platform`) **auto-flows upstream** to the vendor — the federated-demand network's purpose.
- **Customer-domain demand** (their own products / internal infrastructure / operations) **never leaves by default**.
- `sensitivity` is only a **rare override**: `confidential`/`restricted` hard-blocks even platform demand; `public` releases a specific customer-domain item. No manual step for correct behavior.

`cross-org-sharing.ts`: `isPlatformScopedDemand`, `mayShareDemandCrossOrg` (+9 tests). `channel-demand.ts` egress chokepoint gates on context (`digitalProductId + scopeKind + sensitivity`). 31 tests green; typecheck clean; no schema change (field shipped in #4104).

## Why
Answers the operator concern — "we don't want to see a customer's internal infrastructure detail" — automatically, from existing scope. Kernel-governed (DI-3E77E48D5710). Recorded on BI-DC4E526E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)