### PR TITLE
fix(federation): fault-isolate per-item demand projection so one bad item can't strand the rest (BI-8A7E3E56)

### DIFF
--- a/apps/web/lib/federation/demand-reconciliation.test.ts
+++ b/apps/web/lib/federation/demand-reconciliation.test.ts
@@ -24,6 +24,36 @@ describe("relationshipPresetForRole", () => {
 });
 
 describe("runDemandReconciliation", () => {
+  it("fault-isolates a throwing item so every other item still projects (BI-8A7E3E56 follow-up)", async () => {
+    const mkItem = (id: string) => ({
+      itemId: id, title: `Need ${id}`, body: null, workType: "feature", occurrenceCount: 1,
+      createdAt: new Date("2026-08-01T00:00:00Z"), updatedAt: new Date("2026-08-01T00:00:00Z"), digitalProduct: null,
+    });
+    // Middle item throws (e.g. an envelope violation); the loop must skip it and
+    // keep going — not abort and strand every item after it.
+    const queueProjection = vi.fn()
+      .mockResolvedValueOnce({ action: "queued" })
+      .mockRejectedValueOnce(new Error("Demand projection refused: field:not-allowed:x"))
+      .mockResolvedValueOnce({ action: "queued" });
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue(links) },
+      backlogItem: { findMany: vi.fn().mockResolvedValue([mkItem("BI-A"), mkItem("BI-B"), mkItem("BI-C")]) },
+      federatedRecordMirror: { findMany: vi.fn().mockResolvedValue([]) },
+    } as unknown as DemandReconciliationDb;
+
+    const result = await runDemandReconciliation(db, {
+      resolveIdentity: vi.fn().mockResolvedValue({ installationId: `inst_${"a".repeat(32)}`, projectionSecret: "b".repeat(64) }),
+      queueProjection,
+      queueWithdrawal: vi.fn(),
+      reconcileDigests: vi.fn().mockResolvedValue({ linksChecked: 0, requeued: 0, confirmed: 0, failedLinks: 0 }),
+      dispatch: vi.fn().mockResolvedValue({ attempted: 0, delivered: 0, deferred: 0, deadLettered: 0 }),
+    });
+
+    expect(queueProjection).toHaveBeenCalledTimes(3); // BI-C attempted despite BI-B throwing
+    expect(result.projected).toBe(2);
+    expect(result.failed).toBe(1);
+  });
+
   it("automatically queues only platform demand on a trusted same-organization link", async () => {
     const queueProjection = vi.fn().mockResolvedValue({ action: "queued" });
     const db = {

--- a/apps/web/lib/federation/demand-reconciliation.ts
+++ b/apps/web/lib/federation/demand-reconciliation.ts
@@ -13,6 +13,7 @@ import {
 import { resolveFederationIdentity, type FederationIdentityDb } from "./demand-identity";
 import { reconcileDemandDigests } from "./demand-digest";
 import { SAME_ORG_LOCAL_ONLY_SENSITIVITIES } from "./cross-org-sharing";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 interface ReconciliationLink {
   linkId: string;
@@ -87,6 +88,7 @@ export async function runDemandReconciliation(
   let projected = 0;
   let unchanged = 0;
   let withdrawn = 0;
+  let failed = 0;
   const identity = links.length > 0
     ? await (deps.resolveIdentity ?? resolveFederationIdentity)(db)
     : null;
@@ -113,26 +115,38 @@ export async function runDemandReconciliation(
     const eligibleIds = new Set(items.map((item) => item.itemId));
     for (const link of automaticLinks) {
       for (const item of items) {
-        const result = await (deps.queueProjection ?? queueDemandProjection)(db, {
-          link,
-          source: {
-            localRecordRef: item.itemId,
-            title: item.title,
-            summary: shareSafeSummary(item.body, item.title),
-            workType: item.workType,
-            occurrenceCount: item.occurrenceCount,
-            product: item.digitalProduct?.productId ?? null,
-            createdAt: item.createdAt,
-            updatedAt: item.updatedAt,
-          },
-          identity: identity!,
-          contract: DEMAND_PROJECTION_TEMPLATES["same-organization"],
-          audience: "internal",
-          attribution: "organization",
-          now,
-        });
-        if (result.action === "queued") projected++;
-        else unchanged++;
+        // Fault-isolate each item: a single item that throws (envelope violation,
+        // transient DB error) must NOT abort the whole cycle and strand every item
+        // after it — the same "one bad record can't strand the batch" lesson as the
+        // dead-letter fix (BI-8A7E3E56). Skip + log the offender by id and reason so
+        // the exact cause is visible; keep projecting the rest.
+        try {
+          const result = await (deps.queueProjection ?? queueDemandProjection)(db, {
+            link,
+            source: {
+              localRecordRef: item.itemId,
+              title: item.title,
+              summary: shareSafeSummary(item.body, item.title),
+              workType: item.workType,
+              occurrenceCount: item.occurrenceCount,
+              product: item.digitalProduct?.productId ?? null,
+              createdAt: item.createdAt,
+              updatedAt: item.updatedAt,
+            },
+            identity: identity!,
+            contract: DEMAND_PROJECTION_TEMPLATES["same-organization"],
+            audience: "internal",
+            attribution: "organization",
+            now,
+          });
+          if (result.action === "queued") projected++;
+          else unchanged++;
+        } catch (err) {
+          failed++;
+          console.warn(
+            `[demand-reconciliation] projection skipped ${item.itemId} on ${link.linkId}: ${getErrorMessage(err)}`,
+          );
+        }
       }
       const existing = await db.federatedRecordMirror.findMany({
         where: {
@@ -156,5 +170,5 @@ export async function runDemandReconciliation(
     ? await (deps.reconcileDigests ?? reconcileDemandDigests)(db, identity, { now })
     : { linksChecked: 0, requeued: 0, confirmed: 0, failedLinks: 0 };
   const delivery = await (deps.dispatch ?? dispatchDueDemand)(db, { now });
-  return { links: links.length, projected, unchanged, withdrawn, digest, delivery };
+  return { links: links.length, projected, unchanged, withdrawn, failed, digest, delivery };
 }


### PR DESCRIPTION
After same-org sharing broadened 5→~290 eligible, ~10 tail items consistently failed to project. The projection loop calls `queueDemandProjection` per item with **no try/catch**, so one throwing item aborts the whole cycle and strands every item after it — same lesson as the dead-letter fix.

**Fix:** try/catch per item — skip + log the offender (`projection skipped <itemId>: <reason>`, via the canonical `getErrorMessage`), count `failed`, keep going. Unblocks the innocent tail **and** names the exact cause of any genuinely-unprojectable item. TDD: middle-item-throws run projects the other two, `failed=1`. BI-8A7E3E56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)