### PR TITLE
feat: identify gateways before connection setup

### DIFF
--- a/apps/web/components/inventory/AddDiscoveryConnection.tsx
+++ b/apps/web/components/inventory/AddDiscoveryConnection.tsx
@@ -2,10 +2,12 @@
 
 import { useState } from "react";
 import { ConfigureConnectionInline } from "./ConfigureConnectionInline";
+import type { GatewayCandidate } from "@/lib/discovery-connection/gateway-candidate";
 
 type Props = {
   /** Gateway IP detected from discovered network interfaces (e.g., "192.168.0.1") */
   detectedGateway?: string | null;
+  gatewayCandidates?: GatewayCandidate[];
   /**
    * "hero" (default) is the empty-state pitch with detected-gateway copy.
    * "compact" is the small "+ Add another" tile shown beneath an existing list.
@@ -13,13 +15,14 @@ type Props = {
   variant?: "hero" | "compact";
 };
 
-export function AddDiscoveryConnection({ detectedGateway, variant = "hero" }: Props) {
+export function AddDiscoveryConnection({ detectedGateway, gatewayCandidates = [], variant = "hero" }: Props) {
   const [showForm, setShowForm] = useState(false);
 
   if (showForm) {
     return (
       <ConfigureConnectionInline
-        gatewayName={detectedGateway ? `Gateway ${detectedGateway}` : "Network Gateway"}
+        gatewayCandidates={gatewayCandidates}
+        gatewayName={gatewayCandidates[0]?.name ?? (detectedGateway ? `Gateway ${detectedGateway}` : "Network Gateway")}
         gatewayAddress={detectedGateway ?? undefined}
         onComplete={() => setShowForm(false)}
       />
@@ -45,15 +48,15 @@ export function AddDiscoveryConnection({ detectedGateway, variant = "hero" }: Pr
           <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
             Network Discovery
           </p>
-          {detectedGateway ? (
+          {gatewayCandidates.length > 0 ? (
             <>
               <p className="text-sm text-[var(--dpf-text)] mt-1">
-                Gateway detected at <span className="font-mono font-medium">{detectedGateway}</span>
+                {gatewayCandidates.length === 1
+                  ? <>Gateway identified: <span className="font-medium">{gatewayCandidates[0].name}</span></>
+                  : <>{gatewayCandidates.length} possible gateways identified</>}
               </p>
               <p className="text-xs text-[var(--dpf-muted)] mt-1">
-                Connect to your gateway to discover all devices on your network.
-                If this is a Ubiquiti UniFi gateway, you will need an API key from
-                Settings &gt; API in your UniFi console.
+                DPF will use the discovered device identity and recommend the best supported connection method.
               </p>
             </>
           ) : (
@@ -66,9 +69,9 @@ export function AddDiscoveryConnection({ detectedGateway, variant = "hero" }: Pr
         <button
           type="button"
           onClick={() => setShowForm(true)}
-          className="rounded-md bg-[#7c8cf8] px-4 py-1.5 text-sm font-medium text-white hover:bg-[#6b7bf7] transition-colors shrink-0"
+          className="shrink-0 rounded-md bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-[var(--dpf-accent-contrast)] transition-opacity hover:opacity-90"
         >
-          {detectedGateway ? "Configure" : "Add Connection"}
+          {gatewayCandidates.length > 0 ? "Review & Connect" : "Add Connection"}
         </button>
       </div>
     </div>

--- a/apps/web/components/inventory/ConfigureConnectionInline.test.tsx
+++ b/apps/web/components/inventory/ConfigureConnectionInline.test.tsx
@@ -111,7 +111,7 @@ describe("ConfigureConnectionInline", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(await screen.findByText(/choose a gateway/i)).toBeTruthy();
+    expect(await screen.findByText("Choose a gateway before saving this connection.")).toBeTruthy();
     expect(mockConfigureDiscoveryConnection).not.toHaveBeenCalled();
   });
 
@@ -124,7 +124,7 @@ describe("ConfigureConnectionInline", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText(/enter a gateway manually/i));
+    fireEvent.click(screen.getByText(/^manual gateway$/i));
     const recoveryInput = screen.getByLabelText(/gateway address/i) as HTMLInputElement;
     fireEvent.change(recoveryInput, { target: { value: "file:///etc/passwd" } });
     fireEvent.change(screen.getByLabelText(/^API Key/i), {
@@ -149,7 +149,7 @@ describe("ConfigureConnectionInline", () => {
     fireEvent.change(screen.getByLabelText(/^API Key/i), {
       target: { value: "unifi-api-key" },
     });
-    fireEvent.click(screen.getByRole("checkbox", { name: /allow self-signed controller certificate/i }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /allow self-signed certificate/i }));
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(mockConfigureDiscoveryConnection).toHaveBeenCalledTimes(1));

--- a/apps/web/components/inventory/ConfigureConnectionInline.test.tsx
+++ b/apps/web/components/inventory/ConfigureConnectionInline.test.tsx
@@ -15,6 +15,22 @@ vi.mock("@/lib/actions/discovery", () => ({
 
 import { ConfigureConnectionInline } from "./ConfigureConnectionInline";
 
+const UNIFI_CANDIDATE = {
+  entityId: "gw-unifi",
+  entityKey: "unifi:aa:bb:cc:dd:ee:ff",
+  name: "Cloud Gateway Ultra",
+  address: "192.168.0.1",
+  manufacturer: "Ubiquiti",
+  model: "UCG-Ultra",
+  confidence: 0.96,
+  evidence: ["Manufacturer: Ubiquiti", "Model: UCG-Ultra", "Identification confidence 96%"],
+  recommendedCollector: "unifi" as const,
+  recommendation: "DPF identified UniFi/Ubiquiti evidence for this gateway.",
+  canonicalEndpoint: "https://192.168.0.1",
+  matchesDetectedGateway: true,
+  usable: true,
+};
+
 describe("ConfigureConnectionInline", () => {
   afterEach(() => {
     cleanup();
@@ -24,6 +40,101 @@ describe("ConfigureConnectionInline", () => {
     vi.clearAllMocks();
     mockConfigureDiscoveryConnection.mockResolvedValue({ ok: true, connectionId: "conn-1" });
     mockTestDiscoveryConnection.mockResolvedValue({ ok: true, status: "ok", deviceCount: 1 });
+  });
+
+  it("uses an identified gateway as the primary target without rendering an editable URL", () => {
+    render(
+      <ConfigureConnectionInline
+        gatewayCandidates={[UNIFI_CANDIDATE]}
+        gatewayName="Network Gateway"
+        onComplete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Cloud Gateway Ultra")).toBeTruthy();
+    expect(screen.getByText(/Ubiquiti.*UCG-Ultra/i)).toBeTruthy();
+    expect(screen.getByText(/Local address/i)).toBeTruthy();
+    expect(screen.getByText("192.168.0.1")).toBeTruthy();
+    expect(screen.queryByLabelText(/controller url/i)).toBeNull();
+    expect(screen.getByText(/DPF identified UniFi/i)).toBeTruthy();
+  });
+
+  it("submits the selected gateway identity and canonical endpoint", async () => {
+    render(
+      <ConfigureConnectionInline
+        gatewayCandidates={[UNIFI_CANDIDATE]}
+        gatewayName="Network Gateway"
+        onComplete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/^API Key/i), {
+      target: { value: "unifi-api-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(mockConfigureDiscoveryConnection).toHaveBeenCalledTimes(1));
+    expect(mockConfigureDiscoveryConnection).toHaveBeenCalledWith(expect.objectContaining({
+      gatewayEntityId: "gw-unifi",
+      name: "Cloud Gateway Ultra",
+      collectorType: "unifi",
+      endpointUrl: "https://192.168.0.1",
+    }));
+  });
+
+  it("requires a deliberate choice when discovered gateways are ambiguous", async () => {
+    render(
+      <ConfigureConnectionInline
+        gatewayCandidates={[
+          { ...UNIFI_CANDIDATE, matchesDetectedGateway: false },
+          {
+            ...UNIFI_CANDIDATE,
+            entityId: "gw-second",
+            entityKey: "unifi:11:22:33:44:55:66",
+            name: "Second Cloud Gateway",
+            address: "192.168.9.1",
+            canonicalEndpoint: "https://192.168.9.1",
+            matchesDetectedGateway: false,
+          },
+        ]}
+        gatewayName="Network Gateway"
+        onComplete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("option", {
+      name: /Cloud Gateway Ultra.*Ubiquiti.*UCG-Ultra.*192\.168\.0\.1/i,
+    })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText(/^API Key/i), {
+      target: { value: "unifi-api-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText(/choose a gateway/i)).toBeTruthy();
+    expect(mockConfigureDiscoveryConnection).not.toHaveBeenCalled();
+  });
+
+  it("keeps manual endpoint entry behind recovery and preserves invalid input", async () => {
+    render(
+      <ConfigureConnectionInline
+        gatewayCandidates={[UNIFI_CANDIDATE]}
+        gatewayName="Network Gateway"
+        onComplete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(/enter a gateway manually/i));
+    const recoveryInput = screen.getByLabelText(/gateway address/i) as HTMLInputElement;
+    fireEvent.change(recoveryInput, { target: { value: "file:///etc/passwd" } });
+    fireEvent.change(screen.getByLabelText(/^API Key/i), {
+      target: { value: "unifi-api-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText(/HTTP or HTTPS gateway address/i)).toBeTruthy();
+    expect(recoveryInput.value).toBe("file:///etc/passwd");
+    expect(mockConfigureDiscoveryConnection).not.toHaveBeenCalled();
   });
 
   it("sends the closed-LAN TLS choice with the UniFi connection configuration", async () => {

--- a/apps/web/components/inventory/ConfigureConnectionInline.tsx
+++ b/apps/web/components/inventory/ConfigureConnectionInline.tsx
@@ -39,10 +39,20 @@ type Props = {
   existing?: ExistingConnection;
 };
 
+type ConnectionStatus = "idle" | "saving" | "testing" | "success" | "error";
+
+type ConnectionConfiguration = {
+  site?: string;
+  discoverClients?: boolean;
+  tlsInsecure?: boolean;
+  community?: string;
+  subnet?: string;
+};
+
 const COLLECTOR_TYPES = [
   { value: "unifi", label: "Ubiquiti UniFi" },
   { value: "snmp", label: "SNMP (Generic)" },
-  { value: "arp_scan", label: "Network Scan (ARP)" },
+  { value: "arp_scan", label: "ARP scan" },
 ];
 
 function asCollectorType(value: string): DiscoveryCollectorType {
@@ -106,7 +116,7 @@ export function ConfigureConnectionInline({
   const initialSelection = choosePreselectedGateway(candidates);
   const initialCandidate = candidates.find((candidate) => candidate.entityId === initialSelection);
   const [selectedGatewayId, setSelectedGatewayId] = useState(initialSelection ?? "");
-  const [collectorType, setCollectorType] = useState<DiscoveryCollectorType>(
+  const [collectorType, setCollectorType] = useState(
     asCollectorType(existing?.collectorType ?? initialCandidate?.recommendedCollector ?? "unifi"),
   );
   const [manualEndpoint, setManualEndpoint] = useState(gatewayAddress ?? "");
@@ -114,7 +124,7 @@ export function ConfigureConnectionInline({
   const [apiKey, setApiKey] = useState("");
   const [site, setSite] = useState(existing?.site ?? "default");
   const [tlsInsecure, setTlsInsecure] = useState(existing?.tlsInsecure ?? false);
-  const [status, setStatus] = useState<"idle" | "saving" | "testing" | "success" | "error">("idle");
+  const [status, setStatus] = useState("idle" as ConnectionStatus);
   const [message, setMessage] = useState("");
   const [fieldError, setFieldError] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -174,7 +184,7 @@ export function ConfigureConnectionInline({
     startTransition(async () => {
       setStatus("saving");
       setMessage("");
-      const configuration: Record<string, unknown> = {};
+      const configuration: ConnectionConfiguration = {};
       if (isUnifi) Object.assign(configuration, { site, discoverClients: true, tlsInsecure });
       if (isSnmp) configuration.community = apiKey || "public";
       if (isArpScan) configuration.subnet = normalized.value;
@@ -218,22 +228,17 @@ export function ConfigureConnectionInline({
 
   return (
     <div className="mt-4 space-y-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-      <div>
-        <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
-          Configure Discovery Connection
-        </p>
-        <p className="mt-1 text-sm text-[var(--dpf-text)]">
-          Select the gateway DPF identified. Its network endpoint is filled in automatically.
-        </p>
-      </div>
+      <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+        Gateway connection
+      </p>
 
-      {candidates.length > 1 ? (
+      {candidates.length > 1 && (
         <SelectField
           name="gateway"
           label="Gateway"
           value={selectedGatewayId}
           onValueChange={selectGateway}
-          placeholder="Choose an identified gateway"
+          placeholder="Choose a gateway"
           options={candidates.map((candidate) => ({
             value: candidate.entityId,
             label: gatewayOptionLabel(candidate),
@@ -242,7 +247,8 @@ export function ConfigureConnectionInline({
           hint={selectedCandidate?.recommendation ?? "Choose by device name, manufacturer, model, and local address."}
           required
         />
-      ) : selectedCandidate ? (
+      )}
+      {candidates.length <= 1 && selectedCandidate && (
         <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3" aria-label="Selected gateway">
           <p className="font-medium text-[var(--dpf-text)]">{selectedCandidate.name}</p>
           {(selectedCandidate.manufacturer || selectedCandidate.model) && (
@@ -257,9 +263,10 @@ export function ConfigureConnectionInline({
           )}
           <p className="mt-1 text-xs text-[var(--dpf-muted)]">{selectedCandidate.recommendation}</p>
         </section>
-      ) : (
+      )}
+      {candidates.length <= 1 && !selectedCandidate && (
         <p className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm text-[var(--dpf-muted)]">
-          DPF did not find an identifiable gateway. Manual recovery is available below.
+          No gateway identified. Use manual recovery below.
         </p>
       )}
 
@@ -288,7 +295,7 @@ export function ConfigureConnectionInline({
       {isUnifi ? (
         <details className="rounded-md border border-[var(--dpf-border)] px-3 py-2">
           <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-accent)]">
-            Enter a gateway manually
+            Manual gateway
           </summary>
           <div className="mt-3">
             <TextField
@@ -337,7 +344,7 @@ export function ConfigureConnectionInline({
       {isUnifi && (
         <CheckboxField
           name="tls-insecure"
-          label="Allow self-signed controller certificate"
+          label="Allow self-signed certificate"
           checked={tlsInsecure}
           onCheckedChange={setTlsInsecure}
           hint="Use only for a trusted closed-LAN UniFi appliance without a public certificate."

--- a/apps/web/components/inventory/ConfigureConnectionInline.tsx
+++ b/apps/web/components/inventory/ConfigureConnectionInline.tsx
@@ -1,30 +1,41 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import {
   configureDiscoveryConnection,
   testDiscoveryConnection,
 } from "@/lib/actions/discovery";
+import {
+  endpointForCollector,
+  normalizeDiscoveryEndpoint,
+  type DiscoveryCollectorType,
+} from "@/lib/discovery-connection/endpoint";
+import {
+  choosePreselectedGateway,
+  type GatewayCandidate,
+} from "@/lib/discovery-connection/gateway-candidate";
+import {
+  CheckboxField,
+  FormStatus,
+  SelectField,
+  SubmitButton,
+  TextField,
+} from "@/components/ui/form";
 
 type ExistingConnection = {
-  /** DiscoveryConnection.id — present means edit by id (URL changes allowed). */
   id: string;
   collectorType: string;
   site?: string;
   tlsInsecure?: boolean;
-  /** True if the row already has an encrypted API key; lets the form show "leave blank to keep". */
   hasApiKey: boolean;
 };
 
 type Props = {
+  gatewayCandidates?: GatewayCandidate[];
   gatewayEntityId?: string;
   gatewayAddress?: string;
   gatewayName: string;
   onComplete: () => void;
-  /**
-   * When set, the form starts in edit mode: collectorType + site + endpoint are pre-filled
-   * and the API key field becomes optional (omitted on save = keep existing).
-   */
   existing?: ExistingConnection;
 };
 
@@ -32,154 +43,151 @@ const COLLECTOR_TYPES = [
   { value: "unifi", label: "Ubiquiti UniFi" },
   { value: "snmp", label: "SNMP (Generic)" },
   { value: "arp_scan", label: "Network Scan (ARP)" },
-] as const;
+];
 
-function trimTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 0x2f /* "/" */) end--;
-  return value.slice(0, end);
-}
-
-function stripScheme(value: string): string {
-  if (value.startsWith("https://")) return value.slice(8);
-  if (value.startsWith("http://")) return value.slice(7);
-  if (value.startsWith("HTTPS://")) return value.slice(8);
-  if (value.startsWith("HTTP://")) return value.slice(7);
-  return value;
-}
-
-function stripPath(value: string): string {
-  const slashIndex = value.indexOf("/");
-  return slashIndex >= 0 ? value.slice(0, slashIndex) : value;
-}
-
-function isIpv4Octet(value: string): boolean {
-  if (value.length === 0 || value.length > 3) return false;
-  for (const char of value) {
-    if (char < "0" || char > "9") return false;
-  }
-  const octet = Number(value);
-  return octet >= 0 && octet <= 255;
-}
-
-function toIpv4Subnet(value: string): string {
-  const host = stripPath(stripScheme(trimTrailingSlashes(value.trim())));
-  if (host.includes("/")) return host;
-  const parts = host.split(".");
-  if (parts.length !== 4 || !parts.every(isIpv4Octet)) return "";
-  return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
-}
-
-function isIpv4Cidr(value: string): boolean {
-  const [ip, cidr, extra] = value.trim().split("/");
-  if (!ip || !cidr || extra !== undefined) return false;
-  const prefix = Number(cidr);
-  if (!Number.isInteger(prefix) || prefix < 16 || prefix > 32) return false;
-  const parts = ip.split(".");
-  return parts.length === 4 && parts.every(isIpv4Octet);
-}
-
-function defaultEndpointForCollector(collectorType: string, gatewayAddress?: string): string {
-  const raw = gatewayAddress?.trim();
-  if (!raw) return "";
-  if (collectorType === "unifi") return raw.startsWith("http") ? trimTrailingSlashes(raw) : `https://${raw}`;
-  if (collectorType === "snmp") return stripPath(stripScheme(trimTrailingSlashes(raw)));
-  if (collectorType === "arp_scan") return toIpv4Subnet(raw);
-  return raw;
+function asCollectorType(value: string): DiscoveryCollectorType {
+  return value === "snmp" || value === "arp_scan" ? value : "unifi";
 }
 
 function formatConnectionFeedback(status: string, fallback?: string): string {
   switch (status) {
     case "unifi_tls_error":
-      return "The UniFi controller appears to use a self-signed certificate. Enable self-signed certificate support for this closed LAN, or install a trusted certificate on the controller.";
+      return "The UniFi gateway appears to use a self-signed certificate. Allow it for this trusted closed LAN, or install a trusted certificate on the gateway.";
     case "unifi_auth_failed":
-      return "The UniFi controller rejected the API key. Rotate the key in UniFi OS and paste the new value here.";
+      return "The UniFi gateway rejected the API key. Rotate the key in UniFi OS and paste the new value here.";
     case "unifi_unreachable":
-      return "The portal could not reach the UniFi controller from this host. Check the controller URL and local network reachability.";
+      return "DPF could not reach this UniFi gateway from the portal host. Check local network reachability.";
     default:
       return fallback ?? status;
   }
 }
 
+function fallbackCandidate(
+  gatewayEntityId: string | undefined,
+  gatewayAddress: string | undefined,
+  gatewayName: string,
+): GatewayCandidate[] {
+  if (!gatewayAddress) return [];
+  const canonicalEndpoint = endpointForCollector("unifi", gatewayAddress);
+  return [{
+    entityId: gatewayEntityId ?? "detected-gateway",
+    entityKey: gatewayEntityId ?? gatewayAddress,
+    name: gatewayName,
+    address: gatewayAddress,
+    manufacturer: null,
+    model: null,
+    confidence: null,
+    evidence: ["Detected on the local network"],
+    recommendedCollector: "unifi",
+    recommendation: "DPF detected this gateway on the local network.",
+    canonicalEndpoint,
+    matchesDetectedGateway: true,
+    usable: canonicalEndpoint !== null,
+  }];
+}
+
+function gatewayOptionLabel(candidate: GatewayCandidate): string {
+  const identity = [candidate.manufacturer, candidate.model].filter(Boolean).join(" ");
+  return [candidate.name, identity || null, candidate.address].filter(Boolean).join(" — ");
+}
+
 export function ConfigureConnectionInline({
+  gatewayCandidates,
   gatewayEntityId,
   gatewayAddress,
   gatewayName,
   onComplete,
   existing,
 }: Props) {
-  const isEditMode = !!existing;
-  const [collectorType, setCollectorType] = useState(existing?.collectorType ?? "unifi");
-  const [endpointUrl, setEndpointUrl] = useState(
-    defaultEndpointForCollector(existing?.collectorType ?? "unifi", gatewayAddress),
+  const candidates = useMemo(
+    () => gatewayCandidates ?? fallbackCandidate(gatewayEntityId, gatewayAddress, gatewayName),
+    [gatewayCandidates, gatewayEntityId, gatewayAddress, gatewayName],
   );
+  const initialSelection = choosePreselectedGateway(candidates);
+  const initialCandidate = candidates.find((candidate) => candidate.entityId === initialSelection);
+  const [selectedGatewayId, setSelectedGatewayId] = useState(initialSelection ?? "");
+  const [collectorType, setCollectorType] = useState<DiscoveryCollectorType>(
+    asCollectorType(existing?.collectorType ?? initialCandidate?.recommendedCollector ?? "unifi"),
+  );
+  const [manualEndpoint, setManualEndpoint] = useState(gatewayAddress ?? "");
+  const [manualMode, setManualMode] = useState(false);
   const [apiKey, setApiKey] = useState("");
   const [site, setSite] = useState(existing?.site ?? "default");
   const [tlsInsecure, setTlsInsecure] = useState(existing?.tlsInsecure ?? false);
   const [status, setStatus] = useState<"idle" | "saving" | "testing" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
+  const [fieldError, setFieldError] = useState("");
   const [isPending, startTransition] = useTransition();
 
+  const selectedCandidate = candidates.find((candidate) => candidate.entityId === selectedGatewayId);
   const isUnifi = collectorType === "unifi";
   const isSnmp = collectorType === "snmp";
   const isArpScan = collectorType === "arp_scan";
+  const keyRequired = isUnifi && !(existing && existing.hasApiKey);
+  const selectedEndpoint = selectedCandidate?.address
+    ? endpointForCollector(collectorType, selectedCandidate.address)
+    : null;
+  const endpointInput = manualMode || !selectedEndpoint ? manualEndpoint : selectedEndpoint;
 
-  // API key requirement is relaxed in edit mode when one already exists:
-  // omitting it on save preserves the stored ciphertext (server-side upsert
-  // only overwrites `encryptedApiKey` when a new value is supplied).
-  const keyRequired = isUnifi && !(isEditMode && existing?.hasApiKey);
+  const selectGateway = (entityId: string) => {
+    const candidate = candidates.find((item) => item.entityId === entityId);
+    setSelectedGatewayId(entityId);
+    setManualMode(false);
+    setFieldError("");
+    setMessage("");
+    setStatus("idle");
+    if (candidate) setCollectorType(candidate.recommendedCollector);
+  };
+
+  const changeCollector = (value: string) => {
+    const next = asCollectorType(value);
+    setCollectorType(next);
+    const derived = selectedCandidate?.address
+      ? endpointForCollector(next, selectedCandidate.address)
+      : null;
+    setManualEndpoint(derived ?? "");
+    setManualMode(next !== "unifi");
+    setFieldError("");
+    setMessage("");
+    setStatus("idle");
+  };
 
   const handleSave = () => {
-    if (keyRequired && (!endpointUrl || !apiKey)) {
-      setMessage("Controller URL and API key are required");
+    if (!selectedCandidate && !manualMode) {
+      setMessage("Choose a gateway before saving this connection.");
       setStatus("error");
       return;
     }
-    if (isUnifi && !keyRequired && !endpointUrl) {
-      setMessage("Controller URL is required");
+    const normalized = normalizeDiscoveryEndpoint(endpointInput, collectorType);
+    if (!normalized.ok) {
+      setFieldError(normalized.error);
       setStatus("error");
       return;
     }
-    if (isSnmp && !endpointUrl) {
-      setMessage("Target IP address is required");
-      setStatus("error");
-      return;
-    }
-    if (isArpScan && !endpointUrl) {
-      setMessage("Subnet is required (e.g., 192.168.0.0/24)");
-      setStatus("error");
-      return;
-    }
-    if (isArpScan && !isIpv4Cidr(endpointUrl)) {
-      setMessage("Subnet must be CIDR notation, for example 192.168.0.0/24");
+    if (keyRequired && !apiKey) {
+      setMessage("Enter the UniFi API key for this gateway.");
       setStatus("error");
       return;
     }
 
+    setFieldError("");
     startTransition(async () => {
       setStatus("saving");
       setMessage("");
-
       const configuration: Record<string, unknown> = {};
-      if (isUnifi) {
-        configuration.site = site;
-        configuration.discoverClients = true;
-        configuration.tlsInsecure = tlsInsecure;
-      }
+      if (isUnifi) Object.assign(configuration, { site, discoverClients: true, tlsInsecure });
       if (isSnmp) configuration.community = apiKey || "public";
-      if (isArpScan) configuration.subnet = endpointUrl;
+      if (isArpScan) configuration.subnet = normalized.value;
 
       const result = await configureDiscoveryConnection({
         ...(existing?.id ? { id: existing.id } : {}),
-        gatewayEntityId,
-        name: isArpScan ? `Subnet ${endpointUrl}` : gatewayName,
+        gatewayEntityId: manualMode ? undefined : selectedCandidate?.entityId,
+        name: isArpScan
+          ? `Subnet ${normalized.value}`
+          : selectedCandidate?.name ?? gatewayName,
         collectorType,
-        endpointUrl,
-        // In edit mode without a fresh key, send undefined so the server-side
-        // upsert keeps the existing encryptedApiKey.
-        apiKey: isUnifi
-          ? (apiKey || undefined)
-          : isSnmp ? apiKey || "public" : undefined,
+        endpointUrl: normalized.value,
+        apiKey: isUnifi ? (apiKey || undefined) : isSnmp ? apiKey || "public" : undefined,
         configuration,
       });
 
@@ -189,154 +197,162 @@ export function ConfigureConnectionInline({
         return;
       }
 
-      // Test the connection
       setStatus("testing");
-      setMessage("Saved. Testing connection...");
-
+      setMessage("Saved. Testing connection…");
       const testResult = await testDiscoveryConnection(result.connectionId);
       if (!testResult.ok) {
         setStatus("error");
         setMessage(formatConnectionFeedback("error", testResult.error));
         return;
       }
-
-      if (testResult.status === "ok") {
-        setStatus("success");
-        setMessage(
-          `Connected. Discovered ${testResult.deviceCount ?? 0} device(s). The next discovery sweep will pull full topology.`,
-        );
-        setTimeout(onComplete, 3000);
-      } else {
+      if (testResult.status !== "ok") {
         setStatus("error");
-        setMessage(formatConnectionFeedback(testResult.status, testResult.message ?? "Connection test failed"));
+        setMessage(formatConnectionFeedback(testResult.status, testResult.message));
+        return;
       }
+      setStatus("success");
+      setMessage(`Connected. Discovered ${testResult.deviceCount ?? 0} device(s).`);
+      setTimeout(onComplete, 3000);
     });
   };
 
   return (
-    <div className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 space-y-3">
-      <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
-        Configure Discovery Connection
-      </p>
+    <div className="mt-4 space-y-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+          Configure Discovery Connection
+        </p>
+        <p className="mt-1 text-sm text-[var(--dpf-text)]">
+          Select the gateway DPF identified. Its network endpoint is filled in automatically.
+        </p>
+      </div>
+
+      {candidates.length > 1 ? (
+        <SelectField
+          name="gateway"
+          label="Gateway"
+          value={selectedGatewayId}
+          onValueChange={selectGateway}
+          placeholder="Choose an identified gateway"
+          options={candidates.map((candidate) => ({
+            value: candidate.entityId,
+            label: gatewayOptionLabel(candidate),
+            disabled: !candidate.usable,
+          }))}
+          hint={selectedCandidate?.recommendation ?? "Choose by device name, manufacturer, model, and local address."}
+          required
+        />
+      ) : selectedCandidate ? (
+        <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3" aria-label="Selected gateway">
+          <p className="font-medium text-[var(--dpf-text)]">{selectedCandidate.name}</p>
+          {(selectedCandidate.manufacturer || selectedCandidate.model) && (
+            <p className="text-sm text-[var(--dpf-muted)]">
+              {[selectedCandidate.manufacturer, selectedCandidate.model].filter(Boolean).join(" · ")}
+            </p>
+          )}
+          {selectedCandidate.address && (
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              Local address <span className="font-mono text-[var(--dpf-text)]">{selectedCandidate.address}</span>
+            </p>
+          )}
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">{selectedCandidate.recommendation}</p>
+        </section>
+      ) : (
+        <p className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-sm text-[var(--dpf-muted)]">
+          DPF did not find an identifiable gateway. Manual recovery is available below.
+        </p>
+      )}
 
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <label className="block">
-          <span className="text-xs text-[var(--dpf-muted)]">Discovery Method</span>
-          <select
-            value={collectorType}
-            onChange={(e) => {
-              const nextCollectorType = e.target.value;
-              setCollectorType(nextCollectorType);
-              setEndpointUrl(defaultEndpointForCollector(nextCollectorType, gatewayAddress));
-              setStatus("idle");
-              setMessage("");
-            }}
-            className="mt-1 block w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
-          >
-            {COLLECTOR_TYPES.map((ct) => (
-              <option key={ct.value} value={ct.value}>
-                {ct.label}
-              </option>
-            ))}
-          </select>
-        </label>
-
+        <SelectField
+          name="discovery-method"
+          label="Discovery Method"
+          value={collectorType}
+          onValueChange={changeCollector}
+          options={COLLECTOR_TYPES}
+        />
         {isUnifi && (
-          <label className="block">
-            <span className="text-xs text-[var(--dpf-muted)]">Site</span>
-            <input
-              type="text"
-              value={site}
-              onChange={(e) => setSite(e.target.value)}
-              placeholder="default"
-              className="mt-1 block w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
-            />
-          </label>
+          <TextField name="site" label="Site" value={site} onValueChange={setSite} placeholder="default" />
         )}
-
         {isSnmp && (
-          <label className="block">
-            <span className="text-xs text-[var(--dpf-muted)]">Community String</span>
-            <input
-              type="text"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder="public"
-              className="mt-1 block w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
-            />
-          </label>
+          <TextField
+            name="community-string"
+            label="Community String"
+            value={apiKey}
+            onValueChange={setApiKey}
+            placeholder="public"
+          />
         )}
       </div>
 
-      <label className="block">
-        <span className="text-xs text-[var(--dpf-muted)]">
-          {isUnifi ? "Controller URL" : isSnmp ? "Target IP or Hostname" : "Subnet to scan"}
-        </span>
-        <input
-          type={isUnifi ? "url" : "text"}
-          value={endpointUrl}
-          onChange={(e) => setEndpointUrl(e.target.value)}
-          placeholder={isUnifi ? "https://192.168.0.1" : isSnmp ? "192.168.0.1" : "192.168.0.0/24"}
-          className="mt-1 block w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+      {isUnifi ? (
+        <details className="rounded-md border border-[var(--dpf-border)] px-3 py-2">
+          <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-accent)]">
+            Enter a gateway manually
+          </summary>
+          <div className="mt-3">
+            <TextField
+              name="gateway-address"
+              label="Gateway address"
+              value={manualEndpoint}
+              onValueChange={(value) => {
+                setManualEndpoint(value);
+                setManualMode(true);
+                setFieldError("");
+              }}
+              hint="Enter a host or IP address. A scheme and port are optional."
+              error={fieldError}
+              placeholder="192.168.0.1"
+            />
+          </div>
+        </details>
+      ) : (
+        <TextField
+          name="discovery-endpoint"
+          label={isSnmp ? "Target IP or Hostname" : "Subnet to scan"}
+          value={endpointInput}
+          onValueChange={(value) => {
+            setManualEndpoint(value);
+            setManualMode(true);
+            setFieldError("");
+          }}
+          error={fieldError}
+          placeholder={isSnmp ? "192.168.0.1" : "192.168.0.0/24"}
         />
-      </label>
-
-      {isUnifi && (
-        <label className="block">
-          <span className="text-xs text-[var(--dpf-muted)]">
-            API Key{!keyRequired && <span className="ml-1 text-[10px]">(leave blank to keep existing)</span>}
-          </span>
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder={keyRequired ? "Paste your UniFi OS API key" : "•••••••••••••••• (stored)"}
-            className="mt-1 block w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
-          />
-        </label>
       )}
 
       {isUnifi && (
-        <label className="flex items-start gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-          <input
-            type="checkbox"
-            checked={tlsInsecure}
-            onChange={(e) => setTlsInsecure(e.target.checked)}
-            className="mt-0.5 h-4 w-4 rounded border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] accent-[var(--dpf-accent)]"
-          />
-          <span className="min-w-0">
-            <span className="block text-xs font-medium text-[var(--dpf-text)]">
-              Allow self-signed controller certificate
-            </span>
-            <span className="mt-0.5 block text-[11px] leading-4 text-[var(--dpf-muted)]">
-              Use for trusted closed-LAN UniFi appliances that do not have a public certificate.
-            </span>
-          </span>
-        </label>
+        <TextField
+          name="api-key"
+          label={keyRequired ? "API Key" : "API Key (leave blank to keep existing)"}
+          type="password"
+          value={apiKey}
+          onValueChange={setApiKey}
+          autoComplete="off"
+          placeholder={keyRequired ? "Paste your UniFi OS API key" : "Stored securely"}
+          required={keyRequired}
+        />
       )}
 
-      <div className="flex items-center gap-3">
-        <button
-          onClick={handleSave}
-          disabled={isPending}
-          className="rounded-md bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-        >
-          {isPending ? "Connecting..." : "Save & Test"}
-        </button>
+      {isUnifi && (
+        <CheckboxField
+          name="tls-insecure"
+          label="Allow self-signed controller certificate"
+          checked={tlsInsecure}
+          onCheckedChange={setTlsInsecure}
+          hint="Use only for a trusted closed-LAN UniFi appliance without a public certificate."
+        />
+      )}
 
-        {message && (
-          <p
-            className={`text-xs ${
-              status === "success"
-                ? "text-[var(--dpf-success)]"
-                : status === "error"
-                  ? "text-[var(--dpf-error)]"
-                  : "text-[var(--dpf-muted)]"
-            }`}
-          >
-            {message}
-          </p>
-        )}
+      <div className="flex flex-wrap items-center gap-3">
+        <SubmitButton type="button" onClick={handleSave} pending={isPending} pendingLabel="Connecting…">
+          Save &amp; Test
+        </SubmitButton>
+        <FormStatus
+          error={status === "error" ? message : null}
+          success={status === "success" ? message : null}
+        />
+        {status === "testing" && <p className="text-sm text-[var(--dpf-muted)]">{message}</p>}
       </div>
     </div>
   );

--- a/apps/web/components/inventory/DiscoveryOperationsPage.tsx
+++ b/apps/web/components/inventory/DiscoveryOperationsPage.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
-import { INVENTORY_ENTITY_CANONICAL_WHERE, prisma } from "@dpf/db";
+import {
+  INVENTORY_ENTITY_CANONICAL_WHERE,
+  isDockerOriginEntityKey,
+  prisma,
+} from "@dpf/db";
 
 import { PORTFOLIO_COLOURS } from "@/lib/portfolio";
 
@@ -21,6 +25,7 @@ import { SubnetGroupedInventoryPanel } from "@/components/inventory/SubnetGroupe
 import { TopologyGraph } from "@/components/inventory/TopologyGraph";
 import { CustomerTopologyScopeBar } from "@/components/inventory/CustomerTopologyScopeBar";
 import { CollapsibleList } from "@/components/ui/report-kit/CollapsibleList";
+import { buildGatewayCandidates } from "@/lib/discovery-connection/gateway-candidate";
 
 const STATUS_COLOURS: Record<string, string> = {
   active: "var(--dpf-success)",
@@ -73,18 +78,32 @@ export async function DiscoveryOperationsPage({
     prisma.inventoryEntity.findMany({
       where: {
         ...INVENTORY_ENTITY_CANONICAL_WHERE,
-        entityType: "gateway",
+        entityType: { in: ["gateway", "router"] },
         NOT: { name: { contains: "Docker" } },
       },
-      select: { properties: true },
-      take: 5,
+      select: {
+        id: true,
+        entityKey: true,
+        name: true,
+        manufacturer: true,
+        productModel: true,
+        confidence: true,
+        properties: true,
+      },
+      orderBy: [{ confidence: "desc" }, { name: "asc" }],
+      take: 50,
     }),
   ]);
 
-  const realGatewayIp = detectedGateways
+  const physicalGateways = detectedGateways.filter(
+    (gateway) => !isDockerOriginEntityKey(gateway.entityKey, gateway.name),
+  );
+  const defaultGatewayIp = physicalGateways
+    .filter((gateway) => gateway.entityKey.toLowerCase().startsWith("gateway:"))
     .map((gateway) => (gateway.properties as Record<string, unknown>)?.address as string | undefined)
     .find((address) => address && !address.startsWith("172."))
     ?? null;
+  const gatewayCandidates = buildGatewayCandidates(physicalGateways, defaultGatewayIp);
 
   const staleEntities = await countStaleEntitiesSince(latestRun?.startedAt ?? null);
 
@@ -156,7 +175,10 @@ export async function DiscoveryOperationsPage({
 
       <div className="space-y-4">
         <DiscoveryRunSummary run={latestRun} health={health} />
-        <SavedConnectionsPanel detectedGateway={realGatewayIp} />
+        <SavedConnectionsPanel
+          detectedGateway={defaultGatewayIp}
+          gatewayCandidates={gatewayCandidates}
+        />
         <InventoryExceptionQueue queues={triageQueues} />
         <SubnetGroupedInventoryPanel groups={groupedInventory} />
         <PortfolioQualityIssuesPanel issues={openIssues} />

--- a/apps/web/components/inventory/DiscoveryOperationsPage.tsx
+++ b/apps/web/components/inventory/DiscoveryOperationsPage.tsx
@@ -25,7 +25,11 @@ import { SubnetGroupedInventoryPanel } from "@/components/inventory/SubnetGroupe
 import { TopologyGraph } from "@/components/inventory/TopologyGraph";
 import { CustomerTopologyScopeBar } from "@/components/inventory/CustomerTopologyScopeBar";
 import { CollapsibleList } from "@/components/ui/report-kit/CollapsibleList";
-import { buildGatewayCandidates } from "@/lib/discovery-connection/gateway-candidate";
+import {
+  buildGatewayCandidates,
+  gatewayConnectionAddresses,
+  gatewayEvidenceWhere,
+} from "@/lib/discovery-connection/gateway-candidate";
 
 const STATUS_COLOURS: Record<string, string> = {
   active: "var(--dpf-success)",
@@ -51,6 +55,14 @@ type DiscoveryOperationsPageProps = {
 export async function DiscoveryOperationsPage({
   isLegacyAlias = false,
 }: DiscoveryOperationsPageProps) {
+  const gatewayConnectionEvidence = await prisma.discoveryConnection.findMany({
+    select: {
+      collectorType: true,
+      endpointUrl: true,
+      status: true,
+    },
+  });
+  const connectionAddresses = gatewayConnectionAddresses(gatewayConnectionEvidence);
   const [
     products,
     latestRun,
@@ -78,7 +90,7 @@ export async function DiscoveryOperationsPage({
     prisma.inventoryEntity.findMany({
       where: {
         ...INVENTORY_ENTITY_CANONICAL_WHERE,
-        entityType: { in: ["gateway", "router"] },
+        ...gatewayEvidenceWhere(connectionAddresses),
         NOT: { name: { contains: "Docker" } },
       },
       select: {
@@ -102,8 +114,13 @@ export async function DiscoveryOperationsPage({
     .filter((gateway) => gateway.entityKey.toLowerCase().startsWith("gateway:"))
     .map((gateway) => (gateway.properties as Record<string, unknown>)?.address as string | undefined)
     .find((address) => address && !address.startsWith("172."))
+    ?? connectionAddresses[0]
     ?? null;
-  const gatewayCandidates = buildGatewayCandidates(physicalGateways, defaultGatewayIp);
+  const gatewayCandidates = buildGatewayCandidates(
+    physicalGateways,
+    defaultGatewayIp,
+    gatewayConnectionEvidence,
+  );
 
   const staleEntities = await countStaleEntitiesSince(latestRun?.startedAt ?? null);
 

--- a/apps/web/components/inventory/SavedConnectionsPanel.test.tsx
+++ b/apps/web/components/inventory/SavedConnectionsPanel.test.tsx
@@ -8,8 +8,11 @@ vi.mock("@/lib/actions/discovery", () => ({
   listDiscoveryConnections: vi.fn(),
 }));
 vi.mock("./AddDiscoveryConnection", () => ({
-  AddDiscoveryConnection: ({ variant = "hero" }: { variant?: string }) => (
-    <div data-add-cta data-variant={variant} />
+  AddDiscoveryConnection: ({ variant = "hero", gatewayCandidates = [] }: {
+    variant?: string;
+    gatewayCandidates?: unknown[];
+  }) => (
+    <div data-add-cta data-variant={variant} data-gateway-count={gatewayCandidates.length} />
   ),
 }));
 vi.mock("./SavedConnectionRow", () => ({
@@ -26,9 +29,13 @@ const mockList = listDiscoveryConnections as ReturnType<typeof vi.fn>;
 describe("SavedConnectionsPanel", () => {
   it("renders hero CTA when no connections exist", async () => {
     mockList.mockResolvedValue({ ok: true, connections: [] });
-    const html = renderToStaticMarkup(await SavedConnectionsPanel({ detectedGateway: "192.168.0.1" }));
+    const html = renderToStaticMarkup(await SavedConnectionsPanel({
+      detectedGateway: "192.168.0.1",
+      gatewayCandidates: [{ entityId: "gw-1" } as never],
+    }));
     expect(html).toContain('data-add-cta');
     expect(html).toContain('data-variant="hero"');
+    expect(html).toContain('data-gateway-count="1"');
     expect(html).not.toContain('data-row-id');
   });
 

--- a/apps/web/components/inventory/SavedConnectionsPanel.tsx
+++ b/apps/web/components/inventory/SavedConnectionsPanel.tsx
@@ -11,25 +11,27 @@
 import { listDiscoveryConnections } from "@/lib/actions/discovery";
 import { AddDiscoveryConnection } from "./AddDiscoveryConnection";
 import { SavedConnectionRow } from "./SavedConnectionRow";
+import type { GatewayCandidate } from "@/lib/discovery-connection/gateway-candidate";
 
 type Props = {
   detectedGateway: string | null;
+  gatewayCandidates?: GatewayCandidate[];
 };
 
-export async function SavedConnectionsPanel({ detectedGateway }: Props) {
+export async function SavedConnectionsPanel({ detectedGateway, gatewayCandidates = [] }: Props) {
   const result = await listDiscoveryConnections();
 
   // Auth failure — fall back to the first-run hero so the page still renders.
   // The CTA itself is gated by the same permission server-side, so the
   // operator just gets the same "Unauthorized" if they try to save.
   if (!result.ok) {
-    return <AddDiscoveryConnection detectedGateway={detectedGateway} />;
+    return <AddDiscoveryConnection detectedGateway={detectedGateway} gatewayCandidates={gatewayCandidates} />;
   }
 
   const { connections } = result;
 
   if (connections.length === 0) {
-    return <AddDiscoveryConnection detectedGateway={detectedGateway} />;
+    return <AddDiscoveryConnection detectedGateway={detectedGateway} gatewayCandidates={gatewayCandidates} />;
   }
 
   return (
@@ -49,6 +51,7 @@ export async function SavedConnectionsPanel({ detectedGateway }: Props) {
       </div>
       <AddDiscoveryConnection
         detectedGateway={detectedGateway}
+        gatewayCandidates={gatewayCandidates}
         variant="compact"
       />
     </div>

--- a/apps/web/lib/actions/discovery.test.ts
+++ b/apps/web/lib/actions/discovery.test.ts
@@ -131,7 +131,7 @@ describe("configureDiscoveryConnection — edit path", () => {
       configuration: { subnet: "https://192.168.0.1" },
     })).resolves.toEqual({
       ok: false,
-      error: "Subnet must be CIDR notation, for example 192.168.0.0/24",
+      error: "Enter a subnet in CIDR notation, for example 192.168.0.0/24.",
     });
     expect(mockUpdate).not.toHaveBeenCalled();
   });
@@ -147,6 +147,42 @@ describe("configureDiscoveryConnection — edit path", () => {
     expect(result).toEqual({ ok: true, connectionId: "conn-fresh" });
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the shared endpoint contract before persistence", async () => {
+    const result = await configureDiscoveryConnection({
+      gatewayEntityId: "gw-1",
+      name: "Cloud Gateway",
+      collectorType: "unifi",
+      endpointUrl: "file:///etc/passwd",
+      apiKey: "fresh-key",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Use an HTTP or HTTPS gateway address.",
+    });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("canonicalizes equivalent endpoints and preserves gateway identity", async () => {
+    mockUpsert.mockResolvedValue({ id: "conn-fresh" });
+
+    await configureDiscoveryConnection({
+      gatewayEntityId: "gw-1",
+      name: "Cloud Gateway",
+      collectorType: "unifi",
+      endpointUrl: "  HTTP://192.168.0.1/  ",
+      apiKey: "fresh-key",
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { connectionKey: "unifi:192.168.0.1" },
+      create: expect.objectContaining({
+        endpointUrl: "https://192.168.0.1",
+        gatewayEntityId: "gw-1",
+      }),
+    }));
   });
 });
 

--- a/apps/web/lib/actions/discovery.ts
+++ b/apps/web/lib/actions/discovery.ts
@@ -12,6 +12,11 @@ import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { encryptSecret, decryptSecret } from "@/lib/govern/credential-crypto";
+import {
+  discoveryConnectionKey,
+  normalizeDiscoveryEndpoint,
+  type DiscoveryCollectorType,
+} from "@/lib/discovery-connection/endpoint";
 
 const DISCOVERY_REVALIDATE_PATHS = [
   "/platform/tools",
@@ -154,78 +159,9 @@ export async function listDiscoveryConnections(): Promise<
   };
 }
 
-/**
- * Strip every trailing "/" without using `replace(/\/+$/, "")` — that
- * regex tripped a CodeQL polynomial-ReDoS alert on user-supplied input,
- * and an explicit slice loop is both safer and easier to reason about.
- */
-function trimTrailingSlashes(input: string): string {
-  let end = input.length;
-  while (end > 0 && input.charCodeAt(end - 1) === 0x2f /* "/" */) end--;
-  return input.slice(0, end);
-}
-
-/** Strip a leading "http://" or "https://" without a regex (CodeQL-safe). */
-function stripScheme(input: string): string {
-  if (input.startsWith("https://")) return input.slice(8);
-  if (input.startsWith("http://")) return input.slice(7);
-  if (input.startsWith("HTTPS://")) return input.slice(8);
-  if (input.startsWith("HTTP://")) return input.slice(7);
-  return input;
-}
-
-function stripPath(input: string): string {
-  const slashIndex = input.indexOf("/");
-  return slashIndex >= 0 ? input.slice(0, slashIndex) : input;
-}
-
-function isIpv4Octet(input: string): boolean {
-  if (input.length === 0 || input.length > 3) return false;
-  for (const char of input) {
-    if (char < "0" || char > "9") return false;
-  }
-  const octet = Number(input);
-  return octet >= 0 && octet <= 255;
-}
-
-function isIpv4Cidr(input: string): boolean {
-  const [ip, cidr, extra] = input.trim().split("/");
-  if (!ip || !cidr || extra !== undefined) return false;
-  const prefix = Number(cidr);
-  if (!Number.isInteger(prefix) || prefix < 16 || prefix > 32) return false;
-  const parts = ip.split(".");
-  return parts.length === 4 && parts.every(isIpv4Octet);
-}
-
-/**
- * Normalize user input into a proper endpoint URL.
- * Accepts: "192.168.0.1", "http://192.168.0.1", "https://192.168.0.1:8443/"
- * Returns: "https://192.168.0.1" (HTTPS by default for UniFi/SNMP controllers)
- */
-function normalizeEndpointUrl(raw: string, collectorType: string): string {
-  let url = trimTrailingSlashes(raw.trim());
-
-  // For ARP scan, the input is a subnet not a URL
-  if (collectorType === "arp_scan") return url;
-
-  if (collectorType === "snmp") return stripPath(stripScheme(url));
-
-  // If no protocol specified, add one. Fixed-prefix checks instead of a
-  // regex — no backtracking risk.
-  const hasScheme = url.startsWith("http://") || url.startsWith("https://")
-    || url.startsWith("HTTP://") || url.startsWith("HTTPS://");
-  if (!hasScheme) {
-    // UniFi controllers always use HTTPS
-    const protocol = collectorType === "unifi" ? "https" : "http";
-    url = `${protocol}://${url}`;
-  }
-
-  // UniFi should always be HTTPS (common mistake to use http://)
-  if (collectorType === "unifi" && url.startsWith("http://")) {
-    url = url.replace("http://", "https://");
-  }
-
-  return url;
+/** Keep the action boundary closed even when invoked outside the typed UI. */
+function isDiscoveryCollectorType(value: string): value is DiscoveryCollectorType {
+  return value === "unifi" || value === "snmp" || value === "arp_scan";
 }
 
 /**
@@ -247,14 +183,13 @@ export async function configureDiscoveryConnection(input: {
   const authResult = await requireManageDiscovery();
   if (!authResult.ok) return authResult;
 
-  const endpointUrl = normalizeEndpointUrl(input.endpointUrl, input.collectorType);
-  if (input.collectorType === "arp_scan" && !isIpv4Cidr(endpointUrl)) {
-    return {
-      ok: false,
-      error: "Subnet must be CIDR notation, for example 192.168.0.0/24",
-    };
+  if (!isDiscoveryCollectorType(input.collectorType)) {
+    return { ok: false, error: `Unsupported discovery method: ${input.collectorType}` };
   }
-  const connectionKey = `${input.collectorType}:${trimTrailingSlashes(stripScheme(endpointUrl))}`;
+  const normalizedEndpoint = normalizeDiscoveryEndpoint(input.endpointUrl, input.collectorType);
+  if (!normalizedEndpoint.ok) return normalizedEndpoint;
+  const endpointUrl = normalizedEndpoint.value;
+  const connectionKey = discoveryConnectionKey(input.collectorType, endpointUrl);
 
   const encryptedApiKey = input.apiKey ? encryptSecret(input.apiKey) : undefined;
   const configuration = normalizeConnectionConfiguration(input.collectorType, input.configuration);
@@ -364,10 +299,9 @@ export async function testDiscoveryConnection(connectionId: string): Promise<
     const { collectArpScanDiscovery } = await import("@dpf/db/discovery-collectors-arp-scan");
     const configuration = (conn.configuration ?? {}) as Record<string, unknown>;
     const subnet = typeof configuration.subnet === "string" ? configuration.subnet : conn.endpointUrl;
-    if (!isIpv4Cidr(subnet)) {
-      return { ok: false, error: "Subnet must be CIDR notation, for example 192.168.0.0/24" };
-    }
-    const result = await collectArpScanDiscovery({ sourceKind: "arp_scan" }, [{ subnet }]);
+    const normalizedSubnet = normalizeDiscoveryEndpoint(subnet, "arp_scan");
+    if (!normalizedSubnet.ok) return normalizedSubnet;
+    const result = await collectArpScanDiscovery({ sourceKind: "arp_scan" }, [{ subnet: normalizedSubnet.value }]);
     deviceCount = result.items.length;
     testMessage = result.warnings?.some((warning) => warning.startsWith("arp_scan_empty"))
       ? "ARP scan completed, but no hosts responded on that subnet"
@@ -378,8 +312,10 @@ export async function testDiscoveryConnection(connectionId: string): Promise<
     const encryptedCommunity = conn.encryptedApiKey ? decryptSecret(conn.encryptedApiKey) : null;
     const community = encryptedCommunity
       ?? (typeof configuration.community === "string" ? configuration.community : "public");
+    const normalizedAddress = normalizeDiscoveryEndpoint(conn.endpointUrl, "snmp");
+    if (!normalizedAddress.ok) return normalizedAddress;
     const result = await collectSnmpDiscovery({ sourceKind: "snmp" }, [{
-      address: normalizeEndpointUrl(conn.endpointUrl, "snmp"),
+      address: normalizedAddress.value,
       community,
     }]);
     const errorWarning = result.warnings?.find((warning) => warning.startsWith("snmp_error"));

--- a/apps/web/lib/discovery-connection/endpoint.test.ts
+++ b/apps/web/lib/discovery-connection/endpoint.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  endpointForCollector,
+  normalizeDiscoveryEndpoint,
+} from "./endpoint";
+
+describe("normalizeDiscoveryEndpoint", () => {
+  it.each([
+    ["192.168.0.1", "https://192.168.0.1"],
+    ["  HTTPS://gateway.local:8443/  ", "https://gateway.local:8443"],
+    ["http://192.168.0.1", "https://192.168.0.1"],
+  ])("normalizes common UniFi recovery input %s", (input, expected) => {
+    expect(normalizeDiscoveryEndpoint(input, "unifi")).toEqual({
+      ok: true,
+      value: expected,
+    });
+  });
+
+  it.each([
+    "file:///etc/passwd",
+    "https://user:password@192.168.0.1",
+    "https://192.168.0.1/proxy/network",
+    "https://0.0.0.0",
+    "https://169.254.169.254/latest/meta-data",
+    "https://8.8.8.8",
+    "https://example.com",
+    "https://192.168.0.1\r\nHost: example.test",
+  ])("rejects unsafe or non-controller UniFi input %s", (input) => {
+    expect(normalizeDiscoveryEndpoint(input, "unifi")).toMatchObject({ ok: false });
+  });
+
+  it("accepts private physical-network addresses and local hostnames", () => {
+    expect(normalizeDiscoveryEndpoint("10.20.30.1", "unifi")).toMatchObject({ ok: true });
+    expect(normalizeDiscoveryEndpoint("172.20.0.1", "unifi")).toMatchObject({ ok: true });
+    expect(normalizeDiscoveryEndpoint("gateway.local", "unifi")).toMatchObject({ ok: true });
+  });
+
+  it("accepts a host or IP for SNMP and removes accidental URL syntax", () => {
+    expect(normalizeDiscoveryEndpoint("https://core-switch.local/status", "snmp")).toEqual({
+      ok: true,
+      value: "core-switch.local",
+    });
+    expect(normalizeDiscoveryEndpoint("192.168.0.2", "snmp")).toEqual({
+      ok: true,
+      value: "192.168.0.2",
+    });
+  });
+
+  it("returns field-specific guidance instead of throwing", () => {
+    expect(normalizeDiscoveryEndpoint("not a host", "snmp")).toEqual({
+      ok: false,
+      error: "Enter a valid IP address or hostname, for example 192.168.0.1.",
+    });
+    expect(normalizeDiscoveryEndpoint("192.168.0.1", "arp_scan")).toEqual({
+      ok: false,
+      error: "Enter a subnet in CIDR notation, for example 192.168.0.0/24.",
+    });
+    expect(normalizeDiscoveryEndpoint("8.8.8.0/24", "arp_scan")).toEqual({
+      ok: false,
+      error: "Enter a private-network subnet in CIDR notation, for example 192.168.0.0/24.",
+    });
+  });
+
+  it("canonicalizes valid ARP subnets", () => {
+    expect(normalizeDiscoveryEndpoint(" 192.168.0.0/24 ", "arp_scan")).toEqual({
+      ok: true,
+      value: "192.168.0.0/24",
+    });
+    expect(normalizeDiscoveryEndpoint("192.168.44.27/24", "arp_scan")).toEqual({
+      ok: true,
+      value: "192.168.44.0/24",
+    });
+  });
+});
+
+describe("endpointForCollector", () => {
+  it("derives collector-specific endpoints without asking for URL syntax", () => {
+    expect(endpointForCollector("unifi", "192.168.44.1")).toBe("https://192.168.44.1");
+    expect(endpointForCollector("snmp", "192.168.44.1")).toBe("192.168.44.1");
+    expect(endpointForCollector("arp_scan", "192.168.44.1")).toBe("192.168.44.0/24");
+  });
+});

--- a/apps/web/lib/discovery-connection/endpoint.ts
+++ b/apps/web/lib/discovery-connection/endpoint.ts
@@ -1,0 +1,182 @@
+export type DiscoveryCollectorType = "unifi" | "snmp" | "arp_scan";
+
+export type DiscoveryEndpointResult =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+const HOST_ERROR = "Enter a valid IP address or hostname, for example 192.168.0.1.";
+const SUBNET_ERROR = "Enter a subnet in CIDR notation, for example 192.168.0.0/24.";
+const UNIFI_ERROR = "Enter the gateway host or IP address, for example 192.168.0.1.";
+
+function containsControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function isIpv4Octet(value: string): boolean {
+  if (value.length === 0 || value.length > 3) return false;
+  for (const char of value) {
+    if (char < "0" || char > "9") return false;
+  }
+  const number = Number(value);
+  return number >= 0 && number <= 255;
+}
+
+export function isIpv4Address(value: string): boolean {
+  const parts = value.split(".");
+  return parts.length === 4 && parts.every(isIpv4Octet);
+}
+
+export function isIpv4Cidr(value: string): boolean {
+  const [ip, prefix, extra] = value.split("/");
+  if (!ip || !prefix || extra !== undefined || !isIpv4Address(ip)) return false;
+  const number = Number(prefix);
+  return Number.isInteger(number) && number >= 16 && number <= 32;
+}
+
+function canonicalizeIpv4Cidr(value: string): string {
+  const [ip, prefixText] = value.split("/");
+  const prefix = Number(prefixText);
+  const address = ip.split(".").reduce((result, octet) => (
+    ((result << 8) | Number(octet)) >>> 0
+  ), 0);
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  const network = (address & mask) >>> 0;
+  const octets = [24, 16, 8, 0].map((shift) => (network >>> shift) & 0xff);
+  return `${octets.join(".")}/${prefix}`;
+}
+
+function isUnsafeHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === "0.0.0.0" || host === "255.255.255.255" || host === "169.254.169.254") {
+    return true;
+  }
+  if (host === "::" || host === "[::]" || host === "::1" || host === "[::1]") return true;
+  if (host.includes(":")) {
+    const unbracketed = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+    return !(unbracketed.startsWith("fc") || unbracketed.startsWith("fd") || unbracketed.startsWith("fe80:"));
+  }
+  if (isIpv4Address(host)) {
+    const [first, second] = host.split(".").map(Number);
+    const isPrivate = first === 10
+      || (first === 172 && second >= 16 && second <= 31)
+      || (first === 192 && second === 168);
+    return !isPrivate;
+  }
+
+  // Manual recovery is intentionally LAN-only. Single-label mDNS/DNS names
+  // and standardized local suffixes stay usable; public FQDNs do not become
+  // arbitrary server-side probe targets.
+  return host.includes(".")
+    && !host.endsWith(".local")
+    && !host.endsWith(".lan")
+    && !host.endsWith(".home.arpa");
+}
+
+function normalizeHttpEndpoint(raw: string): DiscoveryEndpointResult {
+  const trimmed = raw.trim();
+  if (!trimmed || containsControlCharacter(trimmed)) return { ok: false, error: UNIFI_ERROR };
+
+  const hasScheme = trimmed.includes("://");
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return { ok: false, error: UNIFI_ERROR };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, error: "Use an HTTP or HTTPS gateway address." };
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, error: "Do not include a username or password in the gateway address." };
+  }
+  if (!parsed.hostname || isUnsafeHost(parsed.hostname)) {
+    return { ok: false, error: "That address cannot be used as a gateway target." };
+  }
+  if ((parsed.pathname && parsed.pathname !== "/") || parsed.search || parsed.hash) {
+    return { ok: false, error: "Enter only the gateway host and optional port, without a page path." };
+  }
+
+  parsed.protocol = "https:";
+  parsed.pathname = "";
+  parsed.search = "";
+  parsed.hash = "";
+  return { ok: true, value: parsed.href.endsWith("/") ? parsed.href.slice(0, -1) : parsed.href };
+}
+
+function normalizeHost(raw: string): DiscoveryEndpointResult {
+  const trimmed = raw.trim();
+  if (!trimmed || containsControlCharacter(trimmed)) return { ok: false, error: HOST_ERROR };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed.includes("://") ? trimmed : `http://${trimmed}`);
+  } catch {
+    return { ok: false, error: HOST_ERROR };
+  }
+  if (!parsed.hostname || parsed.username || parsed.password || isUnsafeHost(parsed.hostname)) {
+    return { ok: false, error: HOST_ERROR };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, error: HOST_ERROR };
+  }
+
+  return {
+    ok: true,
+    value: parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname,
+  };
+}
+
+export function normalizeDiscoveryEndpoint(
+  raw: string,
+  collectorType: DiscoveryCollectorType,
+): DiscoveryEndpointResult {
+  if (collectorType === "unifi") return normalizeHttpEndpoint(raw);
+  if (collectorType === "snmp") return normalizeHost(raw);
+
+  const value = raw.trim();
+  if (!isIpv4Cidr(value)) return { ok: false, error: SUBNET_ERROR };
+  const [network] = value.split("/");
+  if (isUnsafeHost(network)) {
+    return {
+      ok: false,
+      error: "Enter a private-network subnet in CIDR notation, for example 192.168.0.0/24.",
+    };
+  }
+  return { ok: true, value: canonicalizeIpv4Cidr(value) };
+}
+
+function toIpv4Subnet(address: string): string | null {
+  const hostResult = normalizeHost(address);
+  if (!hostResult.ok) return null;
+  const host = hostResult.value.split(":")[0];
+  if (!isIpv4Address(host)) return null;
+  const parts = host.split(".");
+  return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
+}
+
+export function endpointForCollector(
+  collectorType: DiscoveryCollectorType,
+  address: string,
+): string | null {
+  if (collectorType === "arp_scan") return toIpv4Subnet(address);
+  const result = normalizeDiscoveryEndpoint(address, collectorType);
+  return result.ok ? result.value : null;
+}
+
+export function discoveryConnectionKey(
+  collectorType: DiscoveryCollectorType,
+  endpoint: string,
+): string {
+  const withoutScheme = endpoint.startsWith("https://")
+    ? endpoint.slice(8)
+    : endpoint.startsWith("http://")
+      ? endpoint.slice(7)
+      : endpoint;
+  return `${collectorType}:${withoutScheme}`;
+}

--- a/apps/web/lib/discovery-connection/gateway-candidate.test.ts
+++ b/apps/web/lib/discovery-connection/gateway-candidate.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildGatewayCandidates,
   choosePreselectedGateway,
+  gatewayConnectionAddresses,
+  gatewayEvidenceWhere,
 } from "./gateway-candidate";
 
 const unifiGateway = {
@@ -123,6 +125,77 @@ describe("buildGatewayCandidates", () => {
       matchesDetectedGateway: true,
     });
     expect(candidates[0].evidence.join(" ")).toMatch(/default_route/i);
+  });
+
+  it("promotes a physical host when a tested UniFi connection targets the same address", () => {
+    const candidates = buildGatewayCandidates([{
+      id: "physical-host",
+      entityKey: "host:arp:192.168.0.1",
+      name: "LAN Host 192.168.0.1",
+      manufacturer: null,
+      productModel: null,
+      confidence: 0.7,
+      properties: { address: "192.168.0.1", discoveredVia: "arp_scan" },
+    }], null, [{
+      collectorType: "unifi",
+      endpointUrl: "https://192.168.0.1",
+      status: "active",
+    }]);
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        entityId: "physical-host",
+        name: "UniFi gateway 192.168.0.1",
+        address: "192.168.0.1",
+        recommendedCollector: "unifi",
+        canonicalEndpoint: "https://192.168.0.1",
+        matchesDetectedGateway: true,
+      }),
+    ]);
+    expect(candidates[0].evidence.join(" ")).toMatch(/active UniFi connection/i);
+  });
+
+  it("does not promote unrelated hosts from connection evidence", () => {
+    const candidates = buildGatewayCandidates([{
+      id: "other-host",
+      entityKey: "host:arp:192.168.0.42",
+      name: "LAN Host 192.168.0.42",
+      manufacturer: null,
+      productModel: null,
+      confidence: 0.7,
+      properties: { address: "192.168.0.42" },
+    }], null, [{
+      collectorType: "unifi",
+      endpointUrl: "https://192.168.0.1",
+      status: "active",
+    }]);
+
+    expect(candidates[0]).toMatchObject({
+      name: "LAN Host 192.168.0.42",
+      recommendedCollector: "arp_scan",
+      matchesDetectedGateway: false,
+    });
+  });
+});
+
+describe("gateway connection evidence query", () => {
+  it("queries the physical host at an authoritative management target", () => {
+    const addresses = gatewayConnectionAddresses([
+      { collectorType: "unifi", endpointUrl: "https://192.168.0.1", status: "active" },
+      { collectorType: "snmp", endpointUrl: "192.168.0.1", status: "unreachable" },
+      { collectorType: "arp_scan", endpointUrl: "192.168.0.0/24", status: "active" },
+    ]);
+
+    expect(addresses).toEqual(["192.168.0.1"]);
+    expect(gatewayEvidenceWhere(addresses)).toEqual({
+      OR: [
+        { entityType: { in: ["gateway", "router"] } },
+        {
+          entityType: "host",
+          properties: { path: ["address"], equals: "192.168.0.1" },
+        },
+      ],
+    });
   });
 });
 

--- a/apps/web/lib/discovery-connection/gateway-candidate.test.ts
+++ b/apps/web/lib/discovery-connection/gateway-candidate.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGatewayCandidates,
+  choosePreselectedGateway,
+} from "./gateway-candidate";
+
+const unifiGateway = {
+  id: "gw-unifi",
+  entityKey: "unifi:aa:bb:cc:dd:ee:ff",
+  name: "Cloud Gateway Ultra",
+  manufacturer: "Ubiquiti",
+  productModel: "UCG-Ultra",
+  confidence: 0.96,
+  properties: { address: "192.168.0.1", discoveredVia: "unifi_api" },
+};
+
+describe("buildGatewayCandidates", () => {
+  it("identifies a UniFi gateway and carries identity evidence separately from its address", () => {
+    expect(buildGatewayCandidates([unifiGateway], "192.168.0.1")).toEqual([
+      expect.objectContaining({
+        entityId: "gw-unifi",
+        name: "Cloud Gateway Ultra",
+        address: "192.168.0.1",
+        manufacturer: "Ubiquiti",
+        model: "UCG-Ultra",
+        recommendedCollector: "unifi",
+        canonicalEndpoint: "https://192.168.0.1",
+        matchesDetectedGateway: true,
+        usable: true,
+      }),
+    ]);
+  });
+
+  it("uses enriched property evidence when canonical identity columns are not populated yet", () => {
+    const [candidate] = buildGatewayCandidates([{
+      ...unifiGateway,
+      manufacturer: null,
+      productModel: null,
+      properties: {
+        address: "192.168.0.1",
+        vendor: "Ubiquiti Networks",
+        modelName: "UniFi Dream Machine Pro",
+        sourceKind: "arp_oui_enrichment",
+      },
+    }], null);
+
+    expect(candidate).toMatchObject({
+      manufacturer: "Ubiquiti Networks",
+      model: "UniFi Dream Machine Pro",
+      recommendedCollector: "unifi",
+    });
+    expect(candidate.evidence.join(" ")).toMatch(/Ubiquiti Networks.*UniFi Dream Machine Pro/i);
+  });
+
+  it("keeps an unidentified gateway usable through the generic scan without calling it UniFi", () => {
+    const [candidate] = buildGatewayCandidates([{
+      id: "gw-generic",
+      entityKey: "arp:192.168.5.1",
+      name: "Gateway 192.168.5.1",
+      manufacturer: null,
+      productModel: null,
+      confidence: 0.65,
+      properties: { address: "192.168.5.1" },
+    }], null);
+
+    expect(candidate).toMatchObject({
+      recommendedCollector: "arp_scan",
+      canonicalEndpoint: "192.168.5.0/24",
+      usable: true,
+    });
+    expect(candidate.evidence.join(" ")).not.toMatch(/UniFi/i);
+  });
+
+  it("recommends SNMP only when discovery evidence explicitly supports it", () => {
+    const [candidate] = buildGatewayCandidates([{
+      id: "gw-snmp",
+      entityKey: "snmp:192.168.8.1",
+      name: "Core Router",
+      manufacturer: "Cisco",
+      productModel: "ISR",
+      confidence: 0.9,
+      properties: { address: "192.168.8.1", sysObjectId: "1.3.6.1.4.1.9" },
+    }], null);
+
+    expect(candidate).toMatchObject({
+      recommendedCollector: "snmp",
+      canonicalEndpoint: "192.168.8.1",
+    });
+  });
+
+  it("retains candidates without an address but marks them unavailable for setup", () => {
+    const [candidate] = buildGatewayCandidates([{
+      ...unifiGateway,
+      id: "gw-no-address",
+      properties: {},
+    }], null);
+
+    expect(candidate).toMatchObject({ usable: false, canonicalEndpoint: null });
+  });
+
+  it("collapses generic route and enriched device records for the same physical gateway", () => {
+    const candidates = buildGatewayCandidates([
+      {
+        id: "gw-route",
+        entityKey: "gateway:192.168.0.1",
+        name: "Gateway 192.168.0.1",
+        manufacturer: null,
+        productModel: null,
+        confidence: 0.9,
+        properties: { address: "192.168.0.1", discoveredVia: "default_route" },
+      },
+      unifiGateway,
+    ], "192.168.0.1");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      entityId: "gw-unifi",
+      name: "Cloud Gateway Ultra",
+      manufacturer: "Ubiquiti",
+      model: "UCG-Ultra",
+      recommendedCollector: "unifi",
+      matchesDetectedGateway: true,
+    });
+    expect(candidates[0].evidence.join(" ")).toMatch(/default_route/i);
+  });
+});
+
+describe("choosePreselectedGateway", () => {
+  it("preselects the one usable gateway", () => {
+    const candidates = buildGatewayCandidates([unifiGateway], null);
+    expect(choosePreselectedGateway(candidates)).toBe("gw-unifi");
+  });
+
+  it("preselects the sole candidate matching the observed default route", () => {
+    const candidates = buildGatewayCandidates([
+      unifiGateway,
+      {
+        ...unifiGateway,
+        id: "gw-other",
+        entityKey: "arp:192.168.9.1",
+        name: "Other router",
+        manufacturer: null,
+        productModel: null,
+        properties: { address: "192.168.9.1" },
+      },
+    ], "192.168.0.1");
+
+    expect(choosePreselectedGateway(candidates)).toBe("gw-unifi");
+  });
+
+  it("requires a deliberate choice when multiple usable candidates are ambiguous", () => {
+    const candidates = buildGatewayCandidates([
+      unifiGateway,
+      {
+        ...unifiGateway,
+        id: "gw-other",
+        entityKey: "unifi:11:22:33:44:55:66",
+        name: "Second Cloud Gateway",
+        properties: { address: "192.168.9.1" },
+      },
+    ], null);
+
+    expect(choosePreselectedGateway(candidates)).toBeNull();
+  });
+});

--- a/apps/web/lib/discovery-connection/gateway-candidate.ts
+++ b/apps/web/lib/discovery-connection/gateway-candidate.ts
@@ -1,0 +1,189 @@
+import {
+  endpointForCollector,
+  type DiscoveryCollectorType,
+} from "./endpoint";
+
+export type GatewayEvidenceInput = {
+  id: string;
+  entityKey: string;
+  name: string;
+  manufacturer: string | null;
+  productModel: string | null;
+  confidence: number | null;
+  properties: unknown;
+};
+
+export type GatewayCandidate = {
+  entityId: string;
+  entityKey: string;
+  name: string;
+  address: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  confidence: number | null;
+  evidence: string[];
+  recommendedCollector: DiscoveryCollectorType;
+  recommendation: string;
+  canonicalEndpoint: string | null;
+  matchesDetectedGateway: boolean;
+  usable: boolean;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function firstString(properties: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = properties[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function evidenceText(input: GatewayEvidenceInput, properties: Record<string, unknown>): string {
+  const values = [
+    input.entityKey,
+    input.name,
+    input.manufacturer,
+    input.productModel,
+    firstString(properties, ["vendor", "manufacturer", "model", "modelName"]),
+    firstString(properties, ["discoveredVia", "sourceKind", "protocol", "sysDescr", "sysObjectId"]),
+  ];
+  return values.filter((value): value is string => typeof value === "string").join(" ").toLowerCase();
+}
+
+function recommendationFor(input: GatewayEvidenceInput, properties: Record<string, unknown>): {
+  collector: DiscoveryCollectorType;
+  reason: string;
+} {
+  const text = evidenceText(input, properties);
+  if (text.includes("ubiquiti") || text.includes("unifi")) {
+    return {
+      collector: "unifi",
+      reason: "DPF identified UniFi/Ubiquiti evidence for this gateway.",
+    };
+  }
+  if (
+    input.entityKey.toLowerCase().startsWith("snmp:")
+    || typeof properties.sysObjectId === "string"
+    || text.includes(" snmp")
+  ) {
+    return {
+      collector: "snmp",
+      reason: "DPF observed SNMP evidence for this gateway.",
+    };
+  }
+  return {
+    collector: "arp_scan",
+    reason: "No management API was identified; start with a safe local subnet scan.",
+  };
+}
+
+function buildEvidence(input: GatewayEvidenceInput, properties: Record<string, unknown>): string[] {
+  const evidence: string[] = [];
+  const manufacturer = input.manufacturer
+    ?? firstString(properties, ["vendor", "manufacturer"]);
+  const model = input.productModel
+    ?? firstString(properties, ["model", "modelName"]);
+  if (manufacturer) evidence.push(`Manufacturer: ${manufacturer}`);
+  if (model) evidence.push(`Model: ${model}`);
+  const discovery = firstString(properties, ["discoveredVia", "sourceKind", "protocol"]);
+  if (discovery) evidence.push(`Observed through ${discovery}`);
+  if (typeof input.confidence === "number") {
+    evidence.push(`Identification confidence ${Math.round(Math.max(0, Math.min(1, input.confidence)) * 100)}%`);
+  }
+  return evidence;
+}
+
+function sameAddress(left: string | null, right: string | null | undefined): boolean {
+  if (!left || !right) return false;
+  const clean = (value: string) => value.trim().toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/$/, "");
+  return clean(left) === clean(right);
+}
+
+export function buildGatewayCandidates(
+  inputs: GatewayEvidenceInput[],
+  detectedGateway: string | null,
+): GatewayCandidate[] {
+  const candidates = inputs.map((input): GatewayCandidate => {
+    const properties = asRecord(input.properties);
+    const address = firstString(properties, ["address", "ip", "host"]);
+    const manufacturer = input.manufacturer
+      ?? firstString(properties, ["vendor", "manufacturer"]);
+    const model = input.productModel
+      ?? firstString(properties, ["model", "modelName"]);
+    const recommendation = recommendationFor(input, properties);
+    const canonicalEndpoint = address
+      ? endpointForCollector(recommendation.collector, address)
+      : null;
+
+    return {
+      entityId: input.id,
+      entityKey: input.entityKey,
+      name: input.name,
+      address,
+      manufacturer,
+      model,
+      confidence: input.confidence,
+      evidence: buildEvidence(input, properties),
+      recommendedCollector: recommendation.collector,
+      recommendation: recommendation.reason,
+      canonicalEndpoint,
+      matchesDetectedGateway: sameAddress(address, detectedGateway),
+      usable: canonicalEndpoint !== null,
+    };
+  });
+
+  const collectorRank: Record<DiscoveryCollectorType, number> = {
+    unifi: 3,
+    snmp: 2,
+    arp_scan: 1,
+  };
+  const identityRank = (candidate: GatewayCandidate): number => (
+    collectorRank[candidate.recommendedCollector] * 100
+    + (candidate.manufacturer ? 20 : 0)
+    + (candidate.model ? 10 : 0)
+    + Math.round((candidate.confidence ?? 0) * 10)
+  );
+  const byPhysicalEndpoint = new Map<string, GatewayCandidate>();
+  for (const candidate of candidates) {
+    const key = candidate.address
+      ? `address:${candidate.address.trim().toLowerCase()}`
+      : `entity:${candidate.entityId}`;
+    const current = byPhysicalEndpoint.get(key);
+    if (!current) {
+      byPhysicalEndpoint.set(key, candidate);
+      continue;
+    }
+
+    const preferred = identityRank(candidate) > identityRank(current) ? candidate : current;
+    const other = preferred === candidate ? current : candidate;
+    byPhysicalEndpoint.set(key, {
+      ...preferred,
+      evidence: [...new Set([...preferred.evidence, ...other.evidence])],
+      matchesDetectedGateway: preferred.matchesDetectedGateway || other.matchesDetectedGateway,
+    });
+  }
+
+  return [...byPhysicalEndpoint.values()].sort((left, right) => {
+    if (left.matchesDetectedGateway !== right.matchesDetectedGateway) {
+      return left.matchesDetectedGateway ? -1 : 1;
+    }
+    if (left.usable !== right.usable) return left.usable ? -1 : 1;
+    const confidenceDelta = (right.confidence ?? 0) - (left.confidence ?? 0);
+    if (confidenceDelta !== 0) return confidenceDelta;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function choosePreselectedGateway(candidates: GatewayCandidate[]): string | null {
+  const usable = candidates.filter((candidate) => candidate.usable);
+  if (usable.length === 1) return usable[0].entityId;
+  const detected = usable.filter((candidate) => candidate.matchesDetectedGateway);
+  return detected.length === 1 ? detected[0].entityId : null;
+}

--- a/apps/web/lib/discovery-connection/gateway-candidate.ts
+++ b/apps/web/lib/discovery-connection/gateway-candidate.ts
@@ -1,5 +1,6 @@
 import {
   endpointForCollector,
+  normalizeDiscoveryEndpoint,
   type DiscoveryCollectorType,
 } from "./endpoint";
 
@@ -29,6 +30,12 @@ export type GatewayCandidate = {
   usable: boolean;
 };
 
+export type GatewayConnectionEvidence = {
+  collectorType: string;
+  endpointUrl: string;
+  status: string;
+};
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -55,10 +62,26 @@ function evidenceText(input: GatewayEvidenceInput, properties: Record<string, un
   return values.filter((value): value is string => typeof value === "string").join(" ").toLowerCase();
 }
 
-function recommendationFor(input: GatewayEvidenceInput, properties: Record<string, unknown>): {
+function recommendationFor(
+  input: GatewayEvidenceInput,
+  properties: Record<string, unknown>,
+  connection: GatewayConnectionEvidence | null,
+): {
   collector: DiscoveryCollectorType;
   reason: string;
 } {
+  if (connection?.status === "active" && connection.collectorType === "unifi") {
+    return {
+      collector: "unifi",
+      reason: "DPF has an active UniFi connection to this physical device.",
+    };
+  }
+  if (connection?.status === "active" && connection.collectorType === "snmp") {
+    return {
+      collector: "snmp",
+      reason: "DPF has an active SNMP connection to this physical device.",
+    };
+  }
   const text = evidenceText(input, properties);
   if (text.includes("ubiquiti") || text.includes("unifi")) {
     return {
@@ -82,8 +105,18 @@ function recommendationFor(input: GatewayEvidenceInput, properties: Record<strin
   };
 }
 
-function buildEvidence(input: GatewayEvidenceInput, properties: Record<string, unknown>): string[] {
+function buildEvidence(
+  input: GatewayEvidenceInput,
+  properties: Record<string, unknown>,
+  connection: GatewayConnectionEvidence | null,
+): string[] {
   const evidence: string[] = [];
+  if (connection?.status === "active") {
+    const label = connection.collectorType === "unifi"
+      ? "UniFi"
+      : connection.collectorType.toUpperCase();
+    evidence.push(`Active ${label} connection targets this device`);
+  }
   const manufacturer = input.manufacturer
     ?? firstString(properties, ["vendor", "manufacturer"]);
   const model = input.productModel
@@ -98,6 +131,44 @@ function buildEvidence(input: GatewayEvidenceInput, properties: Record<string, u
   return evidence;
 }
 
+function connectionAddress(connection: GatewayConnectionEvidence): string | null {
+  if (connection.collectorType !== "unifi" && connection.collectorType !== "snmp") {
+    return null;
+  }
+  const collectorType = connection.collectorType;
+  const normalized = normalizeDiscoveryEndpoint(connection.endpointUrl, collectorType);
+  if (!normalized.ok) return null;
+  try {
+    return new URL(
+      collectorType === "unifi" ? normalized.value : `http://${normalized.value}`,
+    ).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function gatewayConnectionAddresses(
+  connections: GatewayConnectionEvidence[],
+): string[] {
+  return [...new Set(
+    connections
+      .map(connectionAddress)
+      .filter((address): address is string => address !== null),
+  )];
+}
+
+export function gatewayEvidenceWhere(connectionAddresses: string[]) {
+  return {
+    OR: [
+      { entityType: { in: ["gateway", "router"] } },
+      ...connectionAddresses.map((address) => ({
+        entityType: "host",
+        properties: { path: ["address"], equals: address },
+      })),
+    ],
+  };
+}
+
 function sameAddress(left: string | null, right: string | null | undefined): boolean {
   if (!left || !right) return false;
   const clean = (value: string) => value.trim().toLowerCase()
@@ -109,32 +180,51 @@ function sameAddress(left: string | null, right: string | null | undefined): boo
 export function buildGatewayCandidates(
   inputs: GatewayEvidenceInput[],
   detectedGateway: string | null,
+  connections: GatewayConnectionEvidence[] = [],
 ): GatewayCandidate[] {
+  const connectionsByAddress = new Map<string, GatewayConnectionEvidence>();
+  for (const connection of connections) {
+    const address = connectionAddress(connection);
+    if (!address) continue;
+    const current = connectionsByAddress.get(address);
+    if (!current || (current.status !== "active" && connection.status === "active")) {
+      connectionsByAddress.set(address, connection);
+    }
+  }
+
   const candidates = inputs.map((input): GatewayCandidate => {
     const properties = asRecord(input.properties);
     const address = firstString(properties, ["address", "ip", "host"]);
+    const connection = address
+      ? connectionsByAddress.get(address.toLowerCase()) ?? null
+      : null;
     const manufacturer = input.manufacturer
       ?? firstString(properties, ["vendor", "manufacturer"]);
     const model = input.productModel
       ?? firstString(properties, ["model", "modelName"]);
-    const recommendation = recommendationFor(input, properties);
+    const recommendation = recommendationFor(input, properties, connection);
     const canonicalEndpoint = address
       ? endpointForCollector(recommendation.collector, address)
       : null;
+    const displayName = connection?.status === "active"
+      && connection.collectorType === "unifi"
+      && /^LAN Host\b/i.test(input.name)
+      ? `UniFi gateway ${address}`
+      : input.name;
 
     return {
       entityId: input.id,
       entityKey: input.entityKey,
-      name: input.name,
+      name: displayName,
       address,
       manufacturer,
       model,
       confidence: input.confidence,
-      evidence: buildEvidence(input, properties),
+      evidence: buildEvidence(input, properties, connection),
       recommendedCollector: recommendation.collector,
       recommendation: recommendation.reason,
       canonicalEndpoint,
-      matchesDetectedGateway: sameAddress(address, detectedGateway),
+      matchesDetectedGateway: sameAddress(address, detectedGateway) || connection?.status === "active",
       usable: canonicalEndpoint !== null,
     };
   });

--- a/docs/edge-node/unifi-adapter.md
+++ b/docs/edge-node/unifi-adapter.md
@@ -22,11 +22,11 @@ The adapter calls `GET /proxy/network/api/s/{site}/stat/device` and `GET /proxy/
 ## Step 2 — Add the connection in the portal
 
 1. Open **Platform → Tools → Estate Discovery** (`/platform/tools/discovery`).
-2. Click **Add Connection** (or **Configure** on the detected gateway tile if your edge node has already surfaced one).
-3. Fill in:
+2. Click **Review & Connect** on the identified gateway tile. DPF ranks canonical gateway inventory by its network address, manufacturer, model, discovery source, and confidence. When one usable gateway matches the detected network route, it is selected automatically; when several are plausible, choose the named device deliberately.
+3. Review the identified device and fill in:
    - **Discovery Method**: `Ubiquiti UniFi`
    - **Site**: `default` (or the slug from your UniFi UI for multi-site installs)
-   - **Controller URL**: full URL to the controller. UDM/UDM-Pro: `https://<gateway-ip>`. Hosted Network (`https://unifi.ui.com`) is not supported on this path — local LAN only.
+   - **Gateway**: the device identity and endpoint come from discovery evidence; there is no URL to type in the normal path.
    - **API Key**: paste the value from Step 1.
    - **Allow self-signed controller certificate**: enable only for a trusted closed LAN when the UniFi appliance uses its factory/self-signed certificate.
 4. Click **Save & Test**. The portal:
@@ -35,6 +35,8 @@ The adapter calls `GET /proxy/network/api/s/{site}/stat/device` and `GET /proxy/
    - Flips status to `active` on success, or reports `auth_failed` / `unreachable` / `tls_error` with the failure reason.
 
 That's it. No file on disk, no bind mount, no container restart needed.
+
+If discovery cannot identify the correct device, expand **Enter a gateway manually**. Enter a host or IP address; `http://`, `https://`, and an optional port are accepted and normalized to the canonical HTTPS endpoint. Paths, credentials, non-HTTP schemes, control characters, and unsafe targets are rejected with field-specific guidance while preserving the value for correction. Manual entry is recovery, not the primary setup path. Hosted Network (`unifi.ui.com`) is not supported here; this adapter targets the physical network reachable from the portal host.
 
 ## Step 3 — The edge node picks it up automatically
 
@@ -53,7 +55,7 @@ docker compose logs edge-node --tail 50
 The connection row on `/platform/tools/discovery` has per-row **Re-test**, **Edit**, and **Delete** buttons:
 
 - **Re-test** — runs the one-shot probe against the controller and updates `lastTestStatus`.
-- **Edit** — opens the form with controller URL + site pre-filled; leave the API key field blank to keep the existing ciphertext, paste a new value to rotate.
+- **Edit** — opens the form with the linked gateway identity and site pre-filled; leave the API key field blank to keep the existing ciphertext, or paste a new value to rotate. Endpoint changes remain available under manual recovery.
 - **Delete** — removes the row (with a confirmation step). The edge node's next sweep will see it's gone and stop polling that controller.
 
 ## What the adapter emits

--- a/docs/superpowers/plans/2026-08-08-discovery-first-connections.md
+++ b/docs/superpowers/plans/2026-08-08-discovery-first-connections.md
@@ -1,0 +1,128 @@
+# Discovery-First Gateway Connections Implementation Plan
+
+- **Backlog item:** BI-E9F5B1E6
+- **Related, separately planned work:** BI-51F5229B (federation SAS-first Connections UX)
+- **Work capsule:** WC-C3BB5816
+- **Branch:** `feat/discovery-first-connections`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+An operator configures a physical-network discovery connection by selecting an identified gateway. DPF carries the gateway identity and canonical endpoint into the credential/test flow. Raw endpoint input is absent from the primary flow and available only through an explicit recovery disclosure with shared client/server normalization and actionable validation.
+
+This plan extends `InventoryEntity`, `DiscoveryConnection`, and `gatewayEntityId`. It adds no parallel device, endpoint, or connection substrate.
+
+## Research and benchmarking
+
+- Ubiquiti documents detailed local UniFi Application APIs and locates API-key management under the local Network application's Integrations surface. Adopt: identify a local UniFi console and ask only for the credential DPF cannot discover. Source: https://help.ui.com/hc/en-us/articles/30076656117655-Getting-Started-with-the-Official-UniFi-API
+- Home Assistant's integration guidance treats discovery identity as primary, updates a device's address only when stable identity matches, prevents duplicate configuration entries, and keeps reconfigure/reauth as explicit flows. Adopt: bind the connection to `InventoryEntity.id`, deduplicate by identity/canonical endpoint, and separate normal setup from recovery. Reject: IP address or URL as device identity. Sources: https://developers.home-assistant.io/docs/core/integration/config_flow/ and https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/discovery-update-info/
+- Home Assistant instance discovery advertises a friendly name, stable instance identity, host, and port so clients do not ask for an address. Adopt the same presentation hierarchy for existing DPF discovery evidence: friendly name and vendor/model first, address as supporting evidence. Source: https://developers.home-assistant.io/docs/api/instance_discovery/
+
+## Existing substrate
+
+- `apps/web/components/inventory/DiscoveryOperationsPage.tsx` already queries canonical `InventoryEntity` gateway rows but reduces them to the first non-Docker IP; the discovery runner's broader `gateway`/`router` classification must remain aligned here.
+- `apps/web/components/inventory/AddDiscoveryConnection.tsx` and `ConfigureConnectionInline.tsx` prefill that IP but expose an editable URL in the primary flow.
+- `apps/web/lib/actions/discovery.ts` already normalizes some endpoint forms and upserts `DiscoveryConnection`; its URL helper is server-local, incomplete, and does not return field-level validation.
+- `InventoryEntity` already carries stable id/entityKey, name, manufacturer, product model, confidence, observed properties, and software evidence.
+- `DiscoveryConnection` already carries `gatewayEntityId`, normalized endpoint, collector type, credentials, configuration, and test status.
+
+## Design grounding
+
+- **Existing specs/plans reviewed:** `docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md`, `docs/edge-node/unifi-adapter.md`, and the existing discovery-first backlog and UX decision evidence.
+- **Current code substrate reviewed:** the canonical `InventoryEntity` and `DiscoveryConnection` models, discovery server actions, discovery operations route, connection setup/edit panels, shared form primitives, and canonical Docker-origin filtering.
+- **Source of truth:** `InventoryEntity` supplies observed gateway identity and evidence; `DiscoveryConnection` stores the normalized collector endpoint and selected `gatewayEntityId`.
+- **Decision:** extend the existing discovery connection flow with identified-device-first selection and keep normalized manual endpoint entry only as explicit recovery; introduce no parallel route, device store, endpoint store, or connection substrate.
+
+## UX fit review
+
+- **Decision:** fits-with-guardrails
+- **Decision ledger:** `DI-7CD79EFC3BA6` recommends `identified-device-first` with high confidence and no commandment conflict
+- **Owning area:** Platform
+- **Route family:** `/platform/tools/discovery` (canonical) and `/inventory` (legacy alias rendering the same page)
+- **Primary persona:** non-technical platform operator connecting the local network estate
+- **Navigation layer touched:** contextual action inside the existing Discovery Connections panel; no new route or navigation item
+- **Reuse/convergence:** compose shared form primitives (`SelectField`, `TextField`, `CheckboxField`, `SubmitButton`, `FormStatus`) and the existing connection panel; do not create a new setup page or card dialect
+- **Source truth:** canonical `InventoryEntity` gateway rows plus `DiscoveryConnection`; the selected entity id, not a URL, is the setup identity
+- **Empty/failure behavior:** explain when no gateway is identified, preserve a recovery path, retain entered recovery text, and show field-specific validation/test failures
+- **AI boundary:** no prompt send
+- **Required guardrails:** vendor/model/name precede raw address; candidate confidence is evidence not automatic trust; one unambiguous candidate may be preselected but never silently saved; raw endpoint input is collapsed recovery detail; no hardcoded colors
+- **Evidence before merge:** component/action tests, style scan, route-budget measurement manifest, canonical browser exercise at desktop and mobile widths
+- **Captured in:** this section and `docs/ux-fit/2026-08-08-discovery-first-connections.ux-fit.json`
+
+## Backlog coverage
+
+- **Decision:** atomic
+- **Receipt:** `cmsl2mixv0dh601o20yh2yef0`
+- **Parent BI:** `BI-E9F5B1E6`
+- **Deliverable:** `gateway-discovery-first-setup` — sequencing-only inside this BI
+- **Rationale:** candidate resolution, shared normalization/validation, and discovery-first form behavior must ship together. A partial release either preserves raw URL entry as the primary contract or creates a client/server validation split.
+
+## Implementation phases
+
+### 1. Shared candidate and endpoint contracts — sequencing-only
+
+Create pure, client-safe modules under `apps/web/lib/discovery-connection/`:
+
+- `endpoint.ts`: normalize and validate UniFi, SNMP, and ARP recovery input; return a canonical value or a field-specific error; reject credentials, control characters, unsupported schemes, non-root controller paths, and unsafe non-host targets.
+- `gateway-candidate.ts`: convert selected `InventoryEntity` evidence into a stable UI contract, collapse generic-route and enriched-device records that share one physical endpoint, recommend UniFi only from explicit Ubiquiti/UniFi evidence, otherwise retain generic choices, and rank unambiguous candidates without treating confidence as authentication.
+
+TDD evidence:
+
+- First-failing unit tests cover IP/host/scheme/port normalization, invalid and unsafe forms, CIDR validation, UniFi identification, generic fallback, ambiguity, and deterministic ranking.
+
+### 2. Server source truth and duplicate safety — sequencing-only
+
+Update `DiscoveryOperationsPage.tsx` to query complete physical `gateway` and `router` candidate fields, reuse the canonical Docker-origin filter, and pass the typed candidate list to `SavedConnectionsPanel` / `AddDiscoveryConnection`.
+
+Update `apps/web/lib/actions/discovery.ts` to use the shared endpoint contract before any persistence or test request. Preserve edit-by-id behavior, bind `gatewayEntityId`, and make equivalent endpoint keys canonical so save/edit does not create duplicates.
+
+TDD evidence:
+
+- Action tests prove server rejection and canonical keys.
+- Server-component tests prove identified candidates reach the client contract and the legacy alias shares the same behavior.
+
+### 3. Discovery-first form — sequencing-only
+
+Refactor `AddDiscoveryConnection.tsx` and `ConfigureConnectionInline.tsx`:
+
+- render gateway candidates as named choices with vendor/model, address, evidence/recommendation, and ambiguity state;
+- preselect only when exactly one usable best candidate exists;
+- carry the selected entity id and canonical endpoint internally;
+- keep API-key/site/TLS credential choices visible as needed;
+- hide manual endpoint entry in an explicit recovery `<details>` disclosure;
+- compose shared form/status/submit primitives and theme tokens;
+- preserve recovery input and inline error on failure;
+- keep edit/re-test/re-run linked to the saved entity.
+
+TDD evidence:
+
+- Component tests begin red for no primary URL textbox, candidate identity rendering, preselection, deliberate ambiguous selection, recovery disclosure, retained invalid input, and entity-id submission.
+
+### 4. Documentation and measured UX evidence — sequencing-only
+
+Update `docs/edge-node/unifi-adapter.md` so setup describes selecting the discovered gateway and only uses manual endpoint entry as recovery.
+
+Create `docs/ux-fit/2026-08-08-discovery-first-connections.ux-fit.json` from the measured two-option UX decision; its `scope.files` must exactly cover UI-impacting files. Still exercise the real served route at desktop and mobile widths before handoff.
+
+## Completion gate
+
+1. Targeted Vitest suites for the pure contracts, actions, and inventory components pass from this worktree with the runner root confirmed.
+2. `pnpm --filter web build` passes with zero errors.
+3. Style/theme drift checks show no new hardcoded-color or off-scale debt.
+4. The canonical running app is exercised at `/platform/tools/discovery` on desktop and mobile widths for identified, ambiguous, recovery-error, save/test, edit/re-test, and existing-connection states.
+5. The measured UX-fit manifest passes its guard.
+6. Documentation accurately reflects the primary and recovery paths.
+7. Local merged-code CI passes under the governed shared lease before push/PR.
+
+## Risks and rollback
+
+- **Misclassification:** vendor text may be noisy. Only explicit normalized UniFi/Ubiquiti evidence recommends the UniFi collector; all other candidates remain generic/operator-reviewable.
+- **Endpoint breakage:** stricter validation may reject previously stored odd paths. Existing rows remain readable/editable; validation applies on save and gives recovery guidance. Tests pin accepted legacy-equivalent forms.
+- **Duplicate rows:** endpoint spelling changes can alter `connectionKey`. Canonicalization is shared and edit-by-id remains the first choice; tests cover equivalent spellings.
+- **UI regression:** the current components contain hardcoded colors and hand-rolled controls. Touched controls converge to shared primitives and measured route evidence prevents silent budget/accessibility drift.
+- **Rollback:** revert the PR. No schema migration or destructive data rewrite is introduced; existing `DiscoveryConnection` rows remain intact.
+
+## Federation sequencing
+
+`BI-51F5229B` remains covered by `docs/superpowers/plans/2026-08-07-federation-robust-design-build-plan.md` and depends on the active SAS transport work (`BI-7432348C`). Its owning component is currently claimed by `WC-455B85BB`; this branch will not co-claim or mix federation changes into the gateway PR. After that dependency lands, implement `BI-51F5229B` on its own branch/PR using its existing plan.

--- a/docs/superpowers/plans/2026-08-08-discovery-first-connections.md
+++ b/docs/superpowers/plans/2026-08-08-discovery-first-connections.md
@@ -21,7 +21,7 @@ This plan extends `InventoryEntity`, `DiscoveryConnection`, and `gatewayEntityId
 
 ## Existing substrate
 
-- `apps/web/components/inventory/DiscoveryOperationsPage.tsx` already queries canonical `InventoryEntity` gateway rows but reduces them to the first non-Docker IP; the discovery runner's broader `gateway`/`router` classification must remain aligned here.
+- `apps/web/components/inventory/DiscoveryOperationsPage.tsx` already queries canonical `InventoryEntity` gateway rows but reduces them to the first non-Docker IP; the discovery runner's broader `gateway`/`router` classification must remain aligned here. A tested `DiscoveryConnection` target is also authoritative corroboration when physical ARP evidence still classifies the same address as a generic host; exact endpoint correlation may promote that entity without guessing from address shape.
 - `apps/web/components/inventory/AddDiscoveryConnection.tsx` and `ConfigureConnectionInline.tsx` prefill that IP but expose an editable URL in the primary flow.
 - `apps/web/lib/actions/discovery.ts` already normalizes some endpoint forms and upserts `DiscoveryConnection`; its URL helper is server-local, incomplete, and does not return field-level validation.
 - `InventoryEntity` already carries stable id/entityKey, name, manufacturer, product model, confidence, observed properties, and software evidence.
@@ -73,7 +73,7 @@ TDD evidence:
 
 ### 2. Server source truth and duplicate safety — sequencing-only
 
-Update `DiscoveryOperationsPage.tsx` to query complete physical `gateway` and `router` candidate fields, reuse the canonical Docker-origin filter, and pass the typed candidate list to `SavedConnectionsPanel` / `AddDiscoveryConnection`.
+Update `DiscoveryOperationsPage.tsx` to query complete physical `gateway` and `router` candidate fields plus exact physical-host matches for canonical UniFi/SNMP connection targets, reuse the canonical Docker-origin filter, and pass the typed candidate list to `SavedConnectionsPanel` / `AddDiscoveryConnection`. Treat only an active exact-address connection as identity evidence; never infer a gateway from `.1`, inventory order, or subnet position.
 
 Update `apps/web/lib/actions/discovery.ts` to use the shared endpoint contract before any persistence or test request. Preserve edit-by-id behavior, bind `gatewayEntityId`, and make equivalent endpoint keys canonical so save/edit does not create duplicates.
 

--- a/docs/superpowers/plans/2026-08-08-discovery-first-connections.md
+++ b/docs/superpowers/plans/2026-08-08-discovery-first-connections.md
@@ -52,11 +52,11 @@ This plan extends `InventoryEntity`, `DiscoveryConnection`, and `gatewayEntityId
 
 ## Backlog coverage
 
-- **Decision:** atomic
-- **Receipt:** `cmsl2mixv0dh601o20yh2yef0`
-- **Parent BI:** `BI-E9F5B1E6`
-- **Deliverable:** `gateway-discovery-first-setup` — sequencing-only inside this BI
-- **Rationale:** candidate resolution, shared normalization/validation, and discovery-first form behavior must ship together. A partial release either preserves raw URL entry as the primary contract or creates a client/server validation split.
+- Decision: atomic
+- Parent: `BI-E9F5B1E6`
+- Receipt: `cmsl9c0da00lt01nxhz1tybe2`
+- Dependencies: none
+- Rationale: Gateway candidate resolution, shared endpoint normalization, server persistence, and the selection-first form are one release contract. A partial release either preserves raw URL entry as the primary contract or creates a client/server validation split.
 
 ## Implementation phases
 

--- a/docs/ux-fit/2026-08-08-discovery-first-connections.ux-fit.json
+++ b/docs/ux-fit/2026-08-08-discovery-first-connections.ux-fit.json
@@ -1,0 +1,17 @@
+{
+  "version": "1",
+  "decidedOption": "identified-device-first",
+  "decisionInteractionId": "DI-7CD79EFC3BA6",
+  "scope": {
+    "files": [
+      "apps/web/components/inventory/ConfigureConnectionInline.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "identified-device-first",
+      "raw-endpoint-first"
+    ]
+  }
+}

--- a/packages/db/src/docker-origin.test.ts
+++ b/packages/db/src/docker-origin.test.ts
@@ -63,6 +63,7 @@ describe("isDockerOriginEntityKey (server-side)", () => {
       isDockerOriginEntityKey("__dpf_quarantined__cmpjsbvh8006c01lmp4levblx__network_interface:iface:eth0:172.18.0.14"),
     ).toBe(true);
     expect(isDockerOriginEntityKey("network_interface:iface:eth0:172.31.255.254")).toBe(true);
+    expect(isDockerOriginEntityKey("gateway:gateway:172.18.0.1")).toBe(true);
     // Real LAN NIC (192.168) and outside-/12 stay false.
     expect(isDockerOriginEntityKey("network_interface:iface:Ethernet_2:192.168.0.200")).toBe(false);
     expect(isDockerOriginEntityKey("network_interface:iface:eth0:172.15.0.1")).toBe(false);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -508,6 +508,7 @@ export * from "./inventory-asset-bridge";
 export * from "./inventory-entity-lifecycle";
 export * from "./inventory-entity-heap-integrity";
 export * from "./inventory-entity-merge-references";
+export * from "./docker-origin";
 export * from "./device-placement";
 export * from "./portfolio-sources";
 export * from "./backlog-portfolio";


### PR DESCRIPTION
## Summary

- identify physical gateway candidates from canonical inventory evidence and exact active UniFi/SNMP connection targets
- make identified-device selection the primary setup path, carrying the canonical endpoint and `gatewayEntityId` internally
- keep manual gateway entry behind an explicit recovery disclosure with shared client/server normalization, LAN-only validation, and retained actionable errors
- preserve credentials during edit/re-test and canonicalize equivalent connection keys to prevent duplicate rows

Backlog: `BI-E9F5B1E6`  
Work Capsule: `WC-C3BB5816`

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-08-08-discovery-first-connections.md`, the federation robust-design plan, and the UniFi adapter guide.
- Current code substrate reviewed: canonical `InventoryEntity` and `DiscoveryConnection` models, `gatewayEntityId`, discovery actions, Docker-origin filtering, and the existing discovery operations connection components.
- Source of truth: `InventoryEntity` remains physical identity/evidence truth; `DiscoveryConnection` remains normalized endpoint, credential, status, and selected-gateway truth.
- Decision: extend the existing connection flow with identified-device-first selection. An exact active management target may corroborate a generic physical host, but DPF never guesses from `.1`, scan order, or subnet position. No parallel device, endpoint, or connection substrate is introduced.

Adjacent PR #4159 improves scheduled physical topology collection and integrity. This PR is intentionally separate: it owns connection candidate resolution, safe endpoint entry, and setup/edit UX.

## Verification

- focused web Vitest: 6 files / 51 tests passed
- database Docker-origin Vitest: 1 file / 13 tests passed
- TypeScript `--noEmit`: passed with the repository's documented 8 GiB heap setting
- production Next build: passed; 142/142 pages generated, with the repository's 25 pre-existing Edge Runtime warnings and zero build errors
- pregate preflight: 35 guards clean; two host-runtime checks deferred to the governed sandbox
- exhaustive merged-code local CI: passed against current `origin/main`
- authenticated governed preview at `/platform/tools/discovery`:
  - the physical `192.168.0.1` host rendered as the selected `UniFi gateway 192.168.0.1`
  - the canonical address was filled internally and manual entry remained collapsed
  - `file:///etc/passwd` was retained and rejected with `Use an HTTP or HTTPS gateway address.`
  - the same flow remained operable at a 390×844 mobile viewport

The exact-tree independent semantic review was infrastructure-inconclusive with zero findings and publication allowed in shadow mode.

## Documentation impact

The UniFi adapter guide now describes discovered-gateway selection as the normal path and manual address entry as recovery. The implementation plan and measured UX-fit manifest record the candidate, validation, responsive, and source-of-truth contracts.

Docs-Impact-Decision: Updated the operator-facing UniFi setup guide and the implementation/UX evidence surfaces because the primary setup contract changed.
