### PR TITLE
fix: retire removed datastores in portfolio catalog

### DIFF
--- a/docs/data-impact/2026-08-08-retired-datastore-catalog.data-impact.json
+++ b/docs/data-impact/2026-08-08-retired-datastore-catalog.data-impact.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "DigitalProduct portfolio read model",
+    "ProductDependency portfolio relationship graph"
+  ],
+  "migration": {
+    "name": "20260809000500_retire_legacy_datastore_products",
+    "backfill": "Set lifecycleStage and lifecycleStatus to retired for the bounded Neo4j/Qdrant product IDs and remove only inbound ProductDependency edges to those retired products. Preserve every DigitalProduct row and its historical identity."
+  },
+  "tests": [
+    "packages/db/src/digital-product-registry.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:digital-product#legacy-datastore-retirement",
+      "prismaModel": "DigitalProduct",
+      "lifecycleDisposition": "Neo4j and Qdrant product rows remain durable historical records with retired lifecycle state; active portfolio queries exclude them.",
+      "fields": [
+        {
+          "fieldId": "data:digital-product#lifecycleStage",
+          "resolution": "governed",
+          "reason": "The catalog must reflect the completed BET-5 runtime retirement instead of presenting removed stores as operating products.",
+          "provenance": "BI-A1E864A5; runtime cutover merged 2026-07-14"
+        },
+        {
+          "fieldId": "data:digital-product#lifecycleStatus",
+          "resolution": "governed",
+          "reason": "The active-product portfolio filter uses lifecycleStatus, so existing installs require bounded convergence to retired.",
+          "provenance": "BI-A1E864A5; packages/db/data/digital_product_registry.json"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:product-dependency#retired-datastore-edges",
+      "prismaModel": "ProductDependency",
+      "lifecycleDisposition": "Obsolete inbound edges to retired Neo4j and Qdrant products are removed; all unrelated product relationships remain unchanged.",
+      "fields": [
+        {
+          "fieldId": "data:product-dependency#toProductId",
+          "resolution": "governed",
+          "reason": "Active products must not retain dependency relationships to components removed from the canonical architecture.",
+          "provenance": "BI-A1E864A5; packages/db/data/digital_product_registry.json"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/data/digital_product_registry.json
+++ b/packages/db/data/digital_product_registry.json
@@ -57,7 +57,7 @@
                                  "usage_mode":  "used",
                                  "description":  "Self-referential digital product node representing the factory as a first-class product in its own operating portfolio.",
                                  "depends_on_product_ids":  [
-                                                                "infra-neo4j-core",
+                                                                "infra-postgres-core",
                                                                 "infra-docker-runtime"
                                                             ],
                                  "is_part_of_product_ids":  [
@@ -137,9 +137,9 @@
                                                                     "fc-windows-server-neo4j-01"
                                                                 ],
                                  "lifecycle":  {
-                                                   "stage":  "operate",
-                                                   "stage_status":  "active",
-                                                   "effective_from":  "2026-02-20",
+                                                   "stage":  "retire",
+                                                   "stage_status":  "retired",
+                                                   "effective_from":  "2026-07-14",
                                                    "next_review_at":  "2026-05-15",
                                                    "owner_role":  "HR-300"
                                                },
@@ -237,8 +237,7 @@
                                  "description":  "Externally offered platform subscription for digital product portfolio and delivery governance.",
                                  "depends_on_product_ids":  [
                                                                 "dpf-meta",
-                                                                "dpf-ai-workforce",
-                                                                "infra-neo4j-core"
+                                                                "dpf-ai-workforce"
                                                             ],
                                  "realizes_model_ids":  [
                                                             "mdl-dpf-platform-standard"
@@ -421,9 +420,9 @@
                                  "depends_on_product_ids":  [],
                                  "is_part_of_product_ids":  ["dpf-meta"],
                                  "lifecycle":  {
-                                                   "stage":  "operate",
-                                                   "stage_status":  "active",
-                                                   "effective_from":  "2026-03-01",
+                                                   "stage":  "retire",
+                                                   "stage_status":  "retired",
+                                                   "effective_from":  "2026-07-14",
                                                    "next_review_at":  "2026-06-01",
                                                    "owner_role":  "HR-300"
                                                },

--- a/packages/db/prisma/migrations/20260809000500_retire_legacy_datastore_products/migration.sql
+++ b/packages/db/prisma/migrations/20260809000500_retire_legacy_datastore_products/migration.sql
@@ -1,0 +1,31 @@
+-- Complete the BET-5 Neo4j/Qdrant retirement in the DigitalProduct read model.
+--
+-- The runtime services were removed in PR #2967, but the curated products and
+-- an older auto-discovered Qdrant product remained lifecycleStatus='active'.
+-- Preserve the rows and their history; only correct lifecycle state and remove
+-- dependency edges that would keep active products pointing at retired stores.
+-- @migration-safety: data-safe: bounded updates preserve every product row;
+-- the deleted graph edges only target dependencies on explicitly retired IDs.
+UPDATE "DigitalProduct"
+SET
+  "lifecycleStage" = 'retired',
+  "lifecycleStatus" = 'retired',
+  "updatedAt" = CURRENT_TIMESTAMP
+WHERE "productId" IN (
+  'infra-neo4j-core',
+  'infra-qdrant',
+  'infra-qdrant-vector'
+)
+AND (
+  "lifecycleStage" IS DISTINCT FROM 'retired'
+  OR "lifecycleStatus" IS DISTINCT FROM 'retired'
+);
+
+DELETE FROM "ProductDependency" dependency
+USING "DigitalProduct" retired_product
+WHERE dependency."toProductId" = retired_product.id
+  AND retired_product."productId" IN (
+    'infra-neo4j-core',
+    'infra-qdrant',
+    'infra-qdrant-vector'
+  );

--- a/packages/db/src/digital-product-registry.test.ts
+++ b/packages/db/src/digital-product-registry.test.ts
@@ -9,6 +9,10 @@ type RegistryProduct = {
   taxonomy_node_id?: string;
   description?: string;
   depends_on_product_ids?: string[];
+  lifecycle?: {
+    stage?: string;
+    stage_status?: string;
+  };
 };
 
 const registryPath = join(__dirname, "..", "data", "digital_product_registry.json");
@@ -46,5 +50,30 @@ describe("digital product registry BOM workforce mappings", () => {
     const platform = product("dpf-platform-standard");
 
     expect(platform.depends_on_product_ids).toContain("dpf-ai-workforce");
+  });
+});
+
+describe("digital product registry retired datastore mappings", () => {
+  const retiredDatastoreIds = ["infra-neo4j-core", "infra-qdrant-vector"];
+
+  it.each(retiredDatastoreIds)("marks %s retired after the BET-5 cutover", (productId) => {
+    expect(product(productId).lifecycle).toMatchObject({
+      stage: "retire",
+      stage_status: "retired",
+    });
+  });
+
+  it("does not leave active or planned products depending on retired datastores", () => {
+    const offenders = registry.digital_products
+      .filter((candidate) => candidate.lifecycle?.stage_status !== "retired")
+      .filter((candidate) =>
+        candidate.depends_on_product_ids?.some((dependencyId) =>
+          retiredDatastoreIds.includes(dependencyId),
+        ),
+      )
+      .map((candidate) => candidate.product_id);
+
+    expect(offenders).toEqual([]);
+    expect(product("dpf-meta").depends_on_product_ids).toContain("infra-postgres-core");
   });
 });


### PR DESCRIPTION
## Summary

- mark the retired Neo4j and Qdrant catalog products as retired in the canonical registry
- move the DPF meta-product dependency from Neo4j to PostgreSQL and remove the remaining sold-product Neo4j edge
- migrate existing installs so stale curated and auto-discovered datastore cards no longer appear active
- guard the retirement and dependency invariants with registry tests

## Why

Neo4j and Qdrant were removed from the canonical runtime in the BET-5 cutover, but their catalog rows remained active. The portfolio therefore continued presenting removed architectural components as current products.

## Verification

- targeted registry Vitest: 6/6 passed
- migration deploy against the governed isolated PostgreSQL database: passed
- merged-code web typecheck: passed
- exhaustive merged-code suite: 2,615 files and 22,471 tests passed
- merged-code production Next build: passed
- semantic review: passed
- exact local CI: passed for `755436cad4ca`

Local-CI-Evidence: cmsl2kail0dee01o2s6rondgk (fix/retired-datastore-catalog@755436cad4ca56a5e717859e25f7117ec021d531)

## Design grounding

- Existing work: BET-5 datastore retirement in `BI-A1E864A5`
- Source of truth: `packages/db/data/digital_product_registry.json`
- Existing-install convergence: forward-only, bounded, idempotent Prisma migration
- Historical product rows are preserved; only lifecycle state and obsolete inbound dependency edges change
- `infra-qdrant` is the observed active auto-discovered legacy alias, not a registry entry; the migration retires it alongside curated `infra-qdrant-vector`
- `infra-postgres-core` is present and active in the canonical registry

Process-Spine-Decision: localized catalog/data correction under the existing BET-5 retirement; no new capability, route, workflow, or architectural substrate.

Seed-Fit-Decision: global-default

## Documentation impact

No documentation change is needed. This aligns the catalog and existing-install read model with the already-completed and documented runtime retirement; it does not change a user workflow or supported architecture.

The required migration data-impact contract is recorded in `docs/data-impact/2026-08-08-retired-datastore-catalog.data-impact.json`.

## Overlap sweep

No open PR covers this catalog retirement, and the branch contains one concern.

Backlog: `BI-A1E864A5`
