### PR TITLE
feat(federation): demand read model attributes each recipient response to its item (BI-C55675A8)

### DIFF
--- a/apps/web/components/ops/NetworkDemandPanel.test.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.test.tsx
@@ -74,6 +74,7 @@ describe("NetworkDemandPanel", () => {
         founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Central Founder Hub" }],
         responses: [{
           responseId: "rsp_opaque",
+          localItemId: "BI-LOCAL",
           sourceName: "Reseller One",
           responseKind: "help-offer",
           message: "We can validate this.",

--- a/apps/web/lib/federation/demand-read-model.test.ts
+++ b/apps/web/lib/federation/demand-read-model.test.ts
@@ -2,7 +2,49 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@dpf/db", () => ({ prisma: {} }));
 
-import { mapDemandShareTargets, mapNetworkDemandRows } from "./demand-read-model";
+// The mapper's job is correlation, not response-envelope validation (that is
+// covered by demand-response.test.ts). Decode = "has a response object → keep".
+vi.mock("./demand-response", () => ({
+  decodeDemandResponseMirrorPayload: (p: unknown) =>
+    p && typeof p === "object" && (p as { response?: unknown }).response ? p : null,
+}));
+
+import { mapDemandResponses, mapDemandShareTargets, mapNetworkDemandRows } from "./demand-read-model";
+
+describe("mapDemandResponses", () => {
+  const links = [{ linkId: "FL-1", principal: { displayName: "Windows workshop" } }];
+  const payload = {
+    response: { responseId: "rsp_1", responseKind: "interest", message: null },
+    receivedAt: "2026-08-08T00:00:00.000Z",
+  };
+
+  it("attributes each response to the local item it is about, and to the source connection", () => {
+    const rows = mapDemandResponses(
+      [{ federationLinkId: "FL-1", localRecordRef: "BI-LOCAL-1", payload }],
+      links,
+    );
+    expect(rows).toEqual([{
+      responseId: "rsp_1",
+      localItemId: "BI-LOCAL-1",
+      sourceName: "Windows workshop",
+      responseKind: "interest",
+      message: null,
+      receivedAt: "2026-08-08T00:00:00.000Z",
+    }]);
+  });
+
+  it("keeps a legacy unlinked response (null item) and drops malformed payloads", () => {
+    const rows = mapDemandResponses(
+      [
+        { federationLinkId: "FL-1", localRecordRef: null, payload },
+        { federationLinkId: "FL-1", localRecordRef: "BI-X", payload: { bogus: true } },
+      ],
+      links,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ localItemId: null, sourceName: "Windows workshop" });
+  });
+});
 
 describe("mapDemandShareTargets", () => {
   it("offers only cross-company upstream destinations and leaves same-company peers on automatic sync", () => {

--- a/apps/web/lib/federation/demand-read-model.ts
+++ b/apps/web/lib/federation/demand-read-model.ts
@@ -50,6 +50,10 @@ export interface DemandShareContext {
   localItems: LocalDemandShareCandidate[];
   responses: Array<{
     responseId: string;
+    /** The originator's local backlog item this response is about (from the
+     *  linked mirror), so a renderer can show responses ON the item rather than
+     *  as a disconnected global list. Null only for legacy unlinked mirrors. */
+    localItemId: string | null;
     sourceName: string;
     responseKind: "interest" | "help-offer";
     message: string | null;
@@ -95,6 +99,29 @@ export function mapNetworkDemandRows(rows: DemandReadRow[]): NetworkDemandView[]
         envelope.forwarding?.permitted === true
         && envelope.forwarding.audiences.includes("founder"),
       forwardingExpiresAt: envelope.forwarding?.expiresAt ?? null,
+    }];
+  });
+}
+
+/** Pure mapper: incoming demand-response mirrors → the view's response list,
+ *  each carrying the originator's local item id (from the linked mirror) so a
+ *  renderer can attribute a response to the item it is about. Exported for unit
+ *  testing without a DB, matching the other read-model mappers. */
+export function mapDemandResponses(
+  responseMirrors: Array<{ federationLinkId: string; localRecordRef: string | null; payload: unknown }>,
+  links: Array<{ linkId: string; principal: { displayName: string } }>,
+): DemandShareContext["responses"] {
+  return responseMirrors.flatMap((mirror) => {
+    const payload = decodeDemandResponseMirrorPayload(mirror.payload);
+    if (!payload) return [];
+    const source = links.find((link) => link.linkId === mirror.federationLinkId);
+    return [{
+      responseId: payload.response.responseId,
+      localItemId: mirror.localRecordRef,
+      sourceName: source?.principal.displayName ?? "Connected installation",
+      responseKind: payload.response.responseKind,
+      message: payload.response.message ?? null,
+      receivedAt: payload.receivedAt,
     }];
   });
 }
@@ -170,6 +197,7 @@ export const getDemandShareContext = cache(async (): Promise<DemandShareContext>
       where: { recordType: "demand-response", canonicalSide: "peer", syncStatus: "synced" },
       select: {
         federationLinkId: true,
+        localRecordRef: true,
         payload: true,
       },
       orderBy: { lastSyncedAt: "desc" },
@@ -196,18 +224,7 @@ export const getDemandShareContext = cache(async (): Promise<DemandShareContext>
       .filter((link) => link.role === "channel-downstream" && link.peerInstallationId)
       .map((link) => ({ linkId: link.linkId, displayName: link.principal.displayName })),
     localItems,
-    responses: responseMirrors.flatMap((mirror) => {
-      const payload = decodeDemandResponseMirrorPayload(mirror.payload);
-      if (!payload) return [];
-      const source = links.find((link) => link.linkId === mirror.federationLinkId);
-      return [{
-        responseId: payload.response.responseId,
-        sourceName: source?.principal.displayName ?? "Connected installation",
-        responseKind: payload.response.responseKind,
-        message: payload.response.message ?? null,
-        receivedAt: payload.receivedAt,
-      }];
-    }),
+    responses: mapDemandResponses(responseMirrors, links),
     dispositions: dispositionMirrors.flatMap((mirror) => {
       const payload = decodeDemandDispositionMirrorPayload(mirror.payload);
       if (!payload) return [];


### PR DESCRIPTION
Slice 2 of the response-reflection work. Now that #4115 links each incoming response to the originator's item, the read model carries that item id (`localItemId`) via a new pure, unit-tested `mapDemandResponses()` mapper — so a renderer can attribute a response to the item it's about. Data layer only; UI placement remains the deferred UX decision under BI-C55675A8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)