### PR TITLE
fix(routes): refresh accepted agent-card manifest

### DIFF
--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 611,
+  "routeCount": 613,
   "routes": [
     {
       "routePath": "/",
@@ -9,6 +9,29 @@
       "dynamicParams": [],
       "file": "apps/web/app/page.tsx",
       "redirectTo": "/welcome"
+    },
+    {
+      "routePath": "/.well-known/agent-card.json",
+      "kind": "route",
+      "segments": [
+        ".well-known",
+        "agent-card.json"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/.well-known/agent-card.json/route.ts"
+    },
+    {
+      "routePath": "/.well-known/agent-card/[agentId]",
+      "kind": "route",
+      "segments": [
+        ".well-known",
+        "agent-card",
+        "[agentId]"
+      ],
+      "dynamicParams": [
+        "agentId"
+      ],
+      "file": "apps/web/app/.well-known/agent-card/[agentId]/route.ts"
     },
     {
       "routePath": "/.well-known/dpf-instance.json",


### PR DESCRIPTION
## Summary

- regenerate the canonical route manifest against the accepted A2A agent-card handlers
- add `/.well-known/agent-card.json` and `/.well-known/agent-card/[agentId]`
- restore the committed route count from 611 to the generated 613-route truth

## Verification

- `pnpm --filter web check:route-manifest` — 613 routes, current
- `pnpm run pregate:preflight` — 35 guards clean; three source-only runtime checks deferred to the sandbox
- governed exact-tree pregate — web typecheck passed, 2,614 test files / 22,454 tests passed, and the production Docker build completed
- semantic review — low-risk deterministic generated artifact auto-pass

Backlog: BI-E6F8C1D3
