### PR TITLE
fix(sbom): baseline-accept the two image-size DoS advisories

### DIFF
--- a/sbom/vuln-baseline.json
+++ b/sbom/vuln-baseline.json
@@ -8,6 +8,22 @@
       "severity": "moderate",
       "reason": "Trusted-input-only. js-yaml 3.14.2 is a transitive dep of gray-matter, used for build-time frontmatter parsing of our own repo-controlled .md files — never attacker-supplied YAML, so the quadratic-complexity DoS is not reachable. The fix is in js-yaml 4.x, a breaking major gray-matter does not support (consistent with the prior tolerable_risk dismissal, Dependabot #74). Re-evaluate if gray-matter adopts js-yaml 4 or a 3.x patch ships.",
       "expires": "2026-12-31"
+    },
+    {
+      "id": "GHSA-5p2g-fcmc-qvqq",
+      "aliases": ["CVE-2025-71329"],
+      "package": "image-size@1.2.1",
+      "severity": "high",
+      "reason": "No-fix-available + not-reachable + build-time-only. image-size is a transitive dep of metro@0.84.4 (the React Native / Expo bundler) under apps/mobile ONLY — it is never in the apps/web production runtime. The JXL/HEIF infinite-loop DoS is only reachable by parsing an attacker-supplied image; metro parses image ASSETS committed to our own repo at build time, so the vector is not reachable in our threat model. Critically there is NO patched version: the advisory affects image-size <= 2.0.2 (every published release, incl. latest), so bumping/overriding cannot fix it, and 2.x is a breaking major metro cannot consume. Remediation rides a future Expo/RN SDK + metro bump. Re-evaluate when image-size ships a patched release or metro drops the dep.",
+      "expires": "2027-02-28"
+    },
+    {
+      "id": "GHSA-w3rx-r6r6-pgpr",
+      "aliases": ["CVE-2025-71330"],
+      "package": "image-size@1.2.1",
+      "severity": "high",
+      "reason": "No-fix-available + not-reachable + build-time-only. Same package/vector as GHSA-5p2g-fcmc-qvqq (this is the ICNS-parser infinite-loop variant). image-size is transitive via metro@0.84.4 under apps/mobile only, never in the apps/web production runtime; the DoS needs an attacker-supplied image, whereas metro parses our own repo-controlled build assets. No patched version exists (affects <= 2.0.2, every release), and 2.x is a breaking major metro cannot consume. Remediation rides a future Expo/RN SDK + metro bump. Re-evaluate when image-size ships a patched release or metro drops the dep.",
+      "expires": "2027-02-28"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the two `image-size@1.2.1` high advisories to `sbom/vuln-baseline.json` (dismiss-with-justification, `expires: 2027-02-28`):
- `GHSA-5p2g-fcmc-qvqq` / CVE-2025-71329 (JXL/HEIF infinite-loop DoS)
- `GHSA-w3rx-r6r6-pgpr` / CVE-2025-71330 (ICNS infinite-loop DoS)

## Why this is the right remediation (not a bump/override/fork)

- **No fix exists in any release.** The advisory affects `image-size <= 2.0.2` — every published version, including latest. A bump or `pnpm.override` cannot remediate, and `image-size@2.x` is a breaking major that `metro` cannot consume.
- **Not reachable in our threat model.** `image-size` is transitive via `metro@0.84.4` (the React Native / Expo bundler) under **`apps/mobile` only** — never in the `apps/web` production runtime. The DoS requires parsing an *attacker-supplied* image; metro parses image assets **committed to our own repo at build time**.
- **Build-time / dev-only exposure**, on developer/CI machines, not shipped surfaces.
- **Forced re-review**: `expires: 2027-02-28`. The durable fix rides a future Expo/RN SDK + metro bump; the finding auto-resurfaces at expiry.

## Impact

Unblocks the `OSV vulnerability scan` on `main` and on the stuck Dependabot PRs (#4184–4188). Mirrors the existing `js-yaml` accepted entry exactly (trusted-input-only, expiry, re-evaluation trigger).

## Note

This is a **security-posture decision** — accepting two High advisories. Merging = approving the acceptance. Fully reversible (delete the two entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)