### PR TITLE
fix(coworker): Cost & Engagements query every coworker id form (id seam) — EP-COWORKER-IDENTITY-360

### DIFF
--- a/apps/web/app/(shell)/workforce/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/workforce/[agentId]/page.tsx
@@ -97,8 +97,8 @@ export default async function CoworkerIdentityPage({
   const [session, inheritance, cost, engagements] = await Promise.all([
     auth(),
     getCoworkerPostureInheritance(agent.agentId),
-    loadCoworkerCostProjection(runtime.agentId),
-    loadCoworkerEngagements(runtime.agentId, runtime.id),
+    loadCoworkerCostProjection(runtime.agentId, { slugId: runtime.slugId }),
+    loadCoworkerEngagements(runtime.agentId, runtime.id, { slugId: runtime.slugId }),
   ]);
 
   const canWrite =

--- a/apps/web/lib/coworker-identity/cost-projection.ts
+++ b/apps/web/lib/coworker-identity/cost-projection.ts
@@ -17,6 +17,8 @@
 
 import { prisma } from "@dpf/db";
 
+import { coworkerIdentityForms } from "./identity-forms";
+
 /** One row of per-inference metering, trimmed to what the summary needs. */
 export type CostUsageRow = {
   costUsd: number;
@@ -169,28 +171,34 @@ export function summarizeCoworkerCost(input: SummarizeCoworkerCostInput): Cowork
 }
 
 /**
- * Fetch + summarize per-coworker cost. `agentId` is the BUSINESS id (AGT-*).
+ * Fetch + summarize per-coworker cost. `agentId` is the BUSINESS id (AGT-*);
+ * `slugId` is the loaded row's slug when present. Metering rows (TokenUsage,
+ * AgentBudgetEvent) are keyed by the SLUG form for many coworkers, so we query
+ * every id form the coworker's activity may be filed under (see
+ * coworkerIdentityForms — the id seam). AgentExecutionConfig is a 1:1 config row
+ * keyed by the loaded agentId, so it stays a single-id lookup.
  * Fail-open: a read hiccup returns a zeroed summary so the identity page renders
  * an empty-state facet rather than 500-ing (the record-page convention).
  */
 export async function loadCoworkerCostProjection(
   agentId: string,
-  opts?: { now?: Date; windowDays?: number },
+  opts?: { now?: Date; windowDays?: number; slugId?: string | null },
 ): Promise<CoworkerCostSummary> {
   const now = opts?.now ?? new Date();
   const windowDays = opts?.windowDays ?? 30;
   const priorSince = new Date(now.getTime() - 2 * windowDays * 86_400_000);
+  const idForms = coworkerIdentityForms(agentId, opts?.slugId);
 
   try {
     const [usage, budgetEvents, executionConfig] = await Promise.all([
       prisma.tokenUsage.findMany({
-        where: { agentId, createdAt: { gte: priorSince } },
+        where: { agentId: { in: idForms }, createdAt: { gte: priorSince } },
         select: { costUsd: true, inputTokens: true, outputTokens: true, contextKey: true, createdAt: true },
         orderBy: { createdAt: "desc" },
         take: 5000,
       }),
       prisma.agentBudgetEvent.findMany({
-        where: { agentId, createdAt: { gte: new Date(now.getTime() - 86_400_000) } },
+        where: { agentId: { in: idForms }, createdAt: { gte: new Date(now.getTime() - 86_400_000) } },
         select: { eventKind: true, createdAt: true },
         take: 200,
       }),

--- a/apps/web/lib/coworker-identity/engagements-projection.ts
+++ b/apps/web/lib/coworker-identity/engagements-projection.ts
@@ -18,6 +18,8 @@
 import { prisma } from "@dpf/db";
 import { resolveAgentRoleLabel } from "@dpf/db/agent-identity";
 
+import { coworkerIdentityForms } from "./identity-forms";
+
 export type EngagerKind = "person" | "agent";
 
 /** One raw engagement touch, already name-resolved, before aggregation. */
@@ -128,16 +130,21 @@ export function aggregateEngagers(
 export async function loadCoworkerEngagements(
   agentId: string,
   agentCuid: string,
-  opts?: { now?: Date; windowDays?: number },
+  opts?: { now?: Date; windowDays?: number; slugId?: string | null },
 ): Promise<CoworkerEngagementsSummary> {
   const now = opts?.now ?? new Date();
   const windowDays = opts?.windowDays ?? 90;
   const since = new Date(now.getTime() - windowDays * 86_400_000);
+  // CoworkerEngagement.providerAgentId is keyed by the SLUG form for many
+  // coworkers, so match every id form (the id seam — coworkerIdentityForms).
+  // DelegationGrant.granteeAgentId keys on the Agent.id cuid, so it stays a
+  // single-id match.
+  const providerForms = coworkerIdentityForms(agentId, opts?.slugId);
 
   try {
     const [engagements, grants] = await Promise.all([
       prisma.coworkerEngagement.findMany({
-        where: { providerAgentId: agentId, createdAt: { gte: since } },
+        where: { providerAgentId: { in: providerForms }, createdAt: { gte: since } },
         select: {
           requestedByUserId: true,
           requestedByAgentId: true,

--- a/apps/web/lib/coworker-identity/identity-forms.test.ts
+++ b/apps/web/lib/coworker-identity/identity-forms.test.ts
@@ -1,0 +1,39 @@
+// apps/web/lib/coworker-identity/identity-forms.test.ts
+// The id seam that read as $0/0 on the live install (EP-COWORKER-IDENTITY-360).
+import { describe, it, expect } from "vitest";
+
+import { coworkerIdentityForms } from "./identity-forms";
+
+describe("coworkerIdentityForms", () => {
+  it("recovers the slug form from a canonical id whose row carries no slug", () => {
+    // The bug: metering rows are keyed 'build-specialist' but the page loads
+    // 'AGT-WS-BUILD' (canonical, slugId null). Both forms must be queried.
+    const forms = coworkerIdentityForms("AGT-WS-BUILD", null);
+    expect(forms).toContain("AGT-WS-BUILD");
+    expect(forms).toContain("build-specialist");
+  });
+
+  it("recovers the canonical form from a slug id", () => {
+    const forms = coworkerIdentityForms("coo");
+    expect(forms).toContain("coo");
+    expect(forms).toContain("AGT-ORCH-000");
+  });
+
+  it("includes an explicitly loaded slugId", () => {
+    const forms = coworkerIdentityForms("AGT-ORCH-000", "coo");
+    expect(forms).toContain("AGT-ORCH-000");
+    expect(forms).toContain("coo");
+  });
+
+  it("dedupes and never returns empties", () => {
+    const forms = coworkerIdentityForms("coo", "coo");
+    expect(new Set(forms).size).toBe(forms.length);
+    expect(forms.every((f) => f.trim().length > 0)).toBe(true);
+  });
+
+  it("returns at least the input for an unmapped agent id", () => {
+    const forms = coworkerIdentityForms("AGT-UNMAPPED-XYZ");
+    expect(forms).toContain("AGT-UNMAPPED-XYZ");
+    expect(forms.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/lib/coworker-identity/identity-forms.ts
+++ b/apps/web/lib/coworker-identity/identity-forms.ts
@@ -1,0 +1,39 @@
+// apps/web/lib/coworker-identity/identity-forms.ts
+//
+// EP-COWORKER-IDENTITY-360 — the id seam, made concrete. A coworker's activity
+// is written under DIFFERENT id forms across tables: TokenUsage.agentId and
+// CoworkerEngagement.providerAgentId are keyed by the legacy SLUG
+// ("coo", "build-specialist"), while the identity page loads the CANONICAL
+// registry row ("AGT-ORCH-000", "AGT-WS-BUILD"). The dual-seed pair means a
+// canonical row can carry a null slugId, so the slug must be recovered from the
+// registry map, not only from the loaded row. Querying one form silently misses
+// the other and a live-active coworker reads as $0 / 0 engagements (found on the
+// live install, 2026-08-07 — CI could not catch it: the seed used in tests keys
+// consistently).
+//
+// This returns EVERY id form a coworker's activity may be filed under, for use
+// in `where: { agentId: { in: coworkerIdentityForms(...) } }`.
+
+import {
+  CANONICAL_AGENT_ID_TO_COWORKER_SLUG,
+  resolveCanonicalAgentId,
+} from "@dpf/db/agent-identity";
+
+/**
+ * All id forms a coworker's activity rows may be keyed under:
+ * the business/registry agentId, the loaded slugId (if any), the canonical
+ * agentId, and the canonical→slug mapping (recovers "coo" from "AGT-ORCH-000"
+ * even when the loaded row's slugId is null). Deduped, stable order.
+ */
+export function coworkerIdentityForms(agentId: string, slugId?: string | null): string[] {
+  const forms = new Set<string>();
+  const add = (v: string | null | undefined) => {
+    if (v && v.trim()) forms.add(v.trim());
+  };
+  add(agentId);
+  add(slugId);
+  const canonical = resolveCanonicalAgentId(agentId);
+  add(canonical);
+  add(CANONICAL_AGENT_ID_TO_COWORKER_SLUG[canonical]);
+  return [...forms];
+}


### PR DESCRIPTION
## The bug (found on the live install)

Driving the merged Coworker Identity 360 on the running portal, **every coworker's Cost and "who has engaged it" facets read \$0.00 / 0** — even busy ones. CI was all green; only a live drive surfaced it (structural verification is not functional).

Root cause is the **dual-seed id seam**: `TokenUsage.agentId` and `CoworkerEngagement.providerAgentId` are keyed by the legacy **slug** (`coo`, `build-specialist`, `customer-advisor`), but the identity page loads the **canonical** registry row (`AGT-ORCH-000`, `AGT-WS-BUILD`) whose `slugId` is null. The projections queried the canonical id only → matched nothing.

Confirmed against the live DB — Build Lead: **372** tokens under `AGT-WS-BUILD` vs **1,072,855** under `build-specialist`; customer-advisor's 2 engagements are under the slug.

## The fix

`coworkerIdentityForms(agentId, slugId)` resolves **every** id form a coworker's activity may be filed under — business id + loaded slug + canonical + the canonical→slug map (recovers the slug even when the loaded row's `slugId` is null). Cost + Engagements now query `agentId IN forms` / `providerAgentId IN forms`. `AgentExecutionConfig` (1:1) and `DelegationGrant` (cuid) stay single-id.

- **new** `apps/web/lib/coworker-identity/identity-forms.ts` (+ 5 unit tests covering the exact broken cases)
- `cost-projection.ts` / `engagements-projection.ts` — query all id forms
- `page.tsx` — pass `runtime.slugId` to both loaders

## Verification

- 17 unit tests pass (the resolver + the two projection summarizers).
- The **corrected query confirmed against the live DB** returns the real data (1.07M tokens; 2 engagements) that the old query missed.
- Style-drift / UX-fit: clean (no UI-impacting control/route change).

Epic: `EP-COWORKER-IDENTITY-360`. Follows the merged page (#4085) + roster wiring (#4088).

🤖 Generated with [Claude Code](https://claude.com/claude-code)