### PR TITLE
fix(federation): same-org shares all non-sensitive backlog, not just the dpf-portal-tagged subset (BI-8A7E3E56)

### DIFF
--- a/apps/web/lib/federation/cross-org-sharing.test.ts
+++ b/apps/web/lib/federation/cross-org-sharing.test.ts
@@ -4,6 +4,7 @@ import {
   assertMayCrossOrgBoundary,
   isPlatformScopedDemand,
   mayShareDemandCrossOrg,
+  mayShareSameOrgDemand,
   DEFAULT_BACKLOG_SENSITIVITY,
   isBacklogSensitivity,
   mayCrossOrgBoundary,
@@ -80,5 +81,18 @@ describe("mayShareDemandCrossOrg — context-derived, automatic (BI-DC4E526E)", 
   it("hard-blocks confidential/restricted even for platform demand", () => {
     expect(mayShareDemandCrossOrg({ digitalProductId: "dpf-portal", sensitivity: "confidential" })).toBe(false);
     expect(mayShareDemandCrossOrg({ scopeKind: "platform", sensitivity: "restricted" })).toBe(false);
+  });
+});
+
+describe("mayShareSameOrgDemand — trust-by-default within one org (BI-8A7E3E56 follow-up)", () => {
+  it("shares all non-sensitive backlog regardless of product/scope tag", () => {
+    expect(mayShareSameOrgDemand("internal")).toBe(true);   // the default — shares same-org
+    expect(mayShareSameOrgDemand("public")).toBe(true);
+    expect(mayShareSameOrgDemand(undefined)).toBe(true);    // untagged defaults to internal → shares
+    expect(mayShareSameOrgDemand(null)).toBe(true);
+  });
+  it("keeps the genuinely-sensitive tier local even same-org (HR/confidential)", () => {
+    expect(mayShareSameOrgDemand("confidential")).toBe(false);
+    expect(mayShareSameOrgDemand("restricted")).toBe(false);
   });
 });

--- a/apps/web/lib/federation/cross-org-sharing.ts
+++ b/apps/web/lib/federation/cross-org-sharing.ts
@@ -58,6 +58,28 @@ export function assertMayCrossOrgBoundary(sensitivity: unknown): void {
   }
 }
 
+// ─── Same-organization sharing policy (BI-8A7E3E56 follow-up) ────────────────
+//
+// Sovereign installs of ONE organization (e.g. the operator's prod <-> dev) are
+// trust-by-default: "for the same org, all is OK." So same-org federation shares
+// ALL backlog EXCEPT the genuinely-sensitive tier the operator marks to keep off
+// the network entirely (HR, confidential ops). This is deliberately BROADER than
+// the cross-org gate (isPlatformScopedDemand / public-only): same-org is
+// trust-by-default, cross-org is deny-by-default. The prior same-org filter keyed
+// on the `dpf-portal` product tag alone, which most platform BIs never carry, so
+// it silently shared almost nothing — this replaces that proxy with the sensitivity
+// boundary the operator actually reasons about.
+
+/** Sensitivities that stay LOCAL even within one organization (single source of
+ *  truth — the projection query filters on this same list). */
+export const SAME_ORG_LOCAL_ONLY_SENSITIVITIES = ["confidential", "restricted"] as const satisfies readonly BacklogSensitivity[];
+const SAME_ORG_LOCAL_ONLY: ReadonlySet<BacklogSensitivity> = new Set(SAME_ORG_LOCAL_ONLY_SENSITIVITIES);
+
+/** Same-org sharing eligibility: everything except the genuinely-sensitive tier. */
+export function mayShareSameOrgDemand(sensitivity: unknown): boolean {
+  return !SAME_ORG_LOCAL_ONLY.has(normalizeSensitivity(sensitivity));
+}
+
 // ─── Context-derived eligibility (BI-DC4E526E) ──────────────────────────────
 //
 // The PRIMARY cross-org gate is the BI's context, not a hand-set flag: demand for

--- a/apps/web/lib/federation/demand-reconciliation.test.ts
+++ b/apps/web/lib/federation/demand-reconciliation.test.ts
@@ -79,6 +79,27 @@ describe("runDemandReconciliation", () => {
     }));
   });
 
+  it("shares ALL non-sensitive same-org backlog, not just the dpf-portal-tagged subset (BI-8A7E3E56 follow-up)", async () => {
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue(links) },
+      backlogItem: { findMany: vi.fn().mockResolvedValue([]) },
+      federatedRecordMirror: { findMany: vi.fn().mockResolvedValue([]) },
+    } as unknown as DemandReconciliationDb;
+
+    await runDemandReconciliation(db, {
+      resolveIdentity: vi.fn().mockResolvedValue({ installationId: `inst_${"a".repeat(32)}`, projectionSecret: "b".repeat(64) }),
+      queueProjection: vi.fn(),
+      queueWithdrawal: vi.fn(),
+      reconcileDigests: vi.fn().mockResolvedValue({ linksChecked: 0, requeued: 0, confirmed: 0, failedLinks: 0 }),
+      dispatch: vi.fn().mockResolvedValue({ attempted: 0, delivered: 0, deferred: 0, deadLettered: 0 }),
+    });
+
+    const where = (db.backlogItem.findMany as unknown as { mock: { calls: Array<[{ where: Record<string, unknown> }]> } }).mock.calls[0][0].where;
+    // Same-org is trust-by-default: gate on sensitivity, NOT on the dpf-portal product tag.
+    expect(where.sensitivity).toEqual({ notIn: ["confidential", "restricted"] });
+    expect(where).not.toHaveProperty("digitalProduct");
+  });
+
   it("never re-egresses a locally adopted peer envelope", async () => {
     const queueProjection = vi.fn();
     const db = {

--- a/apps/web/lib/federation/demand-reconciliation.ts
+++ b/apps/web/lib/federation/demand-reconciliation.ts
@@ -12,6 +12,7 @@ import {
 } from "./demand-delivery";
 import { resolveFederationIdentity, type FederationIdentityDb } from "./demand-identity";
 import { reconcileDemandDigests } from "./demand-digest";
+import { SAME_ORG_LOCAL_ONLY_SENSITIVITIES } from "./cross-org-sharing";
 
 interface ReconciliationLink {
   linkId: string;
@@ -93,7 +94,12 @@ export async function runDemandReconciliation(
   if (automaticLinks.length > 0) {
     const items = await db.backlogItem.findMany({
       where: {
-        digitalProduct: { productId: "dpf-portal" },
+        // Same-org is trust-by-default ("for the same org, all is OK"): share ALL
+        // non-sensitive backlog, not just the `dpf-portal`-tagged subset (which
+        // most platform BIs never carry, so the old filter shared almost nothing).
+        // The genuinely-sensitive tier (HR/confidential) stays local. Cross-org
+        // links keep the deny-by-default gate elsewhere. See mayShareSameOrgDemand.
+        sensitivity: { notIn: [...SAME_ORG_LOCAL_ONLY_SENSITIVITIES] },
         // Open work only. A closed item is excluded here, drops out of
         // eligibleIds below, and is withdrawn from the peer. See BI-8A8C1D3A.
         status: { in: [...FEDERATION_SYNCABLE_BACKLOG_STATUSES] },


### PR DESCRIPTION
**The real reason almost nothing synced** (5 of ~291 open on the Mac; 32 of ~1000 on the dev peer): the same-org projection filtered on `productId = 'dpf-portal'`, but the vast majority of platform BIs never carry that tag (they're `scopeKind=platform` or untagged — the federation/MCP/A2A slices themselves). A correct transport was moving an almost-empty set. A **policy/design miss**, not plumbing.

**Fix:** same-org is trust-by-default — share **all** syncable, non-received backlog **except** the genuinely-sensitive tier (`confidential`/`restricted`, which stays local). Policy lives in one place (`mayShareSameOrgDemand` in `cross-org-sharing.ts`), consumed by the projection — resolving the divergence from the canonical predicate. **Cross-org unchanged** (still deny-by-default / platform-only / public-only).

**Effect:** on the two same-org dev installs, ~all open non-sensitive platform work federates both ways (was 5↔32). Sensitive items are protected by marking them `confidential`/`restricted`.

Tests: projection gates on sensitivity not product; `mayShareSameOrgDemand` unit-tested. Scalability: projection full-scan/cycle is the same delta epic already named for the digest — tracked, not silently shipped. BI-8A7E3E56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)