### PR TITLE
fix(mcp): gate Tasks capability by protocol version

### DIFF
--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -543,10 +543,12 @@ describe("POST — initialize", () => {
     expect(body.result.protocolVersion).toBe("2024-11-05");
     expect(body.result.serverInfo.name).toBe("dpf-platform");
     expect(body.result.capabilities.tools).toBeDefined();
+    // Pre-Tasks fallback must NOT advertise tasks (breaks Grok Build 1.0.0 etc.).
+    expect(body.result.capabilities.tasks).toBeUndefined();
   });
 
   it("negotiates protocol version — echoes client version when supported", async () => {
-    for (const version of ["2024-11-05", "2025-03-26", "2025-11-25"]) {
+    for (const version of ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]) {
       const res = await POST(
         makeRequest({
           bearer: "dpfmcp_X",
@@ -558,6 +560,51 @@ describe("POST — initialize", () => {
     }
   });
 
+  it("omits capabilities.tasks on pre-Tasks protocol versions (client-compat)", async () => {
+    // Includes Grok Build 1.0.0's negotiated version (2025-06-18).
+    for (const version of ["2024-11-05", "2025-03-26", "2025-06-18"]) {
+      const res = await POST(
+        makeRequest({
+          bearer: "dpfmcp_X",
+          body: {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: { protocolVersion: version },
+          },
+        }),
+      );
+      const body = await res.json();
+      expect(body.result.protocolVersion).toBe(version);
+      expect(body.result.capabilities.tools).toEqual({ listChanged: true });
+      expect(body.result.capabilities.tasks).toBeUndefined();
+    }
+  });
+
+  it("accepts MCP-Protocol-Version: 2025-06-18 on post-initialize calls (Grok)", async () => {
+    resolveMock.mockResolvedValue({
+      tokenId: "tok_grok",
+      userId: "u1",
+      agentId: null,
+      scopes: ["backlog_read"],
+      capability: "read",
+    });
+    const req = new Request("https://localhost/api/mcp/v1", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer dpfmcp_X",
+        "User-Agent": "grok/1.0.0",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.result.tools)).toBe(true);
+  });
+
   it("negotiates protocol version — falls back when client version is unknown", async () => {
     const res = await POST(
       makeRequest({
@@ -567,6 +614,8 @@ describe("POST — initialize", () => {
     );
     const body = await res.json();
     expect(body.result.protocolVersion).toBe("2024-11-05");
+    // Fallback is pre-Tasks — do not advertise tasks on the safe floor.
+    expect(body.result.capabilities.tasks).toBeUndefined();
   });
 });
 

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -35,6 +35,7 @@ import {
 } from "@/lib/mcp/tool-tier";
 import { getLoadedToolNames, loadToolsForSession } from "@/lib/mcp/tool-session-store";
 import {
+  shouldAdvertiseTasksCapability,
   tasksLifecycleEnabled,
   handleTasksGet,
   handleTasksResult,
@@ -57,9 +58,18 @@ type ResolvedAuth = ResolvedMcpToken & {
   source: "pat" | "session-jwt";
 };
 
-// Versions we can speak, newest first. We echo back the highest version the
-// client supports so older clients (e.g. Claude Code pre-2025-11-25) connect.
-const SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-03-26", "2024-11-05"] as const;
+// Versions we can speak, newest first. We echo back the version the client
+// requested when it is in this list so older clients connect. Include every
+// wire revision clients actually send — Grok Build 1.0.0 negotiates
+// `2025-06-18` and re-sends it as `MCP-Protocol-Version` on tools/list; omitting
+// it made initialize fall back but then 400'd subsequent calls.
+// Tasks capability is ONLY advertised on 2025-11-25 (see shouldAdvertiseTasksCapability).
+const SUPPORTED_PROTOCOL_VERSIONS = [
+  "2025-11-25",
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+] as const;
 const FALLBACK_PROTOCOL_VERSION = "2024-11-05";
 const SERVER_NAME = "dpf-platform";
 const SERVER_VERSION = "1.0.0";
@@ -505,8 +515,14 @@ async function handleInitialize(id: JsonRpcId, params?: Record<string, unknown>)
       // that ignore it still work — the lean core tier is always the floor.
       tools: { listChanged: true },
       // Standard MCP Tasks (Phase 0, read-only): tasks/get|result|list|cancel
-      // over the durable TaskRun substrate. Advertised only while enabled.
-      ...(tasksLifecycleEnabled() ? { tasks: { list: true, cancel: true } } : {}),
+      // over the durable TaskRun substrate. Advertise ONLY when the negotiated
+      // protocol is Tasks-aware (2025-11-25+) AND the feature flag is on.
+      // Advertising on 2024-11-05 / 2025-03-26 breaks clients that reject
+      // unknown capability keys at initialize (Grok Build 1.0.0 → CustomResult
+      // handshake failure). Methods remain routable; discovery is gated.
+      ...(shouldAdvertiseTasksCapability(negotiated)
+        ? { tasks: { list: true, cancel: true } }
+        : {}),
     },
     serverInfo: {
       name: SERVER_NAME,

--- a/apps/web/lib/mcp/tasks-lifecycle.test.ts
+++ b/apps/web/lib/mcp/tasks-lifecycle.test.ts
@@ -1,6 +1,11 @@
 // apps/web/lib/mcp/tasks-lifecycle.test.ts
 import { describe, it, expect } from "vitest";
-import { mcpTaskStateForWire, isTerminalTaskStatus, tasksLifecycleEnabled } from "./tasks-lifecycle";
+import {
+  mcpTaskStateForWire,
+  isTerminalTaskStatus,
+  shouldAdvertiseTasksCapability,
+  tasksLifecycleEnabled,
+} from "./tasks-lifecycle";
 
 describe("tasks-lifecycle state adapter (Slice 4 Phase 0)", () => {
   it("maps DPF/A2A statuses to MCP-spec wire states", () => {
@@ -34,6 +39,21 @@ describe("tasks-lifecycle state adapter (Slice 4 Phase 0)", () => {
     expect(tasksLifecycleEnabled()).toBe(true);
     process.env.MCP_TASKS_LIFECYCLE = "off";
     expect(tasksLifecycleEnabled()).toBe(false);
+    if (prev === undefined) delete process.env.MCP_TASKS_LIFECYCLE;
+    else process.env.MCP_TASKS_LIFECYCLE = prev;
+  });
+
+  it("advertises tasks only on Tasks-aware protocol versions when the flag is on", () => {
+    const prev = process.env.MCP_TASKS_LIFECYCLE;
+    delete process.env.MCP_TASKS_LIFECYCLE;
+    // Pre-Tasks clients (Grok Build 1.0.0 → 2025-06-18, older SDKs) — never advertise.
+    expect(shouldAdvertiseTasksCapability("2024-11-05")).toBe(false);
+    expect(shouldAdvertiseTasksCapability("2025-03-26")).toBe(false);
+    expect(shouldAdvertiseTasksCapability("2025-06-18")).toBe(false);
+    // Tasks-aware negotiation may advertise.
+    expect(shouldAdvertiseTasksCapability("2025-11-25")).toBe(true);
+    process.env.MCP_TASKS_LIFECYCLE = "off";
+    expect(shouldAdvertiseTasksCapability("2025-11-25")).toBe(false);
     if (prev === undefined) delete process.env.MCP_TASKS_LIFECYCLE;
     else process.env.MCP_TASKS_LIFECYCLE = prev;
   });

--- a/apps/web/lib/mcp/tasks-lifecycle.ts
+++ b/apps/web/lib/mcp/tasks-lifecycle.ts
@@ -23,6 +23,30 @@ export function tasksLifecycleEnabled(): boolean {
   return process.env.MCP_TASKS_LIFECYCLE !== "off";
 }
 
+/**
+ * Protocol revisions that define the standard Tasks capability
+ * (`capabilities.tasks` + tasks/get|result|list|cancel).
+ *
+ * Tasks arrived with MCP 2025-11-25. Advertising them on older negotiated
+ * versions (2024-11-05 / 2025-03-26 / 2025-06-18) breaks clients whose
+ * InitializeResult deserializers reject unknown capability keys — observed on
+ * Grok Build 1.0.0 as
+ * `expect initialized result, but received: Some(CustomResult(...))`.
+ * Advertise only when the negotiated version is Tasks-aware so pre-Tasks
+ * clients (Grok, older Claude/Codex SDKs, etc.) can still complete handshake.
+ */
+export const MCP_TASKS_PROTOCOL_VERSIONS = Object.freeze(["2025-11-25"] as const);
+
+/**
+ * Whether initialize may include `capabilities.tasks` for this negotiated
+ * protocol version. Feature-flag off OR a pre-Tasks protocol → false.
+ * Pure (aside from the env flag) so route tests and client-compat suites share it.
+ */
+export function shouldAdvertiseTasksCapability(negotiatedProtocolVersion: string): boolean {
+  if (!tasksLifecycleEnabled()) return false;
+  return (MCP_TASKS_PROTOCOL_VERSIONS as readonly string[]).includes(negotiatedProtocolVersion);
+}
+
 // A2A/DPF ↔ MCP-spec state spelling. Internal enum (ops-map, watchdog) is
 // untouched; we only adapt at the wire boundary (design §3).
 const DPF_TO_MCP_STATE: Record<string, string> = {

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -1,12 +1,12 @@
-apps/web/app/api/mcp/v1/route.test.ts	1376
-apps/web/app/api/mcp/v1/route.ts	862
+apps/web/app/api/mcp/v1/route.test.ts	1425
+apps/web/app/api/mcp/v1/route.ts	872
 apps/web/app/api/v1/edge/discovery-runs/route.test.ts	982
 apps/web/components/admin/BusinessModelBuilder.tsx	821
 apps/web/components/admin/McpTokenManager.tsx	1326
 apps/web/components/agent/AgentCoworkerPanel.tsx	1297
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
-apps/web/components/inventory/TopologyGraph.tsx	1031
+apps/web/components/inventory/TopologyGraph.tsx	1030
 apps/web/components/ops/SelfUpgradeClient.test.tsx	1118
 apps/web/components/ops/SelfUpgradeClient.tsx	1124
 apps/web/components/platform/EffectivePermissionsPanel.tsx	844
@@ -53,7 +53,7 @@ apps/web/lib/routing/fallback.test.ts	1140
 apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
-apps/web/lib/tak/agent-grants.test.ts	915
+apps/web/lib/tak/agent-grants.test.ts	914
 apps/web/lib/tak/agent-grants.ts	921
 apps/web/lib/tak/agent-routing.ts	1027
 apps/web/lib/tak/agentic-loop.test.ts	2387
@@ -61,7 +61,7 @@ apps/web/lib/tak/agentic-loop.ts	2737
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	869
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1103
-apps/web/lib/work-capsules/work-capsule-store.ts	1056
+apps/web/lib/work-capsules/work-capsule-store.ts	1052
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118


### PR DESCRIPTION
## Summary

Restore MCP handshake compatibility for clients that do not understand the MCP Tasks capability (notably **Grok Build 1.0.0**, and any other pre–2025-11-25 InitializeResult deserializer).

### Root cause
After the MCP 2025-11-25 / Tasks upgrade, `/api/mcp/v1` advertised `capabilities.tasks` on **every** negotiated protocol version. Clients whose initialize parser rejects unknown capability keys fail with:

`expect initialized result, but received: Some(CustomResult(...))`

Grok additionally negotiates wire protocol **`2025-06-18`**, which DPF did not list, so initialize fell back to `2024-11-05` while still advertising Tasks; post-handshake `tools/list` then 400'd on an unsupported `MCP-Protocol-Version` header.

### Fix
1. Advertise `capabilities.tasks` **only** when the negotiated protocol is `2025-11-25` (and `MCP_TASKS_LIFECYCLE` is on).
2. Accept and echo **`2025-06-18`** as a supported pre-Tasks protocol revision.
3. Unit coverage for pre-Tasks omit, Tasks advertise, and Grok's post-initialize header.

`tasks/*` methods remain feature-flag gated; only discovery/advertise is protocol-gated.

## Test plan
- [x] Unit tests for tasks-lifecycle + mcp route (63 passed)
- [x] Local-CI pregate PASS for `2057a7df254e` (evidence `cmsmi5cd90ynh01n0ruomkjym`)
- [ ] After portal self-upgrade: `grok mcp doctor dpf` handshake OK

## Trailers

Local-CI-Evidence: cmsmi5cd90ynh01n0ruomkjym (fix/mcp-tasks-capability-compat@2057a7df254e)
Docs-Impact-Decision: protocol-version negotiation and capability advertise only — no user-facing MCP tool names, routes, or operator docs change; architecture runbooks remain accurate without edits