### PR TITLE
fix(ci): recover semantic review and build headroom

### DIFF
--- a/apps/web/lib/change-review/semantic-change-review-operation.test.ts
+++ b/apps/web/lib/change-review/semantic-change-review-operation.test.ts
@@ -101,6 +101,31 @@ describe("semantic change-review operation", () => {
     expect(stale.reusedFreshReceipt).toBe(false);
   });
 
+  it("retries a fresh infrastructure-inconclusive receipt for the same immutable identity", async () => {
+    const first = await runSemanticChangeReview(input(), {
+      dispatch: vi.fn().mockResolvedValue({
+        decision: "inconclusive",
+        issues: [],
+        summary: "One required review branch did not complete.",
+        inconclusiveReason: "review-branch-capacity-or-transport-failure",
+      }),
+    });
+    const retryDispatch = vi.fn().mockResolvedValue({
+      decision: "pass",
+      issues: [],
+      summary: "The retry completed with no semantic findings.",
+    });
+
+    const retried = await runSemanticChangeReview(
+      input({ priorReceipt: first.receipt }),
+      { dispatch: retryDispatch },
+    );
+
+    expect(retryDispatch).toHaveBeenCalledOnce();
+    expect(retried.reusedFreshReceipt).toBe(false);
+    expect(retried.receipt.result.decision).toBe("pass");
+  });
+
   it("stops the repair loop after two failed repair rounds", async () => {
     const dispatch = vi.fn().mockResolvedValue({
       decision: "fail",

--- a/apps/web/lib/change-review/semantic-change-review-operation.ts
+++ b/apps/web/lib/change-review/semantic-change-review-operation.ts
@@ -178,7 +178,7 @@ export async function runSemanticChangeReview(
 
   if (input.priorReceipt) {
     const freshness = assessSemanticReviewReceiptFreshness(input.priorReceipt, identity);
-    if (freshness.fresh) {
+    if (freshness.fresh && input.priorReceipt.result.decision !== "inconclusive") {
       return resultForReceipt({
         receipt: input.priorReceipt,
         activation,

--- a/apps/web/lib/nonprod/environment-lease-pool-policy.ts
+++ b/apps/web/lib/nonprod/environment-lease-pool-policy.ts
@@ -20,6 +20,7 @@ export async function resolveNonprodPoolPolicy(input: {
   hostPressure?: LocalCiHostPressure;
   capacityBroker?: LocalCiCapacityBroker;
   manifestSlotCount: number;
+  reserveBuildHeadroom?: boolean;
   now: Date;
 }): Promise<ResolvedLocalCiPoolPolicy> {
   if (input.environmentKey !== "local-integration-ci") {
@@ -43,6 +44,7 @@ export async function resolveNonprodPoolPolicy(input: {
     configValue,
     host: clientPressure,
     manifestSlotCount: input.manifestSlotCount,
+    reserveBuildHeadroom: input.reserveBuildHeadroom,
     env: process.env,
     now: input.now,
   });
@@ -73,6 +75,7 @@ export async function resolveNonprodPoolPolicy(input: {
       server: serverPressure,
     }),
     manifestSlotCount: input.manifestSlotCount,
+    reserveBuildHeadroom: input.reserveBuildHeadroom,
     env: process.env,
     now: input.now,
   });

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import localCiSlotResources from "./local-ci-slot-resources.json";
 
 const recordQueueTransition = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/queue/queue-telemetry", () => ({ recordQueueTransition }));
@@ -333,7 +334,8 @@ describe("durable nonproduction admission", () => {
 
     const hostPressure = {
       observedAt: NOW.toISOString(),
-      availableMemoryBytes: 12 * 1024 ** 3,
+      availableMemoryBytes: 8 * 1024 ** 3
+        + 2 * localCiSlotResources.builderPolicy.memoryBytes,
       sustainedCpuPercent: 20,
       diskFreeBytes: 500 * 1024 ** 3,
       dockerHealthy: true,
@@ -344,7 +346,11 @@ describe("durable nonproduction admission", () => {
     const result = await claim(mockDb, {
       slotManifestVersion: 1,
       hostPressure,
-      capacityBroker: async () => hostPressure,
+      capacityBroker: async () => ({
+        ...hostPressure,
+        dockerAvailableMemoryBytes: 32 * 1024 ** 3,
+        builderMemoryUsageBytes: [0, 0],
+      }),
     });
 
     expect(result).toMatchObject({
@@ -442,7 +448,7 @@ describe("durable nonproduction admission", () => {
       status: "queued",
       poolPolicy: {
         effectiveCapacity: 0,
-        rollbackReason: "host-memory-low",
+        rollbackReason: "host-build-headroom-low",
       },
     });
   });

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -325,6 +325,7 @@ export async function claimNonprodEnvironmentLease(input: {
     hostPressure: input.hostPressure,
     capacityBroker: input.capacityBroker,
     manifestSlotCount: NONPROD_SLOT_KEYS.length,
+    reserveBuildHeadroom: true,
     now,
   });
   const ttlMs = requestedTtlMs(now, input.expiresAt);
@@ -667,6 +668,7 @@ export async function renewNonprodEnvironmentLease(input: {
     hostPressure: input.hostPressure,
     capacityBroker: input.capacityBroker,
     manifestSlotCount: NONPROD_SLOT_KEYS.length,
+    reserveBuildHeadroom: false,
     now,
   });
   return { status: "renewed", lease: updated, poolPolicy };

--- a/apps/web/lib/nonprod/local-ci-capacity-broker.ts
+++ b/apps/web/lib/nonprod/local-ci-capacity-broker.ts
@@ -2,12 +2,16 @@ import { statfs } from "node:fs/promises";
 import { cpus, freemem, loadavg } from "node:os";
 import { dockerSocketGet } from "../platform-runtime/docker-socket.mjs";
 import type { LocalCiHostPressure } from "./local-ci-pool-policy";
+import localCiSlotResources from "./local-ci-slot-resources.json" with {
+  type: "json",
+};
 
 type MaybePromise<T> = T | Promise<T>;
 
 export type LocalCiServerPressureProbes = {
   now: () => Date;
   availableMemoryBytes: () => number;
+  builderMemoryUsageBytes: () => MaybePromise<number[]>;
   sustainedCpuPercent: () => number;
   diskFreeBytes: () => MaybePromise<number>;
   dockerHealthy: () => MaybePromise<boolean>;
@@ -54,10 +58,20 @@ export function mergeLocalCiHostPressure(input: {
       input.client.observedAt,
       input.server.observedAt,
     ),
-    availableMemoryBytes: pessimisticMinimum(
-      input.client.availableMemoryBytes,
-      input.server.availableMemoryBytes,
-    ),
+    // The client samples Windows physical memory. The server runs inside the
+    // bounded Docker/WSL VM, whose MemAvailable is a separate reservation
+    // domain and naturally falls while an approved builder consumes memory.
+    availableMemoryBytes: finite(input.client.availableMemoryBytes)
+      ? input.client.availableMemoryBytes
+      : undefined,
+    dockerAvailableMemoryBytes: finite(input.server.availableMemoryBytes)
+      ? input.server.availableMemoryBytes
+      : undefined,
+    builderMemoryUsageBytes: Array.isArray(
+      input.server.builderMemoryUsageBytes,
+    )
+      ? [...input.server.builderMemoryUsageBytes]
+      : undefined,
     sustainedCpuPercent: pessimisticMaximum(
       input.client.sustainedCpuPercent,
       input.server.sustainedCpuPercent,
@@ -97,9 +111,62 @@ async function defaultDockerHealthy(): Promise<boolean> {
     && typeof info.OSType === "string";
 }
 
+function dockerBuilderContainerName(ordinal: number): string {
+  const version = localCiSlotResources.builderPolicy.version;
+  return `buildx_buildkit_dpf-local-ci-buildkit-v${version}-${ordinal}0`;
+}
+
+export function dockerMemoryWorkingSetBytes(value: unknown): number {
+  if (!value || typeof value !== "object") return Number.NaN;
+  const memoryStats = (value as { memory_stats?: unknown }).memory_stats;
+  if (!memoryStats || typeof memoryStats !== "object") return Number.NaN;
+  const usage = Number((memoryStats as { usage?: unknown }).usage);
+  const stats = (memoryStats as { stats?: unknown }).stats;
+  const inactiveFile = stats && typeof stats === "object"
+    ? Number(
+      (stats as { total_inactive_file?: unknown; inactive_file?: unknown })
+        .total_inactive_file
+        ?? (stats as { inactive_file?: unknown }).inactive_file
+        ?? 0,
+    )
+    : 0;
+  if (!Number.isFinite(usage) || usage < 0 || !Number.isFinite(inactiveFile)) {
+    return Number.NaN;
+  }
+  return Math.max(0, usage - Math.max(0, inactiveFile));
+}
+
+async function defaultBuilderMemoryUsageBytes(): Promise<number[]> {
+  const containers = await dockerSocketGet("/containers/json?all=1") as Array<{
+    Id?: unknown;
+    Names?: unknown;
+  }>;
+  if (!Array.isArray(containers)) throw new Error("docker_container_list_invalid");
+
+  return Promise.all(Object.values(localCiSlotResources.slots).map(
+    async (slot) => {
+      const expectedName = `/${dockerBuilderContainerName(slot.ordinal)}`;
+      const container = containers.find((candidate) => (
+        Array.isArray(candidate.Names)
+        && candidate.Names.includes(expectedName)
+      ));
+      if (typeof container?.Id !== "string") return 0;
+      const stats = await dockerSocketGet(
+        `/containers/${encodeURIComponent(container.Id)}/stats?stream=false`,
+      );
+      const workingSet = dockerMemoryWorkingSetBytes(stats);
+      if (!Number.isFinite(workingSet)) {
+        throw new Error("docker_builder_memory_unmeasurable");
+      }
+      return workingSet;
+    },
+  ));
+}
+
 const DEFAULT_PROBES: LocalCiServerPressureProbes = {
   now: () => new Date(),
   availableMemoryBytes: () => freemem(),
+  builderMemoryUsageBytes: defaultBuilderMemoryUsageBytes,
   sustainedCpuPercent: () => {
     const cpuCount = cpus().length;
     if (cpuCount < 1) return Number.NaN;
@@ -129,6 +196,7 @@ export async function observeLocalCiServerPressure(
   try {
     const [
       availableMemoryBytes,
+      builderMemoryUsageBytes,
       sustainedCpuPercent,
       diskFreeBytes,
       dockerHealthy,
@@ -137,6 +205,7 @@ export async function observeLocalCiServerPressure(
       evidenceIsolationHealthy,
     ] = await Promise.all([
       probes.availableMemoryBytes(),
+      probes.builderMemoryUsageBytes(),
       probes.sustainedCpuPercent(),
       probes.diskFreeBytes(),
       probes.dockerHealthy(),
@@ -147,6 +216,8 @@ export async function observeLocalCiServerPressure(
     return {
       observedAt,
       availableMemoryBytes,
+      dockerAvailableMemoryBytes: availableMemoryBytes,
+      builderMemoryUsageBytes,
       sustainedCpuPercent,
       diskFreeBytes,
       dockerHealthy,

--- a/apps/web/lib/nonprod/local-ci-pool-policy.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-policy.ts
@@ -2,6 +2,9 @@ import pilotGuardrails from "./local-ci-pilot-guardrails.json" with {
   type: "json",
 };
 import { isRecord as isRecordRuntime } from "../shared/is-record.mjs";
+import localCiSlotResources from "./local-ci-slot-resources.json" with {
+  type: "json",
+};
 
 export const LOCAL_CI_POOL_CONFIG_KEY = "local_ci.sandbox_pool";
 export const LOCAL_CI_POOL_POLICY_VERSION = 1 as const;
@@ -17,6 +20,8 @@ export type LocalCiPoolPolicySource =
 export type LocalCiHostPressure = {
   observedAt?: string;
   availableMemoryBytes?: number;
+  dockerAvailableMemoryBytes?: number;
+  builderMemoryUsageBytes?: number[];
   sustainedCpuPercent?: number;
   diskFreeBytes?: number;
   dockerHealthy?: boolean;
@@ -51,6 +56,44 @@ export type ResolvedLocalCiPoolPolicy = {
   rollbackReason: string | null;
   config: LocalCiPoolConfig | null;
 };
+
+export function localCiBuildHeadroomCapacity(input: {
+  dockerAvailableMemoryBytes: number;
+  builderMemoryBytes: number;
+  builderMemoryUsageBytes: number[];
+  manifestCapacity: number;
+}): number {
+  if (
+    !Number.isFinite(input.dockerAvailableMemoryBytes)
+    || input.dockerAvailableMemoryBytes < 0
+    || !Number.isFinite(input.builderMemoryBytes)
+    || input.builderMemoryBytes <= 0
+    || !Number.isFinite(input.manifestCapacity)
+    || input.manifestCapacity < 1
+    || !Array.isArray(input.builderMemoryUsageBytes)
+    || input.builderMemoryUsageBytes.length < Math.floor(input.manifestCapacity)
+    || input.builderMemoryUsageBytes.some(
+      (value) => !Number.isFinite(value) || value < 0,
+    )
+  ) {
+    return 0;
+  }
+
+  let cumulativeReservationBytes = 0;
+  let capacity = 0;
+  for (const usageBytes of input.builderMemoryUsageBytes.slice(
+    0,
+    Math.floor(input.manifestCapacity),
+  )) {
+    cumulativeReservationBytes += Math.max(
+      0,
+      input.builderMemoryBytes - usageBytes,
+    );
+    if (cumulativeReservationBytes > input.dockerAvailableMemoryBytes) break;
+    capacity += 1;
+  }
+  return capacity;
+}
 
 type PolicyEnv = Record<string, string | undefined>;
 type PlatformConfigReader = {
@@ -236,6 +279,7 @@ export function resolveLocalCiPoolPolicy(input: {
   configValue: unknown;
   host: LocalCiHostPressure;
   manifestSlotCount: number;
+  reserveBuildHeadroom?: boolean;
   env?: PolicyEnv;
   now?: Date;
 }): ResolvedLocalCiPoolPolicy {
@@ -270,6 +314,36 @@ export function resolveLocalCiPoolPolicy(input: {
       reason: rollbackReason,
       config,
     });
+  }
+
+  if (input.reserveBuildHeadroom) {
+    const builderMemoryBytes = localCiSlotResources.builderPolicy.memoryBytes;
+    const hostBuildCapacity = localCiBuildHeadroomCapacity({
+      dockerAvailableMemoryBytes:
+        input.host.dockerAvailableMemoryBytes ?? Number.NaN,
+      builderMemoryBytes,
+      builderMemoryUsageBytes: input.host.builderMemoryUsageBytes ?? [],
+      manifestCapacity,
+    });
+
+    if (hostBuildCapacity === 0) {
+      return unavailable({
+        source,
+        requestedCapacity,
+        manifestCapacity,
+        reason: "host-build-headroom-low",
+        config,
+      });
+    }
+    if (hostBuildCapacity === 1 && requestedCapacity === 2) {
+      return singleton({
+        source,
+        requestedCapacity,
+        manifestCapacity,
+        reason: "host-build-capacity-one",
+        config,
+      });
+    }
   }
 
   if (requestedCapacity === 1) {

--- a/scripts/local-ci-capacity-broker.test.mjs
+++ b/scripts/local-ci-capacity-broker.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  dockerMemoryWorkingSetBytes,
   mergeLocalCiHostPressure,
   observeLocalCiServerPressure,
 } from "../apps/web/lib/nonprod/local-ci-capacity-broker.ts";
@@ -17,7 +18,7 @@ const CLIENT = {
   evidenceIsolationHealthy: true,
 };
 
-test("server-owned pressure can only make a client sample less optimistic", () => {
+test("keeps Windows and Docker memory in separate reservation domains", () => {
   const merged = mergeLocalCiHostPressure({
     client: CLIENT,
     server: {
@@ -30,12 +31,15 @@ test("server-owned pressure can only make a client sample less optimistic", () =
       convergenceActive: true,
       fencesHealthy: false,
       evidenceIsolationHealthy: false,
+      builderMemoryUsageBytes: [2 * 1024 ** 3, 0],
     },
   });
 
   assert.deepEqual(merged, {
     observedAt: "2026-07-30T08:00:00.000Z",
-    availableMemoryBytes: 7 * 1024 ** 3,
+    availableMemoryBytes: 16 * 1024 ** 3,
+    dockerAvailableMemoryBytes: 7 * 1024 ** 3,
+    builderMemoryUsageBytes: [2 * 1024 ** 3, 0],
     sustainedCpuPercent: 80,
     diskFreeBytes: 90 * 1024 ** 3,
     dockerHealthy: false,
@@ -45,7 +49,7 @@ test("server-owned pressure can only make a client sample less optimistic", () =
   });
 });
 
-test("a missing server measurement remains unmeasurable instead of trusting the client", () => {
+test("a missing Docker measurement remains unmeasurable without erasing Windows memory", () => {
   const merged = mergeLocalCiHostPressure({
     client: CLIENT,
     server: {
@@ -57,7 +61,8 @@ test("a missing server measurement remains unmeasurable instead of trusting the 
     },
   });
 
-  assert.equal(merged.availableMemoryBytes, undefined);
+  assert.equal(merged.availableMemoryBytes, 16 * 1024 ** 3);
+  assert.equal(merged.dockerAvailableMemoryBytes, undefined);
   assert.equal(merged.sustainedCpuPercent, undefined);
   assert.equal(merged.diskFreeBytes, undefined);
   assert.equal(merged.dockerHealthy, false);
@@ -69,6 +74,7 @@ test("canonical broker converts probe failure into fail-closed pressure", async 
     availableMemoryBytes: () => {
       throw new Error("memory unavailable");
     },
+    builderMemoryUsageBytes: async () => [0, 0],
     sustainedCpuPercent: () => 10,
     diskFreeBytes: async () => 400 * 1024 ** 3,
     dockerHealthy: async () => true,
@@ -84,4 +90,14 @@ test("canonical broker converts probe failure into fail-closed pressure", async 
     fencesHealthy: false,
     evidenceIsolationHealthy: false,
   });
+});
+
+test("Docker builder usage excludes reclaimable inactive file cache", () => {
+  assert.equal(dockerMemoryWorkingSetBytes({
+    memory_stats: {
+      usage: 3 * 1024 ** 3,
+      stats: { inactive_file: 1.5 * 1024 ** 3 },
+    },
+  }), 1.5 * 1024 ** 3);
+  assert.equal(Number.isNaN(dockerMemoryWorkingSetBytes({})), true);
 });

--- a/scripts/local-ci-pool-policy.test.mjs
+++ b/scripts/local-ci-pool-policy.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   LOCAL_CI_POOL_CONFIG_KEY,
+  localCiBuildHeadroomCapacity,
   loadLocalCiPoolConfig,
   resolveLocalCiPoolPolicy,
 } from "../apps/web/lib/nonprod/local-ci-pool-policy.ts";
@@ -83,6 +84,95 @@ test("enables slot 1 only when requested, declared, and all host evidence is saf
   assert.equal(resolved.effectiveCapacity, 2);
   assert.equal(resolved.rollbackReason, null);
   assert.deepEqual(resolved.slotKeys, ["slot-0", "slot-1"]);
+});
+
+test("admission reserves the canonical bounded-build memory above the host safety floor", () => {
+  const resolved = resolveLocalCiPoolPolicy({
+    configValue: {
+      ...PILOT_CONFIG,
+      ceilings: {
+        ...PILOT_CONFIG.ceilings,
+        minAvailableMemoryBytes: 8 * 1024 ** 3,
+      },
+    },
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 11 * 1024 ** 3,
+      dockerAvailableMemoryBytes: 11 * 1024 ** 3,
+      builderMemoryUsageBytes: [0, 0],
+    },
+    manifestSlotCount: 2,
+    reserveBuildHeadroom: true,
+  });
+
+  assert.equal(resolved.hostSafeCapacity, 0);
+  assert.equal(resolved.effectiveCapacity, 0);
+  assert.equal(resolved.rollbackReason, "host-build-headroom-low");
+  assert.deepEqual(resolved.slotKeys, []);
+});
+
+test("admission contracts to one slot when headroom covers only one bounded build", () => {
+  const resolved = resolveLocalCiPoolPolicy({
+    configValue: PILOT_CONFIG,
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 28 * 1024 ** 3,
+      dockerAvailableMemoryBytes: 16 * 1024 ** 3,
+      builderMemoryUsageBytes: [1.5 * 1024 ** 3, 0],
+    },
+    manifestSlotCount: 2,
+    reserveBuildHeadroom: true,
+  });
+
+  assert.equal(resolved.hostSafeCapacity, 1);
+  assert.equal(resolved.effectiveCapacity, 1);
+  assert.equal(resolved.rollbackReason, "host-build-capacity-one");
+  assert.deepEqual(resolved.slotKeys, ["slot-0"]);
+});
+
+test("execution pressure does not reserve bounded-build memory a second time", () => {
+  const resolved = resolveLocalCiPoolPolicy({
+    configValue: {
+      ...PILOT_CONFIG,
+      ceilings: {
+        ...PILOT_CONFIG.ceilings,
+        minAvailableMemoryBytes: 8 * 1024 ** 3,
+      },
+    },
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 11 * 1024 ** 3,
+      dockerAvailableMemoryBytes: 5 * 1024 ** 3,
+    },
+    manifestSlotCount: 2,
+    reserveBuildHeadroom: false,
+  });
+
+  assert.equal(resolved.hostSafeCapacity, 2);
+  assert.equal(resolved.effectiveCapacity, 2);
+  assert.equal(resolved.rollbackReason, null);
+});
+
+test("bounded-build headroom arithmetic fails closed for invalid resource policy", () => {
+  const valid = {
+    dockerAvailableMemoryBytes: 30.5 * 1024 ** 3,
+    builderMemoryBytes: 16 * 1024 ** 3,
+    builderMemoryUsageBytes: [1.5 * 1024 ** 3, 0],
+    manifestCapacity: 2,
+  };
+
+  assert.equal(localCiBuildHeadroomCapacity(valid), 2);
+  for (const builderMemoryBytes of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(localCiBuildHeadroomCapacity({
+      ...valid,
+      builderMemoryBytes,
+    }), 0);
+  }
+  assert.equal(localCiBuildHeadroomCapacity({
+    ...valid,
+    dockerAvailableMemoryBytes: 11 * 1024 ** 3,
+    builderMemoryUsageBytes: [0, 0],
+  }), 0);
 });
 
 test("unmeasurable or unsafe configured host evidence contracts admission to zero", () => {


### PR DESCRIPTION
## Summary

- retry fresh infrastructure-inconclusive semantic review receipts instead of reusing them as terminal outcomes
- separate Windows host memory from Docker/WSL builder memory when evaluating local-CI capacity
- reserve the remaining bounded-builder headroom at admission while keeping active renewal on the Windows host safety fence

## Verification

- 16/16 local-CI capacity policy and broker contract tests
- 8 Vitest files / 56 semantic-review and environment-lease tests
- web typecheck with the sanctioned 8 GiB Node heap
- 35/35 pregate preflight guards
- high-risk, high-assurance semantic review: reviewed, fresh, pass, zero findings
- two exact merged-tree runs reached the optimized production build and were fenced by the deployed renewal policy this change repairs, including a differentiated quiet-host run

## Coordination

- BI-BD3F687C / WC-01B59E82 owns the semantic-review retry change
- BI-7B9C9376 / WC-1BEFE348 owns the local-CI capacity and renewal-topology change

Local-CI-Override: install-bootstrap-recovery: deployed renewal fence prevents the exact capacity-fix build; reviewed exact tree and focused/typecheck/preflight evidence retained
Process-Spine-Decision: localized bugfixes restore existing semantic-review retry and local-CI safety contracts; no new product or operator process surface
