### PR TITLE
fix(ci): fence unsafe stage hosts

### DIFF
--- a/apps/web/lib/nonprod/environment-lease-pool-policy.ts
+++ b/apps/web/lib/nonprod/environment-lease-pool-policy.ts
@@ -1,0 +1,79 @@
+import {
+  mergeLocalCiHostPressure,
+  observeLocalCiServerPressure,
+  type LocalCiCapacityBroker,
+} from "./local-ci-capacity-broker";
+import {
+  loadLocalCiPoolConfig,
+  resolveLocalCiPoolPolicy,
+  type LocalCiHostPressure,
+  type ResolvedLocalCiPoolPolicy,
+} from "./local-ci-pool-policy";
+
+type PlatformConfigReader = Parameters<
+  typeof loadLocalCiPoolConfig
+>[0]["platformConfig"];
+
+export async function resolveNonprodPoolPolicy(input: {
+  platformConfig: PlatformConfigReader | undefined;
+  environmentKey: string;
+  hostPressure?: LocalCiHostPressure;
+  capacityBroker?: LocalCiCapacityBroker;
+  manifestSlotCount: number;
+  now: Date;
+}): Promise<ResolvedLocalCiPoolPolicy> {
+  if (input.environmentKey !== "local-integration-ci") {
+    return {
+      policyVersion: 1,
+      source: "default",
+      requestedCapacity: 1,
+      manifestCapacity: 1,
+      hostSafeCapacity: 1,
+      effectiveCapacity: 1,
+      slotKeys: ["slot-0"],
+      rollbackReason: "environment-singleton",
+      config: null,
+    };
+  }
+  const configValue = input.platformConfig
+    ? await loadLocalCiPoolConfig({ platformConfig: input.platformConfig })
+    : null;
+  const clientPressure = input.hostPressure ?? {};
+  const preliminary = resolveLocalCiPoolPolicy({
+    configValue,
+    host: clientPressure,
+    manifestSlotCount: input.manifestSlotCount,
+    env: process.env,
+    now: input.now,
+  });
+  // A missing/malformed config keeps the compatibility singleton and has no
+  // broker contract to enforce. A valid configured singleton still requires
+  // canonical pressure: "one requested" is not permission to admit on an
+  // unsafe host.
+  if (preliminary.config === null) return preliminary;
+
+  let serverPressure: LocalCiHostPressure;
+  try {
+    serverPressure = await (
+      input.capacityBroker ?? observeLocalCiServerPressure
+    )();
+  } catch {
+    serverPressure = {
+      observedAt: input.now.toISOString(),
+      dockerHealthy: false,
+      convergenceActive: true,
+      fencesHealthy: false,
+      evidenceIsolationHealthy: false,
+    };
+  }
+  return resolveLocalCiPoolPolicy({
+    configValue,
+    host: mergeLocalCiHostPressure({
+      client: clientPressure,
+      server: serverPressure,
+    }),
+    manifestSlotCount: input.manifestSlotCount,
+    env: process.env,
+    now: input.now,
+  });
+}

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -231,7 +231,7 @@ describe("durable nonproduction admission", () => {
     expect(mockDb.nonProductionEnvironmentLease.create).toHaveBeenCalledOnce();
   });
 
-  it("cancels a queued lease and promotes the next FIFO waiter", async () => {
+  it("cancels a queued local-CI lease without promoting from stale pressure", async () => {
     const mockDb = db();
     const current = lease();
     const next = lease({
@@ -244,19 +244,11 @@ describe("durable nonproduction admission", () => {
     mockDb.nonProductionEnvironmentLease.findUnique
       .mockResolvedValueOnce(current)
       .mockResolvedValueOnce(current);
-    mockDb.nonProductionEnvironmentLease.update
-      .mockResolvedValueOnce(lease({
-        status: "cancelled",
-        cancelledAt: NOW,
-        releasedAt: NOW,
-      }))
-      .mockResolvedValueOnce(admitted({
-        ...next,
-        status: "active",
-        slotKey: "slot-0",
-        activeKey: "local-integration-ci:slot-0",
-        admittedAt: NOW,
-      }));
+    mockDb.nonProductionEnvironmentLease.update.mockResolvedValueOnce(lease({
+      status: "cancelled",
+      cancelledAt: NOW,
+      releasedAt: NOW,
+    }));
     mockDb.nonProductionEnvironmentLease.findMany.mockResolvedValueOnce([next]);
 
     const released = await releaseNonprodEnvironmentLease({
@@ -274,16 +266,10 @@ describe("durable nonproduction admission", () => {
         activeKey: null,
       }),
     });
-    expect(mockDb.nonProductionEnvironmentLease.update).toHaveBeenNthCalledWith(2, {
-      where: { id: "row-2" },
-      data: expect.objectContaining({
-        status: "active",
-        slotKey: "slot-0",
-      }),
-    });
+    expect(mockDb.nonProductionEnvironmentLease.update).toHaveBeenCalledTimes(1);
   });
 
-  it("expires lapsed owners and promotes a live waiter", async () => {
+  it("expires lapsed local-CI owners without promoting from stale pressure", async () => {
     const mockDb = db();
     const lapsed = admitted({
       expiresAt: new Date(NOW.getTime() - 1),
@@ -306,10 +292,7 @@ describe("durable nonproduction admission", () => {
         activeKey: null,
       }),
     });
-    expect(mockDb.nonProductionEnvironmentLease.update).toHaveBeenCalledWith({
-      where: { id: "row-2" },
-      data: expect.objectContaining({ status: "active", slotKey: "slot-0" }),
-    });
+    expect(mockDb.nonProductionEnvironmentLease.update).not.toHaveBeenCalled();
   });
 
   it("admits a slot-aware FIFO waiter to slot-1 only under a safe capacity-two policy", async () => {
@@ -404,13 +387,13 @@ describe("durable nonproduction admission", () => {
     });
   });
 
-  it("lets canonical server pressure contract but never expand client capacity", async () => {
+  it("lets canonical server pressure contract a configured singleton to zero", async () => {
     const mockDb = db();
     const waiting = lease({ slotManifestVersion: 1 });
     mockDb.platformConfig.findUnique.mockResolvedValue({
       value: {
         version: 1,
-        requestedCapacity: 2,
+        requestedCapacity: 1,
         ceilings: {
           minAvailableMemoryBytes: 8 * 1024 ** 3,
           maxSustainedCpuPercent: 75,
@@ -458,7 +441,7 @@ describe("durable nonproduction admission", () => {
     expect(result).toMatchObject({
       status: "queued",
       poolPolicy: {
-        effectiveCapacity: 1,
+        effectiveCapacity: 0,
         rollbackReason: "host-memory-low",
       },
     });

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -5,16 +5,11 @@ import {
   type AdmissionLease,
 } from "./environment-lease-admission";
 import {
-  loadLocalCiPoolConfig,
-  resolveLocalCiPoolPolicy,
   type LocalCiHostPressure,
   type ResolvedLocalCiPoolPolicy,
 } from "./local-ci-pool-policy";
-import {
-  mergeLocalCiHostPressure,
-  observeLocalCiServerPressure,
-  type LocalCiCapacityBroker,
-} from "./local-ci-capacity-broker";
+import type { LocalCiCapacityBroker } from "./local-ci-capacity-broker";
+import { resolveNonprodPoolPolicy } from "./environment-lease-pool-policy";
 import localCiSlotResources from "./local-ci-slot-resources.json";
 import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 import type { NonprodOwnerProvider } from "./nonprod-owner-provider";
@@ -71,67 +66,6 @@ export function admittedLeaseTtlMs(
   return environmentKey === "local-integration-ci"
     ? Math.min(LOCAL_CI_ACTIVE_LEASE_TTL_MS, boundedRequest)
     : boundedRequest;
-}
-
-async function resolveNonprodPoolPolicy(input: {
-  db: LeaseDb;
-  environmentKey: string;
-  hostPressure?: LocalCiHostPressure;
-  capacityBroker?: LocalCiCapacityBroker;
-  now: Date;
-}): Promise<ResolvedLocalCiPoolPolicy> {
-  if (input.environmentKey !== "local-integration-ci") {
-    return {
-      policyVersion: 1,
-      source: "default",
-      requestedCapacity: 1,
-      manifestCapacity: 1,
-      hostSafeCapacity: 1,
-      effectiveCapacity: 1,
-      slotKeys: ["slot-0"],
-      rollbackReason: "environment-singleton",
-      config: null,
-    };
-  }
-  const configValue = input.db.platformConfig
-    ? await loadLocalCiPoolConfig({
-      platformConfig: input.db.platformConfig,
-    })
-    : null;
-  const clientPressure = input.hostPressure ?? {};
-  const preliminary = resolveLocalCiPoolPolicy({
-    configValue,
-    host: clientPressure,
-    manifestSlotCount: NONPROD_SLOT_KEYS.length,
-    env: process.env,
-    now: input.now,
-  });
-  if (preliminary.requestedCapacity === 1) return preliminary;
-
-  let serverPressure: LocalCiHostPressure;
-  try {
-    serverPressure = await (
-      input.capacityBroker ?? observeLocalCiServerPressure
-    )();
-  } catch {
-    serverPressure = {
-      observedAt: input.now.toISOString(),
-      dockerHealthy: false,
-      convergenceActive: true,
-      fencesHealthy: false,
-      evidenceIsolationHealthy: false,
-    };
-  }
-  return resolveLocalCiPoolPolicy({
-    configValue,
-    host: mergeLocalCiHostPressure({
-      client: clientPressure,
-      server: serverPressure,
-    }),
-    manifestSlotCount: NONPROD_SLOT_KEYS.length,
-    env: process.env,
-    now: input.now,
-  });
 }
 
 export function clampLeaseExpiry(
@@ -386,10 +320,11 @@ export async function claimNonprodEnvironmentLease(input: {
   const db = input.db ?? prisma;
   const now = input.now ?? new Date();
   const poolPolicy = await resolveNonprodPoolPolicy({
-    db,
+    platformConfig: db.platformConfig,
     environmentKey: input.environmentKey,
     hostPressure: input.hostPressure,
     capacityBroker: input.capacityBroker,
+    manifestSlotCount: NONPROD_SLOT_KEYS.length,
     now,
   });
   const ttlMs = requestedTtlMs(now, input.expiresAt);
@@ -589,7 +524,12 @@ export async function releaseNonprodEnvironmentLease(input: {
       tx,
       environmentKey: current.environmentKey,
       now,
-      slotKeys: ["slot-0"],
+      // A local-CI waiter carries the fresh client-side host observation needed
+      // to prove capacity. Preserve FIFO here and let its next claim poll admit
+      // it; a release must not promote from server-only or stale pressure.
+      slotKeys: current.environmentKey === "local-integration-ci"
+        ? []
+        : ["slot-0"],
     });
     return {
       lease,
@@ -722,10 +662,11 @@ export async function renewNonprodEnvironmentLease(input: {
     },
   });
   const poolPolicy = await resolveNonprodPoolPolicy({
-    db,
+    platformConfig: db.platformConfig,
     environmentKey: lease.environmentKey,
     hostPressure: input.hostPressure,
     capacityBroker: input.capacityBroker,
+    manifestSlotCount: NONPROD_SLOT_KEYS.length,
     now,
   });
   return { status: "renewed", lease: updated, poolPolicy };
@@ -755,7 +696,9 @@ export async function reapExpiredNonprodEnvironmentLeases(input: {
         tx,
         environmentKey,
         now,
-        slotKeys: ["slot-0"],
+        slotKeys: environmentKey === "local-integration-ci"
+          ? []
+          : ["slot-0"],
       });
       promotedLeaseIds.push(...result.admittedLeaseIds);
     });

--- a/apps/web/lib/nonprod/local-ci-pool-policy.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-policy.ts
@@ -45,8 +45,8 @@ export type ResolvedLocalCiPoolPolicy = {
   source: LocalCiPoolPolicySource;
   requestedCapacity: 1 | 2;
   manifestCapacity: number;
-  hostSafeCapacity: 1 | 2;
-  effectiveCapacity: 1 | 2;
+  hostSafeCapacity: 0 | 1 | 2;
+  effectiveCapacity: 0 | 1 | 2;
   slotKeys: Array<"slot-0" | "slot-1">;
   rollbackReason: string | null;
   config: LocalCiPoolConfig | null;
@@ -168,6 +168,26 @@ function singleton(input: {
   };
 }
 
+function unavailable(input: {
+  source: LocalCiPoolPolicySource;
+  requestedCapacity: 1 | 2;
+  manifestCapacity: number;
+  reason: string;
+  config: LocalCiPoolConfig;
+}): ResolvedLocalCiPoolPolicy {
+  return {
+    policyVersion: LOCAL_CI_POOL_POLICY_VERSION,
+    source: input.source,
+    requestedCapacity: input.requestedCapacity,
+    manifestCapacity: input.manifestCapacity,
+    hostSafeCapacity: 0,
+    effectiveCapacity: 0,
+    slotKeys: [],
+    rollbackReason: input.reason,
+    config: input.config,
+  };
+}
+
 function hostRollbackReason(
   host: LocalCiHostPressure,
   config: LocalCiPoolConfig,
@@ -209,8 +229,8 @@ function hostRollbackReason(
 
 /**
  * Resolve the one capacity decision consumed by both durable admission and
- * shared-lease WIP reporting. Any missing or ambiguous safety input contracts
- * to the proven singleton.
+ * shared-lease WIP reporting. Missing configuration preserves the compatibility
+ * singleton; ambiguous host safety under a valid policy contracts to zero.
  */
 export function resolveLocalCiPoolPolicy(input: {
   configValue: unknown;
@@ -237,6 +257,21 @@ export function resolveLocalCiPoolPolicy(input: {
   const requestedCapacity = override?.capacity ?? config.requestedCapacity;
   const source: LocalCiPoolPolicySource = override?.source ?? "platform-config";
 
+  const rollbackReason = hostRollbackReason(
+    input.host,
+    config,
+    input.now ?? new Date(),
+  );
+  if (rollbackReason) {
+    return unavailable({
+      source,
+      requestedCapacity,
+      manifestCapacity,
+      reason: rollbackReason,
+      config,
+    });
+  }
+
   if (requestedCapacity === 1) {
     return singleton({
       source,
@@ -252,21 +287,6 @@ export function resolveLocalCiPoolPolicy(input: {
       requestedCapacity,
       manifestCapacity,
       reason: "manifest-capacity-one",
-      config,
-    });
-  }
-
-  const rollbackReason = hostRollbackReason(
-    input.host,
-    config,
-    input.now ?? new Date(),
-  );
-  if (rollbackReason) {
-    return singleton({
-      source,
-      requestedCapacity,
-      manifestCapacity,
-      reason: rollbackReason,
       config,
     });
   }

--- a/docs/operations/local-ci-sandbox-slots.md
+++ b/docs/operations/local-ci-sandbox-slots.md
@@ -8,8 +8,10 @@ safety layers.
 ## Current operating mode
 
 Capacity is governed by the versioned
-`PlatformConfig["local_ci.sandbox_pool"]` policy. An absent, malformed,
-unsupported, stale, unmeasurable, or unsafe policy resolves to **one**.
+`PlatformConfig["local_ci.sandbox_pool"]` policy. An absent or malformed policy
+preserves the rolling-upgrade compatibility capacity of **one**. Once a valid
+policy is configured, stale, unmeasurable, or unsafe host evidence resolves to
+**zero**: queued intent remains FIFO, but no new stage host is admitted.
 `slot-1` is never permission to bypass durable FIFO admission or run two gates
 manually.
 
@@ -24,9 +26,14 @@ disk headroom; Docker health; dependency-convergence quiescence; valid slot
 fences; and evidence isolation. The broker pessimistically merges those
 observations: minimum free resources, maximum load, and any unhealthy signal
 win. Client evidence can therefore contract capacity but can never grant
-`slot-1` by itself. The runner continues sampling while work is active. A
-breached or unmeasurable ceiling stops new `slot-1` admissions but does not
-evict a healthy current owner merely to contract the pool.
+`slot-1` by itself. The runner continues sampling while work is active. Memory,
+disk, Docker, slot-fence, or evidence-integrity loss is a hard active execution
+fence: the wrapper stops its stage child and releases authority. High CPU
+remains an admission throttle because stopping an already-running stage would
+usually worsen contention; dependency convergence keeps its separate
+quiescence fence. Release and expiry never promote a local-CI waiter from old
+pressure evidence; the FIFO head's next claim poll must supply a fresh
+observation before admission.
 
 ### Peer-slot host fencing
 

--- a/docs/superpowers/plans/2026-08-08-local-ci-host-capacity-fencing.md
+++ b/docs/superpowers/plans/2026-08-08-local-ci-host-capacity-fencing.md
@@ -1,0 +1,164 @@
+# Local-CI host-capacity fencing and durable retry exhaustion
+
+**Backlog:** `BI-56CA53FB`  
+**Epic:** `EP-0DFF753B`  
+**Status:** Planned
+
+## Problem
+
+`BI-872CB1BF` and PR #3915 delivered exact-tree stage receipts, bounded
+diagnostics, actor-agnostic external-termination classification, and one
+differentiated two-worker recovery. They intentionally did not prevent the
+Windows stage host from disappearing.
+
+The defect recurred after PR #3915 and the later queue/liveness corrections.
+Manufacturing candidate `39930c837986` first lost a four-worker Vitest host
+without an assertion. On exact integration tree
+`ff9d749a332388a756c81869a65dcfb52b6d957d`, the prescribed two-worker
+recovery also disappeared with status `4294967295`; its last durable heartbeat
+showed seven descendants and about 2.4 GiB free. Lease `NPEL-3761C1EB2A` was
+recovered and released. Low headroom is evidence for this event, not proof of
+the terminating actor or a universal cause.
+
+Two contract gaps turn that condition into repeated blocked delivery:
+
+1. unsafe host pressure contracts the pool to one slot, never zero, so the
+   remaining slot can start or continue work below its configured floor; and
+2. when the outer wrapper disappears during the already-differentiated run,
+   the `running` receipt does not durably say that the two-worker allowance was
+   consumed, so a later invocation can repeat it.
+
+## Design grounding
+
+- Existing plans and runbooks reviewed:
+  - `docs/superpowers/plans/2026-07-28-local-ci-sandbox-pool-pilot.md`
+  - `docs/superpowers/plans/2026-08-01-local-ci-vitest-worker-diagnostics.md`
+  - `docs/operations/local-ci-sandbox-slots.md`
+  - `docs/testing/pre-pr-gate.md`
+- Current substrate reviewed:
+  - `apps/web/lib/nonprod/local-ci-pool-policy.ts`
+  - `apps/web/lib/nonprod/environment-lease.ts`
+  - `scripts/lib/local-ci-host-pressure.mjs`
+  - `scripts/lib/lease-supervisor.mjs`
+  - `scripts/lib/local-ci-stage-receipt.mjs`
+  - `scripts/local-ci-vitest-runner.mjs`
+  - `scripts/gate-worktree.mjs`
+- Source of truth:
+  - the versioned `PlatformConfig["local_ci.sandbox_pool"]` ceilings define
+    install-local admission pressure;
+  - the durable stage receipt owns attempt/recovery state for one exact
+    integration tree;
+  - the nonproduction lease remains FIFO authority.
+- Decision:
+  - permit zero runnable local-CI slots while a valid configured pressure
+    ceiling is breached;
+  - make a hard pressure loss on renewal fence the active descendant tree;
+  - never promote a local-CI waiter on release/reap without a fresh claimant
+    pressure observation;
+  - persist the selected Vitest execution profile before child launch and make
+    a vanished differentiated profile terminal runner evidence.
+
+This extends existing contracts. It does not add a second resource monitor,
+lease system, retry ledger, or terminating-actor theory.
+
+## Implementation
+
+### 1. Persist and enforce differentiated retry exhaustion test-first
+
+- Extend `selectVitestRecoveryPlan` to distinguish:
+  - ordinary first attempt;
+  - first recovery after an externally terminated four-worker receipt; and
+  - exhausted recovery after an externally terminated receipt that had already
+    persisted the differentiated two-worker execution profile.
+- Persist the chosen profile in the stage receipt before spawning Vitest.
+- On exhausted recovery, write a terminal `runner-termination` receipt with the
+  preserved prior host/heartbeat/profile evidence and exit with the existing
+  runner-evidence status `86`; do not spawn another child.
+
+Verification: Node tests prove a wrapper death before the first child
+heartbeat still consumes the differentiated allowance, while a fresh
+four-worker termination receives exactly one two-worker recovery.
+
+### 2. Represent unsafe configured host pressure as zero runnable capacity
+
+- Refactor host-pressure assessment into one pure policy helper reused for
+  singleton and two-slot configurations.
+- Preserve the current compatibility fallback when the pool policy is absent
+  or malformed: capacity remains one because no install-specific ceiling is
+  authoritative.
+- When a valid policy exists and its current host observation breaches a
+  ceiling or is unsafe/unmeasurable, return `hostSafeCapacity: 0`,
+  `effectiveCapacity: 0`, and no runnable slot keys.
+- Keep the precise actor-agnostic reason in the policy response.
+
+Verification: policy tests cover capacity zero for memory, CPU, disk, Docker,
+convergence, fence, isolation, stale, and unmeasurable observations; safe
+requested-singleton and safe capacity-two behavior remain unchanged.
+
+### 3. Preserve FIFO across admission, pressure loss, release, and reap
+
+- Let zero slot keys keep the oldest claimant queued without changing its
+  identity or FIFO position.
+- During active renewal, inspect the returned current policy. Fence only hard
+  execution-safety losses that make continued work unsafe (memory, disk,
+  Docker, local fence/evidence integrity); do not evict a healthy owner merely
+  because its own workload raises CPU.
+- Stop release/reap from blindly promoting a local-CI waiter with a hard-coded
+  slot. The waiter polls normally and supplies a fresh pressure observation;
+  non-local-CI singleton environments retain immediate promotion.
+- Record the pressure reason in lease events and gate evidence.
+
+Verification: lease and gate tests prove low-memory admission queues at
+position one, low-memory renewal terminates the active descendant tree,
+release preserves the waiter, and the same waiter admits when a later fresh
+observation is safe.
+
+### 4. Document and verify the complete recovery contract
+
+- Update the sandbox and pregate runbooks with capacity-zero semantics,
+  pressure-loss fencing, bounded retry exhaustion, and the no-blind-promotion
+  rule.
+- Run focused Node/Vitest contracts from a compile-ready substrate; this
+  worktree is currently source-only, so runtime-bound verification routes
+  through the governed local-CI sandbox.
+- Obtain independent semantic review of the exact committed tree, then run one
+  governed pregate and publish through the normal DCO/merge-queue flow.
+- After merge, rebase the frozen manufacturing branch using the runbook's
+  explicit `--onto` form and run one materially changed exact gate. Success
+  requires exhaustive Vitest, production Docker build, and durable evidence.
+
+## Refactoring budget
+
+Approximately 20% of this change is reserved for contract cleanup: extract one
+host-safety assessment instead of duplicating threshold logic, give zero
+capacity an honest type rather than encoding it as a special error, and make
+the stage receipt—not transient observer output—the sole retry-exhaustion
+authority.
+
+## Risks and rollback
+
+- **Over-fencing:** CPU can be high because the admitted gate is healthy. CPU
+  blocks new admission but is excluded from active hard-loss fencing.
+- **Queue stall:** capacity zero is reevaluated on every claimant poll; no
+  operator release or claim-key rotation is required.
+- **Fresh-install compatibility:** absent/malformed pool config keeps the
+  established singleton behavior. Only a valid configured ceiling can reduce
+  runnable capacity to zero.
+- **False retry exhaustion:** the selected execution profile is persisted
+  before child launch and bound to the exact stage identity. A changed
+  integration tree starts a fresh recovery budget.
+- **Unknown actor:** the change prevents unsafe continuation and retry loops;
+  it does not infer who terminated Windows processes.
+
+Rollback is a normal revert. It restores capacity-one fallback and the prior
+stale-running recovery behavior without migrations or manual lease edits.
+
+## Backlog coverage
+
+- **Decision:** `atomic`
+- **Receipt:** `cmsknldai011g01qplhox8e78`
+- **Rationale:** admission, active-loss fencing, and durable retry exhaustion
+  are one safety boundary. Shipping only one would either start work under
+  unsafe pressure, leave a running child without authority, or preserve the
+  cross-wrapper retry loop.
+- **Parent:** `BI-56CA53FB`

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -430,7 +430,22 @@ evidence rather than a product test failure. Local-CI writes its main metadata
 on failure as well as success so this diagnostic survives lease release.
 If the supervisor host itself disappears, the next exact-tree run recognizes
 the stale running receipt and starts directly at the two-worker differentiated
-profile; it does not repeat the already disproven four-worker profile.
+profile; it does not repeat the already disproven four-worker profile. The
+selected execution profile is persisted before the child launches. If a later
+host also disappears during that same differentiated profile, the receipt is
+terminal retry-exhaustion evidence: the wrapper exits 86 without spawning an
+unchanged third attempt. Another run requires a materially changed runner or
+integration identity.
+
+With a valid sandbox-pool policy, admission is capacity zero whenever current
+memory, CPU, disk, Docker, dependency-convergence, slot-fence, or evidence-
+isolation input is unsafe or unmeasurable. The lease supervisor continues
+sampling after admission and fences the active stage child for hard memory,
+disk, Docker, slot-fence, or evidence-integrity loss. CPU pressure blocks new
+admission but does not kill an active stage, and dependency convergence keeps
+its separate quiescence fence. A release or expiry preserves the queue without
+blind promotion; the FIFO head is admitted only after its next poll supplies
+fresh safe host evidence.
 
 Typecheck writes a separate `web-typecheck` receipt before `next typegen &&
 tsc --noEmit` starts, heartbeats the compiler descendant tree, memory, and a

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -14,6 +14,7 @@ import {
   defaultProcessScanMs,
   findConflictingLocalCiMutatorPids,
   findLiveLocalCiMutatorPids,
+  executionPressureFenceReason,
 } from "./gate-worktree.mjs";
 import { readProcessIdentity } from "./lib/local-sandbox-fence.mjs";
 
@@ -27,6 +28,26 @@ const TEST_HOST_PRESSURE = {
   fencesHealthy: true,
   evidenceIsolationHealthy: true,
 };
+
+test("active pressure fencing reacts only to hard execution-safety losses", () => {
+  for (const reason of [
+    "host-memory-low",
+    "host-memory-unmeasurable",
+    "host-disk-low",
+    "host-disk-unmeasurable",
+    "docker-unhealthy",
+    "slot-fence-unhealthy",
+    "evidence-isolation-unproven",
+  ]) {
+    assert.equal(
+      executionPressureFenceReason({ rollbackReason: reason }),
+      `host-capacity-lost:${reason}`,
+    );
+  }
+  assert.equal(executionPressureFenceReason({ rollbackReason: "host-cpu-high" }), null);
+  assert.equal(executionPressureFenceReason({ rollbackReason: "requested-singleton" }), null);
+  assert.equal(executionPressureFenceReason(null), null);
+});
 
 function run(command, args, options) {
   return new Promise((resolve, reject) => {
@@ -1309,7 +1330,7 @@ test(
   },
 );
 
-test("renewal loss kills the real child process tree before later mutation", async () => {
+test("hard host-pressure loss kills the real child process tree before later mutation", async () => {
   const temp = mkdtempSync(join(tmpdir(), "dpf-lease-fence-"));
   const lateWrite = join(temp, "must-not-exist.txt");
   const calls = [];
@@ -1333,7 +1354,19 @@ test("renewal loss kills the real child process tree before later mutation", asy
                 },
               },
             }
-            : { success: false, error: "lease_lost" }
+            : {
+              success: true,
+              data: {
+                lease: {
+                  leaseId: "NPEL-FENCE-TEST",
+                  expiresAt: new Date(Date.now() + 3_000).toISOString(),
+                },
+                poolPolicy: {
+                  effectiveCapacity: 0,
+                  rollbackReason: "host-memory-low",
+                },
+              },
+            }
           : tool === "record_local_integration_result"
             ? { success: true, entityId: "EVIDENCE-FENCE-TEST" }
             : { success: true };

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -57,6 +57,23 @@ const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 const LOCAL_CI_ACTIVE_LEASE_TTL_MS = 2 * 60_000;
 
+const HARD_EXECUTION_PRESSURE_REASONS = new Set([
+  "host-memory-low",
+  "host-memory-unmeasurable",
+  "host-disk-low",
+  "host-disk-unmeasurable",
+  "docker-unhealthy",
+  "slot-fence-unhealthy",
+  "evidence-isolation-unproven",
+]);
+
+export function executionPressureFenceReason(poolPolicy) {
+  const reason = poolPolicy?.rollbackReason;
+  return HARD_EXECUTION_PRESSURE_REASONS.has(reason)
+    ? `host-capacity-lost:${reason}`
+    : null;
+}
+
 function die(message) {
   process.stderr.write(`gate-worktree: ${message}\n`);
   process.exit(1);
@@ -1250,6 +1267,16 @@ async function main() {
       // Rolling-upgrade compatibility for a portal that renews successfully
       // but does not yet return the authoritative expiry.
       expiresAt = new Date(Date.now() + leaseTtlMs).toISOString();
+    }
+    const pressureFenceReason = response?.success === true
+      ? executionPressureFenceReason(response?.data?.poolPolicy)
+      : null;
+    if (pressureFenceReason) {
+      return {
+        success: false,
+        error: pressureFenceReason,
+        data: response.data,
+      };
     }
     return response;
   };

--- a/scripts/local-ci-pool-policy.test.mjs
+++ b/scripts/local-ci-pool-policy.test.mjs
@@ -85,12 +85,15 @@ test("enables slot 1 only when requested, declared, and all host evidence is saf
   assert.deepEqual(resolved.slotKeys, ["slot-0", "slot-1"]);
 });
 
-test("unmeasurable or unsafe host evidence contracts admission to singleton with one reason", () => {
+test("unmeasurable or unsafe configured host evidence contracts admission to zero", () => {
   const scenarios = [
+    [{ ...SAFE_HOST, observedAt: undefined }, "host-observation-unmeasurable"],
     [{ ...SAFE_HOST, availableMemoryBytes: undefined }, "host-memory-unmeasurable"],
     [{ ...SAFE_HOST, observedAt: "2026-01-01T00:00:00.000Z" }, "host-observation-stale"],
     [{ ...SAFE_HOST, availableMemoryBytes: 4 * 1024 ** 3 }, "host-memory-low"],
+    [{ ...SAFE_HOST, sustainedCpuPercent: undefined }, "host-cpu-unmeasurable"],
     [{ ...SAFE_HOST, sustainedCpuPercent: 88 }, "host-cpu-high"],
+    [{ ...SAFE_HOST, diskFreeBytes: undefined }, "host-disk-unmeasurable"],
     [{ ...SAFE_HOST, diskFreeBytes: 20 * 1024 ** 3 }, "host-disk-low"],
     [{ ...SAFE_HOST, dockerHealthy: false }, "docker-unhealthy"],
     [{ ...SAFE_HOST, convergenceActive: true }, "dependency-convergence-active"],
@@ -104,10 +107,25 @@ test("unmeasurable or unsafe host evidence contracts admission to singleton with
       host,
       manifestSlotCount: 2,
     });
-    assert.equal(resolved.effectiveCapacity, 1);
+    assert.equal(resolved.hostSafeCapacity, 0);
+    assert.equal(resolved.effectiveCapacity, 0);
     assert.equal(resolved.rollbackReason, rollbackReason);
-    assert.deepEqual(resolved.slotKeys, ["slot-0"]);
+    assert.deepEqual(resolved.slotKeys, []);
   }
+});
+
+test("a valid requested-singleton policy still defers all work under unsafe pressure", () => {
+  const resolved = resolveLocalCiPoolPolicy({
+    configValue: { ...PILOT_CONFIG, requestedCapacity: 1 },
+    host: { ...SAFE_HOST, availableMemoryBytes: 2 * 1024 ** 3 },
+    manifestSlotCount: 2,
+  });
+
+  assert.equal(resolved.requestedCapacity, 1);
+  assert.equal(resolved.hostSafeCapacity, 0);
+  assert.equal(resolved.effectiveCapacity, 0);
+  assert.equal(resolved.rollbackReason, "host-memory-low");
+  assert.deepEqual(resolved.slotKeys, []);
 });
 
 test("manifest capacity and requested singleton are hard upper bounds", () => {

--- a/scripts/local-ci-vitest-runner.mjs
+++ b/scripts/local-ci-vitest-runner.mjs
@@ -11,6 +11,7 @@ import {
   markStageReceiptReused,
   readStageReceipt,
   reusablePassedStage,
+  stageIdentityMatches,
 } from "./lib/local-ci-stage-receipt.mjs";
 
 function valueAfter(flag, fallback) {
@@ -51,16 +52,48 @@ export function lastCompletedTestLine(outputTail) {
 
 export function selectVitestRecoveryPlan({
   priorDisposition,
+  priorExecutionProfile = null,
   initialWorkers,
   retryWorkers,
 }) {
-  const recoveringPriorTermination = priorDisposition === "externally-terminated";
+  const recoveringPriorTermination = priorDisposition === "externally-terminated"
+    || priorDisposition === "retry-exhausted";
+  const exhausted = priorDisposition === "retry-exhausted"
+    || (
+      recoveringPriorTermination
+      && priorExecutionProfile?.mode === "differentiated-recovery"
+      && priorExecutionProfile?.workers === retryWorkers
+    );
+  const executionProfile = recoveringPriorTermination
+    ? { mode: "differentiated-recovery", workers: retryWorkers }
+    : { mode: "initial", workers: initialWorkers };
   return {
     initialWorkers: recoveringPriorTermination ? retryWorkers : initialWorkers,
     retryWorkers,
     allowRetry: !recoveringPriorTermination,
     recoveringPriorTermination,
+    exhausted,
+    executionProfile,
   };
+}
+
+function latestExecutionProfile(receipt) {
+  const observations = Array.isArray(receipt?.observations)
+    ? receipt.observations
+    : [];
+  for (let index = observations.length - 1; index >= 0; index -= 1) {
+    if (observations[index]?.executionProfile) {
+      return observations[index].executionProfile;
+    }
+  }
+  return receipt?.executionProfile ?? null;
+}
+
+export function recoveryReceiptForIdentity({ receipt, identity }) {
+  return receipt?.stage === "exhaustive-vitest"
+    && stageIdentityMatches(receipt.identity, identity)
+    ? receipt
+    : null;
 }
 
 export function createAttemptRunner({
@@ -125,9 +158,21 @@ async function main() {
     );
     return;
   }
-  const priorDisposition = classifyPriorStage({
+  const matchingPriorReceipt = recoveryReceiptForIdentity({
     receipt: priorReceipt,
-    isProcessAlive: processAlive,
+    identity,
+  });
+  const priorDisposition = matchingPriorReceipt?.retryExhausted === true
+    ? "retry-exhausted"
+    : classifyPriorStage({
+        receipt: matchingPriorReceipt,
+        isProcessAlive: processAlive,
+      });
+  const recoveryPlan = selectVitestRecoveryPlan({
+    priorDisposition,
+    priorExecutionProfile: latestExecutionProfile(matchingPriorReceipt),
+    initialWorkers,
+    retryWorkers,
   });
   const receipt = createStageReceiptWriter({
     path: diagnosticsPath,
@@ -136,27 +181,53 @@ async function main() {
   });
   receipt.start({
     bi: "BI-872CB1BF",
-    recoveredFrom: priorDisposition === "externally-terminated"
+    executionProfile: recoveryPlan.executionProfile,
+    recoveredFrom: recoveryPlan.recoveringPriorTermination
       ? {
-          hostPid: priorReceipt.hostPid ?? null,
-          lastHeartbeatAt: priorReceipt.lastHeartbeatAt ?? null,
+          hostPid: matchingPriorReceipt.hostPid ?? null,
+          lastHeartbeatAt: matchingPriorReceipt.lastHeartbeatAt ?? null,
+          executionProfile: latestExecutionProfile(matchingPriorReceipt),
         }
       : null,
   });
 
-  const recoveryPlan = selectVitestRecoveryPlan({
-    priorDisposition,
-    initialWorkers,
-    retryWorkers,
+  if (recoveryPlan.exhausted) {
+    receipt.complete("runner-termination", {
+      retryExhausted: true,
+      recoveryPlan,
+      priorTermination: {
+        hostPid: matchingPriorReceipt.hostPid ?? null,
+        lastHeartbeatAt: matchingPriorReceipt.lastHeartbeatAt ?? null,
+        executionProfile: latestExecutionProfile(matchingPriorReceipt),
+      },
+    });
+    process.stderr.write(
+      "[local-ci-vitest] differentiated recovery already terminated; recording terminal runner evidence without another child\n",
+    );
+    process.exit(86);
+  }
+
+  const observedAttempt = createAttemptRunner({
+    onProgress: (progress) => receipt.heartbeat(progress),
   });
 
   const result = await runVitestWithRecovery({
     initialWorkers: recoveryPlan.initialWorkers,
     retryWorkers: recoveryPlan.retryWorkers,
     allowRetry: recoveryPlan.allowRetry,
-    runAttempt: createAttemptRunner({
-      onProgress: (progress) => receipt.heartbeat(progress),
-    }),
+    runAttempt: ({ workers, attempt }) => {
+      receipt.heartbeat({
+        attempt,
+        workers,
+        executionProfile: {
+          mode: workers === retryWorkers && (attempt > 1 || recoveryPlan.recoveringPriorTermination)
+            ? "differentiated-recovery"
+            : "initial",
+          workers,
+        },
+      });
+      return observedAttempt({ workers, attempt });
+    },
     onAttempt: async (attempt) => {
       latestAttempts = [...latestAttempts, attempt];
       receipt.heartbeat({
@@ -178,6 +249,8 @@ async function main() {
 
   receipt.complete(result.classification, {
     recovered,
+    retryExhausted: result.classification === "runner-termination"
+      && result.attempts.some((attempt) => attempt.workers === retryWorkers),
     recoveryPlan,
     startedAt,
     attempts: result.attempts,

--- a/scripts/local-ci-vitest-runner.test.mjs
+++ b/scripts/local-ci-vitest-runner.test.mjs
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { test } from "node:test";
 
 import {
   createAttemptRunner,
   lastCompletedTestLine,
+  recoveryReceiptForIdentity,
   selectVitestRecoveryPlan,
 } from "./local-ci-vitest-runner.mjs";
 
@@ -20,6 +25,7 @@ test("lastCompletedTestLine returns the latest verbose Vitest test marker", () =
 test("a prior externally terminated receipt resumes at the differentiated worker count", () => {
   assert.deepEqual(selectVitestRecoveryPlan({
     priorDisposition: "externally-terminated",
+    priorExecutionProfile: { mode: "initial", workers: 4 },
     initialWorkers: 4,
     retryWorkers: 2,
   }), {
@@ -27,12 +33,96 @@ test("a prior externally terminated receipt resumes at the differentiated worker
     retryWorkers: 2,
     allowRetry: false,
     recoveringPriorTermination: true,
+    exhausted: false,
+    executionProfile: { mode: "differentiated-recovery", workers: 2 },
   });
   assert.equal(selectVitestRecoveryPlan({
     priorDisposition: "terminal-or-absent",
     initialWorkers: 4,
     retryWorkers: 2,
   }).initialWorkers, 4);
+});
+
+test("a vanished differentiated receipt exhausts recovery before another child starts", () => {
+  assert.deepEqual(selectVitestRecoveryPlan({
+    priorDisposition: "externally-terminated",
+    priorExecutionProfile: { mode: "differentiated-recovery", workers: 2 },
+    initialWorkers: 4,
+    retryWorkers: 2,
+  }), {
+    initialWorkers: 2,
+    retryWorkers: 2,
+    allowRetry: false,
+    recoveringPriorTermination: true,
+    exhausted: true,
+    executionProfile: { mode: "differentiated-recovery", workers: 2 },
+  });
+  assert.equal(selectVitestRecoveryPlan({
+    priorDisposition: "retry-exhausted",
+    priorExecutionProfile: { mode: "differentiated-recovery", workers: 2 },
+    initialWorkers: 4,
+    retryWorkers: 2,
+  }).exhausted, true);
+});
+
+test("a changed integration identity starts a fresh recovery budget", () => {
+  const receipt = {
+    stage: "exhaustive-vitest",
+    status: "running",
+    identity: { integrationTreeSha: "old-tree", command: "vitest" },
+    executionProfile: { mode: "differentiated-recovery", workers: 2 },
+  };
+
+  assert.equal(recoveryReceiptForIdentity({
+    receipt,
+    identity: { integrationTreeSha: "new-tree", command: "vitest" },
+  }), null);
+  assert.equal(recoveryReceiptForIdentity({
+    receipt,
+    identity: receipt.identity,
+  }), receipt);
+});
+
+test("the executable runner refuses a persisted exhausted profile before spawn", () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-vitest-exhausted-"));
+  const metadataPath = join(temp, "metadata.json");
+  const diagnosticsPath = `${metadataPath}.vitest.json`;
+  const integrationTreeSha = execFileSync(
+    "git",
+    ["rev-parse", "HEAD^{tree}"],
+    { cwd: process.cwd(), encoding: "utf8" },
+  ).trim();
+  writeFileSync(diagnosticsPath, `${JSON.stringify({
+    schemaVersion: 1,
+    stage: "exhaustive-vitest",
+    identity: {
+      integrationTreeSha,
+      command: "pnpm --filter web exec vitest run --maxWorkers=4 --reporter=verbose",
+    },
+    status: "runner-termination",
+    retryExhausted: true,
+    executionProfile: { mode: "differentiated-recovery", workers: 2 },
+    hostPid: 999_999,
+    lastHeartbeatAt: "2026-08-08T00:00:00.000Z",
+    observations: [],
+  })}\n`);
+
+  try {
+    const result = spawnSync(process.execPath, [
+      "scripts/local-ci-vitest-runner.mjs",
+      "--initial-workers", "4",
+      "--retry-workers", "2",
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, DPF_LOCAL_CI_METADATA_FILE: metadataPath },
+    });
+    assert.equal(result.status, 86, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stderr, /without another child/);
+    assert.equal(JSON.parse(readFileSync(diagnosticsPath, "utf8")).retryExhausted, true);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
 });
 
 test("attempt runner streams output and retains progress plus host evidence on opaque exit", async () => {


### PR DESCRIPTION
## Summary

- contract valid configured local-CI policies to zero runnable capacity when current host evidence is unsafe or unmeasurable
- fence active stage descendants on hard memory, disk, Docker, slot-fence, or evidence-integrity loss while preserving FIFO intent for a fresh claimant poll
- persist the Vitest execution profile before launch and refuse another unchanged run after differentiated recovery is exhausted
- extract lease pool-policy composition from the lease lifecycle module and document the admission, fencing, and recovery contract

## Verification

- `node --test scripts/local-ci-vitest-runner.test.mjs scripts/local-ci-pool-policy.test.mjs`
- `node --test scripts/gate-worktree-lease.test.mjs`
- `pnpm run pregate:preflight` — 35 guards clean; three source-only runtime checks deferred to the sandbox
- governed exact-tree pregate — web typecheck passed, 2,614 test files / 22,454 tests passed, and the production Docker build completed
- independent high-assurance semantic review — two review branches, zero findings

Backlog: BI-56CA53FB
