### PR TITLE
fix(ci): reserve queued admission windows

### DIFF
--- a/apps/web/lib/change-review/routed-semantic-review.test.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.test.ts
@@ -92,6 +92,28 @@ describe("routed semantic review", () => {
     expect(routeAndCall).not.toHaveBeenCalled();
   });
 
+  it("defers review so an established local-CI queue can take the next safe window", async () => {
+    vi.mocked(inspectLocalProviderCapacity).mockResolvedValue({
+      available: false,
+      reason: "local-ci-queued-capacity-reservation",
+    });
+
+    const result = await dispatchRoutedSemanticReview("review this", {
+      strategyProfile: "high-assurance",
+      reviewerId: "change-reviewer",
+      specialistIds: [],
+      surface: "external",
+    });
+
+    expect(result).toEqual({
+      decision: "inconclusive",
+      issues: [],
+      summary: "Semantic review deferred so the established local-CI queue can claim the next safe host window.",
+      inconclusiveReason: "local-ci-queued-capacity-reservation",
+    });
+    expect(routeAndCall).not.toHaveBeenCalled();
+  });
+
   it("does not defer review for an unrelated nonproduction lease", async () => {
     vi.mocked(inspectLocalProviderCapacity).mockResolvedValue({ available: true, reason: null });
     vi.mocked(routeAndCall).mockResolvedValue({

--- a/apps/web/lib/change-review/routed-semantic-review.ts
+++ b/apps/web/lib/change-review/routed-semantic-review.ts
@@ -41,6 +41,14 @@ async function localCiCapacityGuard(): Promise<SemanticReviewResult | null> {
       inconclusiveReason: "local-ci-active-capacity-reservation",
     };
   }
+  if (capacity.reason === "local-ci-queued-capacity-reservation") {
+    return {
+      decision: "inconclusive",
+      issues: [],
+      summary: "Semantic review deferred so the established local-CI queue can claim the next safe host window.",
+      inconclusiveReason: "local-ci-queued-capacity-reservation",
+    };
+  }
   return {
     decision: "inconclusive",
     issues: [],

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/queue/queue-telemetry", () => ({ recordQueueTransition }));
 import {
   claimNonprodEnvironmentLease,
   clampLeaseExpiry,
+  listCapacityReservingNonprodEnvironmentLeases,
   listActiveNonprodEnvironmentLeases,
   listQueuedNonprodEnvironmentLeases,
   releaseNonprodEnvironmentLease,
@@ -136,6 +137,22 @@ describe("durable nonproduction admission", () => {
     });
     expect(mockDb.nonProductionEnvironmentLease.findMany).toHaveBeenNthCalledWith(2, {
       where: { status: "queued", expiresAt: { gt: NOW } },
+      orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+    });
+  });
+
+  it("reads active and queued capacity reservations in one FIFO snapshot", async () => {
+    const mockDb = db();
+    await listCapacityReservingNonprodEnvironmentLeases({
+      db: mockDb as never,
+      now: NOW,
+    });
+
+    expect(mockDb.nonProductionEnvironmentLease.findMany).toHaveBeenCalledWith({
+      where: {
+        status: { in: ["active", "queued"] },
+        expiresAt: { gt: NOW },
+      },
       orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
     });
   });

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -275,6 +275,27 @@ export async function listQueuedNonprodEnvironmentLeases(input: {
   });
 }
 
+/**
+ * One registry snapshot for host-capacity arbitration. Active leases own the
+ * host now; queued leases reserve the next safe admission window. Keeping both
+ * states in one query prevents a provider from slipping between separate
+ * active/queued reads.
+ */
+export async function listCapacityReservingNonprodEnvironmentLeases(input: {
+  db?: LeaseDb;
+  now?: Date;
+}) {
+  const db = input.db ?? prisma;
+  const now = input.now ?? new Date();
+  return db.nonProductionEnvironmentLease.findMany({
+    where: {
+      status: { in: ["active", "queued"] },
+      expiresAt: { gt: now },
+    },
+    orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+  });
+}
+
 export type ClaimNonprodEnvironmentLeaseResult =
   | {
     status: "admitted";

--- a/apps/web/lib/routing/local-provider-capacity.test.ts
+++ b/apps/web/lib/routing/local-provider-capacity.test.ts
@@ -9,32 +9,45 @@ import {
 
 describe("local provider capacity reservation", () => {
   it("permits local dispatch when governed local CI is inactive", async () => {
-    const listActiveLeases = vi.fn().mockResolvedValue([
-      { environmentKey: "dev-portal" },
+    const listCapacityLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "dev-portal", status: "active" },
     ]);
 
     await expect(
-      inspectLocalProviderCapacity({ listActiveLeases }),
+      inspectLocalProviderCapacity({ listCapacityLeases }),
     ).resolves.toEqual({ available: true, reason: null });
   });
 
   it("defers every local dispatch while governed local CI owns the host", async () => {
-    const listActiveLeases = vi.fn().mockResolvedValue([
-      { environmentKey: "local-integration-ci" },
+    const listCapacityLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "local-integration-ci", status: "active" },
     ]);
 
     await expect(
-      assertLocalProviderCapacityAvailable({ listActiveLeases }),
+      assertLocalProviderCapacityAvailable({ listCapacityLeases }),
     ).rejects.toMatchObject({
       name: "LocalProviderCapacityDeferredError",
       reason: "local-ci-active-capacity-reservation",
     });
   });
 
-  it("fails closed for local dispatch when the lease registry is unavailable", async () => {
-    const listActiveLeases = vi.fn().mockRejectedValue(new Error("registry unavailable"));
+  it("reserves the next safe admission window for an established local-CI queue", async () => {
+    const listCapacityLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "local-integration-ci", status: "queued" },
+    ]);
 
-    const rejection = assertLocalProviderCapacityAvailable({ listActiveLeases });
+    await expect(
+      assertLocalProviderCapacityAvailable({ listCapacityLeases }),
+    ).rejects.toMatchObject({
+      name: "LocalProviderCapacityDeferredError",
+      reason: "local-ci-queued-capacity-reservation",
+    });
+  });
+
+  it("fails closed for local dispatch when the lease registry is unavailable", async () => {
+    const listCapacityLeases = vi.fn().mockRejectedValue(new Error("registry unavailable"));
+
+    const rejection = assertLocalProviderCapacityAvailable({ listCapacityLeases });
 
     await expect(rejection).rejects.toBeInstanceOf(LocalProviderCapacityDeferredError);
     await expect(rejection).rejects.toMatchObject({
@@ -43,21 +56,21 @@ describe("local provider capacity reservation", () => {
   });
 
   it("does not consult the host registry for a cloud provider", async () => {
-    const listActiveLeases = vi.fn().mockRejectedValue(new Error("registry unavailable"));
+    const listCapacityLeases = vi.fn().mockRejectedValue(new Error("registry unavailable"));
 
     await expect(
-      assertProviderDispatchCapacity("openai", { listActiveLeases }),
+      assertProviderDispatchCapacity("openai", { listCapacityLeases }),
     ).resolves.toBeUndefined();
-    expect(listActiveLeases).not.toHaveBeenCalled();
+    expect(listCapacityLeases).not.toHaveBeenCalled();
   });
 
   it("applies the reservation to every local provider alias", async () => {
-    const listActiveLeases = vi.fn().mockResolvedValue([
-      { environmentKey: "local-integration-ci" },
+    const listCapacityLeases = vi.fn().mockResolvedValue([
+      { environmentKey: "local-integration-ci", status: "active" },
     ]);
 
     await expect(
-      assertProviderDispatchCapacity("ollama", { listActiveLeases }),
+      assertProviderDispatchCapacity("ollama", { listCapacityLeases }),
     ).rejects.toMatchObject({ reason: "local-ci-active-capacity-reservation" });
   });
 });

--- a/apps/web/lib/routing/local-provider-capacity.ts
+++ b/apps/web/lib/routing/local-provider-capacity.ts
@@ -1,15 +1,19 @@
-import { listActiveNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
+import { listCapacityReservingNonprodEnvironmentLeases } from "@/lib/nonprod/environment-lease";
 import { isLocalProviderId } from "./provider-locality";
 
 export type LocalProviderCapacityDeferralReason =
   | "local-ci-active-capacity-reservation"
+  | "local-ci-queued-capacity-reservation"
   | "local-ci-capacity-reservation-unavailable";
 
 export type LocalProviderCapacityStatus =
   | { available: true; reason: null }
   | { available: false; reason: LocalProviderCapacityDeferralReason };
 
-type ActiveLeaseReader = () => Promise<Array<{ environmentKey: string }>>;
+type LeaseReader = () => Promise<Array<{
+  environmentKey: string;
+  status?: string;
+}>>;
 
 export class LocalProviderCapacityDeferredError extends Error {
   constructor(public readonly reason: LocalProviderCapacityDeferralReason) {
@@ -20,14 +24,24 @@ export class LocalProviderCapacityDeferredError extends Error {
 
 /** Authoritative host-capacity policy shared by every local inference boundary. */
 export async function inspectLocalProviderCapacity(input: {
-  listActiveLeases?: ActiveLeaseReader;
+  listCapacityLeases?: LeaseReader;
 } = {}): Promise<LocalProviderCapacityStatus> {
-  const listActiveLeases = input.listActiveLeases
-    ?? (() => listActiveNonprodEnvironmentLeases({}));
+  const listCapacityLeases = input.listCapacityLeases
+    ?? (() => listCapacityReservingNonprodEnvironmentLeases({}));
   try {
-    const activeLeases = await listActiveLeases();
-    if (activeLeases.some((lease) => lease.environmentKey === "local-integration-ci")) {
+    const reservations = await listCapacityLeases();
+    if (reservations.some((lease) => (
+      lease.environmentKey === "local-integration-ci" && lease.status === "active"
+    ))) {
       return { available: false, reason: "local-ci-active-capacity-reservation" };
+    }
+    // A live queued claim is bounded by its heartbeat/expiry contract. Giving
+    // it precedence over *new* local inference reserves the next safe host
+    // window without killing provider work that was already in flight.
+    if (reservations.some((lease) => (
+      lease.environmentKey === "local-integration-ci" && lease.status === "queued"
+    ))) {
+      return { available: false, reason: "local-ci-queued-capacity-reservation" };
     }
     return { available: true, reason: null };
   } catch {
@@ -38,7 +52,7 @@ export async function inspectLocalProviderCapacity(input: {
 }
 
 export async function assertLocalProviderCapacityAvailable(input: {
-  listActiveLeases?: ActiveLeaseReader;
+  listCapacityLeases?: LeaseReader;
 } = {}): Promise<void> {
   const status = await inspectLocalProviderCapacity(input);
   if (!status.available) throw new LocalProviderCapacityDeferredError(status.reason);
@@ -47,7 +61,7 @@ export async function assertLocalProviderCapacityAvailable(input: {
 /** Completion-adapter boundary: remote providers remain independent of host leases. */
 export async function assertProviderDispatchCapacity(
   providerId: string,
-  input: { listActiveLeases?: ActiveLeaseReader } = {},
+  input: { listCapacityLeases?: LeaseReader } = {},
 ): Promise<void> {
   if (!isLocalProviderId(providerId)) return;
   await assertLocalProviderCapacityAvailable(input);

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -459,6 +459,23 @@ its separate quiescence fence. A release or expiry preserves the queue without
 blind promotion; the FIFO head is admitted only after its next poll supplies
 fresh safe host evidence.
 
+A live queued `local-integration-ci` claim also reserves the next safe host
+window against **new** local-provider dispatch. Active local inference is never
+terminated: it finishes normally, while completions, embeddings, semantic
+review, background triage, and future local routes receive the same typed
+queued-capacity deferral until the FIFO head can admit. The reservation is
+bounded by the queue claim's existing heartbeat and expiry, so an abandoned
+waiter cannot suppress local inference indefinitely. Cloud providers do not
+consume this host reservation.
+
+Every queued observation persists its queue position, wait age, resolved pool
+policy (including `rollbackReason` and effective slot capacity), and paired
+host-pressure sample in the candidate's SHA-bound gate state. Later recovery or
+terminal writes retain the latest admission record. Diagnose a timeout from
+that durable record; do not infer the refusal from process residency, cancel
+and recreate a healthy FIFO claim, or conflate Docker model residency and GPU
+VRAM with Windows physical-memory telemetry.
+
 Typecheck writes a separate `web-typecheck` receipt before `next typegen &&
 tsc --noEmit` starts, heartbeats the compiler descendant tree, memory, and a
 bounded output tail, and records real compiler exits separately from opaque

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -1112,6 +1112,12 @@ async function main() {
         leaseEvents,
         evidencePending: false,
         queueObserver: queueObserverState(),
+        admission: {
+          queuePosition: admission?.queuePosition ?? null,
+          waitAgeMs: admission?.waitAgeMs ?? null,
+          poolPolicy: claimResponse?.data?.poolPolicy ?? null,
+          hostPressure,
+        },
       });
       break;
     }
@@ -1136,6 +1142,12 @@ async function main() {
         leaseEvents,
         evidencePending: false,
         queueObserver: queueObserverState(),
+        admission: {
+          queuePosition: admission.queuePosition ?? null,
+          waitAgeMs: admission.waitAgeMs ?? null,
+          poolPolicy: claimResponse?.data?.poolPolicy ?? null,
+          hostPressure,
+        },
       });
       if (Date.now() >= deadline) {
         await releaseLeaseOnce();
@@ -1757,6 +1769,9 @@ function writeState(stateFile, {
   evidencePending = false,
   evidencePendingReason = "",
   quiescence = null,
+  recovery = null,
+  queueObserver = null,
+  admission = null,
 }) {
   writeLocalCiGateState(stateFile, {
     branch,
@@ -1771,6 +1786,9 @@ function writeState(stateFile, {
     evidencePending,
     evidencePendingReason,
     quiescence,
+    recovery,
+    queueObserver,
+    admission,
   });
 }
 

--- a/scripts/lib/local-ci-gate-state.mjs
+++ b/scripts/lib/local-ci-gate-state.mjs
@@ -49,7 +49,14 @@ export function writeLocalCiGateState(stateFile, {
   quiescence = null,
   recovery = null,
   queueObserver = null,
+  admission = null,
 }) {
+  const previous = readLocalCiGateState(stateFile);
+  const retainedAdmission = admission ?? (
+    previous?.branch === branch && previous?.sha === sha
+      ? previous.admission ?? null
+      : null
+  );
   mkdirSync(dirname(stateFile), { recursive: true });
   const payload = {
     branch,
@@ -68,6 +75,7 @@ export function writeLocalCiGateState(stateFile, {
   if (quiescence) payload.quiescence = quiescence;
   if (recovery) payload.recovery = recovery;
   if (queueObserver) payload.queueObserver = queueObserver;
+  if (retainedAdmission) payload.admission = retainedAdmission;
   writeGateStateAtomically(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
 }
 

--- a/scripts/lib/local-ci-gate-state.test.mjs
+++ b/scripts/lib/local-ci-gate-state.test.mjs
@@ -73,3 +73,43 @@ test("only matching queued/admitted/running gate states are recoverable", () => 
     { branch: "other", sha: base.sha },
   ), false);
 });
+
+test("queued admission diagnostics survive a later terminal state write", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-state-")), "gate.json");
+  const shared = {
+    branch: "fix/queued-intent-reservation",
+    sha: "e".repeat(40),
+    gatePassed: false,
+    leaseId: "NPEL-QUEUED",
+    evidenceId: "",
+    expiresAt: "2026-08-09T07:00:00.000Z",
+    resilience: null,
+    leaseEvents: [],
+  };
+  const admission = {
+    queuePosition: 1,
+    waitAgeMs: 7_200_000,
+    poolPolicy: {
+      hostSafeCapacity: 0,
+      effectiveCapacity: 0,
+      rollbackReason: "host-stage-headroom-insufficient",
+    },
+    hostPressure: {
+      observedAt: "2026-08-09T05:41:35.000Z",
+      availableMemoryBytes: 35_648_241_664,
+    },
+  };
+
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    status: "queued",
+    admission,
+  });
+  writeLocalCiGateState(stateFile, {
+    ...shared,
+    status: "failed",
+  });
+
+  const state = readLocalCiGateState(stateFile);
+  assert.deepEqual(state.admission, admission);
+});


### PR DESCRIPTION
## Summary

- reserve shared local-provider dispatch capacity while a live local-CI FIFO intent is queued, without interrupting provider work already in flight
- read active and queued lease state from one database snapshot so the dispatch decision cannot race between separate queries
- persist queue position, wait age, pool-policy refusal, and host-pressure evidence through terminal gate-state writes
- document the queued-intent reservation and diagnostic contract

## Verification

- fresh high-assurance semantic review: PASS, zero findings
- TDD regression for terminal admission telemetry: 3/3 passing after the initial red proof
- broader Node contract suite: 30 passed, 1 skipped; one separately reproduced pre-existing 120001 ms wall-clock TTL boundary assertion
- pregate guard-parity preflight: passed
- exact governed admission attempt: preflight passed and durable position/refusal telemetry was recorded before admission; no product stage ran because the shared admission path is the behavior under repair

## Evidence boundaries

- Docker model-list state, GPU VRAM/model residency, WSL/shared-memory accounting, process working set, and Windows free physical memory are separate observations
- no terminating actor or memory-placement mechanism is inferred by this change

Docs-Impact-Decision: updated
Seed-Fit-Decision: global-default
Local-CI-Override: install-bootstrap-recovery: queued-intent admission is the patient under repair
