### PR TITLE
fix(mcp): BI drain batch 3 — high-volume tool contract guidance

### DIFF
--- a/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
@@ -20,7 +20,7 @@ export const backlogPackDefinitions: ToolDefinition[] = [
     description:
       "Create a new backlog item in the ops backlog. Use this tool to add new items — do NOT use update_backlog_item for items that do not exist yet. " +
       "New items default to status=triaging; supply status+triageOutcome together only when explicitly skipping triage (e.g. Build Studio brief intake). When triageOutcome=build, effortSize is required. " +
-      "Before creating: list_backlog_items or search_knowledge for an existing BI on the same defect (BI-MCP-EFF-B31F3D07 — high create volume often means duplicate filing). " +
+      "Before creating: list_backlog_items or search_knowledge for an existing BI on the same defect. " +
       "Do not create-then-recreate on transient errors; read the error and fix the payload once.",
     inputSchema: {
       type: "object",
@@ -135,7 +135,7 @@ export const backlogPackDefinitions: ToolDefinition[] = [
     name: "query_backlog",
     description:
       "Query backlog items and epics. Returns items matching the filter criteria with status, priority, and epic information. " +
-      "Prefer list_backlog_items when you only need item rows with workType/claim filters (BI-MCP-EFF-F7078492). " +
+      "Prefer list_backlog_items when you only need item rows with workType/claim filters. " +
       "Prefer get_next_recommended_work for \"what should I pick next\". " +
       "Do not poll query_backlog in a tight loop — responses include total/truncated; widen filters or raise limit once instead of thrashing.",
     inputSchema: {
@@ -230,7 +230,7 @@ export const backlogPackDefinitions: ToolDefinition[] = [
     name: "list_backlog_items",
     description:
       "List backlog items filtered by status, type, workType, source, epic, claim state, or active-build state. Read-only. Returns semantic IDs (BI-*, EP-*) — never cuids. " +
-      "Prefer one filtered list over many get_backlog_item calls (BI-MCP-EFF-577F9381 / BI-MCP-EFF-1FE23977). " +
+      "Prefer one filtered list over many get_backlog_item calls. " +
       "Use status+unclaimed+limit; honor total/truncated instead of re-listing the same page.",
     inputSchema: {
       type: "object",

--- a/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
@@ -17,7 +17,11 @@ import { backlogStatusToolDefinition } from "./backlog-status-tool-definition";
 export const backlogPackDefinitions: ToolDefinition[] = [
   {
     name: "create_backlog_item",
-    description: "Create a new backlog item in the ops backlog. Use this tool to add new items — do NOT use update_backlog_item for items that do not exist yet. New items default to status=triaging; supply status+triageOutcome together only when explicitly skipping triage (e.g. Build Studio brief intake). When triageOutcome=build, effortSize is required.",
+    description:
+      "Create a new backlog item in the ops backlog. Use this tool to add new items — do NOT use update_backlog_item for items that do not exist yet. " +
+      "New items default to status=triaging; supply status+triageOutcome together only when explicitly skipping triage (e.g. Build Studio brief intake). When triageOutcome=build, effortSize is required. " +
+      "Before creating: list_backlog_items or search_knowledge for an existing BI on the same defect (BI-MCP-EFF-B31F3D07 — high create volume often means duplicate filing). " +
+      "Do not create-then-recreate on transient errors; read the error and fix the payload once.",
     inputSchema: {
       type: "object",
       properties: {
@@ -129,7 +133,11 @@ export const backlogPackDefinitions: ToolDefinition[] = [
   },
   {
     name: "query_backlog",
-    description: "Query backlog items and epics. Returns items matching the filter criteria with status, priority, and epic information.",
+    description:
+      "Query backlog items and epics. Returns items matching the filter criteria with status, priority, and epic information. " +
+      "Prefer list_backlog_items when you only need item rows with workType/claim filters (BI-MCP-EFF-F7078492). " +
+      "Prefer get_next_recommended_work for \"what should I pick next\". " +
+      "Do not poll query_backlog in a tight loop — responses include total/truncated; widen filters or raise limit once instead of thrashing.",
     inputSchema: {
       type: "object",
       properties: {
@@ -220,7 +228,10 @@ export const backlogPackDefinitions: ToolDefinition[] = [
   },
   {
     name: "list_backlog_items",
-    description: "List backlog items filtered by status, type, workType, source, epic, claim state, or active-build state. Read-only. Returns semantic IDs (BI-*, EP-*) — never cuids.",
+    description:
+      "List backlog items filtered by status, type, workType, source, epic, claim state, or active-build state. Read-only. Returns semantic IDs (BI-*, EP-*) — never cuids. " +
+      "Prefer one filtered list over many get_backlog_item calls (BI-MCP-EFF-577F9381 / BI-MCP-EFF-1FE23977). " +
+      "Use status+unclaimed+limit; honor total/truncated instead of re-listing the same page.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/change-review-pack.ts
+++ b/apps/web/lib/mcp/packs/change-review-pack.ts
@@ -33,7 +33,7 @@ const definitions: ToolDefinition[] = [{
   name: "review_semantic_change",
   description:
     "Independently review an immutable committed change before its first publication, record one fresh semantic-review receipt on the Work Capsule, and return whether the author should publish, repair, or escalate. " +
-    "Call ONCE per committed (baseTreeHash, headTreeHash, diffDigest) identity — not as a status poll (BI-MCP-EFF-F345FEE0). " +
+    "Call ONCE per committed (baseTreeHash, headTreeHash, diffDigest) identity — not as a status poll. " +
     "After a publish/repair/escalate decision, do not re-call until the tree digests change. repairRound > 2 escalates instead of looping.",
   inputSchema: {
     type: "object",

--- a/apps/web/lib/mcp/packs/change-review-pack.ts
+++ b/apps/web/lib/mcp/packs/change-review-pack.ts
@@ -32,7 +32,9 @@ const PROFILES: StrategyProfile[] = ["economy", "balanced", "high-assurance", "d
 const definitions: ToolDefinition[] = [{
   name: "review_semantic_change",
   description:
-    "Independently review an immutable committed change before its first publication, record one fresh semantic-review receipt on the Work Capsule, and return whether the author should publish, repair, or escalate.",
+    "Independently review an immutable committed change before its first publication, record one fresh semantic-review receipt on the Work Capsule, and return whether the author should publish, repair, or escalate. " +
+    "Call ONCE per committed (baseTreeHash, headTreeHash, diffDigest) identity — not as a status poll (BI-MCP-EFF-F345FEE0). " +
+    "After a publish/repair/escalate decision, do not re-call until the tree digests change. repairRound > 2 escalates instead of looping.",
   inputSchema: {
     type: "object",
     properties: {

--- a/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
+++ b/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
@@ -136,7 +136,7 @@ const definitions: ToolDefinition[] = [
     description:
       "Request admission to a governed shared nonproduction environment for preview, UX verification, or local integration. " +
       "Reusing claimKey returns the same durable queue entry (idempotent wait). " +
-      "Do not claim in a tight loop without a stable claimKey (BI-MCP-EFF-8815EA40 waste). " +
+      "Do not claim in a tight loop without a stable claimKey. " +
       "When queued, wait and renew with the returned leaseId — do not open a second claim for the same session purpose.",
     inputSchema: {
       type: "object",
@@ -194,7 +194,7 @@ const definitions: ToolDefinition[] = [
     description:
       "Heartbeat an active shared nonproduction environment lease, optionally binding its assigned slot before host mutation. " +
       "Only the owning session can renew, and a lapsed lease is not revivable. " +
-      "Renew on a human-scale cadence (on gate stages / ~minutes), not every few seconds (BI-MCP-EFF-F04CF901 — 617 renews was waste polling). " +
+      "Renew on a human-scale cadence (on gate stages / ~minutes), not every few seconds. " +
       "On owner mismatch or not_found: stop retrying; re-claim with claimKey if work continues.",
     inputSchema: {
       type: "object",

--- a/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
+++ b/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
@@ -133,7 +133,11 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "claim_nonprod_environment_lease",
-    description: "Request admission to a governed shared nonproduction environment for preview, UX verification, or local integration. Reusing claimKey returns the same durable queue entry.",
+    description:
+      "Request admission to a governed shared nonproduction environment for preview, UX verification, or local integration. " +
+      "Reusing claimKey returns the same durable queue entry (idempotent wait). " +
+      "Do not claim in a tight loop without a stable claimKey (BI-MCP-EFF-8815EA40 waste). " +
+      "When queued, wait and renew with the returned leaseId — do not open a second claim for the same session purpose.",
     inputSchema: {
       type: "object",
       properties: {
@@ -187,7 +191,11 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "renew_nonprod_environment_lease",
-    description: "Heartbeat an active shared nonproduction environment lease, optionally binding its assigned slot before host mutation. Only the owning session can renew, and a lapsed lease is not revivable.",
+    description:
+      "Heartbeat an active shared nonproduction environment lease, optionally binding its assigned slot before host mutation. " +
+      "Only the owning session can renew, and a lapsed lease is not revivable. " +
+      "Renew on a human-scale cadence (on gate stages / ~minutes), not every few seconds (BI-MCP-EFF-F04CF901 — 617 renews was waste polling). " +
+      "On owner mismatch or not_found: stop retrying; re-claim with claimKey if work continues.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary

Third BI drain batch (5 MCP efficiency items) — agent-facing tool contracts that cut thrash without substrate redesign.

| BI | Fix |
|----|-----|
| **BI-MCP-EFF-F345FEE0** | review_semantic_change once per digest |
| **BI-MCP-EFF-F7078492** | query_backlog vs list/recommend routing |
| **BI-MCP-EFF-577F9381** | list_backlog_items anti-thrash |
| **BI-MCP-EFF-B31F3D07** | create_backlog_item search-before-create |
| **BI-MCP-EFF-F04CF901** | renew_nonprod human-scale cadence |

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md
  - docs/architecture/mcp-tool-authorization-runbook.md
- Current code substrate reviewed:
  - apps/web/lib/mcp/packs/backlog-pack-definitions.ts
  - apps/web/lib/mcp/packs/change-review-pack.ts
  - apps/web/lib/mcp/packs/nonprod-lease-pack.ts
- Source of truth: MCP tool pack definitions
- Decision: description-only contract guidance; no new routes or behavior

Design-Grounding-Decision: reviewed MCP pack definitions and authorization runbook; tool description contracts only, no UX routes.

Docs-Impact-Decision: agent-facing MCP tool contracts only; no end-user docs impact
Seed-Fit-Decision: global-default