### PR TITLE
docs(agents): require incremental MCP tool discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,7 @@ Tooling detail, hygiene cadence and the enforced-gate list: [backlog & planning 
 
 ## 6. Tool Authorization
 
-Transport, token issuance/rotation, worktree MCP sync, grant-intersection mechanics and the advise-safe BI trail: [MCP tool authorization runbook](docs/architecture/mcp-tool-authorization-runbook.md) and [contributor procedure runbook](docs/architecture/contributor-procedure-runbook.md).
-
+- **Discover MCP tools before fallback.** Codex/Grok start with a lean `tools/list`; call `load_tools` by name/query (`search_tool_marketplace` if needed), refresh the list, then declare it absent. → [MCP authorization runbook](docs/architecture/mcp-tool-authorization-runbook.md)
 - **External coding agents use the MCP JSON-RPC transport at `/api/mcp/v1`.** Bearer tokens follow the `dpfmcp_...` pattern, are issued from Admin > Platform Development > MCP, and live only in local credential files — never commit them.
 - **Tokens carry a coarse scope (`read`/`write`/`admin`) plus granular per-tool grants; default tokens are `read` and cannot call side-effecting tools.** Agent `tool_grants` in `agent_registry.json` are enforced at runtime, intersected with the user's role capabilities. `insufficient_token_scope` is a §1 refusal.
 - **A side-effect tool may stay visible in advise mode only if it is advise-safe** — read-shaped, reversible, and non-committing. Anything else is hidden, not merely warned about.
@@ -150,4 +149,3 @@ Guard implementations, the BI trail and the full §7 decision text: [delivery su
 - **Tooling upgrade = operator-triggered quiesce → reap → upgrade → resume.** Orphaned sidecars must never pin a tool against update. → [kernel principle](docs/founder-kernel/wiki/principles/reap-sidecars-to-upgrade-tools.md)
 - **`:3001` and every shared singleton are lease-gated** ⟦runtime: install-local port — the lease rule is doctrine, the number is not⟧ via `claim_nonprod_environment_lease`. No per-branch CI images, no silent re-bind, no ad-hoc `docker run`/`compose up` from a surface. Hook-refused, so §1's refusal rule governs what to do when one fires.
 - **A built image carries the identity of its bytes** — stamp == built HEAD == target, asserted pre-swap.
-


### PR DESCRIPTION
## Summary

- teach external agents that the default DPF MCP catalogue is lean and incrementally discoverable
- require `load_tools` plus a refreshed `tools/list` before declaring a DPF MCP capability unavailable or using a fallback
- retain the existing MCP authorization runbook as the detailed source of truth

## Why

An observed evaluation treated the initially visible Codex tool set as exhaustive and fell back to direct PostgreSQL inspection. A live `load_tools({ query: "work capsule" })` call then exposed 15 additional granted tools, proving that the missing operational instruction could produce incorrect capability claims.

## Verification

- `git diff --check`
- live deferred-discovery check: `load_tools` exposed 15 granted Work Capsule tools absent from the initial catalogue
- independent semantic review passed with 0 blocking findings: `cmskxc2f602dg01o2g5ovk0pr`
- documentation-only change; runtime build, migration, and UX checks are not applicable

## Backlog

- BI-37C02BDA
- WC-8673AF96

Design-Grounding-Decision: Extended AGENTS.md §6 with the operational rule; kept catalogue mechanics in docs/architecture/mcp-tool-authorization-runbook.md.
Process-Spine-Decision: Filed and linked BI-37C02BDA, claimed WC-8673AF96, and obtained a fresh semantic-review receipt for the committed tree.
Docs-Impact-Decision: This change is itself the required external-agent rulebook correction; no user-facing product documentation changes.
Local-CI-Override: Documentation-only AGENTS.md change; git diff validation and live deferred-tool discovery verification are sufficient.
