### PR TITLE
feat(mcp): find_coworker intent-based discovery meta-tool (Slice 10, BI-5FB59BC6)

### DIFF
--- a/apps/web/lib/mcp/packs/coworker-find.test.ts
+++ b/apps/web/lib/mcp/packs/coworker-find.test.ts
@@ -1,0 +1,69 @@
+// apps/web/lib/mcp/packs/coworker-find.test.ts
+import { describe, it, expect } from "vitest";
+import { matchCoworkers, type CoworkerRosterEntry } from "./coworker-pack";
+
+const ROSTER: CoworkerRosterEntry[] = [
+  {
+    agentId: "AGT-EA",
+    slugId: "ea-architect",
+    displayName: "Enterprise Architect",
+    description: "Reviews database schemas and system architecture.",
+    role: "architect",
+    kind: "advisor",
+    skills: ["schema review", "architecture review"],
+  },
+  {
+    agentId: "AGT-MKT",
+    slugId: "marketing",
+    displayName: "Marketing Lead",
+    description: "Runs campaigns and channel strategy.",
+    role: "marketing",
+    kind: "specialist",
+    skills: ["campaign ideas", "audience segmentation"],
+  },
+  {
+    agentId: "AGT-FIN",
+    slugId: "finance",
+    displayName: "Finance Analyst",
+    description: "Owns the general ledger and financial statements.",
+    role: "finance",
+    kind: "analyst",
+    skills: ["journal entry", "variance analysis"],
+  },
+];
+
+describe("find_coworker matchCoworkers (Slice 10, BI-5FB59BC6)", () => {
+  it("matches by intent across description and skills", () => {
+    const m = matchCoworkers(ROSTER, "review a database schema", 8);
+    expect(m[0]?.agentId).toBe("AGT-EA");
+    expect(m[0]?.matchedOn).toContain("description");
+  });
+
+  it("matches by role/name and weights them above description", () => {
+    const m = matchCoworkers(ROSTER, "marketing", 8);
+    expect(m[0]?.agentId).toBe("AGT-MKT");
+    expect(m[0]?.matchedOn.some((f) => f === "role" || f === "name")).toBe(true);
+  });
+
+  it("returns nothing for a non-matching query", () => {
+    expect(matchCoworkers(ROSTER, "zzz nonexistent", 8)).toEqual([]);
+  });
+
+  it("ignores 1-char noise terms and an empty query", () => {
+    expect(matchCoworkers(ROSTER, "a", 8)).toEqual([]);
+    expect(matchCoworkers(ROSTER, "   ", 8)).toEqual([]);
+  });
+
+  it("respects the limit", () => {
+    // "review" hits EA (skills+description); broaden to hit multiple, then cap.
+    const m = matchCoworkers(ROSTER, "review campaign ledger", 2);
+    expect(m.length).toBeLessThanOrEqual(2);
+  });
+
+  it("projects only the allowlisted fields (no role/kind/skills leak)", () => {
+    const m = matchCoworkers(ROSTER, "architecture", 8);
+    expect(Object.keys(m[0] ?? {}).sort()).toEqual(
+      ["agentId", "description", "displayName", "matchedOn", "slugId"].sort(),
+    );
+  });
+});

--- a/apps/web/lib/mcp/packs/coworker-pack.test.ts
+++ b/apps/web/lib/mcp/packs/coworker-pack.test.ts
@@ -12,14 +12,14 @@ vi.mock("@/lib/tak/coworker-collaboration", () => ({
 import { coworkerPack } from "./coworker-pack";
 import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
 
-const EXPECTED_TOOLS = ["request_coworker", "summon_coworker"];
+const EXPECTED_TOOLS = ["request_coworker", "summon_coworker", "find_coworker"];
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe("coworker pack — registration", () => {
-  it("exposes exactly the two collaboration tools with a handler each", () => {
+  it("exposes exactly the collaboration + discovery tools with a handler each", () => {
     expect(coworkerPack.definitions.map((d) => d.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
     expect(Object.keys(coworkerPack.handlers).sort()).toEqual([...EXPECTED_TOOLS].sort());
   });
@@ -31,12 +31,15 @@ describe("coworker pack — registration", () => {
   });
 
   it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
-    // These tools are advise-safe coordination, ungated in TOOL_TO_GRANTS —
-    // grants is empty, so there is nothing to drift against.
+    // request_coworker/summon_coworker are advise-safe coordination, ungated in
+    // TOOL_TO_GRANTS — pack.grants is empty, so there is nothing to drift against.
     expect(coworkerPack.grants).toEqual({});
     for (const [name, grants] of Object.entries(coworkerPack.grants)) {
       expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
     }
+    // find_coworker is a real read-only discovery tool, gated centrally so it is
+    // discoverable/callable over MCP (BI-5FB59BC6).
+    expect(TOOL_TO_GRANTS["find_coworker"]).toEqual(["backlog_read"]);
   });
 });
 

--- a/apps/web/lib/mcp/packs/coworker-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-pack.ts
@@ -59,6 +59,25 @@ const definitions: ToolDefinition[] = [
     // exempts it from the advise-mode runtime filter (BI-7EB4AE2C).
     adviseCoordination: true,
   },
+  {
+    name: "find_coworker",
+    description:
+      "Discover which coworker to hand a task to, by intent. request_coworker and summon_coworker need an exact agentId or slug; call this first with {query} describing the capability you need (e.g. \"review a database schema\", \"marketing campaign\") to get the matching coworkers' ids, names, and what they do. Read-only discovery — it does not contact anyone. Then pass the chosen agentId to request_coworker or summon_coworker.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Case-insensitive intent/capability keywords matched against coworker name, role, description, and skills.",
+        },
+        limit: { type: "number", description: "Max matches to return (default 8, max 25)." },
+      },
+      required: ["query"],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
 ];
 
 async function requestCoworkerHandler(
@@ -140,9 +159,109 @@ async function summonCoworkerHandler(
   }
 }
 
+export type CoworkerRosterEntry = {
+  agentId: string;
+  slugId: string | null;
+  displayName: string;
+  description: string | null;
+  role: string | null;
+  kind: string;
+  skills: string[];
+};
+
+export type CoworkerMatch = {
+  agentId: string;
+  slugId: string | null;
+  displayName: string;
+  description: string | null;
+  matchedOn: string[];
+};
+
+// Pure intent matcher: score each coworker by how many query terms hit its
+// name/role/kind/description/skills (name and role weighted higher); return the
+// top `limit`, best first. Ties break alphabetically for a stable order.
+export function matchCoworkers(
+  roster: CoworkerRosterEntry[],
+  query: string,
+  limit: number,
+): CoworkerMatch[] {
+  const terms = query.toLowerCase().split(/\s+/).filter((t) => t.length > 1);
+  if (terms.length === 0) return [];
+  return roster
+    .map((c) => {
+      const fields: Array<[string, string, number]> = [
+        ["name", c.displayName.toLowerCase(), 2],
+        ["role", (c.role ?? "").toLowerCase(), 2],
+        ["kind", c.kind.toLowerCase(), 1],
+        ["description", (c.description ?? "").toLowerCase(), 1],
+        ["skills", c.skills.join(" ").toLowerCase(), 1],
+      ];
+      const matchedOn = new Set<string>();
+      let score = 0;
+      for (const term of terms) {
+        for (const [field, hay, weight] of fields) {
+          if (hay.includes(term)) {
+            score += weight;
+            matchedOn.add(field);
+          }
+        }
+      }
+      return { c, score, matchedOn: [...matchedOn] };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || a.c.displayName.localeCompare(b.c.displayName))
+    .slice(0, limit)
+    .map(({ c, matchedOn }) => ({
+      agentId: c.agentId,
+      slugId: c.slugId,
+      displayName: c.displayName,
+      description: c.description,
+      matchedOn,
+    }));
+}
+
+async function findCoworkerHandler(params: Record<string, unknown>): Promise<ToolResult> {
+  const query = String(params["query"] ?? "").trim();
+  if (!query) {
+    return { success: false, error: "invalid_params", message: "find_coworker requires a query." };
+  }
+  const limit = Math.min(Math.max(Number(params["limit"]) || 8, 1), 25);
+  const { prisma } = await import("@dpf/db");
+  const rows = await prisma.agent.findMany({
+    where: { status: "active", archived: false, lifecycleStage: "production" },
+    select: {
+      agentId: true,
+      slugId: true,
+      displayName: true,
+      description: true,
+      role: true,
+      kind: true,
+      skills: { select: { label: true } },
+    },
+  });
+  const roster: CoworkerRosterEntry[] = rows.map((r) => ({
+    agentId: r.agentId,
+    slugId: r.slugId,
+    displayName: r.displayName,
+    description: r.description,
+    role: r.role,
+    kind: r.kind,
+    skills: r.skills.map((s) => s.label),
+  }));
+  const matches = matchCoworkers(roster, query, limit);
+  return {
+    success: true,
+    message: matches.length
+      ? `Found ${matches.length} coworker(s) for "${query}". Pass an agentId to request_coworker or summon_coworker.`
+      : `No coworker matched "${query}". Try broader capability keywords.`,
+    data: { matches, count: matches.length },
+  };
+}
+
 const handlers: Record<string, ToolPackHandler> = {
   request_coworker: (params, userId, context) => requestCoworkerHandler(params, userId, context),
   summon_coworker: (params, userId, context) => summonCoworkerHandler(params, userId, context),
+  find_coworker: (params) => findCoworkerHandler(params),
 };
 
 export const coworkerPack: ToolPack = {

--- a/apps/web/lib/mcp/tool-tier.ts
+++ b/apps/web/lib/mcp/tool-tier.ts
@@ -105,6 +105,7 @@ export const CORE_MCP_TOOL_NAMES: ReadonlySet<string> = new Set([
   "link_backlog_item_to_epic",
   // work / coworker / build visibility
   "get_my_coworker_profile",
+  "find_coworker",
   "get_next_recommended_work",
   "list_work_capsules",
   "get_work_capsule",

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -188,6 +188,9 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   record_local_integration_result: ["backlog_write"],
   record_functional_failure_evidence: ["backlog_write"],
   get_next_recommended_work: ["backlog_read"],
+  // Read-only coworker-roster discovery-by-intent (BI-5FB59BC6); returns ids/
+  // names to then pass to request_coworker/summon_coworker.
+  find_coworker: ["backlog_read"],
   // Coworker self-scoped backlog lens (BI-474A1F55) — read-only, identity-scoped.
   list_my_backlog: ["backlog_read"],
   // Work Capsule control harness (spec 2026-05-14)

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -53,7 +53,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	915
-apps/web/lib/tak/agent-grants.ts	918
+apps/web/lib/tak/agent-grants.ts	921
 apps/web/lib/tak/agent-routing.ts	1027
 apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,9 +3,9 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 362,
-      "reason": "Adds get_recruiting_pipeline (BI-E64D11AE): the HR-coworker read lens over the unified recruiting funnel — native Applications plus Greenhouse-sourced staged rows, deduped by crosswalk — so a coworker sees one pipeline across native and absorbed work. No existing tool carries it: query_employees is People-Core directory, and the backlog/estate read lenses do not touch recruiting entities. It is the coworker surface of the merged dual-read read-model (getRecruitingPipeline, #4067); read-only, +1, under the 15-tool selection cliff.",
-      "recordedAt": "2026-08-06"
+      "value": 363,
+      "reason": "Adds find_coworker — read-only coworker-roster discovery-by-intent (the A2A-plane twin of load_tools). No existing tool carries it: request_coworker/summon_coworker are ACTION verbs that require an exact agentId/slug, so a model that doesn't already know the roster cannot route work. find_coworker returns the matching coworkers' ids so those action tools become usable. BI-5FB59BC6.",
+      "recordedAt": "2026-08-08"
     },
     "registry.packFiles": {
       "value": 87,
@@ -13,9 +13,9 @@
       "recordedAt": "2026-08-06"
     },
     "tier.coreToolNames": {
-      "value": 29,
-      "reason": "Adds WWMD kernel discovery to core for peer CLIs (Grok/Codex): principle_decide + wiki_query. Those clients have no ToolSearch, so a lean core that omitted WWMD blocked AGENTS-required kernel consults even when the token already granted registry_read. Still lean vs full catalogue; authority stays grant/scope gated.",
-      "recordedAt": "2026-08-03"
+      "value": 30,
+      "reason": "Promotes find_coworker into the lean core tier so peer CLIs without client-side ToolSearch (Grok, Codex) can discover the coworker roster to route A2A handoffs — same rationale that keeps principle_decide/wiki_query core. Discovery-only; execution still gates on grants. BI-5FB59BC6.",
+      "recordedAt": "2026-08-08"
     },
     "dispatch.maxAttachedTools": {
       "value": 48


### PR DESCRIPTION
## What

Slice 10 of the MCP `2025-11-25` + A2A adoption program (umbrella `BI-1F4A4861`, epic `EP-E1F1DB58`): **`find_coworker`** — intent-based coworker discovery, the A2A-plane twin of Slice 8's `load_tools`.

**Substrate-verified first (as the BI mandates):** `request_coworker` and `summon_coworker` require an exact `agentId`/slug; there is **no** discovery-by-intent, so a model that doesn't already know the roster cannot route a handoff. Real gap → build.

`find_coworker({query, limit?})` matches the active/production coworker roster by intent (name/role/kind/description/skills, name+role weighted) and returns each match's `agentId`/slug/name/description + which field matched, so the model can then hand off via `request_coworker`/`summon_coworker`.

## Safety / economy

- **Read-only discovery** — contacts no one; execution still gates on grants at `tools/call`.
- Gated via `TOOL_TO_GRANTS` (`backlog_read`) and promoted to the **core tier** so peer CLIs without client-side ToolSearch (Grok, Codex) can discover the roster (same rationale as `principle_decide`/`wiki_query`). Tool-surface baseline raised with a recorded reason.
- The matcher is a **pure function** (unit-tested); results are bounded (`limit ≤ 25`).

## Design grounding

- Reviewed `docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md` (Slice 10) and the shipped Slice 8 `load_tools` pattern.
- Substrate: `apps/web/lib/mcp/packs/coworker-pack.ts`, `apps/web/lib/tak/agent-grants.ts`, `apps/web/lib/tak/agent-routing.ts`.
- Decision: extend the plan — mirror the `load_tools` discovery pattern on the coworker/A2A plane.

## Verification

- `dpf-tdd`: pure matcher unit tests (intent match, weighting, limit, empty/noise, field allowlist); coworker-pack registration test updated for the new tool + central grant. Touched-file vitest: **28 pass**.
- `pnpm typecheck` (web): clean.
- `dpf-local-merge-ci-before-push`: merged-with-`origin/main` local CI **passed** (full suite + typecheck + build).
- No schema change; no migration/data-impact.

## Linked

- BI: BI-5FB59BC6 (Slice 10) · Umbrella: BI-1F4A4861 · Epic: EP-E1F1DB58

Local-CI-Evidence: cmskjor00001q01oloteaattd (feat/mcp-slice10-find-coworker@6508d73b3)

Docs-Impact-Decision: internal MCP discovery tool (`find_coworker`); no customer-facing user-guide route or documented-surface change.

Process-Spine-Decision: this slice is already specified in the governed plan docs/superpowers/plans/2026-08-06-mcp-2025-11-25-a2a-adoption.md (Slice 10, BI-5FB59BC6) under umbrella BI-1F4A4861; it adds one read-only discovery tool that extends the shipped load_tools pattern with no new contract, so no new spec/plan artifact is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
