### PR TITLE
fix(ci): arbitrate local provider and stage capacity

### DIFF
--- a/apps/web/lib/change-review/routed-semantic-review.test.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.test.ts
@@ -3,17 +3,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/inference/routed-inference", () => ({
   routeAndCall: vi.fn(),
 }));
-vi.mock("@/lib/nonprod/environment-lease", () => ({
-  listActiveNonprodEnvironmentLeases: vi.fn(),
+vi.mock("@/lib/routing/local-provider-capacity", () => ({
+  inspectLocalProviderCapacity: vi.fn(),
 }));
 
 import { routeAndCall } from "@/lib/inference/routed-inference";
-import { listActiveNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
+import { inspectLocalProviderCapacity } from "@/lib/routing/local-provider-capacity";
 import { dispatchRoutedSemanticReview } from "./routed-semantic-review";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(listActiveNonprodEnvironmentLeases).mockResolvedValue([] as never);
+  vi.mocked(inspectLocalProviderCapacity).mockResolvedValue({ available: true, reason: null });
 });
 
 describe("routed semantic review", () => {
@@ -53,9 +53,10 @@ describe("routed semantic review", () => {
   });
 
   it("defers review while local CI owns host capacity", async () => {
-    vi.mocked(listActiveNonprodEnvironmentLeases).mockResolvedValue([
-      { environmentKey: "local-integration-ci" },
-    ] as never);
+    vi.mocked(inspectLocalProviderCapacity).mockResolvedValue({
+      available: false,
+      reason: "local-ci-active-capacity-reservation",
+    });
 
     const result = await dispatchRoutedSemanticReview("review this", {
       strategyProfile: "high-assurance",
@@ -74,7 +75,10 @@ describe("routed semantic review", () => {
   });
 
   it("fails closed when the host-capacity registry cannot be read", async () => {
-    vi.mocked(listActiveNonprodEnvironmentLeases).mockRejectedValue(new Error("registry unavailable"));
+    vi.mocked(inspectLocalProviderCapacity).mockResolvedValue({
+      available: false,
+      reason: "local-ci-capacity-reservation-unavailable",
+    });
 
     const result = await dispatchRoutedSemanticReview("review this", {
       strategyProfile: "high-assurance",
@@ -89,9 +93,7 @@ describe("routed semantic review", () => {
   });
 
   it("does not defer review for an unrelated nonproduction lease", async () => {
-    vi.mocked(listActiveNonprodEnvironmentLeases).mockResolvedValue([
-      { environmentKey: "dev-portal" },
-    ] as never);
+    vi.mocked(inspectLocalProviderCapacity).mockResolvedValue({ available: true, reason: null });
     vi.mocked(routeAndCall).mockResolvedValue({
       content: JSON.stringify({ decision: "pass", issues: [], summary: "Pass." }),
     } as never);

--- a/apps/web/lib/change-review/routed-semantic-review.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.ts
@@ -1,5 +1,5 @@
 import { routeAndCall } from "@/lib/inference/routed-inference";
-import { listActiveNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
+import { inspectLocalProviderCapacity } from "@/lib/routing/local-provider-capacity";
 import { CHANGE_REVIEWER_ROUTE_AGENT } from "@/lib/tak/change-reviewer-route";
 import { parseSemanticReviewResponse, type SemanticReviewResult } from "./semantic-change-review";
 import type { SemanticChangeReviewDispatchContext } from "./semantic-change-review-operation";
@@ -31,25 +31,22 @@ function mergeReviewResults(results: SemanticReviewResult[]): SemanticReviewResu
 }
 
 async function localCiCapacityGuard(): Promise<SemanticReviewResult | null> {
-  try {
-    const activeLeases = await listActiveNonprodEnvironmentLeases({});
-    if (!activeLeases.some((lease) => lease.environmentKey === "local-integration-ci")) {
-      return null;
-    }
+  const capacity = await inspectLocalProviderCapacity();
+  if (capacity.available) return null;
+  if (capacity.reason === "local-ci-active-capacity-reservation") {
     return {
       decision: "inconclusive",
       issues: [],
       summary: "Semantic review deferred while governed local CI owns host capacity.",
       inconclusiveReason: "local-ci-active-capacity-reservation",
     };
-  } catch {
-    return {
-      decision: "inconclusive",
-      issues: [],
-      summary: "Semantic review deferred because host-capacity ownership could not be verified.",
-      inconclusiveReason: "local-ci-capacity-reservation-unavailable",
-    };
   }
+  return {
+    decision: "inconclusive",
+    issues: [],
+    summary: "Semantic review deferred because host-capacity ownership could not be verified.",
+    inconclusiveReason: "local-ci-capacity-reservation-unavailable",
+  };
 }
 
 /** Execute the governed Change Reviewer plus content-scoped specialist branches. */

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9780,6 +9780,7 @@
         "oauth-sign-in",
         "device-code-sign-in-xai-grok",
         "none",
+        "local-capacity-during-platform-verification",
         "how-oauth-works",
         "choosing-the-right-method",
         "business-safe-review",

--- a/apps/web/lib/inference/ai-inference.test.ts
+++ b/apps/web/lib/inference/ai-inference.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { classifyHttpError, InferenceError } from "./ai-inference";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/routing/local-provider-capacity", () => ({
+  assertProviderDispatchCapacity: vi.fn(),
+}));
+
+import { callProvider, classifyHttpError, InferenceError } from "./ai-inference";
+import { assertProviderDispatchCapacity } from "@/lib/routing/local-provider-capacity";
+
+beforeEach(() => {
+  vi.mocked(assertProviderDispatchCapacity).mockReset();
+  vi.mocked(assertProviderDispatchCapacity).mockResolvedValue(undefined);
+});
 
 describe("InferenceError", () => {
   it("has correct code and providerId", () => {
@@ -23,6 +34,21 @@ describe("InferenceError", () => {
       isHumanActionRequired: true,
     });
     expect(err.capacity?.action).toBe("add_credits_or_plan");
+  });
+});
+
+describe("callProvider host-capacity boundary", () => {
+  it("stops before provider setup when local capacity is reserved", async () => {
+    const deferred = Object.assign(new Error("local capacity reserved"), {
+      name: "LocalProviderCapacityDeferredError",
+      reason: "local-ci-active-capacity-reservation",
+    });
+    vi.mocked(assertProviderDispatchCapacity).mockRejectedValueOnce(deferred);
+
+    await expect(
+      callProvider("local", "qwen3-coder", [{ role: "user", content: "triage" }], "system"),
+    ).rejects.toBe(deferred);
+    expect(assertProviderDispatchCapacity).toHaveBeenCalledWith("local");
   });
 });
 
@@ -72,7 +98,8 @@ describe("classifyHttpError", () => {
   });
 });
 
-// Note: callProvider itself requires DB + HTTP mocking which is complex.
-// The core logic is tested via ai-provider-priority.test.ts integration tests.
+// Full callProvider execution requires DB + HTTP mocking and is covered through
+// ai-provider-priority integration tests. The host-capacity boundary is tested
+// here because it intentionally runs before provider setup.
 // Format construction correctness is verified by the existing profiling tests
 // (same provider-specific branching logic was extracted from callProviderForProfiling).

--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -50,6 +50,7 @@ import {
   currentInferenceOrigin,
   engineKeyForProvider,
 } from "./inference-admission";
+import { assertProviderDispatchCapacity } from "@/lib/routing/local-provider-capacity";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -452,6 +453,11 @@ export async function callProvider(
     buildId?: string | null;
   },
 ): Promise<InferenceResult> {
+  // Host capacity is a dispatch constraint, not a routing hint. Enforce it at
+  // the shared adapter boundary so direct, agentic, evaluation and fallback
+  // callers cannot start a local model while governed local CI owns the host.
+  await assertProviderDispatchCapacity(providerId);
+
   // 0. EP-COST-001 Phase 2 — pre-call budget gate.
   // Check the agent's daily token budget before dispatching. If the agent has
   // consumed ≥100% of its registry limit today, throw a billing error so the

--- a/apps/web/lib/inference/embedding.test.ts
+++ b/apps/web/lib/inference/embedding.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/routing/local-provider-capacity", () => ({
+  assertLocalProviderCapacityAvailable: vi.fn(),
+}));
+
+import { assertLocalProviderCapacityAvailable } from "@/lib/routing/local-provider-capacity";
+import { generateEmbedding } from "./embedding";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(assertLocalProviderCapacityAvailable).mockResolvedValue(undefined);
+});
+
+describe("generateEmbedding local-CI arbitration", () => {
+  it("does not contact the local embedding provider while local CI owns capacity", async () => {
+    vi.mocked(assertLocalProviderCapacityAvailable).mockRejectedValue(
+      new Error("local-ci-active-capacity-reservation"),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(generateEmbedding("durable knowledge")).resolves.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("dispatches normally when local capacity is available", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(generateEmbedding("durable knowledge")).resolves.toEqual([0.1, 0.2]);
+    expect(assertLocalProviderCapacityAvailable).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/inference/embedding.ts
+++ b/apps/web/lib/inference/embedding.ts
@@ -1,4 +1,5 @@
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { assertLocalProviderCapacityAvailable } from "@/lib/routing/local-provider-capacity";
 // apps/web/lib/embedding.ts
 // Generate text embeddings via local LLM inference (Docker Model Runner or compatible).
 // Uses OpenAI-compatible /v1/embeddings endpoint.
@@ -29,6 +30,7 @@ function getLlmBaseUrl(): string {
  */
 export async function generateEmbedding(text: string): Promise<number[] | null> {
   try {
+    await assertLocalProviderCapacityAvailable();
     const truncated = text.slice(0, MAX_INPUT_LENGTH);
     const baseUrl = getLlmBaseUrl();
 

--- a/apps/web/lib/nonprod/environment-lease-pool-policy.ts
+++ b/apps/web/lib/nonprod/environment-lease-pool-policy.ts
@@ -20,7 +20,7 @@ export async function resolveNonprodPoolPolicy(input: {
   hostPressure?: LocalCiHostPressure;
   capacityBroker?: LocalCiCapacityBroker;
   manifestSlotCount: number;
-  reserveBuildHeadroom?: boolean;
+  reserveAdmissionHeadroom?: boolean;
   now: Date;
 }): Promise<ResolvedLocalCiPoolPolicy> {
   if (input.environmentKey !== "local-integration-ci") {
@@ -44,7 +44,7 @@ export async function resolveNonprodPoolPolicy(input: {
     configValue,
     host: clientPressure,
     manifestSlotCount: input.manifestSlotCount,
-    reserveBuildHeadroom: input.reserveBuildHeadroom,
+    reserveAdmissionHeadroom: input.reserveAdmissionHeadroom,
     env: process.env,
     now: input.now,
   });
@@ -75,7 +75,7 @@ export async function resolveNonprodPoolPolicy(input: {
       server: serverPressure,
     }),
     manifestSlotCount: input.manifestSlotCount,
-    reserveBuildHeadroom: input.reserveBuildHeadroom,
+    reserveAdmissionHeadroom: input.reserveAdmissionHeadroom,
     env: process.env,
     now: input.now,
   });

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -452,6 +452,65 @@ describe("durable nonproduction admission", () => {
       },
     });
   });
+
+  it("keeps a claimant queued when the next host-native stage would spend the continuation floor", async () => {
+    const gib = 1024 ** 3;
+    const mockDb = db();
+    const waiting = lease({ slotManifestVersion: 1 });
+    mockDb.platformConfig.findUnique.mockResolvedValue({
+      value: {
+        version: 1,
+        requestedCapacity: 1,
+        ceilings: {
+          minAvailableMemoryBytes: 8 * gib,
+          maxSustainedCpuPercent: 75,
+          minDiskFreeBytes: 100 * gib,
+        },
+        rollback: {
+          maxServiceDurationRegressionPercent: 15,
+          maxInfrastructureFailureRatePercent: 5,
+          evidenceMismatchTolerance: 0,
+        },
+      },
+    });
+    mockDb.nonProductionEnvironmentLease.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(waiting);
+    mockDb.nonProductionEnvironmentLease.create.mockResolvedValue(waiting);
+    mockDb.nonProductionEnvironmentLease.findMany
+      .mockResolvedValueOnce([waiting])
+      .mockResolvedValueOnce([{ id: "row-1" }]);
+
+    const hostPressure = {
+      observedAt: NOW.toISOString(),
+      availableMemoryBytes: 14 * gib,
+      sustainedCpuPercent: 20,
+      diskFreeBytes: 500 * gib,
+      dockerHealthy: true,
+      convergenceActive: false,
+      fencesHealthy: true,
+      evidenceIsolationHealthy: true,
+    };
+    const result = await claim(mockDb, {
+      slotManifestVersion: 1,
+      hostPressure,
+      capacityBroker: async () => ({
+        ...hostPressure,
+        availableMemoryBytes: 40 * gib,
+        dockerAvailableMemoryBytes: 40 * gib,
+        builderMemoryUsageBytes: [0, 0],
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: "queued",
+      queuePosition: 1,
+      poolPolicy: {
+        effectiveCapacity: 0,
+        rollbackReason: "host-stage-headroom-low",
+      },
+    });
+  });
 });
 
 describe("lease liveness windows", () => {

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -325,7 +325,7 @@ export async function claimNonprodEnvironmentLease(input: {
     hostPressure: input.hostPressure,
     capacityBroker: input.capacityBroker,
     manifestSlotCount: NONPROD_SLOT_KEYS.length,
-    reserveBuildHeadroom: true,
+    reserveAdmissionHeadroom: true,
     now,
   });
   const ttlMs = requestedTtlMs(now, input.expiresAt);
@@ -668,7 +668,7 @@ export async function renewNonprodEnvironmentLease(input: {
     hostPressure: input.hostPressure,
     capacityBroker: input.capacityBroker,
     manifestSlotCount: NONPROD_SLOT_KEYS.length,
-    reserveBuildHeadroom: false,
+    reserveAdmissionHeadroom: false,
     now,
   });
   return { status: "renewed", lease: updated, poolPolicy };

--- a/apps/web/lib/nonprod/local-ci-pool-policy.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-policy.ts
@@ -95,6 +95,41 @@ export function localCiBuildHeadroomCapacity(input: {
   return capacity;
 }
 
+/**
+ * Number of host-native stage slots that can start without spending the
+ * configured continuation floor. The floor is the active-stage safety fence;
+ * the stage envelope is predictable Node/TypeScript/Vitest growth that must be
+ * reserved before admission rather than discovered by killing the stage.
+ */
+export function localCiHostStageHeadroomCapacity(input: {
+  availableMemoryBytes: number;
+  minAvailableMemoryBytes: number;
+  hostStageMemoryBytes: number;
+  manifestCapacity: number;
+}): number {
+  if (
+    !Number.isFinite(input.availableMemoryBytes)
+    || input.availableMemoryBytes < 0
+    || !Number.isFinite(input.minAvailableMemoryBytes)
+    || input.minAvailableMemoryBytes < 0
+    || !Number.isFinite(input.hostStageMemoryBytes)
+    || input.hostStageMemoryBytes <= 0
+    || !Number.isFinite(input.manifestCapacity)
+    || input.manifestCapacity < 1
+  ) {
+    return 0;
+  }
+
+  const reservableBytes = Math.max(
+    0,
+    input.availableMemoryBytes - input.minAvailableMemoryBytes,
+  );
+  return Math.min(
+    Math.floor(input.manifestCapacity),
+    Math.floor(reservableBytes / input.hostStageMemoryBytes),
+  );
+}
+
 type PolicyEnv = Record<string, string | undefined>;
 type PlatformConfigReader = {
   findUnique: (args: {
@@ -279,7 +314,7 @@ export function resolveLocalCiPoolPolicy(input: {
   configValue: unknown;
   host: LocalCiHostPressure;
   manifestSlotCount: number;
-  reserveBuildHeadroom?: boolean;
+  reserveAdmissionHeadroom?: boolean;
   env?: PolicyEnv;
   now?: Date;
 }): ResolvedLocalCiPoolPolicy {
@@ -316,7 +351,7 @@ export function resolveLocalCiPoolPolicy(input: {
     });
   }
 
-  if (input.reserveBuildHeadroom) {
+  if (input.reserveAdmissionHeadroom) {
     const builderMemoryBytes = localCiSlotResources.builderPolicy.memoryBytes;
     const hostBuildCapacity = localCiBuildHeadroomCapacity({
       dockerAvailableMemoryBytes:
@@ -335,12 +370,36 @@ export function resolveLocalCiPoolPolicy(input: {
         config,
       });
     }
+    const hostStageCapacity = localCiHostStageHeadroomCapacity({
+      availableMemoryBytes: input.host.availableMemoryBytes ?? Number.NaN,
+      minAvailableMemoryBytes: config.ceilings.minAvailableMemoryBytes,
+      hostStageMemoryBytes: localCiSlotResources.hostStagePolicy.memoryBytes,
+      manifestCapacity,
+    });
+    if (hostStageCapacity === 0) {
+      return unavailable({
+        source,
+        requestedCapacity,
+        manifestCapacity,
+        reason: "host-stage-headroom-low",
+        config,
+      });
+    }
     if (hostBuildCapacity === 1 && requestedCapacity === 2) {
       return singleton({
         source,
         requestedCapacity,
         manifestCapacity,
         reason: "host-build-capacity-one",
+        config,
+      });
+    }
+    if (hostStageCapacity === 1 && requestedCapacity === 2) {
+      return singleton({
+        source,
+        requestedCapacity,
+        manifestCapacity,
+        reason: "host-stage-capacity-one",
         config,
       });
     }

--- a/apps/web/lib/nonprod/local-ci-slot-resources.json
+++ b/apps/web/lib/nonprod/local-ci-slot-resources.json
@@ -7,6 +7,10 @@
     "cpuPeriod": 100000,
     "maxParallelism": 4
   },
+  "hostStagePolicy": {
+    "version": 1,
+    "memoryBytes": 8589934592
+  },
   "slots": {
     "slot-0": {
       "ordinal": 0,

--- a/apps/web/lib/routing/fallback-local-capacity.test.ts
+++ b/apps/web/lib/routing/fallback-local-capacity.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    modelProvider: { findUnique: vi.fn(), update: vi.fn() },
+    modelProfile: { updateMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/ai-inference", () => ({
+  callProvider: vi.fn(),
+  InferenceError: class InferenceError extends Error {},
+}));
+vi.mock("./rate-tracker", () => ({
+  recordRequest: vi.fn(),
+  learnFromRateLimitResponse: vi.fn(),
+  extractRetryAfterMs: vi.fn(),
+  markEndpointUnavailable: vi.fn(),
+  clearEndpointUnavailable: vi.fn(),
+}));
+vi.mock("./rate-recovery", () => ({ scheduleRecovery: vi.fn() }));
+vi.mock("./loader", () => ({ invalidateRoutingLoaderCache: vi.fn() }));
+vi.mock("@/lib/ai-provider-internals", () => ({ autoDiscoverAndProfile: vi.fn() }));
+vi.mock("./route-outcome", () => ({ recordRouteOutcome: vi.fn(() => Promise.resolve()) }));
+
+import { callProvider } from "@/lib/ai-inference";
+import { prisma } from "@dpf/db";
+import { callWithFallbackChain } from "./fallback";
+import { LocalProviderCapacityDeferredError } from "./local-provider-capacity";
+import type { RouteDecision, SensitivityLevel } from "./types";
+
+const mockCallProvider = vi.mocked(callProvider);
+const mockProviderLookup = vi.mocked(prisma.modelProvider.findUnique);
+
+function decisionWithCloudFallback(): RouteDecision {
+  return {
+    selectedEndpoint: "local-endpoint",
+    selectedModelId: "qwen3-coder",
+    reason: "test",
+    fitnessScore: 1,
+    fallbackChain: ["cloud-endpoint"],
+    candidates: [
+      {
+        endpointId: "local-endpoint", providerId: "local", modelId: "qwen3-coder",
+        endpointName: "Local", fitnessScore: 1, dimensionScores: {},
+        costPerOutputMToken: null, excluded: false,
+      },
+      {
+        endpointId: "cloud-endpoint", providerId: "openai", modelId: "gpt-cloud",
+        endpointName: "Cloud", fitnessScore: 0.8, dimensionScores: {},
+        costPerOutputMToken: null, excluded: false,
+      },
+    ],
+    excludedCount: 0,
+    excludedReasons: [],
+    policyRulesApplied: [],
+    taskType: "sync.triage",
+    sensitivity: "internal" as SensitivityLevel,
+    timestamp: new Date(),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mockProviderLookup.mockResolvedValue({ providerId: "openai", name: "Cloud" } as never);
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe("fallback local-CI capacity arbitration", () => {
+  it("returns the typed deferral for a local-only chain", async () => {
+    mockCallProvider.mockRejectedValueOnce(
+      new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
+    );
+    const decision = decisionWithCloudFallback();
+    decision.fallbackChain = [];
+    decision.candidates = decision.candidates.slice(0, 1);
+
+    await expect(
+      callWithFallbackChain(decision, [{ role: "user", content: "triage" }], "system"),
+    ).rejects.toMatchObject({
+      name: "LocalProviderCapacityDeferredError",
+      reason: "local-ci-active-capacity-reservation",
+    });
+  });
+
+  it("continues from a capacity-deferred local route to a cloud fallback", async () => {
+    mockCallProvider
+      .mockRejectedValueOnce(
+        new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
+      )
+      .mockResolvedValueOnce({
+        content: "triaged", inputTokens: 4, outputTokens: 2, inferenceMs: 20,
+      } as never);
+
+    const pending = callWithFallbackChain(
+      decisionWithCloudFallback(),
+      [{ role: "user", content: "triage" }],
+      "system",
+    );
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toMatchObject({
+      providerId: "openai",
+      content: "triaged",
+      downgraded: true,
+    });
+    expect(mockCallProvider.mock.calls[1]?.slice(0, 2)).toEqual(["openai", "gpt-cloud"]);
+  });
+});

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -20,6 +20,9 @@ import {
 } from "./rate-tracker";
 import { scheduleRecovery } from "./rate-recovery";
 import { isLocalProviderId } from "./provider-locality";
+import {
+  LocalProviderCapacityDeferredError,
+} from "./local-provider-capacity";
 import { invalidateRoutingLoaderCache } from "./loader";
 import { recordRouteOutcome } from "./route-outcome";
 import { autoDiscoverAndProfile } from "@/lib/ai-provider-internals";
@@ -244,6 +247,7 @@ export async function callWithFallbackChain(
   });
 
   const attempts: Array<{ endpointId: string; error: string }> = [];
+  const capacityDeferrals: LocalProviderCapacityDeferredError[] = [];
   let rateLimitRetried = false;
   let overloadRetried = false;
   let transientRetried = false;
@@ -382,6 +386,11 @@ export async function callWithFallbackChain(
           : {}),
       };
     } catch (e) {
+      if (e instanceof LocalProviderCapacityDeferredError) {
+        capacityDeferrals.push(e);
+        attempts.push({ endpointId: entry.providerId, error: e.reason });
+        continue;
+      }
       const errMsg = e instanceof Error ? e.message : String(e);
       attempts.push({ endpointId: entry.providerId, error: errMsg });
       console.warn(`[callWithFallbackChain] ${entry.providerId} failed: ${errMsg}`);
@@ -612,6 +621,10 @@ export async function callWithFallbackChain(
         }).catch((err) => console.error("[outcome] Failed to record error:", err));
       }
     }
+  }
+
+  if (capacityDeferrals.length === chain.length) {
+    throw capacityDeferrals.at(-1)!;
   }
 
   throw new Error(

--- a/apps/web/lib/routing/local-provider-capacity.test.ts
+++ b/apps/web/lib/routing/local-provider-capacity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertLocalProviderCapacityAvailable,
+  assertProviderDispatchCapacity,
+  inspectLocalProviderCapacity,
+  LocalProviderCapacityDeferredError,
+} from "./local-provider-capacity";
+
+describe("local provider capacity reservation", () => {
+  it("permits local dispatch when governed local CI is inactive", async () => {
+    const listActiveLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "dev-portal" },
+    ]);
+
+    await expect(
+      inspectLocalProviderCapacity({ listActiveLeases }),
+    ).resolves.toEqual({ available: true, reason: null });
+  });
+
+  it("defers every local dispatch while governed local CI owns the host", async () => {
+    const listActiveLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "local-integration-ci" },
+    ]);
+
+    await expect(
+      assertLocalProviderCapacityAvailable({ listActiveLeases }),
+    ).rejects.toMatchObject({
+      name: "LocalProviderCapacityDeferredError",
+      reason: "local-ci-active-capacity-reservation",
+    });
+  });
+
+  it("fails closed for local dispatch when the lease registry is unavailable", async () => {
+    const listActiveLeases = vi.fn().mockRejectedValue(new Error("registry unavailable"));
+
+    const rejection = assertLocalProviderCapacityAvailable({ listActiveLeases });
+
+    await expect(rejection).rejects.toBeInstanceOf(LocalProviderCapacityDeferredError);
+    await expect(rejection).rejects.toMatchObject({
+      reason: "local-ci-capacity-reservation-unavailable",
+    });
+  });
+
+  it("does not consult the host registry for a cloud provider", async () => {
+    const listActiveLeases = vi.fn().mockRejectedValue(new Error("registry unavailable"));
+
+    await expect(
+      assertProviderDispatchCapacity("openai", { listActiveLeases }),
+    ).resolves.toBeUndefined();
+    expect(listActiveLeases).not.toHaveBeenCalled();
+  });
+
+  it("applies the reservation to every local provider alias", async () => {
+    const listActiveLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "local-integration-ci" },
+    ]);
+
+    await expect(
+      assertProviderDispatchCapacity("ollama", { listActiveLeases }),
+    ).rejects.toMatchObject({ reason: "local-ci-active-capacity-reservation" });
+  });
+});

--- a/apps/web/lib/routing/local-provider-capacity.ts
+++ b/apps/web/lib/routing/local-provider-capacity.ts
@@ -1,0 +1,54 @@
+import { listActiveNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
+import { isLocalProviderId } from "./provider-locality";
+
+export type LocalProviderCapacityDeferralReason =
+  | "local-ci-active-capacity-reservation"
+  | "local-ci-capacity-reservation-unavailable";
+
+export type LocalProviderCapacityStatus =
+  | { available: true; reason: null }
+  | { available: false; reason: LocalProviderCapacityDeferralReason };
+
+type ActiveLeaseReader = () => Promise<Array<{ environmentKey: string }>>;
+
+export class LocalProviderCapacityDeferredError extends Error {
+  constructor(public readonly reason: LocalProviderCapacityDeferralReason) {
+    super(`Local provider dispatch deferred: ${reason}`);
+    this.name = "LocalProviderCapacityDeferredError";
+  }
+}
+
+/** Authoritative host-capacity policy shared by every local inference boundary. */
+export async function inspectLocalProviderCapacity(input: {
+  listActiveLeases?: ActiveLeaseReader;
+} = {}): Promise<LocalProviderCapacityStatus> {
+  const listActiveLeases = input.listActiveLeases
+    ?? (() => listActiveNonprodEnvironmentLeases({}));
+  try {
+    const activeLeases = await listActiveLeases();
+    if (activeLeases.some((lease) => lease.environmentKey === "local-integration-ci")) {
+      return { available: false, reason: "local-ci-active-capacity-reservation" };
+    }
+    return { available: true, reason: null };
+  } catch {
+    // Starting a resident local model is unsafe when capacity ownership cannot
+    // be proven, so uncertainty is deliberately fail-closed for local only.
+    return { available: false, reason: "local-ci-capacity-reservation-unavailable" };
+  }
+}
+
+export async function assertLocalProviderCapacityAvailable(input: {
+  listActiveLeases?: ActiveLeaseReader;
+} = {}): Promise<void> {
+  const status = await inspectLocalProviderCapacity(input);
+  if (!status.available) throw new LocalProviderCapacityDeferredError(status.reason);
+}
+
+/** Completion-adapter boundary: remote providers remain independent of host leases. */
+export async function assertProviderDispatchCapacity(
+  providerId: string,
+  input: { listActiveLeases?: ActiveLeaseReader } = {},
+): Promise<void> {
+  if (!isLocalProviderId(providerId)) return;
+  await assertLocalProviderCapacityAvailable(input);
+}

--- a/docs/architecture/context-engineering-standards.md
+++ b/docs/architecture/context-engineering-standards.md
@@ -13,6 +13,7 @@ DPF is **local-first by founder strategy**: cloud frontier models are disabled b
 
 - **The local-window contract.** One DMR llama-server, one generation model, ~24,576 tokens. Anything that silently consumes that budget (an unbounded tool result, 50K of tool definitions, a forgotten plan) is an *existential* failure mode, not an inefficiency.
 - **The tool-count cliff.** Tool-selection accuracy collapses past ~15 tools on small local models — encoded as `LOCAL_FALLBACK_MAX_TOOLS = 15` (`apps/web/lib/routing/fallback.ts`). Above it, local fallback is skipped entirely.
+- **The host-capacity boundary.** While governed local CI owns the installation host, the common provider adapter defers new local completion/embedding dispatch and `fallback.ts` may continue to an eligible cloud route. This policy is grounded in the observed overlap between provider/model residency and the Windows free-memory fence; Docker model residency, GPU VRAM, WSL/shared memory, and Windows physical memory remain separate measurements.
 - **The cheapest token is the one we never process.** Every reduction (just-in-time loading, in-environment filtering, concise results) compounds with caching and tiering.
 
 ## The three laws

--- a/docs/specs/routing-resilience-and-failure-observability-spec.md
+++ b/docs/specs/routing-resilience-and-failure-observability-spec.md
@@ -54,6 +54,7 @@ The material repo anchors are:
   - `rateLimitRetried`, `overloadRetried`, and `transientRetried` are scoped to one `callWithFallbackChain()` invocation.
   - The `rate_limit` branch waits up to 60 seconds for the selected endpoint before falling through.
   - Error outcomes are recorded as `RouteOutcome.latencyMs = 0`, so the route outcome row captures the failed attempt but not the wait that preceded the next attempt.
+  - A typed local-CI capacity deferral skips a local endpoint without degrading it and preserves an eligible cloud fallback. The policy uses lease ownership; it does not infer RAM consumption from Docker's displayed model residency or conflate GPU VRAM, WSL/shared memory, and Windows physical-memory telemetry.
 - `apps/web/lib/routing/pipeline-v2.ts`
   - `getExclusionReasonV2()` allows both `active` and `degraded` endpoints through the hard filter.
   - Cost-per-success ranking then applies the normal endpoint scoring path.

--- a/docs/superpowers/plans/2026-08-08-local-provider-ci-capacity-reservation.md
+++ b/docs/superpowers/plans/2026-08-08-local-provider-ci-capacity-reservation.md
@@ -1,6 +1,6 @@
 # Local Provider / Local-CI Capacity Reservation Plan
 
-**Backlog:** `BI-8E2E8BAE`  
+**Backlog:** `BI-8E2E8BAE`
 **Work capsule:** `WC-0E7D2D46`
 
 ## Goal
@@ -25,4 +25,15 @@ Prevent any portal-owned local completion or embedding dispatch from starting a 
 
 ## Documentation impact
 
-This is an operator/runtime contract, not a customer-facing feature. The pre-PR gate runbook records the exclusion behavior and recovery semantics; no user-guide change is required.
+This is primarily an operator/runtime contract. The pre-PR gate runbook records
+the exclusion and recovery semantics, and the provider user guide explains the
+temporary local-capacity deferral without presenting it as provider failure.
+
+## Evidence boundary
+
+The motivating evidence is temporal: local-provider dispatch and model
+residency coincided with the Windows free-physical-memory metric crossing the
+CI fence. Docker's displayed model residency, GPU VRAM, WSL/shared-memory
+accounting, and Windows physical memory remain separate measurements. This plan
+does not infer that displayed model size is ordinary RAM or name a causal
+mechanism without telemetry.

--- a/docs/superpowers/plans/2026-08-08-local-provider-ci-capacity-reservation.md
+++ b/docs/superpowers/plans/2026-08-08-local-provider-ci-capacity-reservation.md
@@ -1,0 +1,28 @@
+# Local Provider / Local-CI Capacity Reservation Plan
+
+**Backlog:** `BI-8E2E8BAE`  
+**Work capsule:** `WC-0E7D2D46`
+
+## Goal
+
+Prevent any portal-owned local completion or embedding dispatch from starting a resident model while governed `local-integration-ci` owns the shared host, without blocking eligible cloud inference.
+
+## Existing substrate
+
+- `callProvider()` is the shared completion adapter boundary used by routed inference, agentic work, evaluation, endpoint checks, voice, and legacy callers.
+- `generateEmbedding()` is the governed embedding choke point for durable knowledge and vector recall.
+- `listActiveNonprodEnvironmentLeases()` is the authoritative active-capacity registry.
+- `callWithFallbackChain()` already owns provider failover and can continue past a capacity-deferred local endpoint.
+- Semantic review already returns infrastructure-inconclusive for capacity deferral; that contract must remain stable.
+
+## Implementation
+
+1. Add one typed local-provider capacity policy over the active lease registry; fail closed only for local dispatch when registry authority is unavailable.
+2. Enforce it at `callProvider()` before provider setup and at `generateEmbedding()` before HTTP dispatch.
+3. Teach the fallback chain to treat the typed condition as a deferred local endpoint, preserving cloud fallback and returning the typed condition for local-only chains.
+4. Refactor semantic review to consume the shared policy while preserving its existing inconclusive result shape.
+5. Prove local, `ollama`, cloud, registry-failure, embedding, fallback, and semantic-review behavior with focused tests; run TypeScript and the canonical exact-tree gate on the combined capacity candidate.
+
+## Documentation impact
+
+This is an operator/runtime contract, not a customer-facing feature. The pre-PR gate runbook records the exclusion behavior and recovery semantics; no user-guide change is required.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -296,9 +296,12 @@ host against new local inference dispatch. The common completion adapter and
 embedding choke point consult the same lease registry immediately before local
 provider contact; a local-only request receives a typed capacity deferral,
 while an eligible cloud fallback remains available. Registry uncertainty fails
-closed for local inference only. This exclusion prevents a post-admission local
-model load from consuming the memory envelope that the exact-tree gate owns;
-it does not terminate a model that was already resident before admission.
+closed for local inference only. This exclusion addresses the observed temporal
+overlap between post-admission local-provider/model residency and the Windows
+host free-memory metric crossing the CI fence; it does not claim that Docker's
+displayed model size is ordinary RAM, conflate GPU VRAM with physical memory,
+or infer the Docker/WSL/shared-memory mechanism. It also does not terminate a
+model that was already resident before admission.
 
 **Fail-fast command order (BI-7BCCDE3D).** Inside an admitted runtime-code
 gate, freshness, Prisma generation, migrations, and the cheap doc/repository

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -291,6 +291,15 @@ intentionally sampled more slowly because each WMI/CIM process-table read is
 itself a heavyweight host operation; `DPF_GATE_PROCESS_SCAN_MS` and
 `DPF_GATE_DESCENDANT_POLL_MS` remain explicit debugging overrides.
 
+While a `local-integration-ci` lease is active, the portal reserves the shared
+host against new local inference dispatch. The common completion adapter and
+embedding choke point consult the same lease registry immediately before local
+provider contact; a local-only request receives a typed capacity deferral,
+while an eligible cloud fallback remains available. Registry uncertainty fails
+closed for local inference only. This exclusion prevents a post-admission local
+model load from consuming the memory envelope that the exact-tree gate owns;
+it does not terminate a model that was already resident before admission.
+
 **Fail-fast command order (BI-7BCCDE3D).** Inside an admitted runtime-code
 gate, freshness, Prisma generation, migrations, and the cheap doc/repository
 guards run first. Web typecheck then runs before exhaustive Vitest, followed by

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -42,13 +42,20 @@ Supported providers: Docker Model Runner, Ollama.
 
 ### Local capacity during platform verification
 
-A local model shares the installation host with governed platform verification.
-While an exact local-CI run owns that host, DPF defers new local completion and
-embedding requests instead of loading another resident model into the gate's
-reserved memory. If the request has an eligible cloud fallback, routing can use
-it; a local-only request waits or returns a capacity deferral rather than
-reporting the local provider as broken. DPF does not terminate a model that was
-already running before verification began.
+A local provider shares the installation's finite execution capacity with
+governed platform verification. While an exact local-CI run owns that capacity,
+DPF defers new local completion and embedding requests. If the request has an
+eligible cloud fallback, routing can use it; a local-only request waits or
+returns a capacity deferral rather than reporting the local provider as broken.
+DPF does not terminate a model that was already running before verification
+began.
+
+The guard uses the Windows host free-physical-memory measurement for CI
+admission and renewal. Docker's displayed model residency, GPU VRAM, possible
+shared or unified memory, WSL accounting, and Windows physical memory are
+different measurements. DPF does not infer that a model's displayed size is
+ordinary RAM consumption or assign a causal mechanism without corresponding
+telemetry.
 
 This behavior is automatic. If local work is temporarily deferred, let the
 active verification finish and retry; do not disable, reconnect, or re-profile

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -40,6 +40,20 @@ Used for local providers that run on your machine or local network. No credentia
 
 Supported providers: Docker Model Runner, Ollama.
 
+### Local capacity during platform verification
+
+A local model shares the installation host with governed platform verification.
+While an exact local-CI run owns that host, DPF defers new local completion and
+embedding requests instead of loading another resident model into the gate's
+reserved memory. If the request has an eligible cloud fallback, routing can use
+it; a local-only request waits or returns a capacity deferral rather than
+reporting the local provider as broken. DPF does not terminate a model that was
+already running before verification began.
+
+This behavior is automatic. If local work is temporarily deferred, let the
+active verification finish and retry; do not disable, reconnect, or re-profile
+the local provider unless its status remains unhealthy after the gate releases.
+
 ## How OAuth Works
 
 1. Go to the provider's detail page (External Services > click the provider).

--- a/scripts/local-ci-pool-policy.test.mjs
+++ b/scripts/local-ci-pool-policy.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   LOCAL_CI_POOL_CONFIG_KEY,
   localCiBuildHeadroomCapacity,
+  localCiHostStageHeadroomCapacity,
   loadLocalCiPoolConfig,
   resolveLocalCiPoolPolicy,
 } from "../apps/web/lib/nonprod/local-ci-pool-policy.ts";
@@ -102,13 +103,75 @@ test("admission reserves the canonical bounded-build memory above the host safet
       builderMemoryUsageBytes: [0, 0],
     },
     manifestSlotCount: 2,
-    reserveBuildHeadroom: true,
+    reserveAdmissionHeadroom: true,
   });
 
   assert.equal(resolved.hostSafeCapacity, 0);
   assert.equal(resolved.effectiveCapacity, 0);
   assert.equal(resolved.rollbackReason, "host-build-headroom-low");
   assert.deepEqual(resolved.slotKeys, []);
+});
+
+test("admission reserves the host-native stage envelope above the safety floor", () => {
+  const gib = 1024 ** 3;
+  const configValue = {
+    ...PILOT_CONFIG,
+    ceilings: {
+      ...PILOT_CONFIG.ceilings,
+      minAvailableMemoryBytes: 8 * gib,
+    },
+  };
+
+  for (const availableMemoryBytes of [12 * gib, 14 * gib]) {
+    const resolved = resolveLocalCiPoolPolicy({
+      configValue,
+      host: {
+        ...SAFE_HOST,
+        availableMemoryBytes,
+        dockerAvailableMemoryBytes: 40 * gib,
+        builderMemoryUsageBytes: [0, 0],
+      },
+      manifestSlotCount: 2,
+      reserveAdmissionHeadroom: true,
+    });
+
+    assert.equal(resolved.hostSafeCapacity, 0);
+    assert.equal(resolved.effectiveCapacity, 0);
+    assert.equal(resolved.rollbackReason, "host-stage-headroom-low");
+    assert.deepEqual(resolved.slotKeys, []);
+  }
+
+  const oneSlot = resolveLocalCiPoolPolicy({
+    configValue,
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 20 * gib,
+      dockerAvailableMemoryBytes: 40 * gib,
+      builderMemoryUsageBytes: [0, 0],
+    },
+    manifestSlotCount: 2,
+    reserveAdmissionHeadroom: true,
+  });
+  assert.equal(oneSlot.hostSafeCapacity, 1);
+  assert.equal(oneSlot.effectiveCapacity, 1);
+  assert.equal(oneSlot.rollbackReason, "host-stage-capacity-one");
+  assert.deepEqual(oneSlot.slotKeys, ["slot-0"]);
+
+  const twoSlots = resolveLocalCiPoolPolicy({
+    configValue,
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 24 * gib,
+      dockerAvailableMemoryBytes: 40 * gib,
+      builderMemoryUsageBytes: [0, 0],
+    },
+    manifestSlotCount: 2,
+    reserveAdmissionHeadroom: true,
+  });
+  assert.equal(twoSlots.hostSafeCapacity, 2);
+  assert.equal(twoSlots.effectiveCapacity, 2);
+  assert.equal(twoSlots.rollbackReason, null);
+  assert.deepEqual(twoSlots.slotKeys, ["slot-0", "slot-1"]);
 });
 
 test("admission contracts to one slot when headroom covers only one bounded build", () => {
@@ -121,7 +184,7 @@ test("admission contracts to one slot when headroom covers only one bounded buil
       builderMemoryUsageBytes: [1.5 * 1024 ** 3, 0],
     },
     manifestSlotCount: 2,
-    reserveBuildHeadroom: true,
+    reserveAdmissionHeadroom: true,
   });
 
   assert.equal(resolved.hostSafeCapacity, 1);
@@ -145,7 +208,7 @@ test("execution pressure does not reserve bounded-build memory a second time", (
       dockerAvailableMemoryBytes: 5 * 1024 ** 3,
     },
     manifestSlotCount: 2,
-    reserveBuildHeadroom: false,
+    reserveAdmissionHeadroom: false,
   });
 
   assert.equal(resolved.hostSafeCapacity, 2);
@@ -173,6 +236,58 @@ test("bounded-build headroom arithmetic fails closed for invalid resource policy
     dockerAvailableMemoryBytes: 11 * 1024 ** 3,
     builderMemoryUsageBytes: [0, 0],
   }), 0);
+});
+
+test("host-stage headroom arithmetic keeps the configured floor unconsumed", () => {
+  const gib = 1024 ** 3;
+  const valid = {
+    availableMemoryBytes: 24 * gib,
+    minAvailableMemoryBytes: 8 * gib,
+    hostStageMemoryBytes: 8 * gib,
+    manifestCapacity: 2,
+  };
+
+  assert.equal(localCiHostStageHeadroomCapacity(valid), 2);
+  assert.equal(localCiHostStageHeadroomCapacity({
+    ...valid,
+    availableMemoryBytes: 20 * gib,
+  }), 1);
+  assert.equal(localCiHostStageHeadroomCapacity({
+    ...valid,
+    availableMemoryBytes: 15 * gib,
+  }), 0);
+  for (const hostStageMemoryBytes of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(localCiHostStageHeadroomCapacity({
+      ...valid,
+      hostStageMemoryBytes,
+    }), 0);
+  }
+});
+
+test("admission intersects Docker and host-stage capacity instead of returning the first partial fit", () => {
+  const gib = 1024 ** 3;
+  const resolved = resolveLocalCiPoolPolicy({
+    configValue: {
+      ...PILOT_CONFIG,
+      ceilings: {
+        ...PILOT_CONFIG.ceilings,
+        minAvailableMemoryBytes: 8 * gib,
+      },
+    },
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 14 * gib,
+      dockerAvailableMemoryBytes: 20 * gib,
+      builderMemoryUsageBytes: [0, 0],
+    },
+    manifestSlotCount: 2,
+    reserveAdmissionHeadroom: true,
+  });
+
+  assert.equal(resolved.hostSafeCapacity, 0);
+  assert.equal(resolved.effectiveCapacity, 0);
+  assert.equal(resolved.rollbackReason, "host-stage-headroom-low");
+  assert.deepEqual(resolved.slotKeys, []);
 });
 
 test("unmeasurable or unsafe configured host evidence contracts admission to zero", () => {


### PR DESCRIPTION
## Summary

Prevent portal-owned local completion and embedding work from starting a resident model while governed local CI owns the shared host, and reserve the next host-native stage memory envelope before a gate admits.

## Changes

- enforce one typed local-provider capacity policy at the shared `callProvider` boundary and embedding choke point; registry uncertainty fails closed for local providers only
- preserve cloud fallback when a local endpoint is capacity-deferred and retain semantic review's infrastructure-inconclusive contract through the same policy
- require admission headroom for the configured host stage envelope in addition to the host safety floor and bounded Docker build envelope
- add focused regression coverage, an implementation plan, and operator-facing documentation

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [ ] Functional verification ran against the **canonical runtime**
  - [x] Evidence captured below
- [x] **Verification-harness limitation acknowledged** — the deployed sandbox is the patient under repair; two differentiated exact corrective runs observed post-admission local-provider/model residency coincident with the Windows host free-memory fence before this shared dispatch exclusion was live

### Verification evidence

- 15/15 local-CI pool-policy tests passed
- 41/41 focused combined web tests passed; graph-related expansion added another 96/96 passing tests
- `pnpm --filter web typecheck` passed with the canonical 16 GiB Node envelope
- `pnpm run pregate:preflight` passed all 35 guards
- fresh high-assurance semantic review passed with two independent branches and zero findings
- hosted and merge-group CI are the runtime verification path for this bootstrap recovery

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Allowed `Local-CI-Override` documented below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` run before PR creation

Local-CI-Override: install-bootstrap-recovery: deployed local-provider dispatch lacks the active local-CI exclusion this PR repairs; prior exact corrective runs preserve separate Docker/VRAM/WSL/Windows-memory observations and reviewed source evidence is retained

## Related issues / Epic

Parent: `EP-0DFF753B`

This PR covers: `BI-A6C56ED8`, `BI-8E2E8BAE`

Work capsules: `WC-D54B43A0`, `WC-0E7D2D46`

## Overlap sweep

No open provider-capacity or local-CI capacity PR overlaps this branch. The two previously separate signed corrections are intentionally composed here so admission and post-admission dispatch share one deployment boundary.

## Notes for the reviewer

The override is the closed-code bootstrap recovery path, not a claim that local exact-tree CI passed. The deployed evaluation runner can currently dispatch qwen after admission; that residency coincided with the Windows free-memory fence, but Docker model size, GPU VRAM, WSL/shared memory, and Windows physical memory are explicitly separate measurements and the causal mechanism is not asserted. This PR closes the shared provider boundary and leaves valid existing model processes untouched.
