### PR TITLE
fix(ops): make coworker activity status trustworthy

### DIFF
--- a/apps/web/components/ops/CoworkerActivityInspectionLink.test.tsx
+++ b/apps/web/components/ops/CoworkerActivityInspectionLink.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { CoworkerActivityInspectionLink } from "./CoworkerActivityInspectionLink";
+
+describe("CoworkerActivityInspectionLink", () => {
+  it("links coworker upgrade blockers to the AI workforce inspection view (BI-FDB25FA6)", () => {
+    const html = renderToStaticMarkup(
+      <CoworkerActivityInspectionLink surface="coworker.reasoning-loop" />,
+    );
+
+    expect(html).toContain('href="/platform/ai/right-now"');
+    expect(html).toContain("Inspect AI workforce activity");
+  });
+
+  it("does not render for blockers outside the coworker surface (BI-FDB25FA6)", () => {
+    const html = renderToStaticMarkup(
+      <CoworkerActivityInspectionLink surface="build-studio.phase.build" />,
+    );
+
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/components/ops/CoworkerActivityInspectionLink.tsx
+++ b/apps/web/components/ops/CoworkerActivityInspectionLink.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export function CoworkerActivityInspectionLink({ surface }: { surface: string }) {
+  if (surface !== "coworker.reasoning-loop") return null;
+
+  return (
+    <Link
+      href="/platform/ai/right-now"
+      className="ml-3.5 inline-flex min-h-11 items-center text-xs font-medium text-[var(--dpf-accent)] hover:underline"
+    >
+      Inspect AI workforce activity
+    </Link>
+  );
+}

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -1,9 +1,9 @@
 "use client";
-
 import { Fragment, useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { rollbackSelfUpgrade, repairPromoterImage } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { CoworkerActivityInspectionLink } from "./CoworkerActivityInspectionLink";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
 import type { SummaryResult, RunImpactDigest } from "@/lib/self-upgrade/impact/types";
 import { UpgradeScopeRibbon } from "@/components/ops/UpgradeScopeRibbon";
@@ -14,7 +14,6 @@ import { isExpectedDuringSwap } from "@/lib/self-upgrade/is-expected-during-swap
 import { SelfUpgradeReadiness } from "@/components/ops/SelfUpgradeReadiness";
 import { BuildStamps } from "@/components/ops/BuildStamps";
 import type { LatestRun, QuiescenceActivity } from "@/lib/self-upgrade/run-types";
-
 type RecoveryPointSummary = {
   status: string;
   members: Array<{ target: string; runId: string | null; status: string }>;
@@ -595,6 +594,7 @@ export default function SelfUpgradeClient({
                         )}
                       </div>
                     )}
+                    <CoworkerActivityInspectionLink surface={b.surface} />
                   </li>
                 ))}
               </ul>

--- a/apps/web/lib/platform-runtime/workforce-activity.test.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.test.ts
@@ -41,6 +41,40 @@ function fakePrisma(data: {
 }
 
 describe("loadWorkforceActivity", () => {
+  it("uses only the canonical live states and never reports stalled work as working (BI-FDB25FA6)", async () => {
+    let taskRunWhere: unknown;
+    const prisma = fakePrisma({
+      agents: [agent({ agentId: "stalled-coworker", displayName: "Stalled Coworker" })],
+      liveRuns: [
+        {
+          taskRunId: "stalled-1",
+          status: "stalled",
+          title: "Old scheduled work",
+          currentAgentId: "stalled-coworker",
+          startedAt: new Date(NOW - 30 * 86_400_000),
+          lastHeartbeatAt: new Date(NOW - 29 * 86_400_000),
+        },
+      ],
+    }) as unknown as {
+      taskRun: { findMany: (args: { where: unknown }) => Promise<unknown[]> };
+    };
+    const originalFindMany = prisma.taskRun.findMany;
+    prisma.taskRun.findMany = async (args) => {
+      taskRunWhere = args.where;
+      return originalFindMany(args);
+    };
+
+    const wf = await loadWorkforceActivity({ prisma: prisma as never, now: () => NOW });
+
+    expect(taskRunWhere).toEqual({
+      archivedAt: null,
+      status: { in: ["working", "active"] },
+    });
+    expect(wf.working).toEqual([]);
+    expect(wf.pulse.workingCount).toBe(0);
+    expect(wf.quiet.map((coworker) => coworker.name)).toEqual(["Stalled Coworker"]);
+  });
+
   it("splits working vs quiet and builds the outcome digest", async () => {
     const prisma = fakePrisma({
       agents: [

--- a/apps/web/lib/platform-runtime/workforce-activity.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.ts
@@ -11,8 +11,8 @@
 
 import { prisma as realPrisma } from "@dpf/db";
 import { summarizeOutcomes, type Outcome } from "./action-outcome-map";
+import { isLiveStatus, TASK_LIVE_STATES } from "@/lib/tak/task-states";
 
-const LIVE_TASK_STATUSES = ["working", "active", "input-required", "auth-required", "stalled"];
 const QUIET_SIGNAL_DAYS = 5;
 const LAST_ACTED_LOOKBACK_DAYS = 30;
 
@@ -122,7 +122,7 @@ export async function loadWorkforceActivity(
       orderBy: [{ tier: "asc" }, { name: "asc" }],
     }),
     prisma.taskRun.findMany({
-      where: { archivedAt: null, status: { in: LIVE_TASK_STATUSES } },
+      where: { archivedAt: null, status: { in: [...TASK_LIVE_STATES] } },
       orderBy: { startedAt: "desc" },
       select: { taskRunId: true, status: true, title: true, currentAgentId: true, startedAt: true, lastHeartbeatAt: true },
     }),
@@ -173,6 +173,9 @@ export async function loadWorkforceActivity(
   // First live task per agent (rows are newest-first).
   const liveByAgent = new Map<string, TaskRunRow>();
   for (const run of liveRuns) {
+    // Keep the projection fail-closed if an injected adapter or future query
+    // returns a non-live row despite the canonical DB filter.
+    if (!isLiveStatus(run.status)) continue;
     if (run.currentAgentId && !liveByAgent.has(run.currentAgentId)) {
       liveByAgent.set(run.currentAgentId, run);
     }

--- a/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
+++ b/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
@@ -64,3 +64,59 @@ per-phase model resolver (lives on Runtime Health).
   outcome mapping, read exclusion, "other" bucket, sensitivity flagging,
   working/quiet split, no-owner counting, ordering. Injected Prisma double.
 - Full local CI on the merged tree before merge.
+
+## 2026-08-08 truth-and-inspection correction — BI-FDB25FA6
+
+The live-install audit found that this page's private `LIVE_TASK_STATUSES` list
+included `stalled`, `input-required`, and `auth-required`, while the canonical
+`TASK_LIVE_STATES` contract intentionally defines only `working | active` as
+live. As a result, old stalled schedules appeared under **Working now** even
+though they could not block Self-Upgrade and had not heartbeated for weeks.
+
+### Backlog coverage
+
+- Decision: atomic
+- Parent: BI-FDB25FA6
+- Receipt: `cmskxrnit03al01o2ab7cuos3`
+- Deliverable: `activity-truth` — converge Right Now and Self-Upgrade inspection
+  on one trustworthy coworker-activity path.
+- Rationale: a blocker link into a view that still labels stalled history as
+  live would be misleading; correcting the view without making the initiating
+  upgrade blocker inspectable leaves the operator's original journey broken.
+  The two seams therefore ship and verify together.
+- Dependencies: none
+
+### Implementation sequence
+
+1. Test-drive the liveness correction: stalled and waiting states must not enter
+   `working`, while canonical `working` and `active` rows still do.
+2. Replace the local status vocabulary with `TASK_LIVE_STATES`; retain quiet
+   coworker/outcome behavior without creating a second status classifier.
+3. Test-drive and add a contextual **Inspect AI workforce activity** link to the
+   Self-Upgrade blocker band, using the existing `/platform/ai/right-now` route.
+4. Verify the targeted tests and production build, then exercise both the
+   zero-live-work and blocker-inspection states through the governed nonprod UX
+   path.
+
+### UX decision record
+
+- Decision: link the coworker-specific Self-Upgrade blocker to the existing
+  **Right Now** workforce view, without adding a second coworker-identity link.
+- WWMD interaction: `DI-15DC5BCA696C`
+- Confidence: high (margin `1.7886216977355875`).
+- Rationale: one contextual action gives the operator a stable workforce-wide
+  inspection surface while keeping upgrade recovery simple. The destination
+  now shares the canonical `TASK_LIVE_STATES` definition, so the action does
+  not direct operators into a contradictory status view.
+
+### Risks and rollback
+
+- Risk: a legitimately waiting task could disappear from the live band. This is
+  intentional: waiting and stalled are not active execution and belong on an
+  attention surface, not under **Working now**. This change does not delete or
+  mutate any TaskRun.
+- Risk: a generic Self-Upgrade blocker may not be coworker-related. The link is
+  rendered only when blocker evidence identifies the coworker reasoning-loop
+  surface.
+- Rollback: revert the application commit. There is no migration or runtime-data
+  rewrite.

--- a/docs/ux-fit/2026-08-08-right-now-activity-truth.ux-fit.json
+++ b/docs/ux-fit/2026-08-08-right-now-activity-truth.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "right-now-only",
+  "decisionInteractionId": "DI-15DC5BCA696C",
+  "scope": {
+    "files": [
+      "apps/web/components/ops/CoworkerActivityInspectionLink.tsx",
+      "apps/web/components/ops/SelfUpgradeClient.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "right-now-only",
+      "direct-coworker-with-fallback",
+      "both-links"
+    ]
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5844,6 +5844,13 @@
     "longSentences": 0,
     "textMass": 55
   },
+  "apps/web/components/ops/CoworkerActivityInspectionLink.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
   "apps/web/components/ops/DemandBoard.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary

- make the AI workforce **Right Now** view use the canonical `working | active` TaskRun states, so stalled or waiting history is not reported as current work
- add a coworker-specific **Inspect AI workforce activity** action to Self-Upgrade blockers, linked to the existing `/platform/ai/right-now` operator view
- add regression tests, the governed UX decision manifest, and backlog/rollback coverage for BI-FDB25FA6

## Design grounding

- Specs/plans reviewed: `docs/superpowers/plans/2026-08-05-workforce-activity-view.md` and the Self-Upgrade activity contract
- Existing substrate reviewed: `TASK_LIVE_STATES` / `isLiveStatus`, the workforce activity projection, and the existing `/platform/ai/right-now` route
- Source of truth: `apps/web/lib/tak/task-states.ts` owns TaskRun liveness; this change removes the page-local competing vocabulary
- Decision: WWMD interaction `DI-15DC5BCA696C` selected one contextual link to **Right Now** over a second identity link or both links; the measured record is in `docs/ux-fit/2026-08-08-right-now-activity-truth.ux-fit.json`

## Verification

- focused Vitest: 3 files, 85 tests passed
- web typecheck: passed
- production Next build: passed
- module-size, UX-fit, doc-index, documentation-impact, and whitespace guards: passed
- exact merged-tree local CI: passed for the published commit
- contributor preview: branch runtime booted successfully; protected routes correctly rejected anonymous sessions. The sanitized preview invalidates production sessions and agents are prohibited from entering passwords, so authenticated end-to-end browser confirmation is reserved for the canonical post-merge Self-Upgrade verification

## Documentation impact

The existing workforce activity plan now records the liveness mismatch, atomic backlog coverage, UX decision, risks, and rollback. No user-guide update is needed: the new action is contextual navigation and does not change an operator procedure or introduce configuration.

## Backlog

- BI-FDB25FA6
