### PR TITLE
feat(federation): cross-org content redaction — title-only, body never crosses (BI-DC4E526E)

### DIFF
--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -176,6 +176,47 @@ describe("selectLocalDemandForLink direction", () => {
   });
 });
 
+describe("selectLocalDemandForLink — cross-org content redaction (BI-DC4E526E)", () => {
+  it("projects TITLE-only as the summary; the raw body never crosses", async () => {
+    const queueProjection = vi.fn().mockResolvedValue({ action: "queued", mirrorId: "m", originVersion: 1 });
+    const resolveIdentity = vi.fn().mockResolvedValue({ installationId: "inst_self", projectionSecret: "s".repeat(64) });
+    const db = {
+      federationLink: {
+        findUnique: vi.fn().mockResolvedValue({
+          linkId: "FL-CH", role: "channel-downstream", linkState: "trusted",
+          peerAuthorityUrl: "https://distributor.example", peerTokenEnc: "token",
+          peerInstallationId: "inst_dist", projectionContractId: null,
+          revokedAt: null, quarantinedAt: null,
+        }),
+        update: vi.fn(),
+      },
+      backlogItem: { findUnique: vi.fn().mockResolvedValue({
+        itemId: "BI-PLAT",
+        title: "Platform sync bug",
+        sensitivity: "internal",
+        scopeKind: "platform",
+        body: "SECRET customer infra detail: 10.0.0.5 admin creds",
+        status: "open",
+        workType: "bug",
+        occurrenceCount: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        digitalProduct: { productId: "dpf-portal" },
+      }) },
+      projectionContract: { findFirst: vi.fn().mockResolvedValue(null), upsert: vi.fn() },
+    };
+
+    await selectLocalDemandForLink(db as never, { linkId: "FL-CH", itemId: "BI-PLAT" }, {
+      queueProjection, resolveIdentity,
+    });
+
+    const source = queueProjection.mock.calls[0][1].source;
+    expect(source.summary).toBe("Platform sync bug");
+    expect(JSON.stringify(source)).not.toContain("SECRET");
+    expect(JSON.stringify(source)).not.toContain("10.0.0.5");
+  });
+});
+
 describe("decodeChannelDemandPolicy", () => {
   it("defaults partner exchange to explicit selection and pseudonymous attribution", () => {
     expect(decodeChannelDemandPolicy(null)).toEqual({

--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -129,13 +129,15 @@ function assertTrustedPartnerLink(link: ChannelLink | null): asserts link is Cha
   }
 }
 
-function safeSummary(body: string | null, title: string): string {
-  const value = (body ?? "")
-    .split("\n")
-    .filter((line) => !line.trim().startsWith("[origin:"))
-    .join("\n")
-    .trim();
-  return value || title;
+// Cross-org content redaction (BI-DC4E526E). The raw backlog BODY may hold a
+// customer's internal detail, so it must NEVER cross an organization boundary —
+// even for platform demand. The projected cross-org summary is the operator's
+// concise TITLE only (bounded), automatically; the body stays local. No operator
+// step is required (cognitive-load aversion): the safe minimum is the default, and
+// an operator-authored shareable summary can be layered on later if richer upstream
+// context is ever wanted.
+function redactedCrossOrgSummary(title: string): string {
+  return (title.trim() || "Shared demand").slice(0, 240);
 }
 
 export function decodeChannelDemandPolicy(value: unknown): ChannelDemandPolicy {
@@ -295,7 +297,8 @@ export async function selectLocalDemandForLink(
     source: {
       localRecordRef: item.itemId,
       title: item.title,
-      summary: safeSummary(item.body, item.title),
+      // Cross-org: title-only, never the raw body (see redactedCrossOrgSummary).
+      summary: redactedCrossOrgSummary(item.title),
       workType: item.workType,
       occurrenceCount: item.occurrenceCount,
       product: item.digitalProduct?.productId ?? null,


### PR DESCRIPTION
Last cross-org privacy slice: at the cross-org egress the projected summary is the operator's title only — the raw backlog body never crosses an org boundary, even for platform demand. Automatic (no operator step). Test proves a body carrying SECRET/10.0.0.5 never appears in the cross-org source. Completes BI-DC4E526E (deny-by-default → context-derived → content-redaction); kernel DI-3E77E48D5710. 203 federation tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)