### PR TITLE
fix(federation): digest reconciliation pages the full inventory — no silent 1,000-record truncation (BI-8A7E3E56)

### DIFF
--- a/apps/web/lib/federation/demand-digest.test.ts
+++ b/apps/web/lib/federation/demand-digest.test.ts
@@ -119,4 +119,46 @@ describe("reconcileDemandDigests", () => {
     }) });
     expect(update).not.toHaveBeenCalledWith(expect.objectContaining({ where: { mirrorId: "dl_poison" } }));
   });
+
+  it("pages the full local inventory in batches — never silently truncates past one batch (scale)", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const mkRow = (mirrorId: string, ref: string) => ({
+      mirrorId, federationLinkId: "link_1", version: 1, syncStatus: "pending", rehealCount: 0,
+      payload: {
+        activity: "dpf.demand.proposed", eventId: `evt_${mirrorId}`, queuedAt: digest.generatedAt,
+        envelope: {
+          originRecordRef: ref, originVersion: 1, payloadDigest: "sha256:x",
+          specVersion: "dpf.demand/1", originInstallationId: "inst_origin",
+        },
+      },
+    });
+    // Three records with batchSize 2 => two batches. The old `take: 1_000` with no
+    // cursor would have processed only the first batch and silently dropped the rest.
+    const all = [mkRow("out_a", "ref_missing"), mkRow("out_b", "ref_stale"), mkRow("out_c", "ref_divergent")];
+    const findMany = vi.fn().mockImplementation((args: { take: number; cursor?: { mirrorId: string }; skip?: number }) => {
+      const cursorId = args.cursor?.mirrorId;
+      const start = cursorId ? all.findIndex((r) => r.mirrorId === cursorId) + (args.skip ?? 0) : 0;
+      return Promise.resolve(all.slice(start, start + args.take));
+    });
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue([
+        { linkId: "link_1", peerAuthorityUrl: "https://peer.example", peerTokenEnc: "encrypted", role: "same-org-peer" },
+      ]) },
+      federatedRecordMirror: { findMany, update },
+    } as unknown as DemandDigestDb;
+    // Peer has everything (needs: []); echo the per-batch record count so `checked` matches.
+    const send = vi.fn().mockImplementation((_target, sentDigest: { records: unknown[] }) =>
+      Promise.resolve({ ok: true, status: 200, body: { ok: true, checked: sentDigest.records.length, needs: [] } }));
+
+    const result = await reconcileDemandDigests(db, {
+      installationId: "inst_origin", projectionSecret: "a".repeat(64),
+    }, { now: new Date("2026-07-20T06:10:00Z"), decryptToken: () => "dpflink_token", send, batchSize: 2 });
+
+    // All three records reconciled across two batches — nothing dropped.
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ linksChecked: 1, requeued: 0, confirmed: 3, failedLinks: 0 });
+    for (const id of ["out_a", "out_b", "out_c"]) {
+      expect(update).toHaveBeenCalledWith({ where: { mirrorId: id }, data: expect.objectContaining({ syncStatus: "synced" }) });
+    }
+  });
 });

--- a/apps/web/lib/federation/demand-digest.ts
+++ b/apps/web/lib/federation/demand-digest.ts
@@ -72,7 +72,16 @@ export async function compareIncomingDemandDigest(
 
 type SendDigest = typeof sendDemandDigestToPeer;
 
-/** Exchange bounded per-link inventories and repair lost delivery/ack state. */
+/** Per-cycle digest batch size. The reconciler pages through the FULL local
+ *  inventory in batches of this size so a link with more than one batch of
+ *  records can never be silently truncated. NOTE: full-inventory-per-cycle is
+ *  O(records) bandwidth per link — acceptable at current scale; the delta/cursored
+ *  and hub-topology reduction is tracked as a separate scale epic. This constant
+ *  bounds memory/payload per request, not total coverage. */
+export const DEMAND_DIGEST_BATCH_SIZE = 1_000;
+
+/** Exchange per-link inventories (paged, never truncated) and repair lost
+ *  delivery/ack state. */
 export async function reconcileDemandDigests(
   db: DemandDigestDb,
   identity: FederationIdentity,
@@ -80,6 +89,8 @@ export async function reconcileDemandDigests(
     now?: Date;
     decryptToken?: typeof decryptPeerToken;
     send?: SendDigest;
+    /** Override the page size (tests). Defaults to DEMAND_DIGEST_BATCH_SIZE. */
+    batchSize?: number;
   } = {},
 ): Promise<{ linksChecked: number; requeued: number; confirmed: number; failedLinks: number }> {
   if (!db.federationLink || !db.federatedRecordMirror.update) {
@@ -94,86 +105,116 @@ export async function reconcileDemandDigests(
   let requeued = 0;
   let confirmed = 0;
   let failedLinks = 0;
+  const batchSize = Math.max(1, options.batchSize ?? DEMAND_DIGEST_BATCH_SIZE);
   for (const link of links) {
-    const rows = await db.federatedRecordMirror.findMany({
-      where: { federationLinkId: link.linkId, recordType: "demand-envelope", canonicalSide: "local" },
-      orderBy: { updatedAt: "asc" },
-      take: 1_000,
-      select: { mirrorId: true, federationLinkId: true, version: true, syncStatus: true, rehealCount: true, payload: true },
-    });
-    if (rows.length === 0) continue;
-    const usable = rows.flatMap((row) => {
-      const payload = decodeDemandOutboxPayload(row.payload);
-      return payload && payload.envelope.specVersion === "dpf.demand/1" && row.mirrorId
-        ? [{ row, payload: { ...payload, envelope: payload.envelope } }]
-        : [];
-    });
-    const records = usable.map(({ payload }) => ({
-      originRecordRef: payload.envelope.originRecordRef,
-      originVersion: payload.envelope.originVersion,
-      payloadDigest: payload.envelope.payloadDigest,
-      withdrawn: payload.activity === "dpf.demand.withdrawn",
-    }));
-    if (records.length === 0) continue;
     const token = (options.decryptToken ?? decryptPeerToken)(link.peerTokenEnc);
     if (!token) {
       failedLinks++;
       continue;
     }
-    const digest: DemandDigestV1 = {
-      specVersion: "dpf.demand-digest/1",
-      originInstallationId: identity.installationId,
-      generatedAt: now.toISOString(),
-      records,
-    };
-    const result: PeerPostResult = await (options.send ?? sendDemandDigestToPeer)(
-      {
-        peerAuthorityUrl: link.peerAuthorityUrl,
-        linkToken: token,
-        linkId: link.linkId,
-        sameOrgLan: link.role === "same-org-peer",
-      },
-      digest,
-      { now },
-    );
-    if (!result.ok || !result.body || typeof result.body !== "object") {
-      failedLinks++;
-      continue;
-    }
-    if (Number((result.body as { checked?: unknown }).checked) !== records.length) {
-      failedLinks++;
-      continue;
-    }
-    linksChecked++;
-    const needs = new Map(
-      (Array.isArray((result.body as { needs?: unknown }).needs) ? (result.body as { needs: DemandDigestNeed[] }).needs : [])
-        .filter((need) => need && typeof need.originRecordRef === "string")
-        .map((need) => [need.originRecordRef, need]),
-    );
-    for (const { row, payload } of usable) {
-      const need = needs.get(payload.envelope.originRecordRef);
-      if (need) {
-        // Dead-letter is recoverable, not terminal: if the peer still needs a
-        // record we gave up on (e.g. it 422'd during the other side's upgrade
-        // window and the producer bug is since fixed), resurrect it — but cap the
-        // resurrections so a genuinely-poison record eventually stays dead instead
-        // of re-sending on every digest cycle forever (BI-8A7E3E56).
-        const wasDeadLettered = row.syncStatus === "dead-letter";
-        if (wasDeadLettered && (row.rehealCount ?? 0) >= MAX_DEMAND_REHEALS) continue;
-        requeued++;
-        await db.federatedRecordMirror.update!({ where: { mirrorId: row.mirrorId }, data: {
-          syncStatus: "pending", deliveryAttempts: 0, nextDeliveryAt: now,
-          lastDeliveryError: `reconciliation:${need.reason}`, deadLetteredAt: null,
-          ...(wasDeadLettered ? { rehealCount: (row.rehealCount ?? 0) + 1 } : {}),
-        } });
-      } else {
-        confirmed++;
-        await db.federatedRecordMirror.update!({ where: { mirrorId: row.mirrorId }, data: {
-          syncStatus: payload.activity === "dpf.demand.withdrawn" ? "withdrawn" : "synced",
-          acknowledgedVersion: row.version, lastSyncedAt: now, nextDeliveryAt: null,
-          lastDeliveryError: null, deadLetteredAt: null,
-        } });
+    // Page through the ENTIRE local inventory in bounded batches. A link with
+    // more than one batch of records must never be silently truncated (the prior
+    // `take: 1_000` with no cursor dropped everything past the first 1,000). Each
+    // batch is a self-contained digest exchange; the peer's `checked` is compared
+    // per batch. Full-inventory-per-cycle bandwidth is the known O(records) cost
+    // deferred to the delta-sync/hub scale epic — correctness is fixed here.
+    let cursorId: string | undefined;
+    let linkOk = false;
+    let linkFailed = false;
+    let batches = 0;
+    for (;;) {
+      const rows = await db.federatedRecordMirror.findMany({
+        where: { federationLinkId: link.linkId, recordType: "demand-envelope", canonicalSide: "local" },
+        orderBy: { mirrorId: "asc" },
+        take: batchSize,
+        ...(cursorId ? { cursor: { mirrorId: cursorId }, skip: 1 } : {}),
+        select: { mirrorId: true, federationLinkId: true, version: true, syncStatus: true, rehealCount: true, payload: true },
+      });
+      if (rows.length === 0) break;
+      const lastId = rows[rows.length - 1]?.mirrorId;
+      const moreLikely = rows.length === batchSize && !!lastId;
+      cursorId = lastId ?? cursorId;
+      batches++;
+
+      const usable = rows.flatMap((row) => {
+        const payload = decodeDemandOutboxPayload(row.payload);
+        return payload && payload.envelope.specVersion === "dpf.demand/1" && row.mirrorId
+          ? [{ row, payload: { ...payload, envelope: payload.envelope } }]
+          : [];
+      });
+      const records = usable.map(({ payload }) => ({
+        originRecordRef: payload.envelope.originRecordRef,
+        originVersion: payload.envelope.originVersion,
+        payloadDigest: payload.envelope.payloadDigest,
+        withdrawn: payload.activity === "dpf.demand.withdrawn",
+      }));
+
+      if (records.length > 0) {
+        const digest: DemandDigestV1 = {
+          specVersion: "dpf.demand-digest/1",
+          originInstallationId: identity.installationId,
+          generatedAt: now.toISOString(),
+          records,
+        };
+        const result: PeerPostResult = await (options.send ?? sendDemandDigestToPeer)(
+          {
+            peerAuthorityUrl: link.peerAuthorityUrl,
+            linkToken: token,
+            linkId: link.linkId,
+            sameOrgLan: link.role === "same-org-peer",
+          },
+          digest,
+          { now },
+        );
+        if (
+          !result.ok || !result.body || typeof result.body !== "object" ||
+          Number((result.body as { checked?: unknown }).checked) !== records.length
+        ) {
+          linkFailed = true;
+          break;
+        }
+        linkOk = true;
+        const needs = new Map(
+          (Array.isArray((result.body as { needs?: unknown }).needs) ? (result.body as { needs: DemandDigestNeed[] }).needs : [])
+            .filter((need) => need && typeof need.originRecordRef === "string")
+            .map((need) => [need.originRecordRef, need]),
+        );
+        for (const { row, payload } of usable) {
+          const need = needs.get(payload.envelope.originRecordRef);
+          if (need) {
+            // Dead-letter is recoverable, not terminal: if the peer still needs a
+            // record we gave up on (e.g. it 422'd during the other side's upgrade
+            // window and the producer bug is since fixed), resurrect it — but cap the
+            // resurrections so a genuinely-poison record eventually stays dead instead
+            // of re-sending on every digest cycle forever (BI-8A7E3E56).
+            const wasDeadLettered = row.syncStatus === "dead-letter";
+            if (wasDeadLettered && (row.rehealCount ?? 0) >= MAX_DEMAND_REHEALS) continue;
+            requeued++;
+            await db.federatedRecordMirror.update!({ where: { mirrorId: row.mirrorId }, data: {
+              syncStatus: "pending", deliveryAttempts: 0, nextDeliveryAt: now,
+              lastDeliveryError: `reconciliation:${need.reason}`, deadLetteredAt: null,
+              ...(wasDeadLettered ? { rehealCount: (row.rehealCount ?? 0) + 1 } : {}),
+            } });
+          } else {
+            confirmed++;
+            await db.federatedRecordMirror.update!({ where: { mirrorId: row.mirrorId }, data: {
+              syncStatus: payload.activity === "dpf.demand.withdrawn" ? "withdrawn" : "synced",
+              acknowledgedVersion: row.version, lastSyncedAt: now, nextDeliveryAt: null,
+              lastDeliveryError: null, deadLetteredAt: null,
+            } });
+          }
+        }
       }
+
+      if (!moreLikely) break;
+    }
+    if (linkFailed) failedLinks++;
+    else if (linkOk) linksChecked++;
+    if (batches > 1) {
+      // Density signal: this link needed multiple digest batches, i.e. > one batch
+      // of shareable records. Correctness holds (all batches processed), but this
+      // is the trigger to prioritize the delta-sync/hub scale epic.
+      console.warn(`[demand-digest] link ${link.linkId} reconciled in ${batches} batches (> ${batchSize} records); full-inventory digest is O(records) — track the delta-sync/hub scale epic.`);
     }
   }
   return { linksChecked, requeued, confirmed, failedLinks };


### PR DESCRIPTION
`reconcileDemandDigests` used `take: 1_000` with **no cursor** — a link with >1,000 shareable records silently dropped everything past the first batch (never digested → peer never learns it's missing them → stranded records never re-heal). Harmless at two installs, a latent correctness cliff for the many-install future.

**Fix:** page the **entire** per-link inventory in bounded batches (cursor on `mirrorId`), each a self-contained digest exchange with per-batch `checked` validation. Coverage is complete regardless of count; batch size bounds only per-request payload. A multi-batch link logs a density warning — the trigger for the deferred delta-sync/hub scale epic (**not** built here, per approved scope).

**TDD:** 3 records at `batchSize: 2` reconcile across 2 batches, nothing dropped; single-batch behavior unchanged.

Scope unchanged — same-org still shares only open `dpf-portal` platform demand; sensitive/foundational backlogs stay local. BI-8A7E3E56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)