### PR TITLE
fix(federation): bind incoming demand responses to the originator's item, not null (BI-C55675A8)

### DIFF
--- a/apps/web/lib/federation/demand-delivery.ts
+++ b/apps/web/lib/federation/demand-delivery.ts
@@ -37,6 +37,7 @@ interface DemandOutboxRow {
   mirrorId: string;
   federationLinkId: string;
   canonicalSide?: string;
+  localRecordRef?: string | null;
   version: bigint;
   syncStatus: string;
   deliveryAttempts: number;

--- a/apps/web/lib/federation/demand-response.test.ts
+++ b/apps/web/lib/federation/demand-response.test.ts
@@ -115,13 +115,17 @@ describe("queueDemandResponse", () => {
 describe("handleIncomingDemandResponse", () => {
   it("persists an idempotent response only for an envelope shared on the same link", async () => {
     const demand = envelope();
-    const shared = [{ payload: {
+    const shared = [{ localRecordRef: "BI-LOCAL-1", payload: {
       envelope: demand, activity: "dpf.demand.proposed", eventId: "evt", queuedAt: demand.createdAt,
     } }];
     const first = db({ shared });
     await expect(handleIncomingDemandResponse(first.value, "link_1", response()))
       .resolves.toMatchObject({ action: "created", responseId: "rsp_opaque" });
     expect(first.create).toHaveBeenCalledTimes(1);
+    // The incoming response is bound to the originator's local item (no longer orphaned).
+    expect(first.create.mock.calls[0][0].data).toMatchObject({
+      recordType: "demand-response", canonicalSide: "peer", localRecordRef: "BI-LOCAL-1",
+    });
 
     const second = db({ shared, existingResponse: { mirrorId: "fdri_existing" } });
     await expect(handleIncomingDemandResponse(second.value, "link_1", response()))

--- a/apps/web/lib/federation/demand-response.ts
+++ b/apps/web/lib/federation/demand-response.ts
@@ -143,17 +143,19 @@ export async function handleIncomingDemandResponse(
   if (violations.length > 0) return { action: "rejected", violations };
   const shared = await db.federatedRecordMirror.findMany({
     where: { federationLinkId: linkId, recordType: "demand-envelope", canonicalSide: "local" },
-    select: { payload: true },
+    select: { payload: true, localRecordRef: true },
     take: 1_000,
   });
-  const matchesSharedEnvelope = shared.some((row) => {
+  // Correlate the incoming response to the exact demand WE projected, and keep the
+  // matched row so we can bind the response to the ORIGINATOR's local item below.
+  const matchedEnvelope = shared.find((row) => {
     const payload = decodeDemandOutboxPayload(row.payload);
     return payload?.envelope.specVersion === "dpf.demand/1"
       && payload.envelope.envelopeId === response.envelopeId
       && payload.envelope.originInstallationId === response.originInstallationId
       && payload.envelope.originRecordRef === response.originRecordRef;
   });
-  if (!matchesSharedEnvelope) return { action: "rejected", violations: ["response:unknown-envelope"] };
+  if (!matchedEnvelope) return { action: "rejected", violations: ["response:unknown-envelope"] };
   const where = {
     federationLinkId_recordType_peerRecordRef: {
       federationLinkId: linkId,
@@ -168,7 +170,10 @@ export async function handleIncomingDemandResponse(
     federationLinkId: linkId,
     recordType: "demand-response",
     canonicalSide: "peer",
-    localRecordRef: null,
+    // Bind the response to the originator's local backlog item (the outbound
+    // mirror's localRecordRef is the BacklogItem id) so it is no longer orphaned
+    // and a read model can surface "who responded" on the item itself.
+    localRecordRef: matchedEnvelope.localRecordRef,
     peerRecordRef: response.responseId,
     syncStatus: "synced",
     version: 1,


### PR DESCRIPTION
Answering the operator's question about status reflecting in the right direction, I found incoming recipient responses (interest/help-offer) were stored with `localRecordRef: null` — **orphaned** from the backlog item they're about, so they never surface where the originator manages the work. `handleIncomingDemandResponse` already matches the inbound response to the exact demand we projected; this keeps that match and binds the response to the outbound mirror's `localRecordRef` (the BacklogItem id). Unit-tested. Slice 1 of BI-C55675A8; read-model/UI surfacing + the recipient disposition emitter follow (need a UX decision, routed through ux-fit review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)