### PR TITLE
fix(federation): demand/incident delivery no longer 422s link:mismatch between two installs (BI-AF675A20)

### DIFF
--- a/apps/web/lib/federation/cloud-event-guard.test.ts
+++ b/apps/web/lib/federation/cloud-event-guard.test.ts
@@ -20,10 +20,30 @@ describe("validateFederationCloudEvent", () => {
     })).toEqual([]);
   });
 
-  it("rejects stale, future, malformed, or cross-link replay", () => {
+  it("accepts a peer's OWN dpflinkid even when it differs from ours (per-side ids)", () => {
+    // The token authenticates + identifies the link; the sender's own link id is
+    // minted independently and never equals ours. This MUST be accepted, or no
+    // two real installs can ever exchange demand (BI-… link:mismatch regression).
     expect(validateFederationCloudEvent({ ...event, dpflinkid: "link_2" }, {
+      linkId: "link_1", now: new Date("2026-07-20T06:05:00.000Z"),
+    })).toEqual([]);
+  });
+
+  it("accepts an event with no dpflinkid at all", () => {
+    const { dpflinkid: _omit, ...noLink } = event;
+    void _omit;
+    expect(validateFederationCloudEvent(noLink, {
+      linkId: "link_1", now: new Date("2026-07-20T06:05:00.000Z"),
+    })).toEqual([]);
+  });
+
+  it("still rejects a malformed dpflinkid, stale time, and bad envelope fields", () => {
+    expect(validateFederationCloudEvent({ ...event, dpflinkid: 42 }, {
+      linkId: "link_1", now: new Date("2026-07-20T06:05:00.000Z"),
+    })).toEqual(expect.arrayContaining(["dpflinkid:invalid"]));
+    expect(validateFederationCloudEvent({ ...event }, {
       linkId: "link_1", now: new Date("2026-07-20T07:00:00.000Z"),
-    })).toEqual(expect.arrayContaining(["link:mismatch", "time:outside-replay-window"]));
+    })).toEqual(expect.arrayContaining(["time:outside-replay-window"]));
     expect(validateFederationCloudEvent({ ...event, id: "", specversion: "0.3" }, {
       linkId: "link_1", now: new Date("2026-07-20T06:05:00.000Z"),
     })).toEqual(expect.arrayContaining(["specversion:unsupported", "id:invalid"]));

--- a/apps/web/lib/federation/cloud-event-guard.ts
+++ b/apps/web/lib/federation/cloud-event-guard.ts
@@ -16,7 +16,22 @@ export function validateFederationCloudEvent(
   if (typeof value.source !== "string" || value.source.length < 1 || value.source.length > 240) violations.push("source:invalid");
   if (typeof value.type !== "string" || value.type.length < 1 || value.type.length > 160) violations.push("type:invalid");
   if (value.datacontenttype !== "application/json") violations.push("datacontenttype:unsupported");
-  if (value.dpflinkid !== context.linkId) violations.push("link:mismatch");
+  // The Bearer token is the sole authenticator and identifies the link on THIS
+  // receiver (context.linkId is resolved from it). `dpflinkid` is the SENDER's
+  // OWN link id — federation links mint independent ids per side at pairing
+  // (enrollment.ts / outbound.ts, via randomUUID) and never share them, so a
+  // sender legitimately advertises an id that differs from context.linkId.
+  // Requiring equality made cross-install delivery impossible — observed live,
+  // every demand POST 422'd with "link:mismatch"; the check only ever passed
+  // because tests reused a single linkId fixture. `dpflinkid` is not used for
+  // authorization or routing anywhere else (the token's link is authoritative),
+  // so validate its shape only, never equality.
+  if (
+    value.dpflinkid !== undefined
+    && (typeof value.dpflinkid !== "string" || value.dpflinkid.length < 1 || value.dpflinkid.length > 240)
+  ) {
+    violations.push("dpflinkid:invalid");
+  }
   const eventTime = typeof value.time === "string" ? Date.parse(value.time) : Number.NaN;
   if (!Number.isFinite(eventTime)) {
     violations.push("time:invalid");


### PR DESCRIPTION
**Root cause of "federated demand never syncs between two installs."** Captured the live 422 body by replaying the stuck Mac→Windows delivery: `{"error":"invalid_cloud_event","violations":["link:mismatch"]}`.

The transport guard (`cloud-event-guard.ts:19`) rejected any event whose `dpflinkid` ≠ the receiver's own `linkId`. But federation links mint **independent** ids per side at pairing (`enrollment.ts`/`outbound.ts`, `randomUUID`) and never share them, while the sender advertises its **own** id — so the equality could never hold across two real installs. It only passed because unit tests reused one linkId fixture.

The Bearer token is the sole authenticator and identifies the link on the receiver (`context.linkId`); `dpflinkid` is used nowhere else for authz/routing. The guard now validates `dpflinkid` **shape only**, never equality. Fixes demand + incident + proposal + approval-relay flows. Not a version/forward-compat issue (#4110 was separate).

**Deploy note:** both installs must run a build with this fix before demand flows (each is a receiver one way). The 5 stuck Mac outbox items deliver once Windows carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)