### PR TITLE
fix: declare root verification runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@mermaid-js/mermaid-cli": "11.15.0",
     "@playwright/test": "^1.62.0",
-    "docx": "^9.7.1"
+    "docx": "^9.7.1",
+    "tsx": "^4.23.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,13 +92,16 @@ importers:
         version: 4.12.1(playwright-core@1.62.0)
       '@mermaid-js/mermaid-cli':
         specifier: 11.15.0
-        version: 11.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(puppeteer@23.11.1(typescript@6.0.3))
+        version: 11.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(puppeteer@23.11.1(typescript@6.0.3))(tsx@4.23.1)
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
       docx:
         specifier: ^9.7.1
         version: 9.7.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
 
   apps/mobile:
     dependencies:
@@ -10984,7 +10987,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.19)':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.19(tsx@4.23.1))':
     dependencies:
       tailwindcss: 3.4.19(tsx@4.23.1)(yaml@2.9.0)
 
@@ -11414,11 +11417,11 @@ snapshots:
       mermaid: 11.16.1
     optional: true
 
-  '@mermaid-js/mermaid-cli@11.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(puppeteer@23.11.1(typescript@6.0.3))':
+  '@mermaid-js/mermaid-cli@11.15.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(puppeteer@23.11.1(typescript@6.0.3))(tsx@4.23.1)':
     dependencies:
       '@fortawesome/fontawesome-free': 7.3.1
       '@mermaid-js/layout-elk': 0.2.2(mermaid@11.16.1)
-      '@mermaid-js/mermaid-zenuml': 0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.16.1)
+      '@mermaid-js/mermaid-zenuml': 0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.16.1)(tsx@4.23.1)
       chalk: 5.6.2
       commander: 13.1.0
       import-meta-resolve: 4.2.0
@@ -11435,9 +11438,9 @@ snapshots:
       - tsx
       - yaml
 
-  '@mermaid-js/mermaid-zenuml@0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.16.1)':
+  '@mermaid-js/mermaid-zenuml@0.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(mermaid@11.16.1)(tsx@4.23.1)':
     dependencies:
-      '@zenuml/core': 3.47.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)
+      '@zenuml/core': 3.47.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(tsx@4.23.1)
       mermaid: 11.16.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -12848,9 +12851,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.85.3': {}
 
@@ -14000,11 +14001,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
-  '@zenuml/core@3.47.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)':
+  '@zenuml/core@3.47.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(tsx@4.23.1)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@headlessui/react': 2.2.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.19)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.19(tsx@4.23.1))
       antlr4: 4.11.0
       class-variance-authority: 0.7.1
       clsx: 2.1.1

--- a/sbom/baseline.json
+++ b/sbom/baseline.json
@@ -1,15 +1,15 @@
 {
   "note": "Drift anchor for scripts/check-sbom-drift.mjs. `firstPartyDivergent` lists the accepted set of packages whose own workspace declarations resolve to >1 version; the guard fails when a NEW name appears. Update intentionally (align the versions, or accept here) — never to silence a real regression. Totals are informational. See docs/architecture/dependency-reduction-routine.md.",
   "totals": {
-    "resolvedComponents": 2013,
-    "uniqueNames": 1740,
-    "duplicatedNames": 213,
-    "excessInstances": 273,
+    "resolvedComponents": 2012,
+    "uniqueNames": 1746,
+    "duplicatedNames": 207,
+    "excessInstances": 266,
     "multiMajorNames": 140,
     "firstPartyDivergentNames": 1,
     "directButTransitiveNames": 13,
-    "dedupeCandidateNames": 71,
-    "directProdNames": 78,
+    "dedupeCandidateNames": 65,
+    "directProdNames": 80,
     "directDevNames": 36,
     "workspaces": 16
   },

--- a/scripts/check-root-script-runtime.test.mjs
+++ b/scripts/check-root-script-runtime.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const rootPackage = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+const PACKAGE_BACKED_RUNTIME_OWNERS = Object.freeze({
+  playwright: "@playwright/test",
+  tsx: "tsx",
+});
+
+function directDependencies(pkg) {
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+}
+
+function packageBackedCommands(scripts) {
+  const commands = [];
+  for (const [scriptName, command] of Object.entries(scripts ?? {})) {
+    for (const segment of command.split(/&&|\|\|/u)) {
+      const executable = segment.trim().split(/\s+/u)[0];
+      const owner = PACKAGE_BACKED_RUNTIME_OWNERS[executable];
+      if (owner) commands.push({ scriptName, executable, owner });
+    }
+  }
+  return commands;
+}
+
+test("root package scripts directly declare every package-backed runtime they invoke", () => {
+  const declared = directDependencies(rootPackage);
+  const undeclared = packageBackedCommands(rootPackage.scripts)
+    .filter(({ owner }) => !declared.has(owner));
+
+  assert.deepEqual(
+    undeclared,
+    [],
+    `Root scripts use undeclared package executables:\n${undeclared
+      .map(({ scriptName, executable, owner }) => `- ${scriptName}: ${executable} (declare ${owner})`)
+      .join("\n")}`,
+  );
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -112,6 +112,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-override-comments.test.mjs"),
       node("scripts/check-build-script-policy.mjs"),
       node("--test", "scripts/check-build-script-policy.test.mjs"),
+      node("--test", "scripts/check-root-script-runtime.test.mjs"),
     ]),
     guard("bundle-boundary-guard", "Bundle Boundary Guard", [
       node("scripts/check-bundle-boundaries.mjs"),


### PR DESCRIPTION
## Summary

- declare `tsx` as a direct root development dependency because root scripts invoke it directly
- add a source-policy guard that fails when a root script uses a package-backed executable without direct root ownership
- refresh the lockfile and SBOM baseline for the declared dependency

## Why

`pnpm verify:preflight` failed from a clean current-main worktree with `tsx: command not found`. The root package invoked `tsx` in six scripts while relying on transitive or incidental installation state. That made canonical live verification dependent on an undeclared runtime.

## Verification

- red-first `node --test scripts/check-root-script-runtime.test.mjs` identified all six undeclared `tsx` script invocations
- green `node --test scripts/check-root-script-runtime.test.mjs scripts/ci-policy-guards.test.mjs`: 9 passed
- `pnpm install --frozen-lockfile`: passed with stable tracked files
- `pnpm verify:preflight -- --feature-sha f32fe55045132fea52595a72ed7330f9695f2e23`: CAN-TEST
- `pnpm verify:preflight -- --feature-sha 5d718354c8261a8bf9bea3dfb7e0705cfc655f60`: CAN-TEST
- `pnpm pregate:preflight`: 35 guards passed
- exact-SHA full local CI: passed at `5d2d954ce51d9071177c281c0be4ad1201884da7`
- independent semantic review: pass, evidence `cmsl5vd1f028s01qlkuvo9m8k`

## Documentation impact

No user-facing documentation change is needed. This restores and enforces an internal verification runtime contract; existing verification procedures remain accurate.

## Backlog

- BI-91E23FB5

Local-CI-Evidence: cmsl5utc1026601qly5g3fdae (fix/preflight-root-tsx-contract@5d2d954ce51d9071177c281c0be4ad1201884da7)

Docs-Impact-Decision: internal verification dependency and source-policy enforcement only; no user-visible route, workflow, or guidance changed.
