### PR TITLE
docs(federation): map remaining robust-design increments

### DIFF
--- a/docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md
+++ b/docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md
@@ -17,33 +17,50 @@ brittle invite-token/paste-URL/wall-clock-version machinery with standard mechan
 (Syncthing device IDs, mDNS/DNS-SD, IETF SAS pairing, ActivityPub-style inbox on the
 canonical `WorkQueue`, version vectors).
 
+## Live backlog coverage
+
+The umbrella BI remains open until the physical acceptance gate passes. Each
+independently shippable increment is mapped below so completion evidence and
+remaining work are visible outside this document.
+
+| Increment | Backlog item | Delivery state at 2026-08-08 |
+| --- | --- | --- |
+| 1. Instance identity | BI-62DE5912 | Done; merged in PR #4097 |
+| 2. mDNS/DNS-SD discovery | BI-52D34506 | Source merged in PR #3308; Windows native-host and real add/remove acceptance remain |
+| 3. SAS pairing | BI-7432348C | Crypto core merged in PR #4098; identity-bound transport and numeric-comparison workflow remain |
+| 4. Introducer / hub | BI-6EF4288A | Open |
+| 5. Queue-based inbox delivery | BI-42617832 | Open |
+| 6. Version-vector conflict model | BI-51FD61F1 | Done; merged in PRs #4099 and #4102 |
+| 7. SAS-first Connections UX; manual recovery only | BI-51F5229B | Open |
+| Physical two-instance acceptance | BI-05EB708F | In progress |
+
 ## Increments
 
 Each is an independent PR; later increments depend on earlier ones as noted.
 
-1. **Instance identity (THIS increment).** A stable Ed25519 signing keypair per install;
+1. **Instance identity (BI-62DE5912; delivered).** A stable Ed25519 signing keypair per install;
    the device ID is its public-key fingerprint (`did_<sha256-hex>`). Foundation for SAS
    pairing, discovery, and address-independent links. Stored in the existing
    `PlatformConfig["federation.identity"]` blob (no migration); private key encrypted at
    rest via `credential-crypto` (same as `peerTokenEnc`). Legacy identities upgrade in
    place on first read. Pure crypto in `lib/federation/instance-identity.ts`.
-2. **mDNS/DNS-SD discovery.** Advertise `_dpf-federation._tcp.local.` (device ID + address);
+2. **mDNS/DNS-SD discovery (BI-52D34506; acceptance incomplete).** Advertise `_dpf-federation._tcp.local.` (device ID + address);
    browse and list nearby installs. Extends `nearby-candidates` / `nearby-pairing-service`.
-3. **SAS pairing.** ECDH ephemeral exchange + 6-digit Short Authentication String numeric
+3. **SAS pairing (BI-7432348C; transport wiring incomplete).** ECDH ephemeral exchange + 6-digit Short Authentication String numeric
    comparison, authenticated against the increment-1 identity keys. Replaces invite-token /
    pasted URL / bare dual-approve (which has zero MITM protection).
-4. **Introducer / hub.** One trusted peer introduces others (customer→reseller→hub), the
+4. **Introducer / hub (BI-6EF4288A).** One trusted peer introduces others (customer→reseller→hub), the
    Syncthing introducer pattern.
-5. **Queue-based inbox delivery.** Deliver demand envelopes to a peer inbox as `WorkQueue`
+5. **Queue-based inbox delivery (BI-42617832).** Deliver demand envelopes to a peer inbox as `WorkQueue`
    jobs (retry/backoff/telemetry), retiring the hand-rolled outbox loop. ActivityPub model.
-6. **Version-vector conflict model.** Per-installation counters on the mirror; one-sided
+6. **Version-vector conflict model (BI-51FD61F1; delivered).** Per-installation counters on the mirror; one-sided
    dominance = clean, divergence = explicit conflict. Kernel-decided over CRDT
    (DI-1BC547243903). Supersedes the wall-clock scalar (interim BigInt fix #4092).
-7. **Deprecate manual pairing UI + finish navigation/labels.** Nav entry landed in #4094;
+7. **SAS-first Connections UX; manual recovery only (BI-51F5229B).** Nav entry landed in #4094;
    this retires the invite/paste/approve flow to recovery-only and fixes the scope/env labels.
 
 ## Acceptance gate (was missing the first time)
 
 Every increment carries unit tests; the epic is not "done" until an **end-to-end
-two-instance validation** (two installs discover → SAS-pair → demand mirrors both ways with
+two-instance validation** (BI-05EB708F: two installs discover → SAS-pair → demand mirrors both ways with
 correct version-vector ordering) passes on real installs.


### PR DESCRIPTION
## Summary

- reconciles the federation robust-design plan with the live PostgreSQL backlog
- assigns one backlog item to each independently shippable increment
- records delivered identity and version-vector slices separately from the open umbrella
- keeps physical Mac/Windows acceptance as the final completion gate

## Backlog

- Umbrella: BI-67315C4A
- Plan coverage: cmskzyf1n087f01o2x7yut2re (8 unique live mappings)
- New remaining slices: BI-7432348C, BI-6EF4288A, BI-42617832, BI-51F5229B
- Physical acceptance: BI-05EB708F

## Verification

- `git diff --check`
- prose lint passed
- documentation link integrity passed
- FPAW standard guard passed
- pregate preflight: 35 guards clean; its two host-skipped TypeScript guards were run directly and passed where applicable
- semantic review: pass, evidence `cmsl005ac08a901o2472t8zso`
- UX: not applicable; planning-only change
- migration: not applicable; no schema change

Local-CI-Override: docs-only planning/backlog traceability change; deterministic documentation guards and exact-tree semantic review passed
