### PR TITLE
docs: add enterprise A2A identity-boundary plan

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -392,6 +392,7 @@
         "103-trace-context-and-delegation",
         "104-integrity-and-non-repudiation",
         "105-privacy-and-minimization",
+        "106-enterprise-identity-boundary-projection",
         "11-protocol-profiles-and-interoperability",
         "111-general-rule",
         "112-core-extensions-and-profile-pattern",

--- a/docs/architecture/GAID.md
+++ b/docs/architecture/GAID.md
@@ -121,7 +121,8 @@ to each external work is maintained in the informative
 | [Model Context Protocol specification](https://modelcontextprotocol.io/specification/2025-11-25/basic) | Tool and context interoperability |
 | [Model Context Protocol authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) | OAuth-based authorization profile for protected MCP deployments |
 | [Anthropic: Introducing the Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) | Background on MCP as an open protocol |
-| [Agent2Agent Protocol specification](https://google-a2a.github.io/A2A/specification/) | Agent-to-agent interoperability and discovery |
+| [Agent2Agent Protocol v1.0 specification](https://a2a-protocol.org/latest/specification/) | Agent-to-agent interoperability, discovery, task lifecycle, extension points, and implementation-defined identity/authorization boundaries |
+| [A2A enterprise implementation guidance](https://a2a-protocol.org/latest/topics/enterprise-ready/) | Enterprise transport security, authorization, minimization, observability, and auditing guidance; does not define agent-subject identity or cross-organization participation disclosure |
 | [Google: Announcing the Agent2Agent Protocol](https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/) | Background on A2A as an open protocol |
 | [Linux Foundation: Agentic AI Foundation announcement](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation?hs_amp=true) | Neutral governance venue for MCP and `AGENTS.md` stewardship |
 | [RFC 4512 Lightweight Directory Access Protocol (LDAP): Directory Information Models](https://www.rfc-editor.org/rfc/rfc4512.html) | Enterprise directory modeling relevant to internal agent identity projection |
@@ -196,6 +197,9 @@ For the purposes of this standard:
 | `public namespace` | The globally resolvable identifier space intended for cross-organizational or public consumption |
 | `private namespace` | An internally governed identifier space intended for local or intra-organizational use |
 | `boundary mapping` | The governed relationship between an internal private identifier and an externally exposed public identifier |
+| `agent participation graph` | The receipt-linked, acyclic record of every materially participating agent subject and its delegation or contribution relationship in an interaction |
+| `boundary projection` | A policy-derived external view of an agent participation graph that exposes only approved identifiers and claims for the relying-party boundary |
+| `participation commitment` | A signed, privacy-preserving cryptographic commitment that binds an external receipt to a fuller protected participation graph without disclosing that graph |
 | `receipt` | A signed record describing a specific agent action, delegation, or decision event |
 | `chain-of-custody` | The traceable sequence linking a principal, agent, delegate, action, evidence, and resulting state transition |
 | `transparency log` | An append-oriented record of public issuance, status change, revocation, or other identity-relevant events |
@@ -213,6 +217,7 @@ An implementation of `GAID`:
 - `MUST NOT` treat a qualification badge as live authorization
 - `MUST` distinguish local authorization from portable authorization class
 - `MUST` preserve chain-of-custody for consequential actions
+- `MUST` distinguish complete internal chain-of-custody from the minimized identity view disclosed across an administrative boundary
 - `SHOULD` support both private and public operation without forcing them to share a single namespace
 - `SHOULD` expose enough structured metadata that relying parties do not need trial-and-error to determine whether an agent is fit for purpose
 - `MAY` support additional badge vocabularies, sectors, or regulatory overlays so long as the core identity and receipt semantics are preserved
@@ -296,6 +301,32 @@ Where a private agent is exposed publicly:
 - the relationship between the private and public identifiers `MUST` be recorded
 - the mapping `MUST` be visible to authorized auditors
 - the mapping `SHOULD NOT` disclose internal-only identifiers to general public consumers unless policy requires it
+
+A boundary mapping is an alias relationship for one enduring agent subject. It is not a second
+agent, a temporary network identity, or permission to derive a public identifier from a private
+identifier without issuer governance.
+
+When an interaction crosses an organization boundary:
+
+- every disclosed agent identifier `MUST` be a `GAID-Public` identifier, unless a stricter
+  bilateral profile explicitly defines another boundary-conformant public assurance class
+- a private `GAID`, private issuer prefix, internal principal identifier, internal installation
+  identifier, or undisclosed agent-topology reference `MUST NOT` appear in the external payload,
+  card, artifact, error, receipt view, or peer-visible telemetry
+- an approved boundary endpoint, installation, or signing-device identifier already required to
+  authenticate the inter-organizational relationship `MAY` remain visible as transport evidence;
+  this exception does not expose internal routing or participant topology
+- the issuer `MUST` resolve each disclosed public identifier through the governed boundary mapping
+  for the same canonical agent subject
+- lack of a required public mapping `MUST` fail closed; an implementation `MUST NOT` fall back to
+  exposing the private identifier
+- the relying-party view `MUST` indicate when material participation details were withheld and
+  `MUST NOT` falsely represent the externally accountable agent as the only agent that performed
+  the work
+
+Same-organization federation `MAY` disclose private or federated identifiers only where the
+relationship policy explicitly allows them. Administrative affinity alone is not disclosure
+authority.
 
 ### 6.6 Delegation, Accreditation, and Root Governance
 
@@ -957,7 +988,8 @@ For multi-step or multi-agent flows:
 - the initiating trace context `SHOULD` be preserved end to end
 - delegated actions `MUST` retain a parent-child receipt relationship
 - the delegated agent's `GAID` `MUST` be recorded
-- the delegating agent's `GAID` `MUST` remain visible in the chain
+- the delegating agent's `GAID` `MUST` remain visible in the protected custody chain and to
+  authorized auditors; an external boundary projection applies Section 10.6
 
 ### 10.4 Integrity and Non-Repudiation
 
@@ -981,6 +1013,49 @@ Accordingly:
 - internal-only context `MAY` be redacted in public-facing receipts while remaining available to authorized auditors
 
 Implementations handling identifiable human context `SHOULD` align receipt and `AIDoc` retention with applicable privacy controls such as `GDPR` and `ISO/IEC 27701`, including minimization, retention, and accountability expectations.
+
+### 10.6 Enterprise Identity-Boundary Projection
+
+An implementation that coordinates more than one agent `MUST` maintain a protected agent
+participation graph for every consequential interaction. The graph `MUST` include each agent
+subject that materially originated, delegated, authorized, approved, transformed, executed, or
+published part of the interaction. Deterministic tools and transport processes are not agent hops
+unless they are themselves governed as agent subjects.
+
+The graph:
+
+- `MUST` identify every participating agent by its canonical GAID in the source administrative
+  boundary
+- `MUST` record delegation and contribution edges using stable hop identifiers and parent
+  references so fan-out and fan-in are not falsely flattened into a linear chain
+- `MUST` bind each material hop to its receipt, trace context, role, time, and originating
+  installation/device evidence where applicable
+- `MUST` be retained in an access-controlled evidence store under the applicable retention policy
+- `MUST NOT` be copied wholesale across an organization boundary merely to satisfy traceability
+
+For an external boundary, the implementation `MUST` derive a separate boundary projection from
+the governing disclosure contract. That projection:
+
+- `MUST` expose only approved `GAID-Public` aliases for externally accountable participants
+- `MUST` state whether participation was minimized
+- `MUST` include a participation commitment when one or more material hops are withheld
+- `MUST NOT` disclose the number, names, private GAIDs, topology, installation identifiers, device
+  identifiers, prompts, or internal roles of withheld participants unless the disclosure contract
+  expressly allows that field
+- `MUST` be integrity-bound to the task, message, artifact, decision, or receipt it accompanies
+
+The participation commitment `MUST` be computed over a deterministic canonical representation of
+the complete protected graph, the interaction context, and the applied projection-policy version.
+It `MUST` use a high-entropy private nonce or an equivalently hiding construction so predictable
+private identifiers cannot be tested by dictionary attack. The commitment and projection `MUST`
+be signed by the boundary's approved signing authority. The nonce and protected graph `MUST`
+remain available for an authorized audit opening, subject to retention and legal policy.
+
+This dual-view model is analogous to an enterprise network boundary: the organization preserves
+its complete internal route and accountability record, while the external party sees only the
+governed public identities and a verifiable commitment that the protected record was not silently
+rewritten. It does not create a new agent-identity scheme; public and private GAIDs remain governed
+aliases of the same canonical subject.
 
 ![Receipt chain](gaid-diagrams/png/03-receipt-chain.png)
 
@@ -1038,6 +1113,12 @@ For `A2A` environments:
 - task and artifact events `SHOULD` preserve chain-of-custody identifiers
 - public agents `SHOULD` bind `Agent Card` metadata to issuer-controlled verification material
 - where `A2A` agent cards advertise `securitySchemes` or authenticated extended cards, the published `GAID` projection `SHOULD` remain consistent across both public and authenticated card variants
+- implementations `SHOULD` carry the GAID identity and participation projection as a versioned,
+  strongly typed A2A extension rather than ungoverned metadata keys
+- a cross-organization A2A response `MUST` apply Sections 6.5 and 10.6 before serialization; A2A
+  transport authentication or tenant routing is not authority to disclose private GAIDs
+- an A2A Agent Card intended for an external organization `MUST NOT` enumerate private agents or
+  internal topology and `MUST` use the public GAID view for every disclosed agent subject
 
 ### 11.6 HTTP and API Profile
 
@@ -1122,6 +1203,8 @@ An implementation conforming to this standard:
 - `SHOULD` bind public agent identity to organizational certificates or equivalent verification material
 - `SHOULD` use transparency logging for public issuance and revocation events
 - `SHOULD` minimize personally identifiable information in public identity documents and receipts
+- `MUST` treat internal agent identity, delegation topology, installation topology, and private
+  namespace structure as protected metadata at an organization boundary
 - `SHOULD` align threat analysis and control mapping with public catalogs such as `OWASP` Top 10 for Agentic Applications, `CSA MAESTRO`, and `MITRE ATLAS`
 - `SHOULD` consider applicable privacy and transparency obligations under frameworks such as the `EU` GPAI Code of Practice, enterprise privacy programs, and sector-specific disclosure rules
 - `MAY` support selective disclosure for regulated or classified environments
@@ -1152,6 +1235,8 @@ A `GAID-Federated` implementation:
 - `MUST` support delegated issuer governance
 - `MUST` support signed `AIDoc` publication
 - `MUST` support receipt integrity and status checking
+- `MUST` support policy-derived boundary projections and protected participation graphs for
+  consequential cross-boundary multi-agent interactions
 - `SHOULD` maintain a transparency log
 - `SHOULD` support organization-attested, independently-assessed, and accredited-certified badges
 - `SHOULD` support verifier-facing trust-list or federation publication
@@ -1164,6 +1249,7 @@ A `GAID-Public` implementation:
 - `MUST` use an accredited issuer model or recognized federated equivalent
 - `MUST` expose public verification material
 - `MUST` support public revocation and status checks
+- `MUST` support governed private-to-public boundary mappings without disclosing private aliases
 - `MUST` provide public-facing badge and assurance disclosures appropriate to relying-party trust
 - `SHOULD` support certificate-backed identity binding for public endpoints and organizational ownership
 - `SHOULD` support hybrid verification in which domain or certificate control, issuer status, and optional decentralized portability can coexist without fragmenting the canonical subject identity

--- a/docs/architecture/agent-standards-external-alignment.md
+++ b/docs/architecture/agent-standards-external-alignment.md
@@ -327,7 +327,7 @@ tokens, proof-of-possession, or enterprise identity policy.
 | External specification | Adopted or profiled use |
 |---|---|
 | Model Context Protocol | Tool discovery and invocation carrier; `TAK` supplies tool policy, approval, data, and evidence controls behind the transport |
-| Agent2Agent Protocol | Agent discovery and communication carrier; `GAID` supplies identity/assurance references and `TAK` supplies delegation narrowing |
+| [Agent2Agent Protocol v1.0](https://a2a-protocol.org/latest/specification/) | Agent discovery, task, artifact, security-scheme, signed-card, multi-tenancy, and extension carrier; `GAID` supplies the agent-subject identity, private/public boundary mapping, protected participation graph, and minimized external identity view that A2A deliberately leaves to the implementation, while `TAK` supplies delegation narrowing |
 | W3C Trace Context | Correlation identifiers across agent, tool, model, queue, and delegate boundaries |
 | RFC 9421 HTTP Message Signatures | Message integrity and signer binding for cross-boundary evidence |
 | RFC 9449 DPoP | Sender-constrained OAuth token use where bearer-token replay is unacceptable |
@@ -338,6 +338,15 @@ tokens, proof-of-possession, or enterprise identity policy.
 The family defines the semantics that these carriers transport. Implementations should preserve
 the native identifiers and verification material of adopted protocols instead of translating them
 into opaque, unverifiable prose.
+
+A2A's enterprise guidance covers transport security, standard web authentication, authorization,
+data minimization, observability, audit, and API management. Its core leaves identity outside A2A
+payload semantics and leaves authorization boundaries implementation-defined; its multi-tenancy
+identifier is opaque routing, not agent identity. Consequently, `GAID` profiles A2A through its
+standard extension points rather than changing the A2A task or transport model. The profile adds
+the enterprise identity concerns A2A does not normatively define: canonical agent subjects,
+private-to-public aliases, full source-side multi-agent custody, public-only boundary projection,
+and signed commitments to withheld participation.
 
 ## 10. Distinctive Augmentation
 

--- a/docs/architecture/gaid-conformance-tests.md
+++ b/docs/architecture/gaid-conformance-tests.md
@@ -39,6 +39,11 @@ Each assertion should identify:
 | `GAID-017` | `Federated` | Qualification scope disclosure | Qualification badge with activities, exclusions, data/risk constraints, autonomy ceiling, evidence, and evaluator | A relying party can distinguish the qualified scope from declared capability and prohibited use |
 | `GAID-018` | `Federated` | Qualification lifecycle status | Status and history tests covering pending revalidation, restriction, suspension, expiry, and revocation | Stale or invalid qualifications are not advertised as current and historical evidence is preserved |
 | `GAID-019` | `All` | Qualification is not authorization | Verifier and runtime-integration tests | Resolving an active qualification never independently grants a token, entitlement, tool, or live action permission |
+| `GAID-020` | `Federated` | Complete multi-agent participation custody | A consequential fan-out/fan-in fixture with canonical GAIDs, roles, stable hop IDs, parent edges, receipts, trace/time, and installation/device evidence | Every materially participating agent is represented in one protected acyclic graph and deterministic tools are not misclassified as agent subjects |
+| `GAID-021` | `Federated` | Policy-derived identity boundary projection | Same-org and cross-org projection fixtures plus the governing disclosure contract | Same-org disclosure matches explicit policy; cross-org output contains only approved public GAID aliases and no private GAID, Principal, hidden topology, installation/device, or source-local evidence identifier |
+| `GAID-022` | `Federated` | Private/public subject continuity | Principal/alias mapping evidence, issuer status, and negative missing-mapping test | Each exposed public GAID and protected private GAID resolve to the same canonical subject; missing required public mapping fails closed without private fallback |
+| `GAID-023` | `Federated` | Minimized-participation commitment | Signed public receipt, retained protected graph, private nonce, projection-policy version, and authorized audit-opening test | The commitment opens for authorized audit and graph/context/policy/nonce mutation fails; the public receipt reveals neither hidden identity/topology nor hidden-hop count by default |
+| `GAID-024` | `Public` | Whole-surface private-identity non-disclosure | Automated scan of messages, task history, artifacts, cards, receipts, errors, peer-visible traces/logs, and exports seeded with private identifiers | No private/internal identity or topology leaves the organization boundary and projection failure occurs before signing or delivery |
 
 ## Evidence Publication Guidance
 
@@ -49,6 +54,7 @@ Implementations should publish, at minimum:
 - representative badge and receipt samples
 - issuer-status or trust-anchor validation material for federated or public profiles
 - known deviations, compensating controls, or profile extensions
+- protected-participation and boundary-projection evidence for federated/public multi-agent systems
 
 ## Use in DPF
 

--- a/docs/superpowers/plans/2026-08-08-federated-a2a-gaid-coordination.md
+++ b/docs/superpowers/plans/2026-08-08-federated-a2a-gaid-coordination.md
@@ -10,11 +10,13 @@
 
 **GAID-binding decision:** `DI-B726A1900E7C`
 
+**Enterprise identity-boundary decision:** `DI-6FE234A7399E`
+
 **Decomposition decision:** `DI-61395D1B7A6D`
 
 **Planning WorkCapsule:** `WC-7528A06C`
 
-**Backlog coverage receipt:** `cmskp5ir603f401qpo83dsnox` (`decomposed`)
+**Backlog coverage receipt:** `cmskqtmc6062001qpizirypwd` (`decomposed`)
 
 > **For build threads:** claim exactly one mapped BI, use one worktree/branch/PR, run `dpf-verify-substrate-first` again against current `origin/main`, and keep `DPF_FEDERATION_A2A_ENABLED` off unless the slice explicitly owns activation. Use `dpf-tdd`, the local merged-code CI gate, independent semantic review, and the DPF DCO PR path.
 
@@ -22,7 +24,15 @@
 
 Deliver a feature-gated, same-organization A2A loop between two already trusted sovereign DPF installations. The loop discovers a projected coworker, proves both the source installation/device and the speaking GAID, creates a receiver-owned task, exchanges additional input/status/artifacts, applies receiver-local TAK and data boundaries, and presents readable provenance to operators.
 
-The release is complete only when Arcamanus production and Arcamanus+DPF development pass the canonical-runtime happy path while wrong-link, wrong-device, stale-card, guessed-task, and cross-organization paths remain denied.
+The implementation also establishes the enterprise identity-boundary contract needed before any
+future cross-org activation: complete source-side custody of every materially participating agent,
+public-only external GAID projection, and a signed privacy-preserving commitment when internal
+participation is withheld. Cross-org execution remains disabled in this plan.
+
+The release is complete only when the organization's designated production and development
+installations pass the canonical-runtime happy path while wrong-link, wrong-device, stale-card,
+guessed-task, and cross-organization paths remain denied. Concrete installation names remain in
+install-local acceptance evidence, not the public specification.
 
 ## 2. Scope decision
 
@@ -59,7 +69,7 @@ This boundary preserves the existing federation rule: raw `BacklogItem` is not t
 Live coverage was recorded against umbrella `BI-BE0E14E0` for this exact plan path.
 
 - Decision: `decomposed`
-- Receipt: `cmskp5ir603f401qpo83dsnox`
+- Receipt: `cmskqtmc6062001qpizirypwd`
 - Independently shippable mappings: six live sibling BIs under `EP-MSP-FEDERATION`
 - Sequencing-only gates: parity/overlap preflight and final two-install umbrella acceptance
 
@@ -88,11 +98,21 @@ Cross-install reuse/coordination references:
 3. Organization, environment/install, device, and GAID remain distinct dimensions.
 4. The receiver authenticates link and device before resolving any GAID claim.
 5. A remote card/claim is evidence only; receiver-local TAK, offer, delegation, consent, and tool-grant intersection remain authoritative.
-6. `TaskRun`/`TaskMessage`/`TaskArtifact` own task execution/history; `CoworkerEngagement` owns the accepted service/authority context.
+6. `TaskRun`/`TaskNode`/`TaskNodeEdge` own execution topology,
+   `TaskMessage`/`TaskArtifact` own history/results, and `CoworkerEngagement` owns the accepted
+   service/authority context; no participation-graph table is added.
 7. Same-org is the only enabled preset; cross-org stays deny-by-default.
 8. Every migration is forward-only and tolerates arbitrary existing data.
 9. Demand federation remains usable when A2A is disabled, unready, quarantined, or failing.
 10. The canonical runtime is the only runtime truth.
+11. Complete source-side participation custody and peer-visible identity disclosure are different
+    views; preserving every agent never authorizes exposing every agent.
+12. Cross-org egress contains only governed `gaid:pub` aliases, never private GAIDs, hidden
+    topology, internal Principal/install/device IDs, or source-local graph references.
+13. One canonical projection service feeds cards, events, tasks, artifacts, receipts, errors, and
+    peer-visible operations; route-local redaction is forbidden.
+14. Minimized participation is explicit and bound to the protected graph by a signed,
+    nonce-hiding commitment that can be opened only through authorized audit.
 
 ## 5. P0 — Parity, overlap, and build preflight
 
@@ -101,7 +121,11 @@ Cross-install reuse/coordination references:
 1. Query the live local BI, its epic, all six child BIs, and synchronized peer references.
 2. Sweep open PRs, active WorkCapsules, code graph, `origin/main`, and the other install's mirrored work before claiming a slice.
 3. Record an explicit counterpart/alias when synchronized work matches one of the peer BIs; do not copy a peer-local identifier into local authority without the sync contract.
-4. Re-check A2A v1.0, MCP Tasks direction, CloudEvents 1.0, RFC 9421, RFC 9530, and RFC 8785 if implementation begins after a standards revision.
+4. Re-check A2A v1.0 core, enterprise, multi-tenancy, Agent Card, and extension guidance; MCP Tasks
+   direction; CloudEvents 1.0; RFC 9421; RFC 9530; and RFC 8785 if implementation begins after a
+   standards revision. Confirm whether upstream A2A has since standardized agent-subject identity,
+   private/public boundary mapping, participation graphs, or selective-disclosure commitments
+   before changing the DPF GAID extension.
 5. Verify worktree readiness. A source-only worktree may author/review docs, but an implementation thread must become compile-ready before claiming source-local gates.
 6. Claim only the selected slice BI and refresh its plan coverage/context before code.
 
@@ -127,11 +151,19 @@ Cross-install reuse/coordination references:
 2. Replace federation advertisement of `gaid:priv:dpf.internal:*` with a governed stable issuer namespace while preserving legacy aliases for local resolution.
 3. Preserve a canonical GAID across installs only when a governed continuity record proves the same enduring subject; matching `agentId` or configuration is insufficient.
 4. Keep all identity resolution on `Principal` + `PrincipalAlias`; do not add an `Agent.gaid` column or remote-agent table.
-5. Verify AIDoc resolution and every current local caller continue to work.
+5. Model private and public GAIDs for one enduring agent as governed aliases of the same Principal;
+   keep issuer on the alias, status in the canonical Principal/AIDoc lifecycle, and mapping proof
+   in the existing protected receipt/evidence substrate with authorized audit visibility. Do not
+   turn `PrincipalAlias` into a provenance store or invent an ephemeral NAT-style identifier.
+6. Deny cross-org projection when a required public alias is absent; never expose the private GAID
+   as fallback.
+7. Verify AIDoc resolution and every current local caller continue to work.
 
 ### Done
 
-Distinct subjects cannot collide, continuity is evidence-backed, legacy aliases resolve locally, and no non-conformant private GAID is advertised as federated assurance.
+Distinct subjects cannot collide, continuity is evidence-backed, legacy aliases resolve locally,
+private/public mappings resolve to one Principal, and no non-conformant private GAID is advertised
+as federated assurance or leaked when public mapping is absent.
 
 ## 7. S2 — Peer-device pinning and signed federation events
 
@@ -181,13 +213,19 @@ Mutation, wrong path/link/device, expired signature, nonce replay, unapproved ro
 2. Add the GAID extension, AIDoc reference/digest, exact offers, and authenticated federation interface.
 3. Canonicalize with RFC 8785 and sign with the installation device key; separately verify AIDoc issuer status/binding.
 4. Project only allowed fields through `ProjectionContract` and store peer cards as link-scoped `FederatedRecordMirror(recordType="agent-card")`.
-5. Implement expiry, refresh, withdrawal, revocation, and key-rotation invalidation.
-6. Extend `find_coworker` and the existing coworker/service catalog with verified, link-scoped remote results.
-7. Fail closed for the authenticated federated card path when identity/signing is unavailable. Do not inherit the current public read-only card's fail-open provenance fallback.
+5. Emit only `gaid:pub` aliases in cross-org/public cards; never enumerate private coworkers,
+   private issuer prefixes, hidden topology, or internal installation/device details.
+6. Declare the versioned GAID A2A boundary extension in the Agent Card and require negotiation for
+   any future cross-org relationship.
+7. Implement expiry, refresh, withdrawal, revocation, and key-rotation invalidation.
+8. Extend `find_coworker` and the existing coworker/service catalog with verified, link-scoped remote results.
+9. Fail closed for the authenticated federated card path when identity/signing is unavailable. Do not inherit the current public read-only card's fail-open provenance fallback.
 
 ### Done
 
-Valid cards verify against the pinned link/device and GAID issuer; stale, withdrawn, wrong-link/key, mismatched-GAID, unapproved-offer, and forbidden-field cases fail without enumerating private coworkers.
+Valid cards verify against the pinned link/device and GAID issuer; stale, withdrawn, wrong-link/key,
+mismatched-GAID, unapproved-offer, private-GAID, topology, and forbidden-field cases fail without
+enumerating private coworkers.
 
 ## 9. S4 — Federated A2A task ingress over canonical TaskRun
 
@@ -209,16 +247,28 @@ Valid cards verify against the pinned link/device and GAID issuer; stale, withdr
 
 1. Reconcile current main with peer Slice 4 `BI-06B66FFD`; complete one `TaskRun` convergence rather than competing migrations or task models.
 2. Add closed, versioned A2A CloudEvent payload contracts with size, version, extension, and idempotency validation.
-3. Store federation/link ownership, origin event, acting/delegating/target GAIDs, origin install/environment, card/AIDoc digests, and verification receipt as typed/indexed task ownership where query/integrity needs justify it.
-4. Implement the non-streaming v1.0 operations required by the first slice: message/send, get/list, additional input, cancel, status/history, and artifact retrieval.
-5. Generate the task ID on the receiver and use `TaskRun` as authority; link `CoworkerEngagement` for service/approval context and persist `TaskMessage`/`TaskArtifact` history.
-6. Bind every operation to the authenticated `FederationLink`, verified agent context, and local target. Task-ID possession is never authorization.
-7. Reuse federation delivery/idempotency/loop patterns. Keep `/api/a2a/*` as internal compatibility adapters, not external trust paths.
-8. Claim A2A binding conformance only if all required operations and semantics are implemented; otherwise label the surface as the DPF federation A2A profile.
+3. Replace the scalar acting/delegating/delegated call-chain metadata with a versioned, receipt-linked
+   participation view derived from canonical `TaskRun`/`TaskNode`/`TaskNodeEdge`, Principal/GAID,
+   artifact producer, and receipt/evidence records. Add only the minimum agent-Principal/GAID and
+   receipt bindings to canonical nodes; do not add an A2A participation-graph table.
+4. Define bounded node, edge, depth, serialized-size, and graph-version rules; support fan-out and
+   fan-in without flattening. Legacy scalar records dual-read as `legacy-incomplete` until migrated.
+5. Store federation/link ownership, origin event, acting/delegating/target GAIDs, origin
+   install/environment, card/AIDoc digests, protected graph reference, applied projection version,
+   commitment, and verification receipt as typed/indexed ownership where query/integrity needs
+   justify it.
+6. Implement the non-streaming v1.0 operations required by the first slice: message/send, get/list, additional input, cancel, status/history, and artifact retrieval.
+7. Generate the task ID on the receiver and use `TaskRun` as authority; link `CoworkerEngagement` for service/approval context and persist `TaskMessage`/`TaskArtifact` history.
+8. Bind every operation to the authenticated `FederationLink`, verified agent context, and local target. Task-ID possession is never authorization.
+9. Reuse federation delivery/idempotency/loop patterns. Keep `/api/a2a/*` as internal compatibility adapters, not external trust paths.
+10. Claim A2A binding conformance only if all required operations and semantics are implemented; otherwise label the surface as the DPF federation A2A profile.
 
 ### Done
 
-Lifecycle/concurrency tests pass; duplicate creates converge; conflicting idempotency payloads fail; guessed/cross-link task IDs, token-only/signature-only calls, replay, and body mutation are denied; existing internal A2A and demand paths remain green.
+Lifecycle/concurrency tests pass; a multi-agent fan-out/fan-in fixture preserves every material hop
+and receipt; graph limits and immutable versioning pass; duplicate creates converge; conflicting
+idempotency payloads fail; guessed/cross-link task IDs, token-only/signature-only calls, replay, and
+body mutation are denied; existing internal A2A and demand paths remain green.
 
 ## 10. S5 — Authority, privacy, receipts, and operations
 
@@ -237,15 +287,29 @@ Lifecycle/concurrency tests pass; duplicate creates converge; conflicting idempo
 
 1. Enforce the fixed ingress order: link token → device signature/digest → replay/idempotency → install/org/environment → issuer/card/AIDoc → target GAID → local TAK/offer/projection/consent → task.
 2. Keep peer claims evidentiary. Intersect local TAK, delegation, offer, consent, tool grants, sensitivity, and projection policy before execution.
-3. Enable only same-org A2A. Existing demand cross-org privacy is the floor; customer-domain, confidential, restricted, prompt, memory, secret, and private-grant material remains denied.
-4. Add per-link/per-GAID size, rate, concurrency, TTL, retention, and artifact-classification limits.
-5. Persist immutable chain-of-custody and authorization receipts without tokens, private keys, raw prompts, or unminimized payloads.
-6. Add bounded-cardinality metrics, structured failure reasons, retry/stuck state, quarantine/revocation behavior, and existing operations-map projection.
-7. Define one fail-closed readiness predicate used by S6 and rollout.
+3. Implement one canonical pre-signing boundary projector consumed by Agent Cards, CloudEvents,
+   task/message/artifact responses, task history, receipts, errors, and peer-visible operations.
+4. For same-org, disclose private/federated GAIDs or topology only when `ProjectionContract`
+   explicitly allows them. For cross-org, require approved `gaid:pub` aliases for every disclosed
+   participant and deny any private/internal identity or topology field.
+5. When material hops are withheld, create `participationMinimized=true` plus a signed commitment
+   over RFC 8785 canonical graph + task/event context + policy version + high-entropy private nonce;
+   retain the nonce/graph for receipted authorized audit opening. Never use an unsalted digest.
+6. Add a whole-response egress scanner for private GAIDs, Principal IDs, private issuer prefixes,
+   hidden hop/edge IDs, internal installation/device IDs, graph references, and forbidden data in
+   payloads, cards, artifacts, errors, receipts, and peer-visible telemetry.
+7. Enable only same-org A2A. Existing demand cross-org privacy is the floor; customer-domain, confidential, restricted, prompt, memory, secret, and private-grant material remains denied.
+8. Add per-link/per-GAID size, rate, concurrency, TTL, retention, graph, and artifact-classification limits.
+9. Persist immutable chain-of-custody and authorization receipts without tokens, private keys, raw prompts, or unminimized payloads.
+10. Add bounded-cardinality metrics, structured failure reasons, retry/stuck state, quarantine/revocation behavior, and existing operations-map projection. Metrics never label hidden participant identity or count.
+11. Define one fail-closed readiness predicate used by S6 and rollout.
 
 ### Done
 
-Negative-egress, revocation-mid-task, cross-org, over-classification, authority-denial, and demand-isolation tests pass; accepted and denied work is legible through existing evidence/operations surfaces.
+Negative-egress, missing-public-alias, private-ID side-channel, commitment mutation/opening,
+revocation-mid-task, cross-org, over-classification, authority-denial, and demand-isolation tests
+pass; accepted and denied work is legible through existing evidence/operations surfaces. Cross-org
+remains disabled after the tests.
 
 ## 11. S6 — Operator readiness UX and activation controls
 
@@ -267,12 +331,18 @@ Negative-egress, revocation-mid-task, cross-org, over-classification, authority-
 2. Show remote coworkers in the existing catalog with peer/environment badges, verified-card freshness, offered outcome, and data boundary.
 3. Provide consequence-first initiation and cancellation showing both agents, both environments, data classes, write/advisory posture, approval boundary, and retention.
 4. Show task lifecycle, messages, artifacts, denials, and verification receipts on existing engagement/interaction surfaces; keep raw proof details behind disclosure.
-5. Make unready states actionable: device confirmation, issuer verification, expired card, quarantine, unsupported version, and cross-org disabled.
-6. Use shared primitives and `--dpf-*` tokens; verify keyboard use, ≥44px targets, text status, visible focus, narrow layouts, reduced motion, light/dark themes, and organization branding.
+5. Give authorized source operators a full participation view; give peer/external views only public
+   accountable agents, “internal participation protected,” commitment state, and the audit-request
+   path. Do not show hidden-hop count by default or imply the public boundary agent acted alone.
+6. Make unready states actionable: device confirmation, issuer verification, expired card, missing
+   public mapping, commitment failure, quarantine, unsupported extension/version, and cross-org disabled.
+7. Use shared primitives and `--dpf-*` tokens; verify keyboard use, ≥44px targets, text status, visible focus, narrow layouts, reduced motion, light/dark themes, and organization branding.
 
 ### Done
 
-Component, accessibility, and measured UX-fit evidence pass; the UI never implies A2A readiness unless S5's canonical predicate is true.
+Component, accessibility, and measured UX-fit evidence pass; the UI never implies A2A readiness
+unless S5's canonical predicate is true and never leaks or falsely attributes protected internal
+participation.
 
 ## 12. Acceptance and rollout
 
@@ -298,10 +368,22 @@ After S1–S6 merge:
 2. Use the governed nonproduction environment/lease and canonical self-upgrade path; never rebuild the live portal from a worktree.
 3. Upgrade both designated same-org installs and explicitly approve device pins and issuer bindings.
 4. Happy path: discover a projected remote coworker; inspect GAID/AIDoc and install/environment provenance; submit a bounded task; receive working/input-required; add input; receive a minimized artifact; complete; retrieve the task and receipt from the initiating side.
-5. Negative paths: wrong/rotated device key, token-only request, replay, stale/withdrawn card, unprojected GAID, task ID from another link, revoked/quarantined link, unsupported version, cross-org preset, and development-to-production consequential work without local approval.
-6. Prove demand federation still functions when A2A is off and when A2A authentication fails.
-7. Run live UX-fit review and record screenshots/evidence against the umbrella WorkCapsule.
-8. Enable `DPF_FEDERATION_A2A_ENABLED` only for the approved same-org link after every positive and negative case passes.
+5. Multi-agent custody path: run a five-agent fixture with delegation plus fan-out/fan-in; prove the
+   source view contains every material GAID/edge/receipt and the allowed same-org projection matches
+   its explicit `ProjectionContract`.
+6. Enterprise boundary dry-run while execution remains disabled: generate the cross-org projection
+   and prove it contains only approved `gaid:pub` participants, minimized-participation state, and a
+   signed commitment. Search payload, history, artifacts, cards, receipts, errors, traces, logs, and
+   operator exports for every seeded private identifier. Open the commitment through the authorized
+   audit path; mutations to graph, context, policy version, or nonce must fail.
+7. Negative paths: wrong/rotated device key, token-only request, replay, stale/withdrawn card,
+   unprojected GAID, missing public mapping, private-ID/topology leak, unsalted/invalid commitment,
+   legacy scalar-only custody, graph-limit breach, task ID from another link, revoked/quarantined
+   link, unsupported extension/version, cross-org preset, and development-to-production
+   consequential work without local approval.
+8. Prove demand federation still functions when A2A is off and when A2A authentication fails.
+9. Run live UX-fit review and record screenshots/evidence against the umbrella WorkCapsule.
+10. Enable `DPF_FEDERATION_A2A_ENABLED` only for the approved same-org link after every positive and negative case passes.
 
 ### Umbrella done
 
@@ -309,6 +391,8 @@ After S1–S6 merge:
 - the cross-install BI view has explicit counterpart mapping and no unresolved duplicate ownership;
 - the live happy path and all negative paths pass on both canonical installs;
 - cross-org remains disabled;
+- enterprise boundary projection and authorized commitment opening are proven without leaking the
+  protected graph;
 - demand regression evidence is green;
 - the spec, plan, route/architecture docs, and operator guidance match shipped behavior.
 
@@ -320,12 +404,14 @@ After S1–S6 merge:
 | --- | --- | --- |
 | Canonical contracts | aligned | protocol types live in the existing DB/shared-contract owner; wire adapters map versions |
 | Identity stewardship | aligned | GAID/AIDoc and `PrincipalAlias` only; no remote-agent or per-agent credential store |
+| Identity-boundary projection | aligned | complete protected graph locally; public GAID aliases and signed commitment externally |
 | Trust/transport | aligned | A2A extends `FederationLink` + CloudEvents + mutual tokens + pinned device signing |
 | Data-model stewardship | aligned with slice separation | link/device fields in S2; task ownership in S4 only when query/integrity requires typed columns |
 | Task source of truth | aligned | `TaskRun` owns lifecycle; `CoworkerEngagement` owns service/authority context |
 | Discovery source of truth | aligned | extend the existing Agent Card builder and `find_coworker` |
 | Backlog sovereignty | aligned with guardrail | BI sync provides mirrored/crosswalk coordination; local `BacklogItem` remains authoritative |
-| Privacy | aligned | same-org only, projection allowlists, receiver-local TAK, deny-by-default cross-org |
+| Privacy | aligned | one pre-signing `ProjectionContract` projector; same-org explicit disclosure; public-only cross-org dry-run; cross-org execution disabled |
+| Enterprise scale | aligned with bounded contract | DAG node/edge/depth/bytes limits, immutable versions, constant-size commitments, no GAID metric labels |
 | Operability | aligned | independent demand/A2A readiness and kill switches; canonical runtime acceptance |
 
 Review corrections carried into the plan:
@@ -336,6 +422,12 @@ Review corrections carried into the plan:
 4. The authenticated federated card path is explicitly fail-closed; the current public read-only builder's fail-open provenance fallback is not reused there.
 5. MCP Tasks/`TaskRun`, Agent Card, and `find_coworker` are dependencies and extension seams, not parallel implementations.
 6. BI parity is a coordination layer outside A2A and cannot create multi-writer backlog authority.
+7. Full chain-of-custody and external disclosure are separated; the former scalar call-chain seam
+   is replaced by the existing receipt/evidence substrate's bounded participation graph.
+8. Public/private identity mapping converges through `PrincipalAlias`, while one canonical
+   `ProjectionContract` service prevents route-by-route redaction drift.
+9. A2A's standard extension points carry the GAID enterprise profile; standard task/card/auth
+   semantics and the federation transport remain unchanged.
 
 ## 14. Rollback and recovery
 

--- a/docs/superpowers/plans/2026-08-08-federated-a2a-gaid-coordination.md
+++ b/docs/superpowers/plans/2026-08-08-federated-a2a-gaid-coordination.md
@@ -1,359 +1,348 @@
-# Federated A2A Coordination with GAID — Implementation Plan
+# Federated A2A Coordination with GAID — Decomposed Implementation Plan
 
-**Date:** 2026-08-08  
-**Status:** Ready for a build thread; no implementation started  
-**Backlog item:** `BI-BE0E14E0` (MSP-federation install) — identical slice anchors under `EP-E1F1DB58` on the A2A-adoption install; see design §3  
-**Epic:** `EP-MSP-FEDERATION` here / `EP-E1F1DB58` on the A2A-adoption install (two sovereign backlogs, same work)  
-**Design WorkCapsule:** `WC-647895E9`  
-**Design:** [`docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md`](../specs/2026-08-08-federated-a2a-gaid-coordination-design.md)  
-**Kernel decision:** `DI-B726A1900E7C`  
-**Backlog coverage receipt:** `cmskls1vz03qi01mu59s9tn3o` (`atomic`)
+**Date:** 2026-08-08
 
-> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+**Status:** Governed implementation scope; ready to execute one slice at a time
+
+**Umbrella backlog item:** `BI-BE0E14E0` under `EP-MSP-FEDERATION`
+
+**Design:** [`docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md`](../specs/2026-08-08-federated-a2a-gaid-coordination-design.md)
+
+**GAID-binding decision:** `DI-B726A1900E7C`
+
+**Decomposition decision:** `DI-61395D1B7A6D`
+
+**Planning WorkCapsule:** `WC-7528A06C`
+
+**Backlog coverage receipt:** `cmskp5ir603f401qpo83dsnox` (`decomposed`)
+
+> **For build threads:** claim exactly one mapped BI, use one worktree/branch/PR, run `dpf-verify-substrate-first` again against current `origin/main`, and keep `DPF_FEDERATION_A2A_ENABLED` off unless the slice explicitly owns activation. Use `dpf-tdd`, the local merged-code CI gate, independent semantic review, and the DPF DCO PR path.
 
 ## 1. Outcome
 
-Deliver one feature-gated, same-organization A2A loop between two already trusted sovereign DPF installations. The loop discovers a projected coworker, proves the source install/device and speaking GAID, creates a receiver-owned task, exchanges additional input/status/artifacts, enforces local TAK and data boundaries, and exposes readable provenance to operators.
+Deliver a feature-gated, same-organization A2A loop between two already trusted sovereign DPF installations. The loop discovers a projected coworker, proves both the source installation/device and the speaking GAID, creates a receiver-owned task, exchanges additional input/status/artifacts, applies receiver-local TAK and data boundaries, and presents readable provenance to operators.
 
-The release is successful only when the organization's production and development installations complete the happy path through the canonical runtime while cross-org, wrong-link, wrong-device, stale-card, and guessed-task paths remain denied.
+The release is complete only when Arcamanus production and Arcamanus+DPF development pass the canonical-runtime happy path while wrong-link, wrong-device, stale-card, guessed-task, and cross-organization paths remain denied.
 
-## 2. Delivery boundary
+## 2. Scope decision
 
-This plan is **atomic at product-release level** even though it has internal phases. None is independently safe or useful to enable:
+The original plan treated the complete vertical slice as one atomic BI. The 2026-08-08 follow-up review found six independently reviewable seams already reflected in the substrate: GAID identity, federation device authentication, Agent Card discovery, canonical task ingress, authority/evidence, and operator readiness.
 
-- device pinning without issuer/card/task enforcement is unused security metadata;
-- card projection without authenticated task ingress leaks discovery without delivering coordination;
-- task ingress without device/GAID binding recreates the vulnerability this slice exists to close;
-- UI before end-to-end enforcement can imply readiness that does not exist;
-- cross-org enablement is explicitly excluded and will require its own future BI.
+`principle_decide` selected **decomposed convergence** with high confidence:
 
-Every phase stays behind `FederationLink` A2A readiness/capability negotiation. The single BI remains correct because the only shippable outcome is the composed same-org vertical slice. The live coverage receipt in §3 is mandatory before implementation.
+| Option | Composite | Result |
+| --- | ---: | --- |
+| Decomposed convergence behind disabled capability gates | **15.417** | selected |
+| One release-sized atomic BI | 4.197 | rejected |
+| Parallel install-specific programs reconciled later | 1.556 | rejected |
+
+Decision ledger: `DI-61395D1B7A6D`; margin `11.220`; strong structured coverage; no commandment conflict. The strongest positive pulls were Research and Use Standards, Ship Real Functionality, Ground New Work in Existing Platform, Single Source of Truth, and one concern per PR. This supersedes the earlier atomic coverage decision for implementation planning; it does not change the reviewed GAID-binding decision.
+
+## 3. BI parity and sovereignty boundary
+
+BI synchronization between the two installations is an operational coordination prerequisite, not part of the A2A protocol and not a new transport.
+
+Before every slice:
+
+1. Query the live backlog through DPF MCP on the install doing the work.
+2. Inspect the synchronized peer view/crosswalk when it is available.
+3. Match work using the sync substrate's install-qualified provenance, title/scope, and explicit counterpart reference; never assume a bare `BI-…` value is globally unique.
+4. If a peer item already owns the same deliverable, reuse or coordinate it instead of filing another local copy.
+5. Keep each install's `BacklogItem` locally authoritative. A remote item is a mirror/coordination reference unless the governed sync contract explicitly adopts it locally.
+
+Current evidence on the MSP-federation install still does not expose `EP-E1F1DB58` or its slice BIs. The reviewed peer-install snapshot remains valid, but this plan does not claim that parity has completed. A future synced view must converge the references below without turning either backlog into a multi-writer replica.
+
+This boundary preserves the existing federation rule: raw `BacklogItem` is not the demand/A2A wire contract, and A2A coordinates agents after work identity and authority have been resolved.
 
 ## Backlog coverage
 
-Live coverage was recorded against parent `BI-BE0E14E0` for this exact plan path.
+Live coverage was recorded against umbrella `BI-BE0E14E0` for this exact plan path.
 
-- Decision: atomic
-- Parent: `BI-BE0E14E0`
-- Receipt: `cmskls1vz03qi01mu59s9tn3o`
-- Dependencies: `BI-COWORKER-360-AGENTCARD` coordination; all delivery phases remain internal to the parent BI. Cross-install coordination references (not local mapped BIs — they live on the A2A-adoption install under `EP-E1F1DB58`): Slice 6 `BI-40648BBF` (agent-card export — consumed by Phase 3), Slice 4 `BI-06B66FFD` (standard MCP Tasks → `TaskRun` convergence — must land as one convergence with Phase 1), Slice 10 `BI-5FB59BC6` (`find_coworker`, shipped #4121 — extended by Phase 3 discovery)
-- Mapped child BIs: none; all phases are internal sequencing under `BI-BE0E14E0`
-- Rationale: the security property exists only as the composed same-organization vertical slice. Device pinning, GAID issuer/card projection, task ingress/ownership, policy, and operator readiness are mutually dependent and stay feature-gated until end-to-end acceptance. Shipping any phase alone either exposes unusable metadata/UI or creates the unauthenticated or under-authorized boundary the BI is meant to eliminate. Cross-organization enablement is excluded and will require a separate future BI.
+- Decision: `decomposed`
+- Receipt: `cmskp5ir603f401qpo83dsnox`
+- Independently shippable mappings: six live sibling BIs under `EP-MSP-FEDERATION`
+- Sequencing-only gates: parity/overlap preflight and final two-install umbrella acceptance
 
-| Deliverable | Independently shippable | Depends on | Live BI mapping |
-| --- | --- | --- | --- |
-| Phase 0 — red contracts | no | — | `BI-BE0E14E0` atomic scope |
-| Phase 1 — schema convergence | no | Phase 0 | `BI-BE0E14E0` atomic scope |
-| Phase 2 — device binding | no | Phase 1 | `BI-BE0E14E0` atomic scope |
-| Phase 3 — GAID/cards | no | Phase 2 | `BI-BE0E14E0` atomic scope |
-| Phase 4 — task path | no | Phases 1–3 | `BI-BE0E14E0` atomic scope |
-| Phase 5 — policy/evidence | no | Phase 4 | `BI-BE0E14E0` atomic scope |
-| Phase 6 — operator UX | no | Phases 2–5 | `BI-BE0E14E0` atomic scope |
-| Phase 7 — acceptance/handoff | no | Phase 6 | `BI-BE0E14E0` atomic scope |
+| Key | Deliverable | Live BI | Depends on | Ship/merge posture |
+| --- | --- | --- | --- | --- |
+| P0 | BI parity, overlap, and substrate preflight | umbrella coordination | — | no implementation |
+| S1 | GAID issuer namespace and identity continuity | `BI-F51DC0D3` | P0 | independent correctness slice |
+| S2 | Peer-device pinning and signed federation events | `BI-51FA49EB` | P0 | independent, A2A disabled |
+| S3 | Signed GAID Agent Cards and remote discovery | `BI-B280E853` | S1, S2 | independent, discovery gated |
+| S4 | Federated A2A task ingress over `TaskRun` | `BI-90E338D8` | S1–S3 | independent, ingress disabled |
+| S5 | Local authority, privacy, receipts, and operations | `BI-0E61A6A7` | S2, S4 | independent safety/readiness slice |
+| S6 | Operator readiness UX and activation controls | `BI-68AF8D86` | S3, S5 | independent UI slice |
+| A | Canonical-runtime two-install acceptance | umbrella closeout | S1–S6 | not a separate product deliverable |
+
+Cross-install reuse/coordination references:
+
+- `BI-06B66FFD`: MCP Tasks lifecycle over canonical `TaskRun`; S4 must consume its completed convergence rather than create competing task state.
+- `BI-40648BBF`: existing A2A Agent Card exporter; S3 extends its builder.
+- `BI-5FB59BC6` / PR #4121: shipped `find_coworker`; S3 adds its link-scoped federated result source.
+- `BI-COWORKER-360-AGENTCARD`: current-install whole-coworker Agent Card/read-model coordination seam.
 
 ## 4. Non-negotiable invariants
 
-1. Reuse GAID/AIDoc and `Principal`/`PrincipalAlias`; no new identity format or remote-agent table.
-2. Reuse `FederationLink`, mutual tokens, installation/device identity, CloudEvents, `ProjectionContract`, and `FederatedRecordMirror`; no parallel transport.
-3. Treat organization, environment/install, device, and GAID as separate dimensions.
-4. Authenticate the link and device before resolving any agent claim.
-5. Treat the remote claim/card as evidence only; the receiver's TAK/delegation/offer/consent policy remains final.
-6. Use `TaskRun`/`TaskMessage`/`TaskArtifact` for task lifecycle/history and `CoworkerEngagement` for the accepted service relationship.
+1. GAID/AIDoc plus `Principal`/`PrincipalAlias` remains the only agent-identity source of truth.
+2. `FederationLink`, mutual tokens, installation/device identity, CloudEvents, `ProjectionContract`, and `FederatedRecordMirror` remain the only cross-install trust, transport, disclosure, and mirror substrate.
+3. Organization, environment/install, device, and GAID remain distinct dimensions.
+4. The receiver authenticates link and device before resolving any GAID claim.
+5. A remote card/claim is evidence only; receiver-local TAK, offer, delegation, consent, and tool-grant intersection remain authoritative.
+6. `TaskRun`/`TaskMessage`/`TaskArtifact` own task execution/history; `CoworkerEngagement` owns the accepted service/authority context.
 7. Same-org is the only enabled preset; cross-org stays deny-by-default.
-8. All migrations are forward-only and tolerate arbitrary existing data.
-9. The canonical runtime is the only runtime truth; worktree tests are source-local evidence only.
+8. Every migration is forward-only and tolerates arbitrary existing data.
+9. Demand federation remains usable when A2A is disabled, unready, quarantined, or failing.
+10. The canonical runtime is the only runtime truth.
 
-## 5. Phase 0 — Claim, preflight, and red contract tests
+## 5. P0 — Parity, overlap, and build preflight
 
-**Delivery:** internal sequencing; not independently shippable.  
-**Dependencies:** live coverage receipt in §3; fresh worktree from `main`; a claimed WorkCapsule for `BI-BE0E14E0`.
+**Delivery:** sequencing-only under `BI-BE0E14E0`; no production code.
 
-### Tasks
+1. Query the live local BI, its epic, all six child BIs, and synchronized peer references.
+2. Sweep open PRs, active WorkCapsules, code graph, `origin/main`, and the other install's mirrored work before claiming a slice.
+3. Record an explicit counterpart/alias when synchronized work matches one of the peer BIs; do not copy a peer-local identifier into local authority without the sync contract.
+4. Re-check A2A v1.0, MCP Tasks direction, CloudEvents 1.0, RFC 9421, RFC 9530, and RFC 8785 if implementation begins after a standards revision.
+5. Verify worktree readiness. A source-only worktree may author/review docs, but an implementation thread must become compile-ready before claiming source-local gates.
+6. Claim only the selected slice BI and refresh its plan coverage/context before code.
 
-1. Start a new isolated worktree/branch for `BI-BE0E14E0`; fetch `origin/main`, confirm compile readiness, and claim the WorkCapsule through DPF MCP.
-2. Run `dpf-verify-substrate-first` again against current `main`; stop if another branch has changed GAID, TaskRun, FederationLink, environment, Agent Card, or A2A contracts.
-3. Use `dpf-tdd` and add failing contract tests before production changes:
-   - `packages/db/src/federation-link-types.test.ts` — A2A readiness requires trusted link, pinned device, approved issuer binding, and same-org relationship;
-   - `packages/db/src/federated-record-sync.test.ts` — `agent-card` mirror create/update/withdraw/revoke semantics;
-   - a new `packages/db/src/federated-a2a-contract.test.ts` — closed event types, A2A version, GAID context, environment registry, size/idempotency validation;
-   - `apps/web/lib/federation/cloud-event-guard.test.ts` — signed A2A events fail without the new security context;
-   - `apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts` — cross-link task isolation and canonical TaskRun mapping;
-   - API route tests for wrong/missing token, device signature, issuer binding, GAID card, task ownership, and cross-org denial.
-4. Capture the expected request/response fixtures under the existing test modules; never place tokens or private keys in committed fixtures.
+**Stop conditions:** unresolved duplicate ownership, a changed canonical contract, a missing live BI, a commandment conflict, or a federation/BI-sync change that makes the install-authority boundary ambiguous.
 
-### Verification
+## 6. S1 — GAID issuer namespace and identity continuity
 
-- Run the selected tests and record the intended red failures, proving each test fails because behavior is absent rather than because fixtures or imports are broken.
-- Confirm no production file changed in this phase except test fixtures/helpers needed to express the contract.
+**BI:** `BI-F51DC0D3`
 
-## 6. Phase 1 — Schema and canonical-contract convergence
+**Delivery:** independent identity-conformance PR; no federation route changes.
 
-**Delivery:** internal sequencing; feature remains disabled.  
-**Dependencies:** Phase 0 red tests.
+### Expected files
 
-### Files
-
-- `packages/db/prisma/schema.prisma`
-- one new forward-only migration under `packages/db/prisma/migrations/`
-- `packages/db/src/federation-link-types.ts` and test
-- `packages/db/src/federated-record-sync.ts` and test
-- new `packages/db/src/federated-a2a-contract.ts` and test
-- `packages/db/src/founder-shared-portfolio.ts` and test
-- `packages/db/src/index.ts`
-- a new data-impact record under `docs/data-impact/`
+- `apps/web/lib/identity/principal-linking.ts` and tests
+- `apps/web/lib/identity/aidoc-resolver.ts` and tests
+- canonical issuer configuration/type owner selected after the preflight
+- one forward-only alias/backfill migration if live data requires it
+- `docs/architecture/GAID.md` implementation note, only if the implementation contract is not already stated
 
 ### Tasks
 
-1. Add a Prisma enum for the existing federation environment vocabulary: `production`, `development`, `test`. Export the generated TypeScript registry once; all federation demand and A2A consumers import it.
-2. Promote `environmentClass` from `FederationLink.metadata` to the typed link field. Backfill valid values; map missing/invalid legacy values to the current safe `development` fallback. Dual-read during rollout, then remove the metadata write path in the same PR.
-3. Add link-owned peer-device fields to `FederationLink`: device ID, Ed25519 public key, pin timestamp, and rotation timestamp. Keep them nullable so demand-only legacy links remain valid.
-4. Extend the existing federation record-type registry with `agent-card` and the smallest required withdrawal/key-attestation type. Do not add a parallel mirror table.
-5. Converge task initiation and storage:
-   - add nullable `TaskRun.initiatingPrincipalId` relation to `Principal`;
-   - backfill it from existing user principal aliases where a canonical mapping exists;
-   - make `TaskRun.userId` nullable only after existing read paths are audited and the migration remains safe for rows without a principal mapping;
-   - add nullable typed/indexed `TaskRun` fields for federation link ownership, origin event ID, acting/delegating/target GAIDs, origin installation/environment, card/AIDoc digests, and verification receipt reference;
-   - add unique idempotency on `(federationLinkId, originEventId)` when both are present;
-   - add nullable unique `CoworkerEngagement.taskRunId` relation;
-   - **coordinate this with Slice 4 (`BI-06B66FFD`, standard MCP Tasks lifecycle over `TaskRun` via `apps/web/lib/mcp/tasks-lifecycle.ts`)** where the installs share it: both converge the same `TaskRun` rows, so they must land as one convergence and one migration, not two competing ones.
-6. Keep `a2aMetadata` for non-authoritative protocol extensions only; new authorization and uniqueness checks must use typed columns.
-7. Make every migration data-state agnostic: no assumption that every User already has a Principal, every link already has metadata, or every engagement already has a task.
+1. Add red tests for cross-install collision, legacy alias lookup, explicit continuity, and the current `priv` versus `private` scope-token split.
+2. Replace federation advertisement of `gaid:priv:dpf.internal:*` with a governed stable issuer namespace while preserving legacy aliases for local resolution.
+3. Preserve a canonical GAID across installs only when a governed continuity record proves the same enduring subject; matching `agentId` or configuration is insufficient.
+4. Keep all identity resolution on `Principal` + `PrincipalAlias`; do not add an `Agent.gaid` column or remote-agent table.
+5. Verify AIDoc resolution and every current local caller continue to work.
 
-### Verification
+### Done
 
-- Prisma schema validation and generated client/type checks pass.
-- Migration applies to a clean database and an upgrade fixture containing: missing link metadata, invalid metadata, demand-only trusted link, task without principal mapping, and legacy engagement-backed A2A task.
-- Registry and pure-contract unit tests pass.
-- Existing federated-demand environment tests remain green.
+Distinct subjects cannot collide, continuity is evidence-backed, legacy aliases resolve locally, and no non-conformant private GAID is advertised as federated assurance.
 
-## 7. Phase 2 — Complete the federation device trust binding
+## 7. S2 — Peer-device pinning and signed federation events
 
-**Delivery:** internal sequencing; A2A readiness can be observed but not enabled.  
-**Dependencies:** Phase 1 schema.
+**BI:** `BI-51FA49EB`
 
-### Files
+**Delivery:** independent security-foundation PR; `DPF_FEDERATION_A2A_ENABLED` remains off.
 
-- `apps/web/lib/federation/instance-identity.ts` and test
-- `apps/web/lib/federation/demand-identity.ts` and test
-- `apps/web/lib/federation/sas-pairing.ts` and test
-- `apps/web/lib/federation/enrollment.ts` and mutual-token tests
-- `apps/web/lib/federation/nearby-pairing-service.ts` and test
-- `apps/web/lib/federation/wire-contract.ts`
-- `apps/web/lib/auth/federation-link-token.ts`
-- new `apps/web/lib/federation/message-signature.ts` and test
+### Expected files
+
+- `packages/db/prisma/schema.prisma` plus one forward-only migration and data-impact record
+- `packages/db/src/federation-link-types.ts` and tests
+- `apps/web/lib/federation/instance-identity.ts`, `demand-identity.ts`, `sas-pairing.ts`, `enrollment.ts`, and tests
+- `apps/web/lib/federation/cloud-event-guard.ts` and tests
+- new `apps/web/lib/federation/message-signature.ts` and tests
 
 ### Tasks
 
-1. Extend enrollment/pairing messages to exchange `inst_…`, `did_…`, and Ed25519 public key inside the authenticated/approved transcript.
-2. Verify `deriveDeviceId(publicKey) === deviceId` before persistence. Include both installation IDs and both device IDs in the SAS transcript.
-3. Require explicit dual approval for first pin and every rotation; do not overwrite a pinned key in response to ordinary traffic.
-4. Implement RFC 9421 signing and verification with Node's existing crypto primitives:
-   - Ed25519 only for v1;
-   - cover method, target URI/authority, content type, `Content-Digest`, A2A/federation version headers, creation/expiry, nonce, and key ID;
-   - strict algorithm/key-ID matching and bounded clock/replay windows;
-   - sign both directions.
-5. Derive A2A readiness from existing link lifecycle plus pinned device and issuer binding. Keep demand readiness independent.
-6. Snapshot the verified public key/fingerprint and signature evidence in immutable verification receipts so historical proof survives key rotation.
+1. Promote the existing production/development/test federation environment vocabulary from metadata to its typed canonical field with a data-state-safe backfill and bounded compatibility read.
+2. Add nullable link-owned peer device ID, Ed25519 public key, pin time, and rotation time; legacy demand links remain valid but A2A-not-ready.
+3. Exchange and verify `inst_…`, `did_…`, and public key in the enrollment/SAS transcript. Require `deriveDeviceId(publicKey) === deviceId`.
+4. Require explicit dual approval for first pin and rotation; ordinary traffic cannot replace a key.
+5. Implement RFC 9421 Ed25519 signing/verification and RFC 9530 `Content-Digest` over method, target/authority, content type, federation/A2A versions, creation/expiry, nonce, key ID, and body.
+6. Reuse the existing CloudEvent `dpflinkid` binding and ±15-minute replay window; do not add another envelope guard.
+7. Derive independent `demand-ready` and `a2a-ready` states and preserve immutable verification evidence across key rotation.
 
-### Verification
+### Done
 
-- Unit vectors prove signing success and failure for body mutation, header mutation, wrong path, wrong device, expired signature, replayed nonce, and old key after cutover.
-- Pairing/enrollment tests prove no silent token-only downgrade and no unapproved key replacement.
-- Existing mutual-token demand exchange tests remain green.
+Mutation, wrong path/link/device, expired signature, nonce replay, unapproved rotation, and token-only downgrade fail; existing mutual-token demand exchange remains green.
 
-## 8. Phase 3 — GAID issuer conformance and link-scoped Agent Cards
+## 8. S3 — Signed GAID Agent Cards and federated discovery
 
-**Delivery:** internal sequencing; discovery is feature-gated.  
-**Dependencies:** Phase 2 device pinning; coordination with `BI-COWORKER-360-AGENTCARD`.
+**BI:** `BI-B280E853`
 
-### Files
+**Delivery:** independent projection/discovery PR; remote discovery remains capability-gated.
 
-- `apps/web/lib/identity/principal-linking.ts` and test
-- `apps/web/lib/identity/aidoc-resolver.ts` and test
-- `apps/web/lib/tak/agent-card-types.ts`
-- `apps/web/lib/tak/agent-card-service.ts` and test
-- `apps/web/lib/coworker-service-catalog/agent-card.ts` and test
-- `apps/web/lib/coworker-service-catalog/gaid-authority.ts` and test
-- `apps/web/lib/federation/exchange-handlers.ts` and test
-- `apps/web/lib/federation/cross-org-sharing.ts` and test
-- `packages/db/src/federated-record-sync.ts`
+### Expected files
+
+- `apps/web/lib/a2a/agent-card.ts` and tests
+- canonical TAK/coworker Agent Card and AIDoc projection modules
+- `apps/web/lib/mcp/packs/coworker-pack.ts` and discovery tests
+- federation exchange/projection handlers
+- `packages/db/src/federated-record-sync.ts` and tests
 
 ### Tasks
 
-1. Replace federation advertisement of `gaid:priv:dpf.internal:*` with a GAID-standard-conformant issuer namespace configuration. Preserve legacy GAID aliases for local lookup/history; do not infer identity continuity from matching `agentId` strings. **Also fix the latent scope-token split first:** `buildPrivateAgentGaid` emits `gaid:priv:…` while `apps/web/lib/coworker-service-catalog/agent-card.ts:105` emits `gaid:private:…`; converge them (add a red test asserting a single canonical scope token) before any cross-install GAID comparison, or matching silently fails on the scope segment.
-2. Represent approved peer GAID issuer namespaces through the link's existing `AuthorityBinding`; validate that every advertised GAID belongs to an approved prefix.
-3. Produce standard A2A v1.0 Agent Cards from the canonical CoworkerIdentity/AIDoc projection. Reuse the existing card builder; do not fork card construction inside federation. The public export builder already exists at `apps/web/lib/a2a/agent-card.ts` (Slice 6 / `BI-40648BBF`) but currently emits `provenance.signed: false` and no `gaid` field — the delta is adding the device-key JWS signature and the GAID `extensions`, projecting the link-scoped extended card from this same builder. Remote-coworker discovery (Phase 6 catalog) extends `find_coworker` (`apps/web/lib/mcp/packs/coworker-pack.ts`, Slice 10 / `BI-5FB59BC6`) with a link-scoped, projection-gated result set rather than a parallel discovery path.
-4. Add the GAID A2A extension metadata, AIDoc reference/digest, exact service-offer capability, and authenticated federation interface.
-5. Canonicalize cards with RFC 8785 and JWS-sign them using the pinned device key. Separately validate AIDoc issuer status/binding; device possession is not issuer authority.
-6. Project only explicitly allowed cards through `ProjectionContract`, persist them as link-scoped `FederatedRecordMirror` rows, and implement expiry, refresh, withdrawal, revocation, and key-rotation invalidation.
-7. Keep the public/minimal well-known card non-enumerating. Remote coworker discovery uses authenticated extended cards/curated link catalog.
+1. Upgrade the existing unsigned A2A v0.3.0/no-GAID exporter to the reviewed v1.0 card profile; do not create a federation-only builder.
+2. Add the GAID extension, AIDoc reference/digest, exact offers, and authenticated federation interface.
+3. Canonicalize with RFC 8785 and sign with the installation device key; separately verify AIDoc issuer status/binding.
+4. Project only allowed fields through `ProjectionContract` and store peer cards as link-scoped `FederatedRecordMirror(recordType="agent-card")`.
+5. Implement expiry, refresh, withdrawal, revocation, and key-rotation invalidation.
+6. Extend `find_coworker` and the existing coworker/service catalog with verified, link-scoped remote results.
+7. Fail closed for the authenticated federated card path when identity/signing is unavailable. Do not inherit the current public read-only card's fail-open provenance fallback.
 
-### Verification
+### Done
 
-- Card schema/version/signature fixtures validate with the pinned A2A version.
-- Negative tests cover unapproved issuer, GAID/card mismatch, stale AIDoc, withdrawn card, wrong link, wrong key, unprojected offer, and forbidden card fields.
-- A legacy local GAID still resolves internally but is not advertised as federated assurance.
+Valid cards verify against the pinned link/device and GAID issuer; stale, withdrawn, wrong-link/key, mismatched-GAID, unapproved-offer, and forbidden-field cases fail without enumerating private coworkers.
 
-## 9. Phase 4 — Federation A2A ingress, task service, and lifecycle adapter
+## 9. S4 — Federated A2A task ingress over canonical TaskRun
 
-**Delivery:** internal sequencing until Phase 6 UI and Phase 7 live acceptance.  
-**Dependencies:** Phases 1–3.
+**BI:** `BI-90E338D8`
 
-### Files
+**Delivery:** independent protocol/task PR; receiving ingress remains disabled until S5.
 
-- new `apps/web/app/api/v1/federation/a2a/route.ts` and test
-- new modules under `apps/web/lib/federation/` for A2A exchange/delivery, following `demand-exchange.ts` and `demand-delivery.ts`
-- `apps/web/lib/federation/cloud-event-guard.ts` and test
-- `apps/web/lib/federation/client.ts` and test
-- `apps/web/lib/federation/outbound.ts`
-- `apps/web/lib/coworker-service-catalog/a2a-tasks.ts` and test
-- `apps/web/lib/coworker-service-catalog/engagements.ts` and test
-- `apps/web/lib/tak/task-records.ts` and test
-- `apps/web/lib/tak/collaboration-authority.ts` and test
-- `apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts` and test
-- `apps/web/app/api/a2a/tasks/[taskId]/route.ts` and test
+### Expected files
+
+- `packages/db/prisma/schema.prisma` plus a forward-only migration/data-impact record if typed ownership fields are needed
+- new canonical A2A contract module under `packages/db/src/`
+- new `/api/v1/federation/a2a` route and tests
+- federation A2A exchange/delivery modules following the demand patterns
+- `apps/web/lib/mcp/tasks-lifecycle.ts`
+- `apps/web/lib/coworker-service-catalog/a2a-tasks.ts`, `engagements.ts`, and tests
+- existing `/api/a2a/*` routes as internal adapters only
 
 ### Tasks
 
-1. Add the versioned DPF federation A2A contract as A2A payload + GAID extension inside the existing CloudEvents transport. Reuse `cloud-event-guard.ts`'s existing `dpflinkid` link-binding (`=== authenticated linkId`, else `link:mismatch`) and ±15-minute replay window verbatim; the new layer is the RFC 9421 signature over them, not a second envelope validator. Gate the receiving route with a `DPF_FEDERATION_A2A_ENABLED` flag sibling to the existing `DPF_FEDERATION_EXCHANGE_ENABLED`, or a per-link A2A capability bit, so demand and A2A enable independently.
-2. Implement the fixed ingress chain from the spec: link token → device signature/digest → replay/idempotency → link installation/org/environment → issuer/card/AIDoc → target GAID → TAK/delegation/offer/projection/consent → task.
-3. Make the receiver generate `TaskRun.taskRunId`; create/link `CoworkerEngagement` for the accepted offer and persist messages/artifacts through `TaskMessage`/`TaskArtifact`.
-4. Implement non-streaming A2A v1.0 operation semantics needed by the slice: send message/create or continue task, get/list task, additional input, cancel, and retrieve artifact/task snapshot.
-5. Scope every operation by the stored `FederationLink` and verified agent context. A task ID is never sufficient authorization.
-6. Implement durable outbox retry/dead-letter and exact-duplicate idempotency using existing federation delivery patterns. Preserve loop/hop guards and trace context.
-7. Convert the current `/api/a2a/*` cross-boundary paths into internal compatibility adapters to the canonical task service. External/partner requests must go through `/api/v1/federation/*`; remove unauthenticated cross-boundary retrieval.
-8. Stop using the local HMAC delegation receipt as sovereign-peer proof. Keep it for legacy local flows; federated receipts use verified device/link evidence.
-9. Label the surface accurately: do not claim a custom A2A binding unless every standard core operation and mapping requirement is met.
+1. Reconcile current main with peer Slice 4 `BI-06B66FFD`; complete one `TaskRun` convergence rather than competing migrations or task models.
+2. Add closed, versioned A2A CloudEvent payload contracts with size, version, extension, and idempotency validation.
+3. Store federation/link ownership, origin event, acting/delegating/target GAIDs, origin install/environment, card/AIDoc digests, and verification receipt as typed/indexed task ownership where query/integrity needs justify it.
+4. Implement the non-streaming v1.0 operations required by the first slice: message/send, get/list, additional input, cancel, status/history, and artifact retrieval.
+5. Generate the task ID on the receiver and use `TaskRun` as authority; link `CoworkerEngagement` for service/approval context and persist `TaskMessage`/`TaskArtifact` history.
+6. Bind every operation to the authenticated `FederationLink`, verified agent context, and local target. Task-ID possession is never authorization.
+7. Reuse federation delivery/idempotency/loop patterns. Keep `/api/a2a/*` as internal compatibility adapters, not external trust paths.
+8. Claim A2A binding conformance only if all required operations and semantics are implemented; otherwise label the surface as the DPF federation A2A profile.
 
-### Verification
+### Done
 
-- Contract/unit/API tests cover every operation and lifecycle transition, including terminal immutability and input/auth-required behavior.
-- Security tests prove token-only, signature-only, wrong-link task reads, task enumeration, body mutation, replay, cross-org, unprojected target, and over-classification all fail.
-- Concurrency test proves two identical creates yield one canonical task; conflicting same-key payloads fail.
-- Existing internal A2A and federated-demand tests remain green.
+Lifecycle/concurrency tests pass; duplicate creates converge; conflicting idempotency payloads fail; guessed/cross-link task IDs, token-only/signature-only calls, replay, and body mutation are denied; existing internal A2A and demand paths remain green.
 
-## 10. Phase 5 — Policy, receipts, observability, and operational controls
+## 10. S5 — Authority, privacy, receipts, and operations
 
-**Delivery:** internal sequencing.  
-**Dependencies:** Phase 4 task path.
+**BI:** `BI-0E61A6A7`
 
-### Files
+**Delivery:** independent safety/readiness PR; owns the activation predicate, not the operator UI.
 
-- `apps/web/lib/federation/cross-org-sharing.ts` and test
-- `apps/web/lib/security/federation-projection.ts` and test
-- `apps/web/lib/work-management/federation-governance.ts` and test
-- existing federation demand activity/observability modules where shared
-- `apps/web/lib/ai-operations-map/project-a2a-interactions.ts` and tests
-- `apps/web/lib/operate/a2a-collaboration-health/*` and tests
+### Expected files
+
+- TAK collaboration-authority and effective-grant modules/tests
+- federation cross-org/projection/security modules/tests
+- canonical task/receipt/evidence owners
+- existing federation activity/health and A2A operations-map projections
 
 ### Tasks
 
-1. Add same-org A2A policy to the existing relationship/projection resolver. Keep every cross-org path explicitly false unless a later BI supplies the full cross-org contract.
-2. Enforce per-link and per-GAID request size, rate, concurrency, task TTL, retention, and artifact classification limits.
-3. Persist immutable verification/authority receipts with link/device/install/GAIDs/org/environment/card/AIDoc/event/task/decision/trace evidence; never persist tokens, private keys, raw prompts, or unminimized payloads.
-4. Add bounded-cardinality metrics and structured failure categories; keep raw GAIDs out of metric labels.
-5. Project the cross-install task into the existing A2A interaction/operations map without creating a new observability graph.
-6. Quarantine-worthy failures surface through existing link controls; no automatic destructive response.
+1. Enforce the fixed ingress order: link token → device signature/digest → replay/idempotency → install/org/environment → issuer/card/AIDoc → target GAID → local TAK/offer/projection/consent → task.
+2. Keep peer claims evidentiary. Intersect local TAK, delegation, offer, consent, tool grants, sensitivity, and projection policy before execution.
+3. Enable only same-org A2A. Existing demand cross-org privacy is the floor; customer-domain, confidential, restricted, prompt, memory, secret, and private-grant material remains denied.
+4. Add per-link/per-GAID size, rate, concurrency, TTL, retention, and artifact-classification limits.
+5. Persist immutable chain-of-custody and authorization receipts without tokens, private keys, raw prompts, or unminimized payloads.
+6. Add bounded-cardinality metrics, structured failure reasons, retry/stuck state, quarantine/revocation behavior, and existing operations-map projection.
+7. Define one fail-closed readiness predicate used by S6 and rollout.
 
-### Verification
+### Done
 
-- Negative egress tests cover prompts, memory, secrets, internal grants, restricted/confidential data, and verbose errors.
-- Health/operations-map tests show accepted and denied coordination with the right provenance and no duplicate events.
-- Link revoke/quarantine mid-task blocks new peer operations while preserving local audit/history.
+Negative-egress, revocation-mid-task, cross-org, over-classification, authority-denial, and demand-isolation tests pass; accepted and denied work is legible through existing evidence/operations surfaces.
 
-## 11. Phase 6 — Operator UX and accessibility
+## 11. S6 — Operator readiness UX and activation controls
 
-**Delivery:** completes the user-visible vertical slice but remains feature-gated until Phase 7.  
-**Dependencies:** Phases 2–5 read models.
+**BI:** `BI-68AF8D86`
 
-### Files
+**Delivery:** independent UI PR over S3/S5 read models.
 
-- `apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx` and test
-- `apps/web/app/(shell)/platform/federation-links/page.tsx`
-- `apps/web/components/platform/coworker-service-catalog/CoworkerCatalogView.tsx` and test
-- existing engagement/task and A2A interaction timeline components, including `apps/web/components/platform/a2a-interaction-graph.ts` where appropriate
-- shared form/status/disclosure primitives only; no new page shell or card system
+### Expected files
+
+- existing federation-link detail/admin components and page
+- existing coworker/service-catalog components
+- existing engagement/task/A2A interaction timeline
+- shared status, disclosure, confirmation, and report primitives
+- required UX-fit evidence
 
 ### Tasks
 
-1. Add one progressive-disclosure “Agent coordination” section to the federation-link detail: readiness, org, environment, install, short device ID, key/card status, last verified event/failure, projection/authority links, and dual-approved pin/rotation action.
-2. Add projected remote coworkers to the existing service catalog with peer, environment, verification, freshness, offered outcome, risk, and data-boundary information.
-3. Add a consequence-first dispatch confirmation showing both agents, both environments/installations, data classes, write/advisory posture, approval boundary, and retention.
-4. Show task messages, lifecycle, artifacts, and verification receipts on the existing timeline/interaction surface. Default view is plain language; raw identifiers and proof details sit behind disclosure.
-5. Use shared components, generated design tokens, `--dpf-*` colors, semantic headings, text status (not color alone), visible focus, ≥44px targets, accessible names, keyboard operation, reduced motion, and responsive narrow layouts.
-6. Make failure states actionable: needs device confirmation, issuer unverified, card expired, link quarantined, and cross-org not enabled each name one safe next step.
+1. Add progressive-disclosure A2A readiness to the federation link: organization, environment/install, short device identity, issuer/card verification, negotiated version/capability, last refresh/failure, and approved pin/rotation actions.
+2. Show remote coworkers in the existing catalog with peer/environment badges, verified-card freshness, offered outcome, and data boundary.
+3. Provide consequence-first initiation and cancellation showing both agents, both environments, data classes, write/advisory posture, approval boundary, and retention.
+4. Show task lifecycle, messages, artifacts, denials, and verification receipts on existing engagement/interaction surfaces; keep raw proof details behind disclosure.
+5. Make unready states actionable: device confirmation, issuer verification, expired card, quarantine, unsupported version, and cross-org disabled.
+6. Use shared primitives and `--dpf-*` tokens; verify keyboard use, ≥44px targets, text status, visible focus, narrow layouts, reduced motion, light/dark themes, and organization branding.
 
-### Verification
+### Done
 
-- Component tests cover readiness states, provenance ordering, confirmation consequence copy, failures, and hidden technical detail.
-- Axe and semantic/ARIA snapshots have no new violations.
-- Visual verification covers light/dark themes, organization branding, desktop/narrow viewport, keyboard-only operation, reduced motion, loading, empty, stale, error, and success states.
+Component, accessibility, and measured UX-fit evidence pass; the UI never implies A2A readiness unless S5's canonical predicate is true.
 
-## 12. Phase 7 — Completion gate and canonical-runtime acceptance
+## 12. Acceptance and rollout
 
-**Delivery:** the only independently releasable outcome: complete same-org A2A slice.  
-**Dependencies:** all prior phases.
+**Owner:** umbrella `BI-BE0E14E0`; not another implementation BI.
 
-### Source-local gate
+### Per-slice gate
 
-1. Run affected Vitest suites for `packages/db` and `apps/web`.
-2. Run Prisma validation/generation and apply the migration to clean and representative upgrade fixtures.
-3. Run the production web build with zero errors.
-4. Run style/token, route-contract, and documentation checks affected by the UI/routes.
-5. Run a regression suite proving federated demand still exchanges when A2A is off and when A2A verification fails.
+Every slice must:
 
-### Canonical-runtime gate
+1. start with red contract/security tests;
+2. pass affected unit tests;
+3. pass Prisma validation/migration fixtures when schema changes;
+4. pass the production web build;
+5. update its architecture/API/operator docs or record a concrete no-docs-needed reason;
+6. receive independent semantic review on the stable commit;
+7. pass exact-tree local merged-code CI, DCO, ready-PR, and merge-queue handoff.
 
-1. Use `dpf-use-shared-nonprod-environment`; claim the governed environment lease before runtime-bound checks.
-2. Advance the canonical nonproduction install only through the governed install/self-upgrade path. Do not rebuild the live portal from the worktree.
-3. Pair or upgrade the two designated same-org test installs and explicitly approve device pins/issuer bindings.
-4. Exercise the happy path:
-   - discover one projected remote coworker;
-   - inspect verified GAID/AIDoc and environment/install provenance;
-   - submit a bounded task;
-   - receive `working` and `input-required`, send additional input, receive a minimized artifact, and reach `completed`;
-   - retrieve the task from the initiating install and inspect the receipt/timeline.
-5. Exercise negative paths live: wrong/rotated device key, stale card, unprojected GAID, cross-org preset, task ID from another link, revoked link, and development-to-production consequential action without local approval.
-6. Run the UX fit review against the live portal. Capture screenshots/evidence links through the governed verification record.
-7. Complete independent semantic review of the stable committed tree, local merged-code CI, DCO-signed commit, push, ready PR, and merge-queue handoff.
+### Canonical-runtime two-install gate
 
-### Definition of done
+After S1–S6 merge:
 
-- All eight BI acceptance criteria pass with recorded evidence.
-- Unit, production build, migration, UX, and final-acceptance evidence is attached to `BI-BE0E14E0`/its WorkCapsule.
-- Cross-org remains disabled and negative-tested.
-- Documentation in §13 is current.
-- `pnpm pr:health <PR>` reports merge-ready; no visual-scan substitution.
+1. Re-run the BI parity/crosswalk audit and confirm both installs show the same implementation graph without ambiguous duplicate ownership.
+2. Use the governed nonproduction environment/lease and canonical self-upgrade path; never rebuild the live portal from a worktree.
+3. Upgrade both designated same-org installs and explicitly approve device pins and issuer bindings.
+4. Happy path: discover a projected remote coworker; inspect GAID/AIDoc and install/environment provenance; submit a bounded task; receive working/input-required; add input; receive a minimized artifact; complete; retrieve the task and receipt from the initiating side.
+5. Negative paths: wrong/rotated device key, token-only request, replay, stale/withdrawn card, unprojected GAID, task ID from another link, revoked/quarantined link, unsupported version, cross-org preset, and development-to-production consequential work without local approval.
+6. Prove demand federation still functions when A2A is off and when A2A authentication fails.
+7. Run live UX-fit review and record screenshots/evidence against the umbrella WorkCapsule.
+8. Enable `DPF_FEDERATION_A2A_ENABLED` only for the approved same-org link after every positive and negative case passes.
 
-## 13. Documentation updates in the implementation PR
+### Umbrella done
 
-- `docs/architecture/GAID.md` — implementation/conformance note for issuer configuration, device-bound HTTP claims, and legacy alias migration; do not duplicate the standard's normative rules.
-- federation architecture/orientation and pairing operator docs — A2A readiness, device pinning/rotation, capability negotiation, and failure recovery.
-- API/contract docs — A2A version, extension URI, event/operation mapping, error taxonomy, and conformance label.
-- service-catalog/coworker help — remote provenance, data boundary, and task ownership.
-- route map if endpoints change.
-- `docs/install/platform-support-watchlist.md` only if Windows/macOS/Linux crypto or key-store behavior differs.
+- all six child BIs are done with governed evidence;
+- the cross-install BI view has explicit counterpart mapping and no unresolved duplicate ownership;
+- the live happy path and all negative paths pass on both canonical installs;
+- cross-org remains disabled;
+- demand regression evidence is green;
+- the spec, plan, route/architecture docs, and operator guidance match shipped behavior.
 
-## 14. Risks and mitigations
+## 13. Architecture review
 
-| Risk | Blast radius | Mitigation |
+**Verdict:** aligned after decomposition.
+
+| Lens | Result | Required control |
 | --- | --- | --- |
-| TaskRun principal convergence breaks existing task creators | every coworker/build/task producer | nullable additive migration, exhaustive call-site grep, backfill, dual-read tests, no fabricated users |
-| Environment migration changes demand classification | founder shared portfolio and production eligibility | reuse existing values/default, backfill fixtures, demand regression tests, no new vocabulary |
-| Device signing breaks current demand links | all sovereign-peer traffic | separate `demand-ready` from `a2a-ready`; no requirement for signatures on legacy demand until its own governed migration |
-| GAID alias migration fragments history | identity, receipts, links | retain legacy aliases, canonical alias mapping, no rename-by-agentId, issuer/status tests |
-| Card projection leaks coworker internals | org/customer privacy | authenticated extended cards, explicit field allowlist, forbidden-field negative tests |
-| Task ID enumeration exposes remote work | cross-link confidentiality | typed link ownership on every read/list/cancel/add-input path; non-enumerating errors |
-| Key rotation destroys historic proof | audit/nonrepudiation | immutable receipt snapshots of verified public key/fingerprint and local acceptance decision |
-| “A2A compliant” overclaim | interoperability and trust | conformance tests; label DPF profile accurately unless all core requirements pass |
-| UI collapses identity dimensions | operator error between prod/dev | fixed org → environment/install → GAID hierarchy; accessible text labels and consequence confirmation |
+| Canonical contracts | aligned | protocol types live in the existing DB/shared-contract owner; wire adapters map versions |
+| Identity stewardship | aligned | GAID/AIDoc and `PrincipalAlias` only; no remote-agent or per-agent credential store |
+| Trust/transport | aligned | A2A extends `FederationLink` + CloudEvents + mutual tokens + pinned device signing |
+| Data-model stewardship | aligned with slice separation | link/device fields in S2; task ownership in S4 only when query/integrity requires typed columns |
+| Task source of truth | aligned | `TaskRun` owns lifecycle; `CoworkerEngagement` owns service/authority context |
+| Discovery source of truth | aligned | extend the existing Agent Card builder and `find_coworker` |
+| Backlog sovereignty | aligned with guardrail | BI sync provides mirrored/crosswalk coordination; local `BacklogItem` remains authoritative |
+| Privacy | aligned | same-org only, projection allowlists, receiver-local TAK, deny-by-default cross-org |
+| Operability | aligned | independent demand/A2A readiness and kill switches; canonical runtime acceptance |
 
-## 15. Rollback and recovery
+Review corrections carried into the plan:
 
-1. Disable A2A capability per link; do not revoke the federation link unless the relationship itself is compromised. Federated demand continues.
-2. Stop A2A outbox delivery and preserve pending/dead-letter events for inspection; never replay after re-enable without current card/link validation.
-3. Keep additive schema fields and backfilled environment data. Rollback application code by deployment; forward-fix migrations rather than reversing committed migrations.
-4. Preserve TaskRun/engagement/message/artifact and verification receipts. Disable remote mutation while allowing authorized local read/audit.
-5. If a key is suspect, quarantine the link, rotate through dual approval, invalidate current card bindings, and require reprojection before A2A readiness returns.
-6. If GAID issuer binding is wrong, withdraw affected cards and block new tasks; preserve aliases/history while correcting the canonical issuer mapping.
-7. Recovery is complete only after demand regression, A2A negative tests, and one fresh signed same-org task pass on the canonical runtime.
+1. The former atomic implementation scope is replaced by six feature-disabled, independently reviewable slices.
+2. GAID conformance is separated from Agent Card federation so identity correctness can land first.
+3. Device/link authentication is separated from task semantics and cannot silently upgrade legacy demand links.
+4. The authenticated federated card path is explicitly fail-closed; the current public read-only builder's fail-open provenance fallback is not reused there.
+5. MCP Tasks/`TaskRun`, Agent Card, and `find_coworker` are dependencies and extension seams, not parallel implementations.
+6. BI parity is a coordination layer outside A2A and cannot create multi-writer backlog authority.
+
+## 14. Rollback and recovery
+
+1. Disable A2A per link without revoking the federation relationship; demand continues.
+2. Stop A2A delivery and preserve pending/dead-letter records for inspection. Revalidate link/card state before replay.
+3. Keep additive schema/backfill data and roll application code through the governed deployment path; forward-fix committed migrations.
+4. Preserve task, engagement, message, artifact, and verification history while remote mutation is disabled.
+5. On device compromise, quarantine the link, rotate by dual approval, invalidate current card bindings, and require reprojection.
+6. On issuer error, withdraw affected cards and block new tasks while preserving alias/history continuity.
+7. Recovery is complete only after demand regression, A2A negative tests, and one fresh signed same-org task pass in the canonical runtime.

--- a/docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md
+++ b/docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md
@@ -2,9 +2,11 @@
 
 **Date:** 2026-08-08
 
-**Status:** Architecture-reviewed; implementation scope decomposed and governed
+**Status:** Architecture-reviewed; enterprise identity-boundary amendment governed; implementation scope decomposed
 
 **Decision:** `DI-B726A1900E7C` — link-bound signed GAID claim
+
+**Identity-boundary decision:** `DI-6FE234A7399E` — protected full participation graph plus public boundary projection and signed commitment
 
 **Implementation-scope decision:** `DI-61395D1B7A6D` — six independently reviewable, feature-gated slices under one same-org umbrella
 
@@ -27,6 +29,14 @@ The selected design carries a typed GAID claim and standard A2A data model insid
 
 This extends the federation substrate. It does not introduce a second transport, a new agent-identity scheme, a remote-agent table, or per-agent credentials.
 
+Enterprise identity is deliberately two-view. Each sovereign source retains a complete,
+receipt-linked graph of every materially participating agent by canonical GAID. Before an event,
+card, artifact, receipt, error, or response crosses an organization boundary, the existing
+`ProjectionContract` derives a boundary view containing only approved `gaid:pub` aliases. When
+internal participants are withheld, the signed response says so and carries a privacy-preserving
+commitment to the protected graph. The public boundary agent remains accountable without exposing
+the company's private agent inventory or topology.
+
 ## 2. Problem and first slice
 
 The organization's production and development installations already exchange federated demand as sovereign peers. The next layer is a coworker on one installation delegating a task to a coworker on the other while an operator can prove:
@@ -45,6 +55,8 @@ The first product slice is same-organization, two-install coordination over an a
 - link-scoped discovery of eligible remote coworkers using A2A v1.0 Agent Cards;
 - authenticated A2A task initiation, status retrieval, additional input, cancellation, and artifact return;
 - device-signed binding of acting/delegating GAIDs to the existing federation request;
+- complete source-side multi-agent participation custody and policy-derived same-org/cross-org
+  identity projection;
 - receiver-side target resolution, TAK authority checks, projection minimization, replay protection, task ownership, and audit receipts;
 - an operator-facing A2A readiness and provenance view on the existing federation-link and engagement surfaces;
 - a compatibility path from the current DPF A2A-shaped service-offer/task implementation to the standard A2A data model.
@@ -108,6 +120,11 @@ The canonical runtime projection is not an `Agent.gaid` column. [`apps/web/lib/i
 
 `buildPrivateAgentGaid` currently emits `gaid:priv:dpf.internal:<agent-id>`. The GAID standard requires a private issuer prefix to include a stable installation, domain, or equivalent namespace discriminator. `dpf.internal` alone cannot guarantee uniqueness across sovereign installations. Therefore, a current private GAID string must not be promoted to “globally verified” merely because it parses.
 
+The GAID standard's enterprise identity-boundary contract is now normative in
+[`docs/architecture/GAID.md`](../../architecture/GAID.md) §§6.5 and 10.6. It distinguishes the
+complete protected participation graph from the public boundary projection. This specification
+profiles that rule for A2A; it does not restate GAID subject semantics or mint a boundary-only ID.
+
 The build slice must first converge issuer configuration and alias continuity using the existing GAID/PrincipalAlias model:
 
 - use a stable, governed issuer namespace shared by the administrative authority for an enduring agent subject;
@@ -126,8 +143,19 @@ For the same-organization slice, the link's approved `AuthorityBinding` names th
 - [`apps/web/lib/tak/coworker-collaboration.ts`](../../../apps/web/lib/tak/coworker-collaboration.ts) already creates local delegation chains through the canonical work-thread path.
 - [`apps/web/lib/tak/agent-card-service.ts`](../../../apps/web/lib/tak/agent-card-service.ts) projects `dpf.agent-card.v1` with GAID/AIDoc and effective tool authority.
 - [`apps/web/lib/coworker-service-catalog/a2a-tasks.ts`](../../../apps/web/lib/coworker-service-catalog/a2a-tasks.ts) already persists A2A-shaped task status, messages, artifacts, GAIDs, call chains, and receipts.
+- `TaskRun` already owns `TaskNode`/`TaskNodeEdge`, which represent parent relationships,
+  fan-out/fan-in dependencies, worker roles, authority/evidence contracts, and influence. `TaskArtifact`
+  already carries producer agent/node references. This is the canonical graph substrate for the
+  participation view; no `AgentParticipationGraph` table is authorized.
 
 The current cross-boundary service-offer POST requires `actingAgentGaid` and `delegatingAgentGaid`, but accepts them as caller-supplied strings. The current delegation receipt is a local HMAC. Neither proves to another sovereign installation that the authenticated peer device vouched for those GAIDs. That is the gap this design closes.
+
+The current A2A task metadata is also scalar: it records acting, delegating, and delegated GAID
+strings, then returns acting/delegating values unchanged in the external task projection. It does
+not model an arbitrary number of participating agents, fan-out/fan-in, GAID scope validation,
+private-to-public boundary mapping, or egress redaction. A build must replace that scalar seam with
+the canonical participation-graph projection in §8.2; it must not bolt redaction onto individual
+routes.
 
 ### 4.3 Federation transport and trust
 
@@ -163,6 +191,11 @@ An independent substrate sweep (2026-08-08, against `origin/main` at `bc5a0debd`
 4. **Fix the `priv`/`private` GAID scope-token split as part of §4.1 conformance.** `buildPrivateAgentGaid` (`apps/web/lib/identity/principal-linking.ts`) emits `gaid:priv:…`, but the catalog fallback at `apps/web/lib/coworker-service-catalog/agent-card.ts:105` emits `gaid:private:…`. Left unfixed, two installs comparing GAID strings will silently mismatch on the scope token before the namespace question is even reached. This is a latent cross-install bug, not cosmetic.
 5. **Name the feature flag on the existing pattern.** Federation receiving routes are gated by `DPF_FEDERATION_EXCHANGE_ENABLED` (`apps/web/app/api/v1/federation/**`). A2A adds a sibling `DPF_FEDERATION_A2A_ENABLED` (or a per-link A2A capability bit) so demand and A2A gate independently — the plan's "feature-gated" phrasing resolves to this concrete flag.
 6. **Reuse the CloudEvent link-binding and replay primitives verbatim.** `cloud-event-guard.ts` already enforces the `dpflinkid` extension (`=== authenticated linkId`, else `link:mismatch`) and a ±15-minute replay window. The A2A event types (§8.3) ride these unchanged; the new work is the RFC 9421 signature layer over them (§9), not a second envelope validator.
+7. **Project participation from the canonical task graph.** `TaskRun` already owns
+   `TaskNode`/`TaskNodeEdge`; `TaskArtifact` already records producer agent/node references. S4 adds
+   the minimum canonical Principal/GAID and receipt bindings those nodes require, then derives the
+   protected participation graph from them. It does not add an A2A participation or receipt graph
+   table.
 
 ## 5. Research and benchmarking
 
@@ -181,6 +214,27 @@ The [A2A v1.0 specification](https://a2a-protocol.org/latest/specification/) def
 - the standard rule that every incoming request is authenticated and authorized by the receiving server.
 
 A2A explicitly leaves identity at the protocol layer. DPF therefore adds a GAID extension profile and uses the federation trust envelope as that protocol-layer identity mechanism. This is an extension, not a competing A2A identity proposal.
+
+The official [enterprise implementation guidance](https://a2a-protocol.org/latest/topics/enterprise-ready/)
+adds useful expectations for TLS, standard web authentication, least privilege, data minimization,
+distributed tracing, audit, and API management. The core specification also requires authorization
+scoping on every operation, permits authenticated extended Agent Cards, supports signed cards, and
+provides negotiated strongly typed extensions. DPF adopts all of those mechanisms.
+
+The enterprise gap is explicit rather than rhetorical:
+
+| Enterprise concern | A2A v1.0 position | DPF GAID profile |
+| --- | --- | --- |
+| Enduring agent-subject identity | identity is handled outside A2A payload semantics | canonical GAID/AIDoc through `Principal` + `PrincipalAlias` |
+| Internal versus external agent identity | no private/public agent alias or boundary-mapping contract | GAID §§6.5 and 10.6 |
+| Multi-agent delegation/contribution custody | task history and trace hooks, but no normative participant graph | receipt-linked acyclic participation graph |
+| Cross-org topology minimization | general data-minimization guidance; authorization model is implementation-defined | `ProjectionContract`-derived public view, no private GAIDs |
+| Proof that withheld lineage was not rewritten | no normative selective-disclosure or commitment object | signed, nonce-hiding participation commitment |
+| Multi-tenancy | opaque routing by URL, credentials, or `tenant` | retained as routing only; never treated as GAID or disclosure authority |
+
+The DPF profile uses A2A's extension negotiation and metadata points. It does not modify standard
+Task, Message, Artifact, Agent Card, authentication, or routing semantics. A peer that does not
+understand the required GAID boundary extension cannot participate in cross-organization DPF A2A.
 
 DPF does **not** declare the CloudEvent carrier itself to be an A2A-compliant custom binding in the first slice. A2A requires a custom binding to implement every core operation and preserve the complete data model and semantics. Instead, DPF treats the CloudEvent as its authenticated federation delivery envelope; the typed payload and adapter implement the A2A operation/data semantics. Public custom-binding conformance is a later standards decision.
 
@@ -239,6 +293,23 @@ The largest positive pulls were Ship Real Functionality, Never Assume — Verify
 
 **Per-agent credential.** Rejected for this layer because it creates a second credential lifecycle, turns every coworker into a remote security principal at transport level, and duplicates the install trust already established by `FederationLink`. A future high-assurance profile may add agent-held proof as an additional factor, but it cannot replace or bypass the link.
 
+### 6.4 Enterprise identity-boundary decision
+
+`principle_decide` recorded `DI-6FE234A7399E` against the platform profile for the second core
+question: how a complete multi-agent GAID chain crosses an organization boundary.
+
+| Option | Composite | Disposition |
+| --- | ---: | --- |
+| Full private/internal chain disclosure | `4.529` | rejected: exposes protected identity and topology |
+| Public alias for every internal hop | `6.975` | rejected: forces unnecessary public issuance and still exposes topology |
+| **Protected full graph + minimized public view + signed commitment** | **`10.673`** | **selected** |
+| Boundary agent only, with no commitment | `6.529` | rejected: loses verifiable custody and can falsely imply sole performance |
+
+Margin over the runner-up was `3.698`; confidence was high; structured coverage was strong; no
+commandment conflict was found. The strongest positive contributions were Ship Real Functionality
+and Research and Use Standards. The selected option also best fits principal convergence,
+projection-contract reuse, data privacy, and evidence density.
+
 ## 7. Target architecture
 
 ```mermaid
@@ -277,6 +348,33 @@ The proof is intentionally layered:
 | Environment | closed installation classification | production, development, staging, or other governed class | identity |
 | Authority | local TAK, delegation, offer, projection, and consent rules | may this action occur here? | transport authenticity |
 
+The enterprise identity boundary is a projection boundary, analogous to network address/topology
+screening but without creating translated agent identities:
+
+```mermaid
+flowchart LR
+    subgraph S["Source organization — protected view"]
+      A1["GAID private — originator"]
+      A2["GAID private — specialists"]
+      A3["GAID public/private — accountable boundary agent"]
+      TG["TaskRun + TaskNode/TaskNodeEdge + receipts"]
+      A1 --> TG
+      A2 --> TG
+      A3 --> TG
+    end
+
+    PC["ProjectionContract\nrelationship + field policy"]
+    BP["Boundary projection\npublic GAIDs + minimized marker"]
+    CM["Signed hiding commitment\nto protected graph"]
+
+    TG --> PC --> BP
+    TG --> CM --> BP
+    BP --> R["External relying party"]
+```
+
+The relying party can verify the boundary signature and later request an authorized commitment
+opening, but cannot enumerate the protected agents or topology from the ordinary response.
+
 ## 8. Canonical contracts
 
 ### 8.1 Federation link identity extension
@@ -307,7 +405,23 @@ type DpfFederatedAgentContextV1 = {
   gaidIssuerBindingRef: string;
   aidocDigest: string;
   agentCardDigest: string;
-  delegationChainRef?: string;
+  boundaryProjection: {
+    mode: "full" | "boundary-minimized";
+    policyRef: string;
+    publicParticipants: Array<{
+      publicHopId: string;
+      agentGaid: string;
+      role: "originator" | "delegator" | "actor" | "contributor" | "approver" | "executor" | "publisher";
+      visibleParentHopIds: string[];
+    }>;
+    participationMinimized: boolean;
+    commitment?: {
+      algorithm: "sha-256";
+      canonicalization: "RFC8785";
+      digest: string;
+      receiptRef: string;
+    };
+  };
   organizationRef: string;
   installationId: string;
   environmentClass: "production" | "development" | "test";
@@ -316,6 +430,43 @@ type DpfFederatedAgentContextV1 = {
 ```
 
 The final field names must be generated from or directly mapped to the A2A extension contract. `organizationRef` resolves to canonical Organization identity; no organization name, logo, or contact duplicate is stored here. Environment remains alongside GAID and never becomes part of GAID.
+
+The source-side task/evidence record holds a `participationGraphRef` that resolves to an immutable
+versioned projection of `TaskRun` + `TaskNode` + `TaskNodeEdge`, joined to canonical Principal/GAID
+and existing receipt/evidence records. A hop is material when an agent originates, delegates, authorizes,
+approves, transforms, executes, or publishes part of the interaction. Stable `hopId` and
+`parentHopIds` fields preserve fan-out/fan-in; this is not limited to a three-scalar call chain.
+Tools, queues, and deterministic infrastructure are not agent hops unless they are independently
+governed agent subjects.
+
+Projection is performed once, before signing and serialization, and the resulting object is reused
+by CloudEvents, A2A Task/Message/Artifact responses, Agent Cards, receipts, errors, and peer-visible
+operational views. Route-local projection logic is forbidden.
+
+For same-org links, `mode="full"` may carry private or federated GAIDs only when the
+`ProjectionContract` explicitly allows every field. For cross-org links:
+
+- `mode` must be `boundary-minimized`;
+- every disclosed participant GAID must be `gaid:pub` and resolve through a governed
+  `PrincipalAlias` boundary mapping for the same canonical Principal;
+- undisclosed participants, their count, roles, edges, installation/device IDs, and private GAIDs
+  are hidden by default;
+- the enrolled boundary installation/device identifiers already disclosed by `FederationLink` may
+  remain as transport evidence, but identifiers for other internal installations/devices are hidden;
+- public hop identifiers and `visibleParentHopIds` are projection-local and never encode or point
+  to a withheld hop;
+- `participationMinimized=true` and `commitment` are mandatory when any material hop is hidden;
+- a public accountable agent must be named, but the projection must not claim that agent was the
+  sole performer;
+- failure to resolve a required public alias or create the commitment denies egress.
+
+The source-local `participationGraphRef` is never serialized across the organization boundary.
+The commitment is a SHA-256 digest over the RFC 8785 canonical form of the full protected graph,
+task/event context, and projection-policy version plus a high-entropy private nonce. The device
+signature covers the public projection and commitment. The nonce and protected graph stay in the
+source evidence store and are disclosed only through an authorized audit opening. A raw unsalted
+hash is forbidden because predictable identifiers would permit dictionary testing. Hidden-hop
+count is not disclosed unless the `ProjectionContract` expressly permits it.
 
 ### 8.3 CloudEvent carrier
 
@@ -354,8 +505,10 @@ The existing implementation currently treats `CoworkerEngagement.engagementId` a
 - `CoworkerEngagement` remains the accepted service offer, contract, funding, approval, and provider relationship.
 - `TaskRun` becomes the canonical A2A task lifecycle and receiver-generated A2A task ID.
 - `TaskMessage` and `TaskArtifact` remain the canonical history and result records.
+- `TaskNode` and `TaskNodeEdge` remain the canonical execution/contribution topology; S4 adds only
+  the minimum agent-Principal/GAID and receipt bindings needed to derive the participation graph.
 - `CoworkerEngagement` gains a nullable unique relation to its `TaskRun`; the existing adapter continues to accept engagement IDs during migration but returns the canonical task ID.
-- `TaskRun` gains typed/indexed federation ownership, origin event/idempotency, GAID, installation/environment, card/AIDoc digest, and receipt-reference fields. Security and uniqueness do not depend on querying `a2aMetadata` JSON.
+- `TaskRun` gains typed/indexed federation ownership, origin event/idempotency, GAID, installation/environment, card/AIDoc digest, protected participation-graph reference, boundary-projection policy/version, commitment, and receipt-reference fields where query or integrity requirements justify them. Security and uniqueness do not depend on querying `a2aMetadata` JSON.
 
 `TaskRun.userId` is currently mandatory, which would tempt a remote GAID to be represented as a fabricated local user. The sound refactor is principal convergence: add `initiatingPrincipalId`, backfill it from each existing user's canonical Principal, make `userId` nullable only after the dual-read/backfill gate, and use the `FederationLink` peer Principal as the transport initiator for federated tasks. The verified acting GAID stays a separate typed claim; the peer-install principal and speaking agent are never collapsed.
 
@@ -368,8 +521,30 @@ At minimum, the receiver can query and index:
 - current A2A task state and context ID;
 - card/AIDoc digest used at acceptance;
 - delegation/authority receipt reference.
+- protected participation-graph/evidence reference and the exact boundary projection/commitment used for each egress.
 
 Task reads, cancellation, and additional messages authorize against this stored link ownership and GAID context, never against possession of a task ID alone. This consolidation is the planned refactoring allocation for the slice; no cosmetic refactor displaces it.
+
+### 8.6 Enterprise scale and topology privacy
+
+The participation graph is a bounded contract, not an unbounded metadata bag:
+
+- graph nodes, edges, depth, serialized bytes, and public participant count have versioned limits;
+  over-limit work is rejected or split into linked tasks before federation egress
+- hop and receipt identifiers are stable within the task but are not metric labels
+- repeated status/artifact events reference an immutable graph version and commitment rather than
+  retransmitting the full protected graph
+- material graph changes create a new immutable version, commitment, and receipt; prior evidence is
+  never overwritten
+- each sovereign install stores its own protected graph and can operate without a global online
+  resolver on the task hot path; public GAID/AIDoc status is cached under bounded freshness rules
+- an organization does not have to publish a GAID for every internal helper; only agents exposed as
+  externally accountable participants require public boundary mappings
+- retry, fan-out, fan-in, partial failure, cancellation, and revocation preserve parent receipt and
+  graph-version links without copying another organization's protected topology
+
+This keeps external evidence size predictable while preserving full source-side accountability for
+large enterprises with many internal agents and installations.
 
 ## 9. Ingress verification and authorization
 
@@ -382,12 +557,18 @@ The receiver processes every cross-install A2A request in this fixed order:
 5. Validate CloudEvents 1.0, time window, event ID uniqueness, event type, payload size, and closed contract version.
 6. Derive the authoritative organization/environment from the link and its explicit `organization-crosswalk`; require body claims to match, never use them as authority.
 7. Require the event's installation ID and device key ID to match the link's approved peer projection.
-8. Validate each GAID syntactically; verify its issuer prefix against the link's approved AuthorityBinding; then require the acting/delegating GAIDs to match a current, non-withdrawn, device-signed Agent Card and issuer-verifiable AIDoc mirror on this link.
+8. Validate each disclosed GAID syntactically and for the relationship scope; cross-org payloads may contain only approved `gaid:pub` aliases. Verify its issuer prefix against the link's approved AuthorityBinding; then require the acting/delegating GAIDs to match a current, non-withdrawn, device-signed Agent Card and issuer-verifiable AIDoc mirror on this link.
 9. Resolve the target GAID locally through `PrincipalAlias`; reject unknown, disabled, revoked, or non-federation-eligible targets.
 10. Evaluate source delegation, target service offer, effective TAK grants, authority band, projection contract, relationship preset, data classification, rate/size/concurrency limits, and any human consent gate.
 11. Create or idempotently return the receiver-owned task and persist a verification receipt containing link, device, installation, GAIDs, organization/environment, card/AIDoc digests, event ID, decision, and trace context.
 
 Any failure is deny-by-default. Error responses reveal the minimum necessary category and correlation ID, not internal agent existence, policies, prompts, or grant details.
+
+Every outbound response follows a corresponding fixed egress order: load the protected graph and
+current relationship → evaluate `ProjectionContract` → resolve public boundary aliases where
+required → build the boundary view → create and persist the nonce-hiding commitment when material
+hops are withheld → scan every output surface for private identifiers → sign → serialize → send.
+Projection failure occurs before signing or outbox persistence as a deliverable event.
 
 ### 9.1 Sender authority is an attestation, not a grant
 
@@ -398,7 +579,12 @@ The peer device signature means “this enrolled installation attests that GAID 
 - `actingAgentGaid` is the agent presently issuing the request.
 - `delegatingAgentGaid` is the accountable upstream agent that delegated this hop; it equals acting GAID when there is no upstream delegation.
 - `targetAgentGaid` is the intended receiver and must resolve locally.
-- multi-hop chains preserve every hop's installation, device, GAID, and receipt; a peer may not collapse the chain to the last speaker.
+- the source-side protected participation graph preserves every material hop's installation,
+  device evidence, GAID, role, edges, and receipt;
+- a peer may not collapse its custody record to the last speaker, but it must apply the GAID
+  boundary projection before disclosure; complete custody does not imply complete peer visibility;
+- the public view names the externally accountable public GAID(s), marks minimized participation,
+  and carries the signed commitment without implying that a boundary agent performed all hidden work;
 - a link may forward only if its projection/authority contract allows forwarding and loop/hop guards pass.
 
 ## 10. A2A operation and lifecycle mapping
@@ -435,6 +621,10 @@ Same-organization does not mean unrestricted. The link may project:
 
 It must not project raw prompts, private memory, hidden instructions, unrestricted tool manifests, secrets, internal model routing, unrelated customer data, or full authority configuration.
 
+Same-org full participation disclosure is allowed only when the link's `ProjectionContract`
+explicitly permits the private/federated GAID fields and topology. Otherwise the same boundary
+projection machinery produces a minimized view; “same organization” is not a bypass.
+
 Production-to-development traffic is visually and programmatically distinct. A development agent cannot act in production merely because both installations share an organization. The production receiver's local policy is authoritative, and consequential or irreversible actions retain their existing human-approval boundaries.
 
 ### 11.2 Cross organization — deny by default
@@ -446,10 +636,19 @@ Cross-org A2A remains disabled unless a future slice adds all of:
 - approved cross-org authority band and data-processing/retention terms;
 - public or otherwise boundary-conformant GAID/AIDoc assurance;
 - authenticated extended-card disclosure policy;
+- public GAID boundary mappings for every externally named agent and a required GAID A2A boundary
+  extension negotiated by both peers;
+- full protected participation custody plus signed, nonce-hiding commitments for every minimized
+  response, artifact, receipt, and task-history view;
 - artifact classification and egress tests;
 - local human approval for every consequential action unless a narrower standing authority is explicitly granted.
 
 The existing demand cross-org rules are the floor, not an alternate policy. Confidential/restricted and customer-domain material does not cross simply because the A2A task requests it.
+
+Cross-org egress is denied if any private GAID, internal Principal ID, hidden hop/edge, internal
+installation/device identifier, or source-local evidence reference remains after projection. This
+applies to ordinary payloads and to less obvious side channels: errors, task history, artifact
+metadata, Agent Cards, receipts, traces, logs exported to the peer, and operator downloads.
 
 ## 12. Operator experience
 
@@ -484,6 +683,12 @@ Before dispatch, the confirmation summarizes:
 
 The existing engagement/task surface shows messages, state changes, artifacts, and receipts in one timeline. Each cross-install event carries a readable provenance chip with accessible text, not color alone. Technical identifiers sit behind disclosure. Verification failure states explain the next safe operator action without exposing secrets.
 
+Authorized source-side operators can inspect the complete participation graph. Peer-facing and
+ordinary external-client views show the public accountable agents, “internal participation
+protected” status, commitment verification state, and audit-request path. They never show private
+GAIDs or a hidden-hop count by default. The interface must not imply that a public boundary agent
+was the sole performer when participation was minimized.
+
 All implementation uses shared UI primitives and `--dpf-*` theme tokens. Keyboard access, semantic headings, focus order, text alternatives, narrow layouts, light/dark themes, and reduced-motion behavior are acceptance criteria.
 
 ## 13. Failure, threat, and recovery model
@@ -500,6 +705,10 @@ All implementation uses shared UI primitives and `--dpf-*` theme tokens. Keyboar
 | device key rotation | dual-approved re-pin; invalidate old signature key at cutover; each immutable receipt snapshots the verified key/fingerprint so historic evidence remains independently checkable |
 | GAID continuity/mint collision | block federation advertisement; resolve through canonical issuer/alias migration |
 | cross-org payload exceeds projection | reject before task creation; log minimized violation metadata |
+| private GAID/topology appears in cross-org egress | reject before signing/outbox persistence; record field-class violation without the leaked value |
+| required public boundary mapping missing | deny egress; do not substitute or expose the private GAID |
+| protected graph changed after public commitment | create a new immutable graph version, commitment, and receipt; never overwrite the prior evidence |
+| commitment cannot be opened during authorized audit | treat as evidence-integrity failure; quarantine affected evidence and investigate signer/storage state |
 | peer asks for consequential action | route through local authority/consent gate; remote assertion cannot approve it |
 | task/status delivery outage | durable outbox retry with backoff/dead-letter; polling recovers current task snapshot |
 
@@ -515,6 +724,10 @@ Metrics and logs are keyed by non-secret identifiers and bounded labels:
 
 Distributed traces preserve W3C `traceparent` across federation while each install controls its own detailed spans. Audit receipts persist exact GAIDs and digests in governed records, not metric labels. Logs never contain bearer tokens, private keys, raw prompts, or unminimized artifacts.
 
+Cross-org metrics distinguish full versus minimized projection and commitment verification using
+bounded labels. They never label by GAID, hidden-hop count, graph topology, or source-local graph
+reference. Authorized audit opening is itself a consequential, receipted event.
+
 ## 15. Migration and compatibility
 
 1. Add peer device fields and nullable task ownership fields with forward-only migrations and backfills that tolerate every existing state.
@@ -526,6 +739,11 @@ Distributed traces preserve W3C `traceparent` across federation while each insta
 7. Put cross-install submission/retrieval behind federation ingress; preserve internal `/api/a2a/*` callers through the shared service layer.
 8. Never share or reuse the current local HMAC receipt secret across installations. Federated receipts use device-verifiable evidence; historic local receipts remain locally valid.
 9. Rollout is capability-negotiated per link and can be disabled without affecting federated demand.
+10. Replace the scalar acting/delegating/delegated metadata seam with a versioned protected
+    participation graph in the existing task/evidence substrate; dual-read legacy scalar records
+    until their graph projection is backfilled or explicitly classified as legacy-incomplete.
+11. Cross-org enablement remains blocked until public alias mapping, public-card projection,
+    commitment creation/opening, and whole-response private-identifier scanning are proven.
 
 ## 16. Acceptance criteria
 
@@ -535,6 +753,8 @@ Distributed traces preserve W3C `traceparent` across federation while each insta
 - A valid link token plus invalid/missing signature is rejected.
 - A valid device signature plus unprojected, expired, withdrawn, malformed, or wrong-link GAID is rejected.
 - the receiver can prove link, device, installation, organization, environment, acting/delegating/target GAIDs, card/AIDoc digests, and decision receipt for every accepted task.
+- the source can prove every materially participating agent and parent relationship in the
+  protected participation graph without requiring the peer to possess private identities;
 - no new agent identity or credential store exists.
 
 ### 16.2 Authority and privacy
@@ -545,6 +765,13 @@ Distributed traces preserve W3C `traceparent` across federation while each insta
 - same-org prod/dev is the only enabled relationship preset;
 - cross-org A2A is negative-tested and denied;
 - forbidden fields and classified artifacts cannot escape through messages, artifacts, errors, or cards.
+- a cross-org fixture containing five internal agents emits only approved `gaid:pub` participants,
+  `participationMinimized=true`, and a signed commitment; no private GAID, hidden hop/edge,
+  internal Principal/install/device ID, or graph reference appears anywhere in the peer response;
+- the commitment opens against the retained source graph for an authorized auditor, and any graph,
+  task-context, policy-version, or nonce mutation fails verification;
+- missing public mapping, unsalted commitment, projection failure, or legacy scalar-only custody
+  denies cross-org egress;
 
 ### 16.3 Protocol behavior
 
@@ -560,6 +787,8 @@ Distributed traces preserve W3C `traceparent` across federation while each insta
 - readiness, rotation, quarantine, and verification failure have clear safe next actions;
 - the dispatch confirmation states outcome, data boundary, and authority consequence;
 - task provenance is accessible, theme-aware, responsive, and keyboard operable;
+- source operators can inspect complete custody while peer/external views show only public
+  accountable identities, protected-participation status, and commitment verification;
 - demand federation continues to work when A2A is disabled or fails.
 
 ## 17. Documentation impact
@@ -585,6 +814,12 @@ The build must update:
 8. Cross-install A2A has no public or unauthenticated shortcut.
 9. Cross-org is deny-by-default and cannot inherit same-org readiness.
 10. No claim of A2A conformance is made unless the exposed binding implements the standard's required operations and semantics.
+11. Complete custody and external disclosure are separate views: a requirement to preserve every
+    hop never authorizes disclosure of every hop.
+12. Cross-org identity projection uses governed GAID public aliases plus `ProjectionContract`; no
+    NAT-style ephemeral identifier, route-local redactor, or second identity table is allowed.
+13. The signed participation commitment binds minimized external evidence to the protected graph
+    without revealing private identifiers or topology.
 
 ## 19. Architecture review (advisory)
 
@@ -597,6 +832,35 @@ The `dpf-architecture-review` pass produced four important findings, all folded 
 3. **The task substrate was ambiguous.** `CoworkerEngagement`, `TaskRun`, `TaskMessage`, and `TaskArtifact` already divide service acceptance from execution history. The spec now names that split and refactors the partial engagement-only A2A adapter onto it instead of creating A2A task/message tables.
 4. **Organization claims cannot be self-asserted.** The spec now derives organization/environment from `FederationLink` and the explicit `organization-crosswalk`, treating matching body fields as signed evidence but never as authority.
 
-Standards checked: A2A v1.0, MCP 2025-11-25 Tasks and 2026-07-28 release-candidate direction, CloudEvents 1.0, RFC 9421, and RFC 8785. No reference-doc improvement is filed: GAID already contains the missing A2A/HTTP binding doctrine, and the gap is implementation conformance rather than absent doctrine.
+The enterprise identity-boundary amendment added five reviewed findings:
+
+5. **Custody is not disclosure.** The former “preserve every hop” wording was valid for the source
+   evidence store but unsafe as a wire rule. The spec now preserves the full graph locally and
+   derives the external view through `ProjectionContract`.
+6. **A scalar call chain is not enterprise lineage.** The current acting/delegating/delegated
+   fields cannot represent parallel contribution, approval, fan-out, or fan-in. The protected
+   participation view is derived from canonical `TaskRun`/`TaskNode`/`TaskNodeEdge` plus receipts;
+   no A2A-only graph or task table is added.
+7. **Public aliases remain one subject.** Private and public GAIDs resolve through
+   `PrincipalAlias` to the same Principal. No ephemeral NAT identifier or per-peer agent identity
+   is introduced.
+8. **Minimization remains auditable.** A signed, nonce-hiding commitment binds the public response
+   to the source graph. A public boundary agent is accountable, but the response explicitly avoids
+   the false claim that it was the sole performer.
+9. **Projection is one pre-signing service.** Cards, events, tasks, artifacts, receipts, errors,
+   and peer-visible operations views consume the same derived boundary object. Route-local
+   redaction would violate canonical-contract and single-source-of-truth requirements.
+
+Standards checked: A2A v1.0 core, enterprise guidance, multi-tenancy and extension model; MCP
+2025-11-25 Tasks and 2026-07-28 release-candidate direction; CloudEvents 1.0; RFC 9421; RFC 9530;
+and RFC 8785. A2A supplies the extension and authorization mechanisms but does not normatively
+define agent-subject identity, private/public boundary mapping, participant topology disclosure,
+or a minimized-lineage commitment. That is a real enterprise profile gap, so the normative GAID
+reference was amended in the same branch and this A2A design now maps to it.
+
+`DI-6FE234A7399E` selected the dual-view commitment model with high confidence (composite `10.673`,
+margin `3.698`, no commandment conflict). This does not enable cross-org A2A in the current release;
+it defines the contract that the same-org implementation must be capable of enforcing and that a
+future cross-org activation must prove.
 
 The implementation-scope review supersedes the former atomic build shape while preserving the single same-org product outcome. `DI-61395D1B7A6D` selected decomposed convergence with high confidence (composite `15.417`, margin `11.220`, no commandment conflict): six feature-gated sibling BIs now own GAID conformance, device signing, signed-card discovery, canonical task ingress, policy/evidence, and operator readiness. The plan's parity preflight coordinates those local records with the A2A-adoption install without making backlog synchronization part of A2A or creating multi-writer authority. Cross-org enablement remains a separate future slice.

--- a/docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md
+++ b/docs/superpowers/specs/2026-08-08-federated-a2a-gaid-coordination-design.md
@@ -1,10 +1,17 @@
 # Federated A2A Coordination with GAID — Design Specification
 
-**Date:** 2026-08-08  
-**Status:** Architecture-reviewed; ready for implementation planning  
-**Decision:** `DI-B726A1900E7C` — link-bound signed GAID claim  
-**Delivery shape:** one same-organization product slice; no implementation in this document branch  
-**Backlog:** `BI-BE0E14E0` under `EP-MSP-FEDERATION` on this install; the same slice is `EP-E1F1DB58`'s A2A-coordination sibling on the A2A-adoption install (see §3 — the two anchors are the same work on two sovereign backlogs, not a contradiction)
+**Date:** 2026-08-08
+
+**Status:** Architecture-reviewed; implementation scope decomposed and governed
+
+**Decision:** `DI-B726A1900E7C` — link-bound signed GAID claim
+
+**Implementation-scope decision:** `DI-61395D1B7A6D` — six independently reviewable, feature-gated slices under one same-org umbrella
+
+**Delivery shape:** one same-organization product outcome, decomposed into governed implementation BIs; no implementation code in this document branch
+
+**Backlog:** umbrella `BI-BE0E14E0` and six mapped siblings under `EP-MSP-FEDERATION` on this install; `EP-E1F1DB58` remains the A2A-adoption install's program anchor (see §3)
+
 **Design WorkCapsule:** `WC-647895E9`
 
 ## 1. Executive decision
@@ -71,6 +78,17 @@ Neither anchor set is fictional. A thread that runs `get_backlog_item("EP-E1F1DB
 - Whichever backlog the build thread runs against, it files/claims the slice there and records the other install's anchor as the cross-reference. The two records converge only when a federation link carries them — which is the capability this slice ships.
 
 Other verified live programs on the MSP-federation install remain: `EP-A2A` (done — earlier internal handoff/summon precedent, not reopened), `EP-TAK-3F9A21` (done — delivered GAID-Private/AIDoc projection, a dependency), `EP-COWORKER-IDENTITY-360` (open — unified coworker read model and whole-coworker Agent Card, a coordination seam).
+
+### 3.1 BI synchronization addendum
+
+The two installations are beginning to synchronize BI visibility. That improves operational coordination but does not collapse sovereignty or become part of the A2A protocol:
+
+- synchronized peer work is a mirror/crosswalk unless the governed backlog-sync contract explicitly adopts it into local authority;
+- a bare `BI-…` remains install-local and must be interpreted with source-install provenance;
+- synchronization must converge counterpart references and prevent duplicate filing; it must not create two writers for one canonical `BacklogItem`;
+- A2A consumes the resulting work identity and coordination context later, after link/device/GAID authority is established. It does not transport or reconcile backlog state.
+
+The implementation plan therefore begins with a live parity/overlap preflight. Current live MCP on the MSP-federation install still does not expose `EP-E1F1DB58` or its slice BIs, so this document does not claim parity is already complete. Once the sync view is available, build threads reuse its canonical crosswalk and explicit counterpart records rather than inventing a second mapping scheme.
 
 ## 4. Verified substrate ledger
 
@@ -581,4 +599,4 @@ The `dpf-architecture-review` pass produced four important findings, all folded 
 
 Standards checked: A2A v1.0, MCP 2025-11-25 Tasks and 2026-07-28 release-candidate direction, CloudEvents 1.0, RFC 9421, and RFC 8785. No reference-doc improvement is filed: GAID already contains the missing A2A/HTTP binding doctrine, and the gap is implementation conformance rather than absent doctrine.
 
-The reviewed recommendation is to file the single same-org slice under the anchor that exists on the build install — `EP-MSP-FEDERATION` here, `EP-E1F1DB58` on the A2A-adoption install (§3 anchoring rule) — then execute the phased plan. Cross-org enablement remains a separate future slice.
+The implementation-scope review supersedes the former atomic build shape while preserving the single same-org product outcome. `DI-61395D1B7A6D` selected decomposed convergence with high confidence (composite `15.417`, margin `11.220`, no commandment conflict): six feature-gated sibling BIs now own GAID conformance, device signing, signed-card discovery, canonical task ingress, policy/evidence, and operator readiness. The plan's parity preflight coordinates those local records with the A2A-adoption install without making backlog synchronization part of A2A or creating multi-writer authority. Cross-org enablement remains a separate future slice.


### PR DESCRIPTION
## Summary

Amends the reviewed federated A2A design for enterprise agent identity boundaries, then decomposes implementation into six governed slices. The design keeps the full GAID participation chain inside the organization trust zone while projecting only approved public identities and commitments across organization boundaries.

## Changes

- Defines the protected participation graph, external projection, disclosure policy, non-disclosure commitment, and audit requirements.
- Aligns GAID guidance and conformance coverage with enterprise internal-versus-external identity handling.
- Maps the implementation plan to six live backlog slices under the existing A2A adoption umbrella.
- Refreshes the generated documentation index.

## Test plan

- [x] Source-only documentation and generated-index change
- [x] `pnpm check:doc-links`
- [x] `pnpm docs:impact`
- [x] `node scripts/check-no-private-identity.mjs`
- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm gate:context`
- [x] `pnpm run pregate:preflight`
- [x] Plan backlog coverage receipt `cmskqtmc6062001qpizirypwd`
- [x] Semantic review receipt `cmskwb2k1003801o1t9xejj3o` for the exact committed tree; reviewer infrastructure was inconclusive with no issues, and shadow policy permits publication

Local-CI-Override: docs-adjacent: generated documentation index plus Markdown specifications; no runtime behavior

## Related issues / Epic

Parent adoption program: `EP-E1F1DB58`

Umbrella: `BI-BE0E14E0`

Implementation slices: `BI-F51DC0D3`, `BI-51FA49EB`, `BI-B280E853`, `BI-90E338D8`, `BI-0E61A6A7`, `BI-68AF8D86`

## Overlap sweep

Open PRs #4137, #4135, and #4130 were reviewed and are unrelated to this documentation concern.

## Notes for the reviewer

This PR contains design, conformance guidance, and implementation planning only. It introduces no runtime code. Concrete private installation names remain in install-local acceptance evidence rather than public repository documentation.
