### PR TITLE
fix(mcp): BI drain batch 8 — CAP thrash contracts for failing tools

### DIFF
--- a/apps/web/lib/mcp/packs/ai-platform-posture-pack.ts
+++ b/apps/web/lib/mcp/packs/ai-platform-posture-pack.ts
@@ -21,7 +21,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "get_ai_platform_posture",
     description:
-      "Read authoritative, real-time AI-layer state in one call: provider status/config, ModelProfile tiers/capabilities/toolFidelity, token spend per provider and per agent (current calendar month), failover-chain integrity (fallback rate + recent fallback chains + provider error codes over a lookback window), agent-to-provider assignment (which provider each agent was most routed to recently), and scheduled-task status (both per-user recurring agent tasks and the platform cron catalog). Read-only — grounds AI-ops posture reporting in real data instead of derived capability-needs feedback.",
+      "Read authoritative, real-time AI-layer state in one call: provider status/config, ModelProfile tiers/capabilities/toolFidelity, token spend per provider and per agent (current calendar month), failover-chain integrity (fallback rate + recent fallback chains + provider error codes over a lookback window), agent-to-provider assignment (which provider each agent was most routed to recently), and scheduled-task status (both per-user recurring agent tasks and the platform cron catalog). Read-only — grounds AI-ops posture reporting in real data instead of derived capability-needs feedback. Call once at the start of a posture review. Cache the result for the session rather than re-polling. On errors, fix grants or runtime readiness once; do not blind-retry identical calls.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/founder-review-pack.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.ts
@@ -34,7 +34,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "list_open_decision_reviews",
     description:
-      "List the OPEN DECISION REVIEWS shown on the /coworker-decisions Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the owning workflow after reviewing the Decision Canvas evidence; this tool lets you understand and recommend.",
+      "List the OPEN DECISION REVIEWS shown on the /coworker-decisions Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the owning workflow after reviewing the Decision Canvas evidence; this tool lets you understand and recommend. Call once when opening a review queue; do not poll in a tight loop. Prefer filters over repeated full-list calls. On errors, fix grants once; do not thrash.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/mcp/packs/storefront-activity-pack.ts
+++ b/apps/web/lib/mcp/packs/storefront-activity-pack.ts
@@ -19,7 +19,8 @@ const definitions: ToolDefinition[] = [
       "List recent guest activity from the public storefront: orders, reservations (bookings), or " +
       "inquiries, newest first, with status and customer. For orders the result includes an " +
       "item-quantity rollup across the whole window (e.g. Margherita Pizza x11) — the demand " +
-      "signal for restocking, staffing, and follow-up proposals. Read-only.",
+      "signal for restocking, staffing, and follow-up proposals. Read-only. " +
+      "Call once per review window with the filters you need. Empty results are a finding, not a retry signal — do not re-call with identical arguments. On errors, fix scope or grants once; do not thrash.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary

Eighth BI drain batch (3 CAP thrash contracts).

| BI | Fix |
|----|-----|
| **BI-CAP-5D66DD26** | `list_storefront_activity` once-per-window thrash guidance |
| **BI-CAP-5DDC42E4** | `get_ai_platform_posture` once-per-session thrash guidance |
| **BI-CAP-62EFA2D5** | `list_open_decision_reviews` no tight-loop thrash guidance |

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md
- Current code substrate reviewed:
  - apps/web/lib/mcp/packs/storefront-activity-pack.ts
  - apps/web/lib/mcp/packs/ai-platform-posture-pack.ts
  - apps/web/lib/mcp/packs/founder-review-pack.ts
- Source of truth: MCP pack tool definitions
- Decision: description-only thrash contracts; no BI-id provenance in agent text

Design-Grounding-Decision: reviewed MCP pack substrate and delivery-surfaces design; thrash contracts only, no new UX routes.

Docs-Impact-Decision: agent MCP contracts only
Seed-Fit-Decision: global-default

## Test plan

- [x] Diff review: tool-level descriptions only (not nested schema fields)
- [x] No `BI-` provenance tokens in descriptions
- [ ] CI Policy Guards / Unit Tests after push