### PR TITLE
Fix restaurant commands on HTTP installs

### DIFF
--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -154,7 +154,10 @@ const props: RestaurantFloorOperationsProps = {
 };
 
 describe("RestaurantFloorOperations", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
 
   beforeEach(() => {
     mocks.execute.mockReset();
@@ -330,6 +333,22 @@ describe("RestaurantFloorOperations", () => {
     );
     await waitFor(() => expect(mocks.refresh).toHaveBeenCalled());
     expect(screen.getByText("Party seated")).toBeTruthy();
+  });
+
+  it("submits host commands when randomUUID is unavailable on an HTTP install", async () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(7),
+    });
+
+    render(<RestaurantFloorOperations {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm seating" }));
+
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledTimes(1));
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(/^seat:booking-waiting:\d+:/),
+      }),
+    );
   });
 
   it("keeps compatibility and assignment state in text, not color alone", () => {

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -14,6 +14,7 @@ import {
   type Intent,
 } from "@/components/ui/report-kit/statusColors";
 import { CartesianSceneCanvas } from "@/components/twin/cartesian/CartesianSceneCanvas";
+import { createClientOperationId } from "@/lib/client-operation-id";
 import type { HospitalityServiceTurnStage } from "@/lib/storefront/hospitality-service-turn";
 import {
   advanceRestaurantServiceTurn,
@@ -267,7 +268,7 @@ export function RestaurantFloorOperations({
     startTransition(async () => {
       const next = await executeRestaurantFloorCommand({
         kind: "assign",
-        idempotencyKey: `seat:${selectedDemand.id}:${Date.now()}:${crypto.randomUUID()}`,
+        idempotencyKey: `seat:${selectedDemand.id}:${Date.now()}:${createClientOperationId()}`,
         expectedVersion: selectedOption.expectedVersion,
         interval: selectedOption.interval,
         entityRefs: {
@@ -290,7 +291,7 @@ export function RestaurantFloorOperations({
   ) => {
     startTransition(async () => {
       const nextResult = await advanceRestaurantServiceTurn({
-        idempotencyKey: `turn:${turn.id}:${next.stage}:${turn.version}:${crypto.randomUUID()}`,
+        idempotencyKey: `turn:${turn.id}:${next.stage}:${turn.version}:${createClientOperationId()}`,
         serviceTurnId: turn.id,
         expectedVersion: turn.version,
         stage: next.stage,
@@ -304,7 +305,7 @@ export function RestaurantFloorOperations({
     if (!selectedMoveCommand || !selectedMoveOption) return;
     startTransition(async () => {
       const nextResult = await moveRestaurantParty({
-        idempotencyKey: `move:${selectedMoveCommand.serviceTurnId}:${selectedMoveCommand.expectedTurnVersion}:${crypto.randomUUID()}`,
+        idempotencyKey: `move:${selectedMoveCommand.serviceTurnId}:${selectedMoveCommand.expectedTurnVersion}:${createClientOperationId()}`,
         serviceTurnId: selectedMoveCommand.serviceTurnId,
         expectedTurnVersion: selectedMoveCommand.expectedTurnVersion,
         expectedSeatingVersion: selectedMoveOption.expectedVersion,

--- a/apps/web/lib/client-operation-id.test.ts
+++ b/apps/web/lib/client-operation-id.test.ts
@@ -20,4 +20,12 @@ describe("createClientOperationId", () => {
 
     expect(createClientOperationId()).toBe("07070707-0707-4707-8707-070707070707");
   });
+
+  it("fails explicitly rather than creating a collision-prone identifier without Web Crypto", () => {
+    vi.stubGlobal("crypto", undefined);
+
+    expect(() => createClientOperationId()).toThrow(
+      "Web Crypto is required to create client operation identifiers",
+    );
+  });
 });

--- a/apps/web/lib/client-operation-id.test.ts
+++ b/apps/web/lib/client-operation-id.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createClientOperationId } from "./client-operation-id";
+
+describe("createClientOperationId", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("uses randomUUID when the secure-context API is available", () => {
+    vi.stubGlobal("crypto", {
+      randomUUID: () => "12345678-1234-4234-9234-123456789abc",
+    });
+
+    expect(createClientOperationId()).toBe("12345678-1234-4234-9234-123456789abc");
+  });
+
+  it("creates a UUID-shaped identifier from getRandomValues on HTTP installs", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(7),
+    });
+
+    expect(createClientOperationId()).toBe("07070707-0707-4707-8707-070707070707");
+  });
+});

--- a/apps/web/lib/client-operation-id.ts
+++ b/apps/web/lib/client-operation-id.ts
@@ -1,0 +1,27 @@
+const UUID_RANDOM_BYTES = 16;
+
+function uuidFromRandomBytes(bytes: Uint8Array): string {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/**
+ * Returns a collision-resistant identifier for client command idempotency.
+ * `randomUUID` requires a secure context in browsers, while `getRandomValues`
+ * remains available on the LAN-hosted HTTP installs DPF supports.
+ */
+export function createClientOperationId(): string {
+  const crypto = globalThis.crypto;
+
+  if (typeof crypto?.randomUUID === "function") return crypto.randomUUID();
+
+  if (typeof crypto?.getRandomValues === "function") {
+    const bytes = new Uint8Array(UUID_RANDOM_BYTES);
+    crypto.getRandomValues(bytes);
+    return uuidFromRandomBytes(bytes);
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/apps/web/lib/client-operation-id.ts
+++ b/apps/web/lib/client-operation-id.ts
@@ -23,5 +23,5 @@ export function createClientOperationId(): string {
     return uuidFromRandomBytes(bytes);
   }
 
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  throw new Error("Web Crypto is required to create client operation identifiers");
 }


### PR DESCRIPTION
## Summary

- make restaurant host command idempotency IDs work on supported LAN-hosted HTTP installs
- prefer `crypto.randomUUID()` in secure contexts and construct an RFC 4122 v4 UUID from `crypto.getRandomValues()` otherwise
- cover seating, turn-stage, and move-party commands with the shared helper and regression tests

## Why

Canonical live acceptance of the delivered restaurant floor reproduced `crypto.randomUUID is not a function` when the host confirmed seating over HTTP. The command never reached the server. This repair preserves cryptographic collision resistance without requiring a secure context.

## Verification

- focused Vitest: 2 files / 13 tests passed on exact rebased head `b3697d87e0513e38c3abc3bcff4a56d597233489`
- fresh high-assurance semantic review: pass with zero findings, evidence `cmslm9r50021z01n03fzutlke`
- exact local CI: literal `gate passed`, evidence `cmsln57vc03a701n0muznidvt`
- local CI typecheck: passed
- exhaustive Vitest: 2,633 files passed; 22,586 tests passed; 4 files / 20 tests skipped; 18 todo
- production OCI build: passed, image `sha256:c9b7e393ca9314f62b7228b4c13716a16b961248591334fbba6ac1341464c7b6`
- terminal smoke probes: portal, MCP, Docker, and PostgreSQL healthy
- canonical live verification will be repeated after protected merge and self-upgrade

Local-CI-Evidence: cmsln57vc03a701n0muznidvt (fix/restaurant-http-command-idempotency@b3697d87e0513e38c3abc3bcff4a56d597233489)

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-07-31-restaurant-business-grade-floor.md` and `docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md`
- Current code substrate reviewed: `apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx` and `apps/web/lib/feedback-event.ts`
- Source of truth: the shared restaurant command surface and existing Web Crypto client identifier pattern
- Decision: localized HTTP compatibility repair; no UX contract or routing change

Operational-Precedent: restaurant-floor

Process-Spine-Decision: localized compatibility bugfix; no capability contract, route, user workflow, or documentation surface changed.

## Documentation impact

No user or operator documentation change is needed: this restores the already-documented restaurant command behavior on a supported deployment shape and does not change routes, wording, or workflow.

Backlog: `BI-9257B747` (blocks final acceptance of `BI-287AA5F7`)