### PR TITLE
fix(ci): arbitrate semantic review against local CI capacity

### DIFF
--- a/apps/web/lib/change-review/routed-semantic-review.test.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/inference/routed-inference", () => ({ routeAndCall: vi.fn() }));
+vi.mock("@/lib/inference/routed-inference", () => ({
+  routeAndCall: vi.fn(),
+}));
+vi.mock("@/lib/nonprod/environment-lease", () => ({
+  listActiveNonprodEnvironmentLeases: vi.fn(),
+}));
 
 import { routeAndCall } from "@/lib/inference/routed-inference";
+import { listActiveNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
 import { dispatchRoutedSemanticReview } from "./routed-semantic-review";
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(listActiveNonprodEnvironmentLeases).mockResolvedValue([] as never);
+});
 
 describe("routed semantic review", () => {
   it("runs the Change Reviewer and requested specialist as independent branches", async () => {
@@ -41,5 +50,60 @@ describe("routed semantic review", () => {
     expect(result.decision).toBe("inconclusive");
     expect(result.inconclusiveReason).toContain("review-branch-capacity-or-transport-failure");
     expect(result.issues).toEqual([]);
+  });
+
+  it("defers review while local CI owns host capacity", async () => {
+    vi.mocked(listActiveNonprodEnvironmentLeases).mockResolvedValue([
+      { environmentKey: "local-integration-ci" },
+    ] as never);
+
+    const result = await dispatchRoutedSemanticReview("review this", {
+      strategyProfile: "high-assurance",
+      reviewerId: "change-reviewer",
+      specialistIds: ["AGT-181"],
+      surface: "external",
+    });
+
+    expect(result).toEqual({
+      decision: "inconclusive",
+      issues: [],
+      summary: "Semantic review deferred while governed local CI owns host capacity.",
+      inconclusiveReason: "local-ci-active-capacity-reservation",
+    });
+    expect(routeAndCall).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the host-capacity registry cannot be read", async () => {
+    vi.mocked(listActiveNonprodEnvironmentLeases).mockRejectedValue(new Error("registry unavailable"));
+
+    const result = await dispatchRoutedSemanticReview("review this", {
+      strategyProfile: "high-assurance",
+      reviewerId: "change-reviewer",
+      specialistIds: [],
+      surface: "external",
+    });
+
+    expect(result.decision).toBe("inconclusive");
+    expect(result.inconclusiveReason).toBe("local-ci-capacity-reservation-unavailable");
+    expect(routeAndCall).not.toHaveBeenCalled();
+  });
+
+  it("does not defer review for an unrelated nonproduction lease", async () => {
+    vi.mocked(listActiveNonprodEnvironmentLeases).mockResolvedValue([
+      { environmentKey: "dev-portal" },
+    ] as never);
+    vi.mocked(routeAndCall).mockResolvedValue({
+      content: JSON.stringify({ decision: "pass", issues: [], summary: "Pass." }),
+    } as never);
+
+    const result = await dispatchRoutedSemanticReview("review this", {
+      strategyProfile: "high-assurance",
+      reviewerId: "change-reviewer",
+      specialistIds: [],
+      surface: "external",
+    });
+
+    expect(result.decision).toBe("pass");
+    expect(routeAndCall).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/lib/change-review/routed-semantic-review.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.ts
@@ -1,4 +1,5 @@
 import { routeAndCall } from "@/lib/inference/routed-inference";
+import { listActiveNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
 import { CHANGE_REVIEWER_ROUTE_AGENT } from "@/lib/tak/change-reviewer-route";
 import { parseSemanticReviewResponse, type SemanticReviewResult } from "./semantic-change-review";
 import type { SemanticChangeReviewDispatchContext } from "./semantic-change-review-operation";
@@ -29,11 +30,42 @@ function mergeReviewResults(results: SemanticReviewResult[]): SemanticReviewResu
   };
 }
 
+async function localCiCapacityGuard(): Promise<SemanticReviewResult | null> {
+  try {
+    const activeLeases = await listActiveNonprodEnvironmentLeases({});
+    if (!activeLeases.some((lease) => lease.environmentKey === "local-integration-ci")) {
+      return null;
+    }
+    return {
+      decision: "inconclusive",
+      issues: [],
+      summary: "Semantic review deferred while governed local CI owns host capacity.",
+      inconclusiveReason: "local-ci-active-capacity-reservation",
+    };
+  } catch {
+    return {
+      decision: "inconclusive",
+      issues: [],
+      summary: "Semantic review deferred because host-capacity ownership could not be verified.",
+      inconclusiveReason: "local-ci-capacity-reservation-unavailable",
+    };
+  }
+}
+
 /** Execute the governed Change Reviewer plus content-scoped specialist branches. */
 export async function dispatchRoutedSemanticReview(
   prompt: string,
   context: SemanticChangeReviewDispatchContext,
 ): Promise<SemanticReviewResult> {
+  // Local-CI admission already accounts for a model that is resident before
+  // the lease is bound. Protect the opposite ordering too: once local CI owns
+  // the host, no semantic-review route may begin because a remote route can
+  // still fall back to the bundled 32k-context model after dispatch. Returning
+  // an infrastructure-inconclusive result keeps the immutable review identity
+  // retryable without misclassifying capacity as a code finding.
+  const capacityGuard = await localCiCapacityGuard();
+  if (capacityGuard) return capacityGuard;
+
   const branches = [
     {
       agentId: "change-reviewer",


### PR DESCRIPTION
## Summary
- reserve local-CI host capacity across the semantic-review dispatch plane
- defer review inference while the governed local integration lease is active
- fail closed when the lease registry cannot establish that capacity is available

## Why
The deployed capacity fence correctly rejects an unsafe host at admission, but a semantic-review model could start after admission and consume the build reserve. Multiple exact archetype candidates then terminated during TypeScript or Vitest with `host-capacity-lost:host-memory-low` and no source assertion. This change closes that cross-plane race at the review dispatch boundary.

## Verification
- targeted routed semantic-review tests: 5 passed
- web TypeScript check: passed
- repository preflight: 35 guards clean
- independent high-assurance semantic review: terminal pass, zero findings
- exact local integration could not self-host because the deployed runtime is the capacity-arbitration patient under repair; hosted CI is the independent merged-tree verifier

BI-7B9C9376
WC-1BEFE348

Local-CI-Override: install-bootstrap-recovery: deployed runtime allows semantic-review inference to start after local-CI admission; the exact reviewed correction cannot self-host under that runtime
Process-Spine-Decision: localized bugfix restores existing semantic-review and local-CI host-capacity ownership contracts; no new product or operator process surface