### PR TITLE
feat(mcp): default Anthropic stable-prefix cache to 1h TTL (Slice 7, BI-4761F54E)

### DIFF
--- a/apps/web/lib/routing/anthropic-cache.test.ts
+++ b/apps/web/lib/routing/anthropic-cache.test.ts
@@ -14,15 +14,30 @@ describe("buildAnthropicSystem (BI-79A5C00F)", () => {
     expect(Array.isArray(result)).toBe(true);
     const blocks = result as AnthropicTextBlock[];
     expect(blocks).toHaveLength(2);
+    // BI-4761F54E (Slice 7): the stable prefix now carries a 1h TTL by default
+    // so long agentic loops whose inter-turn gaps exceed the 5-minute default
+    // keep the cached prefix alive instead of re-billing it at full input rate.
     expect(blocks[0]).toEqual({
       type: "text",
       text: STABLE,
-      cache_control: { type: "ephemeral" },
+      cache_control: { type: "ephemeral", ttl: "1h" },
     });
     expect(blocks[1]).toEqual({ type: "text", text: DYNAMIC });
     // The cached block must never contain dynamic content.
     expect(blocks[0].text).not.toContain(DYNAMIC);
     expect(blocks[1].cache_control).toBeUndefined();
+  });
+
+  it("emits a 5-minute TTL (no ttl field) when cachePrefixTtl: '5m' is requested", () => {
+    const prompt = STABLE + SYSTEM_PROMPT_DYNAMIC_BOUNDARY + DYNAMIC;
+    const blocks = buildAnthropicSystem(prompt, { cachePrefixTtl: "5m" }) as AnthropicTextBlock[];
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("emits a 1-hour TTL when cachePrefixTtl: '1h' is requested explicitly", () => {
+    const prompt = STABLE + SYSTEM_PROMPT_DYNAMIC_BOUNDARY + DYNAMIC;
+    const blocks = buildAnthropicSystem(prompt, { cachePrefixTtl: "1h" }) as AnthropicTextBlock[];
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   it("returns the string UNCHANGED when no boundary is present (simplest-safe)", () => {
@@ -46,7 +61,7 @@ describe("buildAnthropicSystem (BI-79A5C00F)", () => {
     const result = buildAnthropicSystem(prompt) as AnthropicTextBlock[];
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(1);
-    expect(result[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(result[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
     expect(result[0].text).toBe(STABLE);
   });
 });

--- a/apps/web/lib/routing/anthropic-cache.ts
+++ b/apps/web/lib/routing/anthropic-cache.ts
@@ -14,16 +14,36 @@
  * cache_control), because without the boundary we cannot prove which content is
  * dynamic and must never risk caching volatile content.
  *
- * Note: cache_control:{type:"ephemeral"} is the 5-minute TTL (GA, no beta
- * header). A 1-hour TTL (ttl:"1h") is a follow-up: it needs the extended-cache
- * beta header to be confirmed against the live Anthropic API version.
+ * TTL (BI-4761F54E, context-engineering R6/P8): cache_control:{type:"ephemeral"}
+ * is the 5-minute TTL; adding ttl:"1h" extends it to one hour. Both are GA on
+ * the first-party Anthropic API with NO beta header (the older extended-cache
+ * beta requirement is retired). The Anthropic default silently reverted 1h→5m,
+ * so long agentic loops whose inter-turn gaps exceed five minutes lose the
+ * cached prefix and re-pay it at full input rate. We therefore default the
+ * stable prefix to a 1-hour TTL. The 1h write premium (2x vs 1.25x) is scoped
+ * to the genuinely-stable prefix (everything before SYSTEM_PROMPT_DYNAMIC_
+ * BOUNDARY), never volatile content, and only ever reaches the real Anthropic
+ * API — local served models (DMR/llama.cpp) go through the OpenAI-compatible
+ * path and never see cache_control. Callers that know a request is a true
+ * one-shot with no reuse can pass cachePrefixTtl:"5m" to avoid the premium.
  */
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "../tak/prompt-boundary";
+
+export type AnthropicCachePrefixTtl = "5m" | "1h";
 
 export type AnthropicTextBlock = {
   type: "text";
   text: string;
-  cache_control?: { type: "ephemeral" };
+  cache_control?: { type: "ephemeral"; ttl?: "1h" };
+};
+
+export type BuildAnthropicSystemOptions = {
+  /**
+   * TTL for the stable-prefix cache breakpoint. Defaults to "1h" so long
+   * agentic loops keep the cached prefix across inter-turn gaps > 5 min.
+   * "5m" omits the ttl field (Anthropic's 5-minute default) for one-shots.
+   */
+  cachePrefixTtl?: AnthropicCachePrefixTtl;
 };
 
 /**
@@ -33,6 +53,7 @@ export type AnthropicTextBlock = {
  */
 export function buildAnthropicSystem(
   systemPrompt: string | undefined | null,
+  options: BuildAnthropicSystemOptions = {},
 ): string | AnthropicTextBlock[] {
   if (!systemPrompt) return "";
 
@@ -45,8 +66,13 @@ export function buildAnthropicSystem(
   // Boundary at the very start — nothing stable to cache. Leave unchanged.
   if (stablePrefix.trim().length === 0) return systemPrompt;
 
+  const cacheControl: { type: "ephemeral"; ttl?: "1h" } =
+    (options.cachePrefixTtl ?? "1h") === "1h"
+      ? { type: "ephemeral", ttl: "1h" }
+      : { type: "ephemeral" };
+
   const blocks: AnthropicTextBlock[] = [
-    { type: "text", text: stablePrefix, cache_control: { type: "ephemeral" } },
+    { type: "text", text: stablePrefix, cache_control: cacheControl },
   ];
   if (dynamicTail.length > 0) {
     blocks.push({ type: "text", text: dynamicTail });

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -138,7 +138,10 @@ const ACT_MODE_BLOCK = `Mode: ACT. You may execute any tool the employee's role 
 //
 // The marker itself is invisible to the model — it's consumed by the caller
 // (routing/anthropic-cache.ts, used by chat-adapter) to split the prompt into cacheable and non-cacheable
-// segments when the provider supports prompt caching.
+// segments when the provider supports prompt caching. That splitter caches the
+// stable prefix with a 1-hour TTL by default (BI-4761F54E / context-engineering
+// R6/P8) so this assembler's static Identity/Mode blocks survive inter-turn
+// gaps > 5 min in a long agentic loop instead of being re-billed at full rate.
 
 // Single source of truth lives in ./prompt-boundary (dependency-free so the
 // routing layer can split on it without importing this DB-coupled assembler).


### PR DESCRIPTION
## What

Slice 7 of the MCP `2025-11-25` + A2A adoption program (umbrella `BI-1F4A4861`, epic `EP-E1F1DB58`), realizing context-engineering recommendation **R6 / principle P8**: default the Anthropic stable-prefix prompt cache to a **1-hour TTL**.

The Anthropic prompt-cache default silently reverted 1h→5m. Long agentic coworker loops whose inter-turn gaps exceed five minutes therefore lose the cached stable prefix and re-pay it at full input rate. `buildAnthropicSystem` now emits `cache_control: {type: "ephemeral", ttl: "1h"}` on the stable prefix by default; a `cachePrefixTtl: "5m"` option lets a caller opt a true one-shot out of the 2× write premium.

## Why it's safe / bounded

- **1h TTL is GA on the first-party Anthropic API with no beta header** (verified via the `claude-api` skill / platform-availability matrix); the stale comment claiming an `extended-cache` beta requirement is removed.
- Scoped to the **genuinely-stable prefix** only — everything before `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`, never volatile content (this is exactly the risk-mitigation the plan calls for).
- Only ever reaches the real Anthropic API path. **Local served models (DMR/llama.cpp) go through the OpenAI-compatible branch and never see `cache_control`**, so local prefix-KV reuse is unaffected — and this change does not reorder the prefix, so the leading tokens local prefix-KV keys on are unchanged.
- One caller (`chat-adapter.ts:189`); the new option is optional with a default, so the call site is unchanged.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md` (R6/P8); `docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md` (Slice 7).
- Current code substrate reviewed: `apps/web/lib/routing/anthropic-cache.ts`, `apps/web/lib/tak/prompt-assembler.ts`, `apps/web/lib/routing/chat-adapter.ts` (sole caller).
- Source of truth: the merged context-engineering & tool-efficiency design.
- Decision: extend it (implement R6). The `prompt-assembler.ts` edit is a doc-comment-only clarification of the existing cache split — no contract, routing, or UX change.

## Verification

- `dpf-tdd` red→green: updated `anthropic-cache.test.ts` to expect the 1h default + the `cachePrefixTtl` option, then implemented. Touched-file vitest: **7/7 pass**.
- `pnpm typecheck` (web): clean (exit 0).
- `dpf-local-merge-ci-before-push`: merged-with-`origin/main` local CI **passed** (0 test failures across the suite; the anthropic-cache tests pass in the merged run).
- Runtime measurement of `usage.cache_read_input_tokens` staying non-zero across turns, and local served-model prefix-KV reuse, are live-install checks not runnable in a source-only worktree — the change is verified structurally (TTL value + preserved prefix ordering); flag for on-install confirmation.

## Linked

- BI: BI-4761F54E (Slice 7) · Umbrella: BI-1F4A4861 · Epic: EP-E1F1DB58

Local-CI-Evidence: cmsjqkdtq00q701p69d56dmx7 (feat/mcp-slice7-cache-ttl@7fa36a7a9f7d)

Docs-Impact-Decision: internal prompt-cache TTL change (anthropic-cache.ts stable-prefix TTL + a doc-comment clarification in prompt-assembler.ts); no user-visible behavior, route, or documented-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
