### PR TITLE
fix: BI drain — five small reliability fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,21 @@ jobs:
           fetch-depth: 0
       - name: Decide whether heavy CI is needed
         id: decide
+        # BI-9E5E6063: prefer a live merge-base over a potentially stale
+        # pull_request.base.sha so evidence planning does not mis-scope the PR.
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          EVENT_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
           PLAN_PATH="$RUNNER_TEMP/ci-evidence-plan.json"
+          git fetch --quiet origin main 2>/dev/null || true
+          FRESH_BASE="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+          BASE_SHA="${FRESH_BASE:-${EVENT_BASE:-origin/main}}"
+          if [ -n "${EVENT_BASE:-}" ] && [ -n "${FRESH_BASE:-}" ] && [ "$EVENT_BASE" != "$FRESH_BASE" ]; then
+            echo "::notice::event base ($EVENT_BASE) disagrees with merge-base ($FRESH_BASE) — using the fresh one. See BI-9E5E6063."
+          fi
           git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
           node scripts/ci-evidence-plan.mjs \
             --event "$EVENT_NAME" \

--- a/.github/workflows/self-upgrade-acceptance.yml
+++ b/.github/workflows/self-upgrade-acceptance.yml
@@ -22,10 +22,19 @@ jobs:
         with:
           fetch-depth: 0
       - id: paths
+        # BI-9E5E6063: github.event.pull_request.base.sha can go stale against a
+        # fast-moving main and does not self-refresh. Recompute merge-base when
+        # full history is available (fetch-depth:0 above).
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_BASE: ${{ github.event.pull_request.base.sha }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --quiet origin main
+            FRESH_BASE="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+            BASE_SHA="${FRESH_BASE:-$EVENT_BASE}"
+            if [ -n "$EVENT_BASE" ] && [ -n "$FRESH_BASE" ] && [ "$EVENT_BASE" != "$FRESH_BASE" ]; then
+              echo "::notice::github.event.pull_request.base.sha ($EVENT_BASE) disagrees with merge-base ($FRESH_BASE) — using the fresh one. See BI-9E5E6063."
+            fi
             paths=$(git diff --name-only "$BASE_SHA" "$GITHUB_SHA")
             node scripts/self-upgrade-sensitive-paths.mjs $paths >> "$GITHUB_OUTPUT"
           else
@@ -70,14 +79,27 @@ jobs:
             | tee "$DPF_N1_EVIDENCE/signed-promotion-rollback.tap"
       - name: Resolve N-1 baseline
         id: baseline
+        # BI-9E5E6063: prefer a live merge-base over a potentially stale
+        # pull_request.base.sha event field.
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -n "$PR_NUMBER" ] && [ -n "$PR_BASE_SHA" ]; then
+          if [ -n "$PR_NUMBER" ]; then
+            git fetch --quiet origin main
+            FRESH_BASE="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+            BASE_SHA="${FRESH_BASE:-$PR_BASE_SHA}"
+            if [ -z "$BASE_SHA" ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              printf '%s\n' '{"result":"skipped","reason":"no-resolvable-base-sha"}' > "$DPF_N1_EVIDENCE/n-minus-one-evidence.json"
+              exit 0
+            fi
+            if [ -n "$PR_BASE_SHA" ] && [ -n "$FRESH_BASE" ] && [ "$PR_BASE_SHA" != "$FRESH_BASE" ]; then
+              echo "::notice::PR base.sha ($PR_BASE_SHA) disagrees with merge-base ($FRESH_BASE) — using the fresh one. See BI-9E5E6063."
+            fi
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "base_sha=$PR_BASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           latest="$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&sort=updated&direction=desc&per_page=1" --jq '.[0] | [.number, .base.sha] | @tsv')"

--- a/apps/web/lib/mcp/packs/public-web-design-pack.ts
+++ b/apps/web/lib/mcp/packs/public-web-design-pack.ts
@@ -92,11 +92,24 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "evaluate_page",
-    description: "Evaluate a live page for UX and accessibility issues using AI-powered browser automation (browser-use). Navigates to the page, analyzes layout, interactions, and accessibility, and returns structured findings. Works on production pages (default) or sandbox pages (if URL provided).",
+    description:
+      "Evaluate a live page for UX and accessibility issues using AI-powered browser automation (browser-use). " +
+      "Navigates to the page, analyzes layout, interactions, and accessibility, and returns structured findings. " +
+      "Requires the browser-use sidecar (BROWSER_USE_URL, default http://browser-use:8500/mcp) and a reachable target URL. " +
+      "If success=false with DEGRADED / NOT-RUN / connection error: do NOT retry the same call — check sidecar health " +
+      "(GET /health/capability), confirm the URL is reachable from the browser-use container (not host-only localhost), " +
+      "and fall back to code-only review (read the route component + theme tokens) instead of looping. " +
+      "Works on production pages (default) or sandbox pages when an absolute URL is provided.",
     inputSchema: {
       type: "object",
       properties: {
-        url: { type: "string", description: "URL to evaluate. Defaults to the current route if not specified." },
+        url: {
+          type: "string",
+          description:
+            "Absolute URL to evaluate (e.g. http://portal:3000/workspace or https://…/route). " +
+            "Defaults to the current route only when routeContext is set; bare paths without a host fail. " +
+            "Inside Docker, use the service hostname — not Windows/macOS localhost.",
+        },
       },
     },
     requiredCapability: null,
@@ -344,30 +357,64 @@ async function evaluatePageHandler(
 ): Promise<ToolResult> {
   const url = typeof params["url"] === "string" ? params["url"] : null;
   const targetUrl = url || (context?.routeContext ? `http://localhost:3000${context.routeContext}` : null);
-  if (!targetUrl) return { success: false, error: "No URL to evaluate.", message: "Provide a URL or navigate to a page first." };
+  if (!targetUrl) {
+    return {
+      success: false,
+      error: "missing_url",
+      // BI-MCP-EFF-71D7229F: fail with a non-retryable contract message so agents
+      // do not loop the same call (97% historical failure was blind retry).
+      message:
+        "evaluate_page needs an absolute URL (or a portal routeContext). " +
+        "Do not retry without a URL. Fall back to reading the route source for a code-only UX review.",
+    };
+  }
 
   try {
     const BROWSER_USE_URL = process.env.BROWSER_USE_URL || "http://browser-use:8500/mcp";
 
     // Use browser-use to evaluate the page with AI-powered analysis
-    const extractRes = await fetch(BROWSER_USE_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: {
-          name: "browse_open",
-          arguments: { url: targetUrl },
-        },
-      }),
-      signal: AbortSignal.timeout(60000),
-    });
+    let extractRes: Response;
+    try {
+      extractRes = await fetch(BROWSER_USE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "browse_open",
+            arguments: { url: targetUrl },
+          },
+        }),
+        signal: AbortSignal.timeout(60000),
+      });
+    } catch (connectError) {
+      const reason = connectError instanceof Error ? connectError.message : String(connectError);
+      return {
+        success: false,
+        error: "browser_use_unavailable",
+        message:
+          `evaluate_page could not reach browser-use at ${BROWSER_USE_URL}: ${reason}. ` +
+          "Do NOT retry the same call — the sidecar is down or unreachable from this runtime. " +
+          "Check BROWSER_USE_URL and GET /health/capability; fall back to code-only review.",
+        data: { url: targetUrl, browserUseUrl: BROWSER_USE_URL, retryable: false },
+      };
+    }
     const openResult = await extractRes.json();
     const openContent = JSON.parse(openResult?.result?.content?.[0]?.text ?? "{}");
     const sessionId = openContent.session_id;
-    if (!sessionId) throw new Error("Failed to open browser session");
+    if (!sessionId) {
+      return {
+        success: false,
+        error: "browser_session_open_failed",
+        message:
+          "evaluate_page could not open a browser session (no session_id). " +
+          "Do NOT retry blindly — verify browser-use health and that the target URL is reachable from the sidecar network. " +
+          "Fall back to code-only review.",
+        data: { url: targetUrl, retryable: false, openResult },
+      };
+    }
 
     // BI-1BAA177C: a degraded/errored navigation means nothing after this
     // point is evidence — report NOT-RUN instead of success-shaped emptiness.
@@ -376,8 +423,10 @@ async function evaluatePageHandler(
       return {
         success: false,
         error: `Page evaluation DEGRADED — did not run: ${reason}`,
-        message: `Page evaluation did not run: ${reason}. This is a NOT-RUN (browser-use could not drive its browser), not a clean page. Check GET /health/capability on the sidecar.`,
-        data: { url: targetUrl, degraded: true, reason },
+        message:
+          `Page evaluation did not run: ${reason}. This is a NOT-RUN (browser-use could not drive its browser), not a clean page. ` +
+          "Do NOT retry the same args. Check GET /health/capability on the sidecar and use a container-reachable URL.",
+        data: { url: targetUrl, degraded: true, reason, retryable: false },
       };
     }
 

--- a/apps/web/lib/mcp/packs/public-web-design-pack.ts
+++ b/apps/web/lib/mcp/packs/public-web-design-pack.ts
@@ -390,7 +390,7 @@ async function evaluatePageHandler(
         signal: AbortSignal.timeout(60000),
       });
     } catch (connectError) {
-      const reason = connectError instanceof Error ? connectError.message : String(connectError);
+      const reason = getErrorMessage(connectError);
       return {
         success: false,
         error: "browser_use_unavailable",

--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -563,6 +563,7 @@ describe("work capsule store", () => {
       db.workCapsule.findFirst.mockResolvedValueOnce({
         id: "row-1",
         capsuleId: "WC-EXISTING",
+        status: "ready",
         backlogItemId: null,
         epicId: null,
         executorRef: null,
@@ -596,11 +597,12 @@ describe("work capsule store", () => {
       }));
     });
 
-    it("does not late-bind (or write) when the existing capsule already has a backlogItemId", async () => {
+    it("does not late-bind (or write) when the existing capsule already has the same backlogItemId", async () => {
       db.workCapsule.findFirst.mockResolvedValueOnce({
         id: "row-1",
         capsuleId: "WC-EXISTING",
-        backlogItemId: "BI-ALREADY",
+        status: "working",
+        backlogItemId: "BI-7D20BFDF",
         epicId: null,
         executorRef: null,
       });
@@ -618,9 +620,81 @@ describe("work capsule store", () => {
         actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
       });
 
-      expect(result.backlogItemId).toBe("BI-ALREADY");
+      expect(result.capsuleId).toBe("WC-EXISTING");
+      expect(result.backlogItemId).toBe("BI-7D20BFDF");
       expect(db.workCapsule.update).not.toHaveBeenCalled();
       expect(db.workCapsule.create).not.toHaveBeenCalled();
+    });
+
+    // BI-95E37EA1 — abandoned main capsule must not be returned as a successful bind.
+    it("creates a fresh capsule when the only (repo, branch) hit is abandoned for another BI", async () => {
+      // findFirst with status notIn terminal returns null (abandoned filtered out).
+      db.workCapsule.findFirst.mockResolvedValueOnce(null);
+      db.workCapsule.create.mockResolvedValueOnce({
+        id: "row-new",
+        capsuleId: "WC-FRESH01",
+        status: "ready",
+        backlogItemId: "BI-NEWITEM",
+        headBranch: "main",
+        worktreePath: "D:/DPF",
+        executorRef: "session-new",
+      });
+
+      const result = await adoptWorktreeCapsule({
+        db: capsuleDb(),
+        input: {
+          title: "Work on BI-NEWITEM",
+          objective: "Claim-at-start binding for BI-NEWITEM",
+          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+          headBranch: "main",
+          worktreePath: "D:/DPF",
+          backlogItemId: "BI-NEWITEM",
+          executorRef: "session-new",
+          executorKind: "codex-desktop",
+        },
+        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+      });
+
+      expect(result.capsuleId).toBe("WC-FRESH01");
+      expect(result.backlogItemId).toBe("BI-NEWITEM");
+      expect(db.workCapsule.create).toHaveBeenCalledTimes(1);
+      expect(db.workCapsule.update).not.toHaveBeenCalled();
+    });
+
+    it("creates a fresh capsule when a live capsule on the branch is bound to a different BI", async () => {
+      db.workCapsule.findFirst.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-OTHERBI",
+        status: "working",
+        backlogItemId: "BI-OTHER",
+        executorRef: "session-other",
+        epicId: null,
+      });
+      db.workCapsule.create.mockResolvedValueOnce({
+        id: "row-new",
+        capsuleId: "WC-MINE001",
+        status: "ready",
+        backlogItemId: "BI-MINE",
+        executorRef: "session-mine",
+      });
+
+      const result = await adoptWorktreeCapsule({
+        db: capsuleDb(),
+        input: {
+          title: "Mine",
+          objective: "Different BI on same branch.",
+          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+          headBranch: "main",
+          worktreePath: "D:/DPF",
+          backlogItemId: "BI-MINE",
+          executorRef: "session-mine",
+        },
+        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+      });
+
+      expect(result.capsuleId).toBe("WC-MINE001");
+      expect(db.workCapsule.create).toHaveBeenCalledTimes(1);
+      expect(db.workCapsule.update).not.toHaveBeenCalled();
     });
   });
 
@@ -777,10 +851,11 @@ describe("work capsule store", () => {
         claimedByAgentId: "agent-1",
         claimedAt: new Date(),
       });
-      // adopt reuse: existing capsule already bound to this BI.
+      // adopt reuse: existing capsule already bound to this BI + session.
       db.workCapsule.findFirst.mockResolvedValueOnce({
         id: "row-1",
         capsuleId: "WC-CLAIM01",
+        status: "working",
         backlogItemId: "BI-7D20BFDF",
         epicId: null,
         executorRef: "session-A",
@@ -820,7 +895,13 @@ describe("work capsule store", () => {
     }
 
     it("rejects an edit claim that overlaps another active capsule's edit claim", async () => {
-      db.workCapsule.findUnique.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-MINE001", scopeClaims: [] });
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-MINE001",
+        status: "working",
+        archivedAt: null,
+        scopeClaims: [],
+      });
       db.workCapsule.findMany.mockResolvedValueOnce([otherCapsule({})]);
 
       await expect(
@@ -833,6 +914,27 @@ describe("work capsule store", () => {
       ).rejects.toBeInstanceOf(ScopeOverlapError);
 
       // The conflicting write must never reach the DB.
+      expect(db.workCapsule.update).not.toHaveBeenCalled();
+    });
+
+    it("refuses scope claims on an abandoned capsule (BI-95E37EA1)", async () => {
+      db.workCapsule.findUnique.mockResolvedValueOnce({
+        id: "row-stale",
+        capsuleId: "WC-DEAC865E",
+        status: "abandoned",
+        archivedAt: null,
+        scopeClaims: [],
+      });
+
+      await expect(
+        claimWorkCapsuleScope({
+          db: capsuleDb(),
+          capsuleId: "WC-DEAC865E",
+          claims: [{ kind: "path", value: "apps/web/lib/foo.ts", intent: "read" }],
+          actor,
+        }),
+      ).rejects.toThrow(/abandoned and cannot accept scope claims/i);
+
       expect(db.workCapsule.update).not.toHaveBeenCalled();
     });
 

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -219,6 +219,44 @@ export async function createWorkCapsule(args: {
   }
 }
 
+// Statuses that end a capsule's reuse eligibility for (repo, branch) adoption.
+// BI-95E37EA1: an abandoned/complete/archived capsule must NOT be returned as a
+// successful bind for a new BI/session — that poisoned claim-at-start with a
+// false-success pointing at stale ownership.
+const TERMINAL_CAPSULE_STATUSES: WorkCapsuleStatus[] = ["complete", "abandoned", "archived"];
+
+function isTerminalCapsuleStatus(status: unknown): boolean {
+  return typeof status === "string" && (TERMINAL_CAPSULE_STATUSES as string[]).includes(status);
+}
+
+/**
+ * Whether an existing live capsule on (repo, branch) is compatible with a new
+ * adopt/claim request. Same BI + same executor session is idempotent reuse;
+ * unbound (null BI) is late-bind eligible; a different BI or session requires a
+ * fresh capsule so history on the prior capsule stays intact.
+ */
+function isReusableLiveCapsule(
+  existing: {
+    status?: string | null;
+    backlogItemId?: string | null;
+    executorRef?: string | null;
+  },
+  input: { backlogItemId?: string | null; executorRef?: string | null },
+): boolean {
+  if (isTerminalCapsuleStatus(existing.status)) return false;
+  const existingBi = existing.backlogItemId ?? null;
+  const incomingBi = input.backlogItemId ?? null;
+  // Unbound capsule can be late-bound to any BI.
+  if (existingBi == null) return true;
+  // Bound to a different BI → never silently re-home.
+  if (incomingBi != null && existingBi !== incomingBi) return false;
+  // Same BI: reuse when session matches or either side has no session stamp yet.
+  const existingSession = existing.executorRef ?? null;
+  const incomingSession = input.executorRef ?? null;
+  if (existingSession == null || incomingSession == null) return true;
+  return existingSession === incomingSession;
+}
+
 export async function adoptWorktreeCapsule(args: {
   db: CapsuleDb;
   input: CapsuleAdoptionInput;
@@ -229,14 +267,18 @@ export async function adoptWorktreeCapsule(args: {
   }
   const scope = normalizeWorkCapsuleScopeInput(args.input.scope);
 
+  // Prefer a non-terminal capsule on this branch. Terminal capsules keep their
+  // audit trail; a new adopt creates a new WC rather than rewriting them.
   const existing = await args.db.workCapsule.findFirst({
     where: {
       repositoryFullName: args.input.repositoryFullName,
       headBranch: args.input.headBranch,
       archivedAt: null,
+      status: { notIn: TERMINAL_CAPSULE_STATUSES },
     },
+    orderBy: { updatedAt: "desc" },
   });
-  if (existing) {
+  if (existing && isReusableLiveCapsule(existing, args.input)) {
     // Late-bind (BI-7D20BFDF): a branch adopted before its BacklogItem was known
     // has a null backlogItemId. When a claim now supplies one, bind the existing
     // capsule instead of leaving the work orphaned — this is what lets a worktree
@@ -250,6 +292,9 @@ export async function adoptWorktreeCapsule(args: {
             ...(args.input.epicId && existing.epicId == null ? { epicId: args.input.epicId } : {}),
             ...(args.input.executorRef && existing.executorRef == null
               ? { executorRef: args.input.executorRef }
+              : {}),
+            ...(args.input.worktreePath && existing.worktreePath !== args.input.worktreePath
+              ? { worktreePath: args.input.worktreePath }
               : {}),
           },
         });
@@ -266,6 +311,8 @@ export async function adoptWorktreeCapsule(args: {
     }
     return existing;
   }
+  // existing is null, terminal-only on this branch, or live-but-incompatible
+  // (different BI/session) — fall through to create a fresh capsule.
 
   const now = new Date();
   try {
@@ -320,9 +367,11 @@ export async function adoptWorktreeCapsule(args: {
           repositoryFullName: args.input.repositoryFullName,
           headBranch: args.input.headBranch,
           archivedAt: null,
+          status: { notIn: TERMINAL_CAPSULE_STATUSES },
         },
+        orderBy: { updatedAt: "desc" },
       });
-      if (winner) return winner;
+      if (winner && isReusableLiveCapsule(winner, args.input)) return winner;
     }
     throw error;
   }
@@ -788,10 +837,6 @@ export class ScopeOverlapError extends Error {
   }
 }
 
-// A capsule in one of these statuses no longer holds its scope — its claims are
-// inert and never conflict with a fresh claim.
-const TERMINAL_CAPSULE_STATUSES: WorkCapsuleStatus[] = ["complete", "abandoned", "archived"];
-
 // `edit` is an exclusive intent: two `edit` claims on the same scope conflict, as
 // does an `edit` against a `read`. Two `read` claims coexist (non-exclusive).
 function intentsConflict(a: ScopeClaim["intent"], b: ScopeClaim["intent"]): boolean {
@@ -895,6 +940,16 @@ export async function claimWorkCapsuleScope(args: {
     where: { capsuleId: args.capsuleId },
   });
   if (!capsule) throw new Error(`Work Capsule ${args.capsuleId} not found`);
+
+  // BI-95E37EA1: never append scope claims to a terminal or foreign capsule.
+  // The abandoned-main false-success path used to land claims on an unrelated
+  // WC; refuse here so even a stale capsuleId cannot pollute its audit trail.
+  if (isTerminalCapsuleStatus(capsule.status) || capsule.archivedAt != null) {
+    throw new Error(
+      `Work Capsule ${args.capsuleId} is ${capsule.status ?? "terminal"} and cannot accept scope claims. ` +
+        "Claim a live capsule (or re-run claim_backlog_item_for_work to mint a fresh one).",
+    );
+  }
 
   // Capsule-first enforcement: refuse to claim scope already held by another
   // active capsule unless the caller explicitly forces it. This is the lock that

--- a/apps/web/scripts/ux-route-sweep.test.ts
+++ b/apps/web/scripts/ux-route-sweep.test.ts
@@ -5,6 +5,7 @@ import {
   DOM_SETTLE_EXPRESSION,
   captureAccessibilityStructure,
   executionOutcome,
+  findDroppedBaselineRoutes,
   uxSweepAxeOptions,
   waitForRouteDomToSettle,
   withIsolatedSweepPage,
@@ -25,6 +26,43 @@ describe("axe result collection", () => {
       },
       resultTypes: ["violations"],
     });
+  });
+});
+
+describe("findDroppedBaselineRoutes (BI-EE6E0CFC)", () => {
+  it("names committed routes absent from a freeze so refresh cannot silently shrink", () => {
+    const committed = {
+      bootstrapped: true,
+      generator: "test",
+      routes: {
+        "/workspace": {} as never,
+        "/ops/self-upgrade": {} as never,
+        "/admin/scheduled-jobs": {} as never,
+        "/platform": {} as never,
+      },
+    };
+    const frozen = {
+      bootstrapped: true,
+      generator: "test",
+      routes: {
+        "/platform": {} as never,
+      },
+    };
+    expect(findDroppedBaselineRoutes(committed, frozen)).toEqual([
+      "/admin/scheduled-jobs",
+      "/ops/self-upgrade",
+      "/workspace",
+    ]);
+  });
+
+  it("returns empty when freeze covers every committed route", () => {
+    const routes = { "/a": {} as never, "/b": {} as never };
+    expect(
+      findDroppedBaselineRoutes(
+        { bootstrapped: true, generator: "test", routes },
+        { bootstrapped: true, generator: "test", routes: { ...routes, "/c": {} as never } },
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -470,6 +470,22 @@ function loadBaseline(path: string): BaselineFile {
   return JSON.parse(readFileSync(path, "utf8")) as BaselineFile;
 }
 
+/**
+ * BI-EE6E0CFC — routes present in the committed baseline but missing from a
+ * freshly frozen measurement. A non-empty result means the refresh would
+ * silently delete ratchets and must be refused.
+ */
+export function findDroppedBaselineRoutes(
+  committed: BaselineFile | null | undefined,
+  frozen: BaselineFile,
+): string[] {
+  if (!committed?.routes) return [];
+  const frozenRoutes = new Set(Object.keys(frozen.routes ?? {}));
+  return Object.keys(committed.routes)
+    .filter((routePath) => !frozenRoutes.has(routePath))
+    .sort();
+}
+
 function routeArtifactSlug(routePath: string): string {
   return (
     routePath
@@ -633,9 +649,31 @@ async function main(): Promise<void> {
   }
 
   if (updateBaseline) {
+    // BI-EE6E0CFC: never emit a baseline that silently drops routes the
+    // committed file already watches. A refresh that shrinks coverage is not
+    // publishable — the documented "commit the artifact" path would delete
+    // ratchets for routes the sweep failed to measure (timeout, error, auth).
+    const baselinePath = join(ROOT, BASELINE_REL);
+    const frozen = freezeBaseline(measurements, GENERATOR);
+    if (existsSync(baselinePath)) {
+      const committed = loadBaseline(baselinePath);
+      const dropped = findDroppedBaselineRoutes(committed, frozen);
+      if (dropped.length > 0) {
+        console.error(
+          `[ux-sweep] REFUSE TO SHRINK BASELINE — ${dropped.length} committed route(s) missing from this measurement run (BI-EE6E0CFC).`,
+        );
+        for (const routePath of dropped) {
+          console.error(`  - ${routePath}`);
+        }
+        console.error(
+          "Either fix the sweep so these routes measure, declare a sweepExclusionReason in the route-shell registry, or splice only the deliberately re-frozen route(s) rather than replacing the whole file.",
+        );
+        process.exit(1);
+      }
+    }
     writeFileSync(
-      join(ROOT, BASELINE_REL),
-      `${JSON.stringify(freezeBaseline(measurements, GENERATOR), null, 2)}\n`,
+      baselinePath,
+      `${JSON.stringify(frozen, null, 2)}\n`,
       "utf8",
     );
     console.error(`[ux-sweep] froze ${measurements.length} routes into ${BASELINE_REL}`);

--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -653,10 +653,17 @@ async function main(): Promise<void> {
     // committed file already watches. A refresh that shrinks coverage is not
     // publishable — the documented "commit the artifact" path would delete
     // ratchets for routes the sweep failed to measure (timeout, error, auth).
+    // Read once (no existsSync→write TOCTOU; CodeQL js/file-system-race).
     const baselinePath = join(ROOT, BASELINE_REL);
     const frozen = freezeBaseline(measurements, GENERATOR);
-    if (existsSync(baselinePath)) {
-      const committed = loadBaseline(baselinePath);
+    let committed: BaselineFile | null = null;
+    try {
+      committed = JSON.parse(readFileSync(baselinePath, "utf8")) as BaselineFile;
+    } catch (err) {
+      const code = err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : "";
+      if (code !== "ENOENT") throw err;
+    }
+    if (committed) {
       const dropped = findDroppedBaselineRoutes(committed, frozen);
       if (dropped.length > 0) {
         console.error(

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -34,9 +34,11 @@ import {
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 // Line-oriented `<path>\t<loc>` baseline, merged with git's built-in
 // `merge=union` driver (.gitattributes) so concurrent PRs that each re-baseline
-// never conflict (BI-3B0AD9CF). A union merge can leave duplicate paths; the
-// check fails closed on those duplicates (BI-EEB04701) so contributors re-run
-// `--update` rather than living with an ambiguous threshold.
+// never conflict (BI-3B0AD9CF). A union merge can leave duplicate paths;
+// parseBaseline keeps the SMALLER LOC (never loosens a size ceiling) and
+// check mode continues; --update rewrites a clean one-line-per-path file
+// (BI-24115B65). Hard-refusing duplicates defeated the union driver: green
+// merge, then red guard on every rebase.
 const BASELINE_PATH = join(REPO_ROOT, "scripts", "module-size-baseline.txt");
 
 function serializeBaseline(baseline) {
@@ -47,12 +49,8 @@ function serializeBaseline(baseline) {
 }
 
 /**
- * Parse `<path>\t<loc>` lines.
- * Union merges (BI-3B0AD9CF) can leave the same path on multiple lines. When
- * that happens the file is corrupt: fail closed so contributors re-run
- * `--update` rather than silently picking max/min (BI-EEB04701). Until then,
- * if a consumer must resolve in memory, keep the SMALLER LOC so a stale
- * duplicate never loosens the ratchet.
+ * Report paths that appear more than once (union-merge artifact).
+ * Diagnostic only — check mode tolerates them via parseBaseline min-wins.
  */
 export function findDuplicateBaselinePaths(text) {
   const seen = new Map();
@@ -69,6 +67,12 @@ export function findDuplicateBaselinePaths(text) {
   return [...dups].sort();
 }
 
+/**
+ * Parse `<path>\t<loc>` lines.
+ * Union merges (BI-3B0AD9CF) can leave the same path on multiple lines.
+ * Keep the SMALLER LOC so a stale/larger sibling never loosens the ratchet
+ * (size ceiling semantics — min-wins, not max-wins).
+ */
 export function parseBaseline(text) {
   const baseline = {};
   for (const raw of text.split(/\r?\n/)) {
@@ -114,16 +118,16 @@ function main() {
     process.exit(1);
   }
 
+  // BI-24115B65: tolerate union-merge duplicates (min LOC wins). Surface a
+  // notice so contributors can optionally normalize with --update, but do
+  // not fail a green merge on an intentional merge-driver artifact.
   const duplicatePaths = findDuplicateBaselinePaths(baselineText);
   if (duplicatePaths.length > 0) {
-    console.error(
-      "Module-size baseline has duplicate paths (union-merge artifact, BI-EEB04701).\n" +
-        "The on-disk baseline must have one line per path. Re-run:\n" +
-        "  node scripts/check-module-size.mjs --update\n" +
-        "Duplicates:",
+    console.warn(
+      `Module-size baseline has ${duplicatePaths.length} union-merge duplicate path(s); ` +
+        `using the smaller LOC for each (never loosens). Optional cleanup: ` +
+        `node scripts/check-module-size.mjs --update`,
     );
-    for (const p of duplicatePaths) console.error(`  - ${p}`);
-    process.exit(1);
   }
 
   const grew = []; // baselined file now larger than its recorded LOC

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -1,5 +1,6 @@
 // scripts/check-module-size.test.mjs
-// BI-EEB04701 — baseline must not carry silent duplicate path keys.
+// BI-24115B65 — union-merge duplicates are tolerated (min LOC wins); detection
+// remains available for diagnostics / --update cleanup.
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
@@ -7,7 +8,7 @@ import {
   parseBaseline,
 } from "./check-module-size.mjs";
 
-test("parseBaseline keeps the smaller LOC when the same path appears twice", () => {
+test("parseBaseline keeps the smaller LOC when the same path appears twice (union-merge)", () => {
   const text = [
     "apps/web/lib/a.ts\t900",
     "apps/web/lib/b.ts\t1200",
@@ -19,7 +20,16 @@ test("parseBaseline keeps the smaller LOC when the same path appears twice", () 
   assert.equal(parsed["apps/web/lib/b.ts"], 1200);
 });
 
-test("findDuplicateBaselinePaths reports each duplicated path once", () => {
+test("parseBaseline min-wins never loosens a size ceiling across three duplicates", () => {
+  const text = [
+    "apps/web/lib/a.ts\t1100",
+    "apps/web/lib/a.ts\t900",
+    "apps/web/lib/a.ts\t1000",
+  ].join("\n");
+  assert.equal(parseBaseline(text)["apps/web/lib/a.ts"], 900);
+});
+
+test("findDuplicateBaselinePaths reports each duplicated path once (diagnostic)", () => {
   const text = [
     "apps/web/lib/a.ts\t900",
     "apps/web/lib/b.ts\t1200",

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -60,8 +60,8 @@ apps/web/lib/tak/agentic-loop.test.ts	2387
 apps/web/lib/tak/agentic-loop.ts	2737
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	869
-apps/web/lib/work-capsules/work-capsule-store.test.ts	1103
-apps/web/lib/work-capsules/work-capsule-store.ts	1052
+apps/web/lib/work-capsules/work-capsule-store.test.ts	1205
+apps/web/lib/work-capsules/work-capsule-store.ts	1107
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118

--- a/skills/universal/evaluate-page.skill.md
+++ b/skills/universal/evaluate-page.skill.md
@@ -33,7 +33,10 @@ Do not use this for general page summaries; use `analyze-page` instead. Do not u
 
 1. Find the component code for the current route.
 2. Read the page and imported components before judging behavior.
-3. Run the live audit when `evaluate_page` is available.
+3. Run the live audit with `evaluate_page` **once**, only when the browser-use sidecar is expected to be up:
+   - Pass an **absolute** URL reachable from the sidecar network (service hostname inside Docker; not host-only `localhost` from a Windows/macOS agent).
+   - If the tool returns `success=false` with DEGRADED, NOT-RUN, `browser_use_unavailable`, `missing_url`, or `retryable: false` — **stop**. Do not retry the same args (BI-MCP-EFF-71D7229F: blind retries were ~97% of failures).
+   - Fall back to code-only review and state clearly that live audit did not run.
 4. Merge code-level and live findings, deduplicating repeated issues.
 5. Prioritize accessibility, keyboard, contrast, layout stability, labels, and empty/error states.
 6. Create backlog items by category only when findings are real and actionable.
@@ -52,6 +55,7 @@ Do not use this for general page summaries; use `analyze-page` instead. Do not u
 
 - Do not flag stylistic preferences as defects.
 - Do not claim live audit coverage if the tool was unavailable.
+- Never loop `evaluate_page` on identical inputs after a failure — fix URL/sidecar or continue without live evidence.
 - Use exact file paths or visible elements when possible.
 - Group many similar issues into one backlog item per category.
 


### PR DESCRIPTION
## Summary

BI drain session resolving five small, well-scoped open items (MCP verified healthy first).

| BI | Fix |
|----|-----|
| **BI-24115B65** | Module-size baseline tolerates union-merge duplicates (min LOC wins) instead of failing rebases |
| **BI-9E5E6063** | Recompute trustworthy BASE_SHA from live merge-base in evidence planner + self-upgrade acceptance |
| **BI-95E37EA1** | Do not reuse abandoned/foreign branch capsules on claim-at-start; refuse scope claims on terminal WCs |
| **BI-EE6E0CFC** | `--update-baseline` refuses to shrink coverage when committed routes are missing from the freeze |
| **BI-MCP-EFF-71D7229F** | `evaluate_page` tool + skill: non-retryable errors so agents stop blind retries |

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md
  - docs/superpowers/specs/2026-03-20-build-studio-ux-streamlining-design.md (evaluate_page)
  - .gitattributes union-merge rationale for ratchet baselines (BI-3B0AD9CF)
- Current code substrate reviewed:
  - apps/web/lib/work-capsules/work-capsule-store.ts (adopt/claim paths)
  - apps/web/lib/mcp/packs/public-web-design-pack.ts (evaluate_page handler)
  - scripts/check-module-size.mjs and sibling max-wins parsers
  - apps/web/scripts/ux-route-sweep.ts freeze path
- Source of truth:
  - WorkCapsule claim-at-start and terminal status semantics remain the coordination-plane contract
  - evaluate_page remains browser-use backed; failures are NOT-RUN, not zero-findings
- Decision:
  - Localized reliability fixes only; no new UX route, queue, or routing contract

Design-Grounding-Decision: reviewed claim-at-start + evaluate_page specs and work-capsule-store / public-web-design-pack substrate; localized reliability/error-contract fixes, no new UX route or routing contract.

## Gate trailers

Docs-Impact-Decision: internal reliability/CI/MCP tool-contract fixes only; no user-facing route or help-page behavior change
Seed-Fit-Decision: global-default

## Test plan

- [x] `node --test scripts/check-module-size.test.mjs` (4/4)
- [x] `pnpm --filter web exec vitest run lib/work-capsules/work-capsule-store.test.ts` (49/49)
- [x] `pnpm --filter web exec vitest run scripts/ux-route-sweep.test.ts` (15/15)
- [x] `node scripts/check-no-raw-error-message.mjs`
- [x] `node scripts/check-module-size.mjs`
- [ ] CI Policy Guards re-run after this push