### PR TITLE
fix(deps): floor nanoid in the marketing-media probe lockfile (Dependabot #152)

### DIFF
--- a/scripts/probes/marketing-media/pnpm-lock.yaml
+++ b/scripts/probes/marketing-media/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   hono: ^4.12.34
+  nanoid@<3.3.17: ^3.3.17
 
 importers:
 
@@ -727,8 +728,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1551,7 +1552,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-domexception@1.0.0:
     optional: true
@@ -1594,7 +1595,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/scripts/probes/marketing-media/pnpm-workspace.yaml
+++ b/scripts/probes/marketing-media/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ overrides:
   # (Dependabot #140, medium). Transitive of hyperframes, which declares an
   # open `hono: ^4` range. Floor to the patched 4.12.34.
   hono: '^4.12.34'
+  # nanoid < 3.3.17: GHSA-2v37-7h3g-55p8 (Dependabot #152, high) — predictable
+  # output when given a non-integer size. Transitive in this probe's tree
+  # (resolves to 3.3.16); the root floor does not reach this standalone
+  # project. Floor the 3.x line to the patched 3.3.17.
+  'nanoid@<3.3.17': '^3.3.17'
 
 allowBuilds:
   "@google/genai@1.52.0": false


### PR DESCRIPTION
## What

Closes the remaining **nanoid** Dependabot alert (#152, GHSA-2v37-7h3g-55p8, high) that stayed open after [PR #4101](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4101).

## Why it wasn't fixed by #4101

The alert's manifest path is **`scripts/probes/marketing-media/pnpm-lock.yaml`** — a *standalone* pnpm project (`@dpf/marketing-media-probe`) with its own `pnpm-workspace.yaml` + lockfile. The root workspace overrides do not reach it (its workspace file says so explicitly and already repeats the `hono` floor for the same reason). #4101 floored nanoid in the root tree, which cleared the root-lockfile exposure but not this probe's copy, which still resolved `nanoid@3.3.16`.

## How

Repeated the floor in the probe's own overrides, mirroring the existing `hono` security floor there:

```yaml
'nanoid@<3.3.17': '^3.3.17'
```

Only the 3.x line is affected. The probe lockfile was regenerated against a fresh empty store (same fresh-metadata approach as `scripts/regen-lockfile.mjs`); the diff is scoped to **nanoid 3.3.16 → 3.3.18** and a second resolve is a stable no-op (frozen-lockfile CI passes).

## Verification

- `grep nanoid@ scripts/probes/marketing-media/pnpm-lock.yaml` → only `3.3.18` remains; no vulnerable copy.
- Diff scoped to the probe's two files only; `git diff --unified=0` shows a single package change (nanoid).
- `pnpm run pregate:preflight` → 0 (35 guards clean; 3 tsx-runtime guards env-skipped, CI enforces).

## Remaining alerts after this merges

Only the two **image-size** alerts (#150, #151) remain — no fixed version exists (latest release 2.0.2 is still in the vulnerable `≤ 2.0.2` range) and it is a build-time-only `metro` bundler transitive that never processes attacker-supplied input. Left open pending an upstream fix, per prior decision.

One concern per PR: a single security dependency floor.

Local-CI-Evidence: cmsjpy8i700my01pps2so3bon (fix/dependabot-nanoid-probe-lockfile@0b6f4449b)
