### PR TITLE
docs: reconcile A2A GAID design against live cross-install substrate (follow-up to #4124)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-federated-a2a-gaid-coordination.md
+++ b/docs/superpowers/plans/2026-08-08-federated-a2a-gaid-coordination.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-08-08  
 **Status:** Ready for a build thread; no implementation started  
-**Backlog item:** `BI-BE0E14E0`  
-**Epic:** `EP-MSP-FEDERATION`  
+**Backlog item:** `BI-BE0E14E0` (MSP-federation install) — identical slice anchors under `EP-E1F1DB58` on the A2A-adoption install; see design §3  
+**Epic:** `EP-MSP-FEDERATION` here / `EP-E1F1DB58` on the A2A-adoption install (two sovereign backlogs, same work)  
 **Design WorkCapsule:** `WC-647895E9`  
 **Design:** [`docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md`](../specs/2026-08-08-federated-a2a-gaid-coordination-design.md)  
 **Kernel decision:** `DI-B726A1900E7C`  
@@ -36,7 +36,7 @@ Live coverage was recorded against parent `BI-BE0E14E0` for this exact plan path
 - Decision: atomic
 - Parent: `BI-BE0E14E0`
 - Receipt: `cmskls1vz03qi01mu59s9tn3o`
-- Dependencies: `BI-COWORKER-360-AGENTCARD` coordination; all delivery phases remain internal to the parent BI
+- Dependencies: `BI-COWORKER-360-AGENTCARD` coordination; all delivery phases remain internal to the parent BI. Cross-install coordination references (not local mapped BIs — they live on the A2A-adoption install under `EP-E1F1DB58`): Slice 6 `BI-40648BBF` (agent-card export — consumed by Phase 3), Slice 4 `BI-06B66FFD` (standard MCP Tasks → `TaskRun` convergence — must land as one convergence with Phase 1), Slice 10 `BI-5FB59BC6` (`find_coworker`, shipped #4121 — extended by Phase 3 discovery)
 - Mapped child BIs: none; all phases are internal sequencing under `BI-BE0E14E0`
 - Rationale: the security property exists only as the composed same-organization vertical slice. Device pinning, GAID issuer/card projection, task ingress/ownership, policy, and operator readiness are mutually dependent and stay feature-gated until end-to-end acceptance. Shipping any phase alone either exposes unusable metadata/UI or creates the unauthenticated or under-authorized boundary the BI is meant to eliminate. Cross-organization enablement is excluded and will require a separate future BI.
 
@@ -114,7 +114,8 @@ Live coverage was recorded against parent `BI-BE0E14E0` for this exact plan path
    - make `TaskRun.userId` nullable only after existing read paths are audited and the migration remains safe for rows without a principal mapping;
    - add nullable typed/indexed `TaskRun` fields for federation link ownership, origin event ID, acting/delegating/target GAIDs, origin installation/environment, card/AIDoc digests, and verification receipt reference;
    - add unique idempotency on `(federationLinkId, originEventId)` when both are present;
-   - add nullable unique `CoworkerEngagement.taskRunId` relation.
+   - add nullable unique `CoworkerEngagement.taskRunId` relation;
+   - **coordinate this with Slice 4 (`BI-06B66FFD`, standard MCP Tasks lifecycle over `TaskRun` via `apps/web/lib/mcp/tasks-lifecycle.ts`)** where the installs share it: both converge the same `TaskRun` rows, so they must land as one convergence and one migration, not two competing ones.
 6. Keep `a2aMetadata` for non-authoritative protocol extensions only; new authorization and uniqueness checks must use typed columns.
 7. Make every migration data-state agnostic: no assumption that every User already has a Principal, every link already has metadata, or every engagement already has a task.
 
@@ -179,9 +180,9 @@ Live coverage was recorded against parent `BI-BE0E14E0` for this exact plan path
 
 ### Tasks
 
-1. Replace federation advertisement of `gaid:priv:dpf.internal:*` with a GAID-standard-conformant issuer namespace configuration. Preserve legacy GAID aliases for local lookup/history; do not infer identity continuity from matching `agentId` strings.
+1. Replace federation advertisement of `gaid:priv:dpf.internal:*` with a GAID-standard-conformant issuer namespace configuration. Preserve legacy GAID aliases for local lookup/history; do not infer identity continuity from matching `agentId` strings. **Also fix the latent scope-token split first:** `buildPrivateAgentGaid` emits `gaid:priv:…` while `apps/web/lib/coworker-service-catalog/agent-card.ts:105` emits `gaid:private:…`; converge them (add a red test asserting a single canonical scope token) before any cross-install GAID comparison, or matching silently fails on the scope segment.
 2. Represent approved peer GAID issuer namespaces through the link's existing `AuthorityBinding`; validate that every advertised GAID belongs to an approved prefix.
-3. Produce standard A2A v1.0 Agent Cards from the canonical CoworkerIdentity/AIDoc projection. Reuse the existing card builder; do not fork card construction inside federation.
+3. Produce standard A2A v1.0 Agent Cards from the canonical CoworkerIdentity/AIDoc projection. Reuse the existing card builder; do not fork card construction inside federation. The public export builder already exists at `apps/web/lib/a2a/agent-card.ts` (Slice 6 / `BI-40648BBF`) but currently emits `provenance.signed: false` and no `gaid` field — the delta is adding the device-key JWS signature and the GAID `extensions`, projecting the link-scoped extended card from this same builder. Remote-coworker discovery (Phase 6 catalog) extends `find_coworker` (`apps/web/lib/mcp/packs/coworker-pack.ts`, Slice 10 / `BI-5FB59BC6`) with a link-scoped, projection-gated result set rather than a parallel discovery path.
 4. Add the GAID A2A extension metadata, AIDoc reference/digest, exact service-offer capability, and authenticated federation interface.
 5. Canonicalize cards with RFC 8785 and JWS-sign them using the pinned device key. Separately validate AIDoc issuer status/binding; device possession is not issuer authority.
 6. Project only explicitly allowed cards through `ProjectionContract`, persist them as link-scoped `FederatedRecordMirror` rows, and implement expiry, refresh, withdrawal, revocation, and key-rotation invalidation.
@@ -214,7 +215,7 @@ Live coverage was recorded against parent `BI-BE0E14E0` for this exact plan path
 
 ### Tasks
 
-1. Add the versioned DPF federation A2A contract as A2A payload + GAID extension inside the existing CloudEvents transport.
+1. Add the versioned DPF federation A2A contract as A2A payload + GAID extension inside the existing CloudEvents transport. Reuse `cloud-event-guard.ts`'s existing `dpflinkid` link-binding (`=== authenticated linkId`, else `link:mismatch`) and ±15-minute replay window verbatim; the new layer is the RFC 9421 signature over them, not a second envelope validator. Gate the receiving route with a `DPF_FEDERATION_A2A_ENABLED` flag sibling to the existing `DPF_FEDERATION_EXCHANGE_ENABLED`, or a per-link A2A capability bit, so demand and A2A enable independently.
 2. Implement the fixed ingress chain from the spec: link token → device signature/digest → replay/idempotency → link installation/org/environment → issuer/card/AIDoc → target GAID → TAK/delegation/offer/projection/consent → task.
 3. Make the receiver generate `TaskRun.taskRunId`; create/link `CoworkerEngagement` for the accepted offer and persist messages/artifacts through `TaskMessage`/`TaskArtifact`.
 4. Implement non-streaming A2A v1.0 operation semantics needed by the slice: send message/create or continue task, get/list task, additional input, cancel, and retrieve artifact/task snapshot.

--- a/docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md
+++ b/docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md
@@ -4,7 +4,7 @@
 **Status:** Architecture-reviewed; ready for implementation planning  
 **Decision:** `DI-B726A1900E7C` — link-bound signed GAID claim  
 **Delivery shape:** one same-organization product slice; no implementation in this document branch  
-**Backlog:** `BI-BE0E14E0`, filed under `EP-MSP-FEDERATION` (live, in progress)
+**Backlog:** `BI-BE0E14E0` under `EP-MSP-FEDERATION` on this install; the same slice is `EP-E1F1DB58`'s A2A-coordination sibling on the A2A-adoption install (see §3 — the two anchors are the same work on two sovereign backlogs, not a contradiction)
 **Design WorkCapsule:** `WC-647895E9`
 
 ## 1. Executive decision
@@ -53,20 +53,24 @@ The first product slice is same-organization, two-install coordination over an a
 - copying private prompt, memory, tool configuration, or unrestricted agent metadata across the link;
 - implementation code in this design thread.
 
-## 3. Backlog integrity correction
+## 3. Backlog anchoring across two sovereign backlogs
 
-Live backlog queries on 2026-08-08 returned `epic_not_found` for `EP-E1F1DB58` and `not_found` for `BI-1F4A4861`. The ten slice IDs asserted by the earlier adoption plan were also absent. Those identifiers are therefore not authoritative and this specification does not cite them as live coverage.
+This is not a backlog-integrity error; it is the first live proof of the problem this spec exists to solve. Two independent design threads verified backlog anchors against **two different sovereign installs**, and each install's backlog is missing the other's identifiers:
 
-Relevant verified live programs are:
-
-| Program | Live status | Relevance | Disposition |
+| Anchor | This-install (MSP-federation) backlog | A2A-adoption-program backlog | Verified |
 | --- | --- | --- | --- |
-| `EP-MSP-FEDERATION` | in progress | owns `FederationLink`, projection contracts, federated record mirrors, sovereign-peer identity, and governed cross-boundary sharing | **Parent for this slice** |
-| `EP-A2A` | done | owns earlier internal handoff/summon design work; contains one unrelated open WWMD surface and one deferred deliberation item | referenced precedent, not reopened |
-| `EP-TAK-3F9A21` | done | delivered GAID-Private/AIDoc projection and TAK/MCP alignment | dependency, not reopened |
-| `EP-COWORKER-IDENTITY-360` | open | owns the unified coworker read model and whole-coworker Agent Card | dependency/coordination seam |
+| `EP-MSP-FEDERATION`, `EP-A2A`, `EP-TAK-3F9A21`, `EP-COWORKER-IDENTITY-360`, `BI-BE0E14E0` | present | **absent** | 2026-08-08 |
+| `EP-E1F1DB58` (open), umbrella `BI-1F4A4861`, its 10 slice BIs (`BI-DA53D067` … `BI-5FB59BC6`) | **absent** | present | 2026-08-08, live MCP |
 
-`EP-MSP-FEDERATION` is the closest verified in-progress parent because the increment changes how a sovereign peer proves an agent claim at the federation boundary. Filing it there preserves the requested slice-not-epic shape. The slice body must cross-reference `BI-COWORKER-360-AGENTCARD` so that Agent Card projection has one source of truth.
+Neither anchor set is fictional. A thread that runs `get_backlog_item("EP-E1F1DB58")` on the MSP-federation install correctly gets `not_found`, while a thread on the A2A-adoption install correctly retrieves `BI-1F4A4861` ("Umbrella — MCP 2025-11-25 + A2A feature adoption"). (Note also that `get_backlog_item` returns `not_found` for *any* epic ID even on the install where it exists — epics resolve through `list_epics`, not `get_backlog_item`; do not read that as absence.) The divergence is exactly an **install-agnostic-identifier collision across sovereign installs** — the same failure mode §4.1 describes for `gaid:priv:dpf.internal:*`, here applied to backlog IDs. It validates the design rather than undermining it.
+
+**Anchoring rule (act on this):**
+
+- On the **MSP-federation install**, this slice is `BI-BE0E14E0` under `EP-MSP-FEDERATION` (the parent that owns `FederationLink`, projection contracts, federated record mirrors, and sovereign-peer identity), cross-referencing `BI-COWORKER-360-AGENTCARD` for the single Agent Card source of truth.
+- On the **A2A-adoption install**, the identical work is a new slice under `EP-E1F1DB58` (the "MCP 2025-11-25 + A2A feature adoption" program, umbrella `BI-1F4A4861`), sitting after its already-filed siblings — most directly **Slice 6 `BI-40648BBF`** (A2A signed agent-card export), **Slice 4 `BI-06B66FFD`** (standard MCP Tasks lifecycle → `TaskRun` convergence), and **Slice 10 `BI-5FB59BC6`** (`find_coworker`, shipped as #4121). See §4.5 for the concrete reuse those siblings force.
+- Whichever backlog the build thread runs against, it files/claims the slice there and records the other install's anchor as the cross-reference. The two records converge only when a federation link carries them — which is the capability this slice ships.
+
+Other verified live programs on the MSP-federation install remain: `EP-A2A` (done — earlier internal handoff/summon precedent, not reopened), `EP-TAK-3F9A21` (done — delivered GAID-Private/AIDoc projection, a dependency), `EP-COWORKER-IDENTITY-360` (open — unified coworker read model and whole-coworker Agent Card, a coordination seam).
 
 ## 4. Verified substrate ledger
 
@@ -130,6 +134,17 @@ The current `/api/a2a/coworkers/{agentId}/offers/{offerId}` and `/api/a2a/tasks/
 - cross-boundary GAID strings are not cryptographically linked to the peer device or a signed card.
 
 The implementation must keep internal consumers working, but all cross-install traffic moves behind `/api/v1/federation/*`. The existing `/api/a2a/*` code becomes an internal adapter to the canonical task service, not a second external trust path.
+
+### 4.5 Cross-install verification addendum — reuse targets and concrete primitives
+
+An independent substrate sweep (2026-08-08, against `origin/main` at `bc5a0debd`, not the stale root clone) confirmed the substrate above and surfaced six concrete, actionable items the build must honor so it reuses rather than re-invents:
+
+1. **Consume Slice 6, do not rebuild it.** `apps/web/lib/a2a/agent-card.ts` already serves the A2A v0.3.0 card at `/.well-known/agent-card.json` and `/.well-known/agent-card/{agentId}`, gated `EXPORT_GATE` to `active/production/public` only. But today it emits `provenance.signed: false` and carries **no `gaid` field**. The §8.4 target (JWS-signed, GAID-in-`extensions`) is precisely the delta to add onto this existing builder — the link-scoped extended card projects from it, it is not a fork.
+2. **Coordinate `TaskRun` convergence with Slice 4.** `BI-06B66FFD` (standard MCP Tasks lifecycle over `TaskRun`, via `apps/web/lib/mcp/tasks-lifecycle.ts`) converges the bespoke `tasks/submit` onto standard `tasks`. §8.5's `TaskRun`/`CoworkerEngagement` consolidation touches the same rows; the two must land as one convergence, or the second one fights the first. Treat Slice 4 as a hard sequencing dependency where the installs share it.
+3. **Make cross-install discovery the federated twin of `find_coworker`.** `find_coworker` (Slice 10, shipped #4121, `apps/web/lib/mcp/packs/coworker-pack.ts`) is the *local* intent-based discovery meta-tool. §12.2 remote-coworker discovery should extend it with a link-scoped, projection-gated result set — not a parallel discovery path. This was Slice 10's own framing ("A2A-plane twin of `load_tools`").
+4. **Fix the `priv`/`private` GAID scope-token split as part of §4.1 conformance.** `buildPrivateAgentGaid` (`apps/web/lib/identity/principal-linking.ts`) emits `gaid:priv:…`, but the catalog fallback at `apps/web/lib/coworker-service-catalog/agent-card.ts:105` emits `gaid:private:…`. Left unfixed, two installs comparing GAID strings will silently mismatch on the scope token before the namespace question is even reached. This is a latent cross-install bug, not cosmetic.
+5. **Name the feature flag on the existing pattern.** Federation receiving routes are gated by `DPF_FEDERATION_EXCHANGE_ENABLED` (`apps/web/app/api/v1/federation/**`). A2A adds a sibling `DPF_FEDERATION_A2A_ENABLED` (or a per-link A2A capability bit) so demand and A2A gate independently — the plan's "feature-gated" phrasing resolves to this concrete flag.
+6. **Reuse the CloudEvent link-binding and replay primitives verbatim.** `cloud-event-guard.ts` already enforces the `dpflinkid` extension (`=== authenticated linkId`, else `link:mismatch`) and a ±15-minute replay window. The A2A event types (§8.3) ride these unchanged; the new work is the RFC 9421 signature layer over them (§9), not a second envelope validator.
 
 ## 5. Research and benchmarking
 
@@ -566,4 +581,4 @@ The `dpf-architecture-review` pass produced four important findings, all folded 
 
 Standards checked: A2A v1.0, MCP 2025-11-25 Tasks and 2026-07-28 release-candidate direction, CloudEvents 1.0, RFC 9421, and RFC 8785. No reference-doc improvement is filed: GAID already contains the missing A2A/HTTP binding doctrine, and the gap is implementation conformance rather than absent doctrine.
 
-The reviewed recommendation is to file the single same-org slice under the verified in-progress `EP-MSP-FEDERATION`, then execute the phased plan. Cross-org enablement remains a separate future slice.
+The reviewed recommendation is to file the single same-org slice under the anchor that exists on the build install — `EP-MSP-FEDERATION` here, `EP-E1F1DB58` on the A2A-adoption install (§3 anchoring rule) — then execute the phased plan. Cross-org enablement remains a separate future slice.


### PR DESCRIPTION
Follow-up to #4124 (merged while this reconciliation was in flight). A second, independent design thread verified the same work against the live MCP backlog and `origin/main` substrate; two corrections/enhancements to the merged spec + plan result. Design-only; no runtime code, schema, seed, or migration touched.

## What changed

**1. §3 — backlog anchoring is a two-sovereign-install divergence, not a backlog-integrity error.**
The merged spec stated `EP-E1F1DB58` and `BI-1F4A4861` "do not exist" and re-anchored to `EP-MSP-FEDERATION`. Live MCP verification shows the two threads verified **different sovereign backlogs**:
- This-install backlog: `EP-MSP-FEDERATION`, `EP-A2A`, `EP-TAK-3F9A21`, `EP-COWORKER-IDENTITY-360`, `BI-BE0E14E0` present; `EP-E1F1DB58` absent.
- A2A-adoption-program backlog: `EP-E1F1DB58` (open) + umbrella `BI-1F4A4861` + its 10 slice BIs present; the MSP set absent.

Neither anchor set is fictional — it is exactly the install-agnostic-identifier collision the design's own §4.1 describes, applied to backlog IDs (it validates the design). Also documents that `get_backlog_item` returns `not_found` for epics even where they exist (epics resolve via `list_epics`). Replaces the "correction" with an explicit dual-anchor filing rule.

**2. §4.5 (new) + phase edits — concrete reuse targets so the build extends rather than re-invents:**
- Slice 6 `BI-40648BBF` (agent-card export, `apps/web/lib/a2a/agent-card.ts`) currently emits `signed:false` and no `gaid` — it is the card builder to JWS-sign + add the GAID extension to, not a fork.
- Slice 4 `BI-06B66FFD` (standard MCP Tasks lifecycle over `TaskRun`) is the same `TaskRun` convergence §8.5/Phase 1 performs — must land as one convergence.
- Slice 10 `BI-5FB59BC6` (`find_coworker`, shipped #4121) is the local discovery tool Phase 3 discovery extends, not a parallel path.
- `priv`/`private` GAID scope-token split (`principal-linking.ts` vs `coworker-service-catalog/agent-card.ts:105`) — latent cross-install match bug to fix first.
- Name `DPF_FEDERATION_A2A_ENABLED` beside the existing `DPF_FEDERATION_EXCHANGE_ENABLED`; reuse `cloud-event-guard.ts`'s `dpflinkid` binding + 15-min replay window verbatim.

## Verification
- `node scripts/check-doc-links.mjs` — PASS
- `node scripts/gen-doc-index.mjs --check` — doc index fresh
- pre-commit doc-index regen + gitleaks secret scan — clean
- Design-only: unit/build/migration/UX gates N/A.

Docs-Impact-Decision: Architecture spec + phased plan are the deliverables; no user-guide change appropriate before implementation exists.
Local-CI-Override: Docs-only reconciliation of an architecture spec and plan; no executable code, UI route, schema, seed, or migration changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)