### PR TITLE
fix(mcp): BI drain batch 6 — more thrash contracts

### DIFF
--- a/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
@@ -203,7 +203,9 @@ export const backlogPackDefinitions: ToolDefinition[] = [
   },
   {
     name: "list_epics",
-    description: "List epics with item-count rollups. Read-only. Filterable by status and whether the epic has open items. Returned epicId is the semantic id (EP-*), not the internal cuid.",
+    description:
+      "List epics with item-count rollups. Read-only. Filterable by status and whether the epic has open items. Returned epicId is the semantic id (EP-*), not the internal cuid. " +
+      "Prefer one filtered list (status/hasOpenItems/limit) over re-listing the full catalog for every decision.",
     inputSchema: {
       type: "object",
       properties: {
@@ -271,7 +273,9 @@ export const backlogPackDefinitions: ToolDefinition[] = [
   },
   {
     name: "get_next_recommended_work",
-    description: "Return a short ranked list of backlog items the caller could pick up next. Ranks by spec/plan presence, triage outcome, effort size, priority, and active-build state. Read-only.",
+    description:
+      "Return a short ranked list of backlog items the caller could pick up next. Ranks by spec/plan presence, triage outcome, effort size, priority, and active-build state. Read-only. " +
+      "Call once at session start (or after finishing a BI); pass excludeItemIds for rejected candidates instead of re-polling without filters.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/discovery-pack.ts
+++ b/apps/web/lib/mcp/packs/discovery-pack.ts
@@ -90,7 +90,9 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "search_tool_marketplace",
-    description: "Search the cross-source tool marketplace readiness catalog. Use when the user asks what integrations, MCP servers, built-in tools, model requirements, or ungranted/unconfigured tools are available for an AI coworker.",
+    description:
+      "Search the cross-source tool marketplace readiness catalog. Use when the user asks what integrations, MCP servers, built-in tools, model requirements, or ungranted/unconfigured tools are available for an AI coworker. " +
+      "Prefer load_tools with an exact name or intent query once you know the tool — do not re-search the marketplace for the same query every turn.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -30,7 +30,10 @@ const definitions: ToolDefinition[] = [
   {
     name: "principle_decide",
     description:
-      "Advisory only. Score a set of options against the governance principles in scope for the calling population, and return a recommendation plus a per-principle contribution ledger. Uses commandments from Postgres (always included) and relevant core/contextual principles from semantic search. Does not execute the recommended option; the caller retains authority. Use when you have two or more options and want to surface which governance principles pull which way.",
+      "Advisory only. Score a set of options against the governance principles in scope for the calling population, and return a recommendation plus a per-principle contribution ledger. " +
+      "Uses commandments from Postgres (always included) and relevant core/contextual principles from semantic search. Does not execute the recommended option; the caller retains authority. " +
+      "Use when you have two or more options and want to surface which governance principles pull which way. " +
+      "Call once per distinct option set — do not re-score identical options hoping for a different winner.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -274,7 +274,9 @@ const definitions: ToolDefinition[] = [
   {
     name: "start_external_work",
     description:
-      "Register that you are STARTING work on an external session — before any evidence — so a tracked Work Capsule exists immediately and the session is visible to other agents instead of appearing only after the first result. Idempotent per session (or per repo+branch when a worktree is supplied); summary is optional at start.",
+      "Register that you are STARTING work on an external session — before any evidence — so a tracked Work Capsule exists immediately and the session is visible to other agents instead of appearing only after the first result. " +
+      "Idempotent per session (or per repo+branch when a worktree is supplied); summary is optional at start. " +
+      "Call once at session start — re-calling with the same session/worktree is a no-op, not a progress signal.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary

Sixth BI drain batch — additional MCP tool thrash contracts.

| Area | Change |
|------|--------|
| list_epics | filter once, don't re-catalog |
| principle_decide | once per option set |
| start_external_work | once at session start |
| search_tool_marketplace | then load_tools, don't re-search |
| get_next_recommended_work | once per session / use excludeItemIds |

Maps to CAP tool-surface thrash class (BI-CAP-35BFE887 family) + MCP efficiency program.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md
- Current code substrate reviewed:
  - apps/web/lib/mcp/packs/backlog-pack-definitions.ts
  - apps/web/lib/mcp/packs/principle-decide-pack.ts
  - apps/web/lib/mcp/packs/work-capsules-pack.ts
  - apps/web/lib/mcp/packs/discovery-pack.ts
- Source of truth: MCP pack definitions
- Decision: description-only contracts

Design-Grounding-Decision: reviewed delivery-surfaces design and MCP packs; tool description thrash contracts only.

Docs-Impact-Decision: agent MCP contracts only
Seed-Fit-Decision: global-default