### PR TITLE
fix(preview): provide governed contributor login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ NEO4J_URI="bolt://localhost:7687"
 NEO4J_USER="neo4j"
 NEO4J_PASSWORD="dpf_dev_password"
 
+# Separate local-only credential for the sanitized Contributor preview.
+# Do not reuse ADMIN_PASSWORD or any production secret. Minimum 12 characters.
+CONTRIBUTOR_PREVIEW_PASSWORD=""
+
 # Auth.js
 AUTH_SECRET="<generate with: openssl rand -base64 32>"
 AUTH_TRUST_HOST=true

--- a/apps/web/lib/govern/auth-utils.ts
+++ b/apps/web/lib/govern/auth-utils.ts
@@ -6,3 +6,9 @@ export function extractPlatformRole(
   if (!session?.user?.groups?.length) return null;
   return session.user.groups[0]?.platform_role ?? null;
 }
+
+export function resolveWorkforcePlatformRole(
+  groups: ReadonlyArray<{ platformRole: { roleId: string } | null }>,
+): string | null {
+  return groups.find((group) => group.platformRole !== null)?.platformRole?.roleId ?? null;
+}

--- a/apps/web/lib/govern/auth.test.ts
+++ b/apps/web/lib/govern/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractPlatformRole } from "./auth-utils.js";
+import { extractPlatformRole, resolveWorkforcePlatformRole } from "./auth-utils.js";
 
 describe("extractPlatformRole", () => {
   it("returns the platform_role from the first group", () => {
@@ -15,5 +15,20 @@ describe("extractPlatformRole", () => {
 
   it("returns null when session is null", () => {
     expect(extractPlatformRole(null)).toBeNull();
+  });
+});
+
+describe("resolveWorkforcePlatformRole", () => {
+  it("returns null when a sanitized superuser has no cloned platform role", () => {
+    expect(resolveWorkforcePlatformRole([
+      { platformRole: null },
+    ])).toBeNull();
+  });
+
+  it("returns the first available platform role when memberships are populated", () => {
+    expect(resolveWorkforcePlatformRole([
+      { platformRole: null },
+      { platformRole: { roleId: "HR-300" } },
+    ])).toBe("HR-300");
   });
 });

--- a/apps/web/lib/govern/auth.ts
+++ b/apps/web/lib/govern/auth.ts
@@ -7,6 +7,7 @@ import { prisma } from "@dpf/db";
 import { verifyPassword, hashPassword } from "./password";
 import { determineSocialAuthFlow, createTempToken } from "./social-auth";
 import { normalizeAuthRedirect } from "./auth-redirect";
+import { resolveWorkforcePlatformRole } from "./auth-utils";
 
 /**
  * Load social auth credentials from PlatformConfig DB into process.env.
@@ -150,7 +151,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             id: user.id,
             email: user.email,
             type: "admin" as const,
-            platformRole: user.groups[0]?.platformRole.roleId ?? null,
+            platformRole: resolveWorkforcePlatformRole(user.groups),
             isSuperuser: user.isSuperuser,
             accountId: null,
             accountName: null,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -597,6 +597,8 @@ services:
       DPF_DEV_PORTAL_WORKSPACE_ROOT: /workspace
       AUTH_SECRET: dev_secret_change_me
       AUTH_TRUST_HOST: "true"
+      AUTH_URL: http://localhost:3001
+      PUBLIC_URL: http://localhost:3001
       CREDENTIAL_ENCRYPTION_KEY: dev_only_key_not_for_production_0000
       UPLOAD_STORAGE_PATH: /workspace/data/uploads
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -566,6 +566,7 @@ services:
       DATABASE_URL: postgresql://dpf:dpf_dev@dev-postgres:5432/dpf
       PRODUCTION_DATABASE_URL: postgresql://dpf:${POSTGRES_PASSWORD:-dpf_dev}@postgres:5432/dpf
       DPF_ENVIRONMENT: dev
+      CONTRIBUTOR_PREVIEW_PASSWORD: ${CONTRIBUTOR_PREVIEW_PASSWORD:-}
     volumes: *dev-workspace-volumes
     depends_on:
       dev-postgres:

--- a/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
+++ b/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
@@ -26,4 +26,3 @@ This is one atomic repair: the clone sanitization, preview-only credential boots
 - Requiring a separate preview password can stop `dev-init` when it is absent; the error must identify the variable without printing its value.
 - Omitting `UserGroup` removes role-specific preview behavior. The preview administrator remains a superuser, and role-specific authorization testing must use purpose-built fixtures rather than copied production authorization state.
 - Rollback is a normal PR revert. No production schema, credential, or data migration is involved.
-

--- a/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
+++ b/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
@@ -1,0 +1,29 @@
+# Contributor preview authentication repair
+
+**Backlog item:** `BI-1F6C9BE6`
+
+## Outcome
+
+A sanitized Contributor preview invalidates every copied password, omits authorization memberships whose restricted roles are not cloned, and provisions one deterministic preview-admin identity with a separate development-only password. Workforce authorization remains valid when no platform role is present.
+
+## Delivery
+
+This is one atomic repair: the clone sanitization, preview-only credential bootstrap, null-safe authorization projection, Compose wiring, and contributor instructions are not independently useful. Shipping only one part either leaves login unusable or weakens the clone boundary.
+
+1. Add source-local regression tests for copied-password invalidation, `UserGroup` omission, preview-admin provisioning, and role-less superuser authorization.
+2. Refactor confidential-row sanitization into a testable helper; keep all copied hashes invalid and provision only the cloned superuser from `CONTRIBUTOR_PREVIEW_PASSWORD` after the clone completes.
+3. Treat `UserGroup` as restricted because its required parent `PlatformRole` is restricted, and resolve workforce roles through a null-safe pure helper.
+4. Wire the separate preview password into `dev-init` and update contributor instructions without a hardcoded shared password.
+5. Run targeted DB/web/Compose tests, typecheck/build gates, then prove health plus authenticated `/workspace` under a governed Contributor-preview lease.
+
+## Backlog coverage
+
+- Atomic delivery: `BI-1F6C9BE6` covers the full repair.
+- Coverage receipt: unavailable in this session because the active DPF MCP token exposes `search_specs_and_plans` but not `record_plan_backlog_coverage` or `check_plan_backlog_coverage`. This limitation is recorded explicitly rather than represented as a completed live receipt.
+
+## Risks and rollback
+
+- Requiring a separate preview password can stop `dev-init` when it is absent; the error must identify the variable without printing its value.
+- Omitting `UserGroup` removes role-specific preview behavior. The preview administrator remains a superuser, and role-specific authorization testing must use purpose-built fixtures rather than copied production authorization state.
+- Rollback is a normal PR revert. No production schema, credential, or data migration is involved.
+

--- a/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
+++ b/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
@@ -11,7 +11,7 @@ A sanitized Contributor preview invalidates every copied password, omits authori
 This is one atomic repair: the clone sanitization, preview-only credential bootstrap, null-safe authorization projection, Compose wiring, and contributor instructions are not independently useful. Shipping only one part either leaves login unusable or weakens the clone boundary.
 
 1. Add source-local regression tests for copied-password invalidation, `UserGroup` omission, preview-admin provisioning, and role-less superuser authorization.
-2. Refactor confidential-row sanitization into a testable helper; keep all copied hashes invalid and provision only the cloned superuser from `CONTRIBUTOR_PREVIEW_PASSWORD` after the clone completes.
+2. Refactor confidential-row sanitization and preview credential provisioning into focused, testable helpers; keep all copied hashes invalid and provision only the cloned superuser from `CONTRIBUTOR_PREVIEW_PASSWORD` after the clone completes.
 3. Treat `UserGroup` as restricted because its required parent `PlatformRole` is restricted, and resolve workforce roles through a null-safe pure helper.
 4. Wire the separate preview password into `dev-init` and update contributor instructions without a hardcoded shared password.
 5. Run targeted DB/web/Compose tests, typecheck/build gates, then prove health plus authenticated `/workspace` under a governed Contributor-preview lease.

--- a/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
+++ b/docs/superpowers/plans/2026-08-01-contributor-preview-auth.md
@@ -18,8 +18,11 @@ This is one atomic repair: the clone sanitization, preview-only credential boots
 
 ## Backlog coverage
 
-- Atomic delivery: `BI-1F6C9BE6` covers the full repair.
-- Coverage receipt: unavailable in this session because the active DPF MCP token exposes `search_specs_and_plans` but not `record_plan_backlog_coverage` or `check_plan_backlog_coverage`. This limitation is recorded explicitly rather than represented as a completed live receipt.
+- Decision: atomic
+- Parent: `BI-1F6C9BE6`
+- Receipt: `cmsl5j1gz02ms01l83buj3lvp`
+- Rationale: Credential invalidation, development-only admin provisioning, null-safe authorization, preview-origin redirects, and runtime acceptance form one security boundary; shipping a subset leaves the preview unsafe or unusable.
+- Dependencies: none
 
 ## Risks and rollback
 

--- a/docs/user-guide/contributing/dev-container.md
+++ b/docs/user-guide/contributing/dev-container.md
@@ -25,7 +25,12 @@ For developers who want a fully containerized development environment. Everythin
 
 The dev server starts automatically on port 3001. Open `http://localhost:3001` in your browser. Production remains on port 3000.
 
-Login: `admin@dpf.local` / `changeme123`
+Before starting the Contributor preview, set `CONTRIBUTOR_PREVIEW_PASSWORD` in
+the repository `.env` to a development-only password of at least 12 characters.
+Do not reuse `ADMIN_PASSWORD` or another live credential.
+
+Login: `preview-admin@dpf.test` / the value of
+`CONTRIBUTOR_PREVIEW_PASSWORD` in `.env`.
 
 ### What the Dev Container Provides
 
@@ -51,6 +56,7 @@ Login: `admin@dpf.local` / `changeme123`
   ```
 
 - The clone resets the disposable development application tables before copying. Restricted provider, credential, token, and connection records are not copied; production-derived search/vector values are omitted rather than carrying source terms or embeddings into the preview.
+- Every copied workforce password remains invalid. After sanitization, the clone provisions only `preview-admin@dpf.test` from the separate development-only `CONTRIBUTOR_PREVIEW_PASSWORD`; production hashes and passwords are never reused. Authorization memberships are omitted with their restricted platform roles, so the preview cannot retain dangling role references.
 - Additive source-schema differences are expected during concurrent development. Source-only columns or tables are left out of the preview, destination-only columns use their migrated defaults, and a shared column with an incompatible type stops the clone with a precise error instead of risking a corrupt preview.
 - Before copying, the clone verifies the live source's critical identity indexes and their heap semantics. A message naming `InventoryEntity_entityKey_key` or `PlatformIssueReport_dedupeKey_open_key` is a **source-integrity stop**: the live source must be repaired through a forward migration before preview can proceed. Recreating the disposable preview volume cannot repair that source condition.
 - Clone publication is fail-safe: if any table cannot be copied or sanitized, the development application tables are cleared again while Prisma migration history is retained. The Contributor preview will not start against a partially copied relational dataset. Correct the reported source/tooling error and restart the development initialization step to retry.

--- a/packages/db/src/contributor-preview-auth.test.ts
+++ b/packages/db/src/contributor-preview-auth.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTRIBUTOR_PREVIEW_ADMIN_EMAIL,
+  provisionContributorPreviewAdmin,
+  requireContributorPreviewPassword,
+} from "./contributor-preview-auth";
+
+describe("Contributor preview administrator", () => {
+  it("requires a separate development-only password with a minimum length", () => {
+    expect(() => requireContributorPreviewPassword(undefined)).toThrow(
+      "CONTRIBUTOR_PREVIEW_PASSWORD",
+    );
+    expect(() => requireContributorPreviewPassword("too-short")).toThrow(
+      "at least 12 characters",
+    );
+    expect(requireContributorPreviewPassword("preview-password-only")).toBe(
+      "preview-password-only",
+    );
+  });
+
+  it("provisions only the sanitized superuser with the separate development credential", async () => {
+    const statements: Array<{ sql: string; values: unknown[] }> = [];
+    const client = {
+      $queryRawUnsafe: async () => [{ id: "user-super" }],
+      $executeRawUnsafe: async (sql: string, ...values: unknown[]) => {
+        statements.push({ sql, values });
+        return 1;
+      },
+    };
+
+    await provisionContributorPreviewAdmin(
+      client,
+      "preview-password-only",
+      async (password) => `hashed:${password}`,
+    );
+
+    expect(statements).toEqual([
+      expect.objectContaining({
+        sql: expect.stringContaining('UPDATE "User"'),
+        values: [CONTRIBUTOR_PREVIEW_ADMIN_EMAIL, "hashed:preview-password-only", "user-super"],
+      }),
+    ]);
+  });
+
+  it("fails closed when the sanitized clone has no active superuser", async () => {
+    const client = {
+      $queryRawUnsafe: async () => [],
+      $executeRawUnsafe: async () => 1,
+    };
+
+    await expect(provisionContributorPreviewAdmin(
+      client,
+      "preview-password-only",
+      async () => "unused",
+    )).rejects.toThrow("active superuser");
+  });
+});

--- a/packages/db/src/contributor-preview-auth.ts
+++ b/packages/db/src/contributor-preview-auth.ts
@@ -1,0 +1,52 @@
+import { hash as hashBcryptPassword } from "bcryptjs";
+
+type PreviewDatabaseClient = {
+  $queryRawUnsafe(query: string, ...values: unknown[]): Promise<Array<{ id: string }>>;
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+};
+
+type PasswordHasher = (password: string) => Promise<string>;
+
+export const CONTRIBUTOR_PREVIEW_ADMIN_EMAIL = "preview-admin@dpf.test";
+
+export function requireContributorPreviewPassword(
+  password: string | undefined,
+): string {
+  if (!password || password.length < 12) {
+    throw new Error(
+      "CONTRIBUTOR_PREVIEW_PASSWORD must be set to a development-only password of at least 12 characters",
+    );
+  }
+  return password;
+}
+
+export async function provisionContributorPreviewAdmin(
+  client: PreviewDatabaseClient,
+  password: string,
+  hashPassword: PasswordHasher = (value) => hashBcryptPassword(value, 12),
+): Promise<void> {
+  const users = await client.$queryRawUnsafe(
+    `SELECT "id"
+       FROM "User"
+      WHERE "isActive" = true
+        AND "isSuperuser" = true
+      ORDER BY "id"
+      LIMIT 1`,
+  );
+  const user = users[0];
+  if (!user) {
+    throw new Error("Sanitized Contributor preview has no active superuser to provision");
+  }
+
+  const passwordHash = await hashPassword(password);
+  await client.$executeRawUnsafe(
+    `UPDATE "User"
+        SET "email" = $1,
+            "passwordHash" = $2
+      WHERE "id" = $3`,
+    CONTRIBUTOR_PREVIEW_ADMIN_EMAIL,
+    passwordHash,
+    user.id,
+  );
+  console.log(`[sanitized-clone] Provisioned ${CONTRIBUTOR_PREVIEW_ADMIN_EMAIL} with the development-only preview credential`);
+}

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -21,9 +21,6 @@ import {
   insertRowsWithReplicationDisabled,
   resolveCompatibleCopyColumns,
   sanitizeConfidentialRow,
-  provisionContributorPreviewAdmin,
-  CONTRIBUTOR_PREVIEW_ADMIN_EMAIL,
-  requireContributorPreviewPassword,
 } from "./sanitized-clone";
 
 describe("obfuscation", () => {
@@ -61,57 +58,6 @@ describe("obfuscation", () => {
 
     expect(sanitized.passwordHash).not.toBe("$2b$10$live-production-hash");
     expect(sanitized.passwordHash).toMatch(/^\$2a\$10\$devhashplaceholder/);
-  });
-});
-
-describe("Contributor preview administrator", () => {
-  it("requires a separate development-only password with a minimum length", () => {
-    expect(() => requireContributorPreviewPassword(undefined)).toThrow(
-      "CONTRIBUTOR_PREVIEW_PASSWORD",
-    );
-    expect(() => requireContributorPreviewPassword("too-short")).toThrow(
-      "at least 12 characters",
-    );
-    expect(requireContributorPreviewPassword("preview-password-only")).toBe(
-      "preview-password-only",
-    );
-  });
-
-  it("provisions only the sanitized superuser with the separate development credential", async () => {
-    const statements: Array<{ sql: string; values: unknown[] }> = [];
-    const client = {
-      $queryRawUnsafe: async () => [{ id: "user-super" }],
-      $executeRawUnsafe: async (sql: string, ...values: unknown[]) => {
-        statements.push({ sql, values });
-        return 1;
-      },
-    };
-
-    await provisionContributorPreviewAdmin(
-      client as never,
-      "preview-password-only",
-      async (password) => `hashed:${password}`,
-    );
-
-    expect(statements).toEqual([
-      expect.objectContaining({
-        sql: expect.stringContaining('UPDATE "User"'),
-        values: [CONTRIBUTOR_PREVIEW_ADMIN_EMAIL, "hashed:preview-password-only", "user-super"],
-      }),
-    ]);
-  });
-
-  it("fails closed when the sanitized clone has no active superuser", async () => {
-    const client = {
-      $queryRawUnsafe: async () => [],
-      $executeRawUnsafe: async () => 1,
-    };
-
-    await expect(provisionContributorPreviewAdmin(
-      client as never,
-      "preview-password-only",
-      async () => "unused",
-    )).rejects.toThrow("active superuser");
   });
 });
 

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -20,6 +20,10 @@ import {
   runWithDestinationCleanup,
   insertRowsWithReplicationDisabled,
   resolveCompatibleCopyColumns,
+  sanitizeConfidentialRow,
+  provisionContributorPreviewAdmin,
+  CONTRIBUTOR_PREVIEW_ADMIN_EMAIL,
+  requireContributorPreviewPassword,
 } from "./sanitized-clone";
 
 describe("obfuscation", () => {
@@ -47,6 +51,67 @@ describe("obfuscation", () => {
   it("handles null/undefined fields", () => {
     expect(obfuscateField(null, "name", 1)).toBeNull();
     expect(obfuscateField(undefined, "name", 1)).toBeUndefined();
+  });
+
+  it("invalidates copied password hashes instead of preserving a live credential", () => {
+    const sanitized = sanitizeConfidentialRow(
+      { id: "user-1", passwordHash: "$2b$10$live-production-hash" },
+      1,
+    );
+
+    expect(sanitized.passwordHash).not.toBe("$2b$10$live-production-hash");
+    expect(sanitized.passwordHash).toMatch(/^\$2a\$10\$devhashplaceholder/);
+  });
+});
+
+describe("Contributor preview administrator", () => {
+  it("requires a separate development-only password with a minimum length", () => {
+    expect(() => requireContributorPreviewPassword(undefined)).toThrow(
+      "CONTRIBUTOR_PREVIEW_PASSWORD",
+    );
+    expect(() => requireContributorPreviewPassword("too-short")).toThrow(
+      "at least 12 characters",
+    );
+    expect(requireContributorPreviewPassword("preview-password-only")).toBe(
+      "preview-password-only",
+    );
+  });
+
+  it("provisions only the sanitized superuser with the separate development credential", async () => {
+    const statements: Array<{ sql: string; values: unknown[] }> = [];
+    const client = {
+      $queryRawUnsafe: async () => [{ id: "user-super" }],
+      $executeRawUnsafe: async (sql: string, ...values: unknown[]) => {
+        statements.push({ sql, values });
+        return 1;
+      },
+    };
+
+    await provisionContributorPreviewAdmin(
+      client as never,
+      "preview-password-only",
+      async (password) => `hashed:${password}`,
+    );
+
+    expect(statements).toEqual([
+      expect.objectContaining({
+        sql: expect.stringContaining('UPDATE "User"'),
+        values: [CONTRIBUTOR_PREVIEW_ADMIN_EMAIL, "hashed:preview-password-only", "user-super"],
+      }),
+    ]);
+  });
+
+  it("fails closed when the sanitized clone has no active superuser", async () => {
+    const client = {
+      $queryRawUnsafe: async () => [],
+      $executeRawUnsafe: async () => 1,
+    };
+
+    await expect(provisionContributorPreviewAdmin(
+      client as never,
+      "preview-password-only",
+      async () => "unused",
+    )).rejects.toThrow("active superuser");
   });
 });
 
@@ -326,6 +391,7 @@ describe("table classification helpers", () => {
   it("restricted tables should be skipped", () => {
     expect(shouldSkipTable("CredentialEntry")).toBe(true);
     expect(shouldSkipTable("ApiToken")).toBe(true);
+    expect(shouldSkipTable("UserGroup")).toBe(true);
   });
 
   it("keeps provider connections with their restricted provider parent", () => {

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -3,9 +3,9 @@
 // Classification driven by table-classification.ts.
 
 import { getTableSensitivity } from "./table-classification";
-import { hash as hashBcryptPassword } from "bcryptjs";
 import { spawn, type ChildProcess } from "node:child_process";
 import { pipeline } from "node:stream/promises";
+import { provisionContributorPreviewAdmin, requireContributorPreviewPassword } from "./contributor-preview-auth";
 
 // -- Obfuscation Helpers --
 
@@ -36,7 +36,6 @@ const PII_FIELDS: Record<string, (val: string | null, idx: number) => string> = 
 export { PII_FIELDS };
 
 const INVALIDATED_PASSWORD_HASH = "$2a$10$devhashplaceholdernotreal000000000000000000000";
-export const CONTRIBUTOR_PREVIEW_ADMIN_EMAIL = "preview-admin@dpf.test";
 
 export function obfuscateField(
   value: string | null | undefined,
@@ -97,50 +96,6 @@ type RawDatabaseClient = Pick<
   PrismaClient,
   "$queryRawUnsafe" | "$executeRawUnsafe"
 >;
-
-type PasswordHasher = (password: string) => Promise<string>;
-
-export function requireContributorPreviewPassword(
-  password: string | undefined,
-): string {
-  if (!password || password.length < 12) {
-    throw new Error(
-      "CONTRIBUTOR_PREVIEW_PASSWORD must be set to a development-only password of at least 12 characters",
-    );
-  }
-  return password;
-}
-
-export async function provisionContributorPreviewAdmin(
-  client: RawDatabaseClient,
-  password: string,
-  hashPassword: PasswordHasher = (value) => hashBcryptPassword(value, 12),
-): Promise<void> {
-  const users = await client.$queryRawUnsafe<Array<{ id: string }>>(
-    `SELECT "id"
-       FROM "User"
-      WHERE "isActive" = true
-        AND "isSuperuser" = true
-      ORDER BY "id"
-      LIMIT 1`,
-  );
-  const user = users[0];
-  if (!user) {
-    throw new Error("Sanitized Contributor preview has no active superuser to provision");
-  }
-
-  const passwordHash = await hashPassword(password);
-  await client.$executeRawUnsafe(
-    `UPDATE "User"
-        SET "email" = $1,
-            "passwordHash" = $2
-      WHERE "id" = $3`,
-    CONTRIBUTOR_PREVIEW_ADMIN_EMAIL,
-    passwordHash,
-    user.id,
-  );
-  console.log(`[sanitized-clone] Provisioned ${CONTRIBUTOR_PREVIEW_ADMIN_EMAIL} with the development-only preview credential`);
-}
 
 /** Tables that contain audit/log data — clone only the last N rows with obfuscation */
 const AUDIT_TABLES = new Set([

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -3,6 +3,7 @@
 // Classification driven by table-classification.ts.
 
 import { getTableSensitivity } from "./table-classification";
+import { hash as hashBcryptPassword } from "bcryptjs";
 import { spawn, type ChildProcess } from "node:child_process";
 import { pipeline } from "node:stream/promises";
 
@@ -34,6 +35,9 @@ const PII_FIELDS: Record<string, (val: string | null, idx: number) => string> = 
 
 export { PII_FIELDS };
 
+const INVALIDATED_PASSWORD_HASH = "$2a$10$devhashplaceholdernotreal000000000000000000000";
+export const CONTRIBUTOR_PREVIEW_ADMIN_EMAIL = "preview-admin@dpf.test";
+
 export function obfuscateField(
   value: string | null | undefined,
   fieldName: string,
@@ -43,6 +47,23 @@ export function obfuscateField(
   if (value === undefined) return undefined;
   const fn = PII_FIELDS[fieldName];
   return fn ? fn(value, index) : value;
+}
+
+export function sanitizeConfidentialRow(
+  row: Record<string, unknown>,
+  index: number,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => {
+      if (typeof value === "string" && key in PII_FIELDS) {
+        return [key, obfuscateField(value, key, index)];
+      }
+      if (key === "passwordHash") {
+        return [key, INVALIDATED_PASSWORD_HASH];
+      }
+      return [key, value];
+    }),
+  );
 }
 
 // -- Table Classification Helpers --
@@ -76,6 +97,50 @@ type RawDatabaseClient = Pick<
   PrismaClient,
   "$queryRawUnsafe" | "$executeRawUnsafe"
 >;
+
+type PasswordHasher = (password: string) => Promise<string>;
+
+export function requireContributorPreviewPassword(
+  password: string | undefined,
+): string {
+  if (!password || password.length < 12) {
+    throw new Error(
+      "CONTRIBUTOR_PREVIEW_PASSWORD must be set to a development-only password of at least 12 characters",
+    );
+  }
+  return password;
+}
+
+export async function provisionContributorPreviewAdmin(
+  client: RawDatabaseClient,
+  password: string,
+  hashPassword: PasswordHasher = (value) => hashBcryptPassword(value, 12),
+): Promise<void> {
+  const users = await client.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT "id"
+       FROM "User"
+      WHERE "isActive" = true
+        AND "isSuperuser" = true
+      ORDER BY "id"
+      LIMIT 1`,
+  );
+  const user = users[0];
+  if (!user) {
+    throw new Error("Sanitized Contributor preview has no active superuser to provision");
+  }
+
+  const passwordHash = await hashPassword(password);
+  await client.$executeRawUnsafe(
+    `UPDATE "User"
+        SET "email" = $1,
+            "passwordHash" = $2
+      WHERE "id" = $3`,
+    CONTRIBUTOR_PREVIEW_ADMIN_EMAIL,
+    passwordHash,
+    user.id,
+  );
+  console.log(`[sanitized-clone] Provisioned ${CONTRIBUTOR_PREVIEW_ADMIN_EMAIL} with the development-only preview credential`);
+}
 
 /** Tables that contain audit/log data — clone only the last N rows with obfuscation */
 const AUDIT_TABLES = new Set([
@@ -321,6 +386,12 @@ export async function runSanitizedClone(): Promise<void> {
 
   if (!prodUrl) throw new Error("PRODUCTION_DATABASE_URL is not set");
   if (!devUrl) throw new Error("DATABASE_URL is not set");
+  if (process.env.DPF_ENVIRONMENT !== "dev") {
+    throw new Error("Sanitized Contributor preview provisioning requires DPF_ENVIRONMENT=dev");
+  }
+  const previewPassword = requireContributorPreviewPassword(
+    process.env.CONTRIBUTOR_PREVIEW_PASSWORD,
+  );
 
   const prodAdapter = new PrismaPg({ connectionString: prodUrl });
   const devAdapter = new PrismaPg({ connectionString: devUrl });
@@ -399,6 +470,8 @@ export async function runSanitizedClone(): Promise<void> {
             await insertRowsWithReplicationDisabled(dev, tablename, obfuscated);
           }
         }
+
+        await provisionContributorPreviewAdmin(dev, previewPassword);
       },
     );
 
@@ -489,17 +562,7 @@ function obfuscateRows(
     const idx = userId && userIdMap.has(userId)
       ? userIdMap.get(userId)!
       : nextIndex();
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(row)) {
-      if (typeof value === "string" && key in PII_FIELDS) {
-        result[key] = obfuscateField(value, key, idx);
-      } else if (key === "passwordHash") {
-        result[key] = "$2a$10$devhashplaceholdernotreal000000000000000000000";
-      } else {
-        result[key] = value;
-      }
-    }
-    return result;
+    return sanitizeConfidentialRow(row, idx);
   });
 }
 

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -179,7 +179,6 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   // observations for LL144/four-fifths bias audit. PII — obfuscate before any copy.
   ProtectedMonitoringObservation: "confidential",
   User: "confidential",
-  UserGroup: "confidential",
   CustomerContact: "confidential",
   SocialIdentity: "confidential",
   AccountInvite: "confidential",
@@ -285,6 +284,9 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   // -- restricted (16) --
   PasswordResetToken: "restricted",
   PlatformRole: "restricted",
+  // Memberships require PlatformRole, so retaining them while roles are
+  // omitted creates authorization references that can never be resolved.
+  UserGroup: "restricted",
   CredentialEntry: "restricted",
   DataPolicyException: "restricted",
   OAuthPendingFlow: "restricted",

--- a/scripts/dev-postgres-pgvector-contract.test.mjs
+++ b/scripts/dev-postgres-pgvector-contract.test.mjs
@@ -35,3 +35,19 @@ test("Contributor preview waits for a pgvector-capable database", async () => {
     "dev-init must use the disposable migrate converge wrapper (BI-4DB4B415)",
   );
 });
+
+test("Contributor preview receives a separate local-only login credential", async () => {
+  const compose = await readFile(new URL("../docker-compose.yml", import.meta.url), "utf8");
+  const init = composeService(compose, "dev-init");
+
+  assert.match(
+    init,
+    /^      CONTRIBUTOR_PREVIEW_PASSWORD: \$\{CONTRIBUTOR_PREVIEW_PASSWORD:-\}$/m,
+    "dev-init must receive the explicit Contributor preview credential",
+  );
+  assert.doesNotMatch(
+    init,
+    /CONTRIBUTOR_PREVIEW_PASSWORD:.*ADMIN_PASSWORD/,
+    "the preview credential must not reuse the live administrator password",
+  );
+});

--- a/scripts/dev-postgres-pgvector-contract.test.mjs
+++ b/scripts/dev-postgres-pgvector-contract.test.mjs
@@ -51,3 +51,19 @@ test("Contributor preview receives a separate local-only login credential", asyn
     "the preview credential must not reuse the live administrator password",
   );
 });
+
+test("Contributor preview keeps authentication redirects on the preview origin", async () => {
+  const compose = await readFile(new URL("../docker-compose.yml", import.meta.url), "utf8");
+  const portal = composeService(compose, "dev-portal");
+
+  assert.match(
+    portal,
+    /^      PUBLIC_URL: http:\/\/localhost:3001$/m,
+    "dev-portal sign-in must return contributors to the leased preview instead of the live portal",
+  );
+  assert.match(
+    portal,
+    /^      AUTH_URL: http:\/\/localhost:3001$/m,
+    "dev-portal credential errors must remain on the leased preview origin",
+  );
+});


### PR DESCRIPTION
## Summary

- provision a development-only `preview-admin@dpf.test` account after each sanitized Contributor preview clone, using a process-only operator credential
- invalidate copied password hashes before preview publication and fail closed outside `DPF_ENVIRONMENT=dev`
- keep Auth.js login, success, and failure redirects on the Contributor preview origin at `localhost:3001`
- document the governed preview login contract and cover the Compose, PostgreSQL, sanitization, and authentication boundaries with regression tests

## Why

Contributor previews could complete their clone but still leave an external contributor at `/welcome`, with no governed way to authenticate and validate UI changes. A successful credential flow also inherited the canonical portal origin and redirected the authenticated session to `localhost:3000`. This change establishes an isolated, development-only acceptance path without copying production credentials, persisting the operator password, or weakening normal authorization.

## Security and architecture

- `CONTRIBUTOR_PREVIEW_PASSWORD` is required at runtime, must be at least 12 characters, and is never committed or logged
- copied password hashes are replaced by a deliberately invalid placeholder before the preview admin receives its development-only hash
- provisioning is isolated behind the sanitized-clone boundary and rejects non-development environments
- the existing `User`, Auth.js credentials provider, table-classification registry, and governed preview lease remain the canonical substrates; no parallel identity store or auth bypass was added

## Verification

- repository preflight: 35 guards clean
- exact merged-code local CI: passed for `7d87a08ba990ee3c73c3263a15cac932338c7b11` against current `origin/main`; typecheck, full tests, production Docker build, image import, and migration smoke passed in 7:48
- focused PostgreSQL/Compose contract: 3 tests passed
- focused Auth.js redirect and authorization behavior: 18 tests passed
- governed live preview acceptance: valid credentials redirected to `http://localhost:3001/workspace`, established a session, and returned the workspace shell; invalid credentials redirected to `http://localhost:3001/login?error=CredentialsSignin&code=credentials` without a session cookie
- schema migration: not applicable; no schema change was introduced and merged-code migration smoke passed

The independent semantic reviewer reached its terminal shadow-failure policy limit with two unsupported findings: it claimed the required environment-variable name logs the secret value, and that the fixed invalid placeholder hash encodes the copied source hash. Manual source review confirmed neither behavior exists. The exact receipt and rebuttal remain recorded as evidence; publication was permitted by the shadow policy and the deterministic gate passed.

Backlog: `BI-1F6C9BE6`

Local-CI-Evidence: `cmsl6b71s03nt01l8v07ccdfc` (`fix/contributor-preview-auth@7d87a08ba990ee3c73c3263a15cac932338c7b11`)

Process-Spine-Decision: localized authentication and preview-sanitization repair restores the existing governed Contributor preview acceptance path; no new delivery surface or process authority is introduced

Docs-Impact-Decision: the preview-only Compose and restricted-table changes do not alter the linked platform architecture or disaster-recovery contracts; their operator-facing credential and login behavior is documented in the updated dev-container guide
