### PR TITLE
fix(federation): dead-letter is recoverable — digest reconciliation bounded-re-heals stranded demand (BI-8A7E3E56)

### DIFF
--- a/apps/web/lib/federation/demand-delivery.ts
+++ b/apps/web/lib/federation/demand-delivery.ts
@@ -308,7 +308,7 @@ export async function dispatchDueDemand(db: DemandDeliveryDb, options: {
         syncStatus: payload?.activity === "dpf.demand.withdrawn" ? "withdrawn" : "synced",
         acknowledgedVersion: row.version, deliveryAttempts: row.deliveryAttempts + 1,
         lastDeliveryAt: now, lastSyncedAt: now, nextDeliveryAt: null,
-        lastDeliveryError: null, deadLetteredAt: null,
+        lastDeliveryError: null, deadLetteredAt: null, rehealCount: 0,
       } });
       continue;
     }

--- a/apps/web/lib/federation/demand-digest.test.ts
+++ b/apps/web/lib/federation/demand-digest.test.ts
@@ -77,4 +77,46 @@ describe("reconcileDemandDigests", () => {
       syncStatus: "synced", acknowledgedVersion: 5, nextDeliveryAt: null,
     }) });
   });
+
+  it("bounded-re-heals a dead-lettered record the peer still needs, but leaves a poison record dead past the cap (BI-8A7E3E56)", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue([
+        { linkId: "link_1", peerAuthorityUrl: "https://peer.example", peerTokenEnc: "encrypted" },
+      ]) },
+      federatedRecordMirror: {
+        findMany: vi.fn().mockResolvedValue([
+          // Stranded by a transient/upgrade window — the producer bug is fixed, so this recovers.
+          { mirrorId: "dl_recoverable", federationLinkId: "link_1", version: 1, syncStatus: "dead-letter", rehealCount: 0, payload: {
+            activity: "dpf.demand.proposed", eventId: "evt_a", queuedAt: digest.generatedAt,
+            envelope: { ...digest.records[0], specVersion: "dpf.demand/1", originInstallationId: "inst_origin" }, // ref_missing
+          } },
+          // Genuinely poison — already resurrected to the cap; must NOT thrash forever.
+          { mirrorId: "dl_poison", federationLinkId: "link_1", version: 3, syncStatus: "dead-letter", rehealCount: 3, payload: {
+            activity: "dpf.demand.proposed", eventId: "evt_b", queuedAt: digest.generatedAt,
+            envelope: { ...digest.records[1], specVersion: "dpf.demand/1", originInstallationId: "inst_origin" }, // ref_stale
+          } },
+        ]),
+        update,
+      },
+    } as unknown as DemandDigestDb;
+    const send = vi.fn().mockResolvedValue({
+      ok: true, status: 200, body: { ok: true, checked: 2, needs: [
+        { originRecordRef: "ref_missing", reason: "missing" },
+        { originRecordRef: "ref_stale", reason: "missing" },
+      ] },
+    });
+
+    const result = await reconcileDemandDigests(db, {
+      installationId: "inst_origin", projectionSecret: "a".repeat(64),
+    }, { now: new Date("2026-07-20T06:10:00Z"), decryptToken: () => "dpflink_token", send });
+
+    // Only the recoverable dead-letter is requeued; the poison one is left dead.
+    expect(result.requeued).toBe(1);
+    expect(update).toHaveBeenCalledWith({ where: { mirrorId: "dl_recoverable" }, data: expect.objectContaining({
+      syncStatus: "pending", deliveryAttempts: 0, deadLetteredAt: null, rehealCount: 1,
+      nextDeliveryAt: new Date("2026-07-20T06:10:00Z"),
+    }) });
+    expect(update).not.toHaveBeenCalledWith(expect.objectContaining({ where: { mirrorId: "dl_poison" } }));
+  });
 });

--- a/apps/web/lib/federation/demand-digest.ts
+++ b/apps/web/lib/federation/demand-digest.ts
@@ -12,8 +12,14 @@ interface DigestMirrorRow {
   peerRecordRef?: string | null;
   version: bigint;
   syncStatus: string;
+  rehealCount?: number;
   payload: unknown;
 }
+
+/** How many times digest reconciliation may resurrect a dead-lettered record the
+ *  peer still needs. A transient/upgrade window recovers in one resurrection; a
+ *  genuinely-poison record stops thrashing once it has exhausted the cap. */
+export const MAX_DEMAND_REHEALS = 3;
 
 export interface DemandDigestDb {
   federationLink?: {
@@ -93,7 +99,7 @@ export async function reconcileDemandDigests(
       where: { federationLinkId: link.linkId, recordType: "demand-envelope", canonicalSide: "local" },
       orderBy: { updatedAt: "asc" },
       take: 1_000,
-      select: { mirrorId: true, federationLinkId: true, version: true, syncStatus: true, payload: true },
+      select: { mirrorId: true, federationLinkId: true, version: true, syncStatus: true, rehealCount: true, payload: true },
     });
     if (rows.length === 0) continue;
     const usable = rows.flatMap((row) => {
@@ -147,11 +153,18 @@ export async function reconcileDemandDigests(
     for (const { row, payload } of usable) {
       const need = needs.get(payload.envelope.originRecordRef);
       if (need) {
-        if (row.syncStatus === "dead-letter") continue;
+        // Dead-letter is recoverable, not terminal: if the peer still needs a
+        // record we gave up on (e.g. it 422'd during the other side's upgrade
+        // window and the producer bug is since fixed), resurrect it — but cap the
+        // resurrections so a genuinely-poison record eventually stays dead instead
+        // of re-sending on every digest cycle forever (BI-8A7E3E56).
+        const wasDeadLettered = row.syncStatus === "dead-letter";
+        if (wasDeadLettered && (row.rehealCount ?? 0) >= MAX_DEMAND_REHEALS) continue;
         requeued++;
         await db.federatedRecordMirror.update!({ where: { mirrorId: row.mirrorId }, data: {
           syncStatus: "pending", deliveryAttempts: 0, nextDeliveryAt: now,
           lastDeliveryError: `reconciliation:${need.reason}`, deadLetteredAt: null,
+          ...(wasDeadLettered ? { rehealCount: (row.rehealCount ?? 0) + 1 } : {}),
         } });
       } else {
         confirmed++;

--- a/changes/federated-record-mirror-reheal-count.data-impact.json
+++ b/changes/federated-record-mirror-reheal-count.data-impact.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-8A7E3E56. Add FederatedRecordMirror.rehealCount (INTEGER NOT NULL DEFAULT 0): a bounded counter of how many times digest reconciliation has resurrected this outbox record after it dead-lettered. Dead-letter was terminal, permanently stranding demand that failed during a peer's upgrade window; reconcileDemandDigests now re-heals a dead-letter the peer still needs, capped by MAX_DEMAND_REHEALS so a genuinely-poison record eventually stays dead. Additive, non-destructive: no existing row is rewritten; defaults to 0 so every existing row reads as never-resurrected, applies cleanly against any existing data state. No personal data — an operational retry/resurrection counter, not tied to a data subject. Migration: 20260808160000_federated_record_mirror_reheal_count.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "FederatedRecordMirror",
+      "lifecycleDisposition": "retain-for-link-lifetime",
+      "fields": [
+        {
+          "name": "rehealCount",
+          "resolution": "not-applicable",
+          "reason": "Operational delivery-recovery metadata: the number of times digest reconciliation has resurrected this dead-lettered record. Not personal data and not tied to a data subject.",
+          "provenance": "Authored locally by reconcileDemandDigests, incremented only when a dead-lettered local outbox row is resurrected because the peer reports it missing. No new source of data.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260808160000_federated_record_mirror_reheal_count/migration.sql
+++ b/packages/db/prisma/migrations/20260808160000_federated_record_mirror_reheal_count/migration.sql
@@ -1,0 +1,9 @@
+-- FederatedRecordMirror.rehealCount — bounded dead-letter recovery. (BI-8A7E3E56)
+--
+-- Digest reconciliation resurrects a dead-lettered outbox record the peer still
+-- needs (e.g. it 422'd during the peer's upgrade window, since fixed). This
+-- counter bounds those resurrections (MAX_DEMAND_REHEALS) so a transient
+-- stranding recovers while a genuinely-poison record eventually stays dead
+-- instead of thrashing every digest cycle. Additive, non-destructive; defaults
+-- to 0 so every existing row is treated as never-resurrected.
+ALTER TABLE "FederatedRecordMirror" ADD COLUMN "rehealCount" INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15049,6 +15049,10 @@ model FederatedRecordMirror {
   lastDeliveryError   String?
   acknowledgedVersion BigInt?
   deadLetteredAt      DateTime?
+  // How many times digest reconciliation has resurrected this record after it
+  // dead-lettered. Bounded by MAX_DEMAND_REHEALS so a transient/upgrade-window
+  // stranding recovers while a genuinely-poison record eventually stays dead.
+  rehealCount         Int       @default(0)
   // Last projected (already minimized) payload that crossed — never raw data.
   payload             Json?
   createdAt           DateTime  @default(now())


### PR DESCRIPTION
**Root cause (established, not hypothesized):** a transient/upgrade window permanently stranded federated demand. Delivery dead-letters after 8 attempts (nextDeliveryAt=null); `dispatchDueDemand` only selects `pending`, and `reconcileDemandDigests` explicitly *skipped* dead-letter rows — so once the peer's producer bug was fixed, nothing re-sent the records it had already rejected. Live: 30 Windows→Mac records dead-lettered 03:01–03:46Z during the pre-`link:mismatch`-fix window; replays now get 202 but the 30 stayed dead.

**Fix:** the existing repair path (`reconcileDemandDigests`, which already requeues any local record the peer reports missing) now also resurrects a dead-lettered record the peer still needs — **bounded** by `rehealCount` (MAX_DEMAND_REHEALS=3) so a transient stranding recovers in one cycle while a genuinely-poison record eventually stays dead instead of thrashing. `rehealCount` resets to 0 on successful delivery (measures *consecutive* failed resurrections). Peer-confirmed re-heal, not blind time-based.

**W1 folds in:** once both installs deploy, the next digest cycle re-heals the 30 → dispatch redelivers → synced. No bare-SQL one-off.

- `FederatedRecordMirror.rehealCount` additive migration + data-impact manifest.
- TDD: failing-first regression — peer-needed dead-letter recovers (rehealCount+1); past-cap row stays dead.

BI-8A7E3E56. Validation thread re-verifies on the live Windows box after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)