### PR TITLE
feat: add verified business analysis plans

### DIFF
--- a/docs/superpowers/plans/2026-08-01-verified-business-analysis-plan-plan.md
+++ b/docs/superpowers/plans/2026-08-01-verified-business-analysis-plan-plan.md
@@ -1,0 +1,81 @@
+# Verified Business Analysis Plan — implementation plan
+
+- **Date:** 2026-08-01
+- **Design:** [Verified Business Analysis Plan](../specs/2026-08-01-verified-business-analysis-plan-design.md)
+- **Umbrella backlog:** `BI-8EC3E4BF`
+- **Follow-on backlog:** `BI-36358ACF`
+- **Capsule:** `WC-7DCE297F`
+- **Branch:** `feat/verified-business-analysis-contract`
+
+## Outcome
+
+Ship a pure, versioned, deterministic analysis-plan contract that resolves only canonical performance metrics, fails closed on ambiguity or invalid input, and can be reused by the later plan-review UI and watched-question scheduler.
+
+## Scope boundaries
+
+- Edit `packages/storefront-templates` contracts, catalog, exports, and tests.
+- Add this dedicated design/plan and a narrow pointer from the parent business-performance design if conflict-free.
+- Do not edit the active `BI-PLAN-005` claims: `apps/web/lib/performance`, `apps/web/components/performance`, `/performance`, Prisma schema/migrations, rollup queue function, or performance data assets.
+- Do not add a graph database, general query language, SQL generator, runtime service, or dependency.
+
+## Phase 1 — Define done with failing tests
+
+1. Add `business-analysis-plan.test.ts` with fixtures for accepted status, missing comparison clarification, unknown metric refusal, unsupported grouping/filter refusal, deterministic normalization/fingerprint, and metric-definition compatibility.
+2. Run the targeted Vitest file and capture the expected module/export failure.
+3. Keep fixtures in business language and assert issue codes plus paths rather than full prose snapshots.
+
+## Phase 2 — Refactor the canonical metric contract
+
+1. Move metric closed axes into exported frozen tuples and derived union types.
+2. Replace prose-only `aggregation` with typed calculation structure plus a separate human-readable `definition`.
+3. Update the catalog helper and definitions mechanically; retain keys, labels, units, source owners, grain, comparison, sensitivity, and drill-down behavior.
+4. Add a catalog invariant that every map key matches the definition key and every referenced calculation input is non-empty.
+
+This is the reserved refactoring tranche: it removes the untyped aggregation seam and centralizes closed axes before adding the plan compiler. It is approximately 20% of the implementation effort.
+
+## Phase 3 — Implement validation, normalization, and identity
+
+1. Add `business-analysis-plan.ts` with versioned input/result contracts and issue codes.
+2. Implement exhaustive runtime guards for untrusted JSON input.
+3. Resolve metrics from the canonical catalog and enforce metric capabilities.
+4. Separate clarification from refusal and ensure only accepted plans carry an executable normalized plan.
+5. Canonically order set-like values, serialize stable keys, and compute the non-security fingerprint.
+6. Export the contract from the package root.
+
+## Phase 4 — Verify and document
+
+1. Run the targeted test red-to-green, then the full storefront-template suite and typecheck.
+2. Run source-local repository guards affected by docs/package exports.
+3. Route the exact merged candidate through the governed local-CI build gate.
+4. Record test/build/documentation evidence on `WC-7DCE297F` and `BI-8EC3E4BF`.
+5. Run semantic change review against `origin/main...HEAD`; fix every blocker.
+6. Commit with DCO, push, open a ready PR, verify with `pnpm pr:health`, and enter the merge queue.
+
+## Backlog coverage
+
+This plan is atomic. The metric refactor and plan validator are not independently useful: the refactor supplies the closed executable semantics the validator must verify, and shipping either alone would leave two authorities or a validator over prose.
+
+| Key | Deliverable | Backlog | Independently shippable | Depends on |
+| --- | --- | --- | --- | --- |
+| verified-analysis-contract | Typed metric semantics plus deterministic BusinessAnalysisPlan validation | `BI-8EC3E4BF` | no | — |
+
+### Coverage receipt
+
+Recorded by the governed planning tool before production source edits:
+
+- **Receipt:** `cmsakarvh075701qkmznqdvk9`
+- **Decision:** `atomic`
+- **Umbrella:** `BI-8EC3E4BF`
+- **Rationale:** the typed metric refactor and validator form one contract boundary; either shipped alone would leave an incomplete or duplicate semantic authority.
+
+## Verification matrix
+
+| Gate | Evidence |
+| --- | --- |
+| Targeted unit | `business-analysis-plan.test.ts` red then green |
+| Package regression | full `@dpf/storefront-templates` Vitest suite |
+| Types | package typecheck plus production web build |
+| Migration | not applicable; no schema change |
+| UX | not applicable to contract-only slice; explicitly owned by `BI-36358ACF` |
+| Docs | design, plan, package exports, parent-design pointer |
+| Architecture | semantic change review and governed local merged-code gate |

--- a/docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md
+++ b/docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md
@@ -233,6 +233,8 @@ interface BusinessPerformanceSnapshot {
 
 `BI-PLAN-004` owns the eventual governed analytics substrate. The first slice may use an internal rollup table/materialized projection, but only after the data-architecture review proves no in-flight canonical model fits. It must store organization, metric key, period, dimensions hash, value/unit, definition version, source watermark, and computed-at time; it must not store display copy or chart layout.
 
+The question-to-execution seam is specified separately in the [Verified Business Analysis Plan design](2026-08-01-verified-business-analysis-plan-design.md). `BI-8EC3E4BF` adds the typed, deterministic plan contract without changing the `BI-PLAN-005` rollup or route, and `BI-36358ACF` owns the later inspectable plan-review and watched-question interaction.
+
 Rollups refresh asynchronously from source facts and append-only telemetry. The route serves the last valid snapshot with freshness. A failed or late rollup degrades the affected card and raises an observable refresh condition; it does not block Operations or fabricate a current number.
 
 ### Reconciliation rule

--- a/docs/superpowers/specs/2026-08-01-verified-business-analysis-plan-design.md
+++ b/docs/superpowers/specs/2026-08-01-verified-business-analysis-plan-design.md
@@ -1,0 +1,134 @@
+# Verified Business Analysis Plan — design
+
+- **Date:** 2026-08-01
+- **Status:** ready for implementation
+- **Backlog:** `BI-8EC3E4BF`
+- **Follow-on backlog:** `BI-36358ACF`
+- **Parent epic:** `EP-PLANNING-ANALYTICS`
+- **Extends:** [Business Operations and Performance Views](2026-07-28-business-operations-and-performance-views-design.md)
+- **Kernel decision:** `DI-0A0D8B84EE30` — extend the existing metric catalog with a typed plan contract, high confidence
+
+## Executive decision
+
+DPF will add a versioned `BusinessAnalysisPlan` contract between a business question and metric execution. The plan names canonical metric keys, intent, grouping dimensions, filters, time windows, comparison basis, source requirements, and verification checks. A deterministic validator normalizes an accepted plan and assigns a stable fingerprint. Unsupported or ambiguous input fails closed as an inspectable refusal; it never degrades into generated SQL or a guessed metric.
+
+This slice is deliberately a contract/compiler, not a new analytics store. It extends the `PerformanceMetricDefinition` authority in `packages/storefront-templates`, keeps the in-flight `BI-PLAN-005` rollup and `/performance` work untouched, and gives later UI and scheduling work a stable substrate.
+
+## Research and benchmarking
+
+The 2026-08-01 market review found a useful product signal in SpotOnix: business users benefit when interpretation is visible before execution, ambiguity is clarified instead of guessed, and accepted analytical logic can be reused. SpotOnix's published terms describe its named frameworks and methods as proprietary and prohibit using the material to develop competing products. DPF therefore does **not** copy its context-graph, algebra, node taxonomy, UI, or wording. It records only the independently observable customer problem and implements an original design grounded in DPF substrate and open standards.
+
+| Precedent | Adopt | Reject / constrain |
+| --- | --- | --- |
+| [dbt Semantic Layer](https://docs.getdbt.com/) | Define metrics once above physical models; let consumers reference stable semantic keys instead of rewriting joins and formulas. | Do not introduce dbt as a runtime dependency or duplicate DPF's metric catalog. |
+| [W3C PROV-O](https://www.w3.org/TR/prov-o/) | Model a plan as an entity used by an execution activity; retain source entities, derivation, responsible agent, and timestamps as compatible concepts. | Do not require RDF/OWL or a graph database for the first slice. |
+| [OpenLineage facets](https://openlineage.io/docs/spec/facets/dataset-facets/) | Keep source identity/version/freshness and verification results as structured facets that adapters can populate. | Do not expose physical schemas or unrestricted column lineage to business users. |
+| [SpotOnix public evaluation framing](https://beta.spotonix.com/brief/evaluation-guide/) | Treat visible interpretation, refusal, and reuse as market-validated operator needs. | Do not adopt proprietary named frameworks, scrape private systems, or treat vendor claims as implementation evidence. |
+
+## Existing substrate and ownership
+
+| Concern | Canonical owner | Change in this slice |
+| --- | --- | --- |
+| Metric definitions and archetype packs | `packages/storefront-templates/src/performance-metric-catalog.ts` | Replace prose-only aggregation strings with a closed typed calculation contract while preserving human-readable definitions. |
+| Metric shape | `PerformanceMetricDefinition` in `business-view-profile.ts` | Add typed aggregation and allowed grouping/filter capabilities; no parallel registry. |
+| Performance values and rollups | `BI-PLAN-005`, `apps/web/lib/performance`, database rollup models | No change; adapters will consume accepted plans later. |
+| Safe workbook formulas | `apps/web/lib/workbooks/formula` | Architectural precedent only. Do not make Workbooks the business semantic authority. |
+| Repeated execution | `ScheduledAgentTask` | Follow-on `BI-36358ACF`; no schema change in this slice. |
+
+## Design grounding
+
+- **Existing specs/plans reviewed:** the parent [Business Operations and Performance Views](2026-07-28-business-operations-and-performance-views-design.md), the live `BI-PLAN-005` performance-rollup plan, and this feature's implementation plan.
+- **Current code substrate reviewed:** `PerformanceMetricDefinition`, `PERFORMANCE_METRIC_DEFINITIONS`, archetype metric packs, the workbook formula boundary, and the existing `ScheduledAgentTask` reuse seam.
+- **Source of truth:** `packages/storefront-templates/src/performance-metric-catalog.ts` owns governed metric semantics; this versioned plan contract validates references to that catalog without becoming a second metric registry or an execution store.
+- **Decision:** extend the existing metric catalog with a deterministic, fail-closed plan compiler now; leave execution, persistence, scheduling, and visible plan review to their owning follow-on slices.
+
+Operational-Precedent: no-precedent (This analytics contract does not change a spatial workflow or physical-twin interaction.)
+
+## Contract
+
+```ts
+interface BusinessAnalysisPlan {
+  schemaVersion: 1;
+  question: string;
+  intent: "status" | "change" | "diagnosis" | "decision";
+  metrics: readonly BusinessAnalysisMetricRef[];
+  dimensions: readonly BusinessAnalysisDimension[];
+  filters: readonly BusinessAnalysisFilter[];
+  period: BusinessAnalysisPeriod;
+  comparison: BusinessAnalysisComparison;
+  sources: readonly BusinessAnalysisSourceRequirement[];
+  checks: readonly BusinessAnalysisCheck[];
+}
+
+type BusinessAnalysisPlanResult =
+  | { status: "accepted"; plan: NormalizedBusinessAnalysisPlan; fingerprint: string }
+  | { status: "clarification-required"; issues: readonly BusinessAnalysisIssue[] }
+  | { status: "refused"; issues: readonly BusinessAnalysisIssue[] };
+```
+
+All closed axes are TypeScript literal unions sourced from frozen tuples. This package has no runtime schema library today, so adding a dependency only for validation would widen the supply-chain surface. The validator uses explicit guards and exhaustive switches; tests ratchet the axes.
+
+### Metric calculation contract
+
+The current `aggregation: string` mixes display copy with executable meaning. Refactor it into:
+
+- a closed `kind` such as `sum`, `count`, `ratio`, `median`, `closing-balance`, or `grouped-sum`;
+- named input facts/metric keys;
+- an optional numerator/denominator or grouping role;
+- a separate `definition` string for operator-facing explanation.
+
+The first slice validates structure; it does not execute formulas. Execution remains provider-owned so authorization, source joins, and row-level restrictions stay at their canonical boundary.
+
+### Validation and refusal
+
+Validation is deterministic and ordered:
+
+1. Validate the plan shape and closed axes.
+2. Resolve every metric through `PERFORMANCE_METRIC_DEFINITIONS`.
+3. Check requested comparison and grain against the metric contract.
+   Every metric supports `none` for status-only plans in addition to its declared comparison baseline; downstream selectors read this same contract.
+4. Reject duplicate metrics/dimensions, empty identifiers, unsupported dimensions, and filters without an allowed operator.
+5. Require source identity plus freshness policy for every referenced metric owner.
+6. Require checks appropriate to the intent: completeness for all plans, comparison-baseline for change/diagnosis, and decision-boundary for decision plans.
+7. Canonically sort set-like collections, preserve meaningful order only where declared, and fingerprint the normalized representation.
+
+`clarification-required` is reserved for a structurally valid plan with unresolved business choices such as a missing comparison basis. `refused` covers unknown metrics, unsupported operations, policy violations, or malformed input. Neither state is executable.
+
+### Deterministic identity
+
+The package produces a canonical JSON representation with stable key and set ordering, then a dependency-free FNV-1a 64-bit fingerprint. The fingerprint is an identity/checksum, not a security primitive. Security-sensitive signing remains outside this package. Including `schemaVersion` and metric definition versions prevents silent reuse across semantic changes.
+
+## UX handoff
+
+`BI-36358ACF` will render the accepted/clarification/refusal result as a theme-aware plan card after `BI-PLAN-005` merges. The card must answer:
+
+1. What did DPF understand?
+2. Which governed metrics, segments, period, and comparison will it use?
+3. Which sources and freshness limits support the answer?
+4. Which checks passed, need clarification, or caused refusal?
+
+That follow-on may persist accepted plan references and schedule watched questions through `ScheduledAgentTask`; it must not persist raw chat history as semantic authority.
+
+## Security, privacy, and failure behavior
+
+- Metric sensitivity stays attached to the canonical metric definition and is included in validation output for downstream authorization.
+- Plans contain semantic source owner identifiers, not credentials, SQL, secrets, unrestricted physical column names, or row data.
+- A plan never grants access. Execution rechecks the current principal and organization scope.
+- Source freshness is a requirement, not a claim that data is current. Providers attach observed watermarks at execution.
+- Unknown schema versions refuse rather than being coerced.
+
+## Architectural alignment
+
+- **Deployment contracts:** pure TypeScript, no host path, service, port, or deployment delta.
+- **Canonical identity:** organization and product scope remain execution context; the plan does not create a parallel business identity.
+- **No parallel utilities:** metric resolution extends the existing catalog; deterministic serialization is local to the new contract because no shared canonical serializer exists.
+- **No second rule home:** durable rules remain in `AGENTS.md`/kernel; this document owns only the feature design.
+- **Data model:** no Prisma change in this slice. Persistence is deferred until the UI/scheduling design proves the existing scheduled-task JSON contract insufficient.
+
+## Acceptance and verification
+
+- Contract tests start red for accepted, clarification, refusal, deterministic identity, and catalog compatibility cases.
+- `@dpf/storefront-templates` test and typecheck pass.
+- The production web build passes because the package is consumed by the portal build graph.
+- No live UX gate is required for this contract-only slice; `BI-36358ACF` owns visual and interaction verification.
+- Documentation impact: architecture/spec and generated package exports are updated; user documentation waits for the visible workflow.

--- a/packages/storefront-templates/src/business-analysis-plan.test.ts
+++ b/packages/storefront-templates/src/business-analysis-plan.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateBusinessAnalysisPlan,
+  type BusinessAnalysisPlan,
+} from "./business-analysis-plan";
+import { PERFORMANCE_METRIC_DEFINITIONS } from "./performance-metric-catalog";
+
+const acceptedPlan = (): BusinessAnalysisPlan => ({
+  schemaVersion: 1,
+  question: "How did sales and demand change last month?",
+  intent: "change",
+  metrics: [{ key: "sales" }, { key: "demand" }],
+  dimensions: [{ key: "organization" }],
+  filters: [],
+  period: {
+    start: "2026-07-01",
+    end: "2026-07-31",
+    timezone: "America/Chicago",
+    grain: "day",
+  },
+  comparison: { basis: "prior-period" },
+  sources: [
+    { owner: "orders", maximumAge: "P1D" },
+    { owner: "work-intake", maximumAge: "PT1H" },
+  ],
+  checks: [{ kind: "completeness" }, { kind: "comparison-baseline" }],
+});
+
+describe("validateBusinessAnalysisPlan", () => {
+  it("accepts a complete plan resolved through canonical metric definitions", () => {
+    const result = validateBusinessAnalysisPlan(acceptedPlan());
+
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") return;
+
+    expect(result.plan.metrics.map(({ key }) => key)).toEqual(["demand", "sales"]);
+    expect(result.plan.sensitivity).toEqual(["business", "financial"]);
+    expect(result.plan.definitionVersion).toBeTruthy();
+    expect(result.fingerprint).toMatch(/^bap1_[0-9a-f]{16}$/);
+    expect(Object.isFrozen(result.plan)).toBe(true);
+    expect(Object.isFrozen(result.plan.metrics)).toBe(true);
+  });
+
+  it("requests clarification when change intent has no comparison basis", () => {
+    const plan: BusinessAnalysisPlan = {
+      ...acceptedPlan(),
+      comparison: { basis: "none" },
+    };
+
+    const result = validateBusinessAnalysisPlan(plan);
+
+    expect(result.status).toBe("clarification-required");
+    if (result.status !== "clarification-required") return;
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: "comparison-required",
+      path: "comparison.basis",
+    }));
+  });
+
+  it("refuses unknown metrics and unsupported dimensions", () => {
+    const plan: BusinessAnalysisPlan = {
+      ...acceptedPlan(),
+      metrics: [{ key: "invented-margin" }],
+      dimensions: [{ key: "private-column" as "organization" }],
+    };
+
+    const result = validateBusinessAnalysisPlan(plan);
+
+    expect(result.status).toBe("refused");
+    if (result.status !== "refused") return;
+    expect(result.issues.map(({ code }) => code)).toEqual(expect.arrayContaining([
+      "unknown-metric",
+      "unsupported-dimension",
+    ]));
+  });
+
+  it("refuses filter operators outside the closed contract", () => {
+    const plan: unknown = {
+      ...acceptedPlan(),
+      filters: [{ dimension: "organization", operator: "contains-sql", values: ["x"] }],
+    };
+
+    const result = validateBusinessAnalysisPlan(plan);
+
+    expect(result.status).toBe("refused");
+    if (result.status !== "refused") return;
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: "invalid-filter-operator",
+      path: "filters[0].operator",
+    }));
+  });
+
+  it("refuses multiple values for scalar filter operators", () => {
+    for (const operator of ["equals", "not-equals"] as const) {
+      const result = validateBusinessAnalysisPlan({
+        ...acceptedPlan(),
+        filters: [{ dimension: "organization", operator, values: ["north", "south"] }],
+      });
+
+      expect(result.status).toBe("refused");
+      if (result.status !== "refused") continue;
+      expect(result.issues).toContainEqual(expect.objectContaining({
+        code: "invalid-filter",
+        path: "filters[0].values",
+      }));
+    }
+  });
+
+  it("normalizes set-like input into a stable reusable identity", () => {
+    const left = validateBusinessAnalysisPlan(acceptedPlan());
+    const original = acceptedPlan();
+    const reordered: BusinessAnalysisPlan = {
+      ...original,
+      metrics: [...original.metrics].reverse(),
+      sources: [...original.sources].reverse(),
+      checks: [...original.checks].reverse(),
+    };
+    const right = validateBusinessAnalysisPlan(reordered);
+
+    expect(left.status).toBe("accepted");
+    expect(right.status).toBe("accepted");
+    if (left.status !== "accepted" || right.status !== "accepted") return;
+
+    expect(right.plan).toEqual(left.plan);
+    expect(right.fingerprint).toBe(left.fingerprint);
+  });
+
+  it("refuses calendar, timezone, and duration values that only look valid", () => {
+    const invalidCalendar = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      period: { ...acceptedPlan().period, start: "2026-02-30" },
+    });
+    const invalidTimezone = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      period: { ...acceptedPlan().period, timezone: "Central-ish" },
+    });
+    const emptyDuration = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      sources: acceptedPlan().sources.map((source) => ({ ...source, maximumAge: "PT" })),
+    });
+
+    expect(invalidCalendar.status).toBe("refused");
+    expect(invalidTimezone.status).toBe("refused");
+    expect(emptyDuration.status).toBe("refused");
+  });
+
+  it("normalizes equivalent IANA timezone aliases into one semantic identity", () => {
+    const canonical = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      period: { ...acceptedPlan().period, timezone: "America/New_York" },
+    });
+    const alias = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      period: { ...acceptedPlan().period, timezone: "US/Eastern" },
+    });
+
+    expect(canonical.status).toBe("accepted");
+    expect(alias.status).toBe("accepted");
+    if (canonical.status !== "accepted" || alias.status !== "accepted") return;
+    expect(alias.plan.period.timezone).toBe("America/New_York");
+    expect(alias.plan).toEqual(canonical.plan);
+    expect(alias.fingerprint).toBe(canonical.fingerprint);
+  });
+
+  it("canonicalizes mixed JSON scalar filters without order-dependent fingerprints", () => {
+    const first = acceptedPlan();
+    const second = acceptedPlan();
+    const left = validateBusinessAnalysisPlan({
+      ...first,
+      filters: [{ dimension: "organization", operator: "in", values: ["1", 1, false, 0] }],
+    });
+    const right = validateBusinessAnalysisPlan({
+      ...second,
+      filters: [{ dimension: "organization", operator: "in", values: [1, "1", 0, false] }],
+    });
+
+    expect(left.status).toBe("accepted");
+    expect(right.status).toBe("accepted");
+    if (left.status !== "accepted" || right.status !== "accepted") return;
+    expect(right.plan).toEqual(left.plan);
+    expect(right.fingerprint).toBe(left.fingerprint);
+  });
+
+  it("removes duplicate set-like filter values and identical filters from identity", () => {
+    const left = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      filters: [
+        { dimension: "organization", operator: "in", values: ["north", "north", 1, 1] },
+        { dimension: "organization", operator: "in", values: ["north", 1] },
+      ],
+    });
+    const right = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      filters: [{ dimension: "organization", operator: "in", values: [1, "north"] }],
+    });
+
+    expect(left.status).toBe("accepted");
+    expect(right.status).toBe("accepted");
+    if (left.status !== "accepted" || right.status !== "accepted") return;
+    expect(left.plan.filters).toHaveLength(1);
+    expect(left.plan).toEqual(right.plan);
+    expect(left.fingerprint).toBe(right.fingerprint);
+  });
+
+  it("normalizes equivalent freshness durations into one semantic identity", () => {
+    const left = validateBusinessAnalysisPlan(acceptedPlan());
+    const right = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      sources: [
+        { owner: "orders", maximumAge: "PT24H" },
+        { owner: "work-intake", maximumAge: "PT60M" },
+      ],
+    });
+
+    expect(left.status).toBe("accepted");
+    expect(right.status).toBe("accepted");
+    if (left.status !== "accepted" || right.status !== "accepted") return;
+    expect(right.plan.sources).toEqual(left.plan.sources);
+    expect(right.fingerprint).toBe(left.fingerprint);
+  });
+
+  it("refuses non-JSON numbers and duplicate source requirements", () => {
+    const invalidNumber = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      filters: [{ dimension: "organization", operator: "equals", values: [Number.NaN] }],
+    });
+    const duplicateSource = validateBusinessAnalysisPlan({
+      ...acceptedPlan(),
+      sources: [...acceptedPlan().sources, { owner: "orders", maximumAge: "PT2H" }],
+    });
+
+    expect(invalidNumber.status).toBe("refused");
+    expect(duplicateSource.status).toBe("refused");
+    if (duplicateSource.status !== "refused") return;
+    expect(duplicateSource.issues).toContainEqual(expect.objectContaining({
+      code: "duplicate-source-requirement",
+    }));
+  });
+
+  it("keeps every canonical metric on the typed calculation contract", () => {
+    for (const [mapKey, definition] of PERFORMANCE_METRIC_DEFINITIONS) {
+      expect(definition.key).toBe(mapKey);
+      expect(definition.definition.length).toBeGreaterThan(4);
+      expect(definition.calculation.kind).toBeTruthy();
+      expect(definition.calculation.inputs.length).toBeGreaterThan(0);
+      expect(definition.allowedDimensions).toContain("organization");
+      expect(definition.supportedComparisons).toContain("none");
+      expect(definition.supportedComparisons).toContain(definition.comparison);
+    }
+  });
+});

--- a/packages/storefront-templates/src/business-analysis-plan.ts
+++ b/packages/storefront-templates/src/business-analysis-plan.ts
@@ -1,0 +1,605 @@
+import {
+  BUSINESS_ANALYSIS_DIMENSIONS,
+  PERFORMANCE_METRIC_COMPARISONS,
+  PERFORMANCE_METRIC_GRAINS,
+  type BusinessAnalysisDimensionKey,
+  type PerformanceMetricComparison,
+  type PerformanceMetricGrain,
+  type PerformanceMetricSensitivity,
+} from "./business-view-profile";
+import {
+  getPerformanceMetricDefinition,
+  PERFORMANCE_METRIC_DEFINITION_VERSION,
+} from "./performance-metric-catalog";
+
+export const BUSINESS_ANALYSIS_INTENTS = [
+  "status",
+  "change",
+  "diagnosis",
+  "decision",
+] as const;
+export type BusinessAnalysisIntent = (typeof BUSINESS_ANALYSIS_INTENTS)[number];
+
+export const BUSINESS_ANALYSIS_FILTER_OPERATORS = [
+  "equals",
+  "not-equals",
+  "in",
+  "not-in",
+] as const;
+export type BusinessAnalysisFilterOperator = (typeof BUSINESS_ANALYSIS_FILTER_OPERATORS)[number];
+
+export const BUSINESS_ANALYSIS_CHECK_KINDS = [
+  "completeness",
+  "comparison-baseline",
+  "decision-boundary",
+] as const;
+export type BusinessAnalysisCheckKind = (typeof BUSINESS_ANALYSIS_CHECK_KINDS)[number];
+
+export interface BusinessAnalysisMetricRef {
+  readonly key: string;
+}
+
+export interface BusinessAnalysisDimension {
+  readonly key: BusinessAnalysisDimensionKey;
+}
+
+export interface BusinessAnalysisFilter {
+  readonly dimension: BusinessAnalysisDimensionKey;
+  readonly operator: BusinessAnalysisFilterOperator;
+  readonly values: ReadonlyArray<string | number | boolean>;
+}
+
+export interface BusinessAnalysisPeriod {
+  readonly start: string;
+  readonly end: string;
+  readonly timezone: string;
+  readonly grain: PerformanceMetricGrain;
+}
+
+export interface BusinessAnalysisComparison {
+  readonly basis: PerformanceMetricComparison;
+}
+
+export interface BusinessAnalysisSourceRequirement {
+  readonly owner: string;
+  readonly maximumAge: string;
+}
+
+export interface BusinessAnalysisCheck {
+  readonly kind: BusinessAnalysisCheckKind;
+}
+
+export interface BusinessAnalysisPlan {
+  readonly schemaVersion: 1;
+  readonly question: string;
+  readonly intent: BusinessAnalysisIntent;
+  readonly metrics: readonly BusinessAnalysisMetricRef[];
+  readonly dimensions: readonly BusinessAnalysisDimension[];
+  readonly filters: readonly BusinessAnalysisFilter[];
+  readonly period: BusinessAnalysisPeriod;
+  readonly comparison: BusinessAnalysisComparison;
+  readonly sources: readonly BusinessAnalysisSourceRequirement[];
+  readonly checks: readonly BusinessAnalysisCheck[];
+}
+
+export interface NormalizedBusinessAnalysisPlan extends BusinessAnalysisPlan {
+  readonly definitionVersion: string;
+  readonly sensitivity: readonly PerformanceMetricSensitivity[];
+}
+
+export type BusinessAnalysisIssueCode =
+  | "invalid-plan"
+  | "unsupported-schema-version"
+  | "question-required"
+  | "invalid-intent"
+  | "metrics-required"
+  | "invalid-metric"
+  | "unknown-metric"
+  | "duplicate-metric"
+  | "unsupported-dimension"
+  | "duplicate-dimension"
+  | "invalid-filter"
+  | "invalid-filter-operator"
+  | "invalid-period"
+  | "invalid-comparison"
+  | "comparison-required"
+  | "unsupported-comparison"
+  | "invalid-source"
+  | "duplicate-source-requirement"
+  | "missing-source-requirement"
+  | "invalid-check"
+  | "missing-check";
+
+export interface BusinessAnalysisIssue {
+  code: BusinessAnalysisIssueCode;
+  path: string;
+  message: string;
+}
+
+export type BusinessAnalysisPlanResult =
+  | {
+      status: "accepted";
+      plan: NormalizedBusinessAnalysisPlan;
+      fingerprint: string;
+    }
+  | {
+      status: "clarification-required";
+      issues: BusinessAnalysisIssue[];
+    }
+  | {
+      status: "refused";
+      issues: BusinessAnalysisIssue[];
+    };
+
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isOneOf = <T extends string>(value: unknown, values: readonly T[]): value is T =>
+  typeof value === "string" && values.includes(value as T);
+
+const issue = (
+  code: BusinessAnalysisIssueCode,
+  path: string,
+  message: string,
+): BusinessAnalysisIssue => ({ code, path, message });
+
+const unique = <T>(values: readonly T[]): T[] => [...new Set(values)];
+
+const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const byKey = <T extends { key: string }>(left: T, right: T): number =>
+  compareText(left.key, right.key);
+
+const byOwner = (
+  left: BusinessAnalysisSourceRequirement,
+  right: BusinessAnalysisSourceRequirement,
+): number => compareText(left.owner, right.owner);
+
+const byKind = <T extends { kind: string }>(left: T, right: T): number =>
+  compareText(left.kind, right.kind);
+
+const byFilter = (left: BusinessAnalysisFilter, right: BusinessAnalysisFilter): number =>
+  compareText(
+    `${left.dimension}:${left.operator}:${JSON.stringify(left.values)}`,
+    `${right.dimension}:${right.operator}:${JSON.stringify(right.values)}`,
+  );
+
+type JsonScalar = string | number | boolean;
+
+const scalarTypeRank = (value: JsonScalar): number => {
+  switch (typeof value) {
+    case "boolean": return 0;
+    case "number": return 1;
+    case "string": return 2;
+  }
+};
+
+const compareScalar = (left: JsonScalar, right: JsonScalar): number => {
+  const rankDifference = scalarTypeRank(left) - scalarTypeRank(right);
+  if (rankDifference !== 0) return rankDifference;
+  if (typeof left === "number" && typeof right === "number") return left - right;
+  return compareText(String(left), String(right));
+};
+
+const uniqueScalars = (values: readonly JsonScalar[]): JsonScalar[] => {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const identity = `${typeof value}:${JSON.stringify(value)}`;
+    if (seen.has(identity)) return false;
+    seen.add(identity);
+    return true;
+  });
+};
+
+const uniqueBy = <T>(values: readonly T[], identityFor: (value: T) => string): T[] => {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const identity = identityFor(value);
+    if (seen.has(identity)) return false;
+    seen.add(identity);
+    return true;
+  });
+};
+
+const isIsoDate = (value: unknown): value is string => {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+};
+
+const normalizeTimeZone = (value: unknown): string | null => {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone: value })
+      .resolvedOptions()
+      .timeZone;
+  } catch {
+    return null;
+  }
+};
+
+const parseIsoDurationSeconds = (value: unknown): number | null => {
+  if (typeof value !== "string") return null;
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(value);
+  if (!match || match.slice(1).every((part) => part === undefined)) return null;
+  const parts = match.slice(1).map((part) => Number(part ?? 0));
+  if (parts.some((part) => !Number.isSafeInteger(part))) return null;
+  const [days = 0, hours = 0, minutes = 0, seconds = 0] = parts;
+  const total = days * 86_400 + hours * 3_600 + minutes * 60 + seconds;
+  return Number.isSafeInteger(total) ? total : null;
+};
+
+const isIsoDuration = (value: unknown): value is string =>
+  parseIsoDurationSeconds(value) !== null;
+
+const normalizeIsoDuration = (value: string): string => {
+  let remaining = parseIsoDurationSeconds(value)!;
+  if (remaining === 0) return "PT0S";
+  const days = Math.floor(remaining / 86_400);
+  remaining %= 86_400;
+  const hours = Math.floor(remaining / 3_600);
+  remaining %= 3_600;
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  const datePart = days > 0 ? `${days}D` : "";
+  const timePart = [
+    hours > 0 ? `${hours}H` : "",
+    minutes > 0 ? `${minutes}M` : "",
+    seconds > 0 ? `${seconds}S` : "",
+  ].join("");
+  return `P${datePart}${timePart ? `T${timePart}` : ""}`;
+};
+
+function fingerprint(canonical: string): string {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (const byte of new TextEncoder().encode(canonical)) {
+    hash ^= BigInt(byte);
+    hash = (hash * prime) & mask;
+  }
+  return `bap1_${hash.toString(16).padStart(16, "0")}`;
+}
+
+function freezeNormalizedPlan(
+  plan: NormalizedBusinessAnalysisPlan,
+): NormalizedBusinessAnalysisPlan {
+  plan.metrics.forEach(Object.freeze);
+  plan.dimensions.forEach(Object.freeze);
+  plan.filters.forEach((filter) => {
+    Object.freeze(filter.values);
+    Object.freeze(filter);
+  });
+  plan.sources.forEach(Object.freeze);
+  plan.checks.forEach(Object.freeze);
+  Object.freeze(plan.metrics);
+  Object.freeze(plan.dimensions);
+  Object.freeze(plan.filters);
+  Object.freeze(plan.period);
+  Object.freeze(plan.comparison);
+  Object.freeze(plan.sources);
+  Object.freeze(plan.checks);
+  Object.freeze(plan.sensitivity);
+  return Object.freeze(plan);
+}
+
+function parseMetrics(
+  value: unknown,
+  issues: BusinessAnalysisIssue[],
+): BusinessAnalysisMetricRef[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    issues.push(issue("metrics-required", "metrics", "Select at least one governed metric."));
+    return [];
+  }
+
+  const metrics: BusinessAnalysisMetricRef[] = [];
+  const seen = new Set<string>();
+  value.forEach((candidate, index) => {
+    if (!isRecord(candidate) || typeof candidate.key !== "string" || candidate.key.trim() === "") {
+      issues.push(issue("invalid-metric", `metrics[${index}]`, "Metric references require a non-empty key."));
+      return;
+    }
+    const key = candidate.key.trim();
+    if (seen.has(key)) {
+      issues.push(issue("duplicate-metric", `metrics[${index}].key`, `Metric ${key} is repeated.`));
+      return;
+    }
+    seen.add(key);
+    if (!getPerformanceMetricDefinition(key)) {
+      issues.push(issue("unknown-metric", `metrics[${index}].key`, `Metric ${key} is not in the governed catalog.`));
+    }
+    metrics.push({ key });
+  });
+  return metrics;
+}
+
+function parseDimensions(
+  value: unknown,
+  issues: BusinessAnalysisIssue[],
+): BusinessAnalysisDimension[] {
+  if (!Array.isArray(value)) {
+    issues.push(issue("unsupported-dimension", "dimensions", "Dimensions must be an array of governed keys."));
+    return [];
+  }
+  const dimensions: BusinessAnalysisDimension[] = [];
+  const seen = new Set<string>();
+  value.forEach((candidate, index) => {
+    const key = isRecord(candidate) ? candidate.key : undefined;
+    if (!isOneOf(key, BUSINESS_ANALYSIS_DIMENSIONS)) {
+      issues.push(issue("unsupported-dimension", `dimensions[${index}].key`, "Dimension is not in the closed business-analysis contract."));
+      return;
+    }
+    if (seen.has(key)) {
+      issues.push(issue("duplicate-dimension", `dimensions[${index}].key`, `Dimension ${key} is repeated.`));
+      return;
+    }
+    seen.add(key);
+    dimensions.push({ key });
+  });
+  return dimensions;
+}
+
+function parseFilters(value: unknown, issues: BusinessAnalysisIssue[]): BusinessAnalysisFilter[] {
+  if (!Array.isArray(value)) {
+    issues.push(issue("invalid-filter", "filters", "Filters must be an array."));
+    return [];
+  }
+  const filters: BusinessAnalysisFilter[] = [];
+  value.forEach((candidate, index) => {
+    if (!isRecord(candidate)) {
+      issues.push(issue("invalid-filter", `filters[${index}]`, "Filter must be an object."));
+      return;
+    }
+    if (!isOneOf(candidate.operator, BUSINESS_ANALYSIS_FILTER_OPERATORS)) {
+      issues.push(issue("invalid-filter-operator", `filters[${index}].operator`, "Filter operator is not supported."));
+      return;
+    }
+    if (!isOneOf(candidate.dimension, BUSINESS_ANALYSIS_DIMENSIONS)) {
+      issues.push(issue("unsupported-dimension", `filters[${index}].dimension`, "Filter dimension is not supported."));
+      return;
+    }
+    if (!Array.isArray(candidate.values) || candidate.values.length === 0 || candidate.values.some(
+      (entry) => !["string", "number", "boolean"].includes(typeof entry)
+        || (typeof entry === "number" && !Number.isFinite(entry)),
+    )) {
+      issues.push(issue("invalid-filter", `filters[${index}].values`, "Filter values must contain JSON scalar values."));
+      return;
+    }
+    if ((candidate.operator === "equals" || candidate.operator === "not-equals")
+      && candidate.values.length !== 1) {
+      issues.push(issue(
+        "invalid-filter",
+        `filters[${index}].values`,
+        `${candidate.operator} requires exactly one filter value.`,
+      ));
+      return;
+    }
+    filters.push({
+      dimension: candidate.dimension,
+      operator: candidate.operator,
+      values: candidate.values.map((entry) =>
+        typeof entry === "number" && Object.is(entry, -0) ? 0 : entry,
+      ) as JsonScalar[],
+    });
+  });
+  return filters;
+}
+
+function parsePeriod(value: unknown, issues: BusinessAnalysisIssue[]): BusinessAnalysisPeriod | undefined {
+  const timezone = isRecord(value) ? normalizeTimeZone(value.timezone) : null;
+  if (!isRecord(value)
+    || !isIsoDate(value.start)
+    || !isIsoDate(value.end)
+    || value.start > value.end
+    || !timezone
+    || !isOneOf(value.grain, PERFORMANCE_METRIC_GRAINS)) {
+    issues.push(issue("invalid-period", "period", "Period requires ordered ISO dates, a timezone, and a supported grain."));
+    return undefined;
+  }
+  return {
+    start: value.start,
+    end: value.end,
+    timezone,
+    grain: value.grain,
+  };
+}
+
+function parseComparison(
+  value: unknown,
+  issues: BusinessAnalysisIssue[],
+): BusinessAnalysisComparison | undefined {
+  if (!isRecord(value) || !isOneOf(value.basis, PERFORMANCE_METRIC_COMPARISONS)) {
+    issues.push(issue("invalid-comparison", "comparison.basis", "Comparison basis is not supported."));
+    return undefined;
+  }
+  return { basis: value.basis };
+}
+
+function parseSources(
+  value: unknown,
+  issues: BusinessAnalysisIssue[],
+): BusinessAnalysisSourceRequirement[] {
+  if (!Array.isArray(value)) {
+    issues.push(issue("invalid-source", "sources", "Source requirements must be an array."));
+    return [];
+  }
+  const sources: BusinessAnalysisSourceRequirement[] = [];
+  const seen = new Set<string>();
+  value.forEach((candidate, index) => {
+    if (!isRecord(candidate)
+      || typeof candidate.owner !== "string"
+      || candidate.owner.trim() === ""
+      || !isIsoDuration(candidate.maximumAge)) {
+      issues.push(issue("invalid-source", `sources[${index}]`, "Source requires an owner and ISO 8601 maximum age."));
+      return;
+    }
+    const owner = candidate.owner.trim();
+    if (seen.has(owner)) {
+      issues.push(issue(
+        "duplicate-source-requirement",
+        `sources[${index}].owner`,
+        `Source ${owner} has more than one freshness requirement.`,
+      ));
+      return;
+    }
+    seen.add(owner);
+    sources.push({ owner, maximumAge: normalizeIsoDuration(candidate.maximumAge) });
+  });
+  return sources;
+}
+
+function parseChecks(value: unknown, issues: BusinessAnalysisIssue[]): BusinessAnalysisCheck[] {
+  if (!Array.isArray(value)) {
+    issues.push(issue("invalid-check", "checks", "Verification checks must be an array."));
+    return [];
+  }
+  const checks: BusinessAnalysisCheck[] = [];
+  value.forEach((candidate, index) => {
+    const kind = isRecord(candidate) ? candidate.kind : undefined;
+    if (!isOneOf(kind, BUSINESS_ANALYSIS_CHECK_KINDS)) {
+      issues.push(issue("invalid-check", `checks[${index}].kind`, "Verification check is not supported."));
+      return;
+    }
+    checks.push({ kind });
+  });
+  return checks;
+}
+
+export function validateBusinessAnalysisPlan(input: unknown): BusinessAnalysisPlanResult {
+  if (!isRecord(input)) {
+    return {
+      status: "refused",
+      issues: [issue("invalid-plan", "$", "Business analysis plan must be an object.")],
+    };
+  }
+
+  const refusalIssues: BusinessAnalysisIssue[] = [];
+  const clarificationIssues: BusinessAnalysisIssue[] = [];
+
+  if (input.schemaVersion !== 1) {
+    refusalIssues.push(issue("unsupported-schema-version", "schemaVersion", "Only BusinessAnalysisPlan schema version 1 is supported."));
+  }
+  if (typeof input.question !== "string" || input.question.trim() === "") {
+    refusalIssues.push(issue("question-required", "question", "A business question is required."));
+  }
+  if (!isOneOf(input.intent, BUSINESS_ANALYSIS_INTENTS)) {
+    refusalIssues.push(issue("invalid-intent", "intent", "Analysis intent is not supported."));
+  }
+
+  const metrics = parseMetrics(input.metrics, refusalIssues);
+  const dimensions = parseDimensions(input.dimensions, refusalIssues);
+  const filters = parseFilters(input.filters, refusalIssues);
+  const period = parsePeriod(input.period, refusalIssues);
+  const comparison = parseComparison(input.comparison, refusalIssues);
+  const sources = parseSources(input.sources, refusalIssues);
+  const checks = parseChecks(input.checks, refusalIssues);
+
+  const definitions = metrics
+    .map(({ key }) => getPerformanceMetricDefinition(key))
+    .filter((definition) => definition !== undefined);
+
+  for (const dimension of [...dimensions, ...filters.map(({ dimension }) => ({ key: dimension }))]) {
+    for (const definition of definitions) {
+      if (!definition.allowedDimensions.includes(dimension.key)) {
+        refusalIssues.push(issue(
+          "unsupported-dimension",
+          "dimensions",
+          `Metric ${definition.key} does not support dimension ${dimension.key}.`,
+        ));
+      }
+    }
+  }
+
+  if (period) {
+    for (const definition of definitions) {
+      if (definition.grain !== period.grain) {
+        refusalIssues.push(issue(
+          "invalid-period",
+          "period.grain",
+          `Metric ${definition.key} requires ${definition.grain} grain.`,
+        ));
+      }
+    }
+  }
+
+  if (comparison && comparison.basis !== "none") {
+    for (const definition of definitions) {
+      if (!definition.supportedComparisons.includes(comparison.basis)) {
+        refusalIssues.push(issue(
+          "unsupported-comparison",
+          "comparison.basis",
+          `Metric ${definition.key} does not support ${comparison.basis} comparison.`,
+        ));
+      }
+    }
+  }
+
+  if ((input.intent === "change" || input.intent === "diagnosis") && comparison?.basis === "none") {
+    clarificationIssues.push(issue(
+      "comparison-required",
+      "comparison.basis",
+      `${input.intent} analysis requires a comparison basis.`,
+    ));
+  }
+
+  const sourceOwners = new Set(sources.map(({ owner }) => owner));
+  for (const owner of unique(definitions.map(({ sourceOwner }) => sourceOwner))) {
+    if (!sourceOwners.has(owner)) {
+      refusalIssues.push(issue(
+        "missing-source-requirement",
+        "sources",
+        `Metric source ${owner} requires an explicit freshness limit.`,
+      ));
+    }
+  }
+
+  const checkKinds = new Set(checks.map(({ kind }) => kind));
+  if (!checkKinds.has("completeness")) {
+    refusalIssues.push(issue("missing-check", "checks", "Every plan requires a completeness check."));
+  }
+  if ((input.intent === "change" || input.intent === "diagnosis") && !checkKinds.has("comparison-baseline")) {
+    refusalIssues.push(issue("missing-check", "checks", "Change and diagnosis plans require a comparison-baseline check."));
+  }
+  if (input.intent === "decision" && !checkKinds.has("decision-boundary")) {
+    refusalIssues.push(issue("missing-check", "checks", "Decision plans require a decision-boundary check."));
+  }
+
+  if (refusalIssues.length > 0) return { status: "refused", issues: refusalIssues };
+  if (clarificationIssues.length > 0) {
+    return { status: "clarification-required", issues: clarificationIssues };
+  }
+
+  const normalizedFilters = uniqueBy(
+    filters
+      .map((filter) => ({
+        ...filter,
+        values: uniqueScalars(filter.values).sort(compareScalar),
+      }))
+      .sort(byFilter),
+    (filter) => `${filter.dimension}:${filter.operator}:${JSON.stringify(filter.values)}`,
+  );
+
+  const normalized = freezeNormalizedPlan({
+    schemaVersion: 1,
+    question: (input.question as string).trim(),
+    intent: input.intent as BusinessAnalysisIntent,
+    metrics: [...metrics].sort(byKey),
+    dimensions: [...dimensions].sort(byKey),
+    filters: normalizedFilters,
+    period: period!,
+    comparison: comparison!,
+    sources: [...sources].sort(byOwner),
+    checks: unique(checks.map(({ kind }) => kind)).map((kind) => ({ kind })).sort(byKind),
+    definitionVersion: PERFORMANCE_METRIC_DEFINITION_VERSION,
+    sensitivity: unique(definitions.map(({ sensitivity }) => sensitivity)).sort(),
+  });
+
+  return {
+    status: "accepted",
+    plan: normalized,
+    fingerprint: fingerprint(JSON.stringify(normalized)),
+  };
+}

--- a/packages/storefront-templates/src/business-view-profile.ts
+++ b/packages/storefront-templates/src/business-view-profile.ts
@@ -8,16 +8,74 @@ import { resolvePerformanceMetricPack } from "./performance-metric-catalog";
 
 export type OperationsTextAlternative = "list" | "table";
 
+export const PERFORMANCE_METRIC_UNITS = [
+  "count",
+  "currency",
+  "percent",
+  "duration",
+  "rate",
+] as const;
+export type PerformanceMetricUnit = (typeof PERFORMANCE_METRIC_UNITS)[number];
+
+export const PERFORMANCE_METRIC_GRAINS = ["day", "week", "month"] as const;
+export type PerformanceMetricGrain = (typeof PERFORMANCE_METRIC_GRAINS)[number];
+
+export const PERFORMANCE_METRIC_COMPARISONS = [
+  "prior-period",
+  "prior-year",
+  "target",
+  "none",
+] as const;
+export type PerformanceMetricComparison = (typeof PERFORMANCE_METRIC_COMPARISONS)[number];
+
+export const PERFORMANCE_METRIC_SENSITIVITIES = [
+  "business",
+  "financial",
+  "workforce",
+  "customer",
+] as const;
+export type PerformanceMetricSensitivity = (typeof PERFORMANCE_METRIC_SENSITIVITIES)[number];
+
+export const PERFORMANCE_CALCULATION_KINDS = [
+  "sum",
+  "count",
+  "ratio",
+  "median",
+  "closing-balance",
+  "grouped-sum",
+] as const;
+export type PerformanceCalculationKind = (typeof PERFORMANCE_CALCULATION_KINDS)[number];
+
+export const BUSINESS_ANALYSIS_DIMENSIONS = [
+  "organization",
+  "location",
+  "customer",
+  "product",
+  "worker",
+  "channel",
+] as const;
+export type BusinessAnalysisDimensionKey = (typeof BUSINESS_ANALYSIS_DIMENSIONS)[number];
+
+export interface PerformanceMetricCalculation {
+  kind: PerformanceCalculationKind;
+  inputs: readonly string[];
+}
+
 export interface PerformanceMetricDefinition {
   key: string;
   label: string;
-  unit: "count" | "currency" | "percent" | "duration" | "rate";
+  unit: PerformanceMetricUnit;
   sourceOwner: string;
-  grain: "day" | "week" | "month";
+  grain: PerformanceMetricGrain;
+  definition: string;
+  calculation: PerformanceMetricCalculation;
+  allowedDimensions: readonly BusinessAnalysisDimensionKey[];
+  supportedComparisons: readonly PerformanceMetricComparison[];
+  /** @deprecated Compatibility alias derived from definition; use definition for copy and calculation for semantics. */
   aggregation: string;
-  comparison: "prior-period" | "prior-year" | "target" | "none";
+  comparison: PerformanceMetricComparison;
   drilldownRoute?: string;
-  sensitivity: "business" | "financial" | "workforce" | "customer";
+  sensitivity: PerformanceMetricSensitivity;
 }
 
 export interface PerformanceMetricPack {

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -13,6 +13,7 @@ export * from "./resource-capacity-profile";
 export * from "./scene-layout";
 export * from "./business-view-profile";
 export * from "./performance-metric-catalog";
+export * from "./business-analysis-plan";
 export * from "./twin-value-stream";
 export * from "./demo-business";
 export * from "./demo-business-load";

--- a/packages/storefront-templates/src/performance-metric-catalog.ts
+++ b/packages/storefront-templates/src/performance-metric-catalog.ts
@@ -1,8 +1,85 @@
 import type {
+  BusinessAnalysisDimensionKey,
+  PerformanceMetricCalculation,
   PerformanceMetricDefinition,
   PerformanceMetricPack,
 } from "./business-view-profile";
 import type { TwinTemplate } from "./twin-profile";
+
+export const PERFORMANCE_METRIC_DEFINITION_VERSION = "2026-08-01.2";
+
+const calculation = (
+  kind: PerformanceMetricCalculation["kind"],
+  ...inputs: string[]
+): PerformanceMetricCalculation => ({ kind, inputs });
+
+const CALCULATIONS: Readonly<Record<string, PerformanceMetricCalculation>> = {
+  sales: calculation("sum", "recognized-sales"),
+  revenue: calculation("sum", "recognized-revenue"),
+  "gross-margin": calculation("ratio", "gross-profit", "revenue"),
+  "cash-position": calculation("closing-balance", "available-cash"),
+  demand: calculation("count", "accepted-demand"),
+  throughput: calculation("count", "completed-work"),
+  "cycle-time": calculation("median", "accepted-at", "completed-at"),
+  covers: calculation("count", "seated-guests"),
+  "average-check": calculation("ratio", "net-sales", "closed-checks"),
+  "table-utilization": calculation("ratio", "occupied-table-minutes", "available-table-minutes"),
+  "turn-time": calculation("median", "seated-at", "available-at"),
+  "wait-no-show-rate": calculation("ratio", "unseated-or-no-show-parties", "expected-parties"),
+  "labor-percentage": calculation("ratio", "labor-cost", "sales"),
+  appointments: calculation("count", "completed-appointments"),
+  occupancy: calculation("ratio", "booked-resource-minutes", "available-resource-minutes"),
+  "rebooking-retention": calculation("ratio", "returning-clients", "eligible-clients"),
+  "no-show-rate": calculation("ratio", "no-shows", "scheduled-appointments"),
+  "staff-utilization": calculation("ratio", "productive-minutes", "available-minutes"),
+  "retail-mix": calculation("ratio", "retail-sales", "total-sales"),
+  adr: calculation("ratio", "room-revenue", "occupied-rooms"),
+  revpar: calculation("ratio", "room-revenue", "available-rooms"),
+  "booking-pace": calculation("grouped-sum", "net-rooms-booked", "stay-date", "lead-time"),
+  "channel-mix": calculation("grouped-sum", "booked-rooms", "acquisition-channel"),
+  "room-turnaround": calculation("median", "checkout-at", "ready-at"),
+  "out-of-service-nights": calculation("sum", "unavailable-room-nights"),
+  "fleet-utilization": calculation("ratio", "committed-rentable-time", "available-rentable-time"),
+  "rental-revenue": calculation("sum", "recognized-rental-revenue"),
+  "asset-roi": calculation("ratio", "asset-operating-return", "invested-cost"),
+  "asset-downtime": calculation("sum", "unavailable-asset-time"),
+  "late-return-rate": calculation("ratio", "late-returns", "due-returns"),
+  "lost-demand-substitution": calculation("ratio", "unfilled-or-substituted-requests", "accepted-requests"),
+  "open-aging-actions": calculation("count", "open-actions", "aging-band"),
+  "sla-attainment": calculation("ratio", "within-commitment-work", "completed-work"),
+  "work-order-cost": calculation("sum", "approved-work-order-cost"),
+  "vendor-cycle-time": calculation("median", "assigned-at", "completed-at"),
+  collections: calculation("sum", "applied-payments"),
+  "authorized-violations": calculation("count", "role-visible-open-cases"),
+  jobs: calculation("count", "completed-jobs"),
+  conversion: calculation("ratio", "sold-opportunities", "presented-opportunities"),
+  "technician-utilization": calculation("ratio", "productive-technician-time", "available-technician-time"),
+  "drive-time": calculation("sum", "technician-travel-duration"),
+  "first-time-fix-rate": calculation("ratio", "first-visit-completions", "completed-jobs"),
+  "capacity-leakage": calculation("sum", "avoidable-lost-capacity-time"),
+};
+
+const calculationFor = (key: string): PerformanceMetricCalculation => {
+  const configured = CALCULATIONS[key];
+  if (!configured) throw new Error(`Missing typed calculation for metric ${key}`);
+  return configured;
+};
+
+const DEFAULT_DIMENSIONS = ["organization"] as const;
+const LOCATION_DIMENSIONS = ["organization", "location"] as const;
+const CUSTOMER_DIMENSIONS = ["organization", "location", "customer"] as const;
+const PRODUCT_DIMENSIONS = ["organization", "location", "product"] as const;
+const WORKFORCE_DIMENSIONS = ["organization", "location", "worker"] as const;
+const CHANNEL_DIMENSIONS = ["organization", "location", "channel"] as const;
+
+const dimensionsFor = (key: string): readonly BusinessAnalysisDimensionKey[] => {
+  if (["channel-mix", "booking-pace"].includes(key)) return CHANNEL_DIMENSIONS;
+  if (["sales", "revenue", "gross-margin", "average-check", "retail-mix", "rental-revenue", "asset-roi"].includes(key)) return PRODUCT_DIMENSIONS;
+  if (["covers", "wait-no-show-rate", "appointments", "rebooking-retention", "no-show-rate", "late-return-rate", "lost-demand-substitution", "first-time-fix-rate"].includes(key)) return CUSTOMER_DIMENSIONS;
+  if (["labor-percentage", "staff-utilization", "technician-utilization", "drive-time", "capacity-leakage"].includes(key)) return WORKFORCE_DIMENSIONS;
+  if (["table-utilization", "turn-time", "occupancy", "adr", "revpar", "room-turnaround", "out-of-service-nights", "fleet-utilization", "asset-downtime", "open-aging-actions", "sla-attainment", "work-order-cost", "vendor-cycle-time", "collections", "authorized-violations", "jobs", "conversion"].includes(key)) return LOCATION_DIMENSIONS;
+  return DEFAULT_DIMENSIONS;
+};
 
 export interface PriorityPhysicalViewPack {
   archetypeId: string;
@@ -28,6 +105,10 @@ const metric = (
   unit,
   sourceOwner,
   grain,
+  definition: aggregation,
+  calculation: calculationFor(key),
+  allowedDimensions: dimensionsFor(key),
+  supportedComparisons: comparison === "none" ? ["none"] : [comparison, "none"],
   aggregation,
   comparison,
   sensitivity,


### PR DESCRIPTION
## Summary

- add a versioned `BusinessAnalysisPlan.v1` validator and compiler that returns accepted, clarification, or refusal outcomes before analysis executes
- normalize periods, time zones, filters, segments, source requirements, and comparisons into a deterministic frozen plan identity
- extend the canonical performance metric catalog with supported comparisons and versioned definitions instead of creating route-local metric rules
- document the contract, architecture decisions, and implementation plan for BI-8EC3E4BF

## Design grounding

- Specs reviewed: `docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md` and `docs/superpowers/specs/2026-08-01-verified-business-analysis-plan-design.md`
- Code substrate reviewed: the storefront-template business view profiles, performance metric catalog, and package export boundary
- Source of truth: analysis-plan semantics live in `@dpf/storefront-templates`; future UI and execution surfaces consume the same compiled contract
- Decision: extend the existing profile and metric registries with a pure compiler rather than introduce a route-local schema, persistence table, or alternate metric taxonomy

## Verification

- `pnpm --filter @dpf/storefront-templates exec vitest run` — 22 files / 333 tests passed
- `pnpm --filter @dpf/storefront-templates exec tsc --noEmit` — passed
- independent high-assurance semantic review — two branches completed, zero blocking findings
- exact-tree merged-code pregate — 12-command exhaustive plan passed, including migration deploy, generated-doc check, guards, web typecheck, full Vitest, and production image build

## Documentation impact

The contract and its architectural rationale are documented in the linked design and implementation plan. No user-facing workflow changes ship in this contract-only PR; the performance and watched-analysis surfaces follow as separate concerns.

Linked-BI: BI-8EC3E4BF
