### PR TITLE
feat: enforce installation funding authority

### DIFF
--- a/apps/web/app/(shell)/workspace/page.test.tsx
+++ b/apps/web/app/(shell)/workspace/page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
 import { getWorkspaceTiles } from "@/lib/permissions";
 import { buildWorkspaceCommandCenterView } from "@/lib/workspace/command-center";
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
@@ -34,5 +35,12 @@ describe("workspace tile derivation", () => {
 
   it("loads platform workspace data through the workspace-home substrate boundary", () => {
     expect(typeof loadPlatformWorkspaceHomeData).toBe("function");
+  });
+
+  it("mounts installation-purpose confirmation in Workspace behind platform authority", () => {
+    const source = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain("<InstallationPurposePanel");
+    expect(source).toContain('"manage_platform"');
   });
 });

--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -10,6 +10,9 @@ import { WorkspaceStorefrontAttention } from "@/components/owner-first/Workspace
 import { WorkspaceTwinHero } from "@/components/workspace-home/WorkspaceTwinHero";
 import { LocalOnlyProviderNotice } from "@/components/workspace-home/LocalOnlyProviderNotice";
 import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/UnconfiguredWorkspaceHomeNotice";
+import { InstallationPurposePanel } from "@/components/workspace/InstallationPurposePanel";
+import { can } from "@/lib/permissions";
+import { loadInstallationOperatingIntent } from "@/lib/installation-journey/operating-intent";
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
 import { resolveWorkspaceHomeContribution } from "@/lib/workspace-home/registry";
 import { loadWorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
@@ -27,6 +30,10 @@ export default async function WorkspacePage() {
   // BI-655418A7: Simple mode must condense the home body, not only the rail.
   const navMode = resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value);
   const simpleHome = isSimpleNavMode(navMode);
+  const canManageInstallation = can(
+    { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+    "manage_platform",
+  );
 
   const platformHomeData = await loadPlatformWorkspaceHomeData({
     prismaClient: prisma,
@@ -84,6 +91,9 @@ export default async function WorkspacePage() {
 
   return (
     <div data-nav-mode={navMode}>
+      {canManageInstallation ? (
+        <InstallationPurposePanel loaded={await loadInstallationOperatingIntent(prisma)} />
+      ) : null}
       {workspaceHomeResolution.mode === "unconfigured" && <UnconfiguredWorkspaceHomeNotice />}
       {workspaceHomeResolution.mode !== "unconfigured" && !hasCloudProvider && (
         <LocalOnlyProviderNotice />

--- a/apps/web/components/workspace/InstallationPurposePanel.tsx
+++ b/apps/web/components/workspace/InstallationPurposePanel.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { CheckCircle2, Save } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import {
+  type InstallationOperatingPurpose,
+} from "@dpf/db/installation-operating-intent";
+import { confirmInstallationOperatingPurpose } from "@/lib/actions/installation-operating-intent";
+import type { LoadedInstallationOperatingIntent } from "@/lib/installation-journey/operating-intent";
+
+const PURPOSE_OPTIONS: Array<{
+  value: InstallationOperatingPurpose;
+  label: string;
+}> = [
+  { value: "operate-organization", label: "Run our organization" },
+  { value: "evolve-dpf", label: "Safely improve another DPF" },
+  { value: "deliver-managed-services", label: "Operate DPF for customers" },
+  { value: "grow-channel", label: "Grow DPF in a market or region" },
+  { value: "participate-community", label: "Participate in the DPF community" },
+];
+
+export function InstallationPurposePanel({
+  loaded,
+}: {
+  loaded: LoadedInstallationOperatingIntent;
+}) {
+  const router = useRouter();
+  const current = loaded.status === "valid" ? loaded.intent.primaryPurpose : null;
+  const confirmed = loaded.status === "valid" && loaded.intent.confirmation.status === "confirmed";
+  const [purpose, setPurpose] = useState<InstallationOperatingPurpose>(current ?? "operate-organization");
+  const [message, setMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const consequence = purpose === "operate-organization"
+    ? "This installation may make governed funding decisions after the organization stance approves them."
+    : "This installation may contribute demand and evidence, while canonical funding stays with the organization-operating installation.";
+
+  function save() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await confirmInstallationOperatingPurpose(purpose);
+      if (!result.ok) {
+        setMessage(result.error);
+        return;
+      }
+      setMessage("Operating purpose confirmed.");
+      router.refresh();
+    });
+  }
+
+  return (
+    <section className="border-b border-[var(--dpf-border)] px-4 py-4 sm:px-6" aria-labelledby="installation-purpose-heading">
+      <div className="mb-3 flex items-start justify-between gap-4">
+        <div>
+          <h2 id="installation-purpose-heading" className="text-base font-semibold text-[var(--dpf-text)]">Installation purpose</h2>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            Choose which outcome this installation is accountable for first.
+          </p>
+        </div>
+        {confirmed && current ? (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--dpf-success)]">
+            <CheckCircle2 aria-hidden="true" className="h-4 w-4" />
+            Confirmed
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <label className="min-w-0 flex-1 text-xs font-medium text-[var(--dpf-muted)]">
+          Primary operating purpose
+          <select
+            value={purpose}
+            onChange={(event) => setPurpose(event.target.value as InstallationOperatingPurpose)}
+            disabled={isPending}
+            className="mt-1 min-h-10 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 text-sm text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+          >
+            {PURPOSE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={save}
+          disabled={isPending || (confirmed && purpose === current)}
+          className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md bg-[var(--dpf-accent)] px-4 text-sm font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Save aria-hidden="true" className="h-4 w-4" />
+          {isPending ? "Confirming" : "Confirm purpose"}
+        </button>
+      </div>
+
+      <p className="mt-2 text-xs text-[var(--dpf-muted)]">{consequence}</p>
+
+      {message ? <p className="mt-2 text-xs text-[var(--dpf-muted)]" role="status">{message}</p> : null}
+      {loaded.status === "invalid" ? (
+        <p className="mt-2 text-xs text-[var(--dpf-danger)]" role="alert">
+          The stored operating-purpose record needs to be confirmed again.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/actions/installation-operating-intent.test.ts
+++ b/apps/web/lib/actions/installation-operating-intent.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireCapability: vi.fn(),
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+  revalidatePath: vi.fn(),
+  resolvePrincipal: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("@/lib/actions/shared/guards", () => ({ requireCapability: mocks.requireCapability }));
+vi.mock("@/lib/identity/principal-linking", () => ({ resolvePrincipalIdForUser: mocks.resolvePrincipal }));
+vi.mock("@dpf/db", () => ({
+  prisma: { platformConfig: { findUnique: mocks.findUnique, upsert: mocks.upsert } },
+}));
+
+import { confirmInstallationOperatingPurpose } from "./installation-operating-intent";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireCapability.mockResolvedValue({ userId: "principal-1" });
+  mocks.resolvePrincipal.mockResolvedValue("PRN-1");
+  mocks.findUnique.mockResolvedValue(null);
+  mocks.upsert.mockResolvedValue({});
+});
+
+describe("confirmInstallationOperatingPurpose", () => {
+  it("refuses an unknown purpose without writing", async () => {
+    await expect(confirmInstallationOperatingPurpose("production")).resolves.toMatchObject({ ok: false });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("records owner confirmation without granting another capability", async () => {
+    const result = await confirmInstallationOperatingPurpose("operate-organization");
+
+    expect(result).toEqual({ ok: true, primaryPurpose: "operate-organization" });
+    expect(mocks.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { key: "installation.operating-intent.v1" },
+      create: expect.objectContaining({ key: "installation.operating-intent.v1" }),
+    }));
+    const stored = mocks.upsert.mock.calls[0][0].create.value;
+    expect(stored).toMatchObject({
+      schemaVersion: 1,
+      primaryPurpose: "operate-organization",
+      confirmation: { status: "confirmed", confirmedByPrincipalId: "PRN-1" },
+    });
+    expect(stored).not.toHaveProperty("grants");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/workspace");
+  });
+});

--- a/apps/web/lib/actions/installation-operating-intent.ts
+++ b/apps/web/lib/actions/installation-operating-intent.ts
@@ -1,0 +1,74 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma, type Prisma } from "@dpf/db";
+import {
+  INSTALLATION_OPERATING_PURPOSES,
+  parseInstallationOperatingIntent,
+  type InstallationOperatingIntentV1,
+  type InstallationOperatingPurpose,
+} from "@dpf/db/installation-operating-intent";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import { resolvePrincipalIdForUser } from "@/lib/identity/principal-linking";
+import { INSTALLATION_OPERATING_INTENT_KEY } from "@/lib/installation-journey/operating-intent";
+
+export type ConfirmInstallationPurposeResult =
+  | { ok: true; primaryPurpose: InstallationOperatingPurpose }
+  | { ok: false; error: string };
+
+export async function confirmInstallationOperatingPurpose(
+  requestedPurpose: string,
+): Promise<ConfirmInstallationPurposeResult> {
+  if (!(INSTALLATION_OPERATING_PURPOSES as readonly string[]).includes(requestedPurpose)) {
+    return { ok: false, error: "Choose a recognized installation purpose." };
+  }
+
+  const { userId } = await requireCapability("manage_platform");
+  const principalId = (await resolvePrincipalIdForUser(userId)) ?? userId;
+  const primaryPurpose = requestedPurpose as InstallationOperatingPurpose;
+  const existing = await prisma.platformConfig.findUnique({
+    where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+    select: { value: true },
+  });
+  const parsed = parseInstallationOperatingIntent(existing?.value);
+  const now = new Date().toISOString();
+
+  const value: InstallationOperatingIntentV1 = {
+    schemaVersion: 1,
+    primaryPurpose,
+    secondaryPurposes: parsed.ok
+      ? parsed.value.secondaryPurposes.filter((purpose) => purpose !== primaryPurpose)
+      : [],
+    relationshipIntents: parsed.ok ? parsed.value.relationshipIntents : [],
+    ...(parsed.ok && parsed.value.pairedProductionInstallationRef
+      ? { pairedProductionInstallationRef: parsed.value.pairedProductionInstallationRef }
+      : {}),
+    evidence: [
+      ...(parsed.ok ? parsed.value.evidence : []),
+      {
+        source: "human",
+        claim: `The operator confirmed ${primaryPurpose} as this installation's primary purpose.`,
+        observedAt: now,
+      },
+    ],
+    confidence: "high",
+    confirmation: {
+      status: "confirmed",
+      confirmedAt: now,
+      confirmedByPrincipalId: principalId,
+    },
+  };
+
+  await prisma.platformConfig.upsert({
+    where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+    update: { value: value as unknown as Prisma.InputJsonValue },
+    create: {
+      key: INSTALLATION_OPERATING_INTENT_KEY,
+      value: value as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  revalidatePath("/workspace");
+  return { ok: true, primaryPurpose };
+}

--- a/apps/web/lib/installation-journey/operating-intent.test.ts
+++ b/apps/web/lib/installation-journey/operating-intent.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  INSTALLATION_OPERATING_INTENT_KEY,
+  loadInstallationOperatingIntent,
+  resolveInvestmentFundingAuthority,
+} from "./operating-intent";
+
+function dbWith(value: unknown) {
+  return {
+    platformConfig: {
+      findUnique: vi.fn().mockResolvedValue(value === undefined ? null : { value }),
+    },
+  };
+}
+
+const intent = (primaryPurpose: string, status = "confirmed") => ({
+  schemaVersion: 1,
+  primaryPurpose,
+  secondaryPurposes: [],
+  relationshipIntents: [],
+  evidence: [{ source: "human", claim: "Confirmed by the operator.", observedAt: "2026-08-08T12:00:00.000Z" }],
+  confidence: "high",
+  confirmation: status === "confirmed"
+    ? { status, confirmedAt: "2026-08-08T12:00:00.000Z", confirmedByPrincipalId: "principal-1" }
+    : { status },
+});
+
+describe("installation operating intent repository", () => {
+  it("reads the canonical PlatformConfig key", async () => {
+    const db = dbWith(intent("operate-organization"));
+
+    const result = await loadInstallationOperatingIntent(db);
+
+    expect(db.platformConfig.findUnique).toHaveBeenCalledWith({
+      where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+      select: { value: true },
+    });
+    expect(result.status).toBe("valid");
+  });
+
+  it.each([
+    ["missing", dbWith(undefined)],
+    ["invalid", dbWith({ schemaVersion: 99 })],
+  ])("fails closed for %s configuration", async (status, db) => {
+    const loaded = await loadInstallationOperatingIntent(db);
+    expect(loaded.status).toBe(status);
+    expect(resolveInvestmentFundingAuthority(loaded)).toMatchObject({ allowed: false });
+  });
+
+  it("allows only a confirmed organization-operating installation", async () => {
+    const production = await loadInstallationOperatingIntent(dbWith(intent("operate-organization")));
+    const companion = await loadInstallationOperatingIntent(dbWith(intent("evolve-dpf")));
+    const suggested = await loadInstallationOperatingIntent(dbWith(intent("operate-organization", "suggested")));
+
+    expect(resolveInvestmentFundingAuthority(production)).toEqual({ allowed: true });
+    expect(resolveInvestmentFundingAuthority(companion)).toMatchObject({
+      allowed: false,
+      error: "installation_authority_required",
+    });
+    expect(resolveInvestmentFundingAuthority(suggested)).toMatchObject({ allowed: false });
+  });
+});

--- a/apps/web/lib/installation-journey/operating-intent.ts
+++ b/apps/web/lib/installation-journey/operating-intent.ts
@@ -1,0 +1,70 @@
+import {
+  parseInstallationOperatingIntent,
+  type InstallationOperatingIntentV1,
+} from "@dpf/db/installation-operating-intent";
+
+export const INSTALLATION_OPERATING_INTENT_KEY = "installation.operating-intent.v1";
+
+type InstallationIntentDb = {
+  platformConfig: {
+    findUnique(args: {
+      where: { key: string };
+      select: { value: true };
+    }): Promise<{ value: unknown } | null>;
+  };
+};
+
+export type LoadedInstallationOperatingIntent =
+  | { status: "valid"; intent: InstallationOperatingIntentV1 }
+  | { status: "missing" }
+  | { status: "invalid"; error: string };
+
+export type InvestmentFundingAuthority =
+  | { allowed: true }
+  | { allowed: false; error: "installation_authority_required"; message: string };
+
+export async function loadInstallationOperatingIntent(
+  db: InstallationIntentDb,
+): Promise<LoadedInstallationOperatingIntent> {
+  const row = await db.platformConfig.findUnique({
+    where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+    select: { value: true },
+  });
+  if (!row) return { status: "missing" };
+
+  const parsed = parseInstallationOperatingIntent(row.value);
+  return parsed.ok
+    ? { status: "valid", intent: parsed.value }
+    : { status: "invalid", error: parsed.error };
+}
+
+/**
+ * Installation intent never grants funding permission. This prerequisite only
+ * proves that an already-authorized caller is acting on the confirmed business
+ * installation before WWWD decides whether the investment should proceed.
+ */
+export function resolveInvestmentFundingAuthority(
+  loaded: LoadedInstallationOperatingIntent,
+): InvestmentFundingAuthority {
+  if (
+    loaded.status === "valid"
+    && loaded.intent.confirmation.status === "confirmed"
+    && loaded.intent.primaryPurpose === "operate-organization"
+  ) {
+    return { allowed: true };
+  }
+
+  const reason = loaded.status === "missing"
+    ? "This installation has not confirmed its operating purpose."
+    : loaded.status === "invalid"
+      ? "This installation's operating-purpose record is invalid."
+      : loaded.intent.confirmation.status !== "confirmed"
+        ? "This installation's operating purpose still needs owner confirmation."
+        : "Investment funding is owned by the confirmed organization-operating installation.";
+
+  return {
+    allowed: false,
+    error: "installation_authority_required",
+    message: `${reason} This installation may still contribute demand and evidence, but it cannot make the canonical funding decision.`,
+  };
+}

--- a/apps/web/lib/mcp/packs/demand-scoring-administration-authority.test.ts
+++ b/apps/web/lib/mcp/packs/demand-scoring-administration-authority.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  backlogFind: vi.fn(),
+  platformConfigFind: vi.fn(),
+  activityCreate: vi.fn(),
+  loadActivation: vi.fn(),
+  evaluateTransition: vi.fn(),
+  transitionDemand: vi.fn(),
+  evaluateOrgGate: vi.fn(),
+  refreshPlaybook: vi.fn(),
+  authorizationLog: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    backlogItem: { findUnique: mocks.backlogFind },
+    platformConfig: { findUnique: mocks.platformConfigFind },
+    backlogItemActivity: { create: mocks.activityCreate },
+  },
+}));
+vi.mock("@/lib/demand/transition-repository", () => ({
+  loadDemandActivation: mocks.loadActivation,
+  transitionDemandItem: mocks.transitionDemand,
+}));
+vi.mock("@/lib/demand/activation", () => ({ evaluateDemandTransition: mocks.evaluateTransition }));
+vi.mock("@/lib/decision-perspective/org-business-gate", () => ({
+  evaluateOrgBusinessDecisionGate: mocks.evaluateOrgGate,
+}));
+vi.mock("@/lib/product-management/product-management-playbook-refresh", () => ({
+  queueProductManagementPlaybookRefreshForBacklogItem: mocks.refreshPlaybook,
+}));
+vi.mock("@/lib/governance-data", () => ({ createAuthorizationDecisionLog: mocks.authorizationLog }));
+vi.mock("@/lib/demand/volunteering.server", () => ({
+  offerFundedItemToCoworker: vi.fn().mockResolvedValue({ offered: false, agentId: null }),
+  recordVolunteeringAutonomyShadow: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { approveDemandForFundingHandler } from "./demand-scoring-administration";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.backlogFind.mockResolvedValue({
+    id: "row-1",
+    itemId: "BI-1",
+    title: "Important work",
+    organizationId: "org-1",
+    demandScore: 10,
+    demandStage: "shaped",
+    investmentBucket: "grow",
+    effortSize: "small",
+    agentId: null,
+    claimStatus: null,
+  });
+  mocks.loadActivation.mockResolvedValue({ input: {} });
+  mocks.evaluateTransition.mockReturnValue({ allowed: false, code: "funding-decision-required", message: "Needs funding." });
+});
+
+describe("approveDemandForFundingHandler installation authority", () => {
+  it.each([
+    ["missing intent", null],
+    ["development companion", { value: {
+      schemaVersion: 1,
+      primaryPurpose: "evolve-dpf",
+      secondaryPurposes: [],
+      relationshipIntents: [],
+      evidence: [{ source: "human", claim: "Confirmed companion.", observedAt: "2026-08-08T12:00:00.000Z" }],
+      confidence: "high",
+      confirmation: { status: "confirmed", confirmedAt: "2026-08-08T12:00:00.000Z", confirmedByPrincipalId: "principal-1" },
+    } }],
+  ])("refuses %s before WWWD or backlog mutation", async (_label, config) => {
+    mocks.platformConfigFind.mockResolvedValue(config);
+
+    const result = await approveDemandForFundingHandler({ itemId: "BI-1" }, "user-1");
+
+    expect(result).toMatchObject({ success: false, error: "installation_authority_required" });
+    expect(mocks.evaluateOrgGate).not.toHaveBeenCalled();
+    expect(mocks.authorizationLog).toHaveBeenCalledWith(expect.objectContaining({
+      actionKey: "approve_demand_for_funding",
+      decision: "deny",
+      objectRef: "BI-1",
+    }));
+    expect(mocks.transitionDemand).not.toHaveBeenCalled();
+    expect(mocks.activityCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows a confirmed business-production installation to reach WWWD and fund work", async () => {
+    mocks.platformConfigFind.mockResolvedValue({
+      value: {
+        schemaVersion: 1,
+        primaryPurpose: "operate-organization",
+        secondaryPurposes: [],
+        relationshipIntents: [],
+        evidence: [{ source: "human", claim: "Confirmed production role.", observedAt: "2026-08-08T12:00:00.000Z" }],
+        confidence: "high",
+        confirmation: { status: "confirmed", confirmedAt: "2026-08-08T12:00:00.000Z", confirmedByPrincipalId: "principal-1" },
+      },
+    });
+    mocks.evaluateOrgGate.mockResolvedValue({
+      allowed: true,
+      interactionId: "DI-1",
+      operatorMessage: "The organization stance supports funding.",
+      evaluation: { outcomeType: "recommend" },
+      orgProfileSelected: true,
+    });
+    mocks.transitionDemand.mockResolvedValue({ ok: true });
+    mocks.activityCreate.mockResolvedValue({});
+    mocks.refreshPlaybook.mockResolvedValue(undefined);
+
+    const result = await approveDemandForFundingHandler({ itemId: "BI-1" }, "user-1");
+
+    expect(result).toMatchObject({ success: true, data: { funded: true, demandStage: "ready" } });
+    expect(mocks.evaluateOrgGate).toHaveBeenCalledOnce();
+    expect(mocks.transitionDemand).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      itemId: "BI-1",
+      to: "ready",
+      fundingDecisionAllowed: true,
+    }));
+    expect(mocks.authorizationLog).not.toHaveBeenCalled();
+    expect(mocks.activityCreate).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/mcp/packs/demand-scoring-administration.ts
+++ b/apps/web/lib/mcp/packs/demand-scoring-administration.ts
@@ -4,6 +4,11 @@ import type { DemandTransitionDb } from "@/lib/demand/transition-repository";
 import { fundingRiskTier } from "@/lib/demand/funding-risk";
 import type { ToolResult } from "@/lib/mcp-tools";
 import { queueProductManagementPlaybookRefreshForBacklogItem } from "@/lib/product-management/product-management-playbook-refresh";
+import { createAuthorizationDecisionLog } from "@/lib/governance-data";
+import {
+  loadInstallationOperatingIntent,
+  resolveInvestmentFundingAuthority,
+} from "@/lib/installation-journey/operating-intent";
 
 function mergeBucketTargets(current: unknown, incoming: unknown): Record<string, number> {
   const merged: Record<string, number> =
@@ -298,6 +303,30 @@ export async function approveDemandForFundingHandler(
       error: "organization_required",
       message:
         "Classify this demand to an organization before requesting funding.",
+    };
+  }
+
+  const loadedInstallationIntent = await loadInstallationOperatingIntent(prisma);
+  const installationAuthority = resolveInvestmentFundingAuthority(loadedInstallationIntent);
+  if (!installationAuthority.allowed) {
+    await createAuthorizationDecisionLog({
+      actorType: context?.agentId ? "agent" : "user",
+      actorRef: context?.agentId ?? userId,
+      humanContextRef: userId,
+      agentContextRef: context?.agentId ?? null,
+      actionKey: "approve_demand_for_funding",
+      objectRef: item.itemId,
+      routeContext: context?.routeContext ?? "/ops/demand",
+      decision: "deny",
+      rationale: {
+        code: installationAuthority.error,
+        installationIntentStatus: loadedInstallationIntent.status,
+      },
+    });
+    return {
+      success: false,
+      error: installationAuthority.error,
+      message: installationAuthority.message,
     };
   }
 

--- a/docs/superpowers/specs/2026-08-08-purpose-aware-installation-ecosystem-productivity-design.md
+++ b/docs/superpowers/specs/2026-08-08-purpose-aware-installation-ecosystem-productivity-design.md
@@ -696,6 +696,36 @@ Implementation adds one Purpose-Aware Installation Lifecycle block/package to th
 
 **Exit:** a profile can be stored, decoded, derived, confirmed, and changed without affecting trust or capability activation.
 
+**Implemented boundary slice (BI-50136281):** the shared V1 decoder and the
+`installation.operating-intent.v1` repository are mounted as the first milestone
+of the Workspace journey.
+Investment funding now requires a human-confirmed `operate-organization` primary
+purpose before the existing organization WWWD gate runs. Missing, malformed,
+suggested, and development-companion intent fails closed and is audit logged.
+This check is a prerequisite only: user capabilities, MCP grants, TAK, and
+`AuthorityBinding` remain the canonical permission authorities, and confirming a
+purpose neither creates nor widens a grant.
+
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - this purpose-aware installation design and its implementation plan;
+  - the unified delivery-surfaces execution-alignment design;
+  - the coworker authority-binding design and implementation plan.
+- Current code substrate reviewed:
+  - the canonical `PlatformConfig` repository;
+  - Workspace home composition and platform capability checks;
+  - `AuthorityBinding` effective-authority resolution;
+  - the existing investment-funding WWWD gate and authorization audit log.
+- Source of truth:
+  - `installation.operating-intent.v1` owns confirmed installation intent;
+  - user capabilities, MCP grants, TAK, and `AuthorityBinding` continue to own
+    permission; the organization WWWD profile owns the funding judgment.
+- Decision:
+  - mount owner confirmation as the first Workspace journey milestone and use
+    confirmed `operate-organization` intent as a fail-closed prerequisite before
+    the existing funding gate, without creating another authority system.
+
 ### Phase 1 — compiler and evidence model
 
 - pure journey compiler;

--- a/docs/ux-fit/2026-08-08-installation-purpose-workspace.ux-fit.json
+++ b/docs/ux-fit/2026-08-08-installation-purpose-workspace.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "workspace-journey-now",
+  "decisionInteractionId": "DI-0AFBC431BADE",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace/InstallationPurposePanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "workspace-journey-now",
+      "admin-settings-now",
+      "platform-identity-route"
+    ]
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,6 +21,7 @@
     "./customer-lifecycle": "./src/customer-lifecycle.ts",
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
+    "./installation-operating-intent": "./src/installation-operating-intent.ts",
     "./federation-pairing-types": "./src/federation-pairing-types.ts",
     "./federated-demand-contract": "./src/federated-demand-contract.ts",
     "./federated-channel": "./src/federated-channel.ts",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -522,6 +522,7 @@ export * from "./device-catalog";
 // NFT pattern. The helper is test-only — import it directly from
 // `./discovery-fingerprint-catalog` in tests, not via the barrel.
 export * from "./discovery-fingerprint-store";
+export * from "./installation-operating-intent";
 
 // Contributor-inventory-sync ScheduledJob constants — shared between the
 // seed helper and the apps/web Inngest runner so the heartbeat row's name +

--- a/packages/db/src/installation-operating-intent.test.ts
+++ b/packages/db/src/installation-operating-intent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INSTALLATION_OPERATING_PURPOSES,
+  parseInstallationOperatingIntent,
+} from "./installation-operating-intent";
+
+const confirmedIntent = {
+  schemaVersion: 1,
+  primaryPurpose: "operate-organization",
+  secondaryPurposes: ["participate-community"],
+  relationshipIntents: ["same-organization"],
+  evidence: [
+    {
+      source: "human",
+      claim: "The operator confirmed this installation runs the organization.",
+      observedAt: "2026-08-08T12:00:00.000Z",
+    },
+  ],
+  confidence: "high",
+  confirmation: {
+    status: "confirmed",
+    confirmedAt: "2026-08-08T12:00:00.000Z",
+    confirmedByPrincipalId: "principal-1",
+  },
+};
+
+describe("parseInstallationOperatingIntent", () => {
+  it("keeps the purpose vocabulary closed", () => {
+    expect(INSTALLATION_OPERATING_PURPOSES).toEqual([
+      "operate-organization",
+      "evolve-dpf",
+      "deliver-managed-services",
+      "grow-channel",
+      "participate-community",
+    ]);
+  });
+
+  it("accepts a confirmed v1 intent", () => {
+    expect(parseInstallationOperatingIntent(confirmedIntent)).toEqual({
+      ok: true,
+      value: confirmedIntent,
+    });
+  });
+
+  it.each([
+    ["unknown schema", { ...confirmedIntent, schemaVersion: 2 }],
+    ["unknown purpose", { ...confirmedIntent, primaryPurpose: "production" }],
+    ["duplicate purpose", { ...confirmedIntent, secondaryPurposes: ["operate-organization"] }],
+    ["unknown relationship", { ...confirmedIntent, relationshipIntents: ["trusted-peer"] }],
+    ["incomplete confirmation", { ...confirmedIntent, confirmation: { status: "confirmed" } }],
+  ])("rejects %s", (_label, input) => {
+    expect(parseInstallationOperatingIntent(input)).toMatchObject({ ok: false });
+  });
+});

--- a/packages/db/src/installation-operating-intent.ts
+++ b/packages/db/src/installation-operating-intent.ts
@@ -1,0 +1,120 @@
+import {
+  FEDERATION_RELATIONSHIP_PRESETS,
+  type FederationRelationshipPreset,
+} from "./federation-link-types";
+
+export const INSTALLATION_OPERATING_PURPOSES = [
+  "operate-organization",
+  "evolve-dpf",
+  "deliver-managed-services",
+  "grow-channel",
+  "participate-community",
+] as const;
+
+export type InstallationOperatingPurpose = (typeof INSTALLATION_OPERATING_PURPOSES)[number];
+
+export const INSTALLATION_INTENT_EVIDENCE_SOURCES = [
+  "installer",
+  "organization",
+  "business-context",
+  "capability",
+  "federation",
+  "human",
+] as const;
+
+export type InstallationIntentEvidenceSource = (typeof INSTALLATION_INTENT_EVIDENCE_SOURCES)[number];
+export type InstallationIntentConfidence = "high" | "medium" | "low";
+export type InstallationIntentConfirmationStatus = "suggested" | "confirmed" | "needs-review";
+
+export type InstallationOperatingIntentV1 = {
+  schemaVersion: 1;
+  primaryPurpose: InstallationOperatingPurpose;
+  secondaryPurposes: InstallationOperatingPurpose[];
+  relationshipIntents: FederationRelationshipPreset[];
+  pairedProductionInstallationRef?: string;
+  evidence: Array<{
+    source: InstallationIntentEvidenceSource;
+    claim: string;
+    sourceRef?: string;
+    valueFingerprint?: string;
+    observedAt: string;
+  }>;
+  confidence: InstallationIntentConfidence;
+  confirmation: {
+    status: InstallationIntentConfirmationStatus;
+    confirmedAt?: string;
+    confirmedByPrincipalId?: string;
+  };
+};
+
+export type InstallationOperatingIntentParseResult =
+  | { ok: true; value: InstallationOperatingIntentV1 }
+  | { ok: false; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isIsoDate(value: unknown): value is string {
+  return isNonEmptyString(value) && Number.isFinite(Date.parse(value));
+}
+
+function isPurpose(value: unknown): value is InstallationOperatingPurpose {
+  return (INSTALLATION_OPERATING_PURPOSES as readonly unknown[]).includes(value);
+}
+
+function isRelationship(value: unknown): value is FederationRelationshipPreset {
+  return (FEDERATION_RELATIONSHIP_PRESETS as readonly unknown[]).includes(value);
+}
+
+export function parseInstallationOperatingIntent(value: unknown): InstallationOperatingIntentParseResult {
+  if (!isRecord(value) || value.schemaVersion !== 1) {
+    return { ok: false, error: "Unsupported or missing installation operating-intent schema version." };
+  }
+  if (!isPurpose(value.primaryPurpose)) {
+    return { ok: false, error: "Installation primary purpose is not recognized." };
+  }
+  if (!Array.isArray(value.secondaryPurposes) || !value.secondaryPurposes.every(isPurpose)) {
+    return { ok: false, error: "Installation secondary purposes are invalid." };
+  }
+  const purposeSet = new Set([value.primaryPurpose, ...value.secondaryPurposes]);
+  if (purposeSet.size !== value.secondaryPurposes.length + 1) {
+    return { ok: false, error: "Installation purposes must be unique." };
+  }
+  if (!Array.isArray(value.relationshipIntents) || !value.relationshipIntents.every(isRelationship)) {
+    return { ok: false, error: "Installation relationship intent is not recognized." };
+  }
+  if (new Set(value.relationshipIntents).size !== value.relationshipIntents.length) {
+    return { ok: false, error: "Installation relationship intents must be unique." };
+  }
+  if (value.pairedProductionInstallationRef !== undefined && !isNonEmptyString(value.pairedProductionInstallationRef)) {
+    return { ok: false, error: "Paired production installation reference must be a non-empty string." };
+  }
+  if (!Array.isArray(value.evidence) || !value.evidence.every((entry) => {
+    if (!isRecord(entry)) return false;
+    return (INSTALLATION_INTENT_EVIDENCE_SOURCES as readonly unknown[]).includes(entry.source)
+      && isNonEmptyString(entry.claim)
+      && isIsoDate(entry.observedAt)
+      && (entry.sourceRef === undefined || isNonEmptyString(entry.sourceRef))
+      && (entry.valueFingerprint === undefined || isNonEmptyString(entry.valueFingerprint));
+  })) {
+    return { ok: false, error: "Installation intent evidence is invalid." };
+  }
+  if (value.confidence !== "high" && value.confidence !== "medium" && value.confidence !== "low") {
+    return { ok: false, error: "Installation intent confidence is invalid." };
+  }
+  if (!isRecord(value.confirmation)
+    || !["suggested", "confirmed", "needs-review"].includes(String(value.confirmation.status))) {
+    return { ok: false, error: "Installation intent confirmation is invalid." };
+  }
+  if (value.confirmation.status === "confirmed"
+    && (!isIsoDate(value.confirmation.confirmedAt) || !isNonEmptyString(value.confirmation.confirmedByPrincipalId))) {
+    return { ok: false, error: "Confirmed installation intent requires confirmation provenance." };
+  }
+
+  return { ok: true, value: value as InstallationOperatingIntentV1 };
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -8203,6 +8203,13 @@
     "longSentences": 0,
     "textMass": 29
   },
+  "apps/web/components/workspace/InstallationPurposePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 54
+  },
   "apps/web/components/workspace/PlatformReadinessMatrix.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Summary

Makes each DPF installation declare its primary operating purpose and uses that confirmed intent to enforce which installation may approve demand for funding. Arcamanus can be confirmed as the organization-operating authority while companion development installations continue contributing demand and evidence without becoming investment authorities.

## Changes

- adds a closed, versioned installation operating-intent contract in `@dpf/db`
- persists the confirmed intent in canonical `PlatformConfig` state with strict fail-closed decoding
- adds an owner-only Workspace control with an explicit consequence preview
- requires confirmed `operate-organization` intent before demand can be approved for funding
- records denied funding approvals in the existing audit path
- preserves demand and evidence contribution from development companion installations
- updates the governing design spec and UX-fit decision

## Test plan

- [x] **Source checks**
  - [x] Web regression suite: 4 files / 16 tests passed
  - [x] DB contract suite: 1 file / 7 tests passed
  - [x] Scoped web and DB typechecks passed
  - [x] DCO, secret scan, diff check, and 35 preflight guards passed

- [x] **Runtime-bound change**
  - [x] Exact merged-tree full tests, typecheck, and production build passed in governed local CI
  - [x] Gate synthesized against current `main` commit `f3785487fce70169888aa6bd6b71f74cecf9813b`
  - [x] No migration was added or required

- [x] **Verification-harness limitation acknowledged**
  - The contributor preview was first exercised to the authentication boundary before an owner browser session was available. After an authenticated owner session became available, the canonical portal entered a self-upgrade drain and repeatedly refused the governed preview lease at `ready-to-swap`. No unleased or hand-built runtime was used. Interactive owner-path verification remains post-merge on the canonical install.

### Verification evidence

- Exact-tree local CI: `feat/investment-funding-installation-authority@7cd5298c18081a2b3111c0dfb449642d95738919`
- Evidence record: `cmsl5p61m01wm01qletcdxk5p`
- Production build: passed
- Semantic review: exact-tree high-assurance receipt recorded; no findings were returned on the final tree and shadow policy permits publication. A prior complete four-branch pass identified the selector focus treatment, which was repaired before the final commit.
- UX fit: Workspace placement selected by `DI-0AFBC431BADE`; deterministic UX-fit and design-grounding guards passed

Local-CI-Evidence: cmsl5p61m01wm01qletcdxk5p (feat/investment-funding-installation-authority@7cd5298c18081a2b3111c0dfb449642d95738919)

## Related work

This PR completes the code delivery for `BI-50136281` under `WC-C70026FE`.

The owner-authored Arcamanus WWWD stance remains a separate organization-governance publication, not code state.

## Overlap sweep

`gh pr list --state open --limit 100` found no open installation-purpose, funding-authority, investment-authority, or operating-intent overlap.

## Design grounding

- Existing specs/plans reviewed: the purpose-aware installation ecosystem productivity design and unified delivery-surfaces contract.
- Current code substrate reviewed: `PlatformConfig`, the existing Workspace owner surface, demand-scoring administration, audit logging, and canonical principal resolution.
- Source of truth: the typed operating-intent document stored under one canonical `PlatformConfig` key owns installation purpose; demand approval reads that contract rather than inferring authority from hostname, platform, or execution surface.
- Decision: extend the existing Workspace and demand-administration paths. Do not create a parallel installation registry, funding workflow, or Build Studio-only rule.

## Notes for reviewers

- Missing, malformed, unconfirmed, or non-organization-operating intent fails closed for funding approval.
- The control is visible only to principals with `manage_platform`.
- The typed contract reserves evidence metadata for the installation-role discovery work already underway without depending on that future implementation.

Docs-Impact-Decision: the governing design spec now records the implementation boundary and source of truth; no route guide was changed because the control extends the existing owner Workspace and its consequence is stated inline.
