### PR TITLE
fix: classify Scarf install telemetry

### DIFF
--- a/docs/superpowers/plans/2026-08-08-scarf-build-script-policy.md
+++ b/docs/superpowers/plans/2026-08-08-scarf-build-script-policy.md
@@ -1,0 +1,56 @@
+# Scarf build-script policy
+
+Backlog item: `BI-C43B5B50`
+Work Capsule: `WC-09EC4DFA`
+
+## Outcome
+
+Make the repository's treatment of `@scarf/scarf@1.4.0` explicit and prevent a
+future unresolved `allowBuilds` placeholder from reaching `main`.
+
+## Evidence and decision
+
+- `@scarf/scarf@1.4.0` is transitive through Stoplight Prism 5.16.0 in the
+  integration-test harness.
+- Its package manifest declares only `postinstall: node ./report.js`.
+- `report.js` gathers install/dependency/platform data and posts telemetry to
+  `scarf.sh`; Prism has no runtime import of Scarf outside package metadata and
+  documentation.
+- The install script is therefore not required for Prism behavior. The policy
+  decision is `allowBuilds['@scarf/scarf'] = false`, minimizing install-time
+  code execution and outbound telemetry.
+- pnpm's dependency-status check remains the authoritative detector for a new
+  package with an unclassified build script. A source-local policy guard will
+  additionally reject any non-boolean value in the committed `allowBuilds`
+  block so pnpm's generated placeholder cannot be committed.
+
+## Implementation
+
+1. Add a failing regression test for unresolved and malformed `allowBuilds`
+   values, including the live workspace policy.
+2. Implement the source-local policy checker and enroll it in the existing
+   consolidated supply-chain policy guard.
+3. Replace the generated Scarf placeholder with an evidence-commented `false`
+   decision.
+4. Verify the focused tests, the live checker, frozen install/dependency status,
+   repository pregate, and exact merged-code local CI before publication.
+
+No phase is independently shippable: the explicit decision without the guard
+can regress, while the guard cannot pass until the current decision is resolved.
+
+## Backlog coverage
+
+- Decision: `atomic`
+- Umbrella BI: `BI-C43B5B50`
+- Receipt: `cmskztsob07j201o24tr8nz8o`
+- Deliverable `scarf-build-policy` maps to `BI-C43B5B50` and has no dependencies.
+
+## Risk and rollback
+
+Risk is limited to dependency installation policy. Denying the telemetry-only
+script leaves the installed Prism files unchanged. Roll back by reverting this
+PR; if a future Prism release demonstrates a functional install-time need, a
+separate evidence-backed policy PR may change the value to `true`.
+
+UX impact: not applicable; no user interface changes.
+Migration impact: not applicable; no schema or data changes.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -183,6 +183,9 @@ minimumReleaseAge: 1440
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true
+  # Telemetry-only postinstall: report.js sends install/dependency/platform data
+  # to scarf.sh. Stoplight Prism has no runtime import or generated artifact need.
+  '@scarf/scarf': false
   esbuild: true
   msw: true
   prisma: true

--- a/scripts/check-build-script-policy.mjs
+++ b/scripts/check-build-script-policy.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+function unquote(value) {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"')))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Parse the top-level pnpm `allowBuilds` mapping without accepting YAML's
+ * broader scalar coercions. Build-script decisions must be literal booleans.
+ */
+export function parseAllowBuilds(text) {
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((line) => /^allowBuilds:\s*$/.test(line));
+  if (start === -1) throw new Error("no `allowBuilds:` block found");
+
+  const entries = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^[A-Za-z]/.test(line)) break;
+    if (/^\s*(?:#.*)?$/.test(line)) continue;
+
+    const match = line.match(/^\s{2}((?:'[^']+'|"[^"]+"|[^:]+)):\s*(.*?)\s*(?:#.*)?$/);
+    if (!match) {
+      entries.push({ name: `<line ${index + 1}>`, value: line.trim() });
+      continue;
+    }
+    entries.push({ name: unquote(match[1].trim()), value: match[2].trim() });
+  }
+  return entries;
+}
+
+export function auditBuildScriptPolicy(text) {
+  const entries = parseAllowBuilds(text);
+  const decisions = new Map();
+  const unresolved = [];
+  const duplicates = [];
+
+  for (const { name, value } of entries) {
+    if (decisions.has(name) || unresolved.some((entry) => entry.name === name)) {
+      if (!duplicates.includes(name)) duplicates.push(name);
+    }
+    if (value === "true" || value === "false") {
+      decisions.set(name, value === "true");
+    } else {
+      unresolved.push({ name, value });
+    }
+  }
+
+  return { decisions, duplicates, unresolved, scanned: entries.length };
+}
+
+async function main() {
+  const text = await readFile("pnpm-workspace.yaml", "utf8");
+  let result;
+  try {
+    result = auditBuildScriptPolicy(text);
+  } catch (error) {
+    console.error(`Build-script policy guard failed — ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.unresolved.length > 0 || result.duplicates.length > 0) {
+    console.error("Build-script policy guard failed — every allowBuilds entry must have one explicit boolean decision.");
+    for (const entry of result.unresolved) {
+      console.error(`  - ${entry.name}: unresolved value ${JSON.stringify(entry.value)}`);
+    }
+    for (const name of result.duplicates) {
+      console.error(`  - ${name}: duplicate decision`);
+    }
+    console.error("Set each package to true only after review, or false when its install script is unnecessary.");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Build-script policy guard passed (${result.scanned} explicit decisions).`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/check-build-script-policy.test.mjs
+++ b/scripts/check-build-script-policy.test.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  auditBuildScriptPolicy,
+  parseAllowBuilds,
+} from "./check-build-script-policy.mjs";
+
+const workspace = (body) => `packages:\n  - "apps/*"\nallowBuilds:\n${body}\npackageExtensions:\n`;
+
+test("accepts explicit boolean allow and deny decisions", () => {
+  const result = auditBuildScriptPolicy(
+    workspace("  esbuild: true\n  '@scarf/scarf': false"),
+  );
+
+  assert.deepEqual(result.unresolved, []);
+  assert.deepEqual(result.duplicates, []);
+  assert.deepEqual(result.decisions, new Map([
+    ["esbuild", true],
+    ["@scarf/scarf", false],
+  ]));
+});
+
+test("rejects pnpm's unresolved build-script placeholder", () => {
+  const result = auditBuildScriptPolicy(
+    workspace("  '@scarf/scarf': set this to true or false"),
+  );
+
+  assert.deepEqual(result.unresolved, [
+    { name: "@scarf/scarf", value: "set this to true or false" },
+  ]);
+});
+
+test("rejects quoted booleans because they are not policy booleans", () => {
+  const result = auditBuildScriptPolicy(workspace("  sharp: 'true'"));
+
+  assert.deepEqual(result.unresolved, [{ name: "sharp", value: "'true'" }]);
+});
+
+test("rejects duplicate package decisions", () => {
+  const result = auditBuildScriptPolicy(
+    workspace("  sharp: true\n  sharp: false"),
+  );
+
+  assert.deepEqual(result.duplicates, ["sharp"]);
+});
+
+test("requires the allowBuilds policy block", () => {
+  assert.throws(
+    () => parseAllowBuilds("packages:\n  - apps/*\n"),
+    /no `allowBuilds:` block found/,
+  );
+});
+
+test("the live workspace has resolved policy and explicitly denies Scarf telemetry", () => {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const result = auditBuildScriptPolicy(
+    readFileSync(join(root, "pnpm-workspace.yaml"), "utf8"),
+  );
+
+  assert.deepEqual(result.unresolved, []);
+  assert.deepEqual(result.duplicates, []);
+  assert.equal(result.decisions.get("@scarf/scarf"), false);
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -107,9 +107,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("diagram-dependency-pin-guard", "Diagram Dependency Pin Guard", [
       node("scripts/check-diagram-dependency-pins.mjs"),
     ]),
-    guard("override-provenance-guard", "Override Provenance Guard", [
+    guard("override-provenance-guard", "Workspace Supply-Chain Policy", [
       node("scripts/check-override-comments.mjs"),
       node("--test", "scripts/check-override-comments.test.mjs"),
+      node("scripts/check-build-script-policy.mjs"),
+      node("--test", "scripts/check-build-script-policy.test.mjs"),
     ]),
     guard("bundle-boundary-guard", "Bundle Boundary Guard", [
       node("scripts/check-bundle-boundaries.mjs"),


### PR DESCRIPTION
## Summary

Explicitly deny the telemetry-only `@scarf/scarf@1.4.0` postinstall and add a
repository guard that prevents unresolved pnpm `allowBuilds` decisions from
reaching `main`.

## Changes

- set `allowBuilds['@scarf/scarf']` to `false` with the evidence-based rationale
- add a pure source-policy checker for non-boolean and duplicate build-script decisions
- add six regression tests, including the pnpm-generated placeholder and live policy
- enroll the checker in the consolidated workspace supply-chain policy guard
- document the atomic implementation and verified rollback in the governed plan

## Evidence

- `@scarf/scarf@1.4.0` is transitive through Stoplight Prism 5.16.0; its only
  lifecycle behavior is `postinstall: node ./report.js`, which posts install,
  dependency, and platform telemetry to `scarf.sh`.
- Prism contains no runtime Scarf imports outside package metadata and README files.
- `pnpm ignored-builds`: automatically ignored `None`; Scarf is explicitly ignored.
- `pnpm install --frozen-lockfile`: passed.
- `pnpm --filter dpf-integration-test-harness exec prism --version`: `5.16.0`.
- Build-script policy tests: 6/6 passed; CI registry tests: 8/8 passed.
- Exact merged-tree local CI: exhaustive suite and production build passed
  (`fullSuite=true`, 28,416 log lines).
- Independent semantic review: 3 review branches, 0 blocking findings.

One unrelated macOS-only pregate fixture remains red when run from a source
worktree: `/var` versus `/private/var` causes the copied script's direct-entry
identity check not to invoke `main`. The merged-tree sandbox passed the complete
suite; this branch does not touch that fixture or gate implementation.

## Impact

- UX: not applicable; no UI surface changes.
- Migration: not applicable; no schema or data changes.
- Runtime dependency graph: unchanged; only install-script execution policy changes.
- Documentation: governed implementation plan added; no user-facing behavior changed.

## Backlog and plan

- Backlog item: `BI-C43B5B50`
- Work Capsule: `WC-09EC4DFA`
- Plan: `docs/superpowers/plans/2026-08-08-scarf-build-script-policy.md`
- Coverage receipt: `cmskztsob07j201o24tr8nz8o` (`atomic`)

## Overlap sweep

No open PR title or branch matches Scarf or build-script policy. The only newer
`main` changes touched federation and local-CI capacity code, with no file overlap;
the sandbox merged and verified current `main` before the successful run.

Local-CI-Evidence: cmsl0eh90092701o2w70eivn3 (fix/scarf-build-script-policy@b97e15322b0d86c4c835de80d98a5e8e7f36e08b)
Docs-Impact-Decision: internal supply-chain guard and install-script policy; no user-facing route or workflow behavior changes
