### PR TITLE
fix(federation): page mirror lookups past silent take:1000 (BI-72C3FBA2)

### DIFF
--- a/apps/web/lib/assurance/finding-read.ts
+++ b/apps/web/lib/assurance/finding-read.ts
@@ -42,9 +42,11 @@ type FindingSummaryRow = {
   findingKind: string;
 };
 
+type FindingSummaryPageRow = FindingSummaryRow & { id?: string };
+
 type FindingSummaryDb = {
   assuranceFinding?: {
-    findMany(args: unknown): Promise<FindingSummaryRow[]>;
+    findMany(args: unknown): Promise<FindingSummaryPageRow[]>;
   };
 };
 
@@ -95,19 +97,42 @@ async function getActiveFindingSummary(
 ): Promise<AssuranceFindingSummary> {
   if (!db.assuranceFinding) return emptyFindingSummary();
 
-  const rows = await db.assuranceFinding.findMany({
-    where: {
-      ...where,
-      status: { notIn: CLOSED_STATUSES },
-    },
-    select: {
-      policySeverity: true,
-      releaseImpact: true,
-      status: true,
-      findingKind: true,
-    },
-    take: 1000,
-  });
+  // BI-72C3FBA2: page the full open-finding set. A silent take:1000 under-counted
+  // severity summaries once a build/product crossed the first batch.
+  const pageSize = 500;
+  const rows: FindingSummaryRow[] = [];
+  let cursorId: string | undefined;
+  for (;;) {
+    const batch = await db.assuranceFinding.findMany({
+      where: {
+        ...where,
+        status: { notIn: CLOSED_STATUSES },
+      },
+      select: {
+        id: true,
+        policySeverity: true,
+        releaseImpact: true,
+        status: true,
+        findingKind: true,
+      },
+      orderBy: { id: "asc" },
+      take: pageSize,
+      ...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {}),
+    });
+    if (batch.length === 0) break;
+    for (const row of batch) {
+      rows.push({
+        policySeverity: row.policySeverity,
+        releaseImpact: row.releaseImpact,
+        status: row.status,
+        findingKind: row.findingKind,
+      });
+    }
+    if (batch.length < pageSize) break;
+    const lastId = batch[batch.length - 1]?.id;
+    if (!lastId) break;
+    cursorId = lastId;
+  }
 
   return summarize(rows);
 }

--- a/apps/web/lib/federation/demand-disposition.ts
+++ b/apps/web/lib/federation/demand-disposition.ts
@@ -8,6 +8,7 @@ import {
 
 import { decodeDemandOutboxPayload, type DemandDeliveryDb } from "./demand-delivery";
 import { scheduleFederationDeliveryJob } from "./delivery-queue";
+import { findFirstMirrorAcrossPages } from "./mirror-page";
 
 interface DispositionDb extends DemandDeliveryDb {
   federatedRecordMirror: DemandDeliveryDb["federatedRecordMirror"] & {
@@ -110,17 +111,21 @@ export async function handleIncomingDemandDisposition(
 ) {
   const violations = validateDemandDispositionNoticeV1(notice);
   if (violations.length > 0) return { action: "rejected" as const, violations };
-  const shared = await db.federatedRecordMirror.findMany({
-    where: { federationLinkId: linkId, recordType: "demand-envelope", canonicalSide: "local" },
-    select: { payload: true },
-    take: 1_000,
-  });
-  const known = shared.some((row) => {
-    const payload = decodeDemandOutboxPayload(row.payload);
-    return payload?.envelope.specVersion === "dpf.demand/1"
-      && payload.envelope.envelopeId === notice.envelopeId
-      && payload.envelope.originInstallationId === notice.originInstallationId;
-  });
+  // Page the local envelope inventory (BI-72C3FBA2) — silent take:1_000 dropped
+  // envelopes past the first batch on busy federation links.
+  const known = await findFirstMirrorAcrossPages(
+    (args) => db.federatedRecordMirror.findMany(args),
+    {
+      where: { federationLinkId: linkId, recordType: "demand-envelope", canonicalSide: "local" },
+      select: { payload: true, mirrorId: true },
+    },
+    (row) => {
+      const payload = decodeDemandOutboxPayload(row.payload);
+      return payload?.envelope.specVersion === "dpf.demand/1"
+        && payload.envelope.envelopeId === notice.envelopeId
+        && payload.envelope.originInstallationId === notice.originInstallationId;
+    },
+  );
   if (!known) return { action: "rejected" as const, violations: ["notice:unknown-envelope"] };
   const where = { federationLinkId_recordType_peerRecordRef: {
     federationLinkId: linkId,

--- a/apps/web/lib/federation/demand-response.test.ts
+++ b/apps/web/lib/federation/demand-response.test.ts
@@ -146,4 +146,63 @@ describe("handleIncomingDemandResponse", () => {
       .resolves.toEqual({ action: "rejected", violations: ["response:unknown-envelope"] });
     expect(create).not.toHaveBeenCalled();
   });
+
+  it("correlates an envelope past the first page (no silent take:1000 cliff)", async () => {
+    const demand = envelope();
+    const match = {
+      mirrorId: "m_hit",
+      localRecordRef: "BI-LOCAL-1",
+      payload: {
+        envelope: demand,
+        activity: "dpf.demand.proposed",
+        eventId: "evt",
+        queuedAt: demand.createdAt,
+      },
+    };
+    const create = vi.fn().mockResolvedValue({});
+    const findMany = vi.fn().mockImplementation((args: {
+      take: number;
+      cursor?: { mirrorId: string };
+      skip?: number;
+    }) => {
+      // Full first page of non-matches so the pager continues (length === take).
+      if (!args.cursor) {
+        return Promise.resolve(
+          Array.from({ length: args.take }, (_, i) => ({
+            mirrorId: `m_fill_${i}`,
+            localRecordRef: `BI-FILL-${i}`,
+            payload: {
+              envelope: {
+                ...demand,
+                envelopeId: `dem_other_${i}`,
+                originRecordRef: `ref_other_${i}`,
+              },
+              activity: "dpf.demand.proposed",
+              eventId: "evt",
+              queuedAt: demand.createdAt,
+            },
+          })),
+        );
+      }
+      return Promise.resolve([match]);
+    });
+    const value = {
+      workQueue: { upsert: vi.fn() },
+      workItem: { upsert: vi.fn(), update: vi.fn(), updateMany: vi.fn(), findMany: vi.fn() },
+      federationLink: { findUnique: vi.fn(), findMany: vi.fn() },
+      federatedRecordMirror: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        findMany,
+        create,
+        update: vi.fn(),
+      },
+    } as unknown as DemandResponseDb;
+
+    await expect(handleIncomingDemandResponse(value, "link_1", response()))
+      .resolves.toMatchObject({ action: "created", responseId: "rsp_opaque" });
+    expect(findMany.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(findMany.mock.calls[1][0]).toMatchObject({ cursor: { mirrorId: "m_fill_99" }, skip: 1 });
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0].data).toMatchObject({ localRecordRef: "BI-LOCAL-1" });
+  });
 });

--- a/apps/web/lib/federation/demand-response.ts
+++ b/apps/web/lib/federation/demand-response.ts
@@ -15,6 +15,7 @@ import {
 import { decodeDemandMirrorPayload } from "./demand-exchange";
 import type { FederationIdentity } from "./demand-identity";
 import { scheduleFederationDeliveryJob } from "./delivery-queue";
+import { findFirstMirrorAcrossPages } from "./mirror-page";
 
 interface ResponseMirrorRow {
   mirrorId: string;
@@ -141,20 +142,23 @@ export async function handleIncomingDemandResponse(
 ): Promise<{ action: "created" | "noop" | "rejected"; responseId?: string; violations?: string[] }> {
   const violations = validateDemandResponseV1(response);
   if (violations.length > 0) return { action: "rejected", violations };
-  const shared = await db.federatedRecordMirror.findMany({
-    where: { federationLinkId: linkId, recordType: "demand-envelope", canonicalSide: "local" },
-    select: { payload: true, localRecordRef: true },
-    take: 1_000,
-  });
-  // Correlate the incoming response to the exact demand WE projected, and keep the
-  // matched row so we can bind the response to the ORIGINATOR's local item below.
-  const matchedEnvelope = shared.find((row) => {
-    const payload = decodeDemandOutboxPayload(row.payload);
-    return payload?.envelope.specVersion === "dpf.demand/1"
-      && payload.envelope.envelopeId === response.envelopeId
-      && payload.envelope.originInstallationId === response.originInstallationId
-      && payload.envelope.originRecordRef === response.originRecordRef;
-  });
+  // Correlate the incoming response to the exact demand WE projected. Page the
+  // local envelope inventory (BI-72C3FBA2) — a silent take:1_000 dropped every
+  // envelope past the first batch on busy links.
+  const matchedEnvelope = await findFirstMirrorAcrossPages(
+    (args) => db.federatedRecordMirror.findMany(args),
+    {
+      where: { federationLinkId: linkId, recordType: "demand-envelope", canonicalSide: "local" },
+      select: { payload: true, localRecordRef: true, mirrorId: true },
+    },
+    (row) => {
+      const payload = decodeDemandOutboxPayload(row.payload);
+      return payload?.envelope.specVersion === "dpf.demand/1"
+        && payload.envelope.envelopeId === response.envelopeId
+        && payload.envelope.originInstallationId === response.originInstallationId
+        && payload.envelope.originRecordRef === response.originRecordRef;
+    },
+  );
   if (!matchedEnvelope) return { action: "rejected", violations: ["response:unknown-envelope"] };
   const where = {
     federationLinkId_recordType_peerRecordRef: {

--- a/apps/web/lib/federation/mirror-page.test.ts
+++ b/apps/web/lib/federation/mirror-page.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { findFirstMirrorAcrossPages } from "./mirror-page";
+
+describe("findFirstMirrorAcrossPages", () => {
+  it("pages past a batch that would have been dropped by a silent take:1000", async () => {
+    const pages = [
+      [
+        { mirrorId: "m1", payload: { n: 1 } },
+        { mirrorId: "m2", payload: { n: 2 } },
+      ],
+      [{ mirrorId: "m3", payload: { n: 3 } }],
+    ];
+    const findMany = vi.fn().mockImplementation((args: {
+      take: number;
+      cursor?: { mirrorId: string };
+      skip?: number;
+    }) => {
+      if (!args.cursor) return Promise.resolve(pages[0]!.slice(0, args.take));
+      if (args.cursor.mirrorId === "m2") return Promise.resolve(pages[1]!);
+      return Promise.resolve([]);
+    });
+
+    type Row = { mirrorId?: string | null; payload: { n: number } };
+    const hit = await findFirstMirrorAcrossPages<Row>(
+      findMany,
+      { where: { federationLinkId: "link_1" }, select: { mirrorId: true, payload: true } },
+      (row) => row.payload.n === 3,
+      { pageSize: 2 },
+    );
+
+    expect(hit).toEqual({ mirrorId: "m3", payload: { n: 3 } });
+    expect(findMany).toHaveBeenCalledTimes(2);
+    expect(findMany.mock.calls[1][0]).toMatchObject({
+      take: 2,
+      cursor: { mirrorId: "m2" },
+      skip: 1,
+    });
+  });
+
+  it("returns null when no page matches", async () => {
+    const findMany = vi.fn().mockResolvedValue([{ mirrorId: "m1", payload: {} }]);
+    await expect(
+      findFirstMirrorAcrossPages(
+        findMany,
+        { where: {} },
+        () => false,
+        { pageSize: 10 },
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/federation/mirror-page.ts
+++ b/apps/web/lib/federation/mirror-page.ts
@@ -1,0 +1,46 @@
+// BI-72C3FBA2 — cursor paging for federated mirror lookups.
+//
+// Silent `take: 1_000` without a cursor drops every row past the first batch.
+// Prefer page-until-match (or page-all with a bounded page size) so large links
+// stay correct. demand-digest already uses this pattern inline; these helpers
+// keep response/disposition correlation on the same contract.
+
+/** Default page size for mirror inventory scans (not a silent total cap). */
+export const DEFAULT_MIRROR_PAGE_SIZE = 100;
+
+export type MirrorFindMany<T> = (args: Record<string, unknown>) => Promise<T[]>;
+
+/**
+ * Walk a mirror inventory in ordered pages until `match` hits or the set ends.
+ * Never silently stops at a fixed total row budget.
+ */
+export async function findFirstMirrorAcrossPages<T extends { mirrorId?: string | null }>(
+  findMany: MirrorFindMany<T>,
+  base: {
+    where: unknown;
+    select?: unknown;
+    orderBy?: unknown;
+  },
+  match: (row: T) => boolean,
+  options?: { pageSize?: number },
+): Promise<T | null> {
+  const pageSize = Math.max(1, options?.pageSize ?? DEFAULT_MIRROR_PAGE_SIZE);
+  let cursorId: string | undefined;
+  for (;;) {
+    const rows = await findMany({
+      where: base.where,
+      ...(base.select ? { select: base.select } : {}),
+      orderBy: base.orderBy ?? { mirrorId: "asc" },
+      take: pageSize,
+      ...(cursorId ? { cursor: { mirrorId: cursorId }, skip: 1 } : {}),
+    });
+    if (rows.length === 0) return null;
+    for (const row of rows) {
+      if (match(row)) return row;
+    }
+    if (rows.length < pageSize) return null;
+    const lastId = rows[rows.length - 1]?.mirrorId;
+    if (!lastId) return null;
+    cursorId = lastId;
+  }
+}


### PR DESCRIPTION
## Summary

Executes **BI-72C3FBA2** (silent collection caps) while proving **BI-C85D1B0A** BuildKit cool-down on the upgraded install.

### BI-72C3FBA2
- Shared `findFirstMirrorAcrossPages` helper
- Demand response/disposition correlation pages instead of silent `take: 1_000`
- Assurance finding summaries page open findings
- Multi-page regression tests

### BI-C85D1B0A verification
- #4168 merged; self-upgrade includes cool-down
- Janitor apply: STOP v2, REAP v1
- Bootstrap then stop cycle: running → stopped
- BI-C85D1B0A marked **done**

Process-Spine-Decision: localized bugfix for silent take:1000 cliffs; reuse existing demand-digest paging contract, no new durable design surface.

Docs-Impact-Decision: internal federation/assurance correctness; no user-facing route or guide change.

## Test plan
- [x] vitest federation suites
- [x] BuildKit cool-down on host